### PR TITLE
Fix #1884: auto-prune stale gateway sessions via idle timeout

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -5668,6 +5668,19 @@ def main() -> None:
     )
     cleanup_thread.start()
 
+    # Start background session pruner so stale entries don't accumulate across
+    # restarts.  Without this, sessions for dead containers survive until their
+    # 24h TTL lapses and are reloaded on every gateway restart (#1884).
+    try:
+        prune_interval = int(os.environ.get("EGG_SESSION_CLEANUP_INTERVAL_MINUTES", "15"))
+        idle_timeout = int(os.environ.get("EGG_SESSION_IDLE_TIMEOUT_MINUTES", "60"))
+        get_session_manager().start_background_pruner(
+            interval_minutes=prune_interval,
+            idle_timeout_minutes=idle_timeout,
+        )
+    except Exception as e:
+        logger.warning("Failed to start session background pruner", error=str(e))
+
     # Ensure launcher secret is configured - fail startup if not
     try:
         get_launcher_secret()

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -5672,8 +5672,8 @@ def main() -> None:
     # restarts.  Without this, sessions for dead containers survive until their
     # 24h TTL lapses and are reloaded on every gateway restart (#1884).
     try:
-        prune_interval = int(os.environ.get("EGG_SESSION_CLEANUP_INTERVAL_MINUTES", "15"))
-        idle_timeout = int(os.environ.get("EGG_SESSION_IDLE_TIMEOUT_MINUTES", "60"))
+        prune_interval = max(1, int(os.environ.get("EGG_SESSION_CLEANUP_INTERVAL_MINUTES", "15")))
+        idle_timeout = max(5, int(os.environ.get("EGG_SESSION_IDLE_TIMEOUT_MINUTES", "60")))
         get_session_manager().start_background_pruner(
             interval_minutes=prune_interval,
             idle_timeout_minutes=idle_timeout,

--- a/gateway/session_manager.py
+++ b/gateway/session_manager.py
@@ -95,7 +95,8 @@ def _capture_and_cleanup_session(
     Falls back to immediate cleanup if checkpoint capture is unavailable.
 
     Uses a per-container deduplication guard to prevent multiple captures from
-    racing code paths (delete_session, cleanup_orphaned_worktrees, prune_expired).
+    racing code paths (delete_session, cleanup_orphaned_worktrees, prune_expired,
+    prune_idle).
 
     Returns:
         The completion event from async checkpoint storage, or None if capture
@@ -997,7 +998,7 @@ class SessionManager:
 
     def prune_idle_sessions(
         self,
-        idle_timeout_minutes: int = DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES,
+        idle_timeout_minutes: float = DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES,
     ) -> int:
         """Remove sessions whose ``last_seen`` is older than the idle threshold.
 
@@ -1073,8 +1074,8 @@ class SessionManager:
 
     def start_background_pruner(
         self,
-        interval_minutes: int = DEFAULT_CLEANUP_INTERVAL_MINUTES,
-        idle_timeout_minutes: int = DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES,
+        interval_minutes: float = DEFAULT_CLEANUP_INTERVAL_MINUTES,
+        idle_timeout_minutes: float = DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES,
     ) -> None:
         """Start a daemon thread that periodically prunes expired + idle sessions.
 

--- a/gateway/session_manager.py
+++ b/gateway/session_manager.py
@@ -234,6 +234,12 @@ def _capture_and_cleanup_session(
 # Session configuration
 DEFAULT_SESSION_TTL_HOURS = 24
 DEFAULT_CLEANUP_INTERVAL_MINUTES = 15
+# Sessions idle longer than this are evicted even if their explicit TTL has not
+# yet lapsed.  Every successful validate_session() refreshes ``last_seen``, so a
+# stale ``last_seen`` means the container has stopped talking to the gateway —
+# typically because it was terminated or its pipeline was cancelled.  Without
+# this, sessions with a 24-hour TTL accumulate across gateway restarts (#1884).
+DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES = 60
 SESSION_TOKEN_BYTES = 32  # 256 bits
 
 # Persistence file path - use a persistent volume so sessions survive gateway restarts
@@ -432,6 +438,10 @@ class SessionManager:
         # Token lookup: raw_token -> token_hash (for fast validation in memory)
         # This enables O(1) lookup when validating tokens
         self._token_to_hash: dict[str, str] = {}
+
+        # Background pruner state (initialized lazily in start_background_pruner)
+        self._prune_shutdown: threading.Event | None = None
+        self._prune_thread: threading.Thread | None = None
 
         # Load persisted sessions on startup
         self._load_from_disk()
@@ -984,6 +994,149 @@ class SessionManager:
                     )
 
         return len(expired_sessions)
+
+    def prune_idle_sessions(
+        self,
+        idle_timeout_minutes: int = DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES,
+    ) -> int:
+        """Remove sessions whose ``last_seen`` is older than the idle threshold.
+
+        Complements :meth:`prune_expired_sessions`, which only evicts sessions
+        past their explicit ``expires_at``.  Without idle pruning, sessions for
+        dead containers survive until their 24-hour TTL lapses and accumulate
+        across gateway restarts because ``_load_from_disk`` only drops strictly
+        expired entries (#1884).
+
+        Every successful :meth:`validate_session` refreshes ``last_seen`` and
+        ``expires_at`` together, so a stale ``last_seen`` reliably indicates a
+        container that has stopped making requests.
+
+        Args:
+            idle_timeout_minutes: Minutes of inactivity after which a session
+                is considered abandoned.  Defaults to
+                ``DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES``.
+
+        Returns:
+            Number of sessions pruned.
+        """
+        cutoff = datetime.now(UTC) - timedelta(minutes=idle_timeout_minutes)
+        idle_sessions: list[tuple[str, Session]] = []
+
+        with self._lock:
+            idle_hashes = [
+                token_hash
+                for token_hash, session in self._sessions.items()
+                if session.last_seen < cutoff
+            ]
+
+            for token_hash in idle_hashes:
+                session = self._sessions.pop(token_hash)
+                if session.session_token:
+                    self._token_to_hash.pop(session.session_token, None)
+                idle_sessions.append((token_hash, session))
+
+            if idle_sessions:
+                self._save_to_disk()
+
+        # Capture checkpoints concurrently; each capture can wait up to 30s.
+        if idle_sessions:
+            threads = []
+            for token_hash, session in idle_sessions:
+                t = threading.Thread(
+                    target=_capture_and_cleanup_session,
+                    args=(session, "expired"),
+                    daemon=True,
+                )
+                t.start()
+                threads.append((t, token_hash, session))
+
+            for t, token_hash, session in threads:
+                t.join(timeout=35)  # 30s capture timeout + 5s buffer
+                if t.is_alive():
+                    logger.warning(
+                        "Idle session pruned, checkpoint capture still in progress",
+                        event_type="session_idle_timeout",
+                        session_token_hash=token_hash[:16],
+                        container_id=session.container_id,
+                        capture_timed_out=True,
+                    )
+                else:
+                    logger.info(
+                        "Idle session pruned",
+                        event_type="session_idle_timeout",
+                        session_token_hash=token_hash[:16],
+                        container_id=session.container_id,
+                        idle_timeout_minutes=idle_timeout_minutes,
+                    )
+
+        return len(idle_sessions)
+
+    def start_background_pruner(
+        self,
+        interval_minutes: int = DEFAULT_CLEANUP_INTERVAL_MINUTES,
+        idle_timeout_minutes: int = DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES,
+    ) -> None:
+        """Start a daemon thread that periodically prunes expired + idle sessions.
+
+        The loop sleeps ``interval_minutes`` before its first iteration so
+        freshly restored sessions have time to re-validate and refresh
+        ``last_seen`` before being evicted.  No-op if already running.
+        """
+        with self._lock:
+            if self._prune_thread is not None and self._prune_thread.is_alive():
+                return
+
+            self._prune_shutdown = threading.Event()
+            shutdown = self._prune_shutdown
+
+            def _loop() -> None:
+                logger.info(
+                    "Session background pruner started",
+                    interval_minutes=interval_minutes,
+                    idle_timeout_minutes=idle_timeout_minutes,
+                )
+                while not shutdown.is_set():
+                    if shutdown.wait(interval_minutes * 60):
+                        break
+                    try:
+                        expired = self.prune_expired_sessions()
+                        idle = self.prune_idle_sessions(idle_timeout_minutes)
+                        if expired or idle:
+                            logger.info(
+                                "Background prune cycle complete",
+                                pruned_expired=expired,
+                                pruned_idle=idle,
+                                remaining=len(self._sessions),
+                            )
+                    except Exception as e:
+                        logger.warning(
+                            "Background prune cycle failed",
+                            error=str(e),
+                            error_type=type(e).__name__,
+                        )
+
+            self._prune_thread = threading.Thread(
+                target=_loop,
+                name="session-pruner",
+                daemon=True,
+            )
+            self._prune_thread.start()
+
+    def stop_background_pruner(self, timeout: float = 5.0) -> None:
+        """Signal the background pruner to stop and wait for it to exit.
+
+        Primarily used by tests; production gateways run the pruner for the
+        process lifetime.
+        """
+        thread = self._prune_thread
+        shutdown = self._prune_shutdown
+        if shutdown is not None:
+            shutdown.set()
+        if thread is not None:
+            thread.join(timeout=timeout)
+        with self._lock:
+            self._prune_thread = None
+            self._prune_shutdown = None
 
     def list_sessions(self) -> list[dict[str, Any]]:
         """

--- a/gateway/tests/test_session_manager.py
+++ b/gateway/tests/test_session_manager.py
@@ -1904,3 +1904,127 @@ class TestResolveStableRepoPath:
         # Should not raise, returns original path
         result = _resolve_stable_repo_path(str(path))
         assert result == str(path)
+
+
+class TestPruneIdleSessions:
+    """Tests for prune_idle_sessions (last_seen-based eviction — #1884)."""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        return SessionManager(persistence_file=tmp_path / "sessions.json")
+
+    def test_prunes_sessions_with_stale_last_seen(self, manager):
+        """Sessions whose last_seen is older than the cutoff are evicted,
+        even when expires_at is still far in the future."""
+        token_idle, idle = manager.register_session(
+            container_id="idle-container",
+            container_ip="172.18.0.5",
+            mode="private",
+        )
+        # Backdate last_seen past the idle cutoff but leave expires_at fresh so
+        # we know idle-based pruning — not TTL-based pruning — is doing the work.
+        idle.last_seen = datetime.now(UTC) - timedelta(minutes=120)
+
+        token_fresh, fresh = manager.register_session(
+            container_id="fresh-container",
+            container_ip="172.18.0.6",
+            mode="private",
+        )
+
+        pruned = manager.prune_idle_sessions(idle_timeout_minutes=60)
+        assert pruned == 1
+        assert manager.validate_session(token_fresh).valid is True
+        assert manager.validate_session(token_idle).valid is False
+
+    def test_respects_idle_timeout_threshold(self, manager):
+        """A session with last_seen just inside the threshold is kept."""
+        token, session = manager.register_session(
+            container_id="borderline",
+            container_ip="172.18.0.5",
+            mode="private",
+        )
+        session.last_seen = datetime.now(UTC) - timedelta(minutes=29)
+        pruned = manager.prune_idle_sessions(idle_timeout_minutes=30)
+        assert pruned == 0
+        assert manager.validate_session(token).valid is True
+
+    def test_idle_prune_clears_token_cache(self, manager):
+        """Pruned sessions are removed from the raw-token lookup cache."""
+        token, session = manager.register_session(
+            container_id="idle-container",
+            container_ip="172.18.0.5",
+            mode="private",
+        )
+        session.last_seen = datetime.now(UTC) - timedelta(hours=2)
+        manager.prune_idle_sessions(idle_timeout_minutes=60)
+        assert token not in manager._token_to_hash
+
+    def test_idle_prune_persists_to_disk(self, tmp_path):
+        """After pruning, reload from disk does not resurrect the idle sessions."""
+        persist_path = tmp_path / "sessions.json"
+        manager = SessionManager(persistence_file=persist_path)
+
+        _token, session = manager.register_session(
+            container_id="idle-container",
+            container_ip="172.18.0.5",
+            mode="private",
+        )
+        session.last_seen = datetime.now(UTC) - timedelta(hours=2)
+        # Re-save so the disk copy also reflects the backdated last_seen;
+        # otherwise the reload would contain a fresh copy from register_session.
+        manager._save_to_disk()
+
+        manager.prune_idle_sessions(idle_timeout_minutes=60)
+
+        manager2 = SessionManager(persistence_file=persist_path)
+        assert manager2.list_sessions() == []
+
+
+class TestBackgroundPruner:
+    """Tests for the SessionManager background pruner thread."""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        m = SessionManager(persistence_file=tmp_path / "sessions.json")
+        yield m
+        m.stop_background_pruner()
+
+    def test_background_pruner_evicts_idle_sessions(self, manager):
+        """With a fast interval, the pruner eventually removes idle sessions."""
+        _token, session = manager.register_session(
+            container_id="idle-container",
+            container_ip="172.18.0.5",
+            mode="private",
+        )
+        session.last_seen = datetime.now(UTC) - timedelta(hours=2)
+
+        # Poll the internal pruner directly via a very short interval
+        # (expressed in fractional minutes — 1 / 60 min ≈ 1s).
+        manager.start_background_pruner(
+            interval_minutes=1 / 60,  # ~1 second
+            idle_timeout_minutes=60,
+        )
+
+        # Wait up to ~5s for the first prune cycle to run.
+        deadline = datetime.now(UTC) + timedelta(seconds=5)
+        while datetime.now(UTC) < deadline:
+            if not manager._sessions:
+                break
+            threading.Event().wait(0.2)
+
+        assert manager._sessions == {}, "background pruner did not evict idle session"
+
+    def test_start_is_idempotent(self, manager):
+        """Calling start twice does not spawn duplicate threads."""
+        manager.start_background_pruner(interval_minutes=1, idle_timeout_minutes=60)
+        first = manager._prune_thread
+        manager.start_background_pruner(interval_minutes=1, idle_timeout_minutes=60)
+        assert manager._prune_thread is first
+
+    def test_stop_joins_thread(self, manager):
+        """stop_background_pruner exits cleanly and clears thread state."""
+        manager.start_background_pruner(interval_minutes=1, idle_timeout_minutes=60)
+        assert manager._prune_thread is not None
+        manager.stop_background_pruner(timeout=2.0)
+        assert manager._prune_thread is None
+        assert manager._prune_shutdown is None


### PR DESCRIPTION
## Summary
- Adds `prune_idle_sessions()` to `SessionManager` — evicts sessions whose `last_seen` is older than a configurable threshold, so entries for dead/cancelled containers are cleared even when their 24h explicit TTL is still far in the future.
- Adds a daemon background pruner thread (`start_background_pruner` / `stop_background_pruner`) that periodically calls both `prune_expired_sessions()` and `prune_idle_sessions()`.
- Wires the pruner into `gateway.main()` after startup cleanup. Interval and idle threshold are configurable via `EGG_SESSION_CLEANUP_INTERVAL_MINUTES` (default 15 min) and `EGG_SESSION_IDLE_TIMEOUT_MINUTES` (default 60 min).
- First prune fires after the interval — not immediately — so sessions restored from disk have time to re-validate before eviction.

Fixes #1884.

## Why
Per the issue, `sessions.json` had no TTL-based eviction: the 24-hour `expires_at` kept entries alive long after their container was gone, and each gateway restart reloaded (and re-persisted) all of them, producing log spam like "Active session has no transcript buffer" for 17+ containers deleted hours earlier. Idle-based pruning attacks that directly because every successful `validate_session()` refreshes `last_seen`, so stale `last_seen` is a reliable "container has stopped talking" signal.

## Test plan
- [x] `pytest gateway/tests/test_session_manager.py` — 116 passed (7 new tests for `prune_idle_sessions` + background loop)
- [x] Full `gateway/tests/` suite green apart from 3 pre-existing path-traversal failures in `test_phase_api.py::TestPathTraversalProtection` (verified present on `main`, unrelated to this change)
- [x] `ruff check` clean on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)