### PR TITLE
Fix #1959: check_hitl_answers defaults to all phases

### DIFF
--- a/sandbox/egg_agent_tools/handlers/sdlc.py
+++ b/sandbox/egg_agent_tools/handlers/sdlc.py
@@ -8,7 +8,6 @@ from egg_agent_tools.handlers._gateway import (
     container_id_field,
     gateway_request,
     get_contract_identifier,
-    get_phase,
     get_repo_path,
 )
 from egg_agent_tools.handlers.errors import GatewayError, HandlerError
@@ -221,7 +220,9 @@ def check_hitl_answers(req: dict[str, Any]) -> dict[str, Any]:
 
     Request:
         phase (str): optional filter — only return decisions/feedback
-            attached to the given phase.
+            attached to the given phase. When omitted, returns HITL for
+            *all* phases of the pipeline so a later-phase caller can see
+            what earlier phases already resolved.
         include_unresolved (bool): if True, also include unresolved
             decisions. Defaults to False.
         repo_path, pipeline_id, issue: optional overrides.
@@ -229,7 +230,9 @@ def check_hitl_answers(req: dict[str, Any]) -> dict[str, Any]:
     Response:
         { ok: True, decisions: [...], feedback: {...}|None }
     """
-    phase = req.get("phase") or get_phase()
+    phase = req.get("phase")
+    if phase is not None and phase not in _VALID_PHASES:
+        raise HandlerError(f"'phase' must be one of {sorted(_VALID_PHASES)}; got {phase!r}")
     include_unresolved = bool(req.get("include_unresolved", False))
     repo_path = req.get("repo_path") or get_repo_path()
     identifier = _resolve_identifier(req)

--- a/sandbox/egg_agent_tools/handlers/sdlc.py
+++ b/sandbox/egg_agent_tools/handlers/sdlc.py
@@ -216,7 +216,7 @@ def request_feedback(req: dict[str, Any]) -> dict[str, Any]:
 
 
 def check_hitl_answers(req: dict[str, Any]) -> dict[str, Any]:
-    """Fetch resolved decisions and submitted feedback from the contract.
+    """Fetch resolved decisions and feedback (submitted or pending) from the contract.
 
     Request:
         phase (str): optional filter — only return decisions/feedback

--- a/sandbox/egg_agent_tools/tools/sdlc.py
+++ b/sandbox/egg_agent_tools/tools/sdlc.py
@@ -56,7 +56,10 @@ _HITL_ANSWERS_SCHEMA: dict[str, Any] = {
         "phase": {
             "type": "string",
             "enum": ["refine", "plan", "implement", "pr"],
-            "description": "Optional phase filter (defaults to EGG_PHASE)",
+            "description": (
+                "Optional phase filter. When omitted, returns HITL from all "
+                "phases so later-phase callers can see earlier-phase answers."
+            ),
         },
         "include_unresolved": {
             "type": "boolean",
@@ -92,9 +95,10 @@ async def request_feedback(args: dict[str, Any]) -> dict[str, Any]:
 
 @tool(
     "check_hitl_answers",
-    "Fetch resolved HITL decisions and submitted feedback for the current contract, "
-    "optionally filtered by phase. No CLI counterpart — reads straight from the "
-    "contract gateway.",
+    "Fetch resolved HITL decisions and submitted feedback for the current "
+    "contract. With no args, returns everything the operator has already "
+    "resolved across all phases; pass 'phase' to narrow to a single phase. "
+    "No CLI counterpart — reads straight from the contract gateway.",
     _HITL_ANSWERS_SCHEMA,
 )
 async def check_hitl_answers(args: dict[str, Any]) -> dict[str, Any]:

--- a/sandbox/egg_agent_tools/tools/sdlc.py
+++ b/sandbox/egg_agent_tools/tools/sdlc.py
@@ -95,7 +95,7 @@ async def request_feedback(args: dict[str, Any]) -> dict[str, Any]:
 
 @tool(
     "check_hitl_answers",
-    "Fetch resolved HITL decisions and submitted feedback for the current "
+    "Fetch resolved HITL decisions and feedback (submitted or pending) for the current "
     "contract. With no args, returns everything the operator has already "
     "resolved across all phases; pass 'phase' to narrow to a single phase. "
     "No CLI counterpart — reads straight from the contract gateway.",

--- a/tests/sandbox/egg_agent_tools/test_handlers_sdlc.py
+++ b/tests/sandbox/egg_agent_tools/test_handlers_sdlc.py
@@ -253,6 +253,7 @@ class TestCheckHitlAnswers:
             {"id": "d1", "phase": "refine", "resolved": True, "resolution": {"id": "opt-1"}},
             {"id": "d2", "phase": "refine", "resolved": True, "resolution": {"id": "opt-2"}},
             {"id": "d3", "phase": "plan", "resolved": False, "resolution": None},
+            {"id": "d4", "phase": "plan", "resolved": True, "resolution": {"id": "opt-4"}},
         ]
         feedback = {"id": "feedback-1", "phase": "refine", "submitted": True}
         data = {"decisions": decisions, "feedback": feedback}
@@ -266,7 +267,7 @@ class TestCheckHitlAnswers:
             patch.dict("os.environ", {"EGG_PHASE": "plan"}, clear=False),
         ):
             resp = sdlc.check_hitl_answers({})
-        assert {d["id"] for d in resp["decisions"]} == {"d1", "d2"}
+        assert {d["id"] for d in resp["decisions"]} == {"d1", "d2", "d4"}
         assert resp["feedback"] == feedback
 
     def test_phase_filter_applied_to_feedback(self):

--- a/tests/sandbox/egg_agent_tools/test_handlers_sdlc.py
+++ b/tests/sandbox/egg_agent_tools/test_handlers_sdlc.py
@@ -245,6 +245,30 @@ class TestCheckHitlAnswers:
             resp = sdlc.check_hitl_answers({"phase": "plan", "include_unresolved": True})
         assert {d["id"] for d in resp["decisions"]} == {"d1", "d2"}
 
+    def test_no_phase_returns_all_phases_resolved(self):
+        """With no ``phase`` argument, resolved decisions from every phase
+        are returned — including prior phases the operator already closed
+        out. Regression test for #1959."""
+        decisions = [
+            {"id": "d1", "phase": "refine", "resolved": True, "resolution": {"id": "opt-1"}},
+            {"id": "d2", "phase": "refine", "resolved": True, "resolution": {"id": "opt-2"}},
+            {"id": "d3", "phase": "plan", "resolved": False, "resolution": None},
+        ]
+        feedback = {"id": "feedback-1", "phase": "refine", "submitted": True}
+        data = {"decisions": decisions, "feedback": feedback}
+        with (
+            patch(
+                "egg_agent_tools.handlers.sdlc.gateway_request",
+                return_value={"success": True, "data": data},
+            ),
+            patch("egg_agent_tools.handlers.sdlc.get_contract_identifier", return_value=1),
+            # EGG_PHASE must NOT affect the default — prove it by setting one.
+            patch.dict("os.environ", {"EGG_PHASE": "plan"}, clear=False),
+        ):
+            resp = sdlc.check_hitl_answers({})
+        assert {d["id"] for d in resp["decisions"]} == {"d1", "d2"}
+        assert resp["feedback"] == feedback
+
     def test_phase_filter_applied_to_feedback(self):
         data = {
             "decisions": [],
@@ -271,6 +295,10 @@ class TestCheckHitlAnswers:
         ):
             with pytest.raises(GatewayError):
                 sdlc.check_hitl_answers({})
