### PR TITLE
Fix #2053: evict per-pipeline runtime state on cancel/delete/create

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -1473,6 +1473,14 @@ def create_pipeline() -> tuple[Response, int]:
         # Contract creation is deferred to _run_pipeline so it writes
         # into the per-pipeline worktree instead of the main repo.
 
+        # When state_store replaces a terminal pipeline with the same id
+        # (state_store.create_pipeline:850), the in-memory consensus
+        # tracker / message-store entries for the prior run survive. Same
+        # for Redis-backed message-store entries across orchestrator
+        # restarts. Clear here so the new run starts with empty consensus
+        # state regardless of how the prior run ended (#2053).
+        _clear_pipeline_runtime_state(pipeline.id, reason="pipeline_create")
+
         logger.info(
             "Pipeline created",
             pipeline_id=pipeline.id,
@@ -1518,6 +1526,78 @@ def create_pipeline() -> tuple[Response, int]:
         return make_error_response(
             f"Failed to create pipeline: {msg[:500]}",
             status_code=500,
+        )
+
+
+def _clear_pipeline_runtime_state(pipeline_id: str, *, reason: str) -> None:
+    """Evict per-pipeline runtime state that is keyed by pipeline_id alone.
+
+    The peer-consensus tracker, the legacy consensus evaluator, and the
+    inter-agent message store are all keyed by pipeline_id. Without a
+    matching ``run_epoch`` namespace, a fresh pipeline that reuses an id
+    from a prior terminal run (same branch, e.g. ``issue-1965``) will
+    inherit the prior run's CONFIRMED consensus and message history. The
+    leak surfaces in ``wait_for_status_change``'s Path-B envelope, which
+    would report ``concurrent.consensus.is_complete: true`` for a
+    pipeline that has not spawned any agents yet (#2053).
+
+    Called when a pipeline transitions to a terminal status, when its
+    state file is deleted, and immediately after a fresh pipeline is
+    created (covers paths that bypass PATCH/DELETE — auto-FAILED, and
+    Redis-backed message-store entries that survived an orchestrator
+    restart between cancel and resubmit).
+    """
+    try:
+        try:
+            from peer_consensus import remove_peer_consensus_tracker
+        except ImportError:
+            from ..peer_consensus import (  # type: ignore[no-redef]
+                remove_peer_consensus_tracker,
+            )
+        remove_peer_consensus_tracker(pipeline_id)
+    except ImportError:
+        pass
+    except Exception as e:
+        logger.warning(
+            "Failed to clear peer consensus tracker",
+            pipeline_id=pipeline_id,
+            reason=reason,
+            error=str(e),
+        )
+
+    try:
+        try:
+            from consensus import get_consensus_evaluator
+        except ImportError:
+            from ..consensus import get_consensus_evaluator  # type: ignore[no-redef]
+        get_consensus_evaluator().clear(pipeline_id)
+    except ImportError:
+        pass
+    except Exception as e:
+        logger.warning(
+            "Failed to clear legacy consensus state",
+            pipeline_id=pipeline_id,
+            reason=reason,
+            error=str(e),
+        )
+
+    # Reconstruct-from-messages would otherwise replay the prior run's
+    # CONSENSUS_* messages and rebuild a CONFIRMED tracker, defeating the
+    # tracker eviction above.
+    try:
+        try:
+            from message_store import get_message_store
+        except ImportError:
+            from ..message_store import get_message_store  # type: ignore[no-redef]
+        get_message_store().clear(pipeline_id)
+    except ImportError:
+        pass
+    except Exception as e:
+        logger.warning(
+            "Failed to clear message store",
+            pipeline_id=pipeline_id,
+            reason=reason,
+            error=str(e),
         )
 
 
@@ -1687,6 +1767,12 @@ def update_pipeline(pipeline_id: str) -> tuple[Response, int]:
             )
             cleanup_thread.start()
 
