### PR TITLE
Fix #1808: reroute state-sync push + inline fetch+rebase reconcile

### DIFF
--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -655,6 +655,12 @@ class GatewayClient:
         # mutates the checkout at repo_path, which we only want to do when
         # that checkout is a dedicated pipeline worktree.
         if ref is not None:
+            logger.warning(
+                "Push failed for ref-based push (no reconcile available)",
+                pipeline_id=pipeline_id,
+                branch=branch,
+                ref=ref,
+            )
             return False
 
         return self._reconcile_and_retry_push(

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -11,6 +11,7 @@ Provides coordination between the orchestrator and gateway sidecar for:
 import json
 import os
 import socket
+import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -608,25 +609,74 @@ class GatewayClient:
         repo_path: str,
         branch: str,
         mode: Literal["public", "private"] = "public",
+        ref: str | None = None,
     ) -> bool:
-        """Push a worktree branch to remote using a temporary session.
+        """Push a branch to remote using a temporary session.
 
-        Best-effort operation used to push worktree contents to remote —
-        called after contract initialization, phase completion, or pipeline
+        Called after contract initialization, phase completion, or pipeline
         failure. Registers a temp session, pushes, then cleans up the session.
+
+        When ``ref`` is ``None`` (default), pushes the worktree's current
+        ``HEAD`` — used when ``repo_path`` is a worktree checked out to
+        ``branch``. On non-fast-forward rejection, performs
+        ``git fetch origin`` + ``git rebase origin/{branch}`` in the
+        worktree (with ``.egg-state/agent-outputs/`` auto-resolve) and
+        retries the push once.
+
+        When ``ref`` is set, pushes ``refs/heads/{ref}:refs/heads/{branch}``
+        — used when ``repo_path`` is a plain repository (not a worktree
+        checked out to ``branch``) whose ``.git/`` holds the commits to
+        push. Reconcile is skipped: there is no working tree at
+        ``repo_path`` that can be rebased onto the remote tip without
+        disturbing its checkout.
 
         Args:
             pipeline_id: Pipeline ID (used as container_id for the temp session)
-            repo_path: Path to the worktree repo directory
-            branch: Branch name to push
+            repo_path: Path to the repo directory the gateway will ``cd`` into
+            branch: Remote branch name to push to
+            mode: Gateway session mode (public/private)
+            ref: Local ref to push (omit to push worktree HEAD)
 
         Returns:
