### PR TITLE
Fix #2100: re-arm ready-to-confirm nudge after pending_acks rejection

### DIFF
--- a/orchestrator/peer_consensus.py
+++ b/orchestrator/peer_consensus.py
@@ -157,6 +157,24 @@ class PeerConsensusTracker:
             if self._nudged_versions.get(role) == version:
                 del self._nudged_versions[role]
 
+    def _rearm_nudge_after_pending_acks(self, role: str) -> None:
+        """Drop the nudge memo so a re-nudge fires when the guard finally clears.
+
+        A producer that already received a "ready to confirm" STATUS will
+        have an entry in ``_nudged_versions`` at its current proposal
+        version.  If that producer then calls ``confirm`` and the guard
+        rejects with ``pending_acks`` (peer hasn't proposed, reviewer hasn't
+        ACKed, etc.), the laggard's later state change re-runs
+        ``_collect_newly_ready_producers`` — but the memo would suppress
+        the re-emit at the same version, leaving the producer asleep in
+        ``message_wait_loop`` indefinitely (#2100).  Dropping the memo here
+        re-arms the nudge; the next sweep only emits if
+        ``check_confirm_guard`` actually passes, so this can't fire
+        prematurely.
+        """
+        if self.graph.is_producer(role):
+            self._nudged_versions.pop(role, None)
+
     def _collect_newly_ready_producers(self) -> list[dict[str, Any]]:
         """Return producers that newly became ready-to-confirm.
 
@@ -542,6 +560,12 @@ class PeerConsensusTracker:
 
             if not guard.allowed:
                 guard_type = guard.details.get("guard", "unknown")
+
+                # Re-arm the "ready to confirm" nudge for this producer so
+                # the laggard's later proposal/ACK wakes it up via the
+                # normal _collect_newly_ready_producers sweep (#2100).
+                # No-op for reviewer-only roles.
+                self._rearm_nudge_after_pending_acks(agent_role)
 
                 # Global zero-proposal guard (#1648): any producer has
                 # never proposed — blocks all agents from confirming.

--- a/orchestrator/peer_consensus.py
+++ b/orchestrator/peer_consensus.py
@@ -157,20 +157,26 @@ class PeerConsensusTracker:
             if self._nudged_versions.get(role) == version:
                 del self._nudged_versions[role]
 
-    def _rearm_nudge_after_pending_acks(self, role: str) -> None:
+    def _rearm_nudge_on_guard_rejection(self, role: str) -> None:
         """Drop the nudge memo so a re-nudge fires when the guard finally clears.
+
+        Caller MUST hold ``self._lock``.
 
         A producer that already received a "ready to confirm" STATUS will
         have an entry in ``_nudged_versions`` at its current proposal
         version.  If that producer then calls ``confirm`` and the guard
