### PR TITLE
Fix #1768: register feedback field ownership

### DIFF
--- a/shared/egg_contracts/roles.py
+++ b/shared/egg_contracts/roles.py
@@ -62,6 +62,11 @@ FIELD_OWNERSHIP: dict[str, FieldOwner] = {
     # refine/review phases. feedback.* covers nested mutations (e.g. answers).
     "feedback": frozenset({Role.IMPLEMENTER, Role.REVIEWER}),
     "feedback.*": frozenset({Role.IMPLEMENTER, Role.REVIEWER}),
+    # Feedback submission fields: only human can mark feedback as submitted,
+    # mirroring the decisions.*.resolved pattern for defense-in-depth.
+    "feedback.submitted": Role.HUMAN,
+    "feedback.submitted_by": Role.HUMAN,
+    "feedback.submitted_at": Role.HUMAN,
 }
 
 # Fields that any role can read but only the owner can write

--- a/shared/egg_contracts/roles.py
+++ b/shared/egg_contracts/roles.py
@@ -58,6 +58,10 @@ FIELD_OWNERSHIP: dict[str, FieldOwner] = {
     "decisions.*.resolution": Role.HUMAN,
     "decisions.*.resolved_by": Role.HUMAN,
     "decisions.*.resolved_at": Role.HUMAN,
+    # Feedback: open-ended HITL questions, authored by either role during
+    # refine/review phases. feedback.* covers nested mutations (e.g. answers).
+    "feedback": frozenset({Role.IMPLEMENTER, Role.REVIEWER}),
+    "feedback.*": frozenset({Role.IMPLEMENTER, Role.REVIEWER}),
 }
 
 # Fields that any role can read but only the owner can write

--- a/tests/shared/egg_contracts/test_roles.py
+++ b/tests/shared/egg_contracts/test_roles.py
@@ -66,6 +66,12 @@ class TestGetFieldOwner:
         assert isinstance(nested_owner, frozenset)
         assert nested_owner == frozenset({Role.IMPLEMENTER, Role.REVIEWER})
 
+    def test_feedback_submission_human_only(self):
+        """Feedback submission fields are human-only, mirroring decisions.*.resolved."""
+        assert get_field_owner("feedback.submitted") == Role.HUMAN
+        assert get_field_owner("feedback.submitted_by") == Role.HUMAN
+        assert get_field_owner("feedback.submitted_at") == Role.HUMAN
+
     def test_reviewer_fields(self):
         """Test fields owned exclusively by reviewer."""
         assert get_field_owner("acceptance_criteria.0.verified") == Role.REVIEWER
@@ -152,6 +158,12 @@ class TestCanModify:
         assert can_modify(Role.IMPLEMENTER, "feedback.questions.0.answer") is True
         assert can_modify(Role.REVIEWER, "feedback.questions.0.answer") is True
 
+    def test_agents_cannot_modify_feedback_submission(self):
+        """Agents cannot mark feedback as submitted — human-only."""
+        for field in ("feedback.submitted", "feedback.submitted_by", "feedback.submitted_at"):
+            assert can_modify(Role.IMPLEMENTER, field) is False
+            assert can_modify(Role.REVIEWER, field) is False
+
     def test_system_cannot_modify_feedback(self):
         """System no longer implicitly owns feedback after #1768."""
         assert can_modify(Role.SYSTEM, "feedback") is False
@@ -233,3 +245,6 @@ class TestFieldOwnershipConfiguration:
         human_paths = [p for p, r in FIELD_OWNERSHIP.items() if r == Role.HUMAN]
         assert "decisions.*.resolved" in human_paths
         assert "decisions.*.resolution" in human_paths
+        assert "feedback.submitted" in human_paths
+        assert "feedback.submitted_by" in human_paths
+        assert "feedback.submitted_at" in human_paths

--- a/tests/shared/egg_contracts/test_roles.py
+++ b/tests/shared/egg_contracts/test_roles.py
@@ -56,6 +56,16 @@ class TestGetFieldOwner:
         assert Role.IMPLEMENTER in phase_status_owner
         assert Role.REVIEWER in phase_status_owner
 
+    def test_feedback_shared_ownership(self):
+        """Top-level feedback field is shared between implementer and reviewer."""
+        feedback_owner = get_field_owner("feedback")
+        assert isinstance(feedback_owner, frozenset)
+        assert feedback_owner == frozenset({Role.IMPLEMENTER, Role.REVIEWER})
+
+        nested_owner = get_field_owner("feedback.questions.0.answer")
+        assert isinstance(nested_owner, frozenset)
+        assert nested_owner == frozenset({Role.IMPLEMENTER, Role.REVIEWER})
+
     def test_reviewer_fields(self):
         """Test fields owned exclusively by reviewer."""
         assert get_field_owner("acceptance_criteria.0.verified") == Role.REVIEWER
