### PR TITLE
Fix #1939: stable reason codes on phase lifecycle error responses

### DIFF
--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -709,7 +709,19 @@ PIPELINE_TOOLS = [
         "description": (
             "Advance a pipeline to a target phase. When force=true, stops all "
             "running containers before advancing to prevent SIGTERM cascading "
-            "into the new phase."
+            "into the new phase.\n\n"
+            "Error responses include a machine-readable `reason` code (#1939):\n"
+            "- `missing_target_phase` (400) — request body omitted target_phase\n"
+            "- `invalid_phase` (400) — target_phase is not a known phase value\n"
+            "- `invalid_phase_transition` (400) — target is not a valid next "
+            "phase for the current phase (fix: change target or pass force=true)\n"
+            "- `previous_phase_not_complete` (400) — current phase is still "
+            "running or failed (fix: complete_phase first, or pass force=true)\n"
+            "- `health_checks_failed` (409) — Tier 1/2 health checks returned "
+            "FAIL_PIPELINE (fix: resolve underlying health issue, or pass "
+            "force=true; `details.health_results` lists the failed checks)\n"
+            "- `version_conflict` (409) — concurrent modification; retry\n"
+            "- `invalid_pipeline_id` (400), `pipeline_not_found` (404)"
         ),
         "inputSchema": {
             "type": "object",
@@ -733,7 +745,14 @@ PIPELINE_TOOLS = [
     },
     {
         "name": "start_phase",
-        "description": "Start execution of the current phase for a pipeline.",
+        "description": (
+            "Start execution of the current phase for a pipeline.\n\n"
+            "Error responses include a machine-readable `reason` code (#1939):\n"
+            "- `phase_already_running` (400) — phase is already in RUNNING "
+            "status (no action needed)\n"
+            "- `version_conflict` (409) — concurrent modification; retry\n"
+            "- `invalid_pipeline_id` (400), `pipeline_not_found` (404)"
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -751,7 +770,16 @@ PIPELINE_TOOLS = [
             "Mark the current phase as complete for a pipeline, with optional "
             "artifacts. Returns 409 when the phase still has unresolved HITL "
             "decisions; pass force=true to abandon them (the abandoned ids are "
-            "recorded in the phase's artifacts for audit)."
+            "recorded in the phase's artifacts for audit).\n\n"
+            "Error responses include a machine-readable `reason` code (#1939):\n"
+            "- `unresolved_hitl_decisions` (409) — current phase has pending "
+            "HITL decisions (fix: resolve them, or pass force=true; "
+            "`details.unresolved_decision_ids` lists the blocking ids)\n"
+            "- `invalid_artifacts` (400) — artifacts must be a JSON object "
+            "with string values\n"
+            "- `invalid_force_reason` (400) — force_reason must be a string\n"
+            "- `version_conflict` (409) — concurrent modification; retry\n"
+            "- `invalid_pipeline_id` (400), `pipeline_not_found` (404)"
         ),
         "inputSchema": {
             "type": "object",

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -710,7 +710,9 @@ PIPELINE_TOOLS = [
             "Advance a pipeline to a target phase. When force=true, stops all "
             "running containers before advancing to prevent SIGTERM cascading "
             "into the new phase.\n\n"
-            "Error responses include a machine-readable `reason` code (#1939):\n"
+            "Error responses include a machine-readable `reason` code (#1939). "
+            "Note: reason codes are only visible to direct HTTP callers; the "
+            "MCP handler layer does not yet surface them.\n"
             "- `missing_target_phase` (400) — request body omitted target_phase\n"
             "- `invalid_phase` (400) — target_phase is not a known phase value\n"
             "- `invalid_phase_transition` (400) — target is not a valid next "
@@ -747,7 +749,9 @@ PIPELINE_TOOLS = [
         "name": "start_phase",
         "description": (
             "Start execution of the current phase for a pipeline.\n\n"
-            "Error responses include a machine-readable `reason` code (#1939):\n"
+            "Error responses include a machine-readable `reason` code (#1939). "
+            "Note: reason codes are only visible to direct HTTP callers; the "
+            "MCP handler layer does not yet surface them.\n"
             "- `phase_already_running` (400) — phase is already in RUNNING "
             "status (no action needed)\n"
             "- `version_conflict` (409) — concurrent modification; retry\n"
@@ -771,7 +775,9 @@ PIPELINE_TOOLS = [
             "artifacts. Returns 409 when the phase still has unresolved HITL "
             "decisions; pass force=true to abandon them (the abandoned ids are "
             "recorded in the phase's artifacts for audit).\n\n"
-            "Error responses include a machine-readable `reason` code (#1939):\n"
+            "Error responses include a machine-readable `reason` code (#1939). "
+            "Note: reason codes are only visible to direct HTTP callers; the "
+            "MCP handler layer does not yet surface them.\n"
             "- `unresolved_hitl_decisions` (409) — current phase has pending "
             "HITL decisions (fix: resolve them, or pass force=true; "
             "`details.unresolved_decision_ids` lists the blocking ids)\n"
@@ -814,7 +820,13 @@ PIPELINE_TOOLS = [
         "description": (
             "Populate a pipeline's SDLC contract from its plan draft. Reads the "
             "plan document, extracts task structure, and writes tasks and acceptance "
-            "criteria to the contract."
+            "criteria to the contract.\n\n"
+            "Error responses include a machine-readable `reason` code (#1939). "
+            "Note: reason codes are only visible to direct HTTP callers; the "
+            "MCP handler layer does not yet surface them.\n"
+            "- `invalid_pipeline_id` (400), `pipeline_not_found` (404)\n"
+            "- `populate_contract_failed` (500) — internal error during "
+            "contract population"
         ),
         "inputSchema": {
             "type": "object",

--- a/orchestrator/routes/phases.py
+++ b/orchestrator/routes/phases.py
@@ -64,9 +64,19 @@ def make_error_response(
     message: str,
     status_code: int = 400,
     details: dict[str, Any] | None = None,
+    reason: str | None = None,
 ) -> tuple[Response, int]:
-    """Create an error response."""
+    """Create an error response.
+
+    ``reason`` is a stable, machine-readable enum-like code that disambiguates
+    responses sharing the same HTTP status (especially 409, where distinct
+    gates — health checks vs. unresolved HITL — would otherwise collapse into
+    one signal). Callers should switch on ``reason`` rather than parsing
+    ``message``. See #1939.
+    """
     response: dict[str, Any] = {"success": False, "message": message}
+    if reason:
+        response["reason"] = reason
     if details:
         response["details"] = details
     return jsonify(response), status_code
@@ -203,11 +213,13 @@ def get_current_phase(pipeline_id: str) -> tuple[Response, int]:
         return make_error_response(
             f"Invalid pipeline ID format: {pipeline_id}",
             status_code=400,
+            reason="invalid_pipeline_id",
         )
     except PipelineNotFoundError:
         return make_error_response(
             f"Pipeline {pipeline_id} not found",
             status_code=404,
+            reason="pipeline_not_found",
         )
 
 
@@ -243,13 +255,14 @@ def advance_phase(pipeline_id: str) -> tuple[Response, int]:
 
     target_phase_str = data.get("target_phase")
     if not target_phase_str:
-        return make_error_response("Missing target_phase")
+        return make_error_response("Missing target_phase", reason="missing_target_phase")
 
     try:
         target_phase = PipelinePhase(target_phase_str)
     except ValueError:
         return make_error_response(
-            f"Invalid phase: {target_phase_str}. Valid phases: {[p.value for p in PipelinePhase]}"
+            f"Invalid phase: {target_phase_str}. Valid phases: {[p.value for p in PipelinePhase]}",
+            reason="invalid_phase",
         )
 
     force = data.get("force", False)
@@ -264,14 +277,17 @@ def advance_phase(pipeline_id: str) -> tuple[Response, int]:
         if not force:
             is_valid, error = validate_phase_transition(previous_phase, target_phase)
             if not is_valid:
-                return make_error_response(error, status_code=400)
+                return make_error_response(
+                    error, status_code=400, reason="invalid_phase_transition"
+                )
 
             # Check if current phase is complete
             current_execution = pipeline.get_phase_execution(previous_phase)
             if current_execution.status not in (PipelineStatus.COMPLETE, PipelineStatus.PENDING):
                 return make_error_response(
                     f"Current phase {previous_phase.value} is not complete "
-                    f"(status: {current_execution.status.value})"
+                    f"(status: {current_execution.status.value})",
+                    reason="previous_phase_not_complete",
                 )
 
         # Gate phase advance on health checks.  Runs all Tier 1 and Tier 2
@@ -311,6 +327,7 @@ def advance_phase(pipeline_id: str) -> tuple[Response, int]:
                             details={
                                 "health_results": [r.to_dict() for r in hc_results],
                             },
+                            reason="health_checks_failed",
                         )
             except ImportError:
                 pass  # Health check module not available — proceed without gating
@@ -338,7 +355,9 @@ def advance_phase(pipeline_id: str) -> tuple[Response, int]:
             if not force:
                 is_valid, error = validate_phase_transition(previous_phase, target_phase)
                 if not is_valid:
-                    return make_error_response(error, status_code=400)
+                    return make_error_response(
+                        error, status_code=400, reason="invalid_phase_transition"
+                    )
                 current_execution = pipeline.get_phase_execution(previous_phase)
                 if current_execution.status not in (
                     PipelineStatus.COMPLETE,
@@ -346,7 +365,8 @@ def advance_phase(pipeline_id: str) -> tuple[Response, int]:
                 ):
                     return make_error_response(
                         f"Current phase {previous_phase.value} is not complete "
-                        f"(status: {current_execution.status.value})"
+                        f"(status: {current_execution.status.value})",
+                        reason="previous_phase_not_complete",
                     )
 
             # Mark previous phase as complete
@@ -420,16 +440,19 @@ def advance_phase(pipeline_id: str) -> tuple[Response, int]:
         return make_error_response(
             f"Concurrent modification detected for pipeline {pipeline_id}. Please retry.",
             status_code=409,
+            reason="version_conflict",
         )
     except InvalidPipelineIdError:
         return make_error_response(
             f"Invalid pipeline ID format: {pipeline_id}",
             status_code=400,
+            reason="invalid_pipeline_id",
         )
     except PipelineNotFoundError:
         return make_error_response(
             f"Pipeline {pipeline_id} not found",
             status_code=404,
+            reason="pipeline_not_found",
         )
 
 
@@ -459,7 +482,10 @@ def start_phase(pipeline_id: str) -> tuple[Response, int]:
         phase_execution = pipeline.get_phase_execution(pipeline.current_phase)
 
         if phase_execution.status == PipelineStatus.RUNNING:
-            return make_error_response(f"Phase {pipeline.current_phase.value} is already running")
+            return make_error_response(
+                f"Phase {pipeline.current_phase.value} is already running",
+                reason="phase_already_running",
+            )
 
         phase_execution.status = PipelineStatus.RUNNING
         phase_execution.started_at = datetime.now(UTC)
@@ -486,16 +512,19 @@ def start_phase(pipeline_id: str) -> tuple[Response, int]:
         return make_error_response(
             f"Concurrent modification detected for pipeline {pipeline_id}. Please retry.",
             status_code=409,
+            reason="version_conflict",
         )
     except InvalidPipelineIdError:
         return make_error_response(
             f"Invalid pipeline ID format: {pipeline_id}",
             status_code=400,
+            reason="invalid_pipeline_id",
         )
     except PipelineNotFoundError:
         return make_error_response(
             f"Pipeline {pipeline_id} not found",
             status_code=404,
+            reason="pipeline_not_found",
         )
 
 
@@ -616,11 +645,13 @@ def complete_phase(pipeline_id: str) -> tuple[Response, int]:
             return make_error_response(
                 f"artifacts must be a JSON object (got {type(artifacts).__name__})",
                 status_code=400,
+                reason="invalid_artifacts",
             )
         if not all(isinstance(k, str) and isinstance(v, str) for k, v in artifacts.items()):
             return make_error_response(
                 "artifacts must be a JSON object with string values",
                 status_code=400,
+                reason="invalid_artifacts",
             )
 
     force = bool(data.get("force", False))
@@ -629,6 +660,7 @@ def complete_phase(pipeline_id: str) -> tuple[Response, int]:
         return make_error_response(
             "force_reason must be a string",
             status_code=400,
+            reason="invalid_force_reason",
         )
     if isinstance(force_reason, str) and not force_reason.strip():
         # Treat empty/whitespace-only strings the same as absent — an empty
@@ -659,6 +691,7 @@ def complete_phase(pipeline_id: str) -> tuple[Response, int]:
                     "phase": pipeline.current_phase.value,
                     "unresolved_decision_ids": unresolved_ids,
                 },
+                reason="unresolved_hitl_decisions",
             )
 
         phase_execution = pipeline.get_phase_execution(pipeline.current_phase)
@@ -723,16 +756,19 @@ def complete_phase(pipeline_id: str) -> tuple[Response, int]:
         return make_error_response(
             f"Concurrent modification detected for pipeline {pipeline_id}. Please retry.",
             status_code=409,
+            reason="version_conflict",
         )
     except InvalidPipelineIdError:
         return make_error_response(
             f"Invalid pipeline ID format: {pipeline_id}",
             status_code=400,
+            reason="invalid_pipeline_id",
         )
     except PipelineNotFoundError:
         return make_error_response(
             f"Pipeline {pipeline_id} not found",
             status_code=404,
+            reason="pipeline_not_found",
         )
 
 
@@ -798,11 +834,13 @@ def populate_contract(pipeline_id: str) -> tuple[Response, int]:
         return make_error_response(
             f"Invalid pipeline ID format: {pipeline_id}",
             status_code=400,
+            reason="invalid_pipeline_id",
         )
     except PipelineNotFoundError:
         return make_error_response(
             f"Pipeline {pipeline_id} not found",
             status_code=404,
+            reason="pipeline_not_found",
         )
     except Exception as e:
         logger.error(
@@ -813,6 +851,7 @@ def populate_contract(pipeline_id: str) -> tuple[Response, int]:
         return make_error_response(
             f"Failed to populate contract: {e}",
             status_code=500,
+            reason="populate_contract_failed",
         )
 
 
@@ -842,7 +881,7 @@ def fail_phase(pipeline_id: str) -> tuple[Response, int]:
 
     error_message = data.get("error")
     if not error_message:
-        return make_error_response("Missing error message")
+        return make_error_response("Missing error message", reason="missing_error_message")
 
     try:
         store, pipeline = get_state_store_for_pipeline(pipeline_id)
@@ -880,14 +919,17 @@ def fail_phase(pipeline_id: str) -> tuple[Response, int]:
         return make_error_response(
             f"Concurrent modification detected for pipeline {pipeline_id}. Please retry.",
             status_code=409,
+            reason="version_conflict",
         )
     except InvalidPipelineIdError:
         return make_error_response(
             f"Invalid pipeline ID format: {pipeline_id}",
             status_code=400,
+            reason="invalid_pipeline_id",
         )
     except PipelineNotFoundError:
         return make_error_response(
             f"Pipeline {pipeline_id} not found",
             status_code=404,
+            reason="pipeline_not_found",
         )

--- a/orchestrator/routes/phases.py
+++ b/orchestrator/routes/phases.py
@@ -75,7 +75,7 @@ def make_error_response(
     ``message``. See #1939.
     """
     response: dict[str, Any] = {"success": False, "message": message}
-    if reason:
+    if reason is not None:
         response["reason"] = reason
     if details:
         response["details"] = details

--- a/orchestrator/routes/phases.py
+++ b/orchestrator/routes/phases.py
@@ -77,7 +77,7 @@ def make_error_response(
     response: dict[str, Any] = {"success": False, "message": message}
     if reason is not None:
         response["reason"] = reason
-    if details:
+    if details is not None:
         response["details"] = details
     return jsonify(response), status_code
 

--- a/orchestrator/tests/test_phase_error_reason_codes.py
+++ b/orchestrator/tests/test_phase_error_reason_codes.py
@@ -1,0 +1,334 @@
+"""#1939 — phase lifecycle error responses must carry a stable `reason` code.
+
+Two of the advance/complete 409 gates (health-check FAIL_PIPELINE vs.
+unresolved HITL) previously collapsed into an indistinguishable "the server
+said 409" on the caller's side. These tests pin the reason-code contract so
+future callers can switch on `reason` without parsing the human message.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+sys.modules.setdefault("docker", MagicMock())
+sys.modules.setdefault("docker.errors", MagicMock())
+sys.modules.setdefault("docker.types", MagicMock())
+
+from flask import Flask
+from models import DecisionStatus, HITLDecision, Pipeline, PipelinePhase, PipelineStatus
+from routes.phases import phases_bp
+from state_store import InvalidPipelineIdError, PipelineNotFoundError, VersionConflictError
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.register_blueprint(phases_bp)
+    app.config["TESTING"] = True
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _make_pipeline(
+    phase=PipelinePhase.PLAN,
+    phase_status=PipelineStatus.COMPLETE,
+    has_contract=False,
+):
+    pipeline = Pipeline(
+        id="issue-42",
+        issue_number=42,
+        repo="owner/repo",
+        branch="egg/issue-42",
+        has_contract=has_contract,
+    )
+    pipeline.current_phase = phase
+    pipeline.get_phase_execution(phase).status = phase_status
+    return pipeline
+
+
+def _body(resp):
+    return json.loads(resp.data)
+
+
+class TestAdvancePhaseReasonCodes:
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_missing_target_phase(self, mock_get_store, client):
+        # Reached before pipeline load — no store needed.
+        resp = client.post("/api/v1/pipelines/issue-42/phase", json={})
+        assert resp.status_code == 400
+        assert _body(resp)["reason"] == "missing_target_phase"
+        mock_get_store.assert_not_called()
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_invalid_phase(self, mock_get_store, client):
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase",
+            json={"target_phase": "bogus"},
+        )
+        assert resp.status_code == 400
+        assert _body(resp)["reason"] == "invalid_phase"
+        mock_get_store.assert_not_called()
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_invalid_phase_transition(self, mock_get_store, client):
+        # REFINE -> PR is not a valid transition (REFINE can go to PLAN or IMPLEMENT)
+        pipeline = _make_pipeline(phase=PipelinePhase.REFINE)
+        mock_get_store.return_value = (MagicMock(repo_path=Path("/tmp/repo")), pipeline)
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase",
+            json={"target_phase": "pr"},
+        )
+        assert resp.status_code == 400
+        assert _body(resp)["reason"] == "invalid_phase_transition"
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_previous_phase_not_complete(self, mock_get_store, client):
+        # Current phase is RUNNING — advance must be rejected.
+        pipeline = _make_pipeline(phase=PipelinePhase.PLAN, phase_status=PipelineStatus.RUNNING)
+        mock_get_store.return_value = (MagicMock(repo_path=Path("/tmp/repo")), pipeline)
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase",
+            json={"target_phase": "implement"},
+        )
+        assert resp.status_code == 400
+        assert _body(resp)["reason"] == "previous_phase_not_complete"
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_health_checks_failed_409(self, mock_get_store, app, client):
+        """FAIL_PIPELINE health result surfaces as reason=health_checks_failed."""
+        from health_checks.types import HealthAction, HealthResult, HealthStatus, HealthTier
+
+        pipeline = _make_pipeline(phase=PipelinePhase.PLAN)
+        mock_get_store.return_value = (MagicMock(repo_path=Path("/tmp/repo")), pipeline)
+
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = [
+            HealthResult(
+                status=HealthStatus.FAILED,
+                check_name="check-1",
+                tier=HealthTier.PROGRAMMATIC,
+                reasoning="broken",
+                action=HealthAction.FAIL_PIPELINE,
+            ),
+        ]
+        app.config["HEALTH_CHECK_RUNNER"] = mock_runner
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase",
+            json={"target_phase": "implement"},
+        )
+        assert resp.status_code == 409
+        body = _body(resp)
+        assert body["reason"] == "health_checks_failed"
+        # Backward-compat: details.health_results must still be present.
+        assert "health_results" in body["details"]
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_invalid_pipeline_id(self, mock_get_store, client):
+        mock_get_store.side_effect = InvalidPipelineIdError("bad id")
+        resp = client.post(
+            "/api/v1/pipelines/bad-id/phase",
+            json={"target_phase": "implement"},
+        )
+        assert resp.status_code == 400
+        assert _body(resp)["reason"] == "invalid_pipeline_id"
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_pipeline_not_found(self, mock_get_store, client):
+        mock_get_store.side_effect = PipelineNotFoundError("issue-99")
+        resp = client.post(
+            "/api/v1/pipelines/issue-99/phase",
+            json={"target_phase": "implement"},
+        )
+        assert resp.status_code == 404
+        assert _body(resp)["reason"] == "pipeline_not_found"
+
+
+class TestStartPhaseReasonCodes:
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_phase_already_running(self, mock_get_store, client):
+        pipeline = _make_pipeline(
+            phase=PipelinePhase.IMPLEMENT, phase_status=PipelineStatus.RUNNING
+        )
+        mock_get_store.return_value = (MagicMock(), pipeline)
+
+        resp = client.post("/api/v1/pipelines/issue-42/phase/start")
+        assert resp.status_code == 400
+        assert _body(resp)["reason"] == "phase_already_running"
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_version_conflict(self, mock_get_store, client):
+        pipeline = _make_pipeline(
+            phase=PipelinePhase.IMPLEMENT, phase_status=PipelineStatus.PENDING
+        )
+        mock_store = MagicMock()
+        mock_store.save_pipeline.side_effect = VersionConflictError("boom")
+        mock_get_store.return_value = (mock_store, pipeline)
+
+        resp = client.post("/api/v1/pipelines/issue-42/phase/start")
+        assert resp.status_code == 409
+        assert _body(resp)["reason"] == "version_conflict"
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_invalid_pipeline_id(self, mock_get_store, client):
+        mock_get_store.side_effect = InvalidPipelineIdError("bad id")
+        resp = client.post("/api/v1/pipelines/bad-id/phase/start")
+        assert resp.status_code == 400
+        assert _body(resp)["reason"] == "invalid_pipeline_id"
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_pipeline_not_found(self, mock_get_store, client):
+        mock_get_store.side_effect = PipelineNotFoundError("issue-99")
+        resp = client.post("/api/v1/pipelines/issue-99/phase/start")
+        assert resp.status_code == 404
+        assert _body(resp)["reason"] == "pipeline_not_found"
+
+
+class TestCompletePhaseReasonCodes:
+    """The core motivation for #1939 — the `unresolved_hitl_decisions` 409 must
+    be machine-distinguishable from `health_checks_failed` (which fires from a
+    different endpoint, but shares the 409 status)."""
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_unresolved_hitl_decisions_409(self, mock_get_store, _mock_clear, client):
+        pipeline = _make_pipeline(phase=PipelinePhase.REFINE)
+        pipeline.decisions.append(
+            HITLDecision(
+                id="decision-1",
+                question="q",
+                phase=PipelinePhase.REFINE,
+                status=DecisionStatus.PENDING,
+            )
+        )
+        mock_get_store.return_value = (MagicMock(repo_path=Path("/tmp/repo")), pipeline)
+
+        resp = client.post("/api/v1/pipelines/issue-42/phase/complete")
+        assert resp.status_code == 409
+        body = _body(resp)
+        assert body["reason"] == "unresolved_hitl_decisions"
+        # Backward-compat: details.unresolved_decision_ids must still be present.
+        assert body["details"]["unresolved_decision_ids"] == ["decision-1"]
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_invalid_artifacts_non_dict(self, mock_get_store, client):
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase/complete",
+            json={"artifacts": "not-a-dict"},
+        )
+        assert resp.status_code == 400
+        assert _body(resp)["reason"] == "invalid_artifacts"
+        mock_get_store.assert_not_called()
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_invalid_artifacts_non_string_values(self, mock_get_store, client):
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase/complete",
+            json={"artifacts": {"k": 123}},
+        )
+        assert resp.status_code == 400
+        assert _body(resp)["reason"] == "invalid_artifacts"
+        mock_get_store.assert_not_called()
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_invalid_force_reason(self, mock_get_store, client):
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase/complete",
+            json={"force_reason": 42},
+        )
+        assert resp.status_code == 400
+        assert _body(resp)["reason"] == "invalid_force_reason"
+        mock_get_store.assert_not_called()
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_version_conflict(self, mock_get_store, _mock_clear, client):
+        pipeline = _make_pipeline(phase=PipelinePhase.IMPLEMENT)
+        mock_store = MagicMock()
+        mock_store.repo_path = Path("/tmp/repo")
+        mock_store.save_pipeline.side_effect = VersionConflictError("boom")
+        mock_get_store.return_value = (mock_store, pipeline)
+
+        resp = client.post("/api/v1/pipelines/issue-42/phase/complete")
+        assert resp.status_code == 409
+        assert _body(resp)["reason"] == "version_conflict"
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_invalid_pipeline_id(self, mock_get_store, client):
+        mock_get_store.side_effect = InvalidPipelineIdError("bad id")
+        resp = client.post("/api/v1/pipelines/bad-id/phase/complete")
+        assert resp.status_code == 400
+        assert _body(resp)["reason"] == "invalid_pipeline_id"
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_pipeline_not_found(self, mock_get_store, client):
+        mock_get_store.side_effect = PipelineNotFoundError("issue-99")
+        resp = client.post("/api/v1/pipelines/issue-99/phase/complete")
+        assert resp.status_code == 404
+        assert _body(resp)["reason"] == "pipeline_not_found"
+
+
+class TestTwo409sAreDistinguishable:
+    """The whole point: advance_phase 409 vs. complete_phase 409 must carry
+    distinct reason codes a caller can switch on.
+    """
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_409_reasons_are_distinct(self, mock_get_store, _mock_clear, app, client):
+        from health_checks.types import HealthAction, HealthResult, HealthStatus, HealthTier
+
+        # --- Scenario A: advance_phase 409 from failing health checks ---
+        pipeline_a = _make_pipeline(phase=PipelinePhase.PLAN)
+        mock_get_store.return_value = (MagicMock(repo_path=Path("/tmp/repo")), pipeline_a)
+
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = [
+            HealthResult(
+                status=HealthStatus.FAILED,
+                check_name="check-1",
+                tier=HealthTier.PROGRAMMATIC,
+                reasoning="broken",
+                action=HealthAction.FAIL_PIPELINE,
+            ),
+        ]
+        app.config["HEALTH_CHECK_RUNNER"] = mock_runner
+
+        resp_a = client.post(
+            "/api/v1/pipelines/issue-42/phase",
+            json={"target_phase": "implement"},
+        )
+
+        # --- Scenario B: complete_phase 409 from unresolved HITL decisions ---
+        pipeline_b = _make_pipeline(phase=PipelinePhase.REFINE)
+        pipeline_b.decisions.append(
+            HITLDecision(
+                id="decision-1",
+                question="q",
+                phase=PipelinePhase.REFINE,
+                status=DecisionStatus.PENDING,
+            )
+        )
+        mock_get_store.return_value = (MagicMock(repo_path=Path("/tmp/repo")), pipeline_b)
+
+        resp_b = client.post("/api/v1/pipelines/issue-42/phase/complete")
+
+        # Both 409, but distinguishable.
+        assert resp_a.status_code == 409
+        assert resp_b.status_code == 409
+        assert _body(resp_a)["reason"] == "health_checks_failed"
+        assert _body(resp_b)["reason"] == "unresolved_hitl_decisions"
+        assert _body(resp_a)["reason"] != _body(resp_b)["reason"]

--- a/orchestrator/tests/test_phase_error_reason_codes.py
+++ b/orchestrator/tests/test_phase_error_reason_codes.py
@@ -137,6 +137,23 @@ class TestAdvancePhaseReasonCodes:
         assert "health_results" in body["details"]
 
     @patch("routes.phases.get_state_store_for_pipeline")
+    def test_version_conflict(self, mock_get_store, client):
+        pipeline = _make_pipeline(phase=PipelinePhase.PLAN)
+        mock_store = MagicMock(repo_path=Path("/tmp/repo"))
+        # load_pipeline is called inside the lock — return a second
+        # pipeline that will pass re-validation but fail on save.
+        mock_store.load_pipeline.return_value = _make_pipeline(phase=PipelinePhase.PLAN)
+        mock_store.save_pipeline.side_effect = VersionConflictError("boom")
+        mock_get_store.return_value = (mock_store, pipeline)
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase",
+            json={"target_phase": "implement"},
+        )
+        assert resp.status_code == 409
+        assert _body(resp)["reason"] == "version_conflict"
+
+    @patch("routes.phases.get_state_store_for_pipeline")
     def test_invalid_pipeline_id(self, mock_get_store, client):
         mock_get_store.side_effect = InvalidPipelineIdError("bad id")
         resp = client.post(
@@ -279,6 +296,95 @@ class TestCompletePhaseReasonCodes:
         resp = client.post("/api/v1/pipelines/issue-99/phase/complete")
         assert resp.status_code == 404
         assert _body(resp)["reason"] == "pipeline_not_found"
+
+
+class TestGetCurrentPhaseReasonCodes:
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_invalid_pipeline_id(self, mock_get_store, client):
+        mock_get_store.side_effect = InvalidPipelineIdError("bad id")
+        resp = client.get("/api/v1/pipelines/bad-id/phase")
+        assert resp.status_code == 400
+        assert _body(resp)["reason"] == "invalid_pipeline_id"
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_pipeline_not_found(self, mock_get_store, client):
+        mock_get_store.side_effect = PipelineNotFoundError("issue-99")
+        resp = client.get("/api/v1/pipelines/issue-99/phase")
+        assert resp.status_code == 404
+        assert _body(resp)["reason"] == "pipeline_not_found"
+
+
+class TestFailPhaseReasonCodes:
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_missing_error_message(self, mock_get_store, client):
+        resp = client.post("/api/v1/pipelines/issue-42/phase/fail", json={})
+        assert resp.status_code == 400
+        assert _body(resp)["reason"] == "missing_error_message"
+        mock_get_store.assert_not_called()
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_version_conflict(self, mock_get_store, _mock_clear, client):
+        pipeline = _make_pipeline(
+            phase=PipelinePhase.IMPLEMENT, phase_status=PipelineStatus.RUNNING
+        )
+        mock_store = MagicMock()
+        mock_store.save_pipeline.side_effect = VersionConflictError("boom")
+        mock_get_store.return_value = (mock_store, pipeline)
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-42/phase/fail",
+            json={"error": "something broke"},
+        )
+        assert resp.status_code == 409
+        assert _body(resp)["reason"] == "version_conflict"
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_invalid_pipeline_id(self, mock_get_store, client):
+        mock_get_store.side_effect = InvalidPipelineIdError("bad id")
+        resp = client.post(
+            "/api/v1/pipelines/bad-id/phase/fail",
+            json={"error": "something broke"},
+        )
+        assert resp.status_code == 400
+        assert _body(resp)["reason"] == "invalid_pipeline_id"
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_pipeline_not_found(self, mock_get_store, client):
+        mock_get_store.side_effect = PipelineNotFoundError("issue-99")
+        resp = client.post(
+            "/api/v1/pipelines/issue-99/phase/fail",
+            json={"error": "something broke"},
+        )
+        assert resp.status_code == 404
+        assert _body(resp)["reason"] == "pipeline_not_found"
+
+
+class TestPopulateContractReasonCodes:
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_invalid_pipeline_id(self, mock_get_store, client):
+        mock_get_store.side_effect = InvalidPipelineIdError("bad id")
+        resp = client.post("/api/v1/pipelines/bad-id/phase/populate-contract")
+        assert resp.status_code == 400
+        assert _body(resp)["reason"] == "invalid_pipeline_id"
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_pipeline_not_found(self, mock_get_store, client):
+        mock_get_store.side_effect = PipelineNotFoundError("issue-99")
+        resp = client.post("/api/v1/pipelines/issue-99/phase/populate-contract")
+        assert resp.status_code == 404
+        assert _body(resp)["reason"] == "pipeline_not_found"
+
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_populate_contract_failed(self, mock_get_store, client):
+        pipeline = _make_pipeline(phase=PipelinePhase.PLAN)
+        mock_store = MagicMock(repo_path=Path("/tmp/repo"))
+        mock_get_store.return_value = (mock_store, pipeline)
+
+        with patch("routes.resolve_worktree_path", side_effect=RuntimeError("boom")):
+            resp = client.post("/api/v1/pipelines/issue-42/phase/populate-contract")
+        assert resp.status_code == 500
+        assert _body(resp)["reason"] == "populate_contract_failed"
 
 
 class TestTwo409sAreDistinguishable:


### PR DESCRIPTION
## Summary
- Add a stable, top-level `reason` field to every `make_error_response` call in `orchestrator/routes/phases.py` so callers can disambiguate same-status failures (in particular the two 409s: `health_checks_failed` on `advance_phase` vs `unresolved_hitl_decisions` on `complete_phase`) without parsing the human message
- Preserve existing `details` payloads (`health_results`, `unresolved_decision_ids`) for backward compatibility
- Update the `advance_phase`, `start_phase`, and `complete_phase` MCP tool descriptions in `orchestrator/mcp_tools.py` to enumerate the reason codes a caller may see

### Reason codes introduced
- `health_checks_failed` (409 — advance_phase, Tier 1/2 FAIL_PIPELINE)
- `unresolved_hitl_decisions` (409 — complete_phase, pending HITL)
- `invalid_phase_transition` (400 — target not valid for current phase)
- `previous_phase_not_complete` (400 — current phase still RUNNING/FAILED)
- `phase_already_running` (400 — start_phase)
- `missing_target_phase`, `invalid_phase`, `invalid_artifacts`, `invalid_force_reason`, `missing_error_message` (400)
- `version_conflict` (409 — optimistic-lock retry)
- `invalid_pipeline_id` (400), `pipeline_not_found` (404)
- `populate_contract_failed` (500)

Fixes #1939. Sibling tickets #1940 and #1941 are not touched here.

## Test plan
- [x] New `orchestrator/tests/test_phase_error_reason_codes.py` covers every reason code for advance/start/complete, asserts 409 reasons are distinct, and verifies `details` is still populated for backward compat (19 tests, all pass)
- [x] Existing phase tests still pass (`test_complete_phase_endpoint.py`, `test_advance_phase_thread.py`, `test_lifecycle_empty_body.py`, `test_health_check_lifecycle_integration.py`) — 46/46
- [x] Full orchestrator test suite: 4328 passed, 1 skipped, no regressions
- [x] `ruff check` and `ruff format` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)