### PR TITLE
Fix #1840: reconcile stale RUNNING records on non-RUNNING pipelines

### DIFF
--- a/orchestrator/kubernetes_monitor.py
+++ b/orchestrator/kubernetes_monitor.py
@@ -429,8 +429,20 @@ class KubernetesMonitor:
                 except Exception:
                     continue
 
-                if pipeline.status != PipelineStatus.RUNNING:
-                    continue
+                # Reconcile stale RUNNING records on non-RUNNING
+                # pipelines too (#1840). Skip terminal pipelines with
+                # nothing to clean up — the common case.
+                if pipeline.status not in (
+                    PipelineStatus.RUNNING,
+                    PipelineStatus.AWAITING_HUMAN,
+                ):
+                    has_running_records = any(
+                        a.status == AgentExecutionStatus.RUNNING
+                        for pe in pipeline.phases.values()
+                        for a in pe.agents
+                    )
+                    if not has_running_records:
+                        continue
 
                 current_phase_key = pipeline.current_phase.value
                 phase_execution = pipeline.phases.get(current_phase_key)
@@ -858,8 +870,27 @@ def _reconcile_pod_state(store: Any, container_info: ContainerInfo) -> bool:
             except Exception:
                 continue
 
-            if pipeline.status != PipelineStatus.RUNNING:
-                continue
+            # Reconcile stale RUNNING agent/container records even on
+            # non-RUNNING pipelines — a pipeline that went FAILED (or
+            # sits at AWAITING_HUMAN) can still have records stuck at
+            # RUNNING from aborted cleanup paths (#1837/#1840).
+            # Optimization: skip terminal pipelines that have nothing
+            # to clean up — the common case.
+            if pipeline.status not in (
+                PipelineStatus.RUNNING,
+                PipelineStatus.AWAITING_HUMAN,
+            ):
+                has_running_records = any(
+                    ci.status == ContainerStatus.RUNNING
+                    for pe in pipeline.phases.values()
+                    for ci in pe.containers
+                ) or any(
+                    a.status == AgentExecutionStatus.RUNNING
+                    for pe in pipeline.phases.values()
+                    for a in pe.agents
+                )
+                if not has_running_records:
+                    continue
 
             changed = False
 
@@ -930,19 +961,25 @@ def _reconcile_pod_state(store: Any, container_info: ContainerInfo) -> bool:
                         changed = True
 
             if changed:
-                pipeline.status = PipelineStatus.FAILED
-                pipeline.error = (
-                    "Pipeline marked FAILED: agent pod exited unexpectedly "
-                    "during execution. Restart via POST /pipelines/{id}/start."
-                )
+                # Only escalate the pipeline's own status when it was
+                # still RUNNING. Terminal states (FAILED/COMPLETE/
+                # CANCELLED) and AWAITING_HUMAN stay as-is — we only
+                # reconciled stale records underneath them.
+                if pipeline.status == PipelineStatus.RUNNING:
+                    pipeline.status = PipelineStatus.FAILED
+                    pipeline.error = (
+                        "Pipeline marked FAILED: agent pod exited unexpectedly "
+                        "during execution. Restart via POST /pipelines/{id}/start."
+                    )
                 try:
                     store.save_pipeline(
                         pipeline,
                         expected_version=pipeline.version,
                     )
                     logger.warning(
-                        "Runtime reconciliation: pipeline marked FAILED",
+                        "Runtime reconciliation: pipeline records updated",
                         pipeline_id=pipeline_id,
+                        pipeline_status=pipeline.status.value,
                     )
                     return True
                 except VersionConflictError:

--- a/orchestrator/kubernetes_monitor.py
+++ b/orchestrator/kubernetes_monitor.py
@@ -432,20 +432,18 @@ class KubernetesMonitor:
                 # Reconcile stale RUNNING records on non-RUNNING
                 # pipelines too (#1840). Skip terminal pipelines with
                 # nothing to clean up — the common case.
