### PR TITLE
Fix gateway checkpoint handler failing on SSH-form origin URLs

### DIFF
--- a/gateway/checkpoint_handler.py
+++ b/gateway/checkpoint_handler.py
@@ -219,6 +219,38 @@ def _validate_checkpoint_repo(checkpoint_repo: str) -> str:
     return checkpoint_repo
 
 
+def _resolve_checkpoint_target(
+    checkpoint_repo: str | None,
+    remote: str,
+    repo_path: str,
+) -> str:
+    """Resolve the git target for checkpoint fetch/push operations.
+
+    If *checkpoint_repo* is given, validates it and returns an HTTPS URL.
+    Otherwise resolves the remote URL and rewrites SSH to HTTPS so the
+    gateway credential helper can authenticate.  See #1767.
+    """
+    if checkpoint_repo:
+        _validate_checkpoint_repo(checkpoint_repo)
+        target = f"https://github.com/{checkpoint_repo}.git"
+        logger.info(
+            "Using external checkpoint repo",
+            checkpoint_repo=checkpoint_repo,
+            target=target,
+        )
+        return target
+
+    remote_url, err = resolve_remote_url(remote, repo_path)
+    if err:
+        logger.warning(
+            "Failed to resolve remote URL, falling back to remote name",
+            remote=remote,
+            error=err,
+        )
+        return remote
+    return get_authenticated_remote_target(remote, remote_url)
+
+
 # Mapping from agent_role strings to AgentType enum values
 _ROLE_TO_AGENT_TYPE = {
     "coder": AgentType.CODER,
@@ -846,26 +878,7 @@ class CheckpointHandler:
         if not CHECKPOINT_ENABLED:
             return False
 
-        # Determine the push/fetch target: either a separate repo URL or the
-        # existing remote name.
-        if checkpoint_repo:
-            _validate_checkpoint_repo(checkpoint_repo)
-            target = f"https://github.com/{checkpoint_repo}.git"
-            logger.info(
-                "Using external checkpoint repo",
-                checkpoint_repo=checkpoint_repo,
-                target=target,
-            )
-        else:
-            # Resolve the remote to a URL and force HTTPS if the origin is SSH.
-            # The gateway authenticates via GitHub App tokens over HTTPS and
-            # ships no SSH config, so any SSH-form origin inherited from the
-            # host clone would fail at host-key verification. See #1767.
-            remote_url, err = resolve_remote_url(remote, repo_path)
-            if err:
-                target = remote
-            else:
-                target = get_authenticated_remote_target(remote, remote_url)
+        target = _resolve_checkpoint_target(checkpoint_repo, remote, repo_path)
 
         try:
             with tempfile.TemporaryDirectory(prefix="checkpoint_") as temp_dir:
@@ -1089,7 +1102,7 @@ class CheckpointHandler:
         if github_token is None:
             github_token = _resolve_github_token(repo_path)
 
-        target = f"https://github.com/{checkpoint_repo}.git" if checkpoint_repo else "origin"
+        target = _resolve_checkpoint_target(checkpoint_repo, "origin", repo_path)
 
         if not self._branch_exists(repo_path, target, CHECKPOINT_BRANCH, github_token=github_token):
             return None
@@ -1171,7 +1184,7 @@ class CheckpointHandler:
         if github_token is None:
             github_token = _resolve_github_token(repo_path)
 
-        target = f"https://github.com/{checkpoint_repo}.git" if checkpoint_repo else "origin"
+        target = _resolve_checkpoint_target(checkpoint_repo, "origin", repo_path)
 
         if not self._branch_exists(repo_path, target, CHECKPOINT_BRANCH, github_token=github_token):
             return None

--- a/gateway/checkpoint_handler.py
+++ b/gateway/checkpoint_handler.py
@@ -101,14 +101,18 @@ try:
     from .git_client import (
         cleanup_credential_helper,
         create_credential_helper,
+        get_authenticated_remote_target,
         get_token_for_repo,
+        resolve_remote_url,
     )
     from .session_manager import Session
 except ImportError:
     from git_client import (  # type: ignore[no-redef, import-untyped]
         cleanup_credential_helper,
         create_credential_helper,
+        get_authenticated_remote_target,
         get_token_for_repo,
+        resolve_remote_url,
     )
     from session_manager import Session  # type: ignore[no-redef, import-untyped]
 
@@ -853,7 +857,15 @@ class CheckpointHandler:
                 target=target,
             )
         else:
