### PR TITLE
Fix #1811: retarget egg-orch push to assigned branch from work branch

### DIFF
--- a/docs/guides/agent-development.md
+++ b/docs/guides/agent-development.md
@@ -233,7 +233,7 @@ The `egg-orch push --scope-filter` command automatically strips out-of-scope fil
 3. Filters files using the same `allowed`/`blocked`/`block_exempt` logic as the gateway
 4. Squashes filtered commits into one and pushes
 
-Without `--scope-filter`, `egg-orch push` passes through to `git push` unchanged.
+Without `--scope-filter`, `egg-orch push` passes through to `git push`. When `EGG_BRANCH` is set (pipeline sessions) and the current branch is the per-agent work branch, the push is retargeted to `HEAD:$EGG_BRANCH` so the refspec's target matches the gateway's assigned-branch check.
 
 See `sandbox/agent-config/rules/push-recovery.md` for step-by-step recovery instructions available to agents at runtime.
 

--- a/sandbox/egg_lib/cli_push.py
+++ b/sandbox/egg_lib/cli_push.py
@@ -131,11 +131,35 @@ def _get_merge_base(branch: str) -> str:
     return "HEAD~1"
 
 
+def _resolve_push_args(current_branch: str) -> list[str]:
+    """Build ``git push`` args, retargeting to the assigned pipeline branch.
+
+    Pipeline agents run on per-agent work branches (``egg/<pid>-<role>/work``)
+    but the gateway locks the session to the pipeline's assigned branch
+    (``egg/<pid>``). A plain ``git push origin <work-branch>`` produces a
+    ``work:work`` refspec the gateway always rejects. When ``EGG_BRANCH`` is
+    set and differs from the current branch, push ``HEAD:$EGG_BRANCH`` so the
+    target matches the assigned branch.
+    """
+    assigned = os.environ.get("EGG_BRANCH", "").strip()
+    if assigned and assigned != current_branch:
+        return ["git", "push", "origin", f"HEAD:{assigned}"]
+    return ["git", "push", "origin", current_branch]
+
+
 def cmd_push(args: argparse.Namespace) -> None:
     """Handle the push subcommand."""
 
-    # Without --scope-filter, just passthrough to git push.
+    # Without --scope-filter, just passthrough to git push, but retarget the
+    # refspec to the assigned pipeline branch when running on a per-agent
+    # work branch.
     if not args.scope_filter:
+        assigned = os.environ.get("EGG_BRANCH", "").strip()
+        if assigned:
+            current = _get_current_branch()
+            if current and current != assigned:
+                result = subprocess.run(["git", "push", "origin", f"HEAD:{assigned}"], text=True)
+                sys.exit(result.returncode)
         result = subprocess.run(["git", "push"], text=True)
         sys.exit(result.returncode)
 
@@ -192,7 +216,7 @@ def cmd_push(args: argparse.Namespace) -> None:
 
     # If nothing was removed, push as-is — no rewriting needed.
     if not removed:
-        result = subprocess.run(["git", "push", "origin", branch], text=True)
+        result = subprocess.run(_resolve_push_args(branch), text=True)
         sys.exit(result.returncode)
 
     # Some files removed — inform the user and rewrite the commits.
@@ -239,7 +263,7 @@ def cmd_push(args: argparse.Namespace) -> None:
 
     # Step 5: push.
     push_result = subprocess.run(
-        ["git", "push", "origin", branch],
+        _resolve_push_args(branch),
         text=True,
     )
     if push_result.returncode != 0 and orig_head:

--- a/sandbox/egg_lib/cli_push.py
+++ b/sandbox/egg_lib/cli_push.py
@@ -127,23 +127,45 @@ def _get_merge_base(branch: str) -> str:
     if mb_result.returncode == 0:
         return mb_result.stdout.strip()
 
+    # Fallback: on work branches, try origin/$EGG_BRANCH (the assigned
+    # pipeline branch) — the work branch won't exist on the remote but
+    # the assigned branch will.
+    assigned = os.environ.get("EGG_BRANCH", "").strip()
+    if assigned and assigned != branch:
+        mb_result = subprocess.run(
+            ["git", "merge-base", f"origin/{assigned}", "HEAD"],
+            capture_output=True,
+            text=True,
+        )
+        if mb_result.returncode == 0:
+            return mb_result.stdout.strip()
+
     # Last resort: single commit
     return "HEAD~1"
 
 
