### PR TITLE
Add persist_dirs to build_commands for JS/TS deps in private mode

### DIFF
--- a/config/repo_config.py
+++ b/config/repo_config.py
@@ -445,6 +445,11 @@ def get_repo_build_commands(repo: str) -> dict[str, Any]:
         result["commands"] = [str(c) for c in commands]
     else:
         result["commands"] = []
+    persist_dirs = build_cmds.get("persist_dirs", [])
+    if isinstance(persist_dirs, list):
+        result["persist_dirs"] = [str(d) for d in persist_dirs]
+    else:
+        result["persist_dirs"] = []
     return result
 
 

--- a/config/repositories.yaml.example
+++ b/config/repositories.yaml.example
@@ -90,6 +90,11 @@ readable_repos:
 #       the Docker build context so Docker layer caching works correctly.
 #     - commands: Shell commands to run during build (e.g., npm ci, pip install).
 #       Commands run as root in a directory seeded with the watch files.
+#     - persist_dirs: List of directories (relative to repo root) to preserve
+#       from the build context into the Docker image. These are restored into
+#       the mounted repo at container startup. Use this for local dependencies
+#       like node_modules that would otherwise be lost when the build context
+#       is cleaned up. (e.g., node_modules, .venv)
 repo_settings:
   # Example:
   # YOUR_USERNAME/egg:
@@ -115,6 +120,8 @@ repo_settings:
   #       - package-lock.json
   #     commands:
   #       - npm ci
+  #     persist_dirs:
+  #       - node_modules
   # YOUR_USERNAME/python-service:
   #   build_commands:
   #     watch_files:

--- a/sandbox/docker-setup.py
+++ b/sandbox/docker-setup.py
@@ -8,6 +8,7 @@ For additional packages, configure extra_packages in ~/.config/egg/repositories.
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -161,7 +162,7 @@ def get_build_commands(config: dict[str, Any]) -> list[dict[str, Any]]:
     """Extract build_commands from all repo_settings entries.
 
     Returns:
-        List of dicts with 'repo', 'watch_files', and 'commands' keys.
+        List of dicts with 'repo', 'watch_files', 'commands', and 'persist_dirs' keys.
         Only includes repos that have non-empty commands lists.
     """
     repo_settings = config.get("repo_settings", {})
@@ -181,11 +182,15 @@ def get_build_commands(config: dict[str, Any]) -> list[dict[str, Any]]:
         watch_files = build_cmds.get("watch_files", [])
         if not isinstance(watch_files, list):
             watch_files = []
+        persist_dirs = build_cmds.get("persist_dirs", [])
+        if not isinstance(persist_dirs, list):
+            persist_dirs = []
         result.append(
             {
                 "repo": repo_name,
                 "watch_files": [str(f) for f in watch_files],
                 "commands": [str(c) for c in commands],
+                "persist_dirs": [str(d) for d in persist_dirs],
             }
         )
     return result
@@ -316,6 +321,59 @@ def run_build_commands(build_commands: list[dict[str, Any]]) -> None:
                 print(f"  Warning: Command failed: {cmd}: {e}")
 
     print("\n=== Build commands complete ===")
