### PR TITLE
Fix #1787: MCP lifecycle tools send empty body with JSON content-type

### DIFF
--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -1455,7 +1455,11 @@ class PipelineToolHandler:
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {token}",
             }
-            body = json.dumps(data).encode() if data else None
+            # Same GET/non-GET split as _make_request — see #1787.
+            if method == "GET":
+                body = json.dumps(data).encode() if data else None
+            else:
+                body = json.dumps(data if data is not None else {}).encode()
             opener = build_opener(ProxyHandler({}))
             req = Request(url, data=body, headers=headers, method=method)
             with opener.open(req, timeout=timeout) as response:

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -752,7 +752,13 @@ class PipelineToolHandler:
         if lifecycle_secret:
             headers["Authorization"] = f"Bearer {lifecycle_secret}"
             headers["X-Egg-Source"] = "mcp"
-        body = json.dumps(data).encode() if data else None
+        # Always send a JSON body for non-GET requests: Content-Type:
+        # application/json with an empty body makes Flask's get_json() raise
+        # BadRequest(400). See #1787.
+        if method == "GET":
+            body = json.dumps(data).encode() if data else None
+        else:
+            body = json.dumps(data if data is not None else {}).encode()
 
         opener = build_opener(ProxyHandler({}))
         req = Request(url, data=body, headers=headers, method=method)

--- a/orchestrator/routes/phases.py
+++ b/orchestrator/routes/phases.py
@@ -233,7 +233,10 @@ def advance_phase(pipeline_id: str) -> tuple[Response, int]:
             }
         }
     """
-    data = request.get_json() or {}
+    # silent=True: tolerate empty body with Content-Type: application/json,
+    # which would otherwise raise BadRequest(400) before reaching the
+    # "Missing target_phase" error below. See #1787.
+    data = request.get_json(silent=True) or {}
 
     target_phase_str = data.get("target_phase")
     if not target_phase_str:

--- a/orchestrator/routes/phases.py
+++ b/orchestrator/routes/phases.py
@@ -687,7 +687,9 @@ def fail_phase(pipeline_id: str) -> tuple[Response, int]:
             "message": "Phase marked as failed"
         }
     """
-    data = request.get_json() or {}
+    # silent=True: tolerate empty body with Content-Type: application/json.
+    # Same defense-in-depth as advance_phase — see #1787.
+    data = request.get_json(silent=True) or {}
 
     error_message = data.get("error")
     if not error_message:

--- a/orchestrator/tests/test_lifecycle_empty_body.py
+++ b/orchestrator/tests/test_lifecycle_empty_body.py
@@ -97,6 +97,25 @@ class TestEmptyBodyDoesNotCrashLifecycleRoutes:
         mock_get_store.assert_not_called()
 
     @patch("routes.phases.get_state_store_for_pipeline")
