### PR TITLE
Fix #2014: delete shared pipeline branch on cleanup

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -1743,13 +1743,16 @@ def _cleanup_remote_branches(
     pipeline: "Pipeline",
     repo_path: Path,
 ) -> None:
-    """Best-effort cleanup of remote worktree branches for a pipeline.
+    """Best-effort cleanup of remote branches for a pipeline.
 
-    Iterates all containers across all phase executions and deletes their
-    remote worktree branches (``egg/{container_id}/work``).  Failures are
-    logged as warnings and do not block pipeline deletion.
+    Deletes the pipeline's shared branch (``pipeline.branch``, typically
+    ``egg/{pipeline_id}``) and every per-container worktree branch
+    (``egg/{container_id}/work``).  Failures are logged as warnings and do
+    not block pipeline deletion.
     """
     branches: set[str] = set()
+    if pipeline.branch:
+        branches.add(pipeline.branch)
     for phase_exec in pipeline.phases.values():
         for container in phase_exec.containers:
             branches.add(f"egg/{container.container_id}/work")

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -1771,7 +1771,7 @@ def _cleanup_remote_branches(
 
     if deleted:
         logger.info(
-            "Cleaned up remote worktree branches",
+            "Cleaned up remote branches",
             pipeline_id=pipeline_id,
             branches_deleted=deleted,
             branches_total=len(branches),
@@ -1822,12 +1822,12 @@ def delete_pipeline(pipeline_id: str) -> tuple[Response, int]:
                 exc_info=True,
             )
 
-        # Clean up remote worktree branches (best-effort)
+        # Clean up remote branches (best-effort)
         try:
             _cleanup_remote_branches(pipeline_id, _pipeline, repo_path)
         except Exception as e:
             logger.warning(
-                "Failed to clean up remote worktree branches",
+                "Failed to clean up remote branches",
                 pipeline_id=pipeline_id,
                 error=str(e),
             )

--- a/orchestrator/tests/test_pipelines_api.py
+++ b/orchestrator/tests/test_pipelines_api.py
@@ -83,7 +83,8 @@ class TestDeletePipelineBranchCleanup:
     def test_delete_pipeline_cleans_up_remote_branches(
         self, mock_resolve, mock_spawner_fn, mock_gw_fn, client
     ):
-        """Verify delete_remote_branch is called for each container's branch."""
+        """Verify delete_remote_branch is called for the pipeline branch
+        and each container's branch."""
         pipeline = _make_pipeline_with_containers("test-pipeline")
 
         mock_store = MagicMock()
@@ -100,14 +101,15 @@ class TestDeletePipelineBranchCleanup:
         response = client.delete("/api/v1/pipelines/test-pipeline")
         assert response.status_code == 200
 
