### PR TITLE
Fix stale generic drafts persisting on work branches

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -1648,7 +1648,7 @@ def _get_draft_path(
         return f".egg-state/drafts/{prefix}-{phase}.md"
 
 
-def _cleanup_stale_generic_drafts(worktree_path: Path) -> None:
+def _cleanup_stale_generic_drafts(worktree_path: Path) -> bool:
     """Remove unprefixed generic draft files from a worktree.
 
     Legacy pipelines left behind ``analysis.md`` and ``plan.md`` (without
@@ -1661,10 +1661,13 @@ def _cleanup_stale_generic_drafts(worktree_path: Path) -> None:
     immediately.  Falls back to ``os.unlink`` if the file is untracked.
 
     Safe to call when the drafts directory does not exist (no-op).
+
+    Returns ``True`` if a commit was made (i.e. tracked files were removed
+    and committed), ``False`` otherwise.
     """
     drafts_dir = worktree_path / ".egg-state" / "drafts"
     if not drafts_dir.is_dir():
-        return
+        return False
 
     git_base = ["git", "-c", "core.hooksPath=/dev/null", "-C", str(worktree_path)]
     removed = False
@@ -1686,24 +1689,40 @@ def _cleanup_stale_generic_drafts(worktree_path: Path) -> None:
                     timeout=10,
                 )
                 removed = True
-            except subprocess.CalledProcessError:
-                # File may be untracked — just delete it
+            except subprocess.CalledProcessError as exc:
+                # File may be untracked — just delete it from disk.
+                # Warn so that unexpected git rm failures (e.g. index
+                # lock) are diagnosable.
+                logger.warning(
+                    "git rm failed for stale draft, falling back to unlink",
+                    path=str(stale),
+                    error=str(exc),
+                )
                 stale.unlink(missing_ok=True)
 
     if removed:
         try:
             subprocess.run(
-                [*git_base, "commit", "-m", "Remove stale generic draft files"],
+                [
+                    *git_base,
+                    "commit",
+                    "--no-verify",
+                    "-m",
+                    "Remove stale generic draft files",
+                ],
                 capture_output=True,
                 text=True,
                 check=True,
                 timeout=30,
             )
+            return True
         except subprocess.CalledProcessError as commit_err:
             logger.debug(
                 "No changes to commit after stale draft cleanup",
                 error=str(commit_err),
             )
