### PR TITLE
Fix #1853: add get_service_logs MCP tool for gateway/orchestrator pods

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ This index helps both humans and LLMs navigate the documentation efficiently.
 | [Orchestrator CLI](reference/orchestrator-cli.md) | Full `egg-orch` command reference for pipelines, phases, decisions, containers |
 | [Checkpoint Browser](reference/checkpoint-browser.md) | Full `egg-checkpoint` command reference for browsing agent session history |
 | [SDLC Contract](reference/sdlc-contract.md) | Full `egg-contract` command reference for tracking tasks, commits, decisions |
-| [MCP Deployment Tools](reference/mcp-deployment-tools.md) | Five k8s-facing MCP tools: `get_deployment_context`, `validate_deployment_manifests`, `prune_stale_worktrees`, `validate_network_isolation`, `rebuild_and_rollout` |
+| [MCP Deployment Tools](reference/mcp-deployment-tools.md) | Six k8s-facing MCP tools: `get_deployment_context`, `validate_deployment_manifests`, `prune_stale_worktrees`, `validate_network_isolation`, `rebuild_and_rollout`, `get_service_logs` |
 
 ### SDLC Pipeline Templates
 

--- a/docs/reference/mcp-deployment-tools.md
+++ b/docs/reference/mcp-deployment-tools.md
@@ -1,14 +1,17 @@
 # MCP Deployment Tools Reference
 
