### PR TITLE
Fix #1865: stop cleanup_pipeline from deleting sibling pipelines' worktrees

### DIFF
--- a/gateway/tests/test_worktree_isolation.py
+++ b/gateway/tests/test_worktree_isolation.py
@@ -141,3 +141,35 @@ class TestListWorktreesForPipeline:
         )
         result = mgr.list_worktrees_for_pipeline("issue-123")
         assert result == []
+
+    def test_does_not_match_longer_pipeline_id_sharing_prefix(self, manager, temp_dirs):
+        """Pipeline IDs that extend another with '-qualifier' must not collide.
+
+        Regression test for #1865: cleanup of `issue-1758` previously
+        matched `issue-1758-worktree-fix-tester` via naive prefix scan,
+        wiping an active pipeline's worktrees mid-phase.
+        """
+        worktree_base, _ = temp_dirs
+        (worktree_base / "issue-1758" / "egg").mkdir(parents=True)
+        (worktree_base / "issue-1758-tester" / "egg").mkdir(parents=True)
+        (worktree_base / "issue-1758-worktree-fix" / "egg").mkdir(parents=True)
+        (worktree_base / "issue-1758-worktree-fix-tester" / "egg").mkdir(parents=True)
+        (worktree_base / "issue-1758-worktree-fix-reviewer_code" / "egg").mkdir(parents=True)
+
+        result = manager.list_worktrees_for_pipeline("issue-1758")
+        container_ids = {wt.container_id for wt in result}
+        assert container_ids == {"issue-1758", "issue-1758-tester"}
+
+    def test_matches_extended_pipeline_without_cross_contamination(self, manager, temp_dirs):
+        """The longer pipeline's own worktrees should still be returned."""
+        worktree_base, _ = temp_dirs
+        (worktree_base / "issue-1758-tester" / "egg").mkdir(parents=True)
+        (worktree_base / "issue-1758-worktree-fix" / "egg").mkdir(parents=True)
+        (worktree_base / "issue-1758-worktree-fix-tester" / "egg").mkdir(parents=True)
+
+        result = manager.list_worktrees_for_pipeline("issue-1758-worktree-fix")
+        container_ids = {wt.container_id for wt in result}
+        assert container_ids == {
+            "issue-1758-worktree-fix",
+            "issue-1758-worktree-fix-tester",
+        }

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -1258,15 +1258,17 @@ class WorktreeManager:
         if not self.worktree_base.exists():
             return results
 
-        # Prefix match is safe because pipeline IDs are structured as
-        # "issue-{number}" and won't overlap (e.g. "issue-12" won't
-        # match "issue-123-*" because we require a "-" after the ID).
-        prefix = f"{pipeline_id}-"
+        # Only match the pipeline-level worktree or "{pipeline_id}-{role}"
+        # where {role} is shaped like an AgentRole value (lower-case
+        # letters and underscores, no hyphens).  A naive `startswith`
+        # match collides when one pipeline ID is a prefix of another —
+        # e.g. `issue-1758` would spuriously match
+        # `issue-1758-worktree-fix-tester` (#1865).
+        per_agent = re.compile(rf"{re.escape(pipeline_id)}-[a-z_]+\Z")
         for entry in self.worktree_base.iterdir():
             if not entry.is_dir():
                 continue
-            # Match the pipeline-level worktree and any per-agent worktrees
-            if entry.name != pipeline_id and not entry.name.startswith(prefix):
+            if entry.name != pipeline_id and not per_agent.fullmatch(entry.name):
                 continue
             for repo_dir in entry.iterdir():
                 if not repo_dir.is_dir():

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -931,9 +931,7 @@ class WorktreeManager:
             # constraining the suffix shape adds a layer of safety.
             worktree_dir = self.worktree_base / repo_name
             if worktree_dir.exists():
