### PR TITLE
overseer: scrub secrets in AdvisorParseError messages

### DIFF
--- a/shared/egg_overseer/advisor.py
+++ b/shared/egg_overseer/advisor.py
@@ -259,16 +259,22 @@ async def consult_advisor(
         if payload is None:
             # No `{` ever found → no useful inner exception; otherwise
             # chain the most recent ``raw_decode`` failure for context.
+            # Scrub before raising: ``raw`` is the unparsed model output
+            # and ends up in stderr via ``cmd_overseer_consult_advisor``.
             raise AdvisorParseError(
-                f"consult_advisor: SDK response is not valid JSON: {raw!r}"
+                scrub_secrets(f"consult_advisor: SDK response is not valid JSON: {raw!r}")
             ) from last_exc
 
     try:
         verdict = AdvisorVerdict.model_validate(payload)
     except Exception as exc:
+        # Scrub: ``payload`` and the pydantic error both echo input
+        # values that may include credentials the model parroted back.
         raise AdvisorParseError(
-            f"consult_advisor: SDK response failed AdvisorVerdict "
-            f"validation: {exc}; payload={payload!r}"
+            scrub_secrets(
+                f"consult_advisor: SDK response failed AdvisorVerdict "
+                f"validation: {exc}; payload={payload!r}"
+            )
         ) from exc
 
     # Defense-in-depth: scrub the body before it leaves this function.

--- a/shared/egg_overseer/advisor.py
+++ b/shared/egg_overseer/advisor.py
@@ -261,6 +261,11 @@ async def consult_advisor(
             # chain the most recent ``raw_decode`` failure for context.
             # Scrub before raising: ``raw`` is the unparsed model output
             # and ends up in stderr via ``cmd_overseer_consult_advisor``.
+            # NOTE: ``__cause__`` (last_exc) preserves the original
+            # ``JSONDecodeError`` whose ``str()`` can echo input values.
+            # Safe today because no caller renders the chained traceback
+            # — if you add ``traceback.format_exc()`` or
+            # ``logger.exception()`` upstream, scrub there too.
             raise AdvisorParseError(
                 scrub_secrets(f"consult_advisor: SDK response is not valid JSON: {raw!r}")
             ) from last_exc
@@ -270,6 +275,9 @@ async def consult_advisor(
     except Exception as exc:
         # Scrub: ``payload`` and the pydantic error both echo input
         # values that may include credentials the model parroted back.
+        # Same ``__cause__`` caveat as the JSON-decode path above:
+        # ``ValidationError`` carries unscrubbed input; safe only while
+        # callers don't render the chained traceback.
         raise AdvisorParseError(
             scrub_secrets(
                 f"consult_advisor: SDK response failed AdvisorVerdict "

--- a/shared/tests/test_overseer_advisor.py
+++ b/shared/tests/test_overseer_advisor.py
@@ -339,6 +339,47 @@ class TestConsultAdvisor:
                 )
             )
 
+    def test_invalid_json_error_message_is_scrubbed(self) -> None:
+        # Raw model output is embedded in the AdvisorParseError message
+        # and ends up in stderr via cmd_overseer_consult_advisor. If the
+        # model parrots a credential in its prose, the error must not
+        # surface it verbatim.
+        runner = self._runner_returning(f"oops, leaked {_GH_PAT} not json")
+        with pytest.raises(AdvisorParseError) as excinfo:
+            asyncio.run(
+                consult_advisor(
+                    classification={},
+                    health_alerts=[],
+                    progress_events=[],
+                    recent_log_lines=[],
+                    _agent_runner=runner,
+                )
+            )
+        message = str(excinfo.value)
+        assert _GH_PAT not in message
+        assert "[REDACTED:gh-pat]" in message
+
+    def test_validation_error_message_is_scrubbed(self) -> None:
+        # Same concern on the schema-validation path: the payload repr
+        # and pydantic error both echo input values back into the
+        # message string.
+        runner = self._runner_returning(
+            {"decision": "alert", "alert_summary": f"saw token {_GH_PAT}"}
+        )
+        with pytest.raises(AdvisorParseError) as excinfo:
+            asyncio.run(
+                consult_advisor(
+                    classification={},
+                    health_alerts=[],
+                    progress_events=[],
+                    recent_log_lines=[],
+                    _agent_runner=runner,
+                )
+            )
+        message = str(excinfo.value)
+        assert _GH_PAT not in message
+        assert "[REDACTED:gh-pat]" in message
+
     def test_default_model_used_when_config_none(self) -> None:
         seen: dict[str, str] = {}
 


### PR DESCRIPTION
## Summary

Carry-forward from the [#2156 re-review observation 2](https://github.com/jwbron/egg/pull/2156#pullrequestreview-4183944630). Both `AdvisorParseError` raise sites in `consult_advisor` embed unscrubbed content from the model response: `{raw!r}` on the JSON-decode path, and `{exc}` + `{payload!r}` on the schema-validation path. `cmd_overseer_consult_advisor` stringifies the error to stderr, so a credential the model parrots back in its prose lands in logs verbatim.

- `shared/egg_overseer/advisor.py`: wrap the formatted error message at both raise sites with `scrub_secrets`. The function is idempotent and the redaction markers don't match any pattern, so the wrap is a no-op on clean input.
- `shared/tests/test_overseer_advisor.py`: two tests — one JSON-decode path with a `ghp_` token in prose, one schema-validation path with a token in a payload field. Both assert the raw token is absent from `str(exc)` and `[REDACTED:gh-pat]` is present.

## Scope notes

- Scrubbing the message string is sufficient because the only caller (`sandbox/egg_lib/orch_cli.py::cmd_overseer_consult_advisor`) prints `f\"...: {exc}\"` to stderr — never the full traceback. The `__cause__` chain (`json.JSONDecodeError`, `pydantic.ValidationError`) may still echo input values via the chained traceback if anything later renders the full chain, but no current caller does.
- Defense-in-depth only: the prompt instructs the advisor not to echo prose, and `verdict.issue_body` is already scrubbed on the success path. This closes the parse-error path under the same assumption.

## Test plan

- [x] `pytest shared/tests/test_overseer_advisor.py` — 28 passed (26 prior + 2 new)
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green