### PR TITLE
Fix #1878 + #1879: honor skip_cleanup for worktrees, retry transient spawn failures at phase level

### DIFF
--- a/orchestrator/concurrent_executor.py
+++ b/orchestrator/concurrent_executor.py
@@ -55,6 +55,36 @@ SpawnFn = Callable[..., Any]
 MULTI_FAILURE_WINDOW_SECONDS = 60
 
 
+# Substrings (case-insensitive) indicating a spawn failure is worth retrying at
+# the phase level.  Per-role retries in kubernetes_spawner already handle the
+# short (<10s) case; these patterns cover longer gateway outages like a cold
+# start (~30s) where every per-role attempt saw the gateway down.  See #1879.
+_TRANSIENT_AGENT_ERROR_SUBSTRINGS: tuple[str, ...] = (
+    "connection refused",
+    "remote end closed",
+    "closed connection",
+    "connection reset",
+    "timed out",
+    "timeout",
+    "service unavailable",
+    "bad gateway",
+    "failed to create any worktrees",
+    "max retries exceeded",
+)
+
+
+def _is_transient_agent_error(error: str | None) -> bool:
+    """Return True if an AgentExecution.error string looks retry-worthy.
+
+    Conservative: only matches known transient patterns.  Unknown errors are
+    treated as permanent so we fail fast instead of spinning on a real bug.
+    """
+    if not error:
+        return False
+    lowered = error.lower()
+    return any(frag in lowered for frag in _TRANSIENT_AGENT_ERROR_SUBSTRINGS)
+
+
 class ConcurrentPhaseExecutor:
     """Executes a pipeline phase with all agents running concurrently.
 
@@ -235,15 +265,47 @@ class ConcurrentPhaseExecutor:
             auto_repropose_debounce_seconds=config.auto_repropose_debounce_seconds,
             max_auto_repropose=config.max_auto_repropose,
         )
+        for role in roles:
+            tracker.register_agent(role.value)
+
+        return self._spawn_roles(roles, agent_prompts or {})
+
+    def spawn_specific_roles(
+        self,
+        roles: list[AgentRole],
+        agent_prompts: dict[AgentRole, str] | None = None,
+    ) -> list[AgentExecution]:
+        """Spawn a subset of agent roles.
+
+        Used by the phase coordinator's transient-failure retry path
+        (#1879): after ``spawn_all`` returns with some roles in FAILED
+        state, the coordinator classifies failures and calls this to
+        respawn just the failed roles without disturbing survivors.
+
+        Does not touch the consensus tracker — roles were already
+        registered by the original ``spawn_all`` call.
+
+        Args:
+            roles: Agent roles to spawn.
+            agent_prompts: Mapping of role to prompt text (subset is OK).
+
+        Returns:
+            List of AgentExecution records for the respawned roles.
+        """
+        return self._spawn_roles(roles, agent_prompts or {})
+
+    def _spawn_roles(
+        self,
+        roles: list[AgentRole],
+        agent_prompts: dict[AgentRole, str],
+    ) -> list[AgentExecution]:
+        """Spawn the given roles concurrently on the thread pool."""
         executions: list[AgentExecution] = []
 
         with ThreadPoolExecutor(max_workers=self.max_concurrent) as pool:
             futures = {}
             for role in roles:
-                # Register agent for consensus tracking
-                tracker.register_agent(role.value)
-
-                prompt_text = (agent_prompts or {}).get(role, "")
+                prompt_text = agent_prompts.get(role, "")
                 future = pool.submit(self._spawn_agent, role, prompt_text)
                 futures[future] = role
 

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -829,12 +829,18 @@ class KubernetesSpawner:
         self,
         pipeline_id: str,
         force: bool = True,
+        preserve_agent_worktrees: bool = False,
     ) -> int:
         """Clean up all Jobs and sessions for a pipeline.
 
         Args:
             pipeline_id: Pipeline ID
             force: Force removal
+            preserve_agent_worktrees: When True, skip worktree deletion so a
+                subsequent retry can reuse the pipeline-level and per-agent
+                worktrees. Jobs and gateway sessions are still removed so the
+                retry spawns fresh pods. Default False preserves the prior
+                behavior of deleting every worktree.
 
         Returns:
             Number of Jobs removed
@@ -856,6 +862,14 @@ class KubernetesSpawner:
                     job_name=job.job_name,
                     error=str(e),
                 )
