### PR TITLE
Fix #1956: batch-queue pending contract decisions so /sdlc can resolve in one pass

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9389,7 +9389,7 @@ def _queue_and_await_contract_decisions(
         )
         queued_decisions.append((contract_decision.id, queued))
 
-    queued_feedback: Any = None
+    queued_feedback: HITLDecision | None = None
     if pending_feedback is not None:
         questions_payload = [
             {"id": q.id, "question": q.question, "answer": ""} for q in pending_feedback.questions

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9300,6 +9300,12 @@ def _queue_and_await_contract_decisions(
     (e.g. the ``/sdlc`` skill's Phase 4 handler) surface them as individual
     ``choice`` / ``feedback`` decisions.  Resolutions are written back to
     the contract so implement-phase agents see the human's answers.
+
+    All pending decisions (plus the feedback entry, if any) are queued up
+    front before any ``wait_for_decision`` call, so ``get_status`` surfaces
+    them as a single batch.  Callers can then prompt for up to 4 at a time
+    and submit answers in parallel, collapsing what was previously N prompts
+    and N polling cycles into ~⌈N/4⌉ prompts and one cycle (issue #1956).
     """
     try:
         from egg_contracts.loader import load_contract, save_contract
@@ -9367,6 +9373,8 @@ def _queue_and_await_contract_decisions(
                 error=str(e),
             )
 
+    # Pass 1: queue every pending decision + feedback up front.
+    queued_decisions: list[tuple[str, Any]] = []
     for contract_decision in pending_decisions:
         options_labels = [opt.label for opt in contract_decision.options]
         queued = dq.queue_decision(
@@ -9379,14 +9387,33 @@ def _queue_and_await_contract_decisions(
             decision_type="choice",
             phase=phase,
         )
+        queued_decisions.append((contract_decision.id, queued))
+
+    queued_feedback: Any = None
+    if pending_feedback is not None:
+        questions_payload = [
+            {"id": q.id, "question": q.question, "answer": ""} for q in pending_feedback.questions
+        ]
+        queued_feedback = dq.queue_decision(
+            question=f"Open feedback request {pending_feedback.id}",
+            context=(
+                f"Open contract feedback {pending_feedback.id}, "
+                f"registered by an agent during the {phase_value} phase."
+            ),
+            options=[],
+            decision_type="feedback",
+            questions=questions_payload,
+            phase=phase,
+        )
+
+    # Pass 2: wait for each to resolve and persist back to the contract.
+    for contract_id, queued in queued_decisions:
         resolved = dq.wait_for_decision(queued.id)
         if resolved.status != DecisionStatus.RESOLVED:
             continue
         resolution_str = (resolved.resolution or "").strip()
 
-        def _apply(
-            latest: Any, _cd_id: str = contract_decision.id, _res: str = resolution_str
-        ) -> bool:
+        def _apply(latest: Any, _cd_id: str = contract_id, _res: str = resolution_str) -> bool:
             for d in latest.decisions:
                 if d.id == _cd_id:
                     d.resolved = True
@@ -9398,22 +9425,8 @@ def _queue_and_await_contract_decisions(
 
         _save_contract_update(_apply)
 
-    if pending_feedback is not None:
-        questions_payload = [
-            {"id": q.id, "question": q.question, "answer": ""} for q in pending_feedback.questions
-        ]
-        queued = dq.queue_decision(
-            question=f"Open feedback request {pending_feedback.id}",
-            context=(
-                f"Open contract feedback {pending_feedback.id}, "
-                f"registered by an agent during the {phase_value} phase."
-            ),
-            options=[],
-            decision_type="feedback",
-            questions=questions_payload,
-            phase=phase,
-        )
-        resolved = dq.wait_for_decision(queued.id)
+    if queued_feedback is not None and pending_feedback is not None:
+        resolved = dq.wait_for_decision(queued_feedback.id)
         if resolved.status == DecisionStatus.RESOLVED:
             answers: dict[str, str] = {}
             try:

--- a/orchestrator/tests/test_contract_decision_bridge.py
+++ b/orchestrator/tests/test_contract_decision_bridge.py
@@ -332,3 +332,110 @@ def test_bridge_is_noop_when_contract_missing(tmp_path: Path) -> None:
         PipelinePhase.REFINE,
     )
     assert dq.queued == []
+
+
+class _OrderTrackingQueue(_FakeQueue):
+    """FakeQueue that records queue/wait call order (for #1956)."""
+
+    def __init__(self, resolutions: list[str]) -> None:
+        super().__init__(resolutions)
+        self.events: list[tuple[str, str]] = []
+
+    def queue_decision(
+        self,
+        question: str,
+        context: str = "",
+        options: list[str] | None = None,
+        decision_type: str = "choice",
+        questions: list[dict[str, str]] | None = None,
+        phase: PipelinePhase | None = None,
+        content_changed: bool | None = None,
+    ) -> HITLDecision:
+        decision = super().queue_decision(
+            question=question,
+            context=context,
+            options=options,
+            decision_type=decision_type,
+            questions=questions,
+            phase=phase,
+            content_changed=content_changed,
+        )
+        self.events.append(("queue", decision.id))
+        return decision
+
+    def wait_for_decision(self, decision_id: str) -> HITLDecision:
+        self.events.append(("wait", decision_id))
+        return super().wait_for_decision(decision_id)
+
+
+def test_bridge_queues_all_decisions_before_waiting(tmp_path: Path) -> None:
+    """All queue_decision calls must precede the first wait_for_decision.
+
+    Regression test for #1956: previously the bridge queued and waited on
+    decisions one at a time, so ``get_status`` only ever surfaced a single
+    pending decision even when the contract had many. The fix batches the
+    queue pass so the skill can prompt for up to 4 decisions at once.
+    """
+    from routes.pipelines import _queue_and_await_contract_decisions
+
+    identifier = "issue-42"
+    _make_contract_file(
+        tmp_path,
+        identifier,
+        decisions=[
+            {
+                "id": f"decision-{i}",
+                "question": f"Question {i}?",
+                "type": "hitl",
+                "phase": "refine",
+                "options": [
+                    {"id": "opt-a", "label": "A", "description": None},
+                    {"id": "opt-b", "label": "B", "description": None},
+                ],
+                "resolved": False,
+                "resolution": None,
+                "resolved_by": None,
+                "resolved_at": None,
+                "debounce_until": None,
+            }
+            for i in range(1, 4)
+        ],
+        feedback={
+            "id": "feedback-1",
+            "phase": "refine",
+            "questions": [{"id": "Q1", "question": "Notes?", "answer": None}],
+            "submitted": False,
+            "submitted_by": None,
+            "submitted_at": None,
+            "comment_id": None,
+            "debounce_until": None,
+        },
+    )
+    dq = _OrderTrackingQueue(
+        resolutions=[
+            "A",
+            "B",
+            "A",
+            json.dumps({"action": "submit_feedback", "answers": {"Q1": "ok"}}),
+        ]
+    )
+
+    _queue_and_await_contract_decisions(
+        dq,
+        tmp_path,
+        "pipeline-id",
+        identifier,
+        PipelinePhase.REFINE,
+    )
+
+    # 3 choice decisions + 1 feedback decision → 4 queue events, 4 wait events
+    queue_events = [e for e in dq.events if e[0] == "queue"]
+    wait_events = [e for e in dq.events if e[0] == "wait"]
+    assert len(queue_events) == 4
+    assert len(wait_events) == 4
+
+    # Every queue must happen before the first wait — that's what lets
+    # ``get_status`` surface all pending decisions as a single batch.
+    first_wait_idx = next(i for i, e in enumerate(dq.events) if e[0] == "wait")
+    for e in dq.events[:first_wait_idx]:
+        assert e[0] == "queue", f"queue-before-wait invariant broken: {dq.events}"

--- a/orchestrator/tests/test_contract_decision_bridge.py
+++ b/orchestrator/tests/test_contract_decision_bridge.py
@@ -439,3 +439,14 @@ def test_bridge_queues_all_decisions_before_waiting(tmp_path: Path) -> None:
     first_wait_idx = next(i for i, e in enumerate(dq.events) if e[0] == "wait")
     for e in dq.events[:first_wait_idx]:
         assert e[0] == "queue", f"queue-before-wait invariant broken: {dq.events}"
+
+    # Verify contract persistence: all choice decisions resolved with correct
+    # values, and feedback marked submitted with the expected answer.
+    data = json.loads((tmp_path / ".egg-state/contracts/issue-42.json").read_text())
+    for i, expected_res in enumerate(["A", "B", "A"], start=1):
+        d = next(d for d in data["decisions"] if d["id"] == f"decision-{i}")
+        assert d["resolved"] is True, f"decision-{i} not resolved"
+        assert d["resolution"] == expected_res, f"decision-{i} resolution mismatch"
+    fb = data["feedback"]
+    assert fb["submitted"] is True
+    assert fb["questions"][0]["answer"] == "ok"

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -582,9 +582,15 @@ Handle each response:
 
 ## Phase 4 — HITL (Human-in-the-Loop)
 
-When `get_status` returns `pending_decisions`, handle each decision based on its `decision_type`:
+When `get_status` returns `pending_decisions`, partition the batch by `decision_type` and handle each group as described below. A single `get_status` response can surface multiple pending decisions at once (e.g. a refiner that registered 10 `choice` decisions via `register_open_question`); when that happens, group them so the user sees up to 4 per `AskUserQuestion` call rather than one prompt per decision.
 
-Iterate through `pending_decisions` and handle each one individually before resuming monitoring. For each decision, check its `decision_type`:
+**Handling rules by `decision_type`**:
+
+- **`phase_gate`** — always alone. Handle individually per the section below.
+- **`choice`** — may arrive in multiples. Apply the `resolved_questions_map` auto-resolution check (see below) to each one first; auto-resolved decisions are submitted immediately via `provide_input` and omitted from the prompt. For the remaining decisions, **group up to 4 into a single multi-question `AskUserQuestion` call** (one question per decision, that decision's `options` as the choices). After the user answers, call `provide_input` once per `decision_id` with `{"action": "select", "selected": "<chosen option>"}`. Repeat in groups of 4 until every choice decision is resolved. This collapses what was previously N prompts and N polling cycles into ~⌈N/4⌉ prompts and one cycle (#1956).
+- **`feedback`** — typically at most one per phase. Handle individually; within a single feedback decision, continue to batch its `questions[]` array up to 4 per `AskUserQuestion` call (existing behavior, see the `feedback` subsection below).
+
+For the rest of this section, "the decision" refers to a single entry being processed. When multiple `choice` decisions are pending, apply the batching rule above rather than prompting one at a time.
 
 ### Resolved Questions Map
 
@@ -728,6 +734,8 @@ The `get_status` response enriches phase_gate decisions with `draft_content` (th
 After resolving this decision, move to the next pending decision (if any) before resuming monitoring.
 
 ### For `choice` type decisions:
+
+**When multiple `choice` decisions are pending in the same batch, group up to 4 into a single multi-question `AskUserQuestion` call** (see the Phase 4 intro above). The per-decision formatting rules below still apply — each decision contributes one question (its `question` field) and a set of options (its `options` array) to the batched prompt. After collecting the user's answers, call `provide_input` once per `decision_id`.
 
 **Before prompting — check `resolved_questions_map` for a captured answer**:
 

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -735,8 +735,6 @@ After resolving this decision, move to the next pending decision (if any) before
 
 ### For `choice` type decisions:
 
-**When multiple `choice` decisions are pending in the same batch, group up to 4 into a single multi-question `AskUserQuestion` call** (see the Phase 4 intro above). The per-decision formatting rules below still apply — each decision contributes one question (its `question` field) and a set of options (its `options` array) to the batched prompt. After collecting the user's answers, call `provide_input` once per `decision_id`.
-
 **Before prompting — check `resolved_questions_map` for a captured answer**:
 
 1. Compute `normalized_q = decision.question.strip().lower()`.
@@ -752,6 +750,8 @@ After resolving this decision, move to the next pending decision (if any) before
    ```
    Proceed to the next pending decision.
 5. **On no match, or if the stored answer is a free-text / "Other" value that doesn't correspond to any option in `decision.options`**: fall through to the normal prompt flow below. Do not force an invalid selection.
+
+**When multiple `choice` decisions are pending in the same batch, group up to 4 into a single multi-question `AskUserQuestion` call** (see the Phase 4 intro above). The per-decision formatting rules below still apply — each decision contributes one question (its `question` field) and a set of options (its `options` array) to the batched prompt. After collecting the user's answers, call `provide_input` once per `decision_id`.
 
 If the decision includes a `draft_content` field, display it to the user first as context for the decision. If the content is long, show a summary of the key sections (headings and first paragraph of each) followed by the full content. This is especially important for decisions from the refine and plan phases, where the draft contains the analysis or plan that motivates the decision.
 


### PR DESCRIPTION
## Summary

- `_queue_and_await_contract_decisions` now queues all pending HITL decisions + the feedback entry up front, then waits and persists each resolution — instead of queue/wait/persist per decision.
- `get_status` therefore surfaces every pending decision at once, so `/sdlc` can group up to 4 `choice` decisions into a single `AskUserQuestion` call and submit answers via `provide_input` in parallel.
- `/sdlc` skill (Phase 4) updated to describe the new per-type handling rules (phase_gate alone, choice batched up to 4, feedback individually) and cross-references the batching rule from the `choice` subsection.

Fixes #1956.

## Test plan

- [x] `pytest orchestrator/tests/test_contract_decision_bridge.py -v` — all 7 pass (6 existing + 1 new: `test_bridge_queues_all_decisions_before_waiting` asserts every `queue_decision` call precedes the first `wait_for_decision`).
- [x] `pytest orchestrator/tests/test_decision_queue.py orchestrator/tests/test_mcp_tools_enrichment.py -v` — all pass.
- [x] `ruff check` + `ruff format --check` clean on edited files.
- [ ] End-to-end on a real pipeline whose refine phase registers 5+ `choice` decisions: verify `get_status` returns all of them in a single `pending_decisions[]` and `/sdlc` prompts in batches of 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)