-def _resolve_push_args(current_branch: str) -> list[str]:
-    """Build ``git push`` args, retargeting to the assigned pipeline branch.
+def _retarget_refspec(current_branch: str) -> str | None:
+    """Return ``HEAD:<assigned>`` when the push must target the pipeline's assigned branch.
 
     Pipeline agents run on per-agent work branches (``egg/<pid>-<role>/work``)
     but the gateway locks the session to the pipeline's assigned branch
-    (``egg/<pid>``). A plain ``git push origin <work-branch>`` produces a
-    ``work:work`` refspec the gateway always rejects. When ``EGG_BRANCH`` is
-    set and differs from the current branch, push ``HEAD:$EGG_BRANCH`` so the
-    target matches the assigned branch.
+    (``egg/<pid>``).  When ``EGG_BRANCH`` is set and differs from
+    *current_branch*, the push must use ``HEAD:<assigned>`` so the refspec
+    target matches the gateway's push-target check.
+
+    Returns ``None`` when no retargeting is needed.
     """
     assigned = os.environ.get("EGG_BRANCH", "").strip()
     if assigned and assigned != current_branch:
-        return ["git", "push", "origin", f"HEAD:{assigned}"]
+        return f"HEAD:{assigned}"
+    return None
+
+
+def _resolve_push_args(current_branch: str) -> list[str]:
+    """Build ``git push`` args, retargeting to the assigned pipeline branch."""
+    refspec = _retarget_refspec(current_branch)
+    if refspec:
+        return ["git", "push", "origin", refspec]
     return ["git", "push", "origin", current_branch]
 
 
@@ -154,13 +176,11 @@ def cmd_push(args: argparse.Namespace) -> None:
     # refspec to the assigned pipeline branch when running on a per-agent
     # work branch.
     if not args.scope_filter:
-        assigned = os.environ.get("EGG_BRANCH", "").strip()
-        if assigned:
-            current = _get_current_branch()
-            if current and current != assigned:
-                result = subprocess.run(["git", "push", "origin", f"HEAD:{assigned}"], text=True)
-                sys.exit(result.returncode)
-        result = subprocess.run(["git", "push"], text=True)
+        refspec = _retarget_refspec(_get_current_branch())
+        if refspec:
+            result = subprocess.run(["git", "push", "origin", refspec], text=True)
+        else:
+            result = subprocess.run(["git", "push"], text=True)
         sys.exit(result.returncode)
 
     # --scope-filter requires EGG_AGENT_FILE_PATTERNS

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -63,6 +63,8 @@ except ImportError:
     ORCHESTRATOR_PORT = 9849  # noqa: EGG002
     GATEWAY_PORT = 9848  # noqa: EGG002
 
+from egg_lib.cli_push import _retarget_refspec
+
 # Validation pattern for IDs used in URL path segments
 _SAFE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_\-\.]+$")
 
@@ -1225,14 +1227,11 @@ def _consensus_push() -> int:
         print("Error: could not determine current branch for push", file=sys.stderr)
         return 1
 
-    # Pipeline agents run on per-agent work branches (egg/<pid>-<role>/work)
-    # but the gateway locks the session to the pipeline's assigned branch
-    # (egg/<pid>). When EGG_BRANCH is set and differs from the current
-    # branch, target the assigned branch explicitly so the refspec's target
-    # side matches what the gateway's push-target check expects.
-    assigned = os.environ.get("EGG_BRANCH", "").strip()
-    if assigned and assigned != branch:
-        refspec = f"HEAD:{assigned}"
+    # Retarget to the assigned pipeline branch when on a per-agent work
+    # branch (shared logic with cli_push).
+    retarget = _retarget_refspec(branch)
+    if retarget:
+        refspec = retarget
     else:
         # Resolve the remote tracking refspec (e.g. local:remote)
         try:

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -1225,19 +1225,28 @@ def _consensus_push() -> int:
         print("Error: could not determine current branch for push", file=sys.stderr)
         return 1
 
-    # Resolve the remote tracking refspec (e.g. local:remote)
-    try:
-        tracking = subprocess.check_output(
-            ["git", "config", f"branch.{branch}.merge"],
-            text=True,
-            cwd=repo_path or None,
-            stderr=subprocess.DEVNULL,
-        ).strip()
-        # tracking is like "refs/heads/egg/issue-123"
-        remote_branch = tracking.removeprefix("refs/heads/")
-        refspec = f"{branch}:{remote_branch}" if remote_branch != branch else branch
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        refspec = branch
+    # Pipeline agents run on per-agent work branches (egg/<pid>-<role>/work)
+    # but the gateway locks the session to the pipeline's assigned branch
+    # (egg/<pid>). When EGG_BRANCH is set and differs from the current
+    # branch, target the assigned branch explicitly so the refspec's target
+    # side matches what the gateway's push-target check expects.
+    assigned = os.environ.get("EGG_BRANCH", "").strip()
+    if assigned and assigned != branch:
+        refspec = f"HEAD:{assigned}"
+    else:
+        # Resolve the remote tracking refspec (e.g. local:remote)
+        try:
+            tracking = subprocess.check_output(
+                ["git", "config", f"branch.{branch}.merge"],
+                text=True,
+                cwd=repo_path or None,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+            # tracking is like "refs/heads/egg/issue-123"
+            remote_branch = tracking.removeprefix("refs/heads/")
+            refspec = f"{branch}:{remote_branch}" if remote_branch != branch else branch
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            refspec = branch
 
     payload = json.dumps(
         {

--- a/tests/sandbox/test_cli_push.py
+++ b/tests/sandbox/test_cli_push.py
@@ -218,8 +218,10 @@ class TestCmdPushNoScopeFilter:
     def test_passthrough_to_git_push(self, mock_run):
         """Without --scope-filter, just runs git push."""
         mock_run.return_value = MagicMock(returncode=0)
-        with pytest.raises(SystemExit) as exc_info:
-            cmd_push(_make_args(scope_filter=False))
+        env = {k: v for k, v in os.environ.items() if k != "EGG_BRANCH"}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_push(_make_args(scope_filter=False))
         assert exc_info.value.code == 0
         mock_run.assert_called_once_with(["git", "push"], text=True)
 
@@ -227,9 +229,33 @@ class TestCmdPushNoScopeFilter:
     def test_passthrough_failure(self, mock_run):
         """Passthrough preserves git push's exit code on failure."""
         mock_run.return_value = MagicMock(returncode=128)