+
+    persist_build_dirs(build_commands)
+
+
+def persist_build_dirs(
+    build_commands: list[dict[str, Any]],
+    repo_deps_base: Path = Path("/tmp/repo-deps"),
+    prebuilt_base: Path = Path("/opt/prebuilt-deps"),
+) -> None:
+    """Persist directories from build context into the Docker image.
+
+    After build commands run, specified directories (e.g. node_modules) are
+    copied to a persistent location so they survive the /tmp/repo-deps cleanup.
+    They are restored into mounted repos at container startup by entrypoint.py.
+
+    Args:
+        build_commands: List of dicts with 'repo', 'commands', and 'persist_dirs' keys.
+        repo_deps_base: Base path for repo build contexts (default: /tmp/repo-deps).
+        prebuilt_base: Destination base for persisted directories (default: /opt/prebuilt-deps).
+    """
+    persist_count = 0
+    for entry in build_commands:
+        repo = entry["repo"]
+        persist_dirs = entry.get("persist_dirs", [])
+        if not persist_dirs:
+            continue
+
+        repo_dir_name = repo.replace("/", "--")
+        work_dir = repo_deps_base / repo_dir_name
+        dest_base = prebuilt_base / repo_dir_name
+
+        for rel_dir in persist_dirs:
+            src_dir = work_dir / rel_dir
+
+            # Defense-in-depth: validate path stays within work_dir
+            try:
+                src_dir.resolve().relative_to(work_dir.resolve())
+            except ValueError:
+                print(f"  Warning: persist_dirs: {rel_dir} escapes build context, skipping")
+                continue
+
+            if not src_dir.is_dir():
+                print(f"  Warning: persist_dirs: {rel_dir} does not exist after build, skipping")
+                continue
+
+            dest_dir = dest_base / rel_dir
+            dest_dir.parent.mkdir(parents=True, exist_ok=True)
+            print(f"  Persisting {repo}/{rel_dir} -> {dest_dir}")
+            shutil.copytree(src_dir, dest_dir, symlinks=True)
+            persist_count += 1
+
+    if persist_count:
+        print(f"\n=== Persisted {persist_count} directories ===")
 
 
 def configure_system(distro: str) -> None:

