### PR TITLE
Fix #1998: conditional ACK with pre-merge obligations on PR body

### DIFF
--- a/orchestrator/approval_matrix.py
+++ b/orchestrator/approval_matrix.py
@@ -121,7 +121,7 @@ class ApprovalMatrix:
         entry.reason = ""
         entry.timestamp = datetime.now(UTC)
         entry.ack_commit_sha = commit_sha
-        entry.pre_merge_condition = pre_merge_condition or ""
+        entry.pre_merge_condition = (pre_merge_condition or "").strip()
         return entry
 
     def record_nack(

--- a/orchestrator/approval_matrix.py
+++ b/orchestrator/approval_matrix.py
@@ -36,6 +36,9 @@ class ApprovalEntry:
     reason: str = ""  # Reason for NACK
     timestamp: datetime | None = None
     ack_commit_sha: str = ""  # Commit SHA at time of ACK (INV-6)
+    # Optional human-facing obligation attached to a conditional ACK (#1998).
+    # Empty string for unconditional ACKs. Cleared on NACK and on re-propose.
+    pre_merge_condition: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -48,6 +51,7 @@ class ApprovalEntry:
             "reason": self.reason,
             "timestamp": self.timestamp.isoformat() if self.timestamp else None,
             "ack_commit_sha": self.ack_commit_sha,
+            "pre_merge_condition": self.pre_merge_condition,
         }
 
 
@@ -93,8 +97,16 @@ class ApprovalMatrix:
         version: int,
         artifact_refs: list[str] | None = None,
         commit_sha: str = "",
+        pre_merge_condition: str = "",
     ) -> ApprovalEntry:
-        """Record an ACK from a reviewer for a producer's proposal."""
+        """Record an ACK from a reviewer for a producer's proposal.
+
+        ``pre_merge_condition`` (optional, issue #1998) carries a human-facing
+        obligation attached to a conditional ACK — e.g. "a human must ``git mv
+        old/path new/path`` before merging". Empty string means an
+        unconditional ACK. The condition is scoped to this (reviewer, producer,
+        version) edge and is cleared on NACK and re-propose.
+        """
         key = (reviewer, producer)
         entry = self._entries.get(key)
         if entry is None:
@@ -109,6 +121,7 @@ class ApprovalMatrix:
         entry.reason = ""
         entry.timestamp = datetime.now(UTC)
         entry.ack_commit_sha = commit_sha
