### PR TITLE
Fix #1885: parse SSE streams incrementally; add opt-in mem trace sampler

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -24,6 +24,7 @@ Usage:
 """
 
 import argparse
+import codecs
 import functools
 import json
 import os
@@ -4990,35 +4991,180 @@ def _capture_non_streaming_response(
         )
 
 
+SSEResult = tuple[
+    list[dict[str, Any]] | None,
+    dict[str, Any] | None,
+    str | None,
+    str | None,
+]
+
+
+class _SSEAccumulator:
+    """Parse Anthropic SSE streaming responses incrementally.
+
+    Accepts bytes chunks via ``feed()``. Holds only parsed state plus a small
+    partial-line buffer — never the raw response bytes. Call ``result()`` once
+    at end of stream to get ``(content, usage, model, stop_reason)``.
+
+    Why: the previous implementation did ``b"".join(chunks).decode().split("\\n")``
+    at end-of-stream, peaking at ~3× the full response size per concurrent
+    request. At ~15 concurrent streams that's hundreds of MB of transient
+    allocation that the pod's 1Gi cgroup couldn't absorb (see #1885).
+    """
+
+    def __init__(self) -> None:
+        # errors="replace" matches the prior decode() behavior.
+        self._decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        self._line_buf = ""
+        self._content_by_index: dict[int, dict[str, Any]] = {}
+        # Error events produce extra content blocks ordered before indexed
+        # blocks (preserves the pre-refactor ordering).
+        self._error_blocks: list[dict[str, Any]] = []
+        self._usage: dict[str, Any] | None = None
+        self._model: str | None = None
+        self._stop_reason: str | None = None
+        self._finalized = False
+
+    def feed(self, chunk: bytes) -> None:
+        """Decode ``chunk`` and process any complete lines it completes."""
+        if self._finalized or not chunk:
+            return
+        text = self._decoder.decode(chunk)
+        if not text:
+            return
+        if "\n" not in text:
+            self._line_buf += text
+            return
+        combined = self._line_buf + text
+        parts = combined.split("\n")
+        # parts[-1] is either "" (chunk ended on a newline) or the new partial line.
+        self._line_buf = parts[-1]
+        for line in parts[:-1]:
+            self._process_line(line)
+
+    def result(self) -> SSEResult:
+        """Flush any trailing partial line and return the parsed result."""
+        if not self._finalized:
+            tail = self._decoder.decode(b"", final=True)
+            if tail:
+                self._line_buf += tail
+            if self._line_buf:
+                self._process_line(self._line_buf)
+                self._line_buf = ""
+            self._finalized = True
+
+        content_blocks: list[dict[str, Any]] = list(self._error_blocks)
+        for index in sorted(self._content_by_index.keys()):
+            block = self._content_by_index[index]
+            if block.get("type") == "tool_use" and "partial_input" in block:
+                partial_input = block.pop("partial_input")
+                try:
+                    block["input"] = json.loads(partial_input)
+                except json.JSONDecodeError:
+                    logger.debug(
+                        "Failed to parse tool_use input JSON",
+                        tool_id=block.get("id"),
+                    )
+                    block["input"] = {}
+                    block["input_parse_error"] = True
+                    block["raw_partial_input"] = (
+                        partial_input[:RAW_INPUT_TRUNCATE_SIZE]
+                        if len(partial_input) > RAW_INPUT_TRUNCATE_SIZE
+                        else partial_input
+                    )
+            content_blocks.append(block)
+
+        return content_blocks or None, self._usage, self._model, self._stop_reason
+
+    def _process_line(self, line: str) -> None:
+        line = line.strip()
+        if not line.startswith("data: "):
+            return
+        data_str = line[6:]
+        if data_str == "[DONE]":
+            return
+        try:
+            event = json.loads(data_str)
+        except json.JSONDecodeError:
+            return
+        self._process_event(event)
+
+    def _process_event(self, event: dict[str, Any]) -> None:
+        event_type = event.get("type")
+
+        if event_type == "message_start":
+            message = event.get("message", {})
+            self._model = message.get("model")
+            message_usage = message.get("usage", {})
+            if message_usage:
+                if self._usage is None:
+                    self._usage = {}
+                # input_tokens / cache_* come from message_start, not message_delta.
+                if "input_tokens" in message_usage:
+                    self._usage["input_tokens"] = message_usage["input_tokens"]
+                if "cache_read_input_tokens" in message_usage:
+                    self._usage["cache_read_input_tokens"] = message_usage[
+                        "cache_read_input_tokens"
+                    ]
+                if "cache_creation_input_tokens" in message_usage:
+                    self._usage["cache_creation_input_tokens"] = message_usage[
+                        "cache_creation_input_tokens"
+                    ]
+
+        elif event_type == "error":
+            error_info = event.get("error", {})
+            self._error_blocks.append({"type": "error", "error": error_info})
+            self._stop_reason = "error"
+
+        elif event_type == "content_block_start":
+            index = event.get("index", 0)
+            content_block = event.get("content_block", {})
+            self._content_by_index[index] = content_block.copy()
+
+        elif event_type == "content_block_delta":
+            index = event.get("index", 0)
+            delta = event.get("delta", {})
+            delta_type = delta.get("type")
+            if index not in self._content_by_index:
+                self._content_by_index[index] = {
+                    "type": delta_type.replace("_delta", "") if delta_type else "unknown"
+                }
+            block = self._content_by_index[index]
+            if delta_type == "text_delta":
+                text = delta.get("text", "")
+                block["text"] = block.get("text", "") + text
+            elif delta_type == "input_json_delta":
+                partial_json = delta.get("partial_json", "")
+                block["partial_input"] = block.get("partial_input", "") + partial_json
+
+        elif event_type == "message_delta":
+            delta = event.get("delta", {})
+            self._stop_reason = delta.get("stop_reason")
+            event_usage = event.get("usage")
+            if event_usage:
+                if self._usage is None:
+                    self._usage = {}
+                # message_delta contains output_tokens.
+                self._usage.update(event_usage)
+
+
 def _capture_streaming_response(
     container_id: str,
     request_json: dict[str, Any],
-    chunks: list[bytes],
+    result: SSEResult,
     start_time: float,
 ) -> None:
     """
     Capture a streaming API response to the transcript buffer.
 
-    Reassembles the SSE chunks to extract the final message content and usage.
-
     Args:
         container_id: Container ID for buffer lookup
         request_json: Parsed request body
-        chunks: List of SSE response chunks
+        result: Parsed SSE result tuple from ``_SSEAccumulator.result()``
         start_time: Request start time for duration calculation
     """
     duration_ms = (time.time() - start_time) * 1000
-
-    # Reassemble SSE response to get content and usage
-    try:
-        response_content, response_usage, response_model, stop_reason = _parse_sse_response(chunks)
-    except Exception as e:
-        logger.debug(
-            "Failed to parse SSE response for transcript capture",
-            container_id=container_id,
-            error=str(e),
-        )
-        return
+    response_content, response_usage, response_model, stop_reason = result
 
     try:
         buffer = get_transcript_buffer(container_id)
@@ -5039,137 +5185,18 @@ def _capture_streaming_response(
         )
 
 
-def _parse_sse_response(
-    chunks: list[bytes],
-) -> tuple[list[dict[str, Any]] | None, dict[str, Any] | None, str | None, str | None]:
+def _parse_sse_response(chunks: list[bytes]) -> SSEResult:
     """
-    Parse SSE response chunks to extract message content and usage.
+    Parse SSE response chunks and return ``(content, usage, model, stop_reason)``.
 
-    Returns:
-        Tuple of (content, usage, model, stop_reason)
+    Thin wrapper over ``_SSEAccumulator`` retained for test coverage. Production
+    streaming capture feeds the accumulator directly so it never holds the
+    chunks list in memory — see ``proxy_anthropic_messages``.
     """
-    # Combine chunks and parse SSE events
-    full_response = b"".join(chunks).decode("utf-8", errors="replace")
-
-    content_blocks: list[dict[str, Any]] = []
-    usage: dict[str, Any] | None = None
-    model: str | None = None
-    stop_reason: str | None = None
-
-    # Track content blocks being built (keyed by index)
-    content_by_index: dict[int, dict[str, Any]] = {}
-
-    for line in full_response.split("\n"):
-        line = line.strip()
-        if not line.startswith("data: "):
-            continue
-
-        data_str = line[6:]  # Remove "data: " prefix
-        if data_str == "[DONE]":
-            continue
-
-        try:
-            event = json.loads(data_str)
-        except json.JSONDecodeError:
-            continue
-
-        event_type = event.get("type")
-
-        # Extract model and input_tokens from message_start
-        if event_type == "message_start":
-            message = event.get("message", {})
-            model = message.get("model")
-            # Capture input_tokens from message_start (message_delta only has output_tokens)
-            message_usage = message.get("usage", {})
-            if message_usage:
-                if usage is None:
-                    usage = {}
-                # input_tokens comes from message_start, not message_delta
-                if "input_tokens" in message_usage:
-                    usage["input_tokens"] = message_usage["input_tokens"]
-                if "cache_read_input_tokens" in message_usage:
-                    usage["cache_read_input_tokens"] = message_usage["cache_read_input_tokens"]
-                if "cache_creation_input_tokens" in message_usage:
-                    usage["cache_creation_input_tokens"] = message_usage[
-                        "cache_creation_input_tokens"
-                    ]
-
-        # Handle error events from streaming API
-        elif event_type == "error":
-            error_info = event.get("error", {})
-            # Add error as a content block so it's captured in transcript
-            content_blocks.append(
-                {
-                    "type": "error",
-                    "error": error_info,
-                }
-            )
-            stop_reason = "error"
-
-        # Track content block starts
-        elif event_type == "content_block_start":
-            index = event.get("index", 0)
-            content_block = event.get("content_block", {})
-            content_by_index[index] = content_block.copy()
-
-        # Accumulate content block deltas
-        elif event_type == "content_block_delta":
-            index = event.get("index", 0)
-            delta = event.get("delta", {})
-            delta_type = delta.get("type")
-
-            if index not in content_by_index:
-                content_by_index[index] = {
-                    "type": delta_type.replace("_delta", "") if delta_type else "unknown"
-                }
-
-            block = content_by_index[index]
-
-            if delta_type == "text_delta":
-                text = delta.get("text", "")
-                block["text"] = block.get("text", "") + text
-            elif delta_type == "input_json_delta":
-                # For tool_use blocks
-                partial_json = delta.get("partial_json", "")
-                block["partial_input"] = block.get("partial_input", "") + partial_json
-
-        # Extract output_tokens and stop_reason from message_delta
-        elif event_type == "message_delta":
-            delta = event.get("delta", {})
-            stop_reason = delta.get("stop_reason")
-            event_usage = event.get("usage")
-            if event_usage:
-                if usage is None:
-                    usage = {}
-                # message_delta contains output_tokens
-                usage.update(event_usage)
-
-    # Build final content blocks
-    for index in sorted(content_by_index.keys()):
-        block = content_by_index[index]
-        # For tool_use blocks, parse the accumulated JSON
-        if block.get("type") == "tool_use" and "partial_input" in block:
-            partial_input = block.pop("partial_input")
-            try:
-                block["input"] = json.loads(partial_input)
-            except json.JSONDecodeError:
-                # Log warning but still include the block with parse failure noted.
-                # Preserve the raw partial_input for debugging (truncated to avoid bloat).
-                logger.debug(
-                    "Failed to parse tool_use input JSON",
-                    tool_id=block.get("id"),
-                )
-                block["input"] = {}
-                block["input_parse_error"] = True
-                # Include truncated raw input for debugging incomplete streaming responses
-                block["raw_partial_input"] = (
-                    partial_input[:RAW_INPUT_TRUNCATE_SIZE]
-                    if len(partial_input) > RAW_INPUT_TRUNCATE_SIZE
-                    else partial_input
-                )
-        content_blocks.append(block)
-
-    return content_blocks or None, usage, model, stop_reason
+    acc = _SSEAccumulator()
+    for chunk in chunks:
+        acc.feed(chunk)
+    return acc.result()
 
 
 @app.route("/v1/messages", methods=["POST"])
@@ -5226,22 +5253,28 @@ def proxy_anthropic_messages() -> tuple[Response, int] | Response:
             # Forward actual Content-Type from upstream (usually text/event-stream)
             content_type = upstream.headers.get("content-type", "text/event-stream")
 
-            # For streaming, we need to capture the full response while forwarding chunks
-            # Cap memory usage at 10MB to prevent resource exhaustion
+            # Parse the SSE stream incrementally into a small accumulator so
+            # per-request peak memory is O(parsed content), not O(response × 3)
+            # as the prior b"".join(chunks).decode().split("\n") pattern was.
+            # Under concurrent pipeline load that triple allocation was the
+            # gateway's memory high-water mark — see #1885.
+            #
+            # MAX_CAPTURE_SIZE is still enforced as a defensive cap so a
+            # pathologically large upstream response can't drive the
+            # accumulator unbounded, but the raw bytes are never buffered.
             MAX_CAPTURE_SIZE = 10 * 1024 * 1024  # 10MB
-            collected_chunks: list[bytes] = []
-            collected_size = 0
+            accumulator: _SSEAccumulator | None = _SSEAccumulator() if container_id else None
+            bytes_seen = 0
             capture_truncated = False
 
             def generate() -> Any:
-                nonlocal collected_size, capture_truncated
+                nonlocal bytes_seen, capture_truncated
                 try:
                     for chunk in upstream.iter_bytes():
-                        # Only collect chunks until we hit the size limit
-                        if not capture_truncated:
-                            if collected_size + len(chunk) <= MAX_CAPTURE_SIZE:
-                                collected_chunks.append(chunk)
-                                collected_size += len(chunk)
+                        if accumulator is not None and not capture_truncated:
+                            if bytes_seen + len(chunk) <= MAX_CAPTURE_SIZE:
+                                accumulator.feed(chunk)
+                                bytes_seen += len(chunk)
                             else:
                                 capture_truncated = True
                                 logger.debug(
@@ -5252,12 +5285,11 @@ def proxy_anthropic_messages() -> tuple[Response, int] | Response:
                         yield chunk
                 finally:
                     upstream.close()
-                    # Capture to transcript buffer after streaming completes
-                    if container_id:
+                    if accumulator is not None and container_id:
                         _capture_streaming_response(
                             container_id=container_id,
                             request_json=request_json,
-                            chunks=collected_chunks,
+                            result=accumulator.result(),
                             start_time=start_time,
                         )
 
@@ -5719,6 +5751,17 @@ def main() -> None:
         health_port=args.health_port,
     )
     logger.info("Session authentication required for all container operations")
+
+    # Optional tracemalloc sampler (opt-in via GATEWAY_MEM_TRACE=1). Emits
+    # periodic RSS + top-allocation-site log records to stdout so the trail
+    # survives pod OOM via `kubectl logs --previous`. See #1885.
+    try:
+        from .mem_trace import start_if_enabled as _mem_trace_start
+    except ImportError:
+        from mem_trace import (  # type: ignore[no-redef, import-untyped]
+            start_if_enabled as _mem_trace_start,
+        )
+    _mem_trace_start()
 
     # Start dedicated health check server on a separate port so Docker/orchestrator
     # health checks are never blocked by long-running git operations on the main

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -5286,12 +5286,19 @@ def proxy_anthropic_messages() -> tuple[Response, int] | Response:
                 finally:
                     upstream.close()
                     if accumulator is not None and container_id:
-                        _capture_streaming_response(
-                            container_id=container_id,
-                            request_json=request_json,
-                            result=accumulator.result(),
-                            start_time=start_time,
-                        )
+                        try:
+                            _capture_streaming_response(
+                                container_id=container_id,
+                                request_json=request_json,
+                                result=accumulator.result(),
+                                start_time=start_time,
+                            )
+                        except Exception as e:
+                            logger.debug(
+                                "Failed to capture streaming response to transcript",
+                                container_id=container_id,
+                                error=str(e),
+                            )
 
             return Response(
                 stream_with_context(generate()),

--- a/gateway/mem_trace.py
+++ b/gateway/mem_trace.py
@@ -113,6 +113,7 @@ def start_if_enabled() -> bool:
         top_n = int(os.environ.get(TOP_N_ENV_VAR, DEFAULT_TOP_N))
     except ValueError:
         top_n = DEFAULT_TOP_N
+    top_n = max(1, top_n)
 
     if not tracemalloc.is_tracing():
         tracemalloc.start(FRAME_DEPTH)

--- a/gateway/mem_trace.py
+++ b/gateway/mem_trace.py
@@ -83,6 +83,9 @@ def _sampler_loop(interval_seconds: float, top_n: int) -> None:
             logger.warning("gateway_mem_trace_failed", error=str(exc))
 
 
+_started = False
+
+
 def _is_truthy(value: str) -> bool:
     return value.lower() in {"1", "true", "yes", "on"}
 
@@ -91,9 +94,12 @@ def start_if_enabled() -> bool:
     """Start the sampler iff ``GATEWAY_MEM_TRACE`` is truthy.
 
     Returns True if sampling was started, False otherwise. Safe to call multiple
-    times; subsequent calls after the first are no-ops if tracemalloc is already
-    tracing.
+    times; subsequent calls after the first are no-ops.
     """
+    global _started
+    if _started:
+        return False
+
     if not _is_truthy(os.environ.get(ENABLE_ENV_VAR, "")):
         return False
 
@@ -101,6 +107,8 @@ def start_if_enabled() -> bool:
         interval = float(os.environ.get(INTERVAL_ENV_VAR, DEFAULT_INTERVAL_SECONDS))
     except ValueError:
         interval = DEFAULT_INTERVAL_SECONDS
+    interval = max(1.0, interval)
+
     try:
         top_n = int(os.environ.get(TOP_N_ENV_VAR, DEFAULT_TOP_N))
     except ValueError:
@@ -116,6 +124,7 @@ def start_if_enabled() -> bool:
         daemon=True,
     )
     thread.start()
+    _started = True
     logger.info(
         "Memory trace sampler started",
         interval_seconds=interval,

--- a/gateway/mem_trace.py
+++ b/gateway/mem_trace.py
@@ -1,0 +1,125 @@
+"""Optional tracemalloc-based memory sampler for gateway diagnostics.
+
+Enable by setting ``GATEWAY_MEM_TRACE=1`` in the environment. The sampler runs
+on a background daemon thread and emits one structured log record per interval
+(default 30s) containing the current RSS and the top-N allocation sites.
+
+Output goes through the egg-logging logger (stdout), so traces survive a pod
+OOM via ``kubectl logs --previous -n egg-system <gateway-pod>``. We deliberately
+do **not** write to disk: the ``/home/egg/.egg-state`` mount is an ``emptyDir``
+in ``k8s/base/gateway-deployment.yaml`` and is wiped on pod restart, so file
+persistence there wouldn't survive the OOM we're trying to diagnose.
+
+This is opt-in because ``tracemalloc`` adds per-allocation overhead (captures a
+25-frame stack on every allocation). Enable only when actively investigating a
+memory issue. See issue #1885.
+
+Tuning env vars:
+    GATEWAY_MEM_TRACE=1                      — turn on sampling
+    GATEWAY_MEM_TRACE_INTERVAL_SECONDS=30    — seconds between samples
+    GATEWAY_MEM_TRACE_TOP_N=15               — number of top allocation sites
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+import tracemalloc
+from typing import Any
+
+from egg_logging import get_logger
+
+logger = get_logger("gateway.mem_trace")
+
+
+ENABLE_ENV_VAR = "GATEWAY_MEM_TRACE"
+INTERVAL_ENV_VAR = "GATEWAY_MEM_TRACE_INTERVAL_SECONDS"
+TOP_N_ENV_VAR = "GATEWAY_MEM_TRACE_TOP_N"
+
+DEFAULT_INTERVAL_SECONDS = 30.0
+DEFAULT_TOP_N = 15
+FRAME_DEPTH = 25
+
+
+def _read_rss_mb() -> float | None:
+    """Return the process RSS in MB from /proc/self/status, or None on failure."""
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    kb = int(line.split()[1])
+                    return kb / 1024
+    except (OSError, ValueError):
+        return None
+    return None
+
+
+def _sample_once(top_n: int) -> dict[str, Any]:
+    """Take one tracemalloc snapshot and return a log-friendly record."""
+    snap = tracemalloc.take_snapshot()
+    stats = snap.statistics("lineno")[:top_n]
+    return {
+        "rss_mb": _read_rss_mb(),
+        "top": [
+            {
+                "loc": str(s.traceback[-1]) if s.traceback else "<unknown>",
+                "size_kb": s.size // 1024,
+                "count": s.count,
+            }
+            for s in stats
+        ],
+    }
+
+
+def _sampler_loop(interval_seconds: float, top_n: int) -> None:
+    while True:
+        time.sleep(interval_seconds)
+        try:
+            record = _sample_once(top_n)
+            logger.info("gateway_mem_trace", **record)
+        except Exception as exc:
+            # Never let the sampler crash the gateway; just log and keep going.
+            logger.warning("gateway_mem_trace_failed", error=str(exc))
+
+
+def _is_truthy(value: str) -> bool:
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def start_if_enabled() -> bool:
+    """Start the sampler iff ``GATEWAY_MEM_TRACE`` is truthy.
+
+    Returns True if sampling was started, False otherwise. Safe to call multiple
+    times; subsequent calls after the first are no-ops if tracemalloc is already
+    tracing.
+    """
+    if not _is_truthy(os.environ.get(ENABLE_ENV_VAR, "")):
+        return False
+
+    try:
+        interval = float(os.environ.get(INTERVAL_ENV_VAR, DEFAULT_INTERVAL_SECONDS))
+    except ValueError:
+        interval = DEFAULT_INTERVAL_SECONDS
+    try:
+        top_n = int(os.environ.get(TOP_N_ENV_VAR, DEFAULT_TOP_N))
+    except ValueError:
+        top_n = DEFAULT_TOP_N
+
+    if not tracemalloc.is_tracing():
+        tracemalloc.start(FRAME_DEPTH)
+
+    thread = threading.Thread(
+        target=_sampler_loop,
+        args=(interval, top_n),
+        name="gateway-mem-trace",
+        daemon=True,
+    )
+    thread.start()
+    logger.info(
+        "Memory trace sampler started",
+        interval_seconds=interval,
+        top_n=top_n,
+        frame_depth=FRAME_DEPTH,
+    )
+    return True

--- a/gateway/tests/conftest.py
+++ b/gateway/tests/conftest.py
@@ -267,6 +267,12 @@ phase_api = _load_module_with_replaced_imports(
     },
 )
 
