### PR TITLE
Fix #1976: rebase reconcile skips commits already on base branch

### DIFF
--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -708,6 +708,7 @@ class GatewayClient:
         branch: str,
         mode: Literal["public", "private"] = "public",
         ref: str | None = None,
+        base_branch: str | None = None,
     ) -> PushResult:
         """Push a branch to remote using a temporary session.
 
@@ -734,6 +735,11 @@ class GatewayClient:
             branch: Remote branch name to push to
             mode: Gateway session mode (public/private)
             ref: Local ref to push (omit to push worktree HEAD)
+            base_branch: Pipeline's base branch (e.g. ``"main"``).  When
+                set, the reconcile rebase uses ``--onto origin/{branch}
+                origin/{base_branch}`` so commits already on the base
+                branch are not replayed onto the pipeline branch (#1976).
+                Ignored when ``ref`` is set (reconcile is skipped there).
 
         Returns:
             ``PushResult`` whose ``ok`` flag is ``True`` on success and
@@ -776,6 +782,7 @@ class GatewayClient:
             mode=mode,
             refspec=refspec,
             initial_failure=first,
+            base_branch=base_branch,
         )
 
     def _do_push(
@@ -874,6 +881,7 @@ class GatewayClient:
         mode: Literal["public", "private"],
         refspec: str,
         initial_failure: PushResult,
+        base_branch: str | None = None,
     ) -> PushResult:
         """Fetch, rebase the worktree onto ``origin/{branch}``, and retry push.
 
@@ -882,6 +890,11 @@ class GatewayClient:
         through the gateway. Conflicts confined to
         ``.egg-state/agent-outputs/`` are resolved in favour of the remote;
         conflicts elsewhere abort the rebase and return a failure result.
+
+        When ``base_branch`` is provided, ``origin/{base_branch}`` is also
+        fetched before the rebase and used as the ``--onto`` upstream so
+        commits already on main are not replayed onto the pipeline branch
+        (#1976).
 
         Returns ``PushResult(ok=True)`` when the retry push succeeds. On
         failure, the returned ``PushResult`` carries a category that
@@ -943,10 +956,34 @@ class GatewayClient:
                 detail=f"git fetch origin {branch} timed out after 60s",
             )
 
+        # Refresh origin/{base_branch} so the --onto upstream in the rebase
+        # reflects the current main tip (#1976).  A stale origin/{base_branch}
+        # would cause commits that landed on main since the worktree was
+        # created to be replayed as duplicate-by-content commits.  Best-effort:
+        # if fetching the base fails (network, permissions, branch absent),
+        # fall through to the plain ``git rebase origin/{branch}`` form.
+        if base_branch:
+            try:
+                subprocess.run(
+                    [*git_base, "fetch", "origin", base_branch],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=60,
+                )
+            except subprocess.TimeoutExpired:
+                logger.warning(
+                    "Push reconcile: base-branch fetch timed out — proceeding with stale origin/{base}",
+                    pipeline_id=pipeline_id,
+                    branch=branch,
+                    base_branch=base_branch,
+                )
+
         rebase_result = _rebase_with_agent_output_autoresolve(
             git_base=git_base,
             pipeline_id=pipeline_id,
             branch=branch,
+            base_branch=base_branch,
         )
         if not rebase_result.ok:
             return rebase_result
@@ -1359,9 +1396,21 @@ def _rebase_with_agent_output_autoresolve(
     git_base: list[str],
     pipeline_id: str,
     branch: str,
+    base_branch: str | None = None,
     max_autoresolve_iterations: int = 3,
 ) -> PushResult:
     """Rebase the worktree onto ``origin/{branch}`` with agent-outputs auto-resolve.
+
+    When ``base_branch`` is provided and ``origin/{base_branch}`` exists
+    locally, the rebase uses the ``--onto origin/{branch}
+    origin/{base_branch}`` form so only commits that are unique to the
+    local worktree (i.e. ``origin/{base_branch}..HEAD``) are replayed.
+    Without the ``--onto`` form, a plain ``git rebase origin/{branch}``
+    replays the full ``merge-base(HEAD, origin/{branch})..HEAD`` range;
+    when ``origin/{branch}`` is based on an older snapshot of main and
+    HEAD is based on a newer snapshot, that range includes the upstream
+    main commits that landed in between, producing duplicate-by-content
+    commits with different SHAs on the pipeline branch (#1976).
 
     Conflicts confined to ``.egg-state/agent-outputs/`` are resolved in
     favour of the remote (``git checkout --theirs``) and the rebase is
@@ -1378,9 +1427,10 @@ def _rebase_with_agent_output_autoresolve(
     which part of the rebase went wrong (``reconcile_rebase_timeout``,
     ``reconcile_rebase_conflict``, ``reconcile_rebase_failed``).
     """
