### PR TITLE
Fix three k3s-migration bugs surfaced during #1759 validation

### DIFF
--- a/gateway/contract_api.py
+++ b/gateway/contract_api.py
@@ -35,6 +35,7 @@ from egg_contracts import (
     apply_mutation,
     contract_exists,
     export_contract,
+    get_contract_role,
     load_contract,
     save_contract,
     validate_mutation,
@@ -142,6 +143,21 @@ def _get_worktree_helpers() -> tuple[
     return _cached_worktree_helpers
 
 
+def _resolve_role(value: str) -> Role | None:
+    """Resolve a role string to the coarse contract ``Role``.
+
+    Accepts either a coarse ``Role`` value (``implementer``, ``reviewer``,
+    ``human``, ``system``) or a fine-grained ``AgentRole`` value
+    (``coder``, ``refiner``, ``reviewer_code`` …) that the launcher ships
+    in session metadata. Returns ``None`` for unknown values.
+    """
+    normalized = value.lower()
+    try:
+        return Role(normalized)
+    except ValueError:
+        return get_contract_role(normalized)
+
+
 def get_role_from_context() -> Role | None:
     """
     Get the agent role from workflow context.
@@ -164,10 +180,7 @@ def get_role_from_context() -> Role | None:
     if hasattr(g, "session") and g.session:
         session_role = getattr(g.session, "agent_role", None)
         if session_role:
-            try:
-                return Role(session_role.lower())
-            except ValueError:
-                return None
+            return _resolve_role(session_role)
 
     # Testing path: role can be passed in request header for gateway testing
     # SECURITY: Only enabled when EGG_ENABLE_TEST_ROLE_HEADER=1 to prevent
@@ -175,18 +188,12 @@ def get_role_from_context() -> Role | None:
     if os.environ.get("EGG_ENABLE_TEST_ROLE_HEADER") == "1":
         header_role = request.headers.get("X-Egg-Role")
         if header_role:
-            try:
-                return Role(header_role.lower())
-            except ValueError:
-                return None
+            return _resolve_role(header_role)
 
     # Fallback: check environment (least secure, used in development only)
     env_role = os.environ.get("EGG_AGENT_ROLE")
     if env_role:
-        try:
-            return Role(env_role.lower())
-        except ValueError:
-            return None
+        return _resolve_role(env_role)
 
     return None
 

--- a/gateway/phase_api.py
+++ b/gateway/phase_api.py
@@ -50,6 +50,7 @@ from egg_contracts import (
     ContractValidationError,
     Role,
     apply_mutation,
+    get_contract_role,
     load_contract,
     save_contract,
 )
@@ -112,6 +113,30 @@ def validate_repo_path(repo_path: Path) -> tuple[bool, str]:
     return False, f"Path '{repo_path}' is not within allowed directories"
 
 
+def _resolve_transition_role(value: str) -> TransitionRole | None:
+    """Resolve a role string to a ``TransitionRole``.
+
+    Accepts either a direct ``TransitionRole`` value (``implementer``,
+    ``reviewer``, ``human``) or a fine-grained ``AgentRole`` the launcher
+    stores in session metadata (``coder``, ``refiner``, ``reviewer_*`` …).
+    Returns ``None`` for unknown values or for roles whose coarse mapping
+    is ``system`` — overseer and inspector are observers and do not
+    advance phases.
+    """
+    normalized = value.lower()
+    try:
+        return TransitionRole(normalized)
+    except ValueError:
+        pass
+    contract_role = get_contract_role(normalized)
+    if contract_role is None:
+        return None
+    try:
+        return TransitionRole(contract_role.value)
+    except ValueError:
+        return None
+
+
 def get_role_from_context() -> TransitionRole | None:
     """Get the agent role from workflow context.
 
@@ -127,27 +152,18 @@ def get_role_from_context() -> TransitionRole | None:
     if hasattr(g, "session") and g.session:
         session_role = getattr(g.session, "agent_role", None)
         if session_role:
-            try:
-                return TransitionRole(session_role.lower())
-            except ValueError:
-                return None
+            return _resolve_transition_role(session_role)
 
     # Testing path: role from header (only when enabled)
     if os.environ.get("EGG_ENABLE_TEST_ROLE_HEADER") == "1":
         header_role = request.headers.get("X-Egg-Role")
         if header_role:
-            try:
-                return TransitionRole(header_role.lower())
-            except ValueError:
-                return None
+            return _resolve_transition_role(header_role)
 
     # Fallback: environment variable
     env_role = os.environ.get("EGG_AGENT_ROLE")
     if env_role:
-        try:
-            return TransitionRole(env_role.lower())
-        except ValueError:
-            return None
+        return _resolve_transition_role(env_role)
 
     return None
 

--- a/gateway/session_manager.py
+++ b/gateway/session_manager.py
@@ -513,8 +513,11 @@ class SessionManager:
                 error=str(e),
             )
             # Clean up temp file if it exists
-            if temp_file.exists():
-                temp_file.unlink(missing_ok=True)
+            try:
+                if temp_file.exists():
+                    temp_file.unlink(missing_ok=True)
+            except OSError:
+                pass
 
     def register_session(
         self,

--- a/gateway/tests/test_contract_api.py
+++ b/gateway/tests/test_contract_api.py
@@ -123,6 +123,43 @@ class TestGetRoleFromContext:
         assert role is not None
         assert role.value == "implementer"
 
+    @pytest.mark.parametrize(
+        ("fine_role", "expected_coarse"),
+        [
+            ("coder", "implementer"),
+            ("tester", "implementer"),
+            ("documenter", "implementer"),
+            ("refiner", "implementer"),
+            ("architect", "implementer"),
+            ("task_planner", "implementer"),
+            ("risk_analyst", "implementer"),
+            ("autofixer", "implementer"),
+            ("conflict_resolver", "implementer"),
+            ("reviewer_code", "reviewer"),
+            ("reviewer_contract", "reviewer"),
+            ("reviewer_agent_design", "reviewer"),
+            ("reviewer_refine", "reviewer"),
+            ("reviewer_plan", "reviewer"),
+            ("overseer", "system"),
+            ("inspector", "system"),
+        ],
+    )
+    def test_role_from_session_fine_grained_agent_role(
+        self, client, auth_headers, fine_role, expected_coarse
+    ):
+        """Fine-grained AgentRole values map to coarse contract Role (#1766)."""
+        mock_session = MagicMock()
+        mock_session.agent_role = fine_role
+
+        with client.application.test_request_context():
+            from flask import g
+
+            g.session = mock_session
+            role = contract_api.get_role_from_context()
+
+        assert role is not None, f"fine role {fine_role!r} should resolve"
+        assert role.value == expected_coarse
+
     def test_role_from_x_egg_role_header_when_enabled(self, client, auth_headers):
         """Role is resolved from X-Egg-Role header when EGG_ENABLE_TEST_ROLE_HEADER=1."""
         with (

--- a/gateway/tests/test_error_paths.py
+++ b/gateway/tests/test_error_paths.py
@@ -75,31 +75,30 @@ class TestSessionManagerDiskIOErrors:
             persist_path.chmod(0o644)
 
     def test_save_handles_permission_denied(self, tmp_path):
-        """Manager handles permission denied on save.
+        """Manager swallows permission denied on save and keeps the session in memory.
 
-        Note: The current implementation propagates PermissionError from
-        the cleanup path (temp_file.exists() check). This test documents
-        that behavior. Future improvement could catch this in _save_to_disk.
+        ``_save_to_disk`` catches ``OSError`` (which ``PermissionError`` inherits
+        from) so a failed persistence write does not bubble up and crash the
+        gateway; the session is still registered in memory.
         """
         persist_path = tmp_path / "subdir" / "sessions.json"
         persist_path.parent.mkdir()
 
         manager = SessionManager(persistence_file=persist_path)
 
-        # Make directory unwritable
         persist_path.parent.chmod(0o444)
         try:
-            # Current behavior: raises PermissionError from cleanup path
-            # This documents the current behavior - improvement would be
-            # to handle this gracefully in _save_to_disk
-            with pytest.raises(PermissionError):
-                manager.register_session(
-                    container_id="test-container",
-                    container_ip="172.18.0.5",
-                    mode="private",
-                )
+            _, session = manager.register_session(
+                container_id="test-container",
+                container_ip="172.18.0.5",
+                mode="private",
+            )
         finally:
             persist_path.parent.chmod(0o755)
+
+        assert session.container_id == "test-container"
+        assert manager.list_sessions(), "session should remain registered in memory"
+        assert not persist_path.exists(), "save should have failed silently"
 
     def test_save_handles_disk_full_scenario(self, tmp_path, monkeypatch):
         """Manager handles disk full errors during save."""

--- a/gateway/tests/test_phase_api.py
+++ b/gateway/tests/test_phase_api.py
@@ -407,6 +407,47 @@ class TestGetRoleFromContext:
         assert role is not None
         assert role.value == "reviewer"
 
+    @pytest.mark.parametrize(
+        ("fine_role", "expected"),
+        [
+            ("coder", "implementer"),
+            ("refiner", "implementer"),
+            ("task_planner", "implementer"),
+            ("reviewer_code", "reviewer"),
+            ("reviewer_plan", "reviewer"),
+            ("reviewer_refine", "reviewer"),
+        ],
+    )
+    def test_role_from_session_fine_grained(self, client, auth_headers, fine_role, expected):
+        """Fine-grained AgentRole resolves to the coarse TransitionRole (#1766)."""
+        with client.application.test_request_context():
+            from flask import g
+
+            mock_session = MagicMock()
+            mock_session.agent_role = fine_role
+            g.session = mock_session
+
+            role = phase_api.get_role_from_context()
+
+        assert role is not None, f"fine role {fine_role!r} should resolve"
+        assert role.value == expected
+
+    @pytest.mark.parametrize("fine_role", ["overseer", "inspector"])
+    def test_role_from_session_system_roles_cannot_transition(
+        self, client, auth_headers, fine_role
+    ):
+        """Interface roles map to ``system`` which is not a TransitionRole."""
+        with client.application.test_request_context():
+            from flask import g
+
+            mock_session = MagicMock()
+            mock_session.agent_role = fine_role
+            g.session = mock_session
+
+            role = phase_api.get_role_from_context()
+
+        assert role is None
+
     def test_role_from_header_when_enabled(self, client, auth_headers):
         """Role resolved from header when enabled."""
         with (

--- a/orchestrator/kubernetes_client.py
+++ b/orchestrator/kubernetes_client.py
@@ -868,8 +868,14 @@ class KubernetesClient:
         """Resolve a container_id to a Job name.
 
         If *container_id* already starts with the job prefix it is used
-        as-is; otherwise we try to find a job whose UID matches.  As a
-        last resort the raw value is returned.
+        as-is; otherwise we try to find a Job whose UID matches, then
+        fall back to treating the value as a Pod UID and resolving its
+        owning Job. As a last resort the raw value is returned.
+
+        The Pod-UID path exists because ``list_containers`` (which backs
+        ``mcp__egg__list_containers``) reports ``pod.metadata.uid`` as
+        the ``container_id``, so round-tripping that ID through any
+        container-id-keyed endpoint lands here with a Pod UID.
 
         Raises:
             InvalidNameError: If container_id is empty or contains
@@ -887,7 +893,7 @@ class KubernetesClient:
         if container_id.startswith(self.JOB_PREFIX):
             return container_id
 
-        # Attempt UID lookup
+        # Attempt Job UID lookup
         try:
             jobs = self.batch_api.list_namespaced_job(
                 namespace=self.namespace,
@@ -896,6 +902,29 @@ class KubernetesClient:
             for job in jobs.items:
                 if job.metadata.uid == container_id:
                     return job.metadata.name
+        except Exception:
+            pass
+
+        # Attempt Pod UID lookup — list_containers hands out Pod UIDs,
+        # so callers routinely pass them back in. Prefer the Job's
+        # owner_reference since it survives label-scheme changes across
+        # k8s versions (batch.kubernetes.io/job-name vs job-name).
+        try:
+            pods = self.core_api.list_namespaced_pod(
+                namespace=self.namespace,
+                label_selector=f"{LABEL_ORCHESTRATOR}=true",
+            )
+            for pod in pods.items:
+                if pod.metadata.uid != container_id:
+                    continue
+                for owner in pod.metadata.owner_references or []:
+                    if owner.kind == "Job" and owner.name:
+                        return owner.name
+                labels = pod.metadata.labels or {}
+                for key in ("job-name", "batch.kubernetes.io/job-name"):
+                    if labels.get(key):
+                        return labels[key]
+                break
         except Exception:
             pass
 

--- a/orchestrator/kubernetes_monitor.py
+++ b/orchestrator/kubernetes_monitor.py
@@ -33,6 +33,8 @@ except ImportError:
 
 
 from kubernetes_client import (
+    DEFAULT_NAMESPACE,
+    LABEL_ORCHESTRATOR,
     KubernetesClient,
     KubernetesClientError,
     PodNotFoundError,
@@ -41,6 +43,13 @@ from kubernetes_client import (
 from models import ContainerInfo, ContainerStatus
 
 logger = get_logger("orchestrator.kubernetes_monitor")
+
+# Newly-spawned agent pods may briefly appear "missing" to the
+# periodic reconciler while the pod transitions through Pending /
+# ContainerCreating (image resolution, volume mounts, Agent SDK
+# handshake). Skip reconciliation for agents younger than this so
+# those benign race windows do not trip a FAILED verdict. See #1760.
+POD_STARTUP_GRACE_SECONDS = 60
 
 
 class ContainerEvent:
@@ -345,98 +354,12 @@ class KubernetesMonitor:
 
     def _reconciliation_loop(self) -> None:
         """Background loop for periodic pod reconciliation."""
-        from models import AgentExecutionStatus, PipelineStatus
-
         # Sleep before the first sweep
         time.sleep(self._reconciliation_interval)
 
         while self._reconciliation_running:
             try:
-                live_pods = self.k8s_client.list_containers(all=False)
-                live_ids: set[str] = set()
-                for pod in live_pods:
-                    live_ids.add(pod.container_id)
-                    if pod.pod_name:
-                        live_ids.add(pod.pod_name)
-                    if pod.job_name:
-                        live_ids.add(pod.job_name)
-
-                for store in self._reconciliation_stores:
-                    try:
-                        pipeline_ids: list[str] = store.list_pipelines()
-                    except Exception as e:
-                        logger.warning(
-                            "Periodic reconciliation: could not list pipelines",
-                            error=str(e),
-                        )
-                        continue
-
-                    for pipeline_id in pipeline_ids:
-                        try:
-                            pipeline = store.load_pipeline(pipeline_id)
-                        except Exception:
-                            continue
-
-                        if pipeline.status != PipelineStatus.RUNNING:
-                            continue
-
-                        current_phase_key = pipeline.current_phase.value
-                        phase_execution = pipeline.phases.get(current_phase_key)
-                        if phase_execution is None:
-                            continue
-
-                        for agent in phase_execution.agents:
-                            if (
-                                agent.status == AgentExecutionStatus.RUNNING
-                                and agent.container_id
-                                and agent.container_id not in live_ids
-                            ):
-                                # Check actual exit code
-                                actual_exit_code = self._get_pod_exit_code(agent.container_id)
-                                if actual_exit_code == 0:
-                                    if agent.container_id not in self._clean_exit_skipped:
-                                        logger.info(
-                                            "Pod exited cleanly (code 0), "
-                                            "skipping FAILED reconciliation",
-                                            pipeline_id=pipeline_id,
-                                            container_id=agent.container_id,
-                                            agent_role=str(agent.role),
-                                        )
-                                        self._clean_exit_skipped.add(agent.container_id)
-                                    continue
-
-                                if actual_exit_code == 143 and (
-                                    phase_execution.status != PipelineStatus.RUNNING
-                                ):
-                                    if agent.container_id not in self._clean_exit_skipped:
-                                        logger.info(
-                                            "Pod received SIGTERM during phase "
-                                            "transition (exit 143), skipping FAILED "
-                                            "reconciliation",
-                                            pipeline_id=pipeline_id,
-                                            container_id=agent.container_id,
-                                            agent_role=str(agent.role),
-                                        )
-                                        self._clean_exit_skipped.add(agent.container_id)
-                                    continue
-
-                                # Find matching ContainerInfo
-                                matching_ci = None
-                                for ci in phase_execution.containers:
-                                    if ci.container_id == agent.container_id:
-                                        matching_ci = ci
-                                        break
-
-                                if matching_ci is not None:
-                                    _reconcile_pod_state(store, matching_ci)
-                                else:
-                                    logger.debug(
-                                        "Stale agent has no matching ContainerInfo",
-                                        pipeline_id=pipeline_id,
-                                        container_id=agent.container_id,
-                                        agent_role=str(agent.role),
-                                    )
-
+                self._reconciliation_sweep()
             except Exception as e:
                 logger.warning(
                     "Periodic reconciliation sweep failed",
@@ -444,6 +367,187 @@ class KubernetesMonitor:
                 )
 
             time.sleep(self._reconciliation_interval)
+
+    def _reconciliation_sweep(self) -> None:
+        """Run one pass of periodic reconciliation across all stores.
+
+        Extracted from ``_reconciliation_loop`` so that individual sweeps
+        can be exercised deterministically in unit tests.
+        """
+        from models import AgentExecutionStatus, PipelineStatus
+
+        live_pods = self.k8s_client.list_containers(all=False)
+        live_ids: set[str] = set()
+        for pod in live_pods:
+            live_ids.add(pod.container_id)
+            if pod.pod_name:
+                live_ids.add(pod.pod_name)
+            if pod.job_name:
+                live_ids.add(pod.job_name)
+
+        # Agents register ``container_id`` as the Job UID
+        # (``create_container`` returns ``job.metadata.uid``),
+        # but ``list_containers`` returns *pod* UIDs. Without
+        # also indexing Job UIDs, every running agent is
+        # perpetually identified as "missing" and the next
+        # block's detection path runs on every sweep.
+        namespace = getattr(self.k8s_client, "namespace", DEFAULT_NAMESPACE)
+        try:
+            live_jobs = self.k8s_client.list_jobs(
+                namespace,
+                label_selector=f"{LABEL_ORCHESTRATOR}=true",
+            )
+            for job in live_jobs:
+                live_ids.add(job.container_id)
+                if job.job_name:
+                    live_ids.add(job.job_name)
+        except Exception as e:
+            logger.debug(
+                "Periodic reconciliation: list_jobs failed; live_ids will miss Job UIDs this sweep",
+                error=str(e),
+            )
+
+        now = datetime.now(UTC)
+
+        for store in self._reconciliation_stores:
+            try:
+                pipeline_ids: list[str] = store.list_pipelines()
+            except Exception as e:
+                logger.warning(
+                    "Periodic reconciliation: could not list pipelines",
+                    error=str(e),
+                )
+                continue
+
+            for pipeline_id in pipeline_ids:
+                try:
+                    pipeline = store.load_pipeline(pipeline_id)
+                except Exception:
+                    continue
+
+                if pipeline.status != PipelineStatus.RUNNING:
+                    continue
+
+                current_phase_key = pipeline.current_phase.value
+                phase_execution = pipeline.phases.get(current_phase_key)
+                if phase_execution is None:
+                    continue
+
+                for agent in phase_execution.agents:
+                    if not (
+                        agent.status == AgentExecutionStatus.RUNNING
+                        and agent.container_id
+                        and agent.container_id not in live_ids
+                    ):
+                        continue
+
+                    # Grace period for newly-spawned agents.
+                    # Pods transition Pending → ContainerCreating
+                    # → Running over ~5–30s; reconciling during
+                    # that window produces false positives.
+                    if agent.started_at is not None:
+                        age = (now - agent.started_at).total_seconds()
+                        if age < POD_STARTUP_GRACE_SECONDS:
+                            continue
+
+                    # Defense-in-depth: before marking FAILED,
+                    # confirm the pod is actually terminated.
+                    # A pod is genuinely exited only when its
+                    # container has ``state.terminated`` set —
+                    # Pending / Running / CreateContainerConfigError
+                    # (waiting) are not exits. See #1760.
+                    pod_gone = False
+                    info: ContainerInfo | None = None
+                    try:
+                        info = self.k8s_client.get_container_info(agent.container_id)
+                    except PodNotFoundError:
+                        pod_gone = True
+                    except KubernetesClientError as e:
+                        logger.debug(
+                            "Reconciliation: could not fetch pod info, skipping this sweep",
+                            container_id=agent.container_id,
+                            error=str(e),
+                        )
+                        continue
+
+                    actual_exit_code: int | None = None
+                    if info is not None:
+                        if info.status in (
+                            ContainerStatus.PENDING,
+                            ContainerStatus.CREATING,
+                            ContainerStatus.RUNNING,
+                        ):
+                            logger.debug(
+                                "Reconciliation: pod still alive, skipping FAILED reconciliation",
+                                pipeline_id=pipeline_id,
+                                container_id=agent.container_id[:12],
+                                pod_status=info.status.value,
+                            )
+                            continue
+                        # EXITED / FAILED / REMOVED — the pod has
+                        # reached a terminal state. Require exited_at
+                        # to guard against partial status where only
+                        # phase was mapped.
+                        if info.exited_at is None:
+                            logger.debug(
+                                "Reconciliation: terminal status "
+                                "without exited_at, skipping this sweep",
+                                pipeline_id=pipeline_id,
+                                container_id=agent.container_id[:12],
+                                pod_status=info.status.value,
+                            )
+                            continue
+                        actual_exit_code = info.exit_code
+
+                    if actual_exit_code == 0:
+                        if agent.container_id not in self._clean_exit_skipped:
+                            logger.info(
+                                "Pod exited cleanly (code 0), skipping FAILED reconciliation",
+                                pipeline_id=pipeline_id,
+                                container_id=agent.container_id,
+                                agent_role=str(agent.role),
+                            )
+                            self._clean_exit_skipped.add(agent.container_id)
+                        continue
+
+                    if actual_exit_code == 143 and (
+                        phase_execution.status != PipelineStatus.RUNNING
+                    ):
+                        if agent.container_id not in self._clean_exit_skipped:
+                            logger.info(
+                                "Pod received SIGTERM during phase "
+                                "transition (exit 143), skipping FAILED "
+                                "reconciliation",
+                                pipeline_id=pipeline_id,
+                                container_id=agent.container_id,
+                                agent_role=str(agent.role),
+                            )
+                            self._clean_exit_skipped.add(agent.container_id)
+                        continue
+
+                    matching_ci = None
+                    for ci in phase_execution.containers:
+                        if ci.container_id == agent.container_id:
+                            matching_ci = ci
+                            break
+
+                    if matching_ci is not None:
+                        logger.warning(
+                            "Reconciliation: pod terminated, marking agent FAILED",
+                            pipeline_id=pipeline_id,
+                            container_id=agent.container_id[:12],
+                            agent_role=str(agent.role),
+                            exit_code=actual_exit_code,
+                            pod_gone=pod_gone,
+                        )
+                        _reconcile_pod_state(store, matching_ci)
+                    else:
+                        logger.debug(
+                            "Stale agent has no matching ContainerInfo",
+                            pipeline_id=pipeline_id,
+                            container_id=agent.container_id,
+                            agent_role=str(agent.role),
+                        )
 
     def stop(self) -> None:
         """Stop the monitor and periodic reconciliation."""

--- a/orchestrator/kubernetes_monitor.py
+++ b/orchestrator/kubernetes_monitor.py
@@ -535,7 +535,7 @@ class KubernetesMonitor:
                         logger.warning(
                             "Reconciliation: pod terminated, marking agent FAILED",
                             pipeline_id=pipeline_id,
-                            container_id=agent.container_id[:12],
+                            container_id=agent.container_id,
                             agent_role=str(agent.role),
                             exit_code=actual_exit_code,
                             pod_gone=pod_gone,
@@ -590,21 +590,6 @@ class KubernetesMonitor:
         """
         with self._lock:
             return self._pod_states.get(pod_id)
-
-    def _get_pod_exit_code(self, container_id: str) -> int | None:
-        """Get the exit code of a pod that is no longer in the live list.
-
-        Args:
-            container_id: Container/Job identifier
-
-        Returns:
-            Exit code if available, None otherwise.
-        """
-        try:
-            info = self.k8s_client.get_container_info(container_id)
-            return info.exit_code
-        except KubernetesClientError:
-            return None
 
     def check_container_health(self, container_id: str) -> dict[str, Any]:
         """Check health of a specific pod/Job.
@@ -900,7 +885,7 @@ def _reconcile_pod_state(store: Any, container_info: ContainerInfo) -> bool:
                         logger.warning(
                             "Runtime reconciliation: pod exited, marking FAILED",
                             pipeline_id=pipeline_id,
-                            container_id=container_info.container_id[:12],
+                            container_id=container_info.container_id,
                         )
                         ci.status = ContainerStatus.FAILED
                         ci.exit_code = (
@@ -923,7 +908,7 @@ def _reconcile_pod_state(store: Any, container_info: ContainerInfo) -> bool:
                             "Runtime reconciliation: agent pod exited, marking FAILED",
                             pipeline_id=pipeline_id,
                             agent_role=str(agent.role),
-                            container_id=container_info.container_id[:12],
+                            container_id=container_info.container_id,
                         )
                         agent.status = AgentExecutionStatus.FAILED
                         agent.completed_at = datetime.now(UTC)

--- a/orchestrator/tests/test_container_monitor.py
+++ b/orchestrator/tests/test_container_monitor.py
@@ -1,7 +1,7 @@
 """Tests for container_monitor runtime reconciliation handler."""
 
 import sys
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -53,7 +53,14 @@ from models import (
 
 
 def _make_pipeline_with_running_agent(container_id: str = "abc123") -> Pipeline:
-    """Return a RUNNING pipeline with one RUNNING coder agent."""
+    """Return a RUNNING pipeline with one RUNNING coder agent.
+
+    The agent's ``started_at`` is deliberately set 10 minutes in the
+    past so that reconciliation tests bypass the 60-second
+    ``POD_STARTUP_GRACE_SECONDS`` window (see #1760). Tests that
+    specifically exercise grace-period behavior set ``started_at``
+    explicitly.
+    """
     pipeline = Pipeline(
         id="issue-99",
         issue_number=99,
@@ -67,12 +74,13 @@ def _make_pipeline_with_running_agent(container_id: str = "abc123") -> Pipeline:
     phase.status = PipelineStatus.RUNNING
     phase.started_at = datetime.now(UTC)
 
+    past = datetime.now(UTC) - timedelta(minutes=10)
     phase.containers.append(
         ContainerInfo(
             container_id=container_id,
             container_name="egg-coder-issue-99",
             status=ContainerStatus.RUNNING,
-            started_at=datetime.now(UTC),
+            started_at=past,
         )
     )
     phase.agents.append(
@@ -80,7 +88,7 @@ def _make_pipeline_with_running_agent(container_id: str = "abc123") -> Pipeline:
             role=AgentRole.CODER,
             status=AgentExecutionStatus.RUNNING,
             container_id=container_id,
-            started_at=datetime.now(UTC),
+            started_at=past,
         )
     )
     return pipeline
@@ -655,6 +663,8 @@ class TestPeriodicReconciliation:
 
     def test_logs_missing_container_info(self):
         """Loop logs debug message when agent has no matching ContainerInfo."""
+        from kubernetes_client import PodNotFoundError
+
         container_id = "orphan_agent_abc"
         pipeline = Pipeline(
             id="issue-300",
@@ -668,19 +678,22 @@ class TestPeriodicReconciliation:
         phase = pipeline.get_phase_execution(PipelinePhase.IMPLEMENT)
         phase.status = PipelineStatus.RUNNING
         phase.started_at = datetime.now(UTC)
+        past = datetime.now(UTC) - timedelta(minutes=10)
         # Agent has a container_id but no matching ContainerInfo in phase.containers
         phase.agents.append(
             AgentExecution(
                 role=AgentRole.CODER,
                 status=AgentExecutionStatus.RUNNING,
                 container_id=container_id,
-                started_at=datetime.now(UTC),
+                started_at=past,
             )
         )
         store = _make_store(pipeline)
 
         mock_docker = MagicMock()
         mock_docker.list_containers.return_value = []
+        # Pod is gone — required to progress past the termination check.
+        mock_docker.get_container_info.side_effect = PodNotFoundError("gone")
 
         monitor = ContainerMonitor(docker_client=mock_docker, check_interval=1)
 
@@ -767,19 +780,25 @@ class TestPeriodicReconciliation:
             # SHOULD have called _reconcile — non-zero exit
             mock_reconcile.assert_called()
 
-    def test_reconciles_when_exit_code_unknown(self):
-        """Loop reconciles when container exit code cannot be determined.
+    def test_reconciles_when_pod_gone(self):
+        """PodNotFoundError from get_container_info reconciles as FAILED.
 
-        If get_container_info raises, we err on the side of reconciling.
+        After the issue #1760 fix, reconciliation requires either a
+        confirmed-terminated status or a ``PodNotFoundError`` — a
+        generic API error (which may be transient) leaves the sweep
+        to try again, rather than falsely marking a still-alive pod
+        as FAILED. This test covers the "pod is truly gone" branch.
         """
-        container_id = "unknown_exit_abc"
+        from kubernetes_client import PodNotFoundError
+
+        container_id = "gone_abc"
         pipeline = _make_pipeline_with_running_agent(container_id)
         store = _make_store(pipeline)
 
         mock_docker = MagicMock()
         mock_docker.list_containers.return_value = []
-        # Docker can't inspect the container (already removed)
-        mock_docker.get_container_info.side_effect = DockerClientError("container removed")
+        # Pod has been deleted — PodNotFoundError surfaces from the API
+        mock_docker.get_container_info.side_effect = PodNotFoundError("pod gone")
 
         monitor = ContainerMonitor(docker_client=mock_docker, check_interval=1)
 
@@ -790,9 +809,33 @@ class TestPeriodicReconciliation:
 
             _run_one_reconciliation_sweep(monitor)
 
-            # SHOULD have called _reconcile — unknown exit code errs on caution
             mock_reconcile.assert_called()
-            # Verify the correct store and container were reconciled
             call_args = mock_reconcile.call_args
-            assert call_args[0][0] is store  # first positional arg is the store
+            assert call_args[0][0] is store
             assert call_args[0][1].container_id == container_id
+
+    def test_skips_on_transient_api_error(self):
+        """A transient API error skips reconciliation for this sweep.
+
+        Regression guard for #1760: the old code reconciled when the
+        exit-code lookup raised *any* error, which produced false
+        positives when a running pod's status was briefly unavailable.
+        """
+        container_id = "flaky_abc"
+        pipeline = _make_pipeline_with_running_agent(container_id)
+        store = _make_store(pipeline)
+
+        mock_docker = MagicMock()
+        mock_docker.list_containers.return_value = []
+        mock_docker.get_container_info.side_effect = DockerClientError("transient API error")
+
+        monitor = ContainerMonitor(docker_client=mock_docker, check_interval=1)
+
+        with patch("kubernetes_monitor._reconcile_pod_state") as mock_reconcile:
+            monitor._reconciliation_stores = [store]
+            monitor._reconciliation_running = True
+            monitor._reconciliation_interval = 0.01
+
+            _run_one_reconciliation_sweep(monitor)
+
+            mock_reconcile.assert_not_called()

--- a/orchestrator/tests/test_container_monitor.py
+++ b/orchestrator/tests/test_container_monitor.py
@@ -584,6 +584,7 @@ class TestPeriodicReconciliation:
         mock_docker = MagicMock()
         # No live containers — the agent's container is missing
         mock_docker.list_containers.return_value = []
+        mock_docker.list_jobs.return_value = []
 
         monitor = ContainerMonitor(docker_client=mock_docker, check_interval=1)
 
@@ -609,6 +610,7 @@ class TestPeriodicReconciliation:
 
         mock_docker = MagicMock()
         mock_docker.list_containers.return_value = []
+        mock_docker.list_jobs.return_value = []
 
         monitor = ContainerMonitor(docker_client=mock_docker, check_interval=1)
 
@@ -629,6 +631,7 @@ class TestPeriodicReconciliation:
 
         mock_docker = MagicMock()
         mock_docker.list_containers.return_value = []
+        mock_docker.list_jobs.return_value = []
 
         monitor = ContainerMonitor(docker_client=mock_docker, check_interval=1)
 
@@ -646,6 +649,7 @@ class TestPeriodicReconciliation:
         """stop() properly terminates and joins the reconciliation thread."""
         mock_docker = MagicMock()
         mock_docker.list_containers.return_value = []
+        mock_docker.list_jobs.return_value = []
 
         monitor = ContainerMonitor(docker_client=mock_docker, check_interval=1)
 
@@ -692,6 +696,7 @@ class TestPeriodicReconciliation:
 
         mock_docker = MagicMock()
         mock_docker.list_containers.return_value = []
+        mock_docker.list_jobs.return_value = []
         # Pod is gone — required to progress past the termination check.
         mock_docker.get_container_info.side_effect = PodNotFoundError("gone")
 
@@ -727,6 +732,7 @@ class TestPeriodicReconciliation:
         mock_docker = MagicMock()
         # Container is NOT in live list (it exited)
         mock_docker.list_containers.return_value = []
+        mock_docker.list_jobs.return_value = []
         # But when we inspect it, exit code is 0
         mock_docker.get_container_info.return_value = ContainerInfo(
             container_id=container_id,
@@ -759,6 +765,7 @@ class TestPeriodicReconciliation:
 
         mock_docker = MagicMock()
         mock_docker.list_containers.return_value = []
+        mock_docker.list_jobs.return_value = []
         # Non-zero exit code
         mock_docker.get_container_info.return_value = ContainerInfo(
             container_id=container_id,
@@ -797,6 +804,7 @@ class TestPeriodicReconciliation:
 
         mock_docker = MagicMock()
         mock_docker.list_containers.return_value = []
+        mock_docker.list_jobs.return_value = []
         # Pod has been deleted — PodNotFoundError surfaces from the API
         mock_docker.get_container_info.side_effect = PodNotFoundError("pod gone")
 
@@ -827,6 +835,7 @@ class TestPeriodicReconciliation:
 
         mock_docker = MagicMock()
         mock_docker.list_containers.return_value = []
+        mock_docker.list_jobs.return_value = []
         mock_docker.get_container_info.side_effect = DockerClientError("transient API error")
 
         monitor = ContainerMonitor(docker_client=mock_docker, check_interval=1)

--- a/orchestrator/tests/test_kubernetes_client.py
+++ b/orchestrator/tests/test_kubernetes_client.py
@@ -1477,15 +1477,87 @@ class TestResolveJobName:
 
         assert result == "egg-sandbox-found"
 
+    def test_pod_uid_lookup_via_owner_reference(
+        self,
+        k8s_client: KubernetesClient,
+        mock_batch_api: MagicMock,
+        mock_core_api: MagicMock,
+    ):
+        """Pod UID should resolve to its owning Job via owner_references.
+
+        list_containers returns pod.metadata.uid as container_id, so
+        callers routinely pass a Pod UID into container-id-keyed
+        routes (get_container_logs, get_container_info, stop_container,
+        remove_container). Without this path those all 404. See #1764.
+        """
+        mock_batch_api.list_namespaced_job.return_value = MagicMock(items=[])
+
+        owner = MagicMock()
+        owner.kind = "Job"
+        owner.name = "egg-sandbox-refiner"
+        pod = _make_mock_pod(uid="pod-uid-xyz")
+        pod.metadata.owner_references = [owner]
+
+        mock_core_api.list_namespaced_pod.return_value = MagicMock(items=[pod])
+
+        result = k8s_client._resolve_job_name("pod-uid-xyz")
+
+        assert result == "egg-sandbox-refiner"
+
+    def test_pod_uid_lookup_via_job_name_label(
+        self,
+        k8s_client: KubernetesClient,
+        mock_batch_api: MagicMock,
+        mock_core_api: MagicMock,
+    ):
+        """Fall back to the job-name label when owner_references is absent."""
+        mock_batch_api.list_namespaced_job.return_value = MagicMock(items=[])
+
+        pod = _make_mock_pod(
+            uid="pod-uid-xyz",
+            labels={LABEL_ORCHESTRATOR: "true", "job-name": "egg-sandbox-reviewer"},
+        )
+        pod.metadata.owner_references = None
+
+        mock_core_api.list_namespaced_pod.return_value = MagicMock(items=[pod])
+
+        result = k8s_client._resolve_job_name("pod-uid-xyz")
+
+        assert result == "egg-sandbox-reviewer"
+
+    def test_pod_uid_lookup_via_batch_prefixed_label(
+        self,
+        k8s_client: KubernetesClient,
+        mock_batch_api: MagicMock,
+        mock_core_api: MagicMock,
+    ):
+        """Accept the batch.kubernetes.io/job-name label variant too."""
+        mock_batch_api.list_namespaced_job.return_value = MagicMock(items=[])
+
+        pod = _make_mock_pod(
+            uid="pod-uid-xyz",
+            labels={
+                LABEL_ORCHESTRATOR: "true",
+                "batch.kubernetes.io/job-name": "egg-sandbox-overseer",
+            },
+        )
+        pod.metadata.owner_references = None
+
+        mock_core_api.list_namespaced_pod.return_value = MagicMock(items=[pod])
+
+        result = k8s_client._resolve_job_name("pod-uid-xyz")
+
+        assert result == "egg-sandbox-overseer"
+
     def test_uid_not_found_returns_raw(
         self,
         k8s_client: KubernetesClient,
         mock_batch_api: MagicMock,
+        mock_core_api: MagicMock,
     ):
-        """When UID doesn't match any job, return raw container_id."""
-        mock_result = MagicMock()
-        mock_result.items = []
-        mock_batch_api.list_namespaced_job.return_value = mock_result
+        """When UID matches no Job and no Pod, return the raw container_id."""
+        mock_batch_api.list_namespaced_job.return_value = MagicMock(items=[])
+        mock_core_api.list_namespaced_pod.return_value = MagicMock(items=[])
 
         result = k8s_client._resolve_job_name("unknown-id")
 
@@ -1495,13 +1567,116 @@ class TestResolveJobName:
         self,
         k8s_client: KubernetesClient,
         mock_batch_api: MagicMock,
+        mock_core_api: MagicMock,
     ):
-        """API failure during UID lookup should return raw container_id."""
+        """API failures during either lookup should fall back to the raw ID."""
         mock_batch_api.list_namespaced_job.side_effect = Exception("API error")
+        mock_core_api.list_namespaced_pod.side_effect = Exception("API error")
 
         result = k8s_client._resolve_job_name("some-id")
 
         assert result == "some-id"
+
+
+# ---------------------------------------------------------------------------
+# Pod-UID round-trip (regression coverage for #1764)
+# ---------------------------------------------------------------------------
+
+
+class TestPodUidRoundTrip:
+    """End-to-end coverage for passing Pod UIDs into container-id-keyed ops.
+
+    ``list_containers`` returns ``pod.metadata.uid`` as ``container_id``,
+    so callers round-trip Pod UIDs back into these routes. Before the
+    fix for #1764, every container-id-keyed operation 404'd on k8s
+    because ``_resolve_job_name`` couldn't translate a Pod UID to a Job
+    name. These tests pin the end-to-end behaviour.
+    """
+
+    POD_UID = "6b6fd3a8-a6c4-49eb-a9bb-8f1766984ae9"
+    JOB_NAME = "egg-sandbox-issue-1759-refiner"
+    POD_NAME = "egg-sandbox-issue-1759-refiner-ccdgx"
+
+    def _wire_pod_uid_lookup(
+        self,
+        mock_batch_api: MagicMock,
+        mock_core_api: MagicMock,
+        pod: MagicMock,
+    ) -> None:
+        """Point both Job-UID and Pod-UID lookups at a single owning Job.
+
+        ``_resolve_job_name`` tries Jobs first, then Pods. ``get_pod_for_job``
+        reuses the same ``list_namespaced_pod`` mock, so the returned pod
+        must satisfy both the UID scan and the subsequent name lookup.
+        """
+        mock_batch_api.list_namespaced_job.return_value = MagicMock(items=[])
+        mock_core_api.list_namespaced_pod.return_value = MagicMock(items=[pod])
+
+    def _make_owned_pod(self, phase: str = "Running") -> MagicMock:
+        owner = MagicMock()
+        owner.kind = "Job"
+        owner.name = self.JOB_NAME
+        pod = _make_mock_pod(name=self.POD_NAME, uid=self.POD_UID, phase=phase)
+        pod.metadata.owner_references = [owner]
+        pod.status.container_statuses = None
+        return pod
+
+    def test_get_container_logs_by_pod_uid(
+        self,
+        k8s_client: KubernetesClient,
+        mock_batch_api: MagicMock,
+        mock_core_api: MagicMock,
+    ):
+        """get_container_logs must work when given a Pod UID."""
+        self._wire_pod_uid_lookup(mock_batch_api, mock_core_api, self._make_owned_pod())
+        mock_core_api.read_namespaced_pod_log.return_value = "agent tool call ✓\n"
+
+        logs = k8s_client.get_container_logs(self.POD_UID)
+
+        assert "agent tool call" in logs
+
+    def test_get_container_info_by_pod_uid(
+        self,
+        k8s_client: KubernetesClient,
+        mock_batch_api: MagicMock,
+        mock_core_api: MagicMock,
+    ):
+        """get_container_info must work when given a Pod UID."""
+        pod = self._make_owned_pod()
+        self._wire_pod_uid_lookup(mock_batch_api, mock_core_api, pod)
+        mock_core_api.read_namespaced_pod.return_value = pod
+
+        info = k8s_client.get_container_info(self.POD_UID)
+
+        assert info.status == ContainerStatus.RUNNING
+
+    def test_stop_container_by_pod_uid(
+        self,
+        k8s_client: KubernetesClient,
+        mock_batch_api: MagicMock,
+        mock_core_api: MagicMock,
+    ):
+        """stop_container must delete the owning Job when given a Pod UID."""
+        self._wire_pod_uid_lookup(mock_batch_api, mock_core_api, self._make_owned_pod())
+
+        k8s_client.stop_container(self.POD_UID)
+
+        call_kwargs = mock_batch_api.delete_namespaced_job.call_args.kwargs
+        assert call_kwargs["name"] == self.JOB_NAME
+
+    def test_remove_container_by_pod_uid(
+        self,
+        k8s_client: KubernetesClient,
+        mock_batch_api: MagicMock,
+        mock_core_api: MagicMock,
+    ):
+        """remove_container must delete the owning Job when given a Pod UID."""
+        self._wire_pod_uid_lookup(mock_batch_api, mock_core_api, self._make_owned_pod())
+
+        k8s_client.remove_container(self.POD_UID)
+
+        call_kwargs = mock_batch_api.delete_namespaced_job.call_args.kwargs
+        assert call_kwargs["name"] == self.JOB_NAME
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_kubernetes_monitor.py
+++ b/orchestrator/tests/test_kubernetes_monitor.py
@@ -775,3 +775,258 @@ class TestPeriodicReconciliation:
         monitor.start_periodic_reconciliation(mock_store, interval=1)
         monitor.stop()
         assert monitor._reconciliation_running is False
+
+
+# ---------------------------------------------------------------------------
+# TestReconciliationSweep
+#
+# Covers the false-positive fixes from issue #1760: agents register their
+# ``container_id`` as the Job UID, but ``list_containers`` returns Pod
+# UIDs — so without the Job-UID index and the termination guard, every
+# Pending/Running pod was being marked FAILED within ~15s of spawn.
+# ---------------------------------------------------------------------------
+
+
+class TestReconciliationSweep:
+    """Test _reconciliation_sweep termination and grace-period logic."""
+
+    def _make_pipeline(
+        self,
+        *,
+        container_id: str,
+        ci_status: ContainerStatus = ContainerStatus.RUNNING,
+        agent_started_at: datetime | None = None,
+    ):
+        from models import (
+            AgentExecution,
+            AgentExecutionStatus,
+            PhaseExecution,
+            Pipeline,
+            PipelinePhase,
+            PipelineStatus,
+        )
+
+        agent = AgentExecution(
+            role="coder",
+            status=AgentExecutionStatus.RUNNING,
+            container_id=container_id,
+            started_at=agent_started_at,
+        )
+        ci = ContainerInfo(
+            container_id=container_id,
+            container_name="job-1",
+            status=ci_status,
+        )
+        phase_exec = PhaseExecution(
+            phase=PipelinePhase.IMPLEMENT,
+            status=PipelineStatus.RUNNING,
+            agents=[agent],
+            containers=[ci],
+        )
+        pipeline = Pipeline(
+            id="pipe-1",
+            issue_number=1,
+            repo="owner/repo",
+            status=PipelineStatus.RUNNING,
+            current_phase=PipelinePhase.IMPLEMENT,
+            phases={"implement": phase_exec},
+        )
+        store = MagicMock()
+        store.list_pipelines.return_value = [pipeline.id]
+        store.load_pipeline.return_value = pipeline
+        return pipeline, store
+
+    def test_running_pod_not_reconciled(self, monitor, mock_k8s_client):
+        """A pod whose state is still Running must not be marked FAILED.
+
+        Regression test for #1760: the reconciler previously flagged
+        newly-spawned pods as exited because get_container_info returned
+        no exit_code for Running pods and the code fell through to the
+        FAILED path.
+        """
+        # live_ids is empty — simulating the old bug where Job UIDs
+        # were not indexed.
+        mock_k8s_client.list_containers.return_value = []
+        mock_k8s_client.list_jobs.return_value = []
+        mock_k8s_client.get_container_info.return_value = ContainerInfo(
+            container_id="job-uid-1",
+            container_name="job-1",
+            status=ContainerStatus.RUNNING,
+            started_at=datetime.now(UTC),
+        )
+        spawned_long_ago = datetime.now(UTC).replace(year=2024)
+        _, store = self._make_pipeline(
+            container_id="job-uid-1",
+            agent_started_at=spawned_long_ago,
+        )
+        monitor._reconciliation_stores = [store]
+
+        with patch("state_store.get_pipeline_state_lock") as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock()
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+            monitor._reconciliation_sweep()
+
+        store.save_pipeline.assert_not_called()
+
+    def test_pending_pod_not_reconciled(self, monitor, mock_k8s_client):
+        """A Pending / ContainerCreating pod must not be marked FAILED."""
+        mock_k8s_client.list_containers.return_value = []
+        mock_k8s_client.list_jobs.return_value = []
+        mock_k8s_client.get_container_info.return_value = ContainerInfo(
+            container_id="job-uid-1",
+            container_name="job-1",
+            status=ContainerStatus.PENDING,
+        )
+        spawned_long_ago = datetime.now(UTC).replace(year=2024)
+        _, store = self._make_pipeline(
+            container_id="job-uid-1",
+            agent_started_at=spawned_long_ago,
+        )
+        monitor._reconciliation_stores = [store]
+
+        with patch("state_store.get_pipeline_state_lock") as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock()
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+            monitor._reconciliation_sweep()
+
+        store.save_pipeline.assert_not_called()
+
+    def test_grace_period_skips_recent_agents(self, monitor, mock_k8s_client):
+        """Agents spawned within POD_STARTUP_GRACE_SECONDS are skipped.
+
+        The termination check should never be reached during the grace
+        period — so we set get_container_info to raise to prove it.
+        """
+        mock_k8s_client.list_containers.return_value = []
+        mock_k8s_client.list_jobs.return_value = []
+        mock_k8s_client.get_container_info.side_effect = AssertionError(
+            "should not be called inside grace period"
+        )
+        _, store = self._make_pipeline(
+            container_id="job-uid-1",
+            agent_started_at=datetime.now(UTC),
+        )
+        monitor._reconciliation_stores = [store]
+
+        with patch("state_store.get_pipeline_state_lock") as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock()
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+            monitor._reconciliation_sweep()
+
+        store.save_pipeline.assert_not_called()
+
+    def test_job_uid_in_live_ids_skips_reconciliation(self, monitor, mock_k8s_client):
+        """list_jobs results are indexed, so Job UID matches live_ids."""
+        from kubernetes_monitor import LABEL_ORCHESTRATOR
+
+        mock_k8s_client.namespace = "egg-agents"
+        mock_k8s_client.list_containers.return_value = []
+        mock_k8s_client.list_jobs.return_value = [
+            ContainerInfo(
+                container_id="job-uid-1",
+                container_name="egg-sandbox-1",
+                status=ContainerStatus.RUNNING,
+                job_name="egg-sandbox-1",
+            )
+        ]
+        mock_k8s_client.get_container_info.side_effect = AssertionError(
+            "should not be called when Job UID is in live_ids"
+        )
+        spawned_long_ago = datetime.now(UTC).replace(year=2024)
+        _, store = self._make_pipeline(
+            container_id="job-uid-1",
+            agent_started_at=spawned_long_ago,
+        )
+        monitor._reconciliation_stores = [store]
+
+        with patch("state_store.get_pipeline_state_lock") as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock()
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+            monitor._reconciliation_sweep()
+
+        store.save_pipeline.assert_not_called()
+        # Verify list_jobs was queried with the orchestrator label
+        call_kwargs = mock_k8s_client.list_jobs.call_args
+        assert call_kwargs.kwargs["label_selector"] == f"{LABEL_ORCHESTRATOR}=true"
+
+    def test_terminated_pod_marks_failed(self, monitor, mock_k8s_client):
+        """A pod with exited_at set and non-zero exit is reconciled."""
+        from models import PipelineStatus
+
+        mock_k8s_client.list_containers.return_value = []
+        mock_k8s_client.list_jobs.return_value = []
+        mock_k8s_client.get_container_info.return_value = ContainerInfo(
+            container_id="job-uid-1",
+            container_name="job-1",
+            status=ContainerStatus.FAILED,
+            exit_code=1,
+            exited_at=datetime.now(UTC),
+        )
+        spawned_long_ago = datetime.now(UTC).replace(year=2024)
+        _, store = self._make_pipeline(
+            container_id="job-uid-1",
+            agent_started_at=spawned_long_ago,
+        )
+        monitor._reconciliation_stores = [store]
+
+        with patch("state_store.get_pipeline_state_lock") as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock()
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+            monitor._reconciliation_sweep()
+
+        store.save_pipeline.assert_called_once()
+        saved = store.save_pipeline.call_args[0][0]
+        assert saved.status == PipelineStatus.FAILED
+
+    def test_missing_pod_marks_failed(self, monitor, mock_k8s_client):
+        """A pod that has been deleted (PodNotFoundError) is reconciled."""
+        from models import PipelineStatus
+
+        mock_k8s_client.list_containers.return_value = []
+        mock_k8s_client.list_jobs.return_value = []
+        mock_k8s_client.get_container_info.side_effect = PodNotFoundError("gone")
+        spawned_long_ago = datetime.now(UTC).replace(year=2024)
+        _, store = self._make_pipeline(
+            container_id="job-uid-1",
+            agent_started_at=spawned_long_ago,
+        )
+        monitor._reconciliation_stores = [store]
+
+        with patch("state_store.get_pipeline_state_lock") as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock()
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+            monitor._reconciliation_sweep()
+
+        store.save_pipeline.assert_called_once()
+        saved = store.save_pipeline.call_args[0][0]
+        assert saved.status == PipelineStatus.FAILED
+
+    def test_terminal_status_without_exited_at_not_reconciled(self, monitor, mock_k8s_client):
+        """A half-populated terminal status (no exited_at) is skipped.
+
+        Guards against edge cases where the pod phase mapping produced
+        ``EXITED`` from ``Succeeded`` without the API having populated
+        ``containerStatuses[0].state.terminated.finished_at`` yet.
+        """
+        mock_k8s_client.list_containers.return_value = []
+        mock_k8s_client.list_jobs.return_value = []
+        mock_k8s_client.get_container_info.return_value = ContainerInfo(
+            container_id="job-uid-1",
+            container_name="job-1",
+            status=ContainerStatus.EXITED,
+            exit_code=None,
+            exited_at=None,
+        )
+        spawned_long_ago = datetime.now(UTC).replace(year=2024)
+        _, store = self._make_pipeline(
+            container_id="job-uid-1",
+            agent_started_at=spawned_long_ago,
+        )
+        monitor._reconciliation_stores = [store]
+
+        with patch("state_store.get_pipeline_state_lock") as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock()
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+            monitor._reconciliation_sweep()
+
+        store.save_pipeline.assert_not_called()

--- a/orchestrator/tests/test_kubernetes_monitor.py
+++ b/orchestrator/tests/test_kubernetes_monitor.py
@@ -469,24 +469,6 @@ class TestCheckContainerHealth:
 # ---------------------------------------------------------------------------
 
 
-class TestGetPodExitCode:
-    """Test _get_pod_exit_code method."""
-
-    def test_returns_exit_code(self, monitor, mock_k8s_client):
-        """Returns exit code from k8s API."""
-        mock_k8s_client.get_container_info.return_value = ContainerInfo(
-            container_id="u",
-            container_name="n",
-            exit_code=42,
-        )
-        assert monitor._get_pod_exit_code("job-1") == 42
-
-    def test_returns_none_on_error(self, monitor, mock_k8s_client):
-        """Returns None when k8s call fails."""
-        mock_k8s_client.get_container_info.side_effect = KubernetesClientError("fail")
-        assert monitor._get_pod_exit_code("job-1") is None
-
-
 # ---------------------------------------------------------------------------
 # TestGetKubernetesMonitor
 # ---------------------------------------------------------------------------
@@ -914,6 +896,34 @@ class TestReconciliationSweep:
             monitor._reconciliation_sweep()
 
         store.save_pipeline.assert_not_called()
+
+    def test_grace_period_skipped_when_started_at_none(self, monitor, mock_k8s_client):
+        """When started_at is None the grace period is bypassed.
+
+        An agent with ``started_at=None`` (e.g. incomplete timestamp
+        initialisation) should be treated as "old" — the sweep should
+        fall through to the termination check rather than skipping
+        indefinitely.
+        """
+        mock_k8s_client.list_containers.return_value = []
+        mock_k8s_client.list_jobs.return_value = []
+        # Pod is truly gone — should proceed to FAILED reconciliation.
+        mock_k8s_client.get_container_info.side_effect = PodNotFoundError("gone")
+        _, store = self._make_pipeline(
+            container_id="job-uid-1",
+            agent_started_at=None,
+        )
+        monitor._reconciliation_stores = [store]
+
+        with patch("state_store.get_pipeline_state_lock") as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock()
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+            monitor._reconciliation_sweep()
+
+        # started_at=None means the grace period is not applied, so the
+        # sweep should reach the termination check.  With PodNotFoundError
+        # the pod is confirmed gone and reconciliation should fire.
+        store.save_pipeline.assert_called()
 
     def test_job_uid_in_live_ids_skips_reconciliation(self, monitor, mock_k8s_client):
         """list_jobs results are indexed, so Job UID matches live_ids."""

--- a/shared/egg_contracts/__init__.py
+++ b/shared/egg_contracts/__init__.py
@@ -48,6 +48,7 @@ from .agent_recovery import (
     create_retry_manager,
 )
 from .agent_roles import (
+    AGENT_ROLE_TO_CONTRACT_ROLE,
     AGENT_ROLES,
     ARCHITECT_ROLE,
     AUTOFIXER_ROLE,
@@ -71,6 +72,7 @@ from .agent_roles import (
     create_execution_for_role,
     detect_write_overlaps,
     get_all_roles,
+    get_contract_role,
     get_file_patterns,
     get_role_definition,
     get_role_dependencies,
@@ -330,6 +332,7 @@ __all__ = [
     "retry_with_backoff",
     "should_checkpoint_now",
     # Agent Roles
+    "AGENT_ROLE_TO_CONTRACT_ROLE",
     "AGENT_ROLES",
     "ARCHITECT_ROLE",
     "AUTOFIXER_ROLE",
@@ -353,6 +356,7 @@ __all__ = [
     "create_execution_for_role",
     "detect_write_overlaps",
     "get_all_roles",
+    "get_contract_role",
     "get_file_patterns",
     "get_role_definition",
     "get_role_dependencies",

--- a/shared/egg_contracts/agent_roles.py
+++ b/shared/egg_contracts/agent_roles.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
+from .roles import Role
+
 
 class AgentCategory(StrEnum):
     """Category classification for agent roles.
@@ -836,6 +838,52 @@ AGENT_ROLES: dict[AgentRole, AgentRoleDefinition] = {
 # Canonical set of execution role string values — used by the schema,
 # plan parser, and orchestrator for role validation and filtering.
 EXECUTION_ROLE_VALUES = frozenset({AgentRole.CODER, AgentRole.TESTER, AgentRole.DOCUMENTER})
+
+
+# Maps the fine-grained ``AgentRole`` shipped in agent sessions to the
+# coarse-grained ``Role`` enum used for contract field-ownership checks.
+# The gateway's contract and phase APIs consult this to authorize an
+# agent's request — without it, a session with ``agent_role="refiner"``
+# fails ``Role("refiner")`` and the API responds 403 (#1766).
+AGENT_ROLE_TO_CONTRACT_ROLE: dict[AgentRole, Role] = {
+    # Execution: produce code, own implementer-owned contract fields
+    AgentRole.CODER: Role.IMPLEMENTER,
+    AgentRole.TESTER: Role.IMPLEMENTER,
+    AgentRole.DOCUMENTER: Role.IMPLEMENTER,
+    # Analysis: draft plans and analyses; write the same contract fields
+    # an implementer does (commits, notes, decisions).
+    AgentRole.ARCHITECT: Role.IMPLEMENTER,
+    AgentRole.TASK_PLANNER: Role.IMPLEMENTER,
+    AgentRole.RISK_ANALYST: Role.IMPLEMENTER,
+    AgentRole.REFINER: Role.IMPLEMENTER,
+    # Review: verdicts and phase-status/current_phase mutations
+    AgentRole.REVIEWER_CODE: Role.REVIEWER,
+    AgentRole.REVIEWER_CONTRACT: Role.REVIEWER,
+    AgentRole.REVIEWER_AGENT_DESIGN: Role.REVIEWER,
+    AgentRole.REVIEWER_REFINE: Role.REVIEWER,
+    AgentRole.REVIEWER_PLAN: Role.REVIEWER,
+    # Utility: apply code fixes, share implementer privileges
+    AgentRole.AUTOFIXER: Role.IMPLEMENTER,
+    AgentRole.CONFLICT_RESOLVER: Role.IMPLEMENTER,
+    # Interface: observers, not contract authors
+    AgentRole.OVERSEER: Role.SYSTEM,
+    AgentRole.INSPECTOR: Role.SYSTEM,
+}
+
+
+def get_contract_role(role: AgentRole | str) -> Role | None:
+    """Translate a fine-grained ``AgentRole`` to the coarse contract ``Role``.
+
+    The gateway stores the fine role in session metadata but the contract
+    API enforces field ownership against the coarse ``Role`` enum. Returns
+    ``None`` when the input does not name a known fine role.
+    """
+    if isinstance(role, str):
+        try:
+            role = AgentRole(role)
+        except ValueError:
+            return None
+    return AGENT_ROLE_TO_CONTRACT_ROLE.get(role)
 
 
 def get_role_definition(

--- a/tests/shared/egg_contracts/test_agent_roles.py
+++ b/tests/shared/egg_contracts/test_agent_roles.py
@@ -806,3 +806,61 @@ class TestUtilityRoleFileAccess:
         """INSPECTOR role exists with INTERFACE category."""
         defn = get_role_definition(AgentRole.INSPECTOR)
         assert defn.category == AgentCategory.INTERFACE
+
+
+# ---------------------------------------------------------------------------
+# get_contract_role() — fine → coarse role mapping (#1766)
+# ---------------------------------------------------------------------------
+
+
+class TestGetContractRole:
+    """Verify fine-grained AgentRole → coarse contract Role translation."""
+
+    def test_every_fine_role_maps(self):
+        """Every AgentRole has a coarse contract Role — prevents regression
+        where a new fine role silently 403s on the contract API."""
+        from egg_contracts.agent_roles import (
+            AGENT_ROLE_TO_CONTRACT_ROLE,
+            get_contract_role,
+        )
+
+        for fine_role in AgentRole:
+            assert fine_role in AGENT_ROLE_TO_CONTRACT_ROLE, (
+                f"AgentRole.{fine_role.name} has no contract-role mapping"
+            )
+            assert get_contract_role(fine_role) is not None
+
+    @pytest.mark.parametrize(
+        ("fine", "coarse"),
+        [
+            (AgentRole.CODER, "implementer"),
+            (AgentRole.REFINER, "implementer"),
+            (AgentRole.TASK_PLANNER, "implementer"),
+            (AgentRole.AUTOFIXER, "implementer"),
+            (AgentRole.REVIEWER_CODE, "reviewer"),
+            (AgentRole.REVIEWER_PLAN, "reviewer"),
+            (AgentRole.OVERSEER, "system"),
+            (AgentRole.INSPECTOR, "system"),
+        ],
+    )
+    def test_mapping_values(self, fine, coarse):
+        """Spot-check a few representative mappings."""
+        from egg_contracts.agent_roles import get_contract_role
+
+        result = get_contract_role(fine)
+        assert result is not None
+        assert result.value == coarse
+
+    def test_accepts_string_input(self):
+        """String input (as shipped from session metadata) resolves."""
+        from egg_contracts.agent_roles import get_contract_role
+
+        result = get_contract_role("refiner")
+        assert result is not None
+        assert result.value == "implementer"
+
+    def test_unknown_string_returns_none(self):
+        """Unknown role strings return None rather than raising."""
+        from egg_contracts.agent_roles import get_contract_role
+
+        assert get_contract_role("not_a_role") is None


### PR DESCRIPTION
## Summary

Three k3s-runtime bugs that all block end-to-end validation on the new
Kubernetes deployment. Found while running the pipeline for #1759 on a
fresh k3s cluster; each one blocks the next from being observable, so
they're bundled here.

- **Fix #1760** — k8s runtime reconciliation false-positive marked every
  healthy agent pod as FAILED ~15s after spawn. Root cause: agents
  register their \`container_id\` as the Job UID but \`live_ids\` was
  built from Pod UIDs only, so every running agent perpetually looked
  "missing."
- **Fix #1764** — \`get_container_logs\` (and every other container-id-
  keyed route) 404'd when called via MCP. Same Job-UID-vs-Pod-UID
  mismatch, different surface: \`list_containers\` returns Pod UIDs and
  \`_resolve_job_name\` couldn't translate them back to Jobs.
- **Fix #1766** — every \`egg-contract\` / \`egg-orch\` call from an
  agent returned 403 "Cannot determine agent role". Gateway's
  \`get_role_from_context\` tried \`Role(session_role.lower())\` on the
  fine-grained \`AgentRole\` string ("refiner", "coder", …), which only
  accepts the coarse \`Role\` enum ("implementer"/"reviewer"/…).

After all three land, a pipeline progresses refine → plan on k3s,
BRC consensus runs cleanly, and MCP log tooling works.

## Layers, briefly

**#1760 — runtime monitor false-positive**

Three defenses, smallest diff first:
1. Index Job UIDs in \`live_ids\` by also listing Jobs during each sweep.
2. Require the pod to be *actually terminated* (\`PodNotFoundError\` or a
   terminal \`ContainerStatus\` with \`exited_at\` populated) before
   marking FAILED. Running/Pending/Creating pods are skipped.
3. 60s grace period keyed off \`agent.started_at\` to cover
   ContainerCreating / image-pull / handshake races.

Extracted the sweep body into \`_reconciliation_sweep\` so individual
sweeps can be exercised deterministically in unit tests.

**#1764 — Pod UID / Job UID asymmetry**

\`kubernetes_client._resolve_job_name\` now also resolves Pod UIDs via
\`owner_references\`. Covers every container-id-keyed route:
\`/logs\`, \`/health\`, \`GET/DELETE /containers/<id>\`, \`/stop\`.

**#1766 — fine→coarse role mapping at the gateway**

New \`AGENT_ROLE_TO_CONTRACT_ROLE\` table in
\`shared/egg_contracts/agent_roles.py\`; \`get_contract_role()\` helper
consulted by \`gateway/contract_api.py\` and
\`gateway/phase_api.py\`. Review roles → \`Role.REVIEWER\`, execution
roles → \`Role.IMPLEMENTER\`, overseer → \`Role.SYSTEM\`.

## Test plan

- [x] \`pytest orchestrator/tests/test_kubernetes_monitor.py\` — 51 tests
  (44 existing + 7 new for the #1760 termination/grace-period logic).
- [x] \`pytest orchestrator/tests/test_container_monitor.py\` — updated
  fixtures for new grace-period behavior, added \`test_reconciles_when_pod_gone\`
  and \`test_skips_on_transient_api_error\`.
- [x] \`pytest orchestrator/tests/test_kubernetes_client.py\` — new tests
  for Pod-UID → Job-name resolution in \`_resolve_job_name\`.
- [x] \`pytest gateway/tests/test_contract_api.py gateway/tests/test_phase_api.py\` —
  new tests exercising each fine-grained \`AgentRole\` through
  \`get_role_from_context\`.
- [x] \`pytest tests/shared/egg_contracts/test_agent_roles.py\` — asserts
  every \`AgentRole\` value has a mapping.
- [x] Full orchestrator suite: 3814 passed, 1 skipped.
- [x] **Manual validation on local k3s**: pipeline for #1759 spawned 3 agents,
  all survived the 15–60s window that previously triggered the false
  positive, BRC consensus completed for the refine phase,
  \`get_container_logs\` MCP tool returned live logs (was 404 before
  #1764), and \`egg-contract add-decision\` succeeded from the refiner
  agent (was 403 before #1766).

## Not in scope

Additional bugs surfaced during the same session and tracked separately:
- #1763 — SHA-tag local images so \`make deploy\` actually rolls out.
- #1765 — egg-tool discoverability for sandbox agents.
- #1767 — checkpoint storage 272x failures (SSH host-key on gateway pod).
- #1768 — \`egg-contract add-feedback\` 403 (\`feedback\` field ownership
  defaults to SYSTEM).
- #1769 — **security**: \`resolve_decision\` endpoint has no auth; an
  agent auto-approved a phase gate during this validation session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)