+
+    def test_invalid_phase_rejected(self):
+        with pytest.raises(HandlerError):
+            sdlc.check_hitl_answers({"phase": "bogus"})
 
     def test_response_shape_matches_declared_schema(self):
         """Assert the response dict has the documented keys."""


### PR DESCRIPTION
## Summary
- Drop the `EGG_PHASE` fallback in `check_hitl_answers` so a no-arg call returns resolved HITL across *all* phases of the current contract — a plan-phase planner can now see the refine-phase decisions and feedback the operator already resolved.
- Keep `phase` as an explicit narrowing filter, and reject unknown values symmetrically with `register_open_question`.
- Update the tool description and schema so it's clear the default is all-phases.

Fixes #1959. Closes the MCP-surface gap that was driving planner agents back to `python3 -c "import json; ..."` against `.egg-state/contracts/*.json` — exactly what #1946 set out to eliminate.

## Test plan
- [x] `pytest tests/sandbox/egg_agent_tools/test_handlers_sdlc.py` — 20 passed, including two new cases:
  - `test_no_phase_returns_all_phases_resolved` (sets `EGG_PHASE=plan`, asserts refine-phase decisions still come back)
  - `test_invalid_phase_rejected`
- [x] `pytest tests/sandbox/egg_agent_tools/ tests/tools/test_mcp_cli_drift.py` — 183 passed, 3 skipped
- [x] `ruff check` on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)