-                phase_pattern = re.compile(
-                    rf"{re.escape(container_id)}-[a-zA-Z0-9-]+"
-                )
+                phase_pattern = re.compile(rf"{re.escape(container_id)}-[a-zA-Z0-9-]+")
                 for entry in worktree_dir.iterdir():
                     if (
                         entry.is_dir()

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -922,16 +922,23 @@ class WorktreeManager:
                 results.append(result)
         else:
             # Clean all phase worktrees for this container by scanning.
-            # Use container_id + "-" as prefix to match any phase_id format
-            # (phase IDs may not start with "phase-").
+            # Match "{container_id}-{phase}" where {phase} has the shape
+            # of a sanitized phase ID ([a-zA-Z0-9-]+).  A naive
+            # `startswith(prefix)` could collide if another container_id
+            # extends this one (same bug class as #1865).  In practice
+            # the risk is low because container_id already includes the
+            # agent role suffix (e.g. "issue-1758-coder"), but
+            # constraining the suffix shape adds a layer of safety.
             worktree_dir = self.worktree_base / repo_name
             if worktree_dir.exists():
-                prefix = f"{container_id}-"
+                phase_pattern = re.compile(
+                    rf"{re.escape(container_id)}-[a-zA-Z0-9-]+"
+                )
                 for entry in worktree_dir.iterdir():
                     if (
-                        entry.name.startswith(prefix)
+                        entry.is_dir()
                         and entry.name != container_id
-                        and entry.is_dir()
+                        and phase_pattern.fullmatch(entry.name)
                     ):
                         # Extract the phase container ID from dir name
                         phase_container_id = entry.name
@@ -1264,7 +1271,10 @@ class WorktreeManager:
         # match collides when one pipeline ID is a prefix of another —
         # e.g. `issue-1758` would spuriously match
         # `issue-1758-worktree-fix-tester` (#1865).
-        per_agent = re.compile(rf"{re.escape(pipeline_id)}-[a-z_]+\Z")
+        #
+        # Assumes AgentRole values match [a-z_]+ — update if the enum
+        # gains values with digits or other characters.
+        per_agent = re.compile(rf"{re.escape(pipeline_id)}-[a-z_]+")
         for entry in self.worktree_base.iterdir():
             if not entry.is_dir():
                 continue

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -801,15 +801,29 @@ class KubernetesSpawner:
             if role_label and isinstance(role_label, str):
                 worktree_ids_to_clean.add(f"{pipeline_id}-{role_label}")
 
-        # Also scan filesystem for any per-agent worktrees
+        # Also scan filesystem for any per-agent worktrees.  Only match
+        # entries that are either the pipeline-level worktree or a
+        # "{pipeline_id}-{role}" directory where {role} is a known
+        # AgentRole value.  A naive `startswith(f"{pipeline_id}-")`
+        # collides with longer pipeline IDs that share the prefix — e.g.
+        # cleanup of `issue-1758` would match active worktrees of
+        # `issue-1758-worktree-fix-tester`, wiping another pipeline's
+        # state mid-phase (#1865).
         if WORKTREE_BASE_DIR.exists():
-            prefix = f"{pipeline_id}-"
+            valid_suffixes = {f"-{role.value}" for role in AgentRole}
             try:
                 for entry in WORKTREE_BASE_DIR.iterdir():
-                    if entry.is_dir() and (
-                        entry.name == pipeline_id or entry.name.startswith(prefix)
-                    ):
-                        worktree_ids_to_clean.add(entry.name)
+                    if not entry.is_dir():
+                        continue
+                    name = entry.name
+                    if name == pipeline_id:
+                        worktree_ids_to_clean.add(name)
+                        continue
+                    if not name.startswith(pipeline_id):
+                        continue
+                    suffix = name[len(pipeline_id) :]
+                    if suffix in valid_suffixes:
+                        worktree_ids_to_clean.add(name)
             except Exception as e:
                 logger.warning(
                     "Filesystem worktree scan failed during cleanup",

--- a/orchestrator/tests/test_per_agent_worktree.py
+++ b/orchestrator/tests/test_per_agent_worktree.py
@@ -294,6 +294,51 @@ class TestPerAgentWorktreeErrorLogging:
 class TestWorktreeCleanup:
     """Pipeline cleanup must delete per-agent worktrees."""
 
+    def test_cleanup_filesystem_scan_does_not_cross_pipeline_boundary(
+        self, spawner, mock_docker_client, mock_gateway_client, tmp_path, monkeypatch
+    ):
+        """Regression for #1865: cleanup of a short-named pipeline must
+        not wipe an active pipeline whose ID extends it with a hyphenated
+        qualifier.
+
+        `issue-1758` previously matched `issue-1758-worktree-fix-tester`
+        via `startswith(f"{pipeline_id}-")`, deleting another pipeline's
+        worktree mid-phase.  After the fix only "{pipeline_id}-{role}"
+        with a role-shaped suffix (no hyphens) should match.
+        """
+        import kubernetes_spawner
+
+        worktree_base = tmp_path / "worktrees"
+        worktree_base.mkdir()
+        # Short pipeline's own worktrees — should be cleaned.
+        (worktree_base / "issue-1758" / "egg").mkdir(parents=True)
+        (worktree_base / "issue-1758-tester" / "egg").mkdir(parents=True)
+        # Longer pipeline that shares a prefix — must NOT be cleaned.
+        (worktree_base / "issue-1758-worktree-fix" / "egg").mkdir(parents=True)
+        (worktree_base / "issue-1758-worktree-fix-tester" / "egg").mkdir(parents=True)
+        (worktree_base / "issue-1758-worktree-fix-reviewer_code" / "egg").mkdir(parents=True)
+
+        monkeypatch.setattr(kubernetes_spawner, "WORKTREE_BASE_DIR", worktree_base)
+
+        # No jobs — the filesystem scan is the only path under test.
+        mock_docker_client.list_containers.return_value = []
+
+        spawner.cleanup_pipeline("issue-1758")
+
+        delete_calls = mock_gateway_client.delete_worktrees.call_args_list
+        deleted_ids = {
+            c.kwargs.get("container_id", c.args[0] if c.args else None) for c in delete_calls
+        }
+        deleted_ids.discard(None)
+
+        # pipeline-level worktree and role-suffixed per-agent worktree.
+        assert "issue-1758" in deleted_ids
+        assert "issue-1758-tester" in deleted_ids
+        # Must not touch the longer pipeline's worktrees.
+        assert "issue-1758-worktree-fix" not in deleted_ids
+        assert "issue-1758-worktree-fix-tester" not in deleted_ids
+        assert "issue-1758-worktree-fix-reviewer_code" not in deleted_ids
+
     def test_cleanup_deletes_per_agent_worktrees(
         self, spawner, mock_docker_client, mock_gateway_client
     ):


### PR DESCRIPTION
## Summary
- `cleanup_pipeline` scanned `~/.egg-worktrees/` with `entry.name.startswith(f"{pipeline_id}-")`, which cross-matches whenever one pipeline ID is a prefix of another (e.g. cleanup of `issue-1758` hit `issue-1758-worktree-fix-tester`, wiping another active pipeline's worktree mid-phase — observed in #1865).
- The gateway's `list_worktrees_for_pipeline` had the identical bug, with a comment claiming pipeline IDs were always `issue-{number}` (demonstrably false).
- Tightened both scans to match either `{pipeline_id}` exactly or `{pipeline_id}-{role}` where `{role}` matches the shape of every `AgentRole` value — no hyphens. Orchestrator checks the `AgentRole` set directly; gateway (which doesn't import shared) uses `re.fullmatch(r"{pipeline_id}-[a-z_]+")`.

## Test plan
- [x] `pytest orchestrator/tests/test_per_agent_worktree.py gateway/tests/test_worktree_isolation.py gateway/tests/test_worktree_manager.py` — 125 passed
- [x] Verified both new regression tests fail against the pre-fix code (confirms they're load-bearing, not tautological)
- [ ] CI green

Fixes #1865

🤖 Generated with [Claude Code](https://claude.com/claude-code)