### PR TITLE
Fix #1874: keep per-agent worktrees out of gateway cleanup sweeps

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -3793,6 +3793,29 @@ def worktree_list() -> tuple[Response, int] | Response:
 _worktree_prune_lock = threading.Lock()
 
 
+def _derive_worktree_anchor_ids(sessions: list[dict[str, Any]]) -> set[str]:
+    """Return the set of worktree directory names implied by active sessions.
+
+    Session ``container_id`` is the k8s Job name / Docker container name
+    (e.g. ``egg-agent-issue-1758-again-coder``), but per-agent worktrees
+    on disk are named after the orchestrator-assigned
+    ``agent_worktree_id`` of the form ``{pipeline_id}-{agent_role}`` and
+    the pipeline-level worktree is just ``{pipeline_id}``.  Without this
+    derivation, ``cleanup_orphaned_worktrees`` treats every per-agent
+    worktree as an orphan, which wiped live pipelines' worktrees during
+    gateway startup cleanup (#1874).
+    """
+    anchors: set[str] = set()
+    for session_info in sessions:
+        pipeline_id = session_info.get("pipeline_id")
+        agent_role = session_info.get("agent_role")
+        if pipeline_id:
+            anchors.add(pipeline_id)
+            if agent_role:
+                anchors.add(f"{pipeline_id}-{agent_role}")
+    return anchors
+
+
 def _collect_active_container_ids() -> set[str]:
     """Return the best-effort set of container IDs that back live sessions.
 
@@ -3803,7 +3826,10 @@ def _collect_active_container_ids() -> set[str]:
     Consults:
 
     1. Persisted sessions via :func:`get_session_manager` (primary source
-       of truth — survives gateway restarts).
+       of truth — survives gateway restarts).  Each session contributes
+       its own ``container_id`` plus the derived per-agent and
+       pipeline-level worktree anchor IDs so that cleanup never wipes a
+       live pipeline's worktrees (#1874).
     2. ``docker ps`` when Docker is reachable (safety net for sessions
        that outlive the session-manager snapshot).
 
@@ -3814,10 +3840,12 @@ def _collect_active_container_ids() -> set[str]:
     active_container_ids: set[str] = set()
     try:
         session_manager = get_session_manager()
-        for session_info in session_manager.list_sessions():
+        sessions = session_manager.list_sessions()
+        for session_info in sessions:
             cid = session_info.get("container_id")
             if cid:
                 active_container_ids.add(cid)
+        active_container_ids |= _derive_worktree_anchor_ids(sessions)
     except Exception as exc:
         logger.warning(
             "prune: session-manager active-container lookup failed",
@@ -5553,17 +5581,26 @@ def main() -> None:
     # Load sessions BEFORE worktree cleanup so we know which containers are active.
     # After a gateway restart, Docker CLI may not be available inside the container,
     # so we derive the active container set from persisted sessions instead.
+    #
+    # Each session contributes its own ``container_id`` plus the per-agent
+    # and pipeline-level worktree anchor IDs ({pipeline_id}-{role} and
+    # {pipeline_id}).  Without those derived anchors, cleanup would treat
+    # every live pipeline's per-agent worktree as orphaned because the
+    # on-disk dir name never matches the session container_id (#1874).
     active_container_ids: set[str] = set()
     try:
         session_manager = get_session_manager()
         pruned = session_manager.prune_expired_sessions()
         if pruned > 0:
             logger.info(f"Startup session cleanup pruned {pruned} expired session(s)")
-        # Extract active container IDs from surviving sessions
-        for session_info in session_manager.list_sessions():
+        # Extract active container IDs from surviving sessions, plus the
+        # per-agent/pipeline worktree anchors the orchestrator assigns.
+        sessions = session_manager.list_sessions()
+        for session_info in sessions:
             container_id = session_info.get("container_id")
             if container_id:
                 active_container_ids.add(container_id)
+        active_container_ids |= _derive_worktree_anchor_ids(sessions)
         if active_container_ids:
             logger.info(
                 "Active containers from sessions",

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -3816,6 +3816,23 @@ def _derive_worktree_anchor_ids(sessions: list[dict[str, Any]]) -> set[str]:
     return anchors
 
 
+def _container_ids_from_sessions(sessions: list[dict[str, Any]]) -> set[str]:
+    """Return container IDs and worktree anchor IDs from session dicts.
+
+    Each session contributes its own ``container_id`` plus the derived
+    per-agent (``{pipeline_id}-{agent_role}``) and pipeline-level
+    (``{pipeline_id}``) worktree anchor IDs so that cleanup never wipes
+    a live pipeline's worktrees (#1874).
+    """
+    ids: set[str] = set()
+    for session_info in sessions:
+        cid = session_info.get("container_id")
+        if cid:
+            ids.add(cid)
+    ids |= _derive_worktree_anchor_ids(sessions)
+    return ids
+
+
 def _collect_active_container_ids() -> set[str]:
     """Return the best-effort set of container IDs that back live sessions.
 