+
+        if preserve_agent_worktrees:
+            logger.info(
+                "Pipeline cleanup complete (worktrees preserved for retry)",
+                pipeline_id=pipeline_id,
+                jobs_removed=removed,
+            )
+            return removed
 
         # Clean up per-agent worktrees
         worktree_ids_to_clean: set[str] = {pipeline_id}

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -829,14 +829,14 @@ class KubernetesSpawner:
         self,
         pipeline_id: str,
         force: bool = True,
-        preserve_agent_worktrees: bool = False,
+        preserve_worktrees: bool = False,
     ) -> int:
         """Clean up all Jobs and sessions for a pipeline.
 
         Args:
             pipeline_id: Pipeline ID
             force: Force removal
-            preserve_agent_worktrees: When True, skip worktree deletion so a
+            preserve_worktrees: When True, skip worktree deletion so a
                 subsequent retry can reuse the pipeline-level and per-agent
                 worktrees. Jobs and gateway sessions are still removed so the
                 retry spawns fresh pods. Default False preserves the prior
@@ -863,7 +863,7 @@ class KubernetesSpawner:
                     error=str(e),
                 )
 
-        if preserve_agent_worktrees:
+        if preserve_worktrees:
             logger.info(
                 "Pipeline cleanup complete (worktrees preserved for retry)",
                 pipeline_id=pipeline_id,

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -424,6 +424,25 @@ class PipelineConfig(BaseModel):
             "scale by 2.5x (e.g. 2s, 5s, 12.5s). See #1839."
         ),
     )
+    phase_spawn_max_retries: int = Field(
+        default=2,
+        ge=0,
+        description=(
+            "Phase-level retry attempts when at least one role's spawn fails "
+            "with a transient error (e.g. gateway restart). Per-role retries "
+            "(see spawn_max_retries) run first; this second budget bridges "
+            "longer outages like a ~30s gateway cold start. 0 disables "
+            "phase-level retry. See #1879."
+        ),
+    )
+    phase_spawn_retry_initial_backoff_seconds: float = Field(
+        default=30.0,
+        gt=0,
+        description=(
+            "Initial backoff seconds before the first phase-level spawn retry. "
+            "Subsequent attempts scale by 3x (e.g. 30s, 90s). See #1879."
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7226,9 +7226,15 @@ def _run_concurrent_phase(
     )
 
     try:
-        from concurrent_executor import ConcurrentPhaseExecutor
+        from concurrent_executor import (
+            ConcurrentPhaseExecutor,
+            _is_transient_agent_error,
+        )
     except ImportError:
-        from ..concurrent_executor import ConcurrentPhaseExecutor  # type: ignore
+        from ..concurrent_executor import (  # type: ignore
+            ConcurrentPhaseExecutor,
+            _is_transient_agent_error,
+        )
 
     phase_str = phase if isinstance(phase, str) else phase.value
     pipeline_mode = "issue" if pipeline.issue_number is not None else "prompt"
@@ -7318,6 +7324,77 @@ def _run_concurrent_phase(
 
     # Spawn all agents with their prompts.
     executions = executor.spawn_all(agent_prompts=agent_prompts)
+
+    # Phase-level retry for transient spawn failures (#1879).  Per-role
+    # retries in kubernetes_spawner handle short blips (~7s budget); this
+    # outer budget bridges longer outages like a gateway cold start by
+    # respawning only the failed roles while survivors wait idle.  BRC can
+    # not start without the full cohort anyway, so leaving survivors alone
+    # during the retry window does not risk correctness.
+    phase_max_retries = getattr(pipeline.config, "phase_spawn_max_retries", 2)
+    phase_initial_backoff = getattr(
+        pipeline.config, "phase_spawn_retry_initial_backoff_seconds", 30.0
+    )
+    _PHASE_RETRY_BACKOFF_MULTIPLIER = 3.0
+    for attempt in range(phase_max_retries):
+        failed = [e for e in executions if e.status.value == "failed"]
+        if not failed:
+            break
+        transient_failed = [e for e in failed if _is_transient_agent_error(e.error)]
+        if not transient_failed:
+            # All remaining failures are permanent — retrying would just
+            # burn the budget for no benefit.
+            break
+
+        delay = phase_initial_backoff * (_PHASE_RETRY_BACKOFF_MULTIPLIER**attempt)
+        failed_roles = [e.role for e in failed]
+        logger.warning(
+            "Phase-level spawn retry scheduled",
+            pipeline_id=pipeline_id,
+            phase=phase_str,
+            attempt=attempt + 1,
+            max_attempts=phase_max_retries,
+            delay_seconds=delay,
+            failed_roles=[r.value for r in failed_roles],
+            transient_roles=[e.role.value for e in transient_failed],
+        )
+        time.sleep(delay)
+
+        # Clear any half-created gateway worktree state for failed roles
+        # so the retry sees a clean slate.  Survivors' worktrees use
+        # different container_ids and are untouched.
+        for role in failed_roles:
+            agent_worktree_id = f"{pipeline_id}-{role.value}"
+            try:
+                spawner.gateway.delete_worktrees(
+                    container_id=agent_worktree_id,
+                    force=True,
+                )
+            except Exception as clear_err:
+                logger.warning(
+                    "Failed to clear partial worktree before retry",
+                    pipeline_id=pipeline_id,
+                    agent_worktree_id=agent_worktree_id,
+                    error=str(clear_err),
+                )
+
+        retry_executions = executor.spawn_specific_roles(failed_roles, agent_prompts=agent_prompts)
+        by_role = {e.role: e for e in retry_executions}
+        executions = [
+            by_role.get(e.role, e) if e.status.value == "failed" else e for e in executions
+        ]
+
+        still_failed = [e for e in executions if e.status.value == "failed"]
+        logger.info(
+            "Phase-level spawn retry outcome",
+            pipeline_id=pipeline_id,
+            phase=phase_str,
+            attempt=attempt + 1,
+            recovered_roles=[
+                r.value for r in failed_roles if r not in {e.role for e in still_failed}
+            ],
+            still_failed_roles=[e.role.value for e in still_failed],
+        )
 
     # Record spawned containers/agents in pipeline state.
     if store is not None:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -10704,7 +10704,11 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
         # new thread's containers are not killed.  See #1386, #1638.
         if not pipeline_was_restarted:
             try:
-                removed = _spawner.cleanup_pipeline(pipeline_id, force=True)
+                removed = _spawner.cleanup_pipeline(
+                    pipeline_id,
+                    force=True,
+                    preserve_agent_worktrees=skip_cleanup,
+                )
                 if removed > 0:
                     logger.info(
                         "Safety-net cleanup removed orphaned containers",

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -10707,7 +10707,7 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                 removed = _spawner.cleanup_pipeline(
                     pipeline_id,
                     force=True,
-                    preserve_agent_worktrees=skip_cleanup,
+                    preserve_worktrees=skip_cleanup,
                 )
                 if removed > 0:
                     logger.info(

--- a/orchestrator/tests/test_concurrent_executor.py
+++ b/orchestrator/tests/test_concurrent_executor.py
@@ -309,6 +309,112 @@ class TestRolesOverride:
             assert set(registered_roles) == {"coder", "reviewer_code"}
 
 
+class TestIsTransientAgentError:
+    """_is_transient_agent_error classifies spawn error strings for #1879 retry."""
+
+    def test_connection_refused_is_transient(self):
+        from concurrent_executor import _is_transient_agent_error
+
+        assert _is_transient_agent_error("GatewayError: Connection refused")
+
+    def test_remote_end_closed_is_transient(self):
+        from concurrent_executor import _is_transient_agent_error
+
+        assert _is_transient_agent_error("Remote end closed connection without response")
+
+    def test_connection_reset_is_transient(self):
+        from concurrent_executor import _is_transient_agent_error
+
+        assert _is_transient_agent_error(
+            "ConnectionResetError: [Errno 104] Connection reset by peer"
+        )
+
+    def test_timeout_is_transient(self):
+        from concurrent_executor import _is_transient_agent_error
+
+        assert _is_transient_agent_error("HTTPConnectionPool: Read timed out")
+
+    def test_service_unavailable_is_transient(self):
+        from concurrent_executor import _is_transient_agent_error
+
+        assert _is_transient_agent_error("503 Service Unavailable")
+
+    def test_failed_to_create_any_worktrees_is_transient(self):
+        from concurrent_executor import _is_transient_agent_error
+
+        assert _is_transient_agent_error(
+            "KubernetesSpawnError: Failed to create any worktrees for container"
+        )
+
+    def test_permanent_errors_not_transient(self):
+        from concurrent_executor import _is_transient_agent_error
+
+        # Typical permanent failures
+        assert not _is_transient_agent_error("Repository not found")
+        assert not _is_transient_agent_error("HTTP 403 Forbidden")
+        assert not _is_transient_agent_error("2 validation errors for AgentExecution container_id")
+
+    def test_none_is_not_transient(self):
+        from concurrent_executor import _is_transient_agent_error
+
+        assert not _is_transient_agent_error(None)
+        assert not _is_transient_agent_error("")
+
+
+class TestSpawnSpecificRoles:
+    """spawn_specific_roles respawns only the requested roles."""
+
+    def test_only_listed_roles_are_spawned(self):
+        from concurrent_executor import ConcurrentPhaseExecutor
+        from egg_orchestrator.types import AgentRole
+
+        pipeline = _make_pipeline()
+        mock_spawn = MagicMock()
+        mock_spawn.return_value = MagicMock(container_id="new-container")
+
+        # Executor initialised with a full cohort, but the retry call
+        # should only hit the subset we pass in.
+        executor = ConcurrentPhaseExecutor(
+            pipeline,
+            spawn_fn=mock_spawn,
+            roles=[AgentRole.CODER, AgentRole.REVIEWER_CODE, AgentRole.TESTER],
+        )
+
+        with patch("concurrent_executor.emit_event"):
+            executions = executor.spawn_specific_roles(
+                [AgentRole.CODER, AgentRole.TESTER],
+                agent_prompts={
+                    AgentRole.CODER: "coder prompt",
+                    AgentRole.TESTER: "tester prompt",
+                },
+            )
+
+        assert mock_spawn.call_count == 2
+        spawned_roles = {call.kwargs["role"] for call in mock_spawn.call_args_list}
+        assert spawned_roles == {AgentRole.CODER, AgentRole.TESTER}
+        assert {e.role for e in executions} == {AgentRole.CODER, AgentRole.TESTER}
+
+    def test_does_not_register_tracker_agents(self):
+        """spawn_specific_roles must not touch the consensus tracker — the
+        original spawn_all already registered every role."""
+        from concurrent_executor import ConcurrentPhaseExecutor
+        from egg_orchestrator.types import AgentRole
+
+        pipeline = _make_pipeline()
+        mock_spawn = MagicMock()
+        mock_spawn.return_value = MagicMock(container_id="new-container")
+
+        executor = ConcurrentPhaseExecutor(pipeline, spawn_fn=mock_spawn, roles=[AgentRole.CODER])
+
+        with (
+            patch("concurrent_executor.create_peer_consensus_tracker") as mock_tracker,
+            patch("concurrent_executor.emit_event"),
+        ):
+            executor.spawn_specific_roles([AgentRole.CODER], agent_prompts={})
+
+        mock_tracker.assert_not_called()
+
+
 class TestReviewGraphIntegration:
     """Test that the review graph is properly integrated."""
 

