### PR TITLE
Fix #1781: route contract reads/writes through the orchestrator

### DIFF
--- a/gateway/contract_api.py
+++ b/gateway/contract_api.py
@@ -1,47 +1,44 @@
-"""
-Contract API endpoints for the gateway.
+"""Contract API endpoints on the gateway.
 
-Provides REST endpoints for contract mutations with role-based enforcement.
-Role is determined from GitHub Actions workflow context, not agent environment.
+These endpoints are the sandbox's entry point for contract reads and
+writes.  The gateway does not own contract state: it forwards each
+request to the orchestrator (``EGG_ORCHESTRATOR_URL``), which is the
+single source of truth during pipeline execution (see #1781).  This
+preserves the sandbox's "only talk to the gateway" policy while
+eliminating the per-agent worktree divergence that caused spurious
+BRC NACKs.
+
+The gateway still owns:
+  - session authentication (``require_session_auth``)
+  - role resolution from session metadata (prevents header-based
+    privilege escalation)
+
+It sends the verified role to the orchestrator via ``X-Egg-Role``.
 """
 
+import json
 import os
 import re
 import sys
-from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 from flask import Blueprint, Response, g, jsonify, request
 
-# Import gateway authentication - try relative import first (module mode),
-# fall back to absolute import (standalone script mode in container)
 try:
     from .auth import require_session_auth
-    from .git_client import validate_repo_path
 except ImportError:
     from auth import require_session_auth  # type: ignore[no-redef, import-untyped]
-    from git_client import validate_repo_path  # type: ignore[no-redef, import-untyped]
 
 # Add shared directory to path for egg_contracts
 _shared_path = Path(__file__).parent.parent / "shared"
 if _shared_path.exists() and str(_shared_path) not in sys.path:
     sys.path.insert(0, str(_shared_path))
 
-from egg_contracts import (
-    ContractNotFoundError,
-    ContractValidationError,
-    Role,
-    apply_mutation,
-    contract_exists,
-    export_contract,
-    get_contract_role,
-    load_contract,
-    save_contract,
-    validate_mutation,
-)
+from egg_contracts import Role, get_contract_role
 
-# Import gateway logging
 try:
     from egg_logging import get_logger
 except ImportError:
@@ -57,100 +54,27 @@ except ImportError:
 
 logger = get_logger("gateway.contract")
 
-# Blueprint for contract endpoints
 contract_bp = Blueprint("contract", __name__, url_prefix="/api/v1/contract")
 
-# Must match orchestrator/routes/__init__.py _WORKTREE_BASE_DIR and
-# docker-compose volume mounts.
-_WORKTREE_BASE_DIR = Path("/home/egg/.egg-worktrees")
+# Upstream orchestrator that owns contract state. The default matches the
+# docker-compose service name used elsewhere in the gateway
+# (``checkpoint_handler.py``).
+_DEFAULT_ORCHESTRATOR_URL = "http://egg-orchestrator:9849"
 
-# Matches the pipeline_id format used in worktree directory names.
-_VALID_PIPELINE_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+# Default timeout for orchestrator calls. Kept tight (mutations are
+# quick) so a stuck orchestrator surfaces as an error instead of a
+# silent stall.
+_ORCHESTRATOR_TIMEOUT_SECONDS = 30
 
-
-def _resolve_pipeline_worktree(pipeline_id: str, repo_path: Path) -> Path | None:
-    """Try to find the contract in a pipeline's worktree.
-
-    Pipeline worktrees live at ``/home/egg/.egg-worktrees/<pipeline_id>/<repo>/``.
-    This mirrors :func:`orchestrator.routes.resolve_worktree_path` but lives in
-    the gateway to avoid cross-package imports.
-
-    # TODO: consolidate with orchestrator.routes.resolve_worktree_path into shared/
-
-    Returns the worktree repo path if found, otherwise ``None``.
-    """
-    if not _VALID_PIPELINE_ID_RE.match(pipeline_id):
-        return None
-
-    wt_pipeline_dir = _WORKTREE_BASE_DIR / pipeline_id
-    if not wt_pipeline_dir.is_dir():
-        return None
-
-    # Match by repo directory name (last component of the original repo_path)
-    repo_name = repo_path.name
-    candidate = wt_pipeline_dir / repo_name
-    if candidate.is_dir():
-        return candidate
-
-    # Fallback: take the first existing subdirectory (matches orchestrator logic).
-    # This heuristic can mask misconfigurations — log so operators can detect them.
-    try:
-        for entry in wt_pipeline_dir.iterdir():
-            if entry.is_dir():
-                logger.warning(
-                    "Worktree repo name mismatch, using first subdirectory",
-                    expected_repo=repo_name,
-                    actual_subdir=entry.name,
-                    pipeline_id=pipeline_id,
-                )
-                return entry
-    except OSError:
-        pass
-
-    return None
+_VALID_IDENTIFIER_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
-_cached_worktree_helpers: (
-    tuple[
-        Callable[[str, str | None, str], str | None],
-        Callable[[str], tuple[Response, int]],
-    ]
-    | None
-) = None
-
-
-def _get_worktree_helpers() -> tuple[
-    Callable[[str, str | None, str], str | None],
-    Callable[[str], tuple[Response, int]],
-]:
-    """Lazy import of worktree helpers to avoid circular import issues.
-
-    The gateway module is large and loaded after contract_api in the test
-    harness, so we import on first use instead of at module load time.
-    Results are cached at module level to avoid per-request import overhead.
-    """
-    global _cached_worktree_helpers  # noqa: PLW0603
-    if _cached_worktree_helpers is not None:
-        return _cached_worktree_helpers
-    try:
-        from .gateway import make_worktree_not_found_error, map_container_path_to_worktree
-    except ImportError:
-        from gateway import (  # type: ignore[no-redef, attr-defined]
-            make_worktree_not_found_error,
-            map_container_path_to_worktree,
-        )
-    _cached_worktree_helpers = (map_container_path_to_worktree, make_worktree_not_found_error)
-    return _cached_worktree_helpers
+def _orchestrator_url() -> str:
+    return os.environ.get("EGG_ORCHESTRATOR_URL", _DEFAULT_ORCHESTRATOR_URL).rstrip("/")
 
 
 def _resolve_role(value: str) -> Role | None:
-    """Resolve a role string to the coarse contract ``Role``.
-
-    Accepts either a coarse ``Role`` value (``implementer``, ``reviewer``,
-    ``human``, ``system``) or a fine-grained ``AgentRole`` value
-    (``coder``, ``refiner``, ``reviewer_code`` …) that the launcher ships
-    in session metadata. Returns ``None`` for unknown values.
-    """
+    """Resolve a role string to the coarse contract :class:`Role`."""
     normalized = value.lower()
     try:
         return Role(normalized)
@@ -159,38 +83,24 @@ def _resolve_role(value: str) -> Role | None:
 
 
 def get_role_from_context() -> Role | None:
+    """Resolve the caller's contract role from the request context.
+
+    Priority (highest to lowest):
+      1. Session metadata — production path, set by the launcher.
+      2. ``X-Egg-Role`` header — only honored when
+         ``EGG_ENABLE_TEST_ROLE_HEADER=1``.
+      3. ``EGG_AGENT_ROLE`` environment variable — development only.
     """
-    Get the agent role from workflow context.
-
-    Role source priority (highest to lowest):
-    1. Session metadata (production path - set by launcher, most secure)
-    2. X-Egg-Role header (for gateway testing only)
-    3. EGG_AGENT_ROLE environment variable (development fallback)
-
-    In GitHub Actions, the role is passed via workflow inputs and set
-    in the session metadata by the launcher, NOT by the agent.
-    This prevents privilege escalation.
-
-    Returns:
-        The Role if valid, None otherwise
-    """
-    # Production path: role comes from workflow context via session metadata
-    # The session is set by the launcher when starting the container
-    # This takes precedence to prevent header-based privilege escalation
     if hasattr(g, "session") and g.session:
         session_role = getattr(g.session, "agent_role", None)
         if session_role:
             return _resolve_role(session_role)
 
-    # Testing path: role can be passed in request header for gateway testing
-    # SECURITY: Only enabled when EGG_ENABLE_TEST_ROLE_HEADER=1 to prevent
-    # privilege escalation in production when sessions don't have agent_role set
     if os.environ.get("EGG_ENABLE_TEST_ROLE_HEADER") == "1":
         header_role = request.headers.get("X-Egg-Role")
         if header_role:
             return _resolve_role(header_role)
 
-    # Fallback: check environment (least secure, used in development only)
     env_role = os.environ.get("EGG_AGENT_ROLE")
     if env_role:
         return _resolve_role(env_role)
@@ -198,443 +108,254 @@ def get_role_from_context() -> Role | None:
     return None
 
 
-def get_repo_path_from_request(
-    from_query: bool = False,
-) -> tuple[Path | None, str | None, str | None]:
-    """Get the repository path from the request with validation.
-
-    Args:
-        from_query: If True, look for repo_path in query parameters (for GET requests).
-                   If False, look in JSON body (for POST requests).
-
-    Returns:
-        Tuple of (path, error_message, container_id). If error_message is set, path validation failed.
-    """
-    if from_query:
-        # For GET requests, use query parameters
-        repo_path = request.args.get("repo_path")
-        container_id = request.args.get("container_id")
-    else:
-        # For POST requests, use JSON body
-        data = request.get_json() or {}
-        repo_path = data.get("repo_path")
-        container_id = data.get("container_id")
-
-    # Fall back to session container_id if not provided
-    if not container_id and hasattr(g, "session") and g.session:
-        container_id = getattr(g.session, "container_id", None)
-
-    if repo_path:
-        # Validate path to prevent path traversal attacks
-        is_valid, error = validate_repo_path(repo_path)
-        if not is_valid:
-            return None, error, container_id
-        return Path(repo_path), None, container_id
-
-    # Try to get from session
+def _session_pipeline_id() -> str | None:
     if hasattr(g, "session") and g.session:
-        session_repo = getattr(g.session, "repo_path", None)
-        if session_repo:
-            # Session paths are trusted (set by launcher), but validate anyway
-            is_valid, error = validate_repo_path(session_repo)
-            if not is_valid:
-                return None, error, container_id
-            return Path(session_repo), None, container_id
-
-    return None, None, container_id
+        return getattr(g.session, "pipeline_id", None)
+    return None
 
 
-def make_contract_error(
-    message: str,
-    status_code: int = 400,
-    details: dict[str, Any] | None = None,
-) -> tuple[Response, int]:
-    """Create a contract error response."""
-    response: dict[str, Any] = {"success": False, "message": message}
-    if details:
-        response["details"] = details
-    return jsonify(response), status_code
-
-
-def make_contract_success(
-    message: str,
-    data: dict[str, Any] | None = None,
-) -> tuple[Response, int]:
-    """Create a contract success response."""
-    response: dict[str, Any] = {"success": True, "message": message}
-    if data:
-        response["data"] = data
-    return jsonify(response), 200
-
-
-_VALID_IDENTIFIER_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
-
-
-def _validate_identifier(identifier: int | str) -> tuple[Response, int] | None:
-    """Validate a contract identifier against path traversal.
-
-    Returns an error response tuple if invalid, None if valid.
-    """
+def _validate_identifier_value(identifier: int | str) -> tuple[Response, int] | None:
     if isinstance(identifier, int):
         return None
     if not _VALID_IDENTIFIER_RE.match(identifier):
-        return make_contract_error(
+        return _error(
             "Invalid identifier: must contain only alphanumeric characters, hyphens, and underscores",
             status_code=400,
         )
     return None
 
 
-def _get_contract_impl(identifier: int | str) -> tuple[Response, int]:
-    """Shared implementation for get_contract routes.
+def _error(
+    message: str,
+    status_code: int = 400,
+    details: dict[str, Any] | None = None,
+) -> tuple[Response, int]:
+    payload: dict[str, Any] = {"success": False, "message": message}
+    if details:
+        payload["details"] = details
+    return jsonify(payload), status_code
 
-    Supports both integer issue numbers and string pipeline IDs.
+
+def _forward_response(payload: dict[str, Any], status_code: int) -> tuple[Response, int]:
+    """Return the orchestrator's JSON payload unchanged."""
+    return jsonify(payload), status_code
+
+
+def _proxy(
+    method: str,
+    path: str,
+    *,
+    role: Role | None = None,
+    params: dict[str, str] | None = None,
+    json_body: dict[str, Any] | None = None,
+) -> tuple[Response, int]:
+    """Forward a request to the orchestrator and relay its response.
+
+    The orchestrator response is relayed verbatim.  Connection errors
+    surface as 502 so callers can distinguish "orchestrator unreachable"
+    from "contract not found".
     """
-    validation_error = _validate_identifier(identifier)
-    if validation_error:
-        return validation_error
-    repo_path, path_error, container_id = get_repo_path_from_request(from_query=True)
-    if path_error:
-        return make_contract_error(path_error, status_code=400)
-    if not repo_path:
-        repo_path = Path.cwd()
+    url = f"{_orchestrator_url()}{path}"
+    if params:
+        from urllib.parse import urlencode
 
-    # Map container path to worktree path if container_id is provided
-    _map_path, _worktree_err = _get_worktree_helpers()
-    mapped_path = _map_path(str(repo_path), container_id, "contract")
-    if mapped_path is None:
-        return _worktree_err(container_id or "")
-    repo_path = Path(mapped_path)
+        url = f"{url}?{urlencode(params)}"
 
-    include_audit = request.args.get("include_audit_log", "false").lower() == "true"
-    pipeline_id = request.args.get("pipeline_id")
+    headers = {"Accept": "application/json"}
+    if role is not None:
+        headers["X-Egg-Role"] = role.value
+
+    data: bytes | None = None
+    if json_body is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(json_body).encode("utf-8")
 
     try:
-        contract = load_contract(identifier, repo_path)
-        data = export_contract(contract, include_audit_log=include_audit)
-        return make_contract_success("Contract retrieved", data=data)
-    except ContractNotFoundError:
-        # Fallback: try the pipeline's worktree if pipeline_id is provided.
-        # Contracts are written into per-pipeline worktrees, which differ
-        # from the gateway's CWD or the calling agent's worktree.
-        if pipeline_id:
-            wt_path = _resolve_pipeline_worktree(pipeline_id, repo_path)
-            if wt_path:
-                try:
-                    contract = load_contract(identifier, wt_path)
-                    data = export_contract(contract, include_audit_log=include_audit)
-                    logger.info(
-                        "Contract found via pipeline worktree fallback",
-                        identifier=str(identifier),
-                        pipeline_id=pipeline_id,
-                        worktree_path=str(wt_path),
-                    )
-                    return make_contract_success("Contract retrieved", data=data)
-                except ContractNotFoundError:
-                    pass  # genuinely not found, fall through to 404
-                except ContractValidationError:
-                    logger.warning(
-                        "Contract found in pipeline worktree but validation failed",
-                        identifier=str(identifier),
-                        pipeline_id=pipeline_id,
-                        worktree_path=str(wt_path),
-                    )
-                    return make_contract_error(
-                        f"Contract validation failed in pipeline worktree for {identifier}",
-                        status_code=500,
-                    )
+        req = Request(url, data=data, headers=headers, method=method)
+        with urlopen(req, timeout=_ORCHESTRATOR_TIMEOUT_SECONDS) as response:
+            body = response.read().decode("utf-8")
+            try:
+                payload = json.loads(body) if body else {}
+            except json.JSONDecodeError:
+                logger.error(
+                    "Non-JSON response from orchestrator contract API",
+                    path=path,
+                    status=response.status,
+                )
+                return _error("Malformed response from orchestrator", status_code=502)
+            return _forward_response(payload, response.status)
+    except HTTPError as exc:
+        raw = exc.read().decode("utf-8") if hasattr(exc, "read") else ""
+        try:
+            payload = json.loads(raw) if raw else {"success": False, "message": str(exc)}
+        except json.JSONDecodeError:
+            payload = {"success": False, "message": raw or str(exc)}
+        return _forward_response(payload, exc.code)
+    except (URLError, TimeoutError) as exc:
+        logger.error(
+            "Orchestrator unreachable for contract request",
+            path=path,
+            error=str(exc),
+        )
+        return _error(
+            "Orchestrator unreachable — try again",
+            status_code=502,
+        )
 
-        return make_contract_error(
-            f"Contract for {'#' + str(identifier) if isinstance(identifier, int) else identifier} not found",
-            status_code=404,
-        )
-    except ContractValidationError as e:
-        return make_contract_error(
-            f"Contract validation failed: {e}",
-            status_code=500,
-        )
+
+def _context_params(body: dict[str, Any] | None = None) -> dict[str, str]:
+    """Collect bootstrap hints (pipeline_id, repo) to forward upstream."""
+    params: dict[str, str] = {}
+    pipeline_id = None
+    if body:
+        pipeline_id = body.get("pipeline_id")
+    if not pipeline_id:
+        pipeline_id = request.args.get("pipeline_id") or _session_pipeline_id()
+    if pipeline_id:
+        params["pipeline_id"] = pipeline_id
+
+    repo = (body or {}).get("repo") or request.args.get("repo")
+    if repo:
+        params["repo"] = repo
+    return params
 
 
 @contract_bp.route("/<int:issue_number>", methods=["GET"])
 @require_session_auth
 def get_contract(issue_number: int) -> tuple[Response, int]:
-    """
-    Get contract state for an issue by issue number.
-
-    URL params:
-        issue_number: GitHub issue number
-
-    Query params:
-        repo_path: Path to the repository (optional)
-        include_audit_log: Whether to include audit log (default: false)
-    """
+    """Fetch the contract for ``issue_number`` (integer form)."""
     return _get_contract_impl(issue_number)
 
 
 @contract_bp.route("/<identifier>", methods=["GET"])
 @require_session_auth
 def get_contract_by_pipeline_id(identifier: str) -> tuple[Response, int]:
-    """
-    Get contract state by pipeline ID (string identifier).
-
-    Supports JIRA-ticket-driven pipelines where EGG_ISSUE_NUMBER is not set.
-
-    URL params:
-        identifier: Pipeline ID (e.g., "KORE-1191-full")
-
-    Query params:
-        repo_path: Path to the repository (optional)
-        include_audit_log: Whether to include audit log (default: false)
-    """
+    """Fetch the contract by string identifier (pipeline ID)."""
     return _get_contract_impl(identifier)
 
 
-@contract_bp.route("/mutate", methods=["POST"])
-@require_session_auth
-def mutate_contract() -> tuple[Response, int]:
-    """
-    Apply a mutation to a contract.
-
-    Request body:
-        {
-            "identifier": 123 or "KORE-1191-full",  // issue number or pipeline ID
-            "repo_path": "/path/to/repo",  // optional
-            "field_path": "phases.0.tasks.0.commit",
-            "new_value": "abc1234",
-            "actor": "egg",  // optional, defaults to "agent"
-            "reason": "Implementation complete"  // optional
-        }
-
-    The "identifier" field accepts both integer issue numbers and string
-    pipeline IDs. The legacy "issue_number" field is still accepted for
-    backward compatibility.
-
-    The role is determined from workflow context, not the request body.
-    This prevents agents from escalating their privileges.
-
-    Returns:
-        Success: {"success": true, "message": "...", "data": {"contract": {...}}}
-        Error: {"success": false, "message": "...", "details": {...}}
-    """
-    data = request.get_json()
-    if not data:
-        return make_contract_error("Missing request body")
-
-    # Required fields — accept "identifier" with "issue_number" fallback.
-    # Identifier may be int or str, so use explicit None checks to avoid
-    # falsy values (e.g. 0 or "") falling through incorrectly.
-    identifier = data.get("identifier")
-    if identifier is None:
-        identifier = data.get("issue_number")
-    field_path = data.get("field_path")
-    new_value = data.get("new_value")
-
-    if identifier is None:
-        return make_contract_error("Missing identifier or issue_number")
-
-    validation_error = _validate_identifier(identifier)
+def _get_contract_impl(identifier: int | str) -> tuple[Response, int]:
+    validation_error = _validate_identifier_value(identifier)
     if validation_error:
         return validation_error
-    if not field_path:
-        return make_contract_error("Missing field_path")
-    if new_value is None:
-        return make_contract_error("Missing new_value")
 
-    # Optional fields
-    if data.get("repo_path"):
-        is_valid, error = validate_repo_path(data["repo_path"])
-        if not is_valid:
-            return make_contract_error(error, status_code=400)
-        repo_path = Path(data["repo_path"])
-    else:
-        repo_path = Path.cwd()
-    # NOTE: This duplicates the container_id extraction + session fallback
-    # from get_repo_path_from_request(). mutate_contract doesn't use that
-    # helper (pre-existing design), so keep these in sync if the logic changes.
-    container_id = data.get("container_id")
-    if not container_id and hasattr(g, "session") and g.session:
-        container_id = getattr(g.session, "container_id", None)
+    params = _context_params()
+    include_audit = request.args.get("include_audit_log", "false").lower() == "true"
+    if include_audit:
+        params["include_audit_log"] = "true"
 
-    # Map container path to worktree path if container_id is provided
-    _map_path, _worktree_err = _get_worktree_helpers()
-    mapped_path = _map_path(str(repo_path), container_id, "contract")
-    if mapped_path is None:
-        return _worktree_err(container_id or "")
-    repo_path = Path(mapped_path)
-
-    actor = data.get("actor", "agent")
-    reason = data.get("reason")
-
-    # Get role from context (NOT from request body)
-    role = get_role_from_context()
-    if not role:
-        return make_contract_error(
-            "Cannot determine agent role. Role must be set via workflow context.",
-            status_code=403,
-            details={"hint": "Set EGG_AGENT_ROLE via workflow inputs, not agent env vars"},
-        )
-
-    # Load the contract
-    try:
-        contract = load_contract(identifier, repo_path)
-    except ContractNotFoundError:
-        return make_contract_error(
-            f"Contract for {'#' + str(identifier) if isinstance(identifier, int) else identifier} not found",
-            status_code=404,
-        )
-    except ContractValidationError as e:
-        return make_contract_error(
-            f"Contract validation failed: {e}",
-            status_code=500,
-        )
-
-    # Apply the mutation
-    result = apply_mutation(
-        contract=contract,
-        role=role,
-        actor=actor,
-        field_path=field_path,
-        new_value=new_value,
-        reason=reason,
-    )
-
-    if not result.success:
-        logger.warning(
-            "Contract mutation rejected",
-            identifier=identifier,
-            role=role.value,
-            field_path=field_path,
-            error=result.message,
-        )
-        return make_contract_error(
-            result.message,
-            status_code=403,
-            details={
-                "role": role.value,
-                "field_path": field_path,
-            },
-        )
-
-    # Save the updated contract
-    # Type assertion: contract is always set when success is True
-    assert result.contract is not None
-    try:
-        save_contract(result.contract, repo_path)
-    except Exception as e:
-        logger.error(
-            "Failed to save contract",
-            identifier=identifier,
-            error=str(e),
-        )
-        return make_contract_error(
-            f"Failed to save contract: {e}",
-            status_code=500,
-        )
-
-    logger.info(
-        "Contract mutation applied",
-        identifier=identifier,
-        role=role.value,
-        actor=actor,
-        field_path=field_path,
-    )
-
-    return make_contract_success(
-        "Mutation applied successfully",
-        data={"contract": export_contract(result.contract, include_audit_log=False)},
-    )
-
-
-@contract_bp.route("/validate", methods=["POST"])
-@require_session_auth
-def validate_contract_mutation() -> tuple[Response, int]:
-    """
-    Validate a mutation without applying it.
-
-    Request body:
-        {
-            "field_path": "phases.0.tasks.0.status",
-            "new_value": "complete"
-        }
-
-    The role is determined from workflow context.
-
-    Returns:
-        {"success": true, "message": "Mutation allowed"}
-        or
-        {"success": false, "message": "...", "details": {...}}
-    """
-    data = request.get_json()
-    if not data:
-        return make_contract_error("Missing request body")
-
-    field_path = data.get("field_path")
-    new_value = data.get("new_value")
-
-    if not field_path:
-        return make_contract_error("Missing field_path")
-    if new_value is None:
-        return make_contract_error("Missing new_value")
-
-    # Get role from context
-    role = get_role_from_context()
-    if not role:
-        return make_contract_error(
-            "Cannot determine agent role",
-            status_code=403,
-        )
-
-    # Validate the mutation
-    result = validate_mutation(role, field_path, new_value)
-
-    if result.valid:
-        return make_contract_success("Mutation allowed")
-    else:
-        return make_contract_error(
-            result.message,
-            status_code=403,
-            details={
-                "role": role.value,
-                "field_path": result.field_path,
-                "required_role": result.required_role,
-            },
-        )
-
-
-def _check_contract_exists_impl(identifier: int | str) -> tuple[Response, int]:
-    """Shared implementation for contract exists routes."""
-    validation_error = _validate_identifier(identifier)
-    if validation_error:
-        return validation_error
-    repo_path, path_error, container_id = get_repo_path_from_request(from_query=True)
-    if path_error:
-        return make_contract_error(path_error, status_code=400)
-    if not repo_path:
-        repo_path = Path.cwd()
-
-    # Map container path to worktree path if container_id is provided
-    _map_path, _worktree_err = _get_worktree_helpers()
-    mapped_path = _map_path(str(repo_path), container_id, "contract")
-    if mapped_path is None:
-        return _worktree_err(container_id or "")
-    repo_path = Path(mapped_path)
-
-    exists = contract_exists(identifier, repo_path)
-    return make_contract_success(
-        "Contract exists" if exists else "Contract does not exist",
-        data={"exists": exists},
+    return _proxy(
+        "GET",
+        f"/api/v1/contracts/{identifier}",
+        params=params,
     )
 
 
 @contract_bp.route("/exists/<int:issue_number>", methods=["GET"])
 @require_session_auth
 def check_contract_exists(issue_number: int) -> tuple[Response, int]:
-    """Check if a contract exists for an issue by issue number."""
     return _check_contract_exists_impl(issue_number)
 
 
 @contract_bp.route("/exists/<identifier>", methods=["GET"])
 @require_session_auth
 def check_contract_exists_by_pipeline_id(identifier: str) -> tuple[Response, int]:
-    """Check if a contract exists by pipeline ID (string identifier)."""
     return _check_contract_exists_impl(identifier)
+
+
+def _check_contract_exists_impl(identifier: int | str) -> tuple[Response, int]:
+    validation_error = _validate_identifier_value(identifier)
+    if validation_error:
+        return validation_error
+    return _proxy(
+        "GET",
+        f"/api/v1/contracts/{identifier}/exists",
+        params=_context_params(),
+    )
+
+
+@contract_bp.route("/mutate", methods=["POST"])
+@require_session_auth
+def mutate_contract() -> tuple[Response, int]:
+    """Apply a role-validated mutation to the contract.
+
+    Identifier is accepted in the request body for backwards
+    compatibility with the CLI (``egg-contract``) and older callers.
+    """
+    body = request.get_json()
+    if not body:
+        return _error("Missing request body")
+
+    identifier = body.get("identifier")
+    if identifier is None:
+        identifier = body.get("issue_number")
+    if identifier is None:
+        return _error("Missing identifier or issue_number")
+
+    validation_error = _validate_identifier_value(identifier)
+    if validation_error:
+        return validation_error
+
+    field_path = body.get("field_path")
+    new_value = body.get("new_value", ...)
+    if not field_path:
+        return _error("Missing field_path")
+    if new_value is ...:
+        return _error("Missing new_value")
+
+    role = get_role_from_context()
+    if role is None:
+        return _error(
+            "Cannot determine agent role. Role must be set via workflow context.",
+            status_code=403,
+            details={"hint": "Set EGG_AGENT_ROLE via workflow inputs, not agent env vars"},
+        )
+
+    forwarded = {
+        "field_path": field_path,
+        "new_value": new_value,
+        "actor": body.get("actor", "agent"),
+    }
+    if "reason" in body:
+        forwarded["reason"] = body["reason"]
+    # Forward pipeline_id in the body so the orchestrator can bootstrap
+    # from the shared worktree on first access.
+    params = _context_params(body)
+    if "pipeline_id" in params:
+        forwarded["pipeline_id"] = params["pipeline_id"]
+    if "repo" in params:
+        forwarded["repo"] = params["repo"]
+
+    return _proxy(
+        "POST",
+        f"/api/v1/contracts/{identifier}/mutate",
+        role=role,
+        json_body=forwarded,
+    )
+
+
+@contract_bp.route("/validate", methods=["POST"])
+@require_session_auth
+def validate_contract_mutation() -> tuple[Response, int]:
+    """Dry-run a mutation without applying it."""
+    body = request.get_json()
+    if not body:
+        return _error("Missing request body")
+
+    field_path = body.get("field_path")
+    new_value = body.get("new_value", ...)
+    if not field_path:
+        return _error("Missing field_path")
+    if new_value is ...:
+        return _error("Missing new_value")
+
+    role = get_role_from_context()
+    if role is None:
+        return _error("Cannot determine agent role", status_code=403)
+
+    return _proxy(
+        "POST",
+        "/api/v1/contract-mutations/validate",
+        role=role,
+        json_body={"field_path": field_path, "new_value": new_value},
+    )

--- a/gateway/tests/test_contract_api.py
+++ b/gateway/tests/test_contract_api.py
@@ -1,18 +1,26 @@
-"""
-Tests for Contract API endpoints.
+"""Tests for the gateway's contract API (pass-through to orchestrator).
 
-Tests cover:
-- get_role_from_context() role resolution
-- GET /api/v1/contract/<issue_number> - Get contract state
-- GET /api/v1/contract/exists/<issue_number> - Check contract existence
-- POST /api/v1/contract/validate - Validate mutation
-- POST /api/v1/contract/mutate - Apply mutation
+After #1781, the gateway no longer reads or writes contract files
+directly — it proxies every request to the orchestrator's
+``/api/v1/contracts/…`` endpoints.  These tests cover:
+
+- role resolution from session/header/env (unchanged behavior)
+- identifier validation before forwarding
+- request shape forwarded to the orchestrator
+- upstream error relay
+
+Business logic (role permissions, mutation application) lives in the
+orchestrator and is tested in ``orchestrator/tests/test_contracts_routes.py``.
 """
 
+from __future__ import annotations
+
+import io
 import json
 import os
 import sys
 from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError, URLError
 
 import auth
 import contract_api
@@ -25,49 +33,19 @@ import gateway
 
 @pytest.fixture
 def client():
-    """Create test client for Flask app."""
     gateway.app.config["TESTING"] = True
     with gateway.app.test_client() as client:
         yield client
 
 
-@pytest.fixture(autouse=True)
-def mock_worktree_helpers():
-    """Auto-mock _get_worktree_helpers to return passthrough mapping by default.
-
-    The session fixture sets container_id='test-container', which triggers
-    worktree path mapping. Without this mock, tests would fail because the
-    real worktree doesn't exist on disk.
-
-    Individual tests that need to verify worktree mapping behaviour should
-    override this by patching _get_worktree_helpers themselves.
-    """
-    # Passthrough: returns the repo_path unchanged regardless of container_id
-    passthrough_map = MagicMock(side_effect=lambda path, cid, op: path)
-    dummy_err = MagicMock()
-
-    # Clear the module-level cache so each test gets a fresh lookup
-    old_cache = contract_api._cached_worktree_helpers
-    contract_api._cached_worktree_helpers = None
-    with patch.object(
-        contract_api,
-        "_get_worktree_helpers",
-        return_value=(passthrough_map, dummy_err),
-    ):
-        yield
-    contract_api._cached_worktree_helpers = old_cache
-
-
 @pytest.fixture
 def auth_headers():
-    """Return valid session authentication headers with mocked session validation.
-
-    Note: We patch sys.modules entries directly to handle cases where other tests
-    may have loaded different module instances into sys.modules.
-    """
+    """Session-authenticated headers with a mock session on g."""
     mock_session = MagicMock()
     mock_session.mode = "public"
     mock_session.container_id = "test-container"
+    mock_session.pipeline_id = "test-pipeline"
+    mock_session.agent_role = "implementer"
     mock_session.expires_at = None
 
     mock_result = SessionValidationResult(valid=True, session=mock_session)
@@ -80,16 +58,13 @@ def auth_headers():
         visibility="public",
     )
 
-    # Clear auth module's cached references so it picks up our patched module
     auth._session_manager = None
     auth._rate_limiter = None
 
-    # Also clear any package-style cached references
     if "gateway.auth" in sys.modules:
         sys.modules["gateway.auth"]._session_manager = None
         sys.modules["gateway.auth"]._rate_limiter = None
 
-    # Patch the module that's currently in sys.modules
     current_session_manager = sys.modules.get("session_manager", session_manager)
 
     with (
@@ -101,16 +76,46 @@ def auth_headers():
         yield {"Authorization": "Bearer test-session-token"}
 
 
-# ---------------------------------------------------------------------------
-# get_role_from_context tests
-# ---------------------------------------------------------------------------
+def _make_urlopen(status: int, body: dict, *, capture: list | None = None):
+    """Build a urlopen stand-in that returns *body* with *status*.
+
+    Any list passed as ``capture`` collects the requests so tests can
+    assert on what the gateway forwarded.
+    """
+
+    def _fake_urlopen(req, timeout=None):
+        if capture is not None:
+            payload = req.data.decode() if req.data else None
+            capture.append(
+                {
+                    "url": req.full_url,
+                    "method": req.get_method(),
+                    "headers": dict(req.header_items()),
+                    "body": json.loads(payload) if payload else None,
+                }
+            )
+
+        class _Resp:
+            def __init__(self) -> None:
+                self.status = status
+                self._data = json.dumps(body).encode()
+
+            def read(self) -> bytes:
+                return self._data
+
+            def __enter__(self) -> _Resp:
+                return self
+
+            def __exit__(self, *args) -> None:
+                return None
+
+        return _Resp()
+
+    return _fake_urlopen
 
 
 class TestGetRoleFromContext:
-    """Tests for get_role_from_context() helper function."""
-
-    def test_role_from_session_agent_role(self, client, auth_headers):
-        """Role is resolved from g.session.agent_role when present."""
+    def test_role_from_session(self, client):
         mock_session = MagicMock()
         mock_session.agent_role = "implementer"
 
@@ -124,30 +129,14 @@ class TestGetRoleFromContext:
         assert role.value == "implementer"
 
     @pytest.mark.parametrize(
-        ("fine_role", "expected_coarse"),
+        ("fine_role", "expected"),
         [
             ("coder", "implementer"),
-            ("tester", "implementer"),
-            ("documenter", "implementer"),
-            ("refiner", "implementer"),
-            ("architect", "implementer"),
-            ("task_planner", "implementer"),
-            ("risk_analyst", "implementer"),
-            ("autofixer", "implementer"),
-            ("conflict_resolver", "implementer"),
             ("reviewer_code", "reviewer"),
-            ("reviewer_contract", "reviewer"),
-            ("reviewer_agent_design", "reviewer"),
-            ("reviewer_refine", "reviewer"),
-            ("reviewer_plan", "reviewer"),
             ("overseer", "system"),
-            ("inspector", "system"),
         ],
     )
-    def test_role_from_session_fine_grained_agent_role(
-        self, client, auth_headers, fine_role, expected_coarse
-    ):
-        """Fine-grained AgentRole values map to coarse contract Role (#1766)."""
+    def test_fine_grained_role_maps_to_coarse(self, client, fine_role, expected):
         mock_session = MagicMock()
         mock_session.agent_role = fine_role
 
@@ -157,11 +146,10 @@ class TestGetRoleFromContext:
             g.session = mock_session
             role = contract_api.get_role_from_context()
 
-        assert role is not None, f"fine role {fine_role!r} should resolve"
-        assert role.value == expected_coarse
+        assert role is not None
+        assert role.value == expected
 
-    def test_role_from_x_egg_role_header_when_enabled(self, client, auth_headers):
-        """Role is resolved from X-Egg-Role header when EGG_ENABLE_TEST_ROLE_HEADER=1."""
+    def test_header_honored_only_when_flag_set(self, client):
         with (
             client.application.test_request_context(headers={"X-Egg-Role": "reviewer"}),
             patch.dict(os.environ, {"EGG_ENABLE_TEST_ROLE_HEADER": "1"}, clear=False),
@@ -174,10 +162,8 @@ class TestGetRoleFromContext:
         assert role is not None
         assert role.value == "reviewer"
 
-    def test_role_from_x_egg_role_header_blocked_when_env_not_set(self, client, auth_headers):
-        """X-Egg-Role header is ignored when EGG_ENABLE_TEST_ROLE_HEADER is not set."""
-        env = os.environ.copy()
-        env.pop("EGG_ENABLE_TEST_ROLE_HEADER", None)
+    def test_header_ignored_without_flag(self, client):
+        env = {k: v for k, v in os.environ.items() if k not in ("EGG_ENABLE_TEST_ROLE_HEADER",)}
         env.pop("EGG_AGENT_ROLE", None)
 
         with (
@@ -191,10 +177,8 @@ class TestGetRoleFromContext:
 
         assert role is None
 
-    def test_role_from_env_var(self, client, auth_headers):
-        """Role is resolved from EGG_AGENT_ROLE env var as fallback."""
-        env = os.environ.copy()
-        env.pop("EGG_ENABLE_TEST_ROLE_HEADER", None)
+    def test_env_fallback(self, client):
+        env = {k: v for k, v in os.environ.items() if k != "EGG_ENABLE_TEST_ROLE_HEADER"}
         env["EGG_AGENT_ROLE"] = "human"
 
         with (
@@ -209,1256 +193,206 @@ class TestGetRoleFromContext:
         assert role is not None
         assert role.value == "human"
 
-    def test_invalid_role_returns_none(self, client, auth_headers):
-        """Invalid role string returns None."""
-        env = os.environ.copy()
-        env.pop("EGG_ENABLE_TEST_ROLE_HEADER", None)
-        env["EGG_AGENT_ROLE"] = "superadmin"
 
-        with (
-            client.application.test_request_context(),
-            patch.dict(os.environ, env, clear=True),
+class TestProxyToOrchestrator:
+    def test_get_forwards_to_orchestrator(self, client, auth_headers):
+        captured: list = []
+        with patch.object(
+            contract_api,
+            "urlopen",
+            _make_urlopen(200, {"success": True, "data": {"id": 42}}, capture=captured),
         ):
-            from flask import g
+            response = client.get(
+                "/api/v1/contract/42?pipeline_id=test-pipeline&repo=egg",
+                headers=auth_headers,
+            )
 
-            g.session = None
-            role = contract_api.get_role_from_context()
+        assert response.status_code == 200
+        assert len(captured) == 1
+        forwarded = captured[0]
+        assert "/api/v1/contracts/42" in forwarded["url"]
+        assert "pipeline_id=test-pipeline" in forwarded["url"]
+        assert forwarded["method"] == "GET"
 
-        assert role is None
+    def test_get_includes_audit_log_param(self, client, auth_headers):
+        captured: list = []
+        with patch.object(
+            contract_api,
+            "urlopen",
+            _make_urlopen(200, {"success": True, "data": {}}, capture=captured),
+        ):
+            client.get(
+                "/api/v1/contract/42?include_audit_log=true&pipeline_id=test-pipeline",
+                headers=auth_headers,
+            )
 
-    def test_no_role_set_returns_none(self, client, auth_headers):
-        """Returns None when no role source is available."""
-        env = os.environ.copy()
-        env.pop("EGG_ENABLE_TEST_ROLE_HEADER", None)
+        assert "include_audit_log=true" in captured[0]["url"]
+
+    def test_mutate_forwards_role_header_and_body(self, client, auth_headers):
+        captured: list = []
+        with patch.object(
+            contract_api,
+            "urlopen",
+            _make_urlopen(
+                200,
+                {"success": True, "data": {"contract": {"id": 42}}},
+                capture=captured,
+            ),
+        ):
+            response = client.post(
+                "/api/v1/contract/mutate",
+                headers=auth_headers,
+                data=json.dumps(
+                    {
+                        "identifier": 42,
+                        "field_path": "phases.0.tasks.0.commit",
+                        "new_value": "abc1234",
+                    }
+                ),
+                content_type="application/json",
+            )
+
+        assert response.status_code == 200
+        forwarded = captured[0]
+        assert forwarded["url"].endswith("/api/v1/contracts/42/mutate")
+        header_map = {k.lower(): v for k, v in forwarded["headers"].items()}
+        assert header_map.get("x-egg-role") == "implementer"
+        assert forwarded["body"]["field_path"] == "phases.0.tasks.0.commit"
+        assert forwarded["body"]["new_value"] == "abc1234"
+        # pipeline_id comes from the session and is forwarded for bootstrap context.
+        assert forwarded["body"]["pipeline_id"] == "test-pipeline"
+
+    def test_mutate_requires_role(self, client):
+        env = {k: v for k, v in os.environ.items() if k != "EGG_ENABLE_TEST_ROLE_HEADER"}
         env.pop("EGG_AGENT_ROLE", None)
 
+        no_role_session = MagicMock()
+        no_role_session.mode = "public"
+        no_role_session.agent_role = None
+        no_role_session.pipeline_id = "test-pipeline"
+        no_role_session.container_id = "test-container"
+        no_role_session.expires_at = None
+
+        from private_repo_policy import PrivateRepoPolicyResult
+
+        policy = PrivateRepoPolicyResult(
+            allowed=True,
+            reason="Test mode",
+            visibility="public",
+        )
+
+        auth._session_manager = None
+        auth._rate_limiter = None
+
         with (
-            client.application.test_request_context(),
+            patch.object(
+                sys.modules.get("session_manager", session_manager),
+                "validate_session_for_request",
+                return_value=SessionValidationResult(valid=True, session=no_role_session),
+            ),
+            patch.object(gateway, "check_private_repo_access", return_value=policy),
             patch.dict(os.environ, env, clear=True),
         ):
-            from flask import g
-
-            g.session = None
-            role = contract_api.get_role_from_context()
-
-        assert role is None
-
-
-# ---------------------------------------------------------------------------
-# GET /api/v1/contract/<issue_number> tests
-# ---------------------------------------------------------------------------
-
-
-class TestGetContract:
-    """Tests for GET /api/v1/contract/<issue_number> endpoint."""
-
-    def test_get_contract_success(self, client, auth_headers):
-        """Successfully retrieves a contract."""
-        mock_contract = MagicMock()
-        mock_exported = {"issue": 42, "phases": []}
-
-        with (
-            patch.object(contract_api, "load_contract", return_value=mock_contract) as mock_load,
-            patch.object(
-                contract_api, "export_contract", return_value=mock_exported
-            ) as mock_export,
-        ):
-            response = client.get(
-                "/api/v1/contract/42?repo_path=/home/egg/repos/test",
-                headers=auth_headers,
+            response = client.post(
+                "/api/v1/contract/mutate",
+                headers={"Authorization": "Bearer test-session-token"},
+                data=json.dumps(
+                    {
+                        "identifier": 42,
+                        "field_path": "phases",
+                        "new_value": [],
+                    }
+                ),
+                content_type="application/json",
             )
 
-        assert response.status_code == 200
-        data = json.loads(response.data)
-        assert data["success"] is True
-        assert data["message"] == "Contract retrieved"
-        assert data["data"]["issue"] == 42
-        mock_load.assert_called_once()
-        mock_export.assert_called_once_with(mock_contract, include_audit_log=False)
+        assert response.status_code == 403
 
-    def test_get_contract_not_found(self, client, auth_headers):
-        """Returns 404 when contract is not found."""
-        from pathlib import Path
+    def test_upstream_error_relayed(self, client, auth_headers):
+        error_body = json.dumps({"success": False, "message": "Not found"}).encode()
 
-        from egg_contracts import ContractNotFoundError
+        def raising_urlopen(req, timeout=None):
+            raise HTTPError(
+                url=req.full_url,
+                code=404,
+                msg="Not Found",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=io.BytesIO(error_body),
+            )
 
-        with patch.object(
-            contract_api,
-            "load_contract",
-            side_effect=ContractNotFoundError(999, Path("/home/egg/repos/test")),
-        ):
+        with patch.object(contract_api, "urlopen", raising_urlopen):
             response = client.get(
-                "/api/v1/contract/999?repo_path=/home/egg/repos/test",
+                "/api/v1/contract/42?pipeline_id=test-pipeline",
                 headers=auth_headers,
             )
 
         assert response.status_code == 404
-        data = json.loads(response.data)
-        assert data["success"] is False
-        assert "not found" in data["message"].lower()
+        assert json.loads(response.data)["message"] == "Not found"
 
-    def test_get_contract_validation_error(self, client, auth_headers):
-        """Returns 500 when contract validation fails."""
-        from egg_contracts import ContractValidationError
+    def test_orchestrator_unreachable_returns_502(self, client, auth_headers):
+        def raising_urlopen(req, timeout=None):
+            raise URLError("connection refused")
 
+        with patch.object(contract_api, "urlopen", raising_urlopen):
+            response = client.get(
+                "/api/v1/contract/42?pipeline_id=test-pipeline",
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 502
+
+    def test_validate_forwards_without_identifier(self, client, auth_headers):
+        captured: list = []
         with patch.object(
             contract_api,
-            "load_contract",
-            side_effect=ContractValidationError(42, ["Bad schema"]),
+            "urlopen",
+            _make_urlopen(200, {"success": True, "message": "Mutation allowed"}, capture=captured),
         ):
-            response = client.get(
-                "/api/v1/contract/42?repo_path=/home/egg/repos/test",
+            response = client.post(
+                "/api/v1/contract/validate",
                 headers=auth_headers,
-            )
-
-        assert response.status_code == 500
-        data = json.loads(response.data)
-        assert data["success"] is False
-        assert "validation failed" in data["message"].lower()
-
-    def test_get_contract_with_audit_log(self, client, auth_headers):
-        """Passes include_audit_log=True when query param is set."""
-        mock_contract = MagicMock()
-        mock_exported = {"issue": 42, "phases": [], "audit_log": []}
-
-        with (
-            patch.object(contract_api, "load_contract", return_value=mock_contract),
-            patch.object(
-                contract_api, "export_contract", return_value=mock_exported
-            ) as mock_export,
-        ):
-            response = client.get(
-                "/api/v1/contract/42?repo_path=/home/egg/repos/test&include_audit_log=true",
-                headers=auth_headers,
+                data=json.dumps(
+                    {
+                        "field_path": "phases.0.status",
+                        "new_value": "complete",
+                    }
+                ),
+                content_type="application/json",
             )
 
         assert response.status_code == 200
-        mock_export.assert_called_once_with(mock_contract, include_audit_log=True)
-
-
-# ---------------------------------------------------------------------------
-# GET /api/v1/contract/exists/<issue_number> tests
-# ---------------------------------------------------------------------------
-
-
-class TestCheckContractExists:
-    """Tests for GET /api/v1/contract/exists/<issue_number> endpoint."""
-
-    def test_contract_exists(self, client, auth_headers):
-        """Returns exists=True when contract exists."""
-        with patch.object(contract_api, "contract_exists", return_value=True):
-            response = client.get(
-                "/api/v1/contract/exists/42?repo_path=/home/egg/repos/test",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 200
-        data = json.loads(response.data)
-        assert data["success"] is True
-        assert data["data"]["exists"] is True
-        assert "exists" in data["message"].lower()
-
-    def test_contract_does_not_exist(self, client, auth_headers):
-        """Returns exists=False when contract does not exist."""
-        with patch.object(contract_api, "contract_exists", return_value=False):
-            response = client.get(
-                "/api/v1/contract/exists/999?repo_path=/home/egg/repos/test",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 200
-        data = json.loads(response.data)
-        assert data["success"] is True
-        assert data["data"]["exists"] is False
-        assert "does not exist" in data["message"].lower()
-
-
-# ---------------------------------------------------------------------------
-# String identifier (pipeline ID) tests
-# ---------------------------------------------------------------------------
-
-
-class TestGetContractByPipelineId:
-    """Tests for GET /api/v1/contract/<identifier> with string pipeline IDs."""
-
-    def test_get_contract_by_pipeline_id(self, client, auth_headers):
-        """Successfully retrieves a contract by string pipeline ID."""
-        mock_contract = MagicMock()
-        mock_exported = {"pipeline_id": "KORE-1191-full", "phases": []}
-
-        with (
-            patch.object(contract_api, "load_contract", return_value=mock_contract) as mock_load,
-            patch.object(contract_api, "export_contract", return_value=mock_exported),
-        ):
-            response = client.get(
-                "/api/v1/contract/KORE-1191-full?repo_path=/home/egg/repos/test",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 200
-        data = json.loads(response.data)
-        assert data["success"] is True
-        assert data["data"]["pipeline_id"] == "KORE-1191-full"
-        mock_load.assert_called_once()
-        # Verify the identifier passed is the string pipeline ID
-        call_args = mock_load.call_args
-        assert call_args[0][0] == "KORE-1191-full"
-
-    def test_get_contract_pipeline_id_not_found(self, client, auth_headers):
-        """Returns 404 when pipeline ID contract not found."""
-        from pathlib import Path
-
-        from egg_contracts import ContractNotFoundError
-
-        with patch.object(
-            contract_api,
-            "load_contract",
-            side_effect=ContractNotFoundError("KORE-999", Path("/home/egg/repos/test")),
-        ):
-            response = client.get(
-                "/api/v1/contract/KORE-999?repo_path=/home/egg/repos/test",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 404
-        data = json.loads(response.data)
-        assert "not found" in data["message"].lower()
-
-
-class TestCheckContractExistsByPipelineId:
-    """Tests for GET /api/v1/contract/exists/<identifier> with string pipeline IDs."""
-
-    def test_exists_by_pipeline_id(self, client, auth_headers):
-        """Returns exists=True for contract found by pipeline ID."""
-        with patch.object(contract_api, "contract_exists", return_value=True) as mock_exists:
-            response = client.get(
-                "/api/v1/contract/exists/KORE-1191-full?repo_path=/home/egg/repos/test",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 200
-        data = json.loads(response.data)
-        assert data["data"]["exists"] is True
-        mock_exists.assert_called_once()
-        assert mock_exists.call_args[0][0] == "KORE-1191-full"
-
-    def test_not_exists_by_pipeline_id(self, client, auth_headers):
-        """Returns exists=False when pipeline ID contract not found."""
-        with patch.object(contract_api, "contract_exists", return_value=False):
-            response = client.get(
-                "/api/v1/contract/exists/KORE-999?repo_path=/home/egg/repos/test",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 200
-        data = json.loads(response.data)
-        assert data["data"]["exists"] is False
-
-
-# ---------------------------------------------------------------------------
-# Path traversal and routing edge-case tests
-# ---------------------------------------------------------------------------
+        assert captured[0]["url"].endswith("/api/v1/contract-mutations/validate")
 
 
 class TestIdentifierValidation:
-    """Tests for path traversal prevention on string identifier routes."""
-
     @pytest.mark.parametrize(
         "identifier",
         [
             "../../../etc/passwd",
-            "..%2F..%2Fetc%2Fpasswd",
             "drafts/../secret",
             "foo/bar",
             "foo\\bar",
         ],
     )
-    def test_get_contract_rejects_traversal(self, client, auth_headers, identifier):
-        """GET /api/v1/contract/<identifier> rejects path-traversal identifiers."""
+    def test_get_rejects_traversal(self, client, auth_headers, identifier):
         response = client.get(
-            f"/api/v1/contract/{identifier}?repo_path=/home/egg/repos/test",
+            f"/api/v1/contract/{identifier}?pipeline_id=test-pipeline",
             headers=auth_headers,
         )
-        # Flask may return 404 (route not matched due to slashes) or 400 (our validation)
+        # Either our regex rejects (400) or Flask's route matcher doesn't match (404)
         assert response.status_code in (400, 404)
 
-    def test_get_contract_rejects_dot_dot(self, client, auth_headers):
-        """GET /api/v1/contract/<identifier> rejects '..' even without slashes."""
-        response = client.get(
-            "/api/v1/contract/..?repo_path=/home/egg/repos/test",
-            headers=auth_headers,
-        )
-        assert response.status_code in (400, 404)
-
-    def test_exists_rejects_traversal(self, client, auth_headers):
-        """GET /api/v1/contract/exists/<identifier> rejects traversal identifiers."""
-        response = client.get(
-            "/api/v1/contract/exists/..%2Fsecret?repo_path=/home/egg/repos/test",
-            headers=auth_headers,
-        )
-        assert response.status_code in (400, 404)
-
-    def test_mutate_rejects_traversal_identifier(self, client, auth_headers):
-        """POST /api/v1/contract/mutate rejects traversal in identifier field."""
+    def test_mutate_rejects_traversal(self, client, auth_headers):
         response = client.post(
             "/api/v1/contract/mutate",
             headers=auth_headers,
             data=json.dumps(
                 {
                     "identifier": "../../../etc/passwd",
-                    "field_path": "phases.0.tasks.0.commit",
-                    "new_value": "abc1234",
-                    "repo_path": "/home/egg/repos/test",
+                    "field_path": "phases",
+                    "new_value": [],
                 }
             ),
             content_type="application/json",
         )
         assert response.status_code == 400
-        data = json.loads(response.data)
-        assert "invalid identifier" in data["message"].lower()
-
-
-class TestNumericStringRouting:
-    """Verify numeric strings route to <int:issue_number>, not <identifier>."""
-
-    def test_numeric_string_routes_to_int_handler(self, client, auth_headers):
-        """A numeric path like /api/v1/contract/123 hits the int route."""
-        mock_contract = MagicMock()
-        mock_exported = {"issue": {"number": 123}, "phases": []}
-
-        with (
-            patch.object(contract_api, "load_contract", return_value=mock_contract) as mock_load,
-            patch.object(contract_api, "export_contract", return_value=mock_exported),
-        ):
-            response = client.get(
-                "/api/v1/contract/123?repo_path=/home/egg/repos/test",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 200
-        # Verify the identifier passed was an int, not a string
-        call_args = mock_load.call_args
-        assert call_args[0][0] == 123
-        assert isinstance(call_args[0][0], int)
-
-
-# ---------------------------------------------------------------------------
-# POST /api/v1/contract/validate tests
-# ---------------------------------------------------------------------------
-
-
-class TestValidateContractMutation:
-    """Tests for POST /api/v1/contract/validate endpoint."""
-
-    def test_missing_body_returns_400(self, client, auth_headers):
-        """Returns 400 when request body is empty JSON."""
-        response = client.post(
-            "/api/v1/contract/validate",
-            headers=auth_headers,
-            data=json.dumps(None),
-            content_type="application/json",
-        )
-
-        assert response.status_code == 400
-        data = json.loads(response.data)
-        assert data["success"] is False
-        assert "Missing request body" in data["message"]
-
-    def test_missing_field_path_returns_400(self, client, auth_headers):
-        """Returns 400 when field_path is missing."""
-        response = client.post(
-            "/api/v1/contract/validate",
-            headers=auth_headers,
-            data=json.dumps({"new_value": "complete"}),
-            content_type="application/json",
-        )
-
-        assert response.status_code == 400
-        data = json.loads(response.data)
-        assert data["success"] is False
-        assert "field_path" in data["message"]
-
-    def test_missing_new_value_returns_400(self, client, auth_headers):
-        """Returns 400 when new_value is missing."""
-        response = client.post(
-            "/api/v1/contract/validate",
-            headers=auth_headers,
-            data=json.dumps({"field_path": "phases.0.tasks.0.status"}),
-            content_type="application/json",
-        )
-
-        assert response.status_code == 400
-        data = json.loads(response.data)
-        assert data["success"] is False
-        assert "new_value" in data["message"]
-
-    def test_no_role_returns_403(self, client, auth_headers):
-        """Returns 403 when agent role cannot be determined."""
-        with patch.object(contract_api, "get_role_from_context", return_value=None):
-            response = client.post(
-                "/api/v1/contract/validate",
-                headers=auth_headers,
-                data=json.dumps(
-                    {
-                        "field_path": "phases.0.tasks.0.status",
-                        "new_value": "complete",
-                    }
-                ),
-                content_type="application/json",
-            )
-
-        assert response.status_code == 403
-        data = json.loads(response.data)
-        assert data["success"] is False
-        assert "role" in data["message"].lower()
-
-    def test_valid_mutation(self, client, auth_headers):
-        """Returns success when mutation is valid."""
-        from egg_contracts import Role, ValidationResult
-
-        mock_result = ValidationResult(valid=True, message="Mutation allowed")
-
-        with (
-            patch.object(contract_api, "get_role_from_context", return_value=Role.IMPLEMENTER),
-            patch.object(contract_api, "validate_mutation", return_value=mock_result),
-        ):
-            response = client.post(
-                "/api/v1/contract/validate",
-                headers=auth_headers,
-                data=json.dumps(
-                    {
-                        "field_path": "phases.0.tasks.0.commit",
-                        "new_value": "abc1234",
-                    }
-                ),
-                content_type="application/json",
-            )
-
-        assert response.status_code == 200
-        data = json.loads(response.data)
-        assert data["success"] is True
-        assert "allowed" in data["message"].lower()
-
-    def test_invalid_mutation_returns_403(self, client, auth_headers):
-        """Returns 403 when mutation is not allowed for the role."""
-        from egg_contracts import Role, ValidationResult
-
-        mock_result = ValidationResult(
-            valid=False,
-            message="Cannot modify field 'phases.*.tasks.*.status'.",
-            field_path="phases.0.tasks.0.status",
-            required_role="reviewer",
-        )
-
-        with (
-            patch.object(contract_api, "get_role_from_context", return_value=Role.IMPLEMENTER),
-            patch.object(contract_api, "validate_mutation", return_value=mock_result),
-        ):
-            response = client.post(
-                "/api/v1/contract/validate",
-                headers=auth_headers,
-                data=json.dumps(
-                    {
-                        "field_path": "phases.0.tasks.0.status",
-                        "new_value": "complete",
-                    }
-                ),
-                content_type="application/json",
-            )
-
-        assert response.status_code == 403
-        data = json.loads(response.data)
-        assert data["success"] is False
-        assert "details" in data
-        assert data["details"]["role"] == "implementer"
-        assert data["details"]["required_role"] == "reviewer"
-
-
-# ---------------------------------------------------------------------------
-# POST /api/v1/contract/mutate tests
-# ---------------------------------------------------------------------------
-
-
-class TestMutateContract:
-    """Tests for POST /api/v1/contract/mutate endpoint."""
-
-    def test_missing_body_returns_400(self, client, auth_headers):
-        """Returns 400 when request body is empty JSON."""
-        response = client.post(
-            "/api/v1/contract/mutate",
-            headers=auth_headers,
-            data=json.dumps(None),
-            content_type="application/json",
-        )
-
-        assert response.status_code == 400
-        data = json.loads(response.data)
-        assert data["success"] is False
-        assert "Missing request body" in data["message"]
-
-    def test_missing_identifier_returns_400(self, client, auth_headers):
-        """Returns 400 when neither identifier nor issue_number is provided."""
-        response = client.post(
-            "/api/v1/contract/mutate",
-            headers=auth_headers,
-            data=json.dumps(
-                {
-                    "field_path": "phases.0.tasks.0.commit",
-                    "new_value": "abc1234",
-                }
-            ),
-            content_type="application/json",
-        )
-
-        assert response.status_code == 400
-        data = json.loads(response.data)
-        assert data["success"] is False
-        assert "identifier" in data["message"].lower()
-
-    def test_missing_field_path_returns_400(self, client, auth_headers):
-        """Returns 400 when field_path is missing."""
-        response = client.post(
-            "/api/v1/contract/mutate",
-            headers=auth_headers,
-            data=json.dumps(
-                {
-                    "issue_number": 42,
-                    "new_value": "abc1234",
-                }
-            ),
-            content_type="application/json",
-        )
-
-        assert response.status_code == 400
-        data = json.loads(response.data)
-        assert data["success"] is False
-        assert "field_path" in data["message"]
-
-    def test_missing_new_value_returns_400(self, client, auth_headers):
-        """Returns 400 when new_value is missing."""
-        response = client.post(
-            "/api/v1/contract/mutate",
-            headers=auth_headers,
-            data=json.dumps(
-                {
-                    "issue_number": 42,
-                    "field_path": "phases.0.tasks.0.commit",
-                }
-            ),
-            content_type="application/json",
-        )
-
-        assert response.status_code == 400
-        data = json.loads(response.data)
-        assert data["success"] is False
-        assert "new_value" in data["message"]
-
-    def test_no_role_returns_403(self, client, auth_headers):
-        """Returns 403 when agent role cannot be determined."""
-        with patch.object(contract_api, "get_role_from_context", return_value=None):
-            response = client.post(
-                "/api/v1/contract/mutate",
-                headers=auth_headers,
-                data=json.dumps(
-                    {
-                        "issue_number": 42,
-                        "field_path": "phases.0.tasks.0.commit",
-                        "new_value": "abc1234",
-                        "repo_path": "/home/egg/repos/test",
-                    }
-                ),
-                content_type="application/json",
-            )
-
-        assert response.status_code == 403
-        data = json.loads(response.data)
-        assert data["success"] is False
-        assert "role" in data["message"].lower()
-
-    def test_contract_not_found_returns_404(self, client, auth_headers):
-        """Returns 404 when contract is not found."""
-        from pathlib import Path
-
-        from egg_contracts import ContractNotFoundError, Role
-
-        with (
-            patch.object(contract_api, "get_role_from_context", return_value=Role.IMPLEMENTER),
-            patch.object(
-                contract_api,
-                "load_contract",
-                side_effect=ContractNotFoundError(999, Path("/home/egg/repos/test")),
-            ),
-        ):
-            response = client.post(
-                "/api/v1/contract/mutate",
-                headers=auth_headers,
-                data=json.dumps(
-                    {
-                        "issue_number": 999,
-                        "field_path": "phases.0.tasks.0.commit",
-                        "new_value": "abc1234",
-                        "repo_path": "/home/egg/repos/test",
-                    }
-                ),
-                content_type="application/json",
-            )
-
-        assert response.status_code == 404
-        data = json.loads(response.data)
-        assert data["success"] is False
-        assert "not found" in data["message"].lower()
-
-    def test_mutation_denied_returns_403(self, client, auth_headers):
-        """Returns 403 when mutation is denied by role-based enforcement."""
-        from egg_contracts import MutationResult, Role
-
-        mock_contract = MagicMock()
-        mock_mutation_result = MutationResult(
-            success=False,
-            message="Cannot modify field 'phases.*.tasks.*.status'. "
-            "Role 'implementer' is not authorized.",
-        )
-
-        with (
-            patch.object(contract_api, "get_role_from_context", return_value=Role.IMPLEMENTER),
-            patch.object(contract_api, "load_contract", return_value=mock_contract),
-            patch.object(contract_api, "apply_mutation", return_value=mock_mutation_result),
-        ):
-            response = client.post(
-                "/api/v1/contract/mutate",
-                headers=auth_headers,
-                data=json.dumps(
-                    {
-                        "issue_number": 42,
-                        "field_path": "phases.0.tasks.0.status",
-                        "new_value": "complete",
-                        "repo_path": "/home/egg/repos/test",
-                    }
-                ),
-                content_type="application/json",
-            )
-
-        assert response.status_code == 403
-        data = json.loads(response.data)
-        assert data["success"] is False
-        assert "details" in data
-        assert data["details"]["role"] == "implementer"
-
-    def test_mutate_success(self, client, auth_headers):
-        """Successfully applies a mutation and saves the contract."""
-        from egg_contracts import MutationResult, Role
-
-        mock_contract = MagicMock()
-        mock_updated_contract = MagicMock()
-        mock_exported = {"issue": 42, "phases": [{"tasks": [{"commit": "abc1234"}]}]}
-
-        mock_mutation_result = MutationResult(
-            success=True,
-            message="Mutation applied successfully",
-            contract=mock_updated_contract,
-        )
-
-        with (
-            patch.object(contract_api, "get_role_from_context", return_value=Role.IMPLEMENTER),
-            patch.object(contract_api, "load_contract", return_value=mock_contract),
-            patch.object(contract_api, "apply_mutation", return_value=mock_mutation_result),
-            patch.object(contract_api, "save_contract") as mock_save,
-            patch.object(contract_api, "export_contract", return_value=mock_exported),
-        ):
-            response = client.post(
-                "/api/v1/contract/mutate",
-                headers=auth_headers,
-                data=json.dumps(
-                    {
-                        "issue_number": 42,
-                        "field_path": "phases.0.tasks.0.commit",
-                        "new_value": "abc1234",
-                        "actor": "james-in-a-box",
-                        "reason": "Implementation complete",
-                        "repo_path": "/home/egg/repos/test",
-                    }
-                ),
-                content_type="application/json",
-            )
-
-        assert response.status_code == 200
-        data = json.loads(response.data)
-        assert data["success"] is True
-        assert "applied" in data["message"].lower()
-        assert data["data"]["contract"]["issue"] == 42
-        mock_save.assert_called_once()
-
-    def test_mutate_with_identifier_field(self, client, auth_headers):
-        """Mutate accepts 'identifier' field with string pipeline ID."""
-        from egg_contracts import MutationResult, Role
-
-        mock_contract = MagicMock()
-        mock_updated = MagicMock()
-        mock_exported = {"pipeline_id": "KORE-1191-full", "phases": []}
-
-        mock_result = MutationResult(
-            success=True,
-            message="Mutation applied",
-            contract=mock_updated,
-        )
-
-        with (
-            patch.object(contract_api, "get_role_from_context", return_value=Role.IMPLEMENTER),
-            patch.object(contract_api, "load_contract", return_value=mock_contract) as mock_load,
-            patch.object(contract_api, "apply_mutation", return_value=mock_result),
-            patch.object(contract_api, "save_contract"),
-            patch.object(contract_api, "export_contract", return_value=mock_exported),
-        ):
-            response = client.post(
-                "/api/v1/contract/mutate",
-                headers=auth_headers,
-                data=json.dumps(
-                    {
-                        "identifier": "KORE-1191-full",
-                        "field_path": "phases.0.tasks.0.commit",
-                        "new_value": "abc1234",
-                        "repo_path": "/home/egg/repos/test",
-                    }
-                ),
-                content_type="application/json",
-            )
-
-        assert response.status_code == 200
-        data = json.loads(response.data)
-        assert data["success"] is True
-        mock_load.assert_called_once()
-        assert mock_load.call_args[0][0] == "KORE-1191-full"
-
-    def test_mutate_backward_compat_issue_number(self, client, auth_headers):
-        """Mutate still accepts legacy 'issue_number' field."""
-        from egg_contracts import MutationResult, Role
-
-        mock_contract = MagicMock()
-        mock_updated = MagicMock()
-        mock_exported = {"issue": 42, "phases": []}
-
-        mock_result = MutationResult(
-            success=True,
-            message="Mutation applied",
-            contract=mock_updated,
-        )
-
-        with (
-            patch.object(contract_api, "get_role_from_context", return_value=Role.IMPLEMENTER),
-            patch.object(contract_api, "load_contract", return_value=mock_contract) as mock_load,
-            patch.object(contract_api, "apply_mutation", return_value=mock_result),
-            patch.object(contract_api, "save_contract"),
-            patch.object(contract_api, "export_contract", return_value=mock_exported),
-        ):
-            response = client.post(
-                "/api/v1/contract/mutate",
-                headers=auth_headers,
-                data=json.dumps(
-                    {
-                        "issue_number": 42,
-                        "field_path": "phases.0.tasks.0.commit",
-                        "new_value": "abc1234",
-                        "repo_path": "/home/egg/repos/test",
-                    }
-                ),
-                content_type="application/json",
-            )
-
-        assert response.status_code == 200
-        mock_load.assert_called_once()
-        assert mock_load.call_args[0][0] == 42
-
-
-# ---------------------------------------------------------------------------
-# Worktree path mapping tests
-# ---------------------------------------------------------------------------
-
-
-class TestWorktreePathMapping:
-    """Tests for worktree path mapping in contract API endpoints."""
-
-    def test_get_contract_with_container_id_maps_to_worktree(self, client, auth_headers):
-        """GET contract with container_id query param maps repo_path to worktree path."""
-        mock_contract = MagicMock()
-        mock_exported = {"issue": 42, "phases": []}
-
-        with (
-            patch.object(contract_api, "load_contract", return_value=mock_contract) as mock_load,
-            patch.object(contract_api, "export_contract", return_value=mock_exported),
-            patch.object(
-                contract_api,
-                "_get_worktree_helpers",
-                return_value=(
-                    MagicMock(return_value="/home/egg/.egg-worktrees/test-ctr/test"),
-                    MagicMock(),
-                ),
-            ),
-        ):
-            response = client.get(
-                "/api/v1/contract/42?repo_path=/home/egg/repos/test&container_id=test-ctr",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 200
-        data = json.loads(response.data)
-        assert data["success"] is True
-        # Verify load_contract was called with the worktree-mapped path
-        from pathlib import Path
-
-        mock_load.assert_called_once_with(42, Path("/home/egg/.egg-worktrees/test-ctr/test"))
-
-    def test_get_contract_without_container_id_uses_original_path(self, client, auth_headers):
-        """GET contract without container_id uses original repo_path unchanged."""
-        mock_contract = MagicMock()
-        mock_exported = {"issue": 42, "phases": []}
-
-        with (
-            patch.object(contract_api, "load_contract", return_value=mock_contract) as mock_load,
-            patch.object(contract_api, "export_contract", return_value=mock_exported),
-            patch.object(
-                contract_api,
-                "_get_worktree_helpers",
-                return_value=(
-                    # map_container_path_to_worktree returns original path when no container_id
-                    MagicMock(return_value="/home/egg/repos/test"),
-                    MagicMock(),
-                ),
-            ),
-        ):
-            response = client.get(
-                "/api/v1/contract/42?repo_path=/home/egg/repos/test",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 200
-        from pathlib import Path
-
-        mock_load.assert_called_once_with(42, Path("/home/egg/repos/test"))
-
-    def test_get_contract_worktree_not_found_returns_error(self, client, auth_headers):
-        """GET contract returns error when container_id worktree doesn't exist."""
-        from flask import jsonify as flask_jsonify
-
-        def make_err(cid):
-            return flask_jsonify(
-                {"success": False, "message": f"Worktree not found for '{cid}'"}
-            ), 500
-
-        with patch.object(
-            contract_api,
-            "_get_worktree_helpers",
-            return_value=(
-                MagicMock(return_value=None),  # worktree not found
-                make_err,
-            ),
-        ):
-            response = client.get(
-                "/api/v1/contract/42?repo_path=/home/egg/repos/test&container_id=bad-ctr",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 500
-        data = json.loads(response.data)
-        assert data["success"] is False
-
-    def test_mutate_contract_with_container_id_maps_to_worktree(self, client, auth_headers):
-        """POST mutate with container_id in body maps repo_path to worktree path."""
-        from egg_contracts import MutationResult, Role
-
-        mock_contract = MagicMock()
-        mock_updated_contract = MagicMock()
-        mock_exported = {"issue": 42, "phases": []}
-        mock_mutation_result = MutationResult(
-            success=True,
-            message="Mutation applied",
-            contract=mock_updated_contract,
-        )
-
-        mock_map_fn = MagicMock(return_value="/home/egg/.egg-worktrees/test-ctr/test")
-
-        with (
-            patch.object(contract_api, "get_role_from_context", return_value=Role.IMPLEMENTER),
-            patch.object(contract_api, "load_contract", return_value=mock_contract) as mock_load,
-            patch.object(contract_api, "apply_mutation", return_value=mock_mutation_result),
-            patch.object(contract_api, "save_contract") as mock_save,
-            patch.object(contract_api, "export_contract", return_value=mock_exported),
-            patch.object(
-                contract_api,
-                "_get_worktree_helpers",
-                return_value=(mock_map_fn, MagicMock()),
-            ),
-        ):
-            response = client.post(
-                "/api/v1/contract/mutate",
-                headers=auth_headers,
-                data=json.dumps(
-                    {
-                        "issue_number": 42,
-                        "field_path": "phases.0.tasks.0.commit",
-                        "new_value": "abc1234",
-                        "repo_path": "/home/egg/repos/test",
-                        "container_id": "test-ctr",
-                    }
-                ),
-                content_type="application/json",
-            )
-
-        assert response.status_code == 200
-        from pathlib import Path
-
-        # Verify load was called with worktree path
-        mock_load.assert_called_once_with(42, Path("/home/egg/.egg-worktrees/test-ctr/test"))
-        # Verify save was called with worktree path
-        mock_save.assert_called_once_with(
-            mock_updated_contract, Path("/home/egg/.egg-worktrees/test-ctr/test")
-        )
-        # Verify map function was called with container_id
-        mock_map_fn.assert_called_once_with("/home/egg/repos/test", "test-ctr", "contract")
-
-    def test_mutate_contract_worktree_not_found_returns_error(self, client, auth_headers):
-        """POST mutate returns error when container_id worktree doesn't exist."""
-        from egg_contracts import Role
-        from flask import jsonify as flask_jsonify
-
-        def make_err(cid):
-            return flask_jsonify(
-                {"success": False, "message": f"Worktree not found for '{cid}'"}
-            ), 500
-
-        with (
-            patch.object(contract_api, "get_role_from_context", return_value=Role.IMPLEMENTER),
-            patch.object(
-                contract_api,
-                "_get_worktree_helpers",
-                return_value=(
-                    MagicMock(return_value=None),
-                    make_err,
-                ),
-            ),
-        ):
-            response = client.post(
-                "/api/v1/contract/mutate",
-                headers=auth_headers,
-                data=json.dumps(
-                    {
-                        "issue_number": 42,
-                        "field_path": "phases.0.tasks.0.commit",
-                        "new_value": "abc1234",
-                        "repo_path": "/home/egg/repos/test",
-                        "container_id": "bad-ctr",
-                    }
-                ),
-                content_type="application/json",
-            )
-
-        assert response.status_code == 500
-        data = json.loads(response.data)
-        assert data["success"] is False
-
-    def test_exists_with_container_id_maps_to_worktree(self, client, auth_headers):
-        """GET exists with container_id maps repo_path to worktree path."""
-        from pathlib import Path
-
-        mock_map_fn = MagicMock(return_value="/home/egg/.egg-worktrees/test-ctr/test")
-
-        with (
-            patch.object(contract_api, "contract_exists", return_value=True) as mock_exists,
-            patch.object(
-                contract_api,
-                "_get_worktree_helpers",
-                return_value=(mock_map_fn, MagicMock()),
-            ),
-        ):
-            response = client.get(
-                "/api/v1/contract/exists/42?repo_path=/home/egg/repos/test&container_id=test-ctr",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 200
-        data = json.loads(response.data)
-        assert data["data"]["exists"] is True
-        mock_exists.assert_called_once_with(42, Path("/home/egg/.egg-worktrees/test-ctr/test"))
-        mock_map_fn.assert_called_once_with("/home/egg/repos/test", "test-ctr", "contract")
-
-    def test_exists_worktree_not_found_returns_error(self, client, auth_headers):
-        """GET exists returns error when container_id worktree doesn't exist."""
-        from flask import jsonify as flask_jsonify
-
-        def make_err(cid):
-            return flask_jsonify(
-                {"success": False, "message": f"Worktree not found for '{cid}'"}
-            ), 500
-
-        with patch.object(
-            contract_api,
-            "_get_worktree_helpers",
-            return_value=(
-                MagicMock(return_value=None),
-                make_err,
-            ),
-        ):
-            response = client.get(
-                "/api/v1/contract/exists/42?repo_path=/home/egg/repos/test&container_id=bad-ctr",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 500
-        data = json.loads(response.data)
-        assert data["success"] is False
-
-
-# ---------------------------------------------------------------------------
-# get_repo_path_from_request container_id extraction tests
-# ---------------------------------------------------------------------------
-
-
-class TestGetRepoPathFromRequestContainerId:
-    """Tests for container_id extraction in get_repo_path_from_request()."""
-
-    def test_container_id_from_query_params(self, client, auth_headers):
-        """Extracts container_id from query params for GET requests."""
-        with client.application.test_request_context(
-            "/?repo_path=/home/egg/repos/test&container_id=my-container"
-        ):
-            from flask import g
-
-            g.session = None
-            path, error, container_id = contract_api.get_repo_path_from_request(from_query=True)
-
-        assert container_id == "my-container"
-        assert error is None
-        from pathlib import Path
-
-        assert path == Path("/home/egg/repos/test")
-
-    def test_container_id_from_post_body(self, client, auth_headers):
-        """Extracts container_id from JSON body for POST requests."""
-        with client.application.test_request_context(
-            "/",
-            method="POST",
-            data=json.dumps({"repo_path": "/home/egg/repos/test", "container_id": "my-container"}),
-            content_type="application/json",
-        ):
-            from flask import g
-
-            g.session = None
-            path, error, container_id = contract_api.get_repo_path_from_request(from_query=False)
-
-        assert container_id == "my-container"
-        assert error is None
-        from pathlib import Path
-
-        assert path == Path("/home/egg/repos/test")
-
-    def test_container_id_falls_back_to_session(self, client, auth_headers):
-        """Falls back to session container_id when not in request."""
-        mock_session = MagicMock()
-        mock_session.container_id = "session-container"
-        mock_session.repo_path = None
-
-        with client.application.test_request_context("/?repo_path=/home/egg/repos/test"):
-            from flask import g
-
-            g.session = mock_session
-            path, error, container_id = contract_api.get_repo_path_from_request(from_query=True)
-
-        assert container_id == "session-container"
-
-    def test_container_id_none_when_not_available(self, client, auth_headers):
-        """Returns None container_id when not in request or session."""
-        with client.application.test_request_context("/?repo_path=/home/egg/repos/test"):
-            from flask import g
-
-            g.session = None
-            path, error, container_id = contract_api.get_repo_path_from_request(from_query=True)
-
-        assert container_id is None
-
-    def test_request_container_id_takes_priority_over_session(self, client, auth_headers):
-        """Request container_id takes priority over session container_id."""
-        mock_session = MagicMock()
-        mock_session.container_id = "session-container"
-        mock_session.repo_path = None
-
-        with client.application.test_request_context(
-            "/?repo_path=/home/egg/repos/test&container_id=request-container"
-        ):
-            from flask import g
-
-            g.session = mock_session
-            path, error, container_id = contract_api.get_repo_path_from_request(from_query=True)
-
-        assert container_id == "request-container"
-
-
-# ---------------------------------------------------------------------------
-# _get_worktree_helpers tests
-# ---------------------------------------------------------------------------
-
-
-class TestGetWorktreeHelpers:
-    """Tests for _get_worktree_helpers() lazy import function."""
-
-    def test_returns_callable_tuple(self, client):
-        """Returns a 2-tuple of callable functions."""
-        map_fn, err_fn = contract_api._get_worktree_helpers()
-        assert callable(map_fn)
-        assert callable(err_fn)
-
-
-# ---------------------------------------------------------------------------
-# Pipeline worktree fallback tests
-# ---------------------------------------------------------------------------
-
-
-class TestPipelineWorktreeFallback:
-    """Tests for pipeline_id worktree fallback in GET /api/v1/contract/."""
-
-    def test_fallback_finds_contract_in_pipeline_worktree(self, client, auth_headers, tmp_path):
-        """GET contract falls back to pipeline worktree when primary path misses."""
-        from egg_contracts import ContractNotFoundError
-
-        mock_contract = MagicMock()
-        mock_exported = {"issue": 1570, "phases": [{"name": "implement"}]}
-
-        # First call (primary path) raises not found; second call (worktree) succeeds
-        def load_side_effect(identifier, repo_root):
-            if str(repo_root) == "/home/egg/repos/test":
-                raise ContractNotFoundError(identifier, repo_root)
-            return mock_contract
-
-        worktree_repo = tmp_path / "issue-1570-v17" / "test"
-        worktree_repo.mkdir(parents=True)
-
-        with (
-            patch.object(contract_api, "load_contract", side_effect=load_side_effect),
-            patch.object(contract_api, "export_contract", return_value=mock_exported),
-            patch.object(contract_api, "_WORKTREE_BASE_DIR", tmp_path),
-        ):
-            response = client.get(
-                "/api/v1/contract/1570?repo_path=/home/egg/repos/test&pipeline_id=issue-1570-v17",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 200
-        data = json.loads(response.data)
-        assert data["success"] is True
-        assert data["data"]["issue"] == 1570
-
-    def test_fallback_not_triggered_without_pipeline_id(self, client, auth_headers):
-        """GET contract returns 404 without pipeline_id even when worktree exists."""
-        from pathlib import Path
-
-        from egg_contracts import ContractNotFoundError
-
-        with patch.object(
-            contract_api,
-            "load_contract",
-            side_effect=ContractNotFoundError(999, Path("/home/egg/repos/test")),
-        ):
-            response = client.get(
-                "/api/v1/contract/999?repo_path=/home/egg/repos/test",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 404
-
-    def test_fallback_returns_404_for_nonexistent_worktree(self, client, auth_headers, tmp_path):
-        """GET contract returns 404 when pipeline_id worktree directory doesn't exist."""
-        from pathlib import Path
-
-        from egg_contracts import ContractNotFoundError
-
-        with (
-            patch.object(
-                contract_api,
-                "load_contract",
-                side_effect=ContractNotFoundError(1570, Path("/home/egg/repos/test")),
-            ),
-            patch.object(contract_api, "_WORKTREE_BASE_DIR", tmp_path),
-        ):
-            response = client.get(
-                "/api/v1/contract/1570?repo_path=/home/egg/repos/test&pipeline_id=no-such-pipeline",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 404
-
-    def test_fallback_rejects_invalid_pipeline_id(self, client, auth_headers, tmp_path):
-        """GET contract ignores pipeline_id with path traversal characters."""
-        from pathlib import Path
-
-        from egg_contracts import ContractNotFoundError
-
-        with (
-            patch.object(
-                contract_api,
-                "load_contract",
-                side_effect=ContractNotFoundError(1570, Path("/home/egg/repos/test")),
-            ),
-            patch.object(contract_api, "_WORKTREE_BASE_DIR", tmp_path),
-        ):
-            response = client.get(
-                "/api/v1/contract/1570?repo_path=/home/egg/repos/test&pipeline_id=../../etc",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 404
-
-    def test_fallback_uses_first_subdir_when_repo_name_mismatch(
-        self, client, auth_headers, tmp_path
-    ):
-        """Fallback resolves to first subdirectory if repo name doesn't match."""
-        from egg_contracts import ContractNotFoundError
-
-        mock_contract = MagicMock()
-        mock_exported = {"issue": 42, "phases": []}
-
-        def load_side_effect(identifier, repo_root):
-            if str(repo_root) == "/home/egg/repos/test":
-                raise ContractNotFoundError(identifier, repo_root)
-            return mock_contract
-
-        # Worktree has a differently-named repo directory
-        worktree_repo = tmp_path / "my-pipeline" / "other-repo"
-        worktree_repo.mkdir(parents=True)
-
-        with (
-            patch.object(contract_api, "load_contract", side_effect=load_side_effect),
-            patch.object(contract_api, "export_contract", return_value=mock_exported),
-            patch.object(contract_api, "_WORKTREE_BASE_DIR", tmp_path),
-        ):
-            response = client.get(
-                "/api/v1/contract/42?repo_path=/home/egg/repos/test&pipeline_id=my-pipeline",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 200
-
-    def test_fallback_returns_500_for_corrupt_contract_in_worktree(
-        self, client, auth_headers, tmp_path
-    ):
-        """GET contract returns 500 when worktree fallback finds a corrupt contract."""
-        from egg_contracts import ContractNotFoundError, ContractValidationError
-
-        def load_side_effect(identifier, repo_root):
-            if str(repo_root) == "/home/egg/repos/test":
-                raise ContractNotFoundError(identifier, repo_root)
-            # Worktree path — contract exists but is malformed
-            raise ContractValidationError(identifier, ["corrupt YAML"])
-
-        worktree_repo = tmp_path / "pipe-99" / "test"
-        worktree_repo.mkdir(parents=True)
-
-        with (
-            patch.object(contract_api, "load_contract", side_effect=load_side_effect),
-            patch.object(contract_api, "_WORKTREE_BASE_DIR", tmp_path),
-        ):
-            response = client.get(
-                "/api/v1/contract/99?repo_path=/home/egg/repos/test&pipeline_id=pipe-99",
-                headers=auth_headers,
-            )
-
-        assert response.status_code == 500
-        data = json.loads(response.data)
-        assert "validation failed" in data["message"].lower()

--- a/orchestrator/api.py
+++ b/orchestrator/api.py
@@ -39,6 +39,7 @@ app = Flask(__name__)
 try:
     from routes.anchors import anchors_bp
     from routes.containers import containers_bp
+    from routes.contracts import contract_mutations_bp, contracts_bp
     from routes.decisions import decisions_bp
     from routes.health import health_bp
     from routes.messages import messages_bp
@@ -53,6 +54,8 @@ try:
     app.register_blueprint(health_bp)
     app.register_blueprint(pipelines_bp)
     app.register_blueprint(containers_bp)
+    app.register_blueprint(contracts_bp)
+    app.register_blueprint(contract_mutations_bp)
     app.register_blueprint(phases_bp)
     app.register_blueprint(signals_bp)
     app.register_blueprint(decisions_bp)
@@ -63,6 +66,10 @@ try:
 except ImportError:
     from .routes.anchors import anchors_bp  # type: ignore[no-redef]
     from .routes.containers import containers_bp  # type: ignore[no-redef]
+    from .routes.contracts import (  # type: ignore[no-redef]
+        contract_mutations_bp,
+        contracts_bp,
+    )
     from .routes.decisions import decisions_bp  # type: ignore[no-redef]
     from .routes.health import health_bp  # type: ignore[no-redef]
     from .routes.messages import messages_bp  # type: ignore[no-redef]
@@ -77,6 +84,8 @@ except ImportError:
     app.register_blueprint(health_bp)
     app.register_blueprint(pipelines_bp)
     app.register_blueprint(containers_bp)
+    app.register_blueprint(contracts_bp)
+    app.register_blueprint(contract_mutations_bp)
     app.register_blueprint(phases_bp)
     app.register_blueprint(signals_bp)
     app.register_blueprint(decisions_bp)

--- a/orchestrator/contract_store.py
+++ b/orchestrator/contract_store.py
@@ -27,6 +27,7 @@ protect concurrent mutations arriving from multiple Flask threads.
 from __future__ import annotations
 
 import logging
+import re
 import sys
 import threading
 from pathlib import Path
@@ -44,6 +45,9 @@ logger = logging.getLogger("orchestrator.contract_store")
 # ``<base>/<pipeline_id>/<repo>/``.
 _WORKTREE_BASE_DIR = Path("/home/egg/.egg-worktrees")
 
+# Path components must be simple names — no slashes, dots-only, or other
+# characters that could escape the worktree base directory.
+_SAFE_COMPONENT_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 _locks: dict[str, threading.RLock] = {}
 _locks_guard = threading.Lock()
@@ -79,7 +83,9 @@ def resolve_pipeline_worktree(
         repo_hint: Optional repo name (last component of ``owner/repo``)
             to disambiguate when the host runs multiple repos.
     """
-    if not pipeline_id:
+    if not pipeline_id or not _SAFE_COMPONENT_RE.match(pipeline_id):
+        return None
+    if repo_hint and not _SAFE_COMPONENT_RE.match(repo_hint):
         return None
 
     base = _WORKTREE_BASE_DIR / pipeline_id

--- a/orchestrator/contract_store.py
+++ b/orchestrator/contract_store.py
@@ -1,0 +1,114 @@
+"""Orchestrator-owned contract live store.
+
+Fixes #1781: previously the gateway's contract API forwarded writes
+into each caller's per-agent worktree, so producers and reviewers
+saw different copies of the same contract and NACK'd each other on
+phantom divergence.
+
+Under this design, there is exactly one live contract file per
+pipeline — inside the *shared* pipeline worktree at
+``/home/egg/.egg-worktrees/<pipeline_id>/<repo>/.egg-state/contracts/``.
+Agents no longer talk to their own worktree for contract state:
+every ``egg-contract`` command hits the gateway, which proxies to the
+orchestrator's ``/api/v1/contracts/…`` endpoints, which in turn read
+and write the shared-worktree file.  Per-agent worktrees are purely
+code-isolation again.
+
+Serialization to the feature branch keeps happening via
+``_commit_statefiles_to_worktree`` at pipeline checkpoint events
+(phase completion, pre-PR).  Because the live file already lives in
+the shared worktree, those commits pick it up naturally — no
+separate "serialize then commit" dance is needed.
+
+In-process concurrency is serialized via per-identifier RLocks to
+protect concurrent mutations arriving from multiple Flask threads.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+from pathlib import Path
+
+# Shared packages live under ../shared relative to this file.
+_shared_path = Path(__file__).parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+logger = logging.getLogger("orchestrator.contract_store")
+
+
+# Must match gateway/contract_api.py WORKTREE_BASE_DIR and the
+# docker-compose volume mounts.  Pipeline worktrees live at
+# ``<base>/<pipeline_id>/<repo>/``.
+_WORKTREE_BASE_DIR = Path("/home/egg/.egg-worktrees")
+
+
+_locks: dict[str, threading.RLock] = {}
+_locks_guard = threading.Lock()
+
+
+def lock_for(identifier: int | str) -> threading.RLock:
+    """Return the per-identifier lock used to serialize mutations."""
+    key = str(identifier)
+    with _locks_guard:
+        lock = _locks.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _locks[key] = lock
+        return lock
+
+
+def resolve_pipeline_worktree(
+    pipeline_id: str,
+    repo_hint: str | None = None,
+) -> Path | None:
+    """Locate the shared pipeline worktree for *pipeline_id*.
+
+    Returns the path when the worktree exists, or ``None`` if the
+    pipeline is not currently set up on this host (e.g. the worktree
+    has already been cleaned up).
+
+    The worktree is a git checkout, so this also verifies ``.git`` is
+    present before returning a candidate.
+
+    Args:
+        pipeline_id: Pipeline identifier (e.g. ``issue-1781`` or
+            ``pipeline-abc12345``).
+        repo_hint: Optional repo name (last component of ``owner/repo``)
+            to disambiguate when the host runs multiple repos.
+    """
+    if not pipeline_id:
+        return None
+
+    base = _WORKTREE_BASE_DIR / pipeline_id
+    if not base.is_dir():
+        return None
+
+    candidates: list[Path] = []
+    if repo_hint:
+        candidates.append(base / repo_hint)
+
+    # Fall back to any subdirectory that looks like a git checkout.
+    try:
+        for entry in base.iterdir():
+            if entry.is_dir() and entry not in candidates:
+                candidates.append(entry)
+    except OSError:
+        return None
+
+    for candidate in candidates:
+        if (candidate / ".git").exists():
+            if repo_hint and candidate.name != repo_hint:
+                logger.warning(
+                    "Worktree repo name mismatch, using fallback",
+                    extra={
+                        "expected_repo": repo_hint,
+                        "actual_repo": candidate.name,
+                        "pipeline_id": pipeline_id,
+                    },
+                )
+            return candidate
+
+    return None

--- a/orchestrator/routes/contracts.py
+++ b/orchestrator/routes/contracts.py
@@ -1,0 +1,340 @@
+"""Orchestrator contract endpoints.
+
+These endpoints are the authoritative entry point for contract reads
+and writes during pipeline execution.  The gateway proxies agent
+requests here so that every agent observes the same contract
+regardless of which per-agent worktree it is running in (see #1781).
+
+The live contract lives in the *shared* pipeline worktree — not in
+per-agent worktrees, which previously caused producers and reviewers
+to see divergent copies.  Serialization to the feature branch
+continues via ``_commit_statefiles_to_worktree`` at checkpoint
+events; the file is already in the right place by the time commits
+run, so no dedicated "serialize" step is needed.
+
+URL scheme:
+  GET    /api/v1/contracts/<identifier>                 — read
+  GET    /api/v1/contracts/<identifier>/exists          — existence
+  POST   /api/v1/contracts/<identifier>/mutate          — apply mutation
+  POST   /api/v1/contract-mutations/validate            — dry-run
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from flask import Blueprint, Response, jsonify, request
+
+# Shared packages live under ../../shared relative to this file.
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+# The orchestrator package lives one level up.
+_parent_path = Path(__file__).parent.parent
+if str(_parent_path) not in sys.path:
+    sys.path.insert(0, str(_parent_path))
+
+import contract_store  # noqa: E402
+from egg_contracts import (  # noqa: E402
+    ContractNotFoundError,
+    ContractValidationError,
+    Role,
+    apply_mutation,
+    export_contract,
+    get_contract_role,
+    load_contract,
+    save_contract,
+    validate_mutation,
+)
+
+logger = logging.getLogger("orchestrator.contracts")
+
+contracts_bp = Blueprint("contracts", __name__, url_prefix="/api/v1/contracts")
+contract_mutations_bp = Blueprint(
+    "contract_mutations", __name__, url_prefix="/api/v1/contract-mutations"
+)
+
+_VALID_IDENTIFIER_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def _coerce_identifier(raw: str) -> int | str:
+    """Parse a URL identifier into an int (issue number) or str (pipeline id)."""
+    return int(raw) if raw.isdigit() else raw
+
+
+def _validate_identifier(identifier: int | str) -> tuple[Response, int] | None:
+    if isinstance(identifier, int):
+        return None
+    if not _VALID_IDENTIFIER_RE.match(identifier):
+        return _error(
+            "Invalid identifier: only alphanumeric characters, hyphens and underscores are allowed",
+            400,
+        )
+    return None
+
+
+def _error(
+    message: str,
+    status_code: int = 400,
+    details: dict[str, Any] | None = None,
+) -> tuple[Response, int]:
+    payload: dict[str, Any] = {"success": False, "message": message}
+    if details:
+        payload["details"] = details
+    return jsonify(payload), status_code
+
+
+def _success(
+    message: str,
+    data: dict[str, Any] | None = None,
+) -> tuple[Response, int]:
+    payload: dict[str, Any] = {"success": True, "message": message}
+    if data:
+        payload["data"] = data
+    return jsonify(payload), 200
+
+
+def _resolve_role(value: str) -> Role | None:
+    normalized = value.lower()
+    try:
+        return Role(normalized)
+    except ValueError:
+        return get_contract_role(normalized)
+
+
+def _role_from_request() -> Role | None:
+    """Read the caller's role from the forwarded header / body / env.
+
+    The gateway forwards the session-verified role via ``X-Egg-Role``
+    so the orchestrator need not re-authenticate contract calls.
+    """
+    header_role = request.headers.get("X-Egg-Role")
+    if header_role:
+        return _resolve_role(header_role)
+
+    body = request.get_json(silent=True) or {}
+    body_role = body.get("role") or body.get("actor_role")
+    if body_role:
+        return _resolve_role(body_role)
+
+    env_role = os.environ.get("EGG_AGENT_ROLE")
+    if env_role:
+        return _resolve_role(env_role)
+
+    return None
+
+
+def _pipeline_context() -> tuple[str | None, str | None]:
+    """Extract pipeline_id and repo hint from the request."""
+    body = request.get_json(silent=True) or {}
+    pipeline_id = body.get("pipeline_id") or request.args.get("pipeline_id")
+    repo_hint = body.get("repo") or request.args.get("repo")
+    return pipeline_id, repo_hint
+
+
+def _worktree_for_request() -> tuple[Path | None, tuple[Response, int] | None]:
+    """Resolve the shared pipeline worktree from the request context.
+
+    Returns ``(worktree, error)`` where exactly one is non-None.
+    """
+    pipeline_id, repo_hint = _pipeline_context()
+    if not pipeline_id:
+        return None, _error("Missing pipeline_id in request", status_code=400)
+
+    worktree = contract_store.resolve_pipeline_worktree(pipeline_id, repo_hint)
+    if worktree is None:
+        return None, _error(
+            f"Pipeline worktree not found for {pipeline_id}",
+            status_code=404,
+        )
+    return worktree, None
+
+
+@contracts_bp.route("/<identifier>", methods=["GET"])
+def get_contract(identifier: str) -> tuple[Response, int]:
+    """Return the live contract for *identifier*."""
+    ident = _coerce_identifier(identifier)
+    validation_error = _validate_identifier(ident)
+    if validation_error:
+        return validation_error
+
+    worktree, error = _worktree_for_request()
+    if error:
+        return error
+    assert worktree is not None
+
+    include_audit = request.args.get("include_audit_log", "false").lower() == "true"
+
+    try:
+        with contract_store.lock_for(ident):
+            contract = load_contract(ident, worktree)
+    except ContractNotFoundError:
+        return _error(
+            f"Contract for {'#' + str(ident) if isinstance(ident, int) else ident} not found",
+            status_code=404,
+        )
+    except ContractValidationError as exc:
+        return _error(f"Contract validation failed: {exc}", status_code=500)
+
+    return _success(
+        "Contract retrieved",
+        data=export_contract(contract, include_audit_log=include_audit),
+    )
+
+
+@contracts_bp.route("/<identifier>/exists", methods=["GET"])
+def contract_exists(identifier: str) -> tuple[Response, int]:
+    ident = _coerce_identifier(identifier)
+    validation_error = _validate_identifier(ident)
+    if validation_error:
+        return validation_error
+
+    worktree, error = _worktree_for_request()
+    if error:
+        return error
+    assert worktree is not None
+
+    exists = (worktree / ".egg-state" / "contracts" / f"{ident}.json").exists()
+    return _success(
+        "Contract exists" if exists else "Contract does not exist",
+        data={"exists": exists},
+    )
+
+
+@contracts_bp.route("/<identifier>/mutate", methods=["POST"])
+def mutate_contract(identifier: str) -> tuple[Response, int]:
+    """Apply a role-validated mutation to the live contract."""
+    ident = _coerce_identifier(identifier)
+    validation_error = _validate_identifier(ident)
+    if validation_error:
+        return validation_error
+
+    body = request.get_json()
+    if not body:
+        return _error("Missing request body")
+
+    field_path = body.get("field_path")
+    new_value = body.get("new_value", ...)  # sentinel: allow explicit None
+    if not field_path:
+        return _error("Missing field_path")
+    if new_value is ...:
+        return _error("Missing new_value")
+
+    role = _role_from_request()
+    if role is None:
+        return _error(
+            "Cannot determine agent role for contract mutation",
+            status_code=403,
+        )
+
+    worktree, error = _worktree_for_request()
+    if error:
+        return error
+    assert worktree is not None
+
+    actor = body.get("actor", "agent")
+    reason = body.get("reason")
+
+    with contract_store.lock_for(ident):
+        try:
+            contract = load_contract(ident, worktree)
+        except ContractNotFoundError:
+            return _error(
+                f"Contract for {'#' + str(ident) if isinstance(ident, int) else ident} not found",
+                status_code=404,
+            )
+        except ContractValidationError as exc:
+            return _error(f"Contract validation failed: {exc}", status_code=500)
+
+        result = apply_mutation(
+            contract=contract,
+            role=role,
+            actor=actor,
+            field_path=field_path,
+            new_value=new_value,
+            reason=reason,
+        )
+
+        if not result.success:
+            logger.warning(
+                "Contract mutation rejected",
+                extra={
+                    "identifier": str(ident),
+                    "role": role.value,
+                    "field_path": field_path,
+                    "error": result.message,
+                },
+            )
+            return _error(
+                result.message,
+                status_code=403,
+                details={"role": role.value, "field_path": field_path},
+            )
+
+        assert result.contract is not None
+        try:
+            save_contract(result.contract, worktree)
+        except Exception as exc:
+            logger.error(
+                "Failed to save contract",
+                extra={"identifier": str(ident), "error": str(exc)},
+            )
+            return _error(f"Failed to save contract: {exc}", status_code=500)
+
+    logger.info(
+        "Contract mutation applied",
+        extra={
+            "identifier": str(ident),
+            "role": role.value,
+            "actor": actor,
+            "field_path": field_path,
+        },
+    )
+
+    return _success(
+        "Mutation applied successfully",
+        data={"contract": export_contract(result.contract, include_audit_log=False)},
+    )
+
+
+@contract_mutations_bp.route("/validate", methods=["POST"])
+def validate_contract_mutation() -> tuple[Response, int]:
+    """Dry-run a mutation and report whether it would be accepted.
+
+    Role permissions are independent of contract contents, so this
+    endpoint doesn't take an identifier — it just validates role
+    against field_path/new_value via the shared validator.
+    """
+    body = request.get_json()
+    if not body:
+        return _error("Missing request body")
+
+    field_path = body.get("field_path")
+    new_value = body.get("new_value", ...)
+    if not field_path:
+        return _error("Missing field_path")
+    if new_value is ...:
+        return _error("Missing new_value")
+
+    role = _role_from_request()
+    if role is None:
+        return _error("Cannot determine agent role", status_code=403)
+
+    result = validate_mutation(role, field_path, new_value)
+    if result.valid:
+        return _success("Mutation allowed")
+    return _error(
+        result.message,
+        status_code=403,
+        details={
+            "role": role.value,
+            "field_path": result.field_path,
+            "required_role": result.required_role,
+        },
+    )

--- a/orchestrator/routes/contracts.py
+++ b/orchestrator/routes/contracts.py
@@ -52,6 +52,9 @@ from egg_contracts import (  # noqa: E402
     save_contract,
     validate_mutation,
 )
+from egg_contracts import (
+    contract_exists as _contract_exists,
+)
 
 logger = logging.getLogger("orchestrator.contracts")
 
@@ -95,7 +98,7 @@ def _success(
     data: dict[str, Any] | None = None,
 ) -> tuple[Response, int]:
     payload: dict[str, Any] = {"success": True, "message": message}
-    if data:
+    if data is not None:
         payload["data"] = data
     return jsonify(payload), 200
 
@@ -118,6 +121,9 @@ def _role_from_request() -> Role | None:
     if header_role:
         return _resolve_role(header_role)
 
+    # Body fallback exists for internal/dev callers that bypass the
+    # gateway.  The gateway itself strips these fields from forwarded
+    # bodies (it sends the verified role via X-Egg-Role instead).
     body = request.get_json(silent=True) or {}
     body_role = body.get("role") or body.get("actor_role")
     if body_role:
@@ -200,7 +206,7 @@ def contract_exists(identifier: str) -> tuple[Response, int]:
         return error
     assert worktree is not None
 
-    exists = (worktree / ".egg-state" / "contracts" / f"{ident}.json").exists()
+    exists = _contract_exists(ident, worktree)
     return _success(
         "Contract exists" if exists else "Contract does not exist",
         data={"exists": exists},

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9852,6 +9852,27 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                             pipeline_id=pipeline_id,
                         )
 
+                    # Commit any uncommitted contract mutations before
+                    # opening the PR.  Under the orchestrator-owned
+                    # contract model (#1781), late-phase agent mutations
+                    # land directly in the shared worktree file and may
+                    # not yet be on the branch; this ensures the contract
+                    # is captured in git history as part of the PR.
+                    try:
+                        _commit_statefiles_to_worktree(
+                            worktree_repo_path,
+                            "Persist contract before PR creation",
+                            pipeline_identifier=_pipeline_identifier(
+                                pipeline.issue_number, pipeline_id
+                            ),
+                        )
+                    except subprocess.CalledProcessError as git_err:
+                        logger.warning(
+                            "Pre-PR statefile commit failed (continuing)",
+                            pipeline_id=pipeline_id,
+                            error=str(git_err),
+                        )
+
                     # Safety net: re-write BRC history for all completed phases.
                     # Per-phase writes happen at phase completion, but pushes
                     # can fail silently — re-writing here guarantees the files

--- a/orchestrator/tests/test_contracts_routes.py
+++ b/orchestrator/tests/test_contracts_routes.py
@@ -1,0 +1,215 @@
+"""Tests for orchestrator contract endpoints (#1781).
+
+These exercise the single source of truth for contract state:
+the orchestrator's ``/api/v1/contracts/…`` endpoints backed by the
+shared pipeline worktree.  Gateway interactions are tested
+separately in ``gateway/tests/test_contract_api.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import contract_store
+import pytest
+from api import app
+from egg_contracts import create_contract
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+@pytest.fixture
+def fake_worktree(tmp_path: Path, monkeypatch):
+    """Create a fake pipeline worktree that contract_store can discover."""
+    pipeline_id = "issue-1781"
+    worktrees_base = tmp_path / "worktrees"
+    worktrees_base.mkdir()
+
+    worktree = worktrees_base / pipeline_id / "egg"
+    worktree.mkdir(parents=True)
+    (worktree / ".git").mkdir()
+
+    monkeypatch.setattr(contract_store, "_WORKTREE_BASE_DIR", worktrees_base)
+
+    return pipeline_id, worktree
+
+
+def _seed_contract(worktree: Path, pipeline_id: str):
+    create_contract(pipeline_id=pipeline_id, title="Fixture", repo_root=worktree)
+
+
+class TestGetContract:
+    def test_returns_contract(self, client, fake_worktree):
+        pipeline_id, worktree = fake_worktree
+        _seed_contract(worktree, pipeline_id)
+
+        response = client.get(
+            f"/api/v1/contracts/{pipeline_id}",
+            query_string={"pipeline_id": pipeline_id, "repo": "egg"},
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["success"] is True
+        assert data["data"]["pipeline_id"] == pipeline_id
+
+    def test_missing_pipeline_id_rejected(self, client, fake_worktree):
+        pipeline_id, _ = fake_worktree
+        response = client.get(f"/api/v1/contracts/{pipeline_id}")
+        assert response.status_code == 400
+
+    def test_worktree_not_found(self, client, fake_worktree):
+        response = client.get(
+            "/api/v1/contracts/some-id",
+            query_string={"pipeline_id": "missing-id"},
+        )
+        assert response.status_code == 404
+
+    def test_contract_not_found(self, client, fake_worktree):
+        pipeline_id, _ = fake_worktree
+        response = client.get(
+            f"/api/v1/contracts/{pipeline_id}",
+            query_string={"pipeline_id": pipeline_id, "repo": "egg"},
+        )
+        assert response.status_code == 404
+
+    def test_invalid_identifier_rejected(self, client, fake_worktree):
+        pipeline_id, _ = fake_worktree
+        response = client.get(
+            "/api/v1/contracts/has space",
+            query_string={"pipeline_id": pipeline_id, "repo": "egg"},
+        )
+        assert response.status_code == 400
+
+
+class TestMutateContract:
+    def _mutate(self, client, identifier, role, body_overrides=None):
+        body = {
+            "pipeline_id": identifier,
+            "repo": "egg",
+            "field_path": "phases",
+            "new_value": [],
+        }
+        if body_overrides:
+            body.update(body_overrides)
+        return client.post(
+            f"/api/v1/contracts/{identifier}/mutate",
+            json=body,
+            headers={"X-Egg-Role": role},
+        )
+
+    def test_rejects_when_role_missing(self, client, fake_worktree):
+        pipeline_id, worktree = fake_worktree
+        _seed_contract(worktree, pipeline_id)
+
+        response = client.post(
+            f"/api/v1/contracts/{pipeline_id}/mutate",
+            json={
+                "pipeline_id": pipeline_id,
+                "repo": "egg",
+                "field_path": "phases",
+                "new_value": [],
+            },
+        )
+        assert response.status_code == 403
+        assert "role" in json.loads(response.data)["message"].lower()
+
+    def test_writes_visible_from_second_call(self, client, fake_worktree):
+        """Core regression for #1781: a mutation on one request is
+        immediately visible to the next.  Under the pre-fix
+        per-agent-worktree design, producer and consumer saw
+        divergent state.
+        """
+        pipeline_id, worktree = fake_worktree
+        _seed_contract(worktree, pipeline_id)
+
+        decision = {
+            "id": "decision-1",
+            "question": "Is this mutation visible?",
+            "type": "hitl",
+            "options": [],
+            "resolved": False,
+        }
+
+        producer = self._mutate(
+            client,
+            pipeline_id,
+            role="implementer",
+            body_overrides={"field_path": "decisions.0", "new_value": decision},
+        )
+        assert producer.status_code == 200, producer.data
+
+        consumer = client.get(
+            f"/api/v1/contracts/{pipeline_id}",
+            query_string={"pipeline_id": pipeline_id, "repo": "egg"},
+        )
+        assert consumer.status_code == 200
+        decisions = json.loads(consumer.data)["data"]["decisions"]
+        assert any(d["id"] == "decision-1" for d in decisions)
+
+    def test_role_validation_enforced(self, client, fake_worktree):
+        pipeline_id, worktree = fake_worktree
+        _seed_contract(worktree, pipeline_id)
+
+        # Reviewer role cannot register a task commit — that's
+        # implementer territory.
+        response = self._mutate(
+            client,
+            pipeline_id,
+            role="reviewer",
+            body_overrides={
+                "field_path": "phases.0.tasks.0.commit",
+                "new_value": "abc1234",
+            },
+        )
+        assert response.status_code in (403, 400)
+
+
+class TestValidateMutation:
+    def test_allowed(self, client):
+        response = client.post(
+            "/api/v1/contract-mutations/validate",
+            json={"field_path": "phases.0.status", "new_value": "complete"},
+            headers={"X-Egg-Role": "implementer"},
+        )
+        assert response.status_code == 200
+
+    def test_missing_role(self, client):
+        response = client.post(
+            "/api/v1/contract-mutations/validate",
+            json={"field_path": "phases.0.status", "new_value": "complete"},
+        )
+        assert response.status_code == 403
+
+    def test_missing_field_path(self, client):
+        response = client.post(
+            "/api/v1/contract-mutations/validate",
+            json={"new_value": "complete"},
+            headers={"X-Egg-Role": "implementer"},
+        )
+        assert response.status_code == 400
+
+
+class TestResolvePipelineWorktree:
+    def test_returns_worktree_when_present(self, tmp_path, monkeypatch):
+        base = tmp_path / "worktrees"
+        wt = base / "issue-42" / "egg"
+        wt.mkdir(parents=True)
+        (wt / ".git").mkdir()
+
+        monkeypatch.setattr(contract_store, "_WORKTREE_BASE_DIR", base)
+
+        assert contract_store.resolve_pipeline_worktree("issue-42") == wt
+
+    def test_returns_none_when_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(contract_store, "_WORKTREE_BASE_DIR", tmp_path / "worktrees")
+        assert contract_store.resolve_pipeline_worktree("nope") is None
+
+    def test_empty_id_returns_none(self):
+        assert contract_store.resolve_pipeline_worktree("") is None

--- a/orchestrator/tests/test_contracts_routes.py
+++ b/orchestrator/tests/test_contracts_routes.py
@@ -213,3 +213,19 @@ class TestResolvePipelineWorktree:
 
     def test_empty_id_returns_none(self):
         assert contract_store.resolve_pipeline_worktree("") is None
+
+    @pytest.mark.parametrize(
+        "pipeline_id",
+        ["../../etc", "../other", "has/slash", "has..", "a b"],
+    )
+    def test_path_traversal_pipeline_id_rejected(self, pipeline_id):
+        assert contract_store.resolve_pipeline_worktree(pipeline_id) is None
+
+    def test_path_traversal_repo_hint_rejected(self, tmp_path, monkeypatch):
+        base = tmp_path / "worktrees"
+        wt = base / "issue-42" / "egg"
+        wt.mkdir(parents=True)
+        (wt / ".git").mkdir()
+        monkeypatch.setattr(contract_store, "_WORKTREE_BASE_DIR", base)
+
+        assert contract_store.resolve_pipeline_worktree("issue-42", "../../etc") is None


### PR DESCRIPTION
## Summary

Closes #1781.

- The gateway's contract API is now a thin pass-through to new orchestrator endpoints under `/api/v1/contracts/`. The gateway no longer touches per-agent worktrees.
- The orchestrator owns contract state and reads/writes the file in the shared pipeline worktree, so every agent sees the same contract regardless of where it runs.
- An explicit `_commit_statefiles_to_worktree` call is added immediately before `_auto_create_pr` to guarantee the contract lands on the branch before the PR opens.

## Why

Per the issue, per-agent worktrees held their own copies of the contract on their own branches. Producers and reviewers saw divergent state, and BRC cycles wasted turns reconciling via `git fetch`/`git log` detective work. The root cause was the gateway's `_map_path` into the caller's worktree. Lifting state management into the orchestrator (the process that already owns pipeline lifecycle) fixes the divergence at the source.

## Changes

1. **`orchestrator/contract_store.py`** — new module that resolves a pipeline_id to the shared worktree and owns per-identifier RLocks for in-process mutation serialization.
2. **`orchestrator/routes/contracts.py`** — new Flask blueprint:
   - `GET  /api/v1/contracts/<identifier>`
   - `GET  /api/v1/contracts/<identifier>/exists`
   - `POST /api/v1/contracts/<identifier>/mutate`
   - `POST /api/v1/contract-mutations/validate`
   All operations load/save against the shared pipeline worktree.
3. **`gateway/contract_api.py`** — rewritten as a pass-through. Keeps session auth and role resolution (the gateway is still the perimeter), forwards via `EGG_ORCHESTRATOR_URL` with `X-Egg-Role`, and returns `502` when the orchestrator is unreachable.
4. **`orchestrator/routes/pipelines.py`** — adds a `_commit_statefiles_to_worktree` call before `_auto_create_pr` to enforce "contract in repo before PR opens."

## Test plan

- [x] `orchestrator/tests/test_contracts_routes.py` (new): covers happy path, missing pipeline_id, invalid identifier, cross-call visibility regression (producer writes, consumer reads immediately), role validation enforcement.
- [x] `gateway/tests/test_contract_api.py` (rewritten): covers role resolution (preserved) and the new pass-through — forwarded URL/headers/body, upstream error relay, 502 on unreachable orchestrator, identifier validation.
- [x] Existing orchestrator suites around contract and statefile logic still pass: `test_signals.py`, `test_short_flow_contract_population.py`, `test_statefile_reconciliation.py`, `test_populate_contract_endpoint.py`, `test_auto_pr.py`, `test_cleanup_agent_outputs_for_pr.py`, `test_commit_statefiles_scoping.py`.
- [x] `shared/tests/` suite passes unchanged (689 passed, 12 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)