### PR TITLE
Fix #1975: surface PR metadata stub fallback with banner + draft status

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5495,7 +5495,7 @@ def _pr_metadata_from_plan_draft(
     worktree_repo_path: Path,
     issue_number: int | None,
     pipeline_id: str,
-) -> tuple[str | None, str, str, str]:
+) -> tuple[str | None, str, str, str, list[str], str | None]:
     """Parse PR metadata from the plan draft on disk.
 
     Used as a fallback in ``_build_pr_body`` when ``contract.pr`` is not
@@ -5503,16 +5503,24 @@ def _pr_metadata_from_plan_draft(
     branch tip (see #1829). The plan draft itself is reliably on the
     branch even when the contract is not.
 
-    Returns ``(title, description, test_plan, manual_steps)``; ``title``
-    is ``None`` when the draft is missing, unparseable, or has no ``pr:``
-    block, signalling the caller to fall through to the next tier.
+    Returns ``(title, description, test_plan, manual_steps, warnings,
+    draft_rel_path)``. ``title`` is ``None`` when the draft is missing,
+    unparseable, or has no ``pr:`` block, signalling the caller to fall
+    through to the next tier. ``warnings`` is a list of
+    human-readable parse warning strings collected from ``parse_plan``
+    (empty when the parse was clean or the draft was absent); it is
+    surfaced in the PR body when the caller falls through to the stub
+    tier so reviewers can see what went wrong (see #1975).
+    ``draft_rel_path`` is the relative path to the draft that was
+    parsed, or ``None`` if no draft was attempted.
     """
+    warnings_out: list[str] = []
     draft_rel = _get_draft_path("plan", issue_number=issue_number, pipeline_id=pipeline_id)
     if not draft_rel:
-        return None, "", "", ""
+        return None, "", "", "", warnings_out, None
     plan_path = worktree_repo_path / draft_rel
     if not plan_path.exists():
-        return None, "", "", ""
+        return None, "", "", "", warnings_out, draft_rel
     try:
         from egg_contracts.plan_parser import parse_plan
 
@@ -5523,21 +5531,29 @@ def _pr_metadata_from_plan_draft(
             path=str(plan_path),
             error=str(e),
         )
-        return None, "", "", ""
+        warnings_out.append(f"parse_plan raised: {e}")
+        return None, "", "", "", warnings_out, draft_rel
+    for w in result.warnings:
+        msg = w.message
+        if w.context:
+            msg = f"{msg} ({w.context})"
+        warnings_out.append(msg)
     if not result.pr_title:
-        return None, "", "", ""
+        return None, "", "", "", warnings_out, draft_rel
     return (
         result.pr_title,
         result.pr_description or "",
         result.pr_test_plan or "",
         result.pr_manual_steps or "",
+        warnings_out,
+        draft_rel,
     )
 
 
 def _build_pr_body(
     pipeline: Pipeline,
     worktree_repo_path: Path,
-) -> tuple[str, str]:
+) -> tuple[str, str, bool]:
     """Build a PR title and body from contract state.
 
     Uses the planner-generated PR metadata from the contract when available,
@@ -5551,7 +5567,11 @@ def _build_pr_body(
         worktree_repo_path: Path to the worktree repo directory
 
     Returns:
-        Tuple of (title, body)
+        Tuple of (title, body, used_stub_fallback).  ``used_stub_fallback``
+        is True when neither the contract nor the plan draft produced a
+        PR title and the implementation dropped through to the issue
+        title / generic stub (see #1975).  Callers use this to mark the
+        PR as draft so reviewers notice the planner metadata is missing.
     """
     identifier = _pipeline_identifier(pipeline.issue_number, pipeline.id)
     pr_title: str | None = None
