### PR TITLE
Fix #2051: orchestrator push authenticates with launcher secret

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -605,6 +605,55 @@ def require_launcher_auth(f: F) -> F:  # noqa: UP047
     return decorated  # type: ignore[return-value]
 
 
+def require_session_or_launcher_auth(f: F) -> F:  # noqa: UP047
+    """Endpoint accepts either a session token or the launcher secret.
+
+    When the Authorization bearer matches the launcher secret, the request
+    is treated as orchestrator-originated: ``g.session`` is left ``None``
+    and ``g.auth_actor`` is set to ``"launcher"``.  Otherwise the request
+    falls through to ``require_session_auth`` (sandbox/agent path), which
+    sets ``g.session`` and ``g.auth_actor = "session"``.
+
+    The trust split is grounded in the launcher secret already used by
+    ``/api/v1/sessions/create`` and other privileged endpoints — only the
+    orchestrator holds it (mounted at ``/secrets/launcher-secret``), so a
+    request that authenticates with it is by definition not coming from
+    a sandboxed agent.
+
+    Used by ``/api/v1/git/push`` so the orchestrator can run its own
+    failsafe pushes (contract init, state-sync, completion) without the
+    register-session/push/delete ceremony, and without tripping the
+    pipeline-push block (#2028) intended for agents.
+    """
+
+    @functools.wraps(f)
+    def decorated(*args: Any, **kwargs: Any) -> Any:
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            try:
+                launcher_secret = get_launcher_secret()
+            except LauncherSecretNotConfiguredError:
+                launcher_secret = ""
+            if launcher_secret and secrets.compare_digest(auth_header[7:], launcher_secret):
+                g.session = None
+                g.session_mode = None
+                g.session_phase = None
+                g.auth_actor = "launcher"
+                return f(*args, **kwargs)
+
+        # Fall through to session-token validation.  The session decorator
+        # sets g.session/g.session_mode/g.session_phase on success and
+        # returns 401 on failure.
+        @require_session_auth
+        def _wrapped(*a: Any, **kw: Any) -> Any:
+            g.auth_actor = "session"
+            return f(*a, **kw)
+
+        return _wrapped(*args, **kwargs)
+
+    return decorated  # type: ignore[return-value]
+
+
 def make_response(
     success: bool,
     message: str,
@@ -870,7 +919,7 @@ def config_reload() -> Response:
 
 
 @app.route("/api/v1/git/push", methods=["POST"])
-@require_session_auth
+@require_session_or_launcher_auth
 def git_push() -> tuple[Response, int] | Response:
     """
     Handle git push requests.
@@ -951,6 +1000,27 @@ def git_push() -> tuple[Response, int] | Response:
     # Get session mode from request context (set by @require_session_auth decorator)
     session_mode = getattr(g, "session_mode", None)
     session_phase = getattr(g, "session_phase", None)
+
+    # Orchestrator-authenticated push (launcher secret).  The orchestrator
+    # has a different trust boundary than sandboxed agents — its pushes are
+    # programmatic (contract init, state-sync, completion) and bypass the
+    # session-derived enforcement (pipeline-push block, push-target check,
+    # role/phase file restrictions) that exists to sandbox agent commits.
+    # session_mode comes from the request body since there is no session.
+    is_orchestrator_push = getattr(g, "auth_actor", None) == "launcher"
+    if is_orchestrator_push:
+        session_mode = data.get("mode") or session_mode
+        audit_log(
+            "push_orchestrator_authenticated",
+            "git_push",
+            success=True,
+            details={
+                "repo_path": repo_path,
+                "remote": remote,
+                "refspec": refspec,
+                "reason": "Push authenticated with launcher secret — orchestrator-trusted",
+            },
+        )
 
     # Infrastructure branch bypass: pushes to infrastructure branches always succeed
     # regardless of session mode or phase (checkpoints and pipeline state can be

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -612,7 +612,8 @@ def require_session_or_launcher_auth(f: F) -> F:  # noqa: UP047
     is treated as orchestrator-originated: ``g.session`` is left ``None``
     and ``g.auth_actor`` is set to ``"launcher"``.  Otherwise the request
     falls through to ``require_session_auth`` (sandbox/agent path), which
-    sets ``g.session`` and ``g.auth_actor = "session"``.
+    sets ``g.session`` and ``g.session_mode``/``g.session_phase``; this
+    wrapper then sets ``g.auth_actor = "session"``.
 
     The trust split is grounded in the launcher secret already used by
     ``/api/v1/sessions/create`` and other privileged endpoints — only the
@@ -625,6 +626,13 @@ def require_session_or_launcher_auth(f: F) -> F:  # noqa: UP047
     register-session/push/delete ceremony, and without tripping the
     pipeline-push block (#2028) intended for agents.
     """
+
+    # Build the session-auth fallback once at decoration time so we don't
+    # re-create the wrapper closure on every request.
+    @require_session_auth
+    def _session_path(*args: Any, **kwargs: Any) -> Any:
+        g.auth_actor = "session"
+        return f(*args, **kwargs)
 
     @functools.wraps(f)
     def decorated(*args: Any, **kwargs: Any) -> Any:
@@ -644,12 +652,7 @@ def require_session_or_launcher_auth(f: F) -> F:  # noqa: UP047
         # Fall through to session-token validation.  The session decorator
         # sets g.session/g.session_mode/g.session_phase on success and
         # returns 401 on failure.
-        @require_session_auth
-        def _wrapped(*a: Any, **kw: Any) -> Any:
-            g.auth_actor = "session"
-            return f(*a, **kw)
-
-        return _wrapped(*args, **kwargs)
+        return _session_path(*args, **kwargs)
 
     return decorated  # type: ignore[return-value]
 
@@ -1009,7 +1012,22 @@ def git_push() -> tuple[Response, int] | Response:
     # session_mode comes from the request body since there is no session.
     is_orchestrator_push = getattr(g, "auth_actor", None) == "launcher"
     if is_orchestrator_push:
-        session_mode = data.get("mode") or session_mode
+        mode_in = data.get("mode")
+        if mode_in is not None and mode_in not in ("public", "private"):
+            audit_log(
+                "push_blocked",
+                "git_push",
+                success=False,
+                details={
+                    "repo_path": repo_path,
+                    "reason": f"Invalid mode {mode_in!r} on launcher-auth push",
+                },
+            )
+            return make_error(
+                f"Invalid mode {mode_in!r}: must be 'public' or 'private'",
+                status_code=400,
+            )
+        session_mode = mode_in or session_mode
         audit_log(
             "push_orchestrator_authenticated",
             "git_push",

--- a/gateway/tests/test_pipeline_push_block.py
+++ b/gateway/tests/test_pipeline_push_block.py
@@ -675,11 +675,13 @@ class TestOrchestratorLauncherAuthPush:
             assert "mode" in data["message"].lower()
 
     def test_launcher_push_missing_mode_uses_session_default(self, client):
-        """A launcher-auth push without ``mode`` in the body is allowed.
+        """A launcher-auth push without ``mode`` in the body is not rejected by
+        the new validator (only invalid values are).
 
-        Missing ``mode`` is normal for the orchestrator's failsafe pushes that
-        don't care about private-repo policy (defaults are applied downstream
-        by ``check_private_repo_access``).  Only an *invalid* mode is rejected.
+        Note that in production ``check_private_repo_access`` would still 403
+        with "No session mode specified" — this test exercises the validator in
+        isolation (``check_private_repo_access`` is mocked to allow); the
+        orchestrator's ``_do_push`` always sends mode in practice.
         """
         patches = _launcher_auth_context()
         with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:

--- a/gateway/tests/test_pipeline_push_block.py
+++ b/gateway/tests/test_pipeline_push_block.py
@@ -640,9 +640,7 @@ class TestOrchestratorLauncherAuthPush:
         with patch.object(
             gateway,
             "get_launcher_secret",
-            side_effect=gateway.LauncherSecretNotConfiguredError(
-                "Launcher secret not configured"
-            ),
+            side_effect=gateway.LauncherSecretNotConfiguredError("Launcher secret not configured"),
         ):
             response = client.post(
                 "/api/v1/git/push",

--- a/gateway/tests/test_pipeline_push_block.py
+++ b/gateway/tests/test_pipeline_push_block.py
@@ -464,3 +464,169 @@ class TestPipelinePushBlockEdgeCases:
                 assert found_pipeline_deny, (
                     "Expected audit_log to be called with a pipeline-session push denial event"
                 )
+
+
+def _launcher_auth_context():
+    """Patches that let a launcher-authed push reach the success path.
+
+    Mirrors ``_push_context`` but skips session validation — launcher auth
+    sets ``g.session = None`` and is recognised before session-token
+    validation runs.  The git subprocess shim and policy stubs let the
+    push run end-to-end so we can assert the request was accepted.
+    """
+    mock_policy_result = PrivateRepoPolicyResult(
+        allowed=True,
+        reason="Test mode",
+        visibility="public",
+    )
+
+    def run_side_effect(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("args", [])
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        if "remote" in cmd and "get-url" in cmd:
+            result.stdout = "https://github.com/owner/repo.git\n"
+        elif "branch" in cmd and "--show-current" in cmd:
+            result.stdout = "egg/issue-2051\n"
+        elif "push" in cmd:
+            result.stdout = "Everything up-to-date\n"
+        elif "diff" in cmd:
+            result.stdout = ""
+        else:
+            result.stdout = ""
+        return result
+
+    return (
+        patch.object(gateway, "get_launcher_secret", return_value="test-launcher-secret"),
+        patch.object(gateway, "check_private_repo_access", return_value=mock_policy_result),
+        patch("subprocess.run", side_effect=run_side_effect),
+        patch.object(
+            gateway,
+            "get_policy_engine",
+            return_value=MagicMock(
+                check_branch_ownership=MagicMock(
+                    return_value=PolicyResult(
+                        allowed=True,
+                        reason="OK",
+                        details={"branch": "egg/issue-2051"},
+                    )
+                ),
+            ),
+        ),
+        patch.object(gateway, "get_token_for_repo", return_value=("test-token", "bot", "")),
+        patch.object(gateway, "get_changed_files_in_push", return_value=([], None)),
+    )
+
+
+def _do_launcher_push(client, refspec: str = "egg/issue-2051", **extra_payload):
+    """Send a launcher-authed push (no session token, launcher secret bearer)."""
+    payload = {
+        "repo_path": "/home/egg/repos/test-repo",
+        "remote": "origin",
+        "refspec": refspec,
+        **extra_payload,
+    }
+    return client.post(
+        "/api/v1/git/push",
+        headers={"Authorization": "Bearer test-launcher-secret"},
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+class TestOrchestratorLauncherAuthPush:
+    """Verify that launcher-authed pushes bypass agent-targeted enforcement (#2051).
+
+    The orchestrator has a different trust boundary than sandboxed agents
+    — it holds the launcher secret already used by ``/api/v1/sessions/create``.
+    Push requests authenticated with that secret are orchestrator-trusted
+    (programmatic contract init / state-sync / completion pushes) and skip
+    the pipeline-push enforcement that would otherwise block them.
+    """
+
+    def test_launcher_push_to_pipeline_branch_bypasses_block(self, client):
+        """A launcher-authed push to a pipeline branch is NOT blocked.
+
+        Regression for #2051: the orchestrator's contract-init push targets
+        ``egg/issue-<N>`` (a pipeline branch) and previously got a 403
+        because temp sessions inherit ``pipeline_id``.  With launcher auth
+        there is no session, and the push is allowed.
+        """
+        patches = _launcher_auth_context()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            response = _do_launcher_push(client)
+            assert response.status_code == 200, (
+                f"Expected 200 for launcher-auth push, got {response.status_code}: "
+                f"{response.data!r}"
+            )
+
+    def test_launcher_push_skips_consensus_push_requirement(self, client):
+        """Launcher-auth push needs no ``consensus_push`` marker.
+
+        The marker exists for the BRC-on-agent-side path; launcher-auth
+        identifies the orchestrator directly.  No marker is required.
+        """
+        patches = _launcher_auth_context()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            response = _do_launcher_push(client)
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            # Should NOT carry the agent-targeted "use mcp__brc__propose" hint.
+            assert "mcp__brc__propose" not in data.get("message", "")
+
+    def test_launcher_push_audited_as_orchestrator_authenticated(self, client):
+        """Launcher-auth pushes emit a distinct audit event for traceability."""
+        patches = _launcher_auth_context()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            with patch.object(gateway, "audit_log") as mock_audit:
+                response = _do_launcher_push(client)
+                assert response.status_code == 200
+                events = [call.args[0] if call.args else None for call in mock_audit.call_args_list]
+                assert "push_orchestrator_authenticated" in events, (
+                    f"Expected push_orchestrator_authenticated audit event, got {events}"
+                )
+
+    def test_session_token_path_still_blocks_pipeline_push(self, client):
+        """The session-token branch of the auth decorator still enforces #2028.
+
+        Adding launcher auth must NOT loosen enforcement for agent
+        sessions — only sandbox agents are subject to the BRC routing.
+        """
+        session = _make_session("coder")
+        patches = _push_context(session)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+        ):
+            response = _do_push(client)
+            assert response.status_code == 403, (
+                "Session-token push to a pipeline branch must still be blocked"
+            )
+
+    def test_launcher_push_invalid_secret_falls_back_to_session_auth(self, client):
+        """A bearer that is neither the launcher secret nor a valid session
+        token returns 401 from session-auth (the fallback path)."""
+        # Launcher secret patched to a known value; we send a different bearer.
+        with patch.object(gateway, "get_launcher_secret", return_value="real-secret"):
+            response = client.post(
+                "/api/v1/git/push",
+                headers={"Authorization": "Bearer wrong-bearer"},
+                data=json.dumps(
+                    {
+                        "repo_path": "/home/egg/repos/test-repo",
+                        "remote": "origin",
+                        "refspec": "egg/issue-2051",
+                    }
+                ),
+                content_type="application/json",
+            )
+            # session_manager rejects the unknown token via the fallback
+            # require_session_auth path → 401, not 403.
+            assert response.status_code == 401

--- a/gateway/tests/test_pipeline_push_block.py
+++ b/gateway/tests/test_pipeline_push_block.py
@@ -630,3 +630,62 @@ class TestOrchestratorLauncherAuthPush:
             # session_manager rejects the unknown token via the fallback
             # require_session_auth path → 401, not 403.
             assert response.status_code == 401
+
+    def test_launcher_secret_not_configured_falls_back_to_session_auth(self, client):
+        """When the gateway has no launcher secret configured at all, every
+        bearer falls through to session auth and is rejected as 401 cleanly
+        (the ``LauncherSecretNotConfiguredError`` is swallowed inside the
+        decorator)."""
+        # get_launcher_secret raises — simulates an unconfigured gateway.
+        with patch.object(
+            gateway,
+            "get_launcher_secret",
+            side_effect=gateway.LauncherSecretNotConfiguredError(
+                "Launcher secret not configured"
+            ),
+        ):
+            response = client.post(
+                "/api/v1/git/push",
+                headers={"Authorization": "Bearer any-bearer"},
+                data=json.dumps(
+                    {
+                        "repo_path": "/home/egg/repos/test-repo",
+                        "remote": "origin",
+                        "refspec": "egg/issue-2051",
+                    }
+                ),
+                content_type="application/json",
+            )
+            # No launcher secret means we can't match — fall through to
+            # session-auth, which rejects the unknown token cleanly.
+            assert response.status_code == 401
+
+    def test_launcher_push_invalid_mode_rejected(self, client):
+        """A launcher-auth push with a non-{public,private} ``mode`` returns 400.
+
+        The orchestrator's ``_do_push`` is typed
+        ``Literal["public", "private"]``, but if the launcher secret were ever
+        used by another caller, an unknown value would silently degrade to
+        public-mode policy in ``check_private_repo_access``.  Explicit
+        validation closes that gap.
+        """
+        patches = _launcher_auth_context()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            response = _do_launcher_push(client, mode="banana")
+            assert response.status_code == 400
+            data = json.loads(response.data)
+            assert "mode" in data["message"].lower()
+
+    def test_launcher_push_missing_mode_uses_session_default(self, client):
+        """A launcher-auth push without ``mode`` in the body is allowed.
+
+        Missing ``mode`` is normal for the orchestrator's failsafe pushes that
+        don't care about private-repo policy (defaults are applied downstream
+        by ``check_private_repo_access``).  Only an *invalid* mode is rejected.
+        """
+        patches = _launcher_auth_context()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            response = _do_launcher_push(client)  # no mode kwarg
+            assert response.status_code == 200, (
+                f"Expected 200 with no mode, got {response.status_code}: {response.data!r}"
+            )

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -710,10 +710,13 @@ class GatewayClient:
         ref: str | None = None,
         base_branch: str | None = None,
     ) -> PushResult:
-        """Push a branch to remote using a temporary session.
+        """Push a branch to remote with launcher-auth (orchestrator-trusted).
 
         Called after contract initialization, phase completion, or pipeline
-        failure. Registers a temp session, pushes, then cleans up the session.
+        failure.  Authenticates with the launcher secret rather than a
+        sandbox session token: the orchestrator is on the privileged side
+        of the trust boundary and its programmatic pushes bypass the
+        agent-targeted pipeline-push enforcement (#2028, #2051).
 
         When ``ref`` is ``None`` (default), pushes the worktree's current
         ``HEAD`` — used when ``repo_path`` is a worktree checked out to
@@ -793,30 +796,25 @@ class GatewayClient:
         mode: Literal["public", "private"],
         refspec: str,
     ) -> PushResult:
-        """Send a single push request to the gateway.
+        """Send a single push request to the gateway with launcher auth.
 
-        Returns ``PushResult(ok=True)`` on success. On failure the gateway
+        The orchestrator authenticates directly with the launcher secret —
+        no register-session/push/delete ceremony.  The push endpoint
+        recognises launcher auth as orchestrator-trusted and skips the
+        agent-targeted enforcement (pipeline-push block, push-target,
+        role/phase file restrictions).  ``mode`` is forwarded in the
+        request body so the private-repo policy still applies.
+
+        Returns ``PushResult(ok=True)`` on success.  On failure the gateway
         HTTP 500 body carries git stderr in ``details["stderr"]``; we
         classify it into a category and propagate both category and raw
-        stderr so callers can build an operator-actionable error without
-        re-reading source to understand what "False" meant.
+        stderr so callers can build an operator-actionable error.
         """
-        temp_container_id = f"{pipeline_id}-failsafe-push"
-        session_token: str | None = None
         try:
-            session = self.register_session(
-                container_id=temp_container_id,
-                container_ip=self.self_ip,
-                mode=mode,
-                pipeline_id=pipeline_id,
-                branch=branch,
-            )
-            session_token = session.session_token
-
-            # Do NOT include container_id — the repo_path is already resolved.
-            # Including the synthetic container_id would cause
-            # map_container_path_to_worktree() to fail with "worktree not found"
-            # since no real worktree exists for the temp session (see #1500).
+            # Do NOT include container_id — the repo_path is already resolved
+            # (orchestrator-side worktree on the shared hostPath).  Including
+            # one would route through map_container_path_to_worktree() and
+            # fail "worktree not found" (#1500).
             self._make_request(
                 "/api/v1/git/push",
                 method="POST",
@@ -824,8 +822,9 @@ class GatewayClient:
                     "repo_path": repo_path,
                     "remote": "origin",
                     "refspec": refspec,
+                    "mode": mode,
                 },
-                bearer_token=session_token,
+                use_launcher_auth=True,
             )
 
             logger.info(
@@ -866,12 +865,6 @@ class GatewayClient:
                 error=str(e),
             )
             return PushResult(ok=False, category="unknown", detail=str(e))
