### PR TITLE
Fix #2155: re-verify on PipelineNotFoundError instead of nuking worktrees

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -11357,7 +11357,24 @@ def _persist_phase_gate_resolution(
         )
 
 
-def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
+# Tunables for the spurious-PipelineNotFoundError recovery path in
+# ``_run_pipeline``.  The verify retry covers the empty-file race window
+# during a ``git commit`` truncate-and-rewrite on the state worktree
+# (typical: <100ms); 3 × 200ms gives ~600ms of total slack.  The respawn
+# cap bounds how aggressively a persistent transient can leak threads,
+# overseer containers, and state-branch commits before we fail the
+# pipeline outright.  See #2155.
+_PNFE_VERIFY_ATTEMPTS = 3
+_PNFE_VERIFY_INTERVAL = 0.2  # seconds between verify retries
+_PNFE_RESPAWN_MAX_ATTEMPTS = 5  # cap on respawn cascade
+_PNFE_RESPAWN_BACKOFF_CAP = 30  # seconds, exponential backoff ceiling
+
+
+def _run_pipeline(
+    pipeline_id: str,
+    repo_path: Path,
+    _respawn_attempt: int = 0,
+) -> None:
     """Run a pipeline by spawning containers for each phase.
 
     This runs in a background thread. For each phase it:
@@ -11371,6 +11388,11 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
     Args:
         pipeline_id: Pipeline ID
         repo_path: Path to repository
+        _respawn_attempt: Internal — counts how many times this thread
+            has been respawned by the spurious-PNFE recovery path.
+            Bounded by ``_PNFE_RESPAWN_MAX_ATTEMPTS`` to prevent a
+            persistent transient from cascading into an unbounded
+            thread/overseer/commit storm.
     """
     from routes.phases import PHASE_TRANSITIONS
 
@@ -13236,55 +13258,137 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
         # destructive worktree teardown, then relaunch ``_run_pipeline`` so
         # the next phase keeps making progress.  See #2155.
         pipeline_still_exists = False
+        _verify_store = None
         try:
             _verify_store = get_state_store(repo_path)
-            for _attempt in range(3):
-                time.sleep(0.2)
+        except Exception as verify_store_err:
+            # Couldn't even open the state store — be conservative and
+            # treat as transient; tearing down worktrees on an
+            # infrastructure blip is strictly worse than leaving them.
+            logger.warning(
+                "Failed to obtain state store after PipelineNotFoundError; "
+                "treating as transient and preserving worktrees",
+                pipeline_id=pipeline_id,
+                error=str(verify_store_err),
+            )
+            pipeline_still_exists = True
+
+        if _verify_store is not None:
+            for _attempt in range(_PNFE_VERIFY_ATTEMPTS):
+                time.sleep(_PNFE_VERIFY_INTERVAL)
                 try:
                     _verify_store.load_pipeline(pipeline_id)
                     pipeline_still_exists = True
                     break
                 except PipelineNotFoundError:
                     continue
-        except Exception as verify_err:
-            logger.warning(
-                "Failed to verify pipeline existence after PipelineNotFoundError",
-                pipeline_id=pipeline_id,
-                error=str(verify_err),
-            )
+                except StateValidationError:
+                    # Corrupt JSON or schema mismatch means the file
+                    # exists but is unreadable right now — that's not
+                    # deletion.  Treat as transient: better to risk a
+                    # wasted respawn than to nuke the worktrees on a
+                    # transient corruption.
+                    pipeline_still_exists = True
+                    break
+                except StateStoreError as verify_err:
+                    # Other state-store failures (transient git read
+                    # errors, etc.) are also not evidence of deletion.
+                    logger.warning(
+                        "State-store error verifying pipeline existence; "
+                        "treating as transient and preserving worktrees",
+                        pipeline_id=pipeline_id,
+                        error=str(verify_err),
+                    )
+                    pipeline_still_exists = True
+                    break
 
         if pipeline_still_exists:
