### PR TITLE
Fix #1954: stop mounting .egg-worktrees in sandbox pods

### DIFF
--- a/k8s/overlays/local/patches/orchestrator-volumes.yaml
+++ b/k8s/overlays/local/patches/orchestrator-volumes.yaml
@@ -36,12 +36,6 @@ spec:
             # k8s would use a PV-backed repo store instead.
             - name: EGG_HOST_REPO_MAP
               value: '{"jwbron/testing":"/home/jwies/khan/testing","jwbron/egg":"/home/jwies/khan/egg","Khan/webapp":"/home/jwies/khan/webapp","Khan/internal-services":"/home/jwies/khan/internal-services","Khan/jenkins-jobs":"/home/jwies/khan/jenkins-jobs","Khan/buildmaster2":"/home/jwies/khan/buildmaster2"}'
-            # Host path for the shared worktrees directory. Agent Jobs
-            # mount this at /home/egg/.egg-worktrees so per-agent
-            # worktrees created by the orchestrator are visible to the
-            # spawned sandboxes.
-            - name: EGG_HOST_WORKTREES_PATH
-              value: "/home/jwies/.egg-worktrees"
           volumeMounts:
             # repos mount is read-write because the orchestrator creates
             # per-pipeline worktrees inside each repo's .git/worktrees/.

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -662,11 +662,14 @@ class KubernetesSpawner:
                         continue
                     environment[key] = value
 
-            # Build hostPath mounts so the agent pod sees the same repos
-            # and worktrees that the orchestrator does. repo_volumes maps
-            # owner/repo → host_path (from EGG_HOST_REPO_MAP).
-            # EGG_HOST_WORKTREES_PATH is the host directory that the
-            # orchestrator's /home/egg/.egg-worktrees points at.
+            # Build hostPath mounts so the agent pod sees its worktree at
+            # /home/egg/repos/<repo>. repo_volumes maps owner/repo →
+            # host_path of the per-agent worktree (returned by the
+            # gateway's create_worktrees). The sandbox does not get a
+            # mount of the full /home/egg/.egg-worktrees tree — the
+            # worktree content it needs is already reachable at
+            # /home/egg/repos/<repo>, and exposing the sibling tree
+            # confused agents into hunting across both paths (see #1954).
             host_path_mounts: list[dict[str, Any]] = []
             for owner_repo, host_path in (repo_volumes or {}).items():
                 # Include the owner in the k8s volume name so two repos
@@ -688,16 +691,6 @@ class KubernetesSpawner:
                         "name": volume_name,
                         "host_path": host_path,
                         "container_path": f"/home/egg/repos/{owner_repo.split('/')[-1]}",
-                        "read_only": False,
-                    }
-                )
-            worktrees_host = os.environ.get("EGG_HOST_WORKTREES_PATH")
-            if worktrees_host:
-                host_path_mounts.append(
-                    {
-                        "name": "worktrees",
-                        "host_path": worktrees_host,
-                        "container_path": "/home/egg/.egg-worktrees",
                         "read_only": False,
                     }
                 )

--- a/shared/egg_agent/client.py
+++ b/shared/egg_agent/client.py
@@ -275,12 +275,16 @@ async def run_agent_async(
     actual_model: str | None = None
     result_meta: dict[str, Any] = {}
 
+    # Log the effective cwd — when the caller did not pass one, the SDK
+    # inherits os.getcwd(), so log that rather than None.  Keeps
+    # session-init lines diagnostically useful (see #1954).
+    effective_cwd = str(cwd) if cwd else os.getcwd()
     logger.info(
         "Agent session init",
         event_type="system",
         event_subtype="init",
         model=model,
-        cwd=str(cwd) if cwd else None,
+        cwd=effective_cwd,
         permission_mode="bypassPermissions",
         max_turns=max_turns,
         timeout=timeout,

--- a/tests/shared/egg_agent/test_client.py
+++ b/tests/shared/egg_agent/test_client.py
@@ -337,6 +337,34 @@ class TestRunAgentAsync:
             assert result_kwargs["event_subtype"] == "result"
             assert result_kwargs["success"] is True
 
+    @patch("claude_agent_sdk.query", side_effect=_mock_query_success)
+    def test_init_log_cwd_fallback(self, mock_query):
+        """Test that cwd falls back to os.getcwd() when not provided."""
+        with patch("egg_agent.client.logger") as mock_logger:
+            _run_async(run_agent_async("test prompt"))
+
+            init_calls = [
+                c
+                for c in mock_logger.info.call_args_list
+                if c.args and c.args[0] == "Agent session init"
+            ]
+            assert len(init_calls) == 1
+            assert init_calls[0].kwargs["cwd"] == os.getcwd()
+
+    @patch("claude_agent_sdk.query", side_effect=_mock_query_success)
+    def test_init_log_cwd_explicit(self, mock_query):
+        """Test that cwd uses the provided value when passed explicitly."""
+        with patch("egg_agent.client.logger") as mock_logger:
+            _run_async(run_agent_async("test prompt", cwd="/tmp/test-dir"))
+
+            init_calls = [
+                c
+                for c in mock_logger.info.call_args_list
+                if c.args and c.args[0] == "Agent session init"
+            ]
+            assert len(init_calls) == 1
+            assert init_calls[0].kwargs["cwd"] == "/tmp/test-dir"
+
     @patch("claude_agent_sdk.query", side_effect=_mock_query_error)
     def test_structured_logging_on_error(self, mock_query):
         """Test that system/result log is emitted on error paths."""


### PR DESCRIPTION
## Summary

- Sandbox pods saw the same per-agent worktree through two paths: the intended `/home/egg/repos/<repo>` (hostPath → the worktree the gateway created) and a sibling `/home/egg/.egg-worktrees` mount propagated from the orchestrator. The sibling mount was dead weight — no code under `sandbox/` or any agent rule file reads from it — and its presence was confusing agents into a ~30–40s `pwd`/`ls`/`find` rediscovery loop on startup.
- `kubernetes_spawner.spawn_agent_job` no longer reads `EGG_HOST_WORKTREES_PATH` or adds the `/home/egg/.egg-worktrees` hostPath mount to the agent Job spec. The orchestrator's own mount stays — `contract_store`, `_find_missing_worktrees`, and the contract lookup in `routes/pipelines.py` depend on it.
- Removed the now-unused `EGG_HOST_WORKTREES_PATH` env var from the local overlay patch.
- Cosmetic: session-init `cwd=` log in `shared/egg_agent/client.py` now falls back to `os.getcwd()` when no `cwd` is passed, so the log shows where the agent actually runs instead of the literal `None`. Matches the issue's acceptance criterion.

## Test plan

- [x] `pytest orchestrator/tests/ -k "spawner or worktree or mount"` — 283 passed
- [x] `pytest tests/shared/egg_agent/test_client.py` — 44 passed
- [x] `ruff check` clean on changed Python files
- [ ] After deploy, confirm refine-phase agents reach their first MCP tool call within a few seconds and no longer emit `pwd`/`ls`/`find` probes against `/home/egg/repos/*` or `/home/egg/.egg-worktrees/*` before finding the worktree
- [ ] Confirm the session-init log records a populated `cwd=` field (the worktree path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)