### PR TITLE
Increase waitress thread pool for parallel egg instances

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -2753,7 +2753,7 @@ def main():
         app.run(host=args.host, port=args.port, debug=True)
     else:
         # Use waitress for production
-        serve(app, host=args.host, port=args.port)
+        serve(app, host=args.host, port=args.port, threads=8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Waitress defaults to 4 worker threads, but each gateway request blocks a thread for 10-30s while running git/gh subprocesses
- With 5 parallel egg instances, all 4 threads saturate and requests queue up, producing `WARNING:waitress.queue:Task queue depth is N` warnings
- Increase thread pool to 8 to handle concurrent instances with headroom for heartbeats

## Test plan
- [ ] Run 5 egg instances in parallel and verify no `Task queue depth` warnings appear
- [ ] Confirm gateway responsiveness under concurrent load

🤖 Generated with [Claude Code](https://claude.com/claude-code)