--- a/orchestrator/tests/test_concurrent_wait.py
+++ b/orchestrator/tests/test_concurrent_wait.py
@@ -711,3 +711,225 @@ class TestPartialSpawnFailureCleanup:
             (AgentRole.TESTER.value, "Spawn failed"),
             (AgentRole.DOCUMENTER.value, "Spawn failed"),
         ]
+
+
+class TestPhaseLevelTransientRetry:
+    """Phase coordinator retries transient spawn failures before aborting (#1879)."""
+
+    def _make_transient_failed_execution(
+        self, role: AgentRole, error: str = "GatewayError: Connection refused"
+    ):
+        return AgentExecution(role=role, status=AgentExecutionStatus.FAILED, error=error)
+
+    def _make_permanent_failed_execution(
+        self, role: AgentRole, error: str = "Repository not found"
+    ):
+        return AgentExecution(role=role, status=AgentExecutionStatus.FAILED, error=error)
+
+    def _harness(
+        self,
+        spawn_all_result,
+        spawn_specific_side_effect=None,
+        expect_raise=True,
+    ):
+        """Run _run_concurrent_phase with a configurable retry scenario.
+
+        Args:
+            spawn_all_result: List of AgentExecution returned by the initial
+                spawn_all call.
+            spawn_specific_side_effect: A list of return values or side_effect
+                callable for spawn_specific_roles. When None, the method is
+                not expected to be called.
+            expect_raise: If True, expect SpawnFailureError; if False, expect
+                the phase to run the wait loop and return (exit_code, logs).
+                When False, all container_ids in the final executions are
+                given exit_code=0 wait results.
+
+        Returns a dict with harness references for assertions.
+        """
+        pipeline = _make_concurrent_pipeline()
+        phase_exec = _make_phase_execution()
+        mock_store = MagicMock()
+        mock_pipeline_state = MagicMock()
+        mock_pipeline_state.get_phase_execution.return_value = phase_exec
+        mock_store.load_pipeline.return_value = mock_pipeline_state
+
+        mock_docker = MagicMock()
+        mock_gateway = MagicMock()
+        mock_spawner = MagicMock()
+        mock_spawner.backend = mock_docker
+        mock_spawner.docker = mock_docker
+        mock_spawner.gateway = mock_gateway
+        mock_spawner.create_concurrent_spawn_fn.return_value = MagicMock()
+
+        # If the phase should reach the wait loop, wire up wait_for_container /
+        # get_container_info to return exit_code=0 for every final container.
+        final_executions_holder = {"value": list(spawn_all_result)}
+
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = spawn_all_result
+        if spawn_specific_side_effect is not None:
+            if callable(spawn_specific_side_effect):
+                mock_executor_instance.spawn_specific_roles.side_effect = spawn_specific_side_effect
+            else:
+                mock_executor_instance.spawn_specific_roles.side_effect = list(
+                    spawn_specific_side_effect
+                )
+        # When consensus is checked during the wait loop, return "not complete"
+        # so the loop falls through to container-exit detection.
+        mock_executor_instance.check_consensus.return_value = _NO_CONSENSUS
+        MockExecutor = MagicMock(return_value=mock_executor_instance)
+
+        # Wait loop stubs — used only on the recovery path.
+        def _wait_side_effect(container_id, timeout=3600):
+            return ContainerInfo(
+                container_id=container_id,
+                container_name=f"issue-999-{container_id}",
+                status=ContainerStatus.EXITED,
+                exit_code=0,
+                exited_at=datetime.now(UTC),
+            )
+
+        mock_docker.wait_for_container.side_effect = _wait_side_effect
+        mock_docker.get_container_info.side_effect = _wait_side_effect
+
+        mock_state_lock_cm = MagicMock()
+        mock_state_lock_cm.return_value.__enter__ = MagicMock(return_value=None)
+        mock_state_lock_cm.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("concurrent_executor.ConcurrentPhaseExecutor", MockExecutor),
+            patch("routes.pipelines._build_agent_prompt", return_value="test prompt"),
+            patch("routes.pipelines.get_pipeline_state_lock", mock_state_lock_cm),
+            patch("routes.pipelines.time.sleep"),
+        ):
+            raised = None
+            result = None
+            try:
+                result = _run_concurrent_phase(
+                    pipeline_id="issue-999",
+                    pipeline=pipeline,
+                    phase="implement",
+                    spawner=mock_spawner,
+                    repo_volumes={},
+                    gateway_mode="public",
+                    repos=["owner/repo"],
+                    sandbox_env={},
+                    store=mock_store,
+                    certs_volume=None,
+                    worktree_repo_path=Path("/tmp/test-repo"),
+                )
+            except SpawnFailureError as e:
+                raised = e
+
+        if expect_raise:
+            assert raised is not None, "Expected SpawnFailureError but phase returned"
+        else:
+            assert raised is None, f"Did not expect SpawnFailureError: {raised}"
+
+        return {
+            "raised": raised,
+            "result": result,
+            "executor": mock_executor_instance,
+            "docker": mock_docker,
+            "gateway": mock_gateway,
+            "phase_exec": phase_exec,
+            "final_executions_holder": final_executions_holder,
+        }
+
+    def test_transient_failure_retries_and_recovers(self):
+        """One transient failure -> retry succeeds -> phase runs to completion."""
+        initial = [
+            _make_execution(AgentRole.CODER, "coder-abc"),
+            _make_execution(AgentRole.TESTER, "tester-abc"),
+            self._make_transient_failed_execution(AgentRole.DOCUMENTER),
+        ]
+        # Retry recovers documenter with a fresh container_id.
+        retry_result = [_make_execution(AgentRole.DOCUMENTER, "doc-xyz")]
+
+        h = self._harness(initial, spawn_specific_side_effect=[retry_result], expect_raise=False)
+
+        # Retry was attempted exactly once with the transient role.
+        assert h["executor"].spawn_specific_roles.call_count == 1
+        call = h["executor"].spawn_specific_roles.call_args
+        assert call.args[0] == [AgentRole.DOCUMENTER]
+
+        # Gateway cleared half-created worktree for failed role before retry.
+        assert h["gateway"].delete_worktrees.call_count == 1
+        assert h["gateway"].delete_worktrees.call_args.kwargs["container_id"] == (
+            "issue-999-documenter"
+        )
+
+        # Survivors were NOT stopped during the retry window — the existing
+        # abort block should not have run.
+        h["docker"].stop_container.assert_not_called()
+
+    def test_permanent_failure_skips_retry(self):
+        """Permanent failure goes straight to the existing abort path."""
+        initial = [
+            _make_execution(AgentRole.CODER, "coder-abc"),
+            self._make_permanent_failed_execution(AgentRole.TESTER),
+        ]
+
+        h = self._harness(initial, spawn_specific_side_effect=None, expect_raise=True)
+
+        # No retry attempted — classifier recognised a permanent failure.
+        h["executor"].spawn_specific_roles.assert_not_called()
+        h["gateway"].delete_worktrees.assert_not_called()
+
+        # Existing abort path ran: survivor stopped + failure surfaced.
+        assert h["docker"].stop_container.call_count == 1
+        assert h["raised"].failures == [(AgentRole.TESTER.value, "Repository not found")]
+
+    def test_retry_budget_exhausts_then_aborts(self):
+        """Persistent transient failures exhaust the budget and then abort."""
+        initial = [
+            _make_execution(AgentRole.CODER, "coder-abc"),
+            self._make_transient_failed_execution(AgentRole.TESTER),
+        ]
+        # Every retry returns the same transient failure.
+        retry_result = [self._make_transient_failed_execution(AgentRole.TESTER)]
+
+        h = self._harness(
+            initial,
+            spawn_specific_side_effect=[retry_result, retry_result, retry_result],
+            expect_raise=True,
+        )
+
+        # Default phase_spawn_max_retries=2 -> exactly 2 retry attempts.
+        assert h["executor"].spawn_specific_roles.call_count == 2
+
+        # Gateway was cleaned up before each retry.
+        assert h["gateway"].delete_worktrees.call_count == 2
+
+        # Abort path eventually ran once budget exhausted.
+        assert h["docker"].stop_container.call_count == 1
+        assert h["raised"].failures == [
+            (AgentRole.TESTER.value, "GatewayError: Connection refused"),
+        ]
+
+    def test_mixed_transient_and_permanent_retries_only_what_can_recover(self):
+        """Permanent + transient both fail first -> retry runs; transient recovers,
+        permanent stays failed -> abort with just the permanent error."""
+        initial = [
+            _make_execution(AgentRole.CODER, "coder-abc"),
+            self._make_transient_failed_execution(AgentRole.TESTER),
+            self._make_permanent_failed_execution(AgentRole.DOCUMENTER),
+        ]
+        # Retry is called with BOTH failed roles (tester + documenter).  Tester
+        # recovers, documenter fails permanently again.
+        retry_result = [
+            _make_execution(AgentRole.TESTER, "tester-xyz"),
+            self._make_permanent_failed_execution(AgentRole.DOCUMENTER),
+        ]
+
+        h = self._harness(initial, spawn_specific_side_effect=[retry_result], expect_raise=True)
+
+        # First retry attempt ran.
+        assert h["executor"].spawn_specific_roles.call_count == 1
+        retry_call_roles = set(h["executor"].spawn_specific_roles.call_args.args[0])
+        assert retry_call_roles == {AgentRole.TESTER, AgentRole.DOCUMENTER}
+
+        # Second retry was NOT attempted — only permanent remains after round 1.
+        # (The loop breaks because no remaining failure is transient.)
+        assert h["raised"].failures == [(AgentRole.DOCUMENTER.value, "Repository not found")]

