### PR TITLE
gateway: detached-HEAD recovery primitive (#2162)

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -396,6 +396,67 @@ def _lookup_commit_observer_fn(name: str) -> Any:
     return getattr(mod, name, None)
 
 
+def _detached_head_hint(
+    operation: str,
+    exec_path: str,
+    repo_path: str,
+    container_id: str | None,
+) -> str:
+    """Return a recovery hint string when a `commit` lands on detached HEAD.
+
+    Used by the git-execute handler to surface the exact ``update-ref``
+    invocation an agent needs to set its work branch to the new commit
+    (issue #2162).  The empty string means "no hint" — caller appends as-is.
+
+    The trigger is intentionally narrow:
+
+    * Only ``operation == "commit"`` and only when the session has an
+      ``assigned_branch`` — we do not want to noise non-pipeline sessions.
+    * ``git symbolic-ref --quiet HEAD`` must return exactly 1 with empty
+      stdout AND empty stderr.  Returncode 128 (corrupt repo, .git missing,
+      "fatal: ...") and any non-empty stderr are treated as ambiguous and
+      yield no hint — telling the agent to run ``update-ref`` against a
+      broken repository would be misleading.
+    """
+    if operation != "commit":
+        return ""
+    session = getattr(g, "session", None)
+    assigned = getattr(session, "assigned_branch", None) if session else None
+    if not isinstance(assigned, str) or not assigned:
+        return ""
+    try:
+        head_check = subprocess.run(
+            git_cmd("symbolic-ref", "--quiet", "HEAD"),
+            cwd=exec_path,
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    # Tight check: returncode 1 with no stdout and no stderr is unambiguously
+    # detached HEAD.  Anything else (corrupt repo, missing .git, EAGAIN) gets
+    # no hint.
+    if head_check.returncode != 1:
+        return ""
+    if head_check.stdout.strip():
+        return ""
+    if head_check.stderr.strip():
+        return ""
+    logger.info(
+        "detached_head_commit_hint",
+        repo_path=repo_path,
+        container_id=container_id,
+        assigned_branch=assigned,
+    )
+    return (
+        f"\n[gateway] HEAD is detached. Your commit is not on "
+        f"branch '{assigned}'. To set the branch to this commit, run:\n"
+        f"  git update-ref refs/heads/{assigned} HEAD\n"
+    )
+
+
 def _is_checkpoint_repo_for_request(owner: str, repo: str) -> bool:
     """Check if a repository is a checkpoint repo, using all available signals.
 
@@ -2013,7 +2074,8 @@ def git_execute() -> tuple[Response, int] | Response:
     # update-ref is the supported recovery primitive when an agent ends up on
     # detached HEAD with a useful commit (see issue #2162). To keep the blast
     # radius tight, the gateway rejects any update-ref that is not of the form
-    # `update-ref [--no-deref] refs/heads/<assigned_branch> <newvalue> [<oldvalue>]`.
+    # `update-ref <ref> <newvalue> [<oldvalue>]` and force-prepends
+    # `--no-deref` below so symref-following semantics never apply.
     if operation == "update-ref":
         session = getattr(g, "session", None)
         assigned = getattr(session, "assigned_branch", None) if session else None
@@ -2025,8 +2087,7 @@ def git_execute() -> tuple[Response, int] | Response:
             )
         elif len(positional) < 2 or len(positional) > 3:
             denial_reason = (
-                "git update-ref must be of the form "
-                "`git update-ref [--no-deref] <ref> <newvalue> [<oldvalue>]`."
+                "git update-ref must be of the form `git update-ref <ref> <newvalue> [<oldvalue>]`."
             )
         else:
             expected_ref = f"refs/heads/{assigned}"
@@ -2234,6 +2295,14 @@ def git_execute() -> tuple[Response, int] | Response:
     if operation in ("commit", "merge", "am"):
         validated_args = ["--no-verify", *validated_args]
 
+    # SECURITY: Force-prepend `--no-deref` for `update-ref` (#2162). Without it,
+    # update-ref follows symref targets — the underlying ref is updated, not
+    # `refs/heads/<assigned_branch>`. In practice agent branches are never
+    # symrefs, but the gateway is a defense-in-depth boundary and the recovery
+    # flow never wants symref-following semantics.
+    if operation == "update-ref":
+        validated_args = ["--no-deref", *validated_args]
+
     # Build command
     cmd = git_cmd(operation, *validated_args)
 
@@ -2339,38 +2408,9 @@ def git_execute() -> tuple[Response, int] | Response:
             # Detached-HEAD recovery hint (#2162). After a successful commit
             # in a pipeline session, surface a clear hint if HEAD is detached
             # so the agent doesn't spend minutes guessing at policy bypasses
-            # to fast-forward its work branch.
-            stderr_out = result.stderr
-            _hint_session = getattr(g, "session", None)
-            _hint_assigned = (
-                getattr(_hint_session, "assigned_branch", None) if _hint_session else None
-            )
-            if operation == "commit" and isinstance(_hint_assigned, str) and _hint_assigned:
-                try:
-                    head_check = subprocess.run(
-                        git_cmd("symbolic-ref", "--quiet", "HEAD"),
-                        cwd=exec_path,
-                        capture_output=True,
-                        text=True,
-                        timeout=10,
-                        check=False,
-                    )
-                except (OSError, subprocess.TimeoutExpired):
-                    head_check = None
-                if head_check is not None and head_check.returncode != 0:
-                    hint = (
-                        f"\n[gateway] HEAD is detached. Your commit is not on "
-                        f"branch '{_hint_assigned}'. To advance the branch to "
-                        f"this commit, run:\n"
-                        f"  git update-ref refs/heads/{_hint_assigned} HEAD\n"
-                    )
-                    stderr_out = (stderr_out or "") + hint
-                    logger.info(
-                        "detached_head_commit_hint",
-                        repo_path=repo_path,
-                        container_id=container_id,
-                        assigned_branch=_hint_assigned,
-                    )
+            # to update its work branch ref.
+            hint = _detached_head_hint(operation, exec_path, repo_path, container_id)
+            stderr_out = (result.stderr or "") + hint if hint else result.stderr
 
             return make_success(
                 f"git {operation} successful",
@@ -2412,12 +2452,18 @@ def git_execute() -> tuple[Response, int] | Response:
                     },
                 )
 
+            # Surface the detached-HEAD recovery hint on failure too. Common
+            # cases (rebase --onto mid-conflict, missing --allow-empty, index
+            # locks) produce a *failed* commit while detached, and the hint is
+            # exactly what cuts that confusion short.
+            failure_hint = _detached_head_hint(operation, exec_path, repo_path, container_id)
+            failure_stderr = (result.stderr or "") + failure_hint if failure_hint else result.stderr
             return make_error(
                 f"git {operation} failed",
                 status_code=500,
                 details={
                     "stdout": result.stdout,
-                    "stderr": result.stderr,
+                    "stderr": failure_stderr,
                     "returncode": result.returncode,
                 },
             )

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -443,6 +443,18 @@ def _detached_head_hint(
     if head_check.stdout.strip():
         return ""
     if head_check.stderr.strip():
+        # Symbolic-ref returncode==1 with empty stdout but non-empty stderr is
+        # ambiguous (e.g. future git versions writing config-deprecation
+        # warnings).  Log at debug so a missing hint is debuggable rather than
+        # silent, and bail out — telling the agent to run update-ref against
+        # an unclear HEAD state would be misleading.
+        logger.debug(
+            "detached_head_hint_suppressed_stderr",
+            repo_path=repo_path,
+            container_id=container_id,
+            assigned_branch=assigned,
+            stderr=head_check.stderr.strip()[:200],
+        )
         return ""
     logger.info(
         "detached_head_commit_hint",

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -2009,6 +2009,47 @@ def git_execute() -> tuple[Response, int] | Response:
         )
         return make_error(args_error, status_code=400)
 
+    # SECURITY: Scope `git update-ref` to the agent's own assigned branch.
+    # update-ref is the supported recovery primitive when an agent ends up on
+    # detached HEAD with a useful commit (see issue #2162). To keep the blast
+    # radius tight, the gateway rejects any update-ref that is not of the form
+    # `update-ref [--no-deref] refs/heads/<assigned_branch> <newvalue> [<oldvalue>]`.
+    if operation == "update-ref":
+        session = getattr(g, "session", None)
+        assigned = getattr(session, "assigned_branch", None) if session else None
+        positional = [a for a in validated_args if not a.startswith("-")]
+        denial_reason: str | None = None
+        if not isinstance(assigned, str) or not assigned:
+            denial_reason = (
+                "git update-ref is only allowed in pipeline sessions with an assigned branch."
+            )
+        elif len(positional) < 2 or len(positional) > 3:
+            denial_reason = (
+                "git update-ref must be of the form "
+                "`git update-ref [--no-deref] <ref> <newvalue> [<oldvalue>]`."
+            )
+        else:
+            expected_ref = f"refs/heads/{assigned}"
+            if positional[0] != expected_ref:
+                denial_reason = (
+                    f"git update-ref target '{positional[0]}' is not allowed. "
+                    f"Only '{expected_ref}' (your assigned branch) may be updated."
+                )
+        if denial_reason is not None:
+            audit_log(
+                "git_execute_blocked",
+                operation,
+                success=False,
+                details={
+                    "repo_path": repo_path,
+                    "git_args": validated_args,
+                    "container_id": container_id,
+                    "assigned_branch": assigned,
+                    "reason": denial_reason,
+                },
+            )
+            return make_error(denial_reason, status_code=403)
+
     # SECURITY: Block branch-switching for pipeline sessions.
     # Pipeline containers are locked to their worktree branch to prevent
     # cross-contamination between pipeline tasks.
@@ -2294,11 +2335,48 @@ def git_execute() -> tuple[Response, int] | Response:
                     "container_id": container_id,
                 },
             )
+
+            # Detached-HEAD recovery hint (#2162). After a successful commit
+            # in a pipeline session, surface a clear hint if HEAD is detached
+            # so the agent doesn't spend minutes guessing at policy bypasses
+            # to fast-forward its work branch.
+            stderr_out = result.stderr
+            _hint_session = getattr(g, "session", None)
+            _hint_assigned = (
+                getattr(_hint_session, "assigned_branch", None) if _hint_session else None
+            )
+            if operation == "commit" and isinstance(_hint_assigned, str) and _hint_assigned:
+                try:
+                    head_check = subprocess.run(
+                        git_cmd("symbolic-ref", "--quiet", "HEAD"),
+                        cwd=exec_path,
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                        check=False,
+                    )
+                except (OSError, subprocess.TimeoutExpired):
+                    head_check = None
+                if head_check is not None and head_check.returncode != 0:
+                    hint = (
+                        f"\n[gateway] HEAD is detached. Your commit is not on "
+                        f"branch '{_hint_assigned}'. To advance the branch to "
+                        f"this commit, run:\n"
+                        f"  git update-ref refs/heads/{_hint_assigned} HEAD\n"
+                    )
+                    stderr_out = (stderr_out or "") + hint
+                    logger.info(
+                        "detached_head_commit_hint",
+                        repo_path=repo_path,
+                        container_id=container_id,
+                        assigned_branch=_hint_assigned,
+                    )
+
             return make_success(
                 f"git {operation} successful",
                 {
                     "stdout": result.stdout,
-                    "stderr": result.stderr,
+                    "stderr": stderr_out,
                     "returncode": result.returncode,
                 },
             )

--- a/gateway/git_client.py
+++ b/gateway/git_client.py
@@ -861,17 +861,16 @@ GIT_ALLOWED_COMMANDS = {
         ],
     },
     # update-ref is restricted to the safe two-arg form
-    # (`update-ref [--no-deref] <ref> <newvalue> [<oldvalue>]`). The gateway
-    # additionally scopes the target ref to ``refs/heads/<assigned_branch>``
-    # for pipeline sessions — see the update-ref guard in gateway.py.
+    # (`update-ref <ref> <newvalue> [<oldvalue>]`). The gateway additionally
+    # scopes the target ref to ``refs/heads/<assigned_branch>`` for pipeline
+    # sessions and force-prepends ``--no-deref`` server-side (defense in depth
+    # against symref-following) — see the update-ref guard in gateway.py.
     # ``--stdin``/``-d``/``-z``/``--create-reflog`` are intentionally absent
     # from the allowlist (and therefore rejected) to keep the surface area
     # tight: ref deletion and batch updates are not part of the supported
     # recovery flow. Issue #2162.
     "update-ref": {
-        "allowed_flags": [
-            "--no-deref",
-        ],
+        "allowed_flags": [],
     },
 }
 

--- a/gateway/git_client.py
+++ b/gateway/git_client.py
@@ -274,7 +274,7 @@ ALLOWED_FLAG_VALUES: dict[str, set[str]] = {
 
 # Per-operation allowlist of flags that are permitted
 # This is more secure than a blocklist - unknown flags are rejected by default
-GIT_ALLOWED_COMMANDS = {
+GIT_ALLOWED_COMMANDS: dict[str, dict[str, list[str]]] = {
     # === Network operations (require authentication) ===
     "fetch": {
         "allowed_flags": [

--- a/gateway/git_client.py
+++ b/gateway/git_client.py
@@ -860,6 +860,19 @@ GIT_ALLOWED_COMMANDS = {
             "--batch-check",
         ],
     },
+    # update-ref is restricted to the safe two-arg form
+    # (`update-ref [--no-deref] <ref> <newvalue> [<oldvalue>]`). The gateway
+    # additionally scopes the target ref to ``refs/heads/<assigned_branch>``
+    # for pipeline sessions — see the update-ref guard in gateway.py.
+    # ``--stdin``/``-d``/``-z``/``--create-reflog`` are intentionally absent
+    # from the allowlist (and therefore rejected) to keep the surface area
+    # tight: ref deletion and batch updates are not part of the supported
+    # recovery flow. Issue #2162.
+    "update-ref": {
+        "allowed_flags": [
+            "--no-deref",
+        ],
+    },
 }
 
 # Per-subcommand flag normalization: map short flags to long form for consistent

--- a/gateway/tests/test_update_ref_recovery.py
+++ b/gateway/tests/test_update_ref_recovery.py
@@ -1,0 +1,381 @@
+"""Tests for the detached-HEAD recovery primitive (issue #2162).
+
+Covers:
+- ``git update-ref`` is allowed only when scoped to ``refs/heads/<assigned_branch>``.
+- ``update-ref`` is denied for non-pipeline sessions (no assigned_branch).
+- ``update-ref`` is denied when the target ref does not match the assigned branch.
+- ``update-ref`` is denied for malformed positional args (too few / too many).
+- Disallowed flags (``--stdin``, ``-d``, ``-z``) are rejected by the allowlist.
+- A successful ``git commit`` on detached HEAD in a pipeline session
+  surfaces a recovery hint pointing at the ``update-ref`` command.
+"""
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import auth
+import pytest
+import session_manager as session_manager_module
+from private_repo_policy import PrivateRepoPolicyResult
+from session_manager import SessionValidationResult
+
+import gateway
+
+TEST_LAUNCHER_SECRET = "test-launcher-secret-12345"
+
+
+@pytest.fixture
+def client():
+    gateway.app.config["TESTING"] = True
+    with gateway.app.test_client() as client:
+        yield client
+
+
+def _make_session(assigned_branch, phase="implement", agent_role="coder"):
+    mock_session = MagicMock()
+    mock_session.mode = "private"
+    mock_session.container_id = "test-container"
+    mock_session.expires_at = None
+    mock_session.phase = phase
+    mock_session.agent_role = agent_role
+    mock_session.assigned_branch = assigned_branch
+    mock_session.pipeline_id = "issue-42" if assigned_branch else None
+    mock_session.last_branch = assigned_branch
+    mock_session.checkpoint_repo = None
+    mock_session.last_repo_path = None
+    return mock_session
+
+
+def _setup_auth(session):
+    mock_result = SessionValidationResult(valid=True, session=session)
+    mock_policy_result = PrivateRepoPolicyResult(
+        allowed=True,
+        reason="Test mode",
+        visibility="public",
+    )
+    auth._session_manager = None
+    auth._rate_limiter = None
+    if "gateway.auth" in sys.modules:
+        sys.modules["gateway.auth"]._session_manager = None
+        sys.modules["gateway.auth"]._rate_limiter = None
+    current_sm = sys.modules.get("session_manager", session_manager_module)
+    return (
+        {"Authorization": "Bearer test-session-token"},
+        mock_result,
+        mock_policy_result,
+        current_sm,
+    )
+
+
+def _execute(client, headers, args):
+    return client.post(
+        "/api/v1/git/execute",
+        json={
+            "repo_path": "/home/egg/repos/myrepo",
+            "operation": "update-ref",
+            "args": args,
+        },
+        headers=headers,
+    )
+
+
+class TestUpdateRefScope:
+    """update-ref is restricted to refs/heads/<assigned_branch>."""
+
+    @pytest.fixture
+    def auth_with_branch(self):
+        return _setup_auth(_make_session("egg/issue-42-coder/work"))
+
+    @pytest.fixture
+    def auth_without_branch(self):
+        return _setup_auth(_make_session(None))
+
+    def test_update_ref_to_assigned_branch_allowed(self, client, auth_with_branch):
+        """update-ref refs/heads/<assigned> <sha> reaches subprocess."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+            patch.object(gateway, "map_container_path_to_worktree", return_value="/worktree/path"),
+            patch("gateway.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            response = _execute(
+                client,
+                headers,
+                ["refs/heads/egg/issue-42-coder/work", "deadbeef"],
+            )
+            assert response.status_code == 200
+
+    def test_update_ref_with_no_deref_flag_allowed(self, client, auth_with_branch):
+        """--no-deref is permitted; positional args still validated."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+            patch.object(gateway, "map_container_path_to_worktree", return_value="/worktree/path"),
+            patch("gateway.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            response = _execute(
+                client,
+                headers,
+                ["--no-deref", "refs/heads/egg/issue-42-coder/work", "deadbeef"],
+            )
+            assert response.status_code == 200
+
+    def test_update_ref_with_oldvalue_allowed(self, client, auth_with_branch):
+        """The optional <oldvalue> third positional is accepted."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+            patch.object(gateway, "map_container_path_to_worktree", return_value="/worktree/path"),
+            patch("gateway.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            response = _execute(
+                client,
+                headers,
+                ["refs/heads/egg/issue-42-coder/work", "deadbeef", "cafef00d"],
+            )
+            assert response.status_code == 200
+
+    def test_update_ref_to_other_branch_blocked(self, client, auth_with_branch):
+        """update-ref against any other ref is rejected with 403."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+        ):
+            response = _execute(
+                client,
+                headers,
+                ["refs/heads/main", "deadbeef"],
+            )
+            assert response.status_code == 403
+            data = json.loads(response.data)
+            msg = data.get("message", "")
+            assert "refs/heads/main" in msg
+            assert "egg/issue-42-coder/work" in msg
+
+    def test_update_ref_to_remote_ref_blocked(self, client, auth_with_branch):
+        """update-ref against refs/remotes/* is rejected (not your branch)."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+        ):
+            response = _execute(
+                client,
+                headers,
+                ["refs/remotes/origin/main", "deadbeef"],
+            )
+            assert response.status_code == 403
+
+    def test_update_ref_with_no_assigned_branch_blocked(self, client, auth_without_branch):
+        """Sessions without assigned_branch cannot use update-ref at all."""
+        headers, mock_result, mock_policy, current_sm = auth_without_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+        ):
+            response = _execute(
+                client,
+                headers,
+                ["refs/heads/main", "deadbeef"],
+            )
+            assert response.status_code == 403
+            data = json.loads(response.data)
+            assert "pipeline session" in data.get("message", "").lower()
+
+    def test_update_ref_with_too_few_args_blocked(self, client, auth_with_branch):
+        """update-ref with only one positional arg is rejected."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+        ):
+            response = _execute(
+                client,
+                headers,
+                ["refs/heads/egg/issue-42-coder/work"],
+            )
+            assert response.status_code == 403
+
+    def test_update_ref_with_too_many_args_blocked(self, client, auth_with_branch):
+        """update-ref with more than three positional args is rejected."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+        ):
+            response = _execute(
+                client,
+                headers,
+                [
+                    "refs/heads/egg/issue-42-coder/work",
+                    "deadbeef",
+                    "cafef00d",
+                    "extra",
+                ],
+            )
+            assert response.status_code == 403
+
+    def test_update_ref_stdin_flag_blocked_by_allowlist(self, client, auth_with_branch):
+        """--stdin is not in the allowed_flags and is rejected during arg validation."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+        ):
+            response = _execute(client, headers, ["--stdin"])
+            # 400 from arg validation (flag not allowed)
+            assert response.status_code == 400
+
+    def test_update_ref_delete_flag_blocked_by_allowlist(self, client, auth_with_branch):
+        """-d (delete ref) is not in allowed_flags and is rejected during arg validation."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+        ):
+            response = _execute(
+                client,
+                headers,
+                ["-d", "refs/heads/egg/issue-42-coder/work"],
+            )
+            assert response.status_code == 400
+
+
+class TestDetachedHeadCommitHint:
+    """git commit on detached HEAD surfaces a recovery hint in stderr."""
+
+    @pytest.fixture
+    def auth_pipeline(self):
+        return _setup_auth(_make_session("egg/issue-42-coder/work"))
+
+    def _make_commit_subprocess_side_effect(self, head_detached: bool):
+        """Return a subprocess.run side_effect that simulates the commit flow.
+
+        Order of subprocess calls inside git_execute for a `commit`:
+          1. ``git diff --cached --name-only``     (phase-validation staged files)
+          2. ``git rev-parse HEAD``                 (commit observer before-snapshot)
+          3. The actual ``git commit ...`` invocation.
+          4. ``git rev-parse HEAD``                 (commit observer after-snapshot,
+             only if observe_after_git_execute is callable — patched out below)
+          5. ``git symbolic-ref --quiet HEAD``      (detached-HEAD detection)
+        We mock all of these as success and only flip the return code of the
+        symbolic-ref call to simulate detached vs attached HEAD.
+        """
+
+        def side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            cmd_str = " ".join(str(c) for c in cmd)
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+            if "diff" in cmd_str and "--cached" in cmd_str:
+                # No staged files to validate against phase restrictions
+                result.stdout = ""
+            elif "symbolic-ref" in cmd_str:
+                result.returncode = 1 if head_detached else 0
+                result.stdout = "" if head_detached else "refs/heads/egg/issue-42-coder/work\n"
+            else:
+                result.stdout = "ok"
+            return result
+
+        return side_effect
+
+    def test_commit_on_detached_head_includes_hint(self, client, auth_pipeline):
+        """Hint appears in stderr when HEAD is detached after a successful commit."""
+        headers, mock_result, mock_policy, current_sm = auth_pipeline
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+            patch.object(gateway, "map_container_path_to_worktree", return_value="/worktree/path"),
+            patch.object(gateway, "_lookup_commit_observer_fn", return_value=None),
+            patch(
+                "gateway.subprocess.run",
+                side_effect=self._make_commit_subprocess_side_effect(head_detached=True),
+            ),
+        ):
+            response = client.post(
+                "/api/v1/git/execute",
+                json={
+                    "repo_path": "/home/egg/repos/myrepo",
+                    "operation": "commit",
+                    "args": ["-m", "wip"],
+                },
+                headers=headers,
+            )
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            stderr = data.get("data", {}).get("stderr", "") or ""
+            assert "HEAD is detached" in stderr
+            assert "git update-ref refs/heads/egg/issue-42-coder/work HEAD" in stderr
+
+    def test_commit_on_attached_head_no_hint(self, client, auth_pipeline):
+        """Hint is absent when HEAD is on a branch."""
+        headers, mock_result, mock_policy, current_sm = auth_pipeline
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+            patch.object(gateway, "map_container_path_to_worktree", return_value="/worktree/path"),
+            patch.object(gateway, "_lookup_commit_observer_fn", return_value=None),
+            patch(
+                "gateway.subprocess.run",
+                side_effect=self._make_commit_subprocess_side_effect(head_detached=False),
+            ),
+        ):
+            response = client.post(
+                "/api/v1/git/execute",
+                json={
+                    "repo_path": "/home/egg/repos/myrepo",
+                    "operation": "commit",
+                    "args": ["-m", "real"],
+                },
+                headers=headers,
+            )
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            stderr = data.get("data", {}).get("stderr", "") or ""
+            assert "HEAD is detached" not in stderr

--- a/gateway/tests/test_update_ref_recovery.py
+++ b/gateway/tests/test_update_ref_recovery.py
@@ -161,6 +161,10 @@ class TestUpdateRefScope:
             # 400 from arg validation: --no-deref is no longer in the allowlist
             # because the gateway always injects it.
             assert response.status_code == 400
+            # Error message must name the flag so the agent can self-correct
+            # without escalating.
+            data = json.loads(response.data)
+            assert "--no-deref" in data.get("message", "")
 
     def test_update_ref_with_oldvalue_allowed(self, client, auth_with_branch):
         """The optional <oldvalue> third positional is accepted and reaches subprocess."""

--- a/gateway/tests/test_update_ref_recovery.py
+++ b/gateway/tests/test_update_ref_recovery.py
@@ -679,3 +679,63 @@ class TestDetachedHeadCommitHint:
             assert "detached_head_hint_suppressed_stderr" in debug_events, (
                 f"Expected detached_head_hint_suppressed_stderr debug log, got: {debug_events}"
             )
+
+    def test_commit_symbolic_ref_stderr_truncated_to_200_chars(self, client, auth_pipeline):
+        """Suppression-log ``stderr`` payload is truncated to 200 chars.
+
+        Locks in the bound on the debug-log payload size. Without truncation, a
+        misbehaving git that dumps a multi-line warning could bloat logs on
+        every commit.
+        """
+        headers, mock_result, mock_policy, current_sm = auth_pipeline
+        long_stderr = "x" * 5000
+
+        def side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            cmd_str = " ".join(str(c) for c in cmd)
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+            if "diff" in cmd_str and "--cached" in cmd_str:
+                result.stdout = ""
+            elif "symbolic-ref" in cmd_str:
+                result.returncode = 1
+                result.stdout = ""
+                result.stderr = long_stderr
+            else:
+                result.stdout = "ok"
+            return result
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+            patch.object(gateway, "map_container_path_to_worktree", return_value="/worktree/path"),
+            patch.object(gateway, "_lookup_commit_observer_fn", return_value=None),
+            patch("gateway.subprocess.run", side_effect=side_effect),
+            patch.object(gateway, "logger") as mock_logger,
+        ):
+            response = client.post(
+                "/api/v1/git/execute",
+                json={
+                    "repo_path": "/home/egg/repos/myrepo",
+                    "operation": "commit",
+                    "args": ["-m", "wip"],
+                },
+                headers=headers,
+            )
+            assert response.status_code == 200
+            suppression_calls = [
+                call
+                for call in mock_logger.debug.call_args_list
+                if call.args and call.args[0] == "detached_head_hint_suppressed_stderr"
+            ]
+            assert len(suppression_calls) == 1, (
+                f"Expected exactly one suppression debug call, got: {suppression_calls}"
+            )
+            logged_stderr = suppression_calls[0].kwargs.get("stderr", "")
+            assert len(logged_stderr) == 200, (
+                f"Expected stderr truncated to 200 chars, got len={len(logged_stderr)}"
+            )

--- a/gateway/tests/test_update_ref_recovery.py
+++ b/gateway/tests/test_update_ref_recovery.py
@@ -111,8 +111,8 @@ class TestUpdateRefScope:
             )
             assert response.status_code == 200
 
-    def test_update_ref_with_no_deref_flag_allowed(self, client, auth_with_branch):
-        """--no-deref is permitted; positional args still validated."""
+    def test_update_ref_no_deref_injected_server_side(self, client, auth_with_branch):
+        """The gateway force-prepends ``--no-deref`` so symref-following never applies."""
         headers, mock_result, mock_policy, current_sm = auth_with_branch
 
         with (
@@ -127,12 +127,43 @@ class TestUpdateRefScope:
             response = _execute(
                 client,
                 headers,
-                ["--no-deref", "refs/heads/egg/issue-42-coder/work", "deadbeef"],
+                ["refs/heads/egg/issue-42-coder/work", "deadbeef"],
             )
             assert response.status_code == 200
+            # Verify the actual subprocess call includes --no-deref before the
+            # positional args. ``git_cmd`` prepends additional ``-c`` config
+            # flags, so just assert presence + ordering relative to "update-ref".
+            assert mock_run.call_count == 1
+            called_cmd = list(mock_run.call_args[0][0])
+            update_ref_idx = called_cmd.index("update-ref")
+            assert "--no-deref" in called_cmd[update_ref_idx:]
+            no_deref_idx = called_cmd.index("--no-deref", update_ref_idx)
+            assert no_deref_idx == update_ref_idx + 1
+            # Positional args still come through after the injected flag.
+            assert called_cmd[no_deref_idx + 1] == "refs/heads/egg/issue-42-coder/work"
+            assert called_cmd[no_deref_idx + 2] == "deadbeef"
+
+    def test_update_ref_user_passed_no_deref_rejected(self, client, auth_with_branch):
+        """User-passed ``--no-deref`` is redundant (gateway injects it) and rejected."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+        ):
+            response = _execute(
+                client,
+                headers,
+                ["--no-deref", "refs/heads/egg/issue-42-coder/work", "deadbeef"],
+            )
+            # 400 from arg validation: --no-deref is no longer in the allowlist
+            # because the gateway always injects it.
+            assert response.status_code == 400
 
     def test_update_ref_with_oldvalue_allowed(self, client, auth_with_branch):
-        """The optional <oldvalue> third positional is accepted."""
+        """The optional <oldvalue> third positional is accepted and reaches subprocess."""
         headers, mock_result, mock_policy, current_sm = auth_with_branch
 
         with (
@@ -150,6 +181,20 @@ class TestUpdateRefScope:
                 ["refs/heads/egg/issue-42-coder/work", "deadbeef", "cafef00d"],
             )
             assert response.status_code == 200
+            # All three positional args (ref, newvalue, oldvalue) must reach
+            # the subprocess unchanged — `update-ref` uses <oldvalue> as a
+            # CAS guard and silently dropping it would change semantics.
+            assert mock_run.call_count == 1
+            called_cmd = list(mock_run.call_args[0][0])
+            update_ref_idx = called_cmd.index("update-ref")
+            tail = called_cmd[update_ref_idx:]
+            assert "refs/heads/egg/issue-42-coder/work" in tail
+            assert "deadbeef" in tail
+            assert "cafef00d" in tail
+            # Order is preserved: ref, newvalue, oldvalue.
+            ref_idx = tail.index("refs/heads/egg/issue-42-coder/work")
+            assert tail[ref_idx + 1] == "deadbeef"
+            assert tail[ref_idx + 2] == "cafef00d"
 
     def test_update_ref_to_other_branch_blocked(self, client, auth_with_branch):
         """update-ref against any other ref is rejected with 403."""
@@ -258,8 +303,12 @@ class TestUpdateRefScope:
             patch.object(gateway, "validate_repo_path", return_value=(True, "")),
         ):
             response = _execute(client, headers, ["--stdin"])
-            # 400 from arg validation (flag not allowed)
+            # 400 from arg validation (flag not allowed).
             assert response.status_code == 400
+            # Error message must name the flag so the agent can self-correct
+            # without escalating.
+            data = json.loads(response.data)
+            assert "--stdin" in data.get("message", "")
 
     def test_update_ref_delete_flag_blocked_by_allowlist(self, client, auth_with_branch):
         """-d (delete ref) is not in allowed_flags and is rejected during arg validation."""
@@ -277,6 +326,8 @@ class TestUpdateRefScope:
                 ["-d", "refs/heads/egg/issue-42-coder/work"],
             )
             assert response.status_code == 400
+            data = json.loads(response.data)
+            assert "-d" in data.get("message", "")
 
 
 class TestDetachedHeadCommitHint:
@@ -379,3 +430,182 @@ class TestDetachedHeadCommitHint:
             data = json.loads(response.data)
             stderr = data.get("data", {}).get("stderr", "") or ""
             assert "HEAD is detached" not in stderr
+
+    def test_commit_on_detached_head_no_assigned_branch_no_hint(self, client):
+        """Sessions without assigned_branch never see the hint (non-pipeline)."""
+        # Use a session with assigned_branch=None to simulate non-pipeline mode.
+        headers, mock_result, mock_policy, current_sm = _setup_auth(_make_session(None))
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+            patch.object(gateway, "map_container_path_to_worktree", return_value="/worktree/path"),
+            patch.object(gateway, "_lookup_commit_observer_fn", return_value=None),
+            patch(
+                "gateway.subprocess.run",
+                side_effect=self._make_commit_subprocess_side_effect(head_detached=True),
+            ),
+        ):
+            response = client.post(
+                "/api/v1/git/execute",
+                json={
+                    "repo_path": "/home/egg/repos/myrepo",
+                    "operation": "commit",
+                    "args": ["-m", "wip"],
+                },
+                headers=headers,
+            )
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            stderr = data.get("data", {}).get("stderr", "") or ""
+            # Without an assigned_branch the gateway has no recovery target to
+            # name, so the hint must not fire — even though HEAD is detached.
+            assert "HEAD is detached" not in stderr
+            assert "update-ref" not in stderr
+
+    def test_commit_on_detached_head_subprocess_error_no_hint(self, client, auth_pipeline):
+        """If symbolic-ref times out or raises OSError, no hint is surfaced."""
+        headers, mock_result, mock_policy, current_sm = auth_pipeline
+
+        def side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            cmd_str = " ".join(str(c) for c in cmd)
+            if "symbolic-ref" in cmd_str:
+                # Simulate the kernel killing the subprocess with EAGAIN, etc.
+                raise OSError("simulated symbolic-ref failure")
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "ok" if "diff" not in cmd_str else ""
+            result.stderr = ""
+            return result
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+            patch.object(gateway, "map_container_path_to_worktree", return_value="/worktree/path"),
+            patch.object(gateway, "_lookup_commit_observer_fn", return_value=None),
+            patch("gateway.subprocess.run", side_effect=side_effect),
+        ):
+            response = client.post(
+                "/api/v1/git/execute",
+                json={
+                    "repo_path": "/home/egg/repos/myrepo",
+                    "operation": "commit",
+                    "args": ["-m", "wip"],
+                },
+                headers=headers,
+            )
+            # The commit itself succeeded; only the post-hoc check failed.
+            # The hint helper swallows the error and returns no hint.
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            stderr = data.get("data", {}).get("stderr", "") or ""
+            assert "HEAD is detached" not in stderr
+
+    def test_commit_on_corrupt_repo_no_hint(self, client, auth_pipeline):
+        """A corrupt repo (returncode 128, fatal stderr) must not get a misleading hint."""
+        headers, mock_result, mock_policy, current_sm = auth_pipeline
+
+        def side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            cmd_str = " ".join(str(c) for c in cmd)
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+            if "diff" in cmd_str and "--cached" in cmd_str:
+                result.stdout = ""
+            elif "symbolic-ref" in cmd_str:
+                # `git symbolic-ref --quiet HEAD` against a corrupt or missing
+                # .git directory exits 128 with a fatal: line on stderr.  This
+                # is *not* detached HEAD; the hint must stay silent.
+                result.returncode = 128
+                result.stdout = ""
+                result.stderr = (
+                    "fatal: not a git repository (or any of the parent directories): .git\n"
+                )
+            else:
+                result.stdout = "ok"
+            return result
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+            patch.object(gateway, "map_container_path_to_worktree", return_value="/worktree/path"),
+            patch.object(gateway, "_lookup_commit_observer_fn", return_value=None),
+            patch("gateway.subprocess.run", side_effect=side_effect),
+        ):
+            response = client.post(
+                "/api/v1/git/execute",
+                json={
+                    "repo_path": "/home/egg/repos/myrepo",
+                    "operation": "commit",
+                    "args": ["-m", "wip"],
+                },
+                headers=headers,
+            )
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            stderr = data.get("data", {}).get("stderr", "") or ""
+            assert "HEAD is detached" not in stderr
+            assert "update-ref" not in stderr
+
+    def test_commit_failure_on_detached_head_includes_hint(self, client, auth_pipeline):
+        """Hint is surfaced even when the commit *fails* (e.g. mid-rebase conflict)."""
+        headers, mock_result, mock_policy, current_sm = auth_pipeline
+
+        def side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            cmd_str = " ".join(str(c) for c in cmd)
+            result = MagicMock()
+            result.stdout = ""
+            result.stderr = ""
+            if "diff" in cmd_str and "--cached" in cmd_str:
+                result.returncode = 0
+                result.stdout = ""
+            elif "symbolic-ref" in cmd_str:
+                # Detached HEAD: rc=1, no stdout, no stderr.
+                result.returncode = 1
+                result.stdout = ""
+                result.stderr = ""
+            elif "commit" in cmd_str:
+                # The actual `git commit` call fails (e.g. nothing to commit
+                # because conflict markers remain unresolved).
+                result.returncode = 1
+                result.stderr = "nothing to commit, working tree clean\n"
+            else:
+                result.returncode = 0
+                result.stdout = "ok"
+            return result
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+            patch.object(gateway, "map_container_path_to_worktree", return_value="/worktree/path"),
+            patch.object(gateway, "_lookup_commit_observer_fn", return_value=None),
+            patch("gateway.subprocess.run", side_effect=side_effect),
+        ):
+            response = client.post(
+                "/api/v1/git/execute",
+                json={
+                    "repo_path": "/home/egg/repos/myrepo",
+                    "operation": "commit",
+                    "args": ["-m", "wip"],
+                },
+                headers=headers,
+            )
+            # The commit failed, but the hint must still appear so the agent
+            # doesn't burn turns guessing why their commit didn't land.
+            assert response.status_code == 500
+            data = json.loads(response.data)
+            stderr = data.get("data", {}).get("stderr", "") or ""
+            assert "HEAD is detached" in stderr
+            assert "git update-ref refs/heads/egg/issue-42-coder/work HEAD" in stderr

--- a/gateway/tests/test_update_ref_recovery.py
+++ b/gateway/tests/test_update_ref_recovery.py
@@ -613,3 +613,69 @@ class TestDetachedHeadCommitHint:
             stderr = data.get("data", {}).get("stderr", "") or ""
             assert "HEAD is detached" in stderr
             assert "git update-ref refs/heads/egg/issue-42-coder/work HEAD" in stderr
+
+    def test_commit_symbolic_ref_nonempty_stderr_suppresses_hint(self, client, auth_pipeline):
+        """rc=1 with empty stdout but non-empty stderr suppresses the hint and logs at debug.
+
+        Locks in the contract added in the third review pass: if a future git
+        version (or the host environment) leaks a config-deprecation warning
+        onto stderr, the hint must stay silent — telling the agent to run
+        ``update-ref`` against an unclear HEAD state would be misleading — and
+        the suppression must be observable via a debug-level log so the
+        missing hint is debuggable rather than invisible.
+        """
+        headers, mock_result, mock_policy, current_sm = auth_pipeline
+
+        def side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            cmd_str = " ".join(str(c) for c in cmd)
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+            if "diff" in cmd_str and "--cached" in cmd_str:
+                result.stdout = ""
+            elif "symbolic-ref" in cmd_str:
+                # rc=1 (would normally trigger the hint) but stderr is non-empty:
+                # ambiguous state, hint must stay silent.
+                result.returncode = 1
+                result.stdout = ""
+                result.stderr = "warning: deprecated config option foo.bar\n"
+            else:
+                result.stdout = "ok"
+            return result
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+            patch.object(gateway, "map_container_path_to_worktree", return_value="/worktree/path"),
+            patch.object(gateway, "_lookup_commit_observer_fn", return_value=None),
+            patch("gateway.subprocess.run", side_effect=side_effect),
+            patch.object(gateway, "logger") as mock_logger,
+        ):
+            response = client.post(
+                "/api/v1/git/execute",
+                json={
+                    "repo_path": "/home/egg/repos/myrepo",
+                    "operation": "commit",
+                    "args": ["-m", "wip"],
+                },
+                headers=headers,
+            )
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            stderr = data.get("data", {}).get("stderr", "") or ""
+            # No hint surfaced — the stderr-non-empty branch suppresses it.
+            assert "HEAD is detached" not in stderr
+            assert "update-ref" not in stderr
+            # The suppression event was logged at debug so the missing hint
+            # is debuggable rather than silent.
+            debug_events = [
+                call.args[0] if call.args else call.kwargs.get("event", "")
+                for call in mock_logger.debug.call_args_list
+            ]
+            assert "detached_head_hint_suppressed_stderr" in debug_events, (
+                f"Expected detached_head_hint_suppressed_stderr debug log, got: {debug_events}"
+            )

--- a/sandbox/agent-config/rules/README.md
+++ b/sandbox/agent-config/rules/README.md
@@ -68,6 +68,15 @@ Sandbox agents see in-process Claude Agent SDK MCP tools for HITL / BRC / phase 
   - Step-by-step: read anchor → catch up messages → verify files → resume
   - Full guide: `$EGG_REPO_PATH/docs/guides/anchor-recovery.md`
 
+- **branch-recovery.md** - Detached-HEAD recovery in pipeline sessions
+  - When you end up on detached HEAD, advance your work branch with
+    `git update-ref refs/heads/<your-branch> <sha>`
+  - Background: #2162
+
+- **push-recovery.md** - Recovering from a rejected push
+  - What happens when the gateway rejects `git push` for restricted-path
+    modifications, and the conditional-ACK pattern from #1998
+
 ## Design Principles
 
 - **Index, Don't Dump** - Rules are concise; detailed docs are referenced

--- a/sandbox/agent-config/rules/branch-recovery.md
+++ b/sandbox/agent-config/rules/branch-recovery.md
@@ -1,0 +1,32 @@
+# Branch Recovery
+
+In a pipeline session you are locked to a single work branch (your `assigned_branch`). The gateway denies branch switching, force-push, ref deletion, and most ref-mutation primitives. There is one exception, used for **detached-HEAD recovery**.
+
+## When you might end up on detached HEAD
+
+Some operations leave HEAD detached on success or failure — for example, a partway-through `git rebase --onto` or a `git switch --detach`. If you make a commit while detached, the commit is unreachable from your `assigned_branch` and the BRC `propose` step will not see it.
+
+## How to recover
+
+The gateway allows exactly one ref-mutation primitive, scoped to your own branch:
+
+```
+git update-ref refs/heads/<your-assigned-branch> <new-sha>
+```
+
+That advances your work branch ref to the commit you made on detached HEAD. After this, `propose` (which pushes your branch to origin) will include the work.
+
+**You will see a hint in stderr** after a successful `git commit` whenever HEAD is detached, telling you the exact command to run. If you see it, run that command and continue.
+
+## What is **not** allowed (and why)
+
+- `git update-ref` to any ref other than `refs/heads/<your-assigned-branch>` — you can only advance your own branch.
+- `git update-ref --stdin` / `-d` / `-z` — only the safe two-arg form (`<ref> <newvalue> [<oldvalue>]`) is permitted; ref deletion and batch updates are not part of the supported recovery flow.
+- `git branch -f` / `branch -d` — force/delete on the work branch is denied; use `update-ref` instead.
+- `git checkout <branch>` / `git switch <branch>` — branch switching is denied in pipeline sessions.
+
+## Don't keep guessing
+
+If `update-ref` is rejected (wrong ref name, wrong session type, malformed args), the error message tells you exactly why. **Do not** loop on creative `git` invocations trying to bypass the policy. Fix the args and retry, or — if the orphan commit isn't worth saving — propose against the previous on-branch commit and abandon the detached work.
+
+Background: issue #2162.

--- a/sandbox/agent-config/rules/branch-recovery.md
+++ b/sandbox/agent-config/rules/branch-recovery.md
@@ -14,13 +14,13 @@ The gateway allows exactly one ref-mutation primitive, scoped to your own branch
 git update-ref refs/heads/<your-assigned-branch> <new-sha>
 ```
 
-That advances your work branch ref to the commit you made on detached HEAD. After this, `propose` (which pushes your branch to origin) will include the work.
+That sets your work branch ref to the new commit. The implementation does **not** require the new value to be a descendant of the current ref — you can also use this to rewind your branch after a bad direction, or repoint it to an arbitrary commit you've made or fetched. After running the command, `propose` (which pushes your branch to origin) will include the work.
 
 **You will see a hint in stderr** after a successful `git commit` whenever HEAD is detached, telling you the exact command to run. If you see it, run that command and continue.
 
 ## What is **not** allowed (and why)
 
-- `git update-ref` to any ref other than `refs/heads/<your-assigned-branch>` — you can only advance your own branch.
+- `git update-ref` to any ref other than `refs/heads/<your-assigned-branch>` — you can only update your own branch.
 - `git update-ref --stdin` / `-d` / `-z` — only the safe two-arg form (`<ref> <newvalue> [<oldvalue>]`) is permitted; ref deletion and batch updates are not part of the supported recovery flow.
 - `git branch -f` / `branch -d` — force/delete on the work branch is denied; use `update-ref` instead.
 - `git checkout <branch>` / `git switch <branch>` — branch switching is denied in pipeline sessions.

--- a/sandbox/agent-config/rules/branch-recovery.md
+++ b/sandbox/agent-config/rules/branch-recovery.md
@@ -16,7 +16,7 @@ git update-ref refs/heads/<your-assigned-branch> <new-sha>
 
 That sets your work branch ref to the new commit. The implementation does **not** require the new value to be a descendant of the current ref — you can also use this to rewind your branch after a bad direction, or repoint it to an arbitrary commit you've made or fetched. After running the command, `propose` (which pushes your branch to origin) will include the work.
 
-**You will see a hint in stderr** after a successful `git commit` whenever HEAD is detached, telling you the exact command to run. If you see it, run that command and continue.
+**You will see a hint in stderr** after a `git commit` (successful or failed) whenever HEAD is detached, telling you the exact command to run. If you see it, run that command and continue.
 
 ## What is **not** allowed (and why)
 


### PR DESCRIPTION
## Summary

- Adds `git update-ref refs/heads/<assigned_branch> <newvalue> [<oldvalue>]` as a tightly scoped escape hatch in pipeline sessions, so an agent that ends up on detached HEAD with a useful commit can advance its own work-branch ref.
- Surfaces a recovery hint in `git commit` response stderr when HEAD is detached, naming the exact `update-ref` command — so agents don't burn minutes guessing at policy bypasses.
- Documents the procedure in `sandbox/agent-config/rules/branch-recovery.md`.

The branch-switch invariant is preserved: only the agent's own ref can be moved, and only via the safe two-arg form. `--stdin`, `-d`, `-z`, etc. remain denied via the per-op flag allowlist.

Fixes #2162.

## Why this shape

Three options were on the table from the issue:

1. Allow `update-ref` scoped to the agent's own branch.
2. Allow `branch -f <own-branch>` scoped to the agent's own branch.
3. Carve `checkout <own-branch>` out of the branch-switch deny.

(1) is the most surgical: the scope check is one equality against `g.session.assigned_branch` (which the deny path already uses), and we don't widen the branch-switch surface. The other two would either touch porcelain validation (more places for bugs) or invert a strong existing invariant.

## Why a hint and not a block

Blocking detached-HEAD commits would address the entry path at the cost of breaking workflows like resolving a partway-through `git rebase --onto` conflict. The hint gives agents the recovery instruction at the moment they need it without restricting legitimate cases.

## Test plan

- [x] `pytest gateway/tests/test_update_ref_recovery.py` (12 new tests: scope rules, malformed args, flag allowlist, detached-HEAD hint presence/absence)
- [x] Regression: `pytest gateway/tests/test_pipeline_enforcement.py gateway/tests/test_assigned_branch.py gateway/tests/test_branch_switch.py gateway/tests/test_git_client.py` — 196 existing tests still pass
- [x] `ruff check` + `ruff format --check` clean on changed files