### PR TITLE
Fix #1841: propagate full ContainerInfo through concurrent-spawn bookkeeping

### DIFF
--- a/orchestrator/concurrent_executor.py
+++ b/orchestrator/concurrent_executor.py
@@ -307,6 +307,7 @@ class ConcurrentPhaseExecutor:
             role=role,
             status=AgentExecutionStatus.RUNNING,
             container_id=container_id,
+            container_info=result.container_info,
             started_at=datetime.now(UTC),
         )
 

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -177,6 +177,14 @@ class AgentExecution(BaseModel):
         return data
 
     container_id: str | None = Field(default=None, description="Container ID if running")
+    container_info: ContainerInfo | None = Field(
+        default=None,
+        description=(
+            "Full ContainerInfo from the spawner, carrying backend-specific "
+            "fields (e.g. pod_name, namespace, job_name on Kubernetes). "
+            "Optional for backward compatibility with older state files."
+        ),
+    )
     started_at: datetime | None = Field(default=None, description="When started")
     completed_at: datetime | None = Field(default=None, description="When completed")
     commit: str | None = Field(default=None, description="Commit SHA if changes made")

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -8089,22 +8089,13 @@ def _spawn_and_wait(
 
                 # Track container — preserve backend-specific fields
                 # (pod_name, namespace, job_name on K8s) from the spawner.
-                if spawned.container_info is not None:
-                    container_info = spawned.container_info.model_copy(
-                        update={
-                            "status": ContainerStatus.RUNNING,
-                            "started_at": datetime.now(UTC),
-                            "agent_role": agent_role,
-                        }
-                    )
-                else:
-                    container_info = ContainerInfo(
-                        container_id=spawned.container_info.container_id,
-                        container_name=spawned.container_info.container_name,
-                        status=ContainerStatus.RUNNING,
-                        started_at=datetime.now(UTC),
-                        agent_role=agent_role,
-                    )
+                container_info = spawned.container_info.model_copy(
+                    update={
+                        "status": ContainerStatus.RUNNING,
+                        "started_at": datetime.now(UTC),
+                        "agent_role": agent_role,
+                    }
+                )
                 phase_execution.containers.append(container_info)
 
                 # Track agent execution

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7282,13 +7282,26 @@ def _run_concurrent_phase(
                 phase_execution = pip.get_phase_execution(PipelinePhase(phase_str))
                 for exec_info in executions:
                     if exec_info.container_id:
-                        container_info = ContainerInfo(
-                            container_id=exec_info.container_id,
-                            container_name=f"{pipeline_id}-{exec_info.role.value}",
-                            status=ContainerStatus.RUNNING,
-                            started_at=datetime.now(UTC),
-                            agent_role=exec_info.role,
-                        )
+                        spawn_info = exec_info.container_info
+                        if spawn_info is not None:
+                            # Preserve backend-specific fields (pod_name,
+                            # namespace, job_name on k8s) from the spawner
+                            # while overriding the live bookkeeping fields.
+                            container_info = spawn_info.model_copy(
+                                update={
+                                    "status": ContainerStatus.RUNNING,
+                                    "started_at": datetime.now(UTC),
+                                    "agent_role": exec_info.role,
+                                }
+                            )
+                        else:
+                            container_info = ContainerInfo(
+                                container_id=exec_info.container_id,
+                                container_name=f"{pipeline_id}-{exec_info.role.value}",
+                                status=ContainerStatus.RUNNING,
+                                started_at=datetime.now(UTC),
+                                agent_role=exec_info.role,
+                            )
                         phase_execution.containers.append(container_info)
 
                     agent_state = StateAgentExecution(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -8087,14 +8087,24 @@ def _spawn_and_wait(
                 pipeline = store.load_pipeline(pipeline_id)
                 phase_execution = pipeline.get_phase_execution(PipelinePhase(phase))
 
-                # Track container
-                container_info = ContainerInfo(
-                    container_id=spawned.container_info.container_id,
-                    container_name=spawned.container_info.container_name,
-                    status=ContainerStatus.RUNNING,
-                    started_at=datetime.now(UTC),
-                    agent_role=agent_role,
-                )
+                # Track container — preserve backend-specific fields
+                # (pod_name, namespace, job_name on K8s) from the spawner.
+                if spawned.container_info is not None:
+                    container_info = spawned.container_info.model_copy(
+                        update={
+                            "status": ContainerStatus.RUNNING,
+                            "started_at": datetime.now(UTC),
+                            "agent_role": agent_role,
+                        }
+                    )
+                else:
+                    container_info = ContainerInfo(
+                        container_id=spawned.container_info.container_id,
+                        container_name=spawned.container_info.container_name,
+                        status=ContainerStatus.RUNNING,
+                        started_at=datetime.now(UTC),
+                        agent_role=agent_role,
+                    )
                 phase_execution.containers.append(container_info)
 
                 # Track agent execution

--- a/orchestrator/tests/test_concurrent_executor.py
+++ b/orchestrator/tests/test_concurrent_executor.py
@@ -218,6 +218,44 @@ class TestSpawnCreatesTracker:
             )
 
 
+class TestSpawnPropagatesContainerInfo:
+    """Test that _spawn_agent carries the full ContainerInfo from the spawner
+    onto AgentExecution, preserving backend-specific fields like K8s
+    pod_name/namespace/job_name (issue #1841)."""
+
+    def test_spawn_agent_propagates_k8s_container_info(self):
+        from concurrent_executor import ConcurrentPhaseExecutor
+        from egg_orchestrator.types import AgentRole
+        from kubernetes_spawner import SpawnedContainer
+        from models import ContainerInfo, ContainerStatus
+
+        pipeline = _make_pipeline()
+        k8s_info = ContainerInfo(
+            container_id="uid-abc123",
+            container_name="issue-999-coder",
+            status=ContainerStatus.PENDING,
+            namespace="egg-sandbox",
+            job_name="issue-999-coder",
+        )
+        spawn_result = SpawnedContainer(
+            container_info=k8s_info,
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-999",
+            environment={},
+        )
+        mock_spawn = MagicMock(return_value=spawn_result)
+
+        executor = ConcurrentPhaseExecutor(pipeline, spawn_fn=mock_spawn)
+        execution = executor._spawn_agent(AgentRole.CODER)
+
+        assert execution.container_id == "uid-abc123"
+        assert execution.container_info is not None
+        assert execution.container_info.namespace == "egg-sandbox"
+        assert execution.container_info.job_name == "issue-999-coder"
+        assert execution.container_info.container_id == "uid-abc123"
+
+
 class TestRolesOverride:
     """Test that the roles override is respected by the executor."""
 

--- a/orchestrator/tests/test_concurrent_integration.py
+++ b/orchestrator/tests/test_concurrent_integration.py
@@ -616,11 +616,13 @@ class TestSpawnUsesConsensusWrapper:
     def test_spawn_agent_uses_wrapped_command(self):
         """_spawn_agent should produce a bash -c wrapper, not raw claude args."""
         from concurrent_executor import ConcurrentPhaseExecutor
-        from models import AgentRole
+        from models import AgentRole, ContainerInfo
 
         pipeline = _make_concurrent_pipeline()
         mock_spawn = MagicMock()
-        mock_spawn.return_value = MagicMock(container_info=MagicMock(container_id="abc123"))
+        mock_spawn.return_value = MagicMock(
+            container_info=ContainerInfo(container_id="abc123", container_name="abc123"),
+        )
 
         executor = ConcurrentPhaseExecutor(pipeline=pipeline, spawn_fn=mock_spawn)
         executor._spawn_agent(AgentRole.CODER, prompt_text="Do the work")

--- a/orchestrator/tests/test_concurrent_wait.py
+++ b/orchestrator/tests/test_concurrent_wait.py
@@ -334,6 +334,130 @@ class TestRunConcurrentPhaseWait:
     @patch("routes.pipelines.get_pipeline_state_lock")
     @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
     @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
+    def test_recorded_container_preserves_k8s_metadata(
+        self, MockExecutor, mock_build_prompt, mock_state_lock, mock_monotonic, mock_sleep
+    ):
+        """When AgentExecution.container_info carries K8s fields (namespace,
+        job_name, pod_name), the recorded phase_execution.containers[] entry
+        preserves them instead of rebuilding a minimal ContainerInfo (#1841)."""
+        mock_monotonic.return_value = 0.0
+
+        k8s_info = ContainerInfo(
+            container_id="uid-abc123",
+            container_name="issue-999-coder",
+            status=ContainerStatus.PENDING,
+            namespace="egg-sandbox",
+            job_name="issue-999-coder",
+            pod_name="issue-999-coder-xyz",
+        )
+        execution = AgentExecution(
+            role=AgentRole.CODER,
+            status=AgentExecutionStatus.RUNNING,
+            container_id="uid-abc123",
+            container_info=k8s_info,
+            started_at=datetime.now(UTC),
+        )
+        executions = [execution]
+
+        # Wait results must key on the same container_id.
+        wait_results = {
+            "uid-abc123": ContainerInfo(
+                container_id="uid-abc123",
+                container_name="issue-999-coder",
+                status=ContainerStatus.EXITED,
+                exit_code=0,
+                exited_at=datetime.now(UTC),
+            ),
+        }
+        pipeline, mock_store, mock_spawner, mock_docker, phase_exec = self._make_mocks(
+            executions, wait_results=wait_results
+        )
+
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        mock_executor_instance.check_consensus.return_value = _NO_CONSENSUS
+        MockExecutor.return_value = mock_executor_instance
+
+        mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        _run_concurrent_phase(
+            pipeline_id="issue-999",
+            pipeline=pipeline,
+            phase="implement",
+            spawner=mock_spawner,
+            repo_volumes={},
+            gateway_mode="public",
+            repos=["owner/repo"],
+            sandbox_env={},
+            store=mock_store,
+            certs_volume=None,
+            worktree_repo_path=Path("/tmp/test-repo"),
+        )
+
+        assert len(phase_exec.containers) == 1
+        recorded = phase_exec.containers[0]
+        assert recorded.container_id == "uid-abc123"
+        assert recorded.namespace == "egg-sandbox"
+        assert recorded.job_name == "issue-999-coder"
+        assert recorded.pod_name == "issue-999-coder-xyz"
+        # agent_role comes from the bookkeeping path.
+        assert recorded.agent_role == AgentRole.CODER
+        assert recorded.started_at is not None
+
+    @patch("routes.pipelines.time.sleep")
+    @patch("routes.pipelines.time.monotonic")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
+    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
+    def test_recorded_container_fallback_when_info_missing(
+        self, MockExecutor, mock_build_prompt, mock_state_lock, mock_monotonic, mock_sleep
+    ):
+        """Docker-style AgentExecution with no container_info still produces
+        a minimal ContainerInfo record (backward compatibility for #1841)."""
+        mock_monotonic.return_value = 0.0
+
+        executions = [_make_execution(AgentRole.CODER, "coder-abc")]
+        # Precondition: no container_info set (docker-style execution).
+        assert executions[0].container_info is None
+
+        pipeline, mock_store, mock_spawner, mock_docker, phase_exec = self._make_mocks(executions)
+
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        mock_executor_instance.check_consensus.return_value = _NO_CONSENSUS
+        MockExecutor.return_value = mock_executor_instance
+
+        mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        _run_concurrent_phase(
+            pipeline_id="issue-999",
+            pipeline=pipeline,
+            phase="implement",
+            spawner=mock_spawner,
+            repo_volumes={},
+            gateway_mode="public",
+            repos=["owner/repo"],
+            sandbox_env={},
+            store=mock_store,
+            certs_volume=None,
+            worktree_repo_path=Path("/tmp/test-repo"),
+        )
+
+        assert len(phase_exec.containers) == 1
+        recorded = phase_exec.containers[0]
+        assert recorded.container_id == "coder-abc"
+        assert recorded.container_name == "issue-999-coder"
+        assert recorded.namespace is None
+        assert recorded.job_name is None
+        assert recorded.pod_name is None
+
+    @patch("routes.pipelines.time.sleep")
+    @patch("routes.pipelines.time.monotonic")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
+    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
     def test_store_none_does_not_crash(
         self, MockExecutor, mock_build_prompt, mock_state_lock, mock_monotonic, mock_sleep
     ):

--- a/orchestrator/tests/test_concurrent_wait.py
+++ b/orchestrator/tests/test_concurrent_wait.py
@@ -401,7 +401,10 @@ class TestRunConcurrentPhaseWait:
         assert recorded.namespace == "egg-sandbox"
         assert recorded.job_name == "issue-999-coder"
         assert recorded.pod_name == "issue-999-coder-xyz"
-        # agent_role comes from the bookkeeping path.
+        # model_copy initially overrides status to RUNNING, but the wait
+        # loop updates it to EXITED once the container finishes — verify
+        # the final state reflects the wait result.
+        assert recorded.status == ContainerStatus.EXITED
         assert recorded.agent_role == AgentRole.CODER
         assert recorded.started_at is not None
 

--- a/orchestrator/tests/test_spawn_and_wait_k8s.py
+++ b/orchestrator/tests/test_spawn_and_wait_k8s.py
@@ -1,0 +1,98 @@
+"""Tests for _spawn_and_wait K8s metadata preservation.
+
+Verifies that the sequential spawn path (plan, refine, etc.) preserves
+backend-specific ContainerInfo fields (namespace, job_name, pod_name)
+through the bookkeeping block, matching the concurrent-path fix (#1841).
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from models import (
+    AgentRole,
+    ContainerInfo,
+    ContainerStatus,
+    PhaseExecution,
+    PipelinePhase,
+    PipelineStatus,
+)
+from routes.pipelines import _spawn_and_wait
+
+
+def _make_phase_execution() -> PhaseExecution:
+    return PhaseExecution(
+        phase=PipelinePhase.PLAN,
+        status=PipelineStatus.RUNNING,
+    )
+
+
+class TestSpawnAndWaitK8sMetadata:
+    """_spawn_and_wait must preserve K8s fields on the recorded ContainerInfo."""
+
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    def test_recorded_container_preserves_k8s_metadata(self, mock_state_lock):
+        """When the spawner returns a ContainerInfo with K8s fields, the
+        recorded phase_execution.containers[] entry preserves namespace,
+        job_name, and pod_name instead of rebuilding a minimal ContainerInfo."""
+        phase_exec = _make_phase_execution()
+
+        mock_store = MagicMock()
+        mock_pipeline_state = MagicMock()
+        mock_pipeline_state.get_phase_execution.return_value = phase_exec
+        mock_store.load_pipeline.return_value = mock_pipeline_state
+
+        mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Spawner returns a K8s-style ContainerInfo with namespace/job_name/pod_name.
+        k8s_info = ContainerInfo(
+            container_id="uid-abc123",
+            container_name="issue-999-coder",
+            status=ContainerStatus.PENDING,
+            namespace="egg-sandbox",
+            job_name="issue-999-coder",
+            pod_name="issue-999-coder-xyz",
+        )
+        spawned = MagicMock()
+        spawned.container_info = k8s_info
+
+        mock_spawner = MagicMock()
+        mock_spawner.spawn_agent_job.return_value = spawned
+
+        # wait_for_container returns EXITED with exit_code=0.
+        mock_backend = MagicMock()
+        mock_backend.wait_for_container.return_value = ContainerInfo(
+            container_id="uid-abc123",
+            container_name="issue-999-coder",
+            status=ContainerStatus.EXITED,
+            exit_code=0,
+            exited_at=datetime.now(UTC),
+        )
+        mock_spawner.backend = mock_backend
+
+        exit_code, logs = _spawn_and_wait(
+            spawner=mock_spawner,
+            pipeline_id="issue-999",
+            agent_role=AgentRole.CODER,
+            issue_number=999,
+            repo_volumes={},
+            gateway_mode="public",
+            repos=["owner/repo"],
+            phase="plan",
+            sandbox_env={},
+            sandbox_command=["bash", "-c", "echo hi"],
+            store=mock_store,
+        )
+
+        assert exit_code == 0
+        assert len(phase_exec.containers) == 1
+        recorded = phase_exec.containers[0]
+        assert recorded.container_id == "uid-abc123"
+        assert recorded.namespace == "egg-sandbox"
+        assert recorded.job_name == "issue-999-coder"
+        assert recorded.pod_name == "issue-999-coder-xyz"
+        assert recorded.agent_role == AgentRole.CODER
+        assert recorded.started_at is not None
+        # model_copy overrides status to RUNNING, then the update loop
+        # sets it to EXITED after wait_for_container returns.
+        assert recorded.status == ContainerStatus.EXITED


### PR DESCRIPTION
## Summary

- Fixes #1841 — on Kubernetes, `phase_execution.containers[]` records had `pod_name`/`namespace`/`job_name` all null after concurrent spawn because the bookkeeping path rebuilt a minimal `ContainerInfo` from scratch, discarding what the spawner already populated.
- `AgentExecution` now carries an optional `container_info: ContainerInfo | None` field (default `None`, so old persisted state loads fine). `_spawn_agent` populates it from the spawner result, and the bookkeeping block in `_run_concurrent_phase` uses `model_copy(update=...)` to preserve K8s fields while overriding status/started_at/agent_role.
- Docker path is unchanged (falls back to the existing minimal construction when `container_info` is `None`).

## Test plan

- [x] New test in `test_concurrent_executor.py` asserts `_spawn_agent` propagates K8s metadata onto `AgentExecution.container_info`.
- [x] New test in `test_concurrent_wait.py` drives `_run_concurrent_phase` end-to-end and asserts `phase_execution.containers[0]` has non-null `pod_name`/`namespace`/`job_name` when the spawner populated them.
- [x] New fallback test in `test_concurrent_wait.py` confirms Docker-style executions (no `container_info`) still record a minimal `ContainerInfo` — no regression.
- [x] Full orchestrator suite: 3995 passed, 1 skipped.
- [x] `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)