### PR TITLE
Mount local-only repos (no GitHub remote) in private mode

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -3220,6 +3220,7 @@ def session_create() -> tuple[Response, int] | Response:
             "container_ip": "172.18.0.3",
             "mode": "private"|"public",
             "repos": ["owner/repo1", "owner/repo2"],
+            "local_only_repos": ["repo-name"],  // optional; no GitHub remote
             "uid": 1000,
             "gid": 1000
         }
@@ -3244,6 +3245,7 @@ def session_create() -> tuple[Response, int] | Response:
     container_ip = data.get("container_ip")
     mode = data.get("mode")
     repos = data.get("repos", [])
+    local_only_repos = data.get("local_only_repos", [])
     uid = data.get("uid")
     gid = data.get("gid")
     phase = data.get("phase")  # Optional SDLC pipeline phase
@@ -3262,10 +3264,9 @@ def session_create() -> tuple[Response, int] | Response:
         return make_error("Missing container_ip")
     if mode not in ("private", "public", "local"):
         return make_error("Invalid mode: must be 'private', 'public', or 'local'")
-    # repos is required for private/public modes (visibility filtering + worktree
-    # creation) but optional for local mode (orchestrator-internal temp sessions
-    # that only need a session token for git push/fetch authentication).
-    if not repos and mode != "local":
+    # repos is required for private/public modes unless local_only_repos are provided.
+    # local mode (orchestrator-internal temp sessions) needs no repos at all.
+    if not repos and not local_only_repos and mode != "local":
         return make_error("Missing repos list")
 
     # Validate uid/gid if provided
@@ -3369,6 +3370,25 @@ def session_create() -> tuple[Response, int] | Response:
                 visibility=visibility,
                 container_id=container_id,
             )
+
+    # Step 2b: Include local-only repos in private mode.
+    # These repos have no GitHub remote so GitHub visibility cannot be checked.
+    # They are always treated as private: included in private mode, excluded in public mode.
+    if local_only_repos and mode == "private":
+        for repo_name in local_only_repos:
+            filtered_repos.append(repo_name)
+            logger.info(
+                "Including local-only repo in private mode",
+                repo=repo_name,
+                container_id=container_id,
+            )
+    elif local_only_repos and mode != "private":
+        logger.debug(
+            "Excluding local-only repos in non-private mode",
+            repos=local_only_repos,
+            mode=mode,
+            container_id=container_id,
+        )
 
     # Step 3: Create worktrees for filtered repos
     worktrees = {}

