### PR TITLE
Fix #1814: don't silently drop polls when since_id cursor is stale

### DIFF
--- a/orchestrator/message_store.py
+++ b/orchestrator/message_store.py
@@ -107,7 +107,12 @@ class MessageStore:
         Args:
             pipeline_id: Pipeline ID to query.
             role: If set, return messages where to_role is this role or 'all'.
-            since_id: If set, return only messages after this message ID.
+            since_id: If set, return only messages after this message ID. If the
+                cursor is not present in the store (e.g., after a phase-boundary
+                clear or a post-compaction anchor recovery), fall back to
+                returning all messages rather than silently dropping to empty.
+                This matches the Redis backend's behavior and avoids a silent
+                delivery failure that can stall agents.
             limit: Maximum messages to return.
 
         Returns:
@@ -116,16 +121,18 @@ class MessageStore:
         with self._lock:
             msgs = list(self._messages.get(pipeline_id, []))
 
-        # Filter by since_id
+        # Filter by since_id. If the cursor is unknown, degrade to "return all"
+        # instead of returning empty, so a stale cursor doesn't silently hide
+        # new messages from a polling agent.
         if since_id:
-            found = False
-            filtered = []
-            for m in msgs:
-                if found:
-                    filtered.append(m)
-                elif m.id == since_id:
-                    found = True
-            msgs = filtered
+            found_idx = next((i for i, m in enumerate(msgs) if m.id == since_id), None)
+            if found_idx is not None:
+                msgs = msgs[found_idx + 1 :]
+            else:
+                logger.warning(
+                    "since_id not found in store; returning full history",
+                    extra={"pipeline_id": pipeline_id, "since_id": since_id},
+                )
 
         # Filter by role (messages targeted to this role or broadcast)
         if role:

--- a/orchestrator/routes/messages.py
+++ b/orchestrator/routes/messages.py
@@ -76,6 +76,19 @@ def send_message(pipeline_id: str) -> tuple[Response, int]:
     if not message_type:
         return _make_error("Missing message_type")
 
+    # Catch the common shell-escape footgun where a caller sends e.g.
+    # `--to $role` in a context that didn't expand the variable. The message
+    # would otherwise be stored with a literal "$role" to_role and silently
+    # fail to deliver to any real agent poll. See issue #1814.
+    to_role_raw = body.get("to_role", "all")
+    if isinstance(to_role_raw, str) and to_role_raw.startswith("$"):
+        return _make_error(
+            f"to_role looks like an unexpanded shell variable: {to_role_raw!r}. "
+            "Pass the literal role name (e.g. 'architect') or 'all'."
+        )
+    if isinstance(from_role, str) and from_role.startswith("$"):
+        return _make_error(f"from_role looks like an unexpanded shell variable: {from_role!r}.")
+
     # Validate pipeline exists
     try:
         store, pipeline = get_state_store_for_pipeline(pipeline_id)