-            target = remote
+            # Resolve the remote to a URL and force HTTPS if the origin is SSH.
+            # The gateway authenticates via GitHub App tokens over HTTPS and
+            # ships no SSH config, so any SSH-form origin inherited from the
+            # host clone would fail at host-key verification. See #1767.
+            remote_url, err = resolve_remote_url(remote, repo_path)
+            if err:
+                target = remote
+            else:
+                target = get_authenticated_remote_target(remote, remote_url)
 
         try:
             with tempfile.TemporaryDirectory(prefix="checkpoint_") as temp_dir:

--- a/gateway/tests/test_checkpoint_handler.py
+++ b/gateway/tests/test_checkpoint_handler.py
@@ -761,9 +761,7 @@ class TestStoreCheckpointV2RemoteTarget:
             return_value=("", "fatal: No such remote 'origin'"),
         ):
             try:
-                handler.store_checkpoint_v2(
-                    checkpoint, "/fake/repo", checkpoint_repo=None
-                )
+                handler.store_checkpoint_v2(checkpoint, "/fake/repo", checkpoint_repo=None)
             except Exception:
                 pass
 
@@ -794,9 +792,7 @@ class TestFetchAndReadIndexRemoteTarget:
             return_value=resolve_return,
         ):
             try:
-                handler.fetch_and_read_index(
-                    "/fake/repo", checkpoint_repo=checkpoint_repo
-                )
+                handler.fetch_and_read_index("/fake/repo", checkpoint_repo=checkpoint_repo)
             except Exception:
                 pass
 

--- a/gateway/tests/test_checkpoint_handler.py
+++ b/gateway/tests/test_checkpoint_handler.py
@@ -726,6 +726,135 @@ class TestStoreCheckpointV2RemoteTarget:
         )
         assert target == "https://github.com/owner/other-repo.git"
 
