### PR TITLE
Fix decision resolution stored as dict instead of string (#1635)

### DIFF
--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -5,12 +5,13 @@ These models represent the orchestrator's view of pipeline execution,
 including container state, HITL decisions, and agent coordination.
 """
 
+import json
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any, Literal, NamedTuple
 
 from egg_contracts.models import PipelinePhase
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class PipelineStatus(StrEnum):
@@ -176,6 +177,8 @@ class AgentExecution(BaseModel):
 class HITLDecision(BaseModel):
     """A human-in-the-loop decision request."""
 
+    model_config = ConfigDict(validate_assignment=True)
+
     id: str = Field(..., description="Unique decision ID")
     question: str = Field(..., min_length=1, description="Question for human")
     context: str = Field(default="", description="Additional context")
@@ -208,8 +211,6 @@ class HITLDecision(BaseModel):
     @classmethod
     def _serialize_resolution(cls, v: Any) -> str | None:
         """Ensure resolution is always stored as a JSON string, not a dict (#1635)."""
-        import json
-
         if isinstance(v, dict | list):
             return json.dumps(v)
         return v

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -204,6 +204,16 @@ class HITLDecision(BaseModel):
         description="Whether the phase output changed compared to the previous decision's context (literal string comparison, not semantic)",
     )
 
+    @field_validator("resolution", mode="before")
+    @classmethod
+    def _serialize_resolution(cls, v: Any) -> str | None:
+        """Ensure resolution is always stored as a JSON string, not a dict (#1635)."""
+        import json
+
+        if isinstance(v, dict | list):
+            return json.dumps(v)
+        return v
+
 
 class CycleTiming(BaseModel):
     """Timing for a single review cycle within a phase."""

--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -5,6 +5,7 @@ Provides REST endpoints for queuing, polling, and resolving
 human-in-the-loop decisions.
 """
 
+import json
 import re
 import sys
 from pathlib import Path
@@ -412,6 +413,11 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
     resolution = data.get("resolution")
     if not resolution:
         return make_error_response("Missing resolution")
+
+    # Ensure resolution is always a JSON string — callers may send a dict
+    # instead of a pre-serialized string (#1635).
+    if not isinstance(resolution, str):
+        resolution = json.dumps(resolution)
 
     try:
         store, _pipeline = get_state_store_for_pipeline(pipeline_id)

--- a/orchestrator/tests/test_decisions_routes.py
+++ b/orchestrator/tests/test_decisions_routes.py
@@ -528,6 +528,37 @@ class TestResolveDecisionEndpoint:
         assert data["success"] is True
         assert data["data"]["decision"]["status"] == "resolved"
 
+    @patch("routes.decisions.get_state_store_for_pipeline")
+    @patch("routes.decisions.get_decision_queue")
+    def test_resolve_dict_resolution_serialized_to_json_string(
+        self, mock_get_queue, mock_get_store_for_pipeline, client, tmp_path
+    ):
+        """POST resolve with dict resolution serializes it to a JSON string (#1635)."""
+        import json
+
+        mock_get_store_for_pipeline.return_value = _mock_store_for_pipeline(tmp_path)
+        mock_queue = MagicMock()
+
+        resolved_decision = _make_decision(
+            status="resolved",
+            resolution='{"action": "select", "selected": "approve"}',
+        )
+        mock_queue.resolve_decision.return_value = resolved_decision
+        mock_get_queue.return_value = mock_queue
+
+        # Send resolution as a dict (not a string) — this is the bug trigger
+        response = client.post(
+            "/api/v1/pipelines/test-pipeline/decisions/decision-1/resolve",
+            json={"resolution": {"action": "select", "selected": "approve"}},
+        )
+
+        assert response.status_code == 200
+        # The route handler should have serialized the dict to a JSON string
+        call_args = mock_queue.resolve_decision.call_args
+        actual_resolution = call_args[0][1]
+        assert isinstance(actual_resolution, str)
+        assert json.loads(actual_resolution) == {"action": "select", "selected": "approve"}
+
     def test_resolve_missing_resolution_returns_400(self, client, tmp_path):
         """POST resolve without resolution field returns 400."""
         response = client.post(

--- a/orchestrator/tests/test_models.py
+++ b/orchestrator/tests/test_models.py
@@ -193,6 +193,20 @@ class TestHITLDecision:
         )
         assert decision.resolution is None
 
+    def test_dict_resolution_serialized_on_assignment(self):
+        """Dict resolution is serialized when assigned to an existing instance (#1635)."""
+        import json
+
+        decision = HITLDecision(
+            id="decision-1",
+            question="Approve?",
+            resolution=None,
+        )
+        # Direct attribute assignment — requires validate_assignment=True
+        decision.resolution = {"action": "select", "selected": "approve"}
+        assert isinstance(decision.resolution, str)
+        assert json.loads(decision.resolution) == {"action": "select", "selected": "approve"}
+
 
 class TestPhaseExecution:
     """Tests for PhaseExecution model."""

--- a/orchestrator/tests/test_models.py
+++ b/orchestrator/tests/test_models.py
@@ -148,6 +148,51 @@ class TestHITLDecision:
         assert len(decision.questions) == 2
         assert decision.questions[0]["id"] == "q-1"
 
+    def test_dict_resolution_serialized_to_json_string(self):
+        """Dict resolution is auto-serialized to a JSON string (#1635)."""
+        import json
+
+        decision = HITLDecision(
+            id="decision-1",
+            question="Approve?",
+            resolution={"action": "select", "selected": "approve"},
+        )
+        assert isinstance(decision.resolution, str)
+        assert json.loads(decision.resolution) == {
+            "action": "select",
+            "selected": "approve",
+        }
+
+    def test_list_resolution_serialized_to_json_string(self):
+        """List resolution is auto-serialized to a JSON string (#1635)."""
+        import json
+
+        decision = HITLDecision(
+            id="decision-1",
+            question="Approve?",
+            resolution=["option-a", "option-b"],
+        )
+        assert isinstance(decision.resolution, str)
+        assert json.loads(decision.resolution) == ["option-a", "option-b"]
+
+    def test_string_resolution_unchanged(self):
+        """String resolution passes through unchanged (#1635)."""
+        decision = HITLDecision(
+            id="decision-1",
+            question="Approve?",
+            resolution='{"action": "approve"}',
+        )
+        assert decision.resolution == '{"action": "approve"}'
+
+    def test_none_resolution_unchanged(self):
+        """None resolution passes through unchanged (#1635)."""
+        decision = HITLDecision(
+            id="decision-1",
+            question="Approve?",
+            resolution=None,
+        )
+        assert decision.resolution is None
+
 
 class TestPhaseExecution:
     """Tests for PhaseExecution model."""


### PR DESCRIPTION
## Summary
- Serialize dict/list resolutions to JSON strings in the `resolve_decision` route handler before storing — callers (e.g. LLMs via MCP) may send a dict instead of a pre-serialized string
- Add a `field_validator` on `HITLDecision.resolution` as defense-in-depth so the model itself coerces non-string resolutions
- Add tests for both the route handler and model validator

## Test plan
- [x] Existing `TestResolveDecisionEndpoint` tests pass
- [x] Existing `TestHITLDecision` model tests pass
- [x] New route test: dict resolution is serialized to JSON string before reaching the queue
- [x] New model tests: dict, list, string, and None resolutions all handled correctly
- [ ] Verify on a live pipeline that `provide_input` with a phase gate no longer corrupts state

Closes #1635