@@ -89,7 +102,7 @@ def send_message(pipeline_id: str) -> tuple[Response, int]:
     msg = Message(
         pipeline_id=pipeline_id,
         from_role=from_role,
-        to_role=body.get("to_role", "all"),
+        to_role=to_role_raw,
         message_type=message_type,
         subject=body.get("subject", ""),
         body=body.get("body", ""),

--- a/orchestrator/tests/test_brc_nack_iteration.py
+++ b/orchestrator/tests/test_brc_nack_iteration.py
@@ -376,6 +376,7 @@ class TestPollingLoopWithNacks:
 class TestTimeoutWithNacks:
     """Timeout path must return failure when NACKs are unresolved."""
 
+    @pytest.mark.timeout(60)
     @patch("routes.pipelines.time.sleep")
     @patch("routes.pipelines.time.monotonic")
     @patch("routes.pipelines._emit_event")

--- a/orchestrator/tests/test_messages.py
+++ b/orchestrator/tests/test_messages.py
@@ -825,39 +825,31 @@ class TestShellEscapeGuard:
 
     def test_rejects_unexpanded_to_role(self, client, app):
         with app.test_request_context():
-            with patch(
-                "routes.messages.get_state_store_for_pipeline"
-            ) as mock_get_store_for_pipeline:
-                mock_get_store_for_pipeline.return_value = (MagicMock(), _make_pipeline_mock())
-                resp = client.post(
-                    "/api/v1/pipelines/test-pipeline/messages",
-                    json={
-                        "from_role": "overseer",
-                        "to_role": "$role",
-                        "message_type": "STATUS",
-                    },
-                )
-                data = json.loads(resp.data)
-                assert resp.status_code == 400
-                assert "unexpanded shell variable" in data["message"]
+            resp = client.post(
+                "/api/v1/pipelines/test-pipeline/messages",
+                json={
+                    "from_role": "overseer",
+                    "to_role": "$role",
+                    "message_type": "STATUS",
+                },
+            )
+            data = json.loads(resp.data)
+            assert resp.status_code == 400
+            assert "unexpanded shell variable" in data["message"]
 
     def test_rejects_unexpanded_from_role(self, client, app):
         with app.test_request_context():
-            with patch(
-                "routes.messages.get_state_store_for_pipeline"
-            ) as mock_get_store_for_pipeline:
-                mock_get_store_for_pipeline.return_value = (MagicMock(), _make_pipeline_mock())
-                resp = client.post(
-                    "/api/v1/pipelines/test-pipeline/messages",
-                    json={
-                        "from_role": "$EGG_AGENT_ROLE",
-                        "to_role": "architect",
-                        "message_type": "STATUS",
-                    },
-                )
-                data = json.loads(resp.data)
-                assert resp.status_code == 400
-                assert "unexpanded shell variable" in data["message"]
+            resp = client.post(
+                "/api/v1/pipelines/test-pipeline/messages",
+                json={
+                    "from_role": "$EGG_AGENT_ROLE",
+                    "to_role": "architect",
+                    "message_type": "STATUS",
+                },
+            )
+            data = json.loads(resp.data)
+            assert resp.status_code == 400
+            assert "unexpanded shell variable" in data["message"]
 
 
 class TestInvalidPipelineId:

--- a/orchestrator/tests/test_messages.py
+++ b/orchestrator/tests/test_messages.py
@@ -710,6 +710,81 @@ class TestLongPolling:
                 assert data["data"]["count"] == 1
 
 
+class TestSinceIdRecovery:
+    """A stale ``since_id`` (e.g., surviving a phase-boundary ``clear()`` or
+    fed from ``brc_state.last_message_id`` after anchor recovery) previously
+    caused polls to silently return empty. Verify the cursor degrades to
+    full-history replay and that targeted directed delivery still works end
+    to end through the HTTP layer."""
+
+    def test_stale_since_id_returns_all_messages(self, client, app):
+        store = MessageStore()
+        store.add_message(
+            Message(
+                pipeline_id="test-pipeline",
+                from_role="overseer",
+                to_role="architect",
+                message_type=MessageType.STATUS,
+                subject="Signal completion required",
+            )
+        )
+
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (MagicMock(), _make_pipeline_mock())
+
+                resp = client.get(
+                    "/api/v1/pipelines/test-pipeline/messages"
+                    "?role=architect&since_id=nonexistent-cursor-xyz"
+                )
+                data = json.loads(resp.data)
+
+                assert resp.status_code == 200
+                assert data["data"]["count"] == 1
+                assert data["data"]["messages"][0]["from_role"] == "overseer"
+                assert data["data"]["messages"][0]["to_role"] == "architect"
+
+    def test_known_since_id_still_returns_only_newer(self, client, app):
+        store = MessageStore()
+        first = Message(
+            pipeline_id="test-pipeline",
+            from_role="coder",
+            to_role="all",
+            message_type=MessageType.PROGRESS,
+            subject="first",
+        )
+        second = Message(
+            pipeline_id="test-pipeline",
+            from_role="coder",
+            to_role="all",
+            message_type=MessageType.PROGRESS,
+            subject="second",
+        )
+        store.add_message(first)
+        store.add_message(second)
+
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (MagicMock(), _make_pipeline_mock())
+
+                resp = client.get(f"/api/v1/pipelines/test-pipeline/messages?since_id={first.id}")
+                data = json.loads(resp.data)
+
+                assert resp.status_code == 200
+                assert data["data"]["count"] == 1
+                assert data["data"]["messages"][0]["subject"] == "second"
+
+
 class TestMessageStatus:
     """Test message status endpoint."""
 
@@ -739,6 +814,50 @@ class TestMessageStatus:
 
                 assert resp.status_code == 200
                 assert data["data"]["total"] == 1
+
+
+class TestShellEscapeGuard:
+    """Reject message sends where ``to_role`` / ``from_role`` looks like an
+    unexpanded shell variable -- a footgun we hit in practice when a caller
+    runs ``--to $role`` outside a context that expands the variable.
+    Without this guard the message lands in the bus with a literal
+    ``"$role"`` target and silently fails to deliver to any real agent."""
+
+    def test_rejects_unexpanded_to_role(self, client, app):
+        with app.test_request_context():
+            with patch(
+                "routes.messages.get_state_store_for_pipeline"
+            ) as mock_get_store_for_pipeline:
+                mock_get_store_for_pipeline.return_value = (MagicMock(), _make_pipeline_mock())
+                resp = client.post(
+                    "/api/v1/pipelines/test-pipeline/messages",
+                    json={
+                        "from_role": "overseer",
+                        "to_role": "$role",
+                        "message_type": "STATUS",
+                    },
+                )
+                data = json.loads(resp.data)
+                assert resp.status_code == 400
+                assert "unexpanded shell variable" in data["message"]
+
+    def test_rejects_unexpanded_from_role(self, client, app):
+        with app.test_request_context():
+            with patch(
+                "routes.messages.get_state_store_for_pipeline"
+            ) as mock_get_store_for_pipeline:
+                mock_get_store_for_pipeline.return_value = (MagicMock(), _make_pipeline_mock())
+                resp = client.post(
+                    "/api/v1/pipelines/test-pipeline/messages",
+                    json={
+                        "from_role": "$EGG_AGENT_ROLE",
+                        "to_role": "architect",
+                        "message_type": "STATUS",
+                    },
+                )
+                data = json.loads(resp.data)
+                assert resp.status_code == 400
+                assert "unexpanded shell variable" in data["message"]
 
 
 class TestInvalidPipelineId:

--- a/orchestrator/tests/test_redis_message_store.py
+++ b/orchestrator/tests/test_redis_message_store.py
@@ -167,6 +167,15 @@ class TestGetMessages:
         since_msgs = store.get_messages("test-pipeline", since_id=msgs[1].id)
         assert len(since_msgs) == 3  # msgs[2], msgs[3], msgs[4]
 
+    def test_stale_since_id_returns_all_messages(self, store):
+        """A cursor that isn't in the stream (e.g., survived a phase
+        clear or came from a stale anchor) must degrade to full-history
+        replay rather than silently returning empty — matches the
+        in-memory backend and prevents the stall in issue #1814."""
+        self._add_messages(store, 3)
+        msgs = store.get_messages("test-pipeline", since_id="nonexistent-cursor-xyz")
+        assert len(msgs) == 3
+
     def test_limit(self, store):
         self._add_messages(store, 10)
         messages = store.get_messages("test-pipeline", limit=3)

--- a/sandbox/agent-config/rules/overseer.md
+++ b/sandbox/agent-config/rules/overseer.md
@@ -132,6 +132,11 @@ egg-orch overseer alert \
 - **Resolve your own health alerts** (`egg-orch health resolve --alert-type <type>`) once you've classified them and emitted the corresponding `OVERSEER_ALERT`. This keeps the alert dashboard clean and is not pipeline mutation.
 - **Hand off mediation** to the mediator agent if one exists (see [Mediator Boundary](#mediator-boundary)).
 
+#### Sending peer messages correctly
+
+- **Expand variables explicitly.** When sending to multiple agents, invoke `egg-orch message send` once per target with a literal role name instead of a loop like `for role in …; do … --to $role`. Unexpanded `$role` values are now rejected at the send endpoint, but even when they slip through, a literal `$role` to_role will not match any poll.
+- **A successful send is not proof of delivery.** The send endpoint only confirms the message landed in the bus. Before concluding a peer didn't act on a message, verify with `egg-orch message poll --role <target>` (from this overseer's perspective you won't see their mailbox; check `egg-orch message status` for the expected count bump instead) or look for a reply. If you had to recover across a phase transition or post-compaction, your `since_id` cursor may be stale -- the orchestrator now replays full history in that case rather than silently returning empty (issue #1814), but it's worth being explicit about when you're holding a potentially dead cursor.
+
 Anything that mutates pipeline lifecycle state (phases, decisions, consensus, containers) is **not** in this list -- escalate via `OVERSEER_ALERT` instead.
 
 ### Escalation triggers


### PR DESCRIPTION
## Summary

- In-memory `MessageStore` returned empty on an unknown `since_id` instead of degrading to full-history replay — the actual cause of the #1814 stall (not a filter bug, and not shell escaping, both of which were the first hypotheses).
- Now matches the Redis backend's existing graceful behavior and logs a warning when cursor loss is observed.
- Adds a send-handler guard that rejects `to_role` / `from_role` values starting with `$` (the shell-escape footgun we hypothesized but couldn't blame this time).
- Updates `sandbox/agent-config/rules/overseer.md` with a worked example for sending to multiple peers and a "send success ≠ delivery" note.

Broader HTTP-path integration test gap that let #1814 ship tracked separately in #1818.

## Why this is the bug

`orchestrator/message_store.py`'s filter scanned messages looking for `m.id == since_id`. If the cursor wasn't found, `found` never flipped and the result silently became `[]`. Reachable in two real scenarios:

1. `MessageStore.clear(pipeline_id)` is called on phase transition — the cursor the agent last held now refers to nothing.
2. Agents recover across respawns / post-compaction by reading `egg-orch anchor show`, and `brc_state.last_message_id` gets fed straight into `--since`. That cursor easily outlives the messages it references.

Redis already handled this correctly (stale `since_id` → `"0-0"` → XRANGE returns all). In-memory now matches.

## Test plan

- [x] New regression test at the HTTP layer: `TestSinceIdRecovery::test_stale_since_id_returns_all_messages` posts an overseer → architect STATUS, polls with a bogus cursor, asserts count == 1.
- [x] Guardrail test: `test_known_since_id_still_returns_only_newer` confirms a valid cursor still returns only newer messages.
- [x] Redis backend lock-in: `test_stale_since_id_returns_all_messages` in `test_redis_message_store.py`.
- [x] Send-handler guard: `TestShellEscapeGuard` covers both `to_role` and `from_role` rejection paths with 400 + actionable message.
- [x] Full `test_messages.py` + `test_redis_message_store.py` suite passes (53 tests).
- [ ] Reviewer: spot-check overseer.md wording once rendered.

## Related

- Closes #1814
- Follow-up: #1818 (HTTP-path integration tests for targeted directed delivery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)