--- a/sandbox/docker-setup.py
+++ b/sandbox/docker-setup.py
@@ -213,7 +213,7 @@ def load_build_commands_manifest(
         manifest_path: Path to the manifest file (default: /tmp/repo-deps/manifest.json)
 
     Returns:
-        List of dicts with 'repo', 'watch_files', and 'commands' keys.
+        List of dicts with 'repo', 'watch_files', 'commands', and 'persist_dirs' keys.
     """
     path = Path(manifest_path)
     if not path.exists():

--- a/sandbox/egg_lib/docker.py
+++ b/sandbox/egg_lib/docker.py
@@ -376,11 +376,15 @@ def _copy_repo_watch_files(quiet: bool = False) -> None:
         watch_files = build_cmds.get("watch_files", [])
         if not isinstance(watch_files, list):
             watch_files = []
+        persist_dirs = build_cmds.get("persist_dirs", [])
+        if not isinstance(persist_dirs, list):
+            persist_dirs = []
         build_commands_list.append(
             {
                 "repo": repo_name,
                 "watch_files": [str(f) for f in watch_files],
                 "commands": [str(c) for c in commands],
+                "persist_dirs": [str(d) for d in persist_dirs],
             }
         )
 

--- a/sandbox/entrypoint.py
+++ b/sandbox/entrypoint.py
@@ -807,10 +807,15 @@ def restore_prebuilt_deps(
             continue
 
         # Copy prebuilt tree into repo, skipping files that already exist.
-        # We use symlinks=False so that all entries (including symlinks) go
-        # through copy_function. With symlinks=True, copytree handles symlinks
-        # directly via os.symlink() which raises FileExistsError if the
-        # destination already exists — making the restore non-idempotent.
+        # We use symlinks=False so that file-level entries (including file
+        # symlinks) go through copy_function, where we can skip existing
+        # files and handle symlinks manually. Directory symlinks are followed
+        # and expanded into real directories — this is acceptable since
+        # Node.js module resolution works the same either way.
+        # Note: the persist side uses symlinks=True (preserving symlinks),
+        # so directory symlinks become real directories after restore. This
+        # increases disk usage slightly but avoids copytree's non-idempotent
+        # os.symlink() calls which raise FileExistsError on repeat runs.
         def _copy_if_missing(src: str, dst: str, **kwargs: Any) -> None:
             if os.path.exists(dst) or os.path.islink(dst):
                 return

--- a/sandbox/entrypoint.py
+++ b/sandbox/entrypoint.py
@@ -806,19 +806,22 @@ def restore_prebuilt_deps(
             logger.warn(f"No mounted repo found for prebuilt deps: {repo_dir_name}")
             continue
 
-        # Walk the prebuilt directory and copy into the repo
-        for item in repo_dir.rglob("*"):
-            if not item.is_file() and not item.is_symlink():
-                continue
-            rel_path = item.relative_to(repo_dir)
-            dest = target_repo / rel_path
+        # Copy prebuilt tree into repo, skipping files that already exist
+        def _copy_if_missing(src: str, dst: str, **kwargs: Any) -> None:
+            if os.path.exists(dst) or os.path.islink(dst):
+                return
+            try:
+                shutil.copy2(src, dst, **kwargs)
+            except OSError as e:
+                logger.warn(f"  Failed to restore {dst}: {e}")
 
-            # Skip if destination already exists (don't overwrite repo contents)
-            if dest.exists():
-                continue
-
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(item, dest, follow_symlinks=False)
+        shutil.copytree(
+            repo_dir,
+            target_repo,
+            copy_function=_copy_if_missing,
+            dirs_exist_ok=True,
+            symlinks=True,
+        )
 
         restored += 1
         logger.info(f"  Restored prebuilt deps for {repo_dir_name} -> {target_repo}")

--- a/sandbox/entrypoint.py
+++ b/sandbox/entrypoint.py
@@ -761,6 +761,72 @@ def setup_worktrees(config: Config, logger: Logger) -> bool:
     return True
 
 
+def restore_prebuilt_deps(
+    config: Config,
+    logger: Logger,
+    prebuilt_base: Path | None = None,
+) -> None:
+    """Restore pre-built dependencies from Docker image into mounted repos.
+
+    During Docker image build, build_commands may produce artifacts (e.g. node_modules)
+    in /tmp/repo-deps/ which gets deleted. The persist_dirs config causes those
+    directories to be saved to /opt/prebuilt-deps/ instead.
+
+    This function copies them into the actual repo mounts at startup so that
+    private-mode containers have dependencies available without network access.
+    """
+    if prebuilt_base is None:
+        prebuilt_base = Path("/opt/prebuilt-deps")
+    if not prebuilt_base.exists():
+        return
+
+    repos_dir = config.repos_dir
+    restored = 0
+
+    for repo_dir in prebuilt_base.iterdir():
+        if not repo_dir.is_dir():
+            continue
+        # repo_dir is like /opt/prebuilt-deps/Khan--webapp
+        # Convert back to repo name to find mount point
+        # Try each mounted repo to find a match
+        repo_dir_name = repo_dir.name  # e.g. "Khan--webapp"
+
+        # Find the matching mounted repo directory
+        target_repo = None
+        for mounted in repos_dir.iterdir():
+            if not mounted.is_dir():
+                continue
+            # The repo mount name is typically just the repo name (e.g. "webapp")
+            # Match by checking if repo_dir_name ends with --<mount_name>
+            if repo_dir_name.endswith(f"--{mounted.name}"):
+                target_repo = mounted
+                break
+
+        if target_repo is None:
+            logger.warn(f"No mounted repo found for prebuilt deps: {repo_dir_name}")
+            continue
+
+        # Walk the prebuilt directory and copy into the repo
+        for item in repo_dir.rglob("*"):
+            if not item.is_file() and not item.is_symlink():
+                continue
+            rel_path = item.relative_to(repo_dir)
+            dest = target_repo / rel_path
+
+            # Skip if destination already exists (don't overwrite repo contents)
+            if dest.exists():
+                continue
+
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(item, dest, follow_symlinks=False)
+
+        restored += 1
+        logger.info(f"  Restored prebuilt deps for {repo_dir_name} -> {target_repo}")
+
+    if restored:
+        logger.success(f"Restored prebuilt dependencies for {restored} repo(s)")
+
+
 def setup_egg_symlink(config: Config, logger: Logger) -> None:
     """Create ~/egg symlink to runtime scripts.
 
@@ -1931,6 +1997,9 @@ def main() -> None:
             logger.error("Container startup aborted due to worktree configuration failure.")
             logger.error("Please check your egg setup and try again.")
             sys.exit(1)
+
+    with timed_phase("restore_prebuilt_deps", logger):
+        restore_prebuilt_deps(config, logger)
 
     with timed_phase("setup_agent_rules", logger):
         setup_agent_rules(config, logger)

--- a/sandbox/entrypoint.py
+++ b/sandbox/entrypoint.py
@@ -806,22 +806,33 @@ def restore_prebuilt_deps(
             logger.warn(f"No mounted repo found for prebuilt deps: {repo_dir_name}")
             continue
 
-        # Copy prebuilt tree into repo, skipping files that already exist
+        # Copy prebuilt tree into repo, skipping files that already exist.
+        # We use symlinks=False so that all entries (including symlinks) go
+        # through copy_function. With symlinks=True, copytree handles symlinks
+        # directly via os.symlink() which raises FileExistsError if the
+        # destination already exists — making the restore non-idempotent.
         def _copy_if_missing(src: str, dst: str, **kwargs: Any) -> None:
             if os.path.exists(dst) or os.path.islink(dst):
                 return
             try:
-                shutil.copy2(src, dst, **kwargs)
+                if os.path.islink(src):
+                    linkto = os.readlink(src)
+                    os.symlink(linkto, dst)
+                else:
+                    shutil.copy2(src, dst, **kwargs)
             except OSError as e:
                 logger.warn(f"  Failed to restore {dst}: {e}")
 
-        shutil.copytree(
-            repo_dir,
-            target_repo,
-            copy_function=_copy_if_missing,
-            dirs_exist_ok=True,
-            symlinks=True,
-        )
+        try:
+            shutil.copytree(
+                repo_dir,
+                target_repo,
+                copy_function=_copy_if_missing,
+                dirs_exist_ok=True,
+                symlinks=False,
+            )
+        except shutil.Error as e:
+            logger.warn(f"  Some files could not be restored for {repo_dir_name}: {e}")
 
         restored += 1
         logger.info(f"  Restored prebuilt deps for {repo_dir_name} -> {target_repo}")

--- a/tests/sandbox/test_docker_setup.py
+++ b/tests/sandbox/test_docker_setup.py
@@ -777,6 +777,154 @@ class TestLoadExtraPackagesManifest:
         assert dnf == []
 
 
+class TestPersistDirs:
+    """Tests for persist_dirs in build_commands."""
+
+    def test_get_build_commands_includes_persist_dirs(self):
+        """persist_dirs is extracted from config."""
+        config = {
+            "repo_settings": {
+                "org/app": {
+                    "build_commands": {
+                        "watch_files": ["package.json"],
+                        "commands": ["npm ci"],
+                        "persist_dirs": ["node_modules", "dist"],
+                    }
+                }
+            }
+        }
+        result = get_build_commands(config)
+        assert len(result) == 1
+        assert result[0]["persist_dirs"] == ["node_modules", "dist"]
+
+    def test_get_build_commands_defaults_persist_dirs_to_empty(self):
+        """Missing persist_dirs defaults to empty list."""
+        config = {
+            "repo_settings": {
+                "org/app": {
+                    "build_commands": {
+                        "commands": ["npm ci"],
+                    }
+                }
+            }
+        }
+        result = get_build_commands(config)
+        assert result[0]["persist_dirs"] == []
+
+    def test_get_build_commands_handles_non_list_persist_dirs(self):
+        """Non-list persist_dirs defaults to empty list."""
+        config = {
+            "repo_settings": {
+                "org/app": {
+                    "build_commands": {
+                        "commands": ["npm ci"],
+                        "persist_dirs": "not-a-list",
+                    }
+                }
+            }
+        }
+        result = get_build_commands(config)
+        assert result[0]["persist_dirs"] == []
+
+    def test_persist_dirs_copies_to_prebuilt(self, tmp_path, capsys):
+        """persist_dirs copies directories to prebuilt destination."""
+        from docker_setup import persist_build_dirs
+
+        # Create the work directory with node_modules
+        repo_deps = tmp_path / "repo-deps"
+        work_dir = repo_deps / "org--app"
+        nm_dir = work_dir / "node_modules"
+        nm_dir.mkdir(parents=True)
+        (nm_dir / "pkg.json").write_text('{"name": "test"}')
+
+        prebuilt = tmp_path / "prebuilt-deps"
+
+        persist_build_dirs(
+            [
+                {
+                    "repo": "org/app",
+                    "commands": ["npm ci"],
+                    "persist_dirs": ["node_modules"],
+                }
+            ],
+            repo_deps_base=repo_deps,
+            prebuilt_base=prebuilt,
+        )
+
+        assert (prebuilt / "org--app" / "node_modules" / "pkg.json").exists()
+        assert (
+            prebuilt / "org--app" / "node_modules" / "pkg.json"
+        ).read_text() == '{"name": "test"}'
+        captured = capsys.readouterr()
+        assert "Persisting" in captured.out
+        assert "Persisted 1 directories" in captured.out
+
+    def test_persist_dirs_skips_missing_dirs(self, tmp_path, capsys):
+        """persist_dirs skips directories that don't exist after build."""
+        from docker_setup import persist_build_dirs
+
+        repo_deps = tmp_path / "repo-deps"
+        (repo_deps / "org--app").mkdir(parents=True)
+
+        persist_build_dirs(
+            [
+                {
+                    "repo": "org/app",
+                    "commands": ["npm ci"],
+                    "persist_dirs": ["nonexistent_dir"],
+                }
+            ],
+            repo_deps_base=repo_deps,
+            prebuilt_base=tmp_path / "prebuilt",
+        )
+
+        captured = capsys.readouterr()
+        assert "does not exist after build" in captured.out
+
+    def test_persist_dirs_blocks_path_traversal(self, tmp_path, capsys):
+        """persist_dirs rejects paths that escape the build context."""
+        from docker_setup import persist_build_dirs
+
+        repo_deps = tmp_path / "repo-deps"
+        (repo_deps / "org--app").mkdir(parents=True)
+
+        persist_build_dirs(
+            [
+                {
+                    "repo": "org/app",
+                    "commands": ["npm ci"],
+                    "persist_dirs": ["../../../etc"],
+                }
+            ],
+            repo_deps_base=repo_deps,
+            prebuilt_base=tmp_path / "prebuilt",
+        )
+
+        captured = capsys.readouterr()
+        assert "escapes build context" in captured.out
+
+    def test_manifest_preserves_persist_dirs(self, tmp_path):
+        """Test that persist_dirs is preserved through manifest loading."""
+        import json
+
+        manifest = {
+            "build_commands": [
+                {
+                    "repo": "org/app",
+                    "commands": ["npm ci"],
+                    "watch_files": ["package.json"],
+                    "persist_dirs": ["node_modules"],
+                }
+            ]
+        }
+        manifest_file = tmp_path / "manifest.json"
+        manifest_file.write_text(json.dumps(manifest))
+
+        result = load_build_commands_manifest(str(manifest_file))
+        assert len(result) == 1
+        assert result[0]["persist_dirs"] == ["node_modules"]
+
+
 class TestMain:
     """Tests for main entry point."""
 

--- a/tests/sandbox/test_entrypoint.py
+++ b/tests/sandbox/test_entrypoint.py
@@ -818,6 +818,51 @@ class TestRestorePrebuiltDeps:
         captured = capsys.readouterr()
         assert "No mounted repo found" in captured.out
 
+    def test_preserves_file_symlinks(self, temp_dir):
+        """File symlinks survive the restore and point to the correct target."""
+        prebuilt = temp_dir / "prebuilt-deps" / "Khan--webapp"
+        nm = prebuilt / "node_modules"
+        nm.mkdir(parents=True)
+        (nm / "real.js").write_text("content")
+        (nm / "link.js").symlink_to("real.js")
+
+        repos_dir = temp_dir / "repos"
+        (repos_dir / "webapp").mkdir(parents=True)
+
+        config = MagicMock()
+        config.repos_dir = repos_dir
+        logger = entrypoint.Logger(quiet=True)
+
+        entrypoint.restore_prebuilt_deps(config, logger, prebuilt_base=temp_dir / "prebuilt-deps")
+
+        restored_link = repos_dir / "webapp" / "node_modules" / "link.js"
+        assert restored_link.is_symlink()
+        assert os.readlink(str(restored_link)) == "real.js"
+        assert restored_link.read_text() == "content"
+
+    def test_restore_is_idempotent(self, temp_dir):
+        """Calling restore twice does not raise errors or overwrite files."""
+        prebuilt = temp_dir / "prebuilt-deps" / "Khan--webapp"
+        nm = prebuilt / "node_modules"
+        nm.mkdir(parents=True)
+        (nm / "pkg.js").write_text("original")
+        (nm / "link.js").symlink_to("pkg.js")
+
+        repos_dir = temp_dir / "repos"
+        (repos_dir / "webapp").mkdir(parents=True)
+
+        config = MagicMock()
+        config.repos_dir = repos_dir
+        logger = entrypoint.Logger(quiet=True)
+
+        # First restore
+        entrypoint.restore_prebuilt_deps(config, logger, prebuilt_base=temp_dir / "prebuilt-deps")
+        # Second restore — should not raise
+        entrypoint.restore_prebuilt_deps(config, logger, prebuilt_base=temp_dir / "prebuilt-deps")
+
+        assert (repos_dir / "webapp" / "node_modules" / "pkg.js").read_text() == "original"
+        assert (repos_dir / "webapp" / "node_modules" / "link.js").is_symlink()
+
 
 class TestSetupAgentRules:
     """Tests for the setup_agent_rules function."""

--- a/tests/sandbox/test_entrypoint.py
+++ b/tests/sandbox/test_entrypoint.py
@@ -720,6 +720,105 @@ class TestSetupWorktrees:
         assert "3 repo" in captured.out
 
 
+class TestRestorePrebuiltDeps:
+    """Tests for the restore_prebuilt_deps function."""
+
+    def test_noop_when_no_prebuilt_dir(self, temp_dir, capsys):
+        """Does nothing if prebuilt dir doesn't exist."""
+        config = MagicMock()
+        config.repos_dir = temp_dir / "repos"
+        logger = entrypoint.Logger(quiet=False)
+
+        entrypoint.restore_prebuilt_deps(config, logger, prebuilt_base=temp_dir / "nonexistent")
+
+        captured = capsys.readouterr()
+        assert "Restored" not in captured.out
+
+    def test_restores_deps_into_repo(self, temp_dir, capsys):
+        """Copies prebuilt deps into the mounted repo directory."""
+        # Set up prebuilt deps
+        prebuilt = temp_dir / "prebuilt-deps" / "Khan--webapp"
+        nm = prebuilt / "services" / "perseus" / "node_modules" / "express"
+        nm.mkdir(parents=True)
+        (nm / "index.js").write_text("module.exports = {}")
+
+        # Set up mounted repos
+        repos_dir = temp_dir / "repos"
+        webapp = repos_dir / "webapp"
+        (webapp / "services" / "perseus").mkdir(parents=True)
+
+        config = MagicMock()
+        config.repos_dir = repos_dir
+        logger = entrypoint.Logger(quiet=False)
+
+        entrypoint.restore_prebuilt_deps(config, logger, prebuilt_base=temp_dir / "prebuilt-deps")
+
+        assert (webapp / "services" / "perseus" / "node_modules" / "express" / "index.js").exists()
+        assert (
+            webapp / "services" / "perseus" / "node_modules" / "express" / "index.js"
+        ).read_text() == "module.exports = {}"
+        captured = capsys.readouterr()
+        assert "Restored" in captured.out
+
+    def test_skips_existing_files(self, temp_dir):
+        """Does not overwrite files that already exist in the repo."""
+        prebuilt = temp_dir / "prebuilt-deps" / "Khan--webapp"
+        nm = prebuilt / "node_modules"
+        nm.mkdir(parents=True)
+        (nm / "pkg.json").write_text("prebuilt")
+
+        repos_dir = temp_dir / "repos"
+        webapp = repos_dir / "webapp"
+        webapp_nm = webapp / "node_modules"
+        webapp_nm.mkdir(parents=True)
+        (webapp_nm / "pkg.json").write_text("existing")
+
+        config = MagicMock()
+        config.repos_dir = repos_dir
+        logger = entrypoint.Logger(quiet=True)
+
+        entrypoint.restore_prebuilt_deps(config, logger, prebuilt_base=temp_dir / "prebuilt-deps")
+
+        # Existing file should not be overwritten
+        assert (webapp_nm / "pkg.json").read_text() == "existing"
+
+    def test_matches_repo_by_suffix(self, temp_dir, capsys):
+        """Matches prebuilt repo dir Khan--webapp to mounted dir webapp."""
+        prebuilt = temp_dir / "prebuilt-deps"
+        (prebuilt / "Khan--webapp").mkdir(parents=True)
+        (prebuilt / "Khan--webapp" / "test.txt").write_text("hello")
+
+        repos_dir = temp_dir / "repos"
+        (repos_dir / "webapp").mkdir(parents=True)
+
+        config = MagicMock()
+        config.repos_dir = repos_dir
+        logger = entrypoint.Logger(quiet=False)
+
+        entrypoint.restore_prebuilt_deps(config, logger, prebuilt_base=prebuilt)
+
+        assert (repos_dir / "webapp" / "test.txt").exists()
+        assert (repos_dir / "webapp" / "test.txt").read_text() == "hello"
+
+    def test_warns_on_unmatched_repo(self, temp_dir, capsys):
+        """Warns when no mounted repo matches the prebuilt dir name."""
+        prebuilt = temp_dir / "prebuilt-deps"
+        (prebuilt / "Khan--unknown").mkdir(parents=True)
+        (prebuilt / "Khan--unknown" / "file.txt").write_text("data")
+
+        repos_dir = temp_dir / "repos"
+        repos_dir.mkdir(parents=True)
+
+        config = MagicMock()
+        config.repos_dir = repos_dir
+        logger = entrypoint.Logger(quiet=False)
+
+        entrypoint.restore_prebuilt_deps(config, logger, prebuilt_base=prebuilt)
+
+        captured = capsys.readouterr()
+        assert "No mounted repo found" in captured.out
+
+
 class TestSetupAgentRules:
     """Tests for the setup_agent_rules function."""
 


### PR DESCRIPTION
## Summary
- Adds `persist_dirs` option to `build_commands` in `repositories.yaml` that copies specified directories (e.g. `node_modules`) from the Docker build context to `/opt/prebuilt-deps/` before `/tmp/repo-deps/` is cleaned up
- Restores persisted directories into mounted repos at container startup via a new `restore_prebuilt_deps` step in `entrypoint.py`
- Also adds `corepack prepare pnpm@10.22.0 --activate` to the Node monorepo's build commands so pnpm works offline

## Problem
In private mode, JS/TS tests fail because:
1. `make npm_deps` installs `node_modules` into `/tmp/repo-deps/` during Docker build, but that directory is deleted afterward (Dockerfile line 96)
2. `corepack enable` creates a pnpm shim but doesn't cache the binary — at runtime, corepack tries to fetch pnpm from `registry.npmjs.org` which is blocked
3. Unlike Go (`GOMODCACHE`) or Python (`site-packages`), npm/pnpm deps are local to the project directory and don't survive the cleanup

## Test plan
- [x] All 172 existing + new tests pass (`test_docker_setup.py`, `test_entrypoint.py`)
- [ ] Rebuild image with `./egg --rebuild` and verify `node_modules` exist in private mode
- [ ] Verify `pnpm --version` works offline (corepack prepare caches the binary)
- [ ] Verify existing Go/Python deps still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
