### PR TITLE
Fix #2087: fail loudly when sandbox build_commands silently break

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ PYTHON := $(if $(wildcard $(VENV_BIN)/python),$(VENV_BIN)/python,python3)
 EGG_IMAGE_TAG := $(shell git describe --always --dirty 2>/dev/null || echo latest)
 
 .PHONY: help \
-        setup deps venv sync-venv-if-uv install-linters check-linters \
+        setup deps venv sync-venv-if-uv sandbox-deps install-linters check-linters \
         lint lint-python lint-shell lint-yaml lint-docker lint-actions lint-custom \
         test test-all test-record-good security \
         test-integration test-e2e test-security smoketest-long-poll \
@@ -122,6 +122,17 @@ venv:
 # the same `uv sync` behavior as the strict `venv` target. Issue #2065.
 sync-venv-if-uv:
 	@if command -v uv >/dev/null 2>&1; then $(MAKE) venv; fi
+
+# Sync only third-party dependencies into .venv; do NOT install the local
+# `egg` package. This is the variant invoked by sandbox image build_commands,
+# which run in a synthetic context containing only watch_files (Makefile,
+# pyproject.toml, uv.lock) — no source dirs, no README — so a full
+# `uv sync` fails when the hatchling build backend tries to package the
+# project. Dev tools (ruff, pytest, mypy, etc.) install fine without the
+# project itself. Issue #2087.
+sandbox-deps:
+	@echo "==> Syncing dev dependencies (no project install)..."
+	@uv sync --extra dev --no-install-project
 
 # Install all linting tools
 install-linters: venv

--- a/config/README.md
+++ b/config/README.md
@@ -209,6 +209,8 @@ Each `build_commands` entry has:
 - `persist_dirs`: Directories (relative to repo root) to preserve from the build context into the Docker image. After `commands` run, these directories are copied to `/opt/prebuilt-deps/<repo>/` and restored into the mounted repo at container startup by `entrypoint.py`. Use this for local dependencies like `node_modules` that would otherwise be lost when the build context is cleaned up.
 - `persist_system_dirs`: Absolute-path system directories to preserve from the build stage into the final image. After `commands` run, these directories are copied to `/opt/prebuilt-deps/__egg_system_dirs__/<abs_path>/` and the Dockerfile restores them to their original absolute locations. Use this for system-level tool installations that land outside the repo directory (e.g., `/usr/local/go`, `/usr/local/node`). Top-level system paths (`/`, `/etc`, `/usr`, `/var`, etc.) and all paths under `/proc`, `/sys`, `/dev`, `/run`, `/boot` are blocked.
 
