### PR TITLE
Fix #1869: fail fast when per-agent worktree is missing at spawn time

### DIFF
--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -178,6 +178,30 @@ def _classify_spawn_error(e: BaseException | None) -> str | None:
     return f"unknown_{status_code}"
 
 
+# Roles that can run without a per-agent git worktree.  Reviewers and
+# operator-facing roles only poll consensus messages / pipeline state —
+# they never commit or push, so spawning them with ``repos=[]`` is a
+# valid configuration.  Every other role produces or edits files in a
+# worktree, so spawning it without one would stall the pipeline with
+# "Worktree not found" on the first git call (#1869).
+_ROLES_WITHOUT_WORKTREE: frozenset[AgentRole] = frozenset(
+    {
+        AgentRole.REVIEWER_CODE,
+        AgentRole.REVIEWER_CONTRACT,
+        AgentRole.REVIEWER_AGENT_DESIGN,
+        AgentRole.REVIEWER_REFINE,
+        AgentRole.REVIEWER_PLAN,
+        AgentRole.OVERSEER,
+        AgentRole.INSPECTOR,
+    }
+)
+
+
+def _role_needs_worktree(role: AgentRole) -> bool:
+    """Return True for roles whose work cannot proceed without a worktree."""
+    return role not in _ROLES_WITHOUT_WORKTREE
+
+
 def _host_to_local_volumes(repo_volumes: dict[str, str]) -> dict[str, str]:
     """Translate host paths to orchestrator-local paths for filesystem ops.
 
@@ -272,6 +296,25 @@ class KubernetesSpawner:
             if key not in self._restart_locks:
                 self._restart_locks[key] = threading.Lock()
             return self._restart_locks[key]
+
+    def _find_missing_worktrees(self, agent_worktree_id: str, repos: list[str]) -> list[str]:
+        """Return the list of per-agent worktree paths that don't exist on disk.
+
+        Called right before spawning the k8s Job to catch the #1869 class
+        of failure: ``create_worktrees`` returned success but the directory
+        is gone by the time we'd spawn the Job (concurrent cleanup race,
+        or create_worktrees was never called because ``repos`` was empty).
+        Returns an empty list when all worktrees are in place.  Split out
+        as an instance method so tests can monkey-patch it without having
+        to manage a tmp filesystem hierarchy.
+        """
+        missing: list[str] = []
+        for repo in repos:
+            repo_name = repo.split("/")[-1] if "/" in repo else repo
+            expected = WORKTREE_BASE_DIR / agent_worktree_id / repo_name
+            if not expected.exists():
+                missing.append(str(expected))
+        return missing
 
     def spawn_agent_job(
         self,
@@ -491,6 +534,36 @@ class KubernetesSpawner:
                     f"Per-agent worktree creation returned no worktrees "
                     f"for {agent_worktree_id}: {errors}"
                 )
+
+        # Defensive sanity check: confirm the per-agent worktree actually
+        # exists on disk before we spawn the Job.  Producers silently burn
+        # minutes of tokens retrying git against a missing worktree when
+        # ``create_worktrees`` looked like it succeeded but the directory
+        # is gone — e.g. if a concurrent cleanup raced in between creation
+        # and Job spawn, or if ``repos`` was empty so no worktree was ever
+        # made for a role that needs one.  Surface that at spawn time
+        # with an actionable message instead (#1869).
+        if repos:
+            missing = self._find_missing_worktrees(agent_worktree_id, repos)
+            if missing:
+                raise KubernetesSpawnError(
+                    f"Per-agent worktree missing at spawn time for "
+                    f"{agent_worktree_id} (role={agent_role.value}): "
+                    f"{', '.join(missing)}. The worktree was either never "
+                    f"created or deleted before the Job could start — see #1869."
+                )
+        elif _role_needs_worktree(agent_role):
+            # No repos were provided but this role cannot function without
+            # a worktree (any non-reviewer role).  Previously we spawned
+            # anyway; the container would come up, issue a ``git status``,
+            # and get a 500 "Worktree not found" from the gateway on every
+            # call — pipelines stalled until manual cancellation (#1869).
+            raise KubernetesSpawnError(
+                f"Cannot spawn {agent_role.value} for pipeline "
+                f"{pipeline_id}: no repos provided so no per-agent worktree "
+                f"can be created, and this role requires one for git "
+                f"operations. See #1869."
+            )
 
         # Register gateway session (token-only, no container_ip)
         session_info = None

--- a/orchestrator/tests/conftest.py
+++ b/orchestrator/tests/conftest.py
@@ -194,6 +194,34 @@ def _inject_lifecycle_auth(monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True)
+def _skip_worktree_disk_check(monkeypatch):
+    """Bypass the spawner's spawn-time worktree-existence checks (#1869).
+
+    ``KubernetesSpawner.spawn_agent_job`` now verifies both (a) that the
+    per-agent worktree exists on disk after ``create_worktrees`` returns
+    and (b) that producer-class roles were not spawned with ``repos=[]``.
+    In unit tests the gateway is mocked, so no real worktree is ever
+    created and many pre-existing tests spawn producers with empty
+    ``repos`` purely to exercise other spawn mechanics — the checks
+    would trip on those tests.
+
+    Stub both checks with a monkey-patch on the class so tests see the
+    pre-#1869 behavior by default.  Tests specifically exercising the
+    #1869 scenarios re-patch these to the real behavior.
+    """
+    try:
+        import kubernetes_spawner
+        from kubernetes_spawner import KubernetesSpawner
+    except ImportError:
+        yield
+        return
+
+    monkeypatch.setattr(KubernetesSpawner, "_find_missing_worktrees", lambda self, *args, **kw: [])
+    monkeypatch.setattr(kubernetes_spawner, "_role_needs_worktree", lambda role: False)
+    yield
+
+
 @pytest.fixture
 def lifecycle_secret() -> str:
     """The shared test bearer token. Useful for building explicit headers."""

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -240,6 +240,7 @@ class TestSpawnAgentJob:
         result = spawner.spawn_agent_job(
             pipeline_id="pipe-1",
             agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
         )
         assert result.pipeline_id == "pipe-1"
         assert result.agent_role == AgentRole.CODER
@@ -268,6 +269,7 @@ class TestSpawnAgentJob:
             issue_number=42,
             phase="implement",
             branch="egg/issue-42",
+            repos=["owner/repo"],
         )
         env = result.environment
         assert env["EGG_PIPELINE_ID"] == "pipe-2"
@@ -285,6 +287,7 @@ class TestSpawnAgentJob:
             pipeline_id="p",
             agent_role=AgentRole.CODER,
             extra_env={"EGG_AGENT_ROLE": "custom", "MY_KEY": "val"},
+            repos=["owner/repo"],
         )
         assert result.environment["EGG_AGENT_ROLE"] == "custom"
         assert result.environment["MY_KEY"] == "val"
@@ -295,6 +298,7 @@ class TestSpawnAgentJob:
             pipeline_id="pipe-1",
             agent_role=AgentRole.CODER,
             issue_number=99,
+            repos=["owner/repo"],
         )
         call_kwargs = mock_k8s_client.create_container.call_args.kwargs
         labels = call_kwargs["labels"]
@@ -310,6 +314,7 @@ class TestSpawnAgentJob:
             pipeline_id="p",
             agent_role=AgentRole.CODER,
             wait_for_gateway=False,
+            repos=["owner/repo"],
         )
         mock_gateway.check_health.assert_not_called()
 
@@ -324,6 +329,7 @@ class TestSpawnAgentJob:
             spawner.spawn_agent_job(
                 pipeline_id="p",
                 agent_role=AgentRole.CODER,
+                repos=["owner/repo"],
             )
 
     def test_spawn_cleans_existing_job(self, spawner, mock_k8s_client):
@@ -332,6 +338,7 @@ class TestSpawnAgentJob:
         spawner.spawn_agent_job(
             pipeline_id="p",
             agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
         )
         mock_k8s_client.delete_job.assert_called_once_with(
             "egg-sandbox-egg-agent-p-coder", "test-ns"
@@ -368,15 +375,79 @@ class TestSpawnAgentJob:
         assert register_kwargs["worktree_container_id"] == "pipe-1-coder"
 
     def test_spawn_without_repos_omits_worktree_container_id(self, spawner, mock_gateway):
-        """Local-mode spawns skip worktree creation entirely — passing a
+        """Review-only spawns skip worktree creation entirely — passing a
         worktree_container_id would force the gateway to look up a
-        worktree that was never made."""
+        worktree that was never made.
+
+        Uses ``REVIEWER_CODE`` because producers with empty ``repos`` are
+        now rejected at spawn time (#1869).
+        """
         spawner.spawn_agent_job(
             pipeline_id="pipe-1",
-            agent_role=AgentRole.CODER,
+            agent_role=AgentRole.REVIEWER_CODE,
         )
         register_kwargs = mock_gateway.register_session.call_args.kwargs
         assert register_kwargs.get("worktree_container_id") is None
+
+    def test_spawn_producer_without_repos_raises(self, spawner, monkeypatch):
+        """Spawning a producer role with empty ``repos`` now raises.
+
+        Regression guard for #1869: previously the container came up
+        without a worktree and burned tokens retrying git against a
+        gateway that kept returning "Worktree not found" — the
+        pipeline stalled until a human cancelled.
+        """
+        import kubernetes_spawner
+        from kubernetes_spawner import KubernetesSpawnError
+
+        # Undo the conftest autouse stub for this regression test.
+        monkeypatch.setattr(
+            kubernetes_spawner,
+            "_role_needs_worktree",
+            lambda role: role not in kubernetes_spawner._ROLES_WITHOUT_WORKTREE,
+        )
+
+        with pytest.raises(KubernetesSpawnError, match="no repos provided"):
+            spawner.spawn_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+            )
+
+    def test_spawn_missing_worktree_on_disk_raises(self, spawner, monkeypatch):
+        """Spawn fails when the worktree disappears between creation and Job start.
+
+        Simulates the race where ``create_worktrees`` returns success but
+        a concurrent ``cleanup_pipeline`` wipes the directory before the
+        Job can start — surfaced now so producers don't silently burn
+        tokens on a missing worktree (#1869).
+        """
+        from kubernetes_spawner import KubernetesSpawner, KubernetesSpawnError
+
+        # The conftest autouse fixture stubs _find_missing_worktrees to
+        # return empty.  Re-patch here so the check reports the worktree
+        # as missing — simulating a concurrent cleanup race.
+        monkeypatch.setattr(
+            KubernetesSpawner,
+            "_find_missing_worktrees",
+            lambda self, agent_worktree_id, repos: [
+                f"/home/egg/.egg-worktrees/{agent_worktree_id}/repo"
+            ],
+        )
+
+        with pytest.raises(KubernetesSpawnError, match="missing at spawn time"):
+            spawner.spawn_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                repos=["owner/repo"],
+            )
+
+    def test_spawn_reviewer_without_repos_succeeds(self, spawner):
+        """Reviewer roles can spawn without ``repos`` — they never do git."""
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.REVIEWER_CONTRACT,
+        )
+        assert result.agent_role == AgentRole.REVIEWER_CONTRACT
 
     def test_spawn_worktree_failure_raises(self, spawner, mock_gateway):
         """Spawn raises when worktree creation fails."""
@@ -401,6 +472,7 @@ class TestSpawnAgentJob:
             spawner.spawn_agent_job(
                 pipeline_id="p",
                 agent_role=AgentRole.CODER,
+                repos=["owner/repo"],
             )
         mock_gateway.delete_session.assert_called_once_with("tok-abcdef123456")
 
@@ -409,6 +481,7 @@ class TestSpawnAgentJob:
         result = spawner.spawn_agent_job(
             pipeline_id="pipe-5",
             agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
         )
         assert result.environment["EGG_BRANCH"] == "egg/pipe-5/work"
 
@@ -418,6 +491,7 @@ class TestSpawnAgentJob:
             pipeline_id="p",
             agent_role=AgentRole.CODER,
             image="custom-image:v2",
+            repos=["owner/repo"],
         )
         call_kwargs = mock_k8s_client.create_container.call_args.kwargs
         assert call_kwargs["image"] == "custom-image:v2"
@@ -775,6 +849,7 @@ class TestRestartAgentJob:
         result = spawner.restart_agent_job(
             pipeline_id="pipe-1",
             agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
         )
         assert spawner.get_restart_count("pipe-1", "coder") == 1
         assert result.pipeline_id == "pipe-1"
@@ -796,6 +871,7 @@ class TestRestartAgentJob:
         spawner.restart_agent_job(
             pipeline_id="pipe-1",
             agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
         )
         mock_k8s_client.remove_container.assert_called()
 
@@ -805,6 +881,7 @@ class TestRestartAgentJob:
         spawner.restart_agent_job(
             pipeline_id="pipe-1",
             agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
         )
         assert spawner.get_restart_count("pipe-1", "coder") == 1
 
@@ -924,7 +1001,7 @@ class TestCreateConcurrentSpawnFn:
             issue_number=1,
             repo_volumes=None,
             mode="public",
-            repos=None,
+            repos=["owner/repo"],
             phase="implement",
             sandbox_env={"BASE_KEY": "base_val"},
         )

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -56,7 +56,7 @@ class _FakeWorktreeResult:
 
     def __post_init__(self):
         if self.worktrees is None:
-            self.worktrees = {"owner/repo": "/home/egg/.egg-worktrees/test/owner/repo"}
+            self.worktrees = {"owner/repo": "/home/egg/.egg-worktrees/test/repo"}
         if self.errors is None:
             self.errors = []
 
@@ -225,6 +225,21 @@ class TestKubernetesSpawnerInit:
     def test_empty_restart_counts(self, spawner):
         """Restart counts start empty."""
         assert spawner._restart_counts == {}
+
+
+# ---------------------------------------------------------------------------
+# Worktree allowlist validation
+# ---------------------------------------------------------------------------
+
+
+def test_roles_without_worktree_are_valid():
+    """Every entry in _ROLES_WITHOUT_WORKTREE must be a real AgentRole."""
+    from kubernetes_spawner import _ROLES_WITHOUT_WORKTREE
+
+    assert _ROLES_WITHOUT_WORKTREE.issubset(set(AgentRole)), (
+        f"Unknown roles in _ROLES_WITHOUT_WORKTREE: "
+        f"{_ROLES_WITHOUT_WORKTREE - set(AgentRole)}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -441,8 +456,16 @@ class TestSpawnAgentJob:
                 repos=["owner/repo"],
             )
 
-    def test_spawn_reviewer_without_repos_succeeds(self, spawner):
+    def test_spawn_reviewer_without_repos_succeeds(self, spawner, monkeypatch):
         """Reviewer roles can spawn without ``repos`` — they never do git."""
+        import kubernetes_spawner
+
+        # Undo the conftest autouse stub so the real guard runs.
+        monkeypatch.setattr(
+            kubernetes_spawner,
+            "_role_needs_worktree",
+            lambda role: role not in kubernetes_spawner._ROLES_WITHOUT_WORKTREE,
+        )
         result = spawner.spawn_agent_job(
             pipeline_id="pipe-1",
             agent_role=AgentRole.REVIEWER_CONTRACT,

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -237,8 +237,7 @@ def test_roles_without_worktree_are_valid():
     from kubernetes_spawner import _ROLES_WITHOUT_WORKTREE
 
     assert _ROLES_WITHOUT_WORKTREE.issubset(set(AgentRole)), (
-        f"Unknown roles in _ROLES_WITHOUT_WORKTREE: "
-        f"{_ROLES_WITHOUT_WORKTREE - set(AgentRole)}"
+        f"Unknown roles in _ROLES_WITHOUT_WORKTREE: {_ROLES_WITHOUT_WORKTREE - set(AgentRole)}"
     )
 
 


### PR DESCRIPTION
## Summary

- Adds a spawn-time disk check (`_find_missing_worktrees`) that verifies each expected per-agent worktree exists before the k8s Job is created — catches the case where `create_worktrees` appeared to succeed but the directory vanished (concurrent `cleanup_pipeline` race, etc.).
- Adds a role-aware guard so producer-class roles (anything except reviewers / overseer / inspector) can no longer spawn with `repos=[]` — that configuration can only produce a container that fails every git call with "Worktree not found" (#1869).
- Both guards raise `KubernetesSpawnError` with the full worktree path / diagnostic, which `_spawn_agent` already propagates into `pipeline.error` so the failure is visible in the first status poll instead of 6 minutes into a stalled pipeline.

Reported in issue: producers in pipeline `issue-1758-vn` silently spawned without worktrees and burned tokens against gateway `Worktree not found` errors until the operator cancelled the pipeline. Root-cause attribution in the issue points at the #1857 fix, but by the time these checks land the real signal will surface in the error message regardless of whether the underlying cause is empty `repos` at spawn or a cleanup race.

## Test plan

- [x] `pytest orchestrator/tests/test_kubernetes_spawner.py orchestrator/tests/test_container_spawner.py` — all 99 pass, including three new tests:
  - `test_spawn_producer_without_repos_raises` — empty `repos` + producer role now raises instead of silently spawning
  - `test_spawn_missing_worktree_on_disk_raises` — simulates a cleanup race between `create_worktrees` and Job start
  - `test_spawn_reviewer_without_repos_succeeds` — reviewers with empty `repos` still spawn cleanly
- [x] `pytest orchestrator/tests/` — full orchestrator suite passes (4073 passed, 1 skipped)
- [x] `ruff check` / `ruff format` clean on changed files
- [ ] Manual: submit a producer-only pipeline with `repos=[]` and confirm the `pipeline.error` reads "Cannot spawn &lt;role&gt; for pipeline ...: no repos provided..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)