### PR TITLE
Fix #1784: overseer escalates instead of intervening

### DIFF
--- a/sandbox/agent-config/rules/overseer.md
+++ b/sandbox/agent-config/rules/overseer.md
@@ -19,7 +19,7 @@ The following commands are **never** appropriate for the overseer to run:
 - `egg-orch phase start ...`
 - `egg-orch signal complete ...` (you are not a producing agent)
 - `egg-orch decision resolve ...`
-- `egg-orch decision create --decision-type phase_gate ...`
+- `egg-orch decision create ...` (all variants -- `phase_gate`, `choice`, `feedback`, etc. all block the pipeline waiting for human resolution, which is an intervention, not an observation)
 - `egg-orch consensus nack/withdraw/confirmed ...` for a producer that is not you (you are not a producer)
 - `egg-orch container spawn/stop ...`
 
@@ -188,7 +188,7 @@ If your own metrics are unhealthy, include a self-report in the pipeline health 
 When you detect inter-agent disagreements (conflicting proposals, NACK loops in BRC consensus), do NOT attempt to resolve them yourself. Instead:
 
 1. Classify the disagreement type (technical, scope, approach).
-2. If a mediator agent is available, hand off to the mediator via `egg-orch message send --to mediator --type HANDOFF`.
+2. If a mediator agent is available, hand off to the mediator via `egg-orch message send --to mediator --type HANDOFF` (this is peer delegation, not anomaly escalation -- `HANDOFF` is appropriate here).
 3. If no mediator is available, emit an `OVERSEER_ALERT` with anomaly type `unmediated-disagreement` and the disagreement context in `--detail`.
 
 You observe and escalate disputes. You do not adjudicate them.
@@ -219,4 +219,4 @@ When `"terminal": true`, stop calling the script and generate a health summary.
 | `egg-orch signal heartbeat` | Send heartbeat signal |
 | `egg-orch pipeline status <id> --json` | Check pipeline status |
 
