### PR TITLE
Pass GATEWAY_* environment variables to container

### DIFF
--- a/gateway/start-gateway.sh
+++ b/gateway/start-gateway.sh
@@ -157,6 +157,18 @@ if [ -n "${GITHUB_USER_TOKEN:-}" ]; then
     ENV_ARGS+=(-e "GITHUB_USER_TOKEN=$GITHUB_USER_TOKEN")
 fi
 
+# Pass gateway configuration environment variables from secrets.env
+# These are required for policy enforcement (bot identity, branch prefixes, trusted users)
+if [ -n "${GATEWAY_BOT_NAME:-}" ]; then
+    ENV_ARGS+=(-e "GATEWAY_BOT_NAME=$GATEWAY_BOT_NAME")
+fi
+if [ -n "${GATEWAY_BOT_BRANCH_PREFIX:-}" ]; then
+    ENV_ARGS+=(-e "GATEWAY_BOT_BRANCH_PREFIX=$GATEWAY_BOT_BRANCH_PREFIX")
+fi
+if [ -n "${GATEWAY_TRUSTED_USERS:-}" ]; then
+    ENV_ARGS+=(-e "GATEWAY_TRUSTED_USERS=$GATEWAY_TRUSTED_USERS")
+fi
+
 # Extract git identity from user_mode config in repositories.yaml
 # This is used for git commits in user mode repos
 if command -v python3 &> /dev/null; then


### PR DESCRIPTION
## Summary
- Fix gateway startup failure after merging #72 (GATEWAY_BOT_NAME requirement)
- The `start-gateway.sh` script sources `secrets.env` but wasn't passing `GATEWAY_BOT_NAME`, `GATEWAY_BOT_BRANCH_PREFIX`, and `GATEWAY_TRUSTED_USERS` to the Docker container via `-e` flags
- This caused the gateway to fail with `ValueError: GATEWAY_BOT_BRANCH_PREFIX environment variable is required`

## Test plan
- [ ] Restart gateway with `systemctl --user restart egg-gateway`
- [ ] Verify `docker inspect egg-gateway` shows the GATEWAY_* environment variables
- [ ] Confirm git push operations work without the ValueError

🤖 Generated with [Claude Code](https://claude.com/claude-code)