### PR TITLE
fix: make state-store _ensure_worktree idempotent for broken worktrees (#2140)

### DIFF
--- a/orchestrator/state_store.py
+++ b/orchestrator/state_store.py
@@ -216,24 +216,55 @@ class StateStore:
 
         wt = self._worktree_dir
 
-        if wt.exists() and (wt / ".git").exists():
-            # Quick validity check with one retry for transient git
-            # contention (e.g., concurrent _commit_statefiles_to_worktree
-            # holding a lock on the shared .git directory).  See #1396.
+        if wt.exists():
+            # Validate against `git rev-parse` rather than relying on the
+            # presence of `wt/.git`.  The `.git` link can be missing or
+            # broken (e.g., the matching admin dir under
+            # `<repo>/.git/worktrees/...` was orphaned by a crash) while
+            # the worktree directory itself still sits on disk.  In that
+            # state, falling through to `git worktree add` below would
+            # fail with `'<wt>' already exists` and strand the pipeline
+            # on `request_changes` re-runs (#2140).  Probe with rev-parse
+            # and only treat the worktree as healthy when git agrees.
+            #
+            # One retry covers transient git contention (e.g., concurrent
+            # _commit_statefiles_to_worktree holding a lock on the shared
+            # .git directory).  See #1396.
+            healthy = False
             for _attempt in range(2):
                 result = self._run_git("rev-parse", "--is-inside-work-tree", cwd=wt, check=False)
                 if result.returncode == 0:
-                    return wt
+                    healthy = True
+                    break
                 if _attempt == 0:
                     time.sleep(0.1)
-            # Stale/broken — remove and recreate
+            if healthy:
+                return wt
+
             logger.warning(
-                "Worktree validation failed after retry, recreating: worktree=%s returncode=%s",
+                "Worktree validation failed, recreating: worktree=%s returncode=%s",
                 str(wt),
                 result.returncode,
             )
-            shutil.rmtree(wt, ignore_errors=True)
-            self._remove_stale_admin_dir()
+            try:
+                shutil.rmtree(wt)
+            except OSError as exc:
+                raise GitOperationError(
+                    f"Failed to remove stale state worktree at {wt}: {exc}"
+                ) from exc
+            # Force-remove the admin dir too — the matching wt directory
+            # was just removed, but `_remove_stale_admin_dir` checks
+            # `wt.exists()` before deleting, so call the forced variant
+            # to guarantee `git worktree add` won't refuse.
+            self._remove_stale_admin_dir(force=True)
+            if wt.exists():
+                # Defensive: rmtree returned without raising but the
+                # directory persists (e.g., a sub-mount).  Refuse to
+                # call `git worktree add` over it.
+                raise GitOperationError(
+                    f"State worktree at {wt} could not be removed; "
+                    "refusing to recreate over existing directory"
+                )
 
         wt.parent.mkdir(parents=True, exist_ok=True)
 
@@ -269,7 +300,7 @@ class StateStore:
 
         return wt
 
-    def _remove_stale_admin_dir(self) -> None:
+    def _remove_stale_admin_dir(self, force: bool = False) -> None:
         """Remove the git admin dir for the state worktree if it's stale.
 
         When the state worktree directory is gone but its admin dir still
@@ -278,6 +309,13 @@ class StateStore:
         admin dir that belongs to this state worktree — without touching
         admin dirs for other worktrees (e.g., gateway-managed container
         worktrees).
+
+        Args:
+            force: When True, remove the admin dir even if the worktree
+                directory still exists.  Used by ``_ensure_worktree`` after
+                it has just removed a broken worktree directory and is
+                about to recreate it; without this, the orphaned admin
+                dir would still cause ``git worktree add`` to refuse.
         """
         worktrees_dir = self.repo_path / ".git" / "worktrees"
         if not worktrees_dir.exists():
@@ -296,8 +334,7 @@ class StateStore:
                 gitdir_content = gitdir_file.read_text().strip()
                 if gitdir_content.rstrip("/") == expected_gitdir.rstrip("/"):
                     # This admin dir belongs to our state worktree
-                    if not wt.exists():
-                        # Worktree dir is gone — admin dir is stale
+                    if force or not wt.exists():
                         shutil.rmtree(entry, ignore_errors=True)
                     return
             except OSError:

--- a/orchestrator/state_store.py
+++ b/orchestrator/state_store.py
@@ -212,6 +212,12 @@ class StateStore:
         # see the gateway's worktree paths (different bind mounts), so prune
         # would incorrectly remove admin dirs for active gateway worktrees,
         # breaking all container git operations.
+        #
+        # This early call covers the wt-gone case: the worktree directory was
+        # wiped (e.g., state volume reset) but the admin dir under
+        # `<repo>/.git/worktrees/` survived.  The forced call later in this
+        # method (line ~259) covers the wt-broken case: the worktree directory
+        # is on disk but rev-parse rejects it.
         self._remove_stale_admin_dir()
 
         wt = self._worktree_dir

--- a/orchestrator/tests/test_state_store.py
+++ b/orchestrator/tests/test_state_store.py
@@ -1523,3 +1523,147 @@ class TestCommitFailureResilience:
 
         with pytest.raises(PipelineNotFoundError, match="empty"):
             state_store.load_pipeline("issue-704")
+
+
+class TestEnsureWorktreeIdempotency:
+    """Regression tests for #2140 — `_ensure_worktree` must be idempotent
+    against worktree directories that exist on disk but are missing or
+    have a broken `.git` link."""
+
+    def _make_store(self, tmp_path):
+        repo_path = tmp_path / "repo"
+        repo_path.mkdir()
+        (repo_path / ".git").mkdir()
+        worktree_dir = tmp_path / "wt"
+        store = StateStore(repo_path, worktree_dir=worktree_dir)
+        return store, worktree_dir
+
+    def _git_router(self, *, rev_parse_returncodes, branch_exists=True):
+        """Build a `_run_git` side_effect that routes by command.
+
+        - `rev-parse --is-inside-work-tree` → returncodes from
+          `rev_parse_returncodes` (one per call, in order).
+        - `rev-parse --verify refs/heads/...` → branch existence probe.
+        - Anything else → success.
+        """
+        rev_parse_iter = iter(rev_parse_returncodes)
+
+        def run_git(*args, check=True, cwd=None):
+            if args[:2] == ("rev-parse", "--is-inside-work-tree"):
+                rc = next(rev_parse_iter)
+                return MagicMock(stdout="", returncode=rc)
+            if args[:2] == ("rev-parse", "--verify"):
+                return MagicMock(stdout="", returncode=0 if branch_exists else 1)
+            return MagicMock(stdout="", returncode=0)
+
+        return run_git
+
+    def test_idempotent_when_worktree_healthy(self, tmp_path):
+        """Repeat _ensure_worktree calls reuse a healthy worktree —
+        `git worktree add` must NOT be invoked the second time."""
+        store, wt = self._make_store(tmp_path)
+        wt.mkdir()
+        (wt / ".git").write_text("gitdir: /fake\n")
+
+        with patch.object(
+            StateStore, "_run_git", side_effect=self._git_router(rev_parse_returncodes=[0, 0])
+        ) as mock_git:
+            assert store._ensure_worktree() == wt
+            assert store._ensure_worktree() == wt
+
+        # Neither call should have invoked `git worktree add` because the
+        # worktree validated cleanly both times.
+        worktree_add_calls = [
+            c for c in mock_git.call_args_list if c.args[:2] == ("worktree", "add")
+        ]
+        assert worktree_add_calls == []
+
+    def test_recreates_when_dot_git_missing(self, tmp_path):
+        """Worktree dir exists but `.git` link is missing (#2140 trigger).
+
+        Prior to the fix, the validity branch was gated on `(wt / ".git").exists()`,
+        so this case skipped the cleanup entirely and fell through to
+        `git worktree add`, which fails with "already exists"."""
+        store, wt = self._make_store(tmp_path)
+        wt.mkdir()
+        # Intentionally do not create wt/.git — simulates an orphaned admin dir
+        # whose admin metadata under <repo>/.git/worktrees/ is gone.
+        (wt / "leftover.txt").write_text("from cycle 0")
+
+        # rev-parse fails twice (no .git), forcing recreate.
+        with patch.object(
+            StateStore, "_run_git", side_effect=self._git_router(rev_parse_returncodes=[1, 1])
+        ) as mock_git:
+            with patch("state_store.time.sleep"):
+                result = store._ensure_worktree()
+
+        assert result == wt
+        # `git worktree add <wt> <STATE_BRANCH>` must have been called after
+        # cleanup — confirms we took the recreate path, not the failure path.
+        worktree_add_calls = [
+            c for c in mock_git.call_args_list if c.args[:2] == ("worktree", "add")
+        ]
+        assert len(worktree_add_calls) == 1
+        # And the leftover from cycle 0 must be gone (rmtree ran).
+        assert not (wt / "leftover.txt").exists()
+
+    def test_recreates_when_rev_parse_fails(self, tmp_path):
+        """Worktree dir + .git both exist but rev-parse fails twice.
+
+        Existing behavior, but previously cleanup used
+        `shutil.rmtree(..., ignore_errors=True)` which silently masked
+        failures. This test confirms the recreate path still runs."""
+        store, wt = self._make_store(tmp_path)
+        wt.mkdir()
+        (wt / ".git").write_text("gitdir: /broken\n")
+
+        with patch.object(
+            StateStore, "_run_git", side_effect=self._git_router(rev_parse_returncodes=[1, 1])
+        ) as mock_git:
+            with patch("state_store.time.sleep"):
+                result = store._ensure_worktree()
+
+        assert result == wt
+        worktree_add_calls = [
+            c for c in mock_git.call_args_list if c.args[:2] == ("worktree", "add")
+        ]
+        assert len(worktree_add_calls) == 1
+
+    def test_rmtree_failure_raises_git_error(self, tmp_path):
+        """If cleanup rmtree fails, we surface a GitOperationError instead
+        of silently falling through to `git worktree add` (which would
+        produce the cryptic "already exists" failure that motivates #2140)."""
+        store, wt = self._make_store(tmp_path)
+        wt.mkdir()
+        (wt / ".git").write_text("gitdir: /broken\n")
+
+        with patch.object(
+            StateStore, "_run_git", side_effect=self._git_router(rev_parse_returncodes=[1, 1])
+        ):
+            with (
+                patch("state_store.time.sleep"),
+                patch("state_store.shutil.rmtree", side_effect=OSError("permission denied")),
+            ):
+                with pytest.raises(
+                    GitOperationError, match="Failed to remove stale state worktree"
+                ):
+                    store._ensure_worktree()
+
+    def test_force_removes_admin_dir_when_worktree_present(self, tmp_path):
+        """`_remove_stale_admin_dir(force=True)` clears the admin dir even
+        when the worktree directory still exists. The default behavior
+        (force=False) preserves the admin dir in that case."""
+        store, wt = self._make_store(tmp_path)
+        wt.mkdir()  # worktree dir exists
+
+        admin_dir = store.repo_path / ".git" / "worktrees" / "wt"
+        admin_dir.mkdir(parents=True)
+        (admin_dir / "gitdir").write_text(f"{wt}/.git\n")
+
+        # Default: admin dir is preserved because wt exists.
+        store._remove_stale_admin_dir()
+        assert admin_dir.exists()
+
+        # Forced: admin dir is removed.
+        store._remove_stale_admin_dir(force=True)
+        assert not admin_dir.exists()

--- a/orchestrator/tests/test_state_store.py
+++ b/orchestrator/tests/test_state_store.py
@@ -1649,6 +1649,30 @@ class TestEnsureWorktreeIdempotency:
                 ):
                     store._ensure_worktree()
 
