### PR TITLE
Fix false ANTHROPIC_API_KEY warning when OAuth token is present

### DIFF
--- a/sandbox/entrypoint.py
+++ b/sandbox/entrypoint.py
@@ -992,10 +992,10 @@ def setup_claude(config: Config, logger: Logger) -> None:
 
     if config.anthropic_api_key:
         logger.success("Anthropic API key configured")
-    elif config.anthropic_auth_method == "oauth":
+    elif config.anthropic_auth_method == "oauth" or os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
         logger.success("Anthropic OAuth authentication enabled")
     else:
-        logger.warn("ANTHROPIC_API_KEY not set")
+        logger.warn("ANTHROPIC_API_KEY not set and no OAuth token found")
         logger.info("  Set via: export ANTHROPIC_API_KEY=sk-ant-...")
         logger.info("  Or use OAuth: export ANTHROPIC_AUTH_METHOD=oauth")
 


### PR DESCRIPTION
## Summary
- The sandbox entrypoint warned "ANTHROPIC_API_KEY not set" even when a `CLAUDE_CODE_OAUTH_TOKEN` was already present (e.g. injected by the credential proxy via `setup_credential_proxy`)
- Now the warning only fires when **both** `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` are unset

## Test plan
- [ ] Run sandbox with credential proxy enabled (no API key, OAuth token injected) — verify no warning
- [ ] Run sandbox with neither API key nor OAuth token — verify warning appears
- [ ] Run sandbox with explicit `ANTHROPIC_AUTH_METHOD=oauth` — verify success message

🤖 Generated with [Claude Code](https://claude.com/claude-code)