### PR TITLE
Fix pipeline state resolution and add request logging

### DIFF
--- a/orchestrator/api.py
+++ b/orchestrator/api.py
@@ -15,9 +15,10 @@ Usage:
 import argparse
 import os
 import sys
+import time
 from pathlib import Path
 
-from flask import Flask, Response, jsonify
+from flask import Flask, Response, g, jsonify, request
 from waitress import serve
 
 # Add shared directory to path for egg_logging
@@ -41,13 +42,13 @@ app = Flask(__name__)
 
 # Register blueprints
 try:
-    from routes.health import health_bp
-    from routes.pipelines import pipelines_bp
     from routes.containers import containers_bp
-    from routes.phases import phases_bp
-    from routes.signals import signals_bp
     from routes.decisions import decisions_bp
+    from routes.health import health_bp
     from routes.metrics import metrics_bp
+    from routes.phases import phases_bp
+    from routes.pipelines import pipelines_bp
+    from routes.signals import signals_bp
     from webhooks import webhooks_bp
 
     app.register_blueprint(health_bp)
@@ -59,13 +60,13 @@ try:
     app.register_blueprint(metrics_bp)
     app.register_blueprint(webhooks_bp)
 except ImportError:
-    from .routes.health import health_bp  # type: ignore[no-redef]
-    from .routes.pipelines import pipelines_bp  # type: ignore[no-redef]
     from .routes.containers import containers_bp  # type: ignore[no-redef]
-    from .routes.phases import phases_bp  # type: ignore[no-redef]
-    from .routes.signals import signals_bp  # type: ignore[no-redef]
     from .routes.decisions import decisions_bp  # type: ignore[no-redef]
+    from .routes.health import health_bp  # type: ignore[no-redef]
     from .routes.metrics import metrics_bp  # type: ignore[no-redef]
+    from .routes.phases import phases_bp  # type: ignore[no-redef]
+    from .routes.pipelines import pipelines_bp  # type: ignore[no-redef]
+    from .routes.signals import signals_bp  # type: ignore[no-redef]
     from .webhooks import webhooks_bp  # type: ignore[no-redef]
 
     app.register_blueprint(health_bp)
@@ -76,6 +77,26 @@ except ImportError:
     app.register_blueprint(decisions_bp)
     app.register_blueprint(metrics_bp)
     app.register_blueprint(webhooks_bp)
+
+
+@app.before_request
+def log_request_start() -> None:
+    """Record request start time for duration logging."""
+    g.start_time = time.monotonic()
+
+
+@app.after_request
+def log_request_end(response: Response) -> Response:
+    """Log every request with method, path, status, and duration."""
+    duration_ms = round((time.monotonic() - getattr(g, "start_time", time.monotonic())) * 1000)
+    logger.info(
+        "Request",
+        method=request.method,
+        path=request.path,
+        status=response.status_code,
+        duration_ms=duration_ms,
+    )
+    return response
 
 
 @app.errorhandler(Exception)
@@ -138,6 +159,14 @@ def main() -> None:
         host=host,
         port=port,
         debug=debug,
+    )
+
+    repo_path = os.environ.get("EGG_REPO_PATH", "not set")
+    host_repo_map = os.environ.get("EGG_HOST_REPO_MAP", "not set")
+    logger.info(
+        "Configuration",
+        repo_path=repo_path,
+        host_repo_map=host_repo_map,
     )
 
     if debug:

--- a/orchestrator/routes/__init__.py
+++ b/orchestrator/routes/__init__.py
@@ -39,7 +39,7 @@ def get_repo_path() -> Path:
         # If it's not itself a git repo, resolve using the repo name from
         # the request body (e.g. "owner/name" -> base / "name").
         if not (base / ".git").exists():
-            repo = data.get("repo", "")
+            repo = data.get("repo", "") or request.args.get("repo", "")
             if repo:
                 repo_name = repo.split("/")[-1]
                 candidate = base / repo_name

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -30,10 +30,11 @@ except ImportError:
 try:
     from ..container_spawner import ContainerSpawnError, get_container_spawner
     from ..decision_queue import DecisionTimeoutError, get_decision_queue
