### PR TITLE
Fix #1941: populate contract.pr on advance_phase out of plan

### DIFF
--- a/orchestrator/routes/phases.py
+++ b/orchestrator/routes/phases.py
@@ -387,6 +387,57 @@ def advance_phase(pipeline_id: str) -> tuple[Response, int]:
         # advance_phase call would be blocked by the optimistic lock above.
         _clear_concurrent_state(pipeline_id)
 
+        # When leaving the plan phase, parse the plan draft's yaml-tasks
+        # appendix into the contract's pr/phases fields.  _run_pipeline's
+        # per-phase block only runs this for the thread that owned the
+        # plan phase; a force=true advance replaces that thread before it
+        # reaches the populate step, leaving contract.pr empty and the
+        # PR phase's auto-PR path falling back to placeholder title/body
+        # (see #1941).
+        #
+        # Commit the result in-process so _sync_worktree_with_remote in
+        # the newly-spawned thread pushes rather than resets the change.
+        # Failures warn and continue — the advance-phase path is a recovery
+        # hammer; blocking it on populate failures would defeat the purpose.
+        if previous_phase == PipelinePhase.PLAN:
+            try:
+                from routes import resolve_worktree_path
+                from routes.pipelines import (
+                    _commit_statefiles_to_worktree,
+                    _pipeline_identifier,
+                    _populate_contract_from_plan_safe,
+                )
+
+                worktree_path = resolve_worktree_path(pipeline_id, store.repo_path)
+                pipeline_mode = pipeline.mode.value if pipeline.mode else "issue"
+                _populate_contract_from_plan_safe(
+                    worktree_path,
+                    pipeline_id,
+                    pipeline_mode,
+                    pipeline.issue_number,
+                )
+                try:
+                    _commit_statefiles_to_worktree(
+                        worktree_path,
+                        "Populate contract from plan on plan-phase exit",
+                        pipeline_identifier=_pipeline_identifier(
+                            pipeline.issue_number, pipeline_id
+                        ),
+                        pipeline_id=pipeline_id,
+                    )
+                except Exception as commit_err:
+                    logger.warning(
+                        "Failed to commit populated contract on plan exit (continuing)",
+                        pipeline_id=pipeline_id,
+                        error=str(commit_err),
+                    )
+            except Exception as exit_err:
+                logger.warning(
+                    "Failed to run plan-exit populate (continuing)",
+                    pipeline_id=pipeline_id,
+                    error=str(exit_err),
+                )
+
         # Launch a new _run_pipeline thread to process the target phase.
         # Without this, the pipeline stays in RUNNING state with no thread
         # driving agent spawning or consensus detection.  See #1672.

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9045,6 +9045,31 @@ def _synthesize_plan_draft(
     )
 
 
+def _populate_contract_from_plan_safe(
+    repo_path: Path,
+    pipeline_id: str,
+    pipeline_mode: str = "issue",
+    issue_number: int | None = None,
+) -> None:
+    """Run :func:`_populate_contract_from_plan` without propagating failures.
+
+    Shared call path for the two code sites that run the populate step when a
+    pipeline leaves the ``plan`` phase: ``_run_pipeline``'s post-complete
+    block (happy path) and ``advance_phase`` (used by the MCP ``advance_phase``
+    tool, especially with ``force=true``).  Blocking the phase transition on
+    a populate failure would defeat the purpose of the advance hammer — see
+    #1941.
+    """
+    try:
+        _populate_contract_from_plan(repo_path, pipeline_id, pipeline_mode, issue_number)
+    except Exception as pop_err:
+        logger.warning(
+            "Failed to populate contract from plan (continuing)",
+            pipeline_id=pipeline_id,
+            error=str(pop_err),
+        )
+
+
 def _populate_contract_from_plan(
     repo_path: Path,
     pipeline_id: str,
@@ -10807,21 +10832,14 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
             # HITL revision) so the contract reflects the latest approved
             # plan, not a previously rejected draft.
             #
-            # Wrapped in try/except at the call site: #1890 showed an escape
-            # of an uncaught exception here skipped the HITL gate below,
-            # leaving the pipeline stalled until the overseer intervened.
+            # Routed through _populate_contract_from_plan_safe so a raised
+            # exception here cannot skip the HITL gate below (#1890).  The
+            # same helper is invoked from advance_phase so force-advances
+            # out of plan see the same populate step (#1941).
             if current_phase.value == "plan":
-                try:
-                    _populate_contract_from_plan(
-                        worktree_repo_path, pipeline_id, pipeline_mode, pipeline.issue_number
-                    )
-                except Exception as pop_err:
-                    logger.warning(
-                        "Failed to populate contract from plan (continuing)",
-                        pipeline_id=pipeline_id,
-                        phase=current_phase.value,
-                        error=str(pop_err),
-                    )
+                _populate_contract_from_plan_safe(
+                    worktree_repo_path, pipeline_id, pipeline_mode, pipeline.issue_number
+                )
 
             # After refine and plan phases: sync substantive HITL decisions
             # (non-phase-gate) to the contract so implement-phase agents

--- a/orchestrator/tests/test_advance_phase_populate_on_plan_exit.py
+++ b/orchestrator/tests/test_advance_phase_populate_on_plan_exit.py
@@ -138,6 +138,18 @@ class TestAdvancePhasePopulatesOnPlanExit:
     ):
         """Populate is followed by a scoped commit so _sync_worktree_with_remote
         in the new thread pushes the change rather than resetting it."""
