### PR TITLE
Fix #2079: wake stuck producers via brc_confirmation_timeout escalation

### DIFF
--- a/orchestrator/health_monitor.py
+++ b/orchestrator/health_monitor.py
@@ -160,6 +160,11 @@ class HealthMonitor:
         with self._lock:
             self._current_phase = phase
 
+    def get_current_phase(self) -> str | None:
+        """Return the phase last set via :meth:`set_current_phase`."""
+        with self._lock:
+            return self._current_phase
+
     def _get_heartbeat_threshold(self) -> int:
         """Return the heartbeat timeout threshold for the current phase.
 
@@ -768,6 +773,19 @@ class HealthMonitor:
                 if agent_state:
                     agent_state.brc_progress_escalated = False
 
+            # Per-iteration breadcrumb so post-mortems can verify the check
+            # ran and what it observed (#2079).
+            if fully_acked:
+                logger.info(
+                    "BRC progress check observed fully-acked producers",
+                    pipeline_id=self._pipeline_id,
+                    producers={
+                        p: round(now - self._fully_acked_first_seen.get(p, now), 1)
+                        for p in fully_acked
+                    },
+                    timeout_seconds=timeout,
+                )
+
             # Timeout is measured from when the monitor first observed the
             # fully-acked state (_fully_acked_first_seen), not from the
             # original proposal timestamp, because the monitor may start
@@ -783,9 +801,20 @@ class HealthMonitor:
                 if elapsed <= timeout:
                     continue
 
-                # Skip producers with no agent state (never emitted heartbeat/progress)
+                # Skip producers with no agent state (never emitted
+                # heartbeat/progress).  This branch is unexpected in
+                # practice — every producer in the fully-acked set has
+                # at minimum proposed, which routes through MESSAGE_SENT
+                # and registers agent_state.  Log loudly so future
+                # post-mortems can audit (#2079).
                 agent_state = self._agents.get(producer)
                 if not agent_state:
+                    logger.warning(
+                        "BRC progress timeout but producer has no agent_state",
+                        pipeline_id=self._pipeline_id,
+                        producer=producer,
+                        elapsed_seconds=int(elapsed),
+                    )
                     continue
                 if agent_state.brc_progress_escalated:
                     continue
@@ -802,11 +831,21 @@ class HealthMonitor:
                 }
                 actions.append(action)
 
+                logger.warning(
+                    "BRC progress timeout — escalating",
+                    pipeline_id=self._pipeline_id,
+                    producer=producer,
+                    elapsed_seconds=int(elapsed),
+                    timeout_seconds=timeout,
+                )
+
                 escalation_type = "overseer" if self._config.overseer_enabled else "hitl"
                 escalation = {
                     "type": escalation_type,
                     "agent_id": producer,
                     "reason": action["reason"],
+                    "alert_type": "brc_confirmation_timeout",
+                    "elapsed_seconds": int(elapsed),
                     "timestamp": datetime.now(UTC).isoformat(),
                 }
                 escalations.append(escalation)

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -520,12 +520,18 @@ def _send_brc_confirmation_nudge(
     it directly to the stuck producer rather than relying on the
     overseer agent's discretion.
 
-    Uses ``OVERSEER_ALERT`` (not ``STATUS`` or ``NUDGE``) because the
-    producer's post-confirm wait_loop filter is
-    ``CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT`` — only
-    those types wake the wait.  The subject calls out that the alert
-    originated from the orchestrator's deterministic detector rather
-    than the overseer agent.
+    Uses ``OVERSEER_ALERT`` (not ``STATUS`` or ``NUDGE``) because it is
+    the only message type that appears in **both** the producer's
+    pre-confirm wait_loop filter
+    (``CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT``)
+    and post-confirm wait_loop filter
+    (``CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT``), so it
+    wakes the producer regardless of which wait they are blocked on.
+    A wedged producer is in the ``fully_acked but not confirmed`` set,
+    which means they are most likely blocked on the pre-confirm wait.
+    The subject calls out that the alert originated from the
+    orchestrator's deterministic detector rather than the overseer
+    agent.
 
     Returns True when a message was posted, False otherwise (wrong
     alert type, missing fields, message store unavailable, send error).
@@ -537,29 +543,38 @@ def _send_brc_confirmation_nudge(
     if not producer:
         return False
 
-    elapsed = escalation.get("elapsed_seconds", 0)
+    elapsed = escalation.get("elapsed_seconds")
+    # check_brc_progress always populates elapsed_seconds; treat
+    # missing or non-positive values as a malformed escalation rather
+    # than rendering "have not confirmed in 0s" in the body.
+    if elapsed is None or elapsed <= 0:
+        return False
 
     store_fn = _get_message_store()
     if store_fn is None:
         return False
 
-    try:
-        from message_store import Message, MessageType
-    except ImportError:
-        return False
+    # _get_message_store already verified the package is importable;
+    # Message/MessageType live in the same module so a defensive
+    # try/except here would only add per-call import overhead.
+    from message_store import Message, MessageType
 
     body = (
         f"You are PROPOSED and fully ACKed but have not confirmed in "
         f"{elapsed}s. Call `mcp__brc__confirm` now. If it returns "
-        "status='pending_acks' (e.g., another producer hasn't proposed "
-        "yet, or the global zero-proposal guard is blocking you), wait "
-        "on the prerequisite events instead — CONSENSUS_PROPOSE from "
+        "status='pending_acks', the response's ``blocking`` field lists "
+        "the prerequisite events to wait on (CONSENSUS_PROPOSE from "
         "missing producers, CONSENSUS_ACK from your reviewers, or "
-        "CONSENSUS_RE_REVIEW — then retry confirm."
+        "CONSENSUS_RE_REVIEW) — wait on those instead, then retry confirm."
     )
 
     try:
         msg_store = store_fn()
+        # Bypass the POST /messages/send route on purpose: this is an
+        # orchestrator-internal nudge, and we do not want HealthMonitor's
+        # MESSAGE_SENT handler (rate-limit + HEARTBEAT tracking) to see it.
+        # Future audit/observability subscribers should be aware this path
+        # does not emit EventType.MESSAGE_SENT.
         msg_store.add_message(
             Message(
                 pipeline_id=pipeline_id,

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -562,10 +562,11 @@ def _send_brc_confirmation_nudge(
     body = (
         f"You are PROPOSED and fully ACKed but have not confirmed in "
         f"{elapsed}s. Call `mcp__brc__confirm` now. If it returns "
-        "status='pending_acks', the response's ``blocking`` field lists "
-        "the prerequisite events to wait on (CONSENSUS_PROPOSE from "
-        "missing producers, CONSENSUS_ACK from your reviewers, or "
-        "CONSENSUS_RE_REVIEW) — wait on those instead, then retry confirm."
+        "`status='pending_acks'`, read `message` for the guard reason and "
+        "wait on the prerequisite events instead: `CONSENSUS_PROPOSE` if a "
+        "producer hasn't proposed (`zero_proposal_producers`), "
+        "`CONSENSUS_ACK` / `CONSENSUS_RE_REVIEW` if a reviewer's ACK is "
+        "stale or unresolved. Then retry confirm."
     )
 
     try:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -507,6 +507,92 @@ def _check_and_respawn_overseer(
     return overseer_container_id, overseer_respawn_count
 
 
+def _send_brc_confirmation_nudge(
+    escalation: dict[str, Any],
+    pipeline_id: str,
+    phase: str | None,
+) -> bool:
+    """Wake a producer stuck post-ACK with a directed OVERSEER_ALERT (#2079).
+
+    Wired as an escalation callback for HealthMonitor's
+    ``brc_confirmation_timeout`` alert.  The deterministic detector in
+    ``check_brc_progress`` knows the exact remediation, so we deliver
+    it directly to the stuck producer rather than relying on the
+    overseer agent's discretion.
+
+    Uses ``OVERSEER_ALERT`` (not ``STATUS`` or ``NUDGE``) because the
+    producer's post-confirm wait_loop filter is
+    ``CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT`` — only
+    those types wake the wait.  The subject calls out that the alert
+    originated from the orchestrator's deterministic detector rather
+    than the overseer agent.
+
+    Returns True when a message was posted, False otherwise (wrong
+    alert type, missing fields, message store unavailable, send error).
+    """
+    if escalation.get("alert_type") != "brc_confirmation_timeout":
+        return False
+
+    producer = escalation.get("agent_id")
+    if not producer:
+        return False
+
+    elapsed = escalation.get("elapsed_seconds", 0)
+
+    store_fn = _get_message_store()
+    if store_fn is None:
+        return False
+
+    try:
+        from message_store import Message, MessageType
+    except ImportError:
+        return False
+
+    body = (
+        f"You are PROPOSED and fully ACKed but have not confirmed in "
+        f"{elapsed}s. Call `mcp__brc__confirm` now. If it returns "
+        "status='pending_acks' (e.g., another producer hasn't proposed "
+        "yet, or the global zero-proposal guard is blocking you), wait "
+        "on the prerequisite events instead — CONSENSUS_PROPOSE from "
+        "missing producers, CONSENSUS_ACK from your reviewers, or "
+        "CONSENSUS_RE_REVIEW — then retry confirm."
+    )
+
+    try:
+        msg_store = store_fn()
+        msg_store.add_message(
+            Message(
+                pipeline_id=pipeline_id,
+                from_role="orchestrator",
+                to_role=producer,
+                message_type=MessageType.OVERSEER_ALERT,
+                subject="BRC confirmation timeout — call mcp__brc__confirm",
+                body=body,
+                phase=phase,
+                metadata={
+                    "alert_type": "brc_confirmation_timeout",
+                    "elapsed_seconds": elapsed,
+                    "source": "health_monitor",
+                },
+            )
+        )
+        logger.info(
+            "Sent BRC confirmation-timeout nudge",
+            pipeline_id=pipeline_id,
+            producer=producer,
+            elapsed_seconds=elapsed,
+        )
+        return True
+    except Exception as send_err:
+        logger.warning(
+            "Failed to send BRC confirmation-timeout nudge (non-fatal)",
+            pipeline_id=pipeline_id,
+            producer=producer,
+            error=str(send_err),
+        )
+        return False
+
+
 def _teardown_phase_overseer(
     spawner: "ContainerSpawner",
     container_id: str,
@@ -11453,6 +11539,17 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
             )
             # Sync the phase-aware threshold with the current pipeline phase
             health_monitor_instance.set_current_phase(pipeline.current_phase.value)
+
+            # Wake stuck producers directly when check_brc_progress fires
+            # so the deterministic detector actually drives remediation
+            # instead of relying on the overseer agent's discretion (#2079).
+            # The closure reads the monitor's current phase at fire time so
+            # the message records the phase the producer is actually in.
+            def _on_health_escalation(escalation: dict[str, Any]) -> None:
+                phase = health_monitor_instance.get_current_phase()
+                _send_brc_confirmation_nudge(escalation, pipeline_id, phase)
+
+            health_monitor_instance.on_escalation(_on_health_escalation)
 
             # Start a background polling thread for time-based tripwires
             health_monitor_timer = threading.Event()

--- a/orchestrator/tests/test_brc_confirmation_nudge.py
+++ b/orchestrator/tests/test_brc_confirmation_nudge.py
@@ -1,0 +1,208 @@
+"""
+Tests for the BRC confirmation-timeout nudge wired into HealthMonitor escalations.
+
+Covers ``_send_brc_confirmation_nudge`` in ``orchestrator/routes/pipelines.py``,
+which wakes producers stuck post-ACK by posting a directed OVERSEER_ALERT
+when ``check_brc_progress`` fires the deterministic timeout (#2079).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+# Mock docker before importing route modules that depend on it.
+sys.modules.setdefault("docker", MagicMock())
+sys.modules.setdefault("docker.errors", MagicMock())
+sys.modules.setdefault("docker.types", MagicMock())
+
+try:
+    from message_store import Message, MessageType
+    from routes.pipelines import _send_brc_confirmation_nudge
+except ImportError as exc:
+    pytest.skip(
+        f"Required orchestrator modules not available: {exc}",
+        allow_module_level=True,
+    )
+
+
+PIPELINE_ID = "issue-2079"
+
+
+def _make_escalation(
+    *,
+    alert_type: str = "brc_confirmation_timeout",
+    agent_id: str = "documenter",
+    elapsed_seconds: int = 240,
+) -> dict:
+    """Build a HealthMonitor escalation dict matching check_brc_progress."""
+    return {
+        "type": "overseer",
+        "agent_id": agent_id,
+        "alert_type": alert_type,
+        "elapsed_seconds": elapsed_seconds,
+        "reason": (
+            f"Producer {agent_id} fully ACKed but not confirmed "
+            f"for {elapsed_seconds}s (timeout: 180s)"
+        ),
+        "timestamp": "2026-04-25T18:07:22+00:00",
+    }
+
+
+class TestSendBRCConfirmationNudge:
+    """The nudge posts a directed OVERSEER_ALERT to the stuck producer."""
+
+    def test_posts_directed_overseer_alert(self):
+        """A valid escalation results in an OVERSEER_ALERT addressed to the producer."""
+        msg_store = MagicMock()
+        store_factory = MagicMock(return_value=msg_store)
+
+        with patch(
+            "routes.pipelines._get_message_store",
+            return_value=store_factory,
+        ):
+            posted = _send_brc_confirmation_nudge(
+                _make_escalation(agent_id="documenter", elapsed_seconds=240),
+                PIPELINE_ID,
+                phase="implement",
+            )
+
+        assert posted is True
+        msg_store.add_message.assert_called_once()
+        message = msg_store.add_message.call_args[0][0]
+        assert isinstance(message, Message)
+        assert message.pipeline_id == PIPELINE_ID
+        assert message.from_role == "orchestrator"
+        assert message.to_role == "documenter"
+        # Must be OVERSEER_ALERT to wake the producer's post-confirm wait_loop,
+        # whose filter is CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT.
+        assert message.message_type == MessageType.OVERSEER_ALERT
+        assert message.phase == "implement"
+        assert "mcp__brc__confirm" in message.body
+        assert "240s" in message.body
+        assert message.metadata["alert_type"] == "brc_confirmation_timeout"
+        assert message.metadata["elapsed_seconds"] == 240
+        assert message.metadata["source"] == "health_monitor"
+
+    def test_ignores_non_brc_escalations(self):
+        """Escalations from other tripwires are ignored — no message posted."""
+        msg_store = MagicMock()
+        store_factory = MagicMock(return_value=msg_store)
+
+        with patch(
+            "routes.pipelines._get_message_store",
+            return_value=store_factory,
+        ):
+            posted = _send_brc_confirmation_nudge(
+                _make_escalation(alert_type="heartbeat_timeout"),
+                PIPELINE_ID,
+                phase="implement",
+            )
+
+        assert posted is False
+        msg_store.add_message.assert_not_called()
+
+    def test_ignores_escalation_with_no_alert_type(self):
+        """Escalations missing alert_type (legacy tripwires) are ignored."""
+        msg_store = MagicMock()
+        store_factory = MagicMock(return_value=msg_store)
+
+        escalation = _make_escalation()
+        escalation.pop("alert_type")
+
+        with patch(
+            "routes.pipelines._get_message_store",
+            return_value=store_factory,
+        ):
+            posted = _send_brc_confirmation_nudge(
+                escalation,
+                PIPELINE_ID,
+                phase="implement",
+            )
+
+        assert posted is False
+        msg_store.add_message.assert_not_called()
+
+    def test_ignores_escalation_missing_agent_id(self):
+        """Defensive: escalation without agent_id is skipped, not crashed."""
+        msg_store = MagicMock()
+        store_factory = MagicMock(return_value=msg_store)
+
+        escalation = _make_escalation()
+        escalation.pop("agent_id")
+
+        with patch(
+            "routes.pipelines._get_message_store",
+            return_value=store_factory,
+        ):
+            posted = _send_brc_confirmation_nudge(
+                escalation,
+                PIPELINE_ID,
+                phase="implement",
+            )
+
+        assert posted is False
+        msg_store.add_message.assert_not_called()
+
+    def test_returns_false_when_message_store_unavailable(self):
+        """Returns False (does not raise) when the message store factory is None."""
+        with patch(
+            "routes.pipelines._get_message_store",
+            return_value=None,
+        ):
+            posted = _send_brc_confirmation_nudge(
+                _make_escalation(),
+                PIPELINE_ID,
+                phase="implement",
+            )
+
+        assert posted is False
+
+    def test_returns_false_when_send_raises(self):
+        """A send error is logged + swallowed; nudge call itself does not raise."""
+        msg_store = MagicMock()
+        msg_store.add_message.side_effect = RuntimeError("boom")
+        store_factory = MagicMock(return_value=msg_store)
+
+        with patch(
+            "routes.pipelines._get_message_store",
+            return_value=store_factory,
+        ):
+            posted = _send_brc_confirmation_nudge(
+                _make_escalation(),
+                PIPELINE_ID,
+                phase="implement",
+            )
+
+        assert posted is False
+
+    def test_phase_none_passes_through(self):
+        """phase=None is permitted (Message.phase is Optional)."""
+        msg_store = MagicMock()
+        store_factory = MagicMock(return_value=msg_store)
+
+        with patch(
+            "routes.pipelines._get_message_store",
+            return_value=store_factory,
+        ):
+            posted = _send_brc_confirmation_nudge(
+                _make_escalation(),
+                PIPELINE_ID,
+                phase=None,
+            )
+
+        assert posted is True
+        message = msg_store.add_message.call_args[0][0]
+        assert message.phase is None

--- a/orchestrator/tests/test_brc_confirmation_nudge.py
+++ b/orchestrator/tests/test_brc_confirmation_nudge.py
@@ -86,8 +86,11 @@ class TestSendBRCConfirmationNudge:
         assert message.pipeline_id == PIPELINE_ID
         assert message.from_role == "orchestrator"
         assert message.to_role == "documenter"
-        # Must be OVERSEER_ALERT to wake the producer's post-confirm wait_loop,
-        # whose filter is CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT.
+        # Must be OVERSEER_ALERT — it is the only message type in both the
+        # producer's pre-confirm wait_loop filter (CONSENSUS_ACK,CONSENSUS_NACK,
+        # CONSENSUS_RE_REVIEW,OVERSEER_ALERT) and post-confirm filter
+        # (CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT), so it wakes
+        # the producer regardless of which wait they are blocked on.
         assert message.message_type == MessageType.OVERSEER_ALERT
         assert message.phase == "implement"
         assert "mcp__brc__confirm" in message.body
@@ -206,3 +209,188 @@ class TestSendBRCConfirmationNudge:
         assert posted is True
         message = msg_store.add_message.call_args[0][0]
         assert message.phase is None
+
+    def test_missing_elapsed_seconds_rejected(self):
+        """Escalation without elapsed_seconds is treated as malformed."""
+        msg_store = MagicMock()
+        store_factory = MagicMock(return_value=msg_store)
+
+        escalation = _make_escalation()
+        escalation.pop("elapsed_seconds")
+
+        with patch(
+            "routes.pipelines._get_message_store",
+            return_value=store_factory,
+        ):
+            posted = _send_brc_confirmation_nudge(
+                escalation,
+                PIPELINE_ID,
+                phase="implement",
+            )
+
+        assert posted is False
+        msg_store.add_message.assert_not_called()
+
+    def test_zero_or_negative_elapsed_seconds_rejected(self):
+        """elapsed_seconds <= 0 would render 'have not confirmed in 0s' — reject."""
+        msg_store = MagicMock()
+        store_factory = MagicMock(return_value=msg_store)
+
+        with patch(
+            "routes.pipelines._get_message_store",
+            return_value=store_factory,
+        ):
+            for bad_value in (0, -1):
+                posted = _send_brc_confirmation_nudge(
+                    _make_escalation(elapsed_seconds=bad_value),
+                    PIPELINE_ID,
+                    phase="implement",
+                )
+                assert posted is False, f"elapsed_seconds={bad_value} should be rejected"
+
+        msg_store.add_message.assert_not_called()
+
+
+class TestEscalationCallbackWiring:
+    """End-to-end wiring: HealthMonitor escalation -> nudge with current phase.
+
+    Mirrors the closure constructed in ``_run_pipeline``::
+
+        def _on_health_escalation(escalation):
+            phase = health_monitor_instance.get_current_phase()
+            _send_brc_confirmation_nudge(escalation, pipeline_id, phase)
+
+    The closure must read ``get_current_phase()`` at fire time, not at
+    registration time, so a phase transition between ``init_health_monitor``
+    and the first BRC escalation still records the correct phase on the
+    OVERSEER_ALERT.  A refactor that, e.g., reorders ``init_health_monitor``
+    and ``set_current_phase`` would otherwise leave ``get_current_phase()``
+    returning ``None`` for the first escalation without any test catching it.
+    """
+
+    def _make_monitor_with_brc_escalation(self):
+        """Build a HealthMonitor + tracker that will fire a brc_confirmation_timeout."""
+        from events import EventBus, EventType
+        from health_monitor import HealthMonitor
+        from models import PipelineConfig
+
+        bus = EventBus(async_delivery=False)
+        config = PipelineConfig(
+            orchestrator_post_ack_confirmation_timeout_seconds=180,
+            overseer_enabled=True,
+        )
+        monitor = HealthMonitor(
+            event_bus=bus,
+            pipeline_id=PIPELINE_ID,
+            config=config,
+        )
+
+        # Register the producer so it has an AgentState.
+        bus.emit(
+            EventType.PROGRESS_EMITTED,
+            pipeline_id=PIPELINE_ID,
+            data={"agent_id": "documenter", "type": "heartbeat"},
+        )
+
+        return monitor
+
+    def test_callback_records_current_phase_at_fire_time(self):
+        """The closure reads phase at fire time — phase changes propagate."""
+        import time as _time
+
+        monitor = self._make_monitor_with_brc_escalation()
+        # Initial phase recorded on the monitor (matches _run_pipeline ordering:
+        # init_health_monitor -> set_current_phase).
+        monitor.set_current_phase("plan")
+
+        msg_store = MagicMock()
+        store_factory = MagicMock(return_value=msg_store)
+
+        # Closure mirrors _run_pipeline's _on_health_escalation.
+        def _on_health_escalation(escalation):
+            phase = monitor.get_current_phase()
+            _send_brc_confirmation_nudge(escalation, PIPELINE_ID, phase)
+
+        monitor.on_escalation(_on_health_escalation)
+
+        # Phase advances between registration and the first BRC escalation —
+        # the closure must see the new value.
+        monitor.set_current_phase("implement")
+
+        mock_tracker = MagicMock()
+        mock_tracker.get_fully_acked_producers.return_value = {
+            "documenter": _time.time() - 200,
+        }
+
+        base = _time.time()
+        with (
+            patch(
+                "routes.pipelines._get_message_store",
+                return_value=store_factory,
+            ),
+            patch("health_monitor.time") as mock_time,
+            patch(
+                "peer_consensus.get_peer_consensus_tracker",
+                return_value=mock_tracker,
+            ),
+        ):
+            # First call records first-seen at base.
+            mock_time.time.return_value = base
+            monitor.check_brc_progress()
+            # Second call past timeout — fires escalation -> closure -> nudge.
+            mock_time.time.return_value = base + 181
+            monitor.check_brc_progress()
+
+        msg_store.add_message.assert_called_once()
+        message = msg_store.add_message.call_args[0][0]
+        assert message.phase == "implement"
+        assert message.to_role == "documenter"
+        assert message.metadata["alert_type"] == "brc_confirmation_timeout"
+
+    def test_callback_does_not_fire_on_non_brc_escalations(self):
+        """Heartbeat escalations don't carry alert_type='brc_confirmation_timeout'."""
+        import time as _time
+
+        from events import EventBus, EventType
+        from health_monitor import HealthMonitor
+        from models import PipelineConfig
+
+        bus = EventBus(async_delivery=False)
+        config = PipelineConfig(
+            orchestrator_heartbeat_timeout_seconds=60,
+            overseer_enabled=True,
+        )
+        monitor = HealthMonitor(
+            event_bus=bus,
+            pipeline_id=PIPELINE_ID,
+            config=config,
+        )
+        bus.emit(
+            EventType.PROGRESS_EMITTED,
+            pipeline_id=PIPELINE_ID,
+            data={"agent_id": "coder", "type": "heartbeat"},
+        )
+        monitor.set_current_phase("implement")
+
+        msg_store = MagicMock()
+        store_factory = MagicMock(return_value=msg_store)
+
+        def _on_health_escalation(escalation):
+            phase = monitor.get_current_phase()
+            _send_brc_confirmation_nudge(escalation, PIPELINE_ID, phase)
+
+        monitor.on_escalation(_on_health_escalation)
+
+        with (
+            patch(
+                "routes.pipelines._get_message_store",
+                return_value=store_factory,
+            ),
+            patch("health_monitor.time") as mock_time,
+        ):
+            mock_time.time.return_value = _time.time() + 61
+            monitor.check_heartbeats()
+
+        # Heartbeat escalations have no alert_type — the nudge filter
+        # rejects them, so no OVERSEER_ALERT is posted.
+        msg_store.add_message.assert_not_called()

--- a/orchestrator/tests/test_health_monitor.py
+++ b/orchestrator/tests/test_health_monitor.py
@@ -1008,6 +1008,16 @@ class TestImplementPhaseThreshold:
         assert hasattr(monitor, "set_current_phase")
         assert callable(monitor.set_current_phase)
 
+    def test_get_current_phase_round_trips(self):
+        """get_current_phase returns the value last set via set_current_phase (#2079)."""
+        bus = _make_event_bus()
+        monitor = _make_monitor(bus)
+        assert monitor.get_current_phase() is None
+        monitor.set_current_phase("implement")
+        assert monitor.get_current_phase() == "implement"
+        monitor.set_current_phase("plan")
+        assert monitor.get_current_phase() == "plan"
+
     def test_get_heartbeat_threshold_private_method(self):
         """_get_heartbeat_threshold returns correct value per phase."""
         bus = _make_event_bus()
@@ -2154,6 +2164,132 @@ class TestBRCProgressCheck:
 
         assert len(escalations) == 1
         assert escalations[0]["type"] == "hitl"
+
+    def test_escalation_includes_alert_type_and_elapsed(self):
+        """Escalation dict carries alert_type + elapsed_seconds for callbacks (#2079)."""
+        bus = _make_event_bus()
+        config = _make_config(orchestrator_post_ack_confirmation_timeout_seconds=180)
+        monitor = _make_monitor(bus, config)
+
+        escalations: list[dict] = []
+        monitor.on_escalation(lambda e: escalations.append(e))
+
+        _emit_heartbeat(bus, agent_id=PRODUCER_ID)
+
+        mock_tracker = self._make_tracker_with_fully_acked(
+            fully_acked={PRODUCER_ID: time.time()},
+        )
+
+        base = time.time()
+        with (
+            patch("health_monitor.time") as mock_time,
+            patch(
+                "peer_consensus.get_peer_consensus_tracker",
+                return_value=mock_tracker,
+            ),
+        ):
+            mock_time.time.return_value = base
+            monitor.check_brc_progress()  # records first-seen
+
+            mock_time.time.return_value = base + 181
+            monitor.check_brc_progress()
+
+        assert len(escalations) == 1
+        esc = escalations[0]
+        assert esc["alert_type"] == "brc_confirmation_timeout"
+        assert esc["elapsed_seconds"] == 181
+
+    def test_breadcrumb_logged_on_each_observation(self):
+        """Per-iteration breadcrumb makes the check visible in container logs (#2079)."""
+        bus = _make_event_bus()
+        config = _make_config(orchestrator_post_ack_confirmation_timeout_seconds=180)
+        monitor = _make_monitor(bus, config)
+
+        _emit_heartbeat(bus, agent_id=PRODUCER_ID)
+
+        mock_tracker = self._make_tracker_with_fully_acked(
+            fully_acked={PRODUCER_ID: time.time()},
+        )
+
+        with (
+            patch(
+                "peer_consensus.get_peer_consensus_tracker",
+                return_value=mock_tracker,
+            ),
+            patch("health_monitor.logger") as mock_logger,
+        ):
+            monitor.check_brc_progress()
+
+        info_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "BRC progress check observed fully-acked producers" in c.args[0]
+        ]
+        assert len(info_calls) == 1, (
+            "Expected one breadcrumb info log per check_brc_progress call "
+            "with fully-acked producers"
+        )
+        # Breadcrumb must include producer + elapsed metadata for post-mortems.
+        kwargs = info_calls[0].kwargs
+        assert kwargs.get("pipeline_id") == PIPELINE_ID
+        assert PRODUCER_ID in kwargs.get("producers", {})
+
+    def test_no_breadcrumb_when_set_empty(self):
+        """No breadcrumb log when no producers are fully-acked."""
+        bus = _make_event_bus()
+        monitor = _make_monitor(bus)
+
+        mock_tracker = self._make_tracker_with_fully_acked(fully_acked={})
+
+        with (
+            patch(
+                "peer_consensus.get_peer_consensus_tracker",
+                return_value=mock_tracker,
+            ),
+            patch("health_monitor.logger") as mock_logger,
+        ):
+            monitor.check_brc_progress()
+
+        info_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and "BRC progress check observed fully-acked producers" in c.args[0]
+        ]
+        assert info_calls == [], "Should not log breadcrumb on empty fully-acked set"
+
+    def test_warns_when_skipping_producer_without_agent_state(self):
+        """Warn loudly when a fully-acked producer past timeout has no agent_state (#2079)."""
+        bus = _make_event_bus()
+        config = _make_config(orchestrator_post_ack_confirmation_timeout_seconds=180)
+        monitor = _make_monitor(bus, config)
+
+        # Deliberately do NOT emit a heartbeat — producer has no AgentState.
+        mock_tracker = self._make_tracker_with_fully_acked(
+            fully_acked={PRODUCER_ID: time.time()},
+        )
+
+        base = time.time()
+        with (
+            patch("health_monitor.time") as mock_time,
+            patch(
+                "peer_consensus.get_peer_consensus_tracker",
+                return_value=mock_tracker,
+            ),
+            patch("health_monitor.logger") as mock_logger,
+        ):
+            mock_time.time.return_value = base
+            monitor.check_brc_progress()  # records first-seen
+
+            mock_time.time.return_value = base + 181
+            actions = monitor.check_brc_progress()
+
+        assert actions == [], "No action when producer has no agent_state"
+        warn_calls = [
+            c
+            for c in mock_logger.warning.call_args_list
+            if c.args and "no agent_state" in c.args[0]
+        ]
+        assert len(warn_calls) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Tier-1 detector in `check_brc_progress` (`orchestrator/health_monitor.py:731`) already tracks fully-ACKed-but-not-confirmed producers and fires after 180s, but its escalation only added an entry to `_active_alerts` — `_escalation_callbacks` was never registered in production. The only consumer of `_active_alerts` is the overseer agent's discretionary poll of `/api/v1/pipelines/<id>/health/alerts`. On pipeline `issue-1965`, the overseer chose not to act on the alert, and `documenter` sat fully-ACKed-but-not-confirmed for ~37 minutes until the generic `agent-heartbeat-stall` alert finally broke the deadlock.