-        with pytest.raises(SystemExit) as exc_info:
-            cmd_push(_make_args(scope_filter=False))
+        env = {k: v for k, v in os.environ.items() if k != "EGG_BRANCH"}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_push(_make_args(scope_filter=False))
         assert exc_info.value.code == 128
+
+    @patch("egg_lib.cli_push._get_current_branch", return_value="egg/issue-1-tester/work")
+    @patch("egg_lib.cli_push.subprocess.run")
+    def test_retargets_to_assigned_branch_when_egg_branch_set(self, mock_run, _mock_branch):
+        """When EGG_BRANCH != current branch, push retargets via HEAD:$EGG_BRANCH."""
+        mock_run.return_value = MagicMock(returncode=0)
+        with patch.dict(os.environ, {"EGG_BRANCH": "egg/issue-1"}):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_push(_make_args(scope_filter=False))
+        assert exc_info.value.code == 0
+        mock_run.assert_called_once_with(["git", "push", "origin", "HEAD:egg/issue-1"], text=True)
+
+    @patch("egg_lib.cli_push._get_current_branch", return_value="egg/issue-1")
+    @patch("egg_lib.cli_push.subprocess.run")
+    def test_no_retarget_when_egg_branch_matches_current(self, mock_run, _mock_branch):
+        """When EGG_BRANCH == current branch, plain git push is used."""
+        mock_run.return_value = MagicMock(returncode=0)
+        with patch.dict(os.environ, {"EGG_BRANCH": "egg/issue-1"}):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_push(_make_args(scope_filter=False))
+        assert exc_info.value.code == 0
+        mock_run.assert_called_once_with(["git", "push"], text=True)
 
 
 class TestCmdPushScopeFilter:
@@ -284,7 +310,7 @@ class TestCmdPushScopeFilter:
     ):
         """When all files are in scope, pushes without rewriting."""
         patterns = json.dumps({"allowed": ["**/*.py"], "blocked": ["docs/"]})
-        with patch.dict(os.environ, {"EGG_AGENT_FILE_PATTERNS": patterns}):
+        with patch.dict(os.environ, {"EGG_AGENT_FILE_PATTERNS": patterns, "EGG_BRANCH": ""}):
             mock_run_git.return_value = MagicMock(stdout="src/main.py\nsrc/util.py\n", returncode=0)
             mock_subprocess_run.return_value = MagicMock(returncode=0)
             with pytest.raises(SystemExit) as exc_info:
