### PR TITLE
overseer: fix lock docstring in state.py (#2114)

### DIFF
--- a/shared/egg_overseer/state.py
+++ b/shared/egg_overseer/state.py
@@ -16,8 +16,11 @@ The helpers are deliberately lightweight: no orchestrator dependency, no
 DB driver. The advisor-strategy pipeline runs fast enough that file I/O
 on bounded JSON is not a bottleneck. Concurrent writers (overseer
 respawns at phase boundaries) are protected by an ``fcntl.LOCK_EX``
-flock on a sentinel ``agent-timing.lock`` file per the risk_analyst's
-R-PERF-02 / R-SEC-04 mitigation.
+flock on a per-file ``<datafile>.lock`` sentinel created alongside each
+state file (so ``agent-timing.json.lock`` guards the timing file and
+``filed-issues.jsonl.lock`` guards the JSONL — the two files have no
+cross-dependency, so a shared lock would only add false contention)
+per the risk_analyst's R-PERF-02 / R-SEC-04 mitigation.
 """
 
 from __future__ import annotations
@@ -119,11 +122,13 @@ def append_filed_issue(path: str | os.PathLike[str], record: FiledIssueRecord) -
     ``record.model_dump_json()``. Calls ``fsync`` so the record is
     durable before the function returns.
 
-    Concurrency: acquires ``fcntl.LOCK_EX`` via the same
-    ``agent-timing.lock`` sentinel used by ``save_agent_timing``
+    Concurrency: acquires ``fcntl.LOCK_EX`` via a
+    ``filed-issues.jsonl.lock`` sentinel sitting alongside the JSONL
     so concurrent overseer respawns don't interleave records (POSIX
     only guarantees atomic writes ≤ ``PIPE_BUF`` bytes; record JSON
-    can exceed that).
+    can exceed that). This lock is independent of the
+    ``agent-timing.json.lock`` used by ``save_agent_timing`` —
+    the two files have no cross-dependency.
 
     Args:
         path: Filesystem path to ``filed-issues.jsonl``.


### PR DESCRIPTION
## Summary

Closes #2114.

The `append_filed_issue` docstring at `shared/egg_overseer/state.py:122-126` claimed it shared a single `agent-timing.lock` sentinel with `save_agent_timing`, but the implementation derives the lock name from whichever data file is passed in (`<datafile>.lock` via `_lock_path_for`). The two helpers actually use independent locks: `agent-timing.json.lock` for the timing file and `filed-issues.jsonl.lock` for the JSONL. The module-level docstring (lines 17-20) carried the same wrong claim and likely seeded the bug.

## Decision: separate locks is correct, fix the docs

The two state files have no logical cross-dependency:
- `agent-timing.json` — detector timing snapshot (load → mutate → atomic-replace).
- `filed-issues.jsonl` — append-only dedup log for `gh issue create`.

No call site reads/writes both inside a single critical section. A shared lock would create false contention between unrelated paths. The per-file sentinel pattern in `_lock_path_for` is the deliberate design — only the docstrings were inaccurate.

## Call-site audit (issue scope item 3)

- `_file_lock` and `_lock_path_for` are private to `state.py`; no other module references them.
- Public callers (`sandbox/overseer_monitor.py`, `sandbox/egg_lib/overseer_issue_body.py`, tests) do not assume lock isolation or sharing between the two files.
- No code change beyond the two docstrings is needed.

## Changes

- `shared/egg_overseer/state.py:17-25` — module docstring now describes the per-file `<datafile>.lock` sentinel pattern with both concrete names spelled out.
- `shared/egg_overseer/state.py:125-131` — `append_filed_issue` docstring now correctly references `filed-issues.jsonl.lock` and notes it is independent of `agent-timing.json.lock`.

Docs-only; no behavior, schema, tests, or call sites touched.

## Test plan

- [x] Pre-commit hooks pass (ruff legacy alias, ruff format, trailing whitespace, EOF).
- [x] File still parses (`python -c "import ast; ast.parse(...)"`).
- [x] Verified by inspection that the new docstring matches what `_file_lock` + `_lock_path_for` actually do for each call site.