+
+    return False
 
 
 def _read_phase_draft(
@@ -6035,8 +6054,8 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
             # Remove legacy unprefixed draft files (analysis.md, plan.md)
             # that may have been left by earlier pipelines on this branch.
             # Uses git rm so deletions are committed directly.  See #1559.
-            _cleanup_stale_generic_drafts(worktree_repo_path)
-            if pipeline.branch:
+            cleanup_committed = _cleanup_stale_generic_drafts(worktree_repo_path)
+            if cleanup_committed and pipeline.branch:
                 try:
                     spawner.gateway.push_worktree_branch(
                         pipeline_id=pipeline_id,
@@ -6045,7 +6064,7 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                         mode=gateway_mode,
                     )
                 except Exception:
-                    logger.debug(
+                    logger.warning(
                         "Failed to push stale draft cleanup (continuing)",
                         pipeline_id=pipeline_id,
                     )

--- a/orchestrator/tests/test_pipeline_failure_path.py
+++ b/orchestrator/tests/test_pipeline_failure_path.py
@@ -224,20 +224,14 @@ class TestFailurePathPushesWorktreeBranch:
         ):
             _run_pipeline("issue-42", Path("/repo"))
 
-        # push_worktree_branch should be called twice:
-        # once for stale draft cleanup push, once for failure-path push
-        push_calls = mock_gateway.push_worktree_branch.call_args_list
-        assert len(push_calls) == 2, (
-            f"Expected push_worktree_branch to be called twice "
-            f"(stale draft cleanup + failure path), got {len(push_calls)} calls"
+        # push_worktree_branch should be called once for the failure-path push.
+        # Stale draft cleanup does not trigger a push (no drafts dir in test worktree).
+        mock_gateway.push_worktree_branch.assert_called_once_with(
+            pipeline_id="issue-42",
+            repo_path=str(worktree_dir),
+            branch="egg/issue-42",
+            mode="public",
         )
-        for c in push_calls:
-            assert c.kwargs == {
-                "pipeline_id": "issue-42",
-                "repo_path": str(worktree_dir),
-                "branch": "egg/issue-42",
-                "mode": "public",
-            }
 
     @patch(_COMMON_PATCHES[7])
     @patch(_COMMON_PATCHES[6])
@@ -491,13 +485,13 @@ class TestSuccessPathPushesStatefiles:
         assert pipeline.status == PipelineStatus.COMPLETE
 
         # push_worktree_branch should have been called:
-        # - once for stale draft cleanup push
         # - once for auto-PR pre-push (pushes commits before PR creation)
         # - once after phase completion (pushes statefiles)
+        # (stale draft cleanup does not push — no drafts dir in test worktree)
         calls = mock_gateway.push_worktree_branch.call_args_list
-        assert len(calls) == 3, (
-            f"Expected push_worktree_branch to be called 3 times "
-            f"(stale draft cleanup + auto-PR pre-push + phase completion), got {len(calls)} calls"
+        assert len(calls) == 2, (
+            f"Expected push_worktree_branch to be called twice "
+            f"(auto-PR pre-push + phase completion), got {len(calls)} calls"
         )
         for c in calls:
             assert c.kwargs == {
@@ -578,14 +572,14 @@ class TestSuccessPathPushesStatefiles:
         ):
             _run_pipeline("issue-42", Path("/repo"))
 
-        # push_worktree_branch should be called exactly four times:
-        # once for stale draft cleanup, once after contract initialization,
-        # once for auto-PR pre-push, and once after phase completion.
+        # push_worktree_branch should be called exactly three times:
+        # once after contract initialization, once for auto-PR pre-push,
+        # and once after phase completion.
+        # (stale draft cleanup does not push — no drafts dir in test worktree)
         calls = mock_gateway.push_worktree_branch.call_args_list
-        assert len(calls) == 4, (
-            f"Expected push_worktree_branch to be called 4 times "
-            f"(stale draft cleanup + contract init + auto-PR pre-push + phase completion), "
-            f"got {len(calls)} calls"
+        assert len(calls) == 3, (
+            f"Expected push_worktree_branch to be called three times "
+            f"(contract init + auto-PR pre-push + phase completion), got {len(calls)} calls"
         )
         # Verify arguments match for every call
         for c in calls:
@@ -776,13 +770,11 @@ class TestContractPushHardGate:
             "Pipeline should be marked FAILED when contract push fails after retry"
         )
 
-        # push_worktree_branch should be called 3 times:
-        # once for stale draft cleanup (returns False, ignored),
-        # then initial contract push + retry (both return False → pipeline fails)
+        # push_worktree_branch should be called twice (initial + retry).
+        # Stale draft cleanup does not push (no drafts dir in test worktree).
         push_calls = mock_gateway.push_worktree_branch.call_args_list
-        assert len(push_calls) == 3, (
-            f"Expected 3 push attempts (stale draft cleanup + initial + retry), "
-            f"got {len(push_calls)}"
+        assert len(push_calls) == 2, (
+            f"Expected 2 push attempts (initial + retry), got {len(push_calls)}"
         )
 
         # No agents should be spawned after push failure

--- a/orchestrator/tests/test_read_phase_draft.py
+++ b/orchestrator/tests/test_read_phase_draft.py
@@ -76,8 +76,6 @@ class TestReadPhaseDraft:
 
     def test_logs_debug_when_file_missing(self, tmp_path: Path, monkeypatch):
         """Debug log is emitted when the draft file does not exist."""
-        from unittest.mock import MagicMock
-
         import routes.pipelines as mod
 
         mock_logger = MagicMock()
@@ -95,16 +93,18 @@ class TestCleanupStaleGenericDrafts:
     """Tests for _cleanup_stale_generic_drafts."""
 
     def test_removes_generic_analysis_and_plan(self, tmp_path: Path):
-        """Unprefixed analysis.md and plan.md are removed."""
+        """Unprefixed analysis.md and plan.md are removed (untracked fallback)."""
         drafts = tmp_path / ".egg-state" / "drafts"
         drafts.mkdir(parents=True)
         (drafts / "analysis.md").write_text("stale analysis", encoding="utf-8")
         (drafts / "plan.md").write_text("stale plan", encoding="utf-8")
 
-        _cleanup_stale_generic_drafts(tmp_path)
+        result = _cleanup_stale_generic_drafts(tmp_path)
 
         assert not (drafts / "analysis.md").exists()
         assert not (drafts / "plan.md").exists()
+        # Untracked files use os.unlink fallback — no commit is made
+        assert result is False
 
     def test_preserves_prefixed_files(self, tmp_path: Path):
         """Prefixed files like 1553-analysis.md are untouched."""
@@ -122,7 +122,8 @@ class TestCleanupStaleGenericDrafts:
 
     def test_noop_when_no_drafts_dir(self, tmp_path: Path):
         """No error when .egg-state/drafts/ does not exist."""
-        _cleanup_stale_generic_drafts(tmp_path)  # Should not raise
+        result = _cleanup_stale_generic_drafts(tmp_path)
+        assert result is False
 
     def test_noop_when_no_stale_files(self, tmp_path: Path):
         """No error when drafts dir exists but has no generic files."""
@@ -130,6 +131,57 @@ class TestCleanupStaleGenericDrafts:
         drafts.mkdir(parents=True)
         (drafts / "42-analysis.md").write_text("ok", encoding="utf-8")
 
-        _cleanup_stale_generic_drafts(tmp_path)
+        result = _cleanup_stale_generic_drafts(tmp_path)
 
+        assert result is False
         assert (drafts / "42-analysis.md").exists()
+
+    def test_git_rm_success_returns_true(self, tmp_path: Path, monkeypatch):
+        """When git rm succeeds, function commits and returns True."""
+        import routes.pipelines as mod
+
+        drafts = tmp_path / ".egg-state" / "drafts"
+        drafts.mkdir(parents=True)
+        (drafts / "analysis.md").write_text("stale", encoding="utf-8")
+
+        call_log: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            call_log.append(cmd)
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+            return result
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+        result = _cleanup_stale_generic_drafts(tmp_path)
+
+        assert result is True
+        # Should have called git rm then git commit
+        assert any("rm" in c for c in call_log[0])
+        assert any("commit" in c for c in call_log[1])
+        # commit should include --no-verify
+        assert "--no-verify" in call_log[1]
+
+    def test_git_rm_failure_logs_warning(self, tmp_path: Path, monkeypatch):
+        """When git rm fails, a warning is logged and unlink is used."""
+        import routes.pipelines as mod
+
+        drafts = tmp_path / ".egg-state" / "drafts"
+        drafts.mkdir(parents=True)
+        (drafts / "plan.md").write_text("stale", encoding="utf-8")
+
+        mock_logger = MagicMock()
+        monkeypatch.setattr(mod, "logger", mock_logger)
+
+        # Let subprocess.run raise (git rm fails) — default behavior in
+        # non-git tmp_path already does this, but be explicit:
+        result = _cleanup_stale_generic_drafts(tmp_path)
+
+        assert result is False
+        assert not (drafts / "plan.md").exists()
+        # Should have logged a warning about git rm failure
+        mock_logger.warning.assert_called_once()
+        assert "git rm failed" in mock_logger.warning.call_args[0][0]


### PR DESCRIPTION
## Summary
- Add `_cleanup_stale_generic_drafts()` to remove unprefixed `analysis.md` and `plan.md` from `.egg-state/drafts/` at pipeline start, preventing stale content from prior pipelines from confusing phase gate draft resolution
- Uses `git rm` directly instead of `_commit_statefiles_to_worktree` (which only stages pid-prefixed files and would silently skip unprefixed deletions)
- Add debug logging to `_read_phase_draft()` when draft files are not found, making transient failures diagnosable

Closes #1559

## Test plan
- [x] New tests in `test_read_phase_draft.py` for cleanup function (removes generic files, preserves prefixed files, no-op when no drafts dir)
- [x] New test for debug logging on missing drafts
- [ ] Manual: start a pipeline on a branch with stale `analysis.md`, verify it's removed before agents run

🤖 Generated with [Claude Code](https://claude.com/claude-code)