### PR TITLE
Fix private mode: chown .git/worktrees/ at gateway startup

### DIFF
--- a/gateway/entrypoint.sh
+++ b/gateway/entrypoint.sh
@@ -178,11 +178,18 @@ if [ -n "${HOST_UID:-}" ] && [ -n "${HOST_GID:-}" ] && [ "$(id -u)" = "0" ]; the
     # ownership, so these directories may be root-owned inside the
     # container. Only chown the top-level directories (not recursive) —
     # repo file contents are managed by git/gateway worktree operations.
+    # Also chown .git/worktrees/ in each repo so the gateway can create
+    # worktree admin dirs even if a previous root-privileged session left
+    # them root-owned (e.g., sessions before HOST_UID privilege drop was
+    # introduced).
     if [ -d /home/egg/repos ]; then
         chown "$HOST_UID:$HOST_GID" /home/egg/repos
         for repo_dir in /home/egg/repos/*/; do
             if [ -d "$repo_dir" ]; then
                 chown "$HOST_UID:$HOST_GID" "$repo_dir"
+                if [ -d "$repo_dir/.git/worktrees" ]; then
+                    chown -R "$HOST_UID:$HOST_GID" "$repo_dir/.git/worktrees"
+                fi
             fi
         done
     fi


### PR DESCRIPTION
The gateway drops privileges via `gosu` to `HOST_UID:HOST_GID` before starting Python. Sessions that ran before this privilege drop was introduced left `.git/worktrees/` admin dirs owned by root inside the repo bind-mounts. On next launch, the (now unprivileged) gateway cannot create new subdirs there, causing:

```
fatal: could not create directory of '.git/worktrees/<repo>1': Permission denied
```

The affected repo's worktree silently fails to mount, so that repo never appears in the container.

At startup, after dropping privileges, the entrypoint now recursively chowns `.git/worktrees/` in each repo bind-mount to `HOST_UID:HOST_GID`. Only that subdirectory is touched — the rest of `.git/` is left alone.

Issue: none

Test plan:
- With a stale root-owned `.git/worktrees/` in a repo (e.g. `sudo chown -R root:root <repo>/.git/worktrees`), run `egg --private -v` and confirm all repos mount successfully
- With no stale entries, run `egg --private -v` and confirm no regression
- Confirm the chown loop is a no-op when `.git/worktrees/` doesn't exist (fresh clone)

Authored-by: egg