+            # Evict per-pipeline runtime state (consensus tracker, legacy
+            # consensus evaluator, message store) so a future pipeline
+            # that reuses this id (same branch) does not inherit this
+            # run's CONFIRMED consensus or message history (#2053).
+            _clear_pipeline_runtime_state(pipeline_id, reason=f"pipeline_{pipeline.status.value}")
+
         logger.info("Pipeline updated", pipeline_id=pipeline_id)
 
         response_data = {"pipeline": pipeline.model_dump(mode="json")}
@@ -1832,17 +1918,10 @@ def delete_pipeline(pipeline_id: str) -> tuple[Response, int]:
                 error=str(e),
             )
 
-        # Clean up Redis message store keys (stream + counters)
-        try:
-            from message_store import get_message_store
-
-            get_message_store().clear(pipeline_id)
-        except Exception as e:
-            logger.warning(
-                "Failed to clear message store for deleted pipeline",
-                pipeline_id=pipeline_id,
-                error=str(e),
-            )
+        # Clean up the message store stream/counters AND the in-memory
+        # consensus tracker / legacy evaluator so a fresh pipeline that
+        # later reuses this id starts with empty consensus state (#2053).
+        _clear_pipeline_runtime_state(pipeline_id, reason="pipeline_delete")
 
         store.delete_pipeline(pipeline_id)
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -1479,6 +1479,15 @@ def create_pipeline() -> tuple[Response, int]:
         # for Redis-backed message-store entries across orchestrator
         # restarts. Clear here so the new run starts with empty consensus
         # state regardless of how the prior run ended (#2053).