@@ -5559,6 +5579,9 @@ def _build_pr_body(
     pr_test_plan: str = ""
     pr_manual_steps: str = ""
     issue_title: str | None = None
+    plan_draft_warnings: list[str] = []
+    plan_draft_path: str | None = None
+    parsed_plan_draft: bool = False
 
     # Tier 1: load PR metadata from the contract (populated by the plan agent).
     # Contracts are keyed by pipeline_id after key unification (#1773).
@@ -5584,7 +5607,15 @@ def _build_pr_body(
     # metadata.  The draft is reliably on the branch even when the
     # contract write didn't land (#1829).
     if not pr_title:
-        draft_title, draft_desc, draft_test_plan, draft_manual_steps = _pr_metadata_from_plan_draft(
+        parsed_plan_draft = True
+        (
+            draft_title,
+            draft_desc,
+            draft_test_plan,
+            draft_manual_steps,
+            plan_draft_warnings,
+            plan_draft_path,
+        ) = _pr_metadata_from_plan_draft(
             worktree_repo_path,
             issue_number=pipeline.issue_number,
             pipeline_id=pipeline.id,
@@ -5596,11 +5627,38 @@ def _build_pr_body(
             pr_manual_steps = draft_manual_steps
 
     # Tier 3: issue title, then generic stub
+    used_stub_fallback = False
     if not pr_title:
+        used_stub_fallback = True
         pr_title = issue_title or f"Implementation for pipeline {pipeline.id}"
 
     # Assemble body
     body_parts: list[str] = []
+
+    # Fallback banner: when tier-3 fired, surface the failure loudly on
+    # the PR itself so reviewers don't silently merge a PR whose title is
+    # just "Issue #N" (see #1975). Parse warnings from the tier-2
+    # attempt (if any) are listed verbatim so the reader can see the
+    # specific yaml-tasks problem instead of only finding it in
+    # orchestrator logs.
+    if used_stub_fallback:
+        banner_lines = [
+            "> ⚠️ **Automated PR metadata fell back to the issue title.**",
+            "> The plan draft's `pr:` block was missing or could not be parsed,",
+            "> so this PR body is a stub. Opened as a draft to block merge.",
+        ]
+        if plan_draft_path:
+            banner_lines.append(f"> Draft: `{plan_draft_path}`")
+        if plan_draft_warnings:
+            banner_lines.append("> Parse warnings:")
+            for msg in plan_draft_warnings:
+                banner_lines.append(f"> - {msg}")
+        elif parsed_plan_draft and plan_draft_path:
+            banner_lines.append("> No `pr.title` found in the plan draft's yaml-tasks block.")
+        elif parsed_plan_draft and not plan_draft_path:
+            banner_lines.append("> No plan draft was found on disk.")
+        banner_lines.append("> Repair the plan draft and re-run `populate_contract` (see #1974).")
+        body_parts.append("\n".join(banner_lines))
 
     if pr_description:
         body_parts.append(pr_description)
@@ -5637,7 +5695,7 @@ def _build_pr_body(
 
     body = "\n\n".join(body_parts)
 
-    return pr_title, body
+    return pr_title, body, used_stub_fallback
 
 
 def _auto_create_pr(
@@ -5672,7 +5730,18 @@ def _auto_create_pr(
     if not base:
         base = get_default_branch(worktree_repo_path)
 
-    title, body = _build_pr_body(pipeline, worktree_repo_path)
+    title, body, used_stub_fallback = _build_pr_body(pipeline, worktree_repo_path)
+
+    # Force draft when PR metadata fell through to the generic stub
+    # (see #1975).  A draft PR is the loudest signal GitHub offers to
+    # stop a human from silently merging a planner-broken PR whose
+    # title is just "Issue #N".
+    draft = (gateway_mode == "private") or used_stub_fallback
+    if used_stub_fallback:
+        logger.warning(
+            "Auto PR opened as draft: planner metadata fallback used",
+            pipeline_id=pipeline.id,
+        )
 
     try:
         pr_url = spawner.gateway.create_pr(
@@ -5685,7 +5754,7 @@ def _auto_create_pr(
             issue_number=pipeline.issue_number,
             agent_role="orchestrator",
             mode=gateway_mode,
-            draft=(gateway_mode == "private"),
+            draft=draft,
         )
         return pr_url
     except Exception as e:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5520,6 +5520,7 @@ def _pr_metadata_from_plan_draft(
         return None, "", "", "", warnings_out, None
     plan_path = worktree_repo_path / draft_rel
     if not plan_path.exists():
+        warnings_out.append(f"Plan draft not found at {draft_rel}")
         return None, "", "", "", warnings_out, draft_rel
     try:
         from egg_contracts.plan_parser import parse_plan
@@ -5655,8 +5656,6 @@ def _build_pr_body(
                 banner_lines.append(f"> - {msg}")
         elif parsed_plan_draft and plan_draft_path:
             banner_lines.append("> No `pr.title` found in the plan draft's yaml-tasks block.")
-        elif parsed_plan_draft and not plan_draft_path:
-            banner_lines.append("> No plan draft was found on disk.")
         banner_lines.append("> Repair the plan draft and re-run `populate_contract` (see #1974).")
         body_parts.append("\n".join(banner_lines))
 

--- a/orchestrator/tests/test_auto_pr.py
+++ b/orchestrator/tests/test_auto_pr.py
@@ -400,6 +400,8 @@ class TestBuildPrBodyFallbackBanner:
 
         assert used_stub_fallback is True
         assert "fell back to the issue title" in body
+        assert "Plan draft not found" in body
+        assert ".egg-state/drafts/42-plan.md" in body
 
 
 class TestAutoCreatePr:

--- a/orchestrator/tests/test_auto_pr.py
+++ b/orchestrator/tests/test_auto_pr.py
@@ -73,7 +73,7 @@ class TestBuildPrBody:
         contract_file = contract_dir / "42.json"
         contract_file.write_text(json.dumps(_make_contract_json()))
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert title == "Fix authentication bypass in login flow"
         assert "Fixes a bypass" in body
@@ -87,7 +87,7 @@ class TestBuildPrBody:
         contract_file = contract_dir / "42.json"
         contract_file.write_text(json.dumps(_make_contract_json(pr_title=None)))
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert title == "Fix the auth bug"
 
@@ -95,7 +95,7 @@ class TestBuildPrBody:
         """Test fallback to pipeline ID when no contract exists."""
         pipeline = _make_pipeline()
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert "issue-42" in title
 
@@ -103,7 +103,7 @@ class TestBuildPrBody:
         """Test that commit log is NOT included in body (GitHub shows it natively)."""
         pipeline = _make_pipeline()
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert "## Commits" not in body
 
@@ -111,7 +111,7 @@ class TestBuildPrBody:
         """Test that diff stats are NOT included in body (GitHub shows it natively)."""
         pipeline = _make_pipeline()
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert "## Changes" not in body
 
@@ -119,7 +119,7 @@ class TestBuildPrBody:
         """Test that issue reference is added when no PR description."""
         pipeline = _make_pipeline()
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert "Closes #42" in body
 
@@ -127,7 +127,7 @@ class TestBuildPrBody:
         """Test that body ends with attribution."""
         pipeline = _make_pipeline()
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert "Authored-by: egg" in body
 
@@ -135,7 +135,7 @@ class TestBuildPrBody:
         """Test that pipeline context section is included in body."""
         pipeline = _make_pipeline()
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert "## Pipeline Context" in body
         assert "Pipeline: `issue-42`" in body
@@ -145,7 +145,7 @@ class TestBuildPrBody:
         """Test that pipeline context appears before the authored-by line."""
         pipeline = _make_pipeline()
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         context_pos = body.index("## Pipeline Context")
         authored_pos = body.index("Authored-by: egg")
@@ -160,7 +160,7 @@ class TestBuildPrBody:
         contract_file = contract_dir / "42.json"
         contract_file.write_text(json.dumps(_make_contract_json(pr_description="A" * 10_000)))
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert len(body) < 65_536
 
@@ -222,7 +222,7 @@ class TestBuildPrBodyPlanDraftFallback:
             manual_steps="Pre-merge: run migration",
         )
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert title == "Fix the auth bug via plan draft"
         assert "From the plan draft description." in body
@@ -245,7 +245,7 @@ class TestBuildPrBodyPlanDraftFallback:
             manual_steps="None",
         )
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert title == "Draft-only title"
         assert "Draft-only description." in body
@@ -273,7 +273,7 @@ class TestBuildPrBodyPlanDraftFallback:
             manual_steps="None",
         )
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert title == "From contract"
         assert "From contract description." in body
@@ -287,7 +287,7 @@ class TestBuildPrBodyPlanDraftFallback:
         contract_dir.mkdir(parents=True)
         (contract_dir / "42.json").write_text(json.dumps(_make_contract_json(pr_title=None)))
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert title == "Fix the auth bug"
 
@@ -301,9 +301,105 @@ class TestBuildPrBodyPlanDraftFallback:
         drafts_dir.mkdir(parents=True)
         (drafts_dir / "42-plan.md").write_text("# Plan with no yaml-tasks block\n\nJust prose.\n")
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert title == "Fix the auth bug"
+
+
+class TestBuildPrBodyFallbackBanner:
+    """Regression tests for #1975 — when PR metadata falls through to the
+    issue-title/generic stub, the body must surface a visible banner
+    (and the caller must mark the PR as draft) so reviewers don't
+    silently merge a planner-broken PR whose body is empty.
+    """
+
+    def test_banner_present_when_yaml_tasks_parse_fails(self, tmp_path):
+        """A plan draft with a broken yaml-tasks block emits a banner
+        containing the specific PyYAML error message."""
+        pipeline = _make_pipeline()
+        contract_dir = tmp_path / ".egg-state" / "contracts"
+        contract_dir.mkdir(parents=True)
+        (contract_dir / "42.json").write_text(json.dumps(_make_contract_json(pr_title=None)))
+
+        # Reproduces the #1932 failure mode from #1974: unquoted `: int` in
+        # a scalar makes PyYAML think a nested mapping starts mid-line.
+        drafts_dir = tmp_path / ".egg-state" / "drafts"
+        drafts_dir.mkdir(parents=True)
+        (drafts_dir / "42-plan.md").write_text(
+            "# Plan\n\n"
+            "```yaml\n"
+            "# yaml-tasks\n"
+            "phases:\n"
+            "  - id: 1\n"
+            "    name: Phase 1\n"
+            "    tasks:\n"
+            "      - id: TASK-1-1\n"
+            "        description: Add `sequence: int = 0` field to `Event`\n"
+            "```\n"
+        )
+
+        title, body, used_stub_fallback = _build_pr_body(pipeline, tmp_path)
+
+        assert used_stub_fallback is True
+        # Tier 3 still fills in the issue title, but the banner signals it.
+        assert title == "Fix the auth bug"
+        assert "Automated PR metadata fell back to the issue title" in body
+        assert "Opened as a draft to block merge" in body
+        # The specific YAML scanner error surfaces in the body so reviewers
+        # can see the failure without digging through orchestrator logs.
+        assert "Invalid YAML in yaml-tasks" in body
+        assert "mapping values are not allowed here" in body
+        # The plan draft path is surfaced so the reader can find the file.
+        assert ".egg-state/drafts/42-plan.md" in body
+        # Banner comes before the generic "Closes #N" / placeholder test plan
+        # so a human reader sees the warning before the stub content.
+        assert body.index("fell back to the issue title") < body.index("Closes #42")
+        assert body.index("fell back to the issue title") < body.index("## Test Plan")
+
+    def test_banner_absent_when_contract_provides_metadata(self, tmp_path):
+        """No banner is emitted when contract.pr is populated (tier 1)."""
+        pipeline = _make_pipeline()
+        contract_dir = tmp_path / ".egg-state" / "contracts"
+        contract_dir.mkdir(parents=True)
+        (contract_dir / "42.json").write_text(json.dumps(_make_contract_json()))
+
+        _title, body, used_stub_fallback = _build_pr_body(pipeline, tmp_path)
+
+        assert used_stub_fallback is False
+        assert "fell back to the issue title" not in body
+        assert "Opened as a draft" not in body
+
+    def test_banner_absent_when_plan_draft_parses_cleanly(self, tmp_path):
+        """No banner when tier 2 recovers PR metadata from the plan draft."""
+        pipeline = _make_pipeline()
+        contract_dir = tmp_path / ".egg-state" / "contracts"
+        contract_dir.mkdir(parents=True)
+        (contract_dir / "42.json").write_text(json.dumps(_make_contract_json(pr_title=None)))
+        _write_plan_draft(
+            tmp_path,
+            42,
+            title="From plan draft",
+            description="Plan-draft description.",
+            test_plan="- X",
+            manual_steps="None",
+        )
+
+        _title, body, used_stub_fallback = _build_pr_body(pipeline, tmp_path)
+
+        assert used_stub_fallback is False
+        assert "fell back to the issue title" not in body
+
+    def test_banner_notes_missing_draft(self, tmp_path):
+        """When no plan draft exists on disk, the banner says so."""
+        pipeline = _make_pipeline()
+        contract_dir = tmp_path / ".egg-state" / "contracts"
+        contract_dir.mkdir(parents=True)
+        (contract_dir / "42.json").write_text(json.dumps(_make_contract_json(pr_title=None)))
+
+        _title, body, used_stub_fallback = _build_pr_body(pipeline, tmp_path)
+
+        assert used_stub_fallback is True
+        assert "fell back to the issue title" in body
 
 
 class TestAutoCreatePr:
@@ -316,7 +412,10 @@ class TestAutoCreatePr:
         spawner.gateway.create_pr.return_value = "https://github.com/owner/repo/pull/1"
 
         with (
-            patch("routes.pipelines._build_pr_body", return_value=("Fix auth", "Body text")),
+            patch(
+                "routes.pipelines._build_pr_body",
+                return_value=("Fix auth", "Body text", False),
+            ),
             patch("routes.pipelines.get_default_branch", return_value="main"),
         ):
             result = _auto_create_pr(pipeline, Path("/tmp/repo"), spawner)
@@ -342,7 +441,10 @@ class TestAutoCreatePr:
         spawner.gateway.create_pr.return_value = "https://github.com/owner/repo/pull/2"
 
         with (
-            patch("routes.pipelines._build_pr_body", return_value=("Fix auth", "Body text")),
+            patch(
+                "routes.pipelines._build_pr_body",
+                return_value=("Fix auth", "Body text", False),
+            ),
             patch("routes.pipelines.get_default_branch", return_value="main"),
         ):
             result = _auto_create_pr(pipeline, Path("/tmp/repo"), spawner, gateway_mode="private")
@@ -388,12 +490,34 @@ class TestAutoCreatePr:
         spawner.gateway.create_pr.side_effect = Exception("Gateway unreachable")
 
         with (
-            patch("routes.pipelines._build_pr_body", return_value=("Title", "Body")),
+            patch("routes.pipelines._build_pr_body", return_value=("Title", "Body", False)),
             patch("routes.pipelines.get_default_branch", return_value="main"),
         ):
             result = _auto_create_pr(pipeline, Path("/tmp/repo"), spawner)
 
         assert result is None
+
+    def test_stub_fallback_forces_draft_in_public_mode(self):
+        """Regression #1975: when _build_pr_body signals stub fallback, the
+        PR is opened as a draft even in public mode so humans don't
+        silently merge a planner-broken PR."""
+        pipeline = _make_pipeline()
+        spawner = MagicMock()
+        spawner.gateway.create_pr.return_value = "https://github.com/owner/repo/pull/1"
+
+        with (
+            patch(
+                "routes.pipelines._build_pr_body",
+                return_value=("Issue #42", "stub body", True),
+            ),
+            patch("routes.pipelines.get_default_branch", return_value="main"),
+        ):
+            result = _auto_create_pr(pipeline, Path("/tmp/repo"), spawner)
+
+        assert result == "https://github.com/owner/repo/pull/1"
+        call_kwargs = spawner.gateway.create_pr.call_args[1]
+        assert call_kwargs["mode"] == "public"
+        assert call_kwargs["draft"] is True
 
 
 class TestComputeGatewayMode:
@@ -540,7 +664,7 @@ class TestAutoCreatePrPassesBaseBranch:
         spawner.gateway.create_pr.return_value = "https://github.com/owner/repo/pull/1"
 
         with (
-            patch("routes.pipelines._build_pr_body", return_value=("Title", "Body")),
+            patch("routes.pipelines._build_pr_body", return_value=("Title", "Body", False)),
             patch("routes.pipelines.get_default_branch", return_value="master"),
         ):
             result = _auto_create_pr(pipeline, Path("/tmp/repo"), spawner)
@@ -557,7 +681,10 @@ class TestAutoCreatePrPassesBaseBranch:
         spawner.gateway.create_pr.return_value = "https://github.com/owner/repo/pull/3"
 
         with (
-            patch("routes.pipelines._build_pr_body", return_value=("Title", "Body")) as mock_build,
+            patch(
+                "routes.pipelines._build_pr_body",
+                return_value=("Title", "Body", False),
+            ) as mock_build,
             patch("routes.pipelines.get_default_branch") as mock_detect,
         ):
             result = _auto_create_pr(pipeline, Path("/tmp/repo"), spawner)

--- a/orchestrator/tests/test_brc_history.py
+++ b/orchestrator/tests/test_brc_history.py
@@ -1451,7 +1451,7 @@ class TestBuildPrBodyBrcLink:
         (history_dir / "42-plan.md").write_text("stub")
         (history_dir / "42-implement.md").write_text("stub")
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert "_Per-phase BRC transcripts:" in body
         assert "[`plan`](./.egg-state/brc-history/42-plan.md)" in body
@@ -1468,7 +1468,7 @@ class TestBuildPrBodyBrcLink:
         pipeline = _make_pipeline()
         _setup_contract(tmp_path)
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert "Per-phase BRC transcripts" not in body
         assert "Authored-by: egg" in body
@@ -1482,6 +1482,6 @@ class TestBuildPrBodyBrcLink:
         history_dir.mkdir(parents=True)
         (history_dir / "42-implement.md").write_text("stub")
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert body.index("Per-phase BRC transcripts") < body.index("Authored-by: egg")

--- a/orchestrator/tests/test_short_flow_contract_population.py
+++ b/orchestrator/tests/test_short_flow_contract_population.py
@@ -192,7 +192,7 @@ class TestEnsureStatefilesRestoresPRMetadata:
         assert result is True
 
         # Now verify _build_pr_body picks up the PR metadata
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert title == "Add retry logic to API client"
         assert "exponential backoff" in body
@@ -222,7 +222,7 @@ class TestEnsureStatefilesRestoresPRMetadata:
 
         assert result is True
 
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
 
         assert title == "Add retry logic to API client"
         assert "exponential backoff" in body
@@ -288,7 +288,7 @@ class TestEnsureStatefilesRestoresDraftFromRemote:
         assert plan_path.read_text() == SAMPLE_PLAN
 
         # Verify contract has PR metadata from the restored plan
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
         assert title == "Add retry logic to API client"
         assert "exponential backoff" in body
 
@@ -398,7 +398,7 @@ class TestEnsureStatefilesRestoresDraftFromRemote:
         assert plan_path.read_text() == SAMPLE_PLAN
 
         # Verify contract has PR metadata from the restored plan
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
         assert title == "Add retry logic to API client"
         assert "exponential backoff" in body
 

--- a/orchestrator/tests/test_statefile_reconciliation.py
+++ b/orchestrator/tests/test_statefile_reconciliation.py
@@ -244,7 +244,7 @@ class TestEnsureStatefilesFallbackToPipelineModel:
         assert plan_path.read_text() == SAMPLE_PLAN
 
         # Verify contract has PR metadata from the plan
-        title, body = _build_pr_body(pipeline, tmp_path)
+        title, body, _ = _build_pr_body(pipeline, tmp_path)
         assert title == "Add retry logic to API client"
         assert "exponential backoff" in body
 


### PR DESCRIPTION
## Summary

- When `_build_pr_body` falls through to the tier-3 issue-title / generic stub (because neither `contract.pr` nor the plan-draft parse yielded a `pr_title`), prepend a visible warning banner to the PR body that names the failure and lists tier-2 parse warnings verbatim — previously these surfaced only in orchestrator logs.
- `_auto_create_pr` now forces the PR to open as a draft when that fallback fires (even in public mode), so a human can't silently merge a planner-broken PR whose title is just `"Issue #N"`.
- `_pr_metadata_from_plan_draft` gained warnings + draft-path returns so the banner can quote the specific `yaml-tasks` error (e.g. `Invalid YAML in yaml-tasks code fence: mapping values are not allowed here`).

Closes #1975.

## Test plan

- [x] `pytest orchestrator/tests/test_auto_pr.py` — 39 passing, including 5 new regression tests that assert the banner is present only when fallback fires, quotes the specific PyYAML error, points at the plan-draft path, and drafts the PR in public mode.
- [x] `pytest orchestrator/tests/test_brc_history.py orchestrator/tests/test_statefile_reconciliation.py orchestrator/tests/test_short_flow_contract_population.py` — 83 passing (updated call sites for the new 3-tuple return of `_build_pr_body`).
- [ ] Manual: re-run the #1932 repro (plan draft with `description: Add \`sequence: int = 0\`…`) and confirm the auto-opened PR shows the banner and opens as draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)