### PR TITLE
Fix #1829: union pipeline_id prefix in statefile commit glob

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -3932,8 +3932,9 @@ def _commit_statefiles_to_worktree(
 
         matched_set: set[str] = set()
         for pid in prefixes:
-            pattern_dot = str(state_dir / "**" / f"{pid}.*")
-            pattern_dash = str(state_dir / "**" / f"{pid}-*")
+            escaped = glob.escape(pid)
+            pattern_dot = str(state_dir / "**" / f"{escaped}.*")
+            pattern_dash = str(state_dir / "**" / f"{escaped}-*")
             for f in glob.glob(pattern_dot, recursive=True) + glob.glob(
                 pattern_dash, recursive=True
             ):

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -3864,6 +3864,8 @@ def _commit_statefiles_to_worktree(
     worktree_path: Path,
     message: str,
     pipeline_identifier: int | str | None = None,
+    *,
+    pipeline_id: str | None = None,
 ) -> None:
     """Stage and commit ``.egg-state/`` files in *worktree_path*.
 
@@ -3872,8 +3874,17 @@ def _commit_statefiles_to_worktree(
     prevents concurrent pipelines from leaking each other's state files
     into unrelated PRs (see #1390).
 
-    Falls back to staging the entire ``.egg-state/`` directory when
-    *pipeline_identifier* is ``None`` (backwards-compatibility).
+    Most ``.egg-state/`` files are prefixed with the issue number (drafts,
+    reviews, BRC history, agent-outputs), but contract files are keyed by
+    ``pipeline_id`` (e.g. ``issue-1759-v3.json``) and don't share the
+    issue-number prefix.  When *pipeline_id* is provided alongside
+    *pipeline_identifier*, files matching either prefix are staged — this
+    closes the gap where plan-phase contract updates were written to disk
+    but never committed because the glob only saw the issue-number prefix
+    (see #1829).
+
+    Falls back to staging the entire ``.egg-state/`` directory when both
+    *pipeline_identifier* and *pipeline_id* are ``None`` (backwards-compat).
 
     The commit is idempotent (skips when nothing is staged).
     Raises ``subprocess.CalledProcessError`` on git failure.
@@ -3884,6 +3895,7 @@ def _commit_statefiles_to_worktree(
         "_commit_statefiles_to_worktree: entering",
         worktree_path=str(worktree_path),
         pipeline_identifier=str(pipeline_identifier),
+        pipeline_id=str(pipeline_id),
         commit_message=message,
     )
     if not state_dir.exists():
@@ -3891,6 +3903,7 @@ def _commit_statefiles_to_worktree(
             "_commit_statefiles_to_worktree: no .egg-state directory — exiting",
             worktree_path=str(worktree_path),
             pipeline_identifier=str(pipeline_identifier),
+            pipeline_id=str(pipeline_id),
         )
         return  # Nothing to commit yet
 
@@ -3904,23 +3917,34 @@ def _commit_statefiles_to_worktree(
         str(worktree_path),
     ]
 
-    if pipeline_identifier is not None:
+    if pipeline_identifier is not None or pipeline_id is not None:
         # Scope to files belonging to this pipeline only (#1390).
         # Use prefix-anchored patterns with delimiter boundaries to avoid
         # substring false positives (e.g. pipeline 4 matching pipeline 42).
-        pid = str(pipeline_identifier)
-        pattern_dot = str(state_dir / "**" / f"{pid}.*")
-        pattern_dash = str(state_dir / "**" / f"{pid}-*")
-        matched = [
-            f
-            for f in (
-                glob.glob(pattern_dot, recursive=True) + glob.glob(pattern_dash, recursive=True)
-            )
-            if Path(f).is_file()
-        ]
+        # Union both prefixes so issue-number-prefixed files (drafts,
+        # reviews, BRC history) and pipeline-id-keyed files (contracts)
+        # are all staged (#1829).
+        prefixes: list[str] = []
+        if pipeline_identifier is not None:
+            prefixes.append(str(pipeline_identifier))
+        if pipeline_id is not None and pipeline_id not in prefixes:
+            prefixes.append(pipeline_id)
+
+        matched_set: set[str] = set()
+        for pid in prefixes:
+            pattern_dot = str(state_dir / "**" / f"{pid}.*")
+            pattern_dash = str(state_dir / "**" / f"{pid}-*")
+            for f in glob.glob(pattern_dot, recursive=True) + glob.glob(
+                pattern_dash, recursive=True
+            ):
+                if Path(f).is_file():
+                    matched_set.add(f)
+        matched = sorted(matched_set)
         logger.info(
             "_commit_statefiles_to_worktree: glob match results",
             pipeline_identifier=str(pipeline_identifier),
+            pipeline_id=str(pipeline_id),
+            prefixes=prefixes,
             match_count=len(matched),
             matched_paths=[str(Path(f).relative_to(worktree_path)) for f in matched[:20]],
             truncated=len(matched) > 20,
@@ -4251,6 +4275,7 @@ def _ensure_statefiles_on_branch(
             worktree_repo_path,
             f"Restore missing contract for {identifier}",
             pipeline_identifier=identifier,
+            pipeline_id=pipeline.id,
         )
         logger.info(
             "Contract file restored successfully",
@@ -4941,6 +4966,7 @@ def _rewrite_brc_history_for_pr(
             worktree_path,
             "Persist BRC history files for PR",
             pipeline_identifier=identifier,
+            pipeline_id=pipeline_id,
         )
         logger.info(
             "_rewrite_brc_history_for_pr: commit step completed successfully",
@@ -9087,6 +9113,7 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                         pipeline_identifier=_pipeline_identifier(
                             pipeline.issue_number, pipeline_id
                         ),
+                        pipeline_id=pipeline_id,
                     )
                 except subprocess.CalledProcessError as git_err:
                     logger.error(
@@ -9553,6 +9580,7 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                             pipeline_identifier=_pipeline_identifier(
                                 pipeline.issue_number, pipeline_id
                             ),
+                            pipeline_id=pipeline_id,
                         )
                     except subprocess.CalledProcessError as git_err:
                         logger.warning(
@@ -9988,6 +10016,7 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                     worktree_repo_path,
                     f"Persist statefiles after {current_phase.value} phase",
                     pipeline_identifier=_pipeline_identifier(pipeline.issue_number, pipeline_id),
+                    pipeline_id=pipeline_id,
                 )
             except subprocess.CalledProcessError as git_err:
                 logger.warning(
@@ -10332,6 +10361,7 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                         pipeline_identifier=_pipeline_identifier(
                             pipeline.issue_number, pipeline_id
                         ),
+                        pipeline_id=pipeline_id,
                     )
                 except subprocess.CalledProcessError as git_err:
                     logger.warning(
@@ -10704,6 +10734,7 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                                 pipeline_identifier=_pipeline_identifier(
                                     pipeline.issue_number, pipeline_id
                                 ),
+                                pipeline_id=pipeline_id,
                             )
                         except subprocess.CalledProcessError as git_err:
                             logger.warning(

--- a/orchestrator/tests/test_commit_statefiles_scoping.py
+++ b/orchestrator/tests/test_commit_statefiles_scoping.py
@@ -193,3 +193,100 @@ class TestCommitStatefilesScoping:
             _commit_statefiles_to_worktree(tmp_path, "no dir", pipeline_identifier=42)
 
         mock_run.assert_not_called()
+
+
+class TestCommitStatefilesPipelineIdUnion:
+    """Union staging: issue_number-prefixed files AND pipeline_id-keyed files (#1829)."""
+
+    def test_canonical_contract_file_staged_with_pipeline_id(self, tmp_path: Path):
+        """Contract file keyed by pipeline_id is staged even when pipeline_identifier=issue_number.
+
+        Regression for #1829: contract files are named ``{pipeline.id}.json``
+        (e.g. ``issue-1759-v3.json``) while drafts are prefixed with the
+        issue number (e.g. ``1759-plan.md``).  Passing both identifiers
+        ensures both prefixes match.
+        """
+        for subdir in ("contracts", "drafts"):
+            (tmp_path / ".egg-state" / subdir).mkdir(parents=True, exist_ok=True)
+
+        (tmp_path / ".egg-state" / "contracts" / "issue-1759-v3.json").write_text("{}")
+        (tmp_path / ".egg-state" / "drafts" / "1759-plan.md").write_text("plan")
+
+        with patch("subprocess.run", side_effect=_make_run_side_effect()) as mock_run:
+            _commit_statefiles_to_worktree(
+                tmp_path,
+                "plan-phase commit",
+                pipeline_identifier=1759,
+                pipeline_id="issue-1759-v3",
+            )
+
+        add_call = None
+        for c in mock_run.call_args_list:
+            cmd = c[0][0]
+            if "add" in cmd and "--" in cmd:
+                add_call = cmd
+                break
+
+        assert add_call is not None, "Expected a git add call"
+        add_paths = add_call[add_call.index("--") + 1 :]
+        add_filenames = [Path(p).name for p in add_paths]
+
+        assert "issue-1759-v3.json" in add_filenames, (
+            "Contract file keyed by pipeline_id must be staged"
+        )
+        assert "1759-plan.md" in add_filenames, (
+            "Draft file keyed by issue_number must still be staged"
+        )
+
+    def test_pipeline_id_only_stages_matching_contract(self, tmp_path: Path):
+        """When only pipeline_id is provided (no issue_number), its prefix is used."""
+        d = tmp_path / ".egg-state" / "contracts"
+        d.mkdir(parents=True)
+        (d / "pipeline-2d7b273f.json").write_text("{}")
+        (d / "pipeline-abcd1234.json").write_text("{}")
+
+        with patch("subprocess.run", side_effect=_make_run_side_effect()) as mock_run:
+            _commit_statefiles_to_worktree(
+                tmp_path,
+                "pipeline-id-only",
+                pipeline_id="pipeline-2d7b273f",
+            )
+
+        add_call = None
+        for c in mock_run.call_args_list:
+            cmd = c[0][0]
+            if "add" in cmd and "--" in cmd:
+                add_call = cmd
+                break
+
+        assert add_call is not None
+        add_paths = add_call[add_call.index("--") + 1 :]
+        add_filenames = [Path(p).name for p in add_paths]
+        assert "pipeline-2d7b273f.json" in add_filenames
+        assert "pipeline-abcd1234.json" not in add_filenames
+
+    def test_duplicate_prefixes_deduplicated(self, tmp_path: Path):
+        """Passing the same string as both identifiers doesn't double-stage."""
+        d = tmp_path / ".egg-state" / "contracts"
+        d.mkdir(parents=True)
+        (d / "pipe-abc.json").write_text("{}")
+
+        with patch("subprocess.run", side_effect=_make_run_side_effect()) as mock_run:
+            _commit_statefiles_to_worktree(
+                tmp_path,
+                "dedupe",
+                pipeline_identifier="pipe-abc",
+                pipeline_id="pipe-abc",
+            )
+
+        add_call = None
+        for c in mock_run.call_args_list:
+            cmd = c[0][0]
+            if "add" in cmd and "--" in cmd:
+                add_call = cmd
+                break
+
+        assert add_call is not None
+        add_paths = add_call[add_call.index("--") + 1 :]
+        # File should appear exactly once
+        assert add_paths.count(str(Path(".egg-state/contracts/pipe-abc.json"))) == 1

--- a/orchestrator/tests/test_pr_phase_brc_rewrite.py
+++ b/orchestrator/tests/test_pr_phase_brc_rewrite.py
@@ -315,6 +315,7 @@ class TestRewriteBrcHistoryForPr:
             tmp_path,
             "Persist BRC history files for PR",
             pipeline_identifier=42,
+            pipeline_id="issue-42",
         )
 
     def test_outer_except_catches_write_brc_history_exception(self, tmp_path):

--- a/orchestrator/tests/test_statefile_reconciliation.py
+++ b/orchestrator/tests/test_statefile_reconciliation.py
@@ -133,6 +133,7 @@ class TestEnsureStatefilesOnBranch:
             tmp_path,
             "Restore missing contract for 42",
             pipeline_identifier=42,
+            pipeline_id="pipe-1",
         )
 
     def test_recreates_contract_when_missing_pipeline_id(self, tmp_path: Path):
