### PR TITLE
Fix #1977: branch-read fallback for get_contract / exists on finished pipelines

### DIFF
--- a/orchestrator/contract_store.py
+++ b/orchestrator/contract_store.py
@@ -31,11 +31,15 @@ import re
 import sys
 import threading
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 # Shared packages live under ../shared relative to this file.
 _shared_path = Path(__file__).parent.parent / "shared"
 if _shared_path.exists() and str(_shared_path) not in sys.path:
     sys.path.insert(0, str(_shared_path))
+
+if TYPE_CHECKING:
+    from egg_contracts import Contract
 
 logger = logging.getLogger("orchestrator.contract_store")
 
@@ -117,4 +121,57 @@ def resolve_pipeline_worktree(
                 )
             return candidate
 
+    return None
+
+
+def load_contract_from_branch(
+    identifier: int | str,
+    repo_path: Path,
+    branch: str,
+) -> Contract | None:
+    """Read the committed contract for *identifier* from *branch*.
+
+    Enables post-completion reads (PR review, contract audits) once
+    the shared pipeline worktree has been pruned. The on-branch file at
+    ``.egg-state/contracts/<pipeline_id>.json`` is authoritative after
+    the pipeline's final commit.
+
+    Tries ``origin/<branch>`` first — the remote ref survives local
+    cleanup and reflects the last pushed state — then falls back to
+    ``<branch>`` in case the main repo has a local ref but no origin
+    copy (e.g. pre-push crashes).
+
+    Returns ``None`` when neither ref yields the contract file.
+    Propagates ``ContractValidationError`` — a malformed contract is a
+    real failure, not a miss. ``repo_path`` should be the main repo
+    checkout (``StateStore.repo_path``), not a worktree path.
+    """
+    # Lazy import — egg_contracts sits in shared/ and is wired into
+    # sys.path above, but importing at module load would force every
+    # caller of contract_store to pull it in.
+    from egg_contracts import ContractNotFoundError
+    from egg_contracts import load_contract_from_branch as _load_from_branch
+
+    refs = []
+    if not branch.startswith("origin/"):
+        refs.append(f"origin/{branch}")
+    refs.append(branch)
+
+    last_error: ContractNotFoundError | None = None
+    for ref in refs:
+        try:
+            return _load_from_branch(identifier, repo_path, ref)
+        except ContractNotFoundError as exc:
+            last_error = exc
+            continue
+
+    logger.debug(
+        "Branch-read fallback failed",
+        extra={
+            "identifier": str(identifier),
+            "branch": branch,
+            "repo_path": str(repo_path),
+            "error": str(last_error) if last_error else None,
+        },
+    )
     return None

--- a/orchestrator/routes/contracts.py
+++ b/orchestrator/routes/contracts.py
@@ -26,7 +26,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Blueprint, Response, jsonify, request
 
@@ -34,6 +34,9 @@ from flask import Blueprint, Response, jsonify, request
 _shared_path = Path(__file__).parent.parent.parent / "shared"
 if _shared_path.exists() and str(_shared_path) not in sys.path:
     sys.path.insert(0, str(_shared_path))
+
+if TYPE_CHECKING:
+    from egg_contracts import Contract
 
 # The orchestrator package lives one level up.
 _parent_path = Path(__file__).parent.parent