This PR turns the detector's output into a deterministic remediation:

- **Wires an escalation callback** in `_run_pipeline` after `init_health_monitor` that posts a directed `OVERSEER_ALERT` to the stuck producer. Body explains the state and the recovery path (call `mcp__brc__confirm`; if it returns `pending_acks`, wait on the prerequisite events instead of `CONSENSUS_CONFIRMED`).
- **Uses `OVERSEER_ALERT`** because it's the only message type in the producer's post-confirm `wait_loop` filter (`CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT`) — a `STATUS` or `NUDGE` message would not wake it.
- **Adds `alert_type` + `elapsed_seconds`** to the escalation dict so callbacks can discriminate without parsing the reason string.
- **Adds a per-iteration INFO breadcrumb** in `check_brc_progress` so future post-mortems can verify the check ran and what it observed (suggested investigation #1 in the issue).
- **Logs WARNING** instead of silent skip when a fully-acked producer past timeout has no `agent_state` (suggested investigation #2). The branch is unexpected — every producer has at minimum proposed, which routes through `MESSAGE_SENT` and registers state — but worth surfacing.
- **Adds `HealthMonitor.get_current_phase()`** so the callback records the current phase on the message without reaching into private state.

Independent of PR #2077 (server-side `wait_loop` guard for #2064 — a different layer of fix at the wait endpoint).

## Files

- `orchestrator/health_monitor.py` — alert_type/elapsed_seconds in escalation dict, breadcrumb + skip logs, `get_current_phase()` accessor
- `orchestrator/routes/pipelines.py` — `_send_brc_confirmation_nudge` helper + escalation callback wiring in `_run_pipeline`
- `orchestrator/tests/test_health_monitor.py` — escalation dict shape, breadcrumb log, no-agent-state warning, `get_current_phase` round-trip
- `orchestrator/tests/test_brc_confirmation_nudge.py` — 7 unit tests for `_send_brc_confirmation_nudge` covering valid escalation, alert_type filter, missing fields, message-store unavailable, send error, phase=None

## Test plan

- [x] `pytest orchestrator/tests/test_health_monitor.py orchestrator/tests/test_brc_confirmation_nudge.py` — 97/97 pass
- [x] `pytest orchestrator/tests/test_pipelines_routes.py orchestrator/tests/test_pipelines_api.py orchestrator/tests/test_overseer_spawn.py` — 81/81 pass (no regressions in touched code paths)
- [x] `ruff check` clean
- [ ] Live BRC pipeline run that wedges a producer post-ACK to confirm the new OVERSEER_ALERT actually wakes the wait_loop end-to-end (CI / next pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)