### PR TITLE
Fix #1942: flip EGG_MCP_TOOLS default to on

### DIFF
--- a/docs/guides/sdlc-pipeline.md
+++ b/docs/guides/sdlc-pipeline.md
@@ -1439,22 +1439,22 @@ file restrictions to minimize overlap.
 
 ## Agent MCP tools (`EGG_MCP_TOOLS` flag)
 
-**Default: off in iteration 1** — opt in per pipeline via the snippet below.
+**Default: on since [#1942](https://github.com/jwbron/egg/issues/1942)** — set `EGG_MCP_TOOLS=false` per pipeline to opt out.
 
-Sandbox agents can call pipeline lifecycle operations (BRC consensus, HITL decisions, phase context, progress signals, task completion) through first-class Claude Agent SDK MCP tools rather than shelling out to `egg-contract` / `egg-orch` via `Bash`. The tools run **in-process** via `claude_agent_sdk.create_sdk_mcp_server` — no new network service, no new auth layer, no new process. See the [Agent MCP Tools reference](../reference/agent-tools.md) for the full 15-verb inventory (`mcp__sdlc__*`, `mcp__brc__*`, `mcp__phase__*`, `mcp__progress__*`, `mcp__task__*`), schemas, and architecture.
+Sandbox agents call pipeline lifecycle operations (BRC consensus, HITL decisions, phase context, progress signals, task completion) through first-class Claude Agent SDK MCP tools rather than shelling out to `egg-contract` / `egg-orch` via `Bash`. The tools run **in-process** via `claude_agent_sdk.create_sdk_mcp_server` — no new network service, no new auth layer, no new process. See the [Agent MCP Tools reference](../reference/agent-tools.md) for the full 15-verb inventory (`mcp__sdlc__*`, `mcp__brc__*`, `mcp__phase__*`, `mcp__progress__*`, `mcp__task__*`), schemas, and architecture.
 
-**Opt in per-pipeline.** The surface is gated behind the `EGG_MCP_TOOLS` environment variable (default **off** in iteration 1 — tracked in [#1765](https://github.com/jwbron/egg/issues/1765)). Set it on your sandbox pod env to enable:
+**Opt out per-pipeline.** Iteration 1 (#1765) shipped this default-off; #1942 flipped the default after the wire-up stabilised. Set `EGG_MCP_TOOLS` to a falsy value (`false`, `0`, `no`, `off`) on your sandbox pod env to disable:
 
 ```bash
-# Per-pipeline opt-in via submit-task / pipeline-create payload
+# Per-pipeline opt-out via submit-task / pipeline-create payload
 {
   "config": {
-    "env": {"EGG_MCP_TOOLS": "true"}
+    "env": {"EGG_MCP_TOOLS": "false"}
   }
 }
 ```
 
-Or export it in a local-quickstart shell before running `egg-sdlc`. Accepted truthy values: `true`, `1`, `yes`. When the flag is unset or falsy, `shared/egg_agent/client.py::run_agent_async` runs the pre-#1765 code path verbatim — no `mcp_servers` registration, no system-prompt changes, no import cost.
+Or export it in a local-quickstart shell before running `egg-sdlc`. When the flag is opted out, `shared/egg_agent/client.py::run_agent_async` runs the pre-#1765 code path verbatim — no `mcp_servers` registration, no system-prompt changes, no import cost.
 
 The `claude_agent_sdk` harness is the only harness covered in iteration 1 (decision-3); `EGG_HARNESS=egg` does not yet register the tools. Iteration-2 verbs (peer, checkpoint, anchor, overseer, task-gap) are tracked in [#1917](https://github.com/jwbron/egg/issues/1917). The existing `sandbox/bin/egg-*` CLIs continue to work unchanged (decision-4).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,7 @@ This index helps both humans and LLMs navigate the documentation efficiently.
 | [Checkpoint Browser](reference/checkpoint-browser.md) | Full `egg-checkpoint` command reference for browsing agent session history |
 | [SDLC Contract](reference/sdlc-contract.md) | Full `egg-contract` command reference for tracking tasks, commits, decisions |
 | [MCP Deployment Tools](reference/mcp-deployment-tools.md) | Six k8s-facing MCP tools: `get_deployment_context`, `validate_deployment_manifests`, `prune_stale_worktrees`, `validate_network_isolation`, `rebuild_and_rollout`, `get_service_logs` |
-| [Agent MCP Tools](reference/agent-tools.md) | In-process SDK MCP tools sandbox agents call on the `tool_use` stream (15 iteration-1 verbs: `mcp__sdlc__*`, `mcp__brc__*`, `mcp__phase__*`, `mcp__progress__*`, `mcp__task__*`); opt-in via `EGG_MCP_TOOLS` |
+| [Agent MCP Tools](reference/agent-tools.md) | In-process SDK MCP tools sandbox agents call on the `tool_use` stream (15 iteration-1 verbs: `mcp__sdlc__*`, `mcp__brc__*`, `mcp__phase__*`, `mcp__progress__*`, `mcp__task__*`); on by default — set `EGG_MCP_TOOLS=false` to opt out |
 | [Agent Wait Patterns](reference/agent-wait-patterns.md) | Canonical `egg-orch message wait-loop` idiom for BRC STAY ALIVE, the four anti-patterns to avoid, the `egg-orch message wait` exit-code contract, the `HEARTBEAT` metadata schema, and the `EGG_MESSAGE_POLL_MAX_WAIT` / `EGG_ORCH_WAITRESS_THREADS` env-var couplings |
 
 ### SDLC Pipeline Templates

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -16,26 +16,25 @@ same handler functions the `egg-contract` / `egg-orch` CLIs call. The
 work that introduces them is tracked in
 [#1765](https://github.com/jwbron/egg/issues/1765).
 
-## Opt-in — `EGG_MCP_TOOLS`
+## Flag — `EGG_MCP_TOOLS`
 
-The MCP tool surface is gated behind an environment variable:
+The MCP tool surface is **on by default** since [#1942](https://github.com/jwbron/egg/issues/1942). The env var now acts as a kill-switch:
 
-| Flag | Current default | Effect |
-|------|------------------|--------|
-| `EGG_MCP_TOOLS=true` (or `1` / `yes`) | — | Registers the 15 iteration-1 tools on `options.mcp_servers['egg']` and appends `SYSTEM_PROMPT_NUDGE` to `options.system_prompt`. |
-| `EGG_MCP_TOOLS` unset / `false` / `0` | **Default** | Code path is byte-identical to the pre-#1765 behaviour. Non-opt-in pipelines pay no import cost and see no prompt changes. |
+| Flag | Effect |
+|------|--------|
+| `EGG_MCP_TOOLS` unset / `true` / `1` / `yes` | **Default.** Registers the 15 iteration-1 tools (one server per namespace) on `options.mcp_servers` and appends `SYSTEM_PROMPT_NUDGE` to `options.system_prompt`. |
+| `EGG_MCP_TOOLS=false` (or `0` / `no` / `off`) | Opt-out. Code path is byte-identical to the pre-#1765 behaviour — no `mcp_servers` registration, no prompt changes, no import cost. |
 
-The default is **off** for iteration 1 so opt-in pipelines can burn in
-the surface against a subset of workloads. A follow-up PR will flip
-the default to `true` once metrics show ≥15 % reduction in
-turns-per-phase for refine/plan. A later follow-up PR will remove the
-flag entirely.
+Iteration 1 (#1765) shipped the flag default-off while the wire-up burned in.
+#1942 flipped the default to on and kept the env var as a rollback
+switch; a later follow-up will remove the flag entirely once the
+tools are considered stable.
 
-Set the flag on a pipeline via pod env, Docker Compose, or the
-`env` stanza on any submit-task payload. See
+To opt a pipeline out, set `EGG_MCP_TOOLS=false` via pod env, Docker
+Compose, or the `env` stanza on any submit-task payload. See
 [docs/guides/sdlc-pipeline.md — Agent MCP tools
 (EGG_MCP_TOOLS flag)](../guides/sdlc-pipeline.md#agent-mcp-tools-egg_mcp_tools-flag)
-for the per-pipeline opt-in recipe.
+for the per-pipeline recipe.
 
 ## Tool inventory (15 verbs)
 
@@ -50,7 +49,7 @@ The SDK renders an MCP tool in `tool_use` blocks as
 returns a `{namespace: server}` dict — one SDK MCP server per
 namespace, keyed by `sdlc`, `brc`, `phase`, `progress`, or `task` —
 and `shared/egg_agent/client.py::run_agent_async` merges that dict
-into `options.mcp_servers` when `EGG_MCP_TOOLS=true`. With raw
+into `options.mcp_servers` unless `EGG_MCP_TOOLS` is explicitly falsy. With raw
 `@tool` names declared as plain verbs, Claude's composition
 naturally produces the semantic names in the tables below:
 
@@ -153,7 +152,7 @@ never as an agent crash.
 
 ## System-prompt nudge (`SYSTEM_PROMPT_NUDGE`)
 
-When `EGG_MCP_TOOLS=true`, `run_agent_async` appends a short bootstrap
+When the flag is on (the default), `run_agent_async` appends a short bootstrap
 paragraph (`≤200` words) to `options.system_prompt`. The paragraph is
 **generated programmatically** at module import from `TOOL_NAMESPACES`
 — it is not a hand-authored string literal — so adding or renaming a
@@ -190,7 +189,7 @@ name the nudge advertises. No mental prefix-prepending required.
 │ Agent container (Python, claude_agent_sdk)                      │
 │                                                                 │
 │  shared/egg_agent/client.py::run_agent_async                    │
-│      └── EGG_MCP_TOOLS=true ──▶ build_sandbox_mcp_server()      │
+│      └── EGG_MCP_TOOLS ≠ falsy ▶ build_sandbox_mcp_server()     │
 │                                                                 │
 │                ┌─── sandbox/egg_agent_tools/ ───┐               │
 │                │  server.py    (SDK factory)    │               │
@@ -336,7 +335,7 @@ SDK release notes rather than silently breaking every sandbox.
 - [SDLC Contract](sdlc-contract.md) — full `egg-contract` shell
   surface.
 - [SDLC Pipeline Guide](../guides/sdlc-pipeline.md) — per-pipeline
-  opt-in recipe for `EGG_MCP_TOOLS`.
+  opt-out recipe for `EGG_MCP_TOOLS`.
 - [Concurrent Execution Guide](../guides/concurrent-execution.md) —
   where BRC + consensus + message-bus live, which the `mcp__brc__*`
   namespace exposes.

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -22,7 +22,7 @@ The MCP tool surface is **on by default** since [#1942](https://github.com/jwbro
 
 | Flag | Effect |
 |------|--------|
-| `EGG_MCP_TOOLS` unset / `true` / `1` / `yes` | **Default.** Registers the 15 iteration-1 tools (one server per namespace) on `options.mcp_servers` and appends `SYSTEM_PROMPT_NUDGE` to `options.system_prompt`. |
+| `EGG_MCP_TOOLS` unset or any value not listed below | **Default.** Registers the 15 iteration-1 tools (one server per namespace) on `options.mcp_servers` and appends `SYSTEM_PROMPT_NUDGE` to `options.system_prompt`. |
 | `EGG_MCP_TOOLS=false` (or `0` / `no` / `off`) | Opt-out. Code path is byte-identical to the pre-#1765 behaviour — no `mcp_servers` registration, no prompt changes, no import cost. |
 
 Iteration 1 (#1765) shipped the flag default-off while the wire-up burned in.

--- a/docs/releases/agent-mcp-tools.md
+++ b/docs/releases/agent-mcp-tools.md
@@ -24,7 +24,7 @@ The surface is **on by default** since [#1942](https://github.com/jwbron/egg/iss
 
 | Flag | Effect |
 |------|--------|
-| `EGG_MCP_TOOLS` unset / `true` / `1` / `yes` | **Default.** Register the 15 tools and append `SYSTEM_PROMPT_NUDGE` to `options.system_prompt`. |
+| `EGG_MCP_TOOLS` unset or any value not listed below | **Default.** Register the 15 tools and append `SYSTEM_PROMPT_NUDGE` to `options.system_prompt`. |
 | `EGG_MCP_TOOLS=false` / `0` / `no` / `off` | Opt-out. Code path is byte-identical to the pre-#1765 behaviour — no import cost, no prompt changes. |
 
 **Currently `claude_agent_sdk` harness only.** `EGG_HARNESS=egg` is

--- a/docs/releases/agent-mcp-tools.md
+++ b/docs/releases/agent-mcp-tools.md
@@ -18,14 +18,14 @@ pure handler functions (`sandbox/egg_agent_tools/handlers/*.py`), and a
 CI drift test (`tests/tools/test_mcp_cli_drift.py`) enforces the
 one-to-one mapping.
 
-## Opt-in — `EGG_MCP_TOOLS`
+## Flag — `EGG_MCP_TOOLS`
 
-The surface is gated behind a new environment variable:
+The surface is **on by default** since [#1942](https://github.com/jwbron/egg/issues/1942). Iteration 1 shipped it default-off; the flag was flipped once the wire-up was stable. The env var is retained as a rollback switch:
 
-| Flag | Default | Effect |
-|------|---------|--------|
-| `EGG_MCP_TOOLS=true` / `1` / `yes` | off | Register the 15 tools and append `SYSTEM_PROMPT_NUDGE` to `options.system_prompt`. |
-| `EGG_MCP_TOOLS` unset / falsy | default | Code path is byte-identical to the pre-#1765 behaviour. Non-opt-in pipelines pay no import cost and see no prompt changes. |
+| Flag | Effect |
+|------|--------|
+| `EGG_MCP_TOOLS` unset / `true` / `1` / `yes` | **Default.** Register the 15 tools and append `SYSTEM_PROMPT_NUDGE` to `options.system_prompt`. |
+| `EGG_MCP_TOOLS=false` / `0` / `no` / `off` | Opt-out. Code path is byte-identical to the pre-#1765 behaviour — no import cost, no prompt changes. |
 
 **Currently `claude_agent_sdk` harness only.** `EGG_HARNESS=egg` is
 not yet covered (decision-3) and will register the tools in parallel
@@ -99,11 +99,9 @@ test-collection time rather than silently breaking every sandbox.
 
 ## Follow-ups
 
-- **Burn-in window (TBD follow-up issue):** 5–10 opt-in pipelines,
-  compare turns-per-phase and cost-per-phase with/without the flag.
-  Once ≥15 % reduction is confirmed in refine/plan, a follow-up PR
-  flips the default to `true`. A later follow-up PR removes the flag
-  entirely.
+- **Default flipped — [#1942](https://github.com/jwbron/egg/issues/1942):**
+  The tool surface is now on by default; `EGG_MCP_TOOLS=false` is the
+  rollback switch. A later follow-up will remove the flag entirely.
 - **Iteration 2 verbs — [#1917](https://github.com/jwbron/egg/issues/1917):**
   Roughly 15 additional verbs surfaced in the capability audit (peer,
   checkpoint, anchor, overseer, task-gap) are tracked there.

--- a/integration_tests/test_sandbox_mcp_tools_e2e.py
+++ b/integration_tests/test_sandbox_mcp_tools_e2e.py
@@ -1,10 +1,10 @@
 """End-to-end integration test for sandbox MCP tool discovery.
 
-With ``EGG_MCP_TOOLS=true`` and a trivial prompt asking the agent to
-"call mcp__phase__get_context and report back", the agent's first
-``tool_use`` block must name an ``mcp__*`` tool rather than ``Bash``.
-This catches SDK API drift between releases — the offline mocks in the
-unit tests cannot.
+Verifies that the agent's MCP tool surface is registered correctly —
+both with the default (flag unset, tools on) and with an explicit
+``EGG_MCP_TOOLS=true``.  The agent's first ``tool_use`` block must name
+an ``mcp__*`` tool rather than ``Bash``.  This catches SDK API drift
+between releases — the offline mocks in the unit tests cannot.
 
 Gated behind the ``@pytest.mark.integration`` marker so it does not run
 on every PR.  Further gated behind ``EGG_LIVE_SDK=1`` so the live SDK
@@ -37,38 +37,11 @@ def _skip_if_no_sdk() -> None:
         pytest.skip("claude_agent_sdk not installed in this environment")
 
 
-def test_agent_calls_mcp_tool_when_flag_enabled() -> None:
-    """End-to-end: the agent must use the mcp__* tool surface, not Bash.
+def _assert_mcp_servers_registered() -> None:
+    """Run ``run_agent_async`` and assert all namespace servers are wired up.
 
-    Live path (EGG_LIVE_SDK=1): spawn the Claude Agent SDK in-process
-    with a trivial prompt and assert the first tool_use names an mcp__*
-    tool.
-
-    Offline path (default): structurally verify the wire-up so the
-    marker-gated test still produces a signal without spending API
-    tokens.  This asserts that with EGG_MCP_TOOLS=true,
-    ``run_agent_async`` populates ``options.mcp_servers['egg']`` (the
-    necessary precondition for the agent to see the mcp__* tools)."""
-
-    _skip_if_no_sdk()
-
-    os.environ["EGG_MCP_TOOLS"] = "true"
-    live = os.environ.get("EGG_LIVE_SDK", "") in ("1", "true", "yes")
-
-    if live:  # pragma: no cover - only in nightly job
-        # A full live round-trip would go here.  We stop before spending
-        # API credits in the non-live path so this file is safe to
-        # collect in CI.  The real implementation would:
-        #   result = run_agent("Call mcp__phase__get_context and report back.")
-        #   parse result.events for ToolUseBlock
-        #   assert events[0].name.startswith("mcp__")
-        pytest.skip("Live SDK path not implemented here — covered by nightly-only job")
-
-    # Offline structural check: MCP servers are registered on the
-    # options object when the flag is on.  Per decision-7 the sandbox
-    # wire-up uses one server per namespace so the Claude-visible tool
-    # names read ``mcp__<namespace>__<verb>`` rather than being
-    # double-prefixed.
+    Shared helper for both the default-on and explicit-flag tests.
+    """
     from claude_agent_sdk import ClaudeAgentOptions
     from egg_agent_tools import build_sandbox_mcp_server
     from egg_agent_tools.tools import TOOL_NAMESPACES
@@ -127,3 +100,40 @@ def test_agent_calls_mcp_tool_when_flag_enabled() -> None:
     real_servers = build_sandbox_mcp_server()
     assert real_servers
     assert set(real_servers.keys()) == set(TOOL_NAMESPACES)
+
+
+def test_mcp_tools_default_on_when_flag_unset() -> None:
+    """MCP tools must register when EGG_MCP_TOOLS is not set (default-on)."""
+    _skip_if_no_sdk()
+    os.environ.pop("EGG_MCP_TOOLS", None)
+    _assert_mcp_servers_registered()
+
+
+def test_agent_calls_mcp_tool_when_flag_enabled() -> None:
+    """End-to-end: the agent must use the mcp__* tool surface, not Bash.
+
+    Live path (EGG_LIVE_SDK=1): spawn the Claude Agent SDK in-process
+    with a trivial prompt and assert the first tool_use names an mcp__*
+    tool.
+
+    Offline path (default): structurally verify the wire-up so the
+    marker-gated test still produces a signal without spending API
+    tokens.  This asserts that with EGG_MCP_TOOLS=true,
+    ``run_agent_async`` populates ``options.mcp_servers`` (the
+    necessary precondition for the agent to see the mcp__* tools)."""
+
+    _skip_if_no_sdk()
+
+    os.environ["EGG_MCP_TOOLS"] = "true"
+    live = os.environ.get("EGG_LIVE_SDK", "") in ("1", "true", "yes")
+
+    if live:  # pragma: no cover - only in nightly job
+        # A full live round-trip would go here.  We stop before spending
+        # API credits in the non-live path so this file is safe to
+        # collect in CI.  The real implementation would:
+        #   result = run_agent("Call mcp__phase__get_context and report back.")
+        #   parse result.events for ToolUseBlock
+        #   assert events[0].name.startswith("mcp__")
+        pytest.skip("Live SDK path not implemented here — covered by nightly-only job")
+
+    _assert_mcp_servers_registered()

--- a/integration_tests/test_sandbox_mcp_tools_e2e.py
+++ b/integration_tests/test_sandbox_mcp_tools_e2e.py
@@ -102,14 +102,14 @@ def _assert_mcp_servers_registered() -> None:
     assert set(real_servers.keys()) == set(TOOL_NAMESPACES)
 
 
-def test_mcp_tools_default_on_when_flag_unset() -> None:
+def test_mcp_tools_default_on_when_flag_unset(monkeypatch) -> None:
     """MCP tools must register when EGG_MCP_TOOLS is not set (default-on)."""
     _skip_if_no_sdk()
-    os.environ.pop("EGG_MCP_TOOLS", None)
+    monkeypatch.delenv("EGG_MCP_TOOLS", raising=False)
     _assert_mcp_servers_registered()
 
 
-def test_agent_calls_mcp_tool_when_flag_enabled() -> None:
+def test_agent_calls_mcp_tool_when_flag_enabled(monkeypatch) -> None:
     """End-to-end: the agent must use the mcp__* tool surface, not Bash.
 
     Live path (EGG_LIVE_SDK=1): spawn the Claude Agent SDK in-process
@@ -124,7 +124,7 @@ def test_agent_calls_mcp_tool_when_flag_enabled() -> None:
 
     _skip_if_no_sdk()
 
-    os.environ["EGG_MCP_TOOLS"] = "true"
+    monkeypatch.setenv("EGG_MCP_TOOLS", "true")
     live = os.environ.get("EGG_LIVE_SDK", "") in ("1", "true", "yes")
 
     if live:  # pragma: no cover - only in nightly job

--- a/sandbox/agent-config/rules/README.md
+++ b/sandbox/agent-config/rules/README.md
@@ -59,7 +59,7 @@ Claude Code reads `CLAUDE.md` files automatically when starting. During containe
 
 ### Agent MCP tools (opt-in)
 
-When the pipeline sets `EGG_MCP_TOOLS=true`, sandbox agents additionally see in-process Claude Agent SDK MCP tools for HITL / BRC / phase / progress / task operations on the same `tool_use` stream they already handle — prefer these (`mcp__sdlc__*`, `mcp__brc__*`, `mcp__phase__*`, `mcp__progress__*`, `mcp__task__*`) over shelling out to `egg-contract` / `egg-orch` via Bash. The shell CLIs remain available for human operators, tests, and recovery scripts. Full reference: `$EGG_REPO_PATH/docs/reference/agent-tools.md`.
+Sandbox agents see in-process Claude Agent SDK MCP tools for HITL / BRC / phase / progress / task operations on the same `tool_use` stream they already handle (on by default since #1942; set `EGG_MCP_TOOLS=false` on the pod env to opt out). Prefer these (`mcp__sdlc__*`, `mcp__brc__*`, `mcp__phase__*`, `mcp__progress__*`, `mcp__task__*`) over shelling out to `egg-contract` / `egg-orch` via Bash. The shell CLIs remain available for human operators, tests, and recovery scripts. Full reference: `$EGG_REPO_PATH/docs/reference/agent-tools.md`.
 
 ### Recovery
 

--- a/sandbox/agent-config/rules/environment.md
+++ b/sandbox/agent-config/rules/environment.md
@@ -13,7 +13,7 @@ GitHub access MUST go through the gateway sidecar (not the proxy) for policy enf
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `EGG_MCP_TOOLS` | unset (off) | When truthy (`true`, `1`, `yes`), registers the in-process SDK MCP tool surface (15 iteration-1 verbs: `mcp__sdlc__*`, `mcp__brc__*`, `mcp__phase__*`, `mcp__progress__*`, `mcp__task__*`) on `ClaudeAgentOptions.mcp_servers` and appends a bootstrap paragraph to the system prompt. Prefer these tools over Bash-ing `egg-contract` / `egg-orch` when the flag is on. When unset or falsy, the code path is byte-identical to pre-#1765 behaviour. See `../../../docs/reference/agent-tools.md`. Currently `claude_agent_sdk`-only; `EGG_HARNESS=egg` is not yet covered. |
+| `EGG_MCP_TOOLS` | unset (on) | **On by default since #1942.** Registers the in-process SDK MCP tool surface (15 iteration-1 verbs: `mcp__sdlc__*`, `mcp__brc__*`, `mcp__phase__*`, `mcp__progress__*`, `mcp__task__*`) on `ClaudeAgentOptions.mcp_servers` and appends a bootstrap paragraph to the system prompt. Prefer these tools over Bash-ing `egg-contract` / `egg-orch`. Set to `false` / `0` / `no` / `off` to opt out; the code path is then byte-identical to pre-#1765 behaviour. See `../../../docs/reference/agent-tools.md`. Currently `claude_agent_sdk`-only; `EGG_HARNESS=egg` is not yet covered. |
 
 ## Capabilities
 

--- a/sandbox/egg_agent_tools/__init__.py
+++ b/sandbox/egg_agent_tools/__init__.py
@@ -23,9 +23,10 @@ Gating
 ------
 
 ``shared/egg_agent/client.py::run_agent_async`` imports this package
-lazily and only when the ``EGG_MCP_TOOLS`` environment variable is
-truthy.  When the flag is unset the SDK wire-up is byte-identical to
-today, so non-opt-in pipelines pay no cost.
+lazily.  The MCP surface is on by default (since #1942); set
+``EGG_MCP_TOOLS`` to ``false`` / ``0`` / ``no`` / ``off`` to opt out,
+in which case the SDK wire-up is byte-identical to the pre-#1765
+path and the package is not imported.
 """
 
 from __future__ import annotations

--- a/shared/egg_agent/client.py
+++ b/shared/egg_agent/client.py
@@ -208,9 +208,11 @@ async def run_agent_async(
     if system_prompt is not None:
         options.system_prompt = system_prompt
 
-    # --- Opt-in: register in-process SDK MCP servers with egg's agent tools ---
-    # Gated on EGG_MCP_TOOLS so non-opt-in pipelines pay zero cost (no
-    # extra import, no prompt-weight change).  See issue #1765.
+    # --- Register in-process SDK MCP servers with egg's agent tools ---
+    # Default-on since issue #1942.  Set ``EGG_MCP_TOOLS=false`` (or
+    # ``0`` / ``no`` / ``off``) on the pod env to opt out — the kill
+    # switch preserved from #1765's opt-in rollout.  See issue #1765
+    # for the original design and #1942 for the default flip.
     #
     # The factory returns one SDK MCP server per namespace (keys: sdlc,
     # brc, phase, progress, task).  The Claude-visible tool name is
@@ -218,11 +220,8 @@ async def run_agent_async(
     # its namespace is what produces the decision-7 visible names
     # ``mcp__sdlc__register_open_question`` etc.  A single aggregate
     # server would double-prefix (``mcp__egg__mcp__sdlc__...``).
-    # Accept the documented truthy values only — "true"/"1"/"yes".
-    # A narrower set keeps the docs/config surface aligned across
-    # operators and avoids surprises for future maintainers.
-    _mcp_flag_raw = os.environ.get("EGG_MCP_TOOLS", "")
-    if _mcp_flag_raw.strip().lower() in ("true", "1", "yes"):
+    _mcp_flag_raw = os.environ.get("EGG_MCP_TOOLS", "").strip().lower()
+    if _mcp_flag_raw not in ("false", "0", "no", "off"):
         try:
             from egg_agent_tools import (  # noqa: PLC0415
                 SYSTEM_PROMPT_NUDGE,

--- a/tests/shared/egg_agent/test_client.py
+++ b/tests/shared/egg_agent/test_client.py
@@ -864,8 +864,6 @@ class TestMcpToolsFlag:
 
             return SYSTEM_PROMPT_NUDGE
         except ImportError:
-            import pytest
-
             pytest.skip("egg_agent_tools not importable")
 
     @patch("claude_agent_sdk.query", side_effect=_mock_query_success)

--- a/tests/shared/egg_agent/test_client.py
+++ b/tests/shared/egg_agent/test_client.py
@@ -8,6 +8,7 @@ from types import ModuleType
 from typing import Any
 from unittest.mock import patch
 
+import pytest
 from egg_agent.client import _MAX_TOOL_CONTENT_LOG_LEN, _truncate, run_agent, run_agent_async
 
 # ── Mock SDK types ──────────────────────────────────────────────────────────
@@ -841,10 +842,11 @@ class TestRunAgentSync:
         assert "Hello from Claude" in result.stdout
 
 
-# ── EGG_MCP_TOOLS wire-up tests (issue #1765) ──────────────────────────────
+# ── EGG_MCP_TOOLS wire-up tests (issues #1765, #1942) ──────────────────────
 class TestMcpToolsFlag:
     """Capture ClaudeAgentOptions kwargs via a patched constructor and
-    verify the gating behaviour of EGG_MCP_TOOLS."""
+    verify the gating behaviour of EGG_MCP_TOOLS.  Default is on since
+    issue #1942 — set the env to a falsy value to opt out."""
 
     def _patch_options(self, captured: list):
         from claude_agent_sdk import ClaudeAgentOptions as _Real
@@ -856,9 +858,33 @@ class TestMcpToolsFlag:
 
         return _Capturing
 
+    def _require_tools(self):
+        try:
+            from egg_agent_tools import SYSTEM_PROMPT_NUDGE
+
+            return SYSTEM_PROMPT_NUDGE
+        except ImportError:
+            import pytest
+
+            pytest.skip("egg_agent_tools not importable")
+
     @patch("claude_agent_sdk.query", side_effect=_mock_query_success)
-    def test_mcp_tools_flag_off(self, mock_query, monkeypatch):
+    def test_mcp_tools_default_on_when_env_unset(self, mock_query, monkeypatch):
         monkeypatch.delenv("EGG_MCP_TOOLS", raising=False)
+        nudge = self._require_tools()
+        captured: list = []
+        capturing_cls = self._patch_options(captured)
+        with patch("claude_agent_sdk.ClaudeAgentOptions", capturing_cls):
+            _run_async(run_agent_async("hi"))
+        assert len(captured) == 1
+        opts = captured[0]
+        assert getattr(opts, "mcp_servers", None)
+        assert opts.system_prompt == nudge
+
+    @patch("claude_agent_sdk.query", side_effect=_mock_query_success)
+    @pytest.mark.parametrize("value", ["false", "0", "no", "off", "FALSE", "No"])
+    def test_mcp_tools_opt_out_explicit_falsy(self, mock_query, monkeypatch, value):
+        monkeypatch.setenv("EGG_MCP_TOOLS", value)
         captured: list = []
         capturing_cls = self._patch_options(captured)
         with patch("claude_agent_sdk.ClaudeAgentOptions", capturing_cls):
@@ -869,37 +895,27 @@ class TestMcpToolsFlag:
         assert not mcp
 
     @patch("claude_agent_sdk.query", side_effect=_mock_query_success)
-    def test_mcp_tools_flag_on(self, mock_query, monkeypatch):
+    def test_mcp_tools_flag_on_preserves_caller_prompt(self, mock_query, monkeypatch):
         monkeypatch.setenv("EGG_MCP_TOOLS", "true")
+        nudge = self._require_tools()
         captured: list = []
         capturing_cls = self._patch_options(captured)
-        try:
-            from egg_agent_tools import SYSTEM_PROMPT_NUDGE
-        except ImportError:
-            import pytest
-
-            pytest.skip("egg_agent_tools not importable")
         with patch("claude_agent_sdk.ClaudeAgentOptions", capturing_cls):
             _run_async(run_agent_async("hi", system_prompt="existing-prompt"))
         opts = captured[0]
         assert getattr(opts, "mcp_servers", None)
-        assert opts.system_prompt.endswith(SYSTEM_PROMPT_NUDGE)
+        assert opts.system_prompt.endswith(nudge)
         assert opts.system_prompt.startswith("existing-prompt")
 
     @patch("claude_agent_sdk.query", side_effect=_mock_query_success)
     def test_mcp_tools_flag_on_no_caller_prompt(self, mock_query, monkeypatch):
         monkeypatch.setenv("EGG_MCP_TOOLS", "yes")
+        nudge = self._require_tools()
         captured: list = []
         capturing_cls = self._patch_options(captured)
-        try:
-            from egg_agent_tools import SYSTEM_PROMPT_NUDGE
-        except ImportError:
-            import pytest
-
-            pytest.skip("egg_agent_tools not importable")
         with patch("claude_agent_sdk.ClaudeAgentOptions", capturing_cls):
             _run_async(run_agent_async("hi"))
-        assert captured[0].system_prompt == SYSTEM_PROMPT_NUDGE
+        assert captured[0].system_prompt == nudge
 
 
 class TestCanUseToolPassesMcpNames:


### PR DESCRIPTION
## Summary

- Flip `EGG_MCP_TOOLS` default from off (opt-in) to on (opt-out). Registration is now unconditional unless the env is explicitly set to `false` / `0` / `no` / `off`.
- Keep the env var as a rollback switch. Off-path behaviour is byte-identical to pre-#1765.
- Update tests + all docs (reference, release note, sdlc-pipeline guide, docs index, sandbox rules, package docstring) to reflect the new default.

## Why

#1920 landed the in-process SDK MCP tool surface behind a default-off flag. Observation on #1942: in practice no pipelines had opted in, so no burn-in signal was accumulating and every normal pipeline was still watching refiner / reviewer agents re-discover `egg-orch` / `egg-contract` / `.egg-state` layout via `Bash`. We opted to flip now rather than run an explicit burn-in cohort — rollback is `EGG_MCP_TOOLS=false`.

## Test plan

- [x] `pytest tests/shared/egg_agent/test_client.py` — 44 passed (includes new default-on test + 6-value parametrized opt-out test).
- [x] `pytest tests/sandbox/egg_agent_tools` — 154 passed, 3 skipped (skips are pre-existing SDK-absent skips).
- [x] `pytest tests/tools/test_mcp_cli_drift.py` — 27 passed.
- [x] `ruff check` + `ruff format --check` clean on all modified files.
- [ ] First live pipeline after merge: confirm refiner's first tool_use is an `mcp__*` call, not `Bash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)