@@ -130,6 +140,22 @@ class TestCanModify:
         assert can_modify(Role.SYSTEM, "phases.0.tasks.0.status") is False
         assert can_modify(Role.SYSTEM, "phases.0.tasks.0.commit") is False
 
+    def test_agents_can_modify_feedback(self):
+        """Implementer and reviewer can write the top-level feedback field.
+
+        Regression guard for #1768: without an explicit FIELD_OWNERSHIP entry,
+        `feedback` falls through to DEFAULT_OWNER (SYSTEM) and blocks every
+        agent role from calling `egg-contract add-feedback`.
+        """
+        assert can_modify(Role.IMPLEMENTER, "feedback") is True
+        assert can_modify(Role.REVIEWER, "feedback") is True
+        assert can_modify(Role.IMPLEMENTER, "feedback.questions.0.answer") is True
+        assert can_modify(Role.REVIEWER, "feedback.questions.0.answer") is True
+
+    def test_system_cannot_modify_feedback(self):
+        """System no longer implicitly owns feedback after #1768."""
+        assert can_modify(Role.SYSTEM, "feedback") is False
+
 
 class TestGetRolePermissions:
     """Tests for get_role_permissions function."""
@@ -188,6 +214,10 @@ class TestFieldOwnershipConfiguration:
         phase_status = FIELD_OWNERSHIP["phases.*.status"]
         assert isinstance(phase_status, frozenset)
         assert phase_status == frozenset({Role.IMPLEMENTER, Role.REVIEWER})
+
+        feedback = FIELD_OWNERSHIP["feedback"]
+        assert isinstance(feedback, frozenset)
+        assert feedback == frozenset({Role.IMPLEMENTER, Role.REVIEWER})
 
     def test_reviewer_ownership_patterns(self):
         """Test expected reviewer-only ownership patterns exist."""


### PR DESCRIPTION
## Summary

- Registers `feedback` and `feedback.*` in `FIELD_OWNERSHIP` with shared IMPLEMENTER+REVIEWER ownership.
- Unblocks `egg-contract add-feedback` for agents — refiner burned its feedback questions during #1759's refine phase because the top-level `feedback` field silently fell through to SYSTEM.
- Adds regression tests at the authorization layer (the actual bug site).

## Why this fix, at this layer

After #1766 fixed fine→coarse role translation, the refiner resolves to `Role.IMPLEMENTER`. But `get_field_owner("feedback")` had no match and defaulted to `Role.SYSTEM`, so `can_modify(IMPLEMENTER, "feedback")` returned False and the gateway `/contract/mutate` call 403'd.

One correction vs. the issue writeup: #1768 says `add-decision` works because it has a "dedicated blueprint route." It doesn't — `cmd_add_decision` at `sandbox/egg_lib/contract_cli.py:801` also uses `/api/v1/contract/mutate`. The real asymmetry was just which field paths were registered: `decisions.*` was in `FIELD_OWNERSHIP`; `feedback` was not. Registering it matches the existing `phases.*.tasks.*.status` shared-ownership pattern — smallest change, no route/endpoint rearrangement needed.

Option C from the issue (reconsidering `DEFAULT_OWNER = SYSTEM` as a silent footgun for any new contract field) is worth its own follow-up and is not in scope here.

## Test plan

- [x] `pytest tests/shared/egg_contracts/test_roles.py` — 32 passed (28 existing + 4 new).
  - `TestGetFieldOwner::test_feedback_shared_ownership` — top-level and nested paths resolve to the shared frozenset.
  - `TestCanModify::test_agents_can_modify_feedback` — regression guard citing #1768.
  - `TestCanModify::test_system_cannot_modify_feedback` — SYSTEM no longer implicitly owns it.
  - `TestFieldOwnershipConfiguration::test_shared_ownership_patterns` — extended to assert the new entry.
- [x] `ruff check` — clean on both files; pre-commit hooks pass.
- [ ] Manual validation: run a pipeline refine phase and confirm `egg-contract add-feedback` succeeds (deferred to next local k3s run — no k3s cluster available in this session).

## Acceptance criteria from #1768

- [x] `can_modify(Role.IMPLEMENTER, "feedback")` → True (fine-grained `AgentRole.REFINER` → `Role.IMPLEMENTER` via `get_contract_role`).
- [x] `can_modify(Role.REVIEWER, "feedback")` → True (shared ownership).
- [x] No regression in `add-decision` or any other contract mutation — no other FIELD_OWNERSHIP entry was touched, and the full `tests/shared/egg_contracts/` suite passes (minus 2 pre-existing import-path failures unrelated to this change).

Closes #1768

🤖 Generated with [Claude Code](https://claude.com/claude-code)