### PR TITLE
Fix #1839: retry transient worktree-creation failures during agent spawn

### DIFF
--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -13,6 +13,7 @@ Kubernetes deployments:
 import os
 import sys
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -108,6 +109,69 @@ class SpawnedContainer:
     agent_role: AgentRole
     pipeline_id: str
     environment: dict[str, str]
+
+
+# --- spawn-retry policy (#1839) -------------------------------------------
+# A single transient gateway error used to kill the whole pipeline. We now
+# retry a bounded number of times with exponential backoff for failures
+# that look transient (network/timeout/5xx), and fail fast for permanent
+# errors (404 "Repository not found", 400/422 validation, etc.).
+
+DEFAULT_SPAWN_MAX_RETRIES = 2
+DEFAULT_SPAWN_RETRY_INITIAL_BACKOFF_SECONDS = 2.0
+_SPAWN_RETRY_BACKOFF_MULTIPLIER = 2.5
+_TRANSIENT_STATUS_CODES: frozenset[int] = frozenset({408, 429, 500, 502, 503, 504})
+_PERMANENT_STATUS_CODES: frozenset[int] = frozenset({400, 401, 403, 404, 422})
+_PERMANENT_MESSAGE_FRAGMENTS: tuple[str, ...] = (
+    "repository not found",
+    "invalid container_id",
+)
+
+
+def _is_transient_spawn_failure(e: BaseException) -> bool:
+    """Classify whether a worktree-creation failure should be retried.
+
+    Coarse classifier based on ``GatewayError.status_code`` and message
+    content. Refinement via ``GatewayError.details["errors"]`` is blocked
+    on #1838.
+
+    Rules (in priority order):
+    1. Message contains a permanent fragment (e.g. "Repository not found"): permanent.
+    2. ``status_code`` is a known permanent code (400/401/403/404/422): permanent.
+    3. ``status_code`` is a known transient code (408/429/5xx): transient.
+    4. ``status_code`` is any other HTTP status: permanent (fail fast).
+    5. No ``status_code`` (connection-level failure or non-HTTP exception):
+       transient by default — matches the issue #1839 recommendation of
+       "retry by default but bounded."
+    """
+    message = str(e).lower()
+    if any(frag in message for frag in _PERMANENT_MESSAGE_FRAGMENTS):
+        return False
+    status_code = getattr(e, "status_code", None)
+    if status_code is None:
+        return True
+    if status_code in _PERMANENT_STATUS_CODES:
+        return False
+    if status_code in _TRANSIENT_STATUS_CODES:
+        return True
+    return False
+
+
+def _classify_spawn_error(e: BaseException | None) -> str | None:
+    """Short tag used in structured spawn-attempt logs."""
+    if e is None:
+        return None
+    status_code = getattr(e, "status_code", None)
+    if status_code in _PERMANENT_STATUS_CODES:
+        return f"permanent_{status_code}"
+    if status_code in _TRANSIENT_STATUS_CODES:
+        return f"transient_{status_code}"
+    message = str(e).lower()
+    if any(frag in message for frag in _PERMANENT_MESSAGE_FRAGMENTS):
+        return "permanent_message"
+    if status_code is None:
+        return type(e).__name__
+    return f"unknown_{status_code}"
 
 
 def _host_to_local_volumes(repo_volumes: dict[str, str]) -> dict[str, str]:
@@ -223,6 +287,8 @@ class KubernetesSpawner:
         extra_mounts: list["MountSpec"] | None = None,
         preserve_worktree_on_failure: bool = False,
         certs_volume: str | None = None,  # noqa: ARG002 — Docker-era compat
