### PR TITLE
Fix #1855: expose readiness history in check_health

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -66,11 +66,12 @@ WORKDIR /app
 # Copy gateway code
 COPY gateway/*.py ./
 
-# Copy shared modules (egg_logging for logging, egg_config for config parsing, egg_contracts for contract API, egg_restrictions for agent role enforcement)
+# Copy shared modules (egg_logging for logging, egg_config for config parsing, egg_contracts for contract API, egg_restrictions for agent role enforcement, egg_health for health tracking)
 COPY shared/egg_logging/ ./egg_logging/
 COPY shared/egg_config/ ./egg_config/
 COPY shared/egg_contracts/ ./egg_contracts/
 COPY shared/egg_restrictions/ ./egg_restrictions/
+COPY shared/egg_health/ ./egg_health/
 
 # Copy config module (repo_config needed by github_client for user mode)
 # Copy to both /config/ (for package-style imports) and /app/ (for PYTHONPATH)

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -53,7 +53,13 @@ from waitress import serve
 _shared_path = Path(__file__).parent.parent.parent / "shared"
 if _shared_path.exists():
     sys.path.insert(0, str(_shared_path))
+from egg_health import HealthTracker
 from egg_logging import get_logger
+
+# Module-level health tracker. Updated every time the /api/v1/health
+# endpoint is evaluated so callers can distinguish "healthy since process
+# start" from "just came up / recent flapping" (see issue #1855).
+_health_tracker = HealthTracker()
 
 # Import gateway modules - try relative import first (module mode),
 # fall back to absolute import (standalone script mode in container)
@@ -589,6 +595,11 @@ def health_check() -> Response:
     # verified the Python gateway (port 9848), not Squid (port 3129).
     # See: https://github.com/jwbron/egg/issues/1387
     is_healthy = token_valid and launcher_secret_configured and squid_status["listening"]
+
+    # Record this observation so the snapshot can expose transitions (see #1855).
+    _health_tracker.record(is_healthy)
+    tracker_snapshot = _health_tracker.snapshot()
+
     response_data: dict[str, Any] = {
         "status": "healthy" if is_healthy else "degraded",
         "github_token_valid": token_valid,
@@ -597,6 +608,10 @@ def health_check() -> Response:
         "active_sessions": active_sessions,
         "service": "gateway",
         "client_ip": request.remote_addr,
+        "process_start_time": tracker_snapshot["process_start_time"],
+        "healthy_since": tracker_snapshot["healthy_since"],
+        "last_unhealthy_at": tracker_snapshot["last_unhealthy_at"],
+        "recent_transitions": tracker_snapshot["recent_transitions"],
     }
 
     # Include orchestrator status if configured

--- a/gateway/tests/test_gateway_integration.py
+++ b/gateway/tests/test_gateway_integration.py
@@ -80,6 +80,21 @@ class TestHealthEndpoint:
         data = json.loads(response.data)
         assert "status" in data
 
+    def test_health_exposes_readiness_history(self, client):
+        """Gateway /health surfaces the issue #1855 readiness-history fields."""
+        response = client.get("/api/v1/health")
+        data = json.loads(response.data)
+
+        for field in (
+            "process_start_time",
+            "healthy_since",
+            "last_unhealthy_at",
+            "recent_transitions",
+        ):
+            assert field in data, f"missing {field} in gateway health response"
+        assert isinstance(data["recent_transitions"], list)
+        assert data["process_start_time"] is not None
+
 
 class TestGitExecuteEndpoint:
     """Tests for /api/v1/git/execute endpoint."""

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -16,7 +16,7 @@ COPY orchestrator/*.py ./
 COPY orchestrator/routes/ ./routes/
 COPY orchestrator/health_checks/ ./health_checks/
 
-# Copy shared modules (egg_logging, egg_config, egg_contracts, egg_container, egg_agent, egg_git, egg_anchor)
+# Copy shared modules (egg_logging, egg_config, egg_contracts, egg_container, egg_agent, egg_git, egg_anchor, egg_health)
 COPY shared/egg_logging/ ./egg_logging/
 COPY shared/egg_config/ ./egg_config/
 COPY shared/egg_contracts/ ./egg_contracts/
@@ -25,6 +25,7 @@ COPY shared/egg_agent/ ./egg_agent/
 COPY shared/egg_orchestrator/ ./egg_orchestrator/
 COPY shared/egg_git/ ./egg_git/
 COPY shared/egg_anchor/ ./egg_anchor/
+COPY shared/egg_health/ ./egg_health/
 
 # Copy anchor schema files (required by egg_anchor.validator)
 COPY .egg/schemas/ ./.egg/schemas/

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -274,7 +274,14 @@ PIPELINE_TOOLS = [
     # --- Orchestrator-backed diagnostic tools ---
     {
         "name": "check_health",
-        "description": "Check health of the orchestrator and gateway services. Returns combined status.",
+        "description": (
+            "Check health of the orchestrator and gateway services. Returns combined status "
+            "plus per-service readiness history: `healthy_since` (ISO timestamp of the last "
+            "transition to healthy, or process start if never unhealthy this run), "
+            "`last_unhealthy_at` (most recent unhealthy observation, null if none), and a "
+            "bounded `recent_transitions` list. Use this to diagnose readiness flapping or "
+            "recently-started services when race-style failures happen."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {},
@@ -1612,7 +1619,13 @@ class PipelineToolHandler:
     # --- Orchestrator-backed tools ---
 
     def _handle_check_health(self, args: dict[str, Any]) -> dict[str, Any]:
-        """Check orchestrator and gateway health."""
+        """Check orchestrator and gateway health.
+
+        Each per-service entry includes readiness history (``healthy_since``,
+        ``last_unhealthy_at``, ``recent_transitions``) so operators can
+        diagnose "was this service reachable 30 seconds ago?" without having
+        to cross-reference logs. See issue #1855.
+        """
         result: dict[str, Any] = {}
 
         # Orchestrator health
@@ -1621,9 +1634,21 @@ class PipelineToolHandler:
             result["orchestrator"] = {
                 "healthy": orch.get("status") == "healthy",
                 "status": orch.get("status", "unknown"),
+                "healthy_since": orch.get("healthy_since"),
+                "last_unhealthy_at": orch.get("last_unhealthy_at"),
+                "process_start_time": orch.get("process_start_time"),
+                "recent_transitions": orch.get("recent_transitions", []),
             }
         except Exception as e:
-            result["orchestrator"] = {"healthy": False, "status": "unreachable", "error": str(e)}
+            result["orchestrator"] = {
+                "healthy": False,
+                "status": "unreachable",
+                "error": str(e),
+                "healthy_since": None,
+                "last_unhealthy_at": None,
+                "process_start_time": None,
+                "recent_transitions": [],
+            }
 
         # Gateway health — use direct HTTP to avoid importing orchestrator.gateway_client
         # which may not be available when the MCP server runs outside the orchestrator venv
@@ -1640,9 +1665,21 @@ class PipelineToolHandler:
                 "healthy": gw.get("status") == "healthy",
                 "status": gw.get("status", "unknown"),
                 "version": gw.get("version"),
+                "healthy_since": gw.get("healthy_since"),
+                "last_unhealthy_at": gw.get("last_unhealthy_at"),
+                "process_start_time": gw.get("process_start_time"),
+                "recent_transitions": gw.get("recent_transitions", []),
             }
         except Exception as e:
-            result["gateway"] = {"healthy": False, "status": "unreachable", "error": str(e)}
+            result["gateway"] = {
+                "healthy": False,
+                "status": "unreachable",
+                "error": str(e),
+                "healthy_since": None,
+                "last_unhealthy_at": None,
+                "process_start_time": None,
+                "recent_transitions": [],
+            }
 
         result["healthy"] = result.get("orchestrator", {}).get("healthy", False) and result.get(
             "gateway", {}

--- a/orchestrator/routes/health.py
+++ b/orchestrator/routes/health.py
@@ -54,6 +54,9 @@ def health_check() -> tuple[Response, int]:
     # healthy observation. The tracker still populates process_start_time
     # and healthy_since, which is exactly the signal operators need to
     # distinguish "stable for hours" from "came up seconds ago" (#1855).
+    # TODO: When degraded-state evaluation is added (e.g. the "docker":
+    # "unknown" component below), pass the actual health status here
+    # instead of hard-coding True.
     _health_tracker.record(True)
     tracker_snapshot = _health_tracker.snapshot()
 

--- a/orchestrator/routes/health.py
+++ b/orchestrator/routes/health.py
@@ -21,7 +21,14 @@ _shared_path = Path(__file__).parent.parent.parent / "shared"
 if _shared_path.exists() and str(_shared_path) not in sys.path:
     sys.path.insert(0, str(_shared_path))
 
+from egg_health import HealthTracker
+
 health_bp = Blueprint("health", __name__, url_prefix="/api/v1")
+
+# Module-level health tracker — updated every time /api/v1/health is
+# evaluated. Exposes readiness history so operators can tell "healthy
+# since boot" from "just came up" (see issue #1855).
+_health_tracker = HealthTracker()
 
 
 @health_bp.route("/health", methods=["GET"])
@@ -42,7 +49,14 @@ def health_check() -> tuple[Response, int]:
             }
         }
     """
-    # Basic health response
+    # The orchestrator's /health endpoint always responds "healthy" today
+    # (degraded states aren't evaluated here), so each hit records a
+    # healthy observation. The tracker still populates process_start_time
+    # and healthy_since, which is exactly the signal operators need to
+    # distinguish "stable for hours" from "came up seconds ago" (#1855).
+    _health_tracker.record(True)
+    tracker_snapshot = _health_tracker.snapshot()
+
     response = {
         "status": "healthy",
         "service": "egg-orchestrator",
@@ -51,6 +65,10 @@ def health_check() -> tuple[Response, int]:
             "state_store": "ok",
             "docker": "unknown",  # Will be updated when docker client is available
         },
+        "process_start_time": tracker_snapshot["process_start_time"],
+        "healthy_since": tracker_snapshot["healthy_since"],
+        "last_unhealthy_at": tracker_snapshot["last_unhealthy_at"],
+        "recent_transitions": tracker_snapshot["recent_transitions"],
     }
 
     return jsonify(response), 200

--- a/orchestrator/tests/test_health_check_lifecycle_integration.py
+++ b/orchestrator/tests/test_health_check_lifecycle_integration.py
@@ -282,6 +282,23 @@ class TestBasicEndpoints:
         assert data["service"] == "egg-orchestrator"
         assert "timestamp" in data
         assert "components" in data
+        # Readiness history fields (issue #1855) — let operators see when
+        # the service actually came up vs. a point-in-time snapshot.
+        assert data["process_start_time"] is not None
+        # First observation is healthy, so healthy_since == process_start_time.
+        assert data["healthy_since"] == data["process_start_time"]
+        assert data["last_unhealthy_at"] is None
+        assert isinstance(data["recent_transitions"], list)
+
+    def test_health_recent_transitions_accumulate(self, app, client):
+        # Two successive hits should not double-record a transition —
+        # the service has been healthy the whole time.
+        client.get("/api/v1/health")
+        resp = client.get("/api/v1/health")
+        data = json.loads(resp.data)
+        # Still exactly one transition (the initial healthy one).
+        healthy_transitions = [t for t in data["recent_transitions"] if t["state"] == "healthy"]
+        assert len(healthy_transitions) == 1
 
     def test_ready_returns_true(self, app, client):
         resp = client.get("/api/v1/ready")

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -41,9 +41,29 @@ def _mock_gateway_health_response(data):
 
 class TestCheckHealth:
     def test_both_healthy(self, handler):
-        mock_opener = _mock_gateway_health_response({"status": "healthy", "version": "1.0"})
+        mock_opener = _mock_gateway_health_response(
+            {
+                "status": "healthy",
+                "version": "1.0",
+                "healthy_since": "2026-04-22T03:42:15+00:00",
+                "last_unhealthy_at": "2026-04-22T03:42:14+00:00",
+                "process_start_time": "2026-04-22T03:42:00+00:00",
+                "recent_transitions": [
+                    {"ts": "2026-04-22T03:42:14+00:00", "state": "unhealthy"},
+                    {"ts": "2026-04-22T03:42:15+00:00", "state": "healthy"},
+                ],
+            }
+        )
         with patch.object(handler, "_make_request") as mock_req:
-            mock_req.return_value = {"status": "healthy"}
+            mock_req.return_value = {
+                "status": "healthy",
+                "healthy_since": "2026-04-22T03:41:00+00:00",
+                "last_unhealthy_at": None,
+                "process_start_time": "2026-04-22T03:41:00+00:00",
+                "recent_transitions": [
+                    {"ts": "2026-04-22T03:41:00+00:00", "state": "healthy"},
+                ],
+            }
             with patch("urllib.request.build_opener", return_value=mock_opener):
                 result = handler.handle_tool_call("check_health", {})
 
@@ -51,6 +71,13 @@ class TestCheckHealth:
         assert result["orchestrator"]["healthy"] is True
         assert result["gateway"]["healthy"] is True
         assert result["gateway"]["version"] == "1.0"
+
+        # Readiness history flows through per issue #1855.
+        assert result["orchestrator"]["healthy_since"] == "2026-04-22T03:41:00+00:00"
+        assert result["orchestrator"]["last_unhealthy_at"] is None
+        assert result["gateway"]["healthy_since"] == "2026-04-22T03:42:15+00:00"
+        assert result["gateway"]["last_unhealthy_at"] == "2026-04-22T03:42:14+00:00"
+        assert len(result["gateway"]["recent_transitions"]) == 2
 
     def test_orchestrator_unreachable(self, handler):
         mock_opener = _mock_gateway_health_response({"status": "healthy", "version": "1.0"})
@@ -61,6 +88,11 @@ class TestCheckHealth:
         assert result["healthy"] is False
         assert result["orchestrator"]["healthy"] is False
         assert "unreachable" in result["orchestrator"]["status"]
+        # Unreachable services report null history fields so callers can
+        # distinguish "no data" from "observed unhealthy".
+        assert result["orchestrator"]["healthy_since"] is None
+        assert result["orchestrator"]["last_unhealthy_at"] is None
+        assert result["orchestrator"]["recent_transitions"] == []
 
     def test_gateway_unreachable(self, handler):
         with patch.object(handler, "_make_request") as mock_req:
@@ -75,6 +107,9 @@ class TestCheckHealth:
         assert result["orchestrator"]["healthy"] is True
         assert result["gateway"]["healthy"] is False
         assert "unreachable" in result["gateway"]["status"]
+        assert result["gateway"]["healthy_since"] is None
+        assert result["gateway"]["last_unhealthy_at"] is None
+        assert result["gateway"]["recent_transitions"] == []
 
 
 class TestListContainers:

--- a/shared/egg_health/__init__.py
+++ b/shared/egg_health/__init__.py
@@ -1,0 +1,13 @@
+"""Runtime health-transition tracking.
+
+Small, thread-safe utility used by the orchestrator and gateway to annotate
+their ``/api/v1/health`` responses with readiness history so operators can
+tell the difference between "has been healthy for a while" and "just now
+transitioned to healthy after recent flapping/cold-start."
+
+See GitHub issue #1855.
+"""
+
+from .tracker import HealthTracker
+
+__all__ = ["HealthTracker"]

--- a/shared/egg_health/tracker.py
+++ b/shared/egg_health/tracker.py
@@ -1,0 +1,77 @@
+"""HealthTracker: record observed healthy/unhealthy samples and summarise transitions.
+
+The tracker is updated every time the owning service evaluates its health
+(typically each time its ``/api/v1/health`` endpoint is hit). From the
+recorded observations it computes:
+
+- ``healthy_since`` — timestamp of the most recent transition to healthy.
+  If the service has been healthy since the first observation, this is the
+  process start time (matching the "or process start if never unhealthy
+  this run" semantics spelled out in issue #1855).
+- ``last_unhealthy_at`` — most recent unhealthy sample, ``None`` if none
+  have been observed.
+- ``recent_transitions`` — bounded ring buffer of the last N transitions.
+
+The observation-driven model (vs. a background poller) keeps the
+implementation lightweight: in production the endpoint is hit by k8s
+readiness probes on a regular cadence; locally it is hit whenever an
+operator pokes it.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from datetime import UTC, datetime
+from typing import Any
+
+
+class HealthTracker:
+    """Thread-safe tracker for healthy/unhealthy transitions of a single service."""
+
+    def __init__(self, *, max_transitions: int = 10) -> None:
+        self._lock = threading.Lock()
+        self._process_start: datetime = datetime.now(UTC)
+        self._current_healthy: bool | None = None
+        self._healthy_since: datetime | None = None
+        self._last_unhealthy_at: datetime | None = None
+        self._transitions: deque[dict[str, str]] = deque(maxlen=max_transitions)
+
+    def record(self, is_healthy: bool, *, now: datetime | None = None) -> None:
+        """Record a new health observation and update derived state."""
+        ts = now if now is not None else datetime.now(UTC)
+        with self._lock:
+            if self._current_healthy is None:
+                # First observation.
+                if is_healthy:
+                    # "process start if never unhealthy this run"
+                    self._healthy_since = self._process_start
+                else:
+                    self._last_unhealthy_at = ts
+                self._transitions.append(
+                    {"ts": ts.isoformat(), "state": "healthy" if is_healthy else "unhealthy"}
+                )
+            elif self._current_healthy and not is_healthy:
+                self._last_unhealthy_at = ts
+                self._healthy_since = None
+                self._transitions.append({"ts": ts.isoformat(), "state": "unhealthy"})
+            elif not self._current_healthy and is_healthy:
+                self._healthy_since = ts
+                self._transitions.append({"ts": ts.isoformat(), "state": "healthy"})
+            else:
+                # still unhealthy — refresh last_unhealthy_at but don't record
+                # a transition (it wasn't one).
+                self._last_unhealthy_at = ts
+            self._current_healthy = is_healthy
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return a JSON-serialisable snapshot of the tracker state."""
+        with self._lock:
+            return {
+                "process_start_time": self._process_start.isoformat(),
+                "healthy_since": (self._healthy_since.isoformat() if self._healthy_since else None),
+                "last_unhealthy_at": (
+                    self._last_unhealthy_at.isoformat() if self._last_unhealthy_at else None
+                ),
+                "recent_transitions": list(self._transitions),
+            }

--- a/shared/egg_health/tracker.py
+++ b/shared/egg_health/tracker.py
@@ -58,10 +58,11 @@ class HealthTracker:
             elif not self._current_healthy and is_healthy:
                 self._healthy_since = ts
                 self._transitions.append({"ts": ts.isoformat(), "state": "healthy"})
-            else:
+            elif not self._current_healthy and not is_healthy:
                 # still unhealthy — refresh last_unhealthy_at but don't record
                 # a transition (it wasn't one).
                 self._last_unhealthy_at = ts
+            # else: still healthy — nothing to update.
             self._current_healthy = is_healthy
 
     def snapshot(self) -> dict[str, Any]:

--- a/shared/pyproject.toml
+++ b/shared/pyproject.toml
@@ -10,4 +10,4 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["beads*", "egg_agent*", "egg_anchor*", "egg_config*", "egg_container*", "egg_git*", "egg_harness*", "egg_harness_integration*", "egg_logging*", "egg_orchestrator*", "egg_restrictions*", "enrichment*", "git_utils*", "notifications*", "text_utils*"]
+include = ["beads*", "egg_agent*", "egg_anchor*", "egg_config*", "egg_container*", "egg_git*", "egg_harness*", "egg_harness_integration*", "egg_health*", "egg_logging*", "egg_orchestrator*", "egg_restrictions*", "enrichment*", "git_utils*", "notifications*", "text_utils*"]

--- a/shared/tests/test_egg_health.py
+++ b/shared/tests/test_egg_health.py
@@ -1,0 +1,110 @@
+"""Unit tests for shared.egg_health.HealthTracker."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from egg_health import HealthTracker
+
+
+def _at(seconds: int) -> datetime:
+    """Helper: build a deterministic timestamp N seconds after a fixed epoch."""
+    return datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC) + timedelta(seconds=seconds)
+
+
+class TestFirstObservation:
+    def test_first_observation_healthy_uses_process_start(self):
+        tracker = HealthTracker()
+        tracker.record(True, now=_at(5))
+        snap = tracker.snapshot()
+
+        # Per issue #1855: if never unhealthy this run, healthy_since is
+        # the process start time — NOT the observation time.
+        assert snap["healthy_since"] == snap["process_start_time"]
+        assert snap["last_unhealthy_at"] is None
+        assert [t["state"] for t in snap["recent_transitions"]] == ["healthy"]
+
+    def test_first_observation_unhealthy(self):
+        tracker = HealthTracker()
+        tracker.record(False, now=_at(5))
+        snap = tracker.snapshot()
+
+        assert snap["healthy_since"] is None
+        assert snap["last_unhealthy_at"] == _at(5).isoformat()
+        assert [t["state"] for t in snap["recent_transitions"]] == ["unhealthy"]
+
+
+class TestTransitions:
+    def test_healthy_to_unhealthy_resets_healthy_since(self):
+        tracker = HealthTracker()
+        tracker.record(True, now=_at(0))
+        tracker.record(False, now=_at(10))
+        snap = tracker.snapshot()
+
+        assert snap["healthy_since"] is None
+        assert snap["last_unhealthy_at"] == _at(10).isoformat()
+        assert [t["state"] for t in snap["recent_transitions"]] == ["healthy", "unhealthy"]
+
+    def test_unhealthy_to_healthy_records_transition_time(self):
+        tracker = HealthTracker()
+        tracker.record(False, now=_at(0))
+        tracker.record(True, now=_at(30))
+        snap = tracker.snapshot()
+
+        # healthy_since should be the transition time, not process_start.
+        assert snap["healthy_since"] == _at(30).isoformat()
+        assert snap["last_unhealthy_at"] == _at(0).isoformat()
+        assert [t["state"] for t in snap["recent_transitions"]] == ["unhealthy", "healthy"]
+
+    def test_repeated_healthy_does_not_move_healthy_since(self):
+        tracker = HealthTracker()
+        tracker.record(True, now=_at(0))
+        original_since = tracker.snapshot()["healthy_since"]
+        tracker.record(True, now=_at(5))
+        tracker.record(True, now=_at(10))
+        snap = tracker.snapshot()
+
+        assert snap["healthy_since"] == original_since
+        # No new transitions — still just the initial one.
+        assert len(snap["recent_transitions"]) == 1
+
+    def test_repeated_unhealthy_advances_last_unhealthy_at(self):
+        tracker = HealthTracker()
+        tracker.record(False, now=_at(0))
+        tracker.record(False, now=_at(5))
+        tracker.record(False, now=_at(12))
+        snap = tracker.snapshot()
+
+        assert snap["last_unhealthy_at"] == _at(12).isoformat()
+        # No transition — still just the first unhealthy event.
+        assert len(snap["recent_transitions"]) == 1
+
+
+class TestRingBuffer:
+    def test_ring_buffer_is_bounded(self):
+        tracker = HealthTracker(max_transitions=3)
+        # Four transitions: unhealthy, healthy, unhealthy, healthy
+        tracker.record(False, now=_at(0))
+        tracker.record(True, now=_at(1))
+        tracker.record(False, now=_at(2))
+        tracker.record(True, now=_at(3))
+        snap = tracker.snapshot()
+
+        assert len(snap["recent_transitions"]) == 3
+        # Oldest ("unhealthy" at t=0) should have been dropped.
+        assert snap["recent_transitions"][0]["ts"] == _at(1).isoformat()
+
+
+def test_snapshot_shape():
+    tracker = HealthTracker()
+    tracker.record(True)
+    snap = tracker.snapshot()
+    assert set(snap.keys()) == {
+        "process_start_time",
+        "healthy_since",
+        "last_unhealthy_at",
+        "recent_transitions",
+    }
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Adds `healthy_since`, `last_unhealthy_at`, `process_start_time`, and a bounded `recent_transitions` ring buffer to both the orchestrator and gateway `/api/v1/health` responses, and surfaces them through the MCP `check_health` tool.
- Factors the transition-tracking logic into a small shared `egg_health.HealthTracker` utility so both services derive the same fields the same way.
- When a service is unreachable, the MCP tool returns `null`/`[]` for the history fields so callers can distinguish "no data" from "observed unhealthy".

Today `check_health` is a point-in-time snapshot — for race-style failures (e.g. a pipeline submitted during the gateway-startup window) an operator polling afterwards sees both services healthy with no hint that the gateway had just come up. With this change, `healthy_since` close to `now` makes cold-start cases self-evident.

Closes #1855.

## Test plan
- [x] `make lint` passes.
- [x] `pytest shared/tests/test_egg_health.py` — 8 new unit tests for `HealthTracker` (first-observation semantics, transitions, ring-buffer bound).
- [x] `pytest orchestrator/tests/test_mcp_tools.py::TestCheckHealth` — extended to assert the new fields flow through healthy, orchestrator-unreachable, and gateway-unreachable branches.
- [x] `pytest orchestrator/tests/test_health_check_lifecycle_integration.py::TestBasicEndpoints` — orchestrator `/api/v1/health` now exposes the new fields; repeated healthy hits don't duplicate transitions.
- [x] `pytest gateway/tests/test_gateway_integration.py::TestHealthEndpoint` — gateway `/api/v1/health` exposes the new fields.
- [ ] Manual smoke: `curl $ORCH/api/v1/health` / `curl $GW/api/v1/health` and call the MCP `check_health` tool to confirm fields propagate end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)