-        # Should have been called for each unique container
-        assert mock_gw.delete_remote_branch.call_count == 3
+        # Should have been called for each unique container plus the pipeline branch
+        assert mock_gw.delete_remote_branch.call_count == 4
 
         called_branches = {
             call.kwargs.get("branch") or call.args[2]
             for call in mock_gw.delete_remote_branch.call_args_list
         }
         assert called_branches == {
+            "egg/test",
             "egg/container-aaa/work",
             "egg/container-bbb/work",
             "egg/container-ccc/work",
@@ -115,6 +117,41 @@ class TestDeletePipelineBranchCleanup:
 
         # Pipeline should still be deleted even after branch cleanup
         mock_store.delete_pipeline.assert_called_once_with("test-pipeline")
+
+    @patch("routes.pipelines.get_gateway_client")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    def test_delete_pipeline_cleans_up_shared_pipeline_branch(
+        self, mock_resolve, mock_spawner_fn, mock_gw_fn, client
+    ):
+        """Pins invariant from #2014: cleanup must delete the pipeline's
+        shared branch (``pipeline.branch``), not just per-container worktree
+        branches. Without this, resubmitting a cancelled task leaves stale
+        remote commits that poison the next run's history."""
+        pipeline = Pipeline(
+            id="issue-1973",
+            issue_number=1973,
+            repo="owner/repo",
+            branch="egg/issue-1973",
+        )
+
+        mock_store = MagicMock()
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        mock_spawner.cleanup_pipeline.return_value = 0
+        mock_spawner_fn.return_value = mock_spawner
+
+        mock_gw = MagicMock()
+        mock_gw.delete_remote_branch.return_value = True
+        mock_gw_fn.return_value = mock_gw
+
+        response = client.delete("/api/v1/pipelines/issue-1973")
+        assert response.status_code == 200
+
+        mock_gw.delete_remote_branch.assert_called_once()
+        call_args = mock_gw.delete_remote_branch.call_args
+        assert (call_args.kwargs.get("branch") or call_args.args[2]) == "egg/issue-1973"
 
     @patch("routes.pipelines.get_gateway_client")
     @patch("routes.pipelines.get_container_spawner")
@@ -145,15 +182,15 @@ class TestDeletePipelineBranchCleanup:
     @patch("routes.pipelines.get_gateway_client")
     @patch("routes.pipelines.get_container_spawner")
     @patch("routes.pipelines._resolve_pipeline")
-    def test_delete_pipeline_no_containers_skips_cleanup(
+    def test_delete_pipeline_no_branches_skips_cleanup(
         self, mock_resolve, mock_spawner_fn, mock_gw_fn, client
     ):
-        """No branch cleanup when pipeline has no containers."""
+        """No branch cleanup when pipeline has neither a shared branch nor containers."""
         pipeline = Pipeline(
             id="test-pipeline",
             issue_number=42,
             repo="owner/repo",
-            branch="egg/test",
+            branch=None,
         )
 
         mock_store = MagicMock()
@@ -214,10 +251,12 @@ class TestDeletePipelineBranchCleanup:
         response = client.delete("/api/v1/pipelines/test-pipeline")
         assert response.status_code == 200
 
-        # Should only be called once despite the container appearing in two phases
-        mock_gw.delete_remote_branch.assert_called_once()
-        call_args = mock_gw.delete_remote_branch.call_args
-        assert (call_args.kwargs.get("branch") or call_args.args[2]) == "egg/container-shared/work"
+        # Pipeline branch + one container branch (deduplicated across phases)
+        called_branches = {
+            call.kwargs.get("branch") or call.args[2]
+            for call in mock_gw.delete_remote_branch.call_args_list
+        }
+        assert called_branches == {"egg/test", "egg/container-shared/work"}
 
     @patch("routes.pipelines.get_gateway_client")
     @patch("routes.pipelines.get_container_spawner")


### PR DESCRIPTION
## Summary

- `_cleanup_remote_branches` only enumerated per-container worktree branches (`egg/{container_id}/work`), leaving the pipeline's shared branch (`pipeline.branch`, typically `egg/{pipeline_id}`) dangling on the remote after `cancel_task(cleanup=true)` or pipeline DELETE.
- On resubmit, the stale branch either broke the new run with a non-fast-forward push rejection or silently inherited the prior run's commits — neither is what `cleanup=true` promises.
- Fix: include `pipeline.branch` in the deletion set alongside the worktree branches.

Fixes #2014.

## Test plan

- [x] `pytest orchestrator/tests/test_pipelines_api.py` — 33/33 pass
- [x] New test `test_delete_pipeline_cleans_up_shared_pipeline_branch` pins the invariant (no containers, just `pipeline.branch` set → gateway `delete_remote_branch` is called with `egg/issue-1973`)
- [x] Updated `test_delete_pipeline_cleans_up_remote_branches` and `test_delete_pipeline_deduplicates_container_branches` to expect the shared branch in the cleanup set
- [x] Renamed `test_delete_pipeline_no_containers_skips_cleanup` → `test_delete_pipeline_no_branches_skips_cleanup` and cleared `pipeline.branch`, since "no containers" no longer implies "nothing to clean"

🤖 Generated with [Claude Code](https://claude.com/claude-code)