+                current_phase_key = pipeline.current_phase.value
+                phase_execution = pipeline.phases.get(current_phase_key)
+
                 if pipeline.status not in (
                     PipelineStatus.RUNNING,
                     PipelineStatus.AWAITING_HUMAN,
                 ):
-                    has_running_records = any(
-                        a.status == AgentExecutionStatus.RUNNING
-                        for pe in pipeline.phases.values()
-                        for a in pe.agents
+                    has_running_records = phase_execution is not None and any(
+                        a.status == AgentExecutionStatus.RUNNING for a in phase_execution.agents
                     )
                     if not has_running_records:
                         continue
-
-                current_phase_key = pipeline.current_phase.value
-                phase_execution = pipeline.phases.get(current_phase_key)
                 if phase_execution is None:
                     continue
 
@@ -841,8 +839,10 @@ def get_kubernetes_monitor() -> KubernetesMonitor:
 def _reconcile_pod_state(store: Any, container_info: ContainerInfo) -> bool:
     """Update pipeline state for a single pod that has exited.
 
-    Scans all RUNNING pipelines for a container matching the given
-    container_info and marks the container and its agent as FAILED.
+    Scans pipelines for a container matching the given container_info
+    and reconciles stale RUNNING agent/container records.  On RUNNING
+    pipelines the pipeline itself is also marked FAILED; on terminal or
+    AWAITING_HUMAN pipelines only the sub-records are updated.
 
     Args:
         store: StateStore instance

--- a/orchestrator/tests/test_container_monitor.py
+++ b/orchestrator/tests/test_container_monitor.py
@@ -180,8 +180,12 @@ class TestReconcileContainerState:
         assert pipeline.status == PipelineStatus.RUNNING
         store.save_pipeline.assert_not_called()
 
-    def test_ignores_non_running_pipelines(self):
-        """A COMPLETE pipeline is not affected by container exits."""
+    def test_reconciles_stale_records_on_complete_pipeline(self):
+        """A COMPLETE pipeline with stale RUNNING records gets records reconciled.
+
+        The pipeline's own status stays COMPLETE — only the stale agent/container
+        records are updated (#1840).
+        """
         container_id = "dead_container_xyz"
         pipeline = _make_pipeline_with_running_agent(container_id)
         pipeline.status = PipelineStatus.COMPLETE
@@ -190,8 +194,9 @@ class TestReconcileContainerState:
 
         result = _reconcile_container_state(store, exited_info)
 
-        assert result is False
-        store.save_pipeline.assert_not_called()
+        assert result is True
+        assert pipeline.status == PipelineStatus.COMPLETE
+        store.save_pipeline.assert_called_once()
 
     def test_handles_store_list_error(self):
         """Returns False without crashing when store.list_pipelines fails."""
@@ -601,8 +606,8 @@ class TestPeriodicReconciliation:
             assert call_args[0][0] is store
             assert call_args[0][1].container_id == container_id
 
-    def test_skips_non_running_pipelines(self):
-        """Loop skips pipelines that are not in RUNNING status."""
+    def test_reconciles_stale_records_on_complete_pipeline(self):
+        """Loop reconciles COMPLETE pipelines that have stale RUNNING records (#1840)."""
         container_id = "stale_abc"
         pipeline = _make_pipeline_with_running_agent(container_id)
         pipeline.status = PipelineStatus.COMPLETE
@@ -621,7 +626,7 @@ class TestPeriodicReconciliation:
 
             _run_one_reconciliation_sweep(monitor)
 
-            mock_reconcile.assert_not_called()
+            mock_reconcile.assert_called_once()
 
     def test_handles_store_load_pipeline_exception(self):
         """Loop continues without crashing when store.load_pipeline raises."""

--- a/orchestrator/tests/test_kubernetes_monitor.py
+++ b/orchestrator/tests/test_kubernetes_monitor.py
@@ -8,6 +8,7 @@ reconciliation, and singleton management.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -633,8 +634,13 @@ class TestReconcilePodState:
         assert result is False
         store.save_pipeline.assert_not_called()
 
-    def test_reconcile_skips_non_running_pipelines(self):
-        """_reconcile_pod_state skips pipelines that are not RUNNING."""
+    def test_reconcile_skips_terminal_pipeline_with_no_running_records(self):
+        """Terminal pipelines with no stale RUNNING records are a cheap no-op.
+
+        Regression guard for the optimization in #1840's fix: we still
+        short-circuit terminal pipelines when there's nothing to clean
+        up — the common case.
+        """
         from kubernetes_monitor import _reconcile_pod_state
         from models import Pipeline, PipelinePhase, PipelineStatus
 
@@ -662,6 +668,142 @@ class TestReconcilePodState:
             result = _reconcile_pod_state(store, container_info)
 
         assert result is False
+        store.save_pipeline.assert_not_called()
+
+    def test_reconcile_failed_pipeline_with_stale_records_updates_records_only(self):
+        """FAILED pipelines with stale RUNNING records get records reconciled.
+
+        #1840: the old RUNNING-only guard dropped pod-exit events on
+        terminal pipelines, leaving agent/container records stuck at
+        RUNNING forever. The fix reconciles records underneath but
+        preserves the pipeline's terminal status.
+        """
+        from kubernetes_monitor import _reconcile_pod_state
+        from models import (
+            AgentExecution,
+            AgentExecutionStatus,
+            PhaseExecution,
+            Pipeline,
+            PipelinePhase,
+            PipelineStatus,
+        )
+
+        container_info = ContainerInfo(
+            container_id="uid-1",
+            container_name="job-1",
+            status=ContainerStatus.FAILED,
+            exit_code=1,
+            exited_at=datetime(2024, 1, 15, 13, 0, 0, tzinfo=UTC),
+        )
+
+        agent = AgentExecution(
+            role="coder",
+            status=AgentExecutionStatus.RUNNING,
+            container_id="uid-1",
+        )
+        ci = ContainerInfo(
+            container_id="uid-1",
+            container_name="job-1",
+            status=ContainerStatus.RUNNING,
+        )
+        phase_exec = PhaseExecution(
+            phase=PipelinePhase.IMPLEMENT,
+            status=PipelineStatus.RUNNING,
+            agents=[agent],
+            containers=[ci],
+        )
+        pipeline = Pipeline(
+            id="pipe-1",
+            issue_number=1,
+            repo="owner/repo",
+            status=PipelineStatus.FAILED,
+            current_phase=PipelinePhase.IMPLEMENT,
+            phases={"implement": phase_exec},
+        )
+        original_error = pipeline.error
+
+        store = self._make_mock_store(pipeline)
+
+        with patch("state_store.get_pipeline_state_lock") as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock()
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = _reconcile_pod_state(store, container_info)
+
+        assert result is True
+        store.save_pipeline.assert_called_once()
+        saved = store.save_pipeline.call_args[0][0]
+        # Records reconciled.
+        assert saved.phases["implement"].agents[0].status == AgentExecutionStatus.FAILED
+        assert saved.phases["implement"].containers[0].status == ContainerStatus.FAILED
+        # Pipeline's top-level status preserved — FAILED is terminal once set.
+        assert saved.status == PipelineStatus.FAILED
+        assert saved.error == original_error
+
+    def test_reconcile_awaiting_human_pipeline_preserves_status(self):
+        """AWAITING_HUMAN pipelines with stale RUNNING records reconcile records only.
+
+        #1840: the pipeline's top-level status must not be flipped to
+        FAILED by reconciliation — that decision belongs to the human
+        gate, not the monitor.
+        """
+        from kubernetes_monitor import _reconcile_pod_state
+        from models import (
+            AgentExecution,
+            AgentExecutionStatus,
+            PhaseExecution,
+            Pipeline,
+            PipelinePhase,
+            PipelineStatus,
+        )
+
+        container_info = ContainerInfo(
+            container_id="uid-1",
+            container_name="job-1",
+            status=ContainerStatus.FAILED,
+            exit_code=1,
+            exited_at=datetime(2024, 1, 15, 13, 0, 0, tzinfo=UTC),
+        )
+
+        agent = AgentExecution(
+            role="coder",
+            status=AgentExecutionStatus.RUNNING,
+            container_id="uid-1",
+        )
+        ci = ContainerInfo(
+            container_id="uid-1",
+            container_name="job-1",
+            status=ContainerStatus.RUNNING,
+        )
+        phase_exec = PhaseExecution(
+            phase=PipelinePhase.IMPLEMENT,
+            status=PipelineStatus.RUNNING,
+            agents=[agent],
+            containers=[ci],
+        )
+        pipeline = Pipeline(
+            id="pipe-1",
+            issue_number=1,
+            repo="owner/repo",
+            status=PipelineStatus.AWAITING_HUMAN,
+            current_phase=PipelinePhase.IMPLEMENT,
+            phases={"implement": phase_exec},
+        )
+
+        store = self._make_mock_store(pipeline)
+
+        with patch("state_store.get_pipeline_state_lock") as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock()
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = _reconcile_pod_state(store, container_info)
+
+        assert result is True
+        saved = store.save_pipeline.call_args[0][0]
+        assert saved.phases["implement"].agents[0].status == AgentExecutionStatus.FAILED
+        assert saved.phases["implement"].containers[0].status == ContainerStatus.FAILED
+        # AWAITING_HUMAN preserved — only the human gate can transition it.
+        assert saved.status == PipelineStatus.AWAITING_HUMAN
 
 
 # ---------------------------------------------------------------------------
@@ -778,6 +920,7 @@ class TestReconciliationSweep:
         container_id: str,
         ci_status: ContainerStatus = ContainerStatus.RUNNING,
         agent_started_at: datetime | None = None,
+        pipeline_status: Any = None,
     ):
         from models import (
             AgentExecution,
@@ -809,7 +952,7 @@ class TestReconciliationSweep:
             id="pipe-1",
             issue_number=1,
             repo="owner/repo",
-            status=PipelineStatus.RUNNING,
+            status=pipeline_status or PipelineStatus.RUNNING,
             current_phase=PipelinePhase.IMPLEMENT,
             phases={"implement": phase_exec},
         )
@@ -1010,6 +1153,79 @@ class TestReconciliationSweep:
         store.save_pipeline.assert_called_once()
         saved = store.save_pipeline.call_args[0][0]
         assert saved.status == PipelineStatus.FAILED
+
+    def test_sweep_reconciles_stale_records_on_failed_pipeline(self, monitor, mock_k8s_client):
+        """Periodic sweep cleans up stale RUNNING records on FAILED pipelines.
+
+        #1840: once a pipeline went FAILED, the sweep skipped it
+        entirely, so any agent record stuck at RUNNING (e.g. from an
+        aborted cleanup path) survived forever.
+        """
+        from models import AgentExecutionStatus, PipelineStatus
+
+        mock_k8s_client.list_containers.return_value = []
+        mock_k8s_client.list_jobs.return_value = []
+        mock_k8s_client.get_container_info.side_effect = PodNotFoundError("gone")
+        spawned_long_ago = datetime.now(UTC).replace(year=2024)
+        _, store = self._make_pipeline(
+            container_id="job-uid-1",
+            agent_started_at=spawned_long_ago,
+            pipeline_status=PipelineStatus.FAILED,
+        )
+        monitor._reconciliation_stores = [store]
+
+        with patch("state_store.get_pipeline_state_lock") as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock()
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+            monitor._reconciliation_sweep()
+
+        store.save_pipeline.assert_called_once()
+        saved = store.save_pipeline.call_args[0][0]
+        # Stale agent record cleaned up.
+        assert saved.phases["implement"].agents[0].status == AgentExecutionStatus.FAILED
+        # Pipeline's own terminal status preserved.
+        assert saved.status == PipelineStatus.FAILED
+
+    def test_sweep_skips_terminal_pipeline_with_no_running_records(self, monitor, mock_k8s_client):
+        """Terminal pipelines with no stale RUNNING records remain cheap no-ops."""
+        from models import (
+            PhaseExecution,
+            Pipeline,
+            PipelinePhase,
+            PipelineStatus,
+        )
+
+        mock_k8s_client.list_containers.return_value = []
+        mock_k8s_client.list_jobs.return_value = []
+        mock_k8s_client.get_container_info.side_effect = AssertionError(
+            "should not be called when there are no RUNNING records"
+        )
+
+        phase_exec = PhaseExecution(
+            phase=PipelinePhase.IMPLEMENT,
+            status=PipelineStatus.COMPLETE,
+            agents=[],
+            containers=[],
+        )
+        pipeline = Pipeline(
+            id="pipe-1",
+            issue_number=1,
+            repo="owner/repo",
+            status=PipelineStatus.COMPLETE,
+            current_phase=PipelinePhase.IMPLEMENT,
+            phases={"implement": phase_exec},
+        )
+        store = MagicMock()
+        store.list_pipelines.return_value = [pipeline.id]
+        store.load_pipeline.return_value = pipeline
+        monitor._reconciliation_stores = [store]
+
+        with patch("state_store.get_pipeline_state_lock") as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock()
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+            monitor._reconciliation_sweep()
+
+        store.save_pipeline.assert_not_called()
 
     def test_terminal_status_without_exited_at_not_reconciled(self, monitor, mock_k8s_client):
         """A half-populated terminal status (no exited_at) is skipped.

--- a/orchestrator/tests/test_kubernetes_monitor.py
+++ b/orchestrator/tests/test_kubernetes_monitor.py
@@ -8,7 +8,6 @@ reconciliation, and singleton management.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,7 +15,7 @@ from kubernetes_client import (
     KubernetesClientError,
     PodNotFoundError,
 )
-from models import ContainerInfo, ContainerStatus
+from models import ContainerInfo, ContainerStatus, PipelineStatus
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -720,6 +719,7 @@ class TestReconcilePodState:
             current_phase=PipelinePhase.IMPLEMENT,
             phases={"implement": phase_exec},
         )
+        pipeline.error = "Original failure reason"
         original_error = pipeline.error
 
         store = self._make_mock_store(pipeline)
@@ -920,7 +920,7 @@ class TestReconciliationSweep:
         container_id: str,
         ci_status: ContainerStatus = ContainerStatus.RUNNING,
         agent_started_at: datetime | None = None,
-        pipeline_status: Any = None,
+        pipeline_status: PipelineStatus | None = None,
     ):
         from models import (
             AgentExecution,
@@ -952,7 +952,7 @@ class TestReconciliationSweep:
             id="pipe-1",
             issue_number=1,
             repo="owner/repo",
-            status=pipeline_status or PipelineStatus.RUNNING,
+            status=pipeline_status if pipeline_status is not None else PipelineStatus.RUNNING,
             current_phase=PipelinePhase.IMPLEMENT,
             phases={"implement": phase_exec},
         )


### PR DESCRIPTION
## Summary
- Drops the RUNNING-only guard in `_reconcile_pod_state` and `_reconciliation_sweep` (`orchestrator/kubernetes_monitor.py`) so pod-exit events on FAILED/AWAITING_HUMAN pipelines can still clean up stale `agent.status=RUNNING` / `container.status=RUNNING` records.
- Preserves the terminal-is-terminal invariant: the pipeline's top-level status is only escalated to FAILED when it was still RUNNING; FAILED/COMPLETE/CANCELLED/AWAITING_HUMAN pipelines get their records reconciled but their own status is never modified by this path.
- Keeps the common case cheap — terminal pipelines with no RUNNING records short-circuit before taking the write lock.

Fixes #1840.

## Test plan
- [x] `pytest orchestrator/tests/test_kubernetes_monitor.py` — existing 54 tests + 3 new: FAILED pipeline with stale records reconciles records (status preserved), AWAITING_HUMAN likewise, periodic sweep cleans up stale records on FAILED pipeline.
- [x] Full `pytest orchestrator/tests/` passes.
- [x] `ruff check` / `ruff format --check` clean on edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)