### PR TITLE
Fix webapp Go module cache unavailable in private mode

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -7,6 +7,11 @@
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
+# Set GOPATH to /usr/local so the Go module cache populated during `docker build`
+# (via build_commands in repositories.yaml) is accessible at runtime. Without this,
+# Go defaults to $HOME/go at runtime and can't find modules cached under /usr/local/pkg/mod/,
+# causing proxy.golang.org lookups that fail in private mode.
+ENV GOPATH=/usr/local
 
 # Install comprehensive development tools
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Summary

- Set `ENV GOPATH=/usr/local` in the sandbox Dockerfile so the Go module cache is accessible at runtime
- Fixes `go build`/`go test`/`make linc`/`make tesc` failing with `dial tcp: lookup proxy.golang.org` in private mode for Go-monorepo worktrees

## Root cause

`build_commands` in `repositories.yaml` runs `GOPATH=/usr/local make go_deps`, which downloads all modules (including gqlgen, golangci-lint, gotestsum, gci, testify — all confirmed present in the repo's `go.mod`) to `/usr/local/pkg/mod/`. But without `GOPATH` set in the Dockerfile, Go defaults to `$HOME/go` at runtime and looks in `/home/egg/go/pkg/mod/`, which is empty. Any `go build` then attempts to reach `proxy.golang.org`, which fails under private mode network lockdown.

## Fix

One ENV line in the Dockerfile. Go sets module cache files to `0444` and dirs to `0555` (world-readable by design), so the egg user can read the root-owned cache without permission issues. No writes to the module cache are needed when all modules are already present.

## Test plan

- Rebuild the egg sandbox image and start a Go-repo worktree in private mode
- Verify `go build ./...`, `make linc`, and `make tesc` succeed without network access
