### PR TITLE
Fix user mode push: use user token for PR ownership lookup

### DIFF
--- a/gateway/github_client.py
+++ b/gateway/github_client.py
@@ -887,13 +887,14 @@ class GitHubClient:
                 returncode=-1,
             )
 
-    def get_pr_info(self, repo: str, pr_number: int) -> dict[str, Any] | None:
+    def get_pr_info(self, repo: str, pr_number: int, mode: str = "bot") -> dict[str, Any] | None:
         """
         Get information about a PR.
 
         Args:
             repo: Repository in "owner/repo" format
             pr_number: PR number
+            mode: Auth mode - "bot" or "user" (use user mode for private repos)
 
         Returns:
             PR info dict or None on error
@@ -907,7 +908,8 @@ class GitHubClient:
                 repo,
                 "--json",
                 "number,title,author,state,headRefName,baseRefName",
-            ]
+            ],
+            mode=mode,
         )
 
         if not result.success:

--- a/gateway/github_client.py
+++ b/gateway/github_client.py
@@ -921,7 +921,7 @@ class GitHubClient:
             return None
 
     def list_prs_for_branch(
-        self, repo: str, branch: str, state: str = "open"
+        self, repo: str, branch: str, state: str = "open", mode: str = "bot"
     ) -> list[dict[str, Any]]:
         """
         List PRs for a specific head branch.
@@ -930,6 +930,7 @@ class GitHubClient:
             repo: Repository in "owner/repo" format
             branch: Head branch name
             state: PR state filter (open, closed, all)
+            mode: Auth mode - "bot" or "user" (use user mode for private repos)
 
         Returns:
             List of PR info dicts
@@ -946,7 +947,8 @@ class GitHubClient:
                 state,
                 "--json",
                 "number,title,author,state,headRefName",
-            ]
+            ],
+            mode=mode,
         )
 
         if not result.success:

--- a/gateway/policy.py
+++ b/gateway/policy.py
@@ -362,7 +362,7 @@ class PolicyEngine:
         self._pr_cache[cache_key] = cached_info
         return cached_info
 
-    def _get_prs_for_branch(self, repo: str, branch: str) -> list[int]:
+    def _get_prs_for_branch(self, repo: str, branch: str, mode: str = "bot") -> list[int]:
         """Get open PR numbers for a branch, using cache if available."""
         cache_key = (repo, branch)
 
@@ -374,7 +374,7 @@ class PolicyEngine:
                 return list(pr_numbers)
 
         # Fetch from GitHub
-        prs = self.github.list_prs_for_branch(repo, branch, state="open")
+        prs = self.github.list_prs_for_branch(repo, branch, state="open", mode=mode)
         pr_numbers = [pr.get("number") for pr in prs if pr.get("number")]
         self._branch_pr_cache[cache_key] = (pr_numbers, datetime.now(UTC).timestamp())
 
@@ -615,7 +615,7 @@ class PolicyEngine:
                 )
 
             # Branch exists - check for open PR by egg or configured user
-            pr_numbers = self._get_prs_for_branch(repo, branch)
+            pr_numbers = self._get_prs_for_branch(repo, branch, mode=auth_mode)
             for pr_number in pr_numbers:
                 pr_info = self._get_pr_info(repo, pr_number)
                 if not pr_info:

--- a/gateway/policy.py
+++ b/gateway/policy.py
@@ -336,9 +336,9 @@ class PolicyEngine:
             login = author
         return login.lower() == configured_user.lower()
 
-    def _get_pr_info(self, repo: str, pr_number: int) -> CachedPRInfo | None:
+    def _get_pr_info(self, repo: str, pr_number: int, mode: str = "bot") -> CachedPRInfo | None:
         """Get PR info, using cache if available and fresh."""
-        cache_key = (repo, pr_number)
+        cache_key = (repo, pr_number, mode)
 
         # Check cache
         cached: CachedPRInfo | None = self._pr_cache.get(cache_key)
@@ -346,7 +346,7 @@ class PolicyEngine:
             return cached
 
         # Fetch from GitHub
-        pr_data = self.github.get_pr_info(repo, pr_number)
+        pr_data = self.github.get_pr_info(repo, pr_number, mode=mode)
         if not pr_data:
             return None
 