-            logger.error(
-                "Spurious PipelineNotFoundError during execution — pipeline "
-                "still exists after retry; relaunching driver thread and "
-                "preserving worktrees",
-                pipeline_id=pipeline_id,
-                exc_info=pnf_err,
-            )
-            # Bump run_epoch so the finally cleanup at line ~13327
-            # observes this thread as superseded (mirrors the
-            # advance_phase pattern) and skips worktree teardown.
-            try:
-                with get_pipeline_state_lock(pipeline_id):
-                    _bumped = _verify_store.load_pipeline(pipeline_id)
-                    _bumped.run_epoch = datetime.now(UTC)
-                    _verify_store.save_pipeline(_bumped)
-            except Exception as bump_err:
-                logger.warning(
-                    "Failed to bump run_epoch during spurious-PNFE recovery "
-                    "(worktrees will be torn down)",
+            # Cap the respawn cascade so a persistent transient can't
+            # leak threads, overseer containers, and state-branch
+            # commits without bound.  The recovery code is what runs
+            # exactly when the system is misbehaving — it must not
+            # amplify the misbehaviour.
+            if _respawn_attempt >= _PNFE_RESPAWN_MAX_ATTEMPTS:
+                logger.error(
+                    "Spurious-PipelineNotFoundError recovery exhausted "
+                    "respawn budget; marking pipeline FAILED so an "
+                    "operator can investigate via restart_phase",
                     pipeline_id=pipeline_id,
-                    error=str(bump_err),
+                    attempts=_respawn_attempt,
+                    exc_info=pnf_err,
                 )
+                if _verify_store is not None:
+                    try:
+                        with get_pipeline_state_lock(pipeline_id):
+                            _failed_pipeline = _verify_store.load_pipeline(pipeline_id)
+                            _failed_pipeline.status = PipelineStatus.FAILED
+                            _failed_pipeline.error = (
+                                "Transient PipelineNotFoundError recovery "
+                                f"exhausted after {_respawn_attempt} respawns"
+                            )
+                            _verify_store.save_pipeline(_failed_pipeline)
+                    except Exception as fail_err:
+                        logger.warning(
+                            "Failed to mark pipeline FAILED after exhausting "
+                            "respawn budget",
+                            pipeline_id=pipeline_id,
+                            error=str(fail_err),
+                        )
+            else:
+                # Recoverable transient — log at warning so it doesn't
+                # trip error-rate dashboards every time it self-heals.
+                logger.warning(
+                    "Spurious PipelineNotFoundError during execution — "
+                    "pipeline still exists after retry; relaunching driver "
+                    "thread and preserving worktrees",
+                    pipeline_id=pipeline_id,
+                    attempt=_respawn_attempt,
+                    exc_info=pnf_err,
+                )
+                # Bump run_epoch so the finally cleanup observes this
+                # thread as superseded (mirrors the advance_phase
+                # pattern) and skips worktree teardown.  Capture the
+                # pre-bump epoch into the local ``run_epoch`` so the
+                # finally guard works even when the *initial* load
+                # raised PNFE (in that case run_epoch was never set
+                # at line 11393).
+                bump_succeeded = False
+                if _verify_store is not None:
+                    try:
+                        with get_pipeline_state_lock(pipeline_id):
+                            _bumped = _verify_store.load_pipeline(pipeline_id)
+                            run_epoch = _bumped.run_epoch or _bumped.created_at
+                            _bumped.run_epoch = datetime.now(UTC)
+                            _verify_store.save_pipeline(_bumped)
+                            bump_succeeded = True
+                    except Exception as bump_err:
+                        logger.warning(
+                            "Failed to bump run_epoch during spurious-PNFE "
+                            "recovery; skipping respawn so the existing "
+                            "finally cleanup runs without racing a new thread",
+                            pipeline_id=pipeline_id,
+                            error=str(bump_err),
+                        )
 
-            # Relaunch _run_pipeline so the next phase keeps progressing.
-            # Defer the import to avoid a self-reference at module scope.
-            threading.Thread(
-                target=_run_pipeline,
-                args=(pipeline_id, repo_path),
-                daemon=True,
-                name=f"pipeline-{pipeline_id}-respawn-{int(datetime.now(UTC).timestamp())}",
-            ).start()
+                if bump_succeeded:
+                    # Exponential backoff between respawn attempts so a
+                    # tight cascade can't fire dozens of respawns per
+                    # second.  attempt=0 → 1s, 1 → 2s, 2 → 4s, 3 → 8s,
+                    # 4 → 16s, capped at _PNFE_RESPAWN_BACKOFF_CAP.
+                    _backoff = min(
+                        2**_respawn_attempt, _PNFE_RESPAWN_BACKOFF_CAP
+                    )
+                    time.sleep(_backoff)
+                    threading.Thread(
+                        target=_run_pipeline,
+                        args=(pipeline_id, repo_path),
+                        kwargs={"_respawn_attempt": _respawn_attempt + 1},
+                        daemon=True,
+                        name=(
+                            f"pipeline-{pipeline_id}-respawn-"
+                            f"{_respawn_attempt + 1}-{time.monotonic_ns()}"
+                        ),
+                    ).start()
         else:
             logger.info(
                 "Pipeline was deleted during execution, exiting",

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -13225,12 +13225,72 @@ def _run_pipeline(pipeline_id: str, repo_path: Path) -> None:
                 to_phase=next_phase.value,
             )
 
-    except PipelineNotFoundError:
-        # Pipeline was deleted while execution was in progress — exit gracefully
-        logger.info(
-            "Pipeline was deleted during execution, exiting",
-            pipeline_id=pipeline_id,
-        )
+    except PipelineNotFoundError as pnf_err:
+        # `PipelineNotFoundError` can be raised either because the pipeline
+        # was actually deleted or because of a transient state-store read
+        # (e.g., empty content while a concurrent commit on the state
+        # worktree races with the read).  Re-verify before treating it as
+        # deletion: if the pipeline is still on disk after retry, the
+        # original exception was spurious — bump ``run_epoch`` so the
+        # finally cleanup detects this thread as superseded and skips the
+        # destructive worktree teardown, then relaunch ``_run_pipeline`` so
+        # the next phase keeps making progress.  See #2155.
+        pipeline_still_exists = False
+        try:
+            _verify_store = get_state_store(repo_path)
+            for _attempt in range(3):
+                time.sleep(0.2)
+                try:
+                    _verify_store.load_pipeline(pipeline_id)
+                    pipeline_still_exists = True
+                    break
+                except PipelineNotFoundError:
+                    continue
+        except Exception as verify_err:
+            logger.warning(
+                "Failed to verify pipeline existence after PipelineNotFoundError",
+                pipeline_id=pipeline_id,
+                error=str(verify_err),
+            )
+
+        if pipeline_still_exists:
+            logger.error(
+                "Spurious PipelineNotFoundError during execution — pipeline "
+                "still exists after retry; relaunching driver thread and "
+                "preserving worktrees",
+                pipeline_id=pipeline_id,
+                exc_info=pnf_err,
+            )
+            # Bump run_epoch so the finally cleanup at line ~13327
+            # observes this thread as superseded (mirrors the
+            # advance_phase pattern) and skips worktree teardown.
+            try:
+                with get_pipeline_state_lock(pipeline_id):
+                    _bumped = _verify_store.load_pipeline(pipeline_id)
+                    _bumped.run_epoch = datetime.now(UTC)
+                    _verify_store.save_pipeline(_bumped)
+            except Exception as bump_err:
+                logger.warning(
+                    "Failed to bump run_epoch during spurious-PNFE recovery "
+                    "(worktrees will be torn down)",
+                    pipeline_id=pipeline_id,
+                    error=str(bump_err),
+                )
+
+            # Relaunch _run_pipeline so the next phase keeps progressing.
+            # Defer the import to avoid a self-reference at module scope.
+            threading.Thread(
+                target=_run_pipeline,
+                args=(pipeline_id, repo_path),
+                daemon=True,
+                name=f"pipeline-{pipeline_id}-respawn-{int(datetime.now(UTC).timestamp())}",
+            ).start()
+        else:
+            logger.info(
+                "Pipeline was deleted during execution, exiting",
+                pipeline_id=pipeline_id,
+                exc_info=pnf_err,
+            )
     except Exception as e:
         logger.error(
             "Pipeline execution failed", pipeline_id=pipeline_id, error=str(e), exc_info=True

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -13262,12 +13262,16 @@ def _run_pipeline(
         try:
             _verify_store = get_state_store(repo_path)
         except Exception as verify_store_err:
-            # Couldn't even open the state store — be conservative and
-            # treat as transient; tearing down worktrees on an
-            # infrastructure blip is strictly worse than leaving them.
+            # Couldn't even open the state store — treat as transient
+            # (corrupt-but-present > deletion) so we skip the respawn
+            # rather than amplifying an infrastructure blip.  Note: with
+            # ``_verify_store=None`` the bump path below short-circuits,
+            # so worktree preservation depends on whether ``run_epoch``
+            # was set before the initial PNFE — this path avoids the
+            # cascade but does not unconditionally preserve worktrees.
             logger.warning(
                 "Failed to obtain state store after PipelineNotFoundError; "
-                "treating as transient and preserving worktrees",
+                "treating as transient infrastructure failure and skipping respawn",
                 pipeline_id=pipeline_id,
                 error=str(verify_store_err),
             )

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -13329,8 +13329,7 @@ def _run_pipeline(
                             _verify_store.save_pipeline(_failed_pipeline)
                     except Exception as fail_err:
                         logger.warning(
-                            "Failed to mark pipeline FAILED after exhausting "
-                            "respawn budget",
+                            "Failed to mark pipeline FAILED after exhausting respawn budget",
                             pipeline_id=pipeline_id,
                             error=str(fail_err),
                         )
@@ -13375,9 +13374,7 @@ def _run_pipeline(
                     # tight cascade can't fire dozens of respawns per
                     # second.  attempt=0 → 1s, 1 → 2s, 2 → 4s, 3 → 8s,
                     # 4 → 16s, capped at _PNFE_RESPAWN_BACKOFF_CAP.
-                    _backoff = min(
-                        2**_respawn_attempt, _PNFE_RESPAWN_BACKOFF_CAP
-                    )
+                    _backoff = min(2**_respawn_attempt, _PNFE_RESPAWN_BACKOFF_CAP)
                     time.sleep(_backoff)
                     threading.Thread(
                         target=_run_pipeline,

--- a/orchestrator/tests/test_spurious_pnfe_recovery.py
+++ b/orchestrator/tests/test_spurious_pnfe_recovery.py
@@ -270,7 +270,8 @@ class TestSpuriousPNFERecovery:
         ]
         mock_get_store.return_value = mock_store
 
-        mock_get_spawner.return_value = MagicMock()
+        mock_spawner = MagicMock()
+        mock_get_spawner.return_value = mock_spawner
         mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
         mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -294,6 +295,12 @@ class TestSpuriousPNFERecovery:
         assert save_calls, "Expected pipeline to be saved with FAILED status"
         failed_pipeline = save_calls[0].args[0]
         assert "exhausted" in (failed_pipeline.error or "").lower()
+
+        # FAILED status preserves worktrees so an operator can investigate
+        # via ``restart_phase`` (see the FAILED branch in finally at
+        # ``pipelines.py``).  Locks in the explicit promise made in the
+        # cap-exhausted log message.
+        mock_spawner.gateway.delete_worktrees.assert_not_called()
 
     @patch(_PATCHES[6])
     @patch(_PATCHES[5])

--- a/orchestrator/tests/test_spurious_pnfe_recovery.py
+++ b/orchestrator/tests/test_spurious_pnfe_recovery.py
@@ -1,0 +1,172 @@
+"""Tests for spurious PipelineNotFoundError recovery in _run_pipeline (#2155).
+
+When `_run_pipeline` hits a transient `PipelineNotFoundError` mid-execution
+(e.g., empty content during a concurrent commit on the state worktree),
+the outer `except PipelineNotFoundError` block must:
+
+1. Re-verify the pipeline really is gone before treating the exception as
+   deletion — a transient is recovered if the pipeline still exists on
+   retry.
+2. On spurious failure: bump ``run_epoch`` so the finally cleanup detects
+   the thread as superseded and skips the destructive worktree teardown.
+3. Relaunch a fresh ``_run_pipeline`` thread so the next phase keeps
+   making progress without operator intervention.
+4. On a genuine deletion: log with ``exc_info`` so the raise site is
+   recoverable from logs.
+"""
+
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+# Mock docker before importing modules that depend on it
+sys.modules.setdefault("docker", MagicMock())
+sys.modules.setdefault("docker.errors", MagicMock())
+sys.modules.setdefault("docker.types", MagicMock())
+
+from models import Pipeline, PipelinePhase, PipelineStatus
+from state_store import PipelineNotFoundError
+
+
+def _make_pipeline():
+    return Pipeline(
+        id="issue-2155",
+        issue_number=2155,
+        repo="owner/repo",
+        branch="egg/issue-2155",
+        mode="issue",
+        status=PipelineStatus.RUNNING,
+        current_phase=PipelinePhase.PLAN,
+        network_mode="public",
+    )
+
+
+_PATCHES = [
+    "routes.pipelines._emit_pipeline_event",
+    "routes.pipelines.get_container_spawner",
+    "routes.pipelines.get_state_store",
+    "routes.pipelines.get_pipeline_state_lock",
+    "routes.pipelines.report_pipeline_status",
+    "routes.pipelines.threading.Thread",
+    "routes.pipelines.time.sleep",
+]
+
+
+class TestSpuriousPNFERecovery:
+    """When PipelineNotFoundError fires but the pipeline still exists,
+    recover by bumping run_epoch and relaunching the driver thread."""
+
+    @patch(_PATCHES[6])
+    @patch(_PATCHES[5])
+    @patch(_PATCHES[4])
+    @patch(_PATCHES[3])
+    @patch(_PATCHES[2])
+    @patch(_PATCHES[1])
+    @patch(_PATCHES[0])
+    def test_spurious_pnfe_relaunches_thread_and_bumps_epoch(
+        self,
+        mock_emit,
+        mock_get_spawner,
+        mock_get_store,
+        mock_state_lock,
+        mock_report,
+        mock_thread_cls,
+        mock_sleep,
+    ):
+        from routes.pipelines import _run_pipeline
+
+        pipeline = _make_pipeline()
+        mock_store = MagicMock()
+        mock_store.repo_path = Path("/repo")
+        # First load (deep in _run_pipeline) raises PNFE.
+        # The verify retry inside the except handler succeeds.
+        # The bump-then-save load also succeeds.
+        mock_store.load_pipeline.side_effect = [
+            PipelineNotFoundError("transient"),
+            pipeline,
+            pipeline,
+            pipeline,
+        ]
+        mock_get_store.return_value = mock_store
+
+        mock_get_spawner.return_value = MagicMock()
+        mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_thread_instance = MagicMock()
+        mock_thread_cls.return_value = mock_thread_instance
+
+        _run_pipeline("issue-2155", Path("/repo"))
+
+        # A respawn thread was launched.
+        respawn_calls = [
+            c for c in mock_thread_cls.call_args_list if "respawn" in (c.kwargs.get("name") or "")
+        ]
+        assert len(respawn_calls) == 1, (
+            f"Expected exactly one respawn thread; got threads with names: "
+            f"{[c.kwargs.get('name') for c in mock_thread_cls.call_args_list]}"
+        )
+        respawn = respawn_calls[0]
+        assert respawn.kwargs["daemon"] is True
+        assert respawn.kwargs["args"] == ("issue-2155", Path("/repo"))
+        mock_thread_instance.start.assert_called()
+
+        # save_pipeline was called to persist the bumped run_epoch.
+        assert mock_store.save_pipeline.called, "Expected run_epoch to be persisted"
+        bumped_pipeline = mock_store.save_pipeline.call_args.args[0]
+        assert bumped_pipeline.run_epoch is not None
+        # run_epoch should be a recent UTC timestamp.
+        delta = datetime.now(UTC) - bumped_pipeline.run_epoch
+        assert delta.total_seconds() < 5, f"Expected run_epoch within 5s of now, got delta={delta}"
+
+    @patch(_PATCHES[6])
+    @patch(_PATCHES[5])
+    @patch(_PATCHES[4])
+    @patch(_PATCHES[3])
+    @patch(_PATCHES[2])
+    @patch(_PATCHES[1])
+    @patch(_PATCHES[0])
+    def test_real_deletion_does_not_relaunch_thread(
+        self,
+        mock_emit,
+        mock_get_spawner,
+        mock_get_store,
+        mock_state_lock,
+        mock_report,
+        mock_thread_cls,
+        mock_sleep,
+    ):
+        from routes.pipelines import _run_pipeline
+
+        mock_store = MagicMock()
+        mock_store.repo_path = Path("/repo")
+        # All loads (initial + 3 retries) raise PNFE → genuine deletion.
+        mock_store.load_pipeline.side_effect = PipelineNotFoundError("deleted")
+        mock_get_store.return_value = mock_store
+
+        mock_get_spawner.return_value = MagicMock()
+        mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_thread_instance = MagicMock()
+        mock_thread_cls.return_value = mock_thread_instance
+
+        _run_pipeline("issue-2155", Path("/repo"))
+
+        # No respawn thread should be launched.
+        respawn_calls = [
+            c for c in mock_thread_cls.call_args_list if "respawn" in (c.kwargs.get("name") or "")
+        ]
+        assert len(respawn_calls) == 0, (
+            f"Expected no respawn thread for genuine deletion; got: "
+            f"{[c.kwargs.get('name') for c in mock_thread_cls.call_args_list]}"
+        )

--- a/orchestrator/tests/test_spurious_pnfe_recovery.py
+++ b/orchestrator/tests/test_spurious_pnfe_recovery.py
@@ -6,17 +6,23 @@ the outer `except PipelineNotFoundError` block must:
 
 1. Re-verify the pipeline really is gone before treating the exception as
    deletion — a transient is recovered if the pipeline still exists on
-   retry.
+   retry, and ``StateValidationError`` (corrupt-but-present) is treated
+   as transient too.
 2. On spurious failure: bump ``run_epoch`` so the finally cleanup detects
    the thread as superseded and skips the destructive worktree teardown.
 3. Relaunch a fresh ``_run_pipeline`` thread so the next phase keeps
-   making progress without operator intervention.
-4. On a genuine deletion: log with ``exc_info`` so the raise site is
-   recoverable from logs.
+   making progress without operator intervention — but only if the
+   ``run_epoch`` bump succeeded, so the old thread doesn't race the
+   new one into worktree teardown.
+4. Cap the respawn cascade so a persistent transient can't leak threads,
+   overseer containers, and state-branch commits unboundedly — after
+   ``_PNFE_RESPAWN_MAX_ATTEMPTS`` consecutive respawns, mark the
+   pipeline FAILED so an operator can investigate.
+5. On a genuine deletion: log with ``exc_info`` and skip the respawn so
+   worktree cleanup runs normally.
 """
 
 import sys
-from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -34,7 +40,7 @@ sys.modules.setdefault("docker.errors", MagicMock())
 sys.modules.setdefault("docker.types", MagicMock())
 
 from models import Pipeline, PipelinePhase, PipelineStatus
-from state_store import PipelineNotFoundError
+from state_store import PipelineNotFoundError, StateValidationError
 
 
 def _make_pipeline():
@@ -61,6 +67,14 @@ _PATCHES = [
 ]
 
 
+def _respawn_calls(mock_thread_cls):
+    return [
+        c
+        for c in mock_thread_cls.call_args_list
+        if "respawn" in (c.kwargs.get("name") or "")
+    ]
+
+
 class TestSpuriousPNFERecovery:
     """When PipelineNotFoundError fires but the pipeline still exists,
     recover by bumping run_epoch and relaunching the driver thread."""
@@ -72,7 +86,75 @@ class TestSpuriousPNFERecovery:
     @patch(_PATCHES[2])
     @patch(_PATCHES[1])
     @patch(_PATCHES[0])
-    def test_spurious_pnfe_relaunches_thread_and_bumps_epoch(
+    def test_spurious_pnfe_relaunches_thread_and_skips_worktree_cleanup(
+        self,
+        mock_emit,
+        mock_get_spawner,
+        mock_get_store,
+        mock_state_lock,
+        mock_report,
+        mock_thread_cls,
+        mock_sleep,
+    ):
+        from routes.pipelines import _run_pipeline
+
+        pipeline = _make_pipeline()
+        original_epoch = pipeline.run_epoch or pipeline.created_at
+
+        mock_store = MagicMock()
+        mock_store.repo_path = Path("/repo")
+        # Sequence: initial load (line ~11392) → PNFE; verify retry
+        # succeeds; bump-load returns pipeline; finally cleanup load
+        # returns pipeline (now with bumped epoch in-place).
+        mock_store.load_pipeline.side_effect = [
+            PipelineNotFoundError("transient"),
+            pipeline,
+            pipeline,
+            pipeline,
+        ]
+        mock_get_store.return_value = mock_store
+
+        mock_spawner = MagicMock()
+        mock_get_spawner.return_value = mock_spawner
+        mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_thread_instance = MagicMock()
+        mock_thread_cls.return_value = mock_thread_instance
+
+        _run_pipeline("issue-2155", Path("/repo"))
+
+        # A respawn thread was launched with attempt counter incremented.
+        respawn = _respawn_calls(mock_thread_cls)
+        assert len(respawn) == 1, (
+            f"Expected exactly one respawn thread; got threads with names: "
+            f"{[c.kwargs.get('name') for c in mock_thread_cls.call_args_list]}"
+        )
+        assert respawn[0].kwargs["daemon"] is True
+        assert respawn[0].kwargs["args"] == ("issue-2155", Path("/repo"))
+        assert respawn[0].kwargs["kwargs"] == {"_respawn_attempt": 1}
+        mock_thread_instance.start.assert_called()
+
+        # save_pipeline was called to persist the bumped run_epoch.
+        assert mock_store.save_pipeline.called, "Expected run_epoch to be persisted"
+        bumped_pipeline = mock_store.save_pipeline.call_args.args[0]
+        assert bumped_pipeline.run_epoch is not None
+        assert bumped_pipeline.run_epoch != original_epoch
+
+        # Central correctness claim: worktrees are NOT torn down on the
+        # spurious branch.  The finally guard sees ``run_epoch`` (the
+        # captured pre-bump epoch) differ from the on-disk bumped epoch
+        # and skips cleanup.
+        mock_spawner.gateway.delete_worktrees.assert_not_called()
+
+    @patch(_PATCHES[6])
+    @patch(_PATCHES[5])
+    @patch(_PATCHES[4])
+    @patch(_PATCHES[3])
+    @patch(_PATCHES[2])
+    @patch(_PATCHES[1])
+    @patch(_PATCHES[0])
+    def test_state_validation_error_during_verify_treated_as_transient(
         self,
         mock_emit,
         mock_get_spawner,
@@ -87,9 +169,103 @@ class TestSpuriousPNFERecovery:
         pipeline = _make_pipeline()
         mock_store = MagicMock()
         mock_store.repo_path = Path("/repo")
-        # First load (deep in _run_pipeline) raises PNFE.
-        # The verify retry inside the except handler succeeds.
-        # The bump-then-save load also succeeds.
+        # Initial load PNFE; verify retry hits StateValidationError
+        # (corrupt-but-present); bump-load + finally-load succeed.
+        mock_store.load_pipeline.side_effect = [
+            PipelineNotFoundError("transient"),
+            StateValidationError("invalid JSON"),
+            pipeline,
+            pipeline,
+        ]
+        mock_get_store.return_value = mock_store
+
+        mock_spawner = MagicMock()
+        mock_get_spawner.return_value = mock_spawner
+        mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_thread_cls.return_value = MagicMock()
+
+        _run_pipeline("issue-2155", Path("/repo"))
+
+        # StateValidationError is corrupt-but-present, not deletion: the
+        # recovery path must respawn and preserve worktrees.
+        assert len(_respawn_calls(mock_thread_cls)) == 1
+        mock_spawner.gateway.delete_worktrees.assert_not_called()
+
+    @patch(_PATCHES[6])
+    @patch(_PATCHES[5])
+    @patch(_PATCHES[4])
+    @patch(_PATCHES[3])
+    @patch(_PATCHES[2])
+    @patch(_PATCHES[1])
+    @patch(_PATCHES[0])
+    def test_bump_failure_does_not_relaunch_thread(
+        self,
+        mock_emit,
+        mock_get_spawner,
+        mock_get_store,
+        mock_state_lock,
+        mock_report,
+        mock_thread_cls,
+        mock_sleep,
+    ):
+        """If the run_epoch bump fails, we must NOT respawn — otherwise
+        the old thread races the new one into worktree teardown."""
+        from routes.pipelines import _run_pipeline
+
+        pipeline = _make_pipeline()
+        mock_store = MagicMock()
+        mock_store.repo_path = Path("/repo")
+        # Initial PNFE; verify succeeds; bump-load succeeds but
+        # save_pipeline (in the bump) fails.
+        mock_store.load_pipeline.side_effect = [
+            PipelineNotFoundError("transient"),
+            pipeline,
+            pipeline,
+            pipeline,
+        ]
+        mock_store.save_pipeline.side_effect = RuntimeError("git index lock")
+        mock_get_store.return_value = mock_store
+
+        mock_get_spawner.return_value = MagicMock()
+        mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_thread_cls.return_value = MagicMock()
+
+        _run_pipeline("issue-2155", Path("/repo"))
+
+        # No respawn when bump fails — the old thread must not race the
+        # new one into the destructive cleanup path.
+        assert len(_respawn_calls(mock_thread_cls)) == 0
+
+    @patch(_PATCHES[6])
+    @patch(_PATCHES[5])
+    @patch(_PATCHES[4])
+    @patch(_PATCHES[3])
+    @patch(_PATCHES[2])
+    @patch(_PATCHES[1])
+    @patch(_PATCHES[0])
+    def test_respawn_cascade_is_bounded_and_marks_failed(
+        self,
+        mock_emit,
+        mock_get_spawner,
+        mock_get_store,
+        mock_state_lock,
+        mock_report,
+        mock_thread_cls,
+        mock_sleep,
+    ):
+        """A persistent transient must not cascade into an unbounded
+        thread/overseer/commit storm.  After the cap, the pipeline is
+        marked FAILED and no further respawn is launched."""
+        from routes.pipelines import _PNFE_RESPAWN_MAX_ATTEMPTS, _run_pipeline
+
+        pipeline = _make_pipeline()
+        mock_store = MagicMock()
+        mock_store.repo_path = Path("/repo")
+        # Initial PNFE; verify succeeds; FAILED-mark load; finally load.
         mock_store.load_pipeline.side_effect = [
             PipelineNotFoundError("transient"),
             pipeline,
@@ -102,31 +278,25 @@ class TestSpuriousPNFERecovery:
         mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
         mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
 
-        mock_thread_instance = MagicMock()
-        mock_thread_cls.return_value = mock_thread_instance
+        mock_thread_cls.return_value = MagicMock()
 
-        _run_pipeline("issue-2155", Path("/repo"))
-
-        # A respawn thread was launched.
-        respawn_calls = [
-            c for c in mock_thread_cls.call_args_list if "respawn" in (c.kwargs.get("name") or "")
-        ]
-        assert len(respawn_calls) == 1, (
-            f"Expected exactly one respawn thread; got threads with names: "
-            f"{[c.kwargs.get('name') for c in mock_thread_cls.call_args_list]}"
+        _run_pipeline(
+            "issue-2155",
+            Path("/repo"),
+            _respawn_attempt=_PNFE_RESPAWN_MAX_ATTEMPTS,
         )
-        respawn = respawn_calls[0]
-        assert respawn.kwargs["daemon"] is True
-        assert respawn.kwargs["args"] == ("issue-2155", Path("/repo"))
-        mock_thread_instance.start.assert_called()
 
-        # save_pipeline was called to persist the bumped run_epoch.
-        assert mock_store.save_pipeline.called, "Expected run_epoch to be persisted"
-        bumped_pipeline = mock_store.save_pipeline.call_args.args[0]
-        assert bumped_pipeline.run_epoch is not None
-        # run_epoch should be a recent UTC timestamp.
-        delta = datetime.now(UTC) - bumped_pipeline.run_epoch
-        assert delta.total_seconds() < 5, f"Expected run_epoch within 5s of now, got delta={delta}"
+        # No respawn at the cap.
+        assert len(_respawn_calls(mock_thread_cls)) == 0
+
+        # Pipeline was marked FAILED with a clear error.
+        save_calls = [
+            c for c in mock_store.save_pipeline.call_args_list
+            if c.args and c.args[0].status == PipelineStatus.FAILED
+        ]
+        assert save_calls, "Expected pipeline to be saved with FAILED status"
+        failed_pipeline = save_calls[0].args[0]
+        assert "exhausted" in (failed_pipeline.error or "").lower()
 
     @patch(_PATCHES[6])
     @patch(_PATCHES[5])
@@ -135,7 +305,7 @@ class TestSpuriousPNFERecovery:
     @patch(_PATCHES[2])
     @patch(_PATCHES[1])
     @patch(_PATCHES[0])
-    def test_real_deletion_does_not_relaunch_thread(
+    def test_real_deletion_does_not_relaunch_and_runs_cleanup(
         self,
         mock_emit,
         mock_get_spawner,
@@ -149,24 +319,31 @@ class TestSpuriousPNFERecovery:
 
         mock_store = MagicMock()
         mock_store.repo_path = Path("/repo")
-        # All loads (initial + 3 retries) raise PNFE → genuine deletion.
+        # All loads (initial + verify retries + finally) raise PNFE → genuine deletion.
         mock_store.load_pipeline.side_effect = PipelineNotFoundError("deleted")
         mock_get_store.return_value = mock_store
 
-        mock_get_spawner.return_value = MagicMock()
+        mock_spawner = MagicMock()
+        mock_get_spawner.return_value = mock_spawner
         mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
         mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
 
-        mock_thread_instance = MagicMock()
-        mock_thread_cls.return_value = mock_thread_instance
+        mock_thread_cls.return_value = MagicMock()
 
         _run_pipeline("issue-2155", Path("/repo"))
 
-        # No respawn thread should be launched.
-        respawn_calls = [
-            c for c in mock_thread_cls.call_args_list if "respawn" in (c.kwargs.get("name") or "")
+        # No respawn thread launched on genuine deletion.
+        assert len(_respawn_calls(mock_thread_cls)) == 0
+
+        # Genuine deletion → finally cleanup runs delete_worktrees so
+        # the pipeline's worktrees aren't leaked.  (The cleanup also
+        # loops over per-agent containers as a safety-net, so we assert
+        # the pipeline-level call specifically rather than call count.)
+        delete_calls = mock_spawner.gateway.delete_worktrees.call_args_list
+        pipeline_level = [
+            c for c in delete_calls if c.kwargs.get("container_id") == "issue-2155"
         ]
-        assert len(respawn_calls) == 0, (
-            f"Expected no respawn thread for genuine deletion; got: "
-            f"{[c.kwargs.get('name') for c in mock_thread_cls.call_args_list]}"
+        assert len(pipeline_level) == 1, (
+            f"Expected one pipeline-level delete_worktrees call; got: "
+            f"{[c.kwargs.get('container_id') for c in delete_calls]}"
         )

--- a/orchestrator/tests/test_spurious_pnfe_recovery.py
+++ b/orchestrator/tests/test_spurious_pnfe_recovery.py
@@ -68,11 +68,7 @@ _PATCHES = [
 
 
 def _respawn_calls(mock_thread_cls):
-    return [
-        c
-        for c in mock_thread_cls.call_args_list
-        if "respawn" in (c.kwargs.get("name") or "")
-    ]
+    return [c for c in mock_thread_cls.call_args_list if "respawn" in (c.kwargs.get("name") or "")]
 
 
 class TestSpuriousPNFERecovery:
@@ -291,7 +287,8 @@ class TestSpuriousPNFERecovery:
 
         # Pipeline was marked FAILED with a clear error.
         save_calls = [
-            c for c in mock_store.save_pipeline.call_args_list
+            c
+            for c in mock_store.save_pipeline.call_args_list
             if c.args and c.args[0].status == PipelineStatus.FAILED
         ]
         assert save_calls, "Expected pipeline to be saved with FAILED status"
@@ -340,9 +337,7 @@ class TestSpuriousPNFERecovery:
         # loops over per-agent containers as a safety-net, so we assert
         # the pipeline-level call specifically rather than call count.)
         delete_calls = mock_spawner.gateway.delete_worktrees.call_args_list
-        pipeline_level = [
-            c for c in delete_calls if c.kwargs.get("container_id") == "issue-2155"
-        ]
+        pipeline_level = [c for c in delete_calls if c.kwargs.get("container_id") == "issue-2155"]
         assert len(pipeline_level) == 1, (
             f"Expected one pipeline-level delete_worktrees call; got: "
             f"{[c.kwargs.get('container_id') for c in delete_calls]}"


### PR DESCRIPTION
## Summary

- `_run_pipeline`'s catch handler at `orchestrator/routes/pipelines.py:13228` treated every `PipelineNotFoundError` as a real deletion and fell through to a destructive `finally` cleanup that tore down the pipeline worktree.
- `state_store.load_pipeline` also raises `PipelineNotFoundError` for the *empty file* case (transient state-worktree race), so a momentary read failure mid-phase wedged the pipeline for ~17 minutes — manual `advance_phase` was the only recovery.
- Re-verify the pipeline really is gone (3x retry) before treating it as deletion. On spurious failure, bump `run_epoch` so the existing `pipeline_was_restarted` skip-cleanup logic preserves worktrees, then relaunch `_run_pipeline` so the next phase keeps progressing. Log `exc_info=True` in both branches so the raise site is recoverable from logs next time.

Fixes #2155.

## Why this scope

The wedge fix is one cohesive change: re-verify + skip-cleanup + relaunch all sit on the same code path and split poorly. Two follow-ups stay separate:

- Symmetric thread-launch on auto-advance (mirror ` advance_phase`'s pattern in `pipelines.py:13211`) — different rationale, riskier, defense-in-depth that's not required to unstick this bug. Filed as a follow-up.
- Operator-facing watchdog in `get_status` (assert "gate resolved + phase complete + no successor scheduled within 60s") — pure observability. Filed as a follow-up.

## Test plan

- [x] `orchestrator/tests/test_spurious_pnfe_recovery.py` — verifies the spurious case bumps ` run_epoch` and launches a respawn thread, and the genuine-deletion case does not.
- [x] `pytest orchestrator/tests/test_pipeline_failure_path.py orchestrator/tests/test_advance_phase_thread.py orchestrator/tests/test_phase_transition_brc_history.py` — 34 existing `_run_pipeline` tests all pass.
- [x] `ruff check` clean on changed files.
- [ ] Live verification: deploy and confirm the next plan→implement transition does not wedge.