### PR TITLE
Fix three phase-control failure modes from post-consensus stall (#1755)

### DIFF
--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -1887,9 +1887,19 @@ class PipelineToolHandler:
         When force=true, stops all running containers before advancing
         to prevent SIGTERM cascading into the new phase (#1570).
         """
+        from models import PipelinePhase
+
         task_id = quote(args["task_id"], safe="")
         target_phase = args["target_phase"]
         force = args.get("force", False)
+
+        # Validate target_phase up front so an invalid value fails fast
+        # without first tearing down containers. See #1755.
+        try:
+            PipelinePhase(target_phase)
+        except ValueError:
+            valid = [p.value for p in PipelinePhase]
+            return {"error": (f"Invalid target_phase: {target_phase!r}. Valid phases: {valid}")}
 
         # When force=true, stop running containers before the transition
         # to avoid SIGTERM cascading into the new phase.

--- a/orchestrator/routes/phases.py
+++ b/orchestrator/routes/phases.py
@@ -510,15 +510,22 @@ def complete_phase(pipeline_id: str) -> tuple[Response, int]:
     data = request.get_json(silent=True) or {}
 
     artifacts = data.get("artifacts")
-    if artifacts is not None and not isinstance(artifacts, dict):
-        # Reject non-dict artifacts at the boundary — PhaseExecution.artifacts
-        # is typed as dict[str, str], and pydantic's default config does not
-        # validate on assignment, so a bad value would persist to disk and
-        # then fail validation on every subsequent read. See #1755.
-        return make_error_response(
-            f"artifacts must be a JSON object (got {type(artifacts).__name__})",
-            status_code=400,
-        )
+    if artifacts is not None:
+        # Reject non-dict artifacts and dicts with non-string values at the
+        # boundary — PhaseExecution.artifacts is typed as dict[str, str], and
+        # pydantic's default config does not validate on assignment, so a bad
+        # value would persist to disk and then fail validation on every
+        # subsequent read. See #1755.
+        if not isinstance(artifacts, dict):
+            return make_error_response(
+                f"artifacts must be a JSON object (got {type(artifacts).__name__})",
+                status_code=400,
+            )
+        if not all(isinstance(k, str) and isinstance(v, str) for k, v in artifacts.items()):
+            return make_error_response(
+                "artifacts must be a JSON object with string values",
+                status_code=400,
+            )
 
     try:
         store, pipeline = get_state_store_for_pipeline(pipeline_id)

--- a/orchestrator/routes/phases.py
+++ b/orchestrator/routes/phases.py
@@ -504,7 +504,21 @@ def complete_phase(pipeline_id: str) -> tuple[Response, int]:
             }
         }
     """
-    data = request.get_json() or {}
+    # silent=True: Content-Type: application/json with an empty body would
+    # otherwise raise BadRequest(400), which breaks callers that omit
+    # `artifacts` (the field is documented as optional). See #1755.
+    data = request.get_json(silent=True) or {}
+
+    artifacts = data.get("artifacts")
+    if artifacts is not None and not isinstance(artifacts, dict):
+        # Reject non-dict artifacts at the boundary — PhaseExecution.artifacts
+        # is typed as dict[str, str], and pydantic's default config does not
+        # validate on assignment, so a bad value would persist to disk and
+        # then fail validation on every subsequent read. See #1755.
+        return make_error_response(
+            f"artifacts must be a JSON object (got {type(artifacts).__name__})",
+            status_code=400,
+        )
 
     try:
         store, pipeline = get_state_store_for_pipeline(pipeline_id)
@@ -515,8 +529,8 @@ def complete_phase(pipeline_id: str) -> tuple[Response, int]:
         phase_execution.completed_at = datetime.now(UTC)
 
         # Store artifacts if provided
-        if data.get("artifacts"):
-            phase_execution.artifacts = data["artifacts"]
+        if artifacts:
+            phase_execution.artifacts = artifacts
 
         # Determine next phase
         next_phases = PHASE_TRANSITIONS.get(pipeline.current_phase, [])

--- a/orchestrator/tests/test_complete_phase_endpoint.py
+++ b/orchestrator/tests/test_complete_phase_endpoint.py
@@ -107,9 +107,8 @@ class TestCompletePhaseEndpoint:
         assert data["success"] is False
         assert "artifacts" in data["message"]
 
-        # Phase must not have been mutated or saved.
-        phase_exec = pipeline.get_phase_execution(PipelinePhase.IMPLEMENT)
-        assert phase_exec.status != PipelineStatus.COMPLETE
+        # The early return must prevent pipeline state from being loaded.
+        mock_get_store.assert_not_called()
         mock_store.save_pipeline.assert_not_called()
 
     @patch("routes.phases._clear_concurrent_state")
@@ -126,6 +125,32 @@ class TestCompletePhaseEndpoint:
         )
 
         assert resp.status_code == 400
+        mock_get_store.assert_not_called()
+        mock_store.save_pipeline.assert_not_called()
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_non_string_values_artifacts_returns_400(self, mock_get_store, _mock_clear, client):
+        """A dict with non-string values is rejected at the boundary.
+
+        PhaseExecution.artifacts is typed dict[str, str], so values like
+        lists or nested dicts would persist without pydantic catching them
+        and then break on the next read.
+        """
+        pipeline = _make_pipeline()
+        mock_store = MagicMock()
+        mock_get_store.return_value = (mock_store, pipeline)
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase/complete",
+            json={"artifacts": {"key": ["not", "a", "string"]}},
+        )
+
+        assert resp.status_code == 400
+        data = json.loads(resp.data)
+        assert data["success"] is False
+        assert "string values" in data["message"]
+        mock_get_store.assert_not_called()
         mock_store.save_pipeline.assert_not_called()
 
     @patch("routes.phases._clear_concurrent_state")