+    def test_resolve_error_falls_back_to_remote_name(self):
+        """When resolve_remote_url returns an error, fall back to bare remote name."""
+        import checkpoint_handler
+        from egg_contracts.checkpoints import (
+            CheckpointV2,
+            SessionMetadata,
+            TriggerType,
+        )
+
+        handler = checkpoint_handler.CheckpointHandler(github_token="test-token")
+        git_calls = []
+
+        def track_run_git(cwd, args, **kwargs):
+            git_calls.append((cwd, args, kwargs))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        handler._run_git = track_run_git
+        handler._branch_exists = MagicMock(return_value=True)
+
+        now = datetime.now(UTC)
+        checkpoint = CheckpointV2(
+            id="ckpt-a1b2c3d4e5f67890",
+            trigger_type=TriggerType.COMMIT,
+            session_id="test-container",
+            commit_sha="abc123def456789012345678901234567890abcd",
+            session=SessionMetadata(session_id="test-container", started_at=now),
+            created_at=now,
+            session_started_at=now,
+        )
+
+        with patch(
+            "checkpoint_handler.resolve_remote_url",
+            return_value=("", "fatal: No such remote 'origin'"),
+        ):
+            try:
+                handler.store_checkpoint_v2(
+                    checkpoint, "/fake/repo", checkpoint_repo=None
+                )
+            except Exception:
+                pass
+
+        fetch_calls = [c for c in git_calls if "fetch" in c[1]]
+        assert fetch_calls, "Expected a git fetch call"
+        assert fetch_calls[0][1][1] == "origin"
+
+
+class TestFetchAndReadIndexRemoteTarget:
+    """Tests that fetch_and_read_index resolves SSH origins to HTTPS (#1767)."""
+
+    def _get_fetch_target(self, checkpoint_repo, remote_url, resolve_error=None):
+        import checkpoint_handler
+
+        handler = checkpoint_handler.CheckpointHandler(github_token="test-token")
+        git_calls = []
+
+        def track_run_git(cwd, args, **kwargs):
+            git_calls.append((cwd, args, kwargs))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        handler._run_git = track_run_git
+        handler._branch_exists = MagicMock(return_value=True)
+
+        resolve_return = ("", resolve_error) if resolve_error else (remote_url, None)
+        with patch(
+            "checkpoint_handler.resolve_remote_url",
+            return_value=resolve_return,
+        ):
+            try:
+                handler.fetch_and_read_index(
+                    "/fake/repo", checkpoint_repo=checkpoint_repo
+                )
+            except Exception:
+                pass
+
+        fetch_calls = [c for c in git_calls if "fetch" in c[1]]
+        assert fetch_calls, "Expected a git fetch call"
+        return fetch_calls[0][1][1]
+
+    def test_ssh_origin_rewritten_to_https(self):
+        target = self._get_fetch_target(None, "git@github.com:owner/repo.git")
+        assert target == "https://github.com/owner/repo.git"
+
+    def test_https_origin_uses_remote_name(self):
+        target = self._get_fetch_target(None, "https://github.com/owner/repo.git")
+        assert target == "origin"
+
+    def test_checkpoint_repo_overrides_origin(self):
+        target = self._get_fetch_target("owner/other", "git@github.com:owner/repo.git")
+        assert target == "https://github.com/owner/other.git"
+
+
+class TestEnsureRefRemoteTarget:
+    """Tests that ensure_ref resolves SSH origins to HTTPS (#1767)."""
+
+    def _get_fetch_target(self, checkpoint_repo, remote_url, resolve_error=None):
+        import checkpoint_handler
+
+        handler = checkpoint_handler.CheckpointHandler(github_token="test-token")
+        git_calls = []
+
+        def track_run_git(cwd, args, **kwargs):
+            git_calls.append((cwd, args, kwargs))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        handler._run_git = track_run_git
+        handler._branch_exists = MagicMock(return_value=True)
+
+        resolve_return = ("", resolve_error) if resolve_error else (remote_url, None)
+        with patch(
+            "checkpoint_handler.resolve_remote_url",
+            return_value=resolve_return,
+        ):
+            try:
+                handler.ensure_ref("/fake/repo", checkpoint_repo=checkpoint_repo)
+            except Exception:
+                pass
+
+        fetch_calls = [c for c in git_calls if "fetch" in c[1]]
+        assert fetch_calls, "Expected a git fetch call"
+        return fetch_calls[0][1][1]
+
+    def test_ssh_origin_rewritten_to_https(self):
+        target = self._get_fetch_target(None, "git@github.com:owner/repo.git")
+        assert target == "https://github.com/owner/repo.git"
+
+    def test_https_origin_uses_remote_name(self):
+        target = self._get_fetch_target(None, "https://github.com/owner/repo.git")
+        assert target == "origin"
+
 
 class TestResolvePipelineId:
     """Tests for CheckpointHandler._resolve_pipeline_id."""

--- a/gateway/tests/test_checkpoint_handler.py
+++ b/gateway/tests/test_checkpoint_handler.py
@@ -642,6 +642,91 @@ class TestStoreCheckpointV2GitOps:
         assert branch_delete_calls[0][2].get("check") is False
 
 
