### PR TITLE
Fix #1974: require block scalars in yaml-tasks planner prompts

### DIFF
--- a/docs/templates/plan.md
+++ b/docs/templates/plan.md
@@ -76,32 +76,49 @@ pr:
     Post-merge: [any required steps after merging, e.g. deployments]
 phases:
   - id: 1
-    name: [Phase Name]
-    goal: [What this phase achieves]
+    name: |-
+      [Phase Name]
+    goal: |-
+      [What this phase achieves]
     tasks:
       - id: TASK-1-1
-        description: [Task description]
-        acceptance: [Criteria for completion]
+        description: |-
+          [Task description — block scalars keep text with `code: type`
+          snippets, URLs, and other `: ` sequences safe from YAML parsing.]
+        acceptance: |-
+          [Criteria for completion]
         role: coder           # Optional: coder | tester | documenter
         files:
           - [path/to/file]
       - id: TASK-1-2
-        description: [Task description]
-        acceptance: [Criteria for completion]
+        description: |-
+          [Task description]
+        acceptance: |-
+          [Criteria for completion]
         role: tester
         files:
           - [path/to/test_file]
   - id: 2
-    name: [Phase Name]
-    goal: [What this phase achieves]
+    name: |-
+      [Phase Name]
+    goal: |-
+      [What this phase achieves]
     tasks:
       - id: TASK-2-1
-        description: [Task description]
-        acceptance: [Criteria for completion]
+        description: |-
+          [Task description]
+        acceptance: |-
+          [Criteria for completion]
         role: coder
         files:
           - [path/to/file]
 ```
+
+> **YAML safety**: Always use block scalars (`|-`) for `name`, `goal`,
+> `description`, and `acceptance`. Plain unquoted scalars break when the
+> text contains `` `code: type` `` snippets or other `: ` sequences —
+> PyYAML reads them as nested mappings and the parser silently drops back
+> to markdown fallback, losing the `pr:` block (see issue #1974).
 
 > **Role assignment**: The optional `role` field assigns a task to a specific execution agent
 > (`coder`, `tester`, or `documenter`). Assign roles based on which agent is permitted to modify

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5734,7 +5734,7 @@ _YAML_TASKS_SAFETY_GUIDANCE = [
     "break when the text contains `` `code: type` ``, colons in URLs, or "
     "other `: ` sequences, because PyYAML reads them as nested mappings "
     "and the parser drops back to markdown fallback (silently losing the "
-    "`pr:` block). Follow the example below literally — do not inline these "
+    "`pr:` block). Follow the example above literally — do not inline these "
     "values on the same line as the key.",
 ]
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5723,6 +5723,21 @@ _PR_DESCRIPTION_YAML_EXAMPLE = [
     "    components as a result.",
 ]
 
+# YAML safety guidance for planner prompts. Plain (unquoted) scalars break
+# when they contain ``: `` sequences — e.g. "Add `sequence: int = 0` field"
+# parses as a nested mapping and raises ScannerError. Block scalars (``|-``)
+# take the whole indented block literally, so backticks, colons, quotes, and
+# other punctuation are safe. See issue #1974.
+_YAML_TASKS_SAFETY_GUIDANCE = [
+    "**YAML safety**: Use block scalars (`|-`) for every prose field — "
+    "`name`, `goal`, `description`, `acceptance`. Plain unquoted scalars "
+    "break when the text contains `` `code: type` ``, colons in URLs, or "
+    "other `: ` sequences, because PyYAML reads them as nested mappings "
+    "and the parser drops back to markdown fallback (silently losing the "
+    "`pr:` block). Follow the example below literally — do not inline these "
+    "values on the same line as the key.",
+]
+
 
 def _build_phase_prompt(
     phase: str,
@@ -5950,16 +5965,23 @@ def _build_phase_prompt(
                 "    Post-merge: any required steps after merging",
                 "phases:",
                 "  - id: 1",
-                "    name: Phase Name",
-                "    goal: What this phase achieves",
+                "    name: |-",
+                "      Phase Name",
+                "    goal: |-",
+                "      What this phase achieves",
                 "    tasks:",
                 "      - id: TASK-1-1",
-                "        description: What to do",
-                "        acceptance: How to verify it is done",
+                "        description: |-",
+                "          What to do — safe to include `code: type` snippets,",
+                "          URLs, and other punctuation inside a block scalar.",
+                "        acceptance: |-",
+                "          How to verify it is done",
                 "        files:",
                 "          - path/to/file.py",
                 "```",
                 "````",