+        # Use a shared call tracker to verify ordering across mocks.
+        call_order = []
+        mock_populate.side_effect = lambda *a, **kw: call_order.append("populate")
+        orig_commit_side_effect = mock_commit.side_effect
+
+        def _track_commit(*args, **kwargs):
+            call_order.append("commit")
+            if orig_commit_side_effect:
+                return orig_commit_side_effect(*args, **kwargs)
+
+        mock_commit.side_effect = _track_commit
+
         pipeline = _make_pipeline(phase=PipelinePhase.PLAN)
         mock_store = MagicMock()
         mock_store.repo_path = Path("/tmp/repo")
@@ -165,6 +177,16 @@ class TestAdvancePhasePopulatesOnPlanExit:
         assert len(populate_commits) == 1
         assert populate_commits[0].args[0] == Path("/tmp/wt")
         assert populate_commits[0].kwargs["pipeline_identifier"] is not None
+
+        # Verify populate was called *before* the plan-exit commit.
+        # call_order tracks all populate and commit invocations; the
+        # populate entry must precede the first plan-exit commit.
+        assert "populate" in call_order, "populate was never called"
+        populate_idx = call_order.index("populate")
+        commit_indices = [i for i, v in enumerate(call_order) if v == "commit"]
+        assert any(
+            ci > populate_idx for ci in commit_indices
+        ), f"no commit followed populate; call_order={call_order}"
 
     @patch("routes.phases.threading.Thread")
     @patch("routes.pipelines._commit_statefiles_to_worktree")

