### PR TITLE
Fix #1851: gate pipeline submission on gateway readiness

### DIFF
--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -432,6 +432,7 @@ See the [Pipeline Health Monitoring Guide](../docs/guides/pipeline-health-monito
 | `EGG_PRIVATE_MODE` | Private network mode | None |
 | `HOST_HOME` | Host machine home directory (for worktree path translation) | None |
 | `ORCHESTRATOR_PORT` | API port | `9849` |
+| `EGG_GATEWAY_READY_TIMEOUT_SECONDS` | Max wait for the gateway to become healthy at `POST /api/v1/pipelines`. Set to `0` to disable the gate. See #1851. | `60` |
 
 ### Constants
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -825,6 +825,34 @@ def create_pipeline() -> tuple[Response, int]:
     if (issue_number or pipeline_id) and not branch and mode != PipelineMode.BABYSIT:
         return make_error_response("Missing branch")
 
+    # Wait for the gateway to be ready before any gateway-dependent work.
+    # On fresh deploys / pod restarts the orchestrator can accept requests
+    # while the gateway HTTP listener is still coming up; without this gate
+    # the first submission proceeds, hits the gateway during pipeline-level
+    # worktree creation or per-agent fan-out, and surfaces as a cascade of
+    # generic per-agent ConnectionRefused / "Remote end closed connection"
+    # errors that operators have to reverse-engineer.  See #1851.
+    try:
+        _ready_timeout = int(os.environ.get("EGG_GATEWAY_READY_TIMEOUT_SECONDS", "60"))
+    except ValueError:
+        _ready_timeout = 60
+    if _ready_timeout > 0:
+        _gw_ready = get_gateway_client()
+        if not _gw_ready.wait_for_healthy(timeout_seconds=_ready_timeout):
+            _last = _gw_ready.check_health()
+            return make_error_response(
+                f"Gateway not ready after {_ready_timeout}s "
+                f"(status={_last.status}): {_last.error or 'unhealthy'}. "
+                "Retry once the gateway has finished starting up.",
+                status_code=503,
+                details={
+                    "reason": "gateway_not_ready",
+                    "gateway_status": _last.status,
+                    "gateway_error": _last.error,
+                    "timeout_seconds": _ready_timeout,
+                },
+            )
+
     repo_path = get_repo_path()
 
     # Check that the target branch does not already exist on the remote.

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -836,11 +836,12 @@ def create_pipeline() -> tuple[Response, int]:
         _ready_timeout = int(os.environ.get("EGG_GATEWAY_READY_TIMEOUT_SECONDS", "60"))
     except ValueError:
         _ready_timeout = 60
+    _ready_timeout = max(0, _ready_timeout)
     if _ready_timeout > 0:
         _gw_ready = get_gateway_client()
         if not _gw_ready.wait_for_healthy(timeout_seconds=_ready_timeout):
             _last = _gw_ready.check_health()
-            return make_error_response(
+            _resp, _status = make_error_response(
                 f"Gateway not ready after {_ready_timeout}s "
                 f"(status={_last.status}): {_last.error or 'unhealthy'}. "
                 "Retry once the gateway has finished starting up.",
@@ -852,6 +853,8 @@ def create_pipeline() -> tuple[Response, int]:
                     "timeout_seconds": _ready_timeout,
                 },
             )
+            _resp.headers["Retry-After"] = str(_ready_timeout)
+            return _resp, _status
 
     repo_path = get_repo_path()
 

--- a/orchestrator/tests/test_pipeline_creation_babysit_pr.py
+++ b/orchestrator/tests/test_pipeline_creation_babysit_pr.py
@@ -573,3 +573,120 @@ class TestBabysitCreationDuplicate:
         body = response.get_json()
         assert body["success"] is False
         assert "already exists" in body["message"].lower()
+
+
+class TestGatewayReadinessGate:
+    """``create_pipeline`` waits for gateway readiness before any gateway-
+
+    dependent work.  See #1851 — without this gate, fresh deploys hit a
+    window where the orchestrator is up but the gateway HTTP listener
+    isn't, and the first submission cascades into per-agent ConnectionRefused
+    errors that operators have to reverse-engineer.
+    """
+
+    def test_unready_gateway_returns_503_with_named_reason(self, client, monkeypatch):
+        """If ``wait_for_healthy`` times out, return a clear 503 — not a 200
+        followed by a downstream cascade of per-agent spawn failures.
+        """
+        # Cap the wait so the test stays fast even if patching regresses.
+        monkeypatch.setenv("EGG_GATEWAY_READY_TIMEOUT_SECONDS", "1")
+
+        with (
+            patch("routes.pipelines.get_state_store") as mock_store_factory,
+            patch("routes.pipelines.get_repo_path") as mock_repo_path,
+            patch("routes.pipelines.get_gateway_client") as mock_gw,
+        ):
+            mock_repo_path.return_value = "/tmp/repo"
+            mock_gw.return_value.wait_for_healthy.return_value = False
+            mock_gw.return_value.check_health.return_value = MagicMock(
+                status="unreachable", error="Connection refused"
+            )
+
+            response = client.post(
+                "/api/v1/pipelines",
+                json={
+                    "issue_number": 123,
+                    "repo": "owner/repo",
+                    "branch": "egg/issue-123",
+                },
+            )
+
+        assert response.status_code == 503, response.get_json()
+        body = response.get_json()
+        assert body["success"] is False
+        assert "gateway not ready" in body["message"].lower()
+        details = body.get("details", {})
+        assert details.get("reason") == "gateway_not_ready"
+        assert details.get("gateway_status") == "unreachable"
+        assert details.get("gateway_error") == "Connection refused"
+        assert details.get("timeout_seconds") == 1
+        # Pipeline must not be created when the gateway is unreachable.
+        mock_store_factory.assert_not_called()
+
+    def test_ready_gateway_proceeds_to_pipeline_creation(self, client, monkeypatch):
+        """When ``wait_for_healthy`` returns True the route falls through
+        to the existing branch-existence check + creation flow.
+        """
+        monkeypatch.setenv("EGG_GATEWAY_READY_TIMEOUT_SECONDS", "5")
+
+        with (
+            patch("routes.pipelines.get_state_store") as mock_store_factory,
+            patch("routes.pipelines.get_repo_path") as mock_repo_path,
+            patch("routes.pipelines.get_gateway_client") as mock_gw,
+        ):
+            mock_repo_path.return_value = "/tmp/repo"
+            mock_gw.return_value.wait_for_healthy.return_value = True
+            mock_gw.return_value.ls_remote_branch.return_value = False
+            mock_store = MagicMock()
+            fake = MagicMock()
+            fake.id = "issue-123"
+            fake.model_dump.return_value = {"id": "issue-123", "has_contract": True}
+            mock_store.create_pipeline.return_value = fake
+            mock_store_factory.return_value = mock_store
+
+            response = client.post(
+                "/api/v1/pipelines",
+                json={
+                    "issue_number": 123,
+                    "repo": "owner/repo",
+                    "branch": "egg/issue-123",
+                },
+            )
+
+        assert response.status_code in (200, 201), response.get_json()
+        # check_health should NOT be called when wait_for_healthy succeeds —
+        # we only probe again to surface the last-known status on failure.
+        mock_gw.return_value.check_health.assert_not_called()
+
+    def test_zero_timeout_disables_gate(self, client, monkeypatch):
+        """``EGG_GATEWAY_READY_TIMEOUT_SECONDS=0`` skips the gate entirely
+        (escape hatch for environments where the gateway is started out of
+        band, e.g. integration test harnesses that wire it up themselves).
+        """
+        monkeypatch.setenv("EGG_GATEWAY_READY_TIMEOUT_SECONDS", "0")
+
+        with (
+            patch("routes.pipelines.get_state_store") as mock_store_factory,
+            patch("routes.pipelines.get_repo_path") as mock_repo_path,
+            patch("routes.pipelines.get_gateway_client") as mock_gw,
+        ):
+            mock_repo_path.return_value = "/tmp/repo"
+            mock_gw.return_value.ls_remote_branch.return_value = False
+            mock_store = MagicMock()
+            fake = MagicMock()
+            fake.id = "issue-123"
+            fake.model_dump.return_value = {"id": "issue-123", "has_contract": True}
+            mock_store.create_pipeline.return_value = fake
+            mock_store_factory.return_value = mock_store
+
+            response = client.post(
+                "/api/v1/pipelines",
+                json={
+                    "issue_number": 123,
+                    "repo": "owner/repo",
+                    "branch": "egg/issue-123",
+                },
+            )
+
+        assert response.status_code in (200, 201), response.get_json()
+        mock_gw.return_value.wait_for_healthy.assert_not_called()

--- a/orchestrator/tests/test_pipeline_creation_babysit_pr.py
+++ b/orchestrator/tests/test_pipeline_creation_babysit_pr.py
@@ -620,6 +620,8 @@ class TestGatewayReadinessGate:
         assert details.get("gateway_status") == "unreachable"
         assert details.get("gateway_error") == "Connection refused"
         assert details.get("timeout_seconds") == 1
+        # RFC 7231 §6.6.4: Retry-After guides client retry behaviour.
+        assert response.headers.get("Retry-After") == "1"
         # Pipeline must not be created when the gateway is unreachable.
         mock_store_factory.assert_not_called()
 
@@ -664,6 +666,38 @@ class TestGatewayReadinessGate:
         band, e.g. integration test harnesses that wire it up themselves).
         """
         monkeypatch.setenv("EGG_GATEWAY_READY_TIMEOUT_SECONDS", "0")
+
+        with (
+            patch("routes.pipelines.get_state_store") as mock_store_factory,
+            patch("routes.pipelines.get_repo_path") as mock_repo_path,
+            patch("routes.pipelines.get_gateway_client") as mock_gw,
+        ):
+            mock_repo_path.return_value = "/tmp/repo"
+            mock_gw.return_value.ls_remote_branch.return_value = False
+            mock_store = MagicMock()
+            fake = MagicMock()
+            fake.id = "issue-123"
+            fake.model_dump.return_value = {"id": "issue-123", "has_contract": True}
+            mock_store.create_pipeline.return_value = fake
+            mock_store_factory.return_value = mock_store
+
+            response = client.post(
+                "/api/v1/pipelines",
+                json={
+                    "issue_number": 123,
+                    "repo": "owner/repo",
+                    "branch": "egg/issue-123",
+                },
+            )
+
+        assert response.status_code in (200, 201), response.get_json()
+        mock_gw.return_value.wait_for_healthy.assert_not_called()
+
+    def test_negative_timeout_clamped_to_zero(self, client, monkeypatch):
+        """Negative ``EGG_GATEWAY_READY_TIMEOUT_SECONDS`` is clamped to 0
+        (i.e. gate disabled), not silently treated as a truthy value.
+        """
+        monkeypatch.setenv("EGG_GATEWAY_READY_TIMEOUT_SECONDS", "-5")
 
         with (
             patch("routes.pipelines.get_state_store") as mock_store_factory,

--- a/orchestrator/tests/test_pipelines_api.py
+++ b/orchestrator/tests/test_pipelines_api.py
@@ -255,6 +255,7 @@ class TestCreatePipelineMultiRepo:
     ):
         """create_pipeline should call get_repo_path() for all pipeline types."""
         mock_repo_path.return_value = Path("/home/egg/repos/webapp")
+        mock_gw.return_value.ls_remote_branch.return_value = False
         mock_store = MagicMock()
         mock_pipeline = MagicMock()
         mock_pipeline.id = "issue-42"
@@ -699,6 +700,7 @@ class TestCreatePipelineErrorHandling:
     ):
         """OSError during pipeline creation should return 500 with detail, not generic error."""
         mock_repo_path.return_value = Path("/home/egg/repos/webapp")
+        mock_gw.return_value.ls_remote_branch.return_value = False
         mock_store = MagicMock()
         mock_store.create_pipeline.side_effect = OSError("Permission denied")
         mock_get_store.return_value = mock_store

--- a/orchestrator/tests/test_pipelines_api.py
+++ b/orchestrator/tests/test_pipelines_api.py
@@ -247,9 +247,12 @@ class TestDeletePipelineBranchCleanup:
 class TestCreatePipelineMultiRepo:
     """Tests that create_pipeline resolves repo paths in multi-repo setups (#1323)."""
 
+    @patch("routes.pipelines.get_gateway_client")
     @patch("routes.pipelines.get_state_store")
     @patch("routes.pipelines.get_repo_path")
-    def test_create_pipeline_uses_get_repo_path(self, mock_repo_path, mock_get_store, client):
+    def test_create_pipeline_uses_get_repo_path(
+        self, mock_repo_path, mock_get_store, mock_gw, client
+    ):
         """create_pipeline should call get_repo_path() for all pipeline types."""
         mock_repo_path.return_value = Path("/home/egg/repos/webapp")
         mock_store = MagicMock()
@@ -271,10 +274,11 @@ class TestCreatePipelineMultiRepo:
         mock_repo_path.assert_called_once()
         mock_get_store.assert_called_once_with(Path("/home/egg/repos/webapp"))
 
+    @patch("routes.pipelines.get_gateway_client")
     @patch("routes.pipelines.get_state_store")
     @patch("routes.pipelines.get_repo_path")
     def test_create_prompt_pipeline_uses_get_repo_path(
-        self, mock_repo_path, mock_get_store, client
+        self, mock_repo_path, mock_get_store, mock_gw, client
     ):
         """Prompt-driven pipelines (no issue_number) also use get_repo_path()."""
         mock_repo_path.return_value = Path("/home/egg/repos/webapp")
@@ -298,7 +302,10 @@ class TestCreatePipelineMultiRepo:
 
     def test_get_repo_path_returns_400_when_repo_not_found(self, client, tmp_path):
         """get_repo_path() returns 400 when repo subdir is missing in multi-repo setup."""
-        with patch.dict(os.environ, {"EGG_REPO_PATH": str(tmp_path)}):
+        with patch.dict(
+            os.environ,
+            {"EGG_REPO_PATH": str(tmp_path), "EGG_GATEWAY_READY_TIMEOUT_SECONDS": "0"},
+        ):
             response = client.post(
                 "/api/v1/pipelines",
                 json={
@@ -659,10 +666,11 @@ class TestCreatePipelineJiraAndQualifier:
 class TestCreatePipelineErrorHandling:
     """Tests that create_pipeline returns detailed errors for unexpected exceptions (#1396)."""
 
+    @patch("routes.pipelines.get_gateway_client")
     @patch("routes.pipelines.get_state_store")
     @patch("routes.pipelines.get_repo_path")
     def test_non_state_store_error_returns_500_with_detail(
-        self, mock_repo_path, mock_get_store, client
+        self, mock_repo_path, mock_get_store, mock_gw, client
     ):
         """Non-StateStoreError exceptions should return 500 with the error type and message."""
         mock_repo_path.return_value = Path("/home/egg/repos/webapp")
@@ -683,9 +691,12 @@ class TestCreatePipelineErrorHandling:
         assert "ValueError" in body["message"]
         assert "unexpected validation failure" in body["message"]
 
+    @patch("routes.pipelines.get_gateway_client")
     @patch("routes.pipelines.get_state_store")
     @patch("routes.pipelines.get_repo_path")
-    def test_os_error_returns_500_with_detail(self, mock_repo_path, mock_get_store, client):
+    def test_os_error_returns_500_with_detail(
+        self, mock_repo_path, mock_get_store, mock_gw, client
+    ):
         """OSError during pipeline creation should return 500 with detail, not generic error."""
         mock_repo_path.return_value = Path("/home/egg/repos/webapp")
         mock_store = MagicMock()


### PR DESCRIPTION
## Summary
- Add a pre-flight `wait_for_healthy()` gate at the top of `POST /api/v1/pipelines`, just after request-shape validation and before any gateway-dependent work (`ls_remote_branch`, worktree fan-out, etc.). On timeout, return a single `503` with `details.reason = "gateway_not_ready"` instead of cascading into per-agent `ConnectionRefused` / "Remote end closed connection" spawn failures.
- Pipeline state is **not** created on failure — fixes the half-created branch + manual cancel + qualifier-bumped resubmit dance described in #1851.
- Wait window is configurable via `EGG_GATEWAY_READY_TIMEOUT_SECONDS` (default `60`s, set to `0` to disable the gate for harnesses that bring up the gateway out of band).
- Applies to all clients (MCP `submit_task` / `babysit_pr`, CLI, future API users) since they all funnel through `create_pipeline`. The MCP handler already surfaces upstream error messages verbatim.

## Test plan
- [x] `orchestrator/tests/test_pipeline_creation_babysit_pr.py::TestGatewayReadinessGate` — 3 new tests covering the 503 path (with named reason + last-known gateway status/error), the happy path, and the `0`-disables-gate escape hatch.
- [x] Full `test_pipeline_creation_babysit_pr.py` suite (26 tests) passes.
- [x] `test_mcp_tools.py` + `test_start_pipeline.py` pass against the change (194 total).
- [ ] Smoke against a real cold-start k3s deploy: submit a pipeline immediately after `kubectl rollout restart` and confirm a single 503 surfaces while the gateway pod boots, then a retry succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)