+        spawn_max_retries: int = DEFAULT_SPAWN_MAX_RETRIES,
+        spawn_retry_initial_backoff_seconds: float = (DEFAULT_SPAWN_RETRY_INITIAL_BACKOFF_SECONDS),
     ) -> SpawnedContainer:
         """Spawn a Kubernetes Job for an agent.
 
@@ -242,6 +308,10 @@ class KubernetesSpawner:
             base_branch: Branch to base worktrees on
             extra_mounts: Additional mount specs (not used in k8s — handled by pod template)
             preserve_worktree_on_failure: If True, do not delete worktree on failure
+            spawn_max_retries: Additional retry attempts for transient gateway
+                worktree-creation failures. ``0`` disables retry (#1839).
+            spawn_retry_initial_backoff_seconds: Initial backoff between retries;
+                subsequent attempts scale by ``_SPAWN_RETRY_BACKOFF_MULTIPLIER``.
 
         Returns:
             SpawnedContainer with Job and session info
@@ -309,48 +379,114 @@ class KubernetesSpawner:
         worktree_created_this_call = False
 
         if repos:
-            try:
-                wt_result = self.gateway.create_worktrees(
-                    container_id=agent_worktree_id,
-                    repos=repos,
-                    uid=host_uid,
-                    gid=host_gid,
-                    base_branch=base_branch,
-                    # Wire the per-agent worktree's local branch to push to
-                    # the pipeline's assigned branch.  Without this, a naive
-                    # ``git push`` from the agent targets the per-agent
-                    # local branch name, which the gateway rejects as
-                    # ``push_denied_wrong_branch`` — and agents sometimes
-                    # "recover" from that rejection with ``git reset --hard``,
-                    # destroying their own committed work (#1809).
-                    assigned_branch=branch,
-                )
+            max_attempts = max(1, spawn_max_retries + 1)
+            for attempt in range(max_attempts):
+                attempt_started = time.monotonic()
+                try:
+                    wt_result = self.gateway.create_worktrees(
+                        container_id=agent_worktree_id,
+                        repos=repos,
+                        uid=host_uid,
+                        gid=host_gid,
+                        base_branch=base_branch,
+                        # Wire the per-agent worktree's local branch to push to
+                        # the pipeline's assigned branch.  Without this, a naive
+                        # ``git push`` from the agent targets the per-agent
+                        # local branch name, which the gateway rejects as
+                        # ``push_denied_wrong_branch`` — and agents sometimes
+                        # "recover" from that rejection with ``git reset --hard``,
+                        # destroying their own committed work (#1809).
+                        assigned_branch=branch,
+                    )
+                except Exception as e:  # noqa: BLE001 — classify below
+                    duration_ms = int((time.monotonic() - attempt_started) * 1000)
+                    transient = _is_transient_spawn_failure(e)
+                    is_last = attempt >= max_attempts - 1
+                    logger.info(
+                        "Spawn attempt outcome",
+                        event_type="spawn_attempt",
+                        pipeline_id=pipeline_id,
+                        agent_role=agent_role.value,
+                        agent_worktree_id=agent_worktree_id,
+                        phase=phase,
+                        attempt=attempt + 1,
+                        max_attempts=max_attempts,
+                        outcome="failed",
+                        error_category=_classify_spawn_error(e),
+                        error_detail=str(e),
+                        duration_ms=duration_ms,
+                        will_retry=(transient and not is_last),
+                    )
+                    if transient and not is_last:
+                        delay = spawn_retry_initial_backoff_seconds * (
+                            _SPAWN_RETRY_BACKOFF_MULTIPLIER**attempt
+                        )
+                        logger.warning(
+                            "Transient worktree creation failure, retrying",
+                            agent_worktree_id=agent_worktree_id,
+                            attempt=attempt + 1,
+                            max_attempts=max_attempts,
+                            delay_seconds=delay,
+                            error=str(e),
+                        )
+                        time.sleep(delay)
+                        continue
+                    raise KubernetesSpawnError(
+                        f"Per-agent worktree creation failed for "
+                        f"{agent_worktree_id} after {attempt + 1} attempt(s): {e}"
+                    ) from e
+
+                duration_ms = int((time.monotonic() - attempt_started) * 1000)
                 if wt_result and wt_result.success and wt_result.worktrees:
                     repo_volumes = wt_result.worktrees
                     worktree_created_this_call = True
+                    logger.info(
+                        "Spawn attempt outcome",
+                        event_type="spawn_attempt",
+                        pipeline_id=pipeline_id,
+                        agent_role=agent_role.value,
+                        agent_worktree_id=agent_worktree_id,
+                        phase=phase,
+                        attempt=attempt + 1,
+                        max_attempts=max_attempts,
+                        outcome="success",
+                        error_category=None,
+                        error_detail=None,
+                        duration_ms=duration_ms,
+                        will_retry=False,
+                    )
                     logger.info(
                         "Per-agent worktree created",
                         agent_worktree_id=agent_worktree_id,
                         role=agent_role.value,
                         pipeline_id=pipeline_id,
                         worktrees=list(repo_volumes.keys()),
+                        attempt=attempt + 1,
                     )
-                else:
-                    errors = wt_result.errors if wt_result else []
-                    raise KubernetesSpawnError(
-                        f"Per-agent worktree creation returned no worktrees "
-                        f"for {agent_worktree_id}: {errors}"
-                    )
-            except KubernetesSpawnError:
-                raise
-            except GatewayError as e:
+                    break
+                # Empty / unsuccessful result — treat as non-retryable;
+                # the gateway returned structured errors which usually
+                # reflect permanent issues (missing repo, bad ref).
+                errors = wt_result.errors if wt_result else []
+                logger.info(
+                    "Spawn attempt outcome",
+                    event_type="spawn_attempt",
+                    pipeline_id=pipeline_id,
+                    agent_role=agent_role.value,
+                    agent_worktree_id=agent_worktree_id,
+                    phase=phase,
+                    attempt=attempt + 1,
+                    max_attempts=max_attempts,
+                    outcome="failed",
+                    error_category="empty_result",
+                    error_detail=str(errors),
+                    duration_ms=duration_ms,
+                    will_retry=False,
+                )
                 raise KubernetesSpawnError(
-                    f"Per-agent worktree creation failed for {agent_worktree_id}: {e}"
-                ) from e
-            except Exception as e:
-                raise KubernetesSpawnError(
-                    f"Per-agent worktree creation failed for {agent_worktree_id}: {e}"
-                ) from e
+                    f"Per-agent worktree creation returned no worktrees "
+                    f"for {agent_worktree_id}: {errors}"
+                )
 
         # Register gateway session (token-only, no container_ip)
         session_info = None
@@ -1012,6 +1148,8 @@ class KubernetesSpawner:
         image: str | None = None,
         base_branch: str | None = None,
         certs_volume: str | None = None,  # noqa: ARG002 — Docker-era compat
+        spawn_max_retries: int = DEFAULT_SPAWN_MAX_RETRIES,
+        spawn_retry_initial_backoff_seconds: float = (DEFAULT_SPAWN_RETRY_INITIAL_BACKOFF_SECONDS),
     ):
         """Create a spawn callable compatible with ConcurrentPhaseExecutor.
 
