### PR TITLE
Fix gateway crash: missing repo_config module

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -60,7 +60,9 @@ COPY shared/egg_config/ ./egg_config/
 COPY shared/egg_contracts/ ./egg_contracts/
 
 # Copy config module (repo_config needed by github_client for user mode)
+# Copy to both /config/ (for package-style imports) and /app/ (for PYTHONPATH)
 COPY config/repo_config.py /config/
+COPY config/repo_config.py /app/
 
 # Copy Squid configuration for network lockdown
 # squid.conf is the restrictive allowlist-based config (used in private mode)


### PR DESCRIPTION
## Summary
- Gateway container failed to start with `ModuleNotFoundError: No module named 'repo_config'` because `git_client.py`'s runtime path calculation didn't reliably resolve `/config/` inside the container
- Fix: also copy `repo_config.py` to `/app/` which is on `PYTHONPATH`, so the import works without fragile path manipulation

## Test plan
- [x] Rebuilt gateway image and verified container starts successfully
- [ ] Verify `from repo_config import ...` works in gateway, git_client, and github_client

🤖 Generated with [Claude Code](https://claude.com/claude-code)