-        rejects with ``pending_acks`` (peer hasn't proposed, reviewer hasn't
-        ACKed, etc.), the laggard's later state change re-runs
-        ``_collect_newly_ready_producers`` — but the memo would suppress
-        the re-emit at the same version, leaving the producer asleep in
-        ``message_wait_loop`` indefinitely (#2100).  Dropping the memo here
-        re-arms the nudge; the next sweep only emits if
-        ``check_confirm_guard`` actually passes, so this can't fire
-        prematurely.
+        rejects (``pending_acks``: peer hasn't proposed, reviewer hasn't
+        ACKed; or a reviewer-side guard like ``stale_acks`` /
+        ``unresolved_nacks`` on a dual-role agent), the laggard's later
+        state change re-runs ``_collect_newly_ready_producers`` — but the
+        memo would suppress the re-emit at the same version, leaving the
+        producer asleep in ``message_wait_loop`` indefinitely (#2100).
+        Dropping the memo here re-arms the nudge; the next sweep only
+        emits if ``check_confirm_guard`` actually passes (which evaluates
+        both producer- and reviewer-side guards for dual-role agents), so
+        this can't fire prematurely.
+
+        No-op for reviewer-only roles — they hold no producer-side memo.
         """
         if self.graph.is_producer(role):
             self._nudged_versions.pop(role, None)
@@ -564,8 +570,12 @@ class PeerConsensusTracker:
                 # Re-arm the "ready to confirm" nudge for this producer so
                 # the laggard's later proposal/ACK wakes it up via the
                 # normal _collect_newly_ready_producers sweep (#2100).
-                # No-op for reviewer-only roles.
-                self._rearm_nudge_after_pending_acks(agent_role)
+                # Runs before guard_type dispatch so it covers every
+                # rejection path (pending_acks branches and reviewer-side
+                # ValueErrors); guarded by ``is_producer`` so reviewer-only
+                # roles are a no-op and the next sweep's check_confirm_guard
+                # still blocks emission while any side of the guard fails.
+                self._rearm_nudge_on_guard_rejection(agent_role)
 
                 # Global zero-proposal guard (#1648): any producer has
                 # never proposed — blocks all agents from confirming.

--- a/orchestrator/tests/test_peer_consensus_integration.py
+++ b/orchestrator/tests/test_peer_consensus_integration.py
@@ -3152,10 +3152,18 @@ class TestReadyToConfirmNudge:
         t.handle_ack("reviewer_x", "coder", {"artifact_references": ["a.py"]})
 
         # Simulate a prior "ready to confirm" nudge for coder at v1.
-        # In current code paths this can be reached by replay during
-        # tracker reconstruction, by legacy pipelines that pre-date the
-        # #2078 nudge gating, or by an agent that self-confirms based on
-        # direct ACK observation rather than the STATUS message.
+        # We seed the memo directly rather than driving the natural
+        # population path because none of those paths reproduce in a unit
+        # test: the memo only gets set when ``_collect_newly_ready_producers``
+        # finds the producer with ``check_confirm_guard.allowed`` — but if
+        # the guard passed, ``handle_confirmed`` would not reject.  The
+        # buggy state arises in production from (a) replay during tracker
+        # reconstruction, (b) legacy pipelines that pre-date the #2078
+        # nudge gating, or (c) an agent that self-confirms based on direct
+        # ACK observation rather than the STATUS message — all of which
+        # populate the memo at one point and then race a peer's state
+        # change before reaching ``handle_confirmed``.  The seed mimics
+        # the post-race state directly.
         t._nudged_versions["coder"] = 1
 
         # coder eagerly confirms — the global zero-proposal guard rejects
@@ -3199,6 +3207,74 @@ class TestReadyToConfirmNudge:
 
         assert t._nudged_versions.get("coder") == 1, (
             "reviewer rejection must not corrupt unrelated producer memos"
+        )
+
+    def test_dual_role_reviewer_side_rejection_drops_memo_but_blocks_re_emit(self):
+        """Dual-role agent (e.g. ``tester``) hitting a reviewer-side
+        rejection while holding a producer-side memo:
+
+        - The helper runs *before* the ``guard_type`` dispatch, so the
+          producer-side memo is dropped even when the failing guard is
+          ``must_have_reviewed`` / ``stale_acks`` / ``unresolved_nacks``.
+        - Dropping the memo is safe because ``check_confirm_guard``
+          evaluates BOTH the producer- and reviewer-side guards for
+          dual-role agents — the next sweep refuses to re-emit until the
+          reviewer side also clears.
+        - Once the reviewer side clears, the previously-dropped memo
+          allows the sweep to legitimately re-nudge the agent.
+        """
+        graph = ReviewGraph(
+            [
+                ReviewEdge("tester", "coder", ReviewCriticality.CRITICAL),
+                ReviewEdge("reviewer_x", "coder", ReviewCriticality.CRITICAL),
+                ReviewEdge("reviewer_x", "tester", ReviewCriticality.CRITICAL),
+            ]
+        )
+        t = PeerConsensusTracker("test-2100-dual-role", graph, cooldown_seconds=0)
+        for role in ("coder", "tester", "reviewer_x"):
+            t.register_agent(role)
+
+        # Both producers propose v1; reviewer_x ACKs tester so tester is
+        # fully ACKed as a producer.  tester has NOT yet reviewed coder.
+        self._propose(t, "coder", artifacts=["a.py"], commit="abc123")
+        self._propose(t, "tester", artifacts=["t.py"], commit="def456")
+        t.handle_ack("reviewer_x", "tester", {"artifact_references": ["t.py"]})
+
+        # Synthetic producer-side memo for tester at v1 (see seed
+        # justification on the producer-only test above — the natural
+        # population path requires the guard to pass at memo time, which
+        # contradicts the test setup).
+        t._nudged_versions["tester"] = 1
+
+        # tester tries to confirm — reviewer-side guard rejects with
+        # ``must_have_reviewed`` (tester has not ACKed coder).  The helper
+        # runs BEFORE the dispatch, so the producer-side memo is dropped.
+        try:
+            t.handle_confirmed("tester")
+        except ValueError:
+            pass  # expected: must_have_reviewed raises
+
+        assert "tester" not in t._nudged_versions, (
+            "dual-role producer-side memo must be dropped on reviewer-side "
+            "rejection too — the helper runs before guard_type dispatch (#2100)"
+        )
+
+        # reviewer_x ACKs coder.  tester is fully ACKed as a producer but
+        # still missing a review of coder, so the reviewer-side guard
+        # still fails — the next sweep must NOT re-emit a nudge for tester.
+        ack_result = t.handle_ack("reviewer_x", "coder", {"artifact_references": ["a.py"]})
+        assert all(e["role"] != "tester" for e in ack_result["newly_ready"]), (
+            "next sweep must NOT re-emit while the reviewer side still "
+            "fails; check_confirm_guard gates emission on BOTH producer "
+            "and reviewer sides for dual-role agents"
+        )
+
+        # Once tester ACKs coder, both sides clear — sweep emits.
+        final_ack = t.handle_ack("tester", "coder", {"artifact_references": ["a.py"]})
+        ready_roles = {e["role"]: e["version"] for e in final_ack["newly_ready"]}
+        assert ready_roles.get("tester") == 1, (
+            "after both sides clear, the dropped memo allows the sweep to "
+            "re-emit the nudge legitimately"
         )
 
     def test_re_propose_re_arms_nudge(self):

--- a/orchestrator/tests/test_peer_consensus_integration.py
+++ b/orchestrator/tests/test_peer_consensus_integration.py
@@ -3125,6 +3125,82 @@ class TestReadyToConfirmNudge:
         second = t.handle_ack("reviewer_advisory", "coder", {"artifact_references": ["a.py"]})
         assert all(e["role"] != "coder" for e in second["newly_ready"])
 
+    def test_pending_acks_rejection_re_arms_nudge_for_producer(self):
+        """#2100: a producer that already received a "ready to confirm"
+        nudge but then hits a ``pending_acks`` rejection (e.g. self-confirms
+        before the global zero-proposal guard clears) must have its nudge
+        memo dropped, so the laggard's later proposal re-emits the STATUS.
+
+        Without this, the producer sits in ``message_wait_loop`` forever:
+        the original nudge already fired at version 1, and the post-propose
+        sweep would skip the producer because the memo says it has already
+        been nudged at v1.  The agent only recovers after an overseer alert
+        prompts a manual re-confirm.
+        """
+        graph = ReviewGraph(
+            [
+                ReviewEdge("reviewer_x", "coder", ReviewCriticality.CRITICAL),
+                ReviewEdge("reviewer_x", "tester", ReviewCriticality.CRITICAL),
+            ]
+        )
+        t = PeerConsensusTracker("test-2100", graph, cooldown_seconds=0)
+        for role in ("coder", "tester", "reviewer_x"):
+            t.register_agent(role)
+
+        # coder proposes and gets fully ACKed at v1.
+        self._propose(t, "coder", artifacts=["a.py"])
+        t.handle_ack("reviewer_x", "coder", {"artifact_references": ["a.py"]})
+
+        # Simulate a prior "ready to confirm" nudge for coder at v1.
+        # In current code paths this can be reached by replay during
+        # tracker reconstruction, by legacy pipelines that pre-date the
+        # #2078 nudge gating, or by an agent that self-confirms based on
+        # direct ACK observation rather than the STATUS message.
+        t._nudged_versions["coder"] = 1
+
+        # coder eagerly confirms — the global zero-proposal guard rejects
+        # because tester has proposal_version == 0.
+        confirm_result = t.handle_confirmed("coder")
+        assert confirm_result["status"] == "pending_acks"
+
+        # The memo for coder must be dropped so the next sweep can re-emit.
+        assert "coder" not in t._nudged_versions, (
+            "pending_acks rejection must re-arm the nudge for the producer (#2100)"
+        )
+
+        # tester proposes — global guard now clears, coder re-surfaces.
+        tester_result = self._propose(t, "tester", artifacts=["t.py"], commit="def5678")
+        ready_roles = {e["role"]: e["version"] for e in tester_result["newly_ready"]}
+        assert "coder" in ready_roles, (
+            "coder must be re-surfaced once the laggard proposes; "
+            "without this the wait_loop never wakes (#2100)"
+        )
+        assert ready_roles["coder"] == 1
+
+    def test_pending_acks_rejection_no_op_for_reviewer_only_role(self):
+        """The re-arm helper is gated on ``is_producer`` — invoking it for
+        a reviewer-only rejection must not touch unrelated producer memos."""
+        graph = ReviewGraph([ReviewEdge("reviewer_x", "coder", ReviewCriticality.CRITICAL)])
+        t = PeerConsensusTracker("test-2100-reviewer", graph, cooldown_seconds=0)
+        for role in ("coder", "reviewer_x"):
+            t.register_agent(role)
+
+        # Pre-populate a memo for coder that must NOT be touched when a
+        # different role hits a pending_acks rejection.
+        t._nudged_versions["coder"] = 1
+
+        # reviewer_x tries to confirm without having reviewed coder —
+        # raises ValueError (must_have_reviewed). The re-arm helper still
+        # runs first and must be a no-op for this reviewer-only role.
+        try:
+            t.handle_confirmed("reviewer_x")
+        except ValueError:
+            pass  # expected: must_have_reviewed raises
+
+        assert t._nudged_versions.get("coder") == 1, (
+            "reviewer rejection must not corrupt unrelated producer memos"
+        )
+
     def test_re_propose_re_arms_nudge(self):
         """A new proposal version re-arms the nudge so the producer is
         surfaced again once its new ACKs land."""


### PR DESCRIPTION
## Summary

- A producer that received a "ready to confirm" nudge at version V and then hit a `pending_acks` rejection (e.g. because a peer hadn't proposed yet) was never re-nudged once the laggard's proposal cleared the global zero-proposal guard. `_collect_newly_ready_producers` skipped the producer because `_nudged_versions[role]` still equaled V, so the producer sat in `message_wait_loop` until the overseer escalated manually.
- Fix: drop the nudge memo whenever `handle_confirmed` rejects a producer with `pending_acks`. The next state change (peer's PROPOSE/ACK/etc.) re-runs the existing sweep, which only emits when `check_confirm_guard` actually passes — so the rollback is safe and can't fire prematurely.

## Why this shape

The issue suggested two options: re-emit a new STATUS subject (with a wait_loop filter change) or auto-promote pending-acks confirmations. This is a leaner version of Option 1 — re-use the existing nudge mechanism by rolling back the memo, rather than introducing a new STATUS shape and a new wait_loop wake condition. The agent path that already handles "ready to confirm" STATUS messages is preserved unchanged.

## Test plan

- [x] `pytest orchestrator/tests/test_peer_consensus_integration.py::TestReadyToConfirmNudge` — all 6 tests pass, including 2 new regression tests.
- [x] `pytest orchestrator/tests/` — all 4731 tests pass (1 skipped, unrelated).
- [x] `make lint` — clean.
- [x] New tests assert (a) memo is dropped on `pending_acks` rejection and the laggard's proposal re-surfaces the producer in `newly_ready`; (b) the helper is a no-op for reviewer-only roles and does not corrupt unrelated producer memos.

Fixes #2100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)