@@ -292,6 +318,28 @@ class TestCmdPushScopeFilter:
             assert exc_info.value.code == 0
             mock_subprocess_run.assert_called_once_with(
                 ["git", "push", "origin", "egg/test"], text=True
+            )
+
+    @patch("egg_lib.cli_push._get_merge_base", return_value="abc123")
+    @patch("egg_lib.cli_push._get_current_branch", return_value="egg/issue-1-tester/work")
+    @patch("egg_lib.cli_push.subprocess.run")
+    @patch("egg_lib.cli_push._run_git")
+    def test_no_files_removed_retargets_to_assigned_branch(
+        self, mock_run_git, mock_subprocess_run, mock_get_branch, mock_merge_base
+    ):
+        """When EGG_BRANCH is set on a work branch, the push retargets to it."""
+        patterns = json.dumps({"allowed": ["**/*.py"], "blocked": ["docs/"]})
+        with patch.dict(
+            os.environ,
+            {"EGG_AGENT_FILE_PATTERNS": patterns, "EGG_BRANCH": "egg/issue-1"},
+        ):
+            mock_run_git.return_value = MagicMock(stdout="src/main.py\n", returncode=0)
+            mock_subprocess_run.return_value = MagicMock(returncode=0)
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_push(_make_args(scope_filter=True))
+            assert exc_info.value.code == 0
+            mock_subprocess_run.assert_called_once_with(
+                ["git", "push", "origin", "HEAD:egg/issue-1"], text=True
             )
 
     @patch("egg_lib.cli_push._get_merge_base", return_value="abc123")
@@ -303,7 +351,7 @@ class TestCmdPushScopeFilter:
     ):
         """When some files removed, squashes and rewrites commit then pushes."""
         patterns = json.dumps({"allowed": ["**/*.py"], "blocked": ["docs/"]})
-        with patch.dict(os.environ, {"EGG_AGENT_FILE_PATTERNS": patterns}):
+        with patch.dict(os.environ, {"EGG_AGENT_FILE_PATTERNS": patterns, "EGG_BRANCH": ""}):
             # First call: diff returns mixed files
             diff_result = MagicMock(stdout="src/main.py\ndocs/guide.md\n", returncode=0)
             # Subsequent calls: soft-reset, un-stage, re-add, commit succeed
@@ -336,6 +384,38 @@ class TestCmdPushScopeFilter:
             # Verify push was to the correct branch
             push_call = mock_subprocess_run.call_args_list[2]
             assert push_call == call(["git", "push", "origin", "egg/my-branch"], text=True)
+
+    @patch("egg_lib.cli_push._get_merge_base", return_value="abc123")
+    @patch("egg_lib.cli_push._get_current_branch", return_value="egg/issue-1-tester/work")
+    @patch("egg_lib.cli_push.subprocess.run")
+    @patch("egg_lib.cli_push._run_git")
+    def test_rewrite_commit_retargets_to_assigned_branch(
+        self, mock_run_git, mock_subprocess_run, mock_get_branch, mock_merge_base
+    ):
+        """Rewrite path retargets the final push to EGG_BRANCH."""
+        patterns = json.dumps({"allowed": ["**/*.py"], "blocked": ["docs/"]})
+        with patch.dict(
+            os.environ,
+            {"EGG_AGENT_FILE_PATTERNS": patterns, "EGG_BRANCH": "egg/issue-1"},
+        ):
+            diff_result = MagicMock(stdout="src/main.py\ndocs/guide.md\n", returncode=0)
+            mock_run_git.side_effect = [
+                diff_result,
+                MagicMock(returncode=0),  # reset --soft
+                MagicMock(returncode=0),  # reset HEAD -- .
+                MagicMock(returncode=0),  # add
+                MagicMock(returncode=0),  # commit
+            ]
+            mock_subprocess_run.side_effect = [
+                MagicMock(stdout="abc999\n", returncode=0),  # rev-parse HEAD
+                MagicMock(returncode=1),  # diff --cached --quiet -> has staged
+                MagicMock(returncode=0),  # push
+            ]
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_push(_make_args(scope_filter=True))
+            assert exc_info.value.code == 0
+            push_call = mock_subprocess_run.call_args_list[2]
+            assert push_call == call(["git", "push", "origin", "HEAD:egg/issue-1"], text=True)
 
     @patch("egg_lib.cli_push._get_merge_base", return_value="abc123")
     @patch("egg_lib.cli_push._get_current_branch", return_value="egg/my-branch")