@@ -1053,6 +1191,8 @@ class KubernetesSpawner:
                 branch=branch,
                 base_branch=base_branch,
                 command=command,
+                spawn_max_retries=spawn_max_retries,
+                spawn_retry_initial_backoff_seconds=(spawn_retry_initial_backoff_seconds),
             )
 
         return _spawn

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -158,17 +158,21 @@ def _is_transient_spawn_failure(e: BaseException) -> bool:
 
 
 def _classify_spawn_error(e: BaseException | None) -> str | None:
-    """Short tag used in structured spawn-attempt logs."""
+    """Short tag used in structured spawn-attempt logs.
+
+    Priority order matches ``_is_transient_spawn_failure`` so the logged
+    category always agrees with the actual retry decision.
+    """
     if e is None:
         return None
+    message = str(e).lower()
+    if any(frag in message for frag in _PERMANENT_MESSAGE_FRAGMENTS):
+        return "permanent_message"
     status_code = getattr(e, "status_code", None)
     if status_code in _PERMANENT_STATUS_CODES:
         return f"permanent_{status_code}"
     if status_code in _TRANSIENT_STATUS_CODES:
         return f"transient_{status_code}"
-    message = str(e).lower()
-    if any(frag in message for frag in _PERMANENT_MESSAGE_FRAGMENTS):
-        return "permanent_message"
     if status_code is None:
         return type(e).__name__
     return f"unknown_{status_code}"
@@ -847,6 +851,8 @@ class KubernetesSpawner:
         extra_mounts: list["MountSpec"] | None = None,
         max_restarts: int = 2,
         reason: str = "",
