### PR TITLE
Fail sandbox build if Claude CLI install fails

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -217,6 +217,8 @@ RUN if [ "$CLAUDE_AGENT_SDK_VERSION" = "latest" ]; then \
 # build-arg is omitted (e.g. manual docker build without the egg script).
 ARG CLAUDE_CODE_VERSION=stable
 RUN su - egg -c "curl -fsSL https://claude.ai/install.sh | bash -s -- $CLAUDE_CODE_VERSION" && \
+    # Fail the build if the CLI binary is missing (e.g. install script 403'd)
+    test -x /home/egg/.local/bin/claude && \
     # Save installed version for update checks (non-fatal if this fails)
     (/home/egg/.local/bin/claude --version 2>/dev/null | head -1 > /home/egg/.local/VERSION || true) && \
     # Replace bundled ripgrep with system ripgrep to avoid ARM64 crashes on Asahi Linux


### PR DESCRIPTION
## Summary
- Adds a `test -x` check after the Claude Code CLI install step in the sandbox Dockerfile
- If the install script fails (e.g. Cloudflare 403), the build now fails instead of silently pushing a broken image to the registry
- This was the root cause of PR review workflows failing with "Claude Code CLI not found in PATH"

## Test plan
- [ ] Verify the image builds successfully when the install script works
- [ ] Verify the build fails fast if `/home/egg/.local/bin/claude` is missing after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)