--- a/orchestrator/tests/test_complete_phase_endpoint.py
+++ b/orchestrator/tests/test_complete_phase_endpoint.py
@@ -1,0 +1,146 @@
+"""Tests for the POST /<pipeline_id>/phase/complete endpoint.
+
+Regressions for #1755:
+- Empty body must be treated as an empty object, not 400.
+- Non-dict artifacts must be rejected at the boundary, not written to
+  disk (PhaseExecution.artifacts is typed as dict[str, str] but does
+  not validate on assignment, so a poisoned value would break every
+  subsequent read).
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+from models import Pipeline, PipelinePhase, PipelineStatus
+from routes.phases import phases_bp
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.register_blueprint(phases_bp)
+    app.config["TESTING"] = True
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _make_pipeline(phase=PipelinePhase.IMPLEMENT):
+    pipeline = Pipeline(
+        id="issue-42",
+        issue_number=42,
+        repo="owner/repo",
+        branch="egg/issue-42",
+    )
+    pipeline.current_phase = phase
+    return pipeline
+
+
+class TestCompletePhaseEndpoint:
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_empty_body_returns_200(self, mock_get_store, _mock_clear, client):
+        """POST with Content-Type: application/json and empty body must not 400.
+
+        Regression: Flask's default get_json() raises BadRequest for an
+        empty body with a JSON content type, which previously made the
+        optional `artifacts` field effectively required.
+        """
+        pipeline = _make_pipeline()
+        mock_store = MagicMock()
+        mock_get_store.return_value = (mock_store, pipeline)
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase/complete",
+            data=b"",
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["success"] is True
+        assert data["data"]["phase"] == "implement"
+        assert data["data"]["next_phase"] == "pr"
+
+        phase_exec = pipeline.get_phase_execution(PipelinePhase.IMPLEMENT)
+        assert phase_exec.status == PipelineStatus.COMPLETE
+        assert phase_exec.artifacts == {}
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_no_body_returns_200(self, mock_get_store, _mock_clear, client):
+        """POST with no body at all also succeeds."""
+        pipeline = _make_pipeline()
+        mock_store = MagicMock()
+        mock_get_store.return_value = (mock_store, pipeline)
+
+        resp = client.post("/api/v1/pipelines/issue-42/phase/complete")
+
+        assert resp.status_code == 200
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_string_artifacts_returns_400(self, mock_get_store, _mock_clear, client):
+        """A stringified-JSON artifacts value is rejected without mutating state.
+
+        Previously the string was assigned to PhaseExecution.artifacts
+        (typed dict[str, str]) without validation, persisted to disk,
+        and then broke every subsequent read with a 500 when pydantic
+        re-validated the stored pipeline.
+        """
+        pipeline = _make_pipeline()
+        mock_store = MagicMock()
+        mock_get_store.return_value = (mock_store, pipeline)
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase/complete",
+            json={"artifacts": "{}"},
+        )
+
+        assert resp.status_code == 400
+        data = json.loads(resp.data)
+        assert data["success"] is False
+        assert "artifacts" in data["message"]
+
+        # Phase must not have been mutated or saved.
+        phase_exec = pipeline.get_phase_execution(PipelinePhase.IMPLEMENT)
+        assert phase_exec.status != PipelineStatus.COMPLETE
+        mock_store.save_pipeline.assert_not_called()
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_list_artifacts_returns_400(self, mock_get_store, _mock_clear, client):
+        """Non-dict artifacts of any kind are rejected."""
+        pipeline = _make_pipeline()
+        mock_store = MagicMock()
+        mock_get_store.return_value = (mock_store, pipeline)
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase/complete",
+            json={"artifacts": ["a", "b"]},
+        )
+
+        assert resp.status_code == 400
+        mock_store.save_pipeline.assert_not_called()
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_dict_artifacts_stored(self, mock_get_store, _mock_clear, client):
+        """Valid dict artifacts are stored on the phase execution."""
+        pipeline = _make_pipeline()
+        mock_store = MagicMock()
+        mock_get_store.return_value = (mock_store, pipeline)
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase/complete",
+            json={"artifacts": {"commit_sha": "abc123"}},
+        )
+
+        assert resp.status_code == 200
+        phase_exec = pipeline.get_phase_execution(PipelinePhase.IMPLEMENT)
+        assert phase_exec.artifacts == {"commit_sha": "abc123"}

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -1594,6 +1594,26 @@ class TestAdvancePhase:
         assert result["stopped_containers"] == ["c1"]
         assert result["failed_containers"] == ["c2"]
 
+    def test_advance_invalid_target_phase_does_not_touch_containers(self, handler):
+        """Invalid target_phase returns an error before any container stops.
+
+        Regression for #1755: previously, force=true with an invalid
+        target_phase (e.g. 'complete') stopped containers first and
+        surfaced failed_containers in the error response, implying the
+        teardown had already happened when validation failed.
+        """
+        with patch.object(handler, "_make_request") as mock_req:
+            result = handler.handle_tool_call(
+                "advance_phase",
+                {"task_id": "issue-42", "target_phase": "complete", "force": True},
+            )
+
+        mock_req.assert_not_called()
+        assert "error" in result
+        assert "Invalid target_phase" in result["error"]
+        assert "stopped_containers" not in result
+        assert "failed_containers" not in result
+
 
 class TestStartPhase:
     """Tests for the start_phase MCP tool handler."""


### PR DESCRIPTION
## Summary

Fixes the three orchestrator bugs documented in #1755, which together bricked pipeline `issue-1748` after a successful implement-phase consensus.

### Bug 1 — `complete_phase` 400 on missing body
`orchestrator/routes/phases.py`: Flask's default `request.get_json()` raises `BadRequest` when `Content-Type: application/json` is set with an empty body, so the MCP client's legal "no artifacts" POST returned 400. Switched to `get_json(silent=True) or {}`.

### Bug 2 — `advance_phase(force=true)` tore down containers on invalid target_phase
`orchestrator/mcp_tools.py`: the MCP handler force-killed containers before round-tripping to the server for target_phase validation, so a 400 response carried a `failed_containers` list despite the request being rejected. Now the handler validates `target_phase` against the `PipelinePhase` enum up front and returns immediately without touching containers if it's invalid.

### Bug 3 — every read endpoint 500'd after the artifacts-as-string workaround
`orchestrator/routes/phases.py`: when callers worked around Bug 1 by passing `artifacts: "{}"` (a string), the REST handler assigned the string directly to `PhaseExecution.artifacts` (typed `dict[str, str]`). Pydantic's default config does not validate on assignment, so the bad value reached `model_dump_json` → disk → git. Every subsequent `load_pipeline` then failed `Pipeline.model_validate` with a `ValidationError` → `StateValidationError` → 500 across `get_status` / `get_phase` / `get_pipeline_snapshot`. Now the endpoint rejects non-dict `artifacts` at the boundary with a 400 before any state mutation.

## Why this is the minimal fix

Adding `validate_assignment=True` to `PhaseExecution` would also prevent Bug 3 at the model layer, but `phase_execution.*` is assigned in 296 places across 20 files — out of scope for this bugfix. Validating at the REST boundary (the only external ingress for this field) is sufficient.

## Test plan

- [x] New `orchestrator/tests/test_complete_phase_endpoint.py` covers: empty body → 200, no body at all → 200, string artifacts → 400 (without mutating state), list artifacts → 400, dict artifacts stored.
- [x] New test in `TestAdvancePhase` asserts invalid `target_phase` with `force=true` returns an error and makes **zero** `_make_request` calls (no container listing, no stops).
- [x] Existing `TestCompletePhase` / `TestAdvancePhase` MCP tests still pass (12/12).

Closes #1755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)