+        spawn_max_retries: int = DEFAULT_SPAWN_MAX_RETRIES,
+        spawn_retry_initial_backoff_seconds: float = (DEFAULT_SPAWN_RETRY_INITIAL_BACKOFF_SECONDS),
     ) -> SpawnedContainer:
         """Restart an agent Job: delete and respawn preserving worktree.
 
@@ -866,6 +872,10 @@ class KubernetesSpawner:
             extra_mounts: Additional mount specs.
             max_restarts: Maximum restart attempts per agent per phase.
             reason: Human-readable reason for the restart.
+            spawn_max_retries: Retry attempts for transient gateway failures
+                during worktree creation (forwarded to ``spawn_agent_job``).
+            spawn_retry_initial_backoff_seconds: Initial backoff for spawn
+                retries (forwarded to ``spawn_agent_job``).
 
         Returns:
             SpawnedContainer with new Job info.
@@ -942,6 +952,8 @@ class KubernetesSpawner:
                 base_branch=base_branch,
                 extra_mounts=extra_mounts,
                 preserve_worktree_on_failure=True,
+                spawn_max_retries=spawn_max_retries,
+                spawn_retry_initial_backoff_seconds=spawn_retry_initial_backoff_seconds,
             )
 
             logger.info(

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -399,6 +399,23 @@ class PipelineConfig(BaseModel):
         "Valid values: 'plan', 'implement'. When set, the pipeline starts "
         "at this phase instead of 'refine'.",
     )
+    spawn_max_retries: int = Field(
+        default=2,
+        ge=0,
+        description=(
+            "Maximum retry attempts for transient gateway worktree-creation "
+            "failures during agent spawn. Total attempts = spawn_max_retries + 1. "
+            "0 disables retry. See #1839."
+        ),
+    )
+    spawn_retry_initial_backoff_seconds: float = Field(
+        default=2.0,
+        gt=0,
+        description=(
+            "Initial backoff seconds between spawn retries. Subsequent attempts "
+            "scale by 2.5x (e.g. 2s, 5s, 12.5s). See #1839."
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -1490,6 +1490,8 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
             branch=pipeline.branch,
             base_branch=pipeline.branch,
             reason=reason,
+            spawn_max_retries=pipeline.config.spawn_max_retries,
+            spawn_retry_initial_backoff_seconds=pipeline.config.spawn_retry_initial_backoff_seconds,
         )
     except (ContainerSpawnError, KubernetesSpawnError) as e:
         # Revert early status update — the agent is not actually running.

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7260,6 +7260,10 @@ def _run_concurrent_phase(
         sandbox_env=sandbox_env,
         certs_volume=certs_volume,
         base_branch=pipeline.base_branch,
+        spawn_max_retries=getattr(pipeline.config, "spawn_max_retries", 2),
+        spawn_retry_initial_backoff_seconds=getattr(
+            pipeline.config, "spawn_retry_initial_backoff_seconds", 2.0
+        ),
     )
 
     max_concurrent = getattr(pipeline.config, "max_concurrent_agents", 6)

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7260,10 +7260,8 @@ def _run_concurrent_phase(
         sandbox_env=sandbox_env,
         certs_volume=certs_volume,
         base_branch=pipeline.base_branch,
-        spawn_max_retries=getattr(pipeline.config, "spawn_max_retries", 2),
-        spawn_retry_initial_backoff_seconds=getattr(
-            pipeline.config, "spawn_retry_initial_backoff_seconds", 2.0
-        ),
+        spawn_max_retries=pipeline.config.spawn_max_retries,
+        spawn_retry_initial_backoff_seconds=pipeline.config.spawn_retry_initial_backoff_seconds,
     )
 
     max_concurrent = getattr(pipeline.config, "max_concurrent_agents", 6)
@@ -8032,6 +8030,8 @@ def _spawn_and_wait(
     certs_volume: str | None = None,
     branch: str | None = None,
     extra_mounts: "list[MountSpec] | None" = None,
+    spawn_max_retries: int | None = None,
+    spawn_retry_initial_backoff_seconds: float | None = None,
 ) -> tuple[int, str]:
     """Spawn a container, wait for it to exit, clean up, return (exit_code, logs).
 