--- a/orchestrator/tests/test_per_agent_worktrees.py
+++ b/orchestrator/tests/test_per_agent_worktrees.py
@@ -290,7 +290,7 @@ class TestCleanupPipelineWorktrees:
     def test_cleanup_preserves_worktrees_when_requested(
         self, spawner, mock_docker_client, mock_gateway_client
     ):
-        """preserve_agent_worktrees=True skips every worktree deletion (#1878)."""
+        """preserve_worktrees=True skips every worktree deletion (#1878)."""
         container = ContainerInfo(
             container_id="abc123",
             container_name="egg-agent-issue-123-coder",
@@ -300,7 +300,7 @@ class TestCleanupPipelineWorktrees:
         )
         mock_docker_client.list_containers.return_value = [container]
 
-        removed = spawner.cleanup_pipeline("issue-123", preserve_agent_worktrees=True)
+        removed = spawner.cleanup_pipeline("issue-123", preserve_worktrees=True)
 
         # Job is still removed so a retry can spawn a fresh pod...
         assert removed == 1

--- a/orchestrator/tests/test_per_agent_worktrees.py
+++ b/orchestrator/tests/test_per_agent_worktrees.py
@@ -286,3 +286,23 @@ class TestCleanupPipelineWorktrees:
             for call in delete_calls
         ]
         assert "issue-123" in deleted_ids
