### PR TITLE
Fix #1857: dedupe per-agent worktree creation in session_create

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -4083,6 +4083,12 @@ def session_create() -> tuple[Response, int] | Response:
             return make_error("Invalid worktree_container_id: must be non-empty if provided")
         if len(worktree_container_id) > 256:
             return make_error("Invalid worktree_container_id: must be 256 characters or fewer")
+        if ".." in worktree_container_id or not re.match(
+            r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$", worktree_container_id
+        ):
+            return make_error(
+                "Invalid worktree_container_id: contains unsafe characters"
+            )
 
     # Validate local_only_repos if provided
     if local_only_repos:

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -4086,9 +4086,7 @@ def session_create() -> tuple[Response, int] | Response:
         if ".." in worktree_container_id or not re.match(
             r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$", worktree_container_id
         ):
-            return make_error(
-                "Invalid worktree_container_id: contains unsafe characters"
-            )
+            return make_error("Invalid worktree_container_id: contains unsafe characters")
 
     # Validate local_only_repos if provided
     if local_only_repos:

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -3955,7 +3955,12 @@ def session_create() -> tuple[Response, int] | Response:
             "repos": ["owner/repo1", "owner/repo2"],
             "local_only_repos": ["repo-name"],  // optional; no GitHub remote
             "uid": 1000,
-            "gid": 1000
+            "gid": 1000,
+            // Optional: when the caller already created per-agent worktrees
+            // via /api/v1/worktrees/create, pass that container_id here so
+            // the session reuses the existing worktrees instead of racing
+            // to re-create them on the same bare repo (#1857).
+            "worktree_container_id": "pipeline-role"
         }
 
     Response:
@@ -3981,6 +3986,11 @@ def session_create() -> tuple[Response, int] | Response:
     local_only_repos = data.get("local_only_repos", [])
     uid = data.get("uid")
     gid = data.get("gid")
+    # Optional worktree container_id — when provided, look up existing
+    # worktrees created by a prior /api/v1/worktrees/create call instead of
+    # re-creating them here.  Prevents the double create that races on
+    # .git/config.lock for concurrent per-agent spawns (#1857).
+    worktree_container_id = data.get("worktree_container_id")
     phase = data.get("phase")  # Optional SDLC pipeline phase
     pipeline_id = data.get("pipeline_id")  # Optional pipeline run ID
     issue_number = data.get("issue_number")  # Optional GitHub issue number
@@ -4064,6 +4074,15 @@ def session_create() -> tuple[Response, int] | Response:
             return make_error("Invalid branch: must be a string")
         if len(branch) > 256:
             return make_error("Invalid branch: must be 256 characters or fewer")
+
+    # Validate worktree_container_id if provided
+    if worktree_container_id is not None:
+        if not isinstance(worktree_container_id, str):
+            return make_error("Invalid worktree_container_id: must be a string")
+        if not worktree_container_id:
+            return make_error("Invalid worktree_container_id: must be non-empty if provided")
+        if len(worktree_container_id) > 256:
+            return make_error("Invalid worktree_container_id: must be 256 characters or fewer")
 
     # Validate local_only_repos if provided
     if local_only_repos:
@@ -4182,34 +4201,43 @@ def session_create() -> tuple[Response, int] | Response:
             repo_name = repo
 
         try:
-            # For pipeline sessions, prefer the pipeline's existing worktree
-            # branch (which contains artifacts from prior agents) over a fresh
-            # branch from origin/main.  This ensures HITL exec sessions can
-            # see drafts, contracts, and reviews committed by pipeline agents.
-            # See #1016.
-            #
-            # For fresh pipelines (no prior worktree branch), fall back to the
-            # remote default branch (e.g., origin/main) instead of HEAD.  HEAD
-            # may point to a feature branch in the main repo, which would
-            # pollute the worktree with commits outside the current phase's
-            # allowed scope and cause push rejections.  See #860.
-            if pipeline_id:
-                pipeline_work_branch = f"egg/{pipeline_id}/work"
-                if _branch_exists_on_remote(manager, repo_name, pipeline_work_branch):
-                    worktree_base_branch = f"origin/{pipeline_work_branch}"
-                else:
-                    worktree_base_branch = manager.resolve_default_branch(repo_name)
+            if worktree_container_id:
+                # Reuse worktrees created by a prior /api/v1/worktrees/create
+                # call.  Avoids a second concurrent ``git worktree add`` on the
+                # same bare repo, which races on ``.git/config.lock`` (#1857).
+                info = manager.lookup_worktree(
+                    repo_name=repo_name,
+                    container_id=worktree_container_id,
+                )
             else:
-                worktree_base_branch = "HEAD"
+                # For pipeline sessions, prefer the pipeline's existing worktree
+                # branch (which contains artifacts from prior agents) over a fresh
+                # branch from origin/main.  This ensures HITL exec sessions can
+                # see drafts, contracts, and reviews committed by pipeline agents.
+                # See #1016.
+                #
+                # For fresh pipelines (no prior worktree branch), fall back to the
+                # remote default branch (e.g., origin/main) instead of HEAD.  HEAD
+                # may point to a feature branch in the main repo, which would
+                # pollute the worktree with commits outside the current phase's
+                # allowed scope and cause push rejections.  See #860.
+                if pipeline_id:
+                    pipeline_work_branch = f"egg/{pipeline_id}/work"
+                    if _branch_exists_on_remote(manager, repo_name, pipeline_work_branch):
+                        worktree_base_branch = f"origin/{pipeline_work_branch}"
+                    else:
+                        worktree_base_branch = manager.resolve_default_branch(repo_name)
+                else:
+                    worktree_base_branch = "HEAD"
 
-            info = manager.create_worktree(
-                repo_name=repo_name,
-                container_id=container_id,
-                base_branch=worktree_base_branch,
-                uid=uid,
-                gid=gid,
-                assigned_branch=branch,
-            )
+                info = manager.create_worktree(
+                    repo_name=repo_name,
+                    container_id=container_id,
+                    base_branch=worktree_base_branch,
+                    uid=uid,
+                    gid=gid,
+                    assigned_branch=branch,
+                )
             # Capture the first worktree's gateway-side path for checkpoint context
             if first_worktree_path is None:
                 first_worktree_path = str(info.worktree_path)

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -4822,6 +4822,74 @@ class TestSessionCreateReusesExistingWorktrees:
         data = json.loads(response.data)
         assert "worktree_container_id" in data["message"]
 