@@ -162,6 +163,7 @@ class TestEnsureStatefilesOnBranch:
             tmp_path,
             "Restore missing contract for pipe-abc",
             pipeline_identifier="pipe-abc",
+            pipeline_id="pipe-abc",
         )
 
     def test_canonical_path_guard_prevents_recreation(self, tmp_path: Path):


### PR DESCRIPTION
## Summary

- Closes #1829.
- `_commit_statefiles_to_worktree` globbed for a single prefix from `_pipeline_identifier` (issue_number when set, pipeline_id otherwise), but contract files are always keyed by `pipeline.id` (e.g. `issue-1759-v3.json`, `pipeline-2d7b273f.json`). For issue-driven pipelines the glob became `1759.*` / `1759-*` and missed the contract entirely, so plan-phase `_populate_contract_from_plan` writes were silently dropped at the commit step and never reached the PR branch tip.
- Added an optional `pipeline_id` kwarg to `_commit_statefiles_to_worktree`. When set alongside `pipeline_identifier`, both prefixes are globbed and unioned. All seven call sites pass it.
- Added regression tests for the canonical-name case, pipeline-id-only usage, and prefix deduplication. The existing legacy-name tests (`42.json`, `pipe-abc.json`) still pass.

## Why the existing tests didn't catch this

`test_commit_statefiles_scoping.py` seeds `.egg-state/contracts/42.json` — the pre-unification legacy filename. The `#1773` key-unification migrated production to `{pipeline_id}.json` but didn't update these fixtures, so CI stayed green while the glob stopped matching real contract files.

## Test plan

- [x] `pytest orchestrator/tests/test_commit_statefiles_scoping.py -v` (10 passed: 7 existing + 3 new)
- [ ] Run an issue-driven pipeline end-to-end and confirm `.egg-state/contracts/issue-<N>.json` lands on the PR branch with planner-generated `pr.title`/`description`
- [ ] Confirm auto-PR ships with the planner's title and body instead of the stub

🤖 Generated with [Claude Code](https://claude.com/claude-code)