### PR TITLE
Fix #2009: recover orphaned PENDING phases at orchestrator startup

### DIFF
--- a/orchestrator/startup_reconciliation.py
+++ b/orchestrator/startup_reconciliation.py
@@ -131,6 +131,41 @@ def reconcile_stale_containers(store: object, docker_client: object) -> int:
         if phase_execution is None:
             continue
 
+        # Crash-between-submit-and-spawn: pipeline RUNNING but the current
+        # phase never reached `executor.spawn_all`.  `_run_pipeline` is
+        # fire-and-forget from the submit handler, so a crash before the
+        # spawn loop leaves the row PENDING with `started_at=null` and
+        # nothing to resume it (#2009).  Mark FAILED so operators see
+        # something actionable instead of an indefinitely frozen pipeline.
+        if (
+            phase_execution.status == PipelineStatus.PENDING
+            and phase_execution.started_at is None
+            and not phase_execution.containers
+            and not phase_execution.agents
+        ):
+            pipeline.status = PipelineStatus.FAILED
+            pipeline.error = (
+                "Pipeline marked FAILED at orchestrator startup: current phase "
+                f"{current_phase_key!r} never spawned (likely a crash between "
+                "submit and phase start). Restart via POST /pipelines/{id}/start."
+            )
+            try:
+                store.save_pipeline(pipeline)  # type: ignore[attr-defined]
+                recovered += 1
+                logger.warning(
+                    "Startup reconciliation: RUNNING pipeline with un-spawned "
+                    "PENDING phase marked FAILED",
+                    pipeline_id=pipeline_id,
+                    phase=current_phase_key,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Startup reconciliation: could not save pipeline",
+                    pipeline_id=pipeline_id,
+                    error=str(e),
+                )
+            continue
+
         for container_info in phase_execution.containers:
             if container_info.status == ContainerStatus.RUNNING:
                 if container_info.container_id not in live_ids:

--- a/orchestrator/startup_reconciliation.py
+++ b/orchestrator/startup_reconciliation.py
@@ -137,6 +137,10 @@ def reconcile_stale_containers(store: object, docker_client: object) -> int:
         # spawn loop leaves the row PENDING with `started_at=null` and
         # nothing to resume it (#2009).  Mark FAILED so operators see
         # something actionable instead of an indefinitely frozen pipeline.
