### PR TITLE
Fix #1783: restore BRC consensus-timeout fallback on k3s

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7380,6 +7380,88 @@ def _format_nack_summary(nack_details: list[dict]) -> str:
     )
 
 
+def _handle_brc_consensus_timeout(
+    pipeline: Pipeline,
+    pipeline_id: str,
+    consensus_timeout: float,
+    blocking_agents: list[str],
+) -> None:
+    # Extracted from _run_concurrent_phase so k3s-style top-level-module
+    # layouts (and tests) can exercise this path in isolation — issue #1783.
+    _brc_handled = False
+    _brc_timeout_result: dict | None = None
+    try:
+        try:
+            from peer_consensus import get_peer_consensus_tracker
+        except ImportError:
+            from ..peer_consensus import (
+                get_peer_consensus_tracker,  # type: ignore[no-redef]
+            )
+
+        _brc_tracker = get_peer_consensus_tracker(pipeline_id)
+        if _brc_tracker is not None:
+            _brc_timeout_result = _brc_tracker.handle_timeout()
+            _brc_handled = _brc_tracker.is_timeout_handled()
+            logger.info(
+                "BRC timeout handler result",
+                pipeline_id=pipeline_id,
+                action=(_brc_timeout_result.get("action") if _brc_timeout_result else None),
+                brc_handled=_brc_handled,
+            )
+    except Exception as e:
+        logger.warning(
+            "BRC timeout check failed, falling back to HITL",
+            pipeline_id=pipeline_id,
+            error=str(e),
+        )
+
+    if (
+        _brc_handled
+        and _brc_timeout_result is not None
+        and _brc_timeout_result.get("action") == "escalate"
+    ):
+        try:
+            pipeline.add_decision(
+                question=(
+                    f"BRC consensus failure: critical reviewers unconfirmed after "
+                    f"{int(consensus_timeout / 60)} minutes. How to proceed?"
+                ),
+                options=["Continue waiting", "Accept current state", "Abort phase"],
+                phase=pipeline.current_phase,
+            )
+        except Exception as decision_err:
+            logger.error(
+                "Failed to queue HITL decision after BRC escalation — pipeline will stall",
+                pipeline_id=pipeline_id,
+                error=str(decision_err),
+            )
+    elif not _brc_handled:
+        if _emit_event is not None:
+            _emit_event(
+                EventType.CONSENSUS_TIMEOUT,
+                pipeline_id,
+                data={
+                    "timeout_minutes": consensus_timeout / 60,
+                    "blocking_agents": blocking_agents,
+                },
+            )
+        try:
+            pipeline.add_decision(
+                question=(
+                    f"Consensus not reached after {int(consensus_timeout / 60)} minutes. "
+                    f"How to proceed?"
+                ),
+                options=["Continue waiting", "Accept current state", "Abort phase"],
+                phase=pipeline.current_phase,
+            )
+        except Exception as decision_err:
+            logger.error(
+                "Failed to queue HITL decision after consensus timeout — pipeline will stall",
+                pipeline_id=pipeline_id,
+                error=str(decision_err),
+            )
+
+
 def _run_concurrent_phase(
     pipeline_id: str,
     pipeline: Pipeline,
@@ -7825,7 +7907,12 @@ def _run_concurrent_phase(
 
             _hm = get_health_monitor()
             if _hm is not None:
-                from ..peer_consensus import get_peer_consensus_tracker  # type: ignore[import-not-found]  # noqa: I001
+                try:
+                    from peer_consensus import get_peer_consensus_tracker
+                except ImportError:
+                    from ..peer_consensus import (
+                        get_peer_consensus_tracker,  # type: ignore[no-redef]
+                    )
 
                 _brc_tracker = get_peer_consensus_tracker(pipeline_id)
                 if _brc_tracker is not None:
@@ -8079,70 +8166,12 @@ def _run_concurrent_phase(
                 pipeline_id=pipeline_id,
                 timeout_minutes=consensus_timeout / 60,
             )
-            # Let the BRC tracker handle the timeout first — it emits
-            # role-aware events (CONSENSUS_FAILURE or CONSENSUS_TIMEOUT)
-            # and returns whether it handled the situation.  Only fall
-            # back to the generic CONSENSUS_TIMEOUT event and HITL
-            # decision if BRC did not handle it.
-            _brc_handled = False
-            _brc_timeout_result = None
-            try:
-                from ..peer_consensus import get_peer_consensus_tracker  # type: ignore[import-not-found]  # noqa: I001
-
-                _brc_tracker = get_peer_consensus_tracker(pipeline_id)
-                if _brc_tracker is not None:
-                    _brc_timeout_result = _brc_tracker.handle_timeout()
-                    _brc_handled = _brc_tracker.is_timeout_handled()
-                    logger.info(
-                        "BRC timeout handler result",
-                        pipeline_id=pipeline_id,
-                        action=_brc_timeout_result.get("action"),
-                        brc_handled=_brc_handled,
-                    )
-            except Exception as e:
-                logger.warning(
-                    "BRC timeout check failed, falling back to HITL",
-                    pipeline_id=pipeline_id,
-                    error=str(e),
-                )
-
-            if (
-                _brc_handled
-                and _brc_timeout_result is not None
-                and _brc_timeout_result.get("action") == "escalate"
-            ):
-                # BRC handled the timeout but requests escalation —
-                # critical reviewers are unconfirmed.  Still need a HITL
-                # decision so a human can intervene.
-                try:
-                    pipeline.add_decision(
-                        question=(
-                            f"BRC consensus failure: critical reviewers unconfirmed after "
-                            f"{int(consensus_timeout / 60)} minutes. How to proceed?"
-                        ),
-                        options=["Continue waiting", "Accept current state", "Abort phase"],
-                        phase=pipeline.current_phase,
-                    )
-                except Exception:
-                    pass
-            elif not _brc_handled:
-                if _emit_event is not None:
-                    _emit_event(
-                        EventType.CONSENSUS_TIMEOUT,
-                        pipeline_id,
-                        data={
-                            "timeout_minutes": consensus_timeout / 60,
-                            "blocking_agents": consensus.get("blocking_agents", []),
-                        },
-                    )
-                try:
-                    pipeline.add_decision(
-                        question=f"Consensus not reached after {int(consensus_timeout / 60)} minutes. How to proceed?",
-                        options=["Continue waiting", "Accept current state", "Abort phase"],
-                        phase=pipeline.current_phase,
-                    )
-                except Exception:
-                    pass
+            _handle_brc_consensus_timeout(
+                pipeline,
+                pipeline_id,
+                consensus_timeout,
+                consensus.get("blocking_agents", []),
+            )
 
             # Fall back: wait for remaining containers with ThreadPoolExecutor
             remaining = [e for e in active_executions if e.container_id not in exited_containers]

--- a/orchestrator/tests/test_pipelines_routes.py
+++ b/orchestrator/tests/test_pipelines_routes.py
@@ -8,6 +8,7 @@ swallowed add_decision failures so the stall had no visible HITL decision.
 from unittest.mock import MagicMock, patch
 
 import pytest
+from events import EventType
 from models import Pipeline, PipelinePhase
 from routes.pipelines import _handle_brc_consensus_timeout
 
@@ -39,7 +40,14 @@ class TestHandleBrcConsensusTimeout:
 
         assert len(pipeline.decisions) == 1
         assert "Consensus not reached after 30 minutes" in pipeline.decisions[0].question
-        mock_emit.assert_called_once()
+        mock_emit.assert_called_once_with(
+            EventType.CONSENSUS_TIMEOUT,
+            pipeline.id,
+            data={
+                "timeout_minutes": 30.0,
+                "blocking_agents": ["reviewer_code"],
+            },
+        )
 
     @patch("routes.pipelines._emit_event")
     def test_brc_escalate_queues_hitl_decision(self, mock_emit, pipeline):
@@ -78,6 +86,33 @@ class TestHandleBrcConsensusTimeout:
 
     @patch("routes.pipelines.logger")
     @patch("routes.pipelines._emit_event")
+    def test_tracker_import_error_falls_back_to_hitl(self, mock_emit, mock_logger, pipeline):
+        # Regression test for issue #1783: bare relative import raised
+        # ImportError under k3s, and the outer except caught it but the
+        # HITL decision must still be created via the fallback path.
+        with patch(
+            "peer_consensus.get_peer_consensus_tracker",
+            side_effect=ImportError("simulated k3s import failure"),
+        ):
+            _handle_brc_consensus_timeout(
+                pipeline,
+                pipeline.id,
+                consensus_timeout=1800.0,
+                blocking_agents=["reviewer_code"],
+            )
+
+        # The warning log records the import failure
+        mock_logger.warning.assert_called_once()
+        _, warn_kwargs = mock_logger.warning.call_args
+        assert "simulated k3s import failure" in warn_kwargs.get("error", "")
+
+        # Fallback HITL decision is still queued
+        assert len(pipeline.decisions) == 1
+        assert "Consensus not reached after 30 minutes" in pipeline.decisions[0].question
+        mock_emit.assert_called_once()
+
+    @patch("routes.pipelines.logger")
+    @patch("routes.pipelines._emit_event")
     def test_add_decision_failure_is_logged_not_swallowed(self, mock_emit, mock_logger, pipeline):
         # Covers the issue #1783 second-order bug: the except Exception: pass
         # at the old decision-queue call sites hid stall-causing failures.
@@ -92,7 +127,7 @@ class TestHandleBrcConsensusTimeout:
                 blocking_agents=[],
             )
 
-        error_calls = [c for c in mock_logger.error.call_args_list if c]
+        error_calls = list(mock_logger.error.call_args_list)
         assert error_calls, "add_decision failure must be logged at ERROR"
         _, kwargs = error_calls[0]
         assert kwargs.get("pipeline_id") == pipeline.id

--- a/orchestrator/tests/test_pipelines_routes.py
+++ b/orchestrator/tests/test_pipelines_routes.py
@@ -109,7 +109,14 @@ class TestHandleBrcConsensusTimeout:
         # Fallback HITL decision is still queued
         assert len(pipeline.decisions) == 1
         assert "Consensus not reached after 30 minutes" in pipeline.decisions[0].question
-        mock_emit.assert_called_once()
+        mock_emit.assert_called_once_with(
+            EventType.CONSENSUS_TIMEOUT,
+            pipeline.id,
+            data={
+                "timeout_minutes": 30.0,
+                "blocking_agents": ["reviewer_code"],
+            },
+        )
 
     @patch("routes.pipelines.logger")
     @patch("routes.pipelines._emit_event")

--- a/orchestrator/tests/test_pipelines_routes.py
+++ b/orchestrator/tests/test_pipelines_routes.py
@@ -1,0 +1,99 @@
+"""Regression tests for routes/pipelines.py helpers.
+
+Covers issue #1783: the BRC/consensus timeout path used bare relative
+imports that crashed under k3s's top-level-module layout, and silently
+swallowed add_decision failures so the stall had no visible HITL decision.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from models import Pipeline, PipelinePhase
+from routes.pipelines import _handle_brc_consensus_timeout
+
+
+@pytest.fixture
+def pipeline():
+    p = Pipeline(id="issue-1783-test", issue_number=1783, repo="owner/repo")
+    p.current_phase = PipelinePhase.REFINE
+    return p
+
+
+class TestHandleBrcConsensusTimeout:
+    """The timeout handler must reach add_decision under k3s's module layout.
+
+    The test runner imports routes.pipelines via absolute imports (the same
+    layout k3s uses), so a regression that re-introduces a bare relative
+    import would surface here as an ImportError before add_decision runs.
+    """
+
+    @patch("routes.pipelines._emit_event")
+    def test_no_brc_tracker_queues_hitl_decision(self, mock_emit, pipeline):
+        with patch("peer_consensus.get_peer_consensus_tracker", return_value=None):
+            _handle_brc_consensus_timeout(
+                pipeline,
+                pipeline.id,
+                consensus_timeout=1800.0,
+                blocking_agents=["reviewer_code"],
+            )
+
+        assert len(pipeline.decisions) == 1
+        assert "Consensus not reached after 30 minutes" in pipeline.decisions[0].question
+        mock_emit.assert_called_once()
+
+    @patch("routes.pipelines._emit_event")
+    def test_brc_escalate_queues_hitl_decision(self, mock_emit, pipeline):
+        tracker = MagicMock()
+        tracker.handle_timeout.return_value = {"action": "escalate"}
+        tracker.is_timeout_handled.return_value = True
+
+        with patch("peer_consensus.get_peer_consensus_tracker", return_value=tracker):
+            _handle_brc_consensus_timeout(
+                pipeline,
+                pipeline.id,
+                consensus_timeout=1800.0,
+                blocking_agents=[],
+            )
+
+        assert len(pipeline.decisions) == 1
+        assert "BRC consensus failure" in pipeline.decisions[0].question
+        mock_emit.assert_not_called()
+
+    @patch("routes.pipelines._emit_event")
+    def test_brc_handled_without_escalate_no_decision(self, mock_emit, pipeline):
+        tracker = MagicMock()
+        tracker.handle_timeout.return_value = {"action": "proceed"}
+        tracker.is_timeout_handled.return_value = True
+
+        with patch("peer_consensus.get_peer_consensus_tracker", return_value=tracker):
+            _handle_brc_consensus_timeout(
+                pipeline,
+                pipeline.id,
+                consensus_timeout=1800.0,
+                blocking_agents=[],
+            )
+
+        assert len(pipeline.decisions) == 0
+        mock_emit.assert_not_called()
+
+    @patch("routes.pipelines.logger")
+    @patch("routes.pipelines._emit_event")
+    def test_add_decision_failure_is_logged_not_swallowed(self, mock_emit, mock_logger, pipeline):
+        # Covers the issue #1783 second-order bug: the except Exception: pass
+        # at the old decision-queue call sites hid stall-causing failures.
+        with (
+            patch("peer_consensus.get_peer_consensus_tracker", return_value=None),
+            patch.object(Pipeline, "add_decision", side_effect=RuntimeError("boom")),
+        ):
+            _handle_brc_consensus_timeout(
+                pipeline,
+                pipeline.id,
+                consensus_timeout=1800.0,
+                blocking_agents=[],
+            )
+
+        error_calls = [c for c in mock_logger.error.call_args_list if c]
+        assert error_calls, "add_decision failure must be logged at ERROR"
+        _, kwargs = error_calls[0]
+        assert kwargs.get("pipeline_id") == pipeline.id
+        assert "boom" in kwargs.get("error", "")


### PR DESCRIPTION
## Summary

Closes #1783.

- Two inline imports in `orchestrator/routes/pipelines.py` (the BRC timeout fallback at ~8090 and the stall-demotion check at ~7828) used bare relative imports that raise `ImportError` under k3s's top-level-module layout. Both now use the `try: absolute / except ImportError: relative` pattern the rest of the file already uses.
- Two `except Exception: pass` blocks around `pipeline.add_decision` were hiding HITL-queue failures — the reason wedged pipelines had no visible pending decision. They now log at ERROR with `pipeline_id`.
- Extracted the timeout-handling block into `_handle_brc_consensus_timeout` so the path can be unit-tested without driving the full `_run_concurrent_phase`.

## Test plan

- [x] `pytest orchestrator/tests/test_pipelines_routes.py` — 4 new tests pass (no-tracker, escalate, handled-without-escalate, `add_decision` failure logged not swallowed).
- [x] `pytest orchestrator/tests/test_pipelines_api.py` — 32 existing tests still pass.
- [x] `ruff check` + `ruff format` clean on changed files.
- [ ] Next real k3s run that hits the 30-minute consensus timeout should log `BRC timeout handler result` (success) instead of `BRC timeout check failed` and expose a `pending_decisions` entry via `get_status`.

## Out of scope (follow-ups)

- Option B from the issue (unify orchestrator loading convention — relative vs absolute).
- The deeper "consensus loop is not re-entrant after timeout" observation — worth a separate ticket; the issue already names it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)