-    from ..models import AgentRole, PipelineStatus, ReviewVerdict
+    from ..models import AgentRole, Pipeline, PipelineStatus, ReviewVerdict
     from ..state_store import (
         InvalidPipelineIdError,
         PipelineNotFoundError,
+        StateStore,
         StateStoreError,
         StateValidationError,
         get_state_store,
@@ -41,10 +42,11 @@ try:
 except ImportError:
     from container_spawner import ContainerSpawnError, get_container_spawner  # type: ignore
     from decision_queue import DecisionTimeoutError, get_decision_queue  # type: ignore
-    from models import AgentRole, PipelineStatus, ReviewVerdict  # type: ignore
+    from models import AgentRole, Pipeline, PipelineStatus, ReviewVerdict  # type: ignore
     from state_store import (  # type: ignore
         InvalidPipelineIdError,
         PipelineNotFoundError,
+        StateStore,
         StateStoreError,
         StateValidationError,
         get_state_store,
@@ -81,6 +83,73 @@ def make_success_response(
     return jsonify(response), 200
 
 
+def _resolve_pipeline(pipeline_id: str, base_path: Path) -> tuple[StateStore, Pipeline]:
+    """Load a pipeline, scanning repo subdirectories if needed.
+
+    When ``base_path`` is a parent directory containing multiple repos
+    (i.e. it has no ``.git``), and the pipeline is not found at the base
+    level, iterate over immediate subdirectories that are git repos and
+    try to load the pipeline from each.
+
+    Returns:
+        (store, pipeline) tuple
+
+    Raises:
+        PipelineNotFoundError: if the pipeline cannot be found anywhere
+        InvalidPipelineIdError: if the ID format is invalid
+    """
+    # Try the base path first
+    try:
+        store = get_state_store(base_path)
+        pipeline = store.load_pipeline(pipeline_id)
+        return store, pipeline
+    except PipelineNotFoundError:
+        pass
+
+    # If base_path is not itself a git repo, scan subdirectories
+    if not (base_path / ".git").exists():
+        for child in sorted(base_path.iterdir()):
+            if child.is_dir() and (child / ".git").exists():
+                try:
+                    store = get_state_store(child)
+                    pipeline = store.load_pipeline(pipeline_id)
+                    return store, pipeline
+                except (PipelineNotFoundError, StateStoreError):
+                    continue
+
+    raise PipelineNotFoundError(f"Pipeline {pipeline_id} not found")
+
+
+def _collect_all_pipelines(base_path: Path) -> list:
+    """Collect pipelines from base_path and all repo subdirectories."""
+    pipelines = []
+
+    # Check base path itself
+    if (base_path / ".egg-state" / "pipelines").exists():
+        store = get_state_store(base_path)
+        for pid in store.list_pipelines():
+            try:
+                pipelines.append(store.load_pipeline(pid))
+            except StateStoreError:
+                continue
+
+    # Check repo subdirectories if base_path is not a git repo
+    if not (base_path / ".git").exists():
+        for child in sorted(base_path.iterdir()):
+            if child.is_dir() and (child / ".git").exists():
+                try:
+                    store = get_state_store(child)
+                    for pid in store.list_pipelines():
+                        try:
+                            pipelines.append(store.load_pipeline(pid))
+                        except StateStoreError:
+                            continue
+                except StateStoreError:
+                    continue
+
+    return pipelines
+
+
 @pipelines_bp.route("", methods=["GET"])
 def list_pipelines() -> tuple[Response, int]:
     """
@@ -105,18 +174,21 @@ def list_pipelines() -> tuple[Response, int]:
     active_only = request.args.get("active_only", "false").lower() == "true"
 
     try:
-        store = get_state_store(repo_path)
+        all_pipelines = _collect_all_pipelines(repo_path)
 
         if active_only:
-            pipelines = store.get_active_pipelines()
+            pipelines = [
+                p
+                for p in all_pipelines
+                if p.status
+                not in (
+                    PipelineStatus.COMPLETE,
+                    PipelineStatus.FAILED,
+                    PipelineStatus.CANCELLED,
+                )
+            ]
         else:
-            pipeline_ids = store.list_pipelines()
-            pipelines = []
-            for pid in pipeline_ids:
-                try:
-                    pipelines.append(store.load_pipeline(pid))
-                except StateStoreError:
-                    continue
+            pipelines = all_pipelines
 
         # Convert to response format
         pipeline_data = [
@@ -165,8 +237,7 @@ def get_pipeline(pipeline_id: str) -> tuple[Response, int]:
     repo_path = get_repo_path()
 
     try:
-        store = get_state_store(repo_path)
-        pipeline = store.load_pipeline(pipeline_id)
+        _store, pipeline = _resolve_pipeline(pipeline_id, repo_path)
 
         return make_success_response(
             "Pipeline retrieved",
@@ -352,7 +423,7 @@ def update_pipeline(pipeline_id: str) -> tuple[Response, int]:
     repo_path = get_repo_path()
 
     try:
-        store = get_state_store(repo_path)
+        store, _pipeline = _resolve_pipeline(pipeline_id, repo_path)
         pipeline = store.update_pipeline(pipeline_id, data)
 
         logger.info("Pipeline updated", pipeline_id=pipeline_id)
@@ -396,7 +467,7 @@ def delete_pipeline(pipeline_id: str) -> tuple[Response, int]:
     repo_path = get_repo_path()
 
     try:
-        store = get_state_store(repo_path)
+        store, _pipeline = _resolve_pipeline(pipeline_id, repo_path)
         store.delete_pipeline(pipeline_id)
 
         logger.info("Pipeline deleted", pipeline_id=pipeline_id)
@@ -437,8 +508,7 @@ def get_pipeline_status(pipeline_id: str) -> tuple[Response, int]:
     repo_path = get_repo_path()
 
     try:
-        store = get_state_store(repo_path)
-        pipeline = store.load_pipeline(pipeline_id)
+        _store, pipeline = _resolve_pipeline(pipeline_id, repo_path)
 
         pending = pipeline.get_pending_decisions()
 
@@ -1935,8 +2005,9 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
     repo_path = get_repo_path()
 
     try:
-        store = get_state_store(repo_path)
-        pipeline = store.load_pipeline(pipeline_id)
+        store, pipeline = _resolve_pipeline(pipeline_id, repo_path)
+        # Use the store's repo_path so _run_pipeline operates on the correct directory
+        repo_path = store.repo_path
 
         if pipeline.status == PipelineStatus.RUNNING:
             return make_error_response(


### PR DESCRIPTION
Fix pipeline state resolution across repo subdirectories

The orchestrator sets EGG_REPO_PATH to a parent directory containing
multiple repos. get_repo_path() resolved to the correct repo subdir
using the `repo` field from JSON request bodies, but GET/DELETE
requests have no body — they fell through to the parent dir, causing
404s for pipelines that exist and "not a git repository" errors on
start.

Changes:
- get_repo_path() now also checks request.args.get("repo") for subdir
  resolution
- list_pipelines aggregates pipelines across all repo subdirectories
- Detail endpoints (get, status, start, update, delete) fall back to
  scanning subdirectories via _resolve_pipeline() helper
- before_request/after_request middleware logs every request with
  method, path, status code, and duration
- Startup logs resolved EGG_REPO_PATH and EGG_HOST_REPO_MAP

Issue: none

Test plan:
- Create pipeline: POST /api/v1/pipelines with issue mode body
- List pipelines: GET /api/v1/pipelines — should include pipeline from subdir
- Get pipeline: GET /api/v1/pipelines/issue-543 — should find via subdir scan
- Get with param: GET /api/v1/pipelines/issue-543?repo=owner/name — direct resolution
- Start pipeline: POST /api/v1/pipelines/issue-543/start with repo in body
- Verify every request produces a log line

Authored-by: egg