@@ -168,7 +171,7 @@ def _worktree_for_request() -> tuple[Path | None, tuple[Response, int] | None]:
 def _branch_read_contract(
     identifier: int | str,
     pipeline_id: str,
-) -> Any | None:
+) -> Contract | None:
     """Fall back to reading the committed contract from the pipeline's branch.
 
     Used by the GET paths when the shared worktree has been pruned — the

--- a/orchestrator/routes/contracts.py
+++ b/orchestrator/routes/contracts.py
@@ -96,10 +96,13 @@ def _error(
 def _success(
     message: str,
     data: dict[str, Any] | None = None,
+    source: str | None = None,
 ) -> tuple[Response, int]:
     payload: dict[str, Any] = {"success": True, "message": message}
     if data is not None:
         payload["data"] = data
+    if source is not None:
+        payload["source"] = source
     return jsonify(payload), 200
 
 
@@ -162,35 +165,94 @@ def _worktree_for_request() -> tuple[Path | None, tuple[Response, int] | None]:
     return worktree, None
 
 
+def _branch_read_contract(
+    identifier: int | str,
+    pipeline_id: str,
+) -> Any | None:
+    """Fall back to reading the committed contract from the pipeline's branch.
+
+    Used by the GET paths when the shared worktree has been pruned — the
+    ``.egg-state/contracts/<pipeline_id>.json`` file committed to the
+    feature branch is authoritative after the pipeline's final commit
+    and stays accessible via ``git show`` for the life of the PR.
+
+    Returns the loaded ``Contract`` on success, ``None`` when the
+    pipeline record can't be located or the branch has no such file.
+    """
+    # Lazy import: routes/__init__.py pulls in flask/state_store at
+    # import time; importing at module top would make contracts.py
+    # depend on initialisation order. Matches the pattern used by
+    # signals.py / phases.py / decisions.py.
+    from routes import get_state_store_for_pipeline
+    from state_store import InvalidPipelineIdError, PipelineNotFoundError
+
+    try:
+        store, pipeline = get_state_store_for_pipeline(pipeline_id)
+    except (PipelineNotFoundError, InvalidPipelineIdError):
+        return None
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning(
+            "Branch-read fallback could not resolve pipeline",
+            extra={"pipeline_id": pipeline_id, "error": str(exc)},
+        )
+        return None
+
+    branch = pipeline.branch or f"egg/{pipeline_id}"
+    return contract_store.load_contract_from_branch(identifier, store.repo_path, branch)
+
+
 @contracts_bp.route("/<identifier>", methods=["GET"])
 def get_contract(identifier: str) -> tuple[Response, int]:
-    """Return the live contract for *identifier*."""
+    """Return the contract for *identifier*.
+
+    Prefers the live shared-worktree copy. When the worktree has already
+    been pruned (typical after the pipeline reaches PR / complete), falls
+    back to reading the committed contract from the pipeline's branch so
+    post-hoc callers — PR review, auditing, follow-up analysis — can
+    still retrieve it (#1977).
+    """
     ident = _coerce_identifier(identifier)
     validation_error = _validate_identifier(ident)
     if validation_error:
         return validation_error
 
-    worktree, error = _worktree_for_request()
-    if error:
-        return error
-    assert worktree is not None
-
     include_audit = request.args.get("include_audit_log", "false").lower() == "true"
 
-    try:
-        with contract_store.lock_for(ident):
-            contract = load_contract(ident, worktree)
-    except ContractNotFoundError:
-        return _error(
-            f"Contract for {'#' + str(ident) if isinstance(ident, int) else ident} not found",
-            status_code=404,
+    worktree, error = _worktree_for_request()
+    if error is None:
+        assert worktree is not None
+        try:
+            with contract_store.lock_for(ident):
+                contract = load_contract(ident, worktree)
+        except ContractNotFoundError:
+            return _error(
+                f"Contract for {'#' + str(ident) if isinstance(ident, int) else ident} not found",
+                status_code=404,
+            )
+        except ContractValidationError as exc:
+            return _error(f"Contract validation failed: {exc}", status_code=500)
+
+        return _success(
+            "Contract retrieved",
+            data=export_contract(contract, include_audit_log=include_audit),
+            source="worktree",
         )
+
+    # Worktree missing — try the branch before surfacing 404.
+    pipeline_id, _repo_hint = _pipeline_context()
+    if not pipeline_id:
+        return error
+
+    try:
+        contract = _branch_read_contract(ident, pipeline_id)
     except ContractValidationError as exc:
         return _error(f"Contract validation failed: {exc}", status_code=500)
-
+    if contract is None:
+        return error
     return _success(
         "Contract retrieved",
         data=export_contract(contract, include_audit_log=include_audit),
+        source="branch",
     )
 
 
@@ -202,14 +264,31 @@ def contract_exists(identifier: str) -> tuple[Response, int]:
         return validation_error
 
     worktree, error = _worktree_for_request()
-    if error:
-        return error
-    assert worktree is not None
+    if error is None:
+        assert worktree is not None
+        exists = _contract_exists(ident, worktree)
+        return _success(
+            "Contract exists" if exists else "Contract does not exist",
+            data={"exists": exists},
+            source="worktree",
+        )
 
-    exists = _contract_exists(ident, worktree)
+    # Worktree missing — check the branch. "Does this pipeline ever
+    # have a contract?" is a reasonable archival query (#1977).
+    pipeline_id, _repo_hint = _pipeline_context()
+    if not pipeline_id:
+        return error
+
+    try:
+        contract = _branch_read_contract(ident, pipeline_id)
+    except ContractValidationError as exc:
+        return _error(f"Contract validation failed: {exc}", status_code=500)
+    if contract is None:
+        return error
     return _success(
-        "Contract exists" if exists else "Contract does not exist",
-        data={"exists": exists},
+        "Contract exists",
+        data={"exists": True},
+        source="branch",
     )
 
 

--- a/orchestrator/tests/test_contracts_routes.py
+++ b/orchestrator/tests/test_contracts_routes.py
@@ -253,6 +253,7 @@ class TestBranchReadFallback:
             "show",
             "origin/egg/issue-1977:.egg-state/contracts/issue-1977.json",
         ]
+        assert run_mock.call_args_list[0].kwargs["cwd"] == store.repo_path
 
     def test_get_prefers_worktree_when_both_are_available(self, client, tmp_path, monkeypatch):
         """When the worktree exists, the branch fallback must not fire."""
@@ -346,6 +347,67 @@ class TestBranchReadFallback:
         body = json.loads(response.data)
         assert body["data"] == {"exists": True}
         assert body["source"] == "branch"
+
+    def test_get_uses_derived_branch_when_pipeline_branch_is_none(
+        self, client, tmp_path, monkeypatch
+    ):
+        """When pipeline.branch is None, fallback derives egg/<pipeline_id>."""
+        monkeypatch.setattr(contract_store, "_WORKTREE_BASE_DIR", tmp_path / "nowhere")
+
+        store, pipeline = self._fake_pipeline(tmp_path, branch=None)
+        mock_subproc = MagicMock()
+        mock_subproc.stdout = self._contract_json()
+
+        with (
+            patch(
+                "routes.get_state_store_for_pipeline",
+                return_value=(store, pipeline),
+            ),
+            patch("subprocess.run", return_value=mock_subproc) as run_mock,
+        ):
+            response = client.get(
+                f"/api/v1/contracts/{self.PIPELINE_ID}",
+                query_string={"pipeline_id": self.PIPELINE_ID},
+            )
+
+        assert response.status_code == 200, response.data
+        body = json.loads(response.data)
+        assert body["source"] == "branch"
+        # With branch=None the code should derive "egg/<pipeline_id>"
+        # and try origin/egg/<pipeline_id> as the preferred ref.
+        assert run_mock.call_args_list[0].args[0] == [
+            "git",
+            "show",
+            f"origin/egg/{self.PIPELINE_ID}:.egg-state/contracts/{self.PIPELINE_ID}.json",
+        ]
+
+    def test_exists_returns_404_when_worktree_and_branch_both_miss(
+        self, client, tmp_path, monkeypatch
+    ):
+        import subprocess
+
+        monkeypatch.setattr(contract_store, "_WORKTREE_BASE_DIR", tmp_path / "nowhere")
+        store, pipeline = self._fake_pipeline(tmp_path)
+
+        with (
+            patch(
+                "routes.get_state_store_for_pipeline",
+                return_value=(store, pipeline),
+            ),
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.CalledProcessError(128, "git show"),
+            ),
+        ):
+            response = client.get(
+                f"/api/v1/contracts/{self.PIPELINE_ID}/exists",
+                query_string={"pipeline_id": self.PIPELINE_ID},
+            )
+
+        assert response.status_code == 404
+        body = json.loads(response.data)
+        assert body["success"] is False
+        assert "worktree not found" in body["message"].lower()
 
     def test_mutate_still_404_when_worktree_missing(self, client, tmp_path, monkeypatch):
         """Mutations must not use the branch fallback — writes require a live worktree."""

--- a/orchestrator/tests/test_contracts_routes.py
+++ b/orchestrator/tests/test_contracts_routes.py
@@ -210,7 +210,7 @@ class TestBranchReadFallback:
 
     PIPELINE_ID = "issue-1977"
 
-    def _fake_pipeline(self, tmp_path: Path, branch: str = "egg/issue-1977"):
+    def _fake_pipeline(self, tmp_path: Path, branch: str | None = "egg/issue-1977"):
         repo_path = tmp_path / "repo"
         repo_path.mkdir()
         store = SimpleNamespace(repo_path=repo_path)
@@ -380,6 +380,7 @@ class TestBranchReadFallback:
             "show",
             f"origin/egg/{self.PIPELINE_ID}:.egg-state/contracts/{self.PIPELINE_ID}.json",
         ]
+        assert run_mock.call_args_list[0].kwargs["cwd"] == store.repo_path
 
     def test_exists_returns_404_when_worktree_and_branch_both_miss(
         self, client, tmp_path, monkeypatch

--- a/orchestrator/tests/test_contracts_routes.py
+++ b/orchestrator/tests/test_contracts_routes.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import contract_store
 import pytest
 from api import app
-from egg_contracts import create_contract
+from egg_contracts import Contract, create_contract
 
 
 @pytest.fixture
@@ -58,6 +60,7 @@ class TestGetContract:
         data = json.loads(response.data)
         assert data["success"] is True
         assert data["data"]["pipeline_id"] == pipeline_id
+        assert data["source"] == "worktree"
 
     def test_missing_pipeline_id_rejected(self, client, fake_worktree):
         pipeline_id, _ = fake_worktree
@@ -194,6 +197,170 @@ class TestValidateMutation:
             headers={"X-Egg-Role": "implementer"},
         )
         assert response.status_code == 400
+
+
+class TestBranchReadFallback:
+    """Covers the #1977 branch-read fallback path for finished pipelines.
+
+    Once a pipeline completes and its shared worktree is pruned, the
+    committed contract on the feature branch is the only remaining copy.
+    The GET paths fall back to ``git show <branch>:.egg-state/contracts/…``
+    via ``contract_store.load_contract_from_branch``.
+    """
+
+    PIPELINE_ID = "issue-1977"
+
+    def _fake_pipeline(self, tmp_path: Path, branch: str = "egg/issue-1977"):
+        repo_path = tmp_path / "repo"
+        repo_path.mkdir()
+        store = SimpleNamespace(repo_path=repo_path)
+        pipeline = SimpleNamespace(branch=branch)
+        return store, pipeline
+
+    def _contract_json(self) -> str:
+        contract = Contract(pipeline_id=self.PIPELINE_ID)
+        return json.dumps(contract.model_dump(mode="json"), default=str)
+
+    def test_get_falls_back_to_branch_when_worktree_missing(self, client, tmp_path, monkeypatch):
+        # Force resolve_pipeline_worktree to miss.
+        monkeypatch.setattr(contract_store, "_WORKTREE_BASE_DIR", tmp_path / "nowhere")
+
+        store, pipeline = self._fake_pipeline(tmp_path)
+        mock_subproc = MagicMock()
+        mock_subproc.stdout = self._contract_json()
+
+        with (
+            patch(
+                "routes.get_state_store_for_pipeline",
+                return_value=(store, pipeline),
+            ),
+            patch("subprocess.run", return_value=mock_subproc) as run_mock,
+        ):
+            response = client.get(
+                f"/api/v1/contracts/{self.PIPELINE_ID}",
+                query_string={"pipeline_id": self.PIPELINE_ID},
+            )
+
+        assert response.status_code == 200, response.data
+        body = json.loads(response.data)
+        assert body["success"] is True
+        assert body["source"] == "branch"
+        assert body["data"]["pipeline_id"] == self.PIPELINE_ID
+        # Preferred ref is origin/<branch> — that's what a main-repo
+        # checkout sees after the worktree pushed the final commit.
+        assert run_mock.call_args_list[0].args[0] == [
+            "git",
+            "show",
+            "origin/egg/issue-1977:.egg-state/contracts/issue-1977.json",
+        ]
+
+    def test_get_prefers_worktree_when_both_are_available(self, client, tmp_path, monkeypatch):
+        """When the worktree exists, the branch fallback must not fire."""
+        pipeline_id = self.PIPELINE_ID
+        worktrees_base = tmp_path / "worktrees"
+        worktree = worktrees_base / pipeline_id / "egg"
+        worktree.mkdir(parents=True)
+        (worktree / ".git").mkdir()
+        monkeypatch.setattr(contract_store, "_WORKTREE_BASE_DIR", worktrees_base)
+        _seed_contract(worktree, pipeline_id)
+
+        with patch("subprocess.run") as run_mock:
+            response = client.get(
+                f"/api/v1/contracts/{pipeline_id}",
+                query_string={"pipeline_id": pipeline_id, "repo": "egg"},
+            )
+
+        assert response.status_code == 200
+        assert json.loads(response.data)["source"] == "worktree"
+        run_mock.assert_not_called()
+
+    def test_get_returns_404_when_worktree_and_branch_both_miss(
+        self, client, tmp_path, monkeypatch
+    ):
+        import subprocess
+
+        monkeypatch.setattr(contract_store, "_WORKTREE_BASE_DIR", tmp_path / "nowhere")
+        store, pipeline = self._fake_pipeline(tmp_path)
+
+        with (
+            patch(
+                "routes.get_state_store_for_pipeline",
+                return_value=(store, pipeline),
+            ),
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.CalledProcessError(128, "git show"),
+            ),
+        ):
+            response = client.get(
+                f"/api/v1/contracts/{self.PIPELINE_ID}",
+                query_string={"pipeline_id": self.PIPELINE_ID},
+            )
+
+        assert response.status_code == 404
+        body = json.loads(response.data)
+        assert body["success"] is False
+        assert "worktree not found" in body["message"].lower()
+
+    def test_get_returns_404_when_pipeline_record_missing(self, client, tmp_path, monkeypatch):
+        from state_store import PipelineNotFoundError
+
+        monkeypatch.setattr(contract_store, "_WORKTREE_BASE_DIR", tmp_path / "nowhere")
+
+        with (
+            patch(
+                "routes.get_state_store_for_pipeline",
+                side_effect=PipelineNotFoundError("nope"),
+            ),
+            patch("subprocess.run") as run_mock,
+        ):
+            response = client.get(
+                f"/api/v1/contracts/{self.PIPELINE_ID}",
+                query_string={"pipeline_id": self.PIPELINE_ID},
+            )
+
+        assert response.status_code == 404
+        # We should not shell out to git when the pipeline record is missing.
+        run_mock.assert_not_called()
+
+    def test_exists_falls_back_to_branch(self, client, tmp_path, monkeypatch):
+        monkeypatch.setattr(contract_store, "_WORKTREE_BASE_DIR", tmp_path / "nowhere")
+
+        store, pipeline = self._fake_pipeline(tmp_path)
+        mock_subproc = MagicMock()
+        mock_subproc.stdout = self._contract_json()
+
+        with (
+            patch(
+                "routes.get_state_store_for_pipeline",
+                return_value=(store, pipeline),
+            ),
+            patch("subprocess.run", return_value=mock_subproc),
+        ):
+            response = client.get(
+                f"/api/v1/contracts/{self.PIPELINE_ID}/exists",
+                query_string={"pipeline_id": self.PIPELINE_ID},
+            )
+
+        assert response.status_code == 200
+        body = json.loads(response.data)
+        assert body["data"] == {"exists": True}
+        assert body["source"] == "branch"
+
+    def test_mutate_still_404_when_worktree_missing(self, client, tmp_path, monkeypatch):
+        """Mutations must not use the branch fallback — writes require a live worktree."""
+        monkeypatch.setattr(contract_store, "_WORKTREE_BASE_DIR", tmp_path / "nowhere")
+
+        response = client.post(
+            f"/api/v1/contracts/{self.PIPELINE_ID}/mutate",
+            json={
+                "pipeline_id": self.PIPELINE_ID,
+                "field_path": "phases",
+                "new_value": [],
+            },
+            headers={"X-Egg-Role": "implementer"},
+        )
+        assert response.status_code == 404
 
 
 class TestResolvePipelineWorktree:


### PR DESCRIPTION
## Summary

- Adds a branch-read fallback to `GET /api/v1/contracts/<id>` and `GET /api/v1/contracts/<id>/exists` so finished pipelines remain queryable after their shared worktree is pruned. The on-branch `.egg-state/contracts/<pipeline_id>.json` is authoritative after the pipeline's final commit, so `git show` serves it when the live worktree is gone.
- Mutations still require a live worktree and continue to return 404 when pruned — no write path through the branch.
- Response envelope gains `"source": "worktree"|"branch"` so callers can tell which read path fired.

## Implementation

- `contract_store.load_contract_from_branch(identifier, repo_path, branch)`: tries `origin/<branch>` first (authoritative after push) then the local `<branch>`; wraps `egg_contracts.load_contract_from_branch` (which shells out to `git show`).
- `routes/contracts._branch_read_contract(identifier, pipeline_id)`: loads the pipeline record via `get_state_store_for_pipeline` to resolve `pipeline.branch` + the main repo path, then delegates to the contract_store helper. Matches the lazy-import pattern used by other route modules.
- `get_contract` / `contract_exists`: when `_worktree_for_request` returns 404, try the branch read before surfacing the error. The 404 is preserved when both the worktree and the branch miss, and when the pipeline record itself can't be resolved.

Fixes #1977.

## Test plan

- [x] `pytest orchestrator/tests/test_contracts_routes.py` (26 passed — includes 6 new tests covering worktree-preferred, branch fallback on GET, branch fallback on /exists, 404 when both miss, 404 when pipeline record missing, and mutate-still-404 regression guard)
- [x] `pytest gateway/tests/test_contract_api.py` (19 passed — gateway proxy unaffected)
- [x] `pytest tests/shared/egg_contracts/test_loader.py` (38 passed — `load_contract_from_branch` semantics unchanged)
- [x] `ruff check` clean on changed files
- [ ] Post-merge: verify against a finished pipeline in the deployed orchestrator (`curl /api/v1/contracts/<id>?pipeline_id=<id>` returns 200 with `source: branch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)