+class TestStoreCheckpointV2RemoteTarget:
+    """Tests for store_checkpoint_v2 remote URL resolution (issue #1767).
+
+    The gateway pod has no SSH config, so origin URLs inherited from the host
+    clone as SSH must be rewritten to HTTPS before any fetch/push.
+    """
+
+    def _run(self, checkpoint_repo, remote_url):
+        import checkpoint_handler
+        from egg_contracts.checkpoints import (
+            CheckpointV2,
+            SessionMetadata,
+            TriggerType,
+        )
+
+        handler = checkpoint_handler.CheckpointHandler(github_token="test-token")
+        git_calls = []
+
+        def track_run_git(cwd, args, **kwargs):
+            git_calls.append((cwd, args, kwargs))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        handler._run_git = track_run_git
+        handler._branch_exists = MagicMock(return_value=True)
+
+        now = datetime.now(UTC)
+        checkpoint = CheckpointV2(
+            id="ckpt-a1b2c3d4e5f67890",
+            trigger_type=TriggerType.COMMIT,
+            session_id="test-container",
+            commit_sha="abc123def456789012345678901234567890abcd",
+            session=SessionMetadata(session_id="test-container", started_at=now),
+            created_at=now,
+            session_started_at=now,
+        )
+
+        with patch(
+            "checkpoint_handler.resolve_remote_url",
+            return_value=(remote_url, None),
+        ):
+            try:
+                handler.store_checkpoint_v2(
+                    checkpoint, "/fake/repo", checkpoint_repo=checkpoint_repo
+                )
+            except Exception:
+                pass
+
+        fetch_calls = [c for c in git_calls if "fetch" in c[1]]
+        assert fetch_calls, "Expected a git fetch call"
+        # The fetch target is the second arg after 'fetch'
+        return fetch_calls[0][1][1]
+
+    def test_ssh_origin_rewritten_to_https(self):
+        """SSH-form origin URL is rewritten to HTTPS before fetch/push."""
+        target = self._run(
+            checkpoint_repo=None,
+            remote_url="git@github.com:owner/repo.git",
+        )
+        assert target == "https://github.com/owner/repo.git"
+
+    def test_ssh_url_form_rewritten_to_https(self):
+        """ssh:// URL form is rewritten to HTTPS."""
+        target = self._run(
+            checkpoint_repo=None,
+            remote_url="ssh://git@github.com/owner/repo.git",
+        )
+        assert target == "https://github.com/owner/repo.git"
+
+    def test_https_origin_uses_remote_name(self):
+        """HTTPS origin keeps the remote name (credential helper works)."""
+        target = self._run(
+            checkpoint_repo=None,
+            remote_url="https://github.com/owner/repo.git",
+        )
+        assert target == "origin"
+
+    def test_checkpoint_repo_overrides_origin(self):
+        """Explicit checkpoint_repo is used regardless of origin URL."""
+        target = self._run(
+            checkpoint_repo="owner/other-repo",
+            remote_url="git@github.com:owner/repo.git",
+        )
+        assert target == "https://github.com/owner/other-repo.git"
+
+
 class TestResolvePipelineId:
     """Tests for CheckpointHandler._resolve_pipeline_id."""
 


### PR DESCRIPTION
## Summary

- `store_checkpoint_v2` now resolves `origin` to a URL and rewrites SSH → HTTPS before fetch/push, so the gateway (which ships no SSH config) can authenticate via its GitHub App token regardless of how the host cloned the repo.
- Reuses the existing `resolve_remote_url` / `get_authenticated_remote_target` helpers in `gateway/git_client.py` rather than adding a new helper.
- Fixes both state-sync and code-repo checkpoint paths, since both defaulted to `remote="origin"` and hit the same failure mode.

Fixes #1767.

## Test plan

- [x] New `TestStoreCheckpointV2RemoteTarget` cases cover SSH colon form, SSH URL form, HTTPS origin, and explicit `checkpoint_repo` override.
- [x] Full `gateway/tests/test_checkpoint_handler.py` (72 tests) passes.
- [x] Ruff clean on changed files.
- [ ] Post-merge on fresh k3s deploy: no `Host key verification failed` entries in gateway log after a pipeline run.
- [ ] Post-merge: `list_checkpoints` MCP tool returns non-empty results for a running pipeline.
- [ ] Post-merge: state-sync session end produces a `Checkpoint stored` log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)