### PR TITLE
Unify contract key to always use pipeline_id (fixes #1773)

### DIFF
--- a/.github/scripts/checks/run_check.py
+++ b/.github/scripts/checks/run_check.py
@@ -91,10 +91,14 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(error_result.model_dump(mode="json")))
             return 1
 
-        # Parse issue number from contract path
-        # Contract paths are typically: .egg-state/contracts/<issue_number>.json
-        issue_number = int(contract_path.stem)
-        contract = load_contract(issue_number, repo_root=Path(args.repo_root))
+        # Derive identifier from contract path stem. Contract files live at
+        # ``.egg-state/contracts/<identifier>.json`` where ``<identifier>`` is
+        # the canonical pipeline_id (e.g. ``issue-1759`` or ``issue-1759-v2``).
+        # Legacy pre-unification paths use a bare integer (``1759.json``);
+        # pass those through as int so the loader's compat shim resolves them.
+        stem = contract_path.stem
+        identifier: int | str = int(stem) if stem.isdigit() else stem
+        contract = load_contract(identifier, repo_root=Path(args.repo_root))
 
         # Load and run the check
         repo_root = Path(args.repo_root).resolve()

--- a/orchestrator/health_checks/context.py
+++ b/orchestrator/health_checks/context.py
@@ -216,21 +216,29 @@ class PipelineHealthContext:
         return outputs
 
     def _read_contract(self) -> dict[str, object]:
-        """Read and parse the SDLC contract JSON for this pipeline's issue."""
+        """Read and parse the SDLC contract JSON for this pipeline."""
         state_dir = self._resolve_state_dir()
+        pipeline_id = self.pipeline.id
         issue_number = self.pipeline.issue_number
-        if issue_number is None:
-            return {}
 
-        contract_path = state_dir / "contracts" / f"{issue_number}.json"
-        if not contract_path.is_file():
-            return {}
+        # Prefer the canonical pipeline-id-keyed path (e.g.,
+        # ``issue-1759.json`` or ``issue-1759-v2.json``) and fall back to
+        # the pre-unification ``{issue_number}.json`` for legacy contracts.
+        candidates: list[Path] = []
+        if pipeline_id:
+            candidates.append(state_dir / "contracts" / f"{pipeline_id}.json")
+        if issue_number is not None:
+            candidates.append(state_dir / "contracts" / f"{issue_number}.json")
 
-        try:
-            raw = contract_path.read_text(errors="replace")
-            return json.loads(raw)  # type: ignore[no-any-return]
-        except (json.JSONDecodeError, OSError):
-            return {}
+        for contract_path in candidates:
+            if not contract_path.is_file():
+                continue
+            try:
+                raw = contract_path.read_text(errors="replace")
+                return json.loads(raw)  # type: ignore[no-any-return]
+            except (json.JSONDecodeError, OSError):
+                continue
+        return {}
 
     def _fetch_live_container_ids(self) -> set[str]:
         """Query Docker for live container IDs."""

--- a/orchestrator/routes/phases.py
+++ b/orchestrator/routes/phases.py
@@ -597,13 +597,12 @@ def populate_contract(pipeline_id: str) -> tuple[Response, int]:
             issue_number=pipeline.issue_number,
         )
 
-        # Read back the contract to report counts
+        # Read back the contract to report counts. Contracts are keyed by
+        # pipeline_id; the loader's compat shim covers legacy paths.
         try:
             from egg_contracts.loader import load_contract
-            from routes.pipelines import _pipeline_identifier
 