-        finally:
-            if session_token:
-                try:
-                    self.delete_session(session_token)
-                except Exception:
-                    pass
 
     def _reconcile_and_retry_push(
         self,

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -966,33 +966,34 @@ class TestPushWorktreeBranch:
         assert result.category == "gateway_unreachable"
         assert result.detail
 
-    def test_push_worktree_branch_cleans_up_session(self, gateway_client, mock_gateway_server):
-        """Test that temp session is cleaned up after push."""
-        with patch.object(gateway_client, "delete_session") as mock_delete:
-            gateway_client.push_worktree_branch(
-                pipeline_id="issue-42",
-                repo_path="/some/path",
-                branch="egg/issue-42",
-            )
-            # Session should be cleaned up
-            mock_delete.assert_called_once_with("test-token-12345")
+    def test_push_worktree_branch_uses_launcher_auth(self, gateway_client, mock_gateway_server):
+        """Push authenticates with the launcher secret, not a session token.
 
-    def test_push_worktree_branch_registers_session_with_branch(
-        self, gateway_client, mock_gateway_server
-    ):
-        """Test that register_session is called with branch so gateway assigns correct branch."""
-        with patch.object(
-            gateway_client, "register_session", wraps=gateway_client.register_session
-        ) as mock_reg:
+        The orchestrator's failsafe push is on the privileged side of the
+        trust boundary — same secret used by ``/api/v1/sessions/create``.
+        It should NOT register a temp session and should NOT pass a
+        per-session bearer token (#2051).
+        """
+        with (
+            patch.object(
+                gateway_client, "register_session", wraps=gateway_client.register_session
+            ) as mock_reg,
+            patch.object(gateway_client, "delete_session") as mock_delete,
+            patch.object(
+                gateway_client, "_make_request", wraps=gateway_client._make_request
+            ) as mock_req,
+        ):
             gateway_client.push_worktree_branch(
                 pipeline_id="issue-42",
                 repo_path="/some/path",
                 branch="egg/issue-42",
             )
-            mock_reg.assert_called_once()
-            call_kwargs = mock_reg.call_args
-            registered_branch = call_kwargs.kwargs["branch"]
-            assert registered_branch == "egg/issue-42"
+            mock_reg.assert_not_called()
+            mock_delete.assert_not_called()
+            push_calls = [c for c in mock_req.call_args_list if c.args[0] == "/api/v1/git/push"]
+            assert len(push_calls) == 1
+            assert push_calls[0].kwargs.get("use_launcher_auth") is True
+            assert push_calls[0].kwargs.get("bearer_token") is None
 
     def test_push_worktree_branch_uses_head_refspec(self, gateway_client, mock_gateway_server):
         """Test that push uses HEAD:refs/heads/<branch> refspec format.
@@ -1014,6 +1015,9 @@ class TestPushWorktreeBranch:
             assert len(push_calls) == 1
             push_data = push_calls[0].kwargs["data"]
             assert push_data["refspec"] == "HEAD:refs/heads/egg/issue-42"
+            # Mode is forwarded so the gateway can apply private-repo policy
+            # without a session record to read it from.
+            assert push_data.get("mode") == "public"
 
     def test_push_worktree_branch_classifies_gateway_push_rejection(self, gateway_client):
         """When the gateway push endpoint returns 500 with git stderr in
@@ -1275,14 +1279,18 @@ class TestSelfIpResolution:
         assert client.self_ip == "127.0.0.1"
 
     def test_temp_sessions_use_self_ip(self, gateway_client, mock_gateway_server):
-        """Test that temporary sessions register with self_ip, not 127.0.0.1."""
+        """Test that temporary sessions register with self_ip, not 127.0.0.1.
+
+        ``push_worktree_branch`` no longer registers a session (#2051 — it
+        uses launcher auth directly), so this exercises a temp-session
+        path that still does: ``fetch_worktree_branch``.
+        """
         with patch.object(
             gateway_client, "register_session", wraps=gateway_client.register_session
         ) as mock_reg:
-            gateway_client.push_worktree_branch(
+            gateway_client.fetch_worktree_branch(
                 pipeline_id="issue-42",
                 repo_path="/some/path",
-                branch="egg/issue-42",
             )
             mock_reg.assert_called_once()
             call_kwargs = mock_reg.call_args


### PR DESCRIPTION
## Summary

- #2028 dropped the `and concurrent_mode` guard on the gateway's pipeline-push enforcement, so the block now fires for **any** session with a `pipeline_id` that doesn't pass `consensus_push: true`. The orchestrator's failsafe push (`gateway_client._do_push`) was registering a temp session with `pipeline_id` and pushing without the marker — the gateway returned 403, the reconcile path then ran `git fetch origin <branch>` on a never-pushed branch and surfaced the misleading `reconcile_fetch_failed: couldn't find remote ref`. Every fresh `submit_task` blocked at contract init.
- The orchestrator and sandboxed agents have different trust boundaries: the orchestrator already authenticates with the launcher secret (`/secrets/launcher-secret`) on `/api/v1/sessions/create` and other privileged endpoints. This change carries that split into the push handler — orchestrator pushes are launcher-authed and skip the agent-targeted enforcement; agent pushes still go through the BRC routing #2028 set up.
- Cleanup: drops the register-session/push/delete ceremony from `_do_push`, which also stops the per-push `session_ip_audit registered_ip != actual_ip` warnings the gateway logged for every orchestrator failsafe push.

## Implementation

- `gateway/gateway.py` — new `require_session_or_launcher_auth` decorator. Launcher-auth matches set `g.session = None` and `g.auth_actor = \"launcher\"`; unmatched bearers fall through to `require_session_auth`. Applied to `/api/v1/git/push`. When launcher-authed, session-derived enforcement is naturally skipped (those branches were already gated on `g.session` being truthy). Audited as `push_orchestrator_authenticated`. `mode` is read from the request body so the private-repo policy still applies.
- `orchestrator/gateway_client.py::_do_push` — push directly with `use_launcher_auth=True`. No more temp session.

## Out of scope

`delete_remote_branch` has the same architectural problem (session-auth push of `:branch` with `pipeline_id` set, would now 403) but catches exceptions and returns `False`, so it silently fails today rather than blocking pipelines. Tracking separately rather than bundling — same fix shape, but a different code path and different operational impact.

## Test plan

- [x] `pytest gateway/tests/test_pipeline_push_block.py` — 18 pass (12 existing + 6 new launcher-auth cases)
- [x] `pytest orchestrator/tests/test_gateway_client.py orchestrator/tests/test_reconcile_and_push_pr_branch.py orchestrator/tests/test_pipeline_failure_path.py` — 115 pass
- [x] `pytest gateway/tests/test_assigned_branch.py gateway/tests/test_filtered_push_blocked_modify.py gateway/tests/test_push_author_attribution.py` — 44 pass
- [x] `ruff check` clean on changed files
- [ ] After merge: verify a fresh `submit_task` for an issue with no pre-existing `egg/<id>` branch advances past contract init.
- [ ] After merge: verify gateway audit log shows `push_orchestrator_authenticated` for the contract-init push and no `push_denied_pipeline_session` for orchestrator-originated pushes.

Closes #2051.

🤖 Generated with [Claude Code](https://claude.com/claude-code)