### PR TITLE
Fix #1837: finalize spawn-failure cleanup state and surface accurate error

### DIFF
--- a/orchestrator/container_spawner.py
+++ b/orchestrator/container_spawner.py
@@ -10,6 +10,7 @@ from kubernetes_spawner import (
     KubernetesSpawner,
     KubernetesSpawnError,
     SpawnedContainer,
+    SpawnFailureError,
     _host_to_local_volumes,
     get_kubernetes_spawner,
 )
@@ -28,6 +29,7 @@ __all__ = [
     "ContainerSpawner",
     "ContainerSpawnError",
     "SpawnedContainer",
+    "SpawnFailureError",
     "WORKTREE_BASE_DIR",
     "_host_to_local_volumes",
     "get_container_spawner",

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -1074,6 +1074,22 @@ class KubernetesSpawnError(Exception):
     pass
 
 
+class SpawnFailureError(KubernetesSpawnError):
+    """Raised when one or more agents fail to spawn in a concurrent phase.
+
+    Subclasses KubernetesSpawnError (which is aliased as ContainerSpawnError)
+    so existing ``except (ContainerSpawnError, KubernetesSpawnError)`` handlers
+    catch it without modification. The message distinguishes spawn-time
+    failures from container exits so ``pipeline.error`` is accurate.
+    """
+
+    def __init__(self, failures: list[tuple[str, str | None]]) -> None:
+        self.failures = failures
+        parts = [f"{role}: {reason or 'unknown error'}" for role, reason in failures]
+        roles_csv = ", ".join(role for role, _ in failures)
+        super().__init__(f"Spawn failed for {roles_csv} — {'; '.join(parts)}")
+
+
 # Singleton spawner instance
 _spawner: KubernetesSpawner | None = None
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7327,10 +7327,10 @@ def _run_concurrent_phase(
     # non-RUNNING pipeline, so we must finalize here).
     spawn_failures = [e for e in executions if e.status.value == "failed"]
     if spawn_failures:
-        stopped_container_ids: set[str] = set()
+        survivor_container_ids: set[str] = set()
         for e in executions:
             if e.container_id and e.status.value != "failed":
-                stopped_container_ids.add(e.container_id)
+                survivor_container_ids.add(e.container_id)
                 try:
                     spawner.backend.stop_container(e.container_id, timeout=10)
                 except Exception:
@@ -7345,7 +7345,7 @@ def _run_concurrent_phase(
                     now = datetime.now(UTC)
                     for agent_state in phase_execution.agents:
                         if (
-                            agent_state.container_id in stopped_container_ids
+                            agent_state.container_id in survivor_container_ids
                             and agent_state.status == StateAgentStatus.RUNNING
                         ):
                             agent_state.status = StateAgentStatus.FAILED
@@ -7353,7 +7353,7 @@ def _run_concurrent_phase(
                             agent_state.completed_at = now
                     for container_info in phase_execution.containers:
                         if (
-                            container_info.container_id in stopped_container_ids
+                            container_info.container_id in survivor_container_ids
                             and container_info.status == ContainerStatus.RUNNING
                         ):
                             container_info.status = ContainerStatus.FAILED

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -56,7 +56,7 @@ except ImportError:
 
 # Import orchestrator modules - try relative import first
 try:
-    from ..container_spawner import ContainerSpawnError, get_container_spawner
+    from ..container_spawner import ContainerSpawnError, SpawnFailureError, get_container_spawner
     from ..decision_queue import get_decision_queue
     from ..docker_client import ContainerNotFoundError, ContainerOperationError, DockerClientError
     from ..gateway_client import GatewayError
@@ -90,7 +90,11 @@ try:
         get_state_store,
     )
 except ImportError:
-    from container_spawner import ContainerSpawnError, get_container_spawner  # type: ignore
+    from container_spawner import (  # type: ignore
+        ContainerSpawnError,
+        SpawnFailureError,
+        get_container_spawner,
+    )
     from decision_queue import get_decision_queue  # type: ignore
     from docker_client import (  # type: ignore
         ContainerNotFoundError,
@@ -7167,6 +7171,12 @@ def _run_concurrent_phase(
 
     Returns:
         (exit_code, logs) — 0 on success.
+
+    Raises:
+        SpawnFailureError: If any agent fails to spawn. Survivors are stopped
+            and their pipeline-state records are marked FAILED before the
+            exception propagates. Distinguishes spawn failures from container
+            exits so the outer caller's ``pipeline.error`` is accurate.
     """
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -7311,19 +7321,52 @@ def _run_concurrent_phase(
             )
 
     # Check for spawn failures before waiting.  Stop successfully-spawned
-    # containers so they don't continue running after the phase is aborted.
+    # containers so they don't continue running after the phase is aborted,
+    # then write their terminal status back to pipeline state so get_status
+    # agrees with list_containers (kubernetes_monitor won't reconcile a
+    # non-RUNNING pipeline, so we must finalize here).
     spawn_failures = [e for e in executions if e.status.value == "failed"]
     if spawn_failures:
+        stopped_container_ids: set[str] = set()
         for e in executions:
             if e.container_id and e.status.value != "failed":
+                stopped_container_ids.add(e.container_id)
                 try:
                     spawner.backend.stop_container(e.container_id, timeout=10)
                 except Exception:
                     pass
-        logs = "\n".join(
-            f"--- {e.role.value} (status={e.status.value}, error={e.error}) ---" for e in executions
-        )
-        return 1, logs
+
+        if store is not None:
+            try:
+                with get_pipeline_state_lock(pipeline_id):
+                    pip = store.load_pipeline(pipeline_id)
+                    phase_execution = pip.get_phase_execution(PipelinePhase(phase_str))
+                    abort_error = "Aborted during spawn-failure cleanup"
+                    now = datetime.now(UTC)
+                    for agent_state in phase_execution.agents:
+                        if (
+                            agent_state.container_id in stopped_container_ids
+                            and agent_state.status == StateAgentStatus.RUNNING
+                        ):
+                            agent_state.status = StateAgentStatus.FAILED
+                            agent_state.error = abort_error
+                            agent_state.completed_at = now
+                    for container_info in phase_execution.containers:
+                        if (
+                            container_info.container_id in stopped_container_ids
+                            and container_info.status == ContainerStatus.RUNNING
+                        ):
+                            container_info.status = ContainerStatus.FAILED
+                            container_info.exited_at = now
+                    store.save_pipeline(pip)
+            except Exception as cleanup_err:
+                logger.warning(
+                    "Failed to record spawn-failure cleanup in pipeline state",
+                    pipeline_id=pipeline_id,
+                    error=str(cleanup_err),
+                )
+
+        raise SpawnFailureError([(e.role.value, e.error) for e in spawn_failures])
 
     # Consensus-driven polling loop with container-exit fallback.
     #

--- a/orchestrator/tests/test_concurrent_wait.py
+++ b/orchestrator/tests/test_concurrent_wait.py
@@ -430,7 +430,14 @@ class TestPartialSpawnFailureCleanup:
 
     def _invoke(self, executions, docker_side_effect=None):
         """Run _run_concurrent_phase with the given executions and return the
-        raised SpawnFailureError plus the phase_exec used by the mock store."""
+        raised SpawnFailureError plus the phase_exec used by the mock store.
+
+        Note: ``mock_store.load_pipeline()`` always returns the same
+        ``mock_pipeline_state`` object, so mutations made by the recording
+        block (line ~7291) and the cleanup block (line ~7342) both land on
+        the same ``phase_exec``.  This mirrors production where save→load
+        round-trips through the same store within a single lock scope.
+        """
         pipeline = _make_concurrent_pipeline()
         phase_exec = _make_phase_execution()
         mock_store = MagicMock()
@@ -500,7 +507,10 @@ class TestPartialSpawnFailureCleanup:
             _make_failed_execution(AgentRole.DOCUMENTER),
         ]
 
-        _, phase_exec, _, _ = self._invoke(executions)
+        _, phase_exec, _, mock_store = self._invoke(executions)
+
+        # State must be persisted: once for recording agents, once for cleanup.
+        assert mock_store.save_pipeline.call_count >= 2
 
         survivor_agents = {
             a.role: a for a in phase_exec.agents if a.container_id in {"coder-abc", "tester-abc"}
@@ -509,6 +519,8 @@ class TestPartialSpawnFailureCleanup:
         assert survivor_agents[AgentRole.TESTER].status == AgentExecutionStatus.FAILED
         assert survivor_agents[AgentRole.CODER].error is not None
         assert survivor_agents[AgentRole.TESTER].error is not None
+        assert survivor_agents[AgentRole.CODER].completed_at is not None
+        assert survivor_agents[AgentRole.TESTER].completed_at is not None
 
         survivor_containers = {
             c.container_id: c
@@ -518,6 +530,7 @@ class TestPartialSpawnFailureCleanup:
         assert survivor_containers["coder-abc"].status == ContainerStatus.FAILED
         assert survivor_containers["tester-abc"].status == ContainerStatus.FAILED
         assert survivor_containers["coder-abc"].exited_at is not None
+        assert survivor_containers["tester-abc"].exited_at is not None
 
     def test_spawn_failure_error_message_includes_roles_and_reasons(self):
         """SpawnFailureError.__str__ identifies failed roles and their reasons

--- a/orchestrator/tests/test_concurrent_wait.py
+++ b/orchestrator/tests/test_concurrent_wait.py
@@ -8,6 +8,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+from kubernetes_spawner import SpawnFailureError
 from models import (
     AgentExecution,
     AgentExecutionStatus,
@@ -418,14 +420,63 @@ class TestRunConcurrentPhaseWait:
 
 
 class TestPartialSpawnFailureCleanup:
-    """Tests for stopping orphaned containers when some agents fail to spawn."""
+    """Tests for stopping orphaned containers when some agents fail to spawn.
 
-    @patch("routes.pipelines.get_pipeline_state_lock")
-    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
-    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
-    def test_partial_failure_stops_running_containers(
-        self, MockExecutor, mock_build_prompt, mock_state_lock
-    ):
+    Issue #1837: spawn failures raise SpawnFailureError (a KubernetesSpawnError
+    subclass) rather than returning (1, logs), so pipeline.error distinguishes
+    spawn failures from container exits. Survivor state must be written back to
+    the pipeline store before the exception propagates.
+    """
+
+    def _invoke(self, executions, docker_side_effect=None):
+        """Run _run_concurrent_phase with the given executions and return the
+        raised SpawnFailureError plus the phase_exec used by the mock store."""
+        pipeline = _make_concurrent_pipeline()
+        phase_exec = _make_phase_execution()
+        mock_store = MagicMock()
+        mock_pipeline_state = MagicMock()
+        mock_pipeline_state.get_phase_execution.return_value = phase_exec
+        mock_store.load_pipeline.return_value = mock_pipeline_state
+
+        mock_docker = MagicMock()
+        if docker_side_effect is not None:
+            mock_docker.stop_container.side_effect = docker_side_effect
+        mock_spawner = MagicMock()
+        mock_spawner.backend = mock_docker
+        mock_spawner.docker = mock_docker
+        mock_spawner.create_concurrent_spawn_fn.return_value = MagicMock()
+
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        MockExecutor = MagicMock(return_value=mock_executor_instance)
+
+        mock_state_lock_cm = MagicMock()
+        mock_state_lock_cm.return_value.__enter__ = MagicMock(return_value=None)
+        mock_state_lock_cm.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("concurrent_executor.ConcurrentPhaseExecutor", MockExecutor),
+            patch("routes.pipelines._build_agent_prompt", return_value="test prompt"),
+            patch("routes.pipelines.get_pipeline_state_lock", mock_state_lock_cm),
+        ):
+            with pytest.raises(SpawnFailureError) as excinfo:
+                _run_concurrent_phase(
+                    pipeline_id="issue-999",
+                    pipeline=pipeline,
+                    phase="implement",
+                    spawner=mock_spawner,
+                    repo_volumes={},
+                    gateway_mode="public",
+                    repos=["owner/repo"],
+                    sandbox_env={},
+                    store=mock_store,
+                    certs_volume=None,
+                    worktree_repo_path=Path("/tmp/test-repo"),
+                )
+
+        return excinfo.value, phase_exec, mock_docker, mock_store
+
+    def test_partial_failure_stops_running_containers(self):
         """When one agent fails to spawn, running containers are stopped."""
         executions = [
             _make_execution(AgentRole.CODER, "coder-abc"),
@@ -433,140 +484,90 @@ class TestPartialSpawnFailureCleanup:
             _make_failed_execution(AgentRole.DOCUMENTER),
         ]
 
-        pipeline = _make_concurrent_pipeline()
-        mock_store = MagicMock()
-        mock_pipeline_state = MagicMock()
-        mock_pipeline_state.get_phase_execution.return_value = _make_phase_execution()
-        mock_store.load_pipeline.return_value = mock_pipeline_state
+        err, phase_exec, mock_docker, _ = self._invoke(executions)
 
-        mock_docker = MagicMock()
-        mock_spawner = MagicMock()
-        mock_spawner.backend = mock_docker
-        mock_spawner.docker = mock_docker
-        mock_spawner.create_concurrent_spawn_fn.return_value = MagicMock()
-
-        mock_executor_instance = MagicMock()
-        mock_executor_instance.spawn_all.return_value = executions
-        MockExecutor.return_value = mock_executor_instance
-
-        mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
-        mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
-
-        exit_code, logs = _run_concurrent_phase(
-            pipeline_id="issue-999",
-            pipeline=pipeline,
-            phase="implement",
-            spawner=mock_spawner,
-            repo_volumes={},
-            gateway_mode="public",
-            repos=["owner/repo"],
-            sandbox_env={},
-            store=mock_store,
-            certs_volume=None,
-            worktree_repo_path=Path("/tmp/test-repo"),
-        )
-
-        assert exit_code == 1
-        # Both running containers should have been stopped
         assert mock_docker.stop_container.call_count == 2
         stopped_ids = {call.args[0] for call in mock_docker.stop_container.call_args_list}
         assert stopped_ids == {"coder-abc", "tester-abc"}
+        assert err.failures == [(AgentRole.DOCUMENTER.value, "Spawn failed")]
 
-    @patch("routes.pipelines.get_pipeline_state_lock")
-    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
-    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
-    def test_stop_container_error_does_not_block_return(
-        self, MockExecutor, mock_build_prompt, mock_state_lock
-    ):
-        """If stopping a container fails, partial failure still returns (1, logs)."""
+    def test_survivor_state_marked_failed_before_raise(self):
+        """Survivor agents and containers must be written back as FAILED so
+        get_status agrees with list_containers."""
+        executions = [
+            _make_execution(AgentRole.CODER, "coder-abc"),
+            _make_execution(AgentRole.TESTER, "tester-abc"),
+            _make_failed_execution(AgentRole.DOCUMENTER),
+        ]
+
+        _, phase_exec, _, _ = self._invoke(executions)
+
+        survivor_agents = {
+            a.role: a for a in phase_exec.agents if a.container_id in {"coder-abc", "tester-abc"}
+        }
+        assert survivor_agents[AgentRole.CODER].status == AgentExecutionStatus.FAILED
+        assert survivor_agents[AgentRole.TESTER].status == AgentExecutionStatus.FAILED
+        assert survivor_agents[AgentRole.CODER].error is not None
+        assert survivor_agents[AgentRole.TESTER].error is not None
+
+        survivor_containers = {
+            c.container_id: c
+            for c in phase_exec.containers
+            if c.container_id in {"coder-abc", "tester-abc"}
+        }
+        assert survivor_containers["coder-abc"].status == ContainerStatus.FAILED
+        assert survivor_containers["tester-abc"].status == ContainerStatus.FAILED
+        assert survivor_containers["coder-abc"].exited_at is not None
+
+    def test_spawn_failure_error_message_includes_roles_and_reasons(self):
+        """SpawnFailureError.__str__ identifies failed roles and their reasons
+        so pipeline.error is actionable rather than 'Container exited with code 1'."""
+        executions = [
+            _make_execution(AgentRole.CODER, "coder-abc"),
+            _make_failed_execution(AgentRole.TESTER),
+            _make_failed_execution(AgentRole.DOCUMENTER),
+        ]
+
+        err, _, _, _ = self._invoke(executions)
+
+        message = str(err)
+        assert "Spawn failed" in message
+        assert "tester" in message
+        assert "documenter" in message
+        assert "coder" not in message  # coder survived and was stopped, not a spawn failure
+        assert err.failures == [
+            (AgentRole.TESTER.value, "Spawn failed"),
+            (AgentRole.DOCUMENTER.value, "Spawn failed"),
+        ]
+
+    def test_stop_container_error_does_not_block_raise(self):
+        """If stopping a container fails, SpawnFailureError still propagates."""
         executions = [
             _make_execution(AgentRole.CODER, "coder-abc"),
             _make_failed_execution(AgentRole.TESTER),
         ]
 
-        pipeline = _make_concurrent_pipeline()
-        mock_store = MagicMock()
-        mock_pipeline_state = MagicMock()
-        mock_pipeline_state.get_phase_execution.return_value = _make_phase_execution()
-        mock_store.load_pipeline.return_value = mock_pipeline_state
-
-        mock_docker = MagicMock()
-        mock_docker.stop_container.side_effect = Exception("Docker socket error")
-        mock_spawner = MagicMock()
-        mock_spawner.backend = mock_docker
-        mock_spawner.docker = mock_docker
-        mock_spawner.create_concurrent_spawn_fn.return_value = MagicMock()
-
-        mock_executor_instance = MagicMock()
-        mock_executor_instance.spawn_all.return_value = executions
-        MockExecutor.return_value = mock_executor_instance
-
-        mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
-        mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
-
-        exit_code, logs = _run_concurrent_phase(
-            pipeline_id="issue-999",
-            pipeline=pipeline,
-            phase="implement",
-            spawner=mock_spawner,
-            repo_volumes={},
-            gateway_mode="public",
-            repos=["owner/repo"],
-            sandbox_env={},
-            store=mock_store,
-            certs_volume=None,
-            worktree_repo_path=Path("/tmp/test-repo"),
+        err, _, mock_docker, _ = self._invoke(
+            executions, docker_side_effect=Exception("Docker socket error")
         )
 
-        # Should still return failure even though stop_container raised
-        assert exit_code == 1
         assert mock_docker.stop_container.call_count == 1
+        assert "tester" in str(err)
 
-    @patch("routes.pipelines.get_pipeline_state_lock")
-    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
-    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
-    def test_all_spawns_fail_no_containers_to_stop(
-        self, MockExecutor, mock_build_prompt, mock_state_lock
-    ):
-        """When all agents fail to spawn, no stop_container calls."""
+    def test_all_spawns_fail_no_containers_to_stop(self):
+        """When all agents fail to spawn, no stop_container calls and error
+        still names every failed role."""
         executions = [
             _make_failed_execution(AgentRole.CODER),
             _make_failed_execution(AgentRole.TESTER),
             _make_failed_execution(AgentRole.DOCUMENTER),
         ]
 
-        pipeline = _make_concurrent_pipeline()
-        mock_store = MagicMock()
-        mock_pipeline_state = MagicMock()
-        mock_pipeline_state.get_phase_execution.return_value = _make_phase_execution()
-        mock_store.load_pipeline.return_value = mock_pipeline_state
+        err, _, mock_docker, _ = self._invoke(executions)
 
-        mock_docker = MagicMock()
-        mock_spawner = MagicMock()
-        mock_spawner.backend = mock_docker
-        mock_spawner.docker = mock_docker
-        mock_spawner.create_concurrent_spawn_fn.return_value = MagicMock()
-
-        mock_executor_instance = MagicMock()
-        mock_executor_instance.spawn_all.return_value = executions
-        MockExecutor.return_value = mock_executor_instance
-
-        mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
-        mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
-
-        exit_code, logs = _run_concurrent_phase(
-            pipeline_id="issue-999",
-            pipeline=pipeline,
-            phase="implement",
-            spawner=mock_spawner,
-            repo_volumes={},
-            gateway_mode="public",
-            repos=["owner/repo"],
-            sandbox_env={},
-            store=mock_store,
-            certs_volume=None,
-            worktree_repo_path=Path("/tmp/test-repo"),
-        )
-
-        assert exit_code == 1
         mock_docker.stop_container.assert_not_called()
+        assert err.failures == [
+            (AgentRole.CODER.value, "Spawn failed"),
+            (AgentRole.TESTER.value, "Spawn failed"),
+            (AgentRole.DOCUMENTER.value, "Spawn failed"),
+        ]


### PR DESCRIPTION
## Summary

Fixes #1837.

`_run_concurrent_phase`'s spawn-failure cleanup block had two observable bugs:

1. **Stale `RUNNING` state.** Survivor agents and containers were stopped but their records were never updated, so `get_status` reported them as `running` indefinitely while `list_containers` (querying the k3s label selector) returned empty. `kubernetes_monitor` can't reconcile it because it skips non-`RUNNING` pipelines.
2. **Misleading `pipeline.error`.** The spawn-failure path returned `(1, logs)`, which the outer caller formatted as `"Container exited with code 1"` — even though no container exited.

### Changes

- New `SpawnFailureError(KubernetesSpawnError)` exception carries the list of `(role, reason)` failures and formats as `"Spawn failed for <roles> — <role>: <reason>; …"`. Subclasses the existing error so the outer `except (ContainerSpawnError, KubernetesSpawnError)` handler at `pipelines.py:9798` catches it unchanged.
- Spawn-failure cleanup now writes back to pipeline state before raising: survivor `AgentExecution` records flip to `FAILED` with `error="Aborted during spawn-failure cleanup"` and their `ContainerInfo` records flip to `FAILED` with `exited_at` set. This makes `get_status` agree with `list_containers` the moment the pipeline transitions to `FAILED`.
- Replaces the `return 1, logs` with `raise SpawnFailureError(...)` so the outer caller's `pipeline.error` reflects the actual failure mode.

### Out of scope

The two related observations in the issue (`kubernetes_monitor` skipping non-RUNNING pipelines, and `ContainerInfo` losing K8s metadata at the spawn-record site in `pipelines.py:7285-7291`) are left for separate follow-ups as noted in the issue.

## Test plan

- [x] `pytest orchestrator/tests/test_concurrent_wait.py` — 11 passed
- [x] Full orchestrator suite `pytest orchestrator/tests/` — 3994 passed, 1 skipped
- [x] `ruff check` clean on changed files
- [x] Updated `TestPartialSpawnFailureCleanup` tests to assert on `SpawnFailureError` and added coverage for the survivor state write-back

🤖 Generated with [Claude Code](https://claude.com/claude-code)