+                "",
+                *_YAML_TASKS_SAFETY_GUIDANCE,
                 "",
                 "Do NOT use a `pr_plan` key or propose multiple PRs.",
                 "",
@@ -7329,17 +7351,24 @@ def _build_agent_prompt(
                 "    Post-merge: any required steps after merging",
                 "phases:",
                 "  - id: 1",
-                "    name: Phase Name",
-                "    goal: What this phase achieves",
+                "    name: |-",
+                "      Phase Name",
+                "    goal: |-",
+                "      What this phase achieves",
                 "    tasks:",
                 "      - id: TASK-1-1",
-                "        description: What to do",
-                "        acceptance: How to verify it is done",
+                "        description: |-",
+                "          What to do — safe to include `code: type` snippets,",
+                "          URLs, and other punctuation inside a block scalar.",
+                "        acceptance: |-",
+                "          How to verify it is done",
                 "        role: coder  # optional: coder (default), tester, or documenter",
                 "        files:",
                 "          - path/to/file.py",
                 "```",
                 "````",
+                "",
+                *_YAML_TASKS_SAFETY_GUIDANCE,
                 "",
                 "Do NOT use a `pr_plan` key or propose multiple PRs.",
                 "",

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -3067,6 +3067,41 @@ class TestTaskPlannerRoleRestrictions:
         assert "role: coder" in result
 
 
+class TestYamlTasksBlockScalars:
+    """Regression tests for #1974 — planner prompts must demonstrate block
+    scalars for prose fields so agents don't emit plain scalars that break
+    on ``: `` sequences (e.g. `` `code: type` `` snippets)."""
+
+    def test_task_planner_prompt_uses_block_scalars_for_prose_fields(self):
+        result = _build_agent_prompt(
+            role_value="task_planner",
+            phase="plan",
+            pipeline_id="pid-1",
+            pipeline_mode="issue",
+            prompt="# Feature",
+            issue_number=42,
+        )
+        assert "description: |-" in result
+        assert "acceptance: |-" in result
+        assert "name: |-" in result
+        assert "goal: |-" in result
+        assert "YAML safety" in result
+
+    def test_plan_phase_prompt_uses_block_scalars_for_prose_fields(self):
+        result = _build_phase_prompt(
+            phase="plan",
+            pipeline_id="pid-1",
+            pipeline_mode="issue",
+            prompt="# Feature",
+            issue_number=42,
+        )
+        assert "description: |-" in result
+        assert "acceptance: |-" in result
+        assert "name: |-" in result
+        assert "goal: |-" in result
+        assert "YAML safety" in result
+
+
 class TestReviewPromptBaseBranch:
     """Tests for base_branch parameter in _build_review_prompt (issue #1565)."""
 

--- a/shared/egg_contracts/plan_parser.py
+++ b/shared/egg_contracts/plan_parser.py
@@ -23,18 +23,26 @@ Task ID Format:
     Example: TASK-1-1, TASK-2-3
 
 YAML Code Fence Format:
-    The structured appendix should be a YAML code block with the marker comment:
+    The structured appendix should be a YAML code block with the marker comment.
+    Use block scalars (``|-``) for ``name``, ``goal``, ``description``, and
+    ``acceptance`` — plain unquoted scalars break when the value contains a
+    ``: `` sequence (e.g. a backticked ``code: type`` snippet), because PyYAML
+    interprets it as a nested mapping and raises ``ScannerError``. See #1974.
 
     ```yaml
     # yaml-tasks
     phases:
       - id: 1
-        name: Setup
-        goal: Initialize the project
+        name: |-
+          Setup
+        goal: |-
+          Initialize the project
         tasks:
           - id: TASK-1-1
-            description: Create contract JSON schema
-            acceptance: Schema validates sample contracts
+            description: |-
+              Create contract JSON schema
+            acceptance: |-
+              Schema validates sample contracts
             files:
               - .egg/schemas/contract.schema.json
     ```

--- a/tests/shared/egg_contracts/test_plan_parser.py
+++ b/tests/shared/egg_contracts/test_plan_parser.py
@@ -1834,3 +1834,88 @@ phases:
         assert result.pr_title is None
         assert result.pr_description is None
         assert any("missing required 'title' field" in w.message for w in result.warnings)
+
+
+class TestYamlScalarQuotingRegression:
+    """Regression tests for #1974 — task_planner emitting unquoted YAML
+    scalars whose text contained ``: `` sequences, which PyYAML interpreted
+    as the start of a nested mapping and broke contract population.
+    """
+
+    # The exact fragment pattern that broke issue #1932's pipeline.
+    BROKEN_DESCRIPTION = (
+        "Add `sequence: int = 0` field to `Event` dataclass in "
+        "`orchestrator/events.py`. Populate from a new "
+        "`EventBus._sequence: int` counter."
+    )
+
+    def test_unquoted_scalar_with_colon_triggers_parse_warning(self):
+        """Plain-scalar description containing `` `code: type` `` raises a
+        YAML ScannerError inside ``parse_yaml_code_fence``, which records a
+        warning and forces the markdown fallback. This reproduces the silent
+        failure from #1932 — the ``pr:`` block is lost.
+        """
+        content = f"""# Plan
+
+```yaml
+# yaml-tasks
+pr:
+  title: "Fix sequencing"
+  description: |
+    Body.
+phases:
+  - id: 1
+    name: Implementation
+    tasks:
+      - id: TASK-1-1
+        description: {self.BROKEN_DESCRIPTION}
+        acceptance: Works
+```
+"""
+        result = parse_plan(content)
+        # The YAML fence parser records a scanner error warning and falls
+        # back to markdown — which recovers no ``pr:`` block.
+        assert any("Invalid YAML in yaml-tasks code fence" in w.message for w in result.warnings)
+        assert result.pr_title is None
+
+    def test_block_scalar_safely_carries_colon_content(self):
+        """With the description wrapped in a block scalar (``|-``), the same
+        text is preserved literally and parsing succeeds — pr_title is set
+        and the contract-populate path fires normally.
+        """
+        content = f"""# Plan
+
+```yaml
+# yaml-tasks
+pr:
+  title: "Fix sequencing"
+  description: |
+    Body.
+  test_plan: |
+    - Automated: unit test
+phases:
+  - id: 1
+    name: |-
+      Implementation
+    goal: |-
+      Add sequencing
+    tasks:
+      - id: TASK-1-1
+        description: |-
+          {self.BROKEN_DESCRIPTION}
+        acceptance: |-
+          Works
+```
+"""
+        result = parse_plan(content)
+        assert result.success, result.error
+        assert result.pr_title == "Fix sequencing"
+        assert len(result.phases) == 1
+        task = result.phases[0].tasks[0]
+        # Block scalar preserves backticks, colons, and inline code snippets.
+        assert "`sequence: int = 0`" in task.description
+        assert "`EventBus._sequence: int`" in task.description
+        # No YAML scanner warnings.
+        assert not any(
+            "Invalid YAML in yaml-tasks code fence" in w.message for w in result.warnings
+        )


### PR DESCRIPTION
## Summary

- Planner agents were emitting plain-scalar `description:` / `acceptance:` values that contained backticked `` `code: type` `` snippets. PyYAML treated the second `:` as the start of a nested mapping and raised `ScannerError`, so `parse_plan` fell back to markdown and silently dropped the top-level `pr:` block — the downstream symptom on #1932's PR #1971 was a contract never populated and a PR opened with title `"Issue #1932"` and no test plan.
- Both planner prompt sites (`_build_phase_prompt(phase="plan")` and `_build_agent_prompt(role_value="task_planner")`) plus `docs/templates/plan.md` now show `name` / `goal` / `description` / `acceptance` as block scalars (`|-`), with explicit YAML-safety guidance that explains why. Block scalars preserve backticks, colons, and other punctuation literally.
- Chose the prompt-level fix over a post-draft validator (Option 3 in the issue) because the root cause is agent output shape and the example is the single highest-leverage lever; parser-side recovery is the wrong layer since unquoted `text: value` is genuinely ambiguous YAML.

## Test plan

- [x] `pytest tests/shared/egg_contracts/test_plan_parser.py::TestYamlScalarQuotingRegression` — new regression covers the exact #1932 fragment: plain-scalar form still emits the scanner warning that triggered the silent fallback, block-scalar form parses successfully with `pr_title` populated.
- [x] `pytest orchestrator/tests/test_pipeline_prompts.py::TestYamlTasksBlockScalars` — new tests assert both planner prompts emit `description: |-`, `acceptance: |-`, `name: |-`, `goal: |-`, and the "YAML safety" guidance.
- [x] `pytest tests/shared/egg_contracts/test_plan_parser.py orchestrator/tests/test_pipeline_prompts.py orchestrator/tests/test_advance_phase_populate_on_plan_exit.py orchestrator/tests/test_short_flow_contract_population.py orchestrator/tests/test_auto_pr.py shared/egg_contracts/tests/test_plan_parser_dependencies.py` — 485 tests pass, no regressions in the parser / contract-population surface.

Closes #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)