-            contract_id = _pipeline_identifier(pipeline.issue_number, pipeline_id)
-            contract = load_contract(contract_id, worktree_path)
+            contract = load_contract(pipeline_id, worktree_path)
             task_count = sum(len(p.tasks) for p in contract.phases)
             return make_success_response(
                 "Contract populated from plan",

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5482,11 +5482,12 @@ def _build_pr_body(
     pr_test_plan: str = ""
     pr_manual_steps: str = ""
 
-    # Try to load PR metadata from the contract (populated by the plan agent)
+    # Try to load PR metadata from the contract (populated by the plan agent).
+    # Contracts are keyed by pipeline_id after key unification (#1773).
     try:
         from egg_contracts.loader import load_contract
 
-        contract = load_contract(identifier, worktree_repo_path)
+        contract = load_contract(pipeline.id, worktree_repo_path)
         if contract.pr:
             pr_title = contract.pr.title
             pr_description = contract.pr.description

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -3174,11 +3174,10 @@ def _render_contract_tasks(
     except ImportError:
         return None
 
-    # Use issue_number as contract identifier when available
-    contract_id: int | str = _pipeline_identifier(issue_number, pipeline_id)
-
+    # Contracts are keyed by pipeline_id (loader's compat shim handles
+    # legacy paths for in-flight pipelines that predate key unification).
     try:
-        contract = load_contract(contract_id, Path(repo_path))
+        contract = load_contract(pipeline_id, Path(repo_path))
     except Exception:
         return None
 
@@ -4115,40 +4114,31 @@ def _ensure_statefiles_on_branch(
     Returns True if the contract exists (or was successfully restored),
     False if restoration failed.
     """
-    identifier = _pipeline_identifier(pipeline.issue_number, pipeline.id)
-    contract_path = worktree_repo_path / ".egg-state" / "contracts" / f"{identifier}.json"
+    from egg_contracts.loader import contract_exists, create_contract, get_contract_path
 
-    if contract_path.exists():
+    identifier = _pipeline_identifier(pipeline.issue_number, pipeline.id)
+    canonical_path = get_contract_path(identifier, worktree_repo_path)
+
+    # ``contract_exists`` checks both the canonical ``issue-<N>.json`` path
+    # and the pre-unification ``{issue_number}.json`` path, so legacy
+    # in-flight pipelines are still recognized.
+    if contract_exists(identifier, worktree_repo_path):
         return True
 
     logger.warning(
         "Contract file missing from worktree — attempting restoration",
         pipeline_id=pipeline.id,
-        expected_path=str(contract_path),
+        expected_path=str(canonical_path),
     )
 
     try:
-        from egg_contracts.loader import create_contract, get_contract_path
-
-        # Double-check using the canonical contract path from the loader to
-        # guard against path-construction drift between this function and the
-        # contract library.  This prevents data loss if the file exists under
-        # a slightly different naming convention.
-        canonical_path = get_contract_path(identifier, worktree_repo_path)
-        if canonical_path.exists():
-            logger.info(
-                "Contract file found at canonical path — skipping recreation",
-                pipeline_id=pipeline.id,
-                canonical_path=str(canonical_path),
-            )
-            return True
-
         if pipeline.issue_number is not None:
             issue_url = f"https://github.com/{pipeline.repo}/issues/{pipeline.issue_number}"
             create_contract(
                 issue_number=pipeline.issue_number,
                 title=f"Issue #{pipeline.issue_number}",
                 url=issue_url,
+                pipeline_id=pipeline.id,
                 repo_root=worktree_repo_path,
             )
         else:
@@ -8682,11 +8672,8 @@ def _populate_contract_from_plan(
         logger.warning("Plan draft not found, skipping contract population", path=str(plan_path))
         return
 
-    # Use issue_number as contract identifier when available
-    contract_id: int | str = _pipeline_identifier(issue_number, pipeline_id)
-
     try:
-        contract = load_contract(contract_id, repo_path)
+        contract = load_contract(pipeline_id, repo_path)
     except Exception:
         logger.warning(
             "Contract not found for pipeline, skipping population", pipeline_id=pipeline_id
@@ -8799,11 +8786,8 @@ def _sync_pipeline_decisions_to_contract(
         logger.debug("No substantive decisions to sync", pipeline_id=pipeline_id)
         return
 
-    # Use issue_number as contract identifier when available
-    contract_id: int | str = _pipeline_identifier(issue_number, pipeline_id)
-
     try:
-        contract = load_contract(contract_id, repo_path)
+        contract = load_contract(pipeline_id, repo_path)
     except Exception:
         logger.warning(
             "Contract not found, skipping decision sync",
@@ -8914,8 +8898,7 @@ def _persist_phase_gate_resolution(
         from egg_contracts.loader import load_contract, save_contract
         from egg_contracts.models import Decision, DecisionOption, DecisionType
 
-        contract_id: int | str = _pipeline_identifier(issue_number, pipeline_id)
-        contract = load_contract(contract_id, repo_path)
+        contract = load_contract(pipeline_id, repo_path)
 
         existing_questions = {d.question for d in contract.decisions}
         question_text = f"[Phase gate: {phase}] {decision.question}"
@@ -9325,6 +9308,7 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                         issue_number=pipeline.issue_number,
                         title=f"Issue #{pipeline.issue_number}",
                         url=issue_url,
+                        pipeline_id=pipeline.id,
                         repo_root=worktree_repo_path,
                     )
                 else:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -4116,14 +4116,11 @@ def _ensure_statefiles_on_branch(
     """
     from egg_contracts.loader import contract_exists, create_contract, get_contract_path
 
-    identifier = _pipeline_identifier(pipeline.issue_number, pipeline.id)
-    canonical_path = get_contract_path(identifier, worktree_repo_path)
-
-    # ``contract_exists`` checks both the canonical ``issue-<N>.json`` path
-    # and the pre-unification ``{issue_number}.json`` path, so legacy
-    # in-flight pipelines are still recognized.
-    if contract_exists(identifier, worktree_repo_path):
+    # Contract lookup uses pipeline.id directly (canonical key).
+    if contract_exists(pipeline.id, worktree_repo_path):
         return True
+
+    canonical_path = get_contract_path(pipeline.id, worktree_repo_path)
 
     logger.warning(
         "Contract file missing from worktree — attempting restoration",
@@ -4242,6 +4239,8 @@ def _ensure_statefiles_on_branch(
             pipeline.issue_number,
         )
 
+        # File-staging identifier still uses _pipeline_identifier convention.
+        identifier = _pipeline_identifier(pipeline.issue_number, pipeline.id)
         _commit_statefiles_to_worktree(
             worktree_repo_path,
             f"Restore missing contract for {identifier}",

--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -398,10 +398,10 @@ def handle_complete_signal(
         contract_role = _AGENT_ROLE_TO_CONTRACT_ROLE.get(agent_role)
 
         if contract_role is not None:
-            identifier: int | str = (
-                pipeline.issue_number if pipeline.issue_number is not None else pipeline_id
-            )
-            contract = load_contract(identifier, contract_path)
+            # Contracts are keyed by pipeline_id (includes any qualifier) so
+            # qualified pipelines resolve to the correct contract file. The
+            # loader's compat shim handles legacy pre-unification paths.
+            contract = load_contract(pipeline_id, contract_path)
             orch = create_orchestrator(contract)
             orch.complete_agent(contract_role, commit=commit, outputs=outputs)
             updated_contract = orch.apply_to_contract()
@@ -593,10 +593,10 @@ def handle_error_signal(
         contract_role = _AGENT_ROLE_TO_CONTRACT_ROLE.get(agent_role)
 
         if contract_role is not None:
-            identifier: int | str = (
-                pipeline.issue_number if pipeline.issue_number is not None else pipeline_id
-            )
-            contract = load_contract(identifier, contract_path)
+            # Contracts are keyed by pipeline_id (includes any qualifier) so
+            # qualified pipelines resolve to the correct contract file. The
+            # loader's compat shim handles legacy pre-unification paths.
+            contract = load_contract(pipeline_id, contract_path)
             orch = create_orchestrator(contract)
             orch.fail_agent(contract_role, error_message)
             updated_contract = orch.apply_to_contract()

--- a/orchestrator/tests/test_hitl_revision.py
+++ b/orchestrator/tests/test_hitl_revision.py
@@ -1558,7 +1558,7 @@ class TestPhaseGateResolutionPersistence:
         assert len(updated.decisions) == 0
 
     def test_phase_gate_resolution_with_issue_number(self, tmp_path):
-        """When issue_number is provided, it should be used as the contract identifier."""
+        """When issue_number is provided, contract is keyed by pipeline_id."""
         from egg_contracts.loader import load_contract, save_contract
         from egg_contracts.models import Contract
         from routes.pipelines import _persist_phase_gate_resolution
@@ -1569,7 +1569,8 @@ class TestPhaseGateResolutionPersistence:
                 "title": "Test",
                 "repo": "owner/repo",
                 "url": "https://github.com/owner/repo/issues/42",
-            }
+            },
+            pipeline_id="test-pipe",
         )
         save_contract(contract, tmp_path)
 
@@ -1583,7 +1584,7 @@ class TestPhaseGateResolutionPersistence:
             42,
         )
 
-        updated = load_contract(42, tmp_path)
+        updated = load_contract("test-pipe", tmp_path)
         assert len(updated.decisions) == 1
         assert updated.decisions[0].resolution == "Ship it"
 

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -543,11 +543,11 @@ class TestRenderContractTasks:
             assert "[x] **task-1**" in result
 
     def test_issue_mode_uses_issue_number(self):
-        """In issue mode, uses issue_number as contract identifier."""
+        """In issue mode, contract is loaded by pipeline_id."""
         with tempfile.TemporaryDirectory() as tmpdir:
             self._make_contract(
                 tmpdir,
-                42,
+                "pid-1",
                 phases=[
                     {
                         "id": "phase-1",

--- a/orchestrator/tests/test_populate_contract_endpoint.py
+++ b/orchestrator/tests/test_populate_contract_endpoint.py
@@ -72,12 +72,11 @@ class TestPopulateContractEndpoint:
         data = json.loads(resp.data)
         assert data["success"] is False
 
-    @patch("routes.pipelines._pipeline_identifier", return_value="42")
     @patch("routes.pipelines._populate_contract_from_plan")
     @patch("routes.resolve_worktree_path")
     @patch("routes.phases.get_state_store_for_pipeline")
     def test_pipeline_mode_from_pipeline_not_config(
-        self, mock_get_store, mock_resolve_wt, mock_populate, mock_identifier, client
+        self, mock_get_store, mock_resolve_wt, mock_populate, client
     ):
         """pipeline.mode (not pipeline.config.mode) is used for pipeline_mode.
 
@@ -122,12 +121,11 @@ class TestPopulateContractEndpoint:
         assert data["success"] is False
         assert "plan draft not found" in data["message"]
 
-    @patch("routes.pipelines._pipeline_identifier", return_value="42")
     @patch("routes.pipelines._populate_contract_from_plan")
     @patch("routes.resolve_worktree_path")
     @patch("routes.phases.get_state_store_for_pipeline")
     def test_success_with_counts_and_issue_number(
-        self, mock_get_store, mock_resolve_wt, mock_populate, mock_identifier, client
+        self, mock_get_store, mock_resolve_wt, mock_populate, client
     ):
         """Successful populate returns phase/task counts and forwards issue_number."""
         pipeline = _make_pipeline()
@@ -180,12 +178,11 @@ class TestPopulateContractEndpoint:
         assert data["success"] is True
         assert "data" not in data  # No counts on fallback
 
-    @patch("routes.pipelines._pipeline_identifier", return_value="42")
     @patch("routes.pipelines._populate_contract_from_plan")
     @patch("routes.resolve_worktree_path")
     @patch("routes.phases.get_state_store_for_pipeline")
     def test_worktree_path_passed_to_populate(
-        self, mock_get_store, mock_resolve_wt, mock_populate, mock_identifier, client
+        self, mock_get_store, mock_resolve_wt, mock_populate, client
     ):
         """Verify worktree path (not raw repo path) is passed to populate."""
         pipeline = _make_pipeline()

--- a/orchestrator/tests/test_short_flow_contract_population.py
+++ b/orchestrator/tests/test_short_flow_contract_population.py
@@ -756,11 +756,12 @@ class TestSourceBranchArtifactWriteToDisk:
             issue_number=issue_number,
             title=f"Issue #{issue_number}",
             url=f"https://github.com/owner/repo/issues/{issue_number}",
+            pipeline_id=pipeline_id,
             repo_root=tmp_path,
         )
         _populate_contract_from_plan(tmp_path, pipeline_id, "issue", issue_number)
 
-        contract = load_contract(issue_number, tmp_path)
+        contract = load_contract(pipeline_id, tmp_path)
         assert len(contract.phases) == 1
         assert len(contract.phases[0].tasks) == 2
         assert contract.pr is not None

--- a/orchestrator/tests/test_statefile_reconciliation.py
+++ b/orchestrator/tests/test_statefile_reconciliation.py
@@ -94,10 +94,10 @@ class TestEnsureStatefilesOnBranch:
     def test_returns_true_when_contract_exists(self, tmp_path: Path):
         """When the contract file already exists, return True without re-creating."""
         pipeline = _make_pipeline()
-        # Create the expected contract file
+        # Create the expected contract file (keyed by pipeline.id)
         contract_dir = tmp_path / ".egg-state" / "contracts"
         contract_dir.mkdir(parents=True)
-        contract_file = contract_dir / "42.json"
+        contract_file = contract_dir / "pipe-1.json"
         contract_file.write_text("{}")
 
         result = _ensure_statefiles_on_branch(tmp_path, pipeline)

--- a/orchestrator/tests/test_statefile_reconciliation.py
+++ b/orchestrator/tests/test_statefile_reconciliation.py
@@ -120,6 +120,7 @@ class TestEnsureStatefilesOnBranch:
             issue_number=42,
             title="Issue #42",
             url="https://github.com/owner/repo/issues/42",
+            pipeline_id="pipe-1",
             repo_root=tmp_path,
         )
         mock_populate.assert_called_once_with(

--- a/sandbox/egg_lib/contract_cli.py
+++ b/sandbox/egg_lib/contract_cli.py
@@ -73,8 +73,11 @@ def get_contract_identifier(args: argparse.Namespace) -> int | str | None:
     Priority (highest to lowest):
     1. --issue flag (int, for backward compatibility)
     2. --pipeline-id flag (str)
-    3. EGG_ISSUE_NUMBER env var (int)
-    4. EGG_PIPELINE_ID env var (str)
+    3. EGG_PIPELINE_ID env var (str) — preferred because contracts are
+       keyed by pipeline_id on disk; this also covers qualified pipelines
+       (e.g. ``issue-1759-v2``) where the bare issue number can't
+       disambiguate between multiple pipelines for the same issue.
+    4. EGG_ISSUE_NUMBER env var (int) — legacy fallback.
 
     Returns:
         int for issue numbers, str for pipeline IDs, None if nothing found
@@ -85,10 +88,10 @@ def get_contract_identifier(args: argparse.Namespace) -> int | str | None:
     pipeline_id_arg: str | None = getattr(args, "pipeline_id", None)
     if pipeline_id_arg is not None:
         return pipeline_id_arg
-    issue = get_issue_number()
-    if issue is not None:
-        return issue
-    return get_pipeline_id()
+    pipeline_id = get_pipeline_id()
+    if pipeline_id is not None:
+        return pipeline_id
+    return get_issue_number()
 
 
 def get_repo_path() -> str:

--- a/sandbox/egg_lib/sdlc_hitl.py
+++ b/sandbox/egg_lib/sdlc_hitl.py
@@ -131,12 +131,15 @@ def _get_contract_key(
 ) -> str | None:
     """Return the contract file key for the current pipeline.
 
-    Uses issue_number when available, otherwise pipeline_id.
+    Uses pipeline_id when available, otherwise derives a canonical key
+    from the issue_number (``issue-<N>``).
     Returns None if neither identifier is available.
     """
+    if pipeline_id:
+        return pipeline_id
     if issue_number is not None:
-        return str(issue_number)
-    return pipeline_id if pipeline_id else None
+        return f"issue-{issue_number}"
+    return None
 
 
 def _load_pending_contract_decisions(

--- a/shared/egg_contracts/loader.py
+++ b/shared/egg_contracts/loader.py
@@ -41,20 +41,56 @@ class ContractValidationError(Exception):
         super().__init__(f"Contract for {identifier} is invalid: {'; '.join(errors)}")
 
 
-def get_contract_path(identifier: int | str, repo_root: Path | None = None) -> Path:
+def _canonical_key(identifier: int | str) -> str:
+    """Convert a caller-provided identifier to its canonical pipeline-id string.
+
+    Integer issue numbers are mapped to ``issue-<N>`` so that every contract
+    is keyed by a pipeline-id-shaped string on disk. String identifiers are
+    returned unchanged.
     """
-    Get the path to a contract file.
+    if isinstance(identifier, int):
+        return f"issue-{identifier}"
+    return identifier
 
-    Args:
-        identifier: Issue number (int) or pipeline ID (str)
-        repo_root: Optional repository root path. Defaults to current directory.
 
-    Returns:
-        Path to the contract JSON file
+def _legacy_contract_path(identifier: int | str, repo_root: Path | None = None) -> Path | None:
+    """Return the pre-unification contract path for an identifier, if one exists.
+
+    Before contract keys were unified, issue-driven pipelines stored the
+    contract at ``{issue_number}.json`` (bare integer stem). This helper
+    returns that legacy path so read paths can fall back when a contract
+    hasn't been migrated to the new ``issue-<N>.json`` shape yet.
+
+    Returns ``None`` when the identifier has no distinct legacy form (e.g.,
+    non-issue string pipeline IDs).
     """
     if repo_root is None:
         repo_root = Path.cwd()
-    return repo_root / DEFAULT_CONTRACTS_DIR / f"{identifier}.json"
+    if isinstance(identifier, int):
+        return repo_root / DEFAULT_CONTRACTS_DIR / f"{identifier}.json"
+    if identifier.startswith("issue-"):
+        suffix = identifier[len("issue-") :]
+        if suffix.isdigit():
+            return repo_root / DEFAULT_CONTRACTS_DIR / f"{suffix}.json"
+    return None
+
+
+def get_contract_path(identifier: int | str, repo_root: Path | None = None) -> Path:
+    """
+    Get the canonical path to a contract file.
+
+    Args:
+        identifier: Pipeline identifier — either a string (``issue-<N>``,
+            ``issue-<N>-<qualifier>``, or a JIRA ticket) or an integer issue
+            number (which is canonicalized to ``issue-<N>``).
+        repo_root: Optional repository root path. Defaults to current directory.
+
+    Returns:
+        Path to the contract JSON file under ``.egg-state/contracts/``.
+    """
+    if repo_root is None:
+        repo_root = Path.cwd()
+    return repo_root / DEFAULT_CONTRACTS_DIR / f"{_canonical_key(identifier)}.json"
 
 
 def load_contract(identifier: int | str, repo_root: Path | None = None) -> Contract:
@@ -62,7 +98,9 @@ def load_contract(identifier: int | str, repo_root: Path | None = None) -> Contr
     Load a contract from disk.
 
     Args:
-        identifier: Issue number (int) or pipeline ID (str)
+        identifier: Pipeline identifier — either a string (``issue-<N>``,
+            ``issue-<N>-<qualifier>``, or a JIRA ticket) or an integer issue
+            number (canonicalized to ``issue-<N>``).
         repo_root: Optional repository root path
 
     Returns:
@@ -71,11 +109,20 @@ def load_contract(identifier: int | str, repo_root: Path | None = None) -> Contr
     Raises:
         ContractNotFoundError: If the contract doesn't exist
         ContractValidationError: If the contract is invalid
+
+    Note:
+        Falls back to the pre-unification ``{issue_number}.json`` filename
+        when the canonical ``issue-<N>.json`` is absent, so in-flight
+        pipelines created before the key unification continue to resolve.
     """
     path = get_contract_path(identifier, repo_root)
 
     if not path.exists():
-        raise ContractNotFoundError(identifier, path)
+        legacy = _legacy_contract_path(identifier, repo_root)
+        if legacy is not None and legacy.exists():
+            path = legacy
+        else:
+            raise ContractNotFoundError(identifier, path)
 
     try:
         with open(path) as f:
@@ -124,6 +171,16 @@ def save_contract(contract: Contract, repo_root: Path | None = None) -> Path:
             pass
         raise
 
+    # Remove any legacy pre-unification file (e.g. "1759.json") once the
+    # contract has been successfully rewritten under the canonical key.
+    # This prevents two contract files from coexisting for one pipeline.
+    legacy = _legacy_contract_path(contract.contract_key, repo_root)
+    if legacy is not None and legacy != path and legacy.exists():
+        try:
+            legacy.unlink()
+        except OSError:
+            pass
+
     return path
 
 
@@ -132,14 +189,16 @@ def contract_exists(identifier: int | str, repo_root: Path | None = None) -> boo
     Check if a contract exists.
 
     Args:
-        identifier: Issue number (int) or pipeline ID (str)
+        identifier: Pipeline identifier (int issue number or str pipeline_id)
         repo_root: Optional repository root path
 
     Returns:
-        True if the contract exists
+        True if the contract exists at either the canonical or legacy path.
     """
-    path = get_contract_path(identifier, repo_root)
-    return path.exists()
+    if get_contract_path(identifier, repo_root).exists():
+        return True
+    legacy = _legacy_contract_path(identifier, repo_root)
+    return legacy is not None and legacy.exists()
 
 
 def create_contract(
@@ -154,10 +213,12 @@ def create_contract(
     Create a new contract for a pipeline.
 
     Args:
-        issue_number: Optional GitHub issue number
+        issue_number: Optional GitHub issue number (retained as contract
+            metadata; the on-disk filename is driven by ``pipeline_id``).
         title: Issue/task title
         url: Optional issue URL
-        pipeline_id: Optional pipeline ID (used when no issue_number)
+        pipeline_id: Canonical pipeline ID. When ``issue_number`` is given
+            without an explicit ``pipeline_id``, defaults to ``issue-<N>``.
         repo_root: Optional repository root path
         initial_phase: Initial pipeline phase
 
@@ -165,9 +226,11 @@ def create_contract(
         The newly created Contract
     """
     issue = IssueInfo(number=issue_number, title=title, url=url or "") if issue_number else None
+    if pipeline_id is None and issue_number is not None:
+        pipeline_id = f"issue-{issue_number}"
     contract = Contract(
         issue=issue,
-        pipeline_id=pipeline_id if not issue_number else None,
+        pipeline_id=pipeline_id,
         current_phase=initial_phase,
     )
 
@@ -201,25 +264,39 @@ def load_contract_from_branch(
     if branch is None:
         return load_contract(identifier, repo_path)
 
-    # Read file from specific branch using git show
+    # Read file from specific branch using git show.
+    # Try the canonical path first, then fall back to the pre-unification
+    # path so contracts on legacy in-flight branches still resolve.
     import subprocess
 
-    contract_rel_path = f"{DEFAULT_CONTRACTS_DIR}/{identifier}.json"
+    canonical_rel = f"{DEFAULT_CONTRACTS_DIR}/{_canonical_key(identifier)}.json"
+    candidates = [canonical_rel]
+    legacy = _legacy_contract_path(identifier, Path("."))
+    if legacy is not None:
+        legacy_rel = f"{DEFAULT_CONTRACTS_DIR}/{legacy.name}"
+        if legacy_rel != canonical_rel:
+            candidates.append(legacy_rel)
 
-    try:
-        result = subprocess.run(
-            ["git", "show", f"{branch}:{contract_rel_path}"],
-            cwd=repo_path,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        data = json.loads(result.stdout)
+    last_error: subprocess.CalledProcessError | None = None
+    for rel in candidates:
+        try:
+            result = subprocess.run(
+                ["git", "show", f"{branch}:{rel}"],
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            last_error = e
+            continue
+        try:
+            data = json.loads(result.stdout)
+        except json.JSONDecodeError as e:
+            raise ContractValidationError(identifier, [f"Invalid JSON: {e}"]) from e
         return Contract.model_validate(data)
-    except subprocess.CalledProcessError as e:
-        raise ContractNotFoundError(identifier, repo_path / contract_rel_path) from e
-    except json.JSONDecodeError as e:
-        raise ContractValidationError(identifier, [f"Invalid JSON: {e}"]) from e
+
+    raise ContractNotFoundError(identifier, repo_path / canonical_rel) from last_error
 
 
 def list_contracts(repo_root: Path | None = None) -> list[int | str]:
@@ -241,11 +318,16 @@ def list_contracts(repo_root: Path | None = None) -> list[int | str]:
 
     identifiers: list[int | str] = []
     for path in contracts_dir.glob("*.json"):
-        try:
-            identifiers.append(int(path.stem))
-        except ValueError:
-            # Non-numeric filenames are local pipeline IDs
-            identifiers.append(path.stem)
+        stem = path.stem
+        # Recognize both the legacy bare-integer shape ("1759.json") and the
+        # canonical ``issue-<N>.json`` shape as issue-driven pipelines so
+        # callers that filter on ``isinstance(_, int)`` keep working.
+        if stem.isdigit():
+            identifiers.append(int(stem))
+        elif stem.startswith("issue-") and stem[len("issue-") :].isdigit():
+            identifiers.append(int(stem[len("issue-") :]))
+        else:
+            identifiers.append(stem)
 
     return sorted(identifiers, key=str)
 
@@ -255,18 +337,22 @@ def delete_contract(identifier: int | str, repo_root: Path | None = None) -> boo
     Delete a contract from disk.
 
     Args:
-        identifier: Issue number (int) or pipeline ID (str)
+        identifier: Pipeline identifier (int issue number or str pipeline_id)
         repo_root: Optional repository root path
 
     Returns:
-        True if the contract was deleted, False if it didn't exist
+        True if at least one contract file was deleted (canonical and/or
+        legacy), False if no file was found.
     """
-    path = get_contract_path(identifier, repo_root)
-
-    if path.exists():
-        path.unlink()
-        return True
-    return False
+    deleted = False
+    for candidate in (
+        get_contract_path(identifier, repo_root),
+        _legacy_contract_path(identifier, repo_root),
+    ):
+        if candidate is not None and candidate.exists():
+            candidate.unlink()
+            deleted = True
+    return deleted
 
 
 def export_contract(

--- a/shared/egg_contracts/loader.py
+++ b/shared/egg_contracts/loader.py
@@ -316,20 +316,26 @@ def list_contracts(repo_root: Path | None = None) -> list[int | str]:
     if not contracts_dir.exists():
         return []
 
-    identifiers: list[int | str] = []
+    seen: dict[int | str, None] = {}
     for path in contracts_dir.glob("*.json"):
         stem = path.stem
         # Recognize both the legacy bare-integer shape ("1759.json") and the
         # canonical ``issue-<N>.json`` shape as issue-driven pipelines so
         # callers that filter on ``isinstance(_, int)`` keep working.
+        # Skip legacy files when the canonical version already exists to
+        # avoid duplicates during the migration window.
         if stem.isdigit():
-            identifiers.append(int(stem))
+            key = int(stem)
+            canonical = contracts_dir / f"issue-{stem}.json"
+            if canonical.exists():
+                continue  # canonical version exists; skip legacy
+            seen[key] = None
         elif stem.startswith("issue-") and stem[len("issue-") :].isdigit():
-            identifiers.append(int(stem[len("issue-") :]))
+            seen[int(stem[len("issue-") :])] = None
         else:
-            identifiers.append(stem)
+            seen[stem] = None
 
-    return sorted(identifiers, key=str)
+    return sorted(seen.keys(), key=str)
 
 
 def delete_contract(identifier: int | str, repo_root: Path | None = None) -> bool:

--- a/shared/egg_contracts/models.py
+++ b/shared/egg_contracts/models.py
@@ -410,7 +410,14 @@ class Contract(BaseModel):
     )
     issue: IssueInfo | None = Field(default=None, description="Issue metadata")
     pipeline_id: str | None = Field(
-        default=None, description="Pipeline ID for local-mode pipelines"
+        default=None,
+        description=(
+            "Canonical pipeline identifier — the on-disk contract key. "
+            "For issue-driven pipelines this is ``issue-<N>`` (optionally "
+            "``issue-<N>-<qualifier>``); for JIRA-ticket pipelines this is "
+            "the ticket ID (e.g., ``KORE-1234``). Optional only for legacy "
+            "contracts that predate the key unification."
+        ),
     )
     current_phase: PipelinePhase = Field(
         default=PipelinePhase.REFINE, description="Current pipeline phase"
@@ -457,16 +464,18 @@ class Contract(BaseModel):
         return self
 
     @property
-    def contract_key(self) -> int | str:
-        """Return the canonical key used for file naming.
+    def contract_key(self) -> str:
+        """Return the canonical pipeline-id string used for file naming.
 
-        Returns issue.number for issue-mode contracts, pipeline_id for
-        local-mode contracts.
+        Every contract is keyed by its pipeline_id (e.g., ``issue-1759``,
+        ``issue-1759-v2``, or a JIRA-style identifier). For legacy contracts
+        that predate the unification and only have ``issue`` populated, a
+        canonical pipeline-id is synthesized from the issue number.
         """
-        if self.issue is not None:
-            return self.issue.number
-        assert self.pipeline_id is not None
-        return self.pipeline_id
+        if self.pipeline_id is not None:
+            return self.pipeline_id
+        assert self.issue is not None
+        return f"issue-{self.issue.number}"
 
     def get_task(self, phase_id: str, task_id: str) -> Task | None:
         """Get a specific task by phase and task ID."""

--- a/tests/sandbox/test_contract_cli.py
+++ b/tests/sandbox/test_contract_cli.py
@@ -263,17 +263,23 @@ class TestGetContractIdentifier:
         with patch.dict("os.environ", {"EGG_ISSUE_NUMBER": "99"}):
             assert get_contract_identifier(args) == "KORE-123"
 
-    def test_env_issue_number_third(self):
-        """EGG_ISSUE_NUMBER env var used when no flags set."""
+    def test_env_pipeline_id_third(self):
+        """EGG_PIPELINE_ID beats EGG_ISSUE_NUMBER when no flags are set.
+
+        Contracts are keyed by pipeline_id on disk, so the pipeline_id env
+        var wins over the bare issue number. This is what lets qualified
+        pipelines (e.g. ``issue-1759-v2``) find their contract without
+        having to pass ``--pipeline-id`` on every invocation.
+        """
         args = self._make_args()
         with patch.dict("os.environ", {"EGG_ISSUE_NUMBER": "99", "EGG_PIPELINE_ID": "KORE-1"}):
-            assert get_contract_identifier(args) == 99
+            assert get_contract_identifier(args) == "KORE-1"
 
-    def test_env_pipeline_id_last(self):
-        """EGG_PIPELINE_ID env var used as last resort."""
+    def test_env_issue_number_last(self):
+        """EGG_ISSUE_NUMBER is used as the final fallback."""
         args = self._make_args()
-        with patch.dict("os.environ", {"EGG_PIPELINE_ID": "KORE-1191-full"}, clear=True):
-            assert get_contract_identifier(args) == "KORE-1191-full"
+        with patch.dict("os.environ", {"EGG_ISSUE_NUMBER": "99"}, clear=True):
+            assert get_contract_identifier(args) == 99
 
     def test_nothing_set_returns_none(self):
         """Returns None when nothing is set."""

--- a/tests/sandbox/test_sdlc_hitl.py
+++ b/tests/sandbox/test_sdlc_hitl.py
@@ -2205,8 +2205,8 @@ class TestContractDecisionBridge:
     # -- _get_contract_key --
 
     def test_get_contract_key_with_issue_number(self):
-        """Returns str(issue_number) when provided."""
-        assert _get_contract_key(issue_number=42) == "42"
+        """Returns canonical issue-<N> key when issue_number provided."""
+        assert _get_contract_key(issue_number=42) == "issue-42"
 
     def test_get_contract_key_no_identifiers(self):
         """Returns None when no identifiers provided."""
@@ -2361,7 +2361,7 @@ class TestContractDecisionBridge:
 
         self._write_contract(
             tmp_path,
-            "42",
+            "issue-42",
             [
                 {
                     "id": "decision-1",
@@ -2418,7 +2418,7 @@ class TestContractDecisionBridge:
 
         self._write_contract(
             tmp_path,
-            "42",
+            "issue-42",
             [
                 {
                     "id": "decision-1",
@@ -2749,7 +2749,7 @@ class TestContractDecisionBridge:
 
         self._write_contract(
             tmp_path,
-            "42",
+            "issue-42",
             [
                 {
                     "id": "decision-1",
@@ -2782,7 +2782,7 @@ class TestContractDecisionBridge:
 
         assert result == "resolved"
         # Verify the contract decision was resolved
-        data = json.loads((tmp_path / ".egg-state" / "contracts" / "42.json").read_text())
+        data = json.loads((tmp_path / ".egg-state" / "contracts" / "issue-42.json").read_text())
         assert data["decisions"][0]["resolved"] is True
         assert data["decisions"][0]["resolution"] == "PostgreSQL"
         # After answering, approve should not warn about pending questions

--- a/tests/shared/egg_contracts/test_loader.py
+++ b/tests/shared/egg_contracts/test_loader.py
@@ -92,23 +92,28 @@ class TestGetContractPath:
     """Tests for get_contract_path function."""
 
     def test_with_repo_root(self, tmp_path):
-        """Test path construction with explicit repo_root."""
+        """Integer issue numbers canonicalize to ``issue-<N>.json``."""
         path = get_contract_path(42, repo_root=tmp_path)
-        assert path == tmp_path / ".egg-state" / "contracts" / "42.json"
+        assert path == tmp_path / ".egg-state" / "contracts" / "issue-42.json"
 
     def test_without_repo_root_uses_cwd(self):
-        """Test path defaults to cwd when repo_root is None."""
+        """Path defaults to cwd when repo_root is None."""
         path = get_contract_path(7)
-        expected = Path.cwd() / ".egg-state" / "contracts" / "7.json"
+        expected = Path.cwd() / ".egg-state" / "contracts" / "issue-7.json"
         assert path == expected
 
     def test_different_issue_numbers(self, tmp_path):
-        """Test that different issue numbers produce different filenames."""
+        """Different issue numbers produce different filenames."""
         path_1 = get_contract_path(1, repo_root=tmp_path)
         path_2 = get_contract_path(999, repo_root=tmp_path)
-        assert path_1.name == "1.json"
-        assert path_2.name == "999.json"
+        assert path_1.name == "issue-1.json"
+        assert path_2.name == "issue-999.json"
         assert path_1 != path_2
+
+    def test_string_pipeline_id_passes_through(self, tmp_path):
+        """String pipeline IDs are used verbatim as the filename stem."""
+        path = get_contract_path("issue-1759-v2", repo_root=tmp_path)
+        assert path == tmp_path / ".egg-state" / "contracts" / "issue-1759-v2.json"
 
 
 class TestLoadContract:
@@ -167,7 +172,7 @@ class TestSaveContract:
         path = save_contract(contract, repo_root=tmp_path)
 
         assert path.exists()
-        assert path.name == "42.json"
+        assert path.name == "issue-42.json"
 
         # Verify contents are valid JSON that round-trips
         data = json.loads(path.read_text())
@@ -198,7 +203,7 @@ class TestSaveContract:
         """Test that save_contract returns the expected path."""
         contract = _make_contract(issue_number=77)
         path = save_contract(contract, repo_root=tmp_path)
-        expected = tmp_path / ".egg-state" / "contracts" / "77.json"
+        expected = tmp_path / ".egg-state" / "contracts" / "issue-77.json"
         assert path == expected
 
     def test_save_file_has_trailing_newline(self, tmp_path):
@@ -302,8 +307,10 @@ class TestLoadContractFromBranch:
         with patch("subprocess.run", return_value=mock_result) as mock_run:
             loaded = load_contract_from_branch(42, tmp_path, branch="feature/test")
 
+        # Canonical path is tried first; the mock succeeds so the legacy
+        # fallback is never exercised.
         mock_run.assert_called_once_with(
-            ["git", "show", "feature/test:.egg-state/contracts/42.json"],
+            ["git", "show", "feature/test:.egg-state/contracts/issue-42.json"],
             cwd=tmp_path,
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary

- Contracts are now always keyed by `pipeline_id` on disk. Previously unqualified pipelines wrote `.egg-state/contracts/{issue_number}.json` while qualified pipelines wrote `.egg-state/contracts/{pipeline_id}.json`, and the `egg-contract` CLI resolver preferred `EGG_ISSUE_NUMBER` over `EGG_PIPELINE_ID` — so every qualified-pipeline agent hit `Contract for #N not found` on its first call.
- `Contract.contract_key` returns `pipeline_id` unconditionally; `create_contract` always populates it, defaulting to `issue-<N>`. `get_contract_path` canonicalizes integer identifiers to `issue-<N>` so callers land on a single filename shape.
- Loader read paths fall back to the pre-unification `{issue_number}.json` filename when the canonical `issue-<N>.json` is absent, so in-flight pipelines keep working. `save_contract` deletes the legacy file after writing the canonical one, healing each contract on first write — no manual migration needed.
- `egg-contract` env-var priority now prefers `EGG_PIPELINE_ID`, matching where contracts actually live. Orchestrator-internal callers that passed `_pipeline_identifier(issue_number, pipeline_id)` to `load_contract` (silently broken for qualified pipelines) now pass `pipeline_id` directly. `health_checks/context.py` and `.github/scripts/checks/run_check.py` handle both shapes.

## Test plan

- [x] `tests/shared/egg_contracts/test_loader.py` — updated for canonical `issue-<N>.json` filenames; covers save, load, list, delete, and branch-read paths
- [x] `tests/sandbox/test_contract_cli.py` — updated resolver priority tests (EGG_PIPELINE_ID > EGG_ISSUE_NUMBER)
- [ ] Manual: spawn a qualified pipeline (e.g., `--qualifier v2`) and confirm the first `egg-contract add-decision` succeeds without `--pipeline-id`
- [ ] Manual: resume an in-flight pipeline with a pre-existing `{issue_number}.json` contract and confirm the loader's compat shim resolves it, then saves under the new canonical path
- [ ] Full test suite (`make test`) — run in CI

Closes #1773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)