### PR TITLE
tests: remove jira-wrapper artifact-location fallback (#2136)

### DIFF
--- a/tests/sandbox/test_jira_wrapper.py
+++ b/tests/sandbox/test_jira_wrapper.py
@@ -11,12 +11,6 @@ and asserts:
 - Missing ``EGG_SESSION_TOKEN`` fails closed.
 - Missing gateway fails closed with the standard error banner.
 
-The wrapper lives at ``sandbox/scripts/jira`` (canonical) or the artifact
-location ``.egg-state/agent-outputs/1556-sandbox-scripts-jira`` (until a
-role with push rights for ``sandbox/scripts/`` lands it at the canonical
-path).  Either is acceptable for verification; the test prefers the
-canonical location when present.
-
 Note: this file exercises the wrapper directly; the actual route
 enforcement (private-mode gate, project allowlist, etc.) is covered in
 ``gateway/tests/test_jira_routes.py``.  The wrapper's only job is to
@@ -43,18 +37,14 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _CANONICAL = _REPO_ROOT / "sandbox" / "scripts" / "jira"
-_ARTIFACT = _REPO_ROOT / ".egg-state" / "agent-outputs" / "1556-sandbox-scripts-jira"
 
 
 def _locate_wrapper() -> Path:
-    """Return the wrapper path; skip the test if neither is present."""
+    """Return the wrapper path; skip the test if it is not present."""
     if _CANONICAL.exists():
         return _CANONICAL
-    if _ARTIFACT.exists():
-        return _ARTIFACT
     pytest.skip(
-        "sandbox jira wrapper not found at "
-        f"{_CANONICAL} or {_ARTIFACT} — coder proposal #1556 may be incomplete.",
+        f"sandbox jira wrapper not found at {_CANONICAL}.",
         allow_module_level=True,
     )
 


### PR DESCRIPTION
## Summary

- Drops the dead `.egg-state/agent-outputs/1556-sandbox-scripts-jira` fallback in `tests/sandbox/test_jira_wrapper.py`. With #2135 merged, new wrappers land at `sandbox/scripts/jira` directly and the artifact location can never appear.
- Removes the docstring paragraph describing the canonical-vs-artifact dance, the `_ARTIFACT` constant, and the fallback branch in `_locate_wrapper()`; simplifies the skip message accordingly.

Closes #2136.

## Test plan

- [x] `pytest tests/sandbox/test_jira_wrapper.py` — 19/19 passed locally
- [x] Confirmed no remaining references to `_ARTIFACT` or `1556-sandbox-scripts-jira` in the file