+**Fail-fast contract (since #2087):** A non-zero exit from any command, a missing watch-files directory, or a `persist_dirs` / `persist_system_dirs` entry that doesn't exist after the commands run all abort the image build. Earlier behavior printed a warning and continued, which silently produced empty `/opt/prebuilt-deps/<repo>/` trees. Path-traversal rejection in `persist_dirs` remains warn-and-skip — it's a security control, not a misconfiguration we want to crash on.
+
 **How it works:**
 1. `create_dockerfile()` copies each repo's watch files from `local_repos.paths` into the build context at `~/.config/egg/repo-deps/<repo-name>/`
 2. `compute_build_hash()` includes watch file contents, so the image rebuilds automatically when dependency files change

--- a/config/repositories.yaml.example
+++ b/config/repositories.yaml.example
@@ -134,6 +134,27 @@ repo_settings:
   #     commands:
   #       - pip install -r requirements.txt
   #       - pip install -r requirements-dev.txt
+  #
+  # # Python project using uv + a build backend (hatchling, setuptools, ...).
+  # # NOTE: build_commands run in a synthetic context that contains ONLY the
+  # # files in `watch_files` — no source dirs, no README. A bare `uv sync`
+  # # tries to build the local project as a wheel and will fail. Use
+  # # `--no-install-project` (or a Makefile target that wraps it) so only
+  # # third-party deps go into the persisted .venv. The local project is not
+  # # needed for ruff / pytest / mypy / etc. to function in the sandbox. See #2087.
+  # YOUR_USERNAME/uv-python-project:
+  #   build_commands:
+  #     watch_files:
+  #       - Makefile
+  #       - pyproject.toml
+  #       - uv.lock
+  #     commands:
+  #       - curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+  #       - make sandbox-deps    # ← `uv sync --extra dev --no-install-project`
+  #     persist_dirs:
+  #       - .venv
+  #     persist_system_dirs:
+  #       - /usr/local/bin       # ← carries `uv` itself into the runtime image
   # YOUR_USERNAME/go-service:
   #   build_commands:
   #     watch_files:

--- a/config/repositories.yaml.example
+++ b/config/repositories.yaml.example
@@ -154,7 +154,11 @@ repo_settings:
   #     persist_dirs:
   #       - .venv
   #     persist_system_dirs:
-  #       - /usr/local/bin       # ← carries `uv` itself into the runtime image
+  #       # ← carries `uv` itself (and anything else earlier setup steps put
+  #       # under /usr/local/bin) into the runtime image. The persist machinery
+  #       # only handles directories, not single files, so persisting just `uv`
+  #       # would require a wrapper dir.
+  #       - /usr/local/bin
   # YOUR_USERNAME/go-service:
   #   build_commands:
   #     watch_files:

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -206,6 +206,8 @@ Per-repo `build_commands` in `repositories.yaml` allow project-specific dependen
 
 > **Note:** `persist_dirs` and `persist_system_dirs` are not included in `compute_build_hash()`. Changing only these fields won't trigger an automatic rebuild — add or modify a `watch_files` entry or use `egg --rebuild`.
 
+> **Fail-fast contract (since #2087):** A non-zero exit from any command, a missing watch-files directory, or a `persist_dirs` / `persist_system_dirs` entry that doesn't exist after the commands run all abort the image build. Earlier behavior printed a warning and continued, which silently produced empty prebuilt-deps trees. Path-traversal rejection stays warn-and-skip (security control, not misconfiguration).
+
 **Config propagation:** During Docker builds, `repositories.yaml` is not available in the build context. Both `build_commands` and `extra_packages` are propagated via a `manifest.json` file that `create_dockerfile()` writes into `repo-deps/`. The `docker-setup.py` script reads this manifest as a fallback when `repositories.yaml` is not found.
 
 See [Configuration README](../config/README.md#per-repo-build-commands-dependency-caching) for configuration details.

--- a/sandbox/docker-setup.py
+++ b/sandbox/docker-setup.py
@@ -280,11 +280,15 @@ def load_extra_packages_manifest(
         return [], []
 
 
-def run_build_commands(build_commands: list[dict[str, Any]]) -> None:
+def run_build_commands(
+    build_commands: list[dict[str, Any]],
+    repo_deps_base: Path = Path("/tmp/repo-deps"),
+) -> None:
     """Execute build commands for each repo during Docker image build.
 
-    Each repo's commands run in its watch files directory at /tmp/repo-deps/<repo-name>.
-    Commands run as root (same as the rest of docker-setup.py).
+    Each repo's commands run in its watch files directory at
+    `<repo_deps_base>/<repo-name>`. Commands run as root (same as the rest of
+    docker-setup.py).
 
     Failure modes that abort the build (vs. earlier warn-and-continue behavior,
     which silently produced broken images — see #2087):
@@ -295,6 +299,9 @@ def run_build_commands(build_commands: list[dict[str, Any]]) -> None:
 
     Args:
         build_commands: List of dicts from get_build_commands()
+        repo_deps_base: Base path for repo build contexts (default: /tmp/repo-deps).
+            Mirrors persist_build_dirs's parameter so tests can use tmp_path
+            instead of touching the real /tmp/repo-deps tree.
 
     Raises:
         RuntimeError: When any of the failure modes above occurs.
@@ -309,7 +316,7 @@ def run_build_commands(build_commands: list[dict[str, Any]]) -> None:
         commands = entry["commands"]
         # Sanitize repo name for directory path (owner/repo -> owner--repo)
         repo_dir_name = repo.replace("/", "--")
-        work_dir = Path("/tmp/repo-deps") / repo_dir_name
+        work_dir = repo_deps_base / repo_dir_name
 
         print(f"\n--- Build commands for {repo} ---")
 
@@ -343,7 +350,7 @@ def run_build_commands(build_commands: list[dict[str, Any]]) -> None:
 
     print("\n=== Build commands complete ===")
 
-    persist_build_dirs(build_commands)
+    persist_build_dirs(build_commands, repo_deps_base=repo_deps_base)
 
 
 def persist_build_dirs(

--- a/sandbox/docker-setup.py
+++ b/sandbox/docker-setup.py
@@ -286,8 +286,18 @@ def run_build_commands(build_commands: list[dict[str, Any]]) -> None:
     Each repo's commands run in its watch files directory at /tmp/repo-deps/<repo-name>.
     Commands run as root (same as the rest of docker-setup.py).
 
+    Failure modes that abort the build (vs. earlier warn-and-continue behavior,
+    which silently produced broken images — see #2087):
+
+    - The repo's watch_files directory is missing (build manifest declared
+      commands but `_copy_repo_watch_files` produced no source for them).
+    - A command exits non-zero, or raises an exception (e.g. binary not found).
+
     Args:
         build_commands: List of dicts from get_build_commands()
+
+    Raises:
+        RuntimeError: When any of the failure modes above occurs.
     """
     if not build_commands:
         return
@@ -304,11 +314,11 @@ def run_build_commands(build_commands: list[dict[str, Any]]) -> None:
         print(f"\n--- Build commands for {repo} ---")
 
         if not work_dir.exists():
-            print(
-                f"  Warning: Watch files directory {work_dir} does not exist, "
-                f"running commands in /tmp"
+            raise RuntimeError(
+                f"build_commands: watch files directory {work_dir} does not exist "
+                f"for {repo}; check watch_files config and that "
+                f"_copy_repo_watch_files ran"
             )
-            work_dir = Path("/tmp")
 
         for cmd in commands:
             print(f"  Running: {cmd}")
@@ -321,10 +331,15 @@ def run_build_commands(build_commands: list[dict[str, Any]]) -> None:
                     check=False,
                     capture_output=False,
                 )
-                if result.returncode != 0:
-                    print(f"  Warning: Command exited with code {result.returncode}: {cmd}")
             except Exception as e:
-                print(f"  Warning: Command failed: {cmd}: {e}")
+                raise RuntimeError(
+                    f"build_commands: command for {repo} raised an exception: {cmd!r}: {e}"
+                ) from e
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"build_commands: command for {repo} exited with code "
+                    f"{result.returncode}: {cmd!r}"
+                )
 
     print("\n=== Build commands complete ===")
 
@@ -362,7 +377,10 @@ def persist_build_dirs(
         for rel_dir in persist_dirs:
             src_dir = work_dir / rel_dir
 
-            # Defense-in-depth: validate path stays within work_dir
+            # Defense-in-depth: validate path stays within work_dir.
+            # Path traversal is rejected (not raised) so that a malformed config
+            # entry can't crash an otherwise valid build — but the legitimate
+            # absent-after-build case below IS raised (see #2087).
             try:
                 src_dir.resolve().relative_to(work_dir.resolve())
             except ValueError:
@@ -370,8 +388,12 @@ def persist_build_dirs(
                 continue
 
             if not src_dir.is_dir():
-                print(f"  Warning: persist_dirs: {rel_dir} does not exist after build, skipping")
-                continue
+                raise RuntimeError(
+                    f"persist_dirs: {repo!r} declared persist_dir {rel_dir!r} but "
+                    f"it does not exist at {src_dir} after build commands ran. "
+                    f"Either the build commands failed silently, or the watch_files "
+                    f"context is missing inputs the commands need."
+                )
 
             dest_dir = dest_base / rel_dir
             dest_dir.parent.mkdir(parents=True, exist_ok=True)
@@ -417,11 +439,12 @@ def persist_build_dirs(
 
             src_dir = resolved
             if not src_dir.is_dir():
-                print(
-                    f"  Warning: persist_system_dirs: {abs_dir} does not exist "
-                    f"after build ({repo}), skipping"
+                raise RuntimeError(
+                    f"persist_system_dirs: {repo!r} declared {abs_dir!r} but it "
+                    f"does not exist at {src_dir} after build commands ran. "
+                    f"Either the build commands failed silently, or they did "
+                    f"not produce that path."
                 )
-                continue
 
             # Store under __egg_system_dirs__/<abs_path> so it can be restored to the same location
             # Strip leading / for the destination path

--- a/tests/sandbox/test_docker_setup.py
+++ b/tests/sandbox/test_docker_setup.py
@@ -385,9 +385,8 @@ class TestRunBuildCommands:
         """Test that build commands are executed."""
         mock_run.return_value = MagicMock(returncode=0)
 
-        # Create the work directory that run_build_commands expects
-        work_dir = Path("/tmp/repo-deps/org--app")
-        work_dir.mkdir(parents=True, exist_ok=True)
+        repo_deps = tmp_path / "repo-deps"
+        (repo_deps / "org--app").mkdir(parents=True)
 
         build_commands = [
             {
@@ -397,13 +396,7 @@ class TestRunBuildCommands:
             }
         ]
 
-        try:
-            run_build_commands(build_commands)
-        finally:
-            # Clean up
-            import shutil
-
-            shutil.rmtree("/tmp/repo-deps", ignore_errors=True)
+        run_build_commands(build_commands, repo_deps_base=repo_deps)
 
         # Should have called subprocess.run twice (one per command)
         assert mock_run.call_count == 2
@@ -420,12 +413,12 @@ class TestRunBuildCommands:
         assert captured.out == ""
 
     @patch("subprocess.run")
-    def test_command_failure_aborts_build(self, mock_run, capsys):
+    def test_command_failure_aborts_build(self, mock_run, tmp_path, capsys):
         """A failed build command aborts the image build (was warn-only). See #2087."""
         mock_run.return_value = MagicMock(returncode=1)
 
-        work_dir = Path("/tmp/repo-deps/org--app")
-        work_dir.mkdir(parents=True, exist_ok=True)
+        repo_deps = tmp_path / "repo-deps"
+        (repo_deps / "org--app").mkdir(parents=True)
 
         build_commands = [
             {
@@ -435,13 +428,8 @@ class TestRunBuildCommands:
             }
         ]
 
-        try:
-            with pytest.raises(RuntimeError, match="exited with code 1"):
-                run_build_commands(build_commands)
-        finally:
-            import shutil
-
-            shutil.rmtree("/tmp/repo-deps", ignore_errors=True)
+        with pytest.raises(RuntimeError, match="exited with code 1"):
+            run_build_commands(build_commands, repo_deps_base=repo_deps)
 
 
 class TestGetBuildCommandsEdgeCases:
@@ -506,13 +494,16 @@ class TestRunBuildCommandsEdgeCases:
     """Edge case tests for run_build_commands."""
 
     @patch("subprocess.run")
-    def test_missing_work_dir_raises(self, mock_run):
+    def test_missing_work_dir_raises(self, mock_run, tmp_path):
         """When repo work_dir doesn't exist, build aborts (vs. silent /tmp fallback).
 
         The earlier behavior silently fell back to running commands in /tmp,
         which masked real misconfiguration. See #2087.
         """
         mock_run.return_value = MagicMock(returncode=0)
+
+        repo_deps = tmp_path / "repo-deps"
+        repo_deps.mkdir()
 
         build_commands = [
             {
@@ -523,12 +514,12 @@ class TestRunBuildCommandsEdgeCases:
         ]
 
         with pytest.raises(RuntimeError, match="watch files directory.*does not exist"):
-            run_build_commands(build_commands)
+            run_build_commands(build_commands, repo_deps_base=repo_deps)
 
         mock_run.assert_not_called()
 
     @patch("subprocess.run")
-    def test_subprocess_exception_raises(self, mock_run):
+    def test_subprocess_exception_raises(self, mock_run, tmp_path):
         """Subprocess raising an exception aborts the build.
 
         The earlier behavior caught and warned, masking misconfigurations
@@ -536,8 +527,8 @@ class TestRunBuildCommandsEdgeCases:
         """
         mock_run.side_effect = OSError("command not found")
 
-        work_dir = Path("/tmp/repo-deps/org--app")
-        work_dir.mkdir(parents=True, exist_ok=True)
+        repo_deps = tmp_path / "repo-deps"
+        (repo_deps / "org--app").mkdir(parents=True)
 
         build_commands = [
             {
@@ -547,13 +538,8 @@ class TestRunBuildCommandsEdgeCases:
             }
         ]
 
-        try:
-            with pytest.raises(RuntimeError, match="raised an exception"):
-                run_build_commands(build_commands)
-        finally:
-            import shutil
-
-            shutil.rmtree("/tmp/repo-deps", ignore_errors=True)
+        with pytest.raises(RuntimeError, match="raised an exception"):
+            run_build_commands(build_commands, repo_deps_base=repo_deps)
 
     @patch("subprocess.run")
     def test_nonzero_exit_raises_with_exit_code(self, mock_run, tmp_path):
@@ -565,8 +551,8 @@ class TestRunBuildCommandsEdgeCases:
         """
         mock_run.return_value = MagicMock(returncode=127)
 
-        work_dir = Path("/tmp/repo-deps/org--app")
-        work_dir.mkdir(parents=True, exist_ok=True)
+        repo_deps = tmp_path / "repo-deps"
+        (repo_deps / "org--app").mkdir(parents=True)
 
         build_commands = [
             {
@@ -576,21 +562,17 @@ class TestRunBuildCommandsEdgeCases:
             }
         ]
 
-        try:
-            with pytest.raises(RuntimeError, match="exited with code 127"):
-                run_build_commands(build_commands)
-        finally:
-            import shutil
-
-            shutil.rmtree("/tmp/repo-deps", ignore_errors=True)
+        with pytest.raises(RuntimeError, match="exited with code 127"):
+            run_build_commands(build_commands, repo_deps_base=repo_deps)
 
     @patch("subprocess.run")
-    def test_multiple_repos_run_sequentially(self, mock_run, capsys):
+    def test_multiple_repos_run_sequentially(self, mock_run, tmp_path, capsys):
         """Multiple repos' commands all execute."""
         mock_run.return_value = MagicMock(returncode=0)
 
+        repo_deps = tmp_path / "repo-deps"
         for repo_dir in ("org--app-a", "org--app-b"):
-            (Path("/tmp/repo-deps") / repo_dir).mkdir(parents=True, exist_ok=True)
+            (repo_deps / repo_dir).mkdir(parents=True)
 
         build_commands = [
             {
@@ -605,12 +587,7 @@ class TestRunBuildCommandsEdgeCases:
             },
         ]
 
-        try:
-            run_build_commands(build_commands)
-        finally:
-            import shutil
-
-            shutil.rmtree("/tmp/repo-deps", ignore_errors=True)
+        run_build_commands(build_commands, repo_deps_base=repo_deps)
 
         assert mock_run.call_count == 3
         captured = capsys.readouterr()

--- a/tests/sandbox/test_docker_setup.py
+++ b/tests/sandbox/test_docker_setup.py
@@ -420,12 +420,12 @@ class TestRunBuildCommands:
         assert captured.out == ""
 
     @patch("subprocess.run")
-    def test_handles_command_failure(self, mock_run, tmp_path, capsys):
-        """Test that failed commands produce warnings but don't crash."""
+    def test_command_failure_aborts_build(self, mock_run, capsys):
+        """A failed build command aborts the image build (was warn-only). See #2087."""
         mock_run.return_value = MagicMock(returncode=1)
 
-        work_dir = tmp_path / "repo-deps" / "org--app"
-        work_dir.mkdir(parents=True)
+        work_dir = Path("/tmp/repo-deps/org--app")
+        work_dir.mkdir(parents=True, exist_ok=True)
 
         build_commands = [
             {
@@ -435,11 +435,13 @@ class TestRunBuildCommands:
             }
         ]
 
-        # Just run it - should not raise
-        run_build_commands(build_commands)
+        try:
+            with pytest.raises(RuntimeError, match="exited with code 1"):
+                run_build_commands(build_commands)
+        finally:
+            import shutil
 
-        captured = capsys.readouterr()
-        assert "Build commands" in captured.out
+            shutil.rmtree("/tmp/repo-deps", ignore_errors=True)
 
 
 class TestGetBuildCommandsEdgeCases:
@@ -504,8 +506,12 @@ class TestRunBuildCommandsEdgeCases:
     """Edge case tests for run_build_commands."""
 
     @patch("subprocess.run")
-    def test_fallback_to_tmp_when_work_dir_missing(self, mock_run, capsys):
-        """When repo work_dir doesn't exist, falls back to /tmp."""
+    def test_missing_work_dir_raises(self, mock_run):
+        """When repo work_dir doesn't exist, build aborts (vs. silent /tmp fallback).
+
+        The earlier behavior silently fell back to running commands in /tmp,
+        which masked real misconfiguration. See #2087.
+        """
         mock_run.return_value = MagicMock(returncode=0)
 
         build_commands = [
@@ -516,18 +522,22 @@ class TestRunBuildCommandsEdgeCases:
             }
         ]
 
-        run_build_commands(build_commands)
+        with pytest.raises(RuntimeError, match="watch files directory.*does not exist"):
+            run_build_commands(build_commands)
 
-        # Verify it ran with /tmp as cwd
-        call_args = mock_run.call_args
-        assert call_args.kwargs["cwd"] == "/tmp"
-        captured = capsys.readouterr()
-        assert "does not exist" in captured.out
+        mock_run.assert_not_called()
 
     @patch("subprocess.run")
-    def test_subprocess_exception_does_not_crash(self, mock_run, capsys):
-        """Subprocess raising an exception is caught and warned about."""
+    def test_subprocess_exception_raises(self, mock_run):
+        """Subprocess raising an exception aborts the build.
+
+        The earlier behavior caught and warned, masking misconfigurations
+        like "tool not on PATH". See #2087.
+        """
         mock_run.side_effect = OSError("command not found")
+
+        work_dir = Path("/tmp/repo-deps/org--app")
+        work_dir.mkdir(parents=True, exist_ok=True)
 
         build_commands = [
             {
@@ -537,16 +547,22 @@ class TestRunBuildCommandsEdgeCases:
             }
         ]
 
-        # Should not raise
-        run_build_commands(build_commands)
+        try:
+            with pytest.raises(RuntimeError, match="raised an exception"):
+                run_build_commands(build_commands)
+        finally:
+            import shutil
 
-        captured = capsys.readouterr()
-        assert "Command failed" in captured.out
-        assert "command not found" in captured.out
+            shutil.rmtree("/tmp/repo-deps", ignore_errors=True)
 
     @patch("subprocess.run")
-    def test_warning_message_includes_exit_code(self, mock_run, tmp_path, capsys):
-        """Failed commands report the exit code in the warning."""
+    def test_nonzero_exit_raises_with_exit_code(self, mock_run, tmp_path):
+        """Failed commands abort the build and report the exit code.
+
+        The earlier behavior printed a warning and continued, allowing the
+        image to be built without any of the dependencies the commands were
+        supposed to install. See #2087.
+        """
         mock_run.return_value = MagicMock(returncode=127)
 
         work_dir = Path("/tmp/repo-deps/org--app")
@@ -561,19 +577,20 @@ class TestRunBuildCommandsEdgeCases:
         ]
 
         try:
-            run_build_commands(build_commands)
+            with pytest.raises(RuntimeError, match="exited with code 127"):
+                run_build_commands(build_commands)
         finally:
             import shutil
 
             shutil.rmtree("/tmp/repo-deps", ignore_errors=True)
 
-        captured = capsys.readouterr()
-        assert "127" in captured.out
-
     @patch("subprocess.run")
     def test_multiple_repos_run_sequentially(self, mock_run, capsys):
         """Multiple repos' commands all execute."""
         mock_run.return_value = MagicMock(returncode=0)
+
+        for repo_dir in ("org--app-a", "org--app-b"):
+            (Path("/tmp/repo-deps") / repo_dir).mkdir(parents=True, exist_ok=True)
 
         build_commands = [
             {
@@ -588,7 +605,12 @@ class TestRunBuildCommandsEdgeCases:
             },
         ]
 
-        run_build_commands(build_commands)
+        try:
+            run_build_commands(build_commands)
+        finally:
+            import shutil
+
+            shutil.rmtree("/tmp/repo-deps", ignore_errors=True)
 
         assert mock_run.call_count == 3
         captured = capsys.readouterr()
@@ -859,27 +881,30 @@ class TestPersistDirs:
         assert "Persisting" in captured.out
         assert "Persisted 1 directories" in captured.out
 
-    def test_persist_dirs_skips_missing_dirs(self, tmp_path, capsys):
-        """persist_dirs skips directories that don't exist after build."""
+    def test_persist_dirs_raises_on_missing_dir(self, tmp_path):
+        """persist_dirs raises when a declared dir doesn't exist post-build.
+
+        The earlier behavior silently skipped, producing an image where the
+        config promised dependencies but none were actually persisted. See
+        #2087.
+        """
         from docker_setup import persist_build_dirs
 
         repo_deps = tmp_path / "repo-deps"
         (repo_deps / "org--app").mkdir(parents=True)
 
-        persist_build_dirs(
-            [
-                {
-                    "repo": "org/app",
-                    "commands": ["npm ci"],
-                    "persist_dirs": ["nonexistent_dir"],
-                }
-            ],
-            repo_deps_base=repo_deps,
-            prebuilt_base=tmp_path / "prebuilt",
-        )
-
-        captured = capsys.readouterr()
-        assert "does not exist after build" in captured.out
+        with pytest.raises(RuntimeError, match="does not exist .* after build"):
+            persist_build_dirs(
+                [
+                    {
+                        "repo": "org/app",
+                        "commands": ["npm ci"],
+                        "persist_dirs": ["nonexistent_dir"],
+                    }
+                ],
+                repo_deps_base=repo_deps,
+                prebuilt_base=tmp_path / "prebuilt",
+            )
 
     def test_persist_dirs_blocks_path_traversal(self, tmp_path, capsys):
         """persist_dirs rejects paths that escape the build context."""
@@ -1011,28 +1036,31 @@ class TestPersistSystemDirs:
         captured = capsys.readouterr()
         assert "Persisting system dir" in captured.out
 
-    def test_persist_system_dirs_skips_nonexistent(self, tmp_path, capsys):
-        """persist_system_dirs skips directories that don't exist."""
+    def test_persist_system_dirs_raises_on_nonexistent(self, tmp_path):
+        """persist_system_dirs raises when a declared path doesn't exist.
+
+        Same fail-fast contract as `persist_dirs`: if the build commands
+        promised to install something to /usr/local/bin but didn't, the
+        image is broken. See #2087.
+        """
         from docker_setup import persist_build_dirs
 
         repo_deps = tmp_path / "repo-deps"
         (repo_deps / "org--app").mkdir(parents=True)
 
-        persist_build_dirs(
-            [
-                {
-                    "repo": "org/app",
-                    "commands": ["install go"],
-                    "persist_dirs": [],
-                    "persist_system_dirs": ["/nonexistent/path/go"],
-                }
-            ],
-            repo_deps_base=repo_deps,
-            prebuilt_base=tmp_path / "prebuilt",
-        )
-
-        captured = capsys.readouterr()
-        assert "does not exist after build" in captured.out
+        with pytest.raises(RuntimeError, match="does not exist .* after build"):
+            persist_build_dirs(
+                [
+                    {
+                        "repo": "org/app",
+                        "commands": ["install go"],
+                        "persist_dirs": [],
+                        "persist_system_dirs": ["/nonexistent/path/go"],
+                    }
+                ],
+                repo_deps_base=repo_deps,
+                prebuilt_base=tmp_path / "prebuilt",
+            )
 
     def test_persist_system_dirs_skips_relative_paths(self, tmp_path, capsys):
         """persist_system_dirs rejects non-absolute paths."""


### PR DESCRIPTION
## Summary

Fixes #2087: sandbox agents in the egg repo were silently falling back to system Python because `/opt/prebuilt-deps/jwbron--egg/` ended up empty in the image despite the repository config declaring `.venv` in `persist_dirs`.

Two independent fixes:

1. **Stop the silent failure** — `sandbox/docker-setup.py` raised warnings (vs. errors) on three failure modes in `run_build_commands` and on missing-after-build paths in `persist_build_dirs`. All five now raise `RuntimeError`, so a broken image fails the build instead of silently shipping. (Path-traversal rejection stays as a warn-and-skip — that's a security control, not a misconfiguration we want to crash on.)
2. **Make egg's build_commands actually work** — `uv sync` (what `make deps` runs) tries to build the local `egg` package as a wheel. The build context only contains `watch_files` (Makefile, pyproject.toml, uv.lock) — no source dirs, no README — so hatchling errors out and `make deps` fails. New `make sandbox-deps` target runs `uv sync --extra dev --no-install-project`, installing dev tools (ruff, pytest, mypy, etc.) without trying to package the project. Example config updated to demonstrate the pattern for any uv-based Python project.

## Root cause walkthrough

Reproduced the exact failure offline:

```bash
mkdir /tmp/egg-build-test && cd /tmp/egg-build-test
cp <egg-checkout>/{Makefile,pyproject.toml,uv.lock} .
make deps
# ... OSError: Readme file does not exist: README.md
# ... make: *** [Makefile:96: deps] Error 2
```

Inside the Stage 1 image build, `docker-setup.py` saw exit code 2 from `make deps`, printed `Warning: Command exited with code 2`, then proceeded to `persist_build_dirs`. `.venv` didn't exist (because `make deps` failed), so persist printed `Warning: persist_dirs: .venv does not exist after build, skipping` and moved on. Build completed "successfully" with `/opt/prebuilt-deps/` empty.

Same shape as #2065 (uv binary persisted to `/usr/local/bin` but never carried across stages) — a single warning between "config promised X" and "X is missing in the image" was enough to make the image silently broken.

## Operator follow-up (required after merge)

Update `~/.config/egg/repositories.yaml` for `jwbron/egg`, switching the second build command from `make deps` to `make sandbox-deps`:

```yaml
jwbron/egg:
  build_commands:
    watch_files: [Makefile, pyproject.toml, uv.lock]
    commands:
      - curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
      - make sandbox-deps   # ← was `make deps`
    persist_dirs: [.venv]
    persist_system_dirs: [/usr/local/bin]
```

Then trigger a rebuild. With this PR's fail-fast behavior, leaving `make deps` in place will cause the image build to error out loudly instead of silently producing an empty `/opt/prebuilt-deps/` (intended).

## Cross-cut with #2073

The class of misconfiguration that produced #2087 is one of the validator rules #2073's §4 should add — "build_commands declare `persist_dirs` that won't exist after commands run in a watch-files-only context". I'll update #2073's body to capture this concretely.

## Test plan

- [x] `make lint` (ruff + mypy + custom checks) clean
- [x] `pytest tests/sandbox/` — 1536 passed, 4 skipped (includes 5 new/updated tests for the fail-fast contract)
- [x] Verified `make sandbox-deps` produces a working `.venv` from a bare watch-files context (Makefile + pyproject.toml + uv.lock only); `python -c "import ruff; import pytest; import mypy"` succeeds
- [ ] After operator config update, sandbox container rebuild produces `/opt/prebuilt-deps/jwbron--egg/.venv/bin/python` and agents resolve project deps from `.venv` rather than system Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)