@@ -8048,11 +8048,19 @@ def _spawn_and_wait(
             with .git shadowed by /dev/null bind mounts to force gateway git operations.
         certs_volume: Docker named volume for gateway CA certs (mounted at
             /shared/certs read-only). If None, certs are not mounted.
+        spawn_max_retries: Override for spawn retry attempts (None uses spawner default).
+        spawn_retry_initial_backoff_seconds: Override for initial backoff (None uses spawner default).
 
     Returns:
         (exit_code, container_logs) — logs are captured before cleanup on failure.
     """
     from models import ContainerInfo, ContainerStatus, PipelinePhase
+
+    retry_kwargs: dict = {}
+    if spawn_max_retries is not None:
+        retry_kwargs["spawn_max_retries"] = spawn_max_retries
+    if spawn_retry_initial_backoff_seconds is not None:
+        retry_kwargs["spawn_retry_initial_backoff_seconds"] = spawn_retry_initial_backoff_seconds
 
     spawned = spawner.spawn_agent_job(
         pipeline_id=pipeline_id,
@@ -8067,6 +8075,7 @@ def _spawn_and_wait(
         repo_volumes=repo_volumes,
         branch=branch,
         extra_mounts=extra_mounts,
+        **retry_kwargs,
     )
 
     # Record container and agent in phase execution state

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -598,6 +598,18 @@ class TestIsTransientSpawnFailure:
 
         assert _is_transient_spawn_failure(OSError("socket timeout")) is True
 
+    def test_classify_agrees_with_is_transient_on_permanent_message_with_transient_status(
+        self, spawner
+    ):
+        """_classify_spawn_error must return 'permanent_message' when the message
+        contains a permanent fragment, even if the status code is transient (e.g. 500).
+        This ensures the logged error_category agrees with the retry decision."""
+        from kubernetes_spawner import _classify_spawn_error, _is_transient_spawn_failure
+
+        err = _FakeGatewayError("Repository not found", status_code=500)
+        assert _is_transient_spawn_failure(err) is False
+        assert _classify_spawn_error(err) == "permanent_message"
+
 
 # ---------------------------------------------------------------------------
 # TestStopAgentJob

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -395,6 +395,211 @@ class TestSpawnAgentJob:
 
 
 # ---------------------------------------------------------------------------
+# TestSpawnRetry (#1839)
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnRetry:
+    """Test bounded retry behavior for transient worktree-creation failures."""
+
+    def test_transient_then_success(self, spawner, mock_gateway):
+        """A transient failure on attempt 1 is retried; attempt 2 succeeds."""
+        mock_gateway.create_worktrees.side_effect = [
+            _FakeGatewayError("Timed out fetching refs", status_code=504),
+            _FakeWorktreeResult(),
+        ]
+        with patch("kubernetes_spawner.time.sleep") as mock_sleep:
+            result = spawner.spawn_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                repos=["owner/repo"],
+                spawn_max_retries=2,
+                spawn_retry_initial_backoff_seconds=0.01,
+            )
+        assert result.pipeline_id == "pipe-1"
+        assert mock_gateway.create_worktrees.call_count == 2
+        mock_sleep.assert_called_once()
+
+    def test_all_attempts_fail_raises_with_attempt_count(self, spawner, mock_gateway):
+        """When all attempts fail, the final error names the attempt count."""
+        from kubernetes_spawner import KubernetesSpawnError
+
+        mock_gateway.create_worktrees.side_effect = _FakeGatewayError(
+            "Timed out fetching refs", status_code=504
+        )
+        with (
+            patch("kubernetes_spawner.time.sleep"),
+            pytest.raises(KubernetesSpawnError, match=r"after 3 attempt\(s\)"),
+        ):
+            spawner.spawn_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                repos=["owner/repo"],
+                spawn_max_retries=2,
+                spawn_retry_initial_backoff_seconds=0.01,
+            )
+        assert mock_gateway.create_worktrees.call_count == 3
+
+    def test_permanent_failure_fails_fast(self, spawner, mock_gateway):
+        """Permanent failures (404/422) are not retried."""
+        from kubernetes_spawner import KubernetesSpawnError
+
+        mock_gateway.create_worktrees.side_effect = _FakeGatewayError(
+            "Repository not found", status_code=404
+        )
+        with (
+            patch("kubernetes_spawner.time.sleep") as mock_sleep,
+            pytest.raises(KubernetesSpawnError, match=r"after 1 attempt\(s\)"),
+        ):
+            spawner.spawn_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                repos=["owner/repo"],
+                spawn_max_retries=2,
+                spawn_retry_initial_backoff_seconds=0.01,
+            )
+        assert mock_gateway.create_worktrees.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_max_retries_zero_disables_retry(self, spawner, mock_gateway):
+        """spawn_max_retries=0 gives the pre-#1839 single-attempt behavior."""
+        from kubernetes_spawner import KubernetesSpawnError
+
+        mock_gateway.create_worktrees.side_effect = _FakeGatewayError(
+            "Timed out fetching refs", status_code=504
+        )
+        with (
+            patch("kubernetes_spawner.time.sleep") as mock_sleep,
+            pytest.raises(KubernetesSpawnError, match=r"after 1 attempt\(s\)"),
+        ):
+            spawner.spawn_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                repos=["owner/repo"],
+                spawn_max_retries=0,
+            )
+        assert mock_gateway.create_worktrees.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_connection_failure_no_status_code_is_transient(self, spawner, mock_gateway):
+        """GatewayError with status_code=None classifies as transient."""
+        mock_gateway.create_worktrees.side_effect = [
+            _FakeGatewayError("Failed to connect to gateway", status_code=None),
+            _FakeWorktreeResult(),
+        ]
+        with patch("kubernetes_spawner.time.sleep"):
+            result = spawner.spawn_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                repos=["owner/repo"],
+                spawn_max_retries=2,
+                spawn_retry_initial_backoff_seconds=0.01,
+            )
+        assert result.pipeline_id == "pipe-1"
+        assert mock_gateway.create_worktrees.call_count == 2
+
+    def test_empty_worktree_result_not_retried(self, spawner, mock_gateway):
+        """A successful-looking response with no worktrees is treated as permanent."""
+        from kubernetes_spawner import KubernetesSpawnError
+
+        mock_gateway.create_worktrees.return_value = _FakeWorktreeResult(
+            success=True, worktrees={}, errors=["no repos matched"]
+        )
+        with (
+            patch("kubernetes_spawner.time.sleep") as mock_sleep,
+            pytest.raises(KubernetesSpawnError, match="no worktrees"),
+        ):
+            spawner.spawn_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                repos=["owner/repo"],
+                spawn_max_retries=2,
+                spawn_retry_initial_backoff_seconds=0.01,
+            )
+        assert mock_gateway.create_worktrees.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_backoff_scales_between_attempts(self, spawner, mock_gateway):
+        """Backoff grows between retries rather than staying flat."""
+        mock_gateway.create_worktrees.side_effect = [
+            _FakeGatewayError("Timed out", status_code=504),
+            _FakeGatewayError("Timed out", status_code=504),
+            _FakeWorktreeResult(),
+        ]
+        with patch("kubernetes_spawner.time.sleep") as mock_sleep:
+            spawner.spawn_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                repos=["owner/repo"],
+                spawn_max_retries=2,
+                spawn_retry_initial_backoff_seconds=0.01,
+            )
+        delays = [call.args[0] for call in mock_sleep.call_args_list]
+        assert len(delays) == 2
+        assert delays[1] > delays[0]
+
+
+# ---------------------------------------------------------------------------
+# TestIsTransientSpawnFailure (#1839)
+# ---------------------------------------------------------------------------
+
+
+class TestIsTransientSpawnFailure:
+    """Test classification of spawn failures.
+
+    Uses the ``spawner`` fixture (even though not needed directly) so that
+    ``kubernetes_spawner.GatewayError`` is bound to ``_FakeGatewayError``
+    before the classifier runs.
+    """
+
+    def test_transient_status_codes(self, spawner):
+        from kubernetes_spawner import _is_transient_spawn_failure
+
+        for code in (408, 429, 500, 502, 503, 504):
+            err = _FakeGatewayError("x", status_code=code)
+            assert _is_transient_spawn_failure(err) is True, f"status {code}"
+
+    def test_permanent_status_codes(self, spawner):
+        from kubernetes_spawner import _is_transient_spawn_failure
+
+        for code in (400, 401, 403, 404, 422):
+            err = _FakeGatewayError("x", status_code=code)
+            assert _is_transient_spawn_failure(err) is False, f"status {code}"
+
+    def test_repository_not_found_is_permanent(self, spawner):
+        """'Repository not found' trumps status_code heuristics."""
+        from kubernetes_spawner import _is_transient_spawn_failure
+
+        err = _FakeGatewayError("Repository not found", status_code=500)
+        assert _is_transient_spawn_failure(err) is False
+
+    def test_no_status_code_transient_message(self, spawner):
+        from kubernetes_spawner import _is_transient_spawn_failure
+
+        err = _FakeGatewayError("Failed to connect", status_code=None)
+        assert _is_transient_spawn_failure(err) is True
+
+    def test_no_status_code_unknown_message_is_transient(self, spawner):
+        """Unknown error with no status code defaults to transient per #1839."""
+        from kubernetes_spawner import _is_transient_spawn_failure
+
+        err = _FakeGatewayError("mystery gateway error", status_code=None)
+        assert _is_transient_spawn_failure(err) is True
+
+    def test_unknown_http_status_is_permanent(self, spawner):
+        """An HTTP status we don't know is treated as permanent (fail fast)."""
+        from kubernetes_spawner import _is_transient_spawn_failure
+
+        err = _FakeGatewayError("weird", status_code=418)
+        assert _is_transient_spawn_failure(err) is False
+
+    def test_non_gateway_exception_is_transient(self, spawner):
+        from kubernetes_spawner import _is_transient_spawn_failure
+
+        assert _is_transient_spawn_failure(OSError("socket timeout")) is True
+
+
+# ---------------------------------------------------------------------------
 # TestStopAgentJob
 # ---------------------------------------------------------------------------
 

