### PR TITLE
Fix #1988: anchor task-id regex to prevent silent collisions

### DIFF
--- a/shared/egg_contracts/plan_parser.py
+++ b/shared/egg_contracts/plan_parser.py
@@ -315,7 +315,8 @@ def parse_tasks_from_yaml(yaml_data: dict[str, Any]) -> list[ParsedTask]:
     for task_data in task_list:
         task_id = task_data.get("id", "")
         # Parse task ID: TASK-{phase}-{number}
-        match = re.match(r"TASK-(\d+)-(\d+)", task_id, re.IGNORECASE)
+        # Anchored to end-of-string — see #1988.
+        match = re.match(r"TASK-(\d+)-(\d+)\Z", task_id, re.IGNORECASE)
         if match:
             phase_num = int(match.group(1))
             task_num = int(match.group(2))
@@ -495,7 +496,9 @@ def parse_phases_from_yaml(
                 files = []
 
             # Parse task ID: TASK-{phase}-{number}
-            id_match = re.match(r"TASK-(\d+)-(\d+)", str(task_id), re.IGNORECASE)
+            # Anchor to end-of-string so IDs like TASK-1-3A don't silently
+            # match as (1, 3) and collide with TASK-1-3B.  See #1988.
+            id_match = re.match(r"TASK-(\d+)-(\d+)\Z", str(task_id), re.IGNORECASE)
             if id_match:
                 task_phase = int(id_match.group(1))
                 task_num = int(id_match.group(2))
@@ -553,6 +556,22 @@ def parse_phases_from_yaml(
                     role=role,
                 )
             )
+
+        # Sanity check: flag duplicate contract ids within this phase so a
+        # silent collision can't ship (see #1988).  Task.id pattern accepts
+        # duplicates, so Pydantic won't catch this on its own.
+        seen_contract_ids: set[str] = set()
+        for pt in parsed_tasks:
+            contract_id = f"task-{pt.phase_number}-{pt.task_number}"
+            if contract_id in seen_contract_ids:
+                warnings.append(
+                    ParseWarning(
+                        line_number=None,
+                        message=f"Duplicate task id '{contract_id}' in phase {phase_num}",
+                        context=f"Source task ID: {pt.id}",
+                    )
+                )
+            seen_contract_ids.add(contract_id)
 
         phases.append(
             ParsedPhase(

--- a/shared/egg_contracts/plan_parser.py
+++ b/shared/egg_contracts/plan_parser.py
@@ -299,7 +299,9 @@ def parse_yaml_frontmatter(content: str) -> tuple[dict[str, Any] | None, str]:
         return None, content
 
 
-def parse_tasks_from_yaml(yaml_data: dict[str, Any]) -> list[ParsedTask]:
+def parse_tasks_from_yaml(
+    yaml_data: dict[str, Any],
+) -> tuple[list[ParsedTask], list[ParseWarning]]:
     """
     Parse tasks from YAML front matter (legacy flat task list format).
 
@@ -307,9 +309,10 @@ def parse_tasks_from_yaml(yaml_data: dict[str, Any]) -> list[ParsedTask]:
         yaml_data: Parsed YAML data
 
     Returns:
-        List of ParsedTask objects
+        Tuple of (list of ParsedTask objects, list of ParseWarning objects)
     """
     tasks = []
+    warnings: list[ParseWarning] = []
     task_list = yaml_data.get("tasks", [])
 
     for task_data in task_list:
@@ -338,8 +341,16 @@ def parse_tasks_from_yaml(yaml_data: dict[str, Any]) -> list[ParsedTask]:
                     files_affected=files,
                 )
             )
+        else:
+            warnings.append(
+                ParseWarning(
+                    line_number=None,
+                    message=f"Task ID '{task_id}' doesn't match pattern TASK-N-N, skipping",
+                    context=f"Description: {task_data.get('description', 'none')}",
+                )
+            )
 
