### PR TITLE
Fix #2035: pull contract from source_branch on resubmit

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -3646,6 +3646,129 @@ def _read_source_branch_artifacts(
     return updated
 
 
+def _pull_contract_from_source_branch(
+    repo_path: Path,
+    source_branch: str,
+    issue_number: int | None,
+    pipeline_id: str,
+    spawner: Any | None = None,
+    gateway_mode: str = "public",
+) -> bool:
+    """Load a persisted contract from ``origin/<source_branch>`` into the worktree.
+
+    When ``submit_task`` is called with ``source_branch``, the source branch
+    carries ``.egg-state/contracts/<pipeline>.json`` (with any resolved HITL
+    decisions).  Without this helper, ``_run_pipeline`` calls
+    ``create_contract()`` unconditionally and overwrites those decisions with
+    a zero-state contract (#2035).  This helper fetches the source branch,
+    reads the contract via ``git show``, rebinds its pipeline_id to the new
+    pipeline, and writes it into the worktree so the caller can skip
+    ``create_contract()`` and proceed to commit+push the pulled contract.
+
+    Returns True when a contract was successfully pulled, False otherwise.
+    Best-effort: missing, invalid, or unreachable source contracts all yield
+    False so the caller falls back to ``create_contract()``.
+    """
+    from egg_contracts.loader import (
+        ContractNotFoundError,
+        ContractValidationError,
+        load_contract_from_branch,
+        save_contract,
+    )
+
+    # Fetch the source branch so origin/<source_branch> is current.  Mirrors
+    # the pattern in _read_source_branch_artifacts — use the gateway when
+    # available, fall back to raw git for tests / non-sandboxed callers.
+    if spawner is not None:
+        try:
+            spawner.gateway.fetch_branch(
+                pipeline_id=pipeline_id,
+                repo_path=str(repo_path),
+                args=[source_branch],
+                mode=gateway_mode,
+            )
+        except Exception:
+            logger.warning(
+                "Gateway fetch of source branch failed (will try git show anyway)",
+                source_branch=source_branch,
+                pipeline_id=pipeline_id,
+                exc_info=True,
+            )
+    else:
+        try:
+            subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "core.hooksPath=/dev/null",
+                    "-c",
+                    f"safe.directory={repo_path}",
+                    "-C",
+                    str(repo_path),
+                    "fetch",
+                    "origin",
+                    source_branch,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to fetch source branch for contract pull",
+                source_branch=source_branch,
+                exc_info=True,
+            )
+
+    identifier: int | str = issue_number if issue_number is not None else pipeline_id
+
+    try:
+        contract = load_contract_from_branch(
+            identifier,
+            repo_path,
+            branch=f"origin/{source_branch}",
+        )
+    except ContractNotFoundError:
+        logger.debug(
+            "No contract on source branch",
+            pipeline_id=pipeline_id,
+            source_branch=source_branch,
+        )
+        return False
+    except ContractValidationError as e:
+        logger.warning(
+            "Contract on source branch failed validation, falling back to fresh contract",
+            pipeline_id=pipeline_id,
+            source_branch=source_branch,
+            error=str(e),
+        )
+        return False
+    except Exception:
+        logger.warning(
+            "Failed to load contract from source branch",
+            pipeline_id=pipeline_id,
+            source_branch=source_branch,
+            exc_info=True,
+        )
+        return False
+
+    # Rebind to the new pipeline_id so save_contract writes under the new
+    # canonical key when the pipeline was forked with a qualifier
+    # (e.g. source=issue-1965, new=issue-1965-v2).
+    contract.pipeline_id = pipeline_id
+    save_contract(contract, repo_path)
+
+    logger.info(
+        "Loaded contract from source branch",
+        pipeline_id=pipeline_id,
+        source_branch=source_branch,
+        decision_count=len(contract.decisions),
+        phase_count=len(contract.phases),
+    )
+    return True
+
+
 def _read_phase_draft(
     repo_path: Path,
     phase: str,
@@ -10606,6 +10729,11 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
         else:
             certs_volume = certs_volume_raw
 
+        # Capture source_branch before _read_source_branch_artifacts clears
+        # it on success — the contract-pull path below (#2035) runs inside
+        # the contract_synced block and otherwise wouldn't see the value.
+        source_branch_for_contract_pull = pipeline.source_branch
+
         # Read artifacts from source branch if specified and inline values
         # were not provided.  This populates pipeline.plan and
         # pipeline.analysis so the contract creation block below can use them.
@@ -10680,21 +10808,47 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
             try:
                 from egg_contracts.loader import create_contract
 
-                if pipeline.issue_number is not None:
-                    issue_url = f"https://github.com/{pipeline.repo}/issues/{pipeline.issue_number}"
-                    create_contract(
-                        issue_number=pipeline.issue_number,
-                        title=f"Issue #{pipeline.issue_number}",
-                        url=issue_url,
-                        pipeline_id=pipeline.id,
-                        repo_root=worktree_repo_path,
-                    )
-                else:
-                    create_contract(
-                        pipeline_id=pipeline.id,
-                        title=(pipeline.prompt or "")[:100],
-                        repo_root=worktree_repo_path,
-                    )
+                # When source_branch is set, try to carry over the contract
+                # (with any resolved HITL decisions) from there instead of
+                # overwriting with a fresh zero-state contract (#2035).
+                pulled_contract = False
+                if source_branch_for_contract_pull:
+                    try:
+                        pulled_contract = _pull_contract_from_source_branch(
+                            repo_path=worktree_repo_path,
+                            source_branch=source_branch_for_contract_pull,
+                            issue_number=pipeline.issue_number,
+                            pipeline_id=pipeline.id,
+                            spawner=spawner,
+                            gateway_mode=gateway_mode,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Unexpected error pulling contract from source branch — falling back to fresh contract",
+                            pipeline_id=pipeline_id,
+                            source_branch=source_branch_for_contract_pull,
+                            exc_info=True,
+                        )
+                        pulled_contract = False
+
+                if not pulled_contract:
+                    if pipeline.issue_number is not None:
+                        issue_url = (
+                            f"https://github.com/{pipeline.repo}/issues/{pipeline.issue_number}"
+                        )
+                        create_contract(
+                            issue_number=pipeline.issue_number,
+                            title=f"Issue #{pipeline.issue_number}",
+                            url=issue_url,
+                            pipeline_id=pipeline.id,
+                            repo_root=worktree_repo_path,
+                        )
+                    else:
+                        create_contract(
+                            pipeline_id=pipeline.id,
+                            title=(pipeline.prompt or "")[:100],
+                            repo_root=worktree_repo_path,
+                        )
 
                 # Write pre-generated drafts for short-flow pipelines so the
                 # existing plan parser can populate the contract with tasks.

--- a/orchestrator/tests/test_source_branch.py
+++ b/orchestrator/tests/test_source_branch.py
@@ -1417,3 +1417,186 @@ class TestSourceBranchEdgeCases:
 
         assert result is True
         assert pipeline.plan == plan_content
+
+
+# ---------------------------------------------------------------------------
+# 6. _pull_contract_from_source_branch (#2035)
+# ---------------------------------------------------------------------------
+
+
+class TestPullContractFromSourceBranch:
+    """Test that _pull_contract_from_source_branch carries over resolved
+    HITL decisions from ``origin/<source_branch>`` instead of letting
+    ``_run_pipeline`` overwrite them with a fresh zero-state contract.
+    """
+
+    def _make_contract(self, pipeline_id="issue-1570", decisions=None, phases=None):
+        """Build a Contract with the given decisions/phases preserved."""
+        from egg_contracts.models import Contract, IssueInfo
+
+        issue_number = None
+        if pipeline_id.startswith("issue-"):
+            try:
+                issue_number = int(pipeline_id.split("-")[1])
+            except (IndexError, ValueError):
+                pass
+
+        return Contract(
+            issue=IssueInfo(number=issue_number, title="t", url="") if issue_number else None,
+            pipeline_id=pipeline_id,
+            decisions=decisions or [],
+            phases=phases or [],
+        )
+
+    def test_pulls_contract_with_resolved_decisions(self, tmp_path):
+        """Contract with resolved HITL decisions should be loaded and saved."""
+        from egg_contracts.models import Decision, DecisionType
+        from routes.pipelines import _pull_contract_from_source_branch
+
+        source_contract = self._make_contract(
+            pipeline_id="issue-1570",
+            decisions=[
+                Decision(
+                    id="decision-1",
+                    question="Which DB driver?",
+                    type=DecisionType.HITL,
+                    options=[],
+                    resolved=True,
+                    resolution="asyncpg",
+                    resolved_by="human",
+                )
+            ],
+        )
+
+        saved = {}
+
+        def fake_load(identifier, repo_path, branch=None):
+            assert branch == "origin/egg/issue-1570-v3"
+            return source_contract
+
+        def fake_save(contract, repo_root):
+            saved["contract"] = contract
+            saved["repo_root"] = repo_root
+            return repo_root / "contract.json"
+
+        with (
+            patch("subprocess.run") as mock_subprocess,
+            patch("egg_contracts.loader.load_contract_from_branch", side_effect=fake_load),
+            patch("egg_contracts.loader.save_contract", side_effect=fake_save),
+        ):
+            mock_subprocess.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+            result = _pull_contract_from_source_branch(
+                repo_path=tmp_path,
+                source_branch="egg/issue-1570-v3",
+                issue_number=1570,
+                pipeline_id="issue-1570",
+            )
+
+        assert result is True
+        assert "contract" in saved
+        # The pulled contract's decisions must survive the save.
+        assert len(saved["contract"].decisions) == 1
+        assert saved["contract"].decisions[0].resolved is True
+        assert saved["contract"].decisions[0].resolution == "asyncpg"
+
+    def test_rebinds_pipeline_id_when_forking(self, tmp_path):
+        """When forking (source pipeline_id != new pipeline_id), save under the NEW id."""
+        from routes.pipelines import _pull_contract_from_source_branch
+
+        source_contract = self._make_contract(pipeline_id="issue-1570")
+
+        saved = {}
+
+        with (
+            patch("subprocess.run") as mock_subprocess,
+            patch(
+                "egg_contracts.loader.load_contract_from_branch",
+                return_value=source_contract,
+            ),
+            patch("egg_contracts.loader.save_contract") as mock_save,
+        ):
+            mock_subprocess.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+            mock_save.side_effect = lambda c, r: saved.setdefault("contract", c)
+            result = _pull_contract_from_source_branch(
+                repo_path=tmp_path,
+                source_branch="egg/issue-1570",
+                issue_number=1570,
+                pipeline_id="issue-1570-v2",
+            )
+
+        assert result is True
+        # Saved contract must have been rebound to the new pipeline_id so
+        # save_contract writes under the canonical key for the new pipeline.
+        assert saved["contract"].pipeline_id == "issue-1570-v2"
+
+    def test_returns_false_when_no_contract_on_branch(self, tmp_path):
+        """Missing contract on source branch should yield False (not raise)."""
+        from egg_contracts.loader import ContractNotFoundError
+        from routes.pipelines import _pull_contract_from_source_branch
+
+        with (
+            patch("subprocess.run") as mock_subprocess,
+            patch(
+                "egg_contracts.loader.load_contract_from_branch",
+                side_effect=ContractNotFoundError(1570, tmp_path / "missing.json"),
+            ),
+        ):
+            mock_subprocess.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+            result = _pull_contract_from_source_branch(
+                repo_path=tmp_path,
+                source_branch="egg/issue-1570-v3",
+                issue_number=1570,
+                pipeline_id="issue-1570",
+            )
+
+        assert result is False
+
+    def test_returns_false_on_invalid_contract(self, tmp_path):
+        """Invalid contract on source branch should yield False (best-effort)."""
+        from egg_contracts.loader import ContractValidationError
+        from routes.pipelines import _pull_contract_from_source_branch
+
+        with (
+            patch("subprocess.run") as mock_subprocess,
+            patch(
+                "egg_contracts.loader.load_contract_from_branch",
+                side_effect=ContractValidationError(1570, ["Invalid JSON: x"]),
+            ),
+        ):
+            mock_subprocess.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+            result = _pull_contract_from_source_branch(
+                repo_path=tmp_path,
+                source_branch="egg/issue-1570-v3",
+                issue_number=1570,
+                pipeline_id="issue-1570",
+            )
+
+        assert result is False
+
+    def test_uses_gateway_fetch_when_spawner_present(self, tmp_path):
+        """When spawner is provided, fetch must go through the gateway (credentialed)."""
+        from routes.pipelines import _pull_contract_from_source_branch
+
+        mock_spawner = MagicMock()
+        mock_spawner.gateway.fetch_branch = MagicMock()
+
+        with (
+            patch(
+                "egg_contracts.loader.load_contract_from_branch",
+                return_value=self._make_contract(),
+            ),
+            patch("egg_contracts.loader.save_contract"),
+        ):
+            _pull_contract_from_source_branch(
+                repo_path=tmp_path,
+                source_branch="egg/issue-1570-v3",
+                issue_number=1570,
+                pipeline_id="issue-1570",
+                spawner=mock_spawner,
+                gateway_mode="private",
+            )
+
+        mock_spawner.gateway.fetch_branch.assert_called_once()
+        call_kwargs = mock_spawner.gateway.fetch_branch.call_args.kwargs
+        assert call_kwargs["args"] == ["egg/issue-1570-v3"]
+        assert call_kwargs["mode"] == "private"

--- a/orchestrator/tests/test_source_branch.py
+++ b/orchestrator/tests/test_source_branch.py
@@ -1471,6 +1471,7 @@ class TestPullContractFromSourceBranch:
         saved = {}
 
         def fake_load(identifier, repo_path, branch=None):
+            assert identifier == 1570
             assert branch == "origin/egg/issue-1570-v3"
             return source_contract
 
@@ -1507,11 +1508,15 @@ class TestPullContractFromSourceBranch:
 
         saved = {}
 
+        def fake_load(identifier, repo_path, branch=None):
+            assert identifier == 1570
+            return source_contract
+
         with (
             patch("subprocess.run") as mock_subprocess,
             patch(
                 "egg_contracts.loader.load_contract_from_branch",
-                return_value=source_contract,
+                side_effect=fake_load,
             ),
             patch("egg_contracts.loader.save_contract") as mock_save,
         ):
@@ -1600,3 +1605,35 @@ class TestPullContractFromSourceBranch:
         call_kwargs = mock_spawner.gateway.fetch_branch.call_args.kwargs
         assert call_kwargs["args"] == ["egg/issue-1570-v3"]
         assert call_kwargs["mode"] == "private"
+
+    def test_falls_back_to_pipeline_id_when_no_issue_number(self, tmp_path):
+        """When issue_number is None, identifier should fall back to pipeline_id."""
+        from routes.pipelines import _pull_contract_from_source_branch
+
+        source_contract = self._make_contract(pipeline_id="run-abc123")
+
+        def fake_load(identifier, repo_path, branch=None):
+            assert identifier == "run-abc123"
+            return source_contract
+
+        saved = {}
+
+        with (
+            patch("subprocess.run") as mock_subprocess,
+            patch(
+                "egg_contracts.loader.load_contract_from_branch",
+                side_effect=fake_load,
+            ),
+            patch("egg_contracts.loader.save_contract") as mock_save,
+        ):
+            mock_subprocess.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+            mock_save.side_effect = lambda c, r: saved.setdefault("contract", c)
+            result = _pull_contract_from_source_branch(
+                repo_path=tmp_path,
+                source_branch="egg/run-abc123",
+                issue_number=None,
+                pipeline_id="run-abc123",
+            )
+
+        assert result is True
+        assert saved["contract"].pipeline_id == "run-abc123"


### PR DESCRIPTION
## Summary

Closes #2035.

`submit_task(..., source_branch="egg/<pipeline>")` was the documented recovery path for resuming a pipeline after `cancel_task(cleanup=true)`, but it silently lost any resolved HITL decisions sitting in `.egg-state/contracts/<pipeline>.json` on the source branch. Two interacting bugs: `_read_source_branch_artifacts` only carries over plan/analysis drafts, and `_run_pipeline` unconditionally calls `create_contract()` when `contract_synced=False`, overwriting whatever's on disk with a fresh zero-state contract.

This change adds a `_pull_contract_from_source_branch` helper that fetches the source branch, loads the contract via the existing `load_contract_from_branch`, rebinds its `pipeline_id` to the new pipeline (so forks under a qualifier work too), and writes it to the worktree. When the pull succeeds, `_run_pipeline` skips `create_contract()` and falls through to the existing commit + push path so the pulled contract reaches the agent-facing remote branch the same way a fresh one would. `_populate_contract_from_plan` still runs to sync tasks from `plan.md` — it only mutates `phases` and `pr` metadata, so `decisions` ride through unchanged.

Best-effort throughout: `ContractNotFoundError` and `ContractValidationError` both fall back to `create_contract()` so callers without a source contract still get the existing behavior.

Explicitly **not** doing: no `force` flag on `cleanup`, no branch-preservation on cleanup, no `restart_phase` reconstitute path, no implicit "is there a contract in the worktree" detection. `cleanup=true` remains terminal as designed; the gap was that the documented `source_branch` recovery flow was lossy.

## Test plan

- [x] `tests/test_source_branch.py::TestPullContractFromSourceBranch` — 5 new tests covering: pull preserves resolved decisions, rebinds pipeline_id when forking under a qualifier, returns False when no contract on branch, returns False on invalid contract, gateway-credentialed fetch when spawner present.
- [x] Existing `tests/test_source_branch.py` (51 tests) still passes.
- [x] Full orchestrator suite (4595 tests) passes.
- [x] `make lint` clean.
- [ ] Manual verification: resubmit issue with a contract on `source_branch` and confirm resolved decisions appear in the new pipeline's contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)