+        #
+        # Note: a PENDING phase with agents but no containers is intentionally
+        # left to the container loop below — if agents were created, some
+        # spawn work started even if containers weren't registered yet.
         if (
             phase_execution.status == PipelineStatus.PENDING
             and phase_execution.started_at is None

--- a/orchestrator/tests/test_startup_reconciliation.py
+++ b/orchestrator/tests/test_startup_reconciliation.py
@@ -558,6 +558,18 @@ class TestReconcileOrphanedPendingPhase:
         assert pipeline.status == PipelineStatus.FAILED
         assert "implement" in pipeline.error
 
+    def test_save_failure_does_not_increment_recovered(self):
+        """If save_pipeline raises, recovered count is not incremented."""
+        pipeline = _make_pipeline_with_unspawned_phase()
+        store = _make_store(pipeline)
+        store.save_pipeline.side_effect = Exception("disk full")
+        docker_client = _make_docker_client([])
+
+        result = reconcile_stale_containers(store, docker_client)
+
+        assert result == 0
+        store.save_pipeline.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # AWAITING_HUMAN reconciliation tests

--- a/orchestrator/tests/test_startup_reconciliation.py
+++ b/orchestrator/tests/test_startup_reconciliation.py
@@ -456,6 +456,110 @@ class TestReconcileStaleContainers:
 
 
 # ---------------------------------------------------------------------------
+# Orphaned PENDING phase reconciliation (#2009)
+# ---------------------------------------------------------------------------
+
+
+def _make_pipeline_with_unspawned_phase(
+    phase: PipelinePhase = PipelinePhase.REFINE,
+) -> Pipeline:
+    """Return a RUNNING pipeline whose current phase never reached spawn.
+
+    Reproduces the state seen in #2009: the orchestrator created the pipeline
+    + initial phase row, then crashed before `_run_pipeline` reached
+    `executor.spawn_all`.  The phase row is left PENDING with no timestamps
+    and no containers/agents.
+    """
+    pipeline = Pipeline(
+        id="issue-2009",
+        issue_number=2009,
+        repo="owner/repo",
+        branch="egg/issue-2009",
+        mode="issue",
+        status=PipelineStatus.RUNNING,
+        current_phase=phase,
+    )
+    phase_exec = pipeline.get_phase_execution(phase)
+    # Defaults already match: status=PENDING, started_at=None, no containers/agents.
+    assert phase_exec.status == PipelineStatus.PENDING
+    assert phase_exec.started_at is None
+    assert phase_exec.containers == []
+    assert phase_exec.agents == []
+    return pipeline
+
+
+class TestReconcileOrphanedPendingPhase:
+    """Tests for the #2009 startup recovery branch."""
+
+    def test_orphaned_pending_phase_marked_failed(self):
+        """RUNNING pipeline whose current phase never spawned is marked FAILED."""
+        pipeline = _make_pipeline_with_unspawned_phase()
+        store = _make_store(pipeline)
+        docker_client = _make_docker_client([])
+
+        result = reconcile_stale_containers(store, docker_client)
+
+        assert result == 1
+        assert pipeline.status == PipelineStatus.FAILED
+        assert pipeline.error is not None
+        assert "never spawned" in pipeline.error
+        assert "refine" in pipeline.error
+        store.save_pipeline.assert_called_once_with(pipeline)
+
+    def test_running_phase_with_started_at_left_alone(self):
+        """A phase with `started_at` set is mid-spawn, not orphaned — leave alone."""
+        pipeline = _make_pipeline_with_unspawned_phase()
+        phase_exec = pipeline.get_phase_execution(pipeline.current_phase)
+        phase_exec.status = PipelineStatus.RUNNING
+        phase_exec.started_at = datetime.now(UTC)
+
+        store = _make_store(pipeline)
+        docker_client = _make_docker_client([])
+
+        result = reconcile_stale_containers(store, docker_client)
+
+        assert result == 0
+        assert pipeline.status == PipelineStatus.RUNNING
+        store.save_pipeline.assert_not_called()
+
+    def test_pending_phase_with_containers_left_to_container_loop(self):
+        """If containers exist, the existing container-stale check handles it."""
+        pipeline = _make_pipeline_with_unspawned_phase()
+        phase_exec = pipeline.get_phase_execution(pipeline.current_phase)
+        phase_exec.containers.append(
+            ContainerInfo(
+                container_id="live_abc",
+                container_name="egg-coder",
+                status=ContainerStatus.RUNNING,
+                started_at=datetime.now(UTC),
+            )
+        )
+
+        store = _make_store(pipeline)
+        docker_client = _make_docker_client(["live_abc"])
+
+        result = reconcile_stale_containers(store, docker_client)
+
+        # Not the orphaned-pending branch (containers exist), and the live
+        # container check finds nothing stale → pipeline left alone.
+        assert result == 0
+        assert pipeline.status == PipelineStatus.RUNNING
+        store.save_pipeline.assert_not_called()
+
+    def test_orphaned_pending_phase_works_for_any_phase(self):
+        """The recovery branch fires regardless of which phase is current."""
+        pipeline = _make_pipeline_with_unspawned_phase(phase=PipelinePhase.IMPLEMENT)
+        store = _make_store(pipeline)
+        docker_client = _make_docker_client([])
+
+        result = reconcile_stale_containers(store, docker_client)
+
+        assert result == 1
+        assert pipeline.status == PipelineStatus.FAILED
+        assert "implement" in pipeline.error
+
+
+# ---------------------------------------------------------------------------
 # AWAITING_HUMAN reconciliation tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Orchestrator startup reconciler now detects pipelines orphaned by a crash between `submit_task` and the spawn loop, and marks them FAILED with an actionable error.
- Closes #2009.

## Background
`submit_task` is fire-and-forget: the MCP handler creates the pipeline + initial PENDING phase row, then spawns `_run_pipeline` in a background thread to actually start the phase. If the orchestrator crashes between those two steps (or before `_run_pipeline` reaches `executor.spawn_all`), the pipeline is left in this state on disk:

- `pipeline.status = RUNNING`
- `phases[current_phase].status = PENDING`
- `started_at = null`, `work_started_at = null`, `containers = []`, `agents = []`

Existing `reconcile_stale_containers` only handled RUNNING agents/containers that vanished from Docker, so this state slipped through every startup branch — the pipeline sat indefinitely with no retry, no failure transition, and no operator alert.

`phase_spawn_max_retries` doesn't help because it retries individual transient role failures *inside* an in-flight `executor.spawn_all`; a crash *before* that call is invisible to it.

## Approach
Add a fourth recovery branch to `reconcile_stale_containers`, sitting alongside the existing AWAITING_HUMAN / stale-container / consensus-tracker branches. When the current phase is provably un-spawned (PENDING + null `started_at` + empty containers + empty agents), mark the pipeline FAILED with a clear error pointing operators at `POST /pipelines/{id}/start`. This matches the existing recovery contract: the reconciler doesn't auto-respawn (which would require dealing with possible half-created gateway/worktree state from the dead process); it surfaces the failure so the existing restart endpoint can re-drive cleanly.

## Test plan
- [x] New `TestReconcileOrphanedPendingPhase` covers: orphaned phase marked FAILED, RUNNING phase with `started_at` left alone, PENDING phase with containers deferred to existing container loop, recovery works for any phase
- [x] All 23 existing + new tests pass: `pytest orchestrator/tests/test_startup_reconciliation.py`
- [x] `ruff check` + `ruff format --check` clean
- [ ] Operator validation: simulate the crash by killing orchestrator mid-submit, restart, confirm the pipeline transitions FAILED with the expected error message and that `POST /pipelines/{id}/start` recovers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)