### PR TITLE
Fix sandbox .venv permissions: chown restored prebuilt deps

### DIFF
--- a/sandbox/entrypoint.py
+++ b/sandbox/entrypoint.py
@@ -852,9 +852,14 @@ def restore_prebuilt_deps(
         # came from the prebuilt snapshot (e.g. .venv, node_modules) to
         # avoid an expensive recursive chown of the entire repo.
         for prebuilt_subdir in repo_dir.iterdir():
+            if not prebuilt_subdir.is_dir():
+                continue
             restored_path = target_repo / prebuilt_subdir.name
             if restored_path.exists():
-                chown_recursive(restored_path, config.runtime_uid, config.runtime_gid)
+                try:
+                    chown_recursive(restored_path, config.runtime_uid, config.runtime_gid)
+                except subprocess.CalledProcessError as e:
+                    logger.warn(f"  Failed to chown {restored_path}: {e.stderr}")
 
         restored += 1
         logger.info(f"  Restored prebuilt deps for {repo_dir_name} -> {target_repo}")

--- a/tests/sandbox/test_entrypoint.py
+++ b/tests/sandbox/test_entrypoint.py
@@ -732,7 +732,12 @@ class TestRestorePrebuiltDeps:
 
     @pytest.fixture(autouse=True)
     def _patch_chown(self):
-        """Patch chown_recursive since tests run as non-root."""
+        """Patch chown_recursive since tests run as non-root.
+
+        This also prevents chown from being called in tests where restored
+        paths exist (e.g. test_restores_deps_into_repo), keeping those tests
+        focused on copy behavior rather than ownership.
+        """
         with patch("entrypoint.chown_recursive") as self.mock_chown:
             yield
 
@@ -925,6 +930,7 @@ class TestRestorePrebuiltDeps:
         entrypoint.restore_prebuilt_deps(config, logger, prebuilt_base=temp_dir / "prebuilt-deps")
 
         # chown_recursive should be called for each top-level prebuilt subdir
+        assert self.mock_chown.call_count == 2
         chown_paths = {call.args[0] for call in self.mock_chown.call_args_list}
         assert repos_dir / "webapp" / "node_modules" in chown_paths
         assert repos_dir / "webapp" / ".venv" in chown_paths
@@ -932,6 +938,47 @@ class TestRestorePrebuiltDeps:
         for call in self.mock_chown.call_args_list:
             assert call.args[1] == 1000
             assert call.args[2] == 1000
+
+    def test_chown_failure_does_not_crash(self, temp_dir, capsys):
+        """A chown failure logs a warning but does not crash the entrypoint."""
+        prebuilt = temp_dir / "prebuilt-deps" / "Khan--webapp"
+        (prebuilt / ".venv" / "bin").mkdir(parents=True)
+        (prebuilt / ".venv" / "bin" / "python3").write_text("x")
+
+        repos_dir = temp_dir / "repos"
+        (repos_dir / "webapp").mkdir(parents=True)
+
+        self.mock_chown.side_effect = subprocess.CalledProcessError(
+            1, "chown", stderr="Permission denied"
+        )
+        config = self._make_config(repos_dir)
+        logger = entrypoint.Logger(quiet=False)
+
+        # Should not raise
+        entrypoint.restore_prebuilt_deps(config, logger, prebuilt_base=temp_dir / "prebuilt-deps")
+
+        captured = capsys.readouterr()
+        assert "Failed to chown" in captured.out
+
+    def test_skips_non_directory_entries(self, temp_dir):
+        """Top-level files in the prebuilt snapshot are not chowned."""
+        prebuilt = temp_dir / "prebuilt-deps" / "Khan--webapp"
+        (prebuilt / ".venv" / "bin").mkdir(parents=True)
+        (prebuilt / ".venv" / "bin" / "python3").write_text("x")
+        # Add a top-level file in the prebuilt snapshot
+        (prebuilt / "manifest.json").write_text("{}")
+
+        repos_dir = temp_dir / "repos"
+        (repos_dir / "webapp").mkdir(parents=True)
+
+        config = self._make_config(repos_dir)
+        logger = entrypoint.Logger(quiet=True)
+
+        entrypoint.restore_prebuilt_deps(config, logger, prebuilt_base=temp_dir / "prebuilt-deps")
+
+        # Only the directory (.venv) should be chowned, not manifest.json
+        assert self.mock_chown.call_count == 1
+        assert self.mock_chown.call_args_list[0].args[0] == repos_dir / "webapp" / ".venv"
 
 
 class TestSetupAgentRules:


### PR DESCRIPTION
## Summary
- `restore_prebuilt_deps()` runs as root and copies files from `/opt/prebuilt-deps/` into mounted repos, but never fixed ownership afterward
- The agent process runs as the runtime user (via `gosu`), so root-owned files like `.venv/bin/python3` are inaccessible — causing `make lint`, `make deps`, and `.venv/bin/pytest` to fail with "Permission denied"
- After `copytree`, chown each restored top-level subdirectory (e.g. `.venv`, `node_modules`) to the runtime user

Fixes #1426

## Test plan
- [x] Added `test_chowns_restored_dirs` verifying `chown_recursive` is called for each restored subdirectory with correct uid/gid
- [x] All 10 existing `TestRestorePrebuiltDeps` tests pass
- [ ] Verify in sandbox container that `.venv/bin/python3` is accessible and `make lint` / `make deps` work

🤖 Generated with [Claude Code](https://claude.com/claude-code)