### PR TITLE
Raise gateway memory limit to 4Gi as interim fix for OOM crash-loop (#1885)

### DIFF
--- a/k8s/base/gateway-deployment.yaml
+++ b/k8s/base/gateway-deployment.yaml
@@ -77,6 +77,11 @@ spec:
             # by the fail-fast check in gateway.main() (#1803).
             - name: EGG_ORCHESTRATOR_URL
               value: "http://orchestrator.egg-system.svc.cluster.local:9849"
+            # Thread count for the gateway WSGI server. Default is 32
+            # (see gateway/gateway.py DEFAULT_THREADS). Surfaced here so
+            # operators can tune via kustomize overlay without reading source.
+            - name: GATEWAY_THREADS
+              value: "32"
           livenessProbe:
             httpGet:
               path: /api/v1/health
@@ -96,10 +101,10 @@ spec:
           resources:
             requests:
               cpu: 200m
-              memory: 1Gi
+              memory: 2Gi
             limits:
               cpu: "1"
-              memory: 4Gi
+              memory: 4Gi # TODO(#1885): review after leak-vs-load investigation
           volumeMounts:
             - name: secrets
               mountPath: /secrets

--- a/k8s/base/gateway-deployment.yaml
+++ b/k8s/base/gateway-deployment.yaml
@@ -96,10 +96,10 @@ spec:
           resources:
             requests:
               cpu: 200m
-              memory: 512Mi
+              memory: 1Gi
             limits:
               cpu: "1"
-              memory: 1Gi
+              memory: 4Gi
           volumeMounts:
             - name: secrets
               mountPath: /secrets


### PR DESCRIPTION
## Summary

Gateway pod was OOM-killed 4 times in 29 minutes on 2026-04-22 while 3 concurrent pipelines were running. Raises `memory: limits` from 1Gi to 4Gi and `memory: requests` from 512Mi to 1Gi as an interim fix while the root-cause investigation (leak vs. load-pressure — see #1885) continues.

## Why 4Gi

The gateway's Anthropic-streaming proxy path (`gateway/gateway.py:5088` — `proxy_anthropic_messages`) allocates ~30MB of transient memory per in-flight streaming request:

- 10MB `collected_chunks: list[bytes]` (MAX_CAPTURE_SIZE buffer)
- 10MB `b"".join(chunks)` in `_parse_sse_response`
- Similar-sized decoded string + JSON-parsed event dicts

With `threads=32` and 15+ concurrent Anthropic streams during active pipeline work (3 pipelines × ~5 agents), transient memory reaches ~450MB on top of a ~300MB baseline — right at the 1Gi cap. 4Gi provides headroom for 4-5 concurrent pipelines in the current architecture.

## What this does NOT fix

This is a band-aid. The underlying question — whether the gateway *leaks* memory or whether memory *scales linearly with concurrent streams and resets on idle* — is unresolved. Filed as **#1885** for follow-up with a concrete disambiguating test (measure RSS at idle after pipelines finish) and an instrumentation stub if it turns out to be a leak.

Longer-term fix options if the per-request streaming-capture pattern stays hot (tracked in #1885):
- Stream chunks directly to the transcript buffer file as they arrive, instead of collecting all chunks in a Python list then re-processing
- Reduce `MAX_CAPTURE_SIZE` per request
- Lower Flask `threads` count to bound worst-case concurrency

## Test plan

- Automated: none (manifest change only; no code behavior changes)
- Manual: after deploy, run ≥3 concurrent pipelines and observe `kubectl top pod -n egg-system gateway-*` — should no longer OOM under typical load. Capture RSS at steady state (during active pipelines) and at idle (all pipelines complete, no agents running) to feed the #1885 leak-vs-load analysis.

## Related

- **#1885** — Follow-up investigation of gateway memory usage (leak vs. architectural high-water mark). Names candidate leak sites and the disambiguating test.
- **#1883** — Agent resiliency across gateway restarts. If the gateway does go down for any reason, agents shouldn't lose in-flight work.
- **#1884** — Gateway should auto-prune stale sessions. Small contributor to baseline memory.