--- a/sandbox/egg_lib/gateway.py
+++ b/sandbox/egg_lib/gateway.py
@@ -457,6 +457,7 @@ def create_session(
     container_ip: str,
     mode: str,
     repos: list[str],
+    local_only_repos: list[str] | None = None,
     uid: int | None = None,
     gid: int | None = None,
     phase: str | None = None,
@@ -477,7 +478,8 @@ def create_session(
         container_id: Docker container ID
         container_ip: Container's IP address on the Docker network
         mode: Repository visibility mode ("private" or "public")
-        repos: List of repository names (or owner/repo format)
+        repos: List of repository names in owner/repo format (GitHub visibility checked)
+        local_only_repos: Repo names with no GitHub remote; mounted in private mode only
         uid: User ID to set worktree ownership to
         gid: Group ID to set worktree ownership to
         phase: SDLC pipeline phase (e.g., "refine", "plan", "implement", "pr")
@@ -499,6 +501,8 @@ def create_session(
         "mode": mode,
         "repos": repos,
     }
+    if local_only_repos:
+        request_data["local_only_repos"] = local_only_repos
     if uid is not None:
         request_data["uid"] = uid
     if gid is not None:

--- a/sandbox/egg_lib/runtime.py
+++ b/sandbox/egg_lib/runtime.py
@@ -338,23 +338,24 @@ def _setup_session_repos(
             info("No local repositories configured.")
         return None, repos, []
 
-    # Convert local repos to owner/repo format for visibility checking
+    # Convert local repos to owner/repo format for visibility checking.
+    # Repos with no GitHub remote are collected separately as local-only repos;
+    # they skip the GitHub visibility check and are mounted directly in private mode.
     repo_list = []
+    local_only_repo_names = []
     for repo_path in local_repos:
         if repo_path.is_dir():
-            # Get owner/repo from git remote URL
             owner_repo = _get_repo_owner_name(repo_path)
             if owner_repo:
                 repo_list.append(owner_repo)
             else:
-                # Fallback to just repo name (visibility check will skip it)
+                local_only_repo_names.append(repo_path.name)
                 if not quiet:
-                    warn(
-                        f"Could not determine owner for {repo_path.name}, skipping visibility check"
+                    info(
+                        f"  {repo_path.name}: no GitHub remote, treating as local-only (private mode only)"
                     )
-                repo_list.append(repo_path.name)
 
-    if not repo_list:
+    if not repo_list and not local_only_repo_names:
         return None, repos, []
 
     # Create session with atomic visibility filtering
@@ -363,6 +364,7 @@ def _setup_session_repos(
         container_ip=container_ip,
         mode=mode,
         repos=repo_list,
+        local_only_repos=local_only_repo_names,
         uid=os.getuid(),
         gid=os.getgid(),
         phase=phase,

--- a/tests/sandbox/test_gateway_helpers.py
+++ b/tests/sandbox/test_gateway_helpers.py
@@ -562,6 +562,42 @@ class TestCreateSession:
             assert worktrees == {"repo": "/path"}
             assert repos == ["repo"]
 
+    def test_local_only_repos_included_in_request(self):
+        """Passes local_only_repos to the API when provided."""
+        response = {
+            "success": True,
+            "data": {
+                "session_token": "tok-123",
+                "worktrees": {"my-repo": "/path/my-repo"},
+                "filtered_repos": ["my-repo"],
+                "errors": [],
+            },
+        }
+        with patch("egg_lib.gateway.launcher_api_call", return_value=(True, response)) as mock_call:
+            success, token, worktrees, repos, errors = create_session(
+                "container-1", "10.0.0.1", "private", [], local_only_repos=["my-repo"]
+            )
+            assert success is True
+            call_args = mock_call.call_args
+            request_data = call_args[1]["data"]
+            assert request_data["local_only_repos"] == ["my-repo"]
+
+    def test_local_only_repos_omitted_when_empty(self):
+        """Does not send local_only_repos key when list is empty."""
+        response = {
+            "success": True,
+            "data": {
+                "session_token": "tok-123",
+                "worktrees": {},
+                "filtered_repos": [],
+                "errors": [],
+            },
+        }
+        with patch("egg_lib.gateway.launcher_api_call", return_value=(True, response)) as mock_call:
+            create_session("container-1", "10.0.0.1", "public", ["owner/repo"])
+            request_data = mock_call.call_args[1]["data"]
+            assert "local_only_repos" not in request_data
+
     def test_failure(self):
         """Returns failure on API error."""
         with patch("egg_lib.gateway.launcher_api_call", return_value=(False, {"error": "fail"})):


### PR DESCRIPTION
## Summary

- Repos in `local_repos.paths` with no GitHub remote were silently dropped during `egg --private` session creation — no worktree was created, so `~/repos/` was empty in the container
- `parse_owner_repo()` returned `None` for bare repo names (no `/`), causing them to be skipped before the visibility filtering step
- Repos with a GitHub remote were unaffected

## Changes

**`sandbox/egg_lib/runtime.py`**: Split repo list in `_setup_session_repos()` — repos with a parseable GitHub remote go to `repos` (visibility-checked as before); repos with no remote go to `local_only_repos` (new field, bypasses GitHub check).

**`sandbox/egg_lib/gateway.py`**: Added `local_only_repos` parameter to `create_session()`; included in request body when non-empty.

**`gateway/gateway.py`**: New Step 2b in session creation — `local_only_repos` are added directly to `filtered_repos` in private mode (excluded in public mode). Worktree creation in Step 3 handles them identically to visibility-filtered GitHub repos.

No config changes required — detection is automatic based on whether the repo has a parseable GitHub remote.

## Test plan

- `pytest tests/sandbox/test_gateway_helpers.py::TestCreateSession` — 4 tests pass
- Rebuild gateway image and verify `egg --private` mounts local-only repos