+        #
+        # This is the *primary* eviction site for auto-FAILED prior runs,
+        # not just a defensive backstop: paths like restart_agent spawn
+        # failure and _fail_pipeline_for_pr_creation_failure call
+        # store.update_pipeline / store.save_pipeline directly (bypassing
+        # PATCH), so the PATCH-site clear never fires for them. Without
+        # this POST-site clear, those auto-FAILED pipelines would leak
+        # consensus + message-store state into the next run that reuses
+        # the id.
         _clear_pipeline_runtime_state(pipeline.id, reason="pipeline_create")
 
         logger.info(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -1482,7 +1482,7 @@ def create_pipeline() -> tuple[Response, int]:
         #
         # This is the *primary* eviction site for auto-FAILED prior runs,
         # not just a defensive backstop: paths like restart_agent spawn
-        # failure and _fail_pipeline_for_pr_creation_failure call
+        # failure and _handle_pr_creation_failure call
         # store.update_pipeline / store.save_pipeline directly (bypassing
         # PATCH), so the PATCH-site clear never fires for them. Without
         # this POST-site clear, those auto-FAILED pipelines would leak

--- a/orchestrator/tests/test_pipelines_api.py
+++ b/orchestrator/tests/test_pipelines_api.py
@@ -843,3 +843,176 @@ class TestPipelineIdValidation:
 
         with pytest.raises(InvalidPipelineIdError):
             _validate_pipeline_id("not-a-valid-id")
+
+
+class TestRuntimeStateLeakageOnBranchReuse:
+    """Regression tests for #2053.
+
+    A new pipeline that reuses an id from a prior terminal run (same
+    branch, e.g. ``issue-1965``) must not inherit the prior run's
+    consensus tracker, legacy consensus state, or message-store
+    history. Without isolation, ``wait_for_status_change`` reports
+    ``concurrent.consensus.is_complete: true`` for a pipeline that has
+    not spawned any agents.
+    """
+
+    @patch("routes.pipelines.get_decision_queue")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_cancel_clears_runtime_state(
+        self, mock_repo, mock_resolve, mock_spawner_fn, mock_dq_fn, client
+    ):
+        """PATCH to cancelled status evicts consensus + message-store state."""
+        mock_repo.return_value = "/repo"
+        pipeline = _make_cancellable_pipeline("issue-1965")
+
+        mock_store = MagicMock()
+        mock_store.update_pipeline.return_value = pipeline
+        mock_store.load_pipeline.return_value = pipeline
+        pipeline.status = PipelineStatus.CANCELLED
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        mock_spawner.cleanup_pipeline.return_value = 0
+        mock_spawner_fn.return_value = mock_spawner
+
+        mock_dq = MagicMock()
+        mock_dq.get_pending_decisions.return_value = []
+        mock_dq_fn.return_value = mock_dq
+
+        with patch("routes.pipelines._clear_pipeline_runtime_state") as mock_clear:
+            response = client.patch(
+                "/api/v1/pipelines/issue-1965",
+                json={"status": "cancelled"},
+            )
+            assert response.status_code == 200
+            mock_clear.assert_called_once()
+            assert mock_clear.call_args.args[0] == "issue-1965"
+            assert "cancelled" in mock_clear.call_args.kwargs["reason"]
+
+    @patch("routes.pipelines.get_gateway_client")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    def test_delete_clears_runtime_state(self, mock_resolve, mock_spawner_fn, mock_gw_fn, client):
+        """DELETE evicts consensus + message-store state alongside the JSON file."""
+        pipeline = _make_pipeline_with_containers("issue-1965")
+
+        mock_store = MagicMock()
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        mock_spawner.cleanup_pipeline.return_value = 0
+        mock_spawner_fn.return_value = mock_spawner
+
+        mock_gw = MagicMock()
+        mock_gw.delete_remote_branch.return_value = True
+        mock_gw_fn.return_value = mock_gw
+
+        with patch("routes.pipelines._clear_pipeline_runtime_state") as mock_clear:
+            response = client.delete("/api/v1/pipelines/issue-1965")
+            assert response.status_code == 200
+            mock_clear.assert_called_once()
+            assert mock_clear.call_args.args[0] == "issue-1965"
+
+    @patch("routes.pipelines.get_gateway_client")
+    @patch("routes.pipelines.get_state_store")
+    @patch("routes.pipelines.get_repo_path")
+    def test_create_clears_runtime_state(
+        self, mock_repo_path, mock_get_store, mock_gw_client, client
+    ):
+        """POST evicts any lingering state for the created pipeline id.
+
+        Defends against paths that bypass PATCH/DELETE — auto-FAILED
+        pipelines, and Redis-backed message-store entries that survived
+        an orchestrator restart between cancel and resubmit.
+        """
+        mock_repo_path.return_value = Path("/home/egg/repos/webapp")
+        mock_store = MagicMock()
+        mock_pipeline = MagicMock()
+        mock_pipeline.id = "issue-1965"
+        mock_pipeline.model_dump.return_value = {"id": "issue-1965"}
+        mock_store.create_pipeline.return_value = mock_pipeline
+        mock_get_store.return_value = mock_store
+        mock_gw = MagicMock()
+        mock_gw.ls_remote_branch.return_value = False
+        mock_gw_client.return_value = mock_gw
+
+        with patch("routes.pipelines._clear_pipeline_runtime_state") as mock_clear:
+            response = client.post(
+                "/api/v1/pipelines",
+                json={
+                    "issue_number": 1965,
+                    "repo": "Khan/webapp",
+                    "branch": "egg/issue-1965",
+                },
+            )
+            assert response.status_code == 200
+            mock_clear.assert_called_once()
+            assert mock_clear.call_args.args[0] == "issue-1965"
+            assert mock_clear.call_args.kwargs["reason"] == "pipeline_create"
+
+    def test_clear_runtime_state_evicts_real_consensus_and_messages(self):
+        """End-to-end: helper actually clears tracker, evaluator, and messages.
+
+        Seeds a real ``PeerConsensusTracker``, the legacy consensus
+        evaluator, and the message store under the same pipeline id,
+        then invokes ``_clear_pipeline_runtime_state`` and asserts every
+        backend lookup returns empty/None — matching what a fresh
+        pipeline with the same id would observe.
+        """
+        from consensus import ReadinessState, get_consensus_evaluator
+        from message_store import Message, get_message_store
+        from peer_consensus import (
+            create_peer_consensus_tracker,
+            get_peer_consensus_tracker,
+            remove_peer_consensus_tracker,
+        )
+        from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph
+        from routes.pipelines import _clear_pipeline_runtime_state
+
+        pipeline_id = "issue-1965-test"
+        # Defensive: clear any leftover state from a prior test run
+        remove_peer_consensus_tracker(pipeline_id)
+        get_consensus_evaluator().clear(pipeline_id)
+        get_message_store().clear(pipeline_id)
+
+        # Seed peer-consensus tracker (BRC). Presence of the tracker in
+        # the global ``_trackers`` map is the symptom; what's inside it
+        # doesn't matter for the leak.
+        graph = ReviewGraph(
+            edges=[
+                ReviewEdge(
+                    reviewer_role="reviewer_refine",
+                    producer_role="refiner",
+                    criticality=ReviewCriticality.CRITICAL,
+                )
+            ]
+        )
+        tracker = create_peer_consensus_tracker(pipeline_id, graph)
+        assert get_peer_consensus_tracker(pipeline_id) is tracker
+
+        # Seed legacy consensus evaluator
+        evaluator = get_consensus_evaluator()
+        evaluator.register_agent(pipeline_id, "refiner")
+        evaluator.update_readiness(pipeline_id, "refiner", ReadinessState.READY)
+        assert evaluator.get_state(pipeline_id)["agents"]
+
+        # Seed message store
+        store = get_message_store()
+        store.add_message(
+            Message(
+                pipeline_id=pipeline_id,
+                from_role="refiner",
+                to_role="all",
+                message_type="PROGRESS",
+                body="seed",
+            )
+        )
+        assert store.get_status(pipeline_id)["total"] == 1
+
+        _clear_pipeline_runtime_state(pipeline_id, reason="test")
+
+        assert get_peer_consensus_tracker(pipeline_id) is None
+        assert evaluator.get_state(pipeline_id)["agents"] == {}
+        assert store.get_status(pipeline_id)["total"] == 0

--- a/orchestrator/tests/test_pipelines_api.py
+++ b/orchestrator/tests/test_pipelines_api.py
@@ -952,6 +952,99 @@ class TestRuntimeStateLeakageOnBranchReuse:
             assert mock_clear.call_args.args[0] == "issue-1965"
             assert mock_clear.call_args.kwargs["reason"] == "pipeline_create"
 
+    @patch("routes.pipelines.get_gateway_client")
+    @patch("routes.pipelines.get_state_store")
+    @patch("routes.pipelines.get_repo_path")
+    def test_post_clears_real_state_left_by_prior_failed_run(
+        self, mock_repo_path, mock_get_store, mock_gw_client, client
+    ):
+        """POST evicts real Redis/in-memory state from a prior auto-FAILED run.
+
+        This is the integration variant of ``test_create_clears_runtime_state``
+        that exercises the explicit motivation for the POST-site clear:
+        auto-FAILED paths (restart_agent spawn failure,
+        _fail_pipeline_for_pr_creation_failure) write status=FAILED
+        directly via ``store.update_pipeline`` / ``store.save_pipeline``,
+        bypassing PATCH and therefore bypassing the PATCH-site clear. The
+        POST clear is the only safety net for those paths. Seeds real
+        backend state (no mocked ``_clear_pipeline_runtime_state``), POSTs
+        a fresh pipeline with the same id, and asserts every backend is
+        empty afterwards.
+        """
+        from consensus import ReadinessState, get_consensus_evaluator
+        from message_store import Message, get_message_store
+        from peer_consensus import (
+            create_peer_consensus_tracker,
+            get_peer_consensus_tracker,
+            remove_peer_consensus_tracker,
+        )
+        from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph
+
+        pipeline_id = "issue-1965"
+
+        # Defensive: clear any leftover state from a prior test run
+        remove_peer_consensus_tracker(pipeline_id)
+        get_consensus_evaluator().clear(pipeline_id)
+        get_message_store().clear(pipeline_id)
+
+        # Seed state as if a prior run had reached CONFIRMED and then
+        # been auto-FAILED via store.update_pipeline (bypassing PATCH).
+        graph = ReviewGraph(
+            edges=[
+                ReviewEdge(
+                    reviewer_role="reviewer_refine",
+                    producer_role="refiner",
+                    criticality=ReviewCriticality.CRITICAL,
+                )
+            ]
+        )
+        create_peer_consensus_tracker(pipeline_id, graph)
+        evaluator = get_consensus_evaluator()
+        evaluator.register_agent(pipeline_id, "refiner")
+        evaluator.update_readiness(pipeline_id, "refiner", ReadinessState.READY)
+        msg_store = get_message_store()
+        msg_store.add_message(
+            Message(
+                pipeline_id=pipeline_id,
+                from_role="refiner",
+                to_role="all",
+                message_type="PROGRESS",
+                body="prior-run-leak",
+            )
+        )
+
+        # Sanity: prior-run state is present
+        assert get_peer_consensus_tracker(pipeline_id) is not None
+        assert evaluator.get_state(pipeline_id)["agents"]
+        assert msg_store.get_status(pipeline_id)["total"] == 1
+
+        mock_repo_path.return_value = Path("/home/egg/repos/webapp")
+        mock_store = MagicMock()
+        mock_pipeline = MagicMock()
+        mock_pipeline.id = pipeline_id
+        mock_pipeline.model_dump.return_value = {"id": pipeline_id}
+        mock_store.create_pipeline.return_value = mock_pipeline
+        mock_get_store.return_value = mock_store
+        mock_gw = MagicMock()
+        mock_gw.ls_remote_branch.return_value = False
+        mock_gw_client.return_value = mock_gw
+
+        # No patch of _clear_pipeline_runtime_state — exercise the real helper
+        response = client.post(
+            "/api/v1/pipelines",
+            json={
+                "issue_number": 1965,
+                "repo": "Khan/webapp",
+                "branch": "egg/issue-1965",
+            },
+        )
+        assert response.status_code == 200
+
+        # All three backends must be evicted by the POST-site clear
+        assert get_peer_consensus_tracker(pipeline_id) is None
+        assert evaluator.get_state(pipeline_id)["agents"] == {}
+        assert msg_store.get_status(pipeline_id)["total"] == 0
+
     def test_clear_runtime_state_evicts_real_consensus_and_messages(self):
         """End-to-end: helper actually clears tracker, evaluator, and messages.
 

--- a/orchestrator/tests/test_pipelines_api.py
+++ b/orchestrator/tests/test_pipelines_api.py
@@ -955,21 +955,25 @@ class TestRuntimeStateLeakageOnBranchReuse:
     @patch("routes.pipelines.get_gateway_client")
     @patch("routes.pipelines.get_state_store")
     @patch("routes.pipelines.get_repo_path")
-    def test_post_clears_real_state_left_by_prior_failed_run(
+    def test_post_clears_real_runtime_state(
         self, mock_repo_path, mock_get_store, mock_gw_client, client
     ):
-        """POST evicts real Redis/in-memory state from a prior auto-FAILED run.
+        """POST evicts real Redis/in-memory state at the route level.
 
-        This is the integration variant of ``test_create_clears_runtime_state``
-        that exercises the explicit motivation for the POST-site clear:
-        auto-FAILED paths (restart_agent spawn failure,
-        _fail_pipeline_for_pr_creation_failure) write status=FAILED
+        Integration variant of ``test_create_clears_runtime_state`` that
+        exercises the real ``_clear_pipeline_runtime_state`` helper (no
+        mock) through the route handler. Seeds the three backends
+        (``PeerConsensusTracker``, the legacy evaluator, the message
+        store), POSTs a fresh pipeline with the same id, and asserts
+        every backend is empty afterwards.
+
+        This is the route-level safety net for the POST-site clear's
+        primary motivation: auto-FAILED paths (restart_agent spawn
+        failure, _handle_pr_creation_failure) write status=FAILED
         directly via ``store.update_pipeline`` / ``store.save_pipeline``,
-        bypassing PATCH and therefore bypassing the PATCH-site clear. The
-        POST clear is the only safety net for those paths. Seeds real
-        backend state (no mocked ``_clear_pipeline_runtime_state``), POSTs
-        a fresh pipeline with the same id, and asserts every backend is
-        empty afterwards.
+        bypassing PATCH and therefore bypassing the PATCH-site clear.
+        The seeding here represents the residual state such a path would
+        leave behind, not a literal auto-FAILED prior pipeline.
         """
         from consensus import ReadinessState, get_consensus_evaluator
         from message_store import Message, get_message_store


### PR DESCRIPTION
## Summary

- Fixes #2053. The peer-consensus tracker, the legacy consensus evaluator, and the inter-agent message store are all keyed by `pipeline_id` alone. When a fresh pipeline reuses an id from a prior terminal run (same branch — e.g. resubmitting `issue-1965` after a cancel), the new pipeline inherits the prior run's CONFIRMED consensus and message history.
- Adds `_clear_pipeline_runtime_state(pipeline_id, *, reason)` and calls it from three sites: PATCH (transition to terminal), DELETE (replaces the manual message-store clear), and POST (defensive guard immediately after `store.create_pipeline()` succeeds, covering paths that bypass PATCH/DELETE — auto-FAILED pipelines and Redis-backed message-store entries that survived an orchestrator restart between cancel and resubmit).
- Clearing the message store on these boundaries also keeps `reconstruct_tracker_from_messages` honest — without it, reconstruction would replay the prior run's `CONSENSUS_*` events and rebuild a CONFIRMED tracker, defeating in-memory eviction.

## Why a composite `(pipeline_id, run_epoch)` key wasn't needed

`run_epoch` exists in `models.py` but isn't plumbed into consensus or message-store keys. Adopting a composite key would touch many call sites across `peer_consensus.py`, `consensus.py`, `routes/pipelines.py`, `routes/decisions.py`, `routes/signals.py`, `health_monitor.py`, `kubernetes_monitor.py`, `concurrent_executor.py`, `sse.py`, `unified_sse.py`, `startup_reconciliation.py`, etc. Eviction at the lifecycle boundaries (cancel/delete/create) addresses the symptom directly with much less churn and a clear regression test surface. If the ecosystem grows other consumers of cross-run identity later, a composite key can layer on top of this fix.

## Test plan

- [x] `pytest orchestrator/tests/test_pipelines_api.py::TestRuntimeStateLeakageOnBranchReuse` — 4 new tests cover the PATCH, DELETE, POST call sites plus an end-to-end test that drives a real `PeerConsensusTracker`, the legacy evaluator, and the message store and verifies the helper evicts all three.
- [x] `pytest orchestrator/tests/test_pipelines_api.py orchestrator/tests/test_cancel_async_cleanup.py` — 48 passed, no regressions in adjacent tests.
- [x] `pytest orchestrator/tests/test_consensus*.py orchestrator/tests/test_start_pipeline.py orchestrator/tests/test_peer_consensus_integration.py` — 168 passed.
- [x] `make lint` — clean.
- [ ] Manual repro of the original symptom (cancel `issue-N` after CONFIRMED → resubmit → poll `wait_for_status_change` → expect empty consensus block).

## Notes for reviewers

- The new helper is module-private and best-effort: each backend clear is wrapped so a failure in one (e.g. message-store unavailable) doesn't block the others.
- I considered also clearing inside `state_store.create_pipeline()` when it replaces a terminal pipeline (line 850), but coupling the data layer to the consensus / message-store modules felt wrong — the route layer is the right place to wire lifecycle hooks.
- Pre-existing failures in `tests/llm/claude/test_runner.py` (3 tests, `RuntimeError: There is no current event loop in thread 'MainThread'` under Python 3.14) are unrelated to this change. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)