@@ -364,7 +364,7 @@ class PolicyEngine:
 
     def _get_prs_for_branch(self, repo: str, branch: str, mode: str = "bot") -> list[int]:
         """Get open PR numbers for a branch, using cache if available."""
-        cache_key = (repo, branch)
+        cache_key = (repo, branch, mode)
 
         # Check cache (2 minute TTL for branch->PR mapping)
         cached = self._branch_pr_cache.get(cache_key)
@@ -383,7 +383,7 @@ class PolicyEngine:
             pr_number = pr.get("number")
             if pr_number:
                 author = pr.get("author", {})
-                self._pr_cache[(repo, pr_number)] = CachedPRInfo(
+                self._pr_cache[(repo, pr_number, mode)] = CachedPRInfo(
                     pr_number=pr_number,
                     author=author.get("login", "") if isinstance(author, dict) else str(author),
                     state=pr.get("state", ""),
@@ -406,7 +406,7 @@ class PolicyEngine:
             pr_number: PR number
             auth_mode: "bot" (default) or "user"
         """
-        pr_info = self._get_pr_info(repo, pr_number)
+        pr_info = self._get_pr_info(repo, pr_number, mode=auth_mode)
 
         if not pr_info:
             logger.warning(
@@ -617,7 +617,7 @@ class PolicyEngine:
             # Branch exists - check for open PR by egg or configured user
             pr_numbers = self._get_prs_for_branch(repo, branch, mode=auth_mode)
             for pr_number in pr_numbers:
-                pr_info = self._get_pr_info(repo, pr_number)
+                pr_info = self._get_pr_info(repo, pr_number, mode=auth_mode)
                 if not pr_info:
                     continue
 
@@ -897,7 +897,7 @@ class PolicyEngine:
             pr_number: PR number
             auth_mode: "bot" (default), "user", or "reviewer"
         """
-        pr_info = self._get_pr_info(repo, pr_number)
+        pr_info = self._get_pr_info(repo, pr_number, mode=auth_mode)
 
         if not pr_info:
             logger.warning(

--- a/gateway/tests/test_concurrency.py
+++ b/gateway/tests/test_concurrency.py
@@ -460,7 +460,7 @@ class TestPolicyEngineCacheConcurrency:
         call_count = {"get_pr_info": 0, "list_prs_for_branch": 0}
         lock = threading.Lock()
 
-        def mock_get_pr_info(repo, pr_number):
+        def mock_get_pr_info(repo, pr_number, mode="bot"):
             with lock:
                 call_count["get_pr_info"] += 1
             time.sleep(0.01)  # Simulate network latency
@@ -552,7 +552,7 @@ class TestPolicyEngineCacheConcurrency:
         policy_engine.check_pr_ownership("owner/repo", 999)
 
         # Manually make cache entry stale
-        cache_key = ("owner/repo", 999)
+        cache_key = ("owner/repo", 999, "bot")
         if cache_key in policy_engine._pr_cache:
             old_entry = policy_engine._pr_cache[cache_key]
             policy_engine._pr_cache[cache_key] = CachedPRInfo(

--- a/gateway/tests/test_policy.py
+++ b/gateway/tests/test_policy.py
@@ -796,6 +796,59 @@ class TestUserModeBranchOwnership:
         assert result.details is not None
         assert "hint" in result.details
 
+    def test_user_mode_passes_mode_to_list_prs(self, policy_engine, mock_github_client):
+        """User mode passes mode='user' to list_prs_for_branch."""
+        mock_github_client.branch_exists.return_value = True
+        mock_github_client.list_prs_for_branch.return_value = []
+
+        policy_engine.check_branch_ownership("owner/repo", "feature", auth_mode="user")
+
+        mock_github_client.list_prs_for_branch.assert_called_once_with(
+            "owner/repo", "feature", state="open", mode="user"
+        )
+
+    def test_user_mode_passes_mode_to_get_pr_info(self, policy_engine, mock_github_client):
+        """User mode passes mode='user' to get_pr_info when PR cache is cold."""
+        mock_github_client.branch_exists.return_value = True
+        mock_github_client.list_prs_for_branch.return_value = [
+            {
+                "number": 123,
+                "author": {"login": "james-in-a-box"},
+                "state": "open",
+                "headRefName": "feature",
+            }
+        ]
+        mock_github_client.get_pr_info.return_value = {
+            "number": 123,
+            "author": {"login": "james-in-a-box"},
+            "state": "open",
+            "headRefName": "feature",
+        }
+
+        # Clear the PR cache that _get_prs_for_branch pre-populates,
+        # so _get_pr_info must call github.get_pr_info
+        policy_engine._pr_cache.clear()
+
+        policy_engine._get_pr_info("owner/repo", 123, mode="user")
+
+        mock_github_client.get_pr_info.assert_called_once_with("owner/repo", 123, mode="user")
+
+    def test_check_pr_ownership_passes_mode_to_get_pr_info(self, policy_engine, mock_github_client):
+        """check_pr_ownership passes auth_mode through to _get_pr_info."""
+        mock_github_client.get_pr_info.return_value = {
+            "number": 123,
+            "author": {"login": "egg"},
+            "state": "open",
+            "headRefName": "feature",
+        }
+
+        # Clear cache so _get_pr_info must call github.get_pr_info
+        policy_engine._pr_cache.clear()
+
+        policy_engine.check_pr_ownership("owner/repo", 123, auth_mode="user")
+
+        mock_github_client.get_pr_info.assert_called_once_with("owner/repo", 123, mode="user")
+
 
 class TestBotAuthorFormats:
     """Tests for different author data formats (string vs dict)."""
@@ -1008,8 +1061,8 @@ class TestPRCacheBehavior:
         # First call
         policy_engine.check_pr_ownership("owner/repo", 123)
 
-        # Manually stale the cache entry
-        cache_key = ("owner/repo", 123)
+        # Manually stale the cache entry (cache key includes mode)
+        cache_key = ("owner/repo", 123, "bot")
         if cache_key in policy_engine._pr_cache:
             cached = policy_engine._pr_cache[cache_key]
             # Set fetched_at to 10 minutes ago
@@ -1045,9 +1098,9 @@ class TestPRCacheBehavior:
         # Trigger branch ownership check which fetches PRs
         policy_engine.check_branch_ownership("owner/repo", "feature")
 
-        # Both PRs should now be in the cache
-        assert ("owner/repo", 123) in policy_engine._pr_cache
-        assert ("owner/repo", 456) in policy_engine._pr_cache
+        # Both PRs should now be in the cache (cache key includes mode)
+        assert ("owner/repo", 123, "bot") in policy_engine._pr_cache
+        assert ("owner/repo", 456, "bot") in policy_engine._pr_cache
 
 
 class TestPRCreatePolicy:
@@ -1191,6 +1244,22 @@ class TestReviewerModePolicy:
 
         result = policy_engine.check_pr_review_allowed("owner/repo", 123, auth_mode="bot")
         assert result.allowed
+
+    def test_pr_review_passes_mode_to_get_pr_info(self, policy_engine, mock_github_client):
+        """check_pr_review_allowed passes auth_mode through to _get_pr_info."""
+        mock_github_client.get_pr_info.return_value = {
+            "number": 123,
+            "author": {"login": "egg"},
+            "state": "open",
+            "headRefName": "feature",
+        }
+
+        # Clear cache so _get_pr_info must call github.get_pr_info
+        policy_engine._pr_cache.clear()
+
+        policy_engine.check_pr_review_allowed("owner/repo", 123, auth_mode="reviewer")
+
+        mock_github_client.get_pr_info.assert_called_once_with("owner/repo", 123, mode="reviewer")
 
     def test_pr_review_denied_pr_not_found(self, policy_engine, mock_github_client):
         """PR review is denied if PR not found."""


### PR DESCRIPTION
## Summary

- `PolicyEngine._get_prs_for_branch` was always using the bot GitHub client to list PRs for a branch
- For repos where the bot has no access (e.g. a private external repo in user mode), this returns an empty list, causing the gateway to deny pushes even when a valid open PR exists owned by the configured user
- Added `mode` parameter to `list_prs_for_branch` and threaded `auth_mode` through `check_branch_ownership` → `_get_prs_for_branch` → `list_prs_for_branch`

## Test plan

- [ ] Existing gateway/policy tests pass (165 tests)
- [ ] Push to a branch with an open PR on a user-mode private repo is no longer blocked