+    def test_transient_rev_parse_failure_recovers_on_retry(self, tmp_path):
+        """First rev-parse fails, second succeeds — worktree must be reused
+        without recreate.  Locks in the #1396 retry behavior so future
+        refactors don't accidentally collapse it to a single attempt."""
+        store, wt = self._make_store(tmp_path)
+        wt.mkdir()
+        (wt / ".git").write_text("gitdir: /fake\n")
+        (wt / "preserved.txt").write_text("survives transient contention")
+
+        with patch.object(
+            StateStore, "_run_git", side_effect=self._git_router(rev_parse_returncodes=[1, 0])
+        ) as mock_git:
+            with patch("state_store.time.sleep"):
+                result = store._ensure_worktree()
+
+        assert result == wt
+        # No recreate: rmtree never ran (file is preserved) and `git worktree
+        # add` was not invoked.
+        assert (wt / "preserved.txt").exists()
+        worktree_add_calls = [
+            c for c in mock_git.call_args_list if c.args[:2] == ("worktree", "add")
+        ]
+        assert worktree_add_calls == []
+
     def test_force_removes_admin_dir_when_worktree_present(self, tmp_path):
         """`_remove_stale_admin_dir(force=True)` clears the admin dir even
         when the worktree directory still exists. The default behavior


### PR DESCRIPTION
## Summary

Fixes #2140. On `provide_input(action=request_changes)` (and `change_approach`), the orchestrator resets the phase and re-launches `_run_pipeline`. That fresh run instantiates a new `StateStore` (`get_state_store` is not a singleton), which lazily calls `_ensure_worktree`. The previous check was gated on `(wt / ".git").exists()`, so a worktree directory whose `.git` link was missing or broken fell straight through to `git worktree add` and failed with `'<wt>' already exists`, stranding the pipeline in FAILED with no recovery path.

- `orchestrator/state_store.py`: probe with `git rev-parse --is-inside-work-tree` whenever the worktree dir exists (no longer gated on `.git` presence); on validation failure, do a loud `shutil.rmtree(wt)` (no `ignore_errors=True`) and raise `GitOperationError` if removal fails; force-remove the matching admin dir before recreating.
- `orchestrator/state_store.py`: `_remove_stale_admin_dir` gains a `force: bool = False` parameter; default behavior preserved for the entry-point call.
- `orchestrator/tests/test_state_store.py`: new `TestEnsureWorktreeIdempotency` class covering the bug trigger, regression cases, and idempotent re-entry.

## Why this lives in the state store, not the `request_changes` reset path

The same hole strands the pipeline whenever the orchestrator restarts mid-run (the worktree directory persists on the state volume but the matching admin dir under `<repo>/.git/worktrees/` gets orphaned). Fixing it inside `_ensure_worktree` covers `request_changes`, `change_approach`, and orchestrator restarts uniformly without adding a new cleanup hook to the resolution code path.

## Test plan

- [x] `pytest orchestrator/tests/test_state_store.py` (104 passed, including 5 new)
- [x] `pytest orchestrator/tests/test_hitl_revision.py` (75 passed)
- [x] `ruff check` + `ruff format` clean
- [ ] CI green