### PR TITLE
Fix #2120: enforce recent_log_lines byte cap on advisor prompt-builder

### DIFF
--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -428,6 +428,21 @@ class PipelineConfig(BaseModel):
             "until the follow-up advisor-budget issue lands."
         ),
     )
+    overseer_advisor_recent_log_bytes_cap: int = Field(
+        default=256_000,
+        ge=0,
+        description=(
+            "Byte cap for the ``recent_log_lines`` block in the advisor "
+            "prompt (issue #2120). When the joined block exceeds the "
+            "cap, the prompt-builder drops oldest lines first so the "
+            "most-recent lines (highest signal) survive, and prepends a "
+            "marker so the advisor knows truncation happened. 256 KiB "
+            "default sits well under the opus context window with "
+            "headroom for the rest of the prompt; bump for log-heavy "
+            "anomalies, set to 0 to disable (not recommended — leaves "
+            "the prompt-builder open to pathological log payloads)."
+        ),
+    )
     overseer_auto_file_issues_mode: Literal["shadow", "live"] = Field(
         default="shadow",
         description=(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2722,7 +2722,7 @@ def get_pipeline_status(pipeline_id: str) -> tuple[Response, int]:
                 data["config"] = {
                     "overseer_advisor_model": getattr(cfg, "overseer_advisor_model", None),
                     "overseer_advisor_recent_log_bytes_cap": getattr(
-                        cfg, "overseer_advisor_recent_log_bytes_cap", 256_000
+                        cfg, "overseer_advisor_recent_log_bytes_cap", None
                     ),
                     "overseer_auto_file_issues_mode": getattr(
                         cfg, "overseer_auto_file_issues_mode", None

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2721,6 +2721,9 @@ def get_pipeline_status(pipeline_id: str) -> tuple[Response, int]:
             if cfg is not None:
                 data["config"] = {
                     "overseer_advisor_model": getattr(cfg, "overseer_advisor_model", None),
+                    "overseer_advisor_recent_log_bytes_cap": getattr(
+                        cfg, "overseer_advisor_recent_log_bytes_cap", 256_000
+                    ),
                     "overseer_auto_file_issues_mode": getattr(
                         cfg, "overseer_auto_file_issues_mode", None
                     ),

--- a/orchestrator/tests/test_concurrent_status.py
+++ b/orchestrator/tests/test_concurrent_status.py
@@ -250,6 +250,25 @@ class TestPipelineStatusConcurrentEndpoint:
 
     @patch("routes.pipelines.get_repo_path", return_value="/tmp/test-repo")
     @patch("routes.pipelines._resolve_pipeline")
+    def test_status_exposes_overseer_advisor_recent_log_bytes_cap(
+        self, mock_resolve, mock_repo_path, client
+    ):
+        """Issue #2120: the status endpoint exposes the byte-cap config field
+        so the overseer agent can forward it to ``consult-advisor``."""
+        pipeline = _make_concurrent_pipeline(
+            overseer_advisor_recent_log_bytes_cap=65_536,
+        )
+        mock_store = MagicMock()
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        resp = client.get("/api/v1/pipelines/issue-999/status")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        cfg = data["data"]["config"]
+        assert cfg["overseer_advisor_recent_log_bytes_cap"] == 65_536
+
+    @patch("routes.pipelines.get_repo_path", return_value="/tmp/test-repo")
+    @patch("routes.pipelines._resolve_pipeline")
     def test_concurrent_section_absent_for_non_concurrent(
         self, mock_resolve, mock_repo_path, client
     ):

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -2359,6 +2359,17 @@ def _add_json_flag(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--json", action="store_true", help="Output raw JSON")
 
 
+def _non_negative_int(value: str) -> int:
+    """argparse type validator: reject negative ints, mirror PipelineConfig ge=0."""
+    try:
+        ivalue = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a valid integer") from exc
+    if ivalue < 0:
+        raise argparse.ArgumentTypeError(f"{ivalue} must be >= 0 (use 0 to disable)")
+    return ivalue
+
+
 def create_parser() -> argparse.ArgumentParser:
     """Create the argument parser."""
     parser = argparse.ArgumentParser(
@@ -3113,13 +3124,14 @@ def create_parser() -> argparse.ArgumentParser:
     )
     ov_advisor.add_argument(
         "--recent-log-bytes-cap",
-        type=int,
+        type=_non_negative_int,
         default=None,
         help=(
             "Byte cap for the recent_log_lines block in the advisor "
             "prompt (issue #2120). When omitted, consult_advisor uses "
             "the PipelineConfig value or its 256 KiB default. 0 "
-            "disables the cap (not recommended)."
+            "disables the cap (not recommended). Negative values are "
+            "rejected (matches PipelineConfig ge=0)."
         ),
     )
     _add_json_flag(ov_advisor)

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -1809,6 +1809,7 @@ def cmd_overseer_consult_advisor(args: argparse.Namespace) -> int:
         print("Error: inputs.recent_log_lines must be an array", file=sys.stderr)
         return 2
 
+    recent_log_bytes_cap = getattr(args, "recent_log_bytes_cap", None)
     try:
         verdict = asyncio.run(
             consult_advisor(
@@ -1817,6 +1818,7 @@ def cmd_overseer_consult_advisor(args: argparse.Namespace) -> int:
                 progress_events=progress_events,
                 recent_log_lines=recent_log_lines,
                 config=None,
+                recent_log_bytes_cap=recent_log_bytes_cap,
             )
         )
     except AdvisorParseError as exc:
@@ -3107,6 +3109,17 @@ def create_parser() -> argparse.ArgumentParser:
             "--output-file, --json additionally tees the verdict JSON "
             "to stdout; without --output-file, --json is a no-op "
             "since stdout is already JSON."
+        ),
+    )
+    ov_advisor.add_argument(
+        "--recent-log-bytes-cap",
+        type=int,
+        default=None,
+        help=(
+            "Byte cap for the recent_log_lines block in the advisor "
+            "prompt (issue #2120). When omitted, consult_advisor uses "
+            "the PipelineConfig value or its 256 KiB default. 0 "
+            "disables the cap (not recommended)."
         ),
     )
     _add_json_flag(ov_advisor)

--- a/sandbox/tests/test_egg_orch_overseer_consult_advisor.py
+++ b/sandbox/tests/test_egg_orch_overseer_consult_advisor.py
@@ -85,6 +85,38 @@ class TestOverseerConsultAdvisorParser:
         )
         assert ns.recent_log_bytes_cap is None
 
+    def test_parser_recent_log_bytes_cap_rejects_negative(self) -> None:
+        # Issue #2120 review: PipelineConfig has ``ge=0`` on the matching
+        # field, so the CLI mirrors that — negatives raise rather than
+        # silently being treated as "disabled" by the truncation helper.
+        parser = create_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(
+                [
+                    "overseer",
+                    "consult-advisor",
+                    "--inputs-file",
+                    "/tmp/inputs.json",
+                    "--recent-log-bytes-cap",
+                    "-1",
+                ]
+            )
+
+    def test_parser_recent_log_bytes_cap_accepts_zero(self) -> None:
+        # 0 is the documented "disable" sentinel and must remain accepted.
+        parser = create_parser()
+        ns = parser.parse_args(
+            [
+                "overseer",
+                "consult-advisor",
+                "--inputs-file",
+                "/tmp/inputs.json",
+                "--recent-log-bytes-cap",
+                "0",
+            ]
+        )
+        assert ns.recent_log_bytes_cap == 0
+
 
 # ---------------------------------------------------------------------------
 # cmd_overseer_consult_advisor behaviour

--- a/sandbox/tests/test_egg_orch_overseer_consult_advisor.py
+++ b/sandbox/tests/test_egg_orch_overseer_consult_advisor.py
@@ -56,6 +56,35 @@ class TestOverseerConsultAdvisorParser:
         with pytest.raises(SystemExit):
             parser.parse_args(["overseer", "consult-advisor"])
 
+    def test_parser_accepts_recent_log_bytes_cap(self) -> None:
+        # Issue #2120: --recent-log-bytes-cap forwards an integer cap to
+        # consult_advisor. Default is None (defer to PipelineConfig /
+        # advisor module default).
+        parser = create_parser()
+        ns = parser.parse_args(
+            [
+                "overseer",
+                "consult-advisor",
+                "--inputs-file",
+                "/tmp/inputs.json",
+                "--recent-log-bytes-cap",
+                "65536",
+            ]
+        )
+        assert ns.recent_log_bytes_cap == 65536
+
+    def test_parser_recent_log_bytes_cap_defaults_to_none(self) -> None:
+        parser = create_parser()
+        ns = parser.parse_args(
+            [
+                "overseer",
+                "consult-advisor",
+                "--inputs-file",
+                "/tmp/inputs.json",
+            ]
+        )
+        assert ns.recent_log_bytes_cap is None
+
 
 # ---------------------------------------------------------------------------
 # cmd_overseer_consult_advisor behaviour
@@ -67,11 +96,13 @@ def _make_args(
     inputs_file: str | Path,
     output_file: str | Path | None = None,
     json_flag: bool = True,
+    recent_log_bytes_cap: int | None = None,
 ) -> argparse.Namespace:
     return argparse.Namespace(
         inputs_file=str(inputs_file),
         output_file=str(output_file) if output_file else None,
         json=json_flag,
+        recent_log_bytes_cap=recent_log_bytes_cap,
     )
 
 
@@ -186,6 +217,10 @@ class TestOverseerConsultAdvisorCommand:
         assert captured["progress_events"] == [{"step": "edit", "state": "working"}]
         assert captured["recent_log_lines"] == ["line 1", "line 2"]
         assert captured["config"] is None
+        # Issue #2120: cap defaults to None when the flag isn't passed,
+        # leaving consult_advisor to use the PipelineConfig value or
+        # advisor module default.
+        assert captured["recent_log_bytes_cap"] is None
 
     def test_output_file_receives_verdict(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -302,6 +337,27 @@ class TestOverseerConsultAdvisorCommand:
             rc = cmd_overseer_consult_advisor(_make_args(inputs_file=inputs, output_file=out_path))
         assert rc == 2
         assert "cannot write --output-file" in capsys.readouterr().err
+
+    def test_recent_log_bytes_cap_flag_forwarded(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        inputs = tmp_path / "inputs.json"
+        _write_inputs(inputs)
+        captured: dict[str, object] = {}
+
+        async def _fake(**kwargs: object) -> AdvisorVerdict:
+            captured.update(kwargs)
+            return AdvisorVerdict(decision="watch", reasoning="ok")
+
+        with patch(
+            "egg_overseer.advisor.consult_advisor",
+            side_effect=_fake,
+        ):
+            rc = cmd_overseer_consult_advisor(
+                _make_args(inputs_file=inputs, recent_log_bytes_cap=8192)
+            )
+        assert rc == 0
+        assert captured["recent_log_bytes_cap"] == 8192
 
     def test_missing_optional_keys_default_to_empty(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/shared/egg_overseer/advisor.py
+++ b/shared/egg_overseer/advisor.py
@@ -66,6 +66,14 @@ _PROMPT_SYSTEM = (
 )
 
 
+# Default byte cap for the ``recent_log_lines`` block (issue #2120). The
+# advisor model is opus-class with ~200k token context; 256 KiB sits
+# well under that with comfortable headroom for the system prompt,
+# classification, health alerts, progress events, and instructions.
+# Tunable per-pipeline via ``PipelineConfig.overseer_advisor_recent_log_bytes_cap``.
+_DEFAULT_RECENT_LOG_BYTES_CAP = 256_000
+
+
 class AdvisorVerdict(BaseModel):
     """Structured verdict returned by ``consult_advisor``."""
 
@@ -103,17 +111,59 @@ class AdvisorParseError(RuntimeError):
     """Raised when the advisor returns text that doesn't parse to AdvisorVerdict."""
 
 
+def _truncate_log_lines_by_bytes(
+    lines: list[str],
+    cap_bytes: int,
+) -> tuple[list[str], int, int]:
+    """Drop oldest lines until the joined block fits under ``cap_bytes``.
+
+    Walks from the most-recent line backward so the tail (highest-signal
+    for the advisor) is preserved. Byte accounting matches the join
+    used in :func:`_build_prompt`: each line's UTF-8 length plus one
+    byte for the newline that joins it to its neighbor.
+
+    A single line larger than ``cap_bytes`` is dropped along with
+    everything before it; the prompt section will fall through to
+    "(none)" and the caller logs the truncation event so pathological
+    producers stay observable.
+
+    Returns ``(kept_lines, dropped_line_count, dropped_byte_count)``.
+    ``cap_bytes <= 0`` disables the cap and returns the input unchanged.
+    """
+    if cap_bytes <= 0 or not lines:
+        return list(lines), 0, 0
+    kept_reversed: list[str] = []
+    total_bytes = 0
+    for line in reversed(lines):
+        size = len(line.encode("utf-8")) + 1  # +1 == joining "\n"
+        if total_bytes + size > cap_bytes:
+            break
+        kept_reversed.append(line)
+        total_bytes += size
+    kept = list(reversed(kept_reversed))
+    dropped_count = len(lines) - len(kept)
+    if dropped_count == 0:
+        return kept, 0, 0
+    dropped_bytes = sum(len(line.encode("utf-8")) + 1 for line in lines[:dropped_count])
+    return kept, dropped_count, dropped_bytes
+
+
 def _build_prompt(
     *,
     classification: dict[str, Any],
     health_alerts: list[dict[str, Any]],
     progress_events: list[dict[str, Any]],
     recent_log_lines: list[str],
+    truncation_marker: str | None = None,
 ) -> str:
     """Build the single-turn user prompt per ``decision-20`` opt-3.
 
     Distilled summary: classification + last N progress events + active
     health alerts + last K log lines.
+
+    ``truncation_marker``, when non-None, is rendered above the log
+    block so the advisor knows the prompt-builder dropped earlier
+    lines to fit the byte cap (issue #2120).
     """
     sections: list[str] = []
     sections.append("## Haiku classification")
@@ -132,9 +182,11 @@ def _build_prompt(
         sections.append("(none)")
     sections.append("")
     sections.append("## Recent container log lines (last K)")
+    if truncation_marker is not None:
+        sections.append(truncation_marker)
     if recent_log_lines:
         sections.append("\n".join(recent_log_lines))
-    else:
+    elif truncation_marker is None:
         sections.append("(none)")
     sections.append("")
     sections.append(
@@ -153,6 +205,7 @@ async def consult_advisor(
     progress_events: list[dict[str, Any]],
     recent_log_lines: list[str],
     config: PipelineConfig | None = None,
+    recent_log_bytes_cap: int | None = None,
     _agent_runner: Any = None,
 ) -> AdvisorVerdict:
     """Issue the advisor call and return the structured verdict.
@@ -165,6 +218,10 @@ async def consult_advisor(
         recent_log_lines: Last K container log lines.
         config: ``PipelineConfig`` with at least ``overseer_advisor_model``
             populated. Defaults to ``opus`` when None.
+        recent_log_bytes_cap: Optional byte cap for the
+            ``recent_log_lines`` prompt block (issue #2120). Resolution
+            order: explicit arg → ``config.overseer_advisor_recent_log_bytes_cap``
+            → ``_DEFAULT_RECENT_LOG_BYTES_CAP``. ``0`` disables the cap.
         _agent_runner: Test seam — pass an awaitable callable
             ``(prompt: str, model: str) -> str`` to override the default
             ``run_agent_async`` invocation. Production callers leave
@@ -179,11 +236,46 @@ async def consult_advisor(
             valid AdvisorVerdict.
     """
     model = config.overseer_advisor_model if config is not None else "opus"
+    if recent_log_bytes_cap is None:
+        recent_log_bytes_cap = (
+            getattr(config, "overseer_advisor_recent_log_bytes_cap", None)
+            if config is not None
+            else None
+        )
+    if recent_log_bytes_cap is None:
+        recent_log_bytes_cap = _DEFAULT_RECENT_LOG_BYTES_CAP
+
+    kept_lines, dropped_lines, dropped_bytes = _truncate_log_lines_by_bytes(
+        recent_log_lines, recent_log_bytes_cap
+    )
+    truncation_marker: str | None = None
+    if dropped_lines > 0:
+        truncation_marker = (
+            f"[... {dropped_lines} earlier line(s) dropped (~{dropped_bytes} bytes) "
+            f"to fit recent_log_lines byte cap ({recent_log_bytes_cap} bytes); "
+            "most-recent lines retained ...]"
+        )
+        # Metric: pathological log producers show up as a stream of
+        # ``advisor_log_truncated`` events. Emitted before the SDK call
+        # so even an SDK failure leaves the truncation observable.
+        logger.info(
+            "overseer_event",
+            extra={
+                "event": "advisor_log_truncated",
+                "dropped_lines": dropped_lines,
+                "dropped_bytes": dropped_bytes,
+                "cap_bytes": recent_log_bytes_cap,
+                "input_line_count": len(recent_log_lines),
+                "model": model,
+            },
+        )
+
     prompt = _build_prompt(
         classification=classification,
         health_alerts=health_alerts,
         progress_events=progress_events,
-        recent_log_lines=recent_log_lines,
+        recent_log_lines=kept_lines,
+        truncation_marker=truncation_marker,
     )
 
     if _agent_runner is None:

--- a/shared/tests/test_overseer_advisor.py
+++ b/shared/tests/test_overseer_advisor.py
@@ -9,15 +9,85 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 
 import pytest
 from egg_overseer.advisor import (
+    _DEFAULT_RECENT_LOG_BYTES_CAP,
     AdvisorParseError,
     AdvisorVerdict,
+    _truncate_log_lines_by_bytes,
     consult_advisor,
 )
 
 _GH_PAT = "ghp_" + "A" * 36
+
+
+# ---------------------------------------------------------------------------
+# _truncate_log_lines_by_bytes (issue #2120)
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateLogLinesByBytes:
+    def test_under_cap_returns_input_unchanged(self) -> None:
+        lines = ["a", "b", "c"]
+        kept, dropped, dropped_bytes = _truncate_log_lines_by_bytes(lines, cap_bytes=1000)
+        assert kept == lines
+        assert dropped == 0
+        assert dropped_bytes == 0
+
+    def test_drops_oldest_first(self) -> None:
+        lines = ["aaaa", "bbbb", "cccc"]  # each line + newline = 5 bytes
+        # Cap of 11 bytes fits the last 2 (cccc + newline = 5, bbbb + newline = 5, total 10).
+        kept, dropped, dropped_bytes = _truncate_log_lines_by_bytes(lines, cap_bytes=11)
+        assert kept == ["bbbb", "cccc"]
+        assert dropped == 1
+        assert dropped_bytes == 5  # 4 bytes for "aaaa" + 1 for newline
+
+    def test_zero_cap_disables(self) -> None:
+        lines = ["a", "b"]
+        kept, dropped, dropped_bytes = _truncate_log_lines_by_bytes(lines, cap_bytes=0)
+        assert kept == lines
+        assert dropped == 0
+        assert dropped_bytes == 0
+
+    def test_negative_cap_disables(self) -> None:
+        lines = ["a", "b"]
+        kept, dropped, _ = _truncate_log_lines_by_bytes(lines, cap_bytes=-1)
+        assert kept == lines
+        assert dropped == 0
+
+    def test_empty_input_safe(self) -> None:
+        kept, dropped, dropped_bytes = _truncate_log_lines_by_bytes([], cap_bytes=10)
+        assert kept == []
+        assert dropped == 0
+        assert dropped_bytes == 0
+
+    def test_single_line_larger_than_cap_drops_all(self) -> None:
+        # A pathologically long single line (the headline failure mode
+        # in issue #2120) is dropped along with everything before it.
+        # The caller renders a marker so the advisor sees an explicit
+        # "(none)"-with-marker rather than tripping a context-window
+        # overflow downstream.
+        lines = ["short", "x" * 1000]
+        kept, dropped, _ = _truncate_log_lines_by_bytes(lines, cap_bytes=100)
+        assert kept == []
+        assert dropped == 2
+
+    def test_utf8_bytes_not_codepoints(self) -> None:
+        # Multi-byte UTF-8 characters must count as bytes, not codepoints.
+        # "🔥" is 4 UTF-8 bytes; cap of 8 should fit only one such line
+        # (4 bytes + 1 newline = 5, two such lines = 10 > 8).
+        lines = ["🔥", "🔥"]
+        kept, dropped, _ = _truncate_log_lines_by_bytes(lines, cap_bytes=8)
+        assert kept == ["🔥"]
+        assert dropped == 1
+
+    def test_default_cap_constant_is_sane(self) -> None:
+        # Sanity guard: opus context window (~200k tokens, ~600+ KB at
+        # 3 bytes/token avg). Default sits well below that with headroom.
+        assert _DEFAULT_RECENT_LOG_BYTES_CAP > 0
+        assert _DEFAULT_RECENT_LOG_BYTES_CAP <= 1_000_000
 
 
 # ---------------------------------------------------------------------------
@@ -269,6 +339,180 @@ class TestConsultAdvisor:
         assert "progress events" in prompt
         assert "container log lines" in prompt
         assert "AdvisorVerdict" in prompt
+
+    def test_recent_log_bytes_cap_arg_overrides_default(self) -> None:
+        # Smaller cap → truncation marker present in prompt.
+        captured: dict[str, str] = {}
+
+        async def runner(prompt: str, model: str) -> str:
+            captured["prompt"] = prompt
+            return json.dumps({"decision": "watch", "reasoning": "r"})
+
+        # Each line is ~20 bytes; cap of 50 bytes keeps ~2 most-recent lines.
+        lines = [f"line-{i:02d} payload" for i in range(20)]
+        asyncio.run(
+            consult_advisor(
+                classification={"type": "x"},
+                health_alerts=[],
+                progress_events=[],
+                recent_log_lines=lines,
+                recent_log_bytes_cap=50,
+                _agent_runner=runner,
+            )
+        )
+        prompt = captured["prompt"]
+        assert "earlier line(s) dropped" in prompt
+        # Last line must survive; oldest lines must be gone.
+        assert "line-19 payload" in prompt
+        assert "line-00 payload" not in prompt
+
+    def test_recent_log_bytes_cap_zero_disables(self) -> None:
+        captured: dict[str, str] = {}
+
+        async def runner(prompt: str, model: str) -> str:
+            captured["prompt"] = prompt
+            return json.dumps({"decision": "watch", "reasoning": "r"})
+
+        lines = [f"line-{i:02d}" for i in range(10)]
+        asyncio.run(
+            consult_advisor(
+                classification={"type": "x"},
+                health_alerts=[],
+                progress_events=[],
+                recent_log_lines=lines,
+                recent_log_bytes_cap=0,
+                _agent_runner=runner,
+            )
+        )
+        prompt = captured["prompt"]
+        assert "earlier line(s) dropped" not in prompt
+        assert "line-00" in prompt
+        assert "line-09" in prompt
+
+    def test_default_cap_does_not_fire_for_small_inputs(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # No truncation on a typical-size payload — default cap holds.
+        async def runner(prompt: str, model: str) -> str:
+            return json.dumps({"decision": "watch", "reasoning": "r"})
+
+        with caplog.at_level(logging.INFO, logger="egg_overseer.advisor"):
+            asyncio.run(
+                consult_advisor(
+                    classification={"type": "x"},
+                    health_alerts=[],
+                    progress_events=[],
+                    recent_log_lines=["short line"] * 50,
+                    _agent_runner=runner,
+                )
+            )
+        truncation_events = [
+            r for r in caplog.records if getattr(r, "event", None) == "advisor_log_truncated"
+        ]
+        assert truncation_events == []
+
+    def test_truncation_emits_metric_log_event(self, caplog: pytest.LogCaptureFixture) -> None:
+        async def runner(prompt: str, model: str) -> str:
+            return json.dumps({"decision": "watch", "reasoning": "r"})
+
+        lines = [f"line-{i:02d} payload" for i in range(20)]
+        with caplog.at_level(logging.INFO, logger="egg_overseer.advisor"):
+            asyncio.run(
+                consult_advisor(
+                    classification={"type": "x"},
+                    health_alerts=[],
+                    progress_events=[],
+                    recent_log_lines=lines,
+                    recent_log_bytes_cap=50,
+                    _agent_runner=runner,
+                )
+            )
+        truncation_events = [
+            r for r in caplog.records if getattr(r, "event", None) == "advisor_log_truncated"
+        ]
+        assert len(truncation_events) == 1
+        rec = truncation_events[0]
+        assert rec.dropped_lines > 0  # type: ignore[attr-defined]
+        assert rec.dropped_bytes > 0  # type: ignore[attr-defined]
+        assert rec.cap_bytes == 50  # type: ignore[attr-defined]
+        assert rec.input_line_count == 20  # type: ignore[attr-defined]
+
+    def test_pathological_single_line_drops_everything(self) -> None:
+        # A single most-recent line larger than the cap is dropped along
+        # with everything before it; the section falls through to "(none)"
+        # under a marker so the advisor sees the truncation explicitly
+        # instead of an SDK error from a context-window overflow.
+        captured: dict[str, str] = {}
+
+        async def runner(prompt: str, model: str) -> str:
+            captured["prompt"] = prompt
+            return json.dumps({"decision": "watch", "reasoning": "r"})
+
+        huge = "x" * 1000
+        asyncio.run(
+            consult_advisor(
+                classification={"type": "x"},
+                health_alerts=[],
+                progress_events=[],
+                recent_log_lines=["short", huge],
+                recent_log_bytes_cap=100,
+                _agent_runner=runner,
+            )
+        )
+        prompt = captured["prompt"]
+        assert "earlier line(s) dropped" in prompt
+        assert huge not in prompt
+
+    def test_config_field_used_when_arg_omitted(self) -> None:
+        captured: dict[str, str] = {}
+
+        async def runner(prompt: str, model: str) -> str:
+            captured["prompt"] = prompt
+            return json.dumps({"decision": "watch", "reasoning": "r"})
+
+        class _Conf:
+            overseer_advisor_model = "opus"
+            overseer_advisor_recent_log_bytes_cap = 50
+
+        lines = [f"line-{i:02d} payload" for i in range(20)]
+        asyncio.run(
+            consult_advisor(
+                classification={"type": "x"},
+                health_alerts=[],
+                progress_events=[],
+                recent_log_lines=lines,
+                config=_Conf(),  # type: ignore[arg-type]
+                _agent_runner=runner,
+            )
+        )
+        assert "earlier line(s) dropped" in captured["prompt"]
+
+    def test_explicit_arg_overrides_config_field(self) -> None:
+        captured: dict[str, str] = {}
+
+        async def runner(prompt: str, model: str) -> str:
+            captured["prompt"] = prompt
+            return json.dumps({"decision": "watch", "reasoning": "r"})
+
+        class _Conf:
+            overseer_advisor_model = "opus"
+            # Config says "tight cap" but explicit arg disables it.
+            overseer_advisor_recent_log_bytes_cap = 50
+
+        lines = [f"line-{i:02d}" for i in range(10)]
+        asyncio.run(
+            consult_advisor(
+                classification={"type": "x"},
+                health_alerts=[],
+                progress_events=[],
+                recent_log_lines=lines,
+                config=_Conf(),  # type: ignore[arg-type]
+                recent_log_bytes_cap=0,
+                _agent_runner=runner,
+            )
+        )
+        assert "earlier line(s) dropped" not in captured["prompt"]
+        assert "line-00" in captured["prompt"]
 
     def test_prompt_handles_empty_lists_explicitly(self) -> None:
         captured: dict[str, str] = {}


### PR DESCRIPTION
## Summary

- Adds a configurable byte cap (default 256 KiB) on the `recent_log_lines` block of the Opus advisor prompt. Previously the prompt-builder joined the input raw, leaving the advisor exposed to a single pathological log line blowing past the model's context window (AdvisorParseError or hard SDK error), to bursts of merely-long lines silently spending advisor budget above per-call expectations, and to wider secret-leak surface from longer-than-needed inputs.
- When the cap trips, oldest lines are dropped first (most-recent lines carry the most signal for the advisor) and a marker is prepended to the section so the advisor knows truncation happened. A structured `advisor_log_truncated` log event fires with `dropped_lines`, `dropped_bytes`, `cap_bytes`, and `input_line_count` so pathological producers stay observable in oncall dashboards.
- Configurable end to end: new `PipelineConfig.overseer_advisor_recent_log_bytes_cap` field, surfaced on the status endpoint's overseer config payload, and a new `egg-orch overseer consult-advisor --recent-log-bytes-cap N` flag plumbed into `consult_advisor`. Resolution order in the advisor is explicit arg → `config.overseer_advisor_recent_log_bytes_cap` → module default (256 KiB). `0` disables the cap.

Carry-forward from the [#2096 re-review](https://github.com/jwbron/egg/pull/2096#pullrequestreview-4176390282).

Closes #2120.

## Test plan

- [x] `pytest shared/tests/test_overseer_advisor.py` — 41 tests pass (8 new for `_truncate_log_lines_by_bytes` covering under-cap, drop-oldest-first, zero/negative cap disable, empty input, single-line-larger-than-cap, UTF-8 byte accounting, default-constant sanity; 8 new for `consult_advisor` covering arg-overrides-default, zero-cap-disables, default-no-fire, metric event emission, pathological single line, config-field path, explicit-arg-overrides-config-field).
- [x] `pytest sandbox/tests/test_egg_orch_overseer_consult_advisor.py` — 16 tests pass, including 3 new (parser accepts the flag, parser default is `None`, flag forwards through to `consult_advisor`).
- [x] `pytest orchestrator/tests/test_pipelines_routes.py orchestrator/tests/test_pipelines_api.py orchestrator/tests/test_pipelines_status_wait_route.py` — 75 tests pass; new key on the status endpoint config payload doesn't disturb adjacent route tests.
- [x] `ruff check` + `ruff format --check` clean on changed files.
- [x] `mypy shared/egg_overseer/advisor.py` clean (the single error surfaced is a pre-existing one in `orchestrator/models.py:252` that also reproduces on `origin/main`, not introduced by this change).