### PR TITLE
Fix reviewers excluded from phase execution paths

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -4428,7 +4428,7 @@ def _run_multi_agent_phase(
     # Note: phase_obj / all_phases are not passed here because Tier 2
     # dispatch has no contract phases. _build_role_context() handles this
     # gracefully — execution roles still get a summarized background.
-    roles = get_roles_for_phase(phase, include_reviewers=False)
+    roles = get_roles_for_phase(phase, include_reviewers=True)
     agent_prompts_by_role: dict = {}
     for contract_role in roles:
         role_str = contract_role.value
@@ -4635,7 +4635,7 @@ def _run_concurrent_phase(
     # Build per-role prompts (matches _run_multi_agent_phase pattern).
     from egg_contracts.agent_roles import get_roles_for_phase as _get_roles_for_phase
 
-    roles = [AgentRole(r.value) for r in _get_roles_for_phase(phase_str, include_reviewers=False)]
+    roles = [AgentRole(r.value) for r in _get_roles_for_phase(phase_str, include_reviewers=True)]
     agent_prompts: dict[AgentRole, str] = {}
     for role in roles:
         prompt = _build_agent_prompt(


### PR DESCRIPTION
## Summary

- Fix `include_reviewers=False` in `_run_multi_agent_phase` and `_run_concurrent_phase` — both now pass `True`
- Introduced in PR #1132 ("Enable BRC consensus for refine and plan phases"), this bug prevented reviewer agents from being spawned in non-coordinator execution paths, making BRC consensus impossible

## Context

PR #1132 added `get_roles_for_phase()` calls to dynamically look up roles, but passed `include_reviewers=False` to both call sites. This meant only producer roles (e.g. `refiner`) were spawned — reviewer roles (`reviewer_refine`, `reviewer_agent_design`) were silently excluded.

Related: #1161 tracks a separate issue where the coordinator agent also spawns reviewers sequentially instead of concurrently.

## Test plan

- [ ] Verify refine phase spawns `refiner` + `reviewer_refine` + `reviewer_agent_design` in non-coordinator mode
- [ ] Verify plan phase spawns all producer + reviewer roles
- [ ] Verify implement phase is unaffected (was already working)
- [ ] Run `test_concurrent_executor.py` and `test_concurrent_integration.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)