--- a/orchestrator/tests/test_advance_phase_populate_on_plan_exit.py
+++ b/orchestrator/tests/test_advance_phase_populate_on_plan_exit.py
@@ -1,0 +1,318 @@
+"""Regression tests for #1941: advance_phase must populate the contract from
+the plan draft when leaving the plan phase.
+
+Without this, a force=true advance out of `plan` (the supported recovery
+hammer) silently skips the ``yaml-tasks`` → ``contract.pr`` transformation,
+and the PR phase's auto-PR path falls back to placeholder title/body.
+"""
+
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+# Mock docker before importing models
+sys.modules.setdefault("docker", MagicMock())
+sys.modules.setdefault("docker.errors", MagicMock())
+sys.modules.setdefault("docker.types", MagicMock())
+
+from models import (
+    Pipeline,
+    PipelinePhase,
+    PipelineStatus,
+)
+
+try:
+    from flask import Flask
+    from routes.phases import phases_bp
+
+    _HAS_FLASK = True
+except ImportError:
+    _HAS_FLASK = False
+
+
+@pytest.fixture
+def app():
+    if not _HAS_FLASK:
+        pytest.skip("Flask not available")
+    app = Flask(__name__)
+    app.register_blueprint(phases_bp)
+    app.config["TESTING"] = True
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _make_pipeline(
+    pipeline_id="issue-1882",
+    phase=PipelinePhase.PLAN,
+    phase_status=PipelineStatus.COMPLETE,
+    issue_number=1882,
+):
+    pipeline = Pipeline(
+        id=pipeline_id,
+        issue_number=issue_number,
+        repo="owner/repo",
+        branch=f"egg/issue-{issue_number}",
+        status=PipelineStatus.RUNNING,
+        current_phase=phase,
+    )
+    phase_exec = pipeline.get_phase_execution(phase)
+    phase_exec.status = phase_status
+    phase_exec.completed_at = datetime.now(UTC)
+    return pipeline
+
+
+@pytest.mark.skipif(not _HAS_FLASK, reason="Flask not available")
+class TestAdvancePhasePopulatesOnPlanExit:
+    """advance_phase must invoke the populate step when leaving the plan phase."""
+
+    @patch("routes.phases.threading.Thread")
+    @patch("routes.pipelines._commit_statefiles_to_worktree")
+    @patch("routes.pipelines._populate_contract_from_plan_safe")
+    @patch("routes.resolve_worktree_path")
+    @patch("routes.phases.get_pipeline_state_lock")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_force_advance_out_of_plan_calls_populate(
+        self,
+        mock_get_store,
+        mock_get_lock,
+        mock_resolve_wt,
+        mock_populate,
+        mock_commit,
+        mock_thread_cls,
+        client,
+    ):
+        """force=true advance from plan→pr routes through the populate helper."""
+        pipeline = _make_pipeline(phase=PipelinePhase.PLAN)
+        mock_store = MagicMock()
+        mock_store.repo_path = Path("/tmp/repo")
+        mock_store.load_pipeline.return_value = pipeline
+        mock_get_store.return_value = (mock_store, pipeline)
+        mock_get_lock.return_value = MagicMock()
+        mock_resolve_wt.return_value = Path("/tmp/wt")
+        mock_thread_cls.return_value = MagicMock()
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-1882/phase",
+            json={"target_phase": "pr", "force": True},
+        )
+
+        assert resp.status_code == 200
+        mock_populate.assert_called_once()
+        args = mock_populate.call_args[0]
+        assert args[0] == Path("/tmp/wt")
+        assert args[1] == "issue-1882"
+        # pipeline_mode defaults to "issue"
+        assert args[2] == "issue"
+        assert args[3] == 1882
+
+    @patch("routes.phases.threading.Thread")
+    @patch("routes.pipelines._commit_statefiles_to_worktree")
+    @patch("routes.pipelines._populate_contract_from_plan_safe")
+    @patch("routes.resolve_worktree_path")
+    @patch("routes.phases.get_pipeline_state_lock")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_populate_is_followed_by_commit(
+        self,
+        mock_get_store,
+        mock_get_lock,
+        mock_resolve_wt,
+        mock_populate,
+        mock_commit,
+        mock_thread_cls,
+        client,
+    ):
+        """Populate is followed by a scoped commit so _sync_worktree_with_remote
+        in the new thread pushes the change rather than resetting it."""
+        pipeline = _make_pipeline(phase=PipelinePhase.PLAN)
+        mock_store = MagicMock()
+        mock_store.repo_path = Path("/tmp/repo")
+        mock_store.load_pipeline.return_value = pipeline
+        mock_get_store.return_value = (mock_store, pipeline)
+        mock_get_lock.return_value = MagicMock()
+        mock_resolve_wt.return_value = Path("/tmp/wt")
+        mock_thread_cls.return_value = MagicMock()
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-1882/phase",
+            json={"target_phase": "pr", "force": True},
+        )
+
+        assert resp.status_code == 200
+        # _persist_phase_brc_history (called earlier in advance_phase) also
+        # hits _commit_statefiles_to_worktree; the populate-exit commit is
+        # the one that targets the resolved worktree path with pipeline_id.
+        populate_commits = [
+            c
+            for c in mock_commit.call_args_list
+            if c.kwargs.get("pipeline_id") == "issue-1882"
+            and "plan-phase exit" in (c.args[1] if len(c.args) > 1 else "")
+        ]
+        assert len(populate_commits) == 1
+        assert populate_commits[0].args[0] == Path("/tmp/wt")
+        assert populate_commits[0].kwargs["pipeline_identifier"] is not None
+
+    @patch("routes.phases.threading.Thread")
+    @patch("routes.pipelines._commit_statefiles_to_worktree")
+    @patch("routes.pipelines._populate_contract_from_plan_safe")
+    @patch("routes.resolve_worktree_path")
+    @patch("routes.phases.get_pipeline_state_lock")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_advance_from_non_plan_phase_skips_populate(
+        self,
+        mock_get_store,
+        mock_get_lock,
+        mock_resolve_wt,
+        mock_populate,
+        mock_commit,
+        mock_thread_cls,
+        client,
+    ):
+        """An advance that does not leave plan must not call the populate helper."""
+        pipeline = _make_pipeline(
+            phase=PipelinePhase.IMPLEMENT,
+            phase_status=PipelineStatus.COMPLETE,
+        )
+        mock_store = MagicMock()
+        mock_store.repo_path = Path("/tmp/repo")
+        mock_store.load_pipeline.return_value = pipeline
+        mock_get_store.return_value = (mock_store, pipeline)
+        mock_get_lock.return_value = MagicMock()
+        mock_thread_cls.return_value = MagicMock()
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-1882/phase",
+            json={"target_phase": "pr"},
+        )
+
+        assert resp.status_code == 200
+        mock_populate.assert_not_called()
+        # _persist_phase_brc_history also invokes _commit_statefiles_to_worktree;
+        # we only care that the plan-exit commit didn't fire.
+        exit_commits = [
+            c
+            for c in mock_commit.call_args_list
+            if "plan-phase exit" in (c.args[1] if len(c.args) > 1 else "")
+        ]
+        assert exit_commits == []
+
+    @patch("routes.phases.threading.Thread")
+    @patch("routes.pipelines._commit_statefiles_to_worktree")
+    @patch("routes.pipelines._populate_contract_from_plan_safe")
+    @patch("routes.resolve_worktree_path")
+    @patch("routes.phases.get_pipeline_state_lock")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_populate_failure_does_not_block_advance(
+        self,
+        mock_get_store,
+        mock_get_lock,
+        mock_resolve_wt,
+        mock_populate,
+        mock_commit,
+        mock_thread_cls,
+        client,
+    ):
+        """A crash in the populate path must not block a force=true advance.
+
+        The advance-phase hammer is used to unstick pipelines; blocking it on
+        a populate failure would defeat the purpose.
+        """
+        # _populate_contract_from_plan_safe is already exception-swallowing
+        # in production, but guard against regressions where a caller moves
+        # to the non-safe variant.
+        mock_populate.side_effect = RuntimeError("parse failure")
+
+        pipeline = _make_pipeline(phase=PipelinePhase.PLAN)
+        mock_store = MagicMock()
+        mock_store.repo_path = Path("/tmp/repo")
+        mock_store.load_pipeline.return_value = pipeline
+        mock_get_store.return_value = (mock_store, pipeline)
+        mock_get_lock.return_value = MagicMock()
+        mock_resolve_wt.return_value = Path("/tmp/wt")
+        mock_thread_cls.return_value = MagicMock()
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-1882/phase",
+            json={"target_phase": "pr", "force": True},
+        )
+
+        assert resp.status_code == 200
+        # thread still spawned — pipeline continues
+        mock_thread_cls.return_value.start.assert_called_once()
+
+
+@pytest.mark.skipif(not _HAS_FLASK, reason="Flask not available")
+class TestPopulateFromPlanSafeIntegration:
+    """End-to-end check that the populate helper writes contract.pr from the
+    plan draft's yaml-tasks appendix.  Guards against the #1941 symptom where
+    contract.pr remained empty after a force-advance out of plan.
+    """
+
+    def test_populate_from_plan_safe_populates_contract_pr(self, tmp_path):
+        """Given a plan draft with a yaml-tasks appendix and an empty contract.pr,
+        the helper writes the pr block into the contract — exactly the
+        transformation that was being skipped on force=true advances out of
+        plan (#1941).
+        """
+        import textwrap
+
+        from egg_contracts.loader import create_contract, load_contract
+        from routes.pipelines import _populate_contract_from_plan_safe
+
+        pipeline_id = "issue-1882"
+        issue_number = 1882
+
+        # Blank contract — no pr metadata.  Mirrors the state observed on
+        # PR #1937 in #1938.
+        create_contract(pipeline_id=pipeline_id, title="Test", repo_root=tmp_path)
+
+        # Plan draft with a populated yaml-tasks appendix.
+        drafts_dir = tmp_path / ".egg-state" / "drafts"
+        drafts_dir.mkdir(parents=True, exist_ok=True)
+        plan_path = drafts_dir / f"{issue_number}-plan.md"
+        plan_path.write_text(
+            textwrap.dedent("""\
+                # Plan
+
+                ## Phase 1
+
+                ```yaml
+                # yaml-tasks
+                pr:
+                  title: "Fix the thing"
+                  description: |
+                    Closes #1882 with the thing fixed.
+                phases:
+                  - id: 1
+                    name: Implement
+                    goal: Fix the thing
+                    tasks:
+                      - id: TASK-1-1
+                        description: "Fix the thing"
+                        acceptance: "It is fixed"
+                        files:
+                          - src/thing.py
+                ```
+            """)
+        )
+
+        _populate_contract_from_plan_safe(tmp_path, pipeline_id, "issue", issue_number)
+
+        reloaded = load_contract(pipeline_id, tmp_path)
+        assert reloaded.pr is not None
+        assert reloaded.pr.title == "Fix the thing"
+        assert "Closes #1882" in reloaded.pr.description