+    def test_session_create_validates_worktree_container_id_empty(
+        self, client, launcher_auth_headers
+    ):
+        """Empty worktree_container_id is rejected at the API boundary."""
+        response = client.post(
+            "/api/v1/sessions/create",
+            headers=launcher_auth_headers,
+            data=json.dumps(
+                {
+                    "container_id": "egg-agent-pipe-1-coder",
+                    "mode": "private",
+                    "repos": ["owner/repo"],
+                    "pipeline_id": "pipe-1",
+                    "worktree_container_id": "",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert "non-empty" in data["message"]
+
+    def test_session_create_validates_worktree_container_id_too_long(
+        self, client, launcher_auth_headers
+    ):
+        """Overly long worktree_container_id is rejected at the API boundary."""
+        response = client.post(
+            "/api/v1/sessions/create",
+            headers=launcher_auth_headers,
+            data=json.dumps(
+                {
+                    "container_id": "egg-agent-pipe-1-coder",
+                    "mode": "private",
+                    "repos": ["owner/repo"],
+                    "pipeline_id": "pipe-1",
+                    "worktree_container_id": "a" * 257,
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert "256 characters" in data["message"]
+
+    def test_session_create_validates_worktree_container_id_unsafe_chars(
+        self, client, launcher_auth_headers
+    ):
+        """Path traversal and unsafe characters in worktree_container_id
+        are rejected with a clear 400 instead of surfacing as a 500."""
+        for bad_value in ["../evil", "/absolute", "has spaces", ".hidden"]:
+            response = client.post(
+                "/api/v1/sessions/create",
+                headers=launcher_auth_headers,
+                data=json.dumps(
+                    {
+                        "container_id": "egg-agent-pipe-1-coder",
+                        "mode": "private",
+                        "repos": ["owner/repo"],
+                        "pipeline_id": "pipe-1",
+                        "worktree_container_id": bad_value,
+                    }
+                ),
+                content_type="application/json",
+            )
+            assert response.status_code == 400, f"Expected 400 for {bad_value!r}"
+            data = json.loads(response.data)
+            assert "unsafe characters" in data["message"], f"Bad message for {bad_value!r}"
+
 
 class TestWorktreeCreateEndpointResolution:
     """Tests for worktree_create endpoint's resolve_default_branch logic."""

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -4661,6 +4661,168 @@ class TestSessionCreateLocalOnlyRepos:
         assert "unsafe repo name" in data["message"]
 
 
+class TestSessionCreateReusesExistingWorktrees:
+    """Tests that session_create reuses prior worktrees via worktree_container_id.
+
+    Regression: when the orchestrator creates per-agent worktrees via
+    /api/v1/worktrees/create and then calls /api/v1/sessions/create with
+    a different container_id (the k8s job name), the session endpoint used
+    to run its own ``git worktree add`` against the same bare repo.  With
+    multiple concurrent spawns that second create raced on
+    ``.git/config.lock`` and intermittently killed one agent per phase.
+    See #1857.
+    """
+
+    def test_session_create_with_worktree_container_id_skips_create(
+        self, client, launcher_auth_headers, tmp_path
+    ):
+        """When worktree_container_id is set, session_create calls lookup_worktree,
+        not create_worktree — eliminating the .git/config.lock race."""
+        from session_manager import SessionManager
+
+        manager = SessionManager(persistence_file=tmp_path / "sessions.json")
+
+        with (
+            patch.object(gateway, "get_session_manager", return_value=manager),
+            patch.object(gateway, "get_repo_visibility", return_value="private"),
+            patch.object(gateway, "get_worktree_manager") as mock_worktree,
+        ):
+            mock_wt_manager = mock_worktree.return_value
+            mock_wt_info = MagicMock()
+            mock_wt_info.worktree_path = "/home/egg/.egg-worktrees/pipe-1-coder/repo"
+            mock_wt_info.branch = "egg/pipe-1-coder/work"
+            mock_wt_manager.lookup_worktree.return_value = mock_wt_info
+
+            response = client.post(
+                "/api/v1/sessions/create",
+                headers=launcher_auth_headers,
+                data=json.dumps(
+                    {
+                        "container_id": "egg-agent-pipe-1-coder",
+                        "mode": "private",
+                        "repos": ["owner/repo"],
+                        "pipeline_id": "pipe-1",
+                        "agent_role": "coder",
+                        "worktree_container_id": "pipe-1-coder",
+                    }
+                ),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            assert data["success"] is True
+
+            # Lookup — not create — is the whole point of the fix.
+            mock_wt_manager.lookup_worktree.assert_called_once()
+            lookup_kwargs = mock_wt_manager.lookup_worktree.call_args.kwargs
+            assert lookup_kwargs["container_id"] == "pipe-1-coder"
+            assert lookup_kwargs["repo_name"] == "repo"
+            mock_wt_manager.create_worktree.assert_not_called()
+
+            # Worktree path is reported back to the caller.
+            assert "repo" in data["data"]["worktrees"]
+
+    def test_session_create_without_worktree_container_id_still_creates(
+        self, client, launcher_auth_headers, tmp_path
+    ):
+        """Absent worktree_container_id, session_create keeps its existing
+        create_worktree behaviour (backward compatibility for HITL, temp
+        sessions, tests)."""
+        from session_manager import SessionManager
+
+        manager = SessionManager(persistence_file=tmp_path / "sessions.json")
+
+        with (
+            patch.object(gateway, "get_session_manager", return_value=manager),
+            patch.object(gateway, "get_repo_visibility", return_value="private"),
+            patch.object(gateway, "get_worktree_manager") as mock_worktree,
+            patch.object(gateway, "_branch_exists_on_remote", return_value=False),
+        ):
+            mock_wt_manager = mock_worktree.return_value
+            mock_wt_manager.resolve_default_branch.return_value = "origin/main"
+            mock_wt_info = MagicMock()
+            mock_wt_info.worktree_path = "/home/egg/.egg-worktrees/c/repo"
+            mock_wt_info.branch = "egg/c/work"
+            mock_wt_manager.create_worktree.return_value = mock_wt_info
+
+            response = client.post(
+                "/api/v1/sessions/create",
+                headers=launcher_auth_headers,
+                data=json.dumps(
+                    {
+                        "container_id": "egg-agent-pipe-1-coder",
+                        "mode": "private",
+                        "repos": ["owner/repo"],
+                        "pipeline_id": "pipe-1",
+                    }
+                ),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 200
+            mock_wt_manager.create_worktree.assert_called_once()
+            mock_wt_manager.lookup_worktree.assert_not_called()
+
+    def test_session_create_lookup_failure_returns_error(
+        self, client, launcher_auth_headers, tmp_path
+    ):
+        """If the worktree_container_id doesn't resolve to an existing
+        worktree, session_create fails cleanly instead of silently
+        creating a fresh one."""
+        from session_manager import SessionManager
+
+        manager = SessionManager(persistence_file=tmp_path / "sessions.json")
+
+        with (
+            patch.object(gateway, "get_session_manager", return_value=manager),
+            patch.object(gateway, "get_repo_visibility", return_value="private"),
+            patch.object(gateway, "get_worktree_manager") as mock_worktree,
+        ):
+            mock_wt_manager = mock_worktree.return_value
+            mock_wt_manager.lookup_worktree.side_effect = ValueError("Worktree not found")
+
+            response = client.post(
+                "/api/v1/sessions/create",
+                headers=launcher_auth_headers,
+                data=json.dumps(
+                    {
+                        "container_id": "egg-agent-pipe-1-coder",
+                        "mode": "private",
+                        "repos": ["owner/repo"],
+                        "pipeline_id": "pipe-1",
+                        "worktree_container_id": "pipe-1-coder",
+                    }
+                ),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 500
+            mock_wt_manager.create_worktree.assert_not_called()
+
+    def test_session_create_validates_worktree_container_id_type(
+        self, client, launcher_auth_headers
+    ):
+        """worktree_container_id must be a non-empty string when provided."""
+        response = client.post(
+            "/api/v1/sessions/create",
+            headers=launcher_auth_headers,
+            data=json.dumps(
+                {
+                    "container_id": "egg-agent-pipe-1-coder",
+                    "mode": "private",
+                    "repos": ["owner/repo"],
+                    "pipeline_id": "pipe-1",
+                    "worktree_container_id": 12345,
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert "worktree_container_id" in data["message"]
+
+
 class TestWorktreeCreateEndpointResolution:
     """Tests for worktree_create endpoint's resolve_default_branch logic."""
 

--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -653,6 +653,105 @@ class TestWorktreeManagerDockerGitDir:
         assert merge.stdout.strip() == "refs/heads/egg/issue-99"
 
 
+class TestLookupWorktree:
+    """Tests for WorktreeManager.lookup_worktree (#1857).
+
+    lookup_worktree exists so that session_create can reuse a worktree
+    made by a prior /api/v1/worktrees/create call instead of racing to
+    create its own on the same bare repo's ``.git/config.lock``.
+    """
+
+    @pytest.fixture
+    def git_repo(self, tmp_path):
+        """Same real-repo fixture as TestWorktreeManagerDockerGitDir."""
+        import subprocess as sp
+
+        repos_base = tmp_path / "repos"
+        repos_base.mkdir()
+        repo_dir = repos_base / "test-repo"
+        repo_dir.mkdir()
+        result = sp.run(["git", "init"], cwd=repo_dir, capture_output=True, text=True)
+        if result.returncode != 0:
+            pytest.skip(f"git init not available: {result.stderr.strip()}")
+        sp.run(
+            ["git", "commit", "--allow-empty", "-m", "init"],
+            cwd=repo_dir,
+            capture_output=True,
+            check=True,
+            env={
+                **__import__("os").environ,
+                "GIT_AUTHOR_NAME": "test",
+                "GIT_AUTHOR_EMAIL": "t@t",
+                "GIT_COMMITTER_NAME": "test",
+                "GIT_COMMITTER_EMAIL": "t@t",
+            },
+        )
+
+        worktree_base = tmp_path / "worktrees"
+        return worktree_base, repos_base, repo_dir
+
+    def test_lookup_returns_info_for_existing_worktree(self, git_repo):
+        """Lookup returns WorktreeInfo with the same paths the creator saw."""
+        worktree_base, repos_base, _ = git_repo
+        manager = WorktreeManager(worktree_base=worktree_base, repos_base=repos_base)
+
+        created = manager.create_worktree("test-repo", "pipe-1-coder")
+        looked_up = manager.lookup_worktree("test-repo", "pipe-1-coder")
+
+        assert looked_up.container_id == "pipe-1-coder"
+        assert looked_up.repo_name == "test-repo"
+        assert looked_up.worktree_path == created.worktree_path
+        assert looked_up.branch == created.branch
+        assert looked_up.git_dir == created.git_dir
+
+    def test_lookup_raises_when_worktree_missing(self, git_repo):
+        """Lookup must fail loudly rather than silently return a fake path —
+        otherwise a misconfigured caller would get a session pointing at
+        a non-existent worktree."""
+        worktree_base, repos_base, _ = git_repo
+        manager = WorktreeManager(worktree_base=worktree_base, repos_base=repos_base)
+
+        with pytest.raises(ValueError, match="Worktree not found"):
+            manager.lookup_worktree("test-repo", "never-created")
+
+    def test_lookup_raises_when_directory_exists_but_not_a_worktree(self, git_repo):
+        """An empty directory at the expected path shouldn't be treated as
+        a valid worktree — the .git file gating in create_worktree is the
+        same invariant we rely on here."""
+        worktree_base, repos_base, _ = git_repo
+        manager = WorktreeManager(worktree_base=worktree_base, repos_base=repos_base)
+
+        bogus = worktree_base / "broken" / "test-repo"
+        bogus.mkdir(parents=True)
+
+        with pytest.raises(ValueError, match="Worktree not found"):
+            manager.lookup_worktree("test-repo", "broken")
+
+    def test_lookup_rejects_path_traversal(self, tmp_path):
+        """Identifier validation applies to lookup the same way it applies
+        to create_worktree."""
+        worktree_base = tmp_path / "worktrees"
+        repos_base = tmp_path / "repos"
+        repos_base.mkdir()
+        manager = WorktreeManager(worktree_base=worktree_base, repos_base=repos_base)
+
+        with pytest.raises(ValueError, match="container_id"):
+            manager.lookup_worktree("test-repo", "../evil")
+        with pytest.raises(ValueError, match="repo_name"):
+            manager.lookup_worktree("../evil", "container-1")
+
+    def test_lookup_raises_when_repo_missing(self, tmp_path):
+        """Looking up a worktree for a repo that doesn't exist fails before
+        any filesystem check on the worktree path itself."""
+        worktree_base = tmp_path / "worktrees"
+        repos_base = tmp_path / "repos"
+        repos_base.mkdir()
+        manager = WorktreeManager(worktree_base=worktree_base, repos_base=repos_base)
+
+        with pytest.raises(ValueError, match="Repository not found"):
+            manager.lookup_worktree("missing-repo", "container-1")
+
+
 class TestWorktreeManagerRemoteBranchFetch:
     """Tests for create_worktree fetching remote branches that don't exist locally."""
 

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -535,6 +535,13 @@ class WorktreeManager:
         Raises:
             ValueError: If inputs are invalid, the repo doesn't exist, or
                 no valid worktree is present at the expected path.
+
+        Note:
+            Unlike ``create_worktree``'s reuse path, this method deliberately
+            skips ``_chown_recursive`` and ``_configure_push_upstream``.  In
+            the current flow both ``create_worktrees`` and ``register_session``
+            run with the same ``host_uid``/``host_gid``, and push upstream was
+            already configured by the original ``create_worktree`` call.
         """
         validate_identifier(container_id, "container_id")
         validate_identifier(repo_name, "repo_name")

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -512,6 +512,57 @@ class WorktreeManager:
 
         return info
 
+    def lookup_worktree(
+        self,
+        repo_name: str,
+        container_id: str,
+    ) -> WorktreeInfo:
+        """Return info for an existing worktree without creating one.
+
+        Used when the caller already created the worktree in a prior step
+        and just needs its paths (e.g. session_create reusing a worktree
+        that create_worktrees already made — see #1857).  Creating a second
+        worktree for the same agent races on ``.git/config.lock`` in the
+        bare repo and intermittently fails concurrent spawns.
+
+        Args:
+            repo_name: Name of the repository.
+            container_id: Container id under which the worktree was created.
+
+        Returns:
+            WorktreeInfo describing the existing worktree.
+
+        Raises:
+            ValueError: If inputs are invalid, the repo doesn't exist, or
+                no valid worktree is present at the expected path.
+        """
+        validate_identifier(container_id, "container_id")
+        validate_identifier(repo_name, "repo_name")
+
+        main_repo = self.repos_base / repo_name
+        if not main_repo.exists():
+            raise ValueError(f"Repository not found: {repo_name}")
+
+        worktree_path = self.worktree_base / container_id / repo_name
+        git_file = worktree_path / ".git"
+        if not (
+            worktree_path.exists()
+            and git_file.is_file()
+            and git_file.read_text().strip().startswith("gitdir:")
+        ):
+            raise ValueError(
+                f"Worktree not found for container_id={container_id} "
+                f"repo={repo_name} at {worktree_path}"
+            )
+
+        return WorktreeInfo(
+            container_id=container_id,
+            repo_name=repo_name,
+            branch=f"egg/{container_id}/work",
+            worktree_path=worktree_path,
+            git_dir=self._find_worktree_git_dir(main_repo, worktree_path),
+        )
+
     def _get_repo_lock(self, repo_name: str) -> threading.Lock:
         """Get or create a per-repo lock for serializing git operations."""
         with self._repo_locks_guard:

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -290,6 +290,7 @@ class GatewayClient:
         pr_number: int | None = None,
         claude_code_version: str | None = None,
         branch: str | None = None,
+        worktree_container_id: str | None = None,
     ) -> SessionInfo:
         """Register a session for a container.
 
@@ -310,6 +311,11 @@ class GatewayClient:
             pr_number: Optional GitHub PR number for checkpoint linkage
             claude_code_version: Optional Claude Code version string
             branch: Optional git branch for non-pushing session metadata
+            worktree_container_id: Optional container_id under which per-agent
+                worktrees were already created by a prior create_worktrees
+                call.  When provided, the gateway reuses those worktrees
+                instead of re-creating them — avoids a second
+                ``git worktree add`` racing on ``.git/config.lock`` (#1857).
 
         Returns:
             SessionInfo with the created session
@@ -345,6 +351,8 @@ class GatewayClient:
             request_data["claude_code_version"] = claude_code_version
         if branch is not None:
             request_data["branch"] = branch
+        if worktree_container_id is not None:
+            request_data["worktree_container_id"] = worktree_container_id
         result = self._make_request(
             "/api/v1/sessions/create",
             method="POST",

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -513,6 +513,13 @@ class KubernetesSpawner:
                     issue_number=issue_number,
                     claude_code_version=os.environ.get("CLAUDE_CODE_VERSION"),
                     branch=branch,
+                    # Reuse the per-agent worktrees created above under
+                    # agent_worktree_id.  Without this, the gateway would
+                    # race to create a second worktree under job_name and
+                    # intermittently fail on .git/config.lock (#1857).
+                    worktree_container_id=(
+                        agent_worktree_id if worktree_created_this_call else None
+                    ),
                 )
                 session_token = session_info.session_token
 

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -386,6 +386,60 @@ class TestSessionManagement:
         assert session.container_ip == "172.32.0.10"
         assert session.mode == "public"
 
+    def test_register_session_forwards_worktree_container_id(self, gateway_client):
+        """worktree_container_id reaches the wire payload so the gateway can
+        reuse an existing per-agent worktree instead of creating a second
+        one (#1857)."""
+        captured: dict = {}
+
+        def fake_make_request(endpoint, method, data, use_launcher_auth):
+            captured["endpoint"] = endpoint
+            captured["data"] = data
+            return {
+                "success": True,
+                "data": {
+                    "session_token": "tok-1",
+                    "created_at": datetime.now().isoformat(),
+                    "expires_at": datetime.now().isoformat(),
+                },
+            }
+
+        with patch.object(gateway_client, "_make_request", side_effect=fake_make_request):
+            gateway_client.register_session(
+                container_id="egg-agent-pipe-1-coder",
+                mode="private",
+                pipeline_id="pipe-1",
+                worktree_container_id="pipe-1-coder",
+            )
+
+        assert captured["endpoint"] == "/api/v1/sessions/create"
+        assert captured["data"]["worktree_container_id"] == "pipe-1-coder"
+
+    def test_register_session_omits_worktree_container_id_when_none(self, gateway_client):
+        """When the caller doesn't supply worktree_container_id, the field is
+        absent from the payload — keeps the wire contract minimal for callers
+        that still rely on the gateway creating a worktree for them."""
+        captured: dict = {}
+
+        def fake_make_request(endpoint, method, data, use_launcher_auth):
+            captured["data"] = data
+            return {
+                "success": True,
+                "data": {
+                    "session_token": "tok-1",
+                    "created_at": datetime.now().isoformat(),
+                    "expires_at": datetime.now().isoformat(),
+                },
+            }
+
+        with patch.object(gateway_client, "_make_request", side_effect=fake_make_request):
+            gateway_client.register_session(
+                container_id="abc",
+                mode="public",
+            )
+
+        assert "worktree_container_id" not in captured["data"]
+
     def test_register_session_without_secret(self, mock_gateway_server):
         """Test session registration without launcher secret fails."""
         client = GatewayClient(

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -349,6 +349,35 @@ class TestSpawnAgentJob:
         assert call_kwargs["container_id"] == "pipe-1-coder"
         assert call_kwargs["repos"] == ["owner/repo"]
 
+    def test_spawn_passes_worktree_container_id_to_register_session(self, spawner, mock_gateway):
+        """register_session must receive worktree_container_id=agent_worktree_id.
+
+        Regression for #1857: without this, the gateway created a second
+        worktree under the k8s job_name and raced on .git/config.lock with
+        concurrent spawns, intermittently killing one agent per phase.
+        """
+        spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+        )
+        register_kwargs = mock_gateway.register_session.call_args.kwargs
+        # container_id is still the job name (used for session identity).
+        assert register_kwargs["container_id"] == "egg-agent-pipe-1-coder"
+        # But the worktree comes from the earlier create_worktrees call.
+        assert register_kwargs["worktree_container_id"] == "pipe-1-coder"
+
+    def test_spawn_without_repos_omits_worktree_container_id(self, spawner, mock_gateway):
+        """Local-mode spawns skip worktree creation entirely — passing a
+        worktree_container_id would force the gateway to look up a
+        worktree that was never made."""
+        spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.CODER,
+        )
+        register_kwargs = mock_gateway.register_session.call_args.kwargs
+        assert register_kwargs.get("worktree_container_id") is None
+
     def test_spawn_worktree_failure_raises(self, spawner, mock_gateway):
         """Spawn raises when worktree creation fails."""
         from kubernetes_spawner import KubernetesSpawnError


### PR DESCRIPTION
## Summary
- Concurrent pipeline spawns made two worktree-creating gateway calls per agent under different container_ids (`{pipeline_id}-{role}` for `create_worktrees`, then the k8s job_name for `register_session`). Six concurrent `git worktree add` processes raced on the bare repo's `.git/config.lock` and one phase role lost every time, aborting the phase with `Failed to create any worktrees` (#1857).
- Adds `WorktreeManager.lookup_worktree()`, plumbs an optional `worktree_container_id` from `kubernetes_spawner` → `gateway_client.register_session` → `session_create`. When set, the gateway looks up the existing per-agent worktrees instead of racing to recreate them.
- Other `register_session` callers (HITL, temp PR/push/fetch sessions) are unchanged — they don't pass `worktree_container_id` and keep the old create-on-demand path.

## Test plan
- [x] `pytest gateway/tests/test_worktree_manager.py::TestLookupWorktree` — new lookup behavior (existing/missing/invalid/path-traversal/missing-repo)
- [x] `pytest gateway/tests/test_gateway.py::TestSessionCreateReusesExistingWorktrees` — endpoint reuses worktree, falls back to create when arg absent, surfaces lookup failures, validates input
- [x] `pytest orchestrator/tests/test_kubernetes_spawner.py::TestSpawnAgentJob` — confirms spawner passes `worktree_container_id=agent_worktree_id` to `register_session` (and omits it for repo-less spawns)
- [x] `pytest orchestrator/tests/test_gateway_client.py::TestSessionManagement` — `register_session` forwards/omits the field on the wire payload
- [x] Full orchestrator suite: 4024 passed (1 pre-existing skip, 1 pre-existing `test_spawn_unhealthy_gateway_raises` failure unrelated to this change)
- [x] Full gateway suite: 2162 passed (3 pre-existing `test_phase_api.py::TestPathTraversalProtection` failures unrelated to this change)

Fixes #1857.

🤖 Generated with [Claude Code](https://claude.com/claude-code)