### PR TITLE
Fix #2010: calibrate overseer prompt for refine-phase false positives

### DIFF
--- a/sandbox/agent-config/rules/overseer.md
+++ b/sandbox/agent-config/rules/overseer.md
@@ -163,7 +163,7 @@ A producer may legitimately spend time reading, grepping, and exploring before e
 | `plan` | 3 minutes |
 | `implement` | 10 minutes |
 
-Active tool calls (file reads, grep, web searches, `Agent` spawns, `TodoWrite`) observed via `get_container_logs` during this window are **evidence of legitimate work**, not a stall. Only emit `agent-heartbeat-stall` when all three conditions are met: (a) the working-window floor has elapsed, (b) the orchestrator has raised a corresponding health alert, and (c) the container has not exited or become unreachable — if the container is down, escalate immediately regardless of the working-window floor.
+Active tool calls (file reads, grep, web searches, `Agent` spawns, `TodoWrite`) observed via `get_container_logs` during this window are **evidence of legitimate work**, not a stall. Only emit `agent-heartbeat-stall` when both (a) the working-window floor has elapsed AND (b) the orchestrator has raised a corresponding health alert. **Exception**: if the container has exited or become unreachable, escalate immediately regardless of the working-window floor.
 
 ### Escalation triggers
 

--- a/sandbox/agent-config/rules/overseer.md
+++ b/sandbox/agent-config/rules/overseer.md
@@ -145,8 +145,8 @@ Before classifying an anomaly, calibrate against what is **expected** for the cu
 
 **Contract state at phase start:**
 
-| Phase | Expected `show_contract` at phase start | Refiner/coder role |
-|-------|------------------------------------------|--------------------|
+| Phase | Expected `show_contract` at phase start | Agent relationship to contract |
+|-------|------------------------------------------|--------------------------------|
 | `refine` | **Empty or near-empty** (`phases=[]`, `acceptance_criteria=[]`, no `agent_executions`). The refiner *produces* the analysis that populates the contract. | Producer of contract content |
 | `plan` | Populated with refine artifacts (analysis doc, initial acceptance criteria). | Producer of plan; consumer of refine output |
 | `implement` | Populated with refine + plan artifacts (tasks, acceptance criteria, phase configs). | Producer of code; consumer of contract |
@@ -163,7 +163,7 @@ A producer may legitimately spend time reading, grepping, and exploring before e
 | `plan` | 3 minutes |
 | `implement` | 10 minutes |
 
-Active tool calls (file reads, grep, web searches, `Agent` spawns, `TodoWrite`) observed via `get_container_logs` during this window are **evidence of legitimate work**, not a stall. Only emit `agent-heartbeat-stall` when both (a) the working-window floor has elapsed AND (b) the orchestrator has raised a corresponding health alert.
+Active tool calls (file reads, grep, web searches, `Agent` spawns, `TodoWrite`) observed via `get_container_logs` during this window are **evidence of legitimate work**, not a stall. Only emit `agent-heartbeat-stall` when all three conditions are met: (a) the working-window floor has elapsed, (b) the orchestrator has raised a corresponding health alert, and (c) the container has not exited or become unreachable — if the container is down, escalate immediately regardless of the working-window floor.
 
 ### Escalation triggers
 