--- a/orchestrator/tests/test_advance_phase_populate_on_plan_exit.py
+++ b/orchestrator/tests/test_advance_phase_populate_on_plan_exit.py
@@ -184,9 +184,9 @@ class TestAdvancePhasePopulatesOnPlanExit:
         assert "populate" in call_order, "populate was never called"
         populate_idx = call_order.index("populate")
         commit_indices = [i for i, v in enumerate(call_order) if v == "commit"]
-        assert any(
-            ci > populate_idx for ci in commit_indices
-        ), f"no commit followed populate; call_order={call_order}"
+        assert any(ci > populate_idx for ci in commit_indices), (
+            f"no commit followed populate; call_order={call_order}"
+        )
 
     @patch("routes.phases.threading.Thread")
     @patch("routes.pipelines._commit_statefiles_to_worktree")


### PR DESCRIPTION
## Summary

- Extracts `_populate_contract_from_plan_safe` as a shared entry point for the two sites that run the populate step when leaving the `plan` phase.
- `advance_phase` (especially `force=true`) now invokes that helper + commits the result when `previous_phase == PLAN`, so `_sync_worktree_with_remote` in the newly-spawned `_run_pipeline` thread pushes the contract update via the local-ahead path instead of resetting it.
- `_run_pipeline`'s existing post-complete call routes through the same helper; happy-path behavior is unchanged.

Fixes #1941. Before this, a `force=true` advance out of `plan` (the recovery hammer used in #1938) replaced the plan-phase `_run_pipeline` thread before it reached the populate step, leaving `contract.pr` empty and the PR phase's auto-PR path falling back to orchestrator placeholders (observed on PR #1937).

## Test plan

- [x] `pytest orchestrator/tests/test_advance_phase_populate_on_plan_exit.py` — new regression suite:
  - `force=true` advance from `plan → pr` calls the populate helper with the resolved worktree path
  - Populate is followed by a scoped commit with `pipeline_id`
  - Advances that don't leave `plan` skip both populate and commit
  - A populate crash does not block the advance (force=true recovery invariant)
  - Integration: with a real `yaml-tasks` plan draft and empty contract, the helper writes `contract.pr.title` and `contract.pr.description`
- [x] `pytest orchestrator/tests/` — full orchestrator suite passes (4314 passed, 1 skipped)
- [x] `ruff check` + `ruff format --check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)