### PR TITLE
Fix #2166: surface wedged_no_successor in get_status

### DIFF
--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -1629,7 +1629,9 @@ class PipelineToolHandler:
             ``status``, ``running_agents``, ``completed_agents``,
             ``phase_started_at`` / ``phase_elapsed_seconds``,
             ``pending_decisions`` (with draft content enrichment),
-            ``recent_messages``.
+            ``recent_messages``. When the pipeline is wedged between
+            phases (#2166), also includes ``wedged_no_successor`` with
+            ``phase`` / ``completed_at`` / ``since_seconds``.
         """
         task_id = quote(raw_task_id, safe="")
 
@@ -1705,6 +1707,34 @@ class PipelineToolHandler:
         # Extract decisions
         decisions = pipeline_data.get("decisions", [])
         status["pending_decisions"] = [d for d in decisions if d.get("status") == "pending"]
+
+        # Watchdog: flag a pipeline that is nominally RUNNING but stalled
+        # between phases — the current phase reports COMPLETE, no HITL gate
+        # is pending, yet no successor has been scheduled within the
+        # threshold (#2166). Lets operators fail loudly within a minute
+        # instead of polling for 10+ min hoping to spot the absence of
+        # progress.
+        if (
+            pipeline_data.get("status") == "running"
+            and not status["pending_decisions"]
+            and current_phase_key
+            and phase_data.get("status") == "complete"
+        ):
+            phase_completed_at = phase_data.get("completed_at")
+            if phase_completed_at:
+                try:
+                    completed_dt = datetime.fromisoformat(phase_completed_at)
+                    if completed_dt.tzinfo is None:
+                        completed_dt = completed_dt.replace(tzinfo=UTC)
+                    since_seconds = int((now - completed_dt).total_seconds())
+                    if since_seconds > 60:
+                        status["wedged_no_successor"] = {
+                            "phase": current_phase_key,
+                            "completed_at": completed_dt.isoformat(),
+                            "since_seconds": since_seconds,
+                        }
+                except (ValueError, TypeError):
+                    pass
 
         # Enrichment: recent messages (optional)
         try:

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -1714,6 +1714,13 @@ class PipelineToolHandler:
         # threshold (#2166). Lets operators fail loudly within a minute
         # instead of polling for 10+ min hoping to spot the absence of
         # progress.
+        #
+        # NB: this snapshot's pipeline read is not synchronized with the
+        # ``/status/wait`` route's read in ``_handle_wait_for_status_change``.
+        # If a successor phase is scheduled between the two reads, the
+        # merged response there can carry the route's newer ``current_phase``
+        # AND this block's older ``wedged_no_successor`` — a transient
+        # false positive that resolves on the next poll.
         if (
             pipeline_data.get("status") == "running"
             and not status["pending_decisions"]

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -1445,9 +1445,14 @@ class TestGetStatusWedgedNoSuccessor:
         assert "wedged_no_successor" not in result
 
     def test_no_wedge_when_pending_decision_present(self, handler):
-        """Pending HITL gate is the expected pre-advance state, not a wedge."""
+        """Pending HITL gate is the expected pre-advance state, not a wedge.
+
+        Pin ``pipeline_status="running"`` (default) so the pending decision
+        is the *only* clause blocking the wedge — otherwise the watchdog
+        short-circuits on the status guard and never evaluates
+        ``pending_decisions``.
+        """
         resp = self._wedged_pipeline_response(
-            pipeline_status="awaiting_human",
             decisions=[{"id": "d1", "status": "pending", "type": "phase_gate"}],
         )
         with patch.object(
@@ -1530,6 +1535,54 @@ class TestGetStatusWedgedNoSuccessor:
 
         assert "wedged_no_successor" in result
         assert 95 <= result["wedged_no_successor"]["since_seconds"] <= 110
+
+    def test_wedge_with_real_pipeline_model_dump(self, handler):
+        """Watchdog fires for a fixture grounded in ``Pipeline.model_dump(mode="json")``.
+
+        The other tests in this class hand-roll a minimal dict shape. This
+        one constructs a real ``Pipeline`` (matching what
+        ``routes/pipelines.py`` returns) so a future field rename in
+        ``PhaseExecution`` (e.g. renaming ``completed_at``) would break
+        this test instead of silently passing.
+        """
+        from datetime import UTC, datetime, timedelta
+
+        from egg_contracts.models import PipelinePhase
+
+        from orchestrator.models import (
+            PhaseExecution,
+            Pipeline,
+            PipelineStatus,
+        )
+
+        completed_at = datetime.now(UTC) - timedelta(seconds=120)
+        pipeline = Pipeline(
+            id="issue-42",
+            issue_number=42,
+            repo="org/repo",
+            current_phase=PipelinePhase.PLAN,
+            status=PipelineStatus.RUNNING,
+            phases={
+                "plan": PhaseExecution(
+                    phase=PipelinePhase.PLAN,
+                    status=PipelineStatus.COMPLETE,
+                    completed_at=completed_at,
+                ),
+            },
+        )
+        resp = {"data": {"pipeline": pipeline.model_dump(mode="json")}}
+
+        with patch.object(
+            handler,
+            "_make_request",
+            side_effect=[resp, self._messages_response()],
+        ):
+            result = handler.handle_tool_call("get_status", {"task_id": "issue-42"})
+
+        assert "wedged_no_successor" in result
+        wedge = result["wedged_no_successor"]
+        assert wedge["phase"] == "plan"
+        assert 115 <= wedge["since_seconds"] <= 130
 
 
 class TestGetStatusWait:

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -1356,6 +1356,182 @@ class TestGetStatusSyncHandler:
         assert parsed.tzinfo is not None  # timezone-aware
 
 
+class TestGetStatusWedgedNoSuccessor:
+    """Tests for the ``wedged_no_successor`` watchdog field (#2166).
+
+    The watchdog flags a pipeline that is nominally RUNNING but stalled
+    between phases — current phase reports COMPLETE, no HITL gate is
+    pending, yet no successor has been scheduled within 60s of completion.
+    """
+
+    def _wedged_pipeline_response(
+        self,
+        *,
+        pipeline_status: str = "running",
+        phase_status: str = "complete",
+        completed_at: str | None = None,
+        decisions: list | None = None,
+    ):
+        """Pipeline fixture for wedge scenarios.
+
+        Defaults produce a wedge candidate (running + complete phase + no
+        decisions). Pass overrides to construct negative cases.
+        """
+        from datetime import UTC, datetime, timedelta
+
+        if completed_at is None:
+            # Default: 90s ago — past the 60s threshold.
+            completed_at = (datetime.now(UTC) - timedelta(seconds=90)).isoformat()
+        return {
+            "data": {
+                "pipeline": {
+                    "id": "issue-42",
+                    "current_phase": "plan",
+                    "status": pipeline_status,
+                    "repo": "org/repo",
+                    "issue_number": 42,
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "phases": {
+                        "plan": {
+                            "status": phase_status,
+                            "completed_at": completed_at,
+                            "agents": [],
+                        }
+                    },
+                    "decisions": decisions if decisions is not None else [],
+                }
+            }
+        }
+
+    def _messages_response(self):
+        return {"data": {"messages": []}}
+
+    def test_wedge_surfaced_when_complete_and_stale(self, handler):
+        """Phase COMPLETE + RUNNING + no decisions + completed >60s ago → wedge surfaces."""
+        from datetime import UTC, datetime, timedelta
+
+        completed_at = (datetime.now(UTC) - timedelta(seconds=120)).isoformat()
+        resp = self._wedged_pipeline_response(completed_at=completed_at)
+        with patch.object(
+            handler,
+            "_make_request",
+            side_effect=[resp, self._messages_response()],
+        ):
+            result = handler.handle_tool_call("get_status", {"task_id": "issue-42"})
+
+        assert "wedged_no_successor" in result
+        wedge = result["wedged_no_successor"]
+        assert wedge["phase"] == "plan"
+        assert isinstance(wedge["since_seconds"], int)
+        assert 115 <= wedge["since_seconds"] <= 130
+        # completed_at echoed back as ISO string
+        from datetime import datetime as _dt
+
+        parsed = _dt.fromisoformat(wedge["completed_at"])
+        assert parsed.tzinfo is not None
+
+    def test_no_wedge_when_phase_still_running(self, handler):
+        """Phase RUNNING (mid-execution) is not a wedge."""
+        resp = self._wedged_pipeline_response(phase_status="running", completed_at=None)
+        # Drop completed_at — a running phase wouldn't have one set yet.
+        resp["data"]["pipeline"]["phases"]["plan"]["completed_at"] = None
+        with patch.object(
+            handler,
+            "_make_request",
+            side_effect=[resp, self._messages_response()],
+        ):
+            result = handler.handle_tool_call("get_status", {"task_id": "issue-42"})
+
+        assert "wedged_no_successor" not in result
+
+    def test_no_wedge_when_pending_decision_present(self, handler):
+        """Pending HITL gate is the expected pre-advance state, not a wedge."""
+        resp = self._wedged_pipeline_response(
+            pipeline_status="awaiting_human",
+            decisions=[{"id": "d1", "status": "pending", "type": "phase_gate"}],
+        )
+        with patch.object(
+            handler,
+            "_make_request",
+            side_effect=[resp, self._messages_response()],
+        ):
+            result = handler.handle_tool_call("get_status", {"task_id": "issue-42"})
+
+        assert "wedged_no_successor" not in result
+
+    def test_no_wedge_when_within_threshold(self, handler):
+        """Phase completed <60s ago is normal mid-spawn window, not a wedge."""
+        from datetime import UTC, datetime, timedelta
+
+        completed_at = (datetime.now(UTC) - timedelta(seconds=15)).isoformat()
+        resp = self._wedged_pipeline_response(completed_at=completed_at)
+        with patch.object(
+            handler,
+            "_make_request",
+            side_effect=[resp, self._messages_response()],
+        ):
+            result = handler.handle_tool_call("get_status", {"task_id": "issue-42"})
+
+        assert "wedged_no_successor" not in result
+
+    def test_no_wedge_for_terminal_pipeline(self, handler):
+        """Pipeline status COMPLETE (terminal) is not a wedge even if stale."""
+        from datetime import UTC, datetime, timedelta
+
+        completed_at = (datetime.now(UTC) - timedelta(seconds=600)).isoformat()
+        resp = self._wedged_pipeline_response(pipeline_status="complete", completed_at=completed_at)
+        with patch.object(
+            handler,
+            "_make_request",
+            side_effect=[resp, self._messages_response()],
+        ):
+            result = handler.handle_tool_call("get_status", {"task_id": "issue-42"})
+
+        assert "wedged_no_successor" not in result
+
+    def test_no_wedge_when_completed_at_missing(self, handler):
+        """Missing completed_at cannot prove staleness — no warning."""
+        resp = self._wedged_pipeline_response()
+        resp["data"]["pipeline"]["phases"]["plan"]["completed_at"] = None
+        with patch.object(
+            handler,
+            "_make_request",
+            side_effect=[resp, self._messages_response()],
+        ):
+            result = handler.handle_tool_call("get_status", {"task_id": "issue-42"})
+
+        assert "wedged_no_successor" not in result
+
+    def test_no_wedge_for_invalid_completed_at(self, handler):
+        """Garbage completed_at is silently skipped (parser fails closed)."""
+        resp = self._wedged_pipeline_response(completed_at="not-a-timestamp")
+        with patch.object(
+            handler,
+            "_make_request",
+            side_effect=[resp, self._messages_response()],
+        ):
+            result = handler.handle_tool_call("get_status", {"task_id": "issue-42"})
+
+        assert "wedged_no_successor" not in result
+
+    def test_wedge_handles_naive_completed_at(self, handler):
+        """Naive completed_at (no tzinfo) is treated as UTC."""
+        from datetime import UTC, datetime, timedelta
+
+        # Naive ISO timestamp 100s in the past
+        completed_at = (datetime.now(UTC) - timedelta(seconds=100)).strftime("%Y-%m-%dT%H:%M:%S")
+        resp = self._wedged_pipeline_response(completed_at=completed_at)
+        with patch.object(
+            handler,
+            "_make_request",
+            side_effect=[resp, self._messages_response()],
+        ):
+            result = handler.handle_tool_call("get_status", {"task_id": "issue-42"})
+
+        assert "wedged_no_successor" in result
+        assert 95 <= result["wedged_no_successor"]["since_seconds"] <= 110
+
+
 class TestGetStatusWait:
     """Tests for the async ``wait`` handling in ``mcp_server``.
 


### PR DESCRIPTION
## Summary

- Adds an inline watchdog in `_build_status_snapshot` (`orchestrator/mcp_tools.py`) that flags a pipeline stalled between phases. It surfaces a new `wedged_no_successor` field in the `get_status` MCP payload when **all** of these hold: `pipeline.status == running`, current `phase.status == complete`, `pending_decisions == []`, and `now - phase.completed_at > 60s`.
- The field, when present, carries `phase`, `completed_at`, and `since_seconds`. It is **omitted** (not set to `false`/`null`) when the pipeline is healthy — keeps the payload backwards-compatible and lets callers cheaply check `"wedged_no_successor" in result`.
- Inputs already exist on the pipeline payload (`PhaseExecution.completed_at` is a real model field set whenever a phase completes), so no extra fetch / no model change.

## Why inline rather than a Tier 1 health check?

Issue #2166 leaves the choice open ("`get_status` or a Tier 1 health check"). Tier 1 results are not currently surfaced in `get_status` — wiring them in would be a larger change than the warning itself, and all required inputs are already in `pipeline_data`. Inline is a few lines of wall-clock math right after the existing `phase_started_at` block, mirroring that pattern.

## Out of scope

Auto-recovery is intentionally not handled here — driver-thread relaunch is covered by the PR for #2155 (transient `PipelineNotFoundError`) and the follow-up at #2165 (symmetric auto-advance). This PR is purely operator-facing visibility, per the issue's "Out of scope" section.

## Test plan

- [x] `orchestrator/tests/test_mcp_tools.py::TestGetStatusWedgedNoSuccessor` — 8 new tests covering positive case, every negative window from the issue's "Tests to add" list (pre-completion, gate pending, mid-spawn / within-threshold), terminal pipeline status, missing/invalid `completed_at`, and naive-datetime handling.
- [x] Existing `TestGetStatusSyncHandler` (17 tests) still passes — no regression in the snapshot shape callers already depend on.
- [x] Full `orchestrator/tests/` suite: `4819 passed, 1 skipped` in 6m58s.
- [x] `ruff check` + `ruff format --check` clean on both touched files; pre-commit hooks pass on commit.

Closes #2166.