### PR TITLE
Fix #1935: aggressive stall recovery stops pods so phase transitions

### DIFF
--- a/orchestrator/kubernetes_monitor.py
+++ b/orchestrator/kubernetes_monitor.py
@@ -719,19 +719,65 @@ class KubernetesMonitor:
                     )
                     return
 
+                now = datetime.now(UTC)
+                completed_container_ids: set[str] = set()
                 for agent in phase_exec.agents:
                     if agent.status == AgentExecutionStatus.RUNNING:
                         agent.status = AgentExecutionStatus.COMPLETE
-                        agent.completed_at = datetime.now(UTC)
+                        agent.completed_at = now
+                        if agent.container_id:
+                            completed_container_ids.add(agent.container_id)
+
+                # Synthetically mark containers EXITED (exit_code=0) so
+                # _reconcile_pod_state doesn't flip the pipeline to FAILED
+                # when the pods are deleted below.  Mirrors the normal
+                # _update_agents_complete path in routes/pipelines.py
+                # (see #1294).
+                pods_to_stop: list[str] = []
+                for ci in phase_exec.containers:
+                    if (
+                        ci.container_id in completed_container_ids
+                        and ci.status == ContainerStatus.RUNNING
+                    ):
+                        ci.status = ContainerStatus.EXITED
+                        ci.exit_code = 0
+                        ci.exited_at = now
+                        pods_to_stop.append(ci.container_id)
+
+                # Close the open cycle so cycle_timings reflects actual
+                # duration, matching the failure-path writes in
+                # routes/pipelines.py.  Left unset by the prior recovery
+                # path, which made get_phase reports misleading (#1935).
+                if phase_exec.cycle_timings and phase_exec.cycle_timings[-1].completed_at is None:
+                    phase_exec.cycle_timings[-1].completed_at = now
+
                 phase_exec.status = PipelineStatus.COMPLETE
-                phase_exec.completed_at = datetime.now(UTC)
+                phase_exec.completed_at = now
 
                 store.save_pipeline(fresh_pipeline, expected_version=original_version)
                 logger.info(
                     "Aggressive consensus stall recovery complete",
                     pipeline_id=pipeline_id,
                     phase=phase_key,
+                    pods_to_stop=len(pods_to_stop),
                 )
+
+                # Stop pods so the polling loop in _run_concurrent_phase
+                # observes the exits on its next tick and returns, letting
+                # _run_pipeline drive the post-phase transition (HITL gate
+                # or advance_phase).  Without this, containers stayed
+                # RUNNING after recovery and the pipeline sat with
+                # phase.completed_at=null until a human intervened (#1935).
+                for container_id in pods_to_stop:
+                    try:
+                        self.k8s_client.stop_container(container_id, timeout=10)
+                    except Exception:
+                        logger.warning(
+                            "Failed to stop pod during aggressive recovery",
+                            pipeline_id=pipeline_id,
+                            container_id=container_id[:12],
+                            exc_info=True,
+                        )
             except VersionConflictError:
                 # Expected in concurrent environments — another writer updated
                 # the pipeline. Reload and check if the phase already transitioned.

--- a/orchestrator/kubernetes_monitor.py
+++ b/orchestrator/kubernetes_monitor.py
@@ -722,7 +722,7 @@ class KubernetesMonitor:
                 now = datetime.now(UTC)
                 completed_container_ids: set[str] = set()
                 for agent in phase_exec.agents:
-                    if agent.status == AgentExecutionStatus.RUNNING:
+                    if agent.status in (AgentExecutionStatus.RUNNING, AgentExecutionStatus.FAILED):
                         agent.status = AgentExecutionStatus.COMPLETE
                         agent.completed_at = now
                         if agent.container_id:
@@ -772,8 +772,9 @@ class KubernetesMonitor:
                     try:
                         self.k8s_client.stop_container(container_id, timeout=10)
                     except Exception:
-                        logger.warning(
-                            "Failed to stop pod during aggressive recovery",
+                        logger.error(
+                            "Failed to stop pod during aggressive recovery — "
+                            "stall check will not retry; manual intervention may be needed",
                             pipeline_id=pipeline_id,
                             container_id=container_id[:12],
                             exc_info=True,

--- a/orchestrator/tests/test_consensus_stall_check.py
+++ b/orchestrator/tests/test_consensus_stall_check.py
@@ -1,6 +1,7 @@
 """Tests for ConsensusStallCheck health check."""
 
 import sys
+from collections import namedtuple
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -327,6 +328,60 @@ def _make_monitor():
     return ContainerMonitor(docker_client=mock_docker)
 
 
+AggressiveRecoveryFixture = namedtuple(
+    "AggressiveRecoveryFixture",
+    [
+        "monitor",
+        "pipeline",
+        "result",
+        "fresh_pipeline",
+        "store",
+        "mock_pc",
+        "mock_graph",
+        "patches",
+    ],
+)
+
+
+def _setup_aggressive_recovery() -> AggressiveRecoveryFixture:
+    """Common setup for aggressive-recovery tests.
+
+    Returns a named tuple with the monitor, pipelines, result, mock store,
+    and the sys.modules patch dict ready for use as a context manager.
+    """
+    monitor = _make_monitor()
+    pipeline = _make_concurrent_pipeline()
+    result = _make_degraded_result()
+
+    fresh_pipeline = _make_concurrent_pipeline()
+    mock_store = MagicMock()
+    mock_store.load_pipeline.return_value = fresh_pipeline
+
+    mock_pc = MagicMock()
+    mock_pc.get_peer_consensus_tracker.return_value = None
+    mock_pc.reconstruct_tracker_from_messages.return_value = None
+    mock_graph = MagicMock()
+
+    patches = patch.dict(
+        "sys.modules",
+        {
+            "peer_consensus": mock_pc,
+            "review_graph": mock_graph,
+        },
+    )
+
+    return AggressiveRecoveryFixture(
+        monitor=monitor,
+        pipeline=pipeline,
+        result=result,
+        fresh_pipeline=fresh_pipeline,
+        store=mock_store,
+        mock_pc=mock_pc,
+        mock_graph=mock_graph,
+        patches=patches,
+    )
+
+
 class TestHandleConsensusStallRecovery:
     def test_skips_non_consensus_results(self):
         """Non-consensus results are ignored."""
@@ -612,29 +667,11 @@ class TestHandleConsensusStallRecovery:
         reconciler doesn't flip the pipeline to FAILED when pods are
         stopped below (#1294 pattern extended to aggressive recovery
         for #1935)."""
-        monitor = _make_monitor()
-        pipeline = _make_concurrent_pipeline()
-        result = _make_degraded_result()
+        f = _setup_aggressive_recovery()
+        with f.patches:
+            f.monitor._handle_consensus_stall_recovery([f.result], f.pipeline, f.store)
 
-        fresh_pipeline = _make_concurrent_pipeline()
-        mock_store = MagicMock()
-        mock_store.load_pipeline.return_value = fresh_pipeline
-
-        mock_pc = MagicMock()
-        mock_pc.get_peer_consensus_tracker.return_value = None
-        mock_pc.reconstruct_tracker_from_messages.return_value = None
-        mock_graph_mod = MagicMock()
-
-        with patch.dict(
-            "sys.modules",
-            {
-                "peer_consensus": mock_pc,
-                "review_graph": mock_graph_mod,
-            },
-        ):
-            monitor._handle_consensus_stall_recovery([result], pipeline, mock_store)
-
-        phase_exec = fresh_pipeline.phases.get("implement")
+        phase_exec = f.fresh_pipeline.phases.get("implement")
         assert phase_exec is not None
         for ci in phase_exec.containers:
             assert ci.status == ContainerStatus.EXITED
@@ -646,29 +683,11 @@ class TestHandleConsensusStallRecovery:
         polling loop in _run_concurrent_phase detects the exits and
         returns — otherwise the pipeline stays stuck with
         phase.completed_at=null until a human intervenes (#1935)."""
-        monitor = _make_monitor()
-        pipeline = _make_concurrent_pipeline()
-        result = _make_degraded_result()
+        f = _setup_aggressive_recovery()
+        with f.patches:
+            f.monitor._handle_consensus_stall_recovery([f.result], f.pipeline, f.store)
 
-        fresh_pipeline = _make_concurrent_pipeline()
-        mock_store = MagicMock()
-        mock_store.load_pipeline.return_value = fresh_pipeline
-
-        mock_pc = MagicMock()
-        mock_pc.get_peer_consensus_tracker.return_value = None
-        mock_pc.reconstruct_tracker_from_messages.return_value = None
-        mock_graph_mod = MagicMock()
-
-        with patch.dict(
-            "sys.modules",
-            {
-                "peer_consensus": mock_pc,
-                "review_graph": mock_graph_mod,
-            },
-        ):
-            monitor._handle_consensus_stall_recovery([result], pipeline, mock_store)
-
-        stopped_ids = {call.args[0] for call in monitor.k8s_client.stop_container.call_args_list}
+        stopped_ids = {call.args[0] for call in f.monitor.k8s_client.stop_container.call_args_list}
         expected_ids = {"container-coder", "container-tester"}
         assert stopped_ids == expected_ids
 
@@ -677,33 +696,15 @@ class TestHandleConsensusStallRecovery:
         get_phase reports reflect actual phase duration (#1935)."""
         from models import CycleTiming
 
-        monitor = _make_monitor()
-        pipeline = _make_concurrent_pipeline()
-        result = _make_degraded_result()
-
-        fresh_pipeline = _make_concurrent_pipeline()
-        phase_exec = fresh_pipeline.phases.get("implement")
+        f = _setup_aggressive_recovery()
+        phase_exec = f.fresh_pipeline.phases.get("implement")
         assert phase_exec is not None
         phase_exec.cycle_timings.append(
             CycleTiming(cycle=0, started_at=datetime.now(UTC) - timedelta(seconds=60))
         )
 
-        mock_store = MagicMock()
-        mock_store.load_pipeline.return_value = fresh_pipeline
-
-        mock_pc = MagicMock()
-        mock_pc.get_peer_consensus_tracker.return_value = None
-        mock_pc.reconstruct_tracker_from_messages.return_value = None
-        mock_graph_mod = MagicMock()
-
-        with patch.dict(
-            "sys.modules",
-            {
-                "peer_consensus": mock_pc,
-                "review_graph": mock_graph_mod,
-            },
-        ):
-            monitor._handle_consensus_stall_recovery([result], pipeline, mock_store)
+        with f.patches:
+            f.monitor._handle_consensus_stall_recovery([f.result], f.pipeline, f.store)
 
         assert phase_exec.cycle_timings[-1].completed_at is not None
 
@@ -711,12 +712,8 @@ class TestHandleConsensusStallRecovery:
         """Already-closed cycle_timings must not be overwritten."""
         from models import CycleTiming
 
-        monitor = _make_monitor()
-        pipeline = _make_concurrent_pipeline()
-        result = _make_degraded_result()
-
-        fresh_pipeline = _make_concurrent_pipeline()
-        phase_exec = fresh_pipeline.phases.get("implement")
+        f = _setup_aggressive_recovery()
+        phase_exec = f.fresh_pipeline.phases.get("implement")
         assert phase_exec is not None
         earlier = datetime.now(UTC) - timedelta(seconds=30)
         phase_exec.cycle_timings.append(
@@ -727,22 +724,8 @@ class TestHandleConsensusStallRecovery:
             )
         )
 
-        mock_store = MagicMock()
-        mock_store.load_pipeline.return_value = fresh_pipeline
-
-        mock_pc = MagicMock()
-        mock_pc.get_peer_consensus_tracker.return_value = None
-        mock_pc.reconstruct_tracker_from_messages.return_value = None
-        mock_graph_mod = MagicMock()
-
-        with patch.dict(
-            "sys.modules",
-            {
-                "peer_consensus": mock_pc,
-                "review_graph": mock_graph_mod,
-            },
-        ):
-            monitor._handle_consensus_stall_recovery([result], pipeline, mock_store)
+        with f.patches:
+            f.monitor._handle_consensus_stall_recovery([f.result], f.pipeline, f.store)
 
         assert phase_exec.cycle_timings[-1].completed_at == earlier
 
@@ -752,56 +735,44 @@ class TestHandleConsensusStallRecovery:
         transition and will drive it itself."""
         from state_store import VersionConflictError
 
-        monitor = _make_monitor()
-        pipeline = _make_concurrent_pipeline()
-        result = _make_degraded_result()
+        f = _setup_aggressive_recovery()
+        f.store.save_pipeline.side_effect = VersionConflictError("conflict")
 
-        fresh_pipeline = _make_concurrent_pipeline()
-        mock_store = MagicMock()
-        mock_store.load_pipeline.return_value = fresh_pipeline
-        mock_store.save_pipeline.side_effect = VersionConflictError("conflict")
+        with f.patches:
+            f.monitor._handle_consensus_stall_recovery([f.result], f.pipeline, f.store)
 
-        mock_pc = MagicMock()
-        mock_pc.get_peer_consensus_tracker.return_value = None
-        mock_pc.reconstruct_tracker_from_messages.return_value = None
-        mock_graph_mod = MagicMock()
-
-        with patch.dict(
-            "sys.modules",
-            {
-                "peer_consensus": mock_pc,
-                "review_graph": mock_graph_mod,
-            },
-        ):
-            monitor._handle_consensus_stall_recovery([result], pipeline, mock_store)
-
-        monitor.k8s_client.stop_container.assert_not_called()
+        f.monitor.k8s_client.stop_container.assert_not_called()
 
     def test_stop_container_error_does_not_propagate(self):
         """If k8s_client.stop_container raises, aggressive recovery must
         continue stopping the remaining pods and not re-raise."""
-        monitor = _make_monitor()
-        pipeline = _make_concurrent_pipeline()
-        result = _make_degraded_result()
+        f = _setup_aggressive_recovery()
+        f.monitor.k8s_client.stop_container.side_effect = [RuntimeError("boom"), None]
 
-        fresh_pipeline = _make_concurrent_pipeline()
-        mock_store = MagicMock()
-        mock_store.load_pipeline.return_value = fresh_pipeline
-        monitor.k8s_client.stop_container.side_effect = [RuntimeError("boom"), None]
-
-        mock_pc = MagicMock()
-        mock_pc.get_peer_consensus_tracker.return_value = None
-        mock_pc.reconstruct_tracker_from_messages.return_value = None
-        mock_graph_mod = MagicMock()
-
-        with patch.dict(
-            "sys.modules",
-            {
-                "peer_consensus": mock_pc,
-                "review_graph": mock_graph_mod,
-            },
-        ):
-            monitor._handle_consensus_stall_recovery([result], pipeline, mock_store)
+        with f.patches:
+            f.monitor._handle_consensus_stall_recovery([f.result], f.pipeline, f.store)
 
         # Both pods attempted despite the first failing
-        assert monitor.k8s_client.stop_container.call_count == 2
+        assert f.monitor.k8s_client.stop_container.call_count == 2
+
+    def test_aggressive_recovery_includes_failed_agents(self):
+        """FAILED agents (e.g. via signal API while container is still
+        running) must also be completed and their pods stopped, matching
+        the canonical _update_agents_complete path in routes/pipelines.py."""
+        f = _setup_aggressive_recovery()
+        # Mark one agent as FAILED (container still running)
+        phase_exec = f.fresh_pipeline.phases.get("implement")
+        assert phase_exec is not None
+        phase_exec.agents[1].status = AgentExecutionStatus.FAILED
+
+        with f.patches:
+            f.monitor._handle_consensus_stall_recovery([f.result], f.pipeline, f.store)
+
+        # Both agents should be COMPLETE
+        for agent in phase_exec.agents:
+            assert agent.status == AgentExecutionStatus.COMPLETE
+            assert agent.completed_at is not None
+
+        # Both containers should be stopped
+        stopped_ids = {call.args[0] for call in f.monitor.k8s_client.stop_container.call_args_list}
+        assert stopped_ids == {"container-coder", "container-tester"}

--- a/orchestrator/tests/test_consensus_stall_check.py
+++ b/orchestrator/tests/test_consensus_stall_check.py
@@ -606,3 +606,202 @@ class TestHandleConsensusStallRecovery:
         phase_exec = fresh_pipeline.phases.get("implement")
         assert phase_exec is not None
         assert phase_exec.status == PipelineStatus.COMPLETE
+
+    def test_aggressive_recovery_marks_containers_exited(self):
+        """Containers must be marked EXITED synthetically so the pod
+        reconciler doesn't flip the pipeline to FAILED when pods are
+        stopped below (#1294 pattern extended to aggressive recovery
+        for #1935)."""
+        monitor = _make_monitor()
+        pipeline = _make_concurrent_pipeline()
+        result = _make_degraded_result()
+
+        fresh_pipeline = _make_concurrent_pipeline()
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = fresh_pipeline
+
+        mock_pc = MagicMock()
+        mock_pc.get_peer_consensus_tracker.return_value = None
+        mock_pc.reconstruct_tracker_from_messages.return_value = None
+        mock_graph_mod = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "peer_consensus": mock_pc,
+                "review_graph": mock_graph_mod,
+            },
+        ):
+            monitor._handle_consensus_stall_recovery([result], pipeline, mock_store)
+
+        phase_exec = fresh_pipeline.phases.get("implement")
+        assert phase_exec is not None
+        for ci in phase_exec.containers:
+            assert ci.status == ContainerStatus.EXITED
+            assert ci.exit_code == 0
+            assert ci.exited_at is not None
+
+    def test_aggressive_recovery_stops_running_pods(self):
+        """Aggressive recovery must call k8s_client.stop_container so the
+        polling loop in _run_concurrent_phase detects the exits and
+        returns — otherwise the pipeline stays stuck with
+        phase.completed_at=null until a human intervenes (#1935)."""
+        monitor = _make_monitor()
+        pipeline = _make_concurrent_pipeline()
+        result = _make_degraded_result()
+
+        fresh_pipeline = _make_concurrent_pipeline()
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = fresh_pipeline
+
+        mock_pc = MagicMock()
+        mock_pc.get_peer_consensus_tracker.return_value = None
+        mock_pc.reconstruct_tracker_from_messages.return_value = None
+        mock_graph_mod = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "peer_consensus": mock_pc,
+                "review_graph": mock_graph_mod,
+            },
+        ):
+            monitor._handle_consensus_stall_recovery([result], pipeline, mock_store)
+
+        stopped_ids = {call.args[0] for call in monitor.k8s_client.stop_container.call_args_list}
+        expected_ids = {"container-coder", "container-tester"}
+        assert stopped_ids == expected_ids
+
+    def test_aggressive_recovery_closes_open_cycle(self):
+        """Aggressive recovery must close the latest open cycle_timings so
+        get_phase reports reflect actual phase duration (#1935)."""
+        from models import CycleTiming
+
+        monitor = _make_monitor()
+        pipeline = _make_concurrent_pipeline()
+        result = _make_degraded_result()
+
+        fresh_pipeline = _make_concurrent_pipeline()
+        phase_exec = fresh_pipeline.phases.get("implement")
+        assert phase_exec is not None
+        phase_exec.cycle_timings.append(
+            CycleTiming(cycle=0, started_at=datetime.now(UTC) - timedelta(seconds=60))
+        )
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = fresh_pipeline
+
+        mock_pc = MagicMock()
+        mock_pc.get_peer_consensus_tracker.return_value = None
+        mock_pc.reconstruct_tracker_from_messages.return_value = None
+        mock_graph_mod = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "peer_consensus": mock_pc,
+                "review_graph": mock_graph_mod,
+            },
+        ):
+            monitor._handle_consensus_stall_recovery([result], pipeline, mock_store)
+
+        assert phase_exec.cycle_timings[-1].completed_at is not None
+
+    def test_aggressive_recovery_preserves_already_closed_cycle(self):
+        """Already-closed cycle_timings must not be overwritten."""
+        from models import CycleTiming
+
+        monitor = _make_monitor()
+        pipeline = _make_concurrent_pipeline()
+        result = _make_degraded_result()
+
+        fresh_pipeline = _make_concurrent_pipeline()
+        phase_exec = fresh_pipeline.phases.get("implement")
+        assert phase_exec is not None
+        earlier = datetime.now(UTC) - timedelta(seconds=30)
+        phase_exec.cycle_timings.append(
+            CycleTiming(
+                cycle=0,
+                started_at=datetime.now(UTC) - timedelta(seconds=60),
+                completed_at=earlier,
+            )
+        )
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = fresh_pipeline
+
+        mock_pc = MagicMock()
+        mock_pc.get_peer_consensus_tracker.return_value = None
+        mock_pc.reconstruct_tracker_from_messages.return_value = None
+        mock_graph_mod = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "peer_consensus": mock_pc,
+                "review_graph": mock_graph_mod,
+            },
+        ):
+            monitor._handle_consensus_stall_recovery([result], pipeline, mock_store)
+
+        assert phase_exec.cycle_timings[-1].completed_at == earlier
+
+    def test_version_conflict_skips_pod_stop(self):
+        """On VersionConflictError the save didn't land — aggressive
+        recovery must not stop pods, since another writer owns the
+        transition and will drive it itself."""
+        from state_store import VersionConflictError
+
+        monitor = _make_monitor()
+        pipeline = _make_concurrent_pipeline()
+        result = _make_degraded_result()
+
+        fresh_pipeline = _make_concurrent_pipeline()
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = fresh_pipeline
+        mock_store.save_pipeline.side_effect = VersionConflictError("conflict")
+
+        mock_pc = MagicMock()
+        mock_pc.get_peer_consensus_tracker.return_value = None
+        mock_pc.reconstruct_tracker_from_messages.return_value = None
+        mock_graph_mod = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "peer_consensus": mock_pc,
+                "review_graph": mock_graph_mod,
+            },
+        ):
+            monitor._handle_consensus_stall_recovery([result], pipeline, mock_store)
+
+        monitor.k8s_client.stop_container.assert_not_called()
+
+    def test_stop_container_error_does_not_propagate(self):
+        """If k8s_client.stop_container raises, aggressive recovery must
+        continue stopping the remaining pods and not re-raise."""
+        monitor = _make_monitor()
+        pipeline = _make_concurrent_pipeline()
+        result = _make_degraded_result()
+
+        fresh_pipeline = _make_concurrent_pipeline()
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = fresh_pipeline
+        monitor.k8s_client.stop_container.side_effect = [RuntimeError("boom"), None]
+
+        mock_pc = MagicMock()
+        mock_pc.get_peer_consensus_tracker.return_value = None
+        mock_pc.reconstruct_tracker_from_messages.return_value = None
+        mock_graph_mod = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "peer_consensus": mock_pc,
+                "review_graph": mock_graph_mod,
+            },
+        ):
+            monitor._handle_consensus_stall_recovery([result], pipeline, mock_store)
+
+        # Both pods attempted despite the first failing
+        assert monitor.k8s_client.stop_container.call_count == 2


