### PR TITLE
Fix #1803: point gateway's orchestrator proxy at the k3s Service FQDN

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -5451,6 +5451,18 @@ def main() -> None:
         logger.error("Startup failed: launcher secret not configured", error=str(e))
         sys.exit(1)
 
+    # Under k8s the compose-era default hostname "egg-orchestrator" does
+    # not resolve, so falling back to it produces cryptic "Orchestrator
+    # unreachable" errors on the agent side mid-pipeline. Fail startup
+    # instead so the misconfiguration is visible at deploy time (#1803).
+    if os.environ.get("KUBERNETES_SERVICE_HOST") and not os.environ.get("EGG_ORCHESTRATOR_URL"):
+        logger.error(
+            "Startup failed: EGG_ORCHESTRATOR_URL must be set when running in Kubernetes. "
+            "Set it on the gateway Deployment, e.g. "
+            "http://orchestrator.egg-system.svc.cluster.local:9849"
+        )
+        sys.exit(1)
+
     # Register SIGHUP handler for config reload.
     # Usage: docker kill -s HUP egg-gateway
     def _handle_sighup(signum: int, frame: Any) -> None:

--- a/gateway/tests/test_startup_k8s_guard.py
+++ b/gateway/tests/test_startup_k8s_guard.py
@@ -1,0 +1,75 @@
+"""Tests for the Kubernetes startup guard in gateway.main().
+
+When KUBERNETES_SERVICE_HOST is set (i.e. running inside a k8s pod) but
+EGG_ORCHESTRATOR_URL is missing, the gateway must exit immediately with
+code 1 so the misconfiguration surfaces at deploy time (#1803).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "k8s_host, orch_url, should_exit",
+    [
+        # In k8s without orchestrator URL → must exit
+        ("10.0.0.1", None, True),
+        ("10.0.0.1", "", True),
+        # In k8s with orchestrator URL → must NOT exit
+        ("10.0.0.1", "http://orchestrator.egg-system.svc.cluster.local:9849", False),
+        # Not in k8s (no KUBERNETES_SERVICE_HOST) → must NOT exit regardless
+        (None, None, False),
+        ("", None, False),
+    ],
+    ids=[
+        "k8s-no-url-exits",
+        "k8s-empty-url-exits",
+        "k8s-with-url-ok",
+        "not-k8s-no-url-ok",
+        "not-k8s-empty-host-ok",
+    ],
+)
+def test_k8s_orchestrator_url_guard(k8s_host, orch_url, should_exit):
+    """Startup guard exits when in k8s without EGG_ORCHESTRATOR_URL."""
+    import gateway
+
+    env = {}
+    if k8s_host is not None:
+        env["KUBERNETES_SERVICE_HOST"] = k8s_host
+    if orch_url is not None:
+        env["EGG_ORCHESTRATOR_URL"] = orch_url
+
+    with (
+        patch.object(gateway, "get_github_client") as mock_ghc,
+        patch.object(gateway, "get_session_manager") as mock_sm,
+        patch.object(gateway, "get_active_docker_containers", return_value=set()),
+        patch.object(gateway, "startup_cleanup", return_value=0),
+        patch.object(gateway, "get_launcher_secret", return_value="secret"),
+        patch.object(gateway, "serve"),
+        patch("signal.signal"),
+        patch("argparse.ArgumentParser.parse_args") as mock_args,
+        patch.object(gateway.os, "getuid", return_value=1000),
+        patch.dict(gateway.os.environ, env, clear=False),
+    ):
+        # Remove keys that should be absent (None means unset)
+        if k8s_host is None:
+            gateway.os.environ.pop("KUBERNETES_SERVICE_HOST", None)
+        if orch_url is None:
+            gateway.os.environ.pop("EGG_ORCHESTRATOR_URL", None)
+
+        mock_args.return_value = MagicMock(host="0.0.0.0", port=9848, debug=False)
+        mock_ghc.return_value = MagicMock(
+            validate_user_mode_config=MagicMock(return_value=(True, "ok"))
+        )
+        mock_sm.return_value = MagicMock(
+            prune_expired_sessions=MagicMock(return_value=0),
+            list_sessions=MagicMock(return_value=[]),
+        )
+
+        if should_exit:
+            with pytest.raises(SystemExit) as exc_info:
+                gateway.main()
+            assert exc_info.value.code == 1
+        else:
+            gateway.main()

--- a/k8s/base/gateway-deployment.yaml
+++ b/k8s/base/gateway-deployment.yaml
@@ -69,6 +69,14 @@ spec:
               value: "1000"
             - name: HOST_HOME
               value: "/home/egg"
+            # Gateway proxies contract reads/writes to the orchestrator
+            # (see gateway/contract_api.py). The module-level default
+            # "http://egg-orchestrator:9849" is a docker-compose hostname
+            # that doesn't resolve under k3s kube-dns; here we point at
+            # the cluster Service FQDN. Missing this var in k8s is caught
+            # by the fail-fast check in gateway.main() (#1803).
+            - name: EGG_ORCHESTRATOR_URL
+              value: "http://orchestrator.egg-system.svc.cluster.local:9849"
           livenessProbe:
             httpGet:
               path: /api/v1/health


### PR DESCRIPTION
## Summary

- Sets `EGG_ORCHESTRATOR_URL=http://orchestrator.egg-system.svc.cluster.local:9849` on the gateway Deployment (matches what the orchestrator's own Deployment already has). Without this, `gateway/contract_api.py` and `gateway/checkpoint_handler.py` fall back to the docker-compose hostname `egg-orchestrator`, which doesn't resolve under k3s kube-dns, and every agent call through the gateway dies with \"Orchestrator unreachable.\"
- Adds a fail-fast startup check in `gateway.main()`: if `KUBERNETES_SERVICE_HOST` is set but `EGG_ORCHESTRATOR_URL` is not, the pod exits with a clear error instead of waiting to surface the misconfiguration mid-pipeline (Option C from the issue).

Fixes #1803.

## Test plan

- [ ] `make redeploy` — confirm gateway pod comes up with `EGG_ORCHESTRATOR_URL` set to the Service FQDN.
- [ ] From a sandbox agent pod, `egg-contract add-decision …` via the gateway — first call succeeds, no \"Orchestrator unreachable\" error.
- [ ] Confirm `egg-contract add-feedback` and contract mutations behave the same.
- [ ] Negative check: remove the env var from the Deployment locally, redeploy — gateway pod should `CrashLoopBackOff` with the startup error message in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)