### PR TITLE
fix: state-store self-heal + surface wedges as 500 (#2167)

### DIFF
--- a/orchestrator/api.py
+++ b/orchestrator/api.py
@@ -145,27 +145,30 @@ def log_request_end(response: Response) -> Response:
 @app.errorhandler(Exception)
 def handle_unhandled_exception(e: Exception) -> tuple[Response, int]:
     """Return JSON for all unhandled exceptions."""
+    from state_store import GitOperationError
     from werkzeug.exceptions import HTTPException
 
-    # Surface state-store infrastructure failures (e.g. ``git worktree``
+    # Surface state-store infrastructure failures (``git worktree``
     # contention) with the actual error so operators can diagnose without
     # grepping logs.  Routes used to swallow ``GitOperationError`` as
     # ``PipelineNotFoundError`` and return 404, masking a recoverable
     # wedge as "missing pipeline" (#2167).
-    try:
-        from state_store import StateStoreError
-
-        if isinstance(e, StateStoreError):
-            logger.error("State store error", error=str(e), exc_info=True)
-            return jsonify(
-                {
-                    "success": False,
-                    "message": f"State store unavailable: {e}",
-                    "error_type": type(e).__name__,
-                }
-            ), 500
-    except ImportError:  # pragma: no cover — defensive
-        pass
+    #
+    # Narrowed to ``GitOperationError`` deliberately: other ``StateStoreError``
+    # subclasses (``PipelineNotFoundError``, ``InvalidPipelineIdError``,
+    # ``StateValidationError``, ``VersionConflictError``) have correct
+    # status codes when handled at the route level; catching them here
+    # would surface a future "forgot to handle PipelineNotFoundError" as
+    # 500 instead of 404.
+    if isinstance(e, GitOperationError):
+        logger.error("State store error", error=str(e), exc_info=True)
+        return jsonify(
+            {
+                "success": False,
+                "message": f"State store unavailable: {e}",
+                "error_type": type(e).__name__,
+            }
+        ), 500
 
     if isinstance(e, HTTPException):
         return jsonify(

--- a/orchestrator/api.py
+++ b/orchestrator/api.py
@@ -147,6 +147,26 @@ def handle_unhandled_exception(e: Exception) -> tuple[Response, int]:
     """Return JSON for all unhandled exceptions."""
     from werkzeug.exceptions import HTTPException
 
+    # Surface state-store infrastructure failures (e.g. ``git worktree``
+    # contention) with the actual error so operators can diagnose without
+    # grepping logs.  Routes used to swallow ``GitOperationError`` as
+    # ``PipelineNotFoundError`` and return 404, masking a recoverable
+    # wedge as "missing pipeline" (#2167).
+    try:
+        from state_store import StateStoreError
+
+        if isinstance(e, StateStoreError):
+            logger.error("State store error", error=str(e), exc_info=True)
+            return jsonify(
+                {
+                    "success": False,
+                    "message": f"State store unavailable: {e}",
+                    "error_type": type(e).__name__,
+                }
+            ), 500
+    except ImportError:  # pragma: no cover — defensive
+        pass
+
     if isinstance(e, HTTPException):
         return jsonify(
             {

--- a/orchestrator/routes/health.py
+++ b/orchestrator/routes/health.py
@@ -35,7 +35,7 @@ def _probe_state_store() -> tuple[bool, str]:
     """Probe whether the state-store worktree is loadable.
 
     Walks the configured ``EGG_REPO_PATH`` (or each child repo in
-    multi-repo mode) and calls ``_ensure_worktree`` on each.  Reports
+    multi-repo mode) and accesses ``store.worktree`` on each.  Reports
     degraded if any probe raises — typically ``GitOperationError`` from
     ``git worktree add`` contention or a stale ``prunable`` admin dir
     (#2167).  Returns the actual error message so the operator sees it
@@ -43,12 +43,17 @@ def _probe_state_store() -> tuple[bool, str]:
 
     Probe is cheap when healthy: ``_ensure_worktree`` short-circuits
     on a valid worktree via ``git rev-parse --is-inside-work-tree``.
+
+    NOTE: This is not a side-effect-free GET.  ``store.worktree``
+    triggers ``_add_worktree_with_branch_recovery`` on a wedged repo,
+    which may ``shutil.rmtree`` a stale admin dir and retry the
+    ``git worktree add``.  Frequent pollers of ``/api/v1/health``
+    (Prometheus, operator dashboards, ``deployment.py``) will therefore
+    drive recovery attempts during a wedge — the desired behavior, but
+    operators should be aware the probe is curative, not just observational.
     """
-    try:
-        from routes import get_repo_path
-        from state_store import discover_repo_paths, get_state_store
-    except ImportError as exc:  # pragma: no cover — defensive
-        return True, f"probe-skipped: imports unavailable ({exc})"
+    from routes import get_repo_path
+    from state_store import discover_repo_paths, get_state_store
 
     try:
         base_path = get_repo_path()
@@ -68,7 +73,7 @@ def _probe_state_store() -> tuple[bool, str]:
     for repo_path in repos:
         try:
             store = get_state_store(repo_path)
-            store._ensure_worktree()
+            _ = store.worktree
         except Exception as exc:
             return False, f"{type(exc).__name__}: {exc}"
 

--- a/orchestrator/routes/health.py
+++ b/orchestrator/routes/health.py
@@ -31,41 +31,86 @@ health_bp = Blueprint("health", __name__, url_prefix="/api/v1")
 _health_tracker = HealthTracker()
 
 
+def _probe_state_store() -> tuple[bool, str]:
+    """Probe whether the state-store worktree is loadable.
+
+    Walks the configured ``EGG_REPO_PATH`` (or each child repo in
+    multi-repo mode) and calls ``_ensure_worktree`` on each.  Reports
+    degraded if any probe raises — typically ``GitOperationError`` from
+    ``git worktree add`` contention or a stale ``prunable`` admin dir
+    (#2167).  Returns the actual error message so the operator sees it
+    in the health payload instead of having to grep orchestrator logs.
+
+    Probe is cheap when healthy: ``_ensure_worktree`` short-circuits
+    on a valid worktree via ``git rev-parse --is-inside-work-tree``.
+    """
+    try:
+        from routes import get_repo_path
+        from state_store import discover_repo_paths, get_state_store
+    except ImportError as exc:  # pragma: no cover — defensive
+        return True, f"probe-skipped: imports unavailable ({exc})"
+
+    try:
+        base_path = get_repo_path()
+    except Exception as exc:
+        # Request context missing or repo lookup failed — don't flap
+        # the health check on configuration issues unrelated to the
+        # state-store wedge we're trying to detect.
+        return True, f"probe-skipped: {exc}"
+
+    if (base_path / ".git").exists():
+        repos = [base_path]
+    else:
+        repos = list(discover_repo_paths(base_path))
+        if not repos:
+            return True, "probe-skipped: no git repos under base_path"
+
+    for repo_path in repos:
+        try:
+            store = get_state_store(repo_path)
+            store._ensure_worktree()
+        except Exception as exc:
+            return False, f"{type(exc).__name__}: {exc}"
+
+    return True, "ok"
+
+
 @health_bp.route("/health", methods=["GET"])
 def health_check() -> tuple[Response, int]:
     """
     Health check endpoint.
 
-    Returns basic service status and component health.
+    Returns basic service status and component health.  The state-store
+    component is probed live: if ``_ensure_worktree`` fails (e.g. the
+    ``egg/pipeline-state`` branch is pinned by a prunable worktree —
+    #2167), the top-level ``status`` flips to ``degraded`` and the
+    failing error message is reported in ``components.state_store``.
+
+    The HTTP status stays 200 regardless so kubernetes liveness/readiness
+    probes (``/live``, ``/ready``) are unaffected.  Clients reading the
+    health JSON should branch on the ``status`` field, not the HTTP code.
 
     Response:
         {
-            "status": "healthy",
+            "status": "healthy" | "degraded",
             "service": "egg-orchestrator",
             "timestamp": "2024-01-15T12:00:00Z",
             "components": {
-                "state_store": "ok",
-                "docker": "ok"
+                "state_store": "ok" | "<error message>",
+                "docker": "unknown"
             }
         }
     """
-    # The orchestrator's /health endpoint always responds "healthy" today
-    # (degraded states aren't evaluated here), so each hit records a
-    # healthy observation. The tracker still populates process_start_time
-    # and healthy_since, which is exactly the signal operators need to
-    # distinguish "stable for hours" from "came up seconds ago" (#1855).
-    # TODO: When degraded-state evaluation is added (e.g. the "docker":
-    # "unknown" component below), pass the actual health status here
-    # instead of hard-coding True.
-    _health_tracker.record(True)
+    state_store_healthy, state_store_status = _probe_state_store()
+    _health_tracker.record(state_store_healthy)
     tracker_snapshot = _health_tracker.snapshot()
 
     response = {
-        "status": "healthy",
+        "status": "healthy" if state_store_healthy else "degraded",
         "service": "egg-orchestrator",
         "timestamp": datetime.now(UTC).isoformat(),
         "components": {
-            "state_store": "ok",
+            "state_store": state_store_status,
             "docker": "unknown",  # Will be updated when docker client is available
         },
         "process_start_time": tracker_snapshot["process_start_time"],

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -945,6 +945,10 @@ def _resolve_pipeline(pipeline_id: str, base_path: Path) -> tuple[StateStore, Pi
     Raises:
         PipelineNotFoundError: if the pipeline cannot be found anywhere
         InvalidPipelineIdError: if the ID format is invalid
+        GitOperationError: if the state-store worktree cannot be loaded
+            (e.g. ``git worktree add`` contention).  Callers should
+            surface this as 500, not 404 — it is recoverable
+            infrastructure failure, not a missing pipeline.
     """
     from state_store import discover_repo_paths
 
@@ -953,8 +957,14 @@ def _resolve_pipeline(pipeline_id: str, base_path: Path) -> tuple[StateStore, Pi
             store = get_state_store(repo_path)
             pipeline = store.load_pipeline(pipeline_id)
             return store, pipeline
-        except (PipelineNotFoundError, StateStoreError):
+        except PipelineNotFoundError:
             continue
+        # NOTE: do NOT broaden this to ``StateStoreError``.  Swallowing
+        # ``GitOperationError`` here re-raised every state-store wedge
+        # as ``Pipeline not found`` and surfaced to operators as 404,
+        # masking a recoverable git contention as a missing pipeline
+        # (#2167).  Let infrastructure failures propagate so the route
+        # can return 500 with the actual error.
 
     raise PipelineNotFoundError(f"Pipeline {pipeline_id} not found") from None
 

--- a/orchestrator/state_store.py
+++ b/orchestrator/state_store.py
@@ -280,7 +280,7 @@ class StateStore:
             self._restore_from_remote()
 
         if self._state_branch_exists():
-            self._run_git("worktree", "add", str(wt), STATE_BRANCH)
+            self._add_worktree_with_branch_recovery(wt)
         else:
             # First run: create orphan branch
             # Wrap in try/except to clean up on partial failure
@@ -345,6 +345,85 @@ class StateStore:
                     return
             except OSError:
                 continue
+
+    # Matches git's "already used by worktree at '<path>'" failure message.
+    # Used to parse the prunable worktree path from `git worktree add` stderr
+    # so we can drop a single targeted admin dir without scanning all of them.
+    _BRANCH_IN_USE_PATTERN = re.compile(r"is already (?:used by worktree|checked out) at '([^']+)'")
+
+    def _add_worktree_with_branch_recovery(self, wt: Path) -> None:
+        """Run ``git worktree add <wt> <STATE_BRANCH>`` with self-heal.
+
+        The state branch can become pinned by an admin dir under
+        ``{repo}/.git/worktrees/`` whose worktree directory is gone
+        (``prunable``) — for example, after a state-volume reset that
+        wiped ``pipeline-worktree`` while the admin dir survived, or
+        after :func:`get_state_store` switched the worktree path
+        (single-repo → multi-repo deployment) and orphaned the legacy
+        admin dir.  Either way, the next ``worktree add`` fails with
+        ``'<branch>' is already used by worktree at '<path>'`` and the
+        orchestrator wedges every state load (#2167).
+
+        On that specific failure we parse the path from stderr, confirm
+        it is gone from disk (never touch a live worktree), remove the
+        single admin dir whose ``gitdir`` matches that path, and retry
+        the add once.  ``git worktree prune`` is intentionally avoided
+        because the orchestrator pod cannot see the gateway's worktree
+        paths (different bind mounts) and prune would incorrectly
+        remove their admin dirs (see ``_remove_stale_admin_dir``).
+        """
+        try:
+            self._run_git("worktree", "add", str(wt), STATE_BRANCH)
+            return
+        except GitOperationError as exc:
+            match = self._BRANCH_IN_USE_PATTERN.search(str(exc))
+            if not match:
+                raise
+            stale_path = Path(match.group(1))
+            if stale_path.exists():
+                # A live worktree genuinely holds the branch.  Refuse to
+                # touch it; surface the original error.
+                raise
+            removed = self._remove_admin_dir_for_path(stale_path)
+            if not removed:
+                logger.warning(
+                    "Branch %s held by prunable worktree at %s but no admin dir matched",
+                    STATE_BRANCH,
+                    stale_path,
+                )
+                raise
+            logger.info(
+                "Cleared stale admin dir for prunable worktree; retrying add: path=%s",
+                stale_path,
+            )
+            self._run_git("worktree", "add", str(wt), STATE_BRANCH)
+
+    def _remove_admin_dir_for_path(self, target_wt_path: Path) -> bool:
+        """Remove the admin dir whose ``gitdir`` references ``target_wt_path``.
+
+        Returns True if an admin dir was removed.  Used by
+        :meth:`_add_worktree_with_branch_recovery` to clear a single
+        stale entry by path — independent of ``self._worktree_dir``,
+        which may have changed since the admin dir was written.
+        """
+        worktrees_dir = self.repo_path / ".git" / "worktrees"
+        if not worktrees_dir.exists():
+            return False
+
+        expected_gitdir = str(target_wt_path / ".git").rstrip("/")
+        for entry in worktrees_dir.iterdir():
+            if not entry.is_dir():
+                continue
+            gitdir_file = entry / "gitdir"
+            if not gitdir_file.exists():
+                continue
+            try:
+                if gitdir_file.read_text().strip().rstrip("/") == expected_gitdir:
+                    shutil.rmtree(entry, ignore_errors=True)
+                    return True
+            except OSError:
+                continue
+        return False
 
     def _state_branch_exists(self) -> bool:
         """Check if the state branch exists locally."""

--- a/orchestrator/tests/test_health_check_integration.py
+++ b/orchestrator/tests/test_health_check_integration.py
@@ -234,7 +234,13 @@ class TestPipelineHealthEndpoint:
 
 class TestBasicHealthEndpoints:
     def test_health(self, client):
-        resp = client.get("/api/v1/health")
+        # Mock the state-store probe so the test exercises the route shape,
+        # not the live probe behavior.  In test environments the probe
+        # would fail (no /home/egg/.egg-state) and report degraded;
+        # _probe_state_store is independently covered in
+        # test_state_store_wedge_propagation.py (#2167).
+        with patch("routes.health._probe_state_store", return_value=(True, "ok")):
+            resp = client.get("/api/v1/health")
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["status"] == "healthy"

--- a/orchestrator/tests/test_health_check_lifecycle_integration.py
+++ b/orchestrator/tests/test_health_check_lifecycle_integration.py
@@ -275,7 +275,12 @@ class TestBasicEndpoints:
     """Test /health, /ready, /live endpoints."""
 
     def test_health_returns_service_info(self, app, client):
-        resp = client.get("/api/v1/health")
+        # Mock the state-store probe (independently covered in
+        # test_state_store_wedge_propagation.py) so the test exercises
+        # the route response shape, not the live probe behavior — the
+        # probe would fail in test envs without /home/egg/.egg-state.
+        with patch("routes.health._probe_state_store", return_value=(True, "ok")):
+            resp = client.get("/api/v1/health")
         assert resp.status_code == 200
         data = json.loads(resp.data)
         assert data["status"] == "healthy"
@@ -293,8 +298,9 @@ class TestBasicEndpoints:
     def test_health_recent_transitions_accumulate(self, app, client):
         # Two successive hits should not double-record a transition —
         # the service has been healthy the whole time.
-        client.get("/api/v1/health")
-        resp = client.get("/api/v1/health")
+        with patch("routes.health._probe_state_store", return_value=(True, "ok")):
+            client.get("/api/v1/health")
+            resp = client.get("/api/v1/health")
         data = json.loads(resp.data)
         # Still exactly one transition (the initial healthy one).
         healthy_transitions = [t for t in data["recent_transitions"] if t["state"] == "healthy"]

--- a/orchestrator/tests/test_state_store.py
+++ b/orchestrator/tests/test_state_store.py
@@ -1691,3 +1691,128 @@ class TestEnsureWorktreeIdempotency:
         # Forced: admin dir is removed.
         store._remove_stale_admin_dir(force=True)
         assert not admin_dir.exists()
+
+
+class TestBranchHeldByPrunableWorktree:
+    """Regression tests for #2167 — ``git worktree add`` must self-heal
+    when the state branch is pinned by an admin dir whose worktree
+    directory has vanished (``prunable``).  This bites when the
+    deployment-side worktree path changes (single-repo → multi-repo)
+    and the legacy admin dir survives, or when the state volume is
+    wiped while the admin dir under ``<repo>/.git/worktrees/`` does not.
+    Either way every state load 500'd until the admin dir was hand-pruned.
+    """
+
+    def _make_store(self, tmp_path):
+        from state_store import StateStore
+
+        repo_path = tmp_path / "repo"
+        repo_path.mkdir()
+        (repo_path / ".git").mkdir()
+        worktree_dir = tmp_path / "wt"
+        store = StateStore(repo_path, worktree_dir=worktree_dir)
+        return store, worktree_dir
+
+    def test_recovers_from_branch_held_by_prunable_path(self, tmp_path):
+        """Stale admin dir for a vanished path holds the branch — the
+        first ``worktree add`` fails, we drop the matching admin dir,
+        and the retry succeeds.  This is the exact wedge from #2167:
+        legacy ``pipeline-worktree`` admin dir survives, new
+        ``pipeline-worktree-egg`` add fails, every state load 500s."""
+        store, wt = self._make_store(tmp_path)
+
+        # A vanished prunable worktree path.  The directory does not
+        # exist; only the admin dir does.
+        stale_path = tmp_path / "old-pipeline-worktree"
+        admin_dir = store.repo_path / ".git" / "worktrees" / "old-pipeline-worktree"
+        admin_dir.mkdir(parents=True)
+        (admin_dir / "gitdir").write_text(f"{stale_path}/.git\n")
+
+        # Two-call mock: first `worktree add` fails with the contention
+        # error, second succeeds after the admin dir is cleared.
+        call_count = {"n": 0}
+
+        def fake_run(*args, check=True, cwd=None):
+            if args[:2] == ("worktree", "add"):
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    raise GitOperationError(
+                        f"Git command failed: fatal: 'egg/pipeline-state' "
+                        f"is already used by worktree at '{stale_path}'\n"
+                    )
+                return MagicMock(stdout="", returncode=0)
+            if args[:2] == ("rev-parse", "--verify"):
+                return MagicMock(stdout="", returncode=0)
+            return MagicMock(stdout="", returncode=0)
+
+        with patch.object(StateStore, "_run_git", side_effect=fake_run):
+            result = store._ensure_worktree()
+
+        assert result == wt
+        assert call_count["n"] == 2, "expected exactly one retry after admin-dir cleanup"
+        assert not admin_dir.exists(), "stale admin dir should have been removed"
+
+    def test_does_not_prune_when_holding_path_still_exists(self, tmp_path):
+        """If the path mentioned in the error STILL exists on disk, a
+        live worktree genuinely holds the branch — refuse to touch it
+        and re-raise the original error.  Safety guard against pruning
+        a real worktree (e.g., a gateway-managed container worktree if
+        paths ever overlap)."""
+        store, wt = self._make_store(tmp_path)
+
+        live_path = tmp_path / "live-worktree"
+        live_path.mkdir()  # the holding worktree is real
+        admin_dir = store.repo_path / ".git" / "worktrees" / "live-worktree"
+        admin_dir.mkdir(parents=True)
+        (admin_dir / "gitdir").write_text(f"{live_path}/.git\n")
+
+        def fake_run(*args, check=True, cwd=None):
+            if args[:2] == ("worktree", "add"):
+                raise GitOperationError(
+                    f"Git command failed: fatal: 'egg/pipeline-state' "
+                    f"is already used by worktree at '{live_path}'\n"
+                )
+            if args[:2] == ("rev-parse", "--verify"):
+                return MagicMock(stdout="", returncode=0)
+            return MagicMock(stdout="", returncode=0)
+
+        with patch.object(StateStore, "_run_git", side_effect=fake_run):
+            with pytest.raises(GitOperationError, match="is already used by worktree"):
+                store._ensure_worktree()
+
+        # Admin dir for the live worktree must NOT have been removed.
+        assert admin_dir.exists()
+
+    def test_unrelated_git_failure_propagates(self, tmp_path):
+        """Failure messages that are NOT the branch-contention pattern
+        must propagate unmodified.  We only self-heal one specific
+        error — anything else surfaces to the route as 500."""
+        store, wt = self._make_store(tmp_path)
+
+        def fake_run(*args, check=True, cwd=None):
+            if args[:2] == ("worktree", "add"):
+                raise GitOperationError("Git command failed: fatal: out of disk space")
+            if args[:2] == ("rev-parse", "--verify"):
+                return MagicMock(stdout="", returncode=0)
+            return MagicMock(stdout="", returncode=0)
+
+        with patch.object(StateStore, "_run_git", side_effect=fake_run):
+            with pytest.raises(GitOperationError, match="out of disk space"):
+                store._ensure_worktree()
+
+    def test_remove_admin_dir_for_path_independent_of_self_worktree(self, tmp_path):
+        """``_remove_admin_dir_for_path`` must match by the supplied
+        path, not by ``self._worktree_dir`` — that's the whole point
+        for #2167, where the orphaned admin dir references the
+        legacy path that the new StateStore no longer uses."""
+        store, _wt = self._make_store(tmp_path)
+
+        unrelated_path = tmp_path / "different-worktree"
+        admin_dir = store.repo_path / ".git" / "worktrees" / "different-worktree"
+        admin_dir.mkdir(parents=True)
+        (admin_dir / "gitdir").write_text(f"{unrelated_path}/.git\n")
+
+        assert store._remove_admin_dir_for_path(unrelated_path) is True
+        assert not admin_dir.exists()
+        # Calling again — nothing left to remove.
+        assert store._remove_admin_dir_for_path(unrelated_path) is False

--- a/orchestrator/tests/test_state_store_wedge_propagation.py
+++ b/orchestrator/tests/test_state_store_wedge_propagation.py
@@ -1,0 +1,221 @@
+"""
+Regression tests for #2167 — state-store wedges must surface as 500
+with a useful error message, not as 404 "Pipeline not found".
+
+Three layers covered:
+
+1. ``_resolve_pipeline`` no longer swallows ``GitOperationError`` as
+   ``PipelineNotFoundError`` (the original 500→404 trap).
+2. The Flask app-level error handler renders ``StateStoreError``
+   subclasses with the actual error string, not a generic
+   "Internal server error".
+3. ``GET /api/v1/health`` flips ``status`` to ``degraded`` (and
+   surfaces the error in ``components.state_store``) when the
+   state-store probe fails.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+# Add orchestrator + shared to path
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+
+# ---------------------------------------------------------------------------
+# 1. _resolve_pipeline error propagation
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePipelinePropagatesGitErrors:
+    """``_resolve_pipeline`` must let ``GitOperationError`` propagate.
+
+    The previous ``except (PipelineNotFoundError, StateStoreError)``
+    clause caught every state-store wedge and re-raised it as
+    ``PipelineNotFoundError``, which routes returned as 404.  The fix
+    narrows the catch to ``PipelineNotFoundError`` only; infrastructure
+    failures must surface so routes return 500.
+    """
+
+    def test_propagates_git_operation_error(self, tmp_path):
+        from routes.pipelines import _resolve_pipeline
+        from state_store import GitOperationError
+
+        # Pretend we're in multi-repo mode with one repo discovered.
+        repo = tmp_path / "egg"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        wedged_store = MagicMock()
+        wedged_store.load_pipeline.side_effect = GitOperationError(
+            "Git command failed: fatal: 'egg/pipeline-state' "
+            "is already used by worktree at '/tmp/old'"
+        )
+
+        with (
+            patch("state_store.discover_repo_paths", return_value=[repo]),
+            patch("routes.pipelines.get_state_store", return_value=wedged_store),
+        ):
+            with pytest.raises(GitOperationError, match="already used by worktree"):
+                _resolve_pipeline("issue-1924", tmp_path)
+
+    def test_pipeline_not_found_still_works(self, tmp_path):
+        """``PipelineNotFoundError`` is still translated correctly: the
+        loop exhausts and re-raises the canonical "not found" error."""
+        from routes.pipelines import _resolve_pipeline
+        from state_store import PipelineNotFoundError
+
+        repo = tmp_path / "egg"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        store = MagicMock()
+        store.load_pipeline.side_effect = PipelineNotFoundError("nope")
+
+        with (
+            patch("state_store.discover_repo_paths", return_value=[repo]),
+            patch("routes.pipelines.get_state_store", return_value=store),
+        ):
+            with pytest.raises(PipelineNotFoundError, match="issue-1924"):
+                _resolve_pipeline("issue-1924", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# 2. Flask app error handler renders StateStoreError → 500 with detail
+# ---------------------------------------------------------------------------
+
+
+class TestStateStoreErrorHandlerSurfacesDetail:
+    """The app-level error handler must report the actual error string
+    for ``StateStoreError`` subclasses, not the generic 500 fallback.
+    Operators were debugging blind because every wedge looked the same
+    on the wire."""
+
+    @pytest.fixture
+    def client(self):
+        # Import here so the @errorhandler registration in api.py runs.
+        from api import app
+
+        app.config["TESTING"] = True
+        return app.test_client()
+
+    def test_git_operation_error_surfaces_message_and_500(self, client):
+        """Mock _resolve_pipeline to raise GitOperationError; the
+        ``GET /api/v1/pipelines/<id>`` route must return 500 with the
+        actual error message visible in the response body."""
+        from state_store import GitOperationError
+
+        with patch(
+            "routes.pipelines._resolve_pipeline",
+            side_effect=GitOperationError(
+                "Git command failed: fatal: 'egg/pipeline-state' "
+                "is already used by worktree at '/tmp/stale'"
+            ),
+        ):
+            response = client.get("/api/v1/pipelines/issue-1924")
+
+        assert response.status_code == 500
+        body = response.get_json()
+        assert body["success"] is False
+        # Must include the original git error so operators can diagnose
+        # without grepping logs (#2167 ask).
+        assert "is already used by worktree" in body["message"]
+        assert body.get("error_type") == "GitOperationError"
+
+
+# ---------------------------------------------------------------------------
+# 3. /api/v1/health flips to degraded on state-store probe failure
+# ---------------------------------------------------------------------------
+
+
+class TestHealthEndpointReflectsStateStoreFailure:
+    """``GET /api/v1/health`` must report ``degraded`` when the state-store
+    probe fails — the original report had ``check_health`` reporting
+    ``healthy=true`` while every state load was throwing 500."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_health_tracker(self):
+        """``routes.health._health_tracker`` is a module-level singleton.
+        These tests record both healthy and unhealthy observations; if
+        we don't restore, downstream tests that assert tracker
+        invariants (e.g. ``healthy_since == process_start_time``) flake
+        based on execution order."""
+        import routes.health as health_module
+        from egg_health import HealthTracker
+
+        original = health_module._health_tracker
+        health_module._health_tracker = HealthTracker()
+        try:
+            yield
+        finally:
+            health_module._health_tracker = original
+
+    @pytest.fixture
+    def client(self):
+        from routes.health import health_bp
+
+        app = Flask(__name__)
+        app.register_blueprint(health_bp)
+        app.config["TESTING"] = True
+        return app.test_client()
+
+    def test_healthy_when_probe_succeeds(self, client):
+        with patch("routes.health._probe_state_store", return_value=(True, "ok")):
+            response = client.get("/api/v1/health")
+
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["status"] == "healthy"
+        assert body["components"]["state_store"] == "ok"
+
+    def test_degraded_when_probe_fails(self, client):
+        """The exact wedge from #2167: the probe surfaces the
+        worktree-contention error and we flip status."""
+        err_msg = (
+            "GitOperationError: Git command failed: fatal: "
+            "'egg/pipeline-state' is already used by worktree at "
+            "'/home/egg/.egg-state/pipeline-worktree'"
+        )
+        with patch("routes.health._probe_state_store", return_value=(False, err_msg)):
+            response = client.get("/api/v1/health")
+
+        # HTTP status stays 200 so kubernetes probes don't flap, but the
+        # body MUST report degraded so MCP check_health surfaces it.
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["status"] == "degraded"
+        assert "is already used by worktree" in body["components"]["state_store"]
+
+    def test_probe_skipped_when_no_repo_configured(self):
+        """Health probe must not flap on configuration issues unrelated
+        to the wedge we're trying to detect.  When ``get_repo_path``
+        returns a path that has no git repo and no child repos, the
+        probe reports skipped and health stays healthy."""
+        from routes.health import _probe_state_store
+
+        with patch("routes.get_repo_path", return_value=Path("/definitely/not/a/repo")):
+            healthy, status = _probe_state_store()
+
+        assert healthy is True
+        assert "probe-skipped" in status
+
+    def test_probe_skipped_when_request_context_missing(self):
+        """Calling the probe outside a Flask request context must be
+        treated as a configuration issue, not a wedge."""
+        from routes.health import _probe_state_store
+
+        # No Flask app pushed → get_repo_path raises RuntimeError when
+        # it touches `request`.  Probe should swallow and report skipped.
+        healthy, status = _probe_state_store()
+
+        assert healthy is True
+        assert "probe-skipped" in status


### PR DESCRIPTION
Closes #2167.

## Summary

Three fixes for the orchestrator-wide wedge in #2167 — the state branch was pinned by a stale prunable worktree, every state-load 500'd, and the failure surfaced to operators as 404 "Pipeline not found" with `check_health` still reporting `healthy=true`.

- **`orchestrator/state_store.py`** — self-heal `git worktree add` failures of the form `'egg/pipeline-state' is already used by worktree at '<X>'`. Parse `X` from stderr, verify it's gone from disk (never touch a live worktree), drop the single admin dir whose `gitdir` matches `X`, retry once. This catches the case the existing fix from #2140 doesn't: when the legacy admin dir at `pipeline-worktree` survives a deployment switch to `pipeline-worktree-{repo}`, the path-equality check in `_remove_stale_admin_dir` fails to match and cleanup is skipped.
- **`orchestrator/routes/pipelines.py`** — `_resolve_pipeline` no longer catches `StateStoreError` in its multi-repo loop. `GitOperationError` is a `StateStoreError` subclass; the broad except re-raised every git wedge as `PipelineNotFoundError` (→ 404). Now only `PipelineNotFoundError` is caught; infrastructure failures propagate. Combined with a new app-level error handler in `api.py`, callers see `500` with the actual error message and `error_type` field instead of "Internal server error".
- **`orchestrator/routes/health.py`** — `/api/v1/health` now probes the state-store live (`_ensure_worktree`). On failure, top-level `status` flips to `degraded` and the failing error message lands in `components.state_store`. HTTP stays `200` so k8s probes (`/live`, `/ready`) are unaffected. MCP `check_health` already reads the `status` field, so it now reflects the wedge.

## Out of scope

- `_collect_all_pipelines` still silently `continue`s on `StateStoreError` per repo (the side observation that `list_tasks` returned an unrelated Jira-driven pipeline during the wedge). Once the self-heal kicks in, list_tasks recovers; touching the broader silent-skip behavior is a separate decision.

## Test plan

- [x] `TestBranchHeldByPrunableWorktree` (4 cases) — recovery, safety guard against pruning live worktrees, unrelated-error propagation, path-independent admin-dir lookup.
- [x] `TestResolvePipelinePropagatesGitErrors` — `GitOperationError` is no longer translated to `PipelineNotFoundError`; legitimate not-found still surfaces correctly.
- [x] `TestStateStoreErrorHandlerSurfacesDetail` — end-to-end via Flask test client confirms 500 + actual error message + `error_type` field on the wire.
- [x] `TestHealthEndpointReflectsStateStoreFailure` — `/health` flips to `degraded` when probe fails; stays `healthy` when it succeeds; gracefully skipped on missing config / no request context.
- [x] Existing `/api/v1/health` test assertions in `test_health_check_integration.py` and `test_health_check_lifecycle_integration.py` patched to mock the probe (covered independently in the new file).
- [x] Targeted subset (170 tests across state_store, health, pipelines routes) passes; broader run prior to the test-ordering fix passed at 4753 (1 skipped).
