### PR TITLE
Fix #1928: stop test_wait_capped_at_sixty blocking 60s + add pytest timeout default

### DIFF
--- a/gateway/tests/test_worktree_prune_route.py
+++ b/gateway/tests/test_worktree_prune_route.py
@@ -289,23 +289,23 @@ class TestWorktreesPruneMutex:
     """
 
     def test_concurrent_call_returns_409(self, client, launcher_auth_headers, fake_manager):
-        # Pre-acquire the module-level lock to simulate an in-progress run.
-        assert gateway._worktree_prune_lock.acquire(blocking=False)
-        try:
-            with patch.object(gateway, "get_worktree_manager", return_value=fake_manager):
-                response = client.post(
-                    "/api/v1/worktrees/prune",
-                    json={"dry_run": True},
-                    headers=launcher_auth_headers,
-                )
-        finally:
-            gateway._worktree_prune_lock.release()
-        # The route's acquire has a 60s timeout; we shortcut it by holding
-        # the lock but pytest would hang waiting without monkey-patching.
-        # To avoid a 60-second wait, force the lock acquire to fail fast.
-        # (The previous assertion may not return in time under the real
-        # timeout, so we verify behaviour via the helper below.)
-        assert response.status_code in (409, 200), response.status_code
+        # Mock the lock to return False (acquire fails) so the route
+        # returns 409 immediately instead of blocking for the real 60s
+        # timeout — which would hit the pytest-timeout default.
+        fake_lock = MagicMock()
+        fake_lock.acquire.return_value = False
+
+        with (
+            patch.object(gateway, "_worktree_prune_lock", fake_lock),
+            patch.object(gateway, "get_worktree_manager", return_value=fake_manager),
+        ):
+            response = client.post(
+                "/api/v1/worktrees/prune",
+                json={"dry_run": True},
+                headers=launcher_auth_headers,
+            )
+        assert response.status_code == 409
+        fake_lock.release.assert_not_called()
 
     def test_lock_timeout_path_returns_409(self, client, launcher_auth_headers, fake_manager):
         """Direct coverage: when lock.acquire fails, the route returns 409."""

--- a/gateway/tests/test_worktree_prune_route.py
+++ b/gateway/tests/test_worktree_prune_route.py
@@ -289,26 +289,7 @@ class TestWorktreesPruneMutex:
     """
 
     def test_concurrent_call_returns_409(self, client, launcher_auth_headers, fake_manager):
-        # Mock the lock to return False (acquire fails) so the route
-        # returns 409 immediately instead of blocking for the real 60s
-        # timeout — which would hit the pytest-timeout default.
-        fake_lock = MagicMock()
-        fake_lock.acquire.return_value = False
-
-        with (
-            patch.object(gateway, "_worktree_prune_lock", fake_lock),
-            patch.object(gateway, "get_worktree_manager", return_value=fake_manager),
-        ):
-            response = client.post(
-                "/api/v1/worktrees/prune",
-                json={"dry_run": True},
-                headers=launcher_auth_headers,
-            )
-        assert response.status_code == 409
-        fake_lock.release.assert_not_called()
-
-    def test_lock_timeout_path_returns_409(self, client, launcher_auth_headers, fake_manager):
-        """Direct coverage: when lock.acquire fails, the route returns 409."""
+        """When lock.acquire fails (concurrent caller), the route returns 409."""
         fake_lock = MagicMock()
         fake_lock.acquire.return_value = False
 

--- a/orchestrator/tests/test_messages.py
+++ b/orchestrator/tests/test_messages.py
@@ -648,7 +648,7 @@ class TestLongPolling:
                 resp = client.get("/api/v1/pipelines/test-pipeline/messages?wait=-5")
                 assert resp.status_code == 200
 
