### PR TITLE
Fix #2004: conditional ACK 3-way HITL gate + contract persistence

### DIFF
--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -150,6 +150,267 @@ def _handle_restart_agent(pipeline_id: str, question: str) -> None:
         )
 
 
+def _handle_conditional_ack_gate(
+    pipeline_id: str,
+    context: str,
+    resolution: str,
+    repo_path: Path,
+) -> None:
+    """Dispatch the 3-way conditional-ACK HITL gate resolution (#2004).
+
+    ``context`` is the decision's raw context field, prefixed with
+    ``CONDITIONAL_ACK_GATE_MARKER`` and followed by a JSON payload whose
+    ``conditions`` entry is a list of ``{reviewer, producer, condition,
+    version}`` dicts. ``resolution`` is the human's choice — one of the
+    three option strings defined in ``routes.phases``.
+
+    Dispatch:
+
+    - **approve+accept**: write one line per condition to
+      ``contract.pr.deferred_actions`` so obligations survive tracker
+      teardown between phase close and PR creation (#2003 shipped the
+      tracker-backed PR render; this is the durable path).
+    - **reject**: call ``tracker.handle_nack`` on each (reviewer, producer)
+      edge carrying a condition. Producer returns to WORKING; the caller
+      must restart the phase to re-run consensus.
+    - **address-in-pipeline**: call ``matrix.invalidate_ack`` on each
+      conditioning edge. The ACK drops back to PENDING; the producer
+      must re-propose before the phase can complete.
+
+    Silently returns on malformed context or unknown resolution — the
+    resolve_decision endpoint still records the resolution so the human's
+    intent is preserved; dispatch failure falls through to the existing
+    unresolved-decisions guard on the next complete_phase call.
+    """
+    from routes.phases import (  # local import — avoid circular
+        CONDITIONAL_ACK_ADDRESS,
+        CONDITIONAL_ACK_APPROVE,
+        CONDITIONAL_ACK_GATE_MARKER,
+        CONDITIONAL_ACK_REJECT,
+    )
+
+    if not context.startswith(CONDITIONAL_ACK_GATE_MARKER):
+        return
+    payload_str = context[len(CONDITIONAL_ACK_GATE_MARKER) :]
+    try:
+        payload = json.loads(payload_str)
+    except json.JSONDecodeError:
+        logger.warning(
+            "Conditional-ACK gate context is not valid JSON",
+            pipeline_id=pipeline_id,
+        )
+        return
+
+    conditions = payload.get("conditions") or []
+    if not isinstance(conditions, list):
+        return
+
+    if resolution == CONDITIONAL_ACK_APPROVE:
+        _persist_deferred_actions(pipeline_id, conditions, repo_path)
+    elif resolution == CONDITIONAL_ACK_REJECT:
+        _force_nack_conditional_edges(pipeline_id, conditions)
+    elif resolution == CONDITIONAL_ACK_ADDRESS:
+        _invalidate_conditional_acks(pipeline_id, conditions)
+    else:
+        logger.info(
+            "Conditional-ACK gate resolved with unrecognized option",
+            pipeline_id=pipeline_id,
+            resolution=resolution[:80],
+        )
+
+
+def _persist_deferred_actions(
+    pipeline_id: str,
+    conditions: list[dict[str, Any]],
+    repo_path: Path,
+) -> None:
+    """Write conditions to ``contract.pr.deferred_actions`` (#2004).
+
+    Loads the contract from the pipeline's worktree, appends one formatted
+    line per condition, and saves. Writes are deduplicated against any
+    existing entries so resolving the same gate twice (or re-queuing after
+    tracker-state changes) doesn't duplicate bullets on the PR.
+    """
+    try:
+        from egg_contracts.loader import (
+            ContractNotFoundError,
+            ContractValidationError,
+            load_contract,
+            save_contract,
+        )
+        from egg_contracts.models import PRMetadata
+    except ImportError:
+        logger.warning(
+            "egg_contracts unavailable; cannot persist deferred_actions",
+            pipeline_id=pipeline_id,
+        )
+        return
+
+    try:
+        from routes import resolve_worktree_path
+        from routes.pipelines import _pipeline_identifier
+        from state_store import get_state_store
+
+        store = get_state_store(repo_path)
+        pipeline = store.load_pipeline(pipeline_id)
+        worktree_path = resolve_worktree_path(pipeline_id, repo_path)
+        contract_id = _pipeline_identifier(pipeline.issue_number, pipeline.id)
+        contract = load_contract(contract_id, worktree_path)
+    except (ContractNotFoundError, OSError, ValueError, ContractValidationError):
+        logger.warning(
+            "Cannot load contract to persist deferred_actions",
+            pipeline_id=pipeline_id,
+            exc_info=True,
+        )
+        return
+
+    new_lines: list[str] = []
+    for c in conditions:
+        reviewer = str(c.get("reviewer", "")).strip() or "unknown"
+        condition = str(c.get("condition", "")).strip()
+        if not condition:
+            continue
+        new_lines.append(f"{reviewer}: {condition}")
+    if not new_lines:
+        return
+
+    # PR metadata may be absent (e.g. on babysit pipelines with
+    # has_contract=False — unlikely here since the gate requires a tracker,
+    # but defensive). Create a minimal stub using the issue title if so.
+    if contract.pr is None:
+        contract.pr = PRMetadata(
+            title=(contract.issue.title if contract.issue else "Pipeline deferred actions"),
+        )
+
+    existing = set(contract.pr.deferred_actions)
+    merged = list(contract.pr.deferred_actions)
+    for line in new_lines:
+        if line not in existing:
+            merged.append(line)
+            existing.add(line)
+    contract.pr.deferred_actions = merged
+
+    try:
+        save_contract(contract, worktree_path)
+    except (OSError, ValueError):
+        logger.warning(
+            "Failed to save contract with deferred_actions",
+            pipeline_id=pipeline_id,
+            exc_info=True,
+        )
+        return
+
+    logger.info(
+        "Persisted pre-merge obligations to contract",
+        pipeline_id=pipeline_id,
+        deferred_action_count=len(merged),
+    )
+
+
+def _force_nack_conditional_edges(
+    pipeline_id: str,
+    conditions: list[dict[str, Any]],
+) -> None:
+    """Force-NACK each (reviewer, producer) edge carrying a condition (#2004).
+
+    The human has rejected the obligation. This is not a reviewer-
+    authored NACK — there's no proposal artifact to cite, and the
+    ReviewPayload schema rightly rejects empty artifact_references.
+    Instead, drive the approval matrix + producer-phase state directly
+    so the end state matches a normal NACK: edge NACKED at current
+    version, condition cleared, producer back in WORKING.
+    """
+    from peer_consensus import ConsensusPhase
+
+    tracker = get_peer_consensus_tracker(pipeline_id)
+    if tracker is None:
+        logger.warning(
+            "No active tracker to force-NACK conditional ACK",
+            pipeline_id=pipeline_id,
+        )
+        return
+
+    synthetic_reason = "human rejected conditional ACK"
+    nacked: list[tuple[str, str]] = []
+    with tracker._lock:
+        for c in conditions:
+            reviewer = str(c.get("reviewer", "")).strip()
+            producer = str(c.get("producer", "")).strip()
+            if not reviewer or not producer:
+                continue
+            try:
+                version = tracker.matrix.get_proposal_version(producer)
+                tracker.matrix.record_nack(
+                    reviewer,
+                    producer,
+                    version,
+                    reason=synthetic_reason,
+                    artifact_refs=[],
+                )
+                tracker._producer_phases[producer] = ConsensusPhase.WORKING
+                nacked.append((reviewer, producer))
+            except Exception:
+                logger.warning(
+                    "Failed to force-NACK conditional edge",
+                    pipeline_id=pipeline_id,
+                    reviewer=reviewer,
+                    producer=producer,
+                    exc_info=True,
+                )
+    if nacked:
+        logger.info(
+            "Force-NACKed conditional ACK edges",
+            pipeline_id=pipeline_id,
+            edges=nacked,
+        )
+
+
+def _invalidate_conditional_acks(
+    pipeline_id: str,
+    conditions: list[dict[str, Any]],
+) -> None:
+    """Invalidate each conditioning ACK edge so the producer re-proposes (#2004).
+
+    Unlike NACK, invalidation doesn't bump the revision count — the ACK
+    just drops back to PENDING. The producer phase state is reset to
+    WORKING so it can re-propose with the condition folded into its
+    next proposal's scope.
+    """
+    tracker = get_peer_consensus_tracker(pipeline_id)
+    if tracker is None:
+        logger.warning(
+            "No active tracker to invalidate conditional ACK",
+            pipeline_id=pipeline_id,
+        )
+        return
+
+    invalidated: list[tuple[str, str]] = []
+    for c in conditions:
+        reviewer = str(c.get("reviewer", "")).strip()
+        producer = str(c.get("producer", "")).strip()
+        if not reviewer or not producer:
+            continue
+        try:
+            did_invalidate = tracker.matrix.invalidate_ack(reviewer, producer)
+        except Exception:
+            logger.warning(
+                "Failed to invalidate conditional ACK",
+                pipeline_id=pipeline_id,
+                reviewer=reviewer,
+                producer=producer,
+                exc_info=True,
+            )
+            continue
+        if did_invalidate:
+            invalidated.append((reviewer, producer))
+    if invalidated:
+        logger.info(
+            "Invalidated conditional ACK edges for in-pipeline address",
+            pipeline_id=pipeline_id,
+            edges=invalidated,
+        )
+
+
 @decisions_bp.route("/<pipeline_id>/decisions", methods=["GET"])
 def list_decisions(pipeline_id: str) -> tuple[Response, int]:
     """
@@ -469,6 +730,17 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
         # container and respawn a replacement.
         if decision.resolution == "Restart agent":
             _handle_restart_agent(pipeline_id, decision.question)
+
+        # Handle the conditional-ACK 3-way HITL gate (#2004). Context
+        # prefix is the discriminator — the question text is arbitrary
+        # prose and mustn't be relied on for dispatch.
+        if decision.context and decision.resolution:
+            _handle_conditional_ack_gate(
+                pipeline_id,
+                decision.context,
+                decision.resolution,
+                store.repo_path,
+            )
 
         # Handle "Continue without" resolution for failed reviewer decisions.
         # The concurrent executor stores "failed_role:<role>" in the decision

--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -179,8 +179,11 @@ def _handle_conditional_ack_gate(
 
     Silently returns on malformed context or unknown resolution — the
     resolve_decision endpoint still records the resolution so the human's
-    intent is preserved; dispatch failure falls through to the existing
-    unresolved-decisions guard on the next complete_phase call.
+    intent is preserved. Recovery relies on ``_ensure_conditional_ack_gate``
+    re-queuing a new gate on the next ``complete_phase`` call when the
+    tracker still has live conditions (the unresolved-decisions guard only
+    checks ``PENDING`` decisions, so a resolved-but-failed gate would not
+    be caught by that guard alone).
     """
     from routes.phases import (  # local import — avoid circular
         CONDITIONAL_ACK_ADDRESS,
@@ -293,6 +296,11 @@ def _persist_deferred_actions(
     try:
         save_contract(contract, worktree_path)
     except (OSError, ValueError):
+        # The gate decision is already resolved, so the human's intent is
+        # recorded. Recovery depends on the tracker surviving until the
+        # next complete_phase call, where _ensure_conditional_ack_gate
+        # re-queues a new gate. If the tracker is torn down before that
+        # (e.g. orchestrator restart), the obligations are silently lost.
         logger.warning(
             "Failed to save contract with deferred_actions",
             pipeline_id=pipeline_id,
@@ -376,6 +384,8 @@ def _invalidate_conditional_acks(
     WORKING so it can re-propose with the condition folded into its
     next proposal's scope.
     """
+    from peer_consensus import ConsensusPhase
+
     tracker = get_peer_consensus_tracker(pipeline_id)
     if tracker is None:
         logger.warning(
@@ -385,24 +395,26 @@ def _invalidate_conditional_acks(
         return
 
     invalidated: list[tuple[str, str]] = []
-    for c in conditions:
-        reviewer = str(c.get("reviewer", "")).strip()
-        producer = str(c.get("producer", "")).strip()
-        if not reviewer or not producer:
-            continue
-        try:
-            did_invalidate = tracker.matrix.invalidate_ack(reviewer, producer)
-        except Exception:
-            logger.warning(
-                "Failed to invalidate conditional ACK",
-                pipeline_id=pipeline_id,
-                reviewer=reviewer,
-                producer=producer,
-                exc_info=True,
-            )
-            continue
-        if did_invalidate:
-            invalidated.append((reviewer, producer))
+    with tracker._lock:
+        for c in conditions:
+            reviewer = str(c.get("reviewer", "")).strip()
+            producer = str(c.get("producer", "")).strip()
+            if not reviewer or not producer:
+                continue
+            try:
+                did_invalidate = tracker.matrix.invalidate_ack(reviewer, producer)
+            except Exception:
+                logger.warning(
+                    "Failed to invalidate conditional ACK",
+                    pipeline_id=pipeline_id,
+                    reviewer=reviewer,
+                    producer=producer,
+                    exc_info=True,
+                )
+                continue
+            if did_invalidate:
+                tracker._producer_phases[producer] = ConsensusPhase.WORKING
+                invalidated.append((reviewer, producer))
     if invalidated:
         logger.info(
             "Invalidated conditional ACK edges for in-pipeline address",

--- a/orchestrator/routes/phases.py
+++ b/orchestrator/routes/phases.py
@@ -32,6 +32,7 @@ except ImportError:
         return logging.getLogger(name)
 
 
+from decision_queue import get_decision_queue
 from lifecycle_auth import require_lifecycle_secret
 from models import (
     DecisionStatus,
@@ -39,6 +40,7 @@ from models import (
     PipelinePhase,
     PipelineStatus,
 )
+from peer_consensus import get_peer_consensus_tracker
 from state_store import (
     InvalidPipelineIdError,
     PipelineNotFoundError,
@@ -584,6 +586,121 @@ def start_phase(pipeline_id: str) -> tuple[Response, int]:
         )
 
 
+# Context marker prefix used on the 3-way conditional-ACK HITL gate
+# decision (#2004). The resolve_decision handler matches on this prefix
+# to dispatch approve+accept / reject / address-in-pipeline behavior.
+CONDITIONAL_ACK_GATE_MARKER = "conditional_ack_gate:"
+
+# User-facing option labels for the conditional-ACK HITL gate. Exposed as
+# module-level constants so the resolve_decision handler and tests can
+# reference the same strings without duplication (#2004).
+CONDITIONAL_ACK_APPROVE = "Approve and accept obligations"
+CONDITIONAL_ACK_REJECT = "Reject and force NACK"
+CONDITIONAL_ACK_ADDRESS = "Address in-pipeline (invalidate ACK)"
+CONDITIONAL_ACK_OPTIONS = [
+    CONDITIONAL_ACK_APPROVE,
+    CONDITIONAL_ACK_REJECT,
+    CONDITIONAL_ACK_ADDRESS,
+]
+
+
+def _existing_conditional_ack_gate(pipeline: Pipeline) -> str | None:
+    """Return the id of the pending conditional-ACK gate decision, if any.
+
+    The gate decision is identified by a ``CONDITIONAL_ACK_GATE_MARKER``
+    prefix on the decision's context field. Only pending decisions count —
+    a previously-resolved gate for a prior conditional ACK does not block
+    a new round if the producer later attaches a fresh condition.
+    """
+    for decision in pipeline.decisions:
+        if decision.status != DecisionStatus.PENDING:
+            continue
+        if (decision.context or "").startswith(CONDITIONAL_ACK_GATE_MARKER):
+            return decision.id
+    return None
+
+
+def _ensure_conditional_ack_gate(
+    pipeline: Pipeline,
+    repo_path: Path,
+) -> str | None:
+    """Queue the 3-way conditional-ACK HITL gate if conditions are live.
+
+    Looks up the peer-consensus tracker for this pipeline and, if there
+    are any active pre-merge conditions, enqueues a ``choice`` HITL
+    decision (#2004). The decision's context embeds the conditions as
+    JSON so the resolve_decision handler can dispatch without querying
+    the tracker (which may have been torn down by then).
+
+    Returns the decision id when a new gate is queued, the existing
+    pending-decision id when one is already in flight, or ``None`` when
+    no conditions exist (or the tracker is unavailable).
+    """
+    tracker = get_peer_consensus_tracker(pipeline.id)
+    if tracker is None:
+        return None
+    try:
+        conditions = tracker.get_pre_merge_conditions()
+    except Exception:
+        # Never block phase completion on a tracker read failure — the PR
+        # body renderer applies the same guard (#1998).
+        logger.warning(
+            "Failed to read pre-merge conditions from tracker",
+            pipeline_id=pipeline.id,
+            exc_info=True,
+        )
+        return None
+    if not conditions:
+        return None
+
+    existing_id = _existing_conditional_ack_gate(pipeline)
+    if existing_id is not None:
+        return existing_id
+
+    # Render the conditions into the decision question so humans see the
+    # obligation text up front without having to fetch the raw context.
+    question_lines = [
+        "Reviewer(s) issued a conditional ACK with pre-merge obligations:",
+        "",
+    ]
+    for c in conditions:
+        reviewer = c.get("reviewer", "unknown")
+        condition = str(c.get("condition", "")).strip()
+        if not condition:
+            continue
+        question_lines.append(f"- {reviewer}: {condition}")
+    question_lines.extend(
+        [
+            "",
+            "How should we proceed?",
+        ]
+    )
+    question = "\n".join(question_lines)
+
+    # Embed the conditions list in the context so the resolve handler can
+    # act on specific (reviewer, producer) edges without re-querying the
+    # tracker. Prefixed with CONDITIONAL_ACK_GATE_MARKER so the handler
+    # can detect these decisions unambiguously.
+    context_payload = {"conditions": conditions}
+    context = CONDITIONAL_ACK_GATE_MARKER + json.dumps(context_payload)
+
+    queue = get_decision_queue(pipeline.id, repo_path)
+    decision = queue.queue_decision(
+        question=question,
+        context=context,
+        options=list(CONDITIONAL_ACK_OPTIONS),
+        decision_type="choice",
+        phase=pipeline.current_phase,
+    )
+    logger.info(
+        "Queued conditional-ACK HITL gate",
+        pipeline_id=pipeline.id,
+        decision_id=decision.id,
+        condition_count=len(conditions),
+    )
+    return decision.id
+
+
 def _collect_unresolved_phase_decisions(
     pipeline: Pipeline,
     store_repo_path: Path,
@@ -733,6 +850,23 @@ def complete_phase(pipeline_id: str) -> tuple[Response, int]:
     try:
         store, pipeline = get_state_store_for_pipeline(pipeline_id)
         original_version = pipeline.version
+
+        # If any reviewer issued a conditional ACK, surface the 3-way HITL
+        # gate (#2004) before the generic unresolved-decisions guard below.
+        # The gate decision is newly-queued on first call (returning 409 via
+        # the guard), then resolved out-of-band by the resolve_decision
+        # handler, which dispatches approve+accept / reject / address
+        # behavior on the approval matrix and contract. Skipped under
+        # force=true so operators can still drain stuck pipelines.
+        if not force:
+            gate_id = _ensure_conditional_ack_gate(pipeline, store.repo_path)
+            if gate_id is not None:
+                # queue_decision writes through the state store, so the
+                # in-memory ``pipeline`` is stale. Reload only when a gate
+                # was actually queued or already existed; this keeps the
+                # common path (no conditions) from hitting the store twice.
+                pipeline = store.load_pipeline(pipeline_id)
+                original_version = pipeline.version
 
         # Block advance while the current phase still has unresolved HITL
         # decisions. The lifecycle secret authorises *who* can advance; this

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5893,20 +5893,52 @@ def _persist_phase_brc_history(
         )
 
 
-def _build_pre_merge_obligations_section(pipeline_id: str) -> str:
+def _build_pre_merge_obligations_section(
+    pipeline_id: str,
+    contract_deferred_actions: list[str] | None = None,
+) -> str:
     """Render the "Pre-merge Obligations" section from active conditional ACKs.
 
-    Queries the live consensus tracker for conditions attached to current-
-    version ACKs (see ``ApprovalMatrix.get_pre_merge_conditions``). Returns
-    an empty string if the tracker is unavailable or has no conditions, so
-    callers can unconditionally append the result to the PR body.
+    Two sources, in order of preference:
 
-    The section exists to close the loophole where reviewers embedded
-    merge-time obligations ("human must git mv X Y before merging") in ACK
-    prose that the merger could skim past (#1998). Rendered as a visible
-    markdown section up-front on the PR so the obligation is in the
-    merger's line of sight.
+    1. ``contract_deferred_actions`` — strings previously persisted to
+       ``contract.pr.deferred_actions`` when a human approved the
+       conditional-ACK HITL gate (#2004). This is the durable path:
+       the tracker may have been torn down by the time PR creation
+       runs, and the contract survives.
+    2. The live consensus tracker (#1998). Used when the contract has
+       no deferred_actions — either because the gate landed before
+       tracker teardown, or the gate was never required.
+
+    Returns an empty string if neither source yields conditions, so
+    callers can unconditionally append the result to the PR body.
     """
+    # Tier 1 — contract.pr.deferred_actions (persisted across teardown).
+    if contract_deferred_actions:
+        bullets = []
+        for entry in contract_deferred_actions:
+            text = entry.strip()
+            if not text:
+                continue
+            first, *rest = text.splitlines()
+            bullets.append(f"- {first}")
+            bullets.extend(f"  {line}" for line in rest)
+        if bullets:
+            return "\n".join(
+                [
+                    "## ⚠️ Pre-merge Obligations",
+                    "",
+                    "The reviewers below issued a **conditional ACK** — the "
+                    "work is approved, but a human must perform the listed "
+                    "action before merging. Do **not** merge this PR until "
+                    "every obligation is complete.",
+                    "",
+                    *bullets,
+                ]
+            )
+
+    # Tier 2 — live tracker (pre-#2004 path; kept so conditions still
+    # render if the HITL gate hasn't resolved yet, e.g. under force=true).
     try:
         from peer_consensus import get_peer_consensus_tracker
     except ImportError:
@@ -6080,6 +6112,7 @@ def _build_pr_body(
     pr_description: str | None = None
     pr_test_plan: str = ""
     pr_manual_steps: str = ""
+    pr_deferred_actions: list[str] = []
     issue_title: str | None = None
     plan_draft_warnings: list[str] = []
     plan_draft_path: str | None = None
@@ -6096,6 +6129,7 @@ def _build_pr_body(
             pr_description = contract.pr.description
             pr_test_plan = contract.pr.test_plan
             pr_manual_steps = contract.pr.manual_steps
+            pr_deferred_actions = list(contract.pr.deferred_actions)
         if contract.issue:
             issue_title = contract.issue.title
     except Exception as e:
@@ -6165,13 +6199,16 @@ def _build_pr_body(
     elif pipeline.issue_number:
         body_parts.append(f"Closes #{pipeline.issue_number}")
 
-    # Pre-merge obligations from conditional ACKs (issue #1998). Rendered
-    # high in the body so the merger sees them before skimming past the
-    # test plan. Conditions come from the consensus tracker — if the
-    # tracker is gone (orchestrator restart without reconstruction), the
-    # section is silently skipped and reviewers fall back to the planner's
-    # manual_steps below.
-    deferred_section = _build_pre_merge_obligations_section(pipeline.id)
+    # Pre-merge obligations from conditional ACKs (issue #1998, #2004).
+    # Rendered high in the body so the merger sees them before skimming
+    # past the test plan. Prefer the contract-persisted list (written when
+    # the #2004 HITL gate resolves as approve+accept) so obligations
+    # survive tracker teardown; fall back to the live tracker for the
+    # transitional case where the gate hasn't resolved yet.
+    deferred_section = _build_pre_merge_obligations_section(
+        pipeline.id,
+        contract_deferred_actions=pr_deferred_actions,
+    )
     if deferred_section:
         body_parts.append(deferred_section)
 

--- a/orchestrator/tests/test_conditional_ack_hitl_gate.py
+++ b/orchestrator/tests/test_conditional_ack_hitl_gate.py
@@ -1,0 +1,511 @@
+"""Tests for the conditional-ACK 3-way HITL gate (issue #2004).
+
+The gate sits at ``complete_phase`` and forces a human to explicitly
+accept, reject, or redirect pre-merge obligations attached to a
+conditional ACK before the phase can close. This module covers:
+
+- ``complete_phase`` queues a gate when tracker.get_pre_merge_conditions()
+  is non-empty, and the existing unresolved-decisions guard blocks the
+  phase until the gate resolves.
+- Resolution dispatch: approve+accept persists to
+  ``contract.pr.deferred_actions``; reject force-NACKs each edge;
+  address-in-pipeline invalidates each ACK.
+- The PR body renderer prefers ``contract.pr.deferred_actions`` over the
+  live tracker so obligations survive tracker teardown.
+- Idempotence: a second complete_phase call does not re-queue a gate
+  when one is already pending.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+from approval_matrix import ApprovalState  # noqa: E402
+from models import DecisionStatus, HITLDecision, Pipeline, PipelinePhase  # noqa: E402
+from peer_consensus import PeerConsensusTracker  # noqa: E402
+from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph  # noqa: E402
+from routes.decisions import decisions_bp  # noqa: E402
+from routes.phases import (  # noqa: E402
+    CONDITIONAL_ACK_ADDRESS,
+    CONDITIONAL_ACK_APPROVE,
+    CONDITIONAL_ACK_GATE_MARKER,
+    CONDITIONAL_ACK_OPTIONS,
+    CONDITIONAL_ACK_REJECT,
+    phases_bp,
+)
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.register_blueprint(phases_bp)
+    app.register_blueprint(decisions_bp)
+    app.config["TESTING"] = True
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def graph():
+    return ReviewGraph(
+        [
+            ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL),
+            ReviewEdge("reviewer_contract", "coder", ReviewCriticality.CRITICAL),
+        ]
+    )
+
+
+def _make_tracker(graph, condition="git mv legacy/x new/x before merge"):
+    """Return a tracker with one active conditional ACK from reviewer_code."""
+    tracker = PeerConsensusTracker("pipeline-x", graph, cooldown_seconds=0)
+    tracker.register_agent("coder")
+    tracker.register_agent("reviewer_code")
+    tracker.register_agent("reviewer_contract")
+    tracker.handle_propose(
+        "coder",
+        {"summary": "impl", "artifacts": ["src/a.py"], "commit_sha": "abc"},
+    )
+    if condition:
+        tracker.handle_ack(
+            "reviewer_code",
+            "coder",
+            {
+                "artifact_references": ["src/a.py"],
+                "pre_merge_condition": condition,
+            },
+        )
+    return tracker
+
+
+def _make_pipeline(pipeline_id="pipeline-x", phase=PipelinePhase.IMPLEMENT):
+    return Pipeline(
+        id=pipeline_id,
+        issue_number=42,
+        repo="owner/repo",
+        branch="egg/issue-42",
+        has_contract=False,
+        current_phase=phase,
+    )
+
+
+class TestGateEnqueueOnCompletePhase:
+    """complete_phase queues the 3-way gate when conditions are live."""
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    @patch("routes.phases.get_peer_consensus_tracker")
+    def test_pending_condition_queues_gate_and_returns_409(
+        self,
+        mock_get_tracker,
+        mock_get_store,
+        _mock_clear,
+        client,
+        graph,
+        tmp_path,
+    ):
+        pipeline = _make_pipeline()
+        mock_store = MagicMock()
+        mock_store.repo_path = tmp_path
+        mock_get_store.return_value = (mock_store, pipeline)
+        # After the gate writes through queue_decision, load_pipeline
+        # returns the same pipeline with the new decision on it.
+        mock_store.load_pipeline.return_value = pipeline
+        mock_get_tracker.return_value = _make_tracker(graph)
+
+        # Stub queue_decision so we don't touch the real state store —
+        # append directly to pipeline.decisions so the downstream
+        # unresolved-decisions guard sees it.
+        def fake_queue(*, question, context, options, decision_type, phase):
+            decision = pipeline.add_decision(
+                question=question,
+                options=options,
+                decision_type=decision_type,
+                phase=phase,
+            )
+            decision.context = context
+            return decision
+
+        with patch("routes.phases.get_decision_queue") as mock_get_queue:
+            mock_get_queue.return_value.queue_decision.side_effect = fake_queue
+            resp = client.post("/api/v1/pipelines/pipeline-x/phase/complete")
+
+        assert resp.status_code == 409
+        body = resp.get_json()
+        assert body["reason"] == "unresolved_hitl_decisions"
+        # Exactly one pending decision, and it's our gate (context marker).
+        assert len(pipeline.decisions) == 1
+        gate = pipeline.decisions[0]
+        assert gate.decision_type == "choice"
+        assert gate.options == list(CONDITIONAL_ACK_OPTIONS)
+        assert gate.context.startswith(CONDITIONAL_ACK_GATE_MARKER)
+        payload = json.loads(gate.context[len(CONDITIONAL_ACK_GATE_MARKER) :])
+        conds = payload["conditions"]
+        assert len(conds) == 1
+        assert conds[0]["reviewer"] == "reviewer_code"
+        assert conds[0]["producer"] == "coder"
+        assert conds[0]["condition"].startswith("git mv")
+        # Question text must expose the obligation so humans aren't forced
+        # to crack open the context JSON.
+        assert "git mv" in gate.question
+        assert "reviewer_code" in gate.question
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    @patch("routes.phases.get_peer_consensus_tracker")
+    def test_no_conditions_does_not_queue_gate(
+        self,
+        mock_get_tracker,
+        mock_get_store,
+        _mock_clear,
+        client,
+        graph,
+        tmp_path,
+    ):
+        pipeline = _make_pipeline()
+        mock_store = MagicMock()
+        mock_store.repo_path = tmp_path
+        mock_get_store.return_value = (mock_store, pipeline)
+        mock_get_tracker.return_value = _make_tracker(graph, condition="")
+
+        with patch("routes.phases.get_decision_queue") as mock_get_queue:
+            resp = client.post("/api/v1/pipelines/pipeline-x/phase/complete")
+
+        assert resp.status_code == 200
+        mock_get_queue.return_value.queue_decision.assert_not_called()
+        assert pipeline.decisions == []
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    @patch("routes.phases.get_peer_consensus_tracker")
+    def test_force_skips_gate_enqueue(
+        self,
+        mock_get_tracker,
+        mock_get_store,
+        _mock_clear,
+        client,
+        graph,
+        tmp_path,
+    ):
+        """force=true drains the pipeline without surfacing the gate.
+
+        Matches the existing force=true semantics on the HITL
+        unresolved-decisions guard (#1788).
+        """
+        pipeline = _make_pipeline()
+        mock_store = MagicMock()
+        mock_store.repo_path = tmp_path
+        mock_get_store.return_value = (mock_store, pipeline)
+        mock_get_tracker.return_value = _make_tracker(graph)
+
+        with patch("routes.phases.get_decision_queue") as mock_get_queue:
+            resp = client.post(
+                "/api/v1/pipelines/pipeline-x/phase/complete",
+                json={"force": True, "force_reason": "ops override"},
+            )
+
+        assert resp.status_code == 200
+        mock_get_queue.return_value.queue_decision.assert_not_called()
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    @patch("routes.phases.get_peer_consensus_tracker")
+    def test_idempotent_when_gate_already_pending(
+        self,
+        mock_get_tracker,
+        mock_get_store,
+        _mock_clear,
+        client,
+        graph,
+        tmp_path,
+    ):
+        pipeline = _make_pipeline()
+        # Pre-populate a pending gate decision with the marker context.
+        existing = pipeline.add_decision(
+            question="already queued",
+            options=list(CONDITIONAL_ACK_OPTIONS),
+            decision_type="choice",
+            phase=PipelinePhase.IMPLEMENT,
+        )
+        existing.context = CONDITIONAL_ACK_GATE_MARKER + json.dumps({"conditions": []})
+
+        mock_store = MagicMock()
+        mock_store.repo_path = tmp_path
+        mock_get_store.return_value = (mock_store, pipeline)
+        mock_store.load_pipeline.return_value = pipeline
+        mock_get_tracker.return_value = _make_tracker(graph)
+
+        with patch("routes.phases.get_decision_queue") as mock_get_queue:
+            resp = client.post("/api/v1/pipelines/pipeline-x/phase/complete")
+
+        # Guard blocks the phase but nothing new was queued.
+        assert resp.status_code == 409
+        mock_get_queue.return_value.queue_decision.assert_not_called()
+        # Decision list still has exactly the pre-existing one.
+        assert len(pipeline.decisions) == 1
+        assert pipeline.decisions[0].id == existing.id
+
+
+class TestResolutionDispatch:
+    """Resolving the gate triggers the right tracker/contract mutation."""
+
+    def _gate_context(self, conditions):
+        return CONDITIONAL_ACK_GATE_MARKER + json.dumps({"conditions": conditions})
+
+    @patch("routes.decisions._persist_deferred_actions")
+    @patch("routes.decisions.get_state_store_for_pipeline")
+    @patch("routes.decisions.get_decision_queue")
+    def test_approve_accepts_persists_deferred_actions(
+        self,
+        mock_get_queue,
+        mock_get_store_for_pipeline,
+        mock_persist,
+        client,
+        tmp_path,
+    ):
+        conditions = [
+            {"reviewer": "reviewer_code", "producer": "coder", "condition": "git mv X Y"},
+        ]
+        resolved = HITLDecision(
+            id="decision-1",
+            question="conditional ACK",
+            status=DecisionStatus.RESOLVED,
+            resolution=CONDITIONAL_ACK_APPROVE,
+            context=self._gate_context(conditions),
+        )
+        mock_store = MagicMock(repo_path=tmp_path)
+        mock_get_store_for_pipeline.return_value = (mock_store, MagicMock())
+        mock_get_queue.return_value.resolve_decision.return_value = resolved
+
+        resp = client.post(
+            "/api/v1/pipelines/pipeline-x/decisions/decision-1/resolve",
+            json={"resolution": CONDITIONAL_ACK_APPROVE},
+        )
+        assert resp.status_code == 200
+        mock_persist.assert_called_once_with("pipeline-x", conditions, tmp_path)
+
+    @patch("routes.decisions._force_nack_conditional_edges")
+    @patch("routes.decisions.get_state_store_for_pipeline")
+    @patch("routes.decisions.get_decision_queue")
+    def test_reject_force_nacks_edges(
+        self,
+        mock_get_queue,
+        mock_get_store_for_pipeline,
+        mock_force_nack,
+        client,
+        tmp_path,
+    ):
+        conditions = [
+            {"reviewer": "reviewer_code", "producer": "coder", "condition": "git mv X Y"},
+        ]
+        resolved = HITLDecision(
+            id="decision-1",
+            question="conditional ACK",
+            status=DecisionStatus.RESOLVED,
+            resolution=CONDITIONAL_ACK_REJECT,
+            context=self._gate_context(conditions),
+        )
+        mock_store = MagicMock(repo_path=tmp_path)
+        mock_get_store_for_pipeline.return_value = (mock_store, MagicMock())
+        mock_get_queue.return_value.resolve_decision.return_value = resolved
+
+        resp = client.post(
+            "/api/v1/pipelines/pipeline-x/decisions/decision-1/resolve",
+            json={"resolution": CONDITIONAL_ACK_REJECT},
+        )
+        assert resp.status_code == 200
+        mock_force_nack.assert_called_once_with("pipeline-x", conditions)
+
+    @patch("routes.decisions._invalidate_conditional_acks")
+    @patch("routes.decisions.get_state_store_for_pipeline")
+    @patch("routes.decisions.get_decision_queue")
+    def test_address_in_pipeline_invalidates_acks(
+        self,
+        mock_get_queue,
+        mock_get_store_for_pipeline,
+        mock_invalidate,
+        client,
+        tmp_path,
+    ):
+        conditions = [
+            {"reviewer": "reviewer_code", "producer": "coder", "condition": "git mv X Y"},
+        ]
+        resolved = HITLDecision(
+            id="decision-1",
+            question="conditional ACK",
+            status=DecisionStatus.RESOLVED,
+            resolution=CONDITIONAL_ACK_ADDRESS,
+            context=self._gate_context(conditions),
+        )
+        mock_store = MagicMock(repo_path=tmp_path)
+        mock_get_store_for_pipeline.return_value = (mock_store, MagicMock())
+        mock_get_queue.return_value.resolve_decision.return_value = resolved
+
+        resp = client.post(
+            "/api/v1/pipelines/pipeline-x/decisions/decision-1/resolve",
+            json={"resolution": CONDITIONAL_ACK_ADDRESS},
+        )
+        assert resp.status_code == 200
+        mock_invalidate.assert_called_once_with("pipeline-x", conditions)
+
+    @patch("routes.decisions._persist_deferred_actions")
+    @patch("routes.decisions._force_nack_conditional_edges")
+    @patch("routes.decisions._invalidate_conditional_acks")
+    @patch("routes.decisions.get_state_store_for_pipeline")
+    @patch("routes.decisions.get_decision_queue")
+    def test_non_gate_context_is_ignored(
+        self,
+        mock_get_queue,
+        mock_get_store_for_pipeline,
+        mock_invalidate,
+        mock_force_nack,
+        mock_persist,
+        client,
+        tmp_path,
+    ):
+        """Context without the gate marker must not trigger any dispatch."""
+
+        resolved = HITLDecision(
+            id="decision-1",
+            question="other decision",
+            status=DecisionStatus.RESOLVED,
+            resolution="Approve",
+            context="failed_role:reviewer_x",
+        )
+        mock_store = MagicMock(repo_path=tmp_path)
+        mock_get_store_for_pipeline.return_value = (mock_store, MagicMock())
+        mock_get_queue.return_value.resolve_decision.return_value = resolved
+
+        resp = client.post(
+            "/api/v1/pipelines/pipeline-x/decisions/decision-1/resolve",
+            json={"resolution": "Approve"},
+        )
+        assert resp.status_code == 200
+        mock_persist.assert_not_called()
+        mock_force_nack.assert_not_called()
+        mock_invalidate.assert_not_called()
+
+
+class TestForceNackDispatchIntegration:
+    """_force_nack_conditional_edges drives the real tracker."""
+
+    def test_force_nack_transitions_edge_and_producer(self, graph):
+        from routes.decisions import _force_nack_conditional_edges
+
+        tracker = _make_tracker(graph)
+        conditions = [{"reviewer": "reviewer_code", "producer": "coder"}]
+
+        with patch(
+            "routes.decisions.get_peer_consensus_tracker",
+            return_value=tracker,
+        ):
+            _force_nack_conditional_edges("pipeline-x", conditions)
+
+        entry = tracker.matrix.get_entry("reviewer_code", "coder")
+        assert entry is not None
+        assert entry.state == ApprovalState.NACKED
+        assert entry.reason == "human rejected conditional ACK"
+        # Conditions dropped with the NACK (approval_matrix clears them).
+        assert tracker.get_pre_merge_conditions() == []
+
+
+class TestInvalidateDispatchIntegration:
+    """_invalidate_conditional_acks drives the real tracker."""
+
+    def test_invalidate_drops_ack_back_to_pending(self, graph):
+        from routes.decisions import _invalidate_conditional_acks
+
+        tracker = _make_tracker(graph)
+        conditions = [{"reviewer": "reviewer_code", "producer": "coder"}]
+
+        with patch(
+            "routes.decisions.get_peer_consensus_tracker",
+            return_value=tracker,
+        ):
+            _invalidate_conditional_acks("pipeline-x", conditions)
+
+        entry = tracker.matrix.get_entry("reviewer_code", "coder")
+        assert entry is not None
+        assert entry.state == ApprovalState.PENDING
+        assert entry.pre_merge_condition == ""
+
+
+class TestPrRenderPrefersContract:
+    """PR body renderer tier-1 is contract.pr.deferred_actions (#2004)."""
+
+    def test_contract_lines_take_precedence_over_tracker(self, graph):
+        from routes import pipelines as p
+
+        tracker = _make_tracker(graph, condition="stale tracker-only condition")
+
+        with patch(
+            "peer_consensus.get_peer_consensus_tracker",
+            return_value=tracker,
+        ):
+            section = p._build_pre_merge_obligations_section(
+                "pipeline-x",
+                contract_deferred_actions=["reviewer_code: git mv durable/X new/X"],
+            )
+
+        assert "Pre-merge Obligations" in section
+        assert "reviewer_code: git mv durable/X new/X" in section
+        # Tracker-only condition must not appear — contract wins.
+        assert "stale tracker-only condition" not in section
+
+    def test_empty_contract_falls_back_to_tracker(self, graph):
+        from routes import pipelines as p
+
+        tracker = _make_tracker(graph, condition="git mv tracker/X new/X")
+
+        with patch(
+            "peer_consensus.get_peer_consensus_tracker",
+            return_value=tracker,
+        ):
+            section = p._build_pre_merge_obligations_section(
+                "pipeline-x",
+                contract_deferred_actions=[],
+            )
+
+        assert "Pre-merge Obligations" in section
+        assert "git mv tracker/X new/X" in section
+
+    def test_whitespace_only_contract_entries_do_not_render(self):
+        from routes import pipelines as p
+
+        with patch(
+            "peer_consensus.get_peer_consensus_tracker",
+            return_value=None,
+        ):
+            section = p._build_pre_merge_obligations_section(
+                "pipeline-x",
+                contract_deferred_actions=["  ", "\n"],
+            )
+
+        assert section == ""
+
+    def test_none_contract_falls_back_to_tracker(self, graph):
+        """Callers that don't know about contracts still get tracker output."""
+        from routes import pipelines as p
+
+        tracker = _make_tracker(graph, condition="git mv foo bar")
+
+        with patch(
+            "peer_consensus.get_peer_consensus_tracker",
+            return_value=tracker,
+        ):
+            section = p._build_pre_merge_obligations_section("pipeline-x")
+
+        assert "git mv foo bar" in section

--- a/orchestrator/tests/test_conditional_ack_hitl_gate.py
+++ b/orchestrator/tests/test_conditional_ack_hitl_gate.py
@@ -403,6 +403,7 @@ class TestForceNackDispatchIntegration:
     """_force_nack_conditional_edges drives the real tracker."""
 
     def test_force_nack_transitions_edge_and_producer(self, graph):
+        from peer_consensus import ConsensusPhase
         from routes.decisions import _force_nack_conditional_edges
 
         tracker = _make_tracker(graph)
@@ -420,12 +421,15 @@ class TestForceNackDispatchIntegration:
         assert entry.reason == "human rejected conditional ACK"
         # Conditions dropped with the NACK (approval_matrix clears them).
         assert tracker.get_pre_merge_conditions() == []
+        # Producer must be back in WORKING so it can re-propose.
+        assert tracker._producer_phases["coder"] == ConsensusPhase.WORKING
 
 
 class TestInvalidateDispatchIntegration:
     """_invalidate_conditional_acks drives the real tracker."""
 
     def test_invalidate_drops_ack_back_to_pending(self, graph):
+        from peer_consensus import ConsensusPhase
         from routes.decisions import _invalidate_conditional_acks
 
         tracker = _make_tracker(graph)
@@ -441,6 +445,8 @@ class TestInvalidateDispatchIntegration:
         assert entry is not None
         assert entry.state == ApprovalState.PENDING
         assert entry.pre_merge_condition == ""
+        # Producer must be back in WORKING so it can re-propose.
+        assert tracker._producer_phases["coder"] == ConsensusPhase.WORKING
 
 
 class TestPrRenderPrefersContract:

--- a/shared/egg_contracts/models.py
+++ b/shared/egg_contracts/models.py
@@ -256,6 +256,17 @@ class PRMetadata(BaseModel):
         default="",
         description="Manual pre/post-merge steps (migrations, config changes, etc.)",
     )
+    deferred_actions: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Durable record of pre-merge obligations from conditional ACKs "
+            "(#1998/#2004). Each entry is a human-readable line (e.g. "
+            "'reviewer_code: git mv legacy/x new/x'). Written when the 3-way "
+            "HITL gate at complete_phase resolves as approve+accept, so "
+            "obligations survive tracker teardown between phase close and "
+            "PR creation."
+        ),
+    )
 
 
 class CheckDefinition(BaseModel):


### PR DESCRIPTION
## Summary

- Wires the **3-way HITL gate** deferred from #2003: when a reviewer attaches `--pre-merge-condition` to a BRC ACK, `complete_phase` now surfaces a `choice` HITL decision offering **approve+accept** / **reject (force NACK)** / **address in-pipeline (invalidate ACK)** before the phase can close. Closes the silent-auto-flow loophole the original #1998 issue called out.
- Adds durable contract-side storage via `PRMetadata.deferred_actions: list[str]`. On approve+accept the gate's resolution handler writes one `reviewer: condition` line per obligation, and the PR-body renderer now reads the contract as the preferred source — so obligations survive tracker teardown between phase close and PR creation. The live-tracker path in `_build_pre_merge_obligations_section` stays as a transitional fallback.

## Changes

- **Gate enqueue** (`orchestrator/routes/phases.py`): new `_ensure_conditional_ack_gate()` helper queues a `choice` decision with a `conditional_ack_gate:` context-marker JSON payload when `tracker.get_pre_merge_conditions()` is non-empty. Runs before the existing #1788 unresolved-decisions guard so the guard naturally returns 409 on the first `complete_phase` call. Idempotent (a pending gate isn't re-queued). `force=true` skips the gate.
- **Resolution dispatch** (`orchestrator/routes/decisions.py`): `resolve_decision` matches the context marker and routes to three new handlers:
  - `_persist_deferred_actions` — loads the contract, dedups against existing entries, appends `reviewer: condition` lines, and saves. Handles the `contract.pr is None` edge by creating a minimal `PRMetadata` stub.
  - `_force_nack_conditional_edges` — drives the matrix directly (`record_nack` + producer WORKING under the tracker lock) rather than `handle_nack`, since synthetic human-rejection doesn't have artifact citations and `ReviewPayload` rightly rejects empty refs.
  - `_invalidate_conditional_acks` — calls `matrix.invalidate_ack` on each edge; ACK drops back to PENDING.
- **PR render** (`orchestrator/routes/pipelines.py`): `_build_pre_merge_obligations_section` gains a `contract_deferred_actions` parameter and prefers it over the tracker. Wired at the call site to `contract.pr.deferred_actions`.
- **Schema** (`shared/egg_contracts/models.py`): `PRMetadata.deferred_actions: list[str] = []`.
- **Tests** (`orchestrator/tests/test_conditional_ack_hitl_gate.py`): 14 tests covering gate enqueue, resolution dispatch (all three options + non-gate context ignored), real-tracker integration for NACK / invalidate, and PR render contract-over-tracker precedence.

## Test plan

- [x] `make lint` — passes
- [x] `pytest orchestrator/tests/test_conditional_ack_hitl_gate.py` — 14 passed
- [x] Targeted regression: `pytest orchestrator/tests/test_conditional_ack.py orchestrator/tests/test_complete_phase_endpoint.py orchestrator/tests/test_decisions_routes.py orchestrator/tests/test_decision_queue.py orchestrator/tests/test_auto_pr.py` — 151 passed
- [x] Full orchestrator + sandbox suite: `pytest orchestrator/tests/ sandbox/tests/test_brc_cli_args.py` — 4582 passed, 1 skipped
- [ ] Not tested: end-to-end SDLC run with a live reviewer emitting a conditional ACK

## Notes

- The issue pointed to `complete_phase` in `orchestrator/routes/pipelines.py`; the handler actually lives in `orchestrator/routes/phases.py:664` (only referenced by docstring in pipelines.py). Pointer fixed in the implementation.
- "Re-spawn the producer with the condition folded in as an additional requirement" is interpreted as the matrix/tracker state change (edge invalidated, producer back to WORKING). Folding the condition text into the producer's next prompt would require deeper work on the agent-prompt assembly path and is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)