@@ -3841,11 +3858,7 @@ def _collect_active_container_ids() -> set[str]:
     try:
         session_manager = get_session_manager()
         sessions = session_manager.list_sessions()
-        for session_info in sessions:
-            cid = session_info.get("container_id")
-            if cid:
-                active_container_ids.add(cid)
-        active_container_ids |= _derive_worktree_anchor_ids(sessions)
+        active_container_ids |= _container_ids_from_sessions(sessions)
     except Exception as exc:
         logger.warning(
             "prune: session-manager active-container lookup failed",
@@ -5596,11 +5609,7 @@ def main() -> None:
         # Extract active container IDs from surviving sessions, plus the
         # per-agent/pipeline worktree anchors the orchestrator assigns.
         sessions = session_manager.list_sessions()
-        for session_info in sessions:
-            container_id = session_info.get("container_id")
-            if container_id:
-                active_container_ids.add(container_id)
-        active_container_ids |= _derive_worktree_anchor_ids(sessions)
+        active_container_ids |= _container_ids_from_sessions(sessions)
         if active_container_ids:
             logger.info(
                 "Active containers from sessions",

--- a/gateway/session_manager.py
+++ b/gateway/session_manager.py
@@ -990,7 +990,11 @@ class SessionManager:
         List all active (non-expired) sessions.
 
         Returns:
-            List of session info dictionaries (without tokens)
+            List of session info dictionaries (without tokens).  Includes
+            ``pipeline_id`` and ``agent_role`` when the session was created
+            for a pipeline agent so cleanup paths can derive the associated
+            per-agent worktree container id (``{pipeline_id}-{agent_role}``)
+            and skip it during orphan sweeps — see #1874.
         """
         with self._lock:
             return [
@@ -1000,6 +1004,8 @@ class SessionManager:
                     "mode": session.mode,
                     "created_at": session.created_at.isoformat(),
                     "expires_at": session.expires_at.isoformat(),
+                    "pipeline_id": session.pipeline_id,
+                    "agent_role": session.agent_role,
                 }
                 for session in self._sessions.values()
                 if not session.is_expired()

--- a/gateway/tests/test_session_manager.py
+++ b/gateway/tests/test_session_manager.py
@@ -335,6 +335,32 @@ class TestSessionManager:
         sessions = manager.list_sessions()
         assert len(sessions) == 3
 
+    def test_list_sessions_exposes_pipeline_and_role(self, manager):
+        """list_sessions must surface ``pipeline_id`` and ``agent_role`` so
+        cleanup paths can derive per-agent worktree anchor ids (#1874)."""
+        manager.register_session(
+            container_id="egg-agent-issue-42-coder",
+            container_ip=None,
+            mode="public",
+            pipeline_id="issue-42",
+            agent_role="coder",
+        )
+        manager.register_session(
+            container_id="solo-interactive",
+            container_ip=None,
+            mode="public",
+        )
+
+        sessions = {s["container_id"]: s for s in manager.list_sessions()}
+
+        pipeline_session = sessions["egg-agent-issue-42-coder"]
+        assert pipeline_session["pipeline_id"] == "issue-42"
+        assert pipeline_session["agent_role"] == "coder"
+
+        interactive = sessions["solo-interactive"]
+        assert interactive["pipeline_id"] is None
+        assert interactive["agent_role"] is None
+
     def test_clear_all(self, manager):
         """Test clearing all sessions."""
         for i in range(3):

--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -252,6 +252,37 @@ class TestWorktreeManager:
         # Should have attempted cleanup (may fail since it's not a real worktree)
         assert removed >= 0
 
+    def test_cleanup_skips_in_flight_worktrees(self, manager, temp_dirs):
+        """Worktrees tracked in ``_active_worktrees`` must survive cleanup.
+
+        Regression for #1874: a worktree just created by this gateway but
+        whose session has not yet been registered (so its container_id is
+        absent from ``active_containers``) was being wiped when startup or
+        prune cleanup raced with spawn.  ``_active_worktrees`` now shields
+        in-process worktrees from the sweep.
+        """
+        worktree_base, _ = temp_dirs
+
+        container_dir = worktree_base / "issue-1758-again-coder"
+        container_dir.mkdir(parents=True)
+        (container_dir / "webapp").mkdir()
+
+        info = WorktreeInfo(
+            container_id="issue-1758-again-coder",
+            repo_name="webapp",
+            branch="egg/issue-1758-again-coder/work",
+            worktree_path=container_dir / "webapp",
+            git_dir=None,
+        )
+        manager._active_worktrees["issue-1758-again-coder"] = [info]
+
+        # Session not yet registered — only the unrelated container is
+        # in the active set.  Worktree must still survive.
+        removed = manager.cleanup_orphaned_worktrees({"egg-agent-overseer"})
+
+        assert removed == 0
+        assert container_dir.exists()
+
 
 class TestGetActiveDockerContainers:
     """Tests for get_active_docker_containers helper."""

--- a/gateway/tests/test_worktree_prune_route.py
+++ b/gateway/tests/test_worktree_prune_route.py
@@ -484,6 +484,77 @@ class TestCollectActiveContainerIds:
             result = gateway._collect_active_container_ids()
         assert result == set()
 
+    def test_per_agent_worktree_anchors_included(self):
+        """Sessions with ``pipeline_id``+``agent_role`` must contribute the
+        derived ``{pipeline_id}-{agent_role}`` and pipeline-level anchors
+        so that ``cleanup_orphaned_worktrees`` does not wipe the per-agent
+        worktrees on disk (which are named after ``agent_worktree_id``,
+        not the session's ``container_id``).  Regression for #1874.
+        """
+        from unittest.mock import MagicMock, patch
+
+        session_manager = MagicMock()
+        session_manager.list_sessions.return_value = [
+            {
+                "container_id": "egg-agent-issue-1758-again-coder",
+                "pipeline_id": "issue-1758-again",
+                "agent_role": "coder",
+            },
+            {
+                "container_id": "egg-agent-issue-1758-again-documenter",
+                "pipeline_id": "issue-1758-again",
+                "agent_role": "documenter",
+            },
+            # Interactive session with no pipeline context contributes only
+            # its own container id.
+            {"container_id": "solo-interactive", "pipeline_id": None, "agent_role": None},
+        ]
+
+        with (
+            patch.object(gateway, "get_session_manager", return_value=session_manager),
+            patch.object(gateway, "get_active_docker_containers", return_value=set()),
+        ):
+            result = gateway._collect_active_container_ids()
+
+        assert "issue-1758-again-coder" in result
+        assert "issue-1758-again-documenter" in result
+        assert "issue-1758-again" in result
+        assert "egg-agent-issue-1758-again-coder" in result
+        assert "solo-interactive" in result
+
+
+class TestDeriveWorktreeAnchorIds:
+    """Unit tests for the helper that maps session metadata to the worktree
+    dir names the orchestrator uses.  Keeping this standalone means future
+    changes to the naming scheme fail here, loudly, before they can wipe a
+    live pipeline's worktrees."""
+
+    def test_derives_per_agent_and_pipeline_anchors(self):
+        anchors = gateway._derive_worktree_anchor_ids(
+            [
+                {"pipeline_id": "issue-42", "agent_role": "coder"},
+                {"pipeline_id": "issue-42", "agent_role": "tester"},
+            ]
+        )
+        assert anchors == {"issue-42", "issue-42-coder", "issue-42-tester"}
+
+    def test_pipeline_without_role_still_protects_pipeline_level(self):
+        anchors = gateway._derive_worktree_anchor_ids(
+            [{"pipeline_id": "issue-99", "agent_role": None}]
+        )
+        assert anchors == {"issue-99"}
+
+    def test_session_without_pipeline_yields_no_anchors(self):
+        anchors = gateway._derive_worktree_anchor_ids(
+            [{"container_id": "adhoc", "pipeline_id": None, "agent_role": None}]
+        )
+        assert anchors == set()
+
+    def test_missing_keys_handled(self):
+        """Defensive against future session dicts that omit the field."""
+        anchors = gateway._derive_worktree_anchor_ids([{"container_id": "adhoc"}])
+        assert anchors == set()
+
 
 class TestConcurrentSecondCallGets409:
     """End-to-end mutex verification: a real second request during an in-flight

--- a/gateway/tests/test_worktree_prune_route.py
+++ b/gateway/tests/test_worktree_prune_route.py
@@ -387,6 +387,8 @@ class TestListOrphanWorktreePathGuard:
 
     def test_symlink_escape_is_skipped(self, tmp_path, monkeypatch):
         """A symlink pointing outside the worktree base is filtered out."""
+        import threading
+
         from worktree_manager import WorktreeManager
 
         base = tmp_path / "worktrees"
@@ -402,13 +404,51 @@ class TestListOrphanWorktreePathGuard:
         mgr = WorktreeManager.__new__(WorktreeManager)
         mgr.worktree_base = base
         mgr.repos_base = tmp_path / "repos"  # unused for this call
-        # Any other fields the method doesn't touch can stay un-set.
+        mgr._lock = threading.Lock()
+        mgr._active_worktrees = {}
 
         orphans = mgr.list_orphan_worktree_dirs(active_containers=set())
         assert any(o.endswith("normal-dir") for o in orphans)
         assert not any("outside" in o for o in orphans), (
             "symlink escape must not appear in orphan list"
         )
+
+
+class TestListOrphanWorktreeDirsActiveGuard:
+    """``list_orphan_worktree_dirs`` must respect ``_active_worktrees`` so the
+    dry-run prune route accurately reflects what cleanup would actually skip."""
+
+    def test_in_flight_worktree_excluded_from_orphan_list(self, tmp_path):
+        """A dir tracked in ``_active_worktrees`` must not appear as orphan."""
+        import threading
+
+        from worktree_manager import WorktreeInfo, WorktreeManager
+
+        base = tmp_path / "worktrees"
+        base.mkdir()
+        (base / "issue-42-coder").mkdir()
+        (base / "genuine-orphan").mkdir()
+
+        mgr = WorktreeManager.__new__(WorktreeManager)
+        mgr.worktree_base = base
+        mgr.repos_base = tmp_path / "repos"
+        mgr._lock = threading.Lock()
+        mgr._active_worktrees = {
+            "issue-42-coder": [
+                WorktreeInfo(
+                    container_id="issue-42-coder",
+                    repo_name="webapp",
+                    branch="egg/issue-42-coder/work",
+                    worktree_path=base / "issue-42-coder" / "webapp",
+                    git_dir=None,
+                )
+            ]
+        }
+
+        orphans = mgr.list_orphan_worktree_dirs(active_containers=set())
+        orphan_names = [o.split("/")[-1] for o in orphans]
+        assert "genuine-orphan" in orphan_names
+        assert "issue-42-coder" not in orphan_names
 
 
 class TestCollectActiveContainerIds:
@@ -554,6 +594,33 @@ class TestDeriveWorktreeAnchorIds:
         """Defensive against future session dicts that omit the field."""
         anchors = gateway._derive_worktree_anchor_ids([{"container_id": "adhoc"}])
         assert anchors == set()
+
+
+class TestContainerIdsFromSessions:
+    """Unit tests for ``_container_ids_from_sessions`` — the shared helper
+    that both ``_collect_active_container_ids`` and ``main()`` use to build
+    the active set from session metadata."""
+
+    def test_combines_container_ids_and_anchors(self):
+        ids = gateway._container_ids_from_sessions(
+            [
+                {
+                    "container_id": "egg-agent-issue-42-coder",
+                    "pipeline_id": "issue-42",
+                    "agent_role": "coder",
+                },
+                {"container_id": "solo", "pipeline_id": None, "agent_role": None},
+            ]
+        )
+        assert ids == {
+            "egg-agent-issue-42-coder",
+            "issue-42",
+            "issue-42-coder",
+            "solo",
+        }
+
+    def test_empty_sessions_returns_empty(self):
+        assert gateway._container_ids_from_sessions([]) == set()
 
 
 class TestConcurrentSecondCallGets409:

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -1347,6 +1347,17 @@ class WorktreeManager:
             if container_id in active_containers:
                 continue
 
+            # Skip worktrees that this process just created.  create_worktree
+            # populates ``_active_worktrees[container_id]`` before returning,
+            # so any per-agent worktree made during this gateway's lifetime
+            # is protected even if its session was not yet registered when
+            # ``active_containers`` was captured — closing the spawn-vs-prune
+            # race that motivated #1874.  Re-checked per iteration so a
+            # worktree created mid-sweep is still shielded.
+            with self._lock:
+                if container_id in self._active_worktrees:
+                    continue
+
             logger.info(
                 "Cleaning up orphaned worktrees",
                 container_id=container_id,

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -1607,6 +1607,11 @@ class WorktreeManager:
                     continue
             if child.name in active_containers:
                 continue
+            # Mirror the _active_worktrees guard from cleanup_orphaned_worktrees
+            # so dry-run output accurately reflects what cleanup would skip.
+            with self._lock:
+                if child.name in self._active_worktrees:
+                    continue
             orphans.append(str(child))
         return orphans
 


### PR DESCRIPTION
## Summary

- Gateway orphan-worktree cleanup (startup sweep + `/worktrees/prune` route) never preserved per-agent worktrees for live pipelines because `active_containers` was the set of session `container_id`s (k8s Job names like `egg-agent-issue-1758-again-coder`), while the on-disk worktree dirs are named after `agent_worktree_id` (`{pipeline_id}-{role}`, e.g. `issue-1758-again-coder`). The two sets never overlapped, so every active pipeline's per-agent worktree was eligible for deletion as "orphan" whenever a sweep ran.
- This is the race that #1874 tripped on: fresh gateway deploy → background startup cleanup thread → wipes the worktrees `create_worktrees` just built → producers land in a permanent `Worktree not found` loop even though #1872's `_find_missing_worktrees` passed at spawn time.
- Fix surfaces `pipeline_id` + `agent_role` on `SessionManager.list_sessions()` and expands both cleanup paths' active set with the derived `{pipeline_id}` and `{pipeline_id}-{role}` anchors. Defense in depth: `cleanup_orphaned_worktrees` now also skips any `container_id` tracked in `_active_worktrees`, so a worktree created mid-sweep (before `register_session` lands) is still shielded.

## Why #1872 didn't catch it

`_find_missing_worktrees` checks on-disk presence right before spawning the k8s Job. The sweep runs afterwards in a background thread and deletes the dir out from under the already-spawned Job — a pure TOCTOU the orchestrator-side guard can't see.

## Test plan

- [x] `pytest gateway/tests/test_session_manager.py gateway/tests/test_worktree_manager.py gateway/tests/test_worktree_prune_route.py` — 241 pass, including 6 new tests covering the fix
- [x] `pytest gateway/tests/` — only the three pre-existing `test_phase_api.py::TestPathTraversalProtection` failures remain (404-vs-400, independent of this PR; same failures on main)
- [x] `pytest orchestrator/tests/test_kubernetes_spawner.py orchestrator/tests/test_per_agent_worktree.py orchestrator/tests/test_gateway_client.py` — 154 pass
- [x] `ruff check` / `ruff format --check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)