--- a/orchestrator/tests/test_per_agent_worktrees.py
+++ b/orchestrator/tests/test_per_agent_worktrees.py
@@ -203,6 +203,36 @@ class TestWorktreeCreationFallback:
             )
 
 
+class TestSpawnRetryOnTransientFailure:
+    """Transient gateway failures during worktree creation are retried (#1839)."""
+
+    @patch.dict("os.environ", {"HOST_UID": "1000", "HOST_GID": "1000"})
+    def test_transient_failure_retried(self, spawner, mock_docker_client, mock_gateway_client):
+        """A transient failure on first attempt is retried successfully."""
+        from gateway_client import GatewayError
+
+        mock_gateway_client.create_worktrees.side_effect = [
+            GatewayError("Timed out fetching refs", status_code=504),
+            WorktreeResult(
+                success=True,
+                worktrees={"egg": "/home/egg/.egg-worktrees/issue-123-coder/egg"},
+                errors=[],
+            ),
+        ]
+        with patch("kubernetes_spawner.time.sleep"):
+            spawner.spawn_agent_container(
+                pipeline_id="issue-123",
+                agent_role=AgentRole.CODER,
+                repo_volumes={"egg": "/host/path/egg"},
+                repos=["owner/egg"],
+                mode="public",
+                branch="egg/issue-123/work",
+                spawn_max_retries=2,
+                spawn_retry_initial_backoff_seconds=0.01,
+            )
+        assert mock_gateway_client.create_worktrees.call_count == 2
+
+
 class TestCleanupPipelineWorktrees:
     """Tests for per-agent worktree cleanup during pipeline cleanup."""
 


