### PR TITLE
Fix #1809: wire per-agent worktree pushes to the assigned branch

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -3588,6 +3588,7 @@ def worktree_create() -> tuple[Response, int] | Response:
     container_id = data.get("container_id")
     repos = data.get("repos", [])
     base_branch = data.get("base_branch")  # None = resolve per-repo
+    assigned_branch = data.get("assigned_branch")  # None = skip upstream config
     # UID/GID for worktree ownership (default: 1000 for egg user)
     uid = data.get("uid")
     gid = data.get("gid")
@@ -3625,6 +3626,7 @@ def worktree_create() -> tuple[Response, int] | Response:
                 base_branch=effective_branch,
                 uid=uid,
                 gid=gid,
+                assigned_branch=assigned_branch,
             )
             # Translate container path to host path for egg launcher mount sources
             worktrees[repo_name] = translate_to_host_path(str(info.worktree_path))
@@ -4078,6 +4080,7 @@ def session_create() -> tuple[Response, int] | Response:
                 base_branch=worktree_base_branch,
                 uid=uid,
                 gid=gid,
+                assigned_branch=branch,
             )
             # Capture the first worktree's gateway-side path for checkpoint context
             if first_worktree_path is None:

--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -562,6 +562,96 @@ class TestWorktreeManagerDockerGitDir:
         assert git_file.is_file()
         assert git_file.read_text().strip().startswith("gitdir:")
 