-    return tasks
+    return tasks, warnings
 
 
 def parse_phases_from_yaml(
@@ -869,7 +880,8 @@ def parse_plan(content: str) -> ParseResult:
         frontmatter_yaml, markdown_content = parse_yaml_frontmatter(content)
         if frontmatter_yaml and "tasks" in frontmatter_yaml:
             yaml_data = frontmatter_yaml
-            tasks = parse_tasks_from_yaml(frontmatter_yaml)
+            tasks, yaml_warnings = parse_tasks_from_yaml(frontmatter_yaml)
+            warnings.extend(yaml_warnings)
 
             # Parse phases from markdown
             phases = parse_phases_from_markdown(markdown_content)

--- a/tests/shared/egg_contracts/test_plan_parser.py
+++ b/tests/shared/egg_contracts/test_plan_parser.py
@@ -1254,6 +1254,95 @@ phases:
         assert tasks[2].role is None
 
 
+class TestAlphaSuffixAndDuplicates:
+    """Regression tests for #1988 — task id regex was unanchored, letting
+    TASK-1-3A and TASK-1-3B both collapse to task-1-3."""
+
+    def test_alpha_suffix_task_ids_do_not_collide(self):
+        """TASK-1-3A and TASK-1-3B should each get a unique contract id."""
+        yaml_data = {
+            "phases": [
+                {
+                    "id": 1,
+                    "name": "Setup",
+                    "tasks": [
+                        {"id": "TASK-1-1", "description": "First", "acceptance": "Done"},
+                        {"id": "TASK-1-2", "description": "Second", "acceptance": "Done"},
+                        {"id": "TASK-1-3A", "description": "Third-a", "acceptance": "Done"},
+                        {"id": "TASK-1-3B", "description": "Third-b", "acceptance": "Done"},
+                    ],
+                }
+            ]
+        }
+        phases, warnings = parse_phases_from_yaml(yaml_data)
+        contract_ids = [t.to_contract_task().id for t in phases[0].tasks]
+        assert len(contract_ids) == len(set(contract_ids)), (
+            f"Expected unique task ids, got: {contract_ids}"
+        )
+
+    def test_alpha_suffix_task_ids_emit_warnings(self):
+        """Parser should warn when an alpha-suffixed id falls through to the
+        synthesized-id path so reviewers see it."""
+        yaml_data = {
+            "phases": [
+                {
+                    "id": 1,
+                    "name": "Setup",
+                    "tasks": [
+                        {"id": "TASK-1-3A", "description": "A", "acceptance": "Done"},
+                        {"id": "TASK-1-3B", "description": "B", "acceptance": "Done"},
+                    ],
+                }
+            ]
+        }
+        _, warnings = parse_phases_from_yaml(yaml_data)
+        messages = [w.message for w in warnings]
+        assert any("TASK-1-3A" in m for m in messages), messages
+        assert any("TASK-1-3B" in m for m in messages), messages
+
+    def test_plain_numeric_ids_still_parse(self):
+        """Regression: anchoring must not break the common case."""
+        yaml_data = {
+            "phases": [
+                {
+                    "id": 1,
+                    "name": "Setup",
+                    "tasks": [
+                        {"id": "TASK-1-1", "description": "One", "acceptance": "Done"},
+                        {"id": "TASK-1-2", "description": "Two", "acceptance": "Done"},
+                    ],
+                }
+            ]
+        }
+        phases, warnings = parse_phases_from_yaml(yaml_data)
+        # No synthesized-id or duplicate warnings for plain numeric ids.
+        unexpected = [
+            w
+            for w in warnings
+            if "doesn't match pattern" in w.message or "Duplicate task id" in w.message
+        ]
+        assert unexpected == [], unexpected
+        contract_ids = [t.to_contract_task().id for t in phases[0].tasks]
+        assert contract_ids == ["task-1-1", "task-1-2"]
+
+    def test_duplicate_plain_ids_warn(self):
+        """Two identical TASK-1-3 entries should surface a duplicate warning."""
+        yaml_data = {
+            "phases": [
+                {
+                    "id": 1,
+                    "name": "Setup",
+                    "tasks": [
+                        {"id": "TASK-1-3", "description": "First", "acceptance": "Done"},
+                        {"id": "TASK-1-3", "description": "Second", "acceptance": "Done"},
+                    ],
+                }
+            ]
+        }
+        _, warnings = parse_phases_from_yaml(yaml_data)
+        assert any("Duplicate task id" in w.message for w in warnings), warnings
+
+
 class TestParsePlanWithYamlCodeFence:
     """Integration tests for parse_plan with yaml-tasks code fence."""
 

--- a/tests/shared/egg_contracts/test_plan_parser.py
+++ b/tests/shared/egg_contracts/test_plan_parser.py
@@ -13,6 +13,7 @@ from egg_contracts.plan_parser import (
     parse_phases_from_yaml,
     parse_plan,
     parse_tasks_from_markdown,
+    parse_tasks_from_yaml,
     parse_yaml_code_fence,
 )
 
@@ -1341,6 +1342,36 @@ class TestAlphaSuffixAndDuplicates:
         }
         _, warnings = parse_phases_from_yaml(yaml_data)
         assert any("Duplicate task id" in w.message for w in warnings), warnings