+# mem_trace has no relative imports to other gateway modules
+mem_trace = _load_module_with_replaced_imports(
+    "mem_trace",
+    GATEWAY_DIR / "mem_trace.py",
+)
+
 # gateway imports from all
 gateway = _load_module_with_replaced_imports(
     "gateway",

--- a/tests/gateway/test_anthropic_proxy.py
+++ b/tests/gateway/test_anthropic_proxy.py
@@ -861,6 +861,99 @@ class TestParseSSEResponse:
         assert len(raw_input) == RAW_INPUT_TRUNCATE_SIZE
 
 
+class TestSSEAccumulatorChunkBoundaries:
+    """Verify the incremental accumulator produces the same result regardless
+    of how the upstream bytes are split across chunks. The production path
+    (#1885) feeds chunks as they arrive from httpx, so we can't assume any
+    particular event-boundary alignment."""
+
+    CANONICAL_STREAM = (
+        b'data: {"type":"message_start","message":{"id":"msg_1","model":"claude-x",'
+        b'"usage":{"input_tokens":7}}}\n\n'
+        b'data: {"type":"content_block_start","index":0,'
+        b'"content_block":{"type":"text","text":""}}\n\n'
+        b'data: {"type":"content_block_delta","index":0,'
+        b'"delta":{"type":"text_delta","text":"Hello "}}\n\n'
+        b'data: {"type":"content_block_delta","index":0,'
+        b'"delta":{"type":"text_delta","text":"world!"}}\n\n'
+        b'data: {"type":"content_block_stop","index":0}\n\n'
+        b'data: {"type":"message_delta",'
+        b'"delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}\n\n'
+        b"data: [DONE]\n\n"
+    )
+
+    def _feed_and_result(self, splits: list[int]):
+        from gateway.gateway import _SSEAccumulator
+
+        acc = _SSEAccumulator()
+        start = 0
+        for offset in splits:
+            acc.feed(self.CANONICAL_STREAM[start:offset])
+            start = offset
+        acc.feed(self.CANONICAL_STREAM[start:])
+        return acc.result()
+
+    def test_parses_identically_to_single_feed(self):
+        """One-shot feed should match chunked feeds byte-for-byte."""
+        single = self._feed_and_result([])
+        chunked = self._feed_and_result(list(range(1, len(self.CANONICAL_STREAM), 37)))
+        assert single == chunked
+
+    def test_split_mid_line(self):
+        """Splitting mid-line — including mid-JSON — must not drop events."""
+        # Break at every newline boundary *and* halfway through each event.
+        content, usage, model, stop_reason = self._feed_and_result([10, 50, 120, 250, 400])
+        assert model == "claude-x"
+        assert usage == {"input_tokens": 7, "output_tokens": 3}
+        assert stop_reason == "end_turn"
+        assert content is not None
+        assert content[0]["text"] == "Hello world!"
+
+    def test_split_mid_utf8_multibyte(self):
+        """A multi-byte UTF-8 codepoint split across two chunks must still
+        decode correctly — this is the main reason for using an incremental
+        decoder rather than .decode() per chunk."""
+        from gateway.gateway import _SSEAccumulator
+
+        # "héllo" where é is 0xC3 0xA9; split between the two bytes.
+        frame = (
+            b'data: {"type":"message_start","message":{"model":"claude-x"}}\n\n'
+            b'data: {"type":"content_block_start","index":0,'
+            b'"content_block":{"type":"text","text":""}}\n\n'
+            b'data: {"type":"content_block_delta","index":0,'
+            b'"delta":{"type":"text_delta","text":"h\xc3\xa9llo"}}\n\n'
+            b'data: {"type":"content_block_stop","index":0}\n\n'
+            b'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n\n'
+            b"data: [DONE]\n\n"
+        )
+        # Find the position of 0xA9 and split *before* it so 0xC3 lands in one
+        # chunk and 0xA9 in the next.
+        split_at = frame.index(b"\xa9")
+        acc = _SSEAccumulator()
+        acc.feed(frame[:split_at])
+        acc.feed(frame[split_at:])
+        content, _usage, _model, _stop = acc.result()
+        assert content is not None
+        assert content[0]["text"] == "héllo"
+
+    def test_does_not_hold_bytes_after_feed(self):
+        """The accumulator must not retain a reference to fed chunks — that
+        was the #1885 regression. Approximate this by checking that the
+        per-instance byte footprint stays small after feeding a large stream."""
+        import sys
+
+        from gateway.gateway import _SSEAccumulator
+
+        acc = _SSEAccumulator()
+        # Feed 1 MB of irrelevant SSE lines (no data: prefix, so nothing is
+        # retained in content_by_index either).
+        big_chunk = b"comment: ignored\n" * (1024 * 64)  # ~1 MB
+        acc.feed(big_chunk)
+        # line_buf should be empty (chunk ends on \n) and no parsed state held.
+        assert sys.getsizeof(acc._line_buf) < 1024  # type: ignore[attr-defined]
+        assert acc._content_by_index == {}  # type: ignore[attr-defined]
+
+
 class TestTranscriptCaptureFunctions:
     """Tests for transcript capture helper functions."""
 
@@ -913,7 +1006,7 @@ class TestTranscriptCaptureFunctions:
         from unittest.mock import patch
 
         with patch("gateway.transcript_buffer.BUFFER_DIR", tmp_path):
-            from gateway.gateway import _capture_streaming_response
+            from gateway.gateway import _capture_streaming_response, _parse_sse_response
             from gateway.transcript_buffer import TranscriptBuffer
 
             container_id = "test-container-456"
@@ -933,7 +1026,7 @@ class TestTranscriptCaptureFunctions:
             _capture_streaming_response(
                 container_id=container_id,
                 request_json=request_json,
-                chunks=chunks,
+                result=_parse_sse_response(chunks),
                 start_time=time.time() - 0.3,
             )
 

--- a/tests/gateway/test_anthropic_proxy.py
+++ b/tests/gateway/test_anthropic_proxy.py
@@ -940,7 +940,6 @@ class TestSSEAccumulatorChunkBoundaries:
         """The accumulator must not retain a reference to fed chunks — that
         was the #1885 regression. Approximate this by checking that the
         per-instance byte footprint stays small after feeding a large stream."""
-        import sys
 
         from gateway.gateway import _SSEAccumulator
 
@@ -950,7 +949,7 @@ class TestSSEAccumulatorChunkBoundaries:
         big_chunk = b"comment: ignored\n" * (1024 * 64)  # ~1 MB
         acc.feed(big_chunk)
         # line_buf should be empty (chunk ends on \n) and no parsed state held.
-        assert sys.getsizeof(acc._line_buf) < 1024  # type: ignore[attr-defined]
+        assert acc._line_buf == ""  # type: ignore[attr-defined]
         assert acc._content_by_index == {}  # type: ignore[attr-defined]
 
 

--- a/tests/gateway/test_mem_trace.py
+++ b/tests/gateway/test_mem_trace.py
@@ -32,8 +32,10 @@ class TestStartIfEnabled:
         assert start_if_enabled() is False
 
     def test_returns_false_for_falsy_values(self, monkeypatch):
+        import gateway.mem_trace as _mt
         from gateway.mem_trace import ENABLE_ENV_VAR, start_if_enabled
 
+        _mt._started = False
         for value in ("", "0", "false", "no", "off"):
             monkeypatch.setenv(ENABLE_ENV_VAR, value)
             assert start_if_enabled() is False, f"expected False for {value!r}"

--- a/tests/gateway/test_mem_trace.py
+++ b/tests/gateway/test_mem_trace.py
@@ -11,10 +11,15 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _tracemalloc_cleanup():
-    """Ensure tracemalloc state is restored between tests — start_if_enabled
-    calls tracemalloc.start(), which is process-global."""
+    """Ensure tracemalloc and module-level _started state are restored between
+    tests — start_if_enabled uses process-global tracemalloc and a module-level
+    guard."""
+    import gateway.mem_trace as _mt
+
     was_tracing = tracemalloc.is_tracing()
+    was_started = _mt._started
     yield
+    _mt._started = was_started
     if tracemalloc.is_tracing() and not was_tracing:
         tracemalloc.stop()
 
@@ -34,8 +39,11 @@ class TestStartIfEnabled:
             assert start_if_enabled() is False, f"expected False for {value!r}"
 
     def test_returns_true_and_starts_tracing_for_truthy_values(self, monkeypatch):
+        import gateway.mem_trace as _mt
         from gateway.mem_trace import ENABLE_ENV_VAR, start_if_enabled
 
+        # Reset module guard so this test can start fresh.
+        _mt._started = False
         # Stop any prior sampler thread from bleeding into this test by
         # replacing the thread target with a no-op that returns immediately.
         with patch("gateway.mem_trace._sampler_loop") as mock_loop:
@@ -43,6 +51,32 @@ class TestStartIfEnabled:
             monkeypatch.setenv(ENABLE_ENV_VAR, "1")
             assert start_if_enabled() is True
             assert tracemalloc.is_tracing()
+
+    def test_second_call_is_noop(self, monkeypatch):
+        import gateway.mem_trace as _mt
+        from gateway.mem_trace import ENABLE_ENV_VAR, start_if_enabled
+
+        _mt._started = False
+        with patch("gateway.mem_trace._sampler_loop") as mock_loop:
+            mock_loop.return_value = None
+            monkeypatch.setenv(ENABLE_ENV_VAR, "1")
+            assert start_if_enabled() is True
+            assert start_if_enabled() is False  # second call is a no-op
+
+    def test_interval_clamped_to_minimum(self, monkeypatch):
+        import gateway.mem_trace as _mt
+        from gateway.mem_trace import ENABLE_ENV_VAR, INTERVAL_ENV_VAR, start_if_enabled
+
+        _mt._started = False
+        with patch("gateway.mem_trace._sampler_loop") as mock_loop:
+            mock_loop.return_value = None
+            monkeypatch.setenv(ENABLE_ENV_VAR, "1")
+            monkeypatch.setenv(INTERVAL_ENV_VAR, "0")
+            start_if_enabled()
+            # The interval passed to _sampler_loop should be clamped to 1.0
+            mock_loop.assert_called_once()
+            actual_interval = mock_loop.call_args[0][0]
+            assert actual_interval == 1.0
 
 
 class TestReadRssMb:

--- a/tests/gateway/test_mem_trace.py
+++ b/tests/gateway/test_mem_trace.py
@@ -1,0 +1,83 @@
+"""Tests for the opt-in tracemalloc memory sampler (gateway/mem_trace.py)."""
+
+from __future__ import annotations
+
+import os
+import tracemalloc
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _tracemalloc_cleanup():
+    """Ensure tracemalloc state is restored between tests — start_if_enabled
+    calls tracemalloc.start(), which is process-global."""
+    was_tracing = tracemalloc.is_tracing()
+    yield
+    if tracemalloc.is_tracing() and not was_tracing:
+        tracemalloc.stop()
+
+
+class TestStartIfEnabled:
+    def test_returns_false_when_env_unset(self, monkeypatch):
+        from gateway.mem_trace import ENABLE_ENV_VAR, start_if_enabled
+
+        monkeypatch.delenv(ENABLE_ENV_VAR, raising=False)
+        assert start_if_enabled() is False
+
+    def test_returns_false_for_falsy_values(self, monkeypatch):
+        from gateway.mem_trace import ENABLE_ENV_VAR, start_if_enabled
+
+        for value in ("", "0", "false", "no", "off"):
+            monkeypatch.setenv(ENABLE_ENV_VAR, value)
+            assert start_if_enabled() is False, f"expected False for {value!r}"
+
+    def test_returns_true_and_starts_tracing_for_truthy_values(self, monkeypatch):
+        from gateway.mem_trace import ENABLE_ENV_VAR, start_if_enabled
+
+        # Stop any prior sampler thread from bleeding into this test by
+        # replacing the thread target with a no-op that returns immediately.
+        with patch("gateway.mem_trace._sampler_loop") as mock_loop:
+            mock_loop.return_value = None
+            monkeypatch.setenv(ENABLE_ENV_VAR, "1")
+            assert start_if_enabled() is True
+            assert tracemalloc.is_tracing()
+
+
+class TestReadRssMb:
+    def test_reads_rss_on_linux(self):
+        """This test only runs meaningfully on Linux (where /proc/self/status
+        exists). On other platforms the function returns None, which we accept."""
+        from gateway.mem_trace import _read_rss_mb
+
+        result = _read_rss_mb()
+        if os.path.exists("/proc/self/status"):
+            assert result is not None
+            assert result > 0
+        else:
+            assert result is None
+
+
+class TestSampleOnce:
+    def test_produces_expected_shape(self):
+        """Verify the sample record matches the documented schema."""
+        from gateway.mem_trace import _sample_once
+
+        # Needs tracemalloc active to take a snapshot.
+        started_here = not tracemalloc.is_tracing()
+        if started_here:
+            tracemalloc.start(5)
+        try:
+            record = _sample_once(top_n=3)
+        finally:
+            if started_here:
+                tracemalloc.stop()
+
+        assert "rss_mb" in record
+        assert "top" in record
+        assert len(record["top"]) <= 3
+        for entry in record["top"]:
+            assert set(entry.keys()) == {"loc", "size_kb", "count"}
+            assert isinstance(entry["size_kb"], int)
+            assert isinstance(entry["count"], int)


### PR DESCRIPTION
## Summary

Two changes targeting the gateway OOM crash-loop investigated in #1885:

1. **Memory fix: incremental SSE parsing.** The streaming proxy previously held up to 10 MB of raw chunks per in-flight Anthropic request and then allocated another 2–3× at completion time via `b"".join(chunks).decode("utf-8").split("\n")`. At ~15 concurrent streams (3 pipelines × 5 agents) that cleared 1 GiB easily — matching the pod's 1Gi cgroup limit and the observed OOM pattern. A new `_SSEAccumulator` parses chunks as they arrive, retains only a small partial-line buffer plus the usual parsed state, and never holds the raw bytes. Per-request peak drops from O(response × 3) to O(parsed content). `_parse_sse_response(chunks)` is kept as a thin wrapper so existing tests continue to exercise the same behaviour, and `proxy_anthropic_messages` feeds the accumulator directly.

2. **Diagnostic: opt-in tracemalloc sampler.** Set `GATEWAY_MEM_TRACE=1` to start a background thread that logs RSS and the top-N allocation sites every 30s. Output goes to stdout so the trail survives pod OOM via `kubectl logs --previous` — the issue stub suggested writing to `/home/egg/.egg-state`, but that mount is an `emptyDir` in `k8s/base/gateway-deployment.yaml` and is wiped on pod restart, so file persistence there wouldn't survive the OOM we're trying to diagnose.

Companion to the interim band-aid in #1886 (raise limits to 4Gi). This PR targets the root cause so the 4Gi headroom can eventually come back down.

## Why not just the band-aid?

Raising memory is cheap and unblocks work, but it doesn't answer the leak-vs-load question the issue lays out. (1) eliminates the allocation pattern that was the clearest suspect (per-request triple-allocation peak), which removes load-pressure as a confounder in future investigation. (2) gives us a trail for the next OOM — if one still happens after (1), the tracemalloc records will say what actually grew.

## Test plan

- [x] `pytest tests/gateway/test_anthropic_proxy.py` — 46 tests pass; includes 21 existing `_parse_sse_response` tests (behaviour preservation) and 4 new `_SSEAccumulator` chunk-boundary tests (split mid-line, split mid-UTF-8-codepoint, full equivalence with single-feed, does-not-retain-bytes-after-feed).
- [x] `pytest tests/gateway/test_mem_trace.py` — 5 tests covering opt-in gating (unset / falsy / truthy), RSS read, and sample record shape.
- [x] `make lint` clean.
- [x] Combined `tests/gateway/` + `gateway/tests/` run: 2301 pass. The 3 remaining failures (`TestPathTraversalProtection` in `gateway/tests/test_phase_api.py`) are pre-existing and unrelated — this PR does not touch `phase_api.py`.
- [ ] Sanity-check post-merge: after pipelines finish, confirm gateway RSS drops back near baseline (the disambiguating test from the issue body).
- [ ] If issue #1886 (the 4Gi band-aid) gets merged first, rebase this on top; the two changes are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)