+    def test_create_worktree_configures_push_upstream(self, git_repo):
+        """When assigned_branch is set, branch.<local>.merge should point at it.
+
+        Regression test for #1809.  Without this config, the sandbox's push
+        client falls back to pushing the local branch name, which the
+        gateway rejects as push_denied_wrong_branch.  Agents sometimes
+        "recover" from that rejection with ``git reset --hard`` and
+        destroy their committed work.
+        """
+        worktree_base, repos_base, repo_dir = git_repo
+        manager = WorktreeManager(worktree_base=worktree_base, repos_base=repos_base)
+
+        info = manager.create_worktree(
+            "test-repo",
+            "issue-42-coder",
+            assigned_branch="egg/issue-42",
+        )
+        assert info.branch == "egg/issue-42-coder/work"
+
+        # Config is keyed by the per-worktree local branch name; values
+        # make the sandbox's push client build ``<local>:egg/issue-42``.
+        remote = subprocess.run(
+            ["git", "-C", str(repo_dir), "config", "branch.egg/issue-42-coder/work.remote"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert remote.stdout.strip() == "origin"
+        merge = subprocess.run(
+            ["git", "-C", str(repo_dir), "config", "branch.egg/issue-42-coder/work.merge"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert merge.stdout.strip() == "refs/heads/egg/issue-42"
+
+    def test_create_worktree_leaves_upstream_alone_when_assigned_branch_absent(self, git_repo):
+        """Without assigned_branch, the gateway does not touch branch.<local>.merge.
+
+        Git's own ``worktree add -b`` may auto-set tracking against HEAD,
+        and non-pipeline callers rely on that default.  The fix should
+        only act when the caller explicitly passes assigned_branch.
+        """
+        worktree_base, repos_base, repo_dir = git_repo
+        manager = WorktreeManager(worktree_base=worktree_base, repos_base=repos_base)
+
+        manager.create_worktree("test-repo", "nonpipe-container")
+
+        result = subprocess.run(
+            ["git", "-C", str(repo_dir), "config", "branch.egg/nonpipe-container/work.merge"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        # If git set tracking on its own (branching from master/main), that
+        # value must not be overwritten with our pipeline refspec.
+        if result.returncode == 0:
+            assert not result.stdout.strip().startswith("refs/heads/egg/")
+
+    def test_create_worktree_reapplies_upstream_on_reuse(self, git_repo):
+        """When a valid worktree is reused, upstream config is re-applied.
+
+        Restart paths (e.g. restart_agent_job) call create_worktree against
+        an existing per-agent worktree.  If the assigned branch changes or
+        the config was never set (pre-fix worktree), reuse must still end
+        with the correct upstream wired up.
+        """
+        worktree_base, repos_base, repo_dir = git_repo
+        manager = WorktreeManager(worktree_base=worktree_base, repos_base=repos_base)
+
+        # Initial creation without assigned_branch — no upstream written.
+        info1 = manager.create_worktree("test-repo", "reuse-container")
+        assert info1.worktree_path.exists()
+
+        # Second call with assigned_branch — early-return path must set config.
+        info2 = manager.create_worktree(
+            "test-repo",
+            "reuse-container",
+            assigned_branch="egg/issue-99",
+        )
+        assert info2.worktree_path == info1.worktree_path
+
+        merge = subprocess.run(
+            ["git", "-C", str(repo_dir), "config", "branch.egg/reuse-container/work.merge"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert merge.stdout.strip() == "refs/heads/egg/issue-99"
+
 
 class TestWorktreeManagerRemoteBranchFetch:
     """Tests for create_worktree fetching remote branches that don't exist locally."""

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -314,6 +314,7 @@ class WorktreeManager:
                 container_id=container_id,
                 repo=repo_name,
                 path=str(worktree_path),
+                assigned_branch=assigned_branch,
             )
             # Ensure ownership is correct (may have been created with different uid/gid)
             self._chown_recursive(worktree_path, uid, gid)
@@ -547,7 +548,8 @@ class WorktreeManager:
             (f"branch.{branch_name}.merge", f"refs/heads/{assigned_branch}"),
         ):
             result = subprocess.run(
-                ["git", "-C", str(main_repo), "config", key, value],
+                git_cmd("config", key, value),
+                cwd=main_repo,
                 capture_output=True,
                 text=True,
                 check=False,

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -241,6 +241,7 @@ class WorktreeManager:
         base_branch: str = "HEAD",
         uid: int | None = None,
         gid: int | None = None,
+        assigned_branch: str | None = None,
     ) -> WorktreeInfo:
         """
         Create an isolated worktree for a container.
@@ -251,6 +252,12 @@ class WorktreeManager:
             base_branch: Branch or ref to base the worktree on (default: HEAD)
             uid: User ID to set ownership to (default: 1000)
             gid: Group ID to set ownership to (default: 1000)
+            assigned_branch: Remote branch this worktree's pushes should
+                target.  When set, configures ``branch.<local>.merge`` so
+                the sandbox's push client builds a refspec that targets the
+                assigned branch instead of the per-worktree local branch
+                (which the gateway would reject as push_denied_wrong_branch).
+                See #1809.
 
         Returns:
             WorktreeInfo with paths and branch information
@@ -275,6 +282,8 @@ class WorktreeManager:
         validate_identifier(container_id, "container_id")
         validate_identifier(repo_name, "repo_name")
         validate_branch_ref(base_branch, "base_branch")
+        if assigned_branch is not None:
+            validate_branch_ref(assigned_branch, "assigned_branch")
 
         # Find main repo
         main_repo = self.repos_base / repo_name
@@ -309,6 +318,9 @@ class WorktreeManager:
             # Ensure ownership is correct (may have been created with different uid/gid)
             self._chown_recursive(worktree_path, uid, gid)
             self._chown_single(worktree_path.parent, uid, gid)
+            # Re-apply push upstream config in case the assigned branch
+            # changed across calls (idempotent when unchanged).
+            self._configure_push_upstream(main_repo, branch_name, assigned_branch)
             # Return info about existing worktree
             return WorktreeInfo(
                 container_id=container_id,
@@ -466,6 +478,12 @@ class WorktreeManager:
         # Also ensure the container directory itself is writable (non-recursive)
         self._chown_single(worktree_path.parent, uid, gid)
 
+        # Point the per-worktree local branch at the assigned remote branch
+        # so `git push` resolves to a refspec the gateway will accept
+        # (#1809).  Must happen before returning so the sandbox's push
+        # client sees the config on its first push.
+        self._configure_push_upstream(main_repo, branch_name, assigned_branch)
+
         # Find the actual git dir (git names it based on worktree basename)
         git_dir = self._find_worktree_git_dir(main_repo, worktree_path)
 
@@ -499,6 +517,50 @@ class WorktreeManager:
             if repo_name not in self._repo_locks:
                 self._repo_locks[repo_name] = threading.Lock()
             return self._repo_locks[repo_name]
+
+    def _configure_push_upstream(
+        self,
+        main_repo: Path,
+        branch_name: str,
+        assigned_branch: str | None,
+    ) -> None:
+        """Configure the per-worktree branch to push to the assigned branch.
+
+        Without this, the sandbox's push client (``sandbox/egg_lib/orch_cli.py``)
+        reads ``branch.<local>.merge`` and — finding it unset — sends the
+        local branch name as the push destination.  The gateway's
+        ``push_denied_wrong_branch`` policy then rejects the push because
+        ``egg/{container_id}/work`` differs from the pipeline's assigned
+        branch.  Agents sometimes "recover" from that rejection with
+        ``git reset --hard``, destroying their own committed work
+        (#1809).
+
+        Best-effort: logs and returns on failure rather than aborting the
+        worktree creation, since the old behaviour (no upstream) is still
+        workable for non-pipeline sessions.
+        """
+        if not assigned_branch or assigned_branch == branch_name:
+            return
+
+        for key, value in (
+            (f"branch.{branch_name}.remote", "origin"),
+            (f"branch.{branch_name}.merge", f"refs/heads/{assigned_branch}"),
+        ):
+            result = subprocess.run(
+                ["git", "-C", str(main_repo), "config", key, value],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode != 0:
+                logger.warning(
+                    "Failed to configure push upstream for worktree branch",
+                    branch=branch_name,
+                    assigned_branch=assigned_branch,
+                    key=key,
+                    stderr=result.stderr.strip(),
+                )
+                return
 
     def _run_git_worktree_add(
         self,

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -502,6 +502,7 @@ class GatewayClient:
         uid: int | None = None,
         gid: int | None = None,
         base_branch: str | None = None,
+        assigned_branch: str | None = None,
         timeout: int = 120,
     ) -> WorktreeResult:
         """Create isolated worktrees for a container.
@@ -517,6 +518,11 @@ class GatewayClient:
             gid: Group ID for worktree ownership
             base_branch: Branch to base worktrees on. When None, the gateway
                 resolves the remote default branch per-repo (e.g., origin/main).
+            assigned_branch: Remote branch that pushes from the worktree
+                should target.  When set, the gateway configures
+                ``branch.<local>.merge`` so a naive ``git push`` from the
+                worktree resolves to a refspec targeting this branch
+                instead of the per-worktree local branch name.  See #1809.
             timeout: Request timeout in seconds. Defaults to 120s because
                 concurrent pipeline starts may queue behind per-repo locks
                 in the gateway.
@@ -533,6 +539,8 @@ class GatewayClient:
         }
         if base_branch is not None:
             request_data["base_branch"] = base_branch
+        if assigned_branch is not None:
+            request_data["assigned_branch"] = assigned_branch
         if uid is not None:
             request_data["uid"] = uid
         if gid is not None:

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -316,6 +316,14 @@ class KubernetesSpawner:
                     uid=host_uid,
                     gid=host_gid,
                     base_branch=base_branch,
+                    # Wire the per-agent worktree's local branch to push to
+                    # the pipeline's assigned branch.  Without this, a naive
+                    # ``git push`` from the agent targets the per-agent
+                    # local branch name, which the gateway rejects as
+                    # ``push_denied_wrong_branch`` — and agents sometimes
+                    # "recover" from that rejection with ``git reset --hard``,
+                    # destroying their own committed work (#1809).
+                    assigned_branch=branch,
                 )
                 if wt_result and wt_result.success and wt_result.worktrees:
                     repo_volumes = wt_result.worktrees

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -585,6 +585,45 @@ class TestWorktreeManagement:
         assert result.success is True
         assert "repo1" in result.worktrees
 
+    def test_create_worktrees_forwards_assigned_branch(self, gateway_client):
+        """assigned_branch is forwarded to the gateway create-worktree API.
+
+        Regression guard for #1809: the orchestrator must tell the gateway
+        which remote branch a per-agent worktree should push to, otherwise
+        the default ``git push`` is denied by push_denied_wrong_branch.
+        """
+        with patch.object(gateway_client, "_make_request") as mock_request:
+            mock_request.return_value = {
+                "success": True,
+                "data": {"worktrees": {"repo1": "/tmp/wt"}, "errors": []},
+            }
+            gateway_client.create_worktrees(
+                container_id="issue-1759-v3-task_planner",
+                repos=["owner/repo1"],
+                base_branch="main",
+                assigned_branch="egg/issue-1759-v3",
+            )
+
+        assert mock_request.call_count == 1
+        sent = mock_request.call_args.kwargs["data"]
+        assert sent["assigned_branch"] == "egg/issue-1759-v3"
+        assert sent["base_branch"] == "main"
+
+    def test_create_worktrees_omits_assigned_branch_when_none(self, gateway_client):
+        """When assigned_branch is None, the key is omitted from the request."""
+        with patch.object(gateway_client, "_make_request") as mock_request:
+            mock_request.return_value = {
+                "success": True,
+                "data": {"worktrees": {"repo1": "/tmp/wt"}, "errors": []},
+            }
+            gateway_client.create_worktrees(
+                container_id="test",
+                repos=["owner/repo1"],
+            )
+
+        sent = mock_request.call_args.kwargs["data"]
+        assert "assigned_branch" not in sent
+
     def test_delete_worktrees(self, gateway_client, mock_gateway_server):
         """Test deleting worktrees for a container."""
         result = gateway_client.delete_worktrees(

--- a/orchestrator/tests/test_spawn_worktree_guard.py
+++ b/orchestrator/tests/test_spawn_worktree_guard.py
@@ -270,6 +270,29 @@ class TestWorktreeCreationGuard:
         call_kwargs = mock_gateway_client.create_worktrees.call_args.kwargs
         assert call_kwargs.get("base_branch") == "egg/issue-200"
 
+    def test_spawn_passes_branch_as_assigned_branch_to_create_worktrees(
+        self, spawner, mock_docker_client, mock_gateway_client
+    ):
+        """branch is forwarded as assigned_branch so the per-agent worktree
+        is configured to push to the pipeline's shared branch (#1809).
+
+        Without this, the sandbox's push client builds a refspec targeting
+        the per-agent local branch name, which the gateway rejects as
+        push_denied_wrong_branch.
+        """
+        spawner.spawn_agent_container(
+            pipeline_id="issue-1759-v3",
+            agent_role=AgentRole.CODER,
+            issue_number=1759,
+            repos=["owner/my-repo"],
+            repo_volumes=None,
+            branch="egg/issue-1759-v3",
+            base_branch="main",
+        )
+
+        call_kwargs = mock_gateway_client.create_worktrees.call_args.kwargs
+        assert call_kwargs.get("assigned_branch") == "egg/issue-1759-v3"
+
 
 # ---------------------------------------------------------------------------
 # Error handling


### PR DESCRIPTION
## Summary

Closes #1809. The symptom reported there (`Write` → peer `CONSENSUS_PROPOSE` → `Read` NotFound) is real but the hypothesized mechanism (BRC state-sync stomping untracked files) is not what happens. Gateway audit logs for pipeline `issue-1759-v3` around 21:02-21:04 show a different chain:

1. `21:03:02` agent commits draft to local per-agent branch `egg/issue-1759-v3-task_planner/work` via `git add` + `git commit`.
2. `21:03:08` agent `git push` → gateway returns `push_denied_wrong_branch` because the local branch differs from `session.assigned_branch` (`egg/issue-1759-v3`).
3. `21:03:45` agent \"recovers\" with `git reset --hard origin/egg/issue-1759-v3`, moving HEAD to a branch that never contained the commit — the committed file vanishes from the working tree.
4. `21:04:24` agent reads the path → NotFound.

Root cause: per-agent worktrees are created on `egg/{container_id}/work` (`gateway/worktree_manager.py:286`), but the gateway's push-target policy (`gateway/gateway.py:787-823`) only allows pushes to the pipeline's assigned branch. The sandbox's push client at `sandbox/egg_lib/orch_cli.py:1213-1240` already reads `branch.<local>.merge` to build its refspec — that config was just never set, so pushes fell back to the per-agent branch name.

Fix: plumb `assigned_branch` from the spawner through `GatewayClient.create_worktrees`, the gateway worktree API, and into `WorktreeManager.create_worktree`. On creation and on reuse, set `branch.<local>.remote=origin` and `branch.<local>.merge=refs/heads/<assigned_branch>`. The sandbox's push client now produces `<local>:<assigned_branch>`; the policy check passes; the agent never hits the denial or the destructive-recovery step.

### Not in scope for this PR

Three other hardening items surfaced during investigation and belong in follow-ups:
- Gateway guard against `git reset --hard <ref>` when HEAD has commits not reachable from `<ref>` (defense in depth for any future branch-mismatch bug).
- Agent recovery-prompt updates so `push_denied_wrong_branch` never triggers `reset --hard`.
- Per-agent branch base selection — currently based on `pipeline.base_branch` (typically `main`); probably should be `pipeline.branch` so pushes fast-forward. This is the likely cause of the second denial at `21:03:11` (`push_denied_agent_role_restriction`), but it's orthogonal to the self-destruction chain this PR closes.

Not a duplicate of #1810, which fixed two orchestrator-side push failure modes. This PR fixes the agent-side default-push denial.

## Test plan

- [x] `gateway/tests/test_worktree_manager.py` — three new tests: configure on create, don't stomp unrelated branch tracking when `assigned_branch` is absent, re-apply on reuse.
- [x] `orchestrator/tests/test_gateway_client.py` — two new tests verifying `assigned_branch` is forwarded / omitted.
- [x] `orchestrator/tests/test_spawn_worktree_guard.py` — new test verifying `branch` is passed as `assigned_branch` from `spawn_agent_container`.
- [x] Full relevant suites green locally: `gateway/tests/{test_worktree_manager,test_worktree_isolation,test_assigned_branch,test_gateway}.py` and `orchestrator/tests/{test_gateway_client,test_spawn_worktree_guard,test_restart_agent,test_restart_phase,test_kubernetes_spawner}.py` — 528 passing.
- [ ] Verify on a staging pipeline: fresh `issue-*` pipeline produces no `push_denied_wrong_branch` events for pipeline-agent pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)