-    def test_wait_capped_at_sixty(self, client, app, monkeypatch):
+    def test_wait_clamped_to_poll_max_wait(self, client, app, monkeypatch):
         """Wait should be capped by EGG_MESSAGE_POLL_MAX_WAIT.
 
         The route clamps any client-supplied ``wait`` to the configured

--- a/orchestrator/tests/test_messages.py
+++ b/orchestrator/tests/test_messages.py
@@ -648,8 +648,19 @@ class TestLongPolling:
                 resp = client.get("/api/v1/pipelines/test-pipeline/messages?wait=-5")
                 assert resp.status_code == 200
 
-    def test_wait_capped_at_sixty(self, client, app):
-        """Wait should be capped at 60 seconds."""
+    def test_wait_capped_at_sixty(self, client, app, monkeypatch):
+        """Wait should be capped by EGG_MESSAGE_POLL_MAX_WAIT.
+
+        The route clamps any client-supplied ``wait`` to the configured
+        cap before calling ``MessageStore.get_messages``.  We verify the
+        clamp empirically by lowering the cap to 2s and sending
+        ``wait=999`` — the request must return in well under 999s.
+        Without the clamp, this test would block on ``cv.wait`` for the
+        full 999-second budget (issue #1928).
+        """
+        import time as _t
+
+        monkeypatch.setenv("EGG_MESSAGE_POLL_MAX_WAIT", "2")
         store = MessageStore()
 
         with app.test_request_context():
@@ -661,8 +672,12 @@ class TestLongPolling:
             ):
                 mock_get_store_for_pipeline.return_value = (MagicMock(), _make_pipeline_mock())
 
+                start = _t.monotonic()
                 resp = client.get("/api/v1/pipelines/test-pipeline/messages?wait=999")
+                elapsed = _t.monotonic() - start
+
                 assert resp.status_code == 200
+                assert elapsed < 5, f"wait=999 with cap=2 took {elapsed:.1f}s; clamp not applied"
 
     def test_wait_invalid_defaults_to_zero(self, client, app):
         """Invalid wait parameter should default to 0."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,13 @@ python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
 addopts = "-v --tb=short"
+# Per-test timeout cap. Any test that blocks on a condition variable,
+# event, or polling loop without a notify partner (or with a frozen
+# time mock) will be killed by pytest-timeout instead of spinning
+# until CI times out or the developer's machine seizes up.
+# Individual tests can override with @pytest.mark.timeout(N).
+# See issue #1928 for the incident that motivated this default.
+timeout = 60
 filterwarnings = ["ignore::DeprecationWarning"]
 markers = [
     "integration: marks tests as integration tests (require Docker, may be slow)",


### PR DESCRIPTION
## Summary

Closes #1928.

- Rewrite `test_wait_capped_at_sixty` so it actually verifies the wait clamp instead of passively timing out on `cv.wait`. Now monkeypatches `EGG_MESSAGE_POLL_MAX_WAIT=2` and asserts `elapsed < 5` — mirrors the existing `test_wait_timeout_clamped_to_env_cap` and `test_clamp_prevents_abusive_timeout_values` patterns already in the repo.
- Add `timeout = 60` to `[tool.pytest.ini_options]`. `pytest-timeout` has been in dev deps since forever but no default was configured. Any regression that leaves a thread on `cv.wait` / `Event.wait` / a polling loop without a notify partner (or with a frozen `time.monotonic()` mock) now gets killed fast instead of sitting on CPU. This is the same class of hang that drove the `test_consensus_polling` adapt on the #1921 branch (commit `6f60973e`), where a non-advancing `monotonic()` mock caused the new event-driven polling loop to spin until pytest-timeout.

## Before

```
$ pytest orchestrator/tests/test_messages.py --timeout=60
...
test_wait_capped_at_sixty  — blocks 60s at message_store.py:315 cv.wait
1 failed, 50 passed in 64.58s
```

The test's only assertion was `resp.status_code == 200`, which couldn't run because `pytest-timeout` killed the process first. The 60s cap behavior was never actually verified.

## After

```
$ pytest orchestrator/tests/test_messages.py::TestLongPolling -v
5 passed in 2.87s
```

## Why the pytest-timeout default matters

The incident that surfaced #1928 involved 4 machine reboots while reproducing a BRC-timeout scenario. The crash driver turned out to be two tests in `test_consensus_polling.py` spinning on a stale `time.monotonic()` mock under the new event-driven polling loop — covered on the #1921 branch — but the fact that those tests could spin at all (rather than fail fast) is because nothing bounded them. A 60s default makes that class of regression loud instead of silent. Individual tests can still override with `@pytest.mark.timeout(N)`.

## Test plan
- [x] `pytest orchestrator/tests/test_messages.py` passes (51 tests, 6.5s)
- [x] `pytest orchestrator/tests/test_consensus_polling.py test_consensus_timeout_recheck.py test_brc_nack_iteration.py test_message_store.py` passes (52 tests, 7.5s)
- [ ] CI runs full suite under the 60s per-test cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)