@@ -172,7 +172,7 @@ Emit an `OVERSEER_ALERT` when you observe any of these:
 - **Stuck phase transition**: BRC consensus is `complete` (`consensus.state == "confirmed"`) but the phase has not transitioned within ~60 seconds. Anomaly type: `stuck-phase-transition`, priority: `high`. Include the consensus state and the time since confirmation in `--detail`. **Do NOT emit `stuck-phase-transition` when `consensus.state != "confirmed"`** — that is a different failure mode (producer still working, reviewers still ACKing, etc.) and requires a different anomaly type. An empty contract during the refine phase is never grounds for this alert; see [Phase-relative baselines](#phase-relative-baselines).
 - **Orchestrator silent on consensus**: No `CONSENSUS_*` messages from the orchestrator for several minutes while agents are still active. Anomaly type: `orchestrator-consensus-silent`, priority: `high`.
 - **Repeated 401 from any orchestrator endpoint**: You tried a command and got a 401 (or any auth-rejection). **Stop retrying that command immediately.** Anomaly type: `unauthorized-overseer-action`, priority: `medium`. Include which command you tried and why you thought it was needed.
-- **Heartbeat stall on an active agent**: An agent has missed `max_missed_heartbeats` consecutive heartbeats **and** the health alert from the orchestrator confirms it **and** the phase-specific minimum working window (see [Phase-relative baselines](#phase-relative-baselines)) has elapsed. Anomaly type: `agent-heartbeat-stall`, priority depends on the agent's criticality. A producer that has been `WORKING` for less than the phase floor without a `CONSENSUS_PROPOSE` is **not** stalled.
+- **Heartbeat stall on an active agent**: An agent has missed `max_missed_heartbeats` consecutive heartbeats **and** the health alert from the orchestrator confirms it **and** the phase-specific minimum working window (see [Phase-relative baselines](#phase-relative-baselines)) has elapsed. Anomaly type: `agent-heartbeat-stall`, priority depends on the agent's criticality. A producer that has been `WORKING` for less than the phase floor without a `CONSENSUS_PROPOSE` is **not** stalled. Note: active tool-call activity (as described in [Phase-relative baselines](#phase-relative-baselines)) is relevant counter-evidence even outside the first-proposal context — if the agent is producing tool calls, weigh that against the missed-heartbeat signal before alerting.
 - **Persistent agent loop**: Haiku classifier returns `loop` with confidence > 0.8 across two consecutive cycles. Anomaly type: `agent-loop`, priority: `medium`.
 - **Same anomaly seen across N cycles without resolution**: If you've already alerted on the same anomaly and the situation hasn't changed for `overseer_max_cycles_before_re_alert` (default: 3) cycles, re-alert with priority bumped one level.
 

--- a/sandbox/agent-config/rules/overseer.md
+++ b/sandbox/agent-config/rules/overseer.md
@@ -139,18 +139,44 @@ egg-orch overseer alert \
 
 Anything that mutates pipeline lifecycle state (phases, decisions, consensus, containers) is **not** in this list -- escalate via `OVERSEER_ALERT` instead.
 
+### Phase-relative baselines
+
+Before classifying an anomaly, calibrate against what is **expected** for the current phase. A state that looks broken in `implement` can be the normal starting condition for `refine`.
+
+**Contract state at phase start:**
+
+| Phase | Expected `show_contract` at phase start | Refiner/coder role |
+|-------|------------------------------------------|--------------------|
+| `refine` | **Empty or near-empty** (`phases=[]`, `acceptance_criteria=[]`, no `agent_executions`). The refiner *produces* the analysis that populates the contract. | Producer of contract content |
+| `plan` | Populated with refine artifacts (analysis doc, initial acceptance criteria). | Producer of plan; consumer of refine output |
+| `implement` | Populated with refine + plan artifacts (tasks, acceptance criteria, phase configs). | Producer of code; consumer of contract |
+
+An empty contract during `refine` is **not** evidence of a deadlock — it is the expected starting state. Do not emit `stuck-phase-transition` or invent a "refiner has no input" failure mode based on an empty `show_contract` result during refine.
+
+**Minimum producer-working window before first-proposal alerts:**
+
+A producer may legitimately spend time reading, grepping, and exploring before emitting its first `CONSENSUS_PROPOSE`. Do not alert on "no CONSENSUS_PROPOSE yet" inside these windows so long as the container is showing tool-call activity:
+
+| Phase | Minimum working window before first-proposal alerts |
+|-------|------------------------------------------------------|
+| `refine` | 5 minutes |
+| `plan` | 3 minutes |
+| `implement` | 10 minutes |
+
+Active tool calls (file reads, grep, web searches, `Agent` spawns, `TodoWrite`) observed via `get_container_logs` during this window are **evidence of legitimate work**, not a stall. Only emit `agent-heartbeat-stall` when both (a) the working-window floor has elapsed AND (b) the orchestrator has raised a corresponding health alert.
+
 ### Escalation triggers
 
 Emit an `OVERSEER_ALERT` when you observe any of these:
 
-- **Stuck phase transition**: BRC consensus is `complete` (`consensus.state == "confirmed"`) but the phase has not transitioned within ~60 seconds. Anomaly type: `stuck-phase-transition`, priority: `high`. Include the consensus state and the time since confirmation in `--detail`.
+- **Stuck phase transition**: BRC consensus is `complete` (`consensus.state == "confirmed"`) but the phase has not transitioned within ~60 seconds. Anomaly type: `stuck-phase-transition`, priority: `high`. Include the consensus state and the time since confirmation in `--detail`. **Do NOT emit `stuck-phase-transition` when `consensus.state != "confirmed"`** — that is a different failure mode (producer still working, reviewers still ACKing, etc.) and requires a different anomaly type. An empty contract during the refine phase is never grounds for this alert; see [Phase-relative baselines](#phase-relative-baselines).
 - **Orchestrator silent on consensus**: No `CONSENSUS_*` messages from the orchestrator for several minutes while agents are still active. Anomaly type: `orchestrator-consensus-silent`, priority: `high`.
 - **Repeated 401 from any orchestrator endpoint**: You tried a command and got a 401 (or any auth-rejection). **Stop retrying that command immediately.** Anomaly type: `unauthorized-overseer-action`, priority: `medium`. Include which command you tried and why you thought it was needed.
-- **Heartbeat stall on an active agent**: An agent has missed `max_missed_heartbeats` consecutive heartbeats and the health alert from the orchestrator confirms it. Anomaly type: `agent-heartbeat-stall`, priority depends on the agent's criticality.
+- **Heartbeat stall on an active agent**: An agent has missed `max_missed_heartbeats` consecutive heartbeats **and** the health alert from the orchestrator confirms it **and** the phase-specific minimum working window (see [Phase-relative baselines](#phase-relative-baselines)) has elapsed. Anomaly type: `agent-heartbeat-stall`, priority depends on the agent's criticality. A producer that has been `WORKING` for less than the phase floor without a `CONSENSUS_PROPOSE` is **not** stalled.
 - **Persistent agent loop**: Haiku classifier returns `loop` with confidence > 0.8 across two consecutive cycles. Anomaly type: `agent-loop`, priority: `medium`.
 - **Same anomaly seen across N cycles without resolution**: If you've already alerted on the same anomaly and the situation hasn't changed for `overseer_max_cycles_before_re_alert` (default: 3) cycles, re-alert with priority bumped one level.
 
-When in doubt: alert. A spurious alert is cheaper than a silent stuck pipeline.
+When in doubt: alert — a spurious alert is cheaper than a silent stuck pipeline. **But every alert must cite specific observed evidence** (log line, message ID, progress-event reference, `consensus.state` value, elapsed-time figure) that contradicts the "working normally" null hypothesis. "The contract is empty" or "no CONSENSUS_PROPOSE yet" are not evidence on their own; pair them with phase-relative context (see [Phase-relative baselines](#phase-relative-baselines)) before escalating.
 
 ## OVERSEER_ALERT body format
 


### PR DESCRIPTION
## Summary

Fixes #2010. Two false-positive `OVERSEER_ALERT`s fired during the refine phase of pipeline `issue-1973` — both rooted in the overseer LLM misapplying its prompt, not in code. This PR calibrates the prompt so the LLM stops inferring deadlocks from expected refine-phase states.

- Adds a **Phase-relative baselines** section to `sandbox/agent-config/rules/overseer.md` with two tables:
  - Expected `show_contract` state per phase — empty during `refine` is normal, not a deadlock.
  - Minimum producer-working window per phase (refine 5m, plan 3m, implement 10m) before a "no CONSENSUS_PROPOSE yet" alert is reasonable.
- Tightens the `stuck-phase-transition` trigger: explicit "Do NOT emit when `consensus.state != \"confirmed\"`" and never grounded in an empty contract during refine.
- Tightens the `agent-heartbeat-stall` trigger: now requires missed heartbeats **and** an orchestrator health alert **and** the phase-specific working-window floor.
- Keeps the "When in doubt: alert" framing but pairs it with an evidence-citation requirement so the LLM must anchor alerts in observed data (log lines, message IDs, `consensus.state`, elapsed-time figures).

No code or test changes — prompt-only edit in `sandbox/agent-config/rules/overseer.md`.

## Test plan

- [ ] Re-run /sdlc on an issue that reproduces the conditions in #2010 (refine phase with a non-trivial refiner task) and confirm no `stuck-phase-transition` or `agent-heartbeat-stall` alerts fire within the first 5 minutes while the refiner is doing legitimate exploration work.
- [ ] Confirm that a genuine post-`consensus.state == "confirmed"` stall still triggers `stuck-phase-transition` as before.
- [ ] Confirm that a genuine heartbeat stall (missed heartbeats + orchestrator health alert + window elapsed) still triggers `agent-heartbeat-stall`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)