### PR TITLE
Fix autofix workflow on PRs with multi-line titles

### DIFF
--- a/.github/workflows/reusable-check-fixer.yml
+++ b/.github/workflows/reusable-check-fixer.yml
@@ -131,7 +131,9 @@ jobs:
           {
             echo "head-ref=$(echo "$pr_json" | jq -r '.head.ref')"
             echo "head-repo=$(echo "$pr_json" | jq -r '.head.repo.full_name')"
-            echo "title=$(echo "$pr_json" | jq -r '.title')"
+            echo "title<<EOF_TITLE"
+            echo "$pr_json" | jq -r '.title'
+            echo "EOF_TITLE"
           } >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}


### PR DESCRIPTION
## Summary

- The `Fetch PR metadata` step in `.github/workflows/reusable-check-fixer.yml` wrote the PR title to `$GITHUB_OUTPUT` with plain `key=value` syntax. When a PR title spans multiple lines (e.g. PR #2105), GitHub Actions parsed the second line as a malformed output entry and failed the step with `Invalid format ...`, short-circuiting every downstream autofix step (skip check, identify failed jobs, run fixers).
- Switch the `title` output to heredoc syntax so multi-line values are captured intact.

Repro: [run 24945164442](https://github.com/jwbron/egg/actions/runs/24945164442) on PR #2105 — title was `Simplify repository configuration — schema cleanup, layered\nrepo+local config, onboard skill, validator`, and the second line surfaced as `Invalid format 'repo+local config, onboard skill, validator'`.

## Test plan

- [ ] Re-run the autofix workflow against a PR with a multi-line title (e.g. re-trigger on #2105) and confirm `Fetch PR metadata` succeeds and downstream steps execute.
- [ ] Confirm autofix still works on a single-line-title PR (no regression in the common case).