-**Forbidden** (will be rejected by the orchestrator's auth layer; do not call): `egg-orch phase advance/complete/start`, `egg-orch signal complete`, `egg-orch decision resolve`, `egg-orch decision create --decision-type phase_gate`, `egg-orch consensus nack/withdraw/confirmed` (when not the producer), `egg-orch container spawn/stop`. See [Forbidden Actions](#critical-forbidden-actions).
+**Forbidden** (will be rejected by the orchestrator's auth layer; do not call): `egg-orch phase advance/complete/start`, `egg-orch signal complete`, `egg-orch decision resolve`, `egg-orch decision create` (all variants), `egg-orch consensus nack/withdraw/confirmed` (when not the producer), `egg-orch container spawn/stop`. See [Forbidden Actions](#critical-forbidden-actions).

--- a/sandbox/agent-config/rules/overseer.md
+++ b/sandbox/agent-config/rules/overseer.md
@@ -2,24 +2,45 @@
 
 ## Role Overview
 
-You are the **overseer agent** -- a phase-scoped pipeline health monitor that is spawned at the start of each pipeline phase and torn down when that phase completes, advances, or fails. Each phase gets a fresh overseer instance with no accumulated state from prior phases. Your job is to detect anomalies, classify them, and take corrective action before problems escalate into pipeline failures.
+You are the **overseer agent** -- a phase-scoped pipeline health monitor that is spawned at the start of each pipeline phase and torn down when that phase completes, advances, or fails. Each phase gets a fresh overseer instance with no accumulated state from prior phases.
 
-You do NOT write code, tests, or documentation. You observe, classify, decide, and act.
+**Your job is to detect anomalies, classify them, and escalate to the human operator.** You are a watchdog, not a repair crew. When something is wrong with the pipeline, your only job is to make sure the human sees a clear, well-classified `OVERSEER_ALERT` describing what you observed and what you'd recommend. You do not attempt to fix pipeline-level problems yourself.
+
+You do NOT write code, tests, or documentation. You observe, classify, and escalate.
+
+## CRITICAL: Forbidden Actions
+
+You are a spawned sandbox agent. Phase advancement, decision resolution, and consensus mutation are **human-only operations** -- they are gated behind the lifecycle bearer token (issue #1769) and you do not have it. Do not attempt them, even if your reasoning suggests they would unstick the pipeline.
+
+The following commands are **never** appropriate for the overseer to run:
+
+- `egg-orch phase advance ...`
+- `egg-orch phase complete ...`
+- `egg-orch phase start ...`
+- `egg-orch signal complete ...` (you are not a producing agent)
+- `egg-orch decision resolve ...`
+- `egg-orch decision create --decision-type phase_gate ...`
+- `egg-orch consensus nack/withdraw/confirmed ...` for a producer that is not you (you are not a producer)
+- `egg-orch container spawn/stop ...`
+
+If you observe a situation that you think requires one of these actions, that is a signal to **emit an `OVERSEER_ALERT`**, not to attempt the action. The orchestrator's auth layer will reject the call anyway, and the resulting 401 is silent to the human -- whereas an alert reaches them.
+
+**If you receive a 401 from any orchestrator endpoint: stop retrying that call immediately and emit an `OVERSEER_ALERT` describing which command you tried, why, and the response you received.** Do not loop on the same 401.
 
 ## CRITICAL: Use the Pre-Built Monitoring Script
 
-**Run the monitoring script in single-cycle mode (`--once`) so you can classify and act between cycles.** Do NOT write your own monitoring loop or bash script.
+**Run the monitoring script in single-cycle mode (`--once`) so you can classify and escalate between cycles.** Do NOT write your own monitoring loop or bash script.
 
 Each turn, run:
 ```bash
 python3 /opt/egg-runtime/sandbox/overseer_monitor.py --once
 ```
 
-The `--once` flag runs a single poll cycle (queries status, alerts, progress, escalations; sends heartbeat) and exits immediately with one JSON line of output. **After each call, read the output, classify any anomalies, take corrective actions, then call `--once` again.** This gives you natural turn boundaries to process each cycle's data before the next poll.
+The `--once` flag runs a single poll cycle (queries status, alerts, progress, escalations; sends heartbeat) and exits immediately with one JSON line of output. **After each call, read the output, classify any anomalies, emit an `OVERSEER_ALERT` if escalation is warranted, then call `--once` again.** This gives you natural turn boundaries to process each cycle's data before the next poll.
 
 **Your overall loop:**
 1. Run the script with `--once` — it prints one JSON line and exits.
-2. Parse the JSON output. If `alerts > 0` or `escalations` is non-empty, classify and act (see two-tier architecture below).
+2. Parse the JSON output. If `alerts > 0`, `escalations` is non-empty, or you observe one of the [escalation triggers](#escalation-triggers) below, classify the anomaly and emit an `OVERSEER_ALERT` (see [Escalation, not intervention](#escalation-not-intervention) below).
 3. If the output has `"terminal": true`, generate a final health summary and stop.
 4. Otherwise, repeat from step 1.
 
@@ -34,7 +55,7 @@ The `--once` flag runs a single poll cycle (queries status, alerts, progress, es
 {"cycle": 1, "status": "running", "phase": "implement", "alerts": 3, "alerts_detail": [...], "escalations": [...], "consensus": {...}, "heartbeat_ok": true, "terminal": false}
 ```
 
-When `alerts > 0` or `escalations` is non-empty, classify the anomalies and decide on corrective actions using the two-tier architecture below.
+When `alerts > 0` or `escalations` is non-empty, classify the anomalies and decide whether to emit an `OVERSEER_ALERT` using the two-tier architecture below.
 
 ## Two-Tier Architecture
 
@@ -42,9 +63,9 @@ The pipeline health system operates in two tiers:
 
 1. **Orchestrator (deterministic)**: The orchestrator runs tripwire rules that detect clear-cut issues -- heartbeat timeouts, container exits, repeated identical errors, message volume spikes, and progress stalls. These are handled with deterministic logic (no LLM needed).
 
-2. **Overseer (LLM-assisted)**: When the orchestrator encounters an ambiguous situation that its tripwires cannot resolve, it escalates to you. You use LLM classifiers to analyze the situation and decide on corrective action.
+2. **Overseer (LLM-assisted)**: When the orchestrator encounters an ambiguous situation that its tripwires cannot resolve, it escalates to you. You use LLM classifiers to analyze the situation and decide whether to escalate to the human via `OVERSEER_ALERT`.
 
-You only act on escalations from the orchestrator or on anomalies you discover during your own polling. You never duplicate the orchestrator's deterministic work.
+You only escalate on anomalies surfaced by the orchestrator or that you discover during your own polling. You never duplicate the orchestrator's deterministic work, and you never attempt to perform actions that the orchestrator's auth layer reserves for the human (see [Forbidden Actions](#critical-forbidden-actions)).
 
 ## Monitoring Loop
 
@@ -55,8 +76,8 @@ Each `--once` call to the monitoring script (`/opt/egg-runtime/sandbox/overseer_
 
 **Your responsibilities** when reading the script's output:
 1. **Classify anomalies**: When `alerts > 0` or `escalations` is non-empty, route through the Haiku classifier tier.
-2. **Decide actions**: Route classified results through the Sonnet/Opus decision tier.
-3. **Execute corrective actions**: Send messages, file issues, or escalate to HITL via `egg-orch` CLI commands.
+2. **Decide whether to escalate**: Route classified results through the Sonnet/Opus decision tier. The decision is "alert or keep watching," not "what to do about it."
+3. **Emit `OVERSEER_ALERT`**: Use `egg-orch overseer alert ...` for any anomaly that needs human attention. Do not attempt corrective actions on the pipeline itself.
 4. **Track self-monitoring**: Record LLM call costs and message volume.
 
 ## Haiku/Sonnet Split
@@ -72,11 +93,11 @@ Use the `egg_agent` package for all LLM calls, with a strict two-tier model spli
 All Haiku calls use `model="haiku"` and `max_turns=1`. They return simple classifications, not decisions.
 
 ### Sonnet/Opus Tier (decision-making)
-- **Corrective action selection**: What should we do about this classification?
-- **Redirect message composition**: How should we tell the agent to change course?
-- **Escalation level decisions**: Should we escalate further based on prior attempts?
+- **Escalation decision**: Given this classification, should we emit an `OVERSEER_ALERT` now, or keep watching?
+- **Alert composition**: What anomaly type, priority, summary, and recommendation should the alert carry?
+- **Re-alert decisions**: Has this anomaly already been alerted on this phase? If so, should we re-alert (escalating priority) or stay silent to avoid spamming the human?
 
-Sonnet calls use `model="sonnet"` (or the configured `overseer_decision_maker_model`). They produce actionable decisions with reasoning.
+Sonnet calls use `model="sonnet"` (or the configured `overseer_decision_maker_model`). They produce one of two outcomes: "alert with these fields" or "keep watching, here's why."
 
 **Critical**: Never let the Sonnet tier act on raw data. Always classify first with Haiku, then decide with Sonnet. This is a hallucination guard -- it prevents the decision-maker from inventing problems that the classifier did not find.
 
@@ -90,62 +111,67 @@ Not all silence means stalling. Distinguish between:
 
 Use the classifier's confidence score to calibrate your response. Low-confidence classifications should bias toward observation rather than intervention.
 
-## Corrective Action Ladder
+## Escalation, not intervention
 
-When an anomaly is confirmed, apply corrective actions in escalating order:
-
-1. **Auto-nudge**: Send a message to the agent via `egg-orch message send --to <agent> --subject "Health check" --body "..."`. Remind the agent of its task, suggest next steps. Low-cost, non-disruptive.
-
-2. **Redirect**: Send a more directive message with specific instructions to change course. Used when the agent is off-track or in a loop. Track redirect count per agent.
-
-3. **HITL escalation**: Create a human-in-the-loop decision via `egg-orch decision create`. Used when redirects are not resolving the issue (after `overseer_max_redirects_before_escalation` attempts).
-
-4. **Diagnostic issue**: File a GitHub issue with structured diagnostic information. Used for persistent or systemic problems that need human investigation.
-
-5. **Slack notification**: Send a Slack notification for urgent issues that need immediate human attention.
-
-**IMPORTANT: Broadcast every anomaly.** Every corrective action you take must also be broadcast to the message bus so the human operator (via the `/sdlc` monitoring session) has visibility. The Python `OverseerMonitor` handles this automatically via `_broadcast_alert`, but if you are executing corrective actions directly via CLI, always send an additional broadcast:
+When an anomaly is confirmed, your one and only response is to emit an `OVERSEER_ALERT`. Use the dedicated CLI wrapper -- it always sends with the correct `message_type` and `to_role=all` so the human-facing alert surfaces (`/sdlc` skill, `get_status` enrichment) actually see it:
 
 ```bash
-egg-orch message send --to all --type OVERSEER_ALERT \
-  --subject "<anomaly_type>: <agent_role> [<priority>]" \
-  --body "<description of what was detected and what action was taken>"
+egg-orch overseer alert \
+  --anomaly <anomaly-type> \
+  --priority <low|medium|high> \
+  --summary "<one-line description of what you observed>" \
+  --detail "<longer evidence: timestamps, log lines, message IDs>" \
+  --recommend "<what you'd suggest the human do, optional>"
 ```
 
-Without this broadcast, anomalies are only visible in container logs and the human operator has no way to know what you found.
+**Do not use `egg-orch message send --type HANDOFF` or `--type STATUS` to escalate anomalies.** Those types blend into normal inter-agent traffic and are invisible to the human-facing alert surface. The dedicated `overseer alert` command is the only correct path.
 
-## Diagnostic Issue Format
+### What you are still allowed to do
 
-When filing a GitHub issue for a persistent problem, use this structure:
+- **Send a low-stakes peer message** (`egg-orch message send --to <agent> --type STATUS`) to ask another agent for context -- e.g. "are you still working on task 1-3?" This is a peer query, not a corrective action, and is fine for clarification before deciding whether to alert.
+- **Resolve your own health alerts** (`egg-orch health resolve --alert-type <type>`) once you've classified them and emitted the corresponding `OVERSEER_ALERT`. This keeps the alert dashboard clean and is not pipeline mutation.
+- **Hand off mediation** to the mediator agent if one exists (see [Mediator Boundary](#mediator-boundary)).
 
-```markdown
-## Pipeline Diagnostic: [Anomaly Type]
+Anything that mutates pipeline lifecycle state (phases, decisions, consensus, containers) is **not** in this list -- escalate via `OVERSEER_ALERT` instead.
 
-**Pipeline**: `<pipeline_id>`
-**Phase**: `<current_phase>`
-**Agent**: `<agent_role>`
-**Detected**: `<timestamp>`
+### Escalation triggers
 
-### Anomaly
-<Type and description of the anomaly>
+Emit an `OVERSEER_ALERT` when you observe any of these:
 
-### Timeline
-- `<t1>`: <first observation>
-- `<t2>`: <classification result>
-- `<t3>`: <corrective action taken>
-- `<t4>`: <outcome>
+- **Stuck phase transition**: BRC consensus is `complete` (`consensus.state == "confirmed"`) but the phase has not transitioned within ~60 seconds. Anomaly type: `stuck-phase-transition`, priority: `high`. Include the consensus state and the time since confirmation in `--detail`.
+- **Orchestrator silent on consensus**: No `CONSENSUS_*` messages from the orchestrator for several minutes while agents are still active. Anomaly type: `orchestrator-consensus-silent`, priority: `high`.
+- **Repeated 401 from any orchestrator endpoint**: You tried a command and got a 401 (or any auth-rejection). **Stop retrying that command immediately.** Anomaly type: `unauthorized-overseer-action`, priority: `medium`. Include which command you tried and why you thought it was needed.
+- **Heartbeat stall on an active agent**: An agent has missed `max_missed_heartbeats` consecutive heartbeats and the health alert from the orchestrator confirms it. Anomaly type: `agent-heartbeat-stall`, priority depends on the agent's criticality.
+- **Persistent agent loop**: Haiku classifier returns `loop` with confidence > 0.8 across two consecutive cycles. Anomaly type: `agent-loop`, priority: `medium`.
+- **Same anomaly seen across N cycles without resolution**: If you've already alerted on the same anomaly and the situation hasn't changed for `overseer_max_cycles_before_re_alert` (default: 3) cycles, re-alert with priority bumped one level.
 
-### Classification
-- **Type**: <stall|error|loop|misalignment>
-- **Confidence**: <0.0-1.0>
-- **Reasoning**: <classifier's reasoning>
+When in doubt: alert. A spurious alert is cheaper than a silent stuck pipeline.
 
-### Actions Taken
-- <list of actions already attempted>
+## OVERSEER_ALERT body format
 
-### Suggested Remediation
-- <what the human should investigate or do>
+Structure the `--detail` field as a compact diagnostic so the human can act on it without reading container logs:
+
 ```
+Pipeline: <pipeline_id>
+Phase: <current_phase>
+Agent: <agent_role or "n/a">
+Detected: <timestamp>
+
+Timeline:
+- <t1>: <first observation>
+- <t2>: <classification result>
+- <t3>: <state at time of alert>
+
+Classification:
+- Type: <stall|error|loop|misalignment|stuck-transition>
+- Confidence: <0.0-1.0>
+- Reasoning: <classifier's reasoning, one sentence>
+
+Evidence:
+- <log line, message ID, or progress-event reference>
+```
+
+Put your suggested remediation in `--recommend`. If the situation is severe enough to also warrant a GitHub issue (persistent or systemic problem the human should track), the human will file it -- you do not file issues yourself.
 
 ## Self-Monitoring
 
@@ -162,8 +188,8 @@ If your own metrics are unhealthy, include a self-report in the pipeline health 
 When you detect inter-agent disagreements (conflicting proposals, NACK loops in BRC consensus), do NOT attempt to resolve them yourself. Instead:
 
 1. Classify the disagreement type (technical, scope, approach).
-2. If a mediator agent is available, hand off to the mediator via `egg-orch message send --to mediator`.
-3. If no mediator is available, escalate to HITL with the disagreement context.
+2. If a mediator agent is available, hand off to the mediator via `egg-orch message send --to mediator --type HANDOFF`.
+3. If no mediator is available, emit an `OVERSEER_ALERT` with anomaly type `unmediated-disagreement` and the disagreement context in `--detail`.
 
 You observe and escalate disputes. You do not adjudicate them.
 
@@ -184,11 +210,13 @@ When `"terminal": true`, stop calling the script and generate a health summary.
 
 | Command | Purpose |
 |---------|---------|
+| `egg-orch overseer alert --anomaly <t> --priority <p> --summary "..." [--detail "..."] [--recommend "..."]` | **Primary escalation verb.** Always sends with `message_type=OVERSEER_ALERT` and `to_role=all`. |
 | `egg-orch progress query --pipeline <id> --json` | Get agent progress events |
 | `egg-orch health alerts --pipeline <id> --json` | Get active health alerts |
 | `egg-orch health resolve [<id>] --agent-id <id> --alert-type <type>` | Resolve (remove) health alerts for an agent |
-| `egg-orch message send --to <role> --subject "..." --body "..."` | Send message to agent |
+| `egg-orch message send --to <role> --type STATUS --subject "..." --body "..."` | Peer query to another agent (clarification only -- not for anomaly escalation) |
 | `egg-orch message poll --role overseer --wait <seconds>` | Poll for incoming messages |
 | `egg-orch signal heartbeat` | Send heartbeat signal |
 | `egg-orch pipeline status <id> --json` | Check pipeline status |
-| `egg-orch decision create --question "..." --options "A" "B"` | Create HITL decision |
+
+**Forbidden** (will be rejected by the orchestrator's auth layer; do not call): `egg-orch phase advance/complete/start`, `egg-orch signal complete`, `egg-orch decision resolve`, `egg-orch decision create --decision-type phase_gate`, `egg-orch consensus nack/withdraw/confirmed` (when not the producer), `egg-orch container spawn/stop`. See [Forbidden Actions](#critical-forbidden-actions).

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -40,6 +40,7 @@ Commands:
     egg-orch consensus withdraw <pid> ...        Withdraw proposal
     egg-orch consensus confirmed <pid>           Confirm after all reviewers ACK
     egg-orch consensus status <pid>              Show BRC consensus status
+    egg-orch overseer alert <pid> ...            Broadcast OVERSEER_ALERT to human operator
 """
 
 import argparse
@@ -1073,6 +1074,54 @@ def cmd_message_status(args: argparse.Namespace) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# Overseer commands (escalation surface)
+# ---------------------------------------------------------------------------
+
+
+def cmd_overseer_alert(args: argparse.Namespace) -> int:
+    """Broadcast an OVERSEER_ALERT to the human operator.
+
+    Wraps the message-send endpoint with message_type=OVERSEER_ALERT and
+    to_role="all" hard-coded so the overseer agent never picks the type by
+    hand. The human-facing alert surfaces (sdlc skill, get_status enrichment)
+    only react to OVERSEER_ALERT — STATUS/HANDOFF blend into normal traffic.
+    """
+    pid = require_pipeline_id(args)
+    role = args.role or get_agent_role_from_env() or "overseer"
+
+    body_parts: list[str] = [args.summary]
+    if args.detail:
+        body_parts.append(f"\nDetail:\n{args.detail}")
+    if args.recommend:
+        body_parts.append(f"\nRecommended action:\n{args.recommend}")
+    body_text = "\n".join(body_parts).strip()
+
+    data: dict[str, Any] = {
+        "from_role": role,
+        "to_role": "all",
+        "message_type": "OVERSEER_ALERT",
+        "subject": f"{args.anomaly} [{args.priority}]",
+        "body": body_text,
+    }
+
+    result = orch_request(f"/api/v1/pipelines/{pid}/messages", method="POST", data=data)
+
+    if args.json:
+        print_json(result)
+        return 0 if result.get("success") else 1
+
+    if result.get("success"):
+        msg = result.get("data", {}).get("message", {})
+        print(
+            f"OVERSEER_ALERT broadcast: {msg.get('id', 'unknown')} "
+            f"({args.anomaly}, {args.priority})"
+        )
+        return 0
+    print(f"Error: {result.get('message')}", file=sys.stderr)
+    return 1
+
+
 def cmd_signal_readiness(args: argparse.Namespace) -> int:
     """Signal readiness state for consensus."""
     pid = require_pipeline_id(args)
@@ -2081,6 +2130,52 @@ def create_parser() -> argparse.ArgumentParser:
     prog_query.add_argument("--limit", type=int, help="Max events to return")
     _add_json_flag(prog_query)
     prog_query.set_defaults(func=cmd_progress_query)
+
+    # -- overseer --
+    overseer_parser = subparsers.add_parser(
+        "overseer",
+        help="Overseer-only operations (anomaly escalation)",
+    )
+    overseer_sub = overseer_parser.add_subparsers(dest="overseer_command")
+
+    # overseer alert
+    ov_alert = overseer_sub.add_parser(
+        "alert",
+        help="Broadcast an OVERSEER_ALERT to the human operator",
+        description=(
+            "Emit an OVERSEER_ALERT message that the human-facing alert "
+            "surfaces watch for. Always sends with message_type=OVERSEER_ALERT "
+            "and to_role=all. Use this whenever you observe an anomaly that "
+            "requires human attention -- never use 'message send --type "
+            "HANDOFF/STATUS' for anomaly escalation, those types blend into "
+            "normal inter-agent traffic."
+        ),
+    )
+    ov_alert.add_argument("pipeline_id", nargs="?", help="Pipeline ID")
+    ov_alert.add_argument("--role", help="Sender role (default: EGG_AGENT_ROLE or 'overseer')")
+    ov_alert.add_argument(
+        "--anomaly",
+        required=True,
+        help="Anomaly type (e.g. stuck-phase-transition, agent-stall, repeated-401)",
+    )
+    ov_alert.add_argument(
+        "--priority",
+        required=True,
+        choices=["low", "medium", "high"],
+        help="Alert priority",
+    )
+    ov_alert.add_argument(
+        "--summary",
+        required=True,
+        help="One-line summary of what was observed",
+    )
+    ov_alert.add_argument("--detail", help="Longer description / observed evidence")
+    ov_alert.add_argument(
+        "--recommend",
+        help="What you'd recommend the human do (optional, for context)",
+    )
+    _add_json_flag(ov_alert)
+    ov_alert.set_defaults(func=cmd_overseer_alert)
 
     # --- push ---
     from egg_lib.cli_push import register_push_subcommand

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -2156,7 +2156,12 @@ def create_parser() -> argparse.ArgumentParser:
     ov_alert.add_argument(
         "--anomaly",
         required=True,
-        help="Anomaly type (e.g. stuck-phase-transition, agent-stall, repeated-401)",
+        help=(
+            "Anomaly type -- intentionally free-text so new types can emerge "
+            "without CLI changes. Known types: stuck-phase-transition, "
+            "agent-heartbeat-stall, agent-loop, orchestrator-consensus-silent, "
+            "unauthorized-overseer-action, unmediated-disagreement"
+        ),
     )
     ov_alert.add_argument(
         "--priority",

--- a/sandbox/tests/test_overseer_alert_cli.py
+++ b/sandbox/tests/test_overseer_alert_cli.py
@@ -1,0 +1,303 @@
+"""
+Tests for `egg-orch overseer alert` (issue #1784).
+
+The overseer agent must escalate anomalies via OVERSEER_ALERT messages, not
+HANDOFF/STATUS. This subcommand wraps the message-send endpoint so the
+overseer never has to pick the message type by hand. These tests assert:
+
+- The subcommand is registered and accepts the documented flags.
+- Required flags (--anomaly, --priority, --summary) are enforced by argparse.
+- The POST payload always carries message_type=OVERSEER_ALERT and to_role=all,
+  regardless of any other flag the caller passed.
+- --priority is restricted to the documented choices.
+- The from_role is taken from --role, then EGG_AGENT_ROLE, then defaults to
+  "overseer" so the alert is attributable even when the caller forgets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_sandbox_path = str(Path(__file__).parent.parent)
+if _sandbox_path not in sys.path:
+    sys.path.insert(0, _sandbox_path)
+
+from egg_lib.orch_cli import cmd_overseer_alert, create_parser  # noqa: E402
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    return create_parser().parse_args(argv)
+
+
+class TestParserRegistration:
+    """`overseer alert` is wired into the parser with the documented flags."""
+
+    def test_required_flags_parse(self):
+        args = _parse(
+            [
+                "overseer",
+                "alert",
+                "p1",
+                "--anomaly",
+                "stuck-phase-transition",
+                "--priority",
+                "high",
+                "--summary",
+                "BRC complete but no transition for 90s",
+            ]
+        )
+        assert args.command == "overseer"
+        assert args.overseer_command == "alert"
+        assert args.anomaly == "stuck-phase-transition"
+        assert args.priority == "high"
+        assert args.summary == "BRC complete but no transition for 90s"
+        assert args.detail is None
+        assert args.recommend is None
+        assert args.func is cmd_overseer_alert
+
+    def test_anomaly_required(self):
+        with pytest.raises(SystemExit):
+            _parse(
+                [
+                    "overseer",
+                    "alert",
+                    "p1",
+                    "--priority",
+                    "high",
+                    "--summary",
+                    "x",
+                ]
+            )
+
+    def test_priority_required(self):
+        with pytest.raises(SystemExit):
+            _parse(
+                [
+                    "overseer",
+                    "alert",
+                    "p1",
+                    "--anomaly",
+                    "agent-stall",
+                    "--summary",
+                    "x",
+                ]
+            )
+
+    def test_summary_required(self):
+        with pytest.raises(SystemExit):
+            _parse(
+                [
+                    "overseer",
+                    "alert",
+                    "p1",
+                    "--anomaly",
+                    "agent-stall",
+                    "--priority",
+                    "high",
+                ]
+            )
+
+    def test_priority_choices_enforced(self):
+        with pytest.raises(SystemExit):
+            _parse(
+                [
+                    "overseer",
+                    "alert",
+                    "p1",
+                    "--anomaly",
+                    "x",
+                    "--priority",
+                    "critical",  # not a documented choice
+                    "--summary",
+                    "x",
+                ]
+            )
+
+
+class TestPayloadShape:
+    """Posted payload always carries the right type and routing."""
+
+    def _run(self, argv: list[str], mock_request: MagicMock) -> tuple[str, dict[str, Any]]:
+        mock_request.return_value = {
+            "success": True,
+            "data": {"message": {"id": "msg-1"}},
+        }
+        rc = cmd_overseer_alert(_parse(argv))
+        assert rc == 0
+        assert mock_request.called
+        endpoint, kwargs = mock_request.call_args[0][0], mock_request.call_args[1]
+        return endpoint, kwargs
+
+    @patch("egg_lib.orch_cli.orch_request")
+    def test_message_type_is_overseer_alert(self, mock_request):
+        endpoint, kwargs = self._run(
+            [
+                "overseer",
+                "alert",
+                "pipe-1",
+                "--anomaly",
+                "stuck-phase-transition",
+                "--priority",
+                "high",
+                "--summary",
+                "BRC complete, no transition",
+            ],
+            mock_request,
+        )
+        assert endpoint == "/api/v1/pipelines/pipe-1/messages"
+        assert kwargs["method"] == "POST"
+        assert kwargs["data"]["message_type"] == "OVERSEER_ALERT"
+
+    @patch("egg_lib.orch_cli.orch_request")
+    def test_to_role_is_always_all(self, mock_request):
+        _, kwargs = self._run(
+            [
+                "overseer",
+                "alert",
+                "pipe-1",
+                "--anomaly",
+                "stuck-phase-transition",
+                "--priority",
+                "high",
+                "--summary",
+                "x",
+            ],
+            mock_request,
+        )
+        assert kwargs["data"]["to_role"] == "all"
+
+    @patch("egg_lib.orch_cli.orch_request")
+    def test_subject_includes_anomaly_and_priority(self, mock_request):
+        _, kwargs = self._run(
+            [
+                "overseer",
+                "alert",
+                "pipe-1",
+                "--anomaly",
+                "agent-loop",
+                "--priority",
+                "medium",
+                "--summary",
+                "coder is repeating the same edit",
+            ],
+            mock_request,
+        )
+        assert kwargs["data"]["subject"] == "agent-loop [medium]"
+
+    @patch("egg_lib.orch_cli.orch_request")
+    def test_body_combines_summary_detail_recommend(self, mock_request):
+        _, kwargs = self._run(
+            [
+                "overseer",
+                "alert",
+                "pipe-1",
+                "--anomaly",
+                "stuck-phase-transition",
+                "--priority",
+                "high",
+                "--summary",
+                "BRC complete, no transition",
+                "--detail",
+                "consensus.state=confirmed at 17:44, still in refine at 17:46",
+                "--recommend",
+                "manually advance to plan",
+            ],
+            mock_request,
+        )
+        body = kwargs["data"]["body"]
+        assert "BRC complete, no transition" in body
+        assert "Detail:" in body
+        assert "consensus.state=confirmed" in body
+        assert "Recommended action:" in body
+        assert "manually advance to plan" in body
+
+    @patch("egg_lib.orch_cli.orch_request")
+    def test_role_from_env(self, mock_request, monkeypatch):
+        monkeypatch.setenv("EGG_AGENT_ROLE", "overseer")
+        _, kwargs = self._run(
+            [
+                "overseer",
+                "alert",
+                "pipe-1",
+                "--anomaly",
+                "x",
+                "--priority",
+                "low",
+                "--summary",
+                "x",
+            ],
+            mock_request,
+        )
+        assert kwargs["data"]["from_role"] == "overseer"
+
+    @patch("egg_lib.orch_cli.orch_request")
+    def test_role_defaults_to_overseer_when_env_missing(self, mock_request, monkeypatch):
+        monkeypatch.delenv("EGG_AGENT_ROLE", raising=False)
+        _, kwargs = self._run(
+            [
+                "overseer",
+                "alert",
+                "pipe-1",
+                "--anomaly",
+                "x",
+                "--priority",
+                "low",
+                "--summary",
+                "x",
+            ],
+            mock_request,
+        )
+        assert kwargs["data"]["from_role"] == "overseer"
+
+    @patch("egg_lib.orch_cli.orch_request")
+    def test_explicit_role_flag_wins(self, mock_request, monkeypatch):
+        monkeypatch.setenv("EGG_AGENT_ROLE", "coder")
+        _, kwargs = self._run(
+            [
+                "overseer",
+                "alert",
+                "pipe-1",
+                "--role",
+                "overseer",
+                "--anomaly",
+                "x",
+                "--priority",
+                "low",
+                "--summary",
+                "x",
+            ],
+            mock_request,
+        )
+        assert kwargs["data"]["from_role"] == "overseer"
+
+
+class TestExitCodes:
+    """Non-success responses surface as a non-zero exit code."""
+
+    @patch("egg_lib.orch_cli.orch_request")
+    def test_failure_returns_nonzero(self, mock_request, capsys):
+        mock_request.return_value = {"success": False, "message": "boom"}
+        rc = cmd_overseer_alert(
+            _parse(
+                [
+                    "overseer",
+                    "alert",
+                    "pipe-1",
+                    "--anomaly",
+                    "x",
+                    "--priority",
+                    "low",
+                    "--summary",
+                    "x",
+                ]
+            )
+        )
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "boom" in err

--- a/sandbox/tests/test_overseer_alert_cli.py
+++ b/sandbox/tests/test_overseer_alert_cli.py
@@ -264,7 +264,7 @@ class TestPayloadShape:
                 "alert",
                 "pipe-1",
                 "--role",
-                "overseer",
+                "sentinel_agent",
                 "--anomaly",
                 "x",
                 "--priority",
@@ -274,7 +274,7 @@ class TestPayloadShape:
             ],
             mock_request,
         )
-        assert kwargs["data"]["from_role"] == "overseer"
+        assert kwargs["data"]["from_role"] == "sentinel_agent"
 
 
 class TestExitCodes:
@@ -301,3 +301,58 @@ class TestExitCodes:
         assert rc == 1
         err = capsys.readouterr().err
         assert "boom" in err
+
+    @patch("egg_lib.orch_cli.orch_request")
+    def test_json_success_returns_zero(self, mock_request, capsys):
+        mock_request.return_value = {
+            "success": True,
+            "data": {"message": {"id": "msg-42"}},
+        }
+        rc = cmd_overseer_alert(
+            _parse(
+                [
+                    "overseer",
+                    "alert",
+                    "pipe-1",
+                    "--anomaly",
+                    "agent-loop",
+                    "--priority",
+                    "medium",
+                    "--summary",
+                    "coder looping",
+                    "--json",
+                ]
+            )
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        import json
+
+        payload = json.loads(out)
+        assert payload["success"] is True
+
+    @patch("egg_lib.orch_cli.orch_request")
+    def test_json_failure_returns_nonzero(self, mock_request, capsys):
+        mock_request.return_value = {"success": False, "message": "auth denied"}
+        rc = cmd_overseer_alert(
+            _parse(
+                [
+                    "overseer",
+                    "alert",
+                    "pipe-1",
+                    "--anomaly",
+                    "x",
+                    "--priority",
+                    "low",
+                    "--summary",
+                    "x",
+                    "--json",
+                ]
+            )
+        )
+        assert rc == 1
+        out = capsys.readouterr().out
+        import json
+
+        payload = json.loads(out)
+        assert payload["success"] is False

--- a/sandbox/tests/test_overseer_alert_cli.py
+++ b/sandbox/tests/test_overseer_alert_cli.py
@@ -219,7 +219,7 @@ class TestPayloadShape:
 
     @patch("egg_lib.orch_cli.orch_request")
     def test_role_from_env(self, mock_request, monkeypatch):
-        monkeypatch.setenv("EGG_AGENT_ROLE", "overseer")
+        monkeypatch.setenv("EGG_AGENT_ROLE", "sentinel_agent")
         _, kwargs = self._run(
             [
                 "overseer",
@@ -234,7 +234,7 @@ class TestPayloadShape:
             ],
             mock_request,
         )
-        assert kwargs["data"]["from_role"] == "overseer"
+        assert kwargs["data"]["from_role"] == "sentinel_agent"
 
     @patch("egg_lib.orch_cli.orch_request")
     def test_role_defaults_to_overseer_when_env_missing(self, mock_request, monkeypatch):


### PR DESCRIPTION
## Summary

- Reframes the overseer agent's charter from "take corrective action" to **"escalate to the human via `OVERSEER_ALERT`"**. Adds an explicit list of forbidden lifecycle commands (phase advance/complete/start, signal complete, decision resolve, consensus mutation, container spawn/stop) and a stop-retrying-on-401 rule.
- Adds a dedicated `egg-orch overseer alert` CLI subcommand that always sends with `message_type=OVERSEER_ALERT` and `to_role=all`, removing the model's freedom to fall back to `HANDOFF`/`STATUS` for anomaly escalation (the second-order failure documented in the issue's amendment).
- Adds concrete escalation triggers (stuck phase transition, repeated 401, agent loop, etc.) so the prompt tells the overseer *when* to alert, not just *how*.

## Background

In the `issue-1759-auth-gated` validation run, the overseer reasoned its way into calling `egg-orch phase advance` when the orchestrator appeared stuck, got 401s from the #1769 auth layer, and only then fell back to messaging — and even then used the wrong message types. See #1784 for the full transcript and root-cause analysis.

The companion ticket #1786 covers per-role `PATH` restriction (proposal #3 from #1784) as defense-in-depth; it's a separate layer (sandbox container config, no per-role PATH infrastructure exists yet) and warrants its own design.

## Acceptance criteria coverage (#1784)

- [x] Prompt no longer contains the phrase "take corrective action" as an instruction. Both remaining mentions are negations ("Do not attempt corrective actions" / "is not a corrective action").
- [x] Prompt contains an explicit list of forbidden actions (`sandbox/agent-config/rules/overseer.md` § "CRITICAL: Forbidden Actions").
- [x] Prompt enumerates concrete escalation triggers (`overseer.md` § "Escalation triggers"), including the stop-retrying-on-401 rule.
- [x] `OVERSEER_ALERT` is the path of least resistance: dedicated `egg-orch overseer alert` wrapper hard-codes `message_type=OVERSEER_ALERT` and `to_role=all` (addresses the amendment).
- [ ] End-to-end re-run of the stuck-phase scenario producing an `OVERSEER_ALERT` before any privileged call — not yet validated; would need to re-spin a pipeline against the modified prompt.
- [ ] Per-role PATH restriction so forbidden commands are unreachable from disk — tracked separately as #1786.

## Test plan

- [x] `pytest sandbox/tests/test_overseer_alert_cli.py` — 13 new tests covering parser registration, required-flag enforcement, payload shape (always `OVERSEER_ALERT` + `to_role=all`), role precedence, and exit codes.
- [x] `pytest sandbox/tests/test_brc_cli_args.py sandbox/tests/test_overseer_monitor_script.py` — 41 sibling tests still pass.
- [x] `make lint` — clean.
- [ ] Validate against a real stuck-phase pipeline run (next on-call rotation).

## Related

- Closes part of #1784 (companion #1786 for PATH restriction).
- Refs #1769 (the auth that surfaced this), #1783 (the orchestrator bug behind the stuck state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)