+    rebase_cmd = _build_rebase_cmd(git_base, branch, base_branch)
     try:
         rebase_result = subprocess.run(
-            [*git_base, "rebase", f"origin/{branch}"],
+            rebase_cmd,
             capture_output=True,
             text=True,
             check=False,
@@ -1396,7 +1446,7 @@ def _rebase_with_agent_output_autoresolve(
         return PushResult(
             ok=False,
             category="reconcile_rebase_timeout",
-            detail=f"git rebase origin/{branch} timed out after 120s",
+            detail=f"git rebase {' '.join(rebase_cmd[len(git_base) + 1 :])} timed out after 120s",
         )
 
     if rebase_result.returncode == 0:
@@ -1553,6 +1603,34 @@ def _list_unmerged_paths(git_base: list[str]) -> list[str]:
         )
         return []
     return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def _build_rebase_cmd(
+    git_base: list[str],
+    branch: str,
+    base_branch: str | None,
+) -> list[str]:
+    """Construct the ``git rebase`` argv for the push-reconcile path.
+
+    When ``base_branch`` is set and ``origin/{base_branch}`` resolves in
+    the worktree, return the ``--onto origin/{branch} origin/{base_branch}``
+    form so only ``origin/{base_branch}..HEAD`` commits are replayed.
+    Otherwise return the plain ``git rebase origin/{branch}`` form
+    (pre-#1976 behavior) — used as a safe fallback when the base branch
+    is unknown or unavailable locally.
+    """
+    if base_branch:
+        base_ref = f"origin/{base_branch}"
+        verify = subprocess.run(
+            [*git_base, "rev-parse", "--verify", base_ref],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        if verify.returncode == 0:
+            return [*git_base, "rebase", "--onto", f"origin/{branch}", base_ref]
+    return [*git_base, "rebase", f"origin/{branch}"]
 
 
 def _abort_rebase_best_effort(

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -964,7 +964,7 @@ class GatewayClient:
         # fall through to the plain ``git rebase origin/{branch}`` form.
         if base_branch:
             try:
-                subprocess.run(
+                base_fetch = subprocess.run(
                     [*git_base, "fetch", "origin", base_branch],
                     capture_output=True,
                     text=True,
@@ -978,6 +978,16 @@ class GatewayClient:
                     branch=branch,
                     base_branch=base_branch,
                 )
+            else:
+                if base_fetch.returncode != 0:
+                    logger.warning(
+                        "Push reconcile: base-branch fetch failed — proceeding with stale origin/{base}",
+                        pipeline_id=pipeline_id,
+                        branch=branch,
+                        base_branch=base_branch,
+                        returncode=base_fetch.returncode,
+                        stderr=base_fetch.stderr.strip(),
+                    )
 
         rebase_result = _rebase_with_agent_output_autoresolve(
             git_base=git_base,
@@ -1621,14 +1631,17 @@ def _build_rebase_cmd(
     """
     if base_branch:
         base_ref = f"origin/{base_branch}"
-        verify = subprocess.run(
-            [*git_base, "rev-parse", "--verify", base_ref],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=10,
-        )
-        if verify.returncode == 0:
+        try:
+            verify = subprocess.run(
+                [*git_base, "rev-parse", "--verify", base_ref],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            verify = None
+        if verify and verify.returncode == 0:
             return [*git_base, "rebase", "--onto", f"origin/{branch}", base_ref]
     return [*git_base, "rebase", f"origin/{branch}"]
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -4023,6 +4023,7 @@ def _sync_worktree_with_remote(
     worktree_repo_path: Path,
     prior_phase_succeeded: bool = True,
     gateway_mode: Literal["public", "private"] = "public",
+    base_branch: str | None = None,
 ) -> None:
     """Sync a worktree with its remote branch (best-effort).
 
@@ -4045,6 +4046,7 @@ def _sync_worktree_with_remote(
     Safe to call on every pipeline start because it is idempotent when the
     local branch is already up to date.
     """
+    base_branch_for_reconcile = base_branch
     git_base = [
         "git",
         "-c",
@@ -4129,6 +4131,7 @@ def _sync_worktree_with_remote(
                 repo_path=str(worktree_repo_path),
                 branch=branch,
                 mode=gateway_mode,
+                base_branch=base_branch_for_reconcile,
             )
             if push_ok:
                 # Push succeeded — local and remote are now in sync.
@@ -9839,6 +9842,7 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                 worktree_repo_path,
                 prior_phase_succeeded=prior_phase_succeeded,
                 gateway_mode=gateway_mode,
+                base_branch=pipeline.base_branch,
             )
 
             # Remove legacy unprefixed draft files (analysis.md, plan.md)
@@ -9852,6 +9856,7 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                         repo_path=str(worktree_repo_path),
                         branch=pipeline.branch,
                         mode=gateway_mode,
+                        base_branch=pipeline.base_branch,
                     )
                 except Exception:
                     logger.warning(
@@ -10074,6 +10079,7 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                             repo_path=str(worktree_repo_path),
                             branch=push_branch,
                             mode=gateway_mode,
+                            base_branch=pipeline.base_branch,
                         )
                         push_succeeded = bool(push_result)
                         if not push_succeeded:
@@ -10588,6 +10594,7 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                         repo_path=str(worktree_repo_path),
                         branch=pipeline.branch,
                         mode=gateway_mode,
+                        base_branch=pipeline.base_branch,
                     )
                     if push_ok:
                         logger.info(
@@ -10856,6 +10863,7 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                             repo_path=str(worktree_repo_path),
                             branch=pipeline.branch,
                             mode=gateway_mode,
+                            base_branch=pipeline.base_branch,
                         )
                     except Exception as push_err:
                         logger.warning(
@@ -10978,6 +10986,7 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                         repo_path=str(worktree_repo_path),
                         branch=pipeline.branch,
                         mode=gateway_mode,
+                        base_branch=pipeline.base_branch,
                     )
                 except Exception as push_err:
                     logger.warning(
@@ -11341,6 +11350,7 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                             repo_path=str(worktree_repo_path),
                             branch=pipeline.branch,
                             mode=gateway_mode,
+                            base_branch=pipeline.base_branch,
                         )
                     except Exception as push_err:
                         logger.warning(
@@ -11730,6 +11740,7 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                                     repo_path=str(repo_path),
                                     branch=pipeline.branch,
                                     mode=_gw_mode,
+                                    base_branch=pipeline.base_branch,
                                 )
                             except Exception as push_err:
                                 logger.warning(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -10901,7 +10901,11 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
             # draft files that only exist on the remote.
             if pipeline.branch and worktree_repo_path != repo_path:
                 _sync_worktree_with_remote(
-                    spawner, pipeline_id, worktree_repo_path, gateway_mode=gateway_mode
+                    spawner,
+                    pipeline_id,
+                    worktree_repo_path,
+                    gateway_mode=gateway_mode,
+                    base_branch=pipeline.base_branch,
                 )
 
             # After plan phase: populate contract with task structure.

--- a/orchestrator/tests/test_pipeline_failure_path.py
+++ b/orchestrator/tests/test_pipeline_failure_path.py
@@ -231,6 +231,7 @@ class TestFailurePathPushesWorktreeBranch:
             repo_path=str(worktree_dir),
             branch="egg/issue-42",
             mode="public",
+            base_branch=None,
         )
 
     @patch(_COMMON_PATCHES[7])
@@ -287,6 +288,7 @@ class TestFailurePathPushesWorktreeBranch:
             repo_path=str(worktree_dir),
             branch="egg/issue-42/work",
             mode="public",
+            base_branch=None,
         )
 
         # Verify the generated branch was persisted via save_pipeline
@@ -499,6 +501,7 @@ class TestSuccessPathPushesStatefiles:
                 "repo_path": str(worktree_dir),
                 "branch": "egg/issue-42",
                 "mode": "public",
+                "base_branch": None,
             }
 
     @patch("routes.pipelines._auto_create_pr", return_value="https://github.com/owner/repo/pull/1")
@@ -588,6 +591,7 @@ class TestSuccessPathPushesStatefiles:
                 "repo_path": str(worktree_dir),
                 "branch": "egg/issue-42",
                 "mode": "public",
+                "base_branch": None,
             }
 
     @patch("routes.pipelines._auto_create_pr", return_value="https://github.com/owner/repo/pull/1")
@@ -672,6 +676,7 @@ class TestSuccessPathPushesStatefiles:
                 "repo_path": str(worktree_dir),
                 "branch": "egg/issue-42/work",
                 "mode": "public",
+                "base_branch": None,
             },
         )
         assert push_calls[0] == expected_call

--- a/orchestrator/tests/test_reconcile_and_push_pr_branch.py
+++ b/orchestrator/tests/test_reconcile_and_push_pr_branch.py
@@ -24,7 +24,11 @@ prefer rebase over merge and to auto-resolve conflicts under
 import subprocess
 from unittest.mock import MagicMock, patch
 
-from gateway_client import GatewayClient, PushResult
+from gateway_client import (
+    GatewayClient,
+    PushResult,
+    _rebase_with_agent_output_autoresolve,
+)
 
 
 def _run_result(returncode=0, stdout="", stderr=""):
@@ -34,6 +38,48 @@ def _run_result(returncode=0, stdout="", stderr=""):
     result.stdout = stdout
     result.stderr = stderr
     return result
+
+
+def _git(cwd, *args):
+    """Run ``git <args>`` in ``cwd``; raise on failure, return CompletedProcess."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _git_init(path, origin_url):
+    """Initialise a non-bare repo at ``path`` wired to ``origin_url`` with an identity."""
+    _git(path, "init", "-b", "main")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "Test")
+    _git(path, "remote", "add", "origin", origin_url)
+
+
+def _patch_id_of(repo, sha):
+    """Return the patch-id of ``sha`` (``git patch-id`` tolerates empty diffs)."""
+    diff = subprocess.run(
+        ["git", "-C", str(repo), "show", "--no-color", "--format=", sha],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    pid = subprocess.run(
+        ["git", "-C", str(repo), "patch-id", "--stable"],
+        input=diff.stdout,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # patch-id output: "<patch-id> <commit-sha>\n" — take the first field,
+    # or fall back to the commit SHA for empty patches (no diff at all).
+    out = pid.stdout.strip()
+    if out:
+        return out.split()[0]
+    return sha
 
 
 def _make_client(push_results):
@@ -283,3 +329,194 @@ class TestPushWorktreeBranchReconcile:
         assert ok.ok is False
         assert client._do_push.call_count == 1
         mock_run.assert_not_called()
+
+    def test_rebase_without_base_branch_uses_plain_form(self, tmp_path):
+        """Without ``base_branch``, the rebase falls back to ``git rebase origin/{branch}``.
+
+        Preserves pre-#1976 behavior for callers that don't know the
+        pipeline's base branch (e.g. old integration points).
+        """
+        client = _make_client([False, True])
+        with patch(
+            "gateway_client.subprocess.run",
+            side_effect=[_run_result(), _run_result()],
+        ) as mock_run:
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-42",
+                repo_path=str(tmp_path),
+                branch="egg/feature",
+            )
+
+        assert ok.ok is True
+        # Order: fetch, rebase (no --onto, no base-branch fetch/verify).
+        assert mock_run.call_count == 2
+        rebase_cmd = mock_run.call_args_list[1].args[0]
+        assert "rebase" in rebase_cmd
+        assert "--onto" not in rebase_cmd
+        assert "origin/egg/feature" in rebase_cmd
+
+    def test_rebase_with_base_branch_uses_onto_form(self, tmp_path):
+        """With ``base_branch`` and ``origin/{base_branch}`` resolvable,
+        the rebase uses ``--onto origin/{branch} origin/{base_branch}`` so
+        only ``origin/{base_branch}..HEAD`` is replayed — commits already
+        on main are not duplicated onto the pipeline branch (#1976).
+        """
+        client = _make_client([False, True])
+        with patch(
+            "gateway_client.subprocess.run",
+            side_effect=[
+                _run_result(),  # fetch origin {branch}
+                _run_result(),  # fetch origin {base_branch}
+                _run_result(),  # rev-parse --verify origin/{base_branch}
+                _run_result(),  # rebase --onto ...
+            ],
+        ) as mock_run:
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-42",
+                repo_path=str(tmp_path),
+                branch="egg/issue-42",
+                base_branch="main",
+            )
+
+        assert ok.ok is True
+        assert mock_run.call_count == 4
+        base_fetch_cmd = mock_run.call_args_list[1].args[0]
+        assert "fetch" in base_fetch_cmd and "main" in base_fetch_cmd
+        rebase_cmd = mock_run.call_args_list[3].args[0]
+        assert rebase_cmd[-4:] == [
+            "rebase",
+            "--onto",
+            "origin/egg/issue-42",
+            "origin/main",
+        ]
+
+    def test_rebase_does_not_replay_main_commits_when_base_branch_set(self, tmp_path):
+        """End-to-end regression for #1976.
+
+        Reproduces the PR #1971 pathology with a real git repo:
+        - ``origin/egg/issue-N`` is stuck at an old main snapshot +
+          ``contract-init-v1``.
+        - main has moved forward by N upstream commits since that snapshot.
+        - A fresh local worktree is branched from the new main and adds
+          ``contract-init-v2``.
+
+        Without the fix, ``git rebase origin/egg/issue-N`` replays those N
+        upstream commits on top of ``contract-init-v1`` (duplicate-by-content
+        with different SHAs).  With ``base_branch="main"`` passed through,
+        the rebase uses ``--onto origin/egg/issue-N origin/main`` so only
+        ``contract-init-v2`` is replayed.
+
+        Asserts the acceptance criterion from #1976: ``<base>..HEAD`` on
+        the pipeline branch never contains commits whose patch-id matches
+        an already-merged commit on main.
+        """
+        # Build a bare "origin" repo that acts as the remote.
+        origin = tmp_path / "origin.git"
+        subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)], check=True)
+
+        # Seed main with an initial commit (old base).
+        seed = tmp_path / "seed"
+        seed.mkdir()
+        _git_init(seed, str(origin))
+        (seed / "README.md").write_text("initial\n")
+        _git(seed, "add", "README.md")
+        _git(seed, "commit", "-m", "initial main commit")
+        _git(seed, "push", "origin", "main")
+
+        # Stale branch: contract-init-v1 on top of old main.
+        _git(seed, "checkout", "-b", "egg/issue-42")
+        (seed / "contract_v1.md").write_text("v1\n")
+        _git(seed, "add", "contract_v1.md")
+        _git(seed, "commit", "-m", "Initialize SDLC contract for issue #42 (v1)")
+        _git(seed, "push", "origin", "egg/issue-42")
+
+        # Main advances by 3 commits (simulates upstream landings).
+        _git(seed, "checkout", "main")
+        upstream_shas = []
+        for i in range(3):
+            (seed / f"upstream_{i}.md").write_text(f"upstream work {i}\n")
+            _git(seed, "add", f"upstream_{i}.md")
+            _git(seed, "commit", "-m", f"Fix #{100 + i}: upstream landing {i}")
+            sha = _git(seed, "rev-parse", "HEAD").stdout.strip()
+            upstream_shas.append(sha)
+        _git(seed, "push", "origin", "main")
+
+        # Fresh worktree cut from current origin/main + contract-init-v2.
+        work = tmp_path / "work"
+        work.mkdir()
+        _git_init(work, str(origin))
+        _git(work, "fetch", "origin")
+        _git(work, "checkout", "-b", "egg/issue-42-work", "origin/main")
+        (work / "contract_v2.md").write_text("v2\n")
+        _git(work, "add", "contract_v2.md")
+        _git(work, "commit", "-m", "Initialize SDLC contract for issue #42 (v2)")
+
+        # Run the rebase helper in the worktree — emulating the push-reconcile
+        # path after a non-ff rejection.  base_branch="main" should activate
+        # the --onto form and prevent upstream-commit duplication.
+        git_base = [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            f"safe.directory={work}",
+            "-C",
+            str(work),
+        ]
+        result = _rebase_with_agent_output_autoresolve(
+            git_base=git_base,
+            pipeline_id="issue-42",
+            branch="egg/issue-42",
+            base_branch="main",
+        )
+        assert result.ok, f"rebase failed: {result.category} {result.detail}"
+
+        # Collect the patch-ids of every upstream commit that landed on main.
+        upstream_patch_ids = {_patch_id_of(seed, sha) for sha in upstream_shas}
+
+        # Collect patch-ids of commits on the rebased branch that are NOT
+        # on origin/main.  None of them should match an upstream commit.
+        log = _git(work, "log", "--format=%H", "origin/main..HEAD").stdout.strip()
+        branch_only_shas = [s for s in log.splitlines() if s]
+        branch_only_patch_ids = {_patch_id_of(work, sha) for sha in branch_only_shas}
+
+        duplicates = branch_only_patch_ids & upstream_patch_ids
+        assert not duplicates, (
+            f"pipeline branch contains duplicate-by-content commits of main: {duplicates}"
+        )
+
+        # Sanity: we expect exactly the two contract-init commits on the
+        # branch (v1 from origin + v2 from local work) — 0 main-commit replays.
+        assert len(branch_only_shas) == 2, (
+            f"expected 2 branch-only commits, got {len(branch_only_shas)}: {branch_only_shas}"
+        )
+
+    def test_rebase_with_base_branch_falls_back_when_base_missing(self, tmp_path):
+        """When ``origin/{base_branch}`` is not resolvable locally (e.g. the
+        base-branch fetch failed and the tracking ref was never created),
+        the rebase falls back to the plain ``git rebase origin/{branch}``
+        form rather than erroring out.
+        """
+        client = _make_client([False, True])
+        with patch(
+            "gateway_client.subprocess.run",
+            side_effect=[
+                _run_result(),  # fetch origin {branch}
+                _run_result(
+                    returncode=1, stderr="couldn't find remote ref"
+                ),  # fetch origin {base_branch} fails
+                _run_result(returncode=128, stderr="unknown revision"),  # rev-parse verify fails
+                _run_result(),  # rebase (plain form)
+            ],
+        ) as mock_run:
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-42",
+                repo_path=str(tmp_path),
+                branch="egg/issue-42",
+                base_branch="main",
+            )
+
+        assert ok.ok is True
+        rebase_cmd = mock_run.call_args_list[3].args[0]
+        assert "rebase" in rebase_cmd and "--onto" not in rebase_cmd
+        assert "origin/egg/issue-42" in rebase_cmd


### PR DESCRIPTION
## Summary

- Fixes #1976. The push-reconcile path ran `git rebase origin/{branch}` which replays `merge-base(HEAD, origin/{branch})..HEAD`; when `origin/{branch}` was stuck at an older main snapshot (resumed pipeline) and HEAD was fresh off current main, every upstream main commit in between was replayed as a duplicate-by-content commit with a new SHA, producing the ~25k-line noise on PR #1971.
- Threads `pipeline.base_branch` through `push_worktree_branch` → `_reconcile_and_retry_push` → `_rebase_with_agent_output_autoresolve`. When `origin/{base_branch}` resolves locally, the rebase switches to `git rebase --onto origin/{branch} origin/{base_branch}` so only the pipeline's real work — `origin/{base_branch}..HEAD` — gets replayed. Falls back to the pre-existing plain form when the base branch isn't provided or `origin/{base_branch}` isn't available.
- Also refreshes `origin/{base_branch}` before the rebase so its tip reflects current main rather than whatever was cached when the worktree was created.
- Adds a real-repo regression test that reproduces the PR #1971 pathology (old branch base + N upstream commits landed since + fresh worktree) and asserts the acceptance criterion: no patch-id on the rebased branch matches an already-merged commit on main.

## Test plan

- [x] `pytest orchestrator/tests/test_reconcile_and_push_pr_branch.py` — 14 tests pass, including new cases:
  - `test_rebase_without_base_branch_uses_plain_form` (backward compat)
  - `test_rebase_with_base_branch_uses_onto_form` (new form invoked)
  - `test_rebase_does_not_replay_main_commits_when_base_branch_set` (end-to-end regression against a real repo)
  - `test_rebase_with_base_branch_falls_back_when_base_missing` (graceful fallback)
- [x] `pytest orchestrator/tests/test_gateway_client.py orchestrator/tests/test_startup_reconciliation.py` — 111 passed
- [x] Manually verified without the fix the regression test fails: the rebased branch contains 5 branch-only commits (3 replayed upstream main commits + 2 contract-inits) instead of the expected 2.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)