+        entry.pre_merge_condition = pre_merge_condition or ""
         return entry
 
     def record_nack(
@@ -131,6 +144,9 @@ class ApprovalMatrix:
         entry.nack_artifact_refs = artifact_refs or []
         entry.reason = reason
         entry.timestamp = datetime.now(UTC)
+        # A NACK supersedes any prior conditional ACK on this edge — the
+        # producer must re-propose, so any deferred obligation is moot (#1998).
+        entry.pre_merge_condition = ""
 
         # Increment revision count for this edge
         self._revision_counts[key] = self._revision_counts.get(key, 0) + 1
@@ -218,6 +234,10 @@ class ApprovalMatrix:
             entry.state = ApprovalState.PENDING
             entry.artifact_refs = []
             entry.reason = ""
+            # Invalidation drops the ACK entirely; any condition that rode on
+            # that ACK goes with it (#1998). The reviewer must re-ACK to
+            # re-attach a condition if they still want one.
+            entry.pre_merge_condition = ""
             return True
         return False
 
@@ -290,6 +310,40 @@ class ApprovalMatrix:
                 return True
         return False
 
+    def get_pre_merge_conditions(self) -> list[dict[str, Any]]:
+        """Return conditional-ACK obligations scoped to the latest proposal.
+
+        A condition only counts if the reviewer ACKed *the current* proposal
+        version. Stale conditions (attached to a superseded version) are
+        dropped — the producer has re-proposed and the reviewer hasn't
+        re-asserted the obligation on the new version.
+
+        Returns a list of dicts: ``{reviewer, producer, condition, version}``,
+        one per active conditional ACK. Callers (e.g. the PR-body builder,
+        HITL gate) surface these to humans so merge-time obligations aren't
+        silently dropped (#1998).
+        """
+        conditions: list[dict[str, Any]] = []
+        for (reviewer, producer), entry in self._entries.items():
+            if entry.state != ApprovalState.ACKED:
+                continue
+            if not entry.pre_merge_condition:
+                continue
+            latest_version = self._proposal_versions.get(producer, 0)
+            if entry.version != latest_version:
+                # Condition rode on a superseded proposal — the reviewer
+                # hasn't re-attached it to the current version.
+                continue
+            conditions.append(
+                {
+                    "reviewer": reviewer,
+                    "producer": producer,
+                    "condition": entry.pre_merge_condition,
+                    "version": entry.version,
+                }
+            )
+        return conditions
+
     def get_latest_review_versions(self, reviewer: str) -> dict[str, int]:
         """Get the version of each review the reviewer has submitted.
 
@@ -338,6 +392,7 @@ class ApprovalMatrix:
                         else None
                     ),
                     ack_commit_sha=entry_data.get("ack_commit_sha", ""),
+                    pre_merge_condition=entry_data.get("pre_merge_condition", ""),
                 )
 
         for key_str, count in data.get("revision_counts", {}).items():

--- a/orchestrator/attestation_schemas.py
+++ b/orchestrator/attestation_schemas.py
@@ -160,6 +160,7 @@ class ReviewPayload(BaseModel):
     risk_considered: str = Field(default="", description="One risk considered")
     pre_merge_condition: str = Field(
         default="",
+        max_length=1000,
         description=(
             "Structured obligation that must be performed by a human before "
             "merging the PR (issue #1998). Only valid alongside an ACK verdict "

--- a/orchestrator/attestation_schemas.py
+++ b/orchestrator/attestation_schemas.py
@@ -158,6 +158,17 @@ class ReviewPayload(BaseModel):
     )
     reason: str = Field(default="", description="Reason for verdict (required for NACK)")
     risk_considered: str = Field(default="", description="One risk considered")
+    pre_merge_condition: str = Field(
+        default="",
+        description=(
+            "Structured obligation that must be performed by a human before "
+            "merging the PR (issue #1998). Only valid alongside an ACK verdict "
+            "— reviewers issue a conditional ACK when the work is otherwise "
+            "correct but requires a merge-time human action the agents cannot "
+            "perform (e.g. a git mv, a config rotation). Empty string means "
+            "an unconditional ACK."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_artifact_references(self) -> "ReviewPayload":
@@ -173,6 +184,20 @@ class ReviewPayload(BaseModel):
         """Require reason for NACK verdicts."""
         if self.verdict == "NACK" and not self.reason:
             raise ValueError("NACK verdict must include a reason")
+        return self
+
+    @model_validator(mode="after")
+    def validate_condition_only_on_ack(self) -> "ReviewPayload":
+        """Reject a pre_merge_condition attached to a NACK.
+
+        A conditional NACK is nonsensical — NACK already blocks the producer,
+        so there's nothing for a human to approve or defer (#1998).
+        """
+        if self.pre_merge_condition and self.verdict != "ACK":
+            raise ValueError(
+                "pre_merge_condition is only valid on ACK verdicts (conditional ACK); "
+                "NACK already blocks the producer"
+            )
         return self
 
 

--- a/orchestrator/peer_consensus.py
+++ b/orchestrator/peer_consensus.py
@@ -320,8 +320,11 @@ class PeerConsensusTracker:
             # Surface conditional-ACK obligations on the event stream so
             # downstream consumers (PR builder, HITL gate, audit log) can
             # react without having to inspect the matrix directly (#1998).
-            if review.pre_merge_condition:
-                event_data["pre_merge_condition"] = review.pre_merge_condition
+            # Use the normalized value (record_ack strips whitespace) so the
+            # event stream is consistent with persisted matrix state.
+            normalized_condition = (review.pre_merge_condition or "").strip()
+            if normalized_condition:
+                event_data["pre_merge_condition"] = normalized_condition
 
             emit_event(
                 EventType.CONSENSUS_ACK_RECEIVED,
@@ -336,8 +339,8 @@ class PeerConsensusTracker:
                 "fully_acked": fully_acked,
                 "version": ack_version,
             }
-            if review.pre_merge_condition:
-                result["pre_merge_condition"] = review.pre_merge_condition
+            if normalized_condition:
+                result["pre_merge_condition"] = normalized_condition
             return result
 
     def handle_nack(

--- a/orchestrator/peer_consensus.py
+++ b/orchestrator/peer_consensus.py
@@ -302,6 +302,7 @@ class PeerConsensusTracker:
                 ack_version,
                 artifact_refs=review.artifact_references,
                 commit_sha=proposal_commit_sha,
+                pre_merge_condition=review.pre_merge_condition,
             )
 
             # Transition reviewer to REVIEWING
@@ -310,24 +311,34 @@ class PeerConsensusTracker:
             # Check if producer is now fully ACKed
             fully_acked = self.matrix.is_fully_acked(producer_role)
 
+            event_data: dict[str, Any] = {
+                "reviewer": reviewer_role,
+                "producer": producer_role,
+                "version": ack_version,
+                "fully_acked": fully_acked,
+            }
+            # Surface conditional-ACK obligations on the event stream so
+            # downstream consumers (PR builder, HITL gate, audit log) can
+            # react without having to inspect the matrix directly (#1998).
+            if review.pre_merge_condition:
+                event_data["pre_merge_condition"] = review.pre_merge_condition
+
             emit_event(
                 EventType.CONSENSUS_ACK_RECEIVED,
                 self.pipeline_id,
-                data={
-                    "reviewer": reviewer_role,
-                    "producer": producer_role,
-                    "version": ack_version,
-                    "fully_acked": fully_acked,
-                },
+                data=event_data,
             )
 
             self._run_invariant_checks("ack")
 
-            return {
+            result: dict[str, Any] = {
                 "status": "acked",
                 "fully_acked": fully_acked,
                 "version": ack_version,
             }
+            if review.pre_merge_condition:
+                result["pre_merge_condition"] = review.pre_merge_condition
+            return result
 
     def handle_nack(
         self,
@@ -1140,6 +1151,19 @@ class PeerConsensusTracker:
     def get_proposal_commit_sha(self, role: str) -> str:
         """Return the commit SHA from a producer's last proposal (#1473)."""
         return self._proposal_commit_shas.get(role, "")
+
+    def get_pre_merge_conditions(self) -> list[dict[str, Any]]:
+        """Return active conditional-ACK obligations across all producers.
+
+        Delegates to the matrix, which scopes results to current-version ACKs
+        so stale conditions from superseded proposals are dropped (#1998).
+
+        Returns a list of dicts: ``{reviewer, producer, condition, version}``.
+        Callers (PR body builder, HITL gate) surface these to humans so
+        merge-time obligations aren't silently dropped.
+        """
+        with self._lock:
+            return self.matrix.get_pre_merge_conditions()
 
     def get_latest_proposal_timestamp(self) -> datetime | None:
         """Return the timestamp of the most recent CONSENSUS_PROPOSE, or None."""

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5893,6 +5893,62 @@ def _persist_phase_brc_history(
         )
 
 
+def _build_pre_merge_obligations_section(pipeline_id: str) -> str:
+    """Render the "Pre-merge Obligations" section from active conditional ACKs.
+
+    Queries the live consensus tracker for conditions attached to current-
+    version ACKs (see ``ApprovalMatrix.get_pre_merge_conditions``). Returns
+    an empty string if the tracker is unavailable or has no conditions, so
+    callers can unconditionally append the result to the PR body.
+
+    The section exists to close the loophole where reviewers embedded
+    merge-time obligations ("human must git mv X Y before merging") in ACK
+    prose that the merger could skim past (#1998). Rendered as a visible
+    markdown section up-front on the PR so the obligation is in the
+    merger's line of sight.
+    """
+    try:
+        from peer_consensus import get_peer_consensus_tracker
+    except ImportError:
+        return ""
+    tracker = get_peer_consensus_tracker(pipeline_id)
+    if tracker is None:
+        return ""
+    try:
+        conditions = tracker.get_pre_merge_conditions()
+    except Exception as e:  # defensive — never block PR creation on this
+        logger.debug(
+            "Failed to read pre-merge conditions from tracker",
+            pipeline_id=pipeline_id,
+            error=str(e),
+        )
+        return ""
+    if not conditions:
+        return ""
+
+    lines = [
+        "## ⚠️ Pre-merge Obligations",
+        "",
+        "The reviewers below issued a **conditional ACK** — the work is "
+        "approved, but a human must perform the listed action before "
+        "merging. Do **not** merge this PR until every obligation is "
+        "complete.",
+        "",
+    ]
+    for c in conditions:
+        reviewer = c.get("reviewer", "unknown")
+        condition = str(c.get("condition", "")).strip()
+        if not condition:
+            continue
+        # Indent multi-line conditions under the bullet so they stay
+        # visually grouped in rendered markdown.
+        first, *rest = condition.splitlines()
+        lines.append(f"- **{reviewer}** — {first}")
+        for extra in rest:
+            lines.append(f"  {extra}")
+    return "\n".join(lines)
+
+
 def _build_brc_history_link_line(
     worktree_repo_path: Path,
     identifier: int | str | None,
@@ -6104,6 +6160,16 @@ def _build_pr_body(
         body_parts.append(pr_description)
     elif pipeline.issue_number:
         body_parts.append(f"Closes #{pipeline.issue_number}")
+
+    # Pre-merge obligations from conditional ACKs (issue #1998). Rendered
+    # high in the body so the merger sees them before skimming past the
+    # test plan. Conditions come from the consensus tracker — if the
+    # tracker is gone (orchestrator restart without reconstruction), the
+    # section is silently skipped and reviewers fall back to the planner's
+    # manual_steps below.
+    deferred_section = _build_pre_merge_obligations_section(pipeline.id)
+    if deferred_section:
+        body_parts.append(deferred_section)
 
     # Test plan section (always present — placeholder if missing)
     if pr_test_plan:
@@ -6949,6 +7015,24 @@ def _build_brc_preamble(
                 "   ### Non-blocking\n"
                 "   - **file.py:123** — Optional suggestions for improvement.\n"
                 '   "\n'
+                "   ```\n"
+                "\n"
+                "   **Conditional ACK** (issue #1998 — use when the work is "
+                "correct but requires a human action at merge time that agents "
+                "cannot perform themselves, e.g. a `git mv`, a secret "
+                "rotation, a config flip in another repo): add "
+                '`--pre-merge-condition "…"` to the ACK command. The '
+                "obligation is recorded on the approval matrix and rendered "
+                'as a "Pre-merge Obligations" section high up in the '
+                "auto-created PR body so the merger cannot skim past it. Do "
+                "NOT use this to smuggle blocking issues past the producer — "
+                "if the producer could fix it, NACK instead.\n"
+                "   Example:\n"
+                "   ```\n"
+                '   egg-orch consensus ack <role> --files-reviewed "f1" '
+                '--reason "Code is correct but …" '
+                '--pre-merge-condition "A human must `git mv legacy/x '
+                'new/x` before merging — agents cannot push renames through "\n'
                 "   ```\n"
                 "\n"
                 "   `--reason` must be ≥50 chars of substantive content. "

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5910,14 +5910,14 @@ def _build_pre_merge_obligations_section(pipeline_id: str) -> str:
     try:
         from peer_consensus import get_peer_consensus_tracker
     except ImportError:
-        return ""
+        from ..peer_consensus import get_peer_consensus_tracker  # type: ignore[import-not-found]
     tracker = get_peer_consensus_tracker(pipeline_id)
     if tracker is None:
         return ""
     try:
         conditions = tracker.get_pre_merge_conditions()
     except Exception as e:  # defensive — never block PR creation on this
-        logger.debug(
+        logger.warning(
             "Failed to read pre-merge conditions from tracker",
             pipeline_id=pipeline_id,
             error=str(e),
@@ -5946,6 +5946,10 @@ def _build_pre_merge_obligations_section(pipeline_id: str) -> str:
         lines.append(f"- **{reviewer}** — {first}")
         for extra in rest:
             lines.append(f"  {extra}")
+    # If every condition was whitespace-only, no bullets were added — return
+    # empty to avoid rendering a header with zero items (#1998 review).
+    if len(lines) == 4:
+        return ""
     return "\n".join(lines)
 
 
@@ -7032,7 +7036,7 @@ def _build_brc_preamble(
                 '   egg-orch consensus ack <role> --files-reviewed "f1" '
                 '--reason "Code is correct but …" '
                 '--pre-merge-condition "A human must `git mv legacy/x '
-                'new/x` before merging — agents cannot push renames through "\n'
+                'new/x` before merging — agents cannot push renames through"\n'
                 "   ```\n"
                 "\n"
                 "   `--reason` must be ≥50 chars of substantive content. "

--- a/orchestrator/tests/test_conditional_ack.py
+++ b/orchestrator/tests/test_conditional_ack.py
@@ -1,0 +1,293 @@
+"""Tests for the conditional-ACK path (issue #1998).
+
+Conditional ACKs let a reviewer approve a proposal while attaching an
+obligation that a human must perform at merge time — e.g. a ``git mv``
+that agents cannot push through the gateway. These tests cover:
+
+- Schema validation on ``ReviewPayload``
+- Persistence + scoping on ``ApprovalMatrix``
+- Carry-through via ``PeerConsensusTracker.handle_ack``
+- Rendering of the Pre-merge Obligations section in the PR body
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+from approval_matrix import ApprovalMatrix, ApprovalState
+from attestation_schemas import ReviewPayload
+from peer_consensus import PeerConsensusTracker
+from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph
+
+# --- Schema -----------------------------------------------------------------
+
+
+class TestReviewPayloadCondition:
+    def test_ack_accepts_condition(self):
+        payload = ReviewPayload(
+            verdict="ACK",
+            artifact_references=["src/a.py"],
+            pre_merge_condition="git mv legacy/x new/x before merge",
+        )
+        assert payload.pre_merge_condition.startswith("git mv")
+
+    def test_ack_defaults_to_no_condition(self):
+        payload = ReviewPayload(verdict="ACK", artifact_references=["src/a.py"])
+        assert payload.pre_merge_condition == ""
+
+    def test_nack_rejects_condition(self):
+        # A conditional NACK is nonsensical — NACK already blocks the
+        # producer, so there's nothing to defer.
+        with pytest.raises(ValueError, match="only valid on ACK"):
+            ReviewPayload(
+                verdict="NACK",
+                artifact_references=["src/a.py"],
+                reason="broken",
+                pre_merge_condition="do something",
+            )
+
+
+# --- Matrix ----------------------------------------------------------------
+
+
+@pytest.fixture
+def matrix_graph():
+    return ReviewGraph(
+        [
+            ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL),
+            ReviewEdge("reviewer_contract", "coder", ReviewCriticality.CRITICAL),
+        ]
+    )
+
+
+class TestApprovalMatrixCondition:
+    def test_record_ack_stores_condition(self, matrix_graph):
+        matrix = ApprovalMatrix(matrix_graph)
+        matrix.record_proposal("coder")
+        matrix.record_ack(
+            "reviewer_code",
+            "coder",
+            version=1,
+            artifact_refs=["src/a.py"],
+            pre_merge_condition="human must git mv X Y",
+        )
+        entry = matrix.get_entry("reviewer_code", "coder")
+        assert entry is not None
+        assert entry.pre_merge_condition == "human must git mv X Y"
+
+    def test_nack_clears_condition(self, matrix_graph):
+        matrix = ApprovalMatrix(matrix_graph)
+        matrix.record_proposal("coder")
+        matrix.record_ack(
+            "reviewer_code",
+            "coder",
+            version=1,
+            artifact_refs=["src/a.py"],
+            pre_merge_condition="obligation",
+        )
+        matrix.record_nack(
+            "reviewer_code",
+            "coder",
+            version=1,
+            reason="changed my mind",
+            artifact_refs=["src/a.py"],
+        )
+        entry = matrix.get_entry("reviewer_code", "coder")
+        assert entry is not None
+        assert entry.pre_merge_condition == ""
+
+    def test_invalidate_ack_clears_condition(self, matrix_graph):
+        matrix = ApprovalMatrix(matrix_graph)
+        matrix.record_proposal("coder")
+        matrix.record_ack(
+            "reviewer_code",
+            "coder",
+            version=1,
+            pre_merge_condition="obligation",
+        )
+        matrix.invalidate_ack("reviewer_code", "coder")
+        entry = matrix.get_entry("reviewer_code", "coder")
+        assert entry is not None
+        assert entry.state == ApprovalState.PENDING
+        assert entry.pre_merge_condition == ""
+
+    def test_get_pre_merge_conditions_returns_current(self, matrix_graph):
+        matrix = ApprovalMatrix(matrix_graph)
+        matrix.record_proposal("coder")
+        matrix.record_ack(
+            "reviewer_code",
+            "coder",
+            version=1,
+            pre_merge_condition="A",
+        )
+        matrix.record_ack(
+            "reviewer_contract",
+            "coder",
+            version=1,
+            # No condition on this ACK — should not appear in the list.
+        )
+        conditions = matrix.get_pre_merge_conditions()
+        assert len(conditions) == 1
+        assert conditions[0]["reviewer"] == "reviewer_code"
+        assert conditions[0]["producer"] == "coder"
+        assert conditions[0]["condition"] == "A"
+        assert conditions[0]["version"] == 1
+
+    def test_get_pre_merge_conditions_skips_stale(self, matrix_graph):
+        """Condition recorded against version 1 vanishes after re-propose."""
+        matrix = ApprovalMatrix(matrix_graph)
+        matrix.record_proposal("coder")  # v1
+        matrix.record_ack(
+            "reviewer_code",
+            "coder",
+            version=1,
+            pre_merge_condition="A",
+        )
+        matrix.record_proposal("coder")  # v2 — supersedes v1
+        # The ACK on v1 is now stale — the reviewer has not re-asserted
+        # the obligation on v2, so we must not render it as an active
+        # obligation.
+        assert matrix.get_pre_merge_conditions() == []
+
+    def test_round_trip_persistence(self, matrix_graph):
+        matrix = ApprovalMatrix(matrix_graph)
+        matrix.record_proposal("coder")
+        matrix.record_ack(
+            "reviewer_code",
+            "coder",
+            version=1,
+            pre_merge_condition="mv thing",
+        )
+        data = matrix.to_dict()
+        restored = ApprovalMatrix.from_dict(data, matrix_graph)
+        entry = restored.get_entry("reviewer_code", "coder")
+        assert entry is not None
+        assert entry.pre_merge_condition == "mv thing"
+
+
+# --- Tracker ---------------------------------------------------------------
+
+
+class TestTrackerCondition:
+    def test_handle_ack_persists_condition(self, matrix_graph):
+        tracker = PeerConsensusTracker("test-pid", matrix_graph, cooldown_seconds=0)
+        tracker.register_agent("coder")
+        tracker.register_agent("reviewer_code")
+        tracker.register_agent("reviewer_contract")
+
+        tracker.handle_propose(
+            "coder",
+            {
+                "summary": "impl",
+                "artifacts": ["src/a.py"],
+                "commit_sha": "abc123",
+            },
+        )
+        result = tracker.handle_ack(
+            "reviewer_code",
+            "coder",
+            {
+                "artifact_references": ["src/a.py"],
+                "pre_merge_condition": "git mv X Y before merge",
+            },
+        )
+        assert result["status"] == "acked"
+        assert result["pre_merge_condition"] == "git mv X Y before merge"
+
+        conditions = tracker.get_pre_merge_conditions()
+        assert len(conditions) == 1
+        assert conditions[0]["condition"] == "git mv X Y before merge"
+
+    def test_handle_ack_without_condition_is_unchanged(self, matrix_graph):
+        tracker = PeerConsensusTracker("test-pid", matrix_graph, cooldown_seconds=0)
+        tracker.register_agent("coder")
+        tracker.register_agent("reviewer_code")
+        tracker.register_agent("reviewer_contract")
+        tracker.handle_propose(
+            "coder",
+            {"summary": "impl", "artifacts": ["src/a.py"], "commit_sha": "abc"},
+        )
+        result = tracker.handle_ack(
+            "reviewer_code",
+            "coder",
+            {"artifact_references": ["src/a.py"]},
+        )
+        assert "pre_merge_condition" not in result
+        assert tracker.get_pre_merge_conditions() == []
+
+
+# --- PR body rendering -----------------------------------------------------
+
+
+class TestPrBodyRendering:
+    def test_section_rendered_when_conditions_exist(self, matrix_graph):
+        tracker = PeerConsensusTracker("pipeline-X", matrix_graph, cooldown_seconds=0)
+        tracker.register_agent("coder")
+        tracker.register_agent("reviewer_code")
+        tracker.register_agent("reviewer_contract")
+        tracker.handle_propose(
+            "coder",
+            {"summary": "impl", "artifacts": ["src/a.py"], "commit_sha": "abc"},
+        )
+        tracker.handle_ack(
+            "reviewer_code",
+            "coder",
+            {
+                "artifact_references": ["src/a.py"],
+                "pre_merge_condition": "git mv legacy/x new/x",
+            },
+        )
+
+        # Patch the tracker lookup to return our in-memory tracker, since
+        # the module-level registry uses its own dict that may be empty
+        # in some test environments.
+        with patch(
+            "peer_consensus.get_peer_consensus_tracker",
+            return_value=tracker,
+        ):
+            from routes import pipelines as p
+
+            section = p._build_pre_merge_obligations_section("pipeline-X")
+
+        assert "Pre-merge Obligations" in section
+        assert "reviewer_code" in section
+        assert "git mv legacy/x new/x" in section
+
+    def test_section_empty_when_no_tracker(self):
+        with patch(
+            "peer_consensus.get_peer_consensus_tracker",
+            return_value=None,
+        ):
+            from routes import pipelines as p
+
+            assert p._build_pre_merge_obligations_section("missing-pipeline") == ""
+
+    def test_section_empty_when_no_conditions(self, matrix_graph):
+        tracker = PeerConsensusTracker("pipeline-Y", matrix_graph, cooldown_seconds=0)
+        tracker.register_agent("coder")
+        tracker.register_agent("reviewer_code")
+        tracker.register_agent("reviewer_contract")
+        tracker.handle_propose(
+            "coder",
+            {"summary": "impl", "artifacts": ["src/a.py"], "commit_sha": "abc"},
+        )
+        tracker.handle_ack(
+            "reviewer_code",
+            "coder",
+            {"artifact_references": ["src/a.py"]},
+        )
+        with patch(
+            "peer_consensus.get_peer_consensus_tracker",
+            return_value=tracker,
+        ):
+            from routes import pipelines as p
+
+            assert p._build_pre_merge_obligations_section("pipeline-Y") == ""

--- a/orchestrator/tests/test_conditional_ack.py
+++ b/orchestrator/tests/test_conditional_ack.py
@@ -83,6 +83,23 @@ class TestApprovalMatrixCondition:
         assert entry is not None
         assert entry.pre_merge_condition == "human must git mv X Y"
 
+    def test_whitespace_only_condition_normalized_to_empty(self, matrix_graph):
+        """Whitespace-only conditions are stripped at the source (#1998 review)."""
+        matrix = ApprovalMatrix(matrix_graph)
+        matrix.record_proposal("coder")
+        matrix.record_ack(
+            "reviewer_code",
+            "coder",
+            version=1,
+            artifact_refs=["src/a.py"],
+            pre_merge_condition="   ",
+        )
+        entry = matrix.get_entry("reviewer_code", "coder")
+        assert entry is not None
+        assert entry.pre_merge_condition == ""
+        # Should not appear in active conditions either.
+        assert matrix.get_pre_merge_conditions() == []
+
     def test_nack_clears_condition(self, matrix_graph):
         matrix = ApprovalMatrix(matrix_graph)
         matrix.record_proposal("coder")

--- a/orchestrator/tests/test_conditional_ack.py
+++ b/orchestrator/tests/test_conditional_ack.py
@@ -223,6 +223,34 @@ class TestTrackerCondition:
         assert len(conditions) == 1
         assert conditions[0]["condition"] == "git mv X Y before merge"
 
+    def test_handle_ack_whitespace_condition_excluded_from_event_and_result(self, matrix_graph):
+        """Whitespace-only condition should not appear in the return value or
+        event data — it must be consistent with the matrix normalization."""
+        tracker = PeerConsensusTracker("test-pid", matrix_graph, cooldown_seconds=0)
+        tracker.register_agent("coder")
+        tracker.register_agent("reviewer_code")
+        tracker.register_agent("reviewer_contract")
+
+        tracker.handle_propose(
+            "coder",
+            {
+                "summary": "impl",
+                "artifacts": ["src/a.py"],
+                "commit_sha": "abc123",
+            },
+        )
+        result = tracker.handle_ack(
+            "reviewer_code",
+            "coder",
+            {
+                "artifact_references": ["src/a.py"],
+                "pre_merge_condition": "   ",
+            },
+        )
+        # Whitespace-only condition should be treated as no condition.
+        assert "pre_merge_condition" not in result
+        assert tracker.get_pre_merge_conditions() == []
+
     def test_handle_ack_without_condition_is_unchanged(self, matrix_graph):
         tracker = PeerConsensusTracker("test-pid", matrix_graph, cooldown_seconds=0)
         tracker.register_agent("coder")

--- a/sandbox/egg_agent_tools/handlers/brc.py
+++ b/sandbox/egg_agent_tools/handlers/brc.py
@@ -150,6 +150,12 @@ def brc_ack(req: dict[str, Any]) -> dict[str, Any]:
         producer_role (str): required.
         reason (str): required.
         files_reviewed (list[str]): optional list of artifact references.
+        pre_merge_condition (str): optional. Turns this into a **conditional
+            ACK** — the work is approved but a human must perform the named
+            action before merging (e.g. "git mv old/path new/path"). Surfaces
+            as a dedicated "Pre-merge Obligations" section on the auto-created
+            PR so the merger sees it instead of skimming past a prose note in
+            the ACK reason (#1998).
         pipeline_id, role: overrides.
     """
     pid = _require_pipeline_id(req)
@@ -161,14 +167,19 @@ def brc_ack(req: dict[str, Any]) -> dict[str, Any]:
     if not reason:
         raise HandlerError("'reason' is required")
 
+    payload: dict[str, Any] = {
+        "artifact_references": list(req.get("files_reviewed") or []),
+        "reason": reason,
+    }
+    pre_merge_condition = req.get("pre_merge_condition") or ""
+    if pre_merge_condition:
+        payload["pre_merge_condition"] = pre_merge_condition
+
     data = {
         "signal_type": "consensus_ack",
         "agent_role": role,
         "producer_role": producer_role,
-        "payload": {
-            "artifact_references": list(req.get("files_reviewed") or []),
-            "reason": reason,
-        },
+        "payload": payload,
     }
     result = orchestrator_request(f"/api/v1/pipelines/{pid}/signal", method="POST", data=data)
     if not result.get("success"):

--- a/sandbox/egg_agent_tools/tools/brc.py
+++ b/sandbox/egg_agent_tools/tools/brc.py
@@ -68,6 +68,16 @@ _ACK_SCHEMA: dict[str, Any] = {
             "items": {"type": "string"},
             "description": "Artifacts actually reviewed",
         },
+        "pre_merge_condition": {
+            "type": "string",
+            "description": (
+                "Optional conditional-ACK obligation (issue #1998). The work "
+                "is approved but the named action must be performed by a "
+                "human before merging (e.g. 'git mv old/path new/path'). "
+                "Surfaces as a Pre-merge Obligations section on the "
+                "auto-created PR. Leave empty for an unconditional ACK."
+            ),
+        },
         "pipeline_id": {"type": "string"},
         "role": {"type": "string"},
     },

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -1712,6 +1712,7 @@ def cmd_consensus_ack(args: argparse.Namespace) -> int:
         "producer_role": args.producer_role,
         "reason": args.reason,
         "files_reviewed": list(args.files_reviewed or []),
+        "pre_merge_condition": getattr(args, "pre_merge_condition", "") or "",
     }
     try:
         resp = _handlers.brc_ack(req)
@@ -1721,7 +1722,13 @@ def cmd_consensus_ack(args: argparse.Namespace) -> int:
     if args.json:
         print_json(resp.get("signal", {}))
         return 0
-    print(f"ACK sent by {role} for {args.producer_role}")
+    if req["pre_merge_condition"]:
+        print(
+            f"Conditional ACK sent by {role} for {args.producer_role} "
+            f"(obligation: {req['pre_merge_condition']})"
+        )
+    else:
+        print(f"ACK sent by {role} for {args.producer_role}")
     return 0
 
 
@@ -2402,6 +2409,17 @@ def create_parser() -> argparse.ArgumentParser:
         "--reason",
         required=True,
         help="Substantive rationale: what was read, what was checked, why the verdict follows",
+    )
+    cons_ack.add_argument(
+        "--pre-merge-condition",
+        dest="pre_merge_condition",
+        default="",
+        help=(
+            "Optional: mark this as a conditional ACK (#1998). The work is "
+            "approved but the named action must be performed by a human "
+            "before merging (e.g. 'git mv old/path new/path'). Surfaces as "
+            "a Pre-merge Obligations section on the auto-created PR."
+        ),
     )
     _add_json_flag(cons_ack)
     cons_ack.set_defaults(func=cmd_consensus_ack)

--- a/sandbox/tests/test_brc_cli_args.py
+++ b/sandbox/tests/test_brc_cli_args.py
@@ -99,6 +99,46 @@ class TestAckReasonInPayload:
         assert payload["artifact_references"] == ["src/auth.py", "src/models.py"]
 
 
+class TestAckConditionalFlag:
+    """--pre-merge-condition marks the ACK as conditional (issue #1998)."""
+
+    def test_condition_defaults_to_empty(self):
+        """Omitting the flag yields an empty condition (unconditional ACK)."""
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "consensus",
+                "ack",
+                "coder",
+                "issue-42",
+                "--files-reviewed",
+                "src/a.py",
+                "--reason",
+                "All looks good, reviewed a.py and confirmed auth flow is correct",
+            ]
+        )
+        assert getattr(args, "pre_merge_condition", "") == ""
+
+    def test_condition_parses(self):
+        """--pre-merge-condition captures the obligation string."""
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "consensus",
+                "ack",
+                "coder",
+                "issue-42",
+                "--files-reviewed",
+                "src/a.py",
+                "--reason",
+                "Approved, but a file move must happen before merging",
+                "--pre-merge-condition",
+                "A human must `git mv legacy/x new/x` before merge",
+            ]
+        )
+        assert args.pre_merge_condition == "A human must `git mv legacy/x new/x` before merge"
+
+
 # ---------------------------------------------------------------------------
 # PROPOSE: new structured args
 # ---------------------------------------------------------------------------

--- a/shared/prompts/REVIEWER-SYNC.md
+++ b/shared/prompts/REVIEWER-SYNC.md
@@ -54,6 +54,17 @@ review standards differ:
    ACK/NACK lifecycle instructions in the BRC preamble (from `_build_brc_preamble()`),
    including substantive `--reason` requirements (≥50 chars) and `--files-reviewed`
    flags. PR reviewer and sequential SDLC reviewer structure their output organically.
+7. **Conditional ACK (BRC only)**: Concurrent SDLC reviewers can attach a
+   `--pre-merge-condition "…"` flag to an ACK when the work is correct but
+   requires a merge-time human action the agents cannot perform (e.g. a
+   `git mv`, a secret rotation, a cross-repo config flip). The obligation is
+   persisted on the approval matrix edge and rendered as a "Pre-merge
+   Obligations" section on the auto-created PR body so the merger cannot
+   skim past it (#1998). PR reviewer and sequential SDLC reviewer have no
+   analogue — the GHA reviewer runs after the human merger has already seen
+   the PR body, and the sequential reviewer's verdict file does not feed the
+   PR. A conditional ACK is **not** a soft NACK: if the producer could
+   address the obligation, NACK instead.
 
 ## What Must Stay Aligned
 
@@ -83,4 +94,5 @@ When changing review criteria or conventions:
 - [ ] Verify the procedural review steps match between both surfaces
 - [ ] If changing verdict format: check `_build_review_prompt()` (sequential verdict JSON) and `_build_agent_prompt()` + `_build_brc_preamble()` (concurrent ACK/NACK)
 - [ ] If changing ACK/NACK format guidance: update the structured format in `_build_brc_preamble()`
+- [ ] If changing conditional-ACK (`--pre-merge-condition`) behavior: update the BRC preamble example in `_build_brc_preamble()`, the CLI help text in `sandbox/egg_lib/orch_cli.py`, the `_ACK_SCHEMA` description in `sandbox/egg_agent_tools/tools/brc.py`, the `ReviewPayload.pre_merge_condition` docstring in `orchestrator/attestation_schemas.py`, and the PR-body renderer `_build_pre_merge_obligations_section()` in `orchestrator/routes/pipelines.py`
 - [ ] If changing the re-review diff command: update the three PR-reviewer builders (`action/build-review-prompt.sh`, `action/build-agent-mode-design-review-prompt.sh`, `action/build-contract-verification-prompt.sh`), the SDLC reviewer's `_build_review_prompt()` `is_delta_review` branch plus its Delta Review directive, and the `BASE_REF` plumbing in `.github/workflows/reusable-review.yml`. The first-review three-dot `git diff origin/<base>...HEAD` is independent of the delta path.


### PR DESCRIPTION
## Summary

- Reviewers can now attach `--pre-merge-condition "…"` to a BRC ACK when the work is correct but needs a merge-time human action agents can't perform (e.g. a `git mv`, a cross-repo config flip). The condition is persisted on the approval-matrix edge, scoped to the current proposal version, and rendered as a dedicated **"Pre-merge Obligations"** section high in the auto-created PR body so the merger cannot skim past it (#1998).
- **What's deferred (by design):** the 3-way HITL gate from the issue's original proposal (approve-and-accept / force-NACK / address-in-pipeline). This PR ships the structured-signal + propagation half so reviewers stop smuggling obligations into ACK prose; the HITL gate is a clean follow-up that sits on top of the schema and tracker helpers added here. Noting this so the issue is not auto-closed until the HITL layer lands.

## Changes

- **Schema** (`orchestrator/attestation_schemas.py`) — `ReviewPayload.pre_merge_condition: str = ""`; validator rejects conditions attached to NACKs (a conditional NACK is nonsensical).
- **Matrix** (`orchestrator/approval_matrix.py`) — `ApprovalEntry.pre_merge_condition`; persisted on `record_ack`, cleared on NACK and on `invalidate_ack`; round-trips through `to_dict`/`from_dict`. New `get_pre_merge_conditions()` returns only current-version conditions (stale obligations from superseded proposals are dropped).
- **Tracker** (`orchestrator/peer_consensus.py`) — `handle_ack` carries the condition through to the matrix, surfaces it on the `CONSENSUS_ACK_RECEIVED` event and handler result. New `tracker.get_pre_merge_conditions()` delegates to the matrix under the lock.
- **PR body** (`orchestrator/routes/pipelines.py`) — new `_build_pre_merge_obligations_section()` queries the live tracker and renders a ⚠️-headed section right after the PR description. Skipped silently if the tracker is gone (orchestrator restart without reconstruction) so PR creation never blocks on this.
- **CLI + MCP** (`sandbox/egg_lib/orch_cli.py`, `sandbox/egg_agent_tools/handlers/brc.py`, `sandbox/egg_agent_tools/tools/brc.py`) — `--pre-merge-condition` flag on `egg-orch consensus ack`; same field exposed on the `mcp__brc__ack` MCP tool schema.
- **Prompts** (`orchestrator/routes/pipelines.py` `_build_brc_preamble`, `shared/prompts/REVIEWER-SYNC.md`) — reviewer BRC preamble documents the conditional-ACK pattern with an example and the "not a soft NACK" guardrail. `REVIEWER-SYNC.md` adds a row and a checklist entry pointing at every surface to keep in sync.
- **Tests** — `orchestrator/tests/test_conditional_ack.py` covers schema validation, matrix persistence + scoping to current version, tracker carry-through, and PR body rendering (with and without an active tracker). `sandbox/tests/test_brc_cli_args.py` gets `TestAckConditionalFlag` for argparse.

## Test plan

- [x] `make lint` passes
- [x] `pytest orchestrator/tests/test_conditional_ack.py sandbox/tests/test_brc_cli_args.py` — 33 passed
- [x] Related regression sweep: `pytest orchestrator/tests/test_peer_consensus_integration.py orchestrator/tests/test_auto_pr.py orchestrator/tests/test_action_guards.py orchestrator/tests/test_producer_push_consensus.py orchestrator/tests/test_brc_content_validation.py` — 300 passed
- [x] Full orchestrator + sandbox suite — 4624 passed; 9 `test_overseer_alert_cli.py` failures are pre-existing and also fail on `main` (they require a live orchestrator service for network calls)
- [ ] Not tested: end-to-end SDLC pipeline run — follow-up will exercise this alongside the HITL gate work

🤖 Generated with [Claude Code](https://claude.com/claude-code)