### PR DESCRIPTION
## Summary

- Wraps the `gateway.create_worktrees` call in `KubernetesSpawner.spawn_agent_job` in a bounded retry (default 2 retries, 2s initial backoff, 2.5× scale). Transient failures (connection errors, 408/429/5xx) are retried; permanent ones (400/401/403/404/422 or `"Repository not found"` messages) fail fast so we don't waste retry budget on them.
- Emits a structured `event_type=spawn_attempt` log per attempt (pipeline_id, agent_role, attempt, outcome, error_category, error_detail, duration_ms, will_retry) so spawn failures can be analyzed without correlating orchestrator and gateway pod logs.
- Adds two `PipelineConfig` knobs (`spawn_max_retries`, `spawn_retry_initial_backoff_seconds`) and plumbs them through `create_concurrent_spawn_fn` so the concurrent-phase spawner — the path that triggered the original incident — honors pipeline-level retry config.

Fixes #1839.

## Test plan

- [x] `pytest orchestrator/tests/test_kubernetes_spawner.py orchestrator/tests/test_per_agent_worktrees.py orchestrator/tests/test_container_spawner.py` — 102 passed (includes 15 new tests covering transient-then-success, all-attempts-fail, permanent-fail-fast, `spawn_max_retries=0` no-retry, empty-worktree-result not retried, backoff scaling, and the `_is_transient_spawn_failure` classifier matrix).
- [ ] Observe the new `event_type=spawn_attempt` log lines on a real concurrent-phase spawn to confirm they aggregate the way we want for analytics.

## Notes

- The classifier is intentionally coarse (status code + message). Per-repo classification via `GatewayError.details["errors"]` is blocked on #1838 and can be layered in later.
- Spawn-failure cleanup on the orchestrator-state side is the separate #1837 issue; the retry here lands first, and cleanup would only fire after retries exhaust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)