### PR TITLE
Fix #2080: brc_confirm returns ok=False on pending_acks rejection

### DIFF
--- a/sandbox/agent-config/rules/orchestrator.md
+++ b/sandbox/agent-config/rules/orchestrator.md
@@ -41,7 +41,7 @@ BRC consensus + heartbeats:
 - `mcp__brc__propose` — Prefer this over `egg-orch consensus propose`. Producer broadcasts a proposal.
 - `mcp__brc__ack` — Prefer this over `egg-orch consensus ack`. Reviewer ACKs a proposal.
 - `mcp__brc__nack` — Prefer this over `egg-orch consensus nack`. Reviewer NACKs with a blocker reason.
-- `mcp__brc__confirm` — Prefer this over `egg-orch consensus confirmed`. Producer confirms after all reviewers ACK.
+- `mcp__brc__confirm` — Prefer this over `egg-orch consensus confirmed`. Producer confirms after all reviewers ACK. Returns `ok: True` only when the producer transitioned to CONFIRMED; on `ok: False` (status `pending_acks`) the transition was rejected — read `message` for the reason (e.g. `producer_not_fully_acked`, `global_zero_proposal`, `stale_acks`) and take corrective action before retrying.
 - `mcp__brc__wait_for_event` — Prefer this over `egg-orch message wait`. Block on typed BRC messages.
 - `mcp__brc__wait_loop` — Prefer this over `egg-orch message wait-loop`. Loop wait_for_event with retry on transient errors.
 - `mcp__brc__send_heartbeat` — Prefer this over `egg-orch message heartbeat`. Emit a structured HEARTBEAT to the dedicated `/heartbeat` endpoint.

--- a/sandbox/egg_agent_tools/handlers/brc.py
+++ b/sandbox/egg_agent_tools/handlers/brc.py
@@ -227,6 +227,12 @@ def brc_confirm(req: dict[str, Any]) -> dict[str, Any]:
         pipeline_id, role: overrides.
 
     Response carries:
+        ok: True only when the producer transitioned to CONFIRMED.
+            False for "pending_acks" — the orchestrator received the
+            request but rejected the transition (e.g.
+            ``producer_not_fully_acked``, ``global_zero_proposal``,
+            ``stale_acks``). Inspect ``status`` and ``message`` to pick
+            corrective action.
         status: "confirmed"|"pending_acks"
         consensus_reached: bool (only for status=="confirmed")
     """
@@ -243,7 +249,7 @@ def brc_confirm(req: dict[str, Any]) -> dict[str, Any]:
     body = result.get("data", {})
     pending = body.get("status") == "pending_acks"
     return {
-        "ok": True,
+        "ok": not pending,
         "role": role,
         "status": "pending_acks" if pending else "confirmed",
         "consensus_reached": bool(body.get("consensus_reached", False)),

--- a/tests/sandbox/egg_agent_tools/test_cli_parity.py
+++ b/tests/sandbox/egg_agent_tools/test_cli_parity.py
@@ -324,7 +324,7 @@ class TestCmdConsensusConfirmedParity:
         pre-refactor CLI so scripts can distinguish 'waiting' from
         'confirmed')."""
         fake = {
-            "ok": True,
+            "ok": False,
             "status": "pending_acks",
             "consensus_reached": False,
             "role": "coder",

--- a/tests/sandbox/egg_agent_tools/test_handlers_brc.py
+++ b/tests/sandbox/egg_agent_tools/test_handlers_brc.py
@@ -199,6 +199,7 @@ class TestBrcConfirm:
             },
         ):
             resp = brc.brc_confirm({"pipeline_id": "p", "role": "coder"})
+        assert resp["ok"] is True
         assert resp["status"] == "confirmed"
         assert resp["consensus_reached"] is True
 
@@ -211,6 +212,7 @@ class TestBrcConfirm:
             },
         ):
             resp = brc.brc_confirm({"pipeline_id": "p", "role": "coder"})
+        assert resp["ok"] is False
         assert resp["status"] == "pending_acks"
         assert resp["consensus_reached"] is False
 


### PR DESCRIPTION
## Summary

- `mcp__brc__confirm` now sets `ok: False` when the orchestrator rejects the confirm (`status == "pending_acks"`); `ok: True` is reserved for the producer actually transitioning to CONFIRMED.
- Structured response (`status`, `message`, `consensus_reached`, `signal`) is unchanged, so callers can still branch on the rejection reason without exception handling — `pending_acks` is a normal protocol state, not a hard failure.
- Agent rule and handler docstring updated so the new semantics are reflected in instructions, not just code.

## Why

Per #2080: returning `{ok: True, status: "pending_acks"}` made a glance-level read of the response look like success even when the producer's state did not change. On pipeline `issue-1965` (#2064) the documenter agent followed exactly that mis-read into a 36-minute `wait_loop` deadlock. `ok` should mean "did this operation achieve its intent" — the producer didn't transition, so it didn't.

## Why not raise `GatewayError`

`pending_acks` is a legitimate protocol state with actionable reasons (`producer_not_fully_acked`, `global_zero_proposal`, `stale_acks`, etc.). Forcing exception handling for an expected branch would be noisy and unlike the rest of the BRC tool surface that returns structured data. Sibling handlers (`brc_propose`, `brc_ack`, `brc_nack`) raise on `success: False` because they have no in-between state — `brc_confirm` is the only verb with a "deferred" outcome.

## Caller impact

- The only Python caller, `cmd_consensus_confirmed` (`sandbox/egg_lib/orch_cli.py:1681-1708`), branches on `status`, not `ok`. Exit-code parity (0 confirmed / 2 pending / 1 error) is unchanged.
- No agent prompt currently keys on `ok` from this handler. The agent rule update (`sandbox/agent-config/rules/orchestrator.md`) preempts future mis-reads.

## Test plan

- [x] `pytest tests/sandbox/egg_agent_tools/` — 357 pass, 4 skipped
- [x] `make lint-python` — clean
- [x] Updated `test_handlers_brc.py::test_happy_confirmed` and `test_pending_acks` to assert the new `ok` semantics
- [x] Updated `test_cli_parity.py` mock for `pending_acks` to reflect the new contract (`ok: False`)

## Out of scope

- #2078 (upstream "ready to confirm" nudge bug) and #2079 (`check_brc_progress` escalation gap) — independent. This fix is worth doing regardless, since it affects every `pending_acks` path, not just the documenter case.

Refs: #2064, #2078, #2079, PR #2077.

🤖 Generated with [Claude Code](https://claude.com/claude-code)