--- a/tests/sandbox/test_cli_push.py
+++ b/tests/sandbox/test_cli_push.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "sandbox"))
 
 from egg_lib.cli_push import (
     _filter_files,
+    _get_merge_base,
     _matches_any_pattern,
     _matches_pattern,
     cmd_push,
@@ -214,8 +215,9 @@ def _make_args(scope_filter: bool = False) -> argparse.Namespace:
 class TestCmdPushNoScopeFilter:
     """Tests for cmd_push without --scope-filter (passthrough to git push)."""
 
+    @patch("egg_lib.cli_push._get_current_branch", return_value="egg/test")
     @patch("egg_lib.cli_push.subprocess.run")
-    def test_passthrough_to_git_push(self, mock_run):
+    def test_passthrough_to_git_push(self, mock_run, _mock_branch):
         """Without --scope-filter, just runs git push."""
         mock_run.return_value = MagicMock(returncode=0)
         env = {k: v for k, v in os.environ.items() if k != "EGG_BRANCH"}
@@ -225,8 +227,9 @@ class TestCmdPushNoScopeFilter:
         assert exc_info.value.code == 0
         mock_run.assert_called_once_with(["git", "push"], text=True)
 
+    @patch("egg_lib.cli_push._get_current_branch", return_value="egg/test")
     @patch("egg_lib.cli_push.subprocess.run")
-    def test_passthrough_failure(self, mock_run):
+    def test_passthrough_failure(self, mock_run, _mock_branch):
         """Passthrough preserves git push's exit code on failure."""
         mock_run.return_value = MagicMock(returncode=128)
         env = {k: v for k, v in os.environ.items() if k != "EGG_BRANCH"}
@@ -510,6 +513,48 @@ class TestCmdPushScopeFilter:
             with pytest.raises(SystemExit) as exc_info:
                 cmd_push(_make_args(scope_filter=True))
             assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# _get_merge_base tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetMergeBase:
+    """Tests for _get_merge_base, specifically the EGG_BRANCH fallback."""
+
+    @patch("egg_lib.cli_push.subprocess.run")
+    def test_falls_back_to_egg_branch_on_work_branch(self, mock_run):
+        """When upstream and origin/<branch> fail, tries origin/$EGG_BRANCH."""
+        work_branch = "egg/issue-1-tester/work"
+
+        def side_effect(cmd, **kwargs):
+            cmd_str = " ".join(cmd)
+            if f"{work_branch}@{{upstream}}" in cmd_str:
+                return MagicMock(returncode=1)  # no upstream
+            if f"origin/{work_branch}" in cmd_str:
+                return MagicMock(returncode=1)  # doesn't exist on remote
+            if "origin/egg/issue-1" in cmd_str:
+                return MagicMock(stdout="abc123\n", returncode=0)  # found!
+            return MagicMock(returncode=1)
+
+        mock_run.side_effect = side_effect
+        with patch.dict(os.environ, {"EGG_BRANCH": "egg/issue-1"}):
+            result = _get_merge_base(work_branch)
+        assert result == "abc123"
+
+    @patch("egg_lib.cli_push.subprocess.run")
+    def test_egg_branch_fallback_not_used_when_matches_branch(self, mock_run):
+        """When EGG_BRANCH == branch, the EGG_BRANCH fallback is skipped."""
+
+        def side_effect(cmd, **kwargs):
+            return MagicMock(returncode=1)  # all lookups fail
+
+        mock_run.side_effect = side_effect
+        with patch.dict(os.environ, {"EGG_BRANCH": "egg/issue-1"}):
+            result = _get_merge_base("egg/issue-1")
+        # Falls through to HEAD~1 since EGG_BRANCH == branch (no extra attempt)
+        assert result == "HEAD~1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sandbox/test_orch_cli_consensus_push.py
+++ b/tests/sandbox/test_orch_cli_consensus_push.py
@@ -153,6 +153,7 @@ class TestConsensusPushDirectGatewayAPI:
             return ""
 
         with (
+            patch.dict(os.environ, {"EGG_BRANCH": ""}),
             patch("egg_lib.orch_cli.subprocess.check_output", side_effect=mock_check_output),
             patch("urllib.request.urlopen", side_effect=mock_urlopen),
         ):
@@ -180,12 +181,68 @@ class TestConsensusPushDirectGatewayAPI:
             return ""
 
         with (
+            patch.dict(os.environ, {"EGG_BRANCH": ""}),
             patch("egg_lib.orch_cli.subprocess.check_output", side_effect=mock_check_output),
             patch("urllib.request.urlopen", side_effect=mock_urlopen),
         ):
             result = _consensus_push()
             assert result == 0
             assert captured_request["data"]["refspec"] == "egg/my-feature"
+
+    def test_retargets_to_egg_branch_when_on_work_branch(self, gateway_env):
+        """When EGG_BRANCH differs from current work branch, refspec is HEAD:$EGG_BRANCH."""
+        captured_request = {}
+
+        def mock_urlopen(req, **kwargs):
+            captured_request["data"] = json.loads(req.data)
+            resp = MagicMock()
+            resp.read.return_value = json.dumps({"success": True, "data": {}}).encode()
+            resp.__enter__ = lambda s: resp
+            resp.__exit__ = lambda s, *a: None
+            return resp
+
+        def mock_check_output(cmd, **kwargs):
+            if cmd == ["git", "branch", "--show-current"]:
+                return "egg/issue-1669-tester/work\n"
+            # config should not be consulted when retargeting
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        with (
+            patch.dict(os.environ, {"EGG_BRANCH": "egg/issue-1669"}),
+            patch("egg_lib.orch_cli.subprocess.check_output", side_effect=mock_check_output),
+            patch("urllib.request.urlopen", side_effect=mock_urlopen),
+        ):
+            result = _consensus_push()
+            assert result == 0
+            assert captured_request["data"]["refspec"] == "HEAD:egg/issue-1669"
+
+    def test_no_retarget_when_egg_branch_matches_current(self, gateway_env):
+        """When EGG_BRANCH equals current branch, refspec falls back to tracking logic."""
+        captured_request = {}
+
+        def mock_urlopen(req, **kwargs):
+            captured_request["data"] = json.loads(req.data)
+            resp = MagicMock()
+            resp.read.return_value = json.dumps({"success": True, "data": {}}).encode()
+            resp.__enter__ = lambda s: resp
+            resp.__exit__ = lambda s, *a: None
+            return resp
+
+        def mock_check_output(cmd, **kwargs):
+            if cmd == ["git", "branch", "--show-current"]:
+                return "egg/issue-1669\n"
+            if "config" in cmd:
+                raise subprocess.CalledProcessError(1, cmd)
+            return ""
+
+        with (
+            patch.dict(os.environ, {"EGG_BRANCH": "egg/issue-1669"}),
+            patch("egg_lib.orch_cli.subprocess.check_output", side_effect=mock_check_output),
+            patch("urllib.request.urlopen", side_effect=mock_urlopen),
+        ):
+            result = _consensus_push()
+            assert result == 0
+            assert captured_request["data"]["refspec"] == "egg/issue-1669"
 
     def test_includes_auth_header(self, gateway_env):
         """The request should include Authorization: Bearer header."""


### PR DESCRIPTION
## Summary

- Pipeline agents run on per-agent work branches (`egg/<pid>-<role>/work`) while the gateway locks the session to the pipeline's assigned branch (`egg/<pid>`). A plain `git push origin <current>` produced a `work:work` refspec the gateway's push-target check (`gateway/gateway.py:802`) always rejected — `egg-orch push` was broken-by-construction for every pipeline agent.
- When `EGG_BRANCH` is set and differs from the current branch, `egg-orch push` (all three sites: passthrough, no-rewrite, rewrite) and `_consensus_push` now emit `HEAD:$EGG_BRANCH`, so the refspec's target matches the assigned-branch check. No new env var needed — `EGG_BRANCH` is already set by both spawners.
- Behavior unchanged when `EGG_BRANCH` is unset (local dev) or matches the current branch (non-pipeline agents).

Fixes #1811.

## Test plan

- [x] `pytest tests/sandbox/test_cli_push.py tests/sandbox/test_orch_cli_consensus_push.py` — 63 passed, includes 6 new retarget cases
- [x] `pytest gateway/tests/test_assigned_branch.py gateway/tests/test_concurrent_push_block.py gateway/tests/test_push_error_enrichment.py` — 46 passed (gateway side unchanged, verified not regressed)
- [x] `ruff check` + `ruff format` clean on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)