### PR TITLE
Fix #1873: retry agents that die to transient API errors at startup

### DIFF
--- a/docs/guides/concurrent-execution.md
+++ b/docs/guides/concurrent-execution.md
@@ -87,6 +87,7 @@ All concurrent agent containers are wrapped with a shell script defined in `orch
 | `max_restarts` | `2` | Maximum restart attempts (passed to `build_consensus_wrapped_command()`). Shared between clean-exit and transient-crash restarts. |
 | `max_ready_polls` | `10` | Maximum poll cycles (each ~30 s) to wait for global consensus when this agent has already reached `CONFIRMED` |
 | `TRANSIENT_RESTART_BACKOFF_INITIAL` | `5` | Initial backoff delay (seconds) before restarting after a transient crash. Doubles after each crash restart, capped at 30 s. Clean-exit restarts skip the backoff. |
+| `STARTUP_FAILURE_WINDOW_SECONDS` | `30` | Window (seconds) during which exit code 1 is classified as a transient startup failure and retried. Set to `0` to disable. |
 | `EGG_MESSAGE_POLL_INTERVAL` | `30` | Seconds between message polls during restarts |
 
 ## Message Bus

--- a/orchestrator/consensus_wrapper.py
+++ b/orchestrator/consensus_wrapper.py
@@ -42,6 +42,17 @@ MAX_READY_POLL_CYCLES = 10
 # after each consecutive crash restart, capped at 30 seconds.
 TRANSIENT_RESTART_BACKOFF_INITIAL = 5
 
+# Window (in seconds) during which an exit code 1 is classified as a transient
+# startup failure rather than a permanent error. The Agent SDK surfaces
+# API-level errors (network blips, socket closes, 5xx responses during the
+# first few turns) as success=False + exit 1, which exit-code alone cannot
+# distinguish from a prompt-level failure. Agents that exit 1 within this
+# window have almost certainly not done meaningful work yet, so the retry
+# cost is negligible compared to stalling a BRC phase on a transient network
+# hiccup. Agents that exit 1 after doing real work (past the window) are
+# still treated as permanent failures.
+STARTUP_FAILURE_WINDOW_SECONDS = 30
+
 # System prompt injected on restart so the agent treats recovery instructions as
 # trusted operator context (not user input that might be flagged as injection).
 # Placeholders: {restart_number}, {max_restarts}, {brc_state}, {nack_feedback}
@@ -106,6 +117,7 @@ RESTART_COUNT=0
 CRASH_BACKOFF=0
 TRANSIENT_BACKOFF_INITIAL={transient_backoff_initial}
 TRANSIENT_BACKOFF_MAX=30
+STARTUP_FAILURE_WINDOW_SECONDS={startup_failure_window_seconds}
 
 # Log wrapper messages to stderr so they never leak into agent SDK context.
 cw_log() {{
@@ -220,9 +232,29 @@ is_transient_crash() {{
     esac
 }}
 
+# Detect transient startup failures: exit code 1 within the startup window.
+# The Agent SDK reports API-level errors (socket close, 5xx, network) as
+# success=False + exit 1, which looks identical to a permanent prompt error
+# by exit code alone. Gating on agent lifetime distinguishes "died before
+# doing any real work" (retry) from "completed work and failed at the end"
+# (permanent). Returns 0 (true) if retryable, 1 (false) otherwise.
+is_startup_failure() {{
+    local code="$1"
+    local duration="$2"
+    if [ "$code" -ne 1 ]; then
+        return 1
+    fi
+    if [ "$duration" -lt "$STARTUP_FAILURE_WINDOW_SECONDS" ]; then
+        return 0
+    fi
+    return 1
+}}
+
 # --- Initial run ---
+AGENT_START=$SECONDS
 run_agent {initial_prompt}
 AGENT_EXIT=$?
+AGENT_DURATION=$((SECONDS - AGENT_START))
 
 # If not in concurrent mode, exit normally
 if [ "${{EGG_CONCURRENT_MODE:-}}" != "true" ]; then
@@ -257,8 +289,11 @@ if [ "$AGENT_EXIT" -ne 0 ]; then
     if is_transient_crash "$AGENT_EXIT"; then
         cw_log "Transient crash (code $AGENT_EXIT). Will restart with backoff."
         CRASH_BACKOFF=$TRANSIENT_BACKOFF_INITIAL
+    elif is_startup_failure "$AGENT_EXIT" "$AGENT_DURATION"; then
+        cw_log "Startup failure (code $AGENT_EXIT after ${{AGENT_DURATION}}s, likely transient API/network error). Will restart with backoff."
+        CRASH_BACKOFF=$TRANSIENT_BACKOFF_INITIAL
     else
-        cw_log "Agent failed (code $AGENT_EXIT). NOT restarting."
+        cw_log "Agent failed (code $AGENT_EXIT after ${{AGENT_DURATION}}s). NOT restarting."
         exit $AGENT_EXIT
     fi
 fi
@@ -379,8 +414,10 @@ m = {{"restart_number": os.environ["_CW_RESTART"], "max_restarts": os.environ["_
      "anchor_state": os.environ.get("_CW_ANCHOR", "")}}
 sys.stdout.write(re.sub(r"\{{(\w+)\}}", lambda x: m.get(x.group(1), x.group(0)), t))' <<< "$RECOVERY_SYS")
 
+    AGENT_START=$SECONDS
     run_agent {recovery_user_prompt} "$RECOVERY_SYS"
     AGENT_EXIT=$?
+    AGENT_DURATION=$((SECONDS - AGENT_START))
 
     if [ "$AGENT_EXIT" -ne 0 ]; then
         # Same consensus/confirmed check as the initial exit handler (issue #1495).
@@ -406,7 +443,14 @@ sys.stdout.write(re.sub(r"\{{(\w+)\}}", lambda x: m.get(x.group(1), x.group(0)),
             fi
             continue
         fi
-        cw_log "Agent failed on restart $RESTART_COUNT (code $AGENT_EXIT). Stopping."
+        if is_startup_failure "$AGENT_EXIT" "$AGENT_DURATION"; then
+            cw_log "Startup failure on restart $RESTART_COUNT (code $AGENT_EXIT after ${{AGENT_DURATION}}s). Will retry."
+            if [ "$CRASH_BACKOFF" -eq 0 ]; then
+                CRASH_BACKOFF=$TRANSIENT_BACKOFF_INITIAL
+            fi
+            continue
+        fi
+        cw_log "Agent failed on restart $RESTART_COUNT (code $AGENT_EXIT after ${{AGENT_DURATION}}s). Stopping."
         exit $AGENT_EXIT
     fi
 
@@ -458,6 +502,7 @@ def build_consensus_wrapped_command(
     max_restarts: int = MAX_CONSENSUS_RESTARTS,
     max_ready_polls: int = MAX_READY_POLL_CYCLES,
     transient_backoff_initial: int = TRANSIENT_RESTART_BACKOFF_INITIAL,
+    startup_failure_window_seconds: int = STARTUP_FAILURE_WINDOW_SECONDS,
 ) -> list[str]:
     """Build a shell command that runs the agent with a BRC consensus restart wrapper.
 
@@ -475,6 +520,9 @@ def build_consensus_wrapped_command(
             signaled READY (avoids unnecessary restarts).
         transient_backoff_initial: Initial backoff in seconds for transient
             crash restarts. Doubles after each crash, capped at 30s.
+        startup_failure_window_seconds: Agents that exit with code 1 within
+            this many seconds are treated as transient API/network failures
+            and restarted. Set to 0 to disable the heuristic.
 
     Returns:
         Command list suitable for container spawning (bash -c "...").
@@ -503,6 +551,7 @@ def build_consensus_wrapped_command(
         recovery_system_prompt_template=_RECOVERY_SYSTEM_PROMPT,
         recovery_user_prompt=recovery_user_prompt,
         transient_backoff_initial=transient_backoff_initial,
+        startup_failure_window_seconds=startup_failure_window_seconds,
     )
 
     return ["bash", "-c", script]

--- a/orchestrator/tests/test_consensus_race_on_exit.py
+++ b/orchestrator/tests/test_consensus_race_on_exit.py
@@ -654,7 +654,11 @@ class TestWrapperStaleTrackerFallback:
                 f.write("fi\n")
             os.chmod(mock_python, 0o755)  # nosec B103
 
-            cmd = build_consensus_wrapped_command("Do the work", max_restarts=2)
+            # Disable the startup-failure retry heuristic — this test targets
+            # the tracker/bus-fallback path, not retry-on-exit-1 behavior.
+            cmd = build_consensus_wrapped_command(
+                "Do the work", max_restarts=2, startup_failure_window_seconds=0
+            )
             result = self._run_wrapper_command(cmd, tmpdir, agent_role="coder")
 
             # Should fail because agent is genuinely not confirmed

--- a/orchestrator/tests/test_consensus_wrapper.py
+++ b/orchestrator/tests/test_consensus_wrapper.py
@@ -369,21 +369,7 @@ class TestConsensusWrapperBehavior:
         """Non-transient, non-startup-window non-zero exit without consensus should still fail."""
         with tempfile.TemporaryDirectory() as tmpdir:
             log_file = os.path.join(tmpdir, "egg-orch.log")
-            # Create mock egg-orch that returns is_complete=false and no agents
-            mock_orch = os.path.join(tmpdir, "egg-orch")
-            with open(mock_orch, "w") as f:
-                f.write("#!/bin/bash\n")
-                f.write(f'echo "$@" >> {shlex.quote(log_file)}\n')
-                f.write('if echo "$@" | grep -q "pipeline status"; then\n')
-                f.write(
-                    '  echo \'{"data": {"concurrent": {"consensus": {"is_complete": false, "agents": {}}}}}\'\n'
-                )
-                f.write('elif echo "$@" | grep -q "message poll"; then\n')
-                f.write('  echo "[]"\n')
-                f.write("else\n")
-                f.write('  echo "{}"\n')
-                f.write("fi\n")
-            os.chmod(mock_orch, 0o755)  # nosec B103
+            self._make_mock_orch_no_consensus(tmpdir, log_file)
             # Use exit 42: not a signal-transient code, and not exit 1 (so the
             # startup-failure heuristic does not apply) — must fail fast.
             self._make_failing_agent(tmpdir, exit_code=42)
@@ -466,6 +452,31 @@ class TestConsensusWrapperBehavior:
         os.chmod(mock_orch, 0o755)  # nosec B103
 
         _make_mock_agent(tmpdir, claude_log_file)
+
+    @staticmethod
+    def _make_mock_orch_no_consensus(tmpdir: str, log_file: str) -> None:
+        """Create a mock egg-orch that always returns consensus incomplete.
+
+        Handles ``pipeline status`` (returns is_complete=false), ``message poll``
+        (returns empty list), and falls through to ``{}`` for anything else.
+        Does NOT create a mock agent — callers combine this with
+        ``_make_failing_agent`` or a custom agent script.
+        """
+        mock_orch = os.path.join(tmpdir, "egg-orch")
+        with open(mock_orch, "w") as f:
+            f.write("#!/bin/bash\n")
+            f.write(f'echo "$@" >> {shlex.quote(log_file)}\n')
+            f.write('if echo "$@" | grep -q "pipeline status"; then\n')
+            f.write(
+                '  echo \'{"data": {"concurrent": {"consensus": '
+                '{"is_complete": false, "agents": {}}}}}\'\n'
+            )
+            f.write('elif echo "$@" | grep -q "message poll"; then\n')
+            f.write('  echo "[]"\n')
+            f.write("else\n")
+            f.write('  echo "{}"\n')
+            f.write("fi\n")
+        os.chmod(mock_orch, 0o755)  # nosec B103
 
     def test_clean_exit_triggers_restart(self):
         """A zero Claude exit should trigger a restart, not auto-signal READY."""
@@ -961,22 +972,7 @@ class TestConsensusWrapperBehavior:
         """Non-transient, non-startup-window non-zero exit (e.g. exit 42) should NOT restart."""
         with tempfile.TemporaryDirectory() as tmpdir:
             log_file = os.path.join(tmpdir, "egg-orch.log")
-            # Create mock egg-orch that returns is_complete=false and no agents
-            mock_orch = os.path.join(tmpdir, "egg-orch")
-            with open(mock_orch, "w") as f:
-                f.write("#!/bin/bash\n")
-                f.write(f'echo "$@" >> {shlex.quote(log_file)}\n')
-                f.write('if echo "$@" | grep -q "pipeline status"; then\n')
-                f.write(
-                    '  echo \'{"data": {"concurrent": {"consensus": '
-                    '{"is_complete": false, "agents": {}}}}}\'\n'
-                )
-                f.write('elif echo "$@" | grep -q "message poll"; then\n')
-                f.write('  echo "[]"\n')
-                f.write("else\n")
-                f.write('  echo "{}"\n')
-                f.write("fi\n")
-            os.chmod(mock_orch, 0o755)  # nosec B103
+            self._make_mock_orch_no_consensus(tmpdir, log_file)
             # Exit 42 is not a signal-transient code, not exit 1, so it should
             # bypass both is_transient_crash and is_startup_failure.
             self._make_failing_agent(tmpdir, exit_code=42)
@@ -1241,21 +1237,7 @@ class TestConsensusWrapperBehavior:
         """startup_failure_window_seconds=0 disables the heuristic; exit 1 must fail fast."""
         with tempfile.TemporaryDirectory() as tmpdir:
             log_file = os.path.join(tmpdir, "egg-orch.log")
-            mock_orch = os.path.join(tmpdir, "egg-orch")
-            with open(mock_orch, "w") as f:
-                f.write("#!/bin/bash\n")
-                f.write(f'echo "$@" >> {shlex.quote(log_file)}\n')
-                f.write('if echo "$@" | grep -q "pipeline status"; then\n')
-                f.write(
-                    '  echo \'{"data": {"concurrent": {"consensus": '
-                    '{"is_complete": false, "agents": {}}}}}\'\n'
-                )
-                f.write('elif echo "$@" | grep -q "message poll"; then\n')
-                f.write('  echo "[]"\n')
-                f.write("else\n")
-                f.write('  echo "{}"\n')
-                f.write("fi\n")
-            os.chmod(mock_orch, 0o755)  # nosec B103
+            self._make_mock_orch_no_consensus(tmpdir, log_file)
             self._make_failing_agent(tmpdir, exit_code=1)
 
             cmd = build_consensus_wrapped_command(
@@ -1273,21 +1255,7 @@ class TestConsensusWrapperBehavior:
             log_file = os.path.join(tmpdir, "egg-orch.log")
             claude_log = os.path.join(tmpdir, "claude.log")
             call_counter = os.path.join(tmpdir, "agent_call_count")
-            mock_orch = os.path.join(tmpdir, "egg-orch")
-            with open(mock_orch, "w") as f:
-                f.write("#!/bin/bash\n")
-                f.write(f'echo "$@" >> {shlex.quote(log_file)}\n')
-                f.write('if echo "$@" | grep -q "pipeline status"; then\n')
-                f.write(
-                    '  echo \'{"data": {"concurrent": {"consensus": '
-                    '{"is_complete": false, "agents": {}}}}}\'\n'
-                )
-                f.write('elif echo "$@" | grep -q "message poll"; then\n')
-                f.write('  echo "[]"\n')
-                f.write("else\n")
-                f.write('  echo "{}"\n')
-                f.write("fi\n")
-            os.chmod(mock_orch, 0o755)  # nosec B103
+            self._make_mock_orch_no_consensus(tmpdir, log_file)
 
             # Agent logs each call, then always exits 1 — persistent API failure.
             mock_python = os.path.join(tmpdir, "python3")
@@ -1327,21 +1295,7 @@ class TestConsensusWrapperBehavior:
         with tempfile.TemporaryDirectory() as tmpdir:
             log_file = os.path.join(tmpdir, "egg-orch.log")
             claude_log = os.path.join(tmpdir, "claude.log")
-            mock_orch = os.path.join(tmpdir, "egg-orch")
-            with open(mock_orch, "w") as f:
-                f.write("#!/bin/bash\n")
-                f.write(f'echo "$@" >> {shlex.quote(log_file)}\n')
-                f.write('if echo "$@" | grep -q "pipeline status"; then\n')
-                f.write(
-                    '  echo \'{"data": {"concurrent": {"consensus": '
-                    '{"is_complete": false, "agents": {}}}}}\'\n'
-                )
-                f.write('elif echo "$@" | grep -q "message poll"; then\n')
-                f.write('  echo "[]"\n')
-                f.write("else\n")
-                f.write('  echo "{}"\n')
-                f.write("fi\n")
-            os.chmod(mock_orch, 0o755)  # nosec B103
+            self._make_mock_orch_no_consensus(tmpdir, log_file)
 
             # Agent sleeps past the (shortened) window, then exits 1.
             # Window=1s; agent sleeps 3s before exiting — well outside the window.
@@ -1375,21 +1329,7 @@ class TestConsensusWrapperBehavior:
         """Exit code 42 (application error) should NOT be treated as transient."""
         with tempfile.TemporaryDirectory() as tmpdir:
             log_file = os.path.join(tmpdir, "egg-orch.log")
-            mock_orch = os.path.join(tmpdir, "egg-orch")
-            with open(mock_orch, "w") as f:
-                f.write("#!/bin/bash\n")
-                f.write(f'echo "$@" >> {shlex.quote(log_file)}\n')
-                f.write('if echo "$@" | grep -q "pipeline status"; then\n')
-                f.write(
-                    '  echo \'{"data": {"concurrent": {"consensus": '
-                    '{"is_complete": false, "agents": {}}}}}\'\n'
-                )
-                f.write('elif echo "$@" | grep -q "message poll"; then\n')
-                f.write('  echo "[]"\n')
-                f.write("else\n")
-                f.write('  echo "{}"\n')
-                f.write("fi\n")
-            os.chmod(mock_orch, 0o755)  # nosec B103
+            self._make_mock_orch_no_consensus(tmpdir, log_file)
             self._make_failing_agent(tmpdir, exit_code=42)
 
             cmd = build_consensus_wrapped_command("Prompt", max_restarts=2)

--- a/orchestrator/tests/test_consensus_wrapper.py
+++ b/orchestrator/tests/test_consensus_wrapper.py
@@ -11,6 +11,7 @@ from consensus_wrapper import (
     _RECOVERY_USER_PROMPT,
     MAX_CONSENSUS_RESTARTS,
     MAX_READY_POLL_CYCLES,
+    STARTUP_FAILURE_WINDOW_SECONDS,
     TRANSIENT_RESTART_BACKOFF_INITIAL,
     build_consensus_wrapped_command,
 )
@@ -144,6 +145,44 @@ class TestBuildConsensusWrappedCommand:
     def test_transient_crash_constant_value(self):
         """TRANSIENT_RESTART_BACKOFF_INITIAL should be 5 (as specified in plan)."""
         assert TRANSIENT_RESTART_BACKOFF_INITIAL == 5
+
+    def test_is_startup_failure_function_in_script(self):
+        """The wrapper should contain is_startup_failure with exit-1-and-duration gating."""
+        cmd = build_consensus_wrapped_command("Prompt")
+        script = cmd[2]
+        assert "is_startup_failure()" in script
+        assert "STARTUP_FAILURE_WINDOW_SECONDS" in script
+        # Function must compare duration against the window
+        assert 'if [ "$code" -ne 1 ]' in script
+        assert 'if [ "$duration" -lt "$STARTUP_FAILURE_WINDOW_SECONDS" ]' in script
+
+    def test_default_startup_failure_window(self):
+        """Default startup_failure_window_seconds should match module constant."""
+        cmd = build_consensus_wrapped_command("Prompt")
+        script = cmd[2]
+        assert f"STARTUP_FAILURE_WINDOW_SECONDS={STARTUP_FAILURE_WINDOW_SECONDS}" in script
+
+    def test_custom_startup_failure_window(self):
+        """Should support custom startup_failure_window_seconds parameter."""
+        cmd = build_consensus_wrapped_command("Prompt", startup_failure_window_seconds=7)
+        script = cmd[2]
+        assert "STARTUP_FAILURE_WINDOW_SECONDS=7" in script
+
+    def test_agent_duration_tracking_in_script(self):
+        """The wrapper should track agent run duration around each run_agent call."""
+        cmd = build_consensus_wrapped_command("Prompt")
+        script = cmd[2]
+        assert "AGENT_START=$SECONDS" in script
+        assert "AGENT_DURATION=$((SECONDS - AGENT_START))" in script
+        # Both the initial run and the restart-loop run need tracking
+        assert script.count("AGENT_START=$SECONDS") >= 2
+
+    def test_startup_failure_check_in_nonzero_handlers(self):
+        """Both the initial and restart-loop non-zero handlers should call is_startup_failure."""
+        cmd = build_consensus_wrapped_command("Prompt")
+        script = cmd[2]
+        assert script.count('is_startup_failure "$AGENT_EXIT" "$AGENT_DURATION"') >= 2
+        assert "Startup failure" in script
 
     def test_backoff_reset_on_clean_exit(self):
         """The wrapper should reset CRASH_BACKOFF to 0 on clean agent exit."""
@@ -327,7 +366,7 @@ class TestConsensusWrapperBehavior:
             assert "consensus already reached" in result.stderr
 
     def test_nonzero_exit_without_consensus_fails(self):
-        """Non-zero agent exit without consensus should still exit with failure."""
+        """Non-transient, non-startup-window non-zero exit without consensus should still fail."""
         with tempfile.TemporaryDirectory() as tmpdir:
             log_file = os.path.join(tmpdir, "egg-orch.log")
             # Create mock egg-orch that returns is_complete=false and no agents
@@ -345,12 +384,14 @@ class TestConsensusWrapperBehavior:
                 f.write('  echo "{}"\n')
                 f.write("fi\n")
             os.chmod(mock_orch, 0o755)  # nosec B103
-            self._make_failing_agent(tmpdir, exit_code=1)
+            # Use exit 42: not a signal-transient code, and not exit 1 (so the
+            # startup-failure heuristic does not apply) — must fail fast.
+            self._make_failing_agent(tmpdir, exit_code=42)
 
             cmd = build_consensus_wrapped_command("Do the work", max_restarts=2)
             result = self._run_wrapper_command(cmd, tmpdir)
 
-            assert result.returncode == 1
+            assert result.returncode == 42
             assert "NOT restarting" in result.stderr
 
     def test_nonzero_exit_with_agent_confirmed_exits_cleanly(self):
@@ -917,7 +958,7 @@ class TestConsensusWrapperBehavior:
             assert call_count >= 2
 
     def test_non_transient_nonzero_exit_does_not_restart(self):
-        """Non-transient non-zero exit (e.g. exit 1) should NOT restart."""
+        """Non-transient, non-startup-window non-zero exit (e.g. exit 42) should NOT restart."""
         with tempfile.TemporaryDirectory() as tmpdir:
             log_file = os.path.join(tmpdir, "egg-orch.log")
             # Create mock egg-orch that returns is_complete=false and no agents
@@ -936,15 +977,18 @@ class TestConsensusWrapperBehavior:
                 f.write('  echo "{}"\n')
                 f.write("fi\n")
             os.chmod(mock_orch, 0o755)  # nosec B103
-            self._make_failing_agent(tmpdir, exit_code=1)
+            # Exit 42 is not a signal-transient code, not exit 1, so it should
+            # bypass both is_transient_crash and is_startup_failure.
+            self._make_failing_agent(tmpdir, exit_code=42)
 
             cmd = build_consensus_wrapped_command("Do the work", max_restarts=2)
             result = self._run_wrapper_command(cmd, tmpdir)
 
-            assert result.returncode == 1
+            assert result.returncode == 42
             assert "NOT restarting" in result.stderr
-            # Should NOT contain transient crash messages
+            # Should NOT contain transient crash or startup failure messages
             assert "Transient crash" not in result.stderr
+            assert "Startup failure" not in result.stderr
 
     def test_transient_crash_exit_255_triggers_restart(self):
         """Bun segfault exit code 255 should also trigger restart."""
@@ -1111,6 +1155,221 @@ class TestConsensusWrapperBehavior:
             with open(claude_log) as f:
                 call_count = f.read().count("---CLAUDE_CALL_START---")
             assert call_count == 3
+
+    def test_startup_failure_exit_1_triggers_restart(self):
+        """Exit 1 within startup window (socket-close on turn 1) should restart."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = os.path.join(tmpdir, "egg-orch.log")
+            claude_log = os.path.join(tmpdir, "claude.log")
+
+            counter_file = os.path.join(tmpdir, "orch_status_count")
+            call_counter = os.path.join(tmpdir, "agent_call_count")
+            mock_orch = os.path.join(tmpdir, "egg-orch")
+
+            # Mock egg-orch: consensus incomplete initially, complete on 3rd call
+            with open(mock_orch, "w") as f:
+                f.write("#!/bin/bash\n")
+                f.write(f'echo "$@" >> {shlex.quote(log_file)}\n')
+                f.write('if echo "$@" | grep -q "pipeline status"; then\n')
+                f.write("  COUNT=0\n")
+                f.write(f"  if [ -f {shlex.quote(counter_file)} ]; then\n")
+                f.write(f"    COUNT=$(cat {shlex.quote(counter_file)})\n")
+                f.write("  fi\n")
+                f.write("  COUNT=$((COUNT + 1))\n")
+                f.write(f'  echo "$COUNT" > {shlex.quote(counter_file)}\n')
+                f.write('  if [ "$COUNT" -ge 3 ]; then\n')
+                f.write(
+                    '    echo \'{"data": {"concurrent": {"consensus": '
+                    '{"is_complete": true, "agents": {}}}}}\'\n'
+                )
+                f.write("  else\n")
+                f.write(
+                    '    echo \'{"data": {"concurrent": {"consensus": '
+                    '{"is_complete": false, "agents": {}}}}}\'\n'
+                )
+                f.write("  fi\n")
+                f.write('elif echo "$@" | grep -q "message poll"; then\n')
+                f.write('  echo "[]"\n')
+                f.write("else\n")
+                f.write(
+                    '  echo \'{"data": {"concurrent": {"consensus": {"is_complete": false}}}}\'\n'
+                )
+                f.write("fi\n")
+            os.chmod(mock_orch, 0o755)  # nosec B103
+
+            # Mock agent: exits 1 immediately on first call (mimics Agent SDK
+            # surfacing an API socket-close as success=False + exit 1 at turn 1),
+            # then exits 0 on retry.
+            mock_python = os.path.join(tmpdir, "python3")
+            real_python = sys.executable
+            with open(mock_python, "w") as f:
+                f.write("#!/bin/bash\n")
+                f.write('if [ "$1" = "-m" ] && [ "$2" = "egg_agent" ]; then\n')
+                f.write("  CALL_COUNT=0\n")
+                f.write(f"  if [ -f {shlex.quote(call_counter)} ]; then\n")
+                f.write(f"    CALL_COUNT=$(cat {shlex.quote(call_counter)})\n")
+                f.write("  fi\n")
+                f.write("  CALL_COUNT=$((CALL_COUNT + 1))\n")
+                f.write(f'  echo "$CALL_COUNT" > {shlex.quote(call_counter)}\n')
+                f.write(f'  echo "---CLAUDE_CALL_START---" >> {shlex.quote(claude_log)}\n')
+                f.write(f'  echo "ARGS: $*" >> {shlex.quote(claude_log)}\n')
+                f.write(f'  echo "---CLAUDE_CALL_END---" >> {shlex.quote(claude_log)}\n')
+                f.write('  if [ "$CALL_COUNT" -eq 1 ]; then\n')
+                f.write("    exit 1\n")  # first-turn API error
+                f.write("  fi\n")
+                f.write("  exit 0\n")
+                f.write("else\n")
+                f.write(f'  exec {shlex.quote(real_python)} "$@"\n')
+                f.write("fi\n")
+            os.chmod(mock_python, 0o755)  # nosec B103
+
+            cmd = build_consensus_wrapped_command(
+                "Do the work", max_restarts=2, transient_backoff_initial=1
+            )
+            result = self._run_wrapper_command(cmd, tmpdir, timeout=30)
+
+            # Should classify exit 1 as a startup failure and retry.
+            assert "Startup failure" in result.stderr
+            assert "likely transient API/network error" in result.stderr
+            assert "NOT restarting" not in result.stderr
+            # Agent called at least twice (initial + restart)
+            with open(claude_log) as f:
+                call_count = f.read().count("---CLAUDE_CALL_START---")
+            assert call_count >= 2
+
+    def test_startup_failure_window_zero_disables_retry(self):
+        """startup_failure_window_seconds=0 disables the heuristic; exit 1 must fail fast."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = os.path.join(tmpdir, "egg-orch.log")
+            mock_orch = os.path.join(tmpdir, "egg-orch")
+            with open(mock_orch, "w") as f:
+                f.write("#!/bin/bash\n")
+                f.write(f'echo "$@" >> {shlex.quote(log_file)}\n')
+                f.write('if echo "$@" | grep -q "pipeline status"; then\n')
+                f.write(
+                    '  echo \'{"data": {"concurrent": {"consensus": '
+                    '{"is_complete": false, "agents": {}}}}}\'\n'
+                )
+                f.write('elif echo "$@" | grep -q "message poll"; then\n')
+                f.write('  echo "[]"\n')
+                f.write("else\n")
+                f.write('  echo "{}"\n')
+                f.write("fi\n")
+            os.chmod(mock_orch, 0o755)  # nosec B103
+            self._make_failing_agent(tmpdir, exit_code=1)
+
+            cmd = build_consensus_wrapped_command(
+                "Prompt", max_restarts=2, startup_failure_window_seconds=0
+            )
+            result = self._run_wrapper_command(cmd, tmpdir)
+
+            assert result.returncode == 1
+            assert "NOT restarting" in result.stderr
+            assert "Startup failure" not in result.stderr
+
+    def test_startup_failure_respects_max_restarts(self):
+        """Repeated startup failures must hit MAX_RESTARTS and exit, not loop forever."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = os.path.join(tmpdir, "egg-orch.log")
+            claude_log = os.path.join(tmpdir, "claude.log")
+            call_counter = os.path.join(tmpdir, "agent_call_count")
+            mock_orch = os.path.join(tmpdir, "egg-orch")
+            with open(mock_orch, "w") as f:
+                f.write("#!/bin/bash\n")
+                f.write(f'echo "$@" >> {shlex.quote(log_file)}\n')
+                f.write('if echo "$@" | grep -q "pipeline status"; then\n')
+                f.write(
+                    '  echo \'{"data": {"concurrent": {"consensus": '
+                    '{"is_complete": false, "agents": {}}}}}\'\n'
+                )
+                f.write('elif echo "$@" | grep -q "message poll"; then\n')
+                f.write('  echo "[]"\n')
+                f.write("else\n")
+                f.write('  echo "{}"\n')
+                f.write("fi\n")
+            os.chmod(mock_orch, 0o755)  # nosec B103
+
+            # Agent logs each call, then always exits 1 — persistent API failure.
+            mock_python = os.path.join(tmpdir, "python3")
+            real_python = sys.executable
+            with open(mock_python, "w") as f:
+                f.write("#!/bin/bash\n")
+                f.write('if [ "$1" = "-m" ] && [ "$2" = "egg_agent" ]; then\n')
+                f.write("  CALL_COUNT=0\n")
+                f.write(f"  if [ -f {shlex.quote(call_counter)} ]; then\n")
+                f.write(f"    CALL_COUNT=$(cat {shlex.quote(call_counter)})\n")
+                f.write("  fi\n")
+                f.write("  CALL_COUNT=$((CALL_COUNT + 1))\n")
+                f.write(f'  echo "$CALL_COUNT" > {shlex.quote(call_counter)}\n')
+                f.write(f'  echo "---CLAUDE_CALL_START---" >> {shlex.quote(claude_log)}\n')
+                f.write("  exit 1\n")
+                f.write("else\n")
+                f.write(f'  exec {shlex.quote(real_python)} "$@"\n')
+                f.write("fi\n")
+            os.chmod(mock_python, 0o755)  # nosec B103
+
+            cmd = build_consensus_wrapped_command(
+                "Prompt", max_restarts=2, transient_backoff_initial=1
+            )
+            result = self._run_wrapper_command(cmd, tmpdir, timeout=60)
+
+            # Should have exhausted restarts and exited 1 — not looped forever.
+            assert result.returncode == 1
+            assert "Startup failure" in result.stderr
+            assert "Max restarts" in result.stderr or "never reached CONFIRMED" in result.stderr
+            # Agent called 3 times: initial + 2 restarts
+            with open(claude_log) as f:
+                call_count = f.read().count("---CLAUDE_CALL_START---")
+            assert call_count == 3
+
+    def test_startup_failure_after_window_does_not_retry(self):
+        """Exit 1 *after* the startup window should fail fast (genuine post-work error)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = os.path.join(tmpdir, "egg-orch.log")
+            claude_log = os.path.join(tmpdir, "claude.log")
+            mock_orch = os.path.join(tmpdir, "egg-orch")
+            with open(mock_orch, "w") as f:
+                f.write("#!/bin/bash\n")
+                f.write(f'echo "$@" >> {shlex.quote(log_file)}\n')
+                f.write('if echo "$@" | grep -q "pipeline status"; then\n')
+                f.write(
+                    '  echo \'{"data": {"concurrent": {"consensus": '
+                    '{"is_complete": false, "agents": {}}}}}\'\n'
+                )
+                f.write('elif echo "$@" | grep -q "message poll"; then\n')
+                f.write('  echo "[]"\n')
+                f.write("else\n")
+                f.write('  echo "{}"\n')
+                f.write("fi\n")
+            os.chmod(mock_orch, 0o755)  # nosec B103
+
+            # Agent sleeps past the (shortened) window, then exits 1.
+            # Window=1s; agent sleeps 3s before exiting — well outside the window.
+            mock_python = os.path.join(tmpdir, "python3")
+            real_python = sys.executable
+            with open(mock_python, "w") as f:
+                f.write("#!/bin/bash\n")
+                f.write('if [ "$1" = "-m" ] && [ "$2" = "egg_agent" ]; then\n')
+                f.write(f'  echo "---CLAUDE_CALL_START---" >> {shlex.quote(claude_log)}\n')
+                f.write("  sleep 3\n")
+                f.write("  exit 1\n")
+                f.write("else\n")
+                f.write(f'  exec {shlex.quote(real_python)} "$@"\n')
+                f.write("fi\n")
+            os.chmod(mock_python, 0o755)  # nosec B103
+
+            cmd = build_consensus_wrapped_command(
+                "Prompt", max_restarts=2, startup_failure_window_seconds=1
+            )
+            result = self._run_wrapper_command(cmd, tmpdir, timeout=30)
+
+            assert result.returncode == 1
+            assert "NOT restarting" in result.stderr
+            assert "Startup failure" not in result.stderr
+            # Should run only once (no retry on post-window exit 1)
+            with open(claude_log) as f:
+                call_count = f.read().count("---CLAUDE_CALL_START---")
+            assert call_count == 1
 
     def test_non_transient_exit_code_42_does_not_restart(self):
         """Exit code 42 (application error) should NOT be treated as transient."""


### PR DESCRIPTION
## Summary

- Adds `is_startup_failure()` to the consensus wrapper: exit code `1` within a startup window (default 30s) is classified as a likely transient API/network error and routed into the existing backoff + `MAX_RESTARTS` retry machinery.
- The window gate preserves existing fail-fast behavior for genuine post-work failures (agents that exit 1 *after* doing meaningful work) — per the issue's acceptance criteria.
- Configurable via `STARTUP_FAILURE_WINDOW_SECONDS` constant / `startup_failure_window_seconds` parameter; set to `0` to disable.

### Why exit 1 specifically

The Agent SDK surfaces API-level failures (socket close, 5xx, network) as `success=False` followed by a clean exit 1 — indistinguishable by exit code alone from a prompt-level permanent failure. The lifetime heuristic distinguishes "died before doing real work" (retry) from "did work, then failed" (permanent). Other non-1 exit codes remain unaffected.

### Scope choice

Applies only within the startup window. A network blip at turn 50 still fails the phase — parsing the SDK's error payload to classify mid-run failures is a bigger change tracked separately (approach #1 in the issue). Worth revisiting if mid-run blips turn out to matter.

## Test plan

- [x] Full orchestrator test suite passes (4086 tests)
- [x] `make lint` passes
- [x] New structural tests: `is_startup_failure` function, `STARTUP_FAILURE_WINDOW_SECONDS` constant, duration tracking around both `run_agent` call sites
- [x] New behavioral tests:
  - Exit 1 within window → retries with backoff
  - Exit 1 with `startup_failure_window_seconds=0` → fails fast (heuristic disabled)
  - Repeated exit 1 → hits `MAX_RESTARTS` and exits, no infinite loop
  - Exit 1 *after* the window → fails fast (genuine post-work error)
- [x] Existing fail-fast tests updated to use exit 42 (non-1, non-signal) to preserve their intent

Closes #1873