### PR TITLE
Fix #1825: fall back to plan draft when contract lacks PR metadata

### DIFF
--- a/.egg/schemas/contract.schema.json
+++ b/.egg/schemas/contract.schema.json
@@ -453,7 +453,7 @@
     },
     "prMetadata": {
       "type": "object",
-      "description": "Planner-generated PR title and description",
+      "description": "Planner-generated PR title, description, test plan, and manual steps",
       "required": ["title"],
       "properties": {
         "title": {
@@ -464,6 +464,16 @@
         "description": {
           "type": "string",
           "description": "PR description/body explaining the context and changes",
+          "default": ""
+        },
+        "test_plan": {
+          "type": "string",
+          "description": "Test plan: automated tests and manual verification steps",
+          "default": ""
+        },
+        "manual_steps": {
+          "type": "string",
+          "description": "Manual pre/post-merge steps (migrations, config changes, etc.)",
           "default": ""
         }
       },

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5138,6 +5138,49 @@ def _build_brc_consensus_summary(
     return summary
 
 
+def _pr_metadata_from_plan_draft(
+    worktree_repo_path: Path,
+    issue_number: int | None,
+    pipeline_id: str,
+) -> tuple[str | None, str, str, str]:
+    """Parse PR metadata from the plan draft on disk.
+
+    Used as a fallback in ``_build_pr_body`` when ``contract.pr`` is not
+    populated — e.g. when the plan-phase contract write did not reach the
+    branch tip (see #1829). The plan draft itself is reliably on the
+    branch even when the contract is not.
+
+    Returns ``(title, description, test_plan, manual_steps)``; ``title``
+    is ``None`` when the draft is missing, unparseable, or has no ``pr:``
+    block, signalling the caller to fall through to the next tier.
+    """
+    draft_rel = _get_draft_path("plan", issue_number=issue_number, pipeline_id=pipeline_id)
+    if not draft_rel:
+        return None, "", "", ""
+    plan_path = worktree_repo_path / draft_rel
+    if not plan_path.exists():
+        return None, "", "", ""
+    try:
+        from egg_contracts.plan_parser import parse_plan
+
+        result = parse_plan(plan_path.read_text())
+    except Exception as e:
+        logger.debug(
+            "Could not parse plan draft for PR metadata fallback",
+            path=str(plan_path),
+            error=str(e),
+        )
+        return None, "", "", ""
+    if not result.pr_title:
+        return None, "", "", ""
+    return (
+        result.pr_title,
+        result.pr_description or "",
+        result.pr_test_plan or "",
+        result.pr_manual_steps or "",
+    )
+
+
 def _build_pr_body(
     pipeline: Pipeline,
     worktree_repo_path: Path,
@@ -5145,9 +5188,10 @@ def _build_pr_body(
     """Build a PR title and body from contract state.
 
     Uses the planner-generated PR metadata from the contract when available,
-    falling back to the issue title.  Commit logs and diff stats are omitted
-    because GitHub already displays them natively on the PR page, and including
-    them caused body-size blowups (see #1374).
+    falling back to the plan draft on disk (#1829) and then to the issue
+    title.  Commit logs and diff stats are omitted because GitHub already
+    displays them natively on the PR page, and including them caused
+    body-size blowups (see #1374).
 
     Args:
         pipeline: The pipeline state
@@ -5161,8 +5205,9 @@ def _build_pr_body(
     pr_description: str | None = None
     pr_test_plan: str = ""
     pr_manual_steps: str = ""
+    issue_title: str | None = None
 
-    # Try to load PR metadata from the contract (populated by the plan agent).
+    # Tier 1: load PR metadata from the contract (populated by the plan agent).
     # Contracts are keyed by pipeline_id after key unification (#1773).
     try:
         from egg_contracts.loader import load_contract
@@ -5173,10 +5218,8 @@ def _build_pr_body(
             pr_description = contract.pr.description
             pr_test_plan = contract.pr.test_plan
             pr_manual_steps = contract.pr.manual_steps
-
-        # Fall back to issue title if no PR title from contract
-        if not pr_title and contract.issue:
-            pr_title = contract.issue.title
+        if contract.issue:
+            issue_title = contract.issue.title
     except Exception as e:
         logger.debug(
             "Could not load contract for PR metadata",
@@ -5184,9 +5227,24 @@ def _build_pr_body(
             error=str(e),
         )
 
-    # Final fallback for title
+    # Tier 2: parse the plan draft directly when the contract has no PR
+    # metadata.  The draft is reliably on the branch even when the
+    # contract write didn't land (#1829).
     if not pr_title:
-        pr_title = f"Implementation for pipeline {pipeline.id}"
+        draft_title, draft_desc, draft_test_plan, draft_manual_steps = _pr_metadata_from_plan_draft(
+            worktree_repo_path,
+            issue_number=pipeline.issue_number,
+            pipeline_id=pipeline.id,
+        )
+        if draft_title:
+            pr_title = draft_title
+            pr_description = draft_desc
+            pr_test_plan = draft_test_plan
+            pr_manual_steps = draft_manual_steps
+
+    # Tier 3: issue title, then generic stub
+    if not pr_title:
+        pr_title = issue_title or f"Implementation for pipeline {pipeline.id}"
 
     # Assemble body
     body_parts: list[str] = []

--- a/orchestrator/tests/test_auto_pr.py
+++ b/orchestrator/tests/test_auto_pr.py
@@ -170,6 +170,9 @@ def _write_plan_draft(tmp_path, issue_number, *, title, description, test_plan, 
 
     Mirrors the layout the planner produces, which the plan parser reads
     via ``parse_plan``.
+
+    Note: YAML is assembled via string concatenation — inputs must be
+    simple strings with no quotes, newlines, or special YAML characters.
     """
     drafts_dir = tmp_path / ".egg-state" / "drafts"
     drafts_dir.mkdir(parents=True, exist_ok=True)
@@ -227,6 +230,8 @@ class TestBuildPrBodyPlanDraftFallback:
         assert "pytest passes" in body
         assert "## Manual Steps" in body
         assert "run migration" in body
+        # Plan draft provides its own description, so the Closes link must not appear.
+        assert "Closes #42" not in body
 
     def test_uses_plan_draft_when_no_contract_at_all(self, tmp_path):
         """Plan draft is used even when contract load fails entirely."""

--- a/orchestrator/tests/test_auto_pr.py
+++ b/orchestrator/tests/test_auto_pr.py
@@ -165,6 +165,142 @@ class TestBuildPrBody:
         assert len(body) < 65_536
 
 
+def _write_plan_draft(tmp_path, issue_number, *, title, description, test_plan, manual_steps):
+    """Helper: write a plan draft with a ``pr:`` yaml-tasks block.
+
+    Mirrors the layout the planner produces, which the plan parser reads
+    via ``parse_plan``.
+    """
+    drafts_dir = tmp_path / ".egg-state" / "drafts"
+    drafts_dir.mkdir(parents=True, exist_ok=True)
+    plan_path = drafts_dir / f"{issue_number}-plan.md"
+    plan_path.write_text(
+        "# Plan\n\n"
+        "```yaml\n"
+        "# yaml-tasks\n"
+        "pr:\n"
+        f'  title: "{title}"\n'
+        "  description: |\n"
+        f"    {description}\n"
+        "  test_plan: |\n"
+        f"    {test_plan}\n"
+        "  manual_steps: |\n"
+        f"    {manual_steps}\n"
+        "phases:\n"
+        "  - id: 1\n"
+        "    name: Phase 1\n"
+        "    goal: Do something\n"
+        "    tasks: []\n"
+        "```\n"
+    )
+    return plan_path
+
+
+class TestBuildPrBodyPlanDraftFallback:
+    """Tests for the plan-draft fallback in _build_pr_body (#1825 / #1829).
+
+    When ``contract.pr`` is missing (e.g. the plan-phase contract write did
+    not reach the branch tip), ``_build_pr_body`` should parse the plan
+    draft on disk and use its ``pr:`` block.
+    """
+
+    def test_uses_plan_draft_when_contract_has_no_pr(self, tmp_path):
+        """Plan draft is used when contract.pr is absent."""
+        pipeline = _make_pipeline()
+        contract_dir = tmp_path / ".egg-state" / "contracts"
+        contract_dir.mkdir(parents=True)
+        (contract_dir / "42.json").write_text(json.dumps(_make_contract_json(pr_title=None)))
+        _write_plan_draft(
+            tmp_path,
+            42,
+            title="Fix the auth bug via plan draft",
+            description="From the plan draft description.",
+            test_plan="- Automated: pytest passes",
+            manual_steps="Pre-merge: run migration",
+        )
+
+        title, body = _build_pr_body(pipeline, tmp_path)
+
+        assert title == "Fix the auth bug via plan draft"
+        assert "From the plan draft description." in body
+        assert "## Test Plan" in body
+        assert "pytest passes" in body
+        assert "## Manual Steps" in body
+        assert "run migration" in body
+
+    def test_uses_plan_draft_when_no_contract_at_all(self, tmp_path):
+        """Plan draft is used even when contract load fails entirely."""
+        pipeline = _make_pipeline()
+        _write_plan_draft(
+            tmp_path,
+            42,
+            title="Draft-only title",
+            description="Draft-only description.",
+            test_plan="- Test X",
+            manual_steps="None",
+        )
+
+        title, body = _build_pr_body(pipeline, tmp_path)
+
+        assert title == "Draft-only title"
+        assert "Draft-only description." in body
+        assert "Test X" in body
+
+    def test_contract_pr_beats_plan_draft(self, tmp_path):
+        """Contract PR metadata wins over plan draft when both exist."""
+        pipeline = _make_pipeline()
+        contract_dir = tmp_path / ".egg-state" / "contracts"
+        contract_dir.mkdir(parents=True)
+        (contract_dir / "42.json").write_text(
+            json.dumps(
+                _make_contract_json(
+                    pr_title="From contract",
+                    pr_description="From contract description.",
+                )
+            )
+        )
+        _write_plan_draft(
+            tmp_path,
+            42,
+            title="From plan draft",
+            description="Plan-draft description.",
+            test_plan="- X",
+            manual_steps="None",
+        )
+
+        title, body = _build_pr_body(pipeline, tmp_path)
+
+        assert title == "From contract"
+        assert "From contract description." in body
+        assert "From plan draft" not in body
+        assert "Plan-draft description." not in body
+
+    def test_falls_through_to_issue_title_when_draft_missing(self, tmp_path):
+        """When neither contract.pr nor plan draft has PR metadata, issue title is used."""
+        pipeline = _make_pipeline()
+        contract_dir = tmp_path / ".egg-state" / "contracts"
+        contract_dir.mkdir(parents=True)
+        (contract_dir / "42.json").write_text(json.dumps(_make_contract_json(pr_title=None)))
+
+        title, body = _build_pr_body(pipeline, tmp_path)
+
+        assert title == "Fix the auth bug"
+
+    def test_unparseable_plan_draft_falls_through(self, tmp_path):
+        """A plan draft with no pr: block falls through to the issue title."""
+        pipeline = _make_pipeline()
+        contract_dir = tmp_path / ".egg-state" / "contracts"
+        contract_dir.mkdir(parents=True)
+        (contract_dir / "42.json").write_text(json.dumps(_make_contract_json(pr_title=None)))
+        drafts_dir = tmp_path / ".egg-state" / "drafts"
+        drafts_dir.mkdir(parents=True)
+        (drafts_dir / "42-plan.md").write_text("# Plan with no yaml-tasks block\n\nJust prose.\n")
+
+        title, body = _build_pr_body(pipeline, tmp_path)
+
+        assert title == "Fix the auth bug"
+
+
 class TestAutoCreatePr:
     """Tests for _auto_create_pr."""
 

--- a/orchestrator/tests/test_brc_nack_iteration.py
+++ b/orchestrator/tests/test_brc_nack_iteration.py
@@ -376,6 +376,7 @@ class TestPollingLoopWithNacks:
 class TestTimeoutWithNacks:
     """Timeout path must return failure when NACKs are unresolved."""
 
+    @pytest.mark.timeout(60)
     @patch("routes.pipelines.time.sleep")
     @patch("routes.pipelines.time.monotonic")
     @patch("routes.pipelines._emit_event")


### PR DESCRIPTION
## Summary

- Teach `_build_pr_body` to parse `.egg-state/drafts/{prefix}-plan.md` directly when `contract.pr` is absent, so auto-created PRs pick up the planner's title/description/test_plan/manual_steps even if the plan-phase contract write didn't reach the branch tip (#1829).
- Restructure the fallback logic into three independent tiers (contract → plan draft → issue title) so a contract-load failure no longer skips the draft path.
- Align `contract.schema.json:prMetadata` with the pydantic `PRMetadata` model and the planner prompt: add the `test_plan` and `manual_steps` fields (previously declared in pydantic and documented in the prompt but missing from the JSON schema under `additionalProperties: false`).

## Why

Verified on pipeline #1759 (PR #1824): the planner produced a proper `pr:` YAML block in the plan draft on branch `egg/issue-1759-v3`, but the branch's contract file belonged to a stale prior pipeline — so `_build_pr_body` found no contract PR metadata and fell through to the `contract.issue.title = "Issue #1759"` stub. The plan draft itself was on the branch the whole time; parsing it as a fallback converts those runs from \"stub PR\" to \"correct PR\" without requiring the deeper contract-sync fix.

The root-cause contract-sync bug is tracked separately in #1829 — this PR is the lighter-step fallback called out in #1825.

## Test plan

- [x] `pytest orchestrator/tests/test_auto_pr.py` — 34 tests pass including 5 new fallback cases (draft used when contract has no pr, draft used when contract missing entirely, contract wins over draft, unparseable draft falls through, no draft falls through to issue title).
- [x] `pytest shared/egg_contracts/tests orchestrator/tests/test_short_flow_contract_population.py orchestrator/tests/test_populate_contract_endpoint.py orchestrator/tests/test_brc_history.py orchestrator/tests/test_lifecycle_empty_body.py orchestrator/tests/test_hitl_revision.py` — 261 pass.
- [x] `ruff check` + `ruff format` clean.
- [ ] Next live pipeline run: auto-PR title/body should reflect planner output even when the contract lookup comes up empty.

## Related

- #1825 — observed behavior and proposed fix
- #1829 — follow-up root-cause contract-sync bug (this PR does not resolve it; the fallback sidesteps it)
- #1824 — example PR with the stub metadata that motivated the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)