### PR TITLE
Skip __egg_system_dirs__ in restore_prebuilt_deps

### DIFF
--- a/sandbox/entrypoint.py
+++ b/sandbox/entrypoint.py
@@ -789,6 +789,10 @@ def restore_prebuilt_deps(
     for repo_dir in prebuilt_base.iterdir():
         if not repo_dir.is_dir():
             continue
+        # __egg_system_dirs__ contains system-level installs (e.g. /usr/local/go)
+        # already restored by the Dockerfile; skip it here.
+        if repo_dir.name == "__egg_system_dirs__":
+            continue
         # repo_dir is like /opt/prebuilt-deps/Khan--webapp
         # Convert back to repo name to find mount point
         # Try each mounted repo to find a match

--- a/tests/sandbox/test_entrypoint.py
+++ b/tests/sandbox/test_entrypoint.py
@@ -820,6 +820,27 @@ class TestRestorePrebuiltDeps:
         assert (repos_dir / "webapp" / "test.txt").exists()
         assert (repos_dir / "webapp" / "test.txt").read_text() == "hello"
 
+    def test_skips_egg_system_dirs(self, temp_dir, capsys):
+        """__egg_system_dirs__ is not a repo and should be silently skipped."""
+        prebuilt = temp_dir / "prebuilt-deps"
+        (prebuilt / "__egg_system_dirs__" / "usr" / "local" / "go" / "bin").mkdir(parents=True)
+        (prebuilt / "__egg_system_dirs__" / "usr" / "local" / "go" / "bin" / "go").write_text(
+            "binary"
+        )
+
+        repos_dir = temp_dir / "repos"
+        repos_dir.mkdir(parents=True)
+
+        config = MagicMock()
+        config.repos_dir = repos_dir
+        logger = entrypoint.Logger(quiet=False)
+
+        entrypoint.restore_prebuilt_deps(config, logger, prebuilt_base=prebuilt)
+
+        captured = capsys.readouterr()
+        assert "No mounted repo found" not in captured.out
+        assert "__egg_system_dirs__" not in captured.out
+
     def test_warns_on_unmatched_repo(self, temp_dir, capsys):
         """Warns when no mounted repo matches the prebuilt dir name."""
         prebuilt = temp_dir / "prebuilt-deps"


### PR DESCRIPTION
## Summary
- `restore_prebuilt_deps()` iterates `/opt/prebuilt-deps/` and tries to match each subdirectory to a mounted repo. `__egg_system_dirs__` is a special directory for system-level installs (e.g. `/usr/local/go`) that the Dockerfile already restores at build time — it's not a repo.
- Adds a skip for `__egg_system_dirs__` to eliminate the spurious warning on every container startup.
- Adds a test verifying the skip behavior.

## Test plan
- [x] `TestRestorePrebuiltDeps` suite passes (9/9)
- [ ] Verify no `__egg_system_dirs__` warning on container startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)