### PR TITLE
Fix #1850: stop silent-docker-defaulting when runtime detection fails

### DIFF
--- a/docs/reference/mcp-deployment-tools.md
+++ b/docs/reference/mcp-deployment-tools.md
@@ -28,8 +28,17 @@ handlers on `PipelineToolHandler`. The server is rate-limited to 30 req/min
 ## Runtime Gating
 
 The four k8s-specific tools branch on the `EGG_RUNTIME` env var, which is
-read at the orchestrator process boundary. When `EGG_RUNTIME != "kubernetes"`
-(typically Docker for legacy local development), they return:
+read at the orchestrator process boundary. When `EGG_RUNTIME` is unset,
+the orchestrator auto-detects: if `KUBERNETES_SERVICE_HOST` is present
+(injected into every pod by the apiserver) the runtime is inferred to be
+`"kubernetes"`; otherwise it defaults to `"docker"`. The resolved runtime
+and its provenance are returned on `get_deployment_context` as
+`runtime` + `detection_source` (values: `"env"`, `"auto:k8s-service-host"`,
+`"auto:default"`). Issue
+[#1850](https://github.com/jwbron/egg/issues/1850) tracked the earlier
+silent-docker-default that hid in-cluster misconfigs.
+
+When `EGG_RUNTIME != "kubernetes"`, the four k8s-specific tools return:
 
 ```json
 {"error": "not_available_on_runtime", "runtime": "docker"}
@@ -38,6 +47,18 @@ read at the orchestrator process boundary. When `EGG_RUNTIME != "kubernetes"`
 rather than failing the MCP call. `get_deployment_context` is portable — it
 returns a Docker-analog payload on the Docker runtime (matching the
 pre-k3s deployment model).
+
+When the orchestrator claims `"kubernetes"` but every cluster introspection
+probe fails (apiserver unreachable, RBAC denial, missing kubeconfig),
+`get_deployment_context` demotes `runtime` to `"unknown"` and attaches a
+`detection_error` field (for example `"cluster_unreachable"`,
+`"kubernetes_client_init_failed"`). `rebuild_and_rollout` refuses with a
+distinct payload so operators can tell "apiserver unreachable" apart from
+"you're on docker":
+
+```json
+{"error": "runtime_detection_failed", "runtime": "unknown", "detail": "..."}
+```
 
 `validate_network_isolation` additionally gates on
 `get_deployment_context.network_policy_enforcement`. If the detected CNI
@@ -77,6 +98,7 @@ Read-only cluster introspection.
 ```json
 {
   "runtime": "kubernetes",
+  "detection_source": "env",
   "kubeconfig_context": "default",
   "cluster_info": {"server_version": "v1.30.2+k3s1"},
   "namespace": "egg-system",
@@ -89,6 +111,11 @@ Read-only cluster introspection.
   }
 }
 ```
+
+When cluster introspection succeeds but listing deployments comes back
+empty (RBAC denial, empty namespace), `images_unavailable: true` is added
+so operators know the empty map reflects a partial failure rather than a
+cluster with no egg workloads.
 
 **Output shape** (Docker runtime — degrade-gracefully mode):
 

--- a/docs/reference/mcp-deployment-tools.md
+++ b/docs/reference/mcp-deployment-tools.md
@@ -115,7 +115,9 @@ Read-only cluster introspection.
 When cluster introspection succeeds but listing deployments comes back
 empty (RBAC denial, empty namespace), `images_unavailable: true` is added
 so operators know the empty map reflects a partial failure rather than a
-cluster with no egg workloads.
+cluster with no egg workloads. Similarly, `cluster_info.nodes_unavailable: true`
+is set when the version probe succeeds but the node-list probe fails,
+distinguishing "zero nodes" from "count unknown".
 
 **Output shape** (Docker runtime — degrade-gracefully mode):
 

--- a/k8s/base/orchestrator-deployment.yaml
+++ b/k8s/base/orchestrator-deployment.yaml
@@ -52,6 +52,13 @@ spec:
               containerPort: 9850
               protocol: TCP
           env:
+            # Explicit runtime selector — the orchestrator code falls
+            # back to auto-detection via KUBERNETES_SERVICE_HOST when
+            # this is unset, but setting it explicitly prevents silent
+            # docker-defaulting if the auto-detection is ever bypassed
+            # (#1850).
+            - name: EGG_RUNTIME
+              value: "kubernetes"
             - name: EGG_ORCHESTRATOR_URL
               value: "http://orchestrator.egg-system.svc.cluster.local:9849"
             - name: GATEWAY_URL

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -2146,9 +2146,11 @@ class PipelineToolHandler:
     def _handle_get_deployment_context(self, args: dict[str, Any]) -> dict[str, Any]:
         """Return runtime/cluster introspection.
 
-        Always returns a data dict.  On Docker, the response carries an
-        ``error: not_available_on_runtime`` field that callers can check
-        without branching on HTTP status.
+        Always returns a data dict.  On Docker, the response carries a
+        degraded placeholder payload with ``runtime: "docker"`` and
+        ``detection_source`` indicating provenance.  The k8s-gated routes
+        (not this one) use the ``not_available_on_runtime`` / ``runtime_detection_failed``
+        error pattern.
         """
         try:
             result = self._make_request("/api/v1/deployment/context", method="GET")
@@ -2246,8 +2248,8 @@ class PipelineToolHandler:
             return {"error": f"rebuild_and_rollout failed: {exc}"}
 
         data = result.get("data") or {}
-        # not_available_on_runtime short-circuit
-        if data.get("error") == "not_available_on_runtime":
+        # not_available_on_runtime / runtime_detection_failed short-circuit
+        if data.get("error") in ("not_available_on_runtime", "runtime_detection_failed"):
             return data
         stream_id = data.get("progress_stream_id")
         if not stream_id:

--- a/orchestrator/routes/deployment.py
+++ b/orchestrator/routes/deployment.py
@@ -394,7 +394,7 @@ def _build_deployment_context_payload() -> dict[str, Any]:
             {
                 "detection_error": "cluster_unreachable",
                 "detail": "neither VersionApi.get_code nor core_api.list_node succeeded",
-                "cluster_info": {"server_version": None, "nodes": 0},
+                "cluster_info": {"server_version": None, "nodes": 0, "nodes_unavailable": True},
             }
         )
         return payload

--- a/orchestrator/routes/deployment.py
+++ b/orchestrator/routes/deployment.py
@@ -80,9 +80,18 @@ def _resolve_runtime() -> tuple[str, str]:
     failures downstream. Auto-detection closes that gap without changing
     behavior when ``EGG_RUNTIME`` is set explicitly.
     """
+    _KNOWN_RUNTIMES = frozenset({"kubernetes", "docker"})
+
     explicit = os.environ.get("EGG_RUNTIME")
     if explicit:
-        return explicit.lower(), "env"
+        normalized = explicit.lower()
+        if normalized not in _KNOWN_RUNTIMES:
+            logger.warning(
+                "unrecognized EGG_RUNTIME value",
+                value=explicit,
+                known=sorted(_KNOWN_RUNTIMES),
+            )
+        return normalized, "env"
     if os.environ.get("KUBERNETES_SERVICE_HOST"):
         return "kubernetes", "auto:k8s-service-host"
     return "docker", "auto:default"
@@ -395,13 +404,16 @@ def _build_deployment_context_payload() -> dict[str, Any]:
 
     images = _collect_egg_image_tags(k8s, namespace)
 
+    cluster_info: dict[str, Any] = {"server_version": server_version, "nodes": nodes_count}
+    if not nodes_ok:
+        # Distinguish "zero nodes" (not a real scenario) from "probe
+        # failed, count unknown" — same pattern as images_unavailable.
+        cluster_info["nodes_unavailable"] = True
+
     payload.update(
         {
             "kubeconfig_context": os.environ.get("KUBE_CONTEXT"),
-            "cluster_info": {
-                "server_version": server_version,
-                "nodes": nodes_count,
-            },
+            "cluster_info": cluster_info,
             "cni": cni,
             "network_policy_enforcement": bool(enforcement),
             "images": images,

--- a/orchestrator/routes/deployment.py
+++ b/orchestrator/routes/deployment.py
@@ -63,9 +63,35 @@ deployment_bp = Blueprint("deployment", __name__, url_prefix="/api/v1/deployment
 # ---------------------------------------------------------------------------
 
 
+def _resolve_runtime() -> tuple[str, str]:
+    """Return ``(runtime, detection_source)``.
+
+    Resolution order:
+
+    1. ``EGG_RUNTIME`` env var (``"env"`` source) — operator-configured.
+    2. ``KUBERNETES_SERVICE_HOST`` is injected into every pod by the
+       apiserver; treat its presence as a strong in-cluster signal and
+       infer ``"kubernetes"`` (``"auto:k8s-service-host"`` source).
+    3. Otherwise fall back to ``"docker"`` (``"auto:default"`` source).
+
+    Issue #1850: previously defaulted to ``"docker"`` unconditionally, so
+    in-cluster orchestrators whose manifests forgot to set ``EGG_RUNTIME``
+    silently misreported themselves as Docker and masked cluster-access
+    failures downstream. Auto-detection closes that gap without changing
+    behavior when ``EGG_RUNTIME`` is set explicitly.
+    """
+    explicit = os.environ.get("EGG_RUNTIME")
+    if explicit:
+        return explicit.lower(), "env"
+    if os.environ.get("KUBERNETES_SERVICE_HOST"):
+        return "kubernetes", "auto:k8s-service-host"
+    return "docker", "auto:default"
+
+
 def _current_runtime() -> str:
-    """Return the configured runtime ("kubernetes" or "docker")."""
-    return os.environ.get("EGG_RUNTIME", "docker").lower()
+    """Return the resolved runtime label (back-compat shim)."""
+    runtime, _source = _resolve_runtime()
+    return runtime
 
 
 def _not_available_on_runtime() -> tuple[Response, int]:
@@ -83,6 +109,54 @@ def _not_available_on_runtime() -> tuple[Response, int]:
         ),
         200,
     )
+
+
+def _runtime_detection_failed(detail: str) -> tuple[Response, int]:
+    """Return a 200 payload used when runtime detection came back ``unknown``.
+
+    Distinct from ``not_available_on_runtime`` (which means "you explicitly
+    asked for docker, this tool is k8s-only") so operators can tell
+    "apiserver unreachable / detection failed" apart from "tool doesn't
+    apply to docker" (#1850).
+    """
+    return (
+        jsonify(
+            {
+                "success": True,
+                "data": {
+                    "error": "runtime_detection_failed",
+                    "runtime": "unknown",
+                    "detail": detail,
+                },
+            }
+        ),
+        200,
+    )
+
+
+def _probe_kubernetes_reachable() -> tuple[bool, str | None]:
+    """Return ``(reachable, reason_if_not)`` for the k8s apiserver.
+
+    Used by gated routes so they refuse cleanly with
+    ``runtime_detection_failed`` when the process claims ``kubernetes``
+    but can't actually reach the cluster (#1850). Cheap: one VersionApi
+    call; on failure the caller's downstream logic is bypassed.
+    """
+    try:
+        from kubernetes_client import get_kubernetes_client
+    except Exception as exc:  # pragma: no cover - environment wiring
+        return False, f"kubernetes_client_unavailable: {exc}"
+    try:
+        k8s = get_kubernetes_client()
+    except Exception as exc:
+        return False, f"kubernetes_client_init_failed: {exc}"
+    try:
+        from kubernetes import client as k8s_client_pkg
+
+        k8s_client_pkg.VersionApi(k8s.batch_api.api_client).get_code()
+    except Exception as exc:
+        return False, f"apiserver_unreachable: {exc}"
+    return True, None
 
 
 # ---------------------------------------------------------------------------
@@ -215,10 +289,18 @@ def _collect_egg_image_tags(k8s_client: Any, namespace: str) -> dict[str, str]:
 
 
 def _build_deployment_context_payload() -> dict[str, Any]:
-    """Assemble the ``get_deployment_context`` response body."""
-    runtime = _current_runtime()
+    """Assemble the ``get_deployment_context`` response body.
+
+    When ``runtime`` resolves to ``"kubernetes"`` but every cluster probe
+    fails (apiserver unreachable, RBAC denial, missing kubeconfig), the
+    runtime is demoted to ``"unknown"`` with a ``detection_error`` so
+    downstream guards can distinguish "you're on docker" from "I couldn't
+    tell what cluster I'm on" (#1850).
+    """
+    runtime, detection_source = _resolve_runtime()
     payload: dict[str, Any] = {
         "runtime": runtime,
+        "detection_source": detection_source,
         "namespace": os.environ.get("EGG_K8S_NAMESPACE", "egg-system"),
     }
 
@@ -245,9 +327,10 @@ def _build_deployment_context_payload() -> dict[str, Any]:
         from kubernetes_client import get_kubernetes_client
     except Exception as exc:  # pragma: no cover - environment wiring
         logger.warning("kubernetes_client import failed", error=str(exc))
+        payload["runtime"] = "unknown"
         payload.update(
             {
-                "error": "kubernetes_client_unavailable",
+                "detection_error": "kubernetes_client_unavailable",
                 "detail": str(exc),
             }
         )
@@ -257,9 +340,10 @@ def _build_deployment_context_payload() -> dict[str, Any]:
         k8s = get_kubernetes_client()
     except Exception as exc:
         logger.warning("kubernetes client init failed", error=str(exc))
+        payload["runtime"] = "unknown"
         payload.update(
             {
-                "error": "kubernetes_client_init_failed",
+                "detection_error": "kubernetes_client_init_failed",
                 "detail": str(exc),
             }
         )
@@ -267,23 +351,44 @@ def _build_deployment_context_payload() -> dict[str, Any]:
 
     namespace = payload["namespace"]
 
-    # Cluster info
+    # Cluster info — track whether each probe actually reached the
+    # apiserver so we can tell "healthy cluster with zero nodes" (not a
+    # thing) apart from "never got an answer."
     server_version = None
+    version_ok = False
     try:
         from kubernetes import client as k8s_client_pkg
 
         version_api = k8s_client_pkg.VersionApi(k8s.batch_api.api_client)
         vinfo = version_api.get_code()
         server_version = getattr(vinfo, "git_version", None)
-    except Exception:
-        pass
+        version_ok = True
+    except Exception as exc:
+        logger.warning("kubernetes version probe failed", error=str(exc))
 
     nodes_count = 0
+    nodes_ok = False
     try:
         nodes = k8s.core_api.list_node()
         nodes_count = len(getattr(nodes, "items", []) or [])
-    except Exception:
-        pass
+        nodes_ok = True
+    except Exception as exc:
+        logger.warning("kubernetes node list failed", error=str(exc))
+
+    if not version_ok and not nodes_ok:
+        # Neither probe reached the apiserver — we cannot claim the
+        # runtime is kubernetes. Demote so rebuild_and_rollout and other
+        # gated tools can refuse with an honest reason rather than
+        # operating against a cluster that isn't really there.
+        payload["runtime"] = "unknown"
+        payload.update(
+            {
+                "detection_error": "cluster_unreachable",
+                "detail": "neither VersionApi.get_code nor core_api.list_node succeeded",
+                "cluster_info": {"server_version": None, "nodes": 0},
+            }
+        )
+        return payload
 
     is_k3s, k3s_hint = _detect_k3s(k8s)
     cni, enforcement = _detect_cni(k8s)
@@ -304,6 +409,12 @@ def _build_deployment_context_payload() -> dict[str, Any]:
             "k3s_flavor_hint": k3s_hint,
         }
     )
+    if not images:
+        # Empty images on an otherwise-reachable cluster is a partial
+        # failure (RBAC, wrong namespace, empty ns). Flag it so the
+        # operator isn't guessing why the tool's docstring promise of
+        # "deployed image tags" came back empty.
+        payload["images_unavailable"] = True
 
     return payload
 
@@ -1259,6 +1370,10 @@ def rebuild_and_rollout() -> tuple[Response, int]:
 
     Safeties:
     - Gated on ``EGG_RUNTIME=kubernetes`` (docker returns ``not_available_on_runtime``).
+    - Refuses with ``runtime_detection_failed`` when the process claims
+      kubernetes but can't reach the apiserver — kicking off
+      ``make redeploy`` against a nonexistent cluster just wastes cycles
+      and produces confusing output (#1850).
     - Rejects concurrent invocations while a rollout is live
       (returns 409 with the existing stream id).
     - Actual subprocess runs in a background thread so the HTTP
@@ -1269,6 +1384,10 @@ def rebuild_and_rollout() -> tuple[Response, int]:
 
     if _current_runtime() != "kubernetes":
         return _not_available_on_runtime()
+
+    reachable, reason = _probe_kubernetes_reachable()
+    if not reachable:
+        return _runtime_detection_failed(reason or "apiserver unreachable")
 
     cwd = os.environ.get("EGG_REPO_PATH") or "/home/egg/repos/egg"
     if not Path(cwd).exists():

--- a/orchestrator/tests/test_deployment_routes.py
+++ b/orchestrator/tests/test_deployment_routes.py
@@ -92,12 +92,16 @@ class TestGetDeploymentContext:
     def test_docker_runtime_returns_placeholder_payload(self, client, monkeypatch):
         """On Docker the route returns a structured placeholder, not an error."""
         monkeypatch.setenv("EGG_RUNTIME", "docker")
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
         response = client.get("/api/v1/deployment/context")
         assert response.status_code == 200
         body = response.get_json()
         assert body["success"] is True
         data = body["data"]
         assert data["runtime"] == "docker"
+        # #1850: the payload records how runtime was resolved so the
+        # operator can tell env-configured from auto-detected.
+        assert data["detection_source"] == "env"
         # Degraded payload still carries every key the operator expects.
         for key in (
             "namespace",
@@ -113,6 +117,110 @@ class TestGetDeploymentContext:
         assert data["network_policy_enforcement"] is False
         assert data["is_k3s"] is False
         assert data["images"] == {}
+
+    def test_unset_env_with_k8s_service_host_autodetects_kubernetes(self, client, monkeypatch):
+        """EGG_RUNTIME unset + KUBERNETES_SERVICE_HOST set → auto-detect k8s (#1850)."""
+        monkeypatch.delenv("EGG_RUNTIME", raising=False)
+        monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.43.0.1")
+
+        fake_k8s = MagicMock()
+        fake_k8s.core_api.list_node.return_value.items = []
+        fake_version_info = MagicMock()
+        fake_version_info.git_version = "v1.30.2+k3s1"
+
+        with (
+            patch("routes.deployment._detect_k3s", return_value=(True, "v1.30.2+k3s1")),
+            patch("routes.deployment._detect_cni", return_value=("calico", True)),
+            patch(
+                "routes.deployment._collect_egg_image_tags",
+                return_value={"orchestrator": "egg-orchestrator:dev"},
+            ),
+            patch("kubernetes.client.VersionApi") as mock_version_api_cls,
+        ):
+            mock_version_api_cls.return_value.get_code.return_value = fake_version_info
+            with patch.dict(
+                "sys.modules",
+                {
+                    "kubernetes_client": MagicMock(
+                        get_kubernetes_client=MagicMock(return_value=fake_k8s),
+                    )
+                },
+            ):
+                response = client.get("/api/v1/deployment/context")
+
+        assert response.status_code == 200
+        data = response.get_json()["data"]
+        assert data["runtime"] == "kubernetes"
+        assert data["detection_source"] == "auto:k8s-service-host"
+
+    def test_unset_env_with_no_signals_defaults_to_docker(self, client, monkeypatch):
+        """EGG_RUNTIME unset + no KUBERNETES_SERVICE_HOST → auto-default docker."""
+        monkeypatch.delenv("EGG_RUNTIME", raising=False)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        response = client.get("/api/v1/deployment/context")
+        assert response.status_code == 200
+        data = response.get_json()["data"]
+        assert data["runtime"] == "docker"
+        assert data["detection_source"] == "auto:default"
+
+    def test_cluster_unreachable_demotes_to_unknown(self, client, monkeypatch):
+        """Kubernetes env var set but both apiserver probes fail → runtime=unknown (#1850)."""
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+
+        fake_k8s = MagicMock()
+        fake_k8s.core_api.list_node.side_effect = RuntimeError("apiserver down")
+
+        with (
+            patch("kubernetes.client.VersionApi") as mock_version_api_cls,
+            patch.dict(
+                "sys.modules",
+                {
+                    "kubernetes_client": MagicMock(
+                        get_kubernetes_client=MagicMock(return_value=fake_k8s),
+                    )
+                },
+            ),
+        ):
+            mock_version_api_cls.return_value.get_code.side_effect = RuntimeError("apiserver down")
+            response = client.get("/api/v1/deployment/context")
+
+        assert response.status_code == 200
+        data = response.get_json()["data"]
+        assert data["runtime"] == "unknown"
+        assert data["detection_error"] == "cluster_unreachable"
+        # Operator sees the env-configured value via detection_source.
+        assert data["detection_source"] == "env"
+
+    def test_empty_images_flags_images_unavailable(self, client, monkeypatch):
+        """Cluster reachable but image listing came back empty → flag it (#1850)."""
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+
+        fake_k8s = MagicMock()
+        fake_k8s.core_api.list_node.return_value.items = []
+        fake_version_info = MagicMock()
+        fake_version_info.git_version = "v1.30.2+k3s1"
+
+        with (
+            patch("routes.deployment._detect_k3s", return_value=(True, "v1.30.2+k3s1")),
+            patch("routes.deployment._detect_cni", return_value=("calico", True)),
+            patch("routes.deployment._collect_egg_image_tags", return_value={}),
+            patch("kubernetes.client.VersionApi") as mock_version_api_cls,
+        ):
+            mock_version_api_cls.return_value.get_code.return_value = fake_version_info
+            with patch.dict(
+                "sys.modules",
+                {
+                    "kubernetes_client": MagicMock(
+                        get_kubernetes_client=MagicMock(return_value=fake_k8s),
+                    )
+                },
+            ):
+                response = client.get("/api/v1/deployment/context")
+
+        data = response.get_json()["data"]
+        assert data["runtime"] == "kubernetes"
+        assert data["images"] == {}
+        assert data["images_unavailable"] is True
 
     def test_kubernetes_runtime_aggregates_cluster_info(self, client, monkeypatch):
         """On Kubernetes the route aggregates version/cni/images/k3s flags."""
@@ -166,7 +274,7 @@ class TestGetDeploymentContext:
         assert data["images"] == {"orchestrator": "egg-orchestrator:dev"}
 
     def test_kubernetes_client_init_failure_is_reported(self, client, monkeypatch):
-        """Client-init exceptions surface as a ``kubernetes_client_init_failed`` error."""
+        """Client-init exceptions demote runtime to ``unknown`` with detection_error (#1850)."""
         monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
         with patch.dict(
             "sys.modules",
@@ -179,7 +287,8 @@ class TestGetDeploymentContext:
             response = client.get("/api/v1/deployment/context")
         assert response.status_code == 200
         data = response.get_json()["data"]
-        assert data["error"] == "kubernetes_client_init_failed"
+        assert data["runtime"] == "unknown"
+        assert data["detection_error"] == "kubernetes_client_init_failed"
         assert "boom" in data["detail"]
 
 
@@ -845,9 +954,30 @@ class TestRebuildAndRolloutRoute:
     def test_missing_repo_path_returns_500(self, client, monkeypatch, tmp_path):
         monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
         monkeypatch.setenv("EGG_REPO_PATH", str(tmp_path / "nope"))
-        response = client.post("/api/v1/deployment/rebuild-and-rollout", json={})
+        with patch(
+            "routes.deployment._probe_kubernetes_reachable",
+            return_value=(True, None),
+        ):
+            response = client.post("/api/v1/deployment/rebuild-and-rollout", json={})
         assert response.status_code == 500
         assert "not found" in response.get_json()["message"]
+
+    def test_unreachable_cluster_returns_runtime_detection_failed(
+        self, client, monkeypatch, tmp_path
+    ):
+        """Refuse rebuild when apiserver is unreachable (#1850)."""
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+        monkeypatch.setenv("EGG_REPO_PATH", str(tmp_path))
+        with patch(
+            "routes.deployment._probe_kubernetes_reachable",
+            return_value=(False, "apiserver_unreachable: connection refused"),
+        ):
+            response = client.post("/api/v1/deployment/rebuild-and-rollout", json={})
+        assert response.status_code == 200
+        data = response.get_json()["data"]
+        assert data["error"] == "runtime_detection_failed"
+        assert data["runtime"] == "unknown"
+        assert "apiserver_unreachable" in data["detail"]
 
     def test_first_call_returns_202_with_stream_id(self, client, monkeypatch, tmp_path):
         """Initial call returns 202 and a progress_stream_id."""
@@ -872,9 +1002,15 @@ class TestRebuildAndRolloutRoute:
                 dep_mod._REBUILD_IN_PROGRESS = False
                 dep_mod._REBUILD_ACTIVE_STREAM_ID = None
 
-        with patch(
-            "routes.deployment._run_redeploy_subprocess",
-            side_effect=_fake_runner,
+        with (
+            patch(
+                "routes.deployment._run_redeploy_subprocess",
+                side_effect=_fake_runner,
+            ),
+            patch(
+                "routes.deployment._probe_kubernetes_reachable",
+                return_value=(True, None),
+            ),
         ):
             response = client.post("/api/v1/deployment/rebuild-and-rollout", json={})
             assert response.status_code == 202
@@ -896,7 +1032,11 @@ class TestRebuildAndRolloutRoute:
         dep_mod._REBUILD_IN_PROGRESS = True
         dep_mod._REBUILD_ACTIVE_STREAM_ID = "existing-stream"
 
-        response = client.post("/api/v1/deployment/rebuild-and-rollout", json={})
+        with patch(
+            "routes.deployment._probe_kubernetes_reachable",
+            return_value=(True, None),
+        ):
+            response = client.post("/api/v1/deployment/rebuild-and-rollout", json={})
         assert response.status_code == 409
         body = response.get_json()
         assert body["success"] is False

--- a/orchestrator/tests/test_deployment_routes.py
+++ b/orchestrator/tests/test_deployment_routes.py
@@ -190,6 +190,8 @@ class TestGetDeploymentContext:
         assert data["detection_error"] == "cluster_unreachable"
         # Operator sees the env-configured value via detection_source.
         assert data["detection_source"] == "env"
+        # Both probes failed — nodes count is unknown, not zero.
+        assert data["cluster_info"]["nodes_unavailable"] is True
 
     def test_empty_images_flags_images_unavailable(self, client, monkeypatch):
         """Cluster reachable but image listing came back empty → flag it (#1850)."""
@@ -221,6 +223,42 @@ class TestGetDeploymentContext:
         assert data["runtime"] == "kubernetes"
         assert data["images"] == {}
         assert data["images_unavailable"] is True
+
+    def test_nodes_unavailable_on_partial_probe_failure(self, client, monkeypatch):
+        """Version probe ok but node-list probe fails → nodes_unavailable: true."""
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+
+        fake_k8s = MagicMock()
+        fake_k8s.core_api.list_node.side_effect = RuntimeError("RBAC denied")
+        fake_version_info = MagicMock()
+        fake_version_info.git_version = "v1.30.2+k3s1"
+
+        with (
+            patch("routes.deployment._detect_k3s", return_value=(True, "v1.30.2+k3s1")),
+            patch("routes.deployment._detect_cni", return_value=("calico", True)),
+            patch(
+                "routes.deployment._collect_egg_image_tags",
+                return_value={"orchestrator": "egg-orchestrator:dev"},
+            ),
+            patch("kubernetes.client.VersionApi") as mock_version_api_cls,
+        ):
+            mock_version_api_cls.return_value.get_code.return_value = fake_version_info
+            with patch.dict(
+                "sys.modules",
+                {
+                    "kubernetes_client": MagicMock(
+                        get_kubernetes_client=MagicMock(return_value=fake_k8s),
+                    )
+                },
+            ):
+                response = client.get("/api/v1/deployment/context")
+
+        assert response.status_code == 200
+        data = response.get_json()["data"]
+        assert data["runtime"] == "kubernetes"
+        assert data["cluster_info"]["nodes"] == 0
+        assert data["cluster_info"]["nodes_unavailable"] is True
+        assert data["cluster_info"]["server_version"] == "v1.30.2+k3s1"
 
     def test_kubernetes_runtime_aggregates_cluster_info(self, client, monkeypatch):
         """On Kubernetes the route aggregates version/cni/images/k3s flags."""


### PR DESCRIPTION
## Summary

- Auto-detect runtime from `KUBERNETES_SERVICE_HOST` when `EGG_RUNTIME` is unset, with a `detection_source` field recording provenance.
- Demote `runtime` to `"unknown"` (plus `detection_error`) when apiserver introspection fails, so `rebuild_and_rollout` refuses with `runtime_detection_failed` instead of the misleading `not_available_on_runtime: docker`.
- Flag `images_unavailable: true` when cluster introspection succeeds but deployment listing returns empty.
- Set `EGG_RUNTIME=kubernetes` explicitly in the orchestrator k8s manifest — the specific misconfig that triggered #1850.

## Test plan

- [x] `pytest orchestrator/tests/test_deployment_routes.py` — 67 pass including 5 new cases covering auto-detect, cluster-unreachable demotion, empty-images flag, and rebuild refusal.
- [x] Full `pytest orchestrator/tests/` — 4026 pass, 1 skip.
- [x] `ruff check` + `yamllint` on touched files.
- [ ] Deploy to the k3s operator environment that originally surfaced the bug; confirm `get_deployment_context` now returns `runtime: "kubernetes"` and `rebuild_and_rollout` proceeds.

Closes #1850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)