-The MCP server exposes five Kubernetes-facing tools that landed in
+The MCP server exposes Kubernetes-facing tools for agents and operators to
+introspect the cluster, validate committed deployment manifests, prune stale
+worktrees, confirm NetworkPolicy enforcement, read service logs, and kick
+off a rebuild+rollout without dropping to raw `kubectl` /
+`k3s ctr images import`. The first five landed in
 [#1759](https://github.com/jwbron/egg/issues/1759) to close the diagnostic
 blind spot surfaced during the Docker → k3s migration validation
 ([#1553](https://github.com/jwbron/egg/issues/1553),
-[#1692](https://github.com/jwbron/egg/issues/1692)). The tools let agents
-and operators introspect the cluster, validate committed deployment
-manifests, prune stale worktrees, confirm NetworkPolicy enforcement, and
-kick off a rebuild+rollout without dropping to raw `kubectl` /
-`k3s ctr images import`.
+[#1692](https://github.com/jwbron/egg/issues/1692));
+[`get_service_logs`](#get_service_logs) followed in
+[#1853](https://github.com/jwbron/egg/issues/1853) to cover gateway / orchestrator
+pod logs that `get_container_logs` (agent-sandbox only) does not reach.
 
 | Tool | Mutates cluster? | Runtime | Auth |
 |------|------------------|---------|------|
@@ -17,8 +20,9 @@ kick off a rebuild+rollout without dropping to raw `kubectl` /
 | [`prune_stale_worktrees`](#prune_stale_worktrees) | Yes (host filesystem) | k8s only | `@require_lifecycle_secret` on orchestrator proxy; gateway session token on the gateway route |
 | [`validate_network_isolation`](#validate_network_isolation) | Yes (spawns short-lived probe Job) | k8s only | `@require_lifecycle_secret` |
 | [`rebuild_and_rollout`](#rebuild_and_rollout) | Yes (rebuilds images + restarts Deployments) | k8s only | `@require_lifecycle_secret` |
+| [`get_service_logs`](#get_service_logs) | No | k8s only | `@require_lifecycle_secret` |
 
-All five tools live in `PIPELINE_TOOLS` (`orchestrator/mcp_tools.py`) with
+All six tools live in `PIPELINE_TOOLS` (`orchestrator/mcp_tools.py`) with
 handlers on `PipelineToolHandler`. The server is rate-limited to 30 req/min
 — the diagnostic skills that compose these tools cap themselves at
 ≤10 primitive calls per invocation. See
@@ -27,7 +31,7 @@ handlers on `PipelineToolHandler`. The server is rate-limited to 30 req/min
 
 ## Runtime Gating
 
-The four k8s-specific tools branch on the `EGG_RUNTIME` env var, which is
+The five k8s-specific tools branch on the `EGG_RUNTIME` env var, which is
 read at the orchestrator process boundary. When `EGG_RUNTIME != "kubernetes"`
 (typically Docker for legacy local development), they return:
 
@@ -436,6 +440,87 @@ assert "egg-orchestrator" in result["rolled_out_images"]
 exercises this tool end-to-end — tagged `@pytest.mark.slow` and gated
 behind `EGG_INTEGRATION_REBUILD=1` so the default `make test` invocation
 does not rebuild images unless explicitly requested.
+
+## `get_service_logs`
+
+Read logs from the pod(s) backing the `gateway` or `orchestrator`
+Deployment. Complements `get_container_logs`, which covers agent-sandbox
+containers only. Added in
+[#1853](https://github.com/jwbron/egg/issues/1853) after a pipeline failed
+with three agents hitting "Connection refused" at the gateway: operators
+had no in-MCP way to confirm whether the gateway was still coming up, not
+crashing, or refusing requests for some other reason, and had to shell
+into the cluster (`kubectl logs -n egg-system deploy/gateway`) to
+self-serve.
+
+**HTTP route**: `GET /api/v1/deployment/logs`
+
+**Input schema**:
+
+```json
+{
+  "service": "gateway",
+  "lines": 100,
+  "since_seconds": 600
+}
+```
+
+- `service` is required and allowlisted to `"gateway"` or `"orchestrator"`.
+  Agent-pod logs live in the `egg-agents` namespace and are already
+  exposed through `get_container_logs`; keeping this endpoint bounded
+  avoids it turning into a generic kubectl-logs proxy.
+- `lines` defaults to 100 and is capped at 10 000 — enough for real
+  diagnostic scrollback without unbounded response sizes.
+- `since_seconds` (optional) scopes the read to "logs newer than N
+  seconds ago" — useful for "logs around when my pipeline failed at
+  HH:MM."
+
+**Output shape**:
+
+```json
+{
+  "service": "gateway",
+  "namespace": "egg-system",
+  "pods": [
+    {
+      "pod": "gateway-7d4b9c5f9-abcde",
+      "logs": "INFO ... listening on :9848\n..."
+    }
+  ]
+}
+```
+
+Replicas >1 are each returned as their own `{pod, logs}` entry so the
+operator can tell which chunk came from where. A pod that vanishes
+between the selector listing and the log read is skipped rather than
+failing the whole request.
+
+**Error shapes**:
+
+- `404` — the Deployment is not present in `egg-system`, or the
+  selector returned zero pods (fresh rollout still coming up).
+- `500` — Kubernetes API failure (selector missing, apiserver
+  unreachable).
+
+**Non-k8s runtime**:
+
+```json
+{"error": "not_available_on_runtime", "runtime": "docker"}
+```
+
+**Example MCP call** — the concrete miss from #1853, cross-referencing
+gateway logs when multiple agents hit "Connection refused" during spawn:
+
+```python
+logs = await mcp.call_tool("get_service_logs", {
+    "service": "gateway",
+    "lines": 200,
+    "since_seconds": 300,
+})
+for chunk in logs["pods"]:
+    print(chunk["pod"])
+    print(chunk["logs"])
+```
 
 ## See Also
 

--- a/docs/reference/mcp-deployment-tools.md
+++ b/docs/reference/mcp-deployment-tools.md
@@ -485,15 +485,22 @@ self-serve.
     {
       "pod": "gateway-7d4b9c5f9-abcde",
       "logs": "INFO ... listening on :9848\n..."
+    },
+    {
+      "pod": "gateway-7d4b9c5f9-fghij",
+      "logs": "",
+      "error": "Failed to read logs: container in CrashLoopBackOff"
     }
   ]
 }
 ```
 
 Replicas >1 are each returned as their own `{pod, logs}` entry so the
-operator can tell which chunk came from where. A pod that vanishes
-between the selector listing and the log read is skipped rather than
-failing the whole request.
+operator can tell which chunk came from where. Pods that encounter a
+transient non-404 failure (kubelet timeout, `CrashLoopBackOff` with no
+logs yet, etc.) include an `"error"` key so operators see partial
+results from healthy replicas. A pod that vanishes between the selector
+listing and the log read is skipped entirely.
 
 **Error shapes**:
 
@@ -519,7 +526,10 @@ logs = await mcp.call_tool("get_service_logs", {
 })
 for chunk in logs["pods"]:
     print(chunk["pod"])
-    print(chunk["logs"])
+    if "error" in chunk:
+        print(f"  [error] {chunk['error']}")
+    else:
+        print(chunk["logs"])
 ```
 
 ## See Also

--- a/orchestrator/kubernetes_client.py
+++ b/orchestrator/kubernetes_client.py
@@ -911,6 +911,12 @@ class KubernetesClient:
                 # Pod vanished between list and read; skip it rather than
                 # failing the whole request.
                 continue
+            except JobOperationError as exc:
+                # Transient non-404 failure (kubelet timeout, CrashLoopBackOff
+                # with no logs yet, etc.).  Include the pod with an error note
+                # so the operator sees partial results from healthy replicas.
+                chunks.append({"pod": pod_name, "logs": "", "error": str(exc)})
+                continue
             chunks.append({"pod": pod_name, "logs": logs or ""})
 
         return {

--- a/orchestrator/kubernetes_client.py
+++ b/orchestrator/kubernetes_client.py
@@ -825,6 +825,100 @@ class KubernetesClient:
                 raise PodNotFoundError(f"Pod {pod_name} not found in {namespace}") from exc
             raise JobOperationError(f"Failed to get logs for pod {pod_name}: {exc}") from exc
 
+    def get_service_logs(
+        self,
+        service: str,
+        namespace: str,
+        tail_lines: int = 100,
+        since_seconds: int | None = None,
+    ) -> dict[str, Any]:
+        """Read logs from the pod(s) backing a Deployment.
+
+        Resolves *service* to a Deployment in *namespace* whose metadata
+        name matches exactly, pulls the pod selector from
+        ``spec.selector.matchLabels``, and concatenates logs from each
+        matching pod.  Used by the ``get_service_logs`` MCP tool so
+        operators can cross-reference gateway/orchestrator logs without
+        shelling into the cluster (#1853).
+
+        Returns a dict of
+        ``{"service", "namespace", "pods": [{"pod", "logs"}, ...]}``
+        so the caller can see which pod each chunk came from when a
+        Deployment has multiple replicas.
+
+        Raises:
+            PodNotFoundError: If the Deployment is missing or has no pods.
+            JobOperationError: For other k8s API failures.
+        """
+        try:
+            from kubernetes import client as k8s_client_pkg
+        except Exception as exc:  # pragma: no cover - env wiring
+            raise JobOperationError(f"kubernetes client package unavailable: {exc}") from exc
+
+        apps_api = k8s_client_pkg.AppsV1Api(self.batch_api.api_client)
+
+        try:
+            dep = apps_api.read_namespaced_deployment(name=service, namespace=namespace)
+        except Exception as exc:
+            error_msg = str(exc).lower()
+            if "not found" in error_msg or "404" in error_msg:
+                raise PodNotFoundError(f"Deployment {service} not found in {namespace}") from exc
+            raise JobOperationError(
+                f"Failed to read deployment {service} in {namespace}: {exc}"
+            ) from exc
+
+        match_labels = (
+            (getattr(dep.spec, "selector", None) and dep.spec.selector.match_labels) or {}
+            if dep and dep.spec
+            else {}
+        )
+        if not match_labels:
+            raise JobOperationError(
+                f"Deployment {service} in {namespace} has no selector.matchLabels"
+            )
+
+        label_selector = ",".join(f"{k}={v}" for k, v in sorted(match_labels.items()))
+
+        try:
+            pods = self.core_api.list_namespaced_pod(
+                namespace=namespace, label_selector=label_selector
+            )
+        except Exception as exc:
+            raise JobOperationError(
+                f"Failed to list pods for {service} in {namespace}: {exc}"
+            ) from exc
+
+        items = list(getattr(pods, "items", []) or [])
+        if not items:
+            raise PodNotFoundError(
+                f"No pods found for deployment {service} in {namespace} "
+                f"(selector: {label_selector})"
+            )
+
+        chunks: list[dict[str, str]] = []
+        for pod in items:
+            pod_name = (getattr(pod, "metadata", None) and pod.metadata.name) or ""
+            if not pod_name:
+                continue
+            try:
+                logs = self.get_pod_logs(
+                    pod_name,
+                    namespace,
+                    tail_lines=tail_lines,
+                    since_seconds=since_seconds,
+                )
+            except PodNotFoundError:
+                # Pod vanished between list and read; skip it rather than
+                # failing the whole request.
+                continue
+            chunks.append({"pod": pod_name, "logs": logs or ""})
+
+        return {
+            "service": service,
+            "namespace": namespace,
+            "pods": chunks,
+        }
+
     def get_pod_status(
         self,
         pod_name: str,

--- a/orchestrator/kubernetes_client.py
+++ b/orchestrator/kubernetes_client.py
@@ -842,9 +842,11 @@ class KubernetesClient:
         shelling into the cluster (#1853).
 
         Returns a dict of
-        ``{"service", "namespace", "pods": [{"pod", "logs"}, ...]}``
+        ``{"service", "namespace", "pods": [{"pod", "logs"[, "error"]}, ...]}``
         so the caller can see which pod each chunk came from when a
-        Deployment has multiple replicas.
+        Deployment has multiple replicas.  Pods that encounter a
+        transient non-404 failure include an ``"error"`` key with the
+        message and ``"logs": ""``.
 
         Raises:
             PodNotFoundError: If the Deployment is missing or has no pods.

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -768,6 +768,40 @@ PIPELINE_TOOLS = [
         },
     },
     {
+        "name": "get_service_logs",
+        "description": (
+            "Return logs from the gateway or orchestrator Deployment's backing "
+            "pod(s). Complements `get_container_logs` (which covers agent-sandbox "
+            "containers) so operators can cross-reference gateway-side spawn "
+            "failures — 'Connection refused', 'Remote end closed connection', "
+            "'push_worktree_branch returned False' — without shelling into the "
+            "cluster. Only available on the Kubernetes runtime."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "service": {
+                    "type": "string",
+                    "description": "Which service's logs to return.",
+                    "enum": ["gateway", "orchestrator"],
+                },
+                "lines": {
+                    "type": "integer",
+                    "description": "Number of log lines to return (default 100).",
+                    "default": 100,
+                },
+                "since_seconds": {
+                    "type": "integer",
+                    "description": (
+                        "Only return logs newer than this many seconds — useful for "
+                        "scoping to 'logs around when my pipeline failed at HH:MM'."
+                    ),
+                },
+            },
+            "required": ["service"],
+        },
+    },
+    {
         "name": "rebuild_and_rollout",
         "description": (
             "Kick off `make redeploy` (build image → k3s ctr images import → "
@@ -850,6 +884,7 @@ class PipelineToolHandler:
             "prune_stale_worktrees": self._handle_prune_stale_worktrees,
             "validate_network_isolation": self._handle_validate_network_isolation,
             "rebuild_and_rollout": self._handle_rebuild_and_rollout,
+            "get_service_logs": self._handle_get_service_logs,
         }
 
         handler = handlers.get(tool_name)
@@ -2210,6 +2245,27 @@ class PipelineToolHandler:
             )
         except Exception as exc:
             return {"error": f"validate_network_isolation failed: {exc}"}
+        return result.get("data", result)
+
+    def _handle_get_service_logs(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Fetch logs for the gateway or orchestrator Deployment."""
+        service = args.get("service")
+        if not service:
+            return {"error": "service is required"}
+
+        params: list[str] = [f"service={quote(str(service), safe='')}"]
+        lines = args.get("lines")
+        if lines is not None:
+            params.append(f"lines={int(lines)}")
+        since_seconds = args.get("since_seconds")
+        if since_seconds is not None:
+            params.append(f"since_seconds={int(since_seconds)}")
+
+        endpoint = "/api/v1/deployment/logs?" + "&".join(params)
+        try:
+            result = self._make_request(endpoint, method="GET", timeout=30)
+        except Exception as exc:
+            return {"error": f"get_service_logs failed: {exc}"}
         return result.get("data", result)
 
     def _handle_rebuild_and_rollout(self, args: dict[str, Any]) -> dict[str, Any]:

--- a/orchestrator/routes/deployment.py
+++ b/orchestrator/routes/deployment.py
@@ -1,10 +1,11 @@
 """Deployment introspection and action endpoints.
 
 Exposes read-only introspection tools
-(``get_deployment_context``, ``validate_deployment_manifests``) and
-mutating actions (``prune_stale_worktrees`` — proxied to the gateway,
-``validate_network_isolation``, ``rebuild_and_rollout``) for operator
-diagnostics on the Kubernetes runtime.
+(``get_deployment_context``, ``validate_deployment_manifests``,
+``get_service_logs``) and mutating actions (``prune_stale_worktrees`` —
+proxied to the gateway, ``validate_network_isolation``,
+``rebuild_and_rollout``) for operator diagnostics on the Kubernetes
+runtime.
 
 Every route requires the lifecycle bearer token (parity with the
 fix made for #1769) because these are agent-visible via the MCP
@@ -317,6 +318,106 @@ def get_deployment_context() -> tuple[Response, int]:
     except Exception as exc:
         logger.error("get_deployment_context failed", error=str(exc))
         return jsonify({"success": False, "message": f"failed: {exc}"}), 500
+    return jsonify({"success": True, "data": payload}), 200
+
+
+# ---------------------------------------------------------------------------
+# get_service_logs (#1853)
+# ---------------------------------------------------------------------------
+
+# Allowlist of services whose logs are readable via this endpoint.  Keeping
+# the surface bounded avoids turning this into a generic kubectl-logs proxy:
+# agent-pod logs live in the `egg-agents` namespace and are already exposed
+# through the container-scoped `get_container_logs` tool.
+_SERVICE_LOG_ALLOWLIST: frozenset[str] = frozenset({"gateway", "orchestrator"})
+
+_MAX_LOG_LINES = 10_000
+
+
+@deployment_bp.route("/logs", methods=["GET"])
+@require_lifecycle_secret
+def get_service_logs() -> tuple[Response, int]:
+    """Return logs from the pod(s) backing the gateway or orchestrator Deployment.
+
+    Query params:
+        service: one of _SERVICE_LOG_ALLOWLIST (required).
+        lines: tail length, default 100, capped at _MAX_LOG_LINES.
+        since_seconds: only return logs newer than this many seconds.
+    """
+    if _current_runtime() != "kubernetes":
+        return _not_available_on_runtime()
+
+    service = (request.args.get("service") or "").strip()
+    if not service:
+        return jsonify({"success": False, "message": "service is required"}), 400
+    if service not in _SERVICE_LOG_ALLOWLIST:
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "message": (
+                        f"service must be one of {sorted(_SERVICE_LOG_ALLOWLIST)}; got {service!r}"
+                    ),
+                }
+            ),
+            400,
+        )
+
+    try:
+        lines = int(request.args.get("lines", 100))
+    except (ValueError, TypeError):
+        lines = 100
+    if lines <= 0:
+        lines = 100
+    lines = min(lines, _MAX_LOG_LINES)
+
+    since_raw = request.args.get("since_seconds")
+    since_seconds: int | None = None
+    if since_raw is not None:
+        try:
+            since_seconds = int(since_raw)
+        except (ValueError, TypeError):
+            return (
+                jsonify({"success": False, "message": "since_seconds must be an integer"}),
+                400,
+            )
+        if since_seconds <= 0:
+            since_seconds = None
+
+    namespace = os.environ.get("EGG_K8S_NAMESPACE", "egg-system")
+
+    try:
+        from kubernetes_client import (
+            JobOperationError,
+            PodNotFoundError,
+            get_kubernetes_client,
+        )
+    except Exception as exc:  # pragma: no cover - env wiring
+        return jsonify({"success": False, "message": f"kubernetes unavailable: {exc}"}), 503
+
+    try:
+        k8s = get_kubernetes_client()
+    except Exception as exc:
+        return (
+            jsonify({"success": False, "message": f"kubernetes init failed: {exc}"}),
+            503,
+        )
+
+    try:
+        payload = k8s.get_service_logs(
+            service=service,
+            namespace=namespace,
+            tail_lines=lines,
+            since_seconds=since_seconds,
+        )
+    except PodNotFoundError as exc:
+        return jsonify({"success": False, "message": str(exc)}), 404
+    except JobOperationError as exc:
+        return jsonify({"success": False, "message": str(exc)}), 500
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("get_service_logs failed", service=service, error=str(exc))
+        return jsonify({"success": False, "message": f"failed: {exc}"}), 500
+
     return jsonify({"success": True, "data": payload}), 200
 
 
@@ -1367,4 +1468,6 @@ __all__ = [
     "_stream_mark_done",
     "_STREAM_BUFFERS",
     "_STREAM_TERMINATED",
+    "_SERVICE_LOG_ALLOWLIST",
+    "_MAX_LOG_LINES",
 ]

--- a/orchestrator/tests/test_deployment_routes.py
+++ b/orchestrator/tests/test_deployment_routes.py
@@ -33,7 +33,7 @@ _shared_path = Path(__file__).parent.parent.parent / "shared"
 if _shared_path.exists() and str(_shared_path) not in sys.path:
     sys.path.insert(0, str(_shared_path))
 
-from egg_config.constants import TEST_GATEWAY_PORT  # noqa: E402
+from egg_config.constants import GATEWAY_PORT, TEST_GATEWAY_PORT  # noqa: E402
 
 
 @pytest.fixture
@@ -1091,7 +1091,7 @@ class TestGetServiceLogsRoute:
         fake_k8s.get_service_logs.return_value = {
             "service": "gateway",
             "namespace": "egg-test",
-            "pods": [{"pod": "gateway-abc", "logs": "listening on :9848\n"}],
+            "pods": [{"pod": "gateway-abc", "logs": f"listening on :{GATEWAY_PORT}\n"}],
         }
 
         with patch.dict(

--- a/orchestrator/tests/test_deployment_routes.py
+++ b/orchestrator/tests/test_deployment_routes.py
@@ -1048,6 +1048,153 @@ class TestRunRedeploySubprocess:
 
 
 # ---------------------------------------------------------------------------
+# get_service_logs (#1853)
+# ---------------------------------------------------------------------------
+
+
+class TestGetServiceLogsRoute:
+    """GET /api/v1/deployment/logs."""
+
+    def test_docker_runtime_returns_not_available(self, client, monkeypatch):
+        monkeypatch.setenv("EGG_RUNTIME", "docker")
+        response = client.get("/api/v1/deployment/logs?service=gateway")
+        assert response.status_code == 200
+        data = response.get_json()["data"]
+        assert data["error"] == "not_available_on_runtime"
+
+    def test_missing_service_returns_400(self, client, monkeypatch):
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+        response = client.get("/api/v1/deployment/logs")
+        assert response.status_code == 400
+        assert response.get_json()["success"] is False
+
+    def test_unknown_service_returns_400(self, client, monkeypatch):
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+        response = client.get("/api/v1/deployment/logs?service=etcd")
+        assert response.status_code == 400
+        body = response.get_json()
+        assert body["success"] is False
+        assert "gateway" in body["message"]
+        assert "orchestrator" in body["message"]
+
+    def test_invalid_since_seconds_returns_400(self, client, monkeypatch):
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+        response = client.get("/api/v1/deployment/logs?service=gateway&since_seconds=not-a-number")
+        assert response.status_code == 400
+
+    def test_happy_path_returns_pod_logs(self, client, monkeypatch):
+        """When the Deployment exists the route returns its pod logs."""
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+        monkeypatch.setenv("EGG_K8S_NAMESPACE", "egg-test")
+
+        fake_k8s = MagicMock()
+        fake_k8s.get_service_logs.return_value = {
+            "service": "gateway",
+            "namespace": "egg-test",
+            "pods": [{"pod": "gateway-abc", "logs": "listening on :9848\n"}],
+        }
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "kubernetes_client": MagicMock(
+                    get_kubernetes_client=MagicMock(return_value=fake_k8s),
+                    PodNotFoundError=type("PodNotFoundError", (Exception,), {}),
+                    JobOperationError=type("JobOperationError", (Exception,), {}),
+                )
+            },
+        ):
+            response = client.get(
+                "/api/v1/deployment/logs?service=gateway&lines=50&since_seconds=120"
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()["data"]
+        assert data["service"] == "gateway"
+        assert data["namespace"] == "egg-test"
+        assert data["pods"][0]["logs"].startswith("listening")
+        # The handler must have forwarded the parsed integer arguments.
+        kwargs = fake_k8s.get_service_logs.call_args.kwargs
+        assert kwargs["service"] == "gateway"
+        assert kwargs["namespace"] == "egg-test"
+        assert kwargs["tail_lines"] == 50
+        assert kwargs["since_seconds"] == 120
+
+    def test_lines_is_capped_at_max(self, client, monkeypatch):
+        """A huge ``lines`` value is clamped to the module cap."""
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+
+        from routes.deployment import _MAX_LOG_LINES
+
+        fake_k8s = MagicMock()
+        fake_k8s.get_service_logs.return_value = {
+            "service": "gateway",
+            "namespace": "egg-system",
+            "pods": [],
+        }
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "kubernetes_client": MagicMock(
+                    get_kubernetes_client=MagicMock(return_value=fake_k8s),
+                    PodNotFoundError=type("PodNotFoundError", (Exception,), {}),
+                    JobOperationError=type("JobOperationError", (Exception,), {}),
+                )
+            },
+        ):
+            client.get(f"/api/v1/deployment/logs?service=gateway&lines={_MAX_LOG_LINES * 10}")
+
+        assert fake_k8s.get_service_logs.call_args.kwargs["tail_lines"] == _MAX_LOG_LINES
+
+    def test_pod_not_found_returns_404(self, client, monkeypatch):
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+
+        PodNotFoundError = type("PodNotFoundError", (Exception,), {})
+        fake_k8s = MagicMock()
+        fake_k8s.get_service_logs.side_effect = PodNotFoundError(
+            "Deployment gateway not found in egg-system"
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "kubernetes_client": MagicMock(
+                    get_kubernetes_client=MagicMock(return_value=fake_k8s),
+                    PodNotFoundError=PodNotFoundError,
+                    JobOperationError=type("JobOperationError", (Exception,), {}),
+                )
+            },
+        ):
+            response = client.get("/api/v1/deployment/logs?service=gateway")
+
+        assert response.status_code == 404
+        assert response.get_json()["success"] is False
+
+    def test_job_operation_error_returns_500(self, client, monkeypatch):
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+
+        JobOperationError = type("JobOperationError", (Exception,), {})
+        fake_k8s = MagicMock()
+        fake_k8s.get_service_logs.side_effect = JobOperationError("api down")
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "kubernetes_client": MagicMock(
+                    get_kubernetes_client=MagicMock(return_value=fake_k8s),
+                    PodNotFoundError=type("PodNotFoundError", (Exception,), {}),
+                    JobOperationError=JobOperationError,
+                )
+            },
+        ):
+            response = client.get("/api/v1/deployment/logs?service=orchestrator")
+
+        assert response.status_code == 500
+        assert "api down" in response.get_json()["message"]
+
+
+# ---------------------------------------------------------------------------
 # Lifecycle-secret auth regression coverage (parity with #1769)
 # ---------------------------------------------------------------------------
 
@@ -1099,6 +1246,13 @@ class TestDeploymentLifecycleSecretAuth:
     def test_stream_reader_requires_bearer_token(self, client):
         response = client.get(
             "/api/v1/deployment/rebuild-and-rollout/streams/anything",
+            _lifecycle_auth=False,
+        )
+        assert response.status_code == 401
+
+    def test_get_service_logs_requires_bearer_token(self, client):
+        response = client.get(
+            "/api/v1/deployment/logs?service=gateway",
             _lifecycle_auth=False,
         )
         assert response.status_code == 401
@@ -1175,6 +1329,8 @@ def test_expected_public_symbols_are_exported():
         "_stream_mark_done",
         "_STREAM_BUFFERS",
         "_STREAM_TERMINATED",
+        "_SERVICE_LOG_ALLOWLIST",
+        "_MAX_LOG_LINES",
     ):
         assert hasattr(dep_mod, sym), f"missing public symbol: {sym}"
 

--- a/orchestrator/tests/test_kubernetes_client.py
+++ b/orchestrator/tests/test_kubernetes_client.py
@@ -946,6 +946,38 @@ class TestGetServiceLogs:
 
         assert [p["pod"] for p in result["pods"]] == ["gateway-abc"]
 
+    def test_per_pod_operation_error_returns_partial_results(
+        self,
+        k8s_client: KubernetesClient,
+        mock_core_api: MagicMock,
+    ):
+        """A transient non-404 error on one pod returns partial results with an error entry."""
+        dep = self._make_deployment({"app.kubernetes.io/name": "gateway"})
+        apps_patch, _ = self._install_apps_api(dep)
+
+        mock_pods = MagicMock()
+        mock_pods.items = [
+            _make_mock_pod(name="gateway-healthy"),
+            _make_mock_pod(name="gateway-crashloop"),
+        ]
+        mock_core_api.list_namespaced_pod.return_value = mock_pods
+        mock_core_api.read_namespaced_pod_log.side_effect = [
+            "healthy logs\n",
+            Exception("status=500 container in CrashLoopBackOff"),
+        ]
+
+        with apps_patch:
+            result = k8s_client.get_service_logs(service="gateway", namespace="egg-system")
+
+        assert len(result["pods"]) == 2
+        assert result["pods"][0]["pod"] == "gateway-healthy"
+        assert result["pods"][0]["logs"] == "healthy logs\n"
+        assert "error" not in result["pods"][0]
+        assert result["pods"][1]["pod"] == "gateway-crashloop"
+        assert result["pods"][1]["logs"] == ""
+        assert "error" in result["pods"][1]
+        assert "CrashLoopBackOff" in result["pods"][1]["error"]
+
 
 # ---------------------------------------------------------------------------
 # wait_for_container

--- a/orchestrator/tests/test_kubernetes_client.py
+++ b/orchestrator/tests/test_kubernetes_client.py
@@ -825,6 +825,129 @@ class TestGetContainerLogs:
 
 
 # ---------------------------------------------------------------------------
+# get_service_logs (#1853)
+# ---------------------------------------------------------------------------
+
+
+class TestGetServiceLogs:
+    """Tests for KubernetesClient.get_service_logs."""
+
+    def _install_apps_api(self, deployment_or_exc):
+        """Patch ``kubernetes.client.AppsV1Api`` to return ``deployment_or_exc``.
+
+        If *deployment_or_exc* is an Exception instance the patched
+        ``read_namespaced_deployment`` raises it; otherwise the value is
+        used as the return.
+        """
+        fake_apps = MagicMock()
+        if isinstance(deployment_or_exc, Exception):
+            fake_apps.read_namespaced_deployment.side_effect = deployment_or_exc
+        else:
+            fake_apps.read_namespaced_deployment.return_value = deployment_or_exc
+        return patch("kubernetes.client.AppsV1Api", return_value=fake_apps), fake_apps
+
+    def _make_deployment(self, match_labels: dict[str, str]) -> MagicMock:
+        dep = MagicMock()
+        dep.spec.selector.match_labels = dict(match_labels)
+        return dep
+
+    def test_returns_logs_for_each_matching_pod(
+        self,
+        k8s_client: KubernetesClient,
+        mock_core_api: MagicMock,
+    ):
+        dep = self._make_deployment({"app.kubernetes.io/name": "gateway"})
+        apps_patch, _ = self._install_apps_api(dep)
+
+        mock_pods = MagicMock()
+        mock_pods.items = [
+            _make_mock_pod(name="gateway-abc"),
+            _make_mock_pod(name="gateway-def"),
+        ]
+        mock_core_api.list_namespaced_pod.return_value = mock_pods
+        mock_core_api.read_namespaced_pod_log.side_effect = [
+            "gateway-abc line\n",
+            "gateway-def line\n",
+        ]
+
+        with apps_patch:
+            result = k8s_client.get_service_logs(
+                service="gateway", namespace="egg-system", tail_lines=25
+            )
+
+        assert result["service"] == "gateway"
+        assert result["namespace"] == "egg-system"
+        assert [p["pod"] for p in result["pods"]] == ["gateway-abc", "gateway-def"]
+        assert result["pods"][0]["logs"].startswith("gateway-abc")
+
+        # Label selector comes from the Deployment's matchLabels.
+        selector = mock_core_api.list_namespaced_pod.call_args.kwargs["label_selector"]
+        assert selector == "app.kubernetes.io/name=gateway"
+
+        # Tail forwarded to the pod-log call.
+        assert mock_core_api.read_namespaced_pod_log.call_args_list[0].kwargs["tail_lines"] == 25
+
+    def test_deployment_not_found_raises_pod_not_found(
+        self,
+        k8s_client: KubernetesClient,
+    ):
+        # Simulate a 404 from the apps API.
+        apps_patch, _ = self._install_apps_api(Exception("status=404 not found"))
+        with apps_patch, pytest.raises(PodNotFoundError):
+            k8s_client.get_service_logs(service="gateway", namespace="egg-system")
+
+    def test_no_pods_raises_pod_not_found(
+        self,
+        k8s_client: KubernetesClient,
+        mock_core_api: MagicMock,
+    ):
+        dep = self._make_deployment({"app.kubernetes.io/name": "gateway"})
+        apps_patch, _ = self._install_apps_api(dep)
+
+        mock_pods = MagicMock()
+        mock_pods.items = []
+        mock_core_api.list_namespaced_pod.return_value = mock_pods
+
+        with apps_patch, pytest.raises(PodNotFoundError):
+            k8s_client.get_service_logs(service="gateway", namespace="egg-system")
+
+    def test_missing_selector_raises_job_operation_error(
+        self,
+        k8s_client: KubernetesClient,
+    ):
+        dep = MagicMock()
+        dep.spec.selector.match_labels = {}
+        apps_patch, _ = self._install_apps_api(dep)
+        with apps_patch, pytest.raises(JobOperationError):
+            k8s_client.get_service_logs(service="gateway", namespace="egg-system")
+
+    def test_vanished_pod_is_skipped(
+        self,
+        k8s_client: KubernetesClient,
+        mock_core_api: MagicMock,
+    ):
+        """A pod that disappears between list and read should not fail the call."""
+        dep = self._make_deployment({"app.kubernetes.io/name": "gateway"})
+        apps_patch, _ = self._install_apps_api(dep)
+
+        mock_pods = MagicMock()
+        mock_pods.items = [
+            _make_mock_pod(name="gateway-abc"),
+            _make_mock_pod(name="gateway-gone"),
+        ]
+        mock_core_api.list_namespaced_pod.return_value = mock_pods
+        mock_core_api.read_namespaced_pod_log.side_effect = [
+            "live\n",
+            Exception("status=404 pod not found"),
+        ]
+
+        with apps_patch:
+            result = k8s_client.get_service_logs(service="gateway", namespace="egg-system")
+
+        assert [p["pod"] for p in result["pods"]] == ["gateway-abc"]
+
+
+# ---------------------------------------------------------------------------
 # wait_for_container
 # ---------------------------------------------------------------------------
 

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -815,6 +815,7 @@ class TestToolRouting:
             "prune_stale_worktrees",
             "validate_network_isolation",
             "rebuild_and_rollout",
+            "get_service_logs",
         }
         assert tool_names == expected
 
@@ -2467,8 +2468,70 @@ class TestRebuildAndRolloutTool:
         assert "poll" in result["error"].lower()
 
 
+class TestGetServiceLogsTool:
+    """``get_service_logs`` — thin GET proxy with query-string construction."""
+
+    def test_requires_service(self, handler):
+        result = handler.handle_tool_call("get_service_logs", {})
+        assert result.get("error") == "service is required"
+
+    def test_forwards_service_lines_and_since_seconds(self, handler):
+        with patch.object(
+            handler,
+            "_make_request",
+            return_value={
+                "success": True,
+                "data": {
+                    "service": "gateway",
+                    "namespace": "egg-system",
+                    "pods": [{"pod": "gateway-abc", "logs": "ok"}],
+                },
+            },
+        ) as mock_req:
+            result = handler.handle_tool_call(
+                "get_service_logs",
+                {"service": "gateway", "lines": 50, "since_seconds": 300},
+            )
+
+        # The args go into the query string, not the body.
+        endpoint = mock_req.call_args.args[0]
+        assert endpoint.startswith("/api/v1/deployment/logs?")
+        assert "service=gateway" in endpoint
+        assert "lines=50" in endpoint
+        assert "since_seconds=300" in endpoint
+        assert mock_req.call_args.kwargs["method"] == "GET"
+        assert result["pods"][0]["pod"] == "gateway-abc"
+
+    def test_service_is_url_encoded(self, handler):
+        """Any odd characters in service are url-encoded, not splatted raw."""
+        with patch.object(
+            handler,
+            "_make_request",
+            return_value={"success": True, "data": {}},
+        ) as mock_req:
+            handler.handle_tool_call("get_service_logs", {"service": "a/b c"})
+        endpoint = mock_req.call_args.args[0]
+        assert "service=a%2Fb%20c" in endpoint
+
+    def test_http_failure_wraps_into_error(self, handler):
+        with patch.object(handler, "_make_request", side_effect=RuntimeError("gateway down")):
+            result = handler.handle_tool_call("get_service_logs", {"service": "gateway"})
+        assert "error" in result
+        assert "get_service_logs failed" in result["error"]
+
+
 class TestPipelineToolsSchemasForDeployment:
     """Guard the input-schema shape of the five new tools."""
+
+    def test_get_service_logs_enumerates_allowed_services(self):
+        from mcp_tools import PIPELINE_TOOLS
+
+        tools_by_name = {t["name"]: t for t in PIPELINE_TOOLS}
+        schema = tools_by_name["get_service_logs"]["inputSchema"]
+        props = schema["properties"]
+        assert schema.get("required") == ["service"]
+        assert set(props["service"].get("enum", [])) == {"gateway", "orchestrator"}
+        assert props["lines"]["default"] == 100
 
     def test_validate_network_isolation_requires_pipeline_id(self):
         from mcp_tools import PIPELINE_TOOLS

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -2533,6 +2533,17 @@ class TestPipelineToolsSchemasForDeployment:
         assert set(props["service"].get("enum", [])) == {"gateway", "orchestrator"}
         assert props["lines"]["default"] == 100
 
+    def test_get_service_logs_enum_matches_route_allowlist(self):
+        """MCP schema enum and route allowlist must stay in sync."""
+        from mcp_tools import PIPELINE_TOOLS
+        from routes.deployment import _SERVICE_LOG_ALLOWLIST
+
+        tools_by_name = {t["name"]: t for t in PIPELINE_TOOLS}
+        schema_enum = set(
+            tools_by_name["get_service_logs"]["inputSchema"]["properties"]["service"]["enum"]
+        )
+        assert schema_enum == _SERVICE_LOG_ALLOWLIST
+
     def test_validate_network_isolation_requires_pipeline_id(self):
         from mcp_tools import PIPELINE_TOOLS
 


### PR DESCRIPTION
## Summary

- Adds `get_service_logs(service, lines=100, since_seconds=None)` MCP tool covering the `gateway` and `orchestrator` Deployments in the `egg-system` namespace. Complements `get_container_logs`, which only reaches agent-sandbox pods.
- Route `GET /api/v1/deployment/logs` is gated by `@require_lifecycle_secret` and only runs on the Kubernetes runtime (Docker returns the existing `not_available_on_runtime` payload).
- Allowlists `service` to `gateway`/`orchestrator` so this stays a diagnostic endpoint and doesn't drift into a generic kubectl-logs proxy.

Closes #1853.

## Design notes

- `KubernetesClient.get_service_logs` resolves the Deployment, reads its `selector.matchLabels`, lists matching pods, and returns logs keyed by pod so replicas and mid-rollout reads are legible. A pod that vanishes between list and read is skipped rather than failing the whole call.
- `lines` capped at 10 000, `since_seconds` maps directly to the k8s `read_namespaced_pod_log` option (covers the nice-to-have "logs around when my pipeline failed" use case).

## Test plan

- [x] `orchestrator/tests/test_kubernetes_client.py::TestGetServiceLogs` — 5 unit tests exercising the happy path, 404, missing selector, empty pod list, and mid-read pod vanishing.
- [x] `orchestrator/tests/test_deployment_routes.py::TestGetServiceLogsRoute` — 7 route-level tests including Docker short-circuit, allowlist enforcement, line cap, and error mapping.
- [x] Route auth guard regression added to `TestDeploymentLifecycleSecretAuth`.
- [x] `orchestrator/tests/test_mcp_tools.py::TestGetServiceLogsTool` — handler/query-string construction + `TestPipelineToolsSchemasForDeployment::test_get_service_logs_enumerates_allowed_services` schema guard.
- [x] Full orchestrator suite passes locally (`pytest orchestrator/tests/ --timeout=30`).
- [ ] Manual smoke on a live k3s deployment (blocked on reviewer environment — tool is read-only so safe to exercise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)