### PR TITLE
Fix #2065: decouple test/test-all from venv prerequisite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ PYTHON := $(if $(wildcard $(VENV_BIN)/python),$(VENV_BIN)/python,python3)
 EGG_IMAGE_TAG := $(shell git describe --always --dirty 2>/dev/null || echo latest)
 
 .PHONY: help \
-        setup deps venv install-linters check-linters \
+        setup deps venv sync-venv-if-uv install-linters check-linters \
         lint lint-python lint-shell lint-yaml lint-docker lint-actions lint-custom \
         test test-all test-record-good security \
         test-integration test-e2e test-security smoketest-long-poll \
@@ -114,6 +114,14 @@ venv:
 	fi
 	@echo "==> Syncing venv..."
 	@uv sync --extra dev
+
+# Sync the venv if uv is on PATH; no-op otherwise.
+# The sandbox container pre-installs pytest/ruff/mypy globally (see
+# sandbox/Dockerfile) and does not ship uv, so test targets that depend
+# on this stay green there. Dev machines and CI both have uv and get
+# the same `uv sync` behavior as the strict `venv` target. Issue #2065.
+sync-venv-if-uv:
+	@if command -v uv >/dev/null 2>&1; then $(MAKE) venv; fi
 
 # Install all linting tools
 install-linters: venv
@@ -272,7 +280,7 @@ lint-custom:
 ## one place.  LKG sidecar is NEVER updated by `make test` (Q12);
 ## only `make test-all` records LKG on green.
 test: export PYTHONPATH := shared:gateway:orchestrator
-test: venv
+test: sync-venv-if-uv
 	@echo "==> Running narrowed unit tests (changeset-aware; see docs/guides/testing.md)..."
 	@selected_file=$$(mktemp); \
 	PYTEST_ARGS_RAW="$(PYTEST_ARGS)" \
@@ -322,7 +330,7 @@ test: venv
 ## unchanged (decision-d2).  Local developers can run it any time
 ## to refresh their LKG without remembering the script invocation.
 test-all: export PYTHONPATH := shared:gateway:orchestrator
-test-all: venv  ## Run the full unit-test suite + record LKG on green
+test-all: sync-venv-if-uv  ## Run the full unit-test suite + record LKG on green
 	@echo "==> Running full unit-test suite (issue #1973: this updates LKG on green)..."
 	@$(PYTEST) tests/ gateway/tests/ orchestrator/tests/ shared/tests/ -v -m "not functional" $(PYTEST_ARGS); \
 	pytest_rc=$$?; \


### PR DESCRIPTION
## Summary

- The sandbox container pre-installs pytest/ruff/mypy globally (`sandbox/Dockerfile` lines 156-178) but does not ship `uv`. The Makefile comment at lines 12-13 already documents this design (\"CI uses venv (via uv sync); the sandbox has tools installed globally\"), but `test:` and `test-all:` were declared with `venv` as a hard prerequisite — and `venv:` exits with `ERROR: uv is not installed.` when uv is missing.
- Result: the BRC tester inside the sandbox could never invoke `make test`, fell back to ad-hoc `pytest` invocations that missed half of `pyproject.toml`'s `testpaths`, and several failing tests slipped through to CI on PR #2061 (see [run 24937921821](https://github.com/jwbron/egg/actions/runs/24937921821/job/73026597273)).
- Add a `sync-venv-if-uv` target that delegates to `venv` only when `uv` is on PATH; depend on it from `test:` and `test-all:`. Dev machines and CI continue to run `uv sync --extra dev` exactly as before; the sandbox now uses the existing PYTEST/PYTHON system-PATH fallbacks the Makefile already wires up.

Closes #2065.

## Test plan

- [x] `make test` and `make test-all` still trigger `uv sync` on a host with uv installed.
- [x] `env -i PATH=/bin:/usr/bin make sync-venv-if-uv` is a clean no-op when uv is absent.
- [ ] Confirm in-sandbox `make test` runs the full changeset-aware selection on the next BRC run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)