### PR DESCRIPTION
## Summary

Closes #1935.

When `ConsensusStallCheck` fired DEGRADED and tracker reconstruction couldn't short-circuit (Track 1), aggressive recovery marked agents + `phase_exec` COMPLETE but left pods RUNNING. The polling loop in `_run_concurrent_phase` never observed the exits, so it never returned — and `_run_pipeline` never reached the post-phase logic that creates the `phase_gate` or calls `advance_phase`. The pipeline sat with `phase.completed_at=null` until a human ran `advance_phase` manually.

This extends aggressive recovery in `orchestrator/kubernetes_monitor.py` to drive the full cleanup that the normal `_update_agents_complete` path does:

1. **Synthetically mark RUNNING containers EXITED (`exit_code=0`)** so `_reconcile_pod_state` doesn't flip the pipeline to FAILED when the pods are deleted. Mirrors the `#1294` pattern.
2. **Close `cycle_timings[-1].completed_at` if open**, matching the failure-path writes in `routes/pipelines.py` so `get_phase` reports reflect actual duration.
3. **After a successful save, call `k8s_client.stop_container`** for each RUNNING pod. The polling loop observes the exits on its next tick, returns 0, and `_run_pipeline` drives the `phase_gate` / `advance_phase` transition through its normal path.

`VersionConflictError` still short-circuits before the pod stops — another writer owns the transition and will drive it itself. Individual `stop_container` exceptions are logged and swallowed so one failing pod doesn't abort the rest.