-            True if push succeeded, False otherwise
+            True if push (possibly after reconcile) succeeded, False otherwise
         """
+        refspec = f"refs/heads/{ref}:refs/heads/{branch}" if ref else f"HEAD:refs/heads/{branch}"
+
+        if self._do_push(
+            pipeline_id=pipeline_id,
+            repo_path=repo_path,
+            branch=branch,
+            mode=mode,
+            refspec=refspec,
+        ):
+            return True
+
+        # Reconcile is only meaningful for worktree-HEAD pushes: the rebase
+        # mutates the checkout at repo_path, which we only want to do when
+        # that checkout is a dedicated pipeline worktree.
+        if ref is not None:
+            return False
+
+        return self._reconcile_and_retry_push(
+            pipeline_id=pipeline_id,
+            worktree_path=repo_path,
+            branch=branch,
+            mode=mode,
+            refspec=refspec,
+        )
+
+    def _do_push(
+        self,
+        pipeline_id: str,
+        repo_path: str,
+        branch: str,
+        mode: Literal["public", "private"],
+        refspec: str,
+    ) -> bool:
+        """Send a single push request to the gateway. Returns True on success."""
         temp_container_id = f"{pipeline_id}-failsafe-push"
         session_token: str | None = None
         try:
-            # Register a temporary session for the push
             session = self.register_session(
                 container_id=temp_container_id,
                 container_ip=self.self_ip,
@@ -636,43 +686,135 @@ class GatewayClient:
             )
             session_token = session.session_token
 
-            # Push the branch.  Do NOT include container_id — the repo_path
-            # is already the resolved worktree path.  Including the synthetic
-            # container_id would cause map_container_path_to_worktree() to
-            # fail with "worktree not found" since no real worktree exists
-            # for the temp session (see #1500).
+            # Do NOT include container_id — the repo_path is already resolved.
+            # Including the synthetic container_id would cause
+            # map_container_path_to_worktree() to fail with "worktree not found"
+            # since no real worktree exists for the temp session (see #1500).
             self._make_request(
                 "/api/v1/git/push",
                 method="POST",
                 data={
                     "repo_path": repo_path,
                     "remote": "origin",
-                    "refspec": f"HEAD:refs/heads/{branch}",
+                    "refspec": refspec,
                 },
                 bearer_token=session_token,
             )
 
             logger.info(
-                "Pushed worktree branch to remote",
+                "Pushed branch to remote",
                 pipeline_id=pipeline_id,
                 branch=branch,
+                refspec=refspec,
             )
             return True
         except Exception as e:
-            logger.warning(
-                "Best-effort push failed (work preserved locally in worktree)",
+            # First-attempt failure is logged at INFO: either reconcile will
+            # recover (handled by the caller) or the reconcile/unrecoverable
+            # path will log at WARNING/ERROR with detail.
+            logger.info(
+                "Push attempt failed — caller may retry via reconcile",
                 pipeline_id=pipeline_id,
                 branch=branch,
+                refspec=refspec,
                 error=str(e),
             )
             return False
         finally:
-            # Clean up temp session
             if session_token:
                 try:
                     self.delete_session(session_token)
                 except Exception:
                     pass
+
+    def _reconcile_and_retry_push(
+        self,
+        pipeline_id: str,
+        worktree_path: str,
+        branch: str,
+        mode: Literal["public", "private"],
+        refspec: str,
+    ) -> bool:
+        """Fetch, rebase the worktree onto ``origin/{branch}``, and retry push.
+
+        Runs directly against the worktree filesystem (shared hostPath) so
+        the orchestrator can mutate the checkout without round-tripping
+        through the gateway. Conflicts confined to
+        ``.egg-state/agent-outputs/`` are resolved in favour of the remote;
+        conflicts elsewhere abort the rebase and return False.
+
+        Returns True if the retry push succeeded, False otherwise. On
+        False, callers should treat the work as stranded locally and
+        surface an operator-actionable error (the housekeeping commits
+        are lost, but the agents' prior pushes are still on origin).
+        """
+        logger.warning(
+            "Push rejected — attempting fetch+rebase+retry to reconcile divergence",
+            pipeline_id=pipeline_id,
+            branch=branch,
+        )
+
+        git_base = [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            f"safe.directory={worktree_path}",
+            "-C",
+            str(worktree_path),
+        ]
+
+        try:
+            subprocess.run(
+                [*git_base, "fetch", "origin", branch],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=60,
+            )
+        except subprocess.CalledProcessError as fetch_err:
+            logger.error(
+                "Push reconcile: fetch failed — work remains on local worktree only",
+                pipeline_id=pipeline_id,
+                branch=branch,
+                stderr=fetch_err.stderr,
+            )
+            return False
+        except subprocess.TimeoutExpired:
+            logger.error(
+                "Push reconcile: fetch timed out — work remains on local worktree only",
+                pipeline_id=pipeline_id,
+                branch=branch,
+            )
+            return False
+
+        if not _rebase_with_agent_output_autoresolve(
+            git_base=git_base,
+            pipeline_id=pipeline_id,
+            branch=branch,
+        ):
+            return False
+
+        logger.info(
+            "Push reconcile: rebase succeeded — retrying push",
+            pipeline_id=pipeline_id,
+            branch=branch,
+        )
+        if self._do_push(
+            pipeline_id=pipeline_id,
+            repo_path=worktree_path,
+            branch=branch,
+            mode=mode,
+            refspec=refspec,
+        ):
+            return True
+
+        logger.error(
+            "Push reconcile: retry push still failed — work remains on local worktree only",
+            pipeline_id=pipeline_id,
+            branch=branch,
+        )
+        return False
 
     def delete_remote_branch(
         self,
@@ -1042,6 +1184,206 @@ class GatewayClient:
         except Exception as e:
             logger.warning("Failed to query repo visibility", repo=repo, error=str(e))
             return None
+
+
+# =============================================================================
+# Rebase helpers for push_worktree_branch reconcile path
+# =============================================================================
+
+
+def _rebase_with_agent_output_autoresolve(
+    git_base: list[str],
+    pipeline_id: str,
+    branch: str,
+    max_autoresolve_iterations: int = 3,
+) -> bool:
+    """Rebase the worktree onto ``origin/{branch}`` with agent-outputs auto-resolve.
+
+    Conflicts confined to ``.egg-state/agent-outputs/`` are resolved in
+    favour of the remote (``git checkout --theirs``) and the rebase is
+    continued; conflicts anywhere else cause the rebase to be aborted
+    and ``False`` returned.
+
+    The auto-resolve loop is bounded by ``max_autoresolve_iterations``
+    to defend against pathological cases where every replayed commit
+    re-introduces an agent-outputs conflict — three iterations is
+    plenty for a handful of housekeeping commits.
+
+    Returns ``True`` when the rebase finished cleanly (possibly after
+    auto-resolve), ``False`` on any other failure.
+    """
+    try:
+        rebase_result = subprocess.run(
+            [*git_base, "rebase", f"origin/{branch}"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        logger.error(
+            "Push reconcile: rebase timed out — aborting",
+            pipeline_id=pipeline_id,
+            branch=branch,
+        )
+        _abort_rebase_best_effort(git_base, pipeline_id, branch)
+        return False
+
+    if rebase_result.returncode == 0:
+        return True
+
+    for iteration in range(max_autoresolve_iterations):
+        unmerged_paths = _list_unmerged_paths(git_base)
+        if not unmerged_paths:
+            logger.error(
+                "Push reconcile: rebase stopped with no unmerged paths — aborting",
+                pipeline_id=pipeline_id,
+                branch=branch,
+                stdout=rebase_result.stdout,
+                stderr=rebase_result.stderr,
+            )
+            _abort_rebase_best_effort(git_base, pipeline_id, branch)
+            return False
+
+        non_ephemeral = [p for p in unmerged_paths if not p.startswith(".egg-state/agent-outputs/")]
+        if non_ephemeral:
+            logger.error(
+                "Push reconcile: rebase failed — conflicts outside agent-outputs, aborting",
+                pipeline_id=pipeline_id,
+                branch=branch,
+                conflicting_paths=unmerged_paths,
+                stdout=rebase_result.stdout,
+                stderr=rebase_result.stderr,
+            )
+            _abort_rebase_best_effort(git_base, pipeline_id, branch)
+            return False
+
+        logger.warning(
+            "Push reconcile: auto-resolving agent-outputs conflicts (taking remote)",
+            pipeline_id=pipeline_id,
+            branch=branch,
+            resolved_paths=unmerged_paths,
+            iteration=iteration + 1,
+        )
+        try:
+            subprocess.run(
+                [
+                    *git_base,
+                    "checkout",
+                    "--theirs",
+                    "--",
+                    ".egg-state/agent-outputs",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            )
+            # Some paths may have been deleted on ``--theirs``; --all handles that.
+            subprocess.run(
+                [*git_base, "add", "--all", "--", ".egg-state/agent-outputs"],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as resolve_err:
+            logger.error(
+                "Push reconcile: auto-resolve failed — aborting rebase",
+                pipeline_id=pipeline_id,
+                branch=branch,
+                error=str(resolve_err),
+            )
+            _abort_rebase_best_effort(git_base, pipeline_id, branch)
+            return False
+
+        # If resolution cleared the index, ``--continue`` errors with
+        # "No changes - did you forget to use 'git add'?". Use --skip.
+        diff_result = subprocess.run(
+            [*git_base, "diff", "--cached", "--quiet"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        continue_cmd = "--skip" if diff_result.returncode == 0 else "--continue"
+
+        # GIT_EDITOR=true suppresses editor prompt on --continue only.
+        env = {**os.environ, "GIT_EDITOR": "true"} if continue_cmd == "--continue" else None
+        try:
+            rebase_result = subprocess.run(
+                [*git_base, "rebase", continue_cmd],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=120,
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            logger.error(
+                "Push reconcile: rebase --continue timed out — aborting",
+                pipeline_id=pipeline_id,
+                branch=branch,
+            )
+            _abort_rebase_best_effort(git_base, pipeline_id, branch)
+            return False
+
+        if rebase_result.returncode == 0:
+            return True
+
+    logger.error(
+        "Push reconcile: rebase auto-resolve exceeded iteration limit — aborting",
+        pipeline_id=pipeline_id,
+        branch=branch,
+        max_iterations=max_autoresolve_iterations,
+    )
+    _abort_rebase_best_effort(git_base, pipeline_id, branch)
+    return False
+
+
+def _list_unmerged_paths(git_base: list[str]) -> list[str]:
+    """Return the set of paths currently in a conflicted state in the worktree.
+
+    Returns an empty list when the query itself fails — callers should be
+    aware that ``[]`` can mean either "no conflicts" or "query failed".
+    """
+    result = subprocess.run(
+        [*git_base, "diff", "--name-only", "--diff-filter=U"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        logger.warning(
+            "_list_unmerged_paths: git diff --diff-filter=U failed",
+            returncode=result.returncode,
+            stderr=result.stderr,
+        )
+        return []
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def _abort_rebase_best_effort(
+    git_base: list[str],
+    pipeline_id: str,
+    branch: str,
+) -> None:
+    """Run ``git rebase --abort`` and swallow any failure (worktree is junk anyway)."""
+    try:
+        subprocess.run(
+            [*git_base, "rebase", "--abort"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except Exception:
+        logger.warning(
+            "Push reconcile: rebase --abort also failed",
+            pipeline_id=pipeline_id,
+            branch=branch,
+        )
 
 
 class GatewayError(Exception):

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -4664,7 +4664,9 @@ def _finalize_pr_phase_failed(
     of the full polling loop.
 
     ``push_ok`` reflects whether the preceding
-    :func:`_reconcile_and_push_pr_branch` call succeeded.  Regardless,
+    :func:`GatewayClient.push_worktree_branch` call succeeded (the client
+    reconciles non-fast-forward rejections internally via fetch+rebase+retry;
+    see #1706/#1731/#1808).  Regardless,
     we call :func:`_auto_create_pr` — when ``push_ok`` is False the PR is
     opened against whatever is currently on ``origin/<pipeline.branch>``
     (the agents' work), dropping the orchestrator's housekeeping commits
@@ -4954,333 +4956,6 @@ def _rewrite_brc_history_for_pr(
         "_rewrite_brc_history_for_pr: exiting",
         pipeline_id=pipeline_id,
     )
-
-
-def _reconcile_and_push_pr_branch(
-    spawner,
-    worktree_path: Path,
-    pipeline_id: str,
-    branch: str,
-    gateway_mode: Literal["public", "private"],
-) -> bool:
-    """Push the PR-phase worktree branch, reconciling with the remote on failure.
-
-    The PR-phase worktree is checked out from ``origin/{branch}`` at phase
-    entry, then has local-only commits layered on top (BRC history rewrite
-    via :func:`_rewrite_brc_history_for_pr`). Between the worktree checkout
-    and this push, the remote tip can advance — for example from checkpoint-handler
-    pushes or concurrent agent activity — leaving the worktree behind its
-    remote and causing the non-fast-forward ``HEAD:refs/heads/{branch}``
-    push to be rejected (see #1706).
-
-    :func:`GatewayClient.push_worktree_branch` swallows push failures and
-    returns ``False``, so the caller cannot distinguish success from a
-    silent rejection by catching exceptions.  This helper checks the
-    return value directly and, on failure, performs ``git fetch origin``
-    plus ``git rebase origin/{branch}`` in the worktree to replay the
-    orchestrator's local housekeeping commits on top of the remote tip,
-    then retries the push once.
-
-    Rebase is preferred over merge here because the orchestrator's
-    local-only commits (BRC history, statefile commits) are small,
-    append-only housekeeping; rebasing them onto the remote tip avoids a
-    merge commit in the PR history and matches the manual rescue path
-    documented in #1731.
-
-    Rebase conflicts confined to ``.egg-state/agent-outputs/`` are
-    auto-resolved by taking the remote version — those paths hold
-    ephemeral coder→tester handoff artifacts that the tester has already
-    consumed, so the orchestrator's local copy is disposable.  Conflicts
-    in any other path are treated as a hard failure: the rebase is
-    aborted (so the worktree is left in a clean state) and ``False`` is
-    returned.
-
-    Returns ``True`` if the push ultimately succeeded, ``False`` otherwise.
-    On ``False``, callers can still open a PR against the current remote
-    HEAD — the agents' work is already on origin; only the orchestrator's
-    housekeeping commits are lost.
-    """
-    if spawner.gateway.push_worktree_branch(
-        pipeline_id=pipeline_id,
-        repo_path=str(worktree_path),
-        branch=branch,
-        mode=gateway_mode,
-    ):
-        return True
-
-    logger.warning(
-        "PR-phase push failed — attempting fetch+rebase+retry to reconcile divergence",
-        pipeline_id=pipeline_id,
-        branch=branch,
-    )
-
-    git_base = [
-        "git",
-        "-c",
-        "core.hooksPath=/dev/null",
-        "-c",
-        f"safe.directory={worktree_path}",
-        "-C",
-        str(worktree_path),
-    ]
-
-    try:
-        subprocess.run(
-            [*git_base, "fetch", "origin", branch],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=60,
-        )
-    except subprocess.CalledProcessError as fetch_err:
-        logger.error(
-            "PR-phase reconcile: fetch failed",
-            pipeline_id=pipeline_id,
-            branch=branch,
-            stderr=fetch_err.stderr,
-        )
-        return False
-    except subprocess.TimeoutExpired:
-        logger.error(
-            "PR-phase reconcile: fetch timed out",
-            pipeline_id=pipeline_id,
-            branch=branch,
-        )
-        return False
-
-    rebase_ok = _rebase_with_agent_output_autoresolve(
-        git_base=git_base,
-        pipeline_id=pipeline_id,
-        branch=branch,
-    )
-    if not rebase_ok:
-        return False
-
-    logger.info(
-        "PR-phase reconcile: rebase succeeded — retrying push",
-        pipeline_id=pipeline_id,
-        branch=branch,
-    )
-    retry_ok = spawner.gateway.push_worktree_branch(
-        pipeline_id=pipeline_id,
-        repo_path=str(worktree_path),
-        branch=branch,
-        mode=gateway_mode,
-    )
-    if not retry_ok:
-        logger.error(
-            "PR-phase reconcile: retry push still failed",
-            pipeline_id=pipeline_id,
-            branch=branch,
-        )
-    return retry_ok
-
-
-def _rebase_with_agent_output_autoresolve(
-    git_base: list[str],
-    pipeline_id: str,
-    branch: str,
-    max_autoresolve_iterations: int = 3,
-) -> bool:
-    """Rebase the worktree onto ``origin/{branch}`` with agent-outputs auto-resolve.
-
-    Called by :func:`_reconcile_and_push_pr_branch` after a successful fetch.
-    Conflicts confined to ``.egg-state/agent-outputs/`` are resolved in
-    favour of the remote (``git checkout --theirs``) and the rebase is
-    continued; conflicts anywhere else cause the rebase to be aborted and
-    ``False`` returned.
-
-    The auto-resolve loop is bounded by ``max_autoresolve_iterations`` to
-    defend against pathological cases where every replayed commit
-    re-introduces an agent-outputs conflict — three iterations is plenty
-    for a handful of housekeeping commits.
-
-    Returns ``True`` when the rebase finished cleanly (possibly after
-    auto-resolve), ``False`` on any other failure.
-    """
-    try:
-        rebase_result = subprocess.run(
-            [*git_base, "rebase", f"origin/{branch}"],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=120,
-        )
-    except subprocess.TimeoutExpired:
-        logger.error(
-            "PR-phase reconcile: rebase timed out — aborting",
-            pipeline_id=pipeline_id,
-            branch=branch,
-        )
-        _abort_rebase_best_effort(git_base, pipeline_id, branch)
-        return False
-
-    if rebase_result.returncode == 0:
-        return True
-
-    # Non-zero exit: rebase stopped on a conflict.  Inspect the unmerged
-    # paths and auto-resolve when they are all under agent-outputs.
-    for iteration in range(max_autoresolve_iterations):
-        unmerged_paths = _list_unmerged_paths(git_base)
-        if not unmerged_paths:
-            # Nothing unmerged but rebase didn't exit 0 — unusual state.
-            # Abort rather than guess.
-            logger.error(
-                "PR-phase reconcile: rebase stopped with no unmerged paths — aborting",
-                pipeline_id=pipeline_id,
-                branch=branch,
-                stdout=rebase_result.stdout,
-                stderr=rebase_result.stderr,
-            )
-            _abort_rebase_best_effort(git_base, pipeline_id, branch)
-            return False
-
-        non_ephemeral = [p for p in unmerged_paths if not p.startswith(".egg-state/agent-outputs/")]
-        if non_ephemeral:
-            logger.error(
-                "PR-phase reconcile: rebase failed — conflicts outside agent-outputs, aborting",
-                pipeline_id=pipeline_id,
-                branch=branch,
-                conflicting_paths=unmerged_paths,
-                stdout=rebase_result.stdout,
-                stderr=rebase_result.stderr,
-            )
-            _abort_rebase_best_effort(git_base, pipeline_id, branch)
-            return False
-
-        logger.warning(
-            "PR-phase reconcile: auto-resolving agent-outputs conflicts (taking remote)",
-            pipeline_id=pipeline_id,
-            branch=branch,
-            resolved_paths=unmerged_paths,
-            iteration=iteration + 1,
-        )
-        try:
-            subprocess.run(
-                [
-                    *git_base,
-                    "checkout",
-                    "--theirs",
-                    "--",
-                    ".egg-state/agent-outputs",
-                ],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=30,
-            )
-            # Add the resolved paths.  Some may have been deleted on
-            # ``--theirs`` — ``git add`` handles that via --all on the path.
-            subprocess.run(
-                [*git_base, "add", "--all", "--", ".egg-state/agent-outputs"],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=30,
-            )
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as resolve_err:
-            logger.error(
-                "PR-phase reconcile: auto-resolve failed — aborting rebase",
-                pipeline_id=pipeline_id,
-                branch=branch,
-                error=str(resolve_err),
-            )
-            _abort_rebase_best_effort(git_base, pipeline_id, branch)
-            return False
-
-        # Re-check: if resolution cleared the index and there's nothing
-        # new to commit for this rebase step, ``--continue`` would error
-        # with "No changes - did you forget to use 'git add'?".  Use
-        # ``--skip`` in that case.
-        diff_result = subprocess.run(
-            [*git_base, "diff", "--cached", "--quiet"],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=30,
-        )
-        continue_cmd = "--skip" if diff_result.returncode == 0 else "--continue"
-
-        # GIT_EDITOR=true is only needed for --continue (suppresses editor
-        # prompt); --skip never opens an editor.  Avoid copying os.environ
-        # when unnecessary — it's mutable global state and the dict snapshot
-        # could race with background threads (e.g. _health_monitor_poll).
-        env = {**os.environ, "GIT_EDITOR": "true"} if continue_cmd == "--continue" else None
-        try:
-            rebase_result = subprocess.run(
-                [*git_base, "rebase", continue_cmd],
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=120,
-                env=env,
-            )
-        except subprocess.TimeoutExpired:
-            logger.error(
-                "PR-phase reconcile: rebase --continue timed out — aborting",
-                pipeline_id=pipeline_id,
-                branch=branch,
-            )
-            _abort_rebase_best_effort(git_base, pipeline_id, branch)
-            return False
-
-        if rebase_result.returncode == 0:
-            return True
-        # Loop: rebase stopped again, inspect unmerged paths next iteration.
-
-    logger.error(
-        "PR-phase reconcile: rebase auto-resolve exceeded iteration limit — aborting",
-        pipeline_id=pipeline_id,
-        branch=branch,
-        max_iterations=max_autoresolve_iterations,
-    )
-    _abort_rebase_best_effort(git_base, pipeline_id, branch)
-    return False
-
-
-def _list_unmerged_paths(git_base: list[str]) -> list[str]:
-    """Return the set of paths currently in a conflicted state in the worktree.
-
-    Returns an empty list when the query itself fails — callers should be
-    aware that ``[]`` can mean either "no conflicts" or "query failed".
-    """
-    result = subprocess.run(
-        [*git_base, "diff", "--name-only", "--diff-filter=U"],
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=30,
-    )
-    if result.returncode != 0:
-        logger.warning(
-            "_list_unmerged_paths: git diff --diff-filter=U failed",
-            returncode=result.returncode,
-            stderr=result.stderr,
-        )
-        return []
-    return [line for line in result.stdout.splitlines() if line.strip()]
-
-
-def _abort_rebase_best_effort(
-    git_base: list[str],
-    pipeline_id: str,
-    branch: str,
-) -> None:
-    """Run ``git rebase --abort`` and swallow any failure (worktree is junk anyway)."""
-    try:
-        subprocess.run(
-            [*git_base, "rebase", "--abort"],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=30,
-        )
-    except Exception:
-        logger.warning(
-            "PR-phase reconcile: rebase --abort also failed",
-            pipeline_id=pipeline_id,
-            branch=branch,
-        )
 
 
 def _msg_version(m: Any) -> int:
@@ -9924,8 +9599,8 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
 
                 # Push latest commits before creating PR.  If the push fails
                 # (e.g. the remote advanced while the PR-phase worktree was
-                # adding BRC commits), reconcile via fetch+rebase and
-                # retry once — see _reconcile_and_push_pr_branch and #1706/#1731.
+                # adding BRC commits), push_worktree_branch reconciles via
+                # fetch+rebase and retries once internally (#1706/#1731/#1808).
                 # Babysit-pr with a tripped head-move guard skips the push
                 # entirely to preserve the existing PR state (#1748).
                 push_ok = True
@@ -9956,12 +9631,11 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                     except Exception:
                         commits_ahead = "unknown"
 
-                    push_ok = _reconcile_and_push_pr_branch(
-                        spawner,
-                        worktree_repo_path,
-                        pipeline_id,
-                        pipeline.branch,
-                        gateway_mode,
+                    push_ok = spawner.gateway.push_worktree_branch(
+                        pipeline_id=pipeline_id,
+                        repo_path=str(worktree_repo_path),
+                        branch=pipeline.branch,
+                        mode=gateway_mode,
                     )
                     if push_ok:
                         logger.info(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9126,27 +9126,21 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                             )
                 if worktree_repo_path != repo_path:
                     push_err_msg = ""
-                    for attempt in range(2):
-                        try:
-                            push_succeeded = spawner.gateway.push_worktree_branch(
-                                pipeline_id=pipeline_id,
-                                repo_path=str(worktree_repo_path),
-                                branch=push_branch,
-                                mode=gateway_mode,
-                            )
-                            if push_succeeded:
-                                break
+                    # push_worktree_branch reconciles non-fast-forward
+                    # rejections internally (fetch+rebase+retry), so a
+                    # single call is sufficient — no outer retry needed.
+                    try:
+                        push_succeeded = spawner.gateway.push_worktree_branch(
+                            pipeline_id=pipeline_id,
+                            repo_path=str(worktree_repo_path),
+                            branch=push_branch,
+                            mode=gateway_mode,
+                        )
+                        if not push_succeeded:
                             push_err_msg = "push_worktree_branch returned False"
-                        except Exception as push_err:
-                            push_succeeded = False
-                            push_err_msg = str(push_err)
-                        if attempt == 0 and not push_succeeded:
-                            logger.warning(
-                                "Contract init push failed, retrying",
-                                pipeline_id=pipeline_id,
-                                error=push_err_msg,
-                            )
-                            time.sleep(2)
+                    except Exception as push_err:
+                        push_succeeded = False
+                        push_err_msg = str(push_err)
 
                     if not push_succeeded:
                         logger.error(

--- a/orchestrator/state_store.py
+++ b/orchestrator/state_store.py
@@ -652,7 +652,13 @@ class StateStore:
     def sync_to_remote(self) -> bool:
         """Push the state branch to remote (best-effort).
 
-        Uses the gateway client to push via a temporary session.
+        Pushes the state branch ref from the main repo's object DB, not
+        from the state worktree. The state worktree lives under
+        ``/home/egg/.egg-state/`` which is a pod-local ``emptyDir`` —
+        the gateway pod cannot ``cd`` into it. The main repo under
+        ``/home/egg/repos/`` is a shared hostPath that both pods see,
+        and the state branch's commits and ref live in its ``.git/``
+        object DB, so the push only needs the main repo path (see #1808).
 
         Returns:
             True on success, False on failure (logged, never raises)
@@ -663,9 +669,10 @@ class StateStore:
             client = get_gateway_client()
             return client.push_worktree_branch(
                 pipeline_id="state-sync",
-                repo_path=str(self.worktree),
+                repo_path=str(self.repo_path),
                 branch=STATE_BRANCH,
                 mode=self._detect_gateway_mode(),
+                ref=STATE_BRANCH,
             )
         except Exception as e:
             logger.warning(

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -772,6 +772,33 @@ class TestPushWorktreeBranch:
             push_data = push_calls[0].kwargs["data"]
             assert push_data["refspec"] == "HEAD:refs/heads/egg/issue-42"
 
+    def test_push_worktree_branch_ref_param_uses_branch_refspec(
+        self, gateway_client, mock_gateway_server
+    ):
+        """Test that ``ref=`` produces refs/heads/<ref>:refs/heads/<branch>.
+
+        Used for state-sync pushes (#1808): the gateway ``cd``s into the
+        main repo (shared hostPath) and pushes the state branch ref from
+        the shared ``.git/`` object DB, since the state worktree itself
+        lives in a pod-local unshared volume.
+        """
+        with patch.object(
+            gateway_client, "_make_request", wraps=gateway_client._make_request
+        ) as mock_req:
+            gateway_client.push_worktree_branch(
+                pipeline_id="state-sync",
+                repo_path="/home/egg/repos/myrepo",
+                branch="egg/pipeline-state",
+                ref="egg/pipeline-state",
+            )
+            push_calls = [c for c in mock_req.call_args_list if c.args[0] == "/api/v1/git/push"]
+            assert len(push_calls) == 1
+            push_data = push_calls[0].kwargs["data"]
+            assert (
+                push_data["refspec"]
+                == "refs/heads/egg/pipeline-state:refs/heads/egg/pipeline-state"
+            )
+
 
 class TestDeleteRemoteBranch:
     """Tests for delete_remote_branch method."""

--- a/orchestrator/tests/test_pipeline_failure_path.py
+++ b/orchestrator/tests/test_pipeline_failure_path.py
@@ -698,7 +698,7 @@ class TestContractPushHardGate:
     @patch(_COMMON_PATCHES[2])
     @patch(_COMMON_PATCHES[1])
     @patch(_COMMON_PATCHES[0])
-    def test_pipeline_fails_when_contract_push_fails_after_retry(
+    def test_pipeline_fails_when_contract_push_fails(
         self,
         mock_emit,
         mock_get_spawner,
@@ -711,7 +711,7 @@ class TestContractPushHardGate:
         mock_commit_statefiles,
         mock_auto_create_pr,
     ):
-        """When push_worktree_branch fails twice (initial + retry), the pipeline
+        """When push_worktree_branch fails (reconcile is internal), the pipeline
         should be marked FAILED and no agents should be spawned."""
         from routes.pipelines import WORKTREE_BASE_DIR, _run_pipeline
 
@@ -770,11 +770,12 @@ class TestContractPushHardGate:
             "Pipeline should be marked FAILED when contract push fails after retry"
         )
 
-        # push_worktree_branch should be called twice (initial + retry).
+        # push_worktree_branch is called once — reconcile (fetch+rebase+retry)
+        # is now internal to the client, so no outer retry loop.
         # Stale draft cleanup does not push (no drafts dir in test worktree).
         push_calls = mock_gateway.push_worktree_branch.call_args_list
-        assert len(push_calls) == 2, (
-            f"Expected 2 push attempts (initial + retry), got {len(push_calls)}"
+        assert len(push_calls) == 1, (
+            f"Expected 1 push attempt (reconcile is internal), got {len(push_calls)}"
         )
 
         # No agents should be spawned after push failure
@@ -790,7 +791,7 @@ class TestContractPushHardGate:
     @patch(_COMMON_PATCHES[2])
     @patch(_COMMON_PATCHES[1])
     @patch(_COMMON_PATCHES[0])
-    def test_pipeline_continues_when_contract_push_succeeds_on_retry(
+    def test_pipeline_continues_when_contract_push_succeeds(
         self,
         mock_emit,
         mock_get_spawner,
@@ -803,7 +804,7 @@ class TestContractPushHardGate:
         mock_commit_statefiles,
         mock_auto_create_pr,
     ):
-        """When push fails first but succeeds on retry, the pipeline should continue."""
+        """When push succeeds (possibly via internal reconcile), the pipeline continues."""
         from routes.pipelines import WORKTREE_BASE_DIR, _run_pipeline
 
         pipeline = Pipeline(
@@ -833,8 +834,8 @@ class TestContractPushHardGate:
             pipeline,
         )
 
-        # Fail first, succeed on retry
-        mock_gateway.push_worktree_branch.side_effect = [False, True]
+        # Succeed (reconcile is internal to push_worktree_branch)
+        mock_gateway.push_worktree_branch.return_value = True
         mock_spawn_wait.return_value = (0, "success")
 
         worktree_dir = WORKTREE_BASE_DIR / "issue-42" / "repo"

--- a/orchestrator/tests/test_pipeline_failure_path.py
+++ b/orchestrator/tests/test_pipeline_failure_path.py
@@ -742,7 +742,7 @@ class TestContractPushHardGate:
             pipeline,
         )
 
-        # Make push fail both times (initial + retry)
+        # Make push fail (reconcile is internal to push_worktree_branch)
         mock_gateway.push_worktree_branch.return_value = False
 
         worktree_dir = WORKTREE_BASE_DIR / "issue-42" / "repo"

--- a/orchestrator/tests/test_reconcile_and_push_pr_branch.py
+++ b/orchestrator/tests/test_reconcile_and_push_pr_branch.py
@@ -1,9 +1,14 @@
 """
-Tests for ``_reconcile_and_push_pr_branch``.
+Tests for the reconcile-on-failure path inside ``push_worktree_branch``.
 
-Covers the PR-phase push reconciliation path (originally added for #1706,
-rewritten for #1731 to prefer rebase over merge and to auto-resolve
-conflicts under ``.egg-state/agent-outputs/`` by taking the remote side):
+Reconcile was originally a wrapper (``_reconcile_and_push_pr_branch``)
+around the gateway client push; it was folded into
+``GatewayClient.push_worktree_branch`` itself in #1808 so every push
+call site gets the same fetch+rebase+retry behavior without a wrapper.
+
+Cases covered (originally added for #1706, rewritten for #1731 to
+prefer rebase over merge and to auto-resolve conflicts under
+``.egg-state/agent-outputs/`` by taking the remote side):
 
 - First push attempt succeeds → return True, no fetch/rebase attempted.
 - First push fails → fetch+rebase+retry path engaged.
@@ -12,10 +17,14 @@ conflicts under ``.egg-state/agent-outputs/`` by taking the remote side):
 - Rebase conflict only under .egg-state/agent-outputs/ → auto-resolve and continue.
 - Rebase timeout → rebase --abort, return False.
 - Rebase succeeds but retry push still fails → return False.
+- ``ref`` set (state-sync style, #1808): no reconcile — rebase is only
+  meaningful when ``repo_path`` is a worktree checked out to the branch.
 """
 
 import subprocess
 from unittest.mock import MagicMock, patch
+
+from gateway_client import GatewayClient
 
 
 def _run_result(returncode=0, stdout="", stderr=""):
@@ -27,44 +36,47 @@ def _run_result(returncode=0, stdout="", stderr=""):
     return result
 
 
-def _make_spawner(push_results):
-    """Return a spawner whose ``gateway.push_worktree_branch`` yields ``push_results`` in order."""
-    spawner = MagicMock()
-    spawner.gateway.push_worktree_branch.side_effect = list(push_results)
-    return spawner
+def _make_client(push_results):
+    """Return a GatewayClient whose ``_do_push`` yields ``push_results`` in order."""
+    client = GatewayClient(
+        gateway_host="test-gateway",
+        gateway_port=9848,  # noqa: EGG002
+        launcher_secret="test-secret",
+    )
+    client._do_push = MagicMock(side_effect=list(push_results))
+    return client
 
 
-class TestReconcileAndPushPrBranch:
+class TestPushWorktreeBranchReconcile:
     def test_first_push_success_skips_fetch_and_rebase(self, tmp_path):
         """When the initial push succeeds, no git subprocess calls happen."""
-        from routes.pipelines import _reconcile_and_push_pr_branch
-
-        spawner = _make_spawner([True])
-        with patch("routes.pipelines.subprocess.run") as mock_run:
-            ok = _reconcile_and_push_pr_branch(
-                spawner, tmp_path, "issue-42", "egg/feature", "public"
+        client = _make_client([True])
+        with patch("gateway_client.subprocess.run") as mock_run:
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-42",
+                repo_path=str(tmp_path),
+                branch="egg/feature",
             )
 
         assert ok is True
-        assert spawner.gateway.push_worktree_branch.call_count == 1
+        assert client._do_push.call_count == 1
         mock_run.assert_not_called()
 
     def test_push_fail_then_fetch_rebase_retry_succeeds(self, tmp_path):
         """On initial failure: fetch, rebase, retry; all succeed → True."""
-        from routes.pipelines import _reconcile_and_push_pr_branch
-
-        spawner = _make_spawner([False, True])
-        # Two subprocess.run calls expected: fetch, rebase (clean — rc=0).
+        client = _make_client([False, True])
         with patch(
-            "routes.pipelines.subprocess.run",
+            "gateway_client.subprocess.run",
             side_effect=[_run_result(), _run_result()],
         ) as mock_run:
-            ok = _reconcile_and_push_pr_branch(
-                spawner, tmp_path, "issue-42", "egg/feature", "public"
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-42",
+                repo_path=str(tmp_path),
+                branch="egg/feature",
             )
 
         assert ok is True
-        assert spawner.gateway.push_worktree_branch.call_count == 2
+        assert client._do_push.call_count == 2
         assert mock_run.call_count == 2
         fetch_cmd = mock_run.call_args_list[0].args[0]
         rebase_cmd = mock_run.call_args_list[1].args[0]
@@ -73,9 +85,7 @@ class TestReconcileAndPushPrBranch:
 
     def test_push_fail_then_fetch_fails_gives_up(self, tmp_path):
         """If fetch itself fails, rebase is not attempted and result is False."""
-        from routes.pipelines import _reconcile_and_push_pr_branch
-
-        spawner = _make_spawner([False])
+        client = _make_client([False])
 
         def _run_side_effect(cmd, *args, **kwargs):
             if "fetch" in cmd:
@@ -84,23 +94,21 @@ class TestReconcileAndPushPrBranch:
                 )
             raise AssertionError(f"Unexpected subprocess invocation: {cmd}")
 
-        with patch("routes.pipelines.subprocess.run", side_effect=_run_side_effect):
-            ok = _reconcile_and_push_pr_branch(
-                spawner, tmp_path, "issue-42", "egg/feature", "public"
+        with patch("gateway_client.subprocess.run", side_effect=_run_side_effect):
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-42",
+                repo_path=str(tmp_path),
+                branch="egg/feature",
             )
 
         assert ok is False
-        assert spawner.gateway.push_worktree_branch.call_count == 1
+        assert client._do_push.call_count == 1
 
     def test_rebase_conflict_outside_agent_outputs_aborts(self, tmp_path):
         """Conflict in a non-ephemeral path triggers ``git rebase --abort`` and returns False."""
-        from routes.pipelines import _reconcile_and_push_pr_branch
-
-        spawner = _make_spawner([False])
-        # fetch ok, rebase returns non-zero, diff --name-only returns a code path,
-        # rebase --abort ok
+        client = _make_client([False])
         with patch(
-            "routes.pipelines.subprocess.run",
+            "gateway_client.subprocess.run",
             side_effect=[
                 _run_result(),  # fetch
                 _run_result(returncode=1, stdout="CONFLICT"),  # rebase (conflict)
@@ -108,28 +116,22 @@ class TestReconcileAndPushPrBranch:
                 _run_result(),  # rebase --abort
             ],
         ) as mock_run:
-            ok = _reconcile_and_push_pr_branch(
-                spawner, tmp_path, "issue-42", "egg/feature", "public"
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-42",
+                repo_path=str(tmp_path),
+                branch="egg/feature",
             )
 
         assert ok is False
-        # No retry push after a failed rebase
-        assert spawner.gateway.push_worktree_branch.call_count == 1
-        # Last subprocess call must be `git rebase --abort`
+        assert client._do_push.call_count == 1
         abort_cmd = mock_run.call_args_list[-1].args[0]
         assert "rebase" in abort_cmd and "--abort" in abort_cmd
 
     def test_rebase_conflict_only_in_agent_outputs_auto_resolves(self, tmp_path):
         """Conflicts confined to .egg-state/agent-outputs/ auto-resolve to remote side."""
-        from routes.pipelines import _reconcile_and_push_pr_branch
-
-        spawner = _make_spawner([False, True])  # first push fails, retry push ok
-        # Sequence:
-        #   fetch ok → rebase (conflict) → diff --name-only (agent-outputs only)
-        #   → checkout --theirs → add → diff --cached --quiet (index has changes: rc=1)
-        #   → rebase --continue (clean — rc=0) → retry push ok
+        client = _make_client([False, True])
         with patch(
-            "routes.pipelines.subprocess.run",
+            "gateway_client.subprocess.run",
             side_effect=[
                 _run_result(),  # fetch
                 _run_result(returncode=1, stdout="CONFLICT"),  # rebase
@@ -142,13 +144,14 @@ class TestReconcileAndPushPrBranch:
                 _run_result(),  # rebase --continue (success)
             ],
         ) as mock_run:
-            ok = _reconcile_and_push_pr_branch(
-                spawner, tmp_path, "issue-42", "egg/feature", "public"
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-42",
+                repo_path=str(tmp_path),
+                branch="egg/feature",
             )
 
         assert ok is True
-        assert spawner.gateway.push_worktree_branch.call_count == 2
-        # Assert we called checkout --theirs and rebase --continue
+        assert client._do_push.call_count == 2
         all_cmds = [c.args[0] for c in mock_run.call_args_list]
         assert any("checkout" in c and "--theirs" in c for c in all_cmds)
         assert any("rebase" in c and "--continue" in c for c in all_cmds)
@@ -158,11 +161,9 @@ class TestReconcileAndPushPrBranch:
         empty, ``git rebase --skip`` is used instead of ``--continue`` to avoid
         the 'No changes - did you forget to use git add?' error.
         """
-        from routes.pipelines import _reconcile_and_push_pr_branch
-
-        spawner = _make_spawner([False, True])
+        client = _make_client([False, True])
         with patch(
-            "routes.pipelines.subprocess.run",
+            "gateway_client.subprocess.run",
             side_effect=[
                 _run_result(),  # fetch
                 _run_result(returncode=1, stdout="CONFLICT"),  # rebase
@@ -173,23 +174,22 @@ class TestReconcileAndPushPrBranch:
                 _run_result(),  # rebase --skip (success)
             ],
         ) as mock_run:
-            ok = _reconcile_and_push_pr_branch(
-                spawner, tmp_path, "issue-42", "egg/feature", "public"
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-42",
+                repo_path=str(tmp_path),
+                branch="egg/feature",
             )
 
         assert ok is True
-        # Assert we chose --skip over --continue
         all_cmds = [c.args[0] for c in mock_run.call_args_list]
         assert any("rebase" in c and "--skip" in c for c in all_cmds)
         assert not any("rebase" in c and "--continue" in c for c in all_cmds)
 
     def test_rebase_mixed_conflict_aborts(self, tmp_path):
         """A conflict list that includes any non-agent-outputs path aborts the rebase."""
-        from routes.pipelines import _reconcile_and_push_pr_branch
-
-        spawner = _make_spawner([False])
+        client = _make_client([False])
         with patch(
-            "routes.pipelines.subprocess.run",
+            "gateway_client.subprocess.run",
             side_effect=[
                 _run_result(),  # fetch
                 _run_result(returncode=1, stdout="CONFLICT"),  # rebase
@@ -199,13 +199,13 @@ class TestReconcileAndPushPrBranch:
                 _run_result(),  # rebase --abort
             ],
         ) as mock_run:
-            ok = _reconcile_and_push_pr_branch(
-                spawner, tmp_path, "issue-42", "egg/feature", "public"
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-42",
+                repo_path=str(tmp_path),
+                branch="egg/feature",
             )
 
         assert ok is False
-        # We should NOT have invoked checkout --theirs — that path is reserved
-        # for the agent-outputs-only case.
         all_cmds = [c.args[0] for c in mock_run.call_args_list]
         assert not any("checkout" in c and "--theirs" in c for c in all_cmds)
         abort_cmd = mock_run.call_args_list[-1].args[0]
@@ -213,9 +213,7 @@ class TestReconcileAndPushPrBranch:
 
     def test_rebase_timeout_aborts(self, tmp_path):
         """Rebase TimeoutExpired triggers ``git rebase --abort`` and returns False."""
-        from routes.pipelines import _reconcile_and_push_pr_branch
-
-        spawner = _make_spawner([False])
+        client = _make_client([False])
 
         call_count = 0
 
@@ -228,42 +226,50 @@ class TestReconcileAndPushPrBranch:
                 raise subprocess.TimeoutExpired(cmd=cmd, timeout=120)  # rebase times out
             return _run_result()  # rebase --abort
 
-        with patch("routes.pipelines.subprocess.run", side_effect=_run_side_effect) as mock_run:
-            ok = _reconcile_and_push_pr_branch(
-                spawner, tmp_path, "issue-42", "egg/feature", "public"
+        with patch("gateway_client.subprocess.run", side_effect=_run_side_effect) as mock_run:
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-42",
+                repo_path=str(tmp_path),
+                branch="egg/feature",
             )
 
         assert ok is False
-        assert spawner.gateway.push_worktree_branch.call_count == 1
+        assert client._do_push.call_count == 1
         abort_cmd = mock_run.call_args_list[-1].args[0]
         assert "rebase" in abort_cmd and "--abort" in abort_cmd
 
     def test_rebase_succeeds_retry_fails(self, tmp_path):
         """Successful reconcile but still-failing retry push returns False."""
-        from routes.pipelines import _reconcile_and_push_pr_branch
-
-        spawner = _make_spawner([False, False])
+        client = _make_client([False, False])
         with patch(
-            "routes.pipelines.subprocess.run",
+            "gateway_client.subprocess.run",
             side_effect=[_run_result(), _run_result()],  # fetch, rebase
         ):
-            ok = _reconcile_and_push_pr_branch(
-                spawner, tmp_path, "issue-42", "egg/feature", "public"
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-42",
+                repo_path=str(tmp_path),
+                branch="egg/feature",
             )
 
         assert ok is False
-        assert spawner.gateway.push_worktree_branch.call_count == 2
+        assert client._do_push.call_count == 2
 
-    def test_worktree_path_passed_to_gateway_push(self, tmp_path):
-        """The worktree path is threaded through to push_worktree_branch."""
-        from routes.pipelines import _reconcile_and_push_pr_branch
+    def test_ref_push_skips_reconcile(self, tmp_path):
+        """When ``ref`` is set (state-sync style), reconcile is skipped.
 
-        worktree = tmp_path / "my-worktree"
-        spawner = _make_spawner([True])
-        _reconcile_and_push_pr_branch(spawner, worktree, "issue-42", "egg/feature", "private")
+        The rebase would mutate the checkout at repo_path, which for a
+        ``ref``-based push is not a dedicated pipeline worktree but a
+        shared repo whose checkout we must not disturb (see #1808).
+        """
+        client = _make_client([False])
+        with patch("gateway_client.subprocess.run") as mock_run:
+            ok = client.push_worktree_branch(
+                pipeline_id="state-sync",
+                repo_path=str(tmp_path),
+                branch="egg/pipeline-state",
+                ref="egg/pipeline-state",
+            )
 
-        call = spawner.gateway.push_worktree_branch.call_args
-        assert call.kwargs["repo_path"] == str(worktree)
-        assert call.kwargs["pipeline_id"] == "issue-42"
-        assert call.kwargs["branch"] == "egg/feature"
-        assert call.kwargs["mode"] == "private"
+        assert ok is False
+        assert client._do_push.call_count == 1
+        mock_run.assert_not_called()

--- a/orchestrator/tests/test_state_store.py
+++ b/orchestrator/tests/test_state_store.py
@@ -1164,7 +1164,12 @@ class TestRemoteSync:
     """Tests for remote sync (push/restore) of the state branch."""
 
     def test_sync_to_remote_calls_gateway_client(self, state_store):
-        """sync_to_remote calls push_worktree_branch on the gateway client."""
+        """sync_to_remote calls push_worktree_branch on the gateway client.
+
+        Regression for #1808: must push via the main repo path (shared
+        hostPath) with an explicit ``ref``, not the state worktree path
+        which lives in the orchestrator pod's unshared emptyDir.
+        """
         mock_client = MagicMock()
         mock_client.push_worktree_branch.return_value = True
 
@@ -1175,9 +1180,10 @@ class TestRemoteSync:
         assert result is True
         mock_client.push_worktree_branch.assert_called_once_with(
             pipeline_id="state-sync",
-            repo_path=str(state_store.worktree),
+            repo_path=str(state_store.repo_path),
             branch="egg/pipeline-state",
             mode="public",
+            ref="egg/pipeline-state",
         )
 
     def test_sync_to_remote_returns_false_on_failure(self, state_store):


### PR DESCRIPTION
## Summary

Two independent "Best-effort push failed" modes were leaking from every pipeline run, both caused by gaps in `push_worktree_branch`:

- **Mode A (state-sync missing dir)**: `StateStore.sync_to_remote` passed `repo_path=str(self.worktree)` pointing at `/home/egg/.egg-state/pipeline-worktree` — a pod-local `emptyDir` that exists on the orchestrator but not on the gateway pod. Every state-sync tick failed ENOENT in the gateway.
- **Mode B (non-fast-forward rejects)**: only the PR-phase push site reconciled via `_reconcile_and_push_pr_branch`; the other ~6 call sites sent a plain push and stranded work when the remote had advanced.

## Fix

- **Mode A** — push via the main repo path (shared hostPath) using an explicit `ref=STATE_BRANCH`. The state branch's commits and ref live in the shared `.git/` object DB, so no working tree at `repo_path` is needed. `push_worktree_branch` gains an optional `ref` param that produces `refs/heads/{ref}:refs/heads/{branch}` instead of `HEAD:refs/heads/{branch}`.
- **Mode B** — fold the reconcile into `push_worktree_branch` itself so every call site gets fetch+rebase+retry (with `.egg-state/agent-outputs/` auto-resolve) for free. The wrapper is deleted and its sole caller now invokes `push_worktree_branch` directly. Reconcile is skipped when `ref` is set (state-sync style) since the rebase would mutate a checkout we don't own.
- **Logging** — first-attempt failure is INFO (reconcile may recover); unrecoverable failures log WARNING/ERROR with detail. Addresses issue acceptance criterion 3.

## Test plan

- [x] All 10 reconcile tests (migrated to target `push_worktree_branch` directly) pass.
- [x] `test_gateway_client.py` — existing push tests pass; new test for `ref=` refspec added.
- [x] `test_state_store.py` — `sync_to_remote` now asserts `repo_path=self.repo_path`, `ref=STATE_BRANCH`.
- [x] Full orchestrator test suite: 3886 passed, 1 skipped.
- [ ] Verify in staging: fresh pipeline run produces zero "Best-effort push failed" warnings from state-sync; non-fast-forward rejection on a pipeline branch is reconciled silently.

Closes #1808

🤖 Generated with [Claude Code](https://claude.com/claude-code)