+
+    def test_legacy_parse_tasks_from_yaml_skips_alpha_suffix_with_warning(self):
+        """Legacy parse_tasks_from_yaml should skip alpha-suffixed IDs and warn."""
+        yaml_data = {
+            "tasks": [
+                {"id": "TASK-1-1", "description": "Normal", "acceptance": "Done"},
+                {"id": "TASK-1-3A", "description": "Alpha-A", "acceptance": "Done"},
+                {"id": "TASK-1-3B", "description": "Alpha-B", "acceptance": "Done"},
+            ]
+        }
+        tasks, warnings = parse_tasks_from_yaml(yaml_data)
+        # Only the plain numeric ID should parse
+        assert len(tasks) == 1
+        assert tasks[0].id == "TASK-1-1"
+        # Both alpha-suffixed IDs should produce warnings
+        messages = [w.message for w in warnings]
+        assert any("TASK-1-3A" in m for m in messages), messages
+        assert any("TASK-1-3B" in m for m in messages), messages
+
+    def test_legacy_parse_tasks_from_yaml_plain_ids_no_warnings(self):
+        """Legacy parse_tasks_from_yaml should parse plain numeric IDs without warnings."""
+        yaml_data = {
+            "tasks": [
+                {"id": "TASK-1-1", "description": "One", "acceptance": "Done"},
+                {"id": "TASK-1-2", "description": "Two", "acceptance": "Done"},
+            ]
+        }
+        tasks, warnings = parse_tasks_from_yaml(yaml_data)
+        assert len(tasks) == 2
+        assert warnings == []
 
 
 class TestParsePlanWithYamlCodeFence:


### PR DESCRIPTION
## Summary

- Anchor the `TASK-(\d+)-(\d+)` regex in `plan_parser.py` (both the yaml-fence path at :498 and the legacy front-matter path at :318) so alpha-suffix IDs like `TASK-1-3A` no longer silently match as `(1, 3)`.
- With the anchor, `TASK-1-3A` falls into the existing synthesized-id + `ParseWarning` fallback (:504-513) instead of colliding with `TASK-1-3B` under the same `task-1-3` contract id.
- Add a post-parse sanity check in `parse_phases_from_yaml` that emits a `ParseWarning` if any duplicate contract id survives within a phase — backstops future variants of this class of bug, since `Task.id`'s Pydantic pattern accepts duplicates.

Chose the warn-and-synthesize path over preserving the alpha suffix: it's self-contained (no schema changes), matches the fallback that already exists, and signals to prompt authors that alpha-suffix splits aren't a supported authoring pattern today.

Fixes #1988.

## Test plan

- [x] New `TestAlphaSuffixAndDuplicates` tests: `TASK-1-3A`/`TASK-1-3B` produce unique contract ids with warnings; plain numeric ids still parse without warnings; duplicate literal ids trigger the new sanity warning.
- [x] Full `tests/shared/egg_contracts` suite passes (917 tests; 2 pre-existing module-import failures in `test_agent_roles.py` are unrelated).
- [x] Ruff lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)