### Why not the other two fixes from the issue

- **Re-check consensus at entry (fix 1 in the issue):** would regress #1749 (`test_existing_complete_tracker_falls_through_to_aggressive`). That test locks in the rule "tracker is complete + polling loop didn't act → Track 2 must fire," which is exactly the case #1935 observed. The root cause here is that Track 2 was incomplete, not that it ran.
- **Janitor for orphan phases (fix 3):** a separate, broader defense-in-depth feature; left for a follow-up issue.

## Tests

`orchestrator/tests/test_consensus_stall_check.py` — **27 passed** (6 new, in `TestHandleConsensusStallRecovery`):

- `test_aggressive_recovery_marks_containers_exited`
- `test_aggressive_recovery_stops_running_pods`
- `test_aggressive_recovery_closes_open_cycle`
- `test_aggressive_recovery_preserves_already_closed_cycle`
- `test_version_conflict_skips_pod_stop`
- `test_stop_container_error_does_not_propagate`

Also verified `orchestrator/tests/test_kubernetes_monitor.py` (57 passed) plus the related consensus suites (`test_consensus_timeout_recheck`, `test_brc_nack_iteration`, `test_consensus_polling`, `test_consensus_complete_with_failures`, `test_incomplete_consensus_stall`) — 57 passed.

## Test plan

- [ ] CI runs full orchestrator test suite
- [ ] Next real stall-recovery event: verify `kubernetes_monitor` logs `Aggressive consensus stall recovery complete pods_to_stop=N`, pods transition to EXITED via k8s API, polling loop returns 0, and phase advances (either `phase_gate` created with `hitl_gates=true` or `advance_phase` called with `hitl_gates=false`) — no manual intervention.
- [ ] `get_phase` reports show `phase.completed_at` set and `cycle_timings[-1].completed_at` populated after recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)