### PR TITLE
Teach agents to use directed BRC messages for coordination (#1718)

### DIFF
--- a/.egg-state/contracts/1718.json
+++ b/.egg-state/contracts/1718.json
@@ -1,0 +1,107 @@
+{
+  "schemaVersion": "1.0",
+  "issue": {
+    "number": 1718,
+    "title": "Issue #1718",
+    "url": "https://github.com/jwbron/egg/issues/1718"
+  },
+  "pipeline_id": null,
+  "current_phase": "refine",
+  "acceptance_criteria": [],
+  "phases": [
+    {
+      "id": "phase-1",
+      "name": "Implement",
+      "status": "pending",
+      "review_cycles": 0,
+      "max_cycles": 3,
+      "escalated": false,
+      "escalation_reason": null,
+      "tasks": [
+        {
+          "id": "task-1-1",
+          "description": "Extend `_build_brc_preamble` in `orchestrator/routes/pipelines.py` with role-gated directed coordination guidance for HANDOFF/QUESTION/STATUS.",
+          "status": "pending",
+          "commit": null,
+          "checkpoint_id": null,
+          "notes": "",
+          "acceptance_criteria": "Preamble for producer contains `egg-orch message send` and `HANDOFF`; reviewer contains `QUESTION` guidance.",
+          "files_affected": [
+            "orchestrator/routes/pipelines.py"
+          ],
+          "role": null,
+          "review_cycles": 0,
+          "max_cycles": 3,
+          "escalated": false
+        },
+        {
+          "id": "task-1-2",
+          "description": "Update `--type` help text in `sandbox/egg_lib/orch_cli.py:1782` to include `HANDOFF`.",
+          "status": "pending",
+          "commit": null,
+          "checkpoint_id": null,
+          "notes": "",
+          "acceptance_criteria": "Help text lists HANDOFF.",
+          "files_affected": [
+            "sandbox/egg_lib/orch_cli.py"
+          ],
+          "role": null,
+          "review_cycles": 0,
+          "max_cycles": 3,
+          "escalated": false
+        },
+        {
+          "id": "task-1-3",
+          "description": "Add 'Directed Coordination' subsection to `docs/guides/concurrent-execution.md` with CLI form, use cases, and coder-to-tester worked example.",
+          "status": "pending",
+          "commit": null,
+          "checkpoint_id": null,
+          "notes": "",
+          "acceptance_criteria": "Guide contains new section with CLI example and worked example.",
+          "files_affected": [
+            "docs/guides/concurrent-execution.md"
+          ],
+          "role": null,
+          "review_cycles": 0,
+          "max_cycles": 3,
+          "escalated": false
+        },
+        {
+          "id": "task-1-4",
+          "description": "Add test in `orchestrator/tests/test_pipeline_prompts.py` asserting BRC preamble contains directed coordination guidance.",
+          "status": "pending",
+          "commit": null,
+          "checkpoint_id": null,
+          "notes": "",
+          "acceptance_criteria": "Test passes; fails if task-1-1 reverted.",
+          "files_affected": [
+            "orchestrator/tests/test_pipeline_prompts.py"
+          ],
+          "role": null,
+          "review_cycles": 0,
+          "max_cycles": 3,
+          "escalated": false
+        }
+      ],
+      "dependencies": [],
+      "commit": null,
+      "review_feedback": []
+    }
+  ],
+  "decisions": [],
+  "workflow_owner": null,
+  "audit_log": [],
+  "refine_review_cycles": 0,
+  "refine_review_feedback": "",
+  "plan_review_cycles": 0,
+  "plan_review_feedback": "",
+  "pr": {
+    "title": "Teach agents to use directed BRC messages for coordination (#1718)",
+    "description": "Resolves #1718. Adds prompt-level guidance for directed peer-to-peer coordination,\nfixes CLI --type help text, and documents the pattern with a worked example.",
+    "test_plan": "- Automated: new prompt test asserts `_build_brc_preamble` contains `egg-orch message send` and `HANDOFF`\n- Manual: run `egg-orch message send --help` and confirm `HANDOFF` appears\n- Manual: read `docs/guides/concurrent-execution.md` new section",
+    "manual_steps": "Pre-merge: none.\nPost-merge: none."
+  },
+  "feedback": null,
+  "phase_configs": null,
+  "agent_executions": []
+}

--- a/.egg-state/drafts/1718-analysis.md
+++ b/.egg-state/drafts/1718-analysis.md
@@ -1,0 +1,10 @@
+## Analysis — Issue #1718
+
+### Problem
+During BRC consensus, agents have no clear structured path to coordinate with peers. The `egg-orch message send` CLI exists but the BRC preamble never tells agents to use it.
+
+### Files affected
+- `orchestrator/routes/pipelines.py` — extend `_build_brc_preamble` (~5251) with directed coordination guidance
+- `sandbox/egg_lib/orch_cli.py:1782` — update `--type` help text to include `HANDOFF`
+- `docs/guides/concurrent-execution.md` — add directed coordination subsection with worked example
+- `orchestrator/tests/test_pipeline_prompts.py` — add test asserting BRC preamble contains new guidance

--- a/.egg-state/drafts/1718-plan.md
+++ b/.egg-state/drafts/1718-plan.md
@@ -1,0 +1,56 @@
+# Plan: Teach agents to use directed BRC messaging
+
+## Summary
+
+Add prompt-level guidance in `_build_brc_preamble` for HANDOFF/QUESTION/STATUS. Fix CLI help text, add docs with worked example, add prompt test.
+
+## Implementation
+
+### Phase 1: Implement
+
+**Tasks**:
+1. **[task-1-1]** Extend `_build_brc_preamble` with role-gated directed coordination guidance.
+2. **[task-1-2]** Update `--type` help text to include `HANDOFF`.
+3. **[task-1-3]** Add "Directed Coordination" subsection to concurrent-execution guide.
+4. **[task-1-4]** Add prompt test asserting guidance is injected.
+
+```yaml
+# yaml-tasks
+pr:
+  title: "Teach agents to use directed BRC messages for coordination (#1718)"
+  description: |
+    Resolves #1718. Adds prompt-level guidance for directed peer-to-peer coordination,
+    fixes CLI --type help text, and documents the pattern with a worked example.
+  test_plan: |
+    - Automated: new prompt test asserts `_build_brc_preamble` contains `egg-orch message send` and `HANDOFF`
+    - Manual: run `egg-orch message send --help` and confirm `HANDOFF` appears
+    - Manual: read `docs/guides/concurrent-execution.md` new section
+  manual_steps: |
+    Pre-merge: none.
+    Post-merge: none.
+phases:
+  - id: 1
+    name: Implement
+    goal: "Agents know via BRC preamble when to use egg-orch message send for directed coordination."
+    tasks:
+      - id: task-1-1
+        description: "Extend `_build_brc_preamble` in `orchestrator/routes/pipelines.py` with role-gated directed coordination guidance for HANDOFF/QUESTION/STATUS."
+        acceptance: "Preamble for producer contains `egg-orch message send` and `HANDOFF`; reviewer contains `QUESTION` guidance."
+        files:
+          - orchestrator/routes/pipelines.py
+      - id: task-1-2
+        description: "Update `--type` help text in `sandbox/egg_lib/orch_cli.py:1782` to include `HANDOFF`."
+        acceptance: "Help text lists HANDOFF."
+        files:
+          - sandbox/egg_lib/orch_cli.py
+      - id: task-1-3
+        description: "Add 'Directed Coordination' subsection to `docs/guides/concurrent-execution.md` with CLI form, use cases, and coder-to-tester worked example."
+        acceptance: "Guide contains new section with CLI example and worked example."
+        files:
+          - docs/guides/concurrent-execution.md
+      - id: task-1-4
+        description: "Add test in `orchestrator/tests/test_pipeline_prompts.py` asserting BRC preamble contains directed coordination guidance."
+        acceptance: "Test passes; fails if task-1-1 reverted."
+        files:
+          - orchestrator/tests/test_pipeline_prompts.py
+```

--- a/docs/guides/agent-teams.md
+++ b/docs/guides/agent-teams.md
@@ -167,11 +167,14 @@ Not all messages need the same rigor:
 | Message type | Signal cost | Rationale |
 |-------------|-------------|-----------|
 | STATUS, PROGRESS | Cheap talk | Low overhead, informative when interests are aligned |
+| HANDOFF, QUESTION | Cheap talk | Directed coordination — low overhead, enables role-boundary artifact transfers and clarification requests |
 | CONSENSUS_PROPOSE | Costly signal | Attestations are harder to produce without doing the work |
 | CONSENSUS_ACK | Costly signal | Must reference specific artifacts reviewed (prevents rubber-stamping) |
 | CONSENSUS_NACK | Costly signal | Must include specific, actionable objection with artifact references |
 
 This distinction comes from game theory: cheap talk (Crawford & Sobel, 1982) works when interests are fully aligned, but LLM agents are *unreliable communicators* — they may genuinely believe bad work is good. Costly signals (requiring verifiable evidence) address this.
+
+> **Directed coordination messages** (`HANDOFF`, `QUESTION`, `STATUS`, `PROGRESS`) are cheap talk by design — they carry no attestation burden and serve to keep agents unblocked. The critical distinction is that they flow *outside* the BRC consensus protocol: a `HANDOFF` message does not replace a `CONSENSUS_PROPOSE`, and a `QUESTION` does not replace a `CONSENSUS_NACK`. See [Concurrent Execution — Directed Coordination](concurrent-execution.md#directed-coordination) for the CLI syntax, message type guidance, and worked examples.
 
 #### Anti-Sycophancy Measures
 

--- a/docs/guides/concurrent-execution.md
+++ b/docs/guides/concurrent-execution.md
@@ -249,7 +249,7 @@ egg-orch message poll --wait 30
 When a directed message arrives:
 
 1. **HANDOFF**: Act on the handoff artifact. If it requires work, do the work and acknowledge via a `STATUS` or `PROGRESS` message back.
-2. **QUESTION**: Answer the question via a `STATUS` message or `egg-orch message send --to <asker> --type STATUS`.
+2. **QUESTION**: Answer the question via `egg-orch message send --to <asker> --type STATUS`. (`STATUS` serves as the generic reply type since the directed coordination vocabulary does not include a dedicated `RESPONSE` type.)
 3. **STATUS/PROGRESS**: Use the information to inform your own work — no response required unless the status changes your plan.
 
 ### Best Practices

--- a/docs/guides/concurrent-execution.md
+++ b/docs/guides/concurrent-execution.md
@@ -167,6 +167,98 @@ The message store is cleared when the phase transitions. Each new phase executio
 
 **Note:** BRC messages (consensus messages and orchestrator-adjacent types like `HANDOFF`, `AGENT_FAILED`, `STATUS`, etc.) are persisted to `.egg-state/brc-history/{identifier}-{phase}.md` and `.json` at phase completion. Messages are filtered by phase, so each history file contains only that phase's BRC activity. See [BRC History Persistence](#brc-history-persistence) below.
 
+## Directed Coordination
+
+The message bus supports **directed coordination** — structured peer-to-peer messages for coordination needs that fall outside the formal BRC consensus protocol. While consensus messages (`CONSENSUS_PROPOSE`, `CONSENSUS_ACK`, etc.) handle the review-and-converge lifecycle, directed messages handle the day-to-day coordination that keeps agents unblocked and informed.
+
+### Why Not Proposal Text?
+
+A common anti-pattern is embedding coordination requests in proposal summaries — for example, writing "tester agent should push those test files" in a `CONSENSUS_PROPOSE` body. This fails for several reasons:
+
+1. **Discovery is accidental.** The other agent only sees the request if it happens to read the proposal text.
+2. **No structured record.** Proposal text is free-form — there's no way to filter, query, or act on coordination requests programmatically.
+3. **Wrong audience.** Proposals are broadcast to reviewers, not to the specific agent that needs to act.
+
+Directed messages solve all three: they are delivered to the target agent's poll stream, have a structured type for filtering, and are persisted in BRC history for traceability.
+
+### CLI Syntax
+
+```bash
+egg-orch message send --to <role> --type <type> --subject "<subject>" --body "<body>"
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--to` | Yes | Target agent role (e.g., `tester`, `coder`) or `all` for broadcast |
+| `--type` | Yes | Message type: `HANDOFF`, `QUESTION`, `STATUS`, `PROGRESS` |
+| `--subject` | No | Short description of the message |
+| `--body` | No | Detailed message content |
+
+The pipeline ID is auto-resolved from `EGG_PIPELINE_ID` if set; otherwise pass it as a positional argument.
+
+### When to Use Each Type
+
+| Type | Use when | Example |
+|------|----------|---------|
+| `HANDOFF` | You've produced an artifact that another agent needs to act on, especially when role boundaries prevent you from completing the work yourself | Coder can't push test files → HANDOFF to tester with file paths |
+| `QUESTION` | You need clarification from a specific agent before you can proceed with your own work | Tester asks coder: "What's the expected return type for `process_batch()`?" |
+| `STATUS` | Your current state affects a peer's decisions or timing | Documenter tells reviewer: "Docs not ready yet, reviewing coder output first" |
+| `PROGRESS` | You've completed a milestone that peers may be waiting on | Coder tells tester: "API endpoints committed and pushed" |
+
+### Worked Example: Role-Boundary Handoff (Coder → Tester)
+
+This example is based on a real coordination gap observed in the issue-1707 pipeline. The coder implemented both source code and tests, but couldn't push the test files because role boundaries restrict the coder to source files only. Without directed messaging, the coder embedded "tester agent should push those" in its proposal text — the tester eventually wrote the tests independently after ~10 minutes of unnecessary delay.
+
+**With directed messaging**, the flow looks like this:
+
+```bash
+# 1. Coder finishes implementation and writes test scaffolding locally,
+#    but can't push test files (role boundary: coder → source files only).
+#    Coder sends a HANDOFF to tester with the test content:
+egg-orch message send --to tester --type HANDOFF \
+  --subject "Test files for new auth module" \
+  --body "I've written test scaffolding in tests/test_auth.py but can't push
+due to role boundaries. The tests cover: login flow, token refresh, and
+session expiry. Key test patterns:
+- test_login_success: POST /auth/login with valid creds → 200 + token
+- test_login_invalid: POST /auth/login with bad creds → 401
+- test_token_refresh: POST /auth/refresh with valid token → new token
+Please pull my latest commit (abc1234) and create the test file."
+
+# 2. Tester receives the HANDOFF on its next poll cycle:
+egg-orch message poll --wait 30
+
+# 3. Tester syncs the worktree to get the coder's latest source code:
+git fetch origin && git merge origin/egg/issue-1707 --no-edit
+
+# 4. Tester writes the tests based on the HANDOFF guidance,
+#    commits, and pushes (tester has write access to test files).
+```
+
+This eliminates the ~10 minute coordination delay — the tester receives an explicit, structured notification and knows exactly what to do.
+
+### Receiving and Acting on Directed Messages
+
+Agents should check for directed messages during their regular poll cycle:
+
+```bash
+# Poll for messages (includes both consensus and directed messages)
+egg-orch message poll --wait 30
+```
+
+When a directed message arrives:
+
+1. **HANDOFF**: Act on the handoff artifact. If it requires work, do the work and acknowledge via a `STATUS` or `PROGRESS` message back.
+2. **QUESTION**: Answer the question via a `STATUS` message or `egg-orch message send --to <asker> --type STATUS`.
+3. **STATUS/PROGRESS**: Use the information to inform your own work — no response required unless the status changes your plan.
+
+### Best Practices
+
+- **Be specific.** Include file paths, commit SHAs, and concrete details — not just "please handle this."
+- **Send early.** Don't wait until your proposal to communicate coordination needs. Send a HANDOFF as soon as you know another agent needs to act.
+- **One message per concern.** Don't bundle unrelated coordination requests in a single message.
+- **Use the right type.** `HANDOFF` signals "you need to do something"; `QUESTION` signals "I'm blocked until you answer"; `STATUS` and `PROGRESS` are informational.
+
 ## Readiness Signaling Protocol
 
 Agents signal their readiness for phase completion using the `readiness` signal type via the pipeline signal endpoint:

--- a/docs/guides/sdlc-pipeline.md
+++ b/docs/guides/sdlc-pipeline.md
@@ -1245,7 +1245,7 @@ Agents communicate via the orchestrator message bus using structured envelopes:
 │  pipeline_id: "issue-999"                            │
 │  from_role: "coder"                                  │
 │  to_role: "tester" | "all"                           │
-│  message_type: "PROGRESS" | "QUESTION" | "STATUS"    │
+│  message_type: "PROGRESS" | "QUESTION" | "STATUS" | "HANDOFF" │
 │  subject: "API endpoints complete"                   │
 │  body: "Implemented GET/POST/DELETE for /api/users"  │
 │  timestamp: "2026-03-11T10:30:00Z"                   │
@@ -1260,13 +1260,17 @@ Agents communicate via the orchestrator message bus using structured envelopes:
 | `QUESTION` | Ask another agent for clarification | Tester: "Expected status for invalid input?" |
 | `RESPONSE` | Reply to a question | Coder: "400 Bad Request" |
 | `STATUS` | Share current activity | Documenter: "Documenting API section" |
+| `HANDOFF` | Signal a role-boundary artifact for another agent | Coder: "Test scaffolding ready — tester should create test files" |
 | `AGENT_FAILED` | System notification of failure | System: "Tester agent crashed" |
 
 **CLI commands**:
 
 ```bash
-# Send a message to another agent
+# Send a progress update to another agent
 egg-orch message send --to tester --type PROGRESS --subject "API done" --body "..."
+
+# Send a role-boundary handoff
+egg-orch message send --to tester --type HANDOFF --subject "Test files ready" --body "See commit abc1234"
 
 # Poll for new messages
 egg-orch message poll [--since msg-abc123] [--limit 50]

--- a/docs/guides/sdlc-pipeline.md
+++ b/docs/guides/sdlc-pipeline.md
@@ -1258,7 +1258,7 @@ Agents communicate via the orchestrator message bus using structured envelopes:
 |------|---------|---------|
 | `PROGRESS` | Notify about completed work | Coder: "API endpoints committed" |
 | `QUESTION` | Ask another agent for clarification | Tester: "Expected status for invalid input?" |
-| `RESPONSE` | Reply to a question | Coder: "400 Bad Request" |
+| `STATUS` (reply) | Reply to a question | Coder: "400 Bad Request" |
 | `STATUS` | Share current activity | Documenter: "Documenting API section" |
 | `HANDOFF` | Signal a role-boundary artifact for another agent | Coder: "Test scaffolding ready — tester should create test files" |
 | `AGENT_FAILED` | System notification of failure | System: "Tester agent crashed" |
@@ -1379,7 +1379,7 @@ Response includes a `concurrent` section:
     "max_concurrent_agents": 6,
     "messages": {
       "total": 12,
-      "by_type": {"PROGRESS": 5, "QUESTION": 3, "RESPONSE": 3, "STATUS": 1}
+      "by_type": {"PROGRESS": 5, "QUESTION": 3, "STATUS": 4, "HANDOFF": 0}
     },
     "consensus": {
       "agents": {

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ This index helps both humans and LLMs navigate the documentation efficiently.
 | [Reusable Workflows](guides/reusable-workflows.md) | Using egg's reusable workflows in external repositories |
 | [SDLC Pipeline](guides/sdlc-pipeline.md) | Operational guide for the structurally enforced SDLC pipeline |
 | [Agent Teams](guides/agent-teams.md) | Agent team communication and Deliberative Consensus (BRC protocol + evidence-backed deliberation) |
-| [Concurrent Execution](guides/concurrent-execution.md) | Concurrent agent execution: message bus, readiness signaling, consensus protocol |
+| [Concurrent Execution](guides/concurrent-execution.md) | Concurrent agent execution: message bus, directed coordination, readiness signaling, consensus protocol |
 | [Checkpoint Access](guides/checkpoint-access.md) | Querying cross-agent checkpoints in multi-agent pipelines |
 | [Pipeline Health Monitoring](guides/pipeline-health-monitoring.md) | Two-tier health monitoring: orchestrator tripwires + overseer agent |
 | [Babysit-PR](guides/babysit-pr.md) | Autonomous PR review/fix loop: conflict resolution, CI fixing, code review, feedback addressing |
@@ -121,6 +121,7 @@ Each major component has detailed documentation:
 | **Agent anchor / recovery changes** | [Anchor Recovery Guide](guides/anchor-recovery.md) | [egg_anchor README](../shared/egg_anchor/README.md), [Orchestrator CLI](reference/orchestrator-cli.md), [Concurrent Execution](guides/concurrent-execution.md) |
 | **Babysit-PR / PR review loops** | [Babysit-PR Guide](guides/babysit-pr.md) | [GitHub Automation](guides/github-automation.md), [SDLC Pipeline Guide](guides/sdlc-pipeline.md), [`egg_babysit` README](../shared/egg_babysit/README.md) |
 | **Concurrent execution mode** | [Concurrent Execution Guide](guides/concurrent-execution.md) | [SDLC Pipeline Guide](guides/sdlc-pipeline.md), [Checkpoint Access](guides/checkpoint-access.md), [Orchestrator Architecture](architecture/orchestrator.md) |
+| **Directed agent coordination** | [Concurrent Execution: Directed Coordination](guides/concurrent-execution.md#directed-coordination) | [Orchestrator CLI](reference/orchestrator-cli.md), [SDLC Pipeline Guide](guides/sdlc-pipeline.md) |
 | **Agent roles and file permissions** | [Agent Roles Reference](reference/agent-roles.md) | [SDLC Pipeline Guide](guides/sdlc-pipeline.md), [Architecture Overview](architecture/README.md) |
 | **Agent failure recovery** | [Agent Recovery Reference](reference/agent-recovery.md) | [Concurrent Execution Guide](guides/concurrent-execution.md), [Orchestrator Architecture](architecture/orchestrator.md) |
 | **Restarting stuck agents/phases** | [Agent Recovery Reference](reference/agent-recovery.md#agent-level-restart) | [Pipeline Health Monitoring](guides/pipeline-health-monitoring.md), [Orchestrator CLI](reference/orchestrator-cli.md), [Phase Management MCP Tools](reference/orchestrator-cli.md#phase-management-mcp-tools) |

--- a/docs/reference/agent-roles.md
+++ b/docs/reference/agent-roles.md
@@ -139,6 +139,8 @@ All agents within a phase run concurrently via BRC consensus. Concurrency is ena
 - Commits on the worktree branch
 - `.egg-state/agent-outputs/{identifier}-coder-output.json` — Handoff data
 
+**Directed coordination**: When role boundaries prevent the coder from pushing certain file types (e.g., test files, documentation), use `egg-orch message send --to <role> --type HANDOFF` to notify the responsible agent with file paths, commit SHAs, and guidance. See [Directed Coordination](../guides/concurrent-execution.md#directed-coordination) for details and a worked coder→tester example.
+
 **Prompt context**: Plan document, summarized background.
 
 ### `tester`
@@ -153,6 +155,8 @@ All agents within a phase run concurrently via BRC consensus. Concurrency is ena
 - Test file commits on the worktree branch
 - `.egg-state/agent-outputs/{identifier}-tester-output.json` — Handoff data (includes lint/type-check results and gaps found)
 
+**Directed coordination**: The tester may receive `HANDOFF` messages from the coder when role boundaries prevent the coder from pushing test files. On receiving a HANDOFF, sync the worktree (`git fetch origin && git merge origin/<branch> --no-edit`), review the coder's guidance, and create the test files. Acknowledge via a `STATUS` or `PROGRESS` message back. See [Directed Coordination](../guides/concurrent-execution.md#directed-coordination).
+
 **Prompt context**: Summarized background, coder handoff data, task list.
 
 ### `documenter`
@@ -166,6 +170,8 @@ All agents within a phase run concurrently via BRC consensus. Concurrency is ena
 **Outputs**:
 - Documentation commits on the worktree branch
 - `.egg-state/agent-outputs/{identifier}-documenter-output.json` — Handoff data
+
+**Directed coordination**: The documenter may receive `STATUS` or `PROGRESS` messages from the coder about API changes, new features, or breaking changes that require documentation updates. Use `QUESTION` messages (`egg-orch message send --to coder --type QUESTION`) to ask for clarification about implementation details when the code diff is ambiguous. See [Directed Coordination](../guides/concurrent-execution.md#directed-coordination).
 
 **Prompt context**: Summarized background, task list, pointers to relevant docs.
 

--- a/docs/reference/orchestrator-cli.md
+++ b/docs/reference/orchestrator-cli.md
@@ -36,7 +36,7 @@ Run `egg-orch --help` for full usage. All commands support `--json` for machine-
 | `egg-orch gateway health` | Check gateway health |
 | `egg-orch gateway phase --issue <n>` | Get current phase from gateway |
 | `egg-orch gateway permissions <phase>` | Get allowed ops for a phase |
-| `egg-orch message send [<id>] --to <role\|all> --type <type> --subject "..." --body "..."` | Send inter-agent message (concurrent mode) |
+| `egg-orch message send [<id>] --to <role\|all> --type <type> --subject "..." --body "..."` | Send directed or broadcast message. Types: `HANDOFF`, `QUESTION`, `STATUS`, `PROGRESS` |
 | `egg-orch message poll [<id>] [--since <id>] [--limit <n>]` | Poll for messages from other agents (concurrent mode) |
 | `egg-orch message status [<id>]` | Get message bus status (concurrent mode) |
 | `egg-orch signal readiness [<id>] --state <WORKING\|READY\|BLOCKED\|OBJECTING> [--reason "..."]` | Signal readiness state (concurrent mode) |
@@ -89,6 +89,26 @@ egg-orch signal progress --percent 50 --task "Running tests"
 egg-orch signal complete --commit abc1234
 egg-orch signal error --error "Test failure" --recoverable
 ```
+
+**Send directed messages to peers (concurrent mode):**
+```bash
+# HANDOFF: Signal a role-boundary artifact for another agent
+egg-orch message send --to tester --type HANDOFF \
+  --subject "Test files for auth module" \
+  --body "Test scaffolding ready — see commit abc1234"
+
+# QUESTION: Ask a specific agent for clarification
+egg-orch message send --to coder --type QUESTION \
+  --subject "Expected return type" \
+  --body "What should process_batch() return on empty input?"
+
+# STATUS: Inform a peer of your current state
+egg-orch message send --to reviewer_code --type STATUS \
+  --subject "Docs in progress" \
+  --body "Documentation not ready for review yet, finishing API docs"
+```
+
+See [Directed Coordination](../guides/concurrent-execution.md#directed-coordination) for detailed usage guidance and worked examples.
 
 **Emit structured progress (health monitoring):**
 ```bash

--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -75,7 +75,7 @@ Pipeline state is stored on a dedicated `egg/pipeline-state` orphan branch acces
 
 By default, agents within the refine, plan, and implement phases run simultaneously via BRC consensus (configurable via `concurrent_phases`). When `concurrent_execution: true` is set, this extends to all phases. Agents coordinate through:
 
-- **Message bus** — Agents exchange typed messages (PROGRESS, QUESTION, RESPONSE, STATUS, AGENT_FAILED) via the orchestrator's message API. Messages can target a specific role or broadcast to all agents.
+- **Message bus** — Agents exchange typed messages (PROGRESS, QUESTION, STATUS, HANDOFF, AGENT_FAILED) via the orchestrator's message API. Messages can target a specific role or broadcast to all agents.
 - **BRC action guards** — Each protocol action (propose, ACK, NACK, confirm, withdraw) has formal preconditions defined in `orchestrator/action_guards.py`. Guards are the canonical protocol specification — `PeerConsensusTracker` delegates to them before mutating state. See [Concurrent Execution — Action Guards](../docs/guides/concurrent-execution.md#action-guards).
 - **Readiness consensus** — Each agent signals its readiness state (WORKING, READY, BLOCKED, OBJECTING). The phase advances only when all agents reach READY. Any OBJECTING agent blocks phase completion.
 - **Shared pipeline branch** — All concurrent agents operate on the pipeline's shared branch (e.g., `egg/issue-999`). Agents coordinate commits via the message bus.

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5460,43 +5460,52 @@ def _build_brc_preamble(
             ]
         )
 
-    # Directed peer-to-peer coordination guidance
-    coord_lines: list[str] = [
-        "### Directed Coordination\n",
-        "Use `egg-orch message send` to communicate directly with specific agents "
-        "when broadcast is unnecessary:\n",
-        "```",
-        'egg-orch message send --to <role> --type <TYPE> --subject "..." --body "..."',
-        "```\n",
-    ]
+    # Directed coordination guidance — role-gated
+    lines.append("### Directed Coordination")
+    lines.append(
+        "In addition to the BRC consensus flow (PROPOSE/ACK/NACK), you can send "
+        "directed peer-to-peer messages to specific agents using "
+        "`egg-orch message send --to <role> --type <TYPE>`. These directed messages "
+        "are **supplementary** to BRC consensus — they do NOT replace the "
+        "PROPOSE/ACK/NACK lifecycle and are never required for consensus to proceed.\n"
+    )
 
     if is_producer:
-        coord_lines.extend(
+        lines.extend(
             [
-                "**As a producer, use:**",
-                "- **HANDOFF**: Signal a downstream agent that your output is ready for them. "
-                "Example: coder → tester after pushing test-relevant commits.",
-                "- **STATUS**: Share progress updates with a specific peer "
-                "(e.g., notify documenter of API changes).\n",
+                "**As a producer**, use directed messages to coordinate handoffs and "
+                "broadcast progress:",
+                "- **HANDOFF**: When your work is ready for a specific peer to act on, "
+                "send a HANDOFF message so they know to begin. For example, a coder "
+                "notifying the tester that implementation is complete.",
+                "  ```",
+                '  egg-orch message send --to tester --type HANDOFF --subject "Auth module ready" '
+                '--body "auth.py is complete, tests can begin"',
+                "  ```",
+                "- **STATUS**: Broadcast progress updates to all agents when you reach "
+                "significant milestones (e.g., halfway through implementation, blocked "
+                "on a dependency).",
+                "  ```",
+                '  egg-orch message send --to all --type STATUS --subject "Implementation 50% complete" '
+                '--body "Core logic done, working on edge cases"',
+                "  ```\n",
             ]
         )
 
     if is_reviewer:
-        coord_lines.extend(
+        lines.extend(
             [
-                "**As a reviewer, use:**",
-                "- **QUESTION**: Ask a producer for clarification before ACK/NACK. "
-                "Prefer this over NACK when the issue might be a misunderstanding.\n",
+                "**As a reviewer**, use directed messages to request clarification:",
+                "- **QUESTION**: Ask a producer for clarification before or during your "
+                "review. This avoids unnecessary NACKs for ambiguities that can be "
+                "resolved with a quick exchange.",
+                "  ```",
+                '  egg-orch message send --to coder --type QUESTION --subject "Clarify auth flow" '
+                '--body "Is the token refresh handled in auth.py or middleware?"',
+                "  ```\n",
             ]
         )
 
-    coord_lines.append(
-        "Only use directed messages for coordination that does NOT fit the "
-        "consensus flow (propose/ack/nack). Never replace a NACK with a QUESTION "
-        "when you've identified a real defect.\n"
-    )
-
-    lines.extend(coord_lines)
 
     lines.extend(
         [

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5506,7 +5506,6 @@ def _build_brc_preamble(
             ]
         )
 
-
     lines.extend(
         [
             "**If you exit before the orchestrator stops you, you have FAILED your role.** "

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5460,6 +5460,44 @@ def _build_brc_preamble(
             ]
         )
 
+    # Directed peer-to-peer coordination guidance
+    coord_lines: list[str] = [
+        "### Directed Coordination\n",
+        "Use `egg-orch message send` to communicate directly with specific agents "
+        "when broadcast is unnecessary:\n",
+        "```",
+        'egg-orch message send --to <role> --type <TYPE> --subject "..." --body "..."',
+        "```\n",
+    ]
+
+    if is_producer:
+        coord_lines.extend(
+            [
+                "**As a producer, use:**",
+                "- **HANDOFF**: Signal a downstream agent that your output is ready for them. "
+                "Example: coder → tester after pushing test-relevant commits.",
+                "- **STATUS**: Share progress updates with a specific peer "
+                "(e.g., notify documenter of API changes).\n",
+            ]
+        )
+
+    if is_reviewer:
+        coord_lines.extend(
+            [
+                "**As a reviewer, use:**",
+                "- **QUESTION**: Ask a producer for clarification before ACK/NACK. "
+                "Prefer this over NACK when the issue might be a misunderstanding.\n",
+            ]
+        )
+
+    coord_lines.append(
+        "Only use directed messages for coordination that does NOT fit the "
+        "consensus flow (propose/ack/nack). Never replace a NACK with a QUESTION "
+        "when you've identified a real defect.\n"
+    )
+
+    lines.extend(coord_lines)
+
     lines.extend(
         [
             "**If you exit before the orchestrator stops you, you have FAILED your role.** "

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -3265,3 +3265,208 @@ class TestAgentPromptBaseBranchPassthrough:
         )
         # Coder prompt uses _build_phase_prompt, not _build_role_context
         assert result  # Just verify it doesn't crash
+
+
+class TestDirectedCoordinationGuidance:
+    """Tests for directed coordination guidance in BRC preamble (issue #1718).
+
+    Validates that ``_build_brc_preamble`` includes the new 'Directed Coordination'
+    section with ``egg-orch message send`` CLI form and role-appropriate guidance
+    for HANDOFF, STATUS, and QUESTION message types.
+    """
+
+    # --- Section presence ---
+
+    def test_preamble_includes_directed_coordination_section(self):
+        """BRC preamble includes the 'Directed Coordination' subsection header."""
+        preamble = _build_brc_preamble("coder", "implement")
+        assert "### Directed Coordination" in preamble
+
+    def test_preamble_includes_message_send_cli(self):
+        """BRC preamble includes the ``egg-orch message send`` CLI example."""
+        preamble = _build_brc_preamble("coder", "implement")
+        assert "egg-orch message send" in preamble
+
+    def test_preamble_includes_cli_full_form(self):
+        """BRC preamble shows the full CLI form with --to, --type, --subject, --body."""
+        preamble = _build_brc_preamble("coder", "implement")
+        assert "--to <role>" in preamble
+        assert "--type <TYPE>" in preamble
+
+    # --- Producer-specific guidance ---
+
+    def test_producer_gets_handoff_guidance(self):
+        """Producer preamble includes HANDOFF guidance."""
+        preamble = _build_brc_preamble("coder", "implement")
+        assert "HANDOFF" in preamble
+
+    def test_producer_gets_status_guidance(self):
+        """Producer preamble includes STATUS guidance for directed messages."""
+        preamble = _build_brc_preamble("coder", "implement")
+        assert "STATUS" in preamble
+
+    def test_producer_handoff_has_example(self):
+        """Producer HANDOFF guidance includes a concrete example."""
+        preamble = _build_brc_preamble("coder", "implement")
+        # Should mention coder → tester as the canonical handoff example
+        assert "coder" in preamble and "tester" in preamble
+
+    def test_producer_guidance_labeled(self):
+        """Producer guidance is labeled 'As a producer'."""
+        preamble = _build_brc_preamble("coder", "implement")
+        assert "As a producer" in preamble
+
+    # --- Reviewer-specific guidance ---
+
+    def test_reviewer_gets_question_guidance(self):
+        """Reviewer preamble includes QUESTION guidance."""
+        preamble = _build_brc_preamble("reviewer_code", "implement")
+        assert "QUESTION" in preamble
+
+    def test_reviewer_guidance_labeled(self):
+        """Reviewer guidance is labeled 'As a reviewer'."""
+        preamble = _build_brc_preamble("reviewer_code", "implement")
+        assert "As a reviewer" in preamble
+
+    def test_reviewer_question_avoids_unnecessary_nacks(self):
+        """Reviewer guidance recommends QUESTION to avoid unnecessary NACKs."""
+        preamble = _build_brc_preamble("reviewer_code", "implement")
+        assert "unnecessary NACKs" in preamble or "NACK" in preamble
+
+    def test_reviewer_does_not_get_producer_guidance(self):
+        """Pure reviewer does not get producer-specific guidance (HANDOFF/STATUS)."""
+        preamble = _build_brc_preamble("reviewer_code", "implement")
+        assert "As a producer" not in preamble
+
+    def test_producer_does_not_get_reviewer_question_guidance(self):
+        """Pure producer does not get reviewer-specific QUESTION guidance."""
+        preamble = _build_brc_preamble("coder", "implement")
+        assert "As a reviewer" not in preamble
+
+    # --- Dual-role agents (tester) ---
+
+    def test_dual_role_gets_both_producer_and_reviewer_guidance(self):
+        """Dual-role agent (tester) gets both producer and reviewer guidance."""
+        preamble = _build_brc_preamble("tester", "implement")
+        assert "As a producer" in preamble
+        assert "As a reviewer" in preamble
+
+    def test_dual_role_gets_handoff_and_question(self):
+        """Dual-role agent gets both HANDOFF and QUESTION guidance."""
+        preamble = _build_brc_preamble("tester", "implement")
+        assert "HANDOFF" in preamble
+        assert "QUESTION" in preamble
+
+    # --- Guard-rail guidance ---
+
+    def test_directed_messages_supplementary_to_consensus(self):
+        """Preamble clarifies directed messages are supplementary to BRC consensus."""
+        preamble = _build_brc_preamble("coder", "implement")
+        assert "supplementary" in preamble or "do NOT replace" in preamble.lower()
+
+    # --- Section ordering ---
+
+    def test_directed_coordination_after_reviewer_lifecycle(self):
+        """Directed Coordination appears after Reviewer Lifecycle for dual-role agents."""
+        preamble = _build_brc_preamble("tester", "implement")
+        reviewer_pos = preamble.index("### Reviewer Lifecycle")
+        coord_pos = preamble.index("### Directed Coordination")
+        assert reviewer_pos < coord_pos, (
+            "Directed Coordination should come after Reviewer Lifecycle"
+        )
+
+    def test_directed_coordination_after_producer_lifecycle(self):
+        """Directed Coordination appears after Producer Lifecycle."""
+        preamble = _build_brc_preamble("coder", "implement")
+        producer_pos = preamble.index("### Producer Lifecycle")
+        coord_pos = preamble.index("### Directed Coordination")
+        assert producer_pos < coord_pos, (
+            "Directed Coordination should come after Producer Lifecycle"
+        )
+
+    def test_directed_coordination_before_exit_warning(self):
+        """Directed Coordination appears before the 'exit = FAILED' warning."""
+        preamble = _build_brc_preamble("coder", "implement")
+        coord_pos = preamble.index("### Directed Coordination")
+        exit_pos = preamble.index("you have FAILED your role")
+        assert coord_pos < exit_pos, "Directed Coordination should come before the exit warning"
+
+    # --- Phase variations ---
+
+    def test_directed_coordination_in_plan_phase(self):
+        """Directed Coordination section is present in plan phase preamble."""
+        preamble = _build_brc_preamble("architect", "plan")
+        assert "### Directed Coordination" in preamble
+        assert "egg-orch message send" in preamble
+
+    def test_directed_coordination_in_refine_phase(self):
+        """Directed Coordination section is present in refine phase preamble."""
+        preamble = _build_brc_preamble("refiner", "refine")
+        assert "### Directed Coordination" in preamble
+        assert "HANDOFF" in preamble
+
+    # --- Contract reviewer (pure reviewer) ---
+
+    def test_contract_reviewer_gets_question_not_handoff_producer_block(self):
+        """Contract reviewer gets QUESTION guidance but not producer HANDOFF block."""
+        preamble = _build_brc_preamble("reviewer_contract", "implement")
+        assert "QUESTION" in preamble
+        assert "As a reviewer" in preamble
+        assert "As a producer" not in preamble
+
+    # --- Full agent prompt integration ---
+
+    def test_directed_coordination_in_concurrent_agent_prompt(self):
+        """Directed Coordination appears in the full agent prompt when concurrent=True."""
+        result = _build_agent_prompt(
+            role_value="coder",
+            phase="implement",
+            pipeline_id="test-pipe",
+            pipeline_mode="issue",
+            prompt="# Feature",
+            issue_number=42,
+            concurrent=True,
+        )
+        assert "### Directed Coordination" in result
+        assert "egg-orch message send" in result
+
+    def test_no_directed_coordination_in_sequential_agent_prompt(self):
+        """Directed Coordination does NOT appear in sequential (non-concurrent) agent prompt."""
+        result = _build_agent_prompt(
+            role_value="coder",
+            phase="implement",
+            pipeline_id="test-pipe",
+            pipeline_mode="issue",
+            prompt="# Feature",
+            issue_number=42,
+            concurrent=False,
+        )
+        assert "### Directed Coordination" not in result
+
+    # --- CLI examples in guidance ---
+
+    def test_producer_handoff_has_cli_example(self):
+        """Producer HANDOFF guidance includes a concrete egg-orch CLI example."""
+        preamble = _build_brc_preamble("coder", "implement")
+        assert "egg-orch message send --to tester --type HANDOFF" in preamble
+
+    def test_producer_status_has_cli_example(self):
+        """Producer STATUS guidance includes a concrete egg-orch CLI example."""
+        preamble = _build_brc_preamble("coder", "implement")
+        assert "egg-orch message send --to all --type STATUS" in preamble
+
+    def test_reviewer_question_has_cli_example(self):
+        """Reviewer QUESTION guidance includes a concrete egg-orch CLI example."""
+        preamble = _build_brc_preamble("reviewer_code", "implement")
+        assert "egg-orch message send --to coder --type QUESTION" in preamble
+
+    # --- Regression guard ---
+
+    def test_revert_of_coordination_detected(self):
+        """If directed coordination is removed, this test fails — regression guard."""
+        preamble = _build_brc_preamble("coder", "implement")
+        # Must contain the CLI example AND at least one message type
+        assert "egg-orch message send" in preamble
+        assert "HANDOFF" in preamble
+        # Must clarify relationship to consensus
+        assert "supplementary" in preamble or "consensus" in preamble.lower()

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -1783,7 +1783,7 @@ def create_parser() -> argparse.ArgumentParser:
     msg_send.add_argument("pipeline_id", nargs="?", help="Pipeline ID")
     msg_send.add_argument("--role", help="Sender role (default: EGG_AGENT_ROLE)")
     msg_send.add_argument("--to", required=True, help="Target role or 'all'")
-    msg_send.add_argument("--type", required=True, help="Message type (PROGRESS, QUESTION, STATUS)")
+    msg_send.add_argument("--type", required=True, help="Message type (PROGRESS, QUESTION, STATUS, HANDOFF)")
     msg_send.add_argument("--subject", help="Message subject")
     msg_send.add_argument("--body", help="Message body")
     _add_json_flag(msg_send)

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -1783,7 +1783,9 @@ def create_parser() -> argparse.ArgumentParser:
     msg_send.add_argument("pipeline_id", nargs="?", help="Pipeline ID")
     msg_send.add_argument("--role", help="Sender role (default: EGG_AGENT_ROLE)")
     msg_send.add_argument("--to", required=True, help="Target role or 'all'")
-    msg_send.add_argument("--type", required=True, help="Message type (PROGRESS, QUESTION, STATUS, HANDOFF)")
+    msg_send.add_argument(
+        "--type", required=True, help="Message type (PROGRESS, QUESTION, STATUS, HANDOFF)"
+    )
     msg_send.add_argument("--subject", help="Message subject")
     msg_send.add_argument("--body", help="Message body")
     _add_json_flag(msg_send)

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -1784,7 +1784,10 @@ def create_parser() -> argparse.ArgumentParser:
     msg_send.add_argument("--role", help="Sender role (default: EGG_AGENT_ROLE)")
     msg_send.add_argument("--to", required=True, help="Target role or 'all'")
     msg_send.add_argument(
-        "--type", required=True, help="Message type (PROGRESS, QUESTION, STATUS, HANDOFF)"
+        "--type",
+        required=True,
+        choices=["PROGRESS", "QUESTION", "STATUS", "HANDOFF"],
+        help="Message type (PROGRESS, QUESTION, STATUS, HANDOFF)",
     )
     msg_send.add_argument("--subject", help="Message subject")
     msg_send.add_argument("--body", help="Message body")

--- a/sandbox/tests/test_brc_cli_args.py
+++ b/sandbox/tests/test_brc_cli_args.py
@@ -1,5 +1,5 @@
 """
-Tests for BRC CLI argument changes (issue #1716).
+Tests for BRC CLI argument changes (issues #1716 and #1718).
 
 Verifies:
 - ``egg-orch consensus ack`` requires ``--reason`` (exits non-zero without it)
@@ -7,8 +7,11 @@ Verifies:
 - ``egg-orch consensus propose`` accepts new structured args
   (``--files-changed``, ``--tests-run``, ``--tasks``) and includes them in
   the signal payload under the correct keys.
+- ``egg-orch message send --type`` help text includes HANDOFF.
+- ``egg-orch message send --type HANDOFF`` parses successfully.
 """
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -262,3 +265,83 @@ class TestProposeStructuredArgsInPayload:
         assert payload["files_changed"] == []
         assert payload["tests_run"] == []
         assert payload["tasks_satisfied"] == []
+
+
+# ---------------------------------------------------------------------------
+# MESSAGE SEND: --type help text includes HANDOFF (issue #1718)
+# ---------------------------------------------------------------------------
+
+
+def _find_msg_send_type_action(
+    parser: argparse.ArgumentParser,
+) -> argparse.Action:
+    """Navigate argparse tree to find the ``--type`` action of ``message send``."""
+    subparsers_group = parser._subparsers
+    assert subparsers_group is not None, "parser has no _subparsers"
+    msg_send_parser: argparse.ArgumentParser | None = None
+    for action in subparsers_group._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            msg_parser = action.choices.get("message")
+            if msg_parser:
+                inner_group = msg_parser._subparsers
+                assert inner_group is not None, "message parser has no _subparsers"
+                for sub_action in inner_group._actions:
+                    if isinstance(sub_action, argparse._SubParsersAction):
+                        msg_send_parser = sub_action.choices.get("send")
+                        break
+            break
+    assert msg_send_parser is not None, "Could not find 'message send' subparser"
+
+    type_action: argparse.Action | None = None
+    for act in msg_send_parser._actions:
+        if hasattr(act, "option_strings") and "--type" in act.option_strings:
+            type_action = act
+            break
+    assert type_action is not None, "Could not find --type argument"
+    return type_action
+
+
+class TestMessageSendTypeHelpText:
+    """``egg-orch message send --type`` help text includes HANDOFF."""
+
+    def test_type_help_includes_handoff(self):
+        """The --type argument help text lists HANDOFF as a valid type."""
+        parser = create_parser()
+        type_action = _find_msg_send_type_action(parser)
+        help_text = type_action.help
+        assert help_text is not None, "--type has no help text"
+        assert "HANDOFF" in help_text, f"Expected 'HANDOFF' in --type help text, got: {help_text}"
+
+    def test_type_help_includes_all_message_types(self):
+        """The --type argument help text lists all expected message types."""
+        parser = create_parser()
+        type_action = _find_msg_send_type_action(parser)
+        help_text = type_action.help
+        assert help_text is not None, "--type has no help text"
+        for msg_type in ("PROGRESS", "QUESTION", "STATUS", "HANDOFF"):
+            assert msg_type in help_text, (
+                f"Expected '{msg_type}' in --type help text, got: {help_text}"
+            )
+
+    def test_message_send_accepts_handoff_type(self):
+        """``egg-orch message send --type HANDOFF`` parses successfully."""
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "message",
+                "send",
+                "issue-42",
+                "--to",
+                "tester",
+                "--type",
+                "HANDOFF",
+                "--subject",
+                "Test files ready",
+                "--body",
+                "See commit abc1234",
+            ]
+        )
+        assert args.type == "HANDOFF"
+        assert args.to == "tester"
+        assert args.subject == "Test files ready"
+        assert args.body == "See commit abc1234"

--- a/sandbox/tests/test_brc_cli_args.py
+++ b/sandbox/tests/test_brc_cli_args.py
@@ -351,3 +351,24 @@ class TestMessageSendTypeHelpText:
         assert args.to == "tester"
         assert args.subject == "Test files ready"
         assert args.body == "See commit abc1234"
+
+    def test_message_send_rejects_invalid_type(self):
+        """``egg-orch message send --type HANDOF`` (typo) exits non-zero."""
+        parser = create_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(
+                [
+                    "message",
+                    "send",
+                    "issue-42",
+                    "--to",
+                    "tester",
+                    "--type",
+                    "HANDOF",
+                    "--subject",
+                    "Test files ready",
+                    "--body",
+                    "See commit abc1234",
+                ]
+            )
+        assert exc_info.value.code != 0

--- a/sandbox/tests/test_brc_cli_args.py
+++ b/sandbox/tests/test_brc_cli_args.py
@@ -275,7 +275,13 @@ class TestProposeStructuredArgsInPayload:
 def _find_msg_send_type_action(
     parser: argparse.ArgumentParser,
 ) -> argparse.Action:
-    """Navigate argparse tree to find the ``--type`` action of ``message send``."""
+    """Navigate argparse tree to find the ``--type`` action of ``message send``.
+
+    NOTE: This helper accesses argparse private APIs (``_subparsers``,
+    ``_SubParsersAction``) because there is no public API for introspecting
+    subparser trees.  If a future Python version changes these internals,
+    update the traversal logic here.
+    """
     subparsers_group = parser._subparsers
     assert subparsers_group is not None, "parser has no _subparsers"
     msg_send_parser: argparse.ArgumentParser | None = None


### PR DESCRIPTION
Resolves #1718. Adds prompt-level guidance for directed peer-to-peer coordination,
fixes CLI --type help text, and documents the pattern with a worked example.

## Test Plan

- Automated: new prompt test asserts `_build_brc_preamble` contains `egg-orch message send` and `HANDOFF`
- Manual: run `egg-orch message send --help` and confirm `HANDOFF` appears
- Manual: read `docs/guides/concurrent-execution.md` new section

## Manual Steps

Pre-merge: none.
Post-merge: none.

## Pipeline Context

Pipeline: `issue-1718-v2`
Issue: #1718

Authored-by: egg