+    def test_fail_phase_empty_body_returns_clear_error(self, mock_get_store, client):
+        """fail_phase requires error — empty body must return the
+        'Missing error message' domain error, not a JSON parse 400.
+        """
+        pipeline = _make_pipeline(
+            phase=PipelinePhase.IMPLEMENT, phase_status=PipelineStatus.RUNNING
+        )
+        mock_get_store.return_value = (MagicMock(), pipeline)
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase/fail",
+            data=b"",
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 400
+        assert b"error" in resp.data.lower()
+
+    @patch("routes.phases.get_state_store_for_pipeline")
     def test_start_phase_empty_body(self, mock_get_store, client):
         """start_phase takes no body — empty body must not 400."""
         pipeline = _make_pipeline(
@@ -119,7 +138,12 @@ class TestEmptyBodyDoesNotCrashLifecycleRoutes:
     def test_populate_contract_empty_body(
         self, mock_get_store, mock_resolve_wt, _mock_populate, client
     ):
-        """populate_contract takes no body — empty body must not 400."""
+        """populate_contract takes no body — empty body must not 400.
+
+        Note: this route never calls get_json(), so it is not vulnerable to
+        the #1787 bug directly. This is a structural smoke test confirming
+        that sending an empty body doesn't cause unexpected failures.
+        """
         pipeline = _make_pipeline()
         mock_store = MagicMock()
         mock_store.repo_path = Path("/tmp/repo")

--- a/orchestrator/tests/test_lifecycle_empty_body.py
+++ b/orchestrator/tests/test_lifecycle_empty_body.py
@@ -1,0 +1,136 @@
+"""Hardening tests for lifecycle endpoints receiving empty-body POSTs.
+
+Regression for #1787: MCP lifecycle tools previously sent no body at all
+when their optional fields were omitted, while still sending
+``Content-Type: application/json``. Flask's default ``get_json()`` raises
+BadRequest(400) for an empty body with a JSON content type, which made
+``complete_phase`` and similar tools unreachable via MCP without artifacts.
+
+The sender fix lives in ``mcp_tools._make_request`` (always send ``{}``).
+These tests harden the receivers so the same mistake from any future
+caller does not reintroduce the opaque 400.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+sys.modules.setdefault("docker", MagicMock())
+sys.modules.setdefault("docker.errors", MagicMock())
+sys.modules.setdefault("docker.types", MagicMock())
+
+from flask import Flask
+from models import Pipeline, PipelinePhase, PipelineStatus
+from routes.phases import phases_bp
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.register_blueprint(phases_bp)
+    app.config["TESTING"] = True
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _make_pipeline(phase=PipelinePhase.PLAN, phase_status=PipelineStatus.COMPLETE):
+    pipeline = Pipeline(
+        id="issue-42",
+        issue_number=42,
+        repo="owner/repo",
+        branch="egg/issue-42",
+        status=PipelineStatus.RUNNING,
+        current_phase=phase,
+    )
+    phase_exec = pipeline.get_phase_execution(phase)
+    phase_exec.status = phase_status
+    return pipeline
+
+
+class TestEmptyBodyDoesNotCrashLifecycleRoutes:
+    """Empty body with Content-Type: application/json must not return a JSON
+    parse error (400 with no message). Each route either succeeds on empty
+    body (no required fields) or returns a clear domain-level 400.
+    """
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_complete_phase_empty_body(self, mock_get_store, _mock_clear, client):
+        pipeline = _make_pipeline(phase=PipelinePhase.IMPLEMENT)
+        mock_get_store.return_value = (MagicMock(), pipeline)
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase/complete",
+            data=b"",
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 200
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_advance_phase_empty_body_returns_clear_error(self, mock_get_store, client):
+        """advance_phase requires target_phase — empty body must return the
+        'Missing target_phase' domain error, not a JSON parse 400.
+        """
+        pipeline = _make_pipeline()
+        mock_get_store.return_value = (MagicMock(), pipeline)
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase",
+            data=b"",
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 400
+        assert b"target_phase" in resp.data
+        # State store must not be touched when the request is rejected.
+        mock_get_store.assert_not_called()
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_start_phase_empty_body(self, mock_get_store, client):
+        """start_phase takes no body — empty body must not 400."""
+        pipeline = _make_pipeline(
+            phase=PipelinePhase.IMPLEMENT, phase_status=PipelineStatus.PENDING
+        )
+        mock_store = MagicMock()
+        mock_get_store.return_value = (mock_store, pipeline)
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase/start",
+            data=b"",
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 200
+
+    @patch("routes.pipelines._populate_contract_from_plan")
+    @patch("routes.resolve_worktree_path")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_populate_contract_empty_body(
+        self, mock_get_store, mock_resolve_wt, _mock_populate, client
+    ):
+        """populate_contract takes no body — empty body must not 400."""
+        pipeline = _make_pipeline()
+        mock_store = MagicMock()
+        mock_store.repo_path = Path("/tmp/repo")
+        mock_get_store.return_value = (mock_store, pipeline)
+        mock_resolve_wt.return_value = Path("/tmp/wt")
+
+        with patch("egg_contracts.loader.load_contract", side_effect=Exception("skip")):
+            resp = client.post(
+                "/api/v1/pipelines/issue-42/phase/populate-contract",
+                data=b"",
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 200

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -2040,3 +2040,74 @@ class TestBabysitPr:
         assert schema["required"] == ["pr_number", "repo"]
         assert schema["properties"]["pr_number"]["type"] == "integer"
         assert schema["properties"]["repo"]["type"] == "string"
+
+
+class TestMakeRequestBody:
+    """Regression tests for #1787: empty-body POST breaks Flask get_json().
+
+    The MCP lifecycle tools (complete_phase, populate_contract, start_phase)
+    previously sent no body at all when their optional fields were omitted.
+    Flask's default get_json() raises BadRequest(400) for an empty body with
+    Content-Type: application/json, so these tools returned an opaque 400.
+    """
+
+    def _capture_opener(self):
+        """Build a mock urllib opener that records the Request and returns {}.
+
+        Returns (mock_opener, captured) where captured["req"] is the Request
+        object passed to opener.open().
+        """
+        import json as _json
+
+        captured = {}
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = _json.dumps({}).encode()
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        def _open(req, timeout=None):
+            captured["req"] = req
+            return mock_response
+
+        mock_opener = MagicMock()
+        mock_opener.open.side_effect = _open
+        return mock_opener, captured
+
+    def test_post_with_no_data_sends_empty_json_object(self, handler):
+        """POST with data=None must send b'{}', not no body."""
+        mock_opener, captured = self._capture_opener()
+        with patch("urllib.request.build_opener", return_value=mock_opener):
+            handler._make_request("/api/v1/pipelines/foo/phase/complete", method="POST")
+
+        req = captured["req"]
+        assert req.data == b"{}"
+        assert req.get_header("Content-type") == "application/json"
+
+    def test_post_with_empty_dict_sends_empty_json_object(self, handler):
+        """POST with data={} must send b'{}', not no body."""
+        mock_opener, captured = self._capture_opener()
+        with patch("urllib.request.build_opener", return_value=mock_opener):
+            handler._make_request("/api/v1/pipelines/foo/phase/complete", method="POST", data={})
+
+        assert captured["req"].data == b"{}"
+
+    def test_post_with_data_sends_data(self, handler):
+        """POST with data preserves existing behavior."""
+        mock_opener, captured = self._capture_opener()
+        with patch("urllib.request.build_opener", return_value=mock_opener):
+            handler._make_request(
+                "/api/v1/pipelines/foo/phase/complete",
+                method="POST",
+                data={"artifacts": {"k": "v"}},
+            )
+
+        assert json.loads(captured["req"].data) == {"artifacts": {"k": "v"}}
+
+    def test_get_with_no_data_sends_no_body(self, handler):
+        """GET must not send a body just because POST now does."""
+        mock_opener, captured = self._capture_opener()
+        with patch("urllib.request.build_opener", return_value=mock_opener):
+            handler._make_request("/api/v1/pipelines/foo", method="GET")
+
+        assert captured["req"].data is None


### PR DESCRIPTION
## Summary
- `_make_request` in `orchestrator/mcp_tools.py` now always sends a JSON body (`{}` by default) on non-GET methods. Previously it sent no body while still setting `Content-Type: application/json`, which made Flask's `get_json()` raise `BadRequest(400)` — so `complete_phase`, `populate_contract`, etc. returned an opaque 400 whenever the caller omitted optional fields.
- `advance_phase` now uses `request.get_json(silent=True)` for consistency with `complete_phase` (already fixed in #1755), so a future caller repeating the empty-body mistake gets the clear `Missing target_phase` domain error instead of a JSON parse 400.

This restores the "unblock a stuck pipeline" use case that motivated the lifecycle-secret work in #1769.

Fixes #1787.

## Test plan
- [x] New unit tests in `orchestrator/tests/test_mcp_tools.py::TestMakeRequestBody` — POST with no data / empty dict sends `b'{}'`, POST with data preserves behavior, GET stays body-less.
- [x] New hardening tests in `orchestrator/tests/test_lifecycle_empty_body.py` — each lifecycle route (`complete_phase`, `advance_phase`, `start_phase`, `populate_contract`) handles empty body without a JSON-parse 400.
- [x] Full orchestrator route/MCP test suite passes (138 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)