+
+    def test_cleanup_preserves_worktrees_when_requested(
+        self, spawner, mock_docker_client, mock_gateway_client
+    ):
+        """preserve_agent_worktrees=True skips every worktree deletion (#1878)."""
+        container = ContainerInfo(
+            container_id="abc123",
+            container_name="egg-agent-issue-123-coder",
+            status=ContainerStatus.EXITED,
+            agent_role=AgentRole.CODER,
+            job_name="egg-sandbox-egg-agent-issue-123-coder",
+        )
+        mock_docker_client.list_containers.return_value = [container]
+
+        removed = spawner.cleanup_pipeline("issue-123", preserve_agent_worktrees=True)
+
+        # Job is still removed so a retry can spawn a fresh pod...
+        assert removed == 1
+        # ...but no worktree — pipeline-level or per-agent — is deleted.
+        assert mock_gateway_client.delete_worktrees.call_count == 0

--- a/orchestrator/tests/test_pipeline_failure_path.py
+++ b/orchestrator/tests/test_pipeline_failure_path.py
@@ -1685,11 +1685,11 @@ class TestSafetyNetContainerCleanup:
 
         # cleanup_pipeline should have been called as safety net.  When the
         # pipeline ended in FAILED, the caller also passes
-        # preserve_agent_worktrees=True so a retry can reuse the worktrees
+        # preserve_worktrees=True so a retry can reuse the worktrees
         # (#1878).
         mock_spawner = mock_get_spawner.return_value
         mock_spawner.cleanup_pipeline.assert_called_with(
-            "issue-42", force=True, preserve_agent_worktrees=True
+            "issue-42", force=True, preserve_worktrees=True
         )
 
 

--- a/orchestrator/tests/test_pipeline_failure_path.py
+++ b/orchestrator/tests/test_pipeline_failure_path.py
@@ -1683,9 +1683,14 @@ class TestSafetyNetContainerCleanup:
         ):
             _run_pipeline("issue-42", Path("/repo"))
 
-        # cleanup_pipeline should have been called as safety net
+        # cleanup_pipeline should have been called as safety net.  When the
+        # pipeline ended in FAILED, the caller also passes
+        # preserve_agent_worktrees=True so a retry can reuse the worktrees
+        # (#1878).
         mock_spawner = mock_get_spawner.return_value
-        mock_spawner.cleanup_pipeline.assert_called_with("issue-42", force=True)
+        mock_spawner.cleanup_pipeline.assert_called_with(
+            "issue-42", force=True, preserve_agent_worktrees=True
+        )
 
 
 class TestInitialStatefileCommitFailure:


### PR DESCRIPTION
This branch bundles two cohesive changes — #1878 is the cleanup-API prerequisite, #1879 is the phase-level retry that depends on it.

## Summary

### #1878 — cleanup_pipeline preserves worktrees on pipeline failure

- On pipeline failure, `_run_pipeline` already sets `skip_cleanup=True` and logs `"Pipeline failed, preserving worktrees for retry"`, but the safety-net `spawner.cleanup_pipeline(pipeline_id, force=True)` immediately deletes both the pipeline-level worktree and every `{pipeline_id}-{role}` per-agent worktree (`kubernetes_spawner.py:861-921`).
- Add `preserve_worktrees: bool = False` parameter to `cleanup_pipeline`. When true, Jobs and gateway sessions are still removed so a retry can spawn fresh pods, but every worktree is retained.
- Update the safety-net call in `orchestrator/routes/pipelines.py` to pass `preserve_worktrees=skip_cleanup` so the log line and actual behavior agree.
- No production behavior change on its own — enables #1879.

### #1879 — phase coordinator retries transient spawn failures

- Per-role retries from #1842 (3 attempts, ~7s budget) aren't long enough to bridge a gateway cold start (~30s). Once they exhaust, `_run_concurrent_phase` applies an all-or-nothing rule: one failed role stops every survivor and raises `SpawnFailureError`, throwing away real work (observed in `issue-1758-more-more` on 2026-04-22).
- Add a bounded phase-level retry inside `_run_concurrent_phase`. If any spawn failure matches a known transient pattern (`connection refused`, `remote end closed`, `timed out`, `service unavailable`, `failed to create any worktrees`, …), respawn just the failed roles via `executor.spawn_specific_roles()` with `30s`/`90s` backoff (default 2 attempts).
- Survivors are left running during the retry window — BRC can't start without the full cohort anyway, so there's no correctness risk.
- Before each retry, clear any half-created gateway worktree state for the failed roles so `create_worktrees` sees a clean slate (addresses the "worktree already exists" gotcha called out in the issue).
- If all failures are permanent, or the retry budget exhausts, fall through to the existing abort path unchanged.
- New `phase_spawn_max_retries` (default 2) and `phase_spawn_retry_initial_backoff_seconds` (default 30s) config fields make the budget tunable.

## Test plan

- [x] `pytest orchestrator/tests/test_per_agent_worktrees.py` — new `test_cleanup_preserves_worktrees_when_requested` passes; existing `test_cleanup_deletes_per_agent_worktrees` still covers default behavior.
- [x] `pytest orchestrator/tests/test_pipeline_failure_path.py::TestSafetyNetContainerCleanup` — FAILED path now expects the new kwarg.
- [x] `pytest orchestrator/tests/test_concurrent_executor.py::TestIsTransientAgentError` — 8 classification cases (transient patterns + permanent + empty/None).
- [x] `pytest orchestrator/tests/test_concurrent_executor.py::TestSpawnSpecificRoles` — only listed roles are spawned; no consensus-tracker re-registration.
- [x] `pytest orchestrator/tests/test_concurrent_wait.py::TestPhaseLevelTransientRetry` — 4 scenarios: transient recovers, permanent skips retry, budget exhausts, mixed transient + permanent.
- [x] Full orchestrator suite: 4087 passed, 1 skipped (pre-#1879 baseline) + new tests all green.
- [x] `ruff check` clean on changed files.

Closes #1878.
Closes #1879.

🤖 Generated with [Claude Code](https://claude.com/claude-code)