### PR TITLE
Add bounded Jira write verbs to the gateway (create/edit/comment/link)

### DIFF
--- a/.egg-state/agent-outputs/1924-architect-output.json
+++ b/.egg-state/agent-outputs/1924-architect-output.json
@@ -1,0 +1,706 @@
+{
+  "issue": 1924,
+  "phase": "plan",
+  "agent": "architect",
+  "title": "Add write operations to Jira gateway (create/update/comment/link)",
+
+  "summary": "Architecture analysis for the v1.1 write extension of the Jira gateway. The work is a pure additive extension of the v1 read-only surface that #1556 landed (gateway/jira_client.py, gateway/jira_policy.py, gateway/jira_credentials.py, sandbox/scripts/jira, gateway/tests/test_jira_*.py) — same gateway sidecar, same @require_session_auth + @require_private_mode chain, same context-filters.yaml-driven project allowlist, same audit shape, same httpx.MockTransport test harness, same Squid '*.atlassian.net never in allowed_domains' invariant. The write-specific complexity sits in five places: (a) four narrow per-verb routes (createJiraIssue / editJiraIssue / addCommentToJiraIssue / createIssueLink) instead of a single generic /execute path, with each route bypassing validate_jira_api_path because every write path is hardcoded by the per-verb client method; (b) a method-allowlist split that keeps /execute and validate_jira_api_path locked to GET-only forever while the new write client methods issue POST/PUT directly through _request; (c) curated request-body schemas per verb (project/ticket allowlist, issuetype, summary length, label cap, optional epicLink shorthand, optional notifyUsers) instead of passthrough of arbitrary Atlassian fields; (d) an in-process gateway-level idempotency cache keyed by (verb, project, idempotency_key) with a 5-minute TTL covering createJiraIssue and addCommentToJiraIssue (editJiraIssue and createIssueLink omitted — see notes); (e) a plain-text → ADF wrapper helper so sandbox agents pass --description / --body strings and never hand-roll Atlassian Document Format JSON. The permanent denylist (transitions, worklog, attachments, watchers, DELETE) is unchanged and continues to apply to /execute and validate_jira_api_path; the write client methods bypass that path validator only because each method hardcodes a single upstream path that does not contain any denied segment. Several refine HITL questions remain open at the time of this analysis and gate concrete design choices (custom-field exposure, epic-link mechanism, idempotency requirement, link-type allowlist source, notifyUsers default, body input format, issuetype identifier, link allowlist semantics, per-role / per-phase write gating, response shapes, body-size caps, cross-project parent acceptance, sandbox flag ergonomics, audit redaction, adversarial test location, multi-tenant hooks, link-comment payload, dry-run, plan-apply rollback, error envelope, doc home); this analysis records the architectural baseline that satisfies every required invariant and names the slots where each unresolved decision lands so plan tasks can be written deterministically once HITL closes.",
+
+  "problem_statement": {
+    "description": "The v1 Jira gateway (#1556) landed read-only — sandboxed agents can fetch tickets, search via JQL, and read comments, but they cannot write. #1557 (Jira-epic SDLC pipelines) is now blocked on writes: refine needs to push the agent-authored analysis to the epic's Description (editJiraIssue), plan needs to create child tickets under the epic with parent/Epic Link set (createJiraIssue), edit existing children when scope shifts (editJiraIssue), drop comments pointing at survivors during consolidation (addCommentToJiraIssue), and wire cross-task dependency edges (createIssueLink). #1924 is the bounded write extension that closes that gap.",
+    "goals": [
+      "Add four narrow Atlassian write verbs behind dedicated /api/v1/jira/* routes: createJiraIssue, editJiraIssue, addCommentToJiraIssue, createIssueLink.",
+      "Inherit every v1 invariant: zero credentials in the sandbox, private-mode-only routing, project allowlist enforcement on every write, structured per-verb audit, fail-closed on missing creds (HTTP 503) / missing allowlist / public mode (HTTP 403).",
+      "Keep transitions / worklogs / attachments / watchers / DELETE permanently denied at validate_jira_api_path; the write extension does NOT widen that escape hatch.",
+      "Land as a pure additive extension — no re-architecture of jira_client.py, jira_policy.py, gateway.py route layer, sandbox/scripts/jira, or the gateway/tests/test_jira_*.py harness.",
+      "Make sandbox agents idempotency-safe by exposing a caller-supplied idempotency_key on createJiraIssue and addCommentToJiraIssue, served from an in-process gateway cache.",
+      "Hide ADF construction from the sandbox: agents pass plain-text --description / --body strings; the gateway wraps them in a minimal Atlassian Document Format paragraph node before calling Atlassian.",
+      "Preserve the route-enumeration regression: every /api/v1/jira/* view function carries __egg_requires_private_mode__ = True (test_jira_routes.py) and the new routes extend that test."
+    ],
+    "non_goals": [
+      "Workflow transitions (status changes) — explicitly out of scope; orchestrator handles transitions with its own creds, never via the agent-facing gateway.",
+      "Worklogs, attachments, watchers, deletions — permanent denylist; no v1.1 carve-out.",
+      "Markdown / HTML → ADF rendering — gateway only wraps plain text in a single ADF paragraph; richer rendering deferred.",
+      "Multi-tenant Atlassian — single-tenant inherited from #1556 with no further work in #1924.",
+      "Persistent (disk / Redis) idempotency cache — in-memory per-process is enough for the realistic retry window (orchestrator retries within seconds of a transient 5xx); revisit only on multi-replica gateway deployments.",
+      "Generic /execute write surface — /execute stays GET-only forever; writes are exposed only through the four dedicated routes."
+    ],
+    "consumers_unblocked": [
+      "#1557 — Jira-epic SDLC pipelines: refine apply (editJiraIssue → epic Description), plan apply fresh-epic (createJiraIssue with parent/Epic Link → child tickets), plan apply reassess (editJiraIssue + createJiraIssue + addCommentToJiraIssue + createIssueLink), Won't-Done transitions stay out of scope (orchestrator-only).",
+      "Future impact-analysis / pipeline-control skills that need to drop bot comments or link related tickets without holding Atlassian creds in the sandbox."
+    ]
+  },
+
+  "current_architecture": {
+    "description": "Gateway sidecar is the existing choke point between sandbox and external services. #1556 generalised the Jira plumbing — credentials, mode-gate, context-filters allowlist, audit log, route-enumeration regression test, sandbox bash wrapper. Adding writes is a structural extension: every reusable building block stays where it is, every new file follows an existing pattern, and the only edit to existing code is the path/method validator's separation between '/execute enforcement' (stays GET-only) and 'write client methods' (hardcoded paths, bypass the validator entirely).",
+    "reusable_infrastructure": [
+      {
+        "component": "@require_session_auth → @require_private_mode decorator chain",
+        "location": "gateway/auth.py + gateway/mode_gate.py",
+        "reuse": "Apply unchanged to every new write route. mode_gate.py's __egg_requires_private_mode__ marker is asserted by the route-enumeration regression test in gateway/tests/test_jira_routes.py."
+      },
+      {
+        "component": "Squid network-allowlist with *.atlassian.net excluded",
+        "location": "gateway/allowed_domains.txt + gateway/tests/test_allowed_domains.py::test_atlassian_domains_absent",
+        "reuse": "No change. Containers cannot bypass the gateway via direct REST. The existing regression continues to enforce this for the write routes by extension."
+      },
+      {
+        "component": "Mtime-cached credential loader (Atlassian basic auth)",
+        "location": "gateway/jira_credentials.py (JiraCredentialsManager, JiraCredentialsUnavailable)",
+        "reuse": "Unchanged. Write routes call the same get_jira_credentials() / creds_provider arg, so missing creds still surface as HTTP 503 with the same error envelope."
+      },
+      {
+        "component": "Mtime-cached YAML project allowlist",
+        "location": "gateway/jira_policy.py (JiraPolicy.allowed_projects / is_project_allowed / extract_project_key)",
+        "reuse": "Unchanged. Write routes call is_project_allowed against (a) request.body.fields.project.key for createJiraIssue, (b) the parsed project of the request ticket key for editJiraIssue / addCommentToJiraIssue, (c) both inwardIssue and outwardIssue projects for createIssueLink (strict semantics — refine decision pending)."
+      },
+      {
+        "component": "JiraClient._request (single HTTP call + GET-only 429 retry)",
+        "location": "gateway/jira_client.py:299-381",
+        "reuse": "Unchanged. The retryable check at line 322 (`retryable = method.upper() == 'GET'`) and the early-exit at line 376 already encode 'writes never auto-retry on 429' — no change needed. Write client methods invoke _request with method='POST' or 'PUT' and inherit the one-shot semantics."
+      },
+      {
+        "component": "Path/method validator (validate_jira_api_path) and JIRA_API_ALLOWED_PATHS",
+        "location": "gateway/jira_client.py:179-236, ALLOWED_METHODS = {'GET'}, JIRA_WRITE_VERBS_DENIED = {'transitions','worklog','attachments','watchers','DELETE','PUT','PATCH'}",
+        "reuse": "Unchanged for /execute. The validator's contract stays narrow: only /execute calls it, and /execute remains GET-only forever. The four write client methods (create_issue, edit_issue, add_comment, create_issue_link) bypass the validator because they hardcode their upstream paths in code, none of which contain a denied segment."
+      },
+      {
+        "component": "Audit-log helper",
+        "location": "gateway/gateway.py audit_log() + _session_jira_context() (lines 4292-4308)",
+        "reuse": "Unchanged. New event names follow the jira_* convention: jira_ticket_create / jira_ticket_create_rejected / jira_ticket_create_denied / jira_ticket_create_upstream_error / jira_upstream_rate_limited (already emitted on 429), and analogous suites for ticket_edit, comment_add, issue_link_create. _session_jira_context() needs no changes (session_mode, pipeline_id, agent_role, jira_ticket are already captured)."
+      },
+      {
+        "component": "Route-enumeration regression test pattern",
+        "location": "gateway/tests/test_jira_routes.py (walks app.url_map, asserts __egg_requires_private_mode__ on every /api/v1/jira/* view function)",
+        "reuse": "Extend in place: the existing test will pick up the four new routes automatically; no new test file is required for the regression."
+      },
+      {
+        "component": "POST /api/v1/config/reload hook",
+        "location": "gateway/gateway.py reload_jira_credentials() / reload_jira_policy() (around lines 880-910)",
+        "reuse": "Unchanged. Writes use the same loaders, so the existing reload covers them."
+      },
+      {
+        "component": "Sandbox bash wrapper pattern",
+        "location": "sandbox/scripts/jira (call_gateway helper, EGG_SESSION_TOKEN Bearer, gateway-availability probe, JSON body construction via Python heredocs)",
+        "reuse": "Extend in place. Four new subcommands (jira ticket create, jira ticket edit, jira ticket comment add, jira link create) reuse call_gateway and the existing JSON-construction helper. Optional --idempotency-key is forwarded as a body field; --description / --body / --body-file / --body-stdin produce the input string passed to the gateway, which wraps it in ADF."
+      },
+      {
+        "component": "Wrapper reference doc pattern",
+        "location": "docs/reference/jira-wrapper.md",
+        "reuse": "Extended (not replaced) with a Write Endpoints section: per-verb table, request-body schema, ADF wrapping rules, idempotency semantics, audit event names. Doc home subject to refine HITL Q27 (extend existing, new file, or both)."
+      }
+    ],
+    "v1_constraints_carried_forward": [
+      "Zero Atlassian credentials in the sandbox — write routes use the same creds_provider=get_jira_credentials pattern.",
+      "Private-mode-only — every new route gets @require_session_auth + @require_private_mode and is asserted by test_jira_routes.py route-enumeration.",
+      "Project allowlist enforced before any Atlassian call — fail-closed when the project is not in jira.projects.",
+      "Permanent path denylist: transitions / worklog / attachments / watchers / DELETE rejected by validate_jira_api_path (unchanged); write client methods do not name any of these segments in their hardcoded paths.",
+      "/execute stays GET-only forever — ALLOWED_METHODS in jira_client.py is unchanged.",
+      "Writes never auto-retry on 429 — _request's retryable=GET-only check already encodes this; route layer surfaces 429 with jira_upstream_rate_limited audit and lets the caller (orchestrator) decide.",
+      "Audit on success and rejection — every write call emits an audit record; rejected calls never reach Atlassian.",
+      "*.atlassian.net never in Squid allowed_domains — direct egress remains impossible (test_allowed_domains.py regression covers writes by extension)."
+    ]
+  },
+
+  "external_constraints": {
+    "atlassian_v3_endpoints_used": [
+      {
+        "verb": "createJiraIssue",
+        "upstream": "POST /rest/api/3/issue",
+        "body_shape": "{fields: {project:{key:'FOO'}, issuetype:{name:'Task' or id:'10001'}, summary:'...', description:ADF, labels:[...], parent:{key:'FOO-1'} OR customfield_10014:'FOO-1'}}",
+        "response": "201 with {id, key, self}",
+        "quirks": "Epic Link mechanism varies per project (parent.key on next-gen / company-managed; customfield_10014 on classic / team-managed) — refine decision-2 pending. Custom fields are out of scope unless explicitly opted in (refine decision-1 pending)."
+      },
+      {
+        "verb": "editJiraIssue",
+        "upstream": "PUT /rest/api/3/issue/{issueIdOrKey}",
+        "body_shape": "{fields:{summary:'...', description:ADF, labels:['a','b']}, update:{labels:[{add:'x'},{remove:'y'}]}}",
+        "response": "204 No Content (no body)",
+        "quirks": "Supports ?notifyUsers=false (suppress email — refine decision-5 pending) and ?returnIssue=true (echo post-edit body — refine decision-14 pending). gateway translates route-layer addLabels/removeLabels into Atlassian's update.labels add/remove block."
+      },
+      {
+        "verb": "addCommentToJiraIssue",
+        "upstream": "POST /rest/api/3/issue/{issueIdOrKey}/comment",
+        "body_shape": "{body: ADF, visibility?: {type:'role',value:'Administrators'}}",
+        "response": "201 with full comment object",
+        "quirks": "visibility (role/group restriction) deferred per refine decision-6 pending. ADF body required — gateway wraps plain-text input."
+      },
+      {
+        "verb": "createIssueLink",
+        "upstream": "POST /rest/api/3/issueLink",
+        "body_shape": "{type:{name:'Blocks'}, inwardIssue:{key:'FOO-1'}, outwardIssue:{key:'FOO-2'}, comment?:{body:ADF}}",
+        "response": "201 Created (no body in v3)",
+        "quirks": "Type names are per-instance — refine decision-4 pending (hardcoded {Blocks, Relates}, operator-configurable, or accept upstream's set). NOT idempotent at Atlassian — duplicate (inward, outward, type) triples create duplicate links on retry; refine decision-19 (Q28) addresses this."
+      }
+    ],
+    "method_allowlist_split": {
+      "decision": "validate_jira_api_path keeps ALLOWED_METHODS = {'GET'}. New write client methods (create_issue, edit_issue, add_comment, create_issue_link) bypass the path validator because each hardcodes its upstream path in code. The path-segment denylist (transitions/worklog/attachments/watchers) remains permanent — verified by code review that no write client method names any denied segment.",
+      "rationale": "Defense-in-depth: a future maintainer who adds POST/PUT to ALLOWED_METHODS for a read use case cannot accidentally expose a write surface, because writes are not gated by the validator. Per analysis B1; B2 was rejected for tight coupling between /execute and the write surface."
+    },
+    "idempotency_cache": {
+      "scope": "In-memory per-gateway-process, 5-minute TTL (refine decision-14 pending; default per analysis D1).",
+      "key_shape": "(verb, project, idempotency_key) → (timestamp, response)",
+      "verbs_covered": "createJiraIssue, addCommentToJiraIssue (both have non-idempotent semantics under retry — duplicate ticket / double-post). editJiraIssue is naturally idempotent on a stable ticket; createIssueLink is NOT idempotent at Atlassian and is gated by refine decision-19 (Q28) — extend the same cache to createIssueLink for symmetry, OR document that orchestrator must scan existing inwardIssue links before retry, OR accept duplicates and de-dup elsewhere.",
+      "memory_envelope": "Bounded — one process, short TTL, small dict; eviction is lazy (on insert / lookup). Tests verify TTL expiry and per-key isolation."
+    },
+    "adf_wrapping": {
+      "policy": "Gateway wraps plain-text description / body input in a minimal ADF paragraph node: {type:'doc', version:1, content:[{type:'paragraph', content:[{type:'text', text:S}]}]}.",
+      "passthrough": "Refine decision-7 pending — analysis recommends 'both' (accept plain-text and pre-built ADF dict; gateway distinguishes by isinstance check).",
+      "wrapper_helper_location": "New gateway/jira_adf.py with a single wrap_text(s) function (≤30 lines). Called by the four write routes before invoking the JiraClient method."
+    },
+    "rate_limiting": {
+      "policy": "Writes never auto-retry on 429 — already encoded in JiraClient._request line 322 (retryable=GET-only). The route emits jira_upstream_rate_limited on the (single) 429 attempt and surfaces 429 to the caller (refine feedback Q1 pending — confirms the audit event still fires).",
+      "rationale": "Atlassian's per-user write quota is tighter than read; auto-retrying writes risks compounding the duplicate-ticket / double-post problem. Orchestrator decides retry strategy with idempotency keys."
+    },
+    "redaction": {
+      "audit_body_redaction": "Refine feedback Q5 pending — analysis recommends logging only structural metadata (field names changed, content lengths, label counts, link type names) and never body content. label values may be safe to log (low PII); confirm with HITL.",
+      "rationale": "Description / comment bodies may contain PII or sensitive context; the audit log is high-stakes and persistent."
+    },
+    "permanent_denylist_unchanged": [
+      "transitions",
+      "worklog",
+      "attachments",
+      "watchers",
+      "HTTP DELETE",
+      "HTTP PATCH (path validator only — write client methods use POST or PUT)"
+    ]
+  },
+
+  "proposed_architecture": {
+    "module_breakdown": [
+      {
+        "module": "gateway/jira_client.py",
+        "purpose": "Extend the v1 client with four write methods; reuse _request unchanged.",
+        "additions": [
+          "JiraClient.create_issue(project_key, issuetype, summary, description=None, labels=None, parent=None, epic_link=None, custom_fields=None) -> dict — issues POST /rest/api/3/issue with hardcoded path; translates route-layer args to Atlassian fields; returns Atlassian's {id, key, self} (refine decision-12 pending — raw vs normalised envelope).",
+          "JiraClient.edit_issue(ticket, summary=None, description=None, labels=None, add_labels=None, remove_labels=None, custom_fields=None, notify_users=None, return_issue=False) -> dict — issues PUT /rest/api/3/issue/{ticket}?notifyUsers=...&returnIssue=...; translates add_labels/remove_labels into Atlassian update.labels add/remove; returns 204 envelope or echoed ticket per refine decision-13.",
+          "JiraClient.add_comment(ticket, body, idempotency_response=None) -> dict — issues POST /rest/api/3/issue/{ticket}/comment with ADF body; returns Atlassian's full comment object.",
+          "JiraClient.create_issue_link(link_type, inward_issue, outward_issue, comment=None) -> dict — issues POST /rest/api/3/issueLink; returns 201 envelope.",
+          "JiraUpstreamWriteError (subclass of existing JiraUpstreamError, OR the existing one extended) — carries field-level Atlassian error messages (errorMessages / errors dict) for the route layer to surface per refine feedback Q9 pending."
+        ],
+        "non_changes": [
+          "_request body unchanged (lines 299-381) — already encodes GET-only 429 retry.",
+          "validate_jira_api_path unchanged (lines 179-236) — write client methods do NOT call it.",
+          "ALLOWED_METHODS = {'GET'} unchanged.",
+          "JIRA_WRITE_VERBS_DENIED set unchanged."
+        ],
+        "approximate_added_lines": "~250-350 (each write method ~50-80 lines including docstrings and Atlassian-shape translation; shared helpers ~50 lines)."
+      },
+      {
+        "module": "gateway/jira_adf.py (new)",
+        "purpose": "Plain-text → minimal ADF paragraph wrapping helper (no Markdown / HTML).",
+        "key_functions": [
+          "wrap_text(s: str) -> dict — returns {type:'doc',version:1,content:[{type:'paragraph',content:[{type:'text',text:s}]}]}; splits multi-line input into one paragraph per non-empty line if needed.",
+          "is_adf_dict(o) -> bool — duck-type check used by routes when accepting both plain-text and pre-built ADF (refine decision-7 pending)."
+        ],
+        "rationale": "Bash construction of ADF in sandbox/scripts/jira is awkward and bug-prone; centralising the wrap in the gateway means agents pass --description '...' as plain text and the wire body remains valid ADF. Module is tiny (≤80 lines) and has no third-party deps.",
+        "approximate_size": "60-80 lines."
+      },
+      {
+        "module": "gateway/jira_idempotency.py (new)",
+        "purpose": "In-process gateway-level idempotency cache for create / comment writes.",
+        "key_classes_or_functions": [
+          "IdempotencyCache (dataclass-style; threading.Lock-guarded dict; configurable TTL — default 300s)",
+          "IdempotencyCache.get(verb, project, key) -> dict | None — returns cached response if present and not expired.",
+          "IdempotencyCache.set(verb, project, key, response) -> None — stores (timestamp, response).",
+          "IdempotencyCache.evict_expired() -> None — lazy eviction on insert / lookup."
+        ],
+        "scope": "Single module-level instance; per-gateway-process; TTL 300s (refine decision-14 pending — could become persistent for multi-replica).",
+        "shared_use_consideration": "Future Confluence / Confluence-write surface might reuse this — module name is 'jira_idempotency' for v1.1; rename to 'idempotency.py' if a second consumer lands.",
+        "approximate_size": "120-160 lines (including thread-safety + TTL + eviction)."
+      },
+      {
+        "module": "gateway/jira_policy.py",
+        "additions": [
+          "Optional: link_type_allowlist() -> frozenset[str] — reads jira.link_types from config/context-filters.yaml if refine decision-4 picks the configurable option. Default fallback {'Blocks', 'Relates'} only if hardcoded option chosen.",
+          "Optional: custom_field_allowlist() -> frozenset[str] — reads jira.custom_fields if refine decision-1 picks the operator-configured option."
+        ],
+        "non_changes": [
+          "is_project_allowed / extract_project_key / allowed_projects — unchanged; reused verbatim by every write route."
+        ],
+        "approximate_added_lines": "0-80 depending on HITL outcomes."
+      },
+      {
+        "module": "gateway/gateway.py — Jira write route block",
+        "purpose": "Add four narrow write routes mirroring the v1 read route block (currently 4365-4759).",
+        "new_routes": [
+          {
+            "route": "POST /api/v1/jira/ticket/create",
+            "decorators": ["@require_session_auth", "@require_private_mode"],
+            "request_body_schema": "{projectKey, issuetype, summary, description?, labels?, parent?, epicLink?, customFields?, idempotency_key?, notifyUsers?}",
+            "validation": [
+              "projectKey must be in JiraPolicy.allowed_projects().",
+              "issuetype must match the configured shape (name / id / both — refine decision-8 pending). For name, accept Task/Story/Bug/Epic/Sub-task by default.",
+              "summary length ≤ refine feedback Q2 cap (Atlassian's 255 default).",
+              "description (if present) is plain-text ≤ refine feedback Q2 cap OR pre-built ADF dict (refine decision-7).",
+              "labels list count + per-label length ≤ refine feedback Q2 caps; per-label shape ^[A-Za-z0-9._-]+$.",
+              "parent.key (if present) must be a valid TICKET-KEY in an allowlisted project; cross-project parent gated by refine decision-15 (Q17).",
+              "epicLink shorthand: refine decision-2 picks parent.key vs customfield_10014 vs both.",
+              "customFields map: refine decision-1 (none / operator-allowlisted / structural).",
+              "idempotency_key: refine decision-3 (required / optional / none).",
+              "If idempotency_key present, consult IdempotencyCache.get(verb='create', project=projectKey, key=k); short-circuit on hit."
+            ],
+            "upstream": "JiraClient.create_issue(...)",
+            "audit_event": "jira_ticket_create / jira_ticket_create_rejected / jira_ticket_create_denied / jira_ticket_create_upstream_error / jira_ticket_create_idempotent_hit / jira_upstream_rate_limited (on 429)",
+            "response_shape": "Refine decision-12 (raw {id, key, self} OR normalised {key, id, browse_url, status:'created'}).",
+            "approximate_lines": "~120 (route handler + audit + response shaping)"
+          },
+          {
+            "route": "POST /api/v1/jira/ticket/edit",
+            "decorators": ["@require_session_auth", "@require_private_mode"],
+            "request_body_schema": "{ticket, summary?, description?, labels?, addLabels?, removeLabels?, customFields?, notifyUsers?}",
+            "validation": [
+              "ticket must parse as TICKET-KEY (^[A-Z][A-Z0-9_]*-\\d+$); JiraPolicy.is_project_allowed(extract_project_key(ticket)) gates.",
+              "summary / description / labels caps as for create.",
+              "addLabels / removeLabels: lists of well-formed labels; combine with Atlassian update.labels.",
+              "notifyUsers: bool, default per refine decision-5; routed as ?notifyUsers=... query string.",
+              "customFields per refine decision-1."
+            ],
+            "upstream": "JiraClient.edit_issue(...)",
+            "audit_event": "jira_ticket_edit / jira_ticket_edit_rejected / jira_ticket_edit_denied / jira_ticket_edit_upstream_error / jira_upstream_rate_limited",
+            "response_shape": "Refine decision-13 ({status:'updated', key} OR echoed post-edit ticket via ?returnIssue=true).",
+            "approximate_lines": "~110"
+          },
+          {
+            "route": "POST /api/v1/jira/ticket/comment/add",
+            "decorators": ["@require_session_auth", "@require_private_mode"],
+            "request_body_schema": "{ticket, body, idempotency_key?}",
+            "validation": [
+              "ticket allowlist as for edit.",
+              "body: plain-text or ADF dict per refine decision-7; length ≤ refine feedback Q2 cap.",
+              "idempotency_key: refine decision-3.",
+              "If idempotency_key present, consult IdempotencyCache.get(verb='comment', project=extract_project_key(ticket), key=k); short-circuit on hit.",
+              "visibility field NOT exposed (refine decision-6 pending — analysis recommends hidden in v1)."
+            ],
+            "upstream": "JiraClient.add_comment(ticket, ADF_body)",
+            "audit_event": "jira_comment_add / jira_comment_add_rejected / jira_comment_add_denied / jira_comment_add_upstream_error / jira_comment_add_idempotent_hit / jira_upstream_rate_limited",
+            "response_shape": "Atlassian's full comment object (id, body rendered, author, created).",
+            "approximate_lines": "~90"
+          },
+          {
+            "route": "POST /api/v1/jira/issue-link/create",
+            "decorators": ["@require_session_auth", "@require_private_mode"],
+            "request_body_schema": "{type, inwardIssue, outwardIssue, comment?, idempotency_key?}",
+            "validation": [
+              "type name: refine decision-4 (hardcoded {Blocks, Relates} OR operator-configurable jira.link_types OR upstream-recognised any-name).",
+              "inwardIssue and outwardIssue: TICKET-KEY shape.",
+              "Project allowlist semantics: refine decision-9 (both / either / one-allowlist + linkable-only-list).",
+              "comment payload: refine decision-16 (Q23) — surface 'comment' field OR require separate addCommentToJiraIssue.",
+              "idempotency_key for createIssueLink: refine decision-19 (Q28) — extend IdempotencyCache, OR scan existing inwardIssue links upstream first, OR accept duplicates (the third option is the simplest; the first is most aligned with create / comment for symmetry)."
+            ],
+            "upstream": "JiraClient.create_issue_link(...)",
+            "audit_event": "jira_issue_link_create / jira_issue_link_create_rejected / jira_issue_link_create_denied / jira_issue_link_create_upstream_error / jira_upstream_rate_limited",
+            "response_shape": "{status:'created', type, inwardIssue, outwardIssue} (Atlassian returns 201 with no body).",
+            "approximate_lines": "~100"
+          }
+        ],
+        "shared_helpers_to_add": [
+          "_jira_write_audit_context(verb, body, response_status) — emits structural-only audit (field names changed, content lengths, label counts) per refine feedback Q5; never logs body content.",
+          "_jira_write_error_from_upstream(exc) — extends _jira_error_from_upstream with field-level errorMessages / errors surfacing per refine feedback Q9 (decision pending: passthrough vs richer envelope).",
+          "_resolve_adf_or_text(input) — accepts plain-text str OR ADF dict per refine decision-7; calls jira_adf.wrap_text on the str path.",
+          "_validate_idempotency_key(k) — opaque-string shape check (≤128 chars, ASCII)."
+        ],
+        "phase_filter_integration": "Refine decision-11 (Q11) picks per-phase write gating. If chosen, gateway/phase_filter.py grows a JIRA_WRITE_VERBS_PER_PHASE map (e.g., refine→{ticket_edit}, plan→{ticket_create, ticket_edit, comment_add, issue_link_create}); routes consult phase via g.session_phase before policy / Atlassian.",
+        "per_role_gating": "Refine decision-10 (Q10) picks per-role write gating. If chosen, a small map (planner→{ticket_create, issue_link_create}, refiner→{ticket_edit}, etc.) is checked against g.session.agent_role before policy.",
+        "approximate_added_lines": "~500-650 in gateway.py (matching the v1 read block size; Jira reads are ~485 lines for 4 routes; writes are 4 routes plus richer body validation, so somewhat larger)."
+      },
+      {
+        "module": "sandbox/scripts/jira",
+        "purpose": "Sandbox bash wrapper. Extend with four new subcommands.",
+        "subcommands": [
+          "jira ticket create --project KEY --type Task --summary \"...\" [--description \"...\"|--description-file PATH|--description-stdin] [--labels a,b] [--parent FOO-1] [--epic-link FOO-2] [--idempotency-key K] [--no-notify]",
+          "jira ticket edit TICKET [--summary \"...\"] [--description \"...\"|--description-file PATH|--description-stdin] [--labels a,b] [--add-labels x,y] [--remove-labels z] [--no-notify] [--return-issue]",
+          "jira ticket comment add TICKET [--body \"...\"|--body-file PATH|--body-stdin] [--idempotency-key K]",
+          "jira link create --type Blocks --inward FOO-1 --outward FOO-2 [--comment \"...\"|--comment-file PATH|--comment-stdin] [--idempotency-key K]"
+        ],
+        "naming_decision": "Verb-noun subcommands matching the v1 read style (jira ticket get, jira ticket comments) — confirmed by analysis E1 and refine feedback Q4 pending.",
+        "shared_environment": "EGG_SESSION_TOKEN + GATEWAY_URL same as v1; reuse call_gateway helper; reuse fail-closed messaging.",
+        "ergonomic_inputs": "--description / --body accept inline text; --*-file reads from a path; --*-stdin reads from stdin (multi-line bodies).",
+        "approximate_added_lines": "~300-450 in the existing wrapper (subcommand dispatch + flag parsing + JSON construction)."
+      },
+      {
+        "module": "config/context-filters.yaml",
+        "additions": [
+          "Optional jira.link_types: [Blocks, Relates] (only if refine decision-4 picks operator-configurable).",
+          "Optional jira.custom_fields: [customfield_10014, customfield_10100] (only if refine decision-1 picks operator-allowlist)."
+        ],
+        "fail_closed": "Empty list / missing section behaves identically to v1 — defaults match the analysis recommendation per HITL outcome."
+      },
+      {
+        "module": "config/secrets.template.env",
+        "non_changes": "ATLASSIAN_BASE_URL / _USERNAME / _API_TOKEN already shared with #1931; no secrets-template changes for #1924."
+      },
+      {
+        "module": "sandbox/agent-config/rules/environment.md",
+        "additions": [
+          "Update the existing Jira wrapper subsection (current lines 50-65) with the four new subcommands and their --idempotency-key / --no-notify / --return-issue / --description-file / --body-stdin flags.",
+          "Note the ADF wrapping invariant — agents pass plain text, gateway wraps."
+        ]
+      },
+      {
+        "module": "docs/reference/jira-wrapper.md",
+        "purpose": "Extend the existing user-facing reference with a Write Endpoints section. (Refine decision-18 / Q27 picks: extend, new file, or both.)",
+        "sections_to_add": [
+          "Write endpoint surface (table of /api/v1/jira/ticket/create / edit / comment/add / issue-link/create + upstream Atlassian endpoints).",
+          "Per-route request body schema, validation rules, response shape, audit event names.",
+          "ADF wrapping invariant (plain-text accepted; ADF dict passthrough per refine decision-7).",
+          "Idempotency semantics (caller-supplied key, 5-minute TTL, per-process cache, applies to create / comment).",
+          "Permanent denylist reminder (transitions / worklog / attachments / watchers / DELETE — unchanged).",
+          "Configuration: jira.link_types and jira.custom_fields (only if refine decisions land on the configurable options)."
+        ]
+      },
+      {
+        "module": "docs/architecture/network-isolation.md",
+        "addition": "Add the four new /api/v1/jira/* write routes to the private-mode endpoint table; note the exception is identical to the v1 reads."
+      },
+      {
+        "module": "gateway/tests/test_jira_*.py",
+        "files_to_create_or_extend": [
+          "test_jira_client.py — extend with per-method shape tests for create_issue / edit_issue / add_comment / create_issue_link via httpx.MockTransport; ADF body assembly; addLabels/removeLabels translation; ?notifyUsers=...&returnIssue=... query construction; 429 surfaces (no auto-retry); 4xx field-level error envelope.",
+          "test_jira_routes.py — extend with per-route 200 / 400 / 403 / 503 grid for the four new routes; project-allowlist gating; ticket-allowlist gating; private-mode 403; missing creds 503; route-enumeration regression already covers __egg_requires_private_mode__ on the new routes; audit assertions per route.",
+          "test_jira_idempotency.py (new) — IdempotencyCache hit / miss / TTL expiry / per-key isolation / per-verb isolation; verifies eviction is lazy and thread-safe.",
+          "test_jira_adf.py (new) — wrap_text shape; multi-line splitting; is_adf_dict duck-type; Unicode handling.",
+          "test_jira_writes_adversarial.py (new — refine feedback Q6 pending; analysis recommends a separate file for clarity) — oversized summary / description / labels; unknown issuetype name; custom-field smuggling (refine decision-1 path); non-allowlisted link type; cross-project parent (refine decision-15 path); malformed idempotency key; unicode in TICKET-KEY; pre-built ADF with disallowed mark types.",
+          "test_jira_policy.py — extend with link_type_allowlist / custom_field_allowlist tests if refine HITL picks the configurable options.",
+          "tests/sandbox/test_jira_wrapper.py (new — if missing) — subcommand smoke tests with mocked gateway: every new subcommand produces the expected JSON body and posts to the right route."
+        ]
+      }
+    ],
+    "data_flow": {
+      "happy_path_create_issue": [
+        "1. Sandbox agent runs `jira ticket create --project ENG --type Task --summary 'Wire reviewer_security' --description 'Long description' --parent ENG-100 --idempotency-key plan-node-42`.",
+        "2. sandbox/scripts/jira POSTs JSON {projectKey:'ENG', issuetype:{name:'Task'}, summary:'...', description:'Long description', parent:{key:'ENG-100'}, idempotency_key:'plan-node-42'} to GATEWAY_URL/api/v1/jira/ticket/create with EGG_SESSION_TOKEN Bearer.",
+        "3. @require_session_auth populates g.session_mode + g.session.",
+        "4. @require_private_mode rejects unless g.session_mode == 'private'.",
+        "5. Route validates body: projectKey ∈ allowed_projects(); issuetype shape; summary length; description present; parent.key parse; idempotency_key shape.",
+        "6. Route consults IdempotencyCache.get('create', 'ENG', 'plan-node-42') — cache miss.",
+        "7. Route calls jira_adf.wrap_text('Long description') → ADF dict.",
+        "8. Route calls JiraClient.create_issue(project_key='ENG', issuetype={'name':'Task'}, summary='...', description=ADF, parent={'key':'ENG-100'}).",
+        "9. Client loads creds via get_jira_credentials(); issues POST /rest/api/3/issue with Basic auth and Atlassian-shape body.",
+        "10. _request returns 201 with {id, key:'ENG-101', self}; on 429 surfaces as upstream error (no retry); on 4xx with errorMessages, JiraUpstreamError carries the field-level details.",
+        "11. Route stashes (timestamp, response) in IdempotencyCache.set('create', 'ENG', 'plan-node-42', response).",
+        "12. Route emits audit jira_ticket_create with structural-only body context (summary length, has_description, label_count, parent_key, agent_role, pipeline_id, jira_ticket).",
+        "13. Route returns response (raw or normalised envelope per refine decision-12) to wrapper; wrapper prints to stdout."
+      ],
+      "rejected_path_non_allowlisted_project": [
+        "1. Agent runs `jira ticket create --project SECURITY --type Task --summary '...'`.",
+        "2. Wrapper POSTs to /api/v1/jira/ticket/create.",
+        "3. Route validates body: SECURITY ∉ allowed_projects().",
+        "4. Route emits audit jira_ticket_create_denied (reason=project_not_allowed, project=SECURITY).",
+        "5. Route returns HTTP 403 {error:'project_not_allowed', project:'SECURITY'} — no Atlassian call made."
+      ],
+      "rejected_path_public_mode": [
+        "1. Agent in public-mode session runs any write subcommand.",
+        "2. @require_private_mode rejects → HTTP 403 {error:'private_mode_required'}.",
+        "3. Audit jira_<verb>_denied (reason=private_mode_required) — no Atlassian call."
+      ],
+      "rejected_path_missing_creds": [
+        "1. Agent runs write subcommand; gateway has no Atlassian creds in secrets.env.",
+        "2. Route calls JiraClient.create_issue → JiraCredentialsUnavailable raised.",
+        "3. Route translates to HTTP 503 with same envelope as v1 reads.",
+        "4. Audit jira_<verb>_upstream_error (reason=credentials_unavailable)."
+      ],
+      "idempotent_hit_path": [
+        "1. Orchestrator retries createJiraIssue with the same idempotency_key='plan-node-42' within the 5-minute TTL after a transient gateway crash.",
+        "2. IdempotencyCache.get returns the cached response.",
+        "3. Route emits audit jira_ticket_create_idempotent_hit (verb=create, project=ENG, key=plan-node-42).",
+        "4. Route returns the cached response (same {id, key, self}) — no Atlassian call. The orchestrator's 'did this already succeed?' problem is solved without involving Atlassian."
+      ]
+    }
+  },
+
+  "design_decisions": [
+    {
+      "decision": "Four dedicated narrow routes (A1) vs generalised /execute write surface (A2) vs RESTful HTTP-method paths (A3)",
+      "chosen": "A1 — four narrow routes (POST /api/v1/jira/ticket/create / edit / comment/add / issue-link/create)",
+      "rationale": "A1 preserves the verb allowlist by construction (one Python handler per Atlassian write), gives each verb its own audit operation name and per-route test grid, mirrors the gh wrapper structure operators already see, and keeps /execute's GET-only invariant unbreakable. A2 collapses audit naming and couples /execute's read-only invariant to the write logic. A3 (RESTful HTTP methods) is inconsistent with v1's POST-everywhere convention.",
+      "alternatives_rejected": ["A2: /execute write surface", "A3: RESTful HTTP-method paths"]
+    },
+    {
+      "decision": "Method-allowlist split (B1) vs widened validate_jira_api_path (B2)",
+      "chosen": "B1 — validate_jira_api_path stays GET-only; write client methods bypass it by hardcoding paths",
+      "rationale": "B1 means a future maintainer who widens ALLOWED_METHODS for a read use case cannot accidentally expose a write surface. The path-segment denylist (transitions/worklog/attachments/watchers) remains permanent because no write client method names a denied segment in its hardcoded path. B2 couples /execute exposure to write-method config — a regression hazard.",
+      "alternatives_rejected": ["B2: widen validate_jira_api_path"]
+    },
+    {
+      "decision": "Curated field allowlist + structural validation (C1) vs Atlassian-passthrough (C2) vs minimal validation (C3)",
+      "chosen": "C1 — curated per-verb body schemas with project / ticket / issuetype / labels / size validation",
+      "rationale": "C1 rejects garbage at the route layer before any Atlassian call, makes custom fields explicitly opt-in (so agents cannot accidentally smuggle Security Level / Sprint / Components / watchers — refine decision-1 controls the exposure scope), and makes the bash wrapper trivial because the gateway handles ADF wrapping. C2 lets agents set arbitrary custom fields — escalation risk. C3 is too permissive on size / shape and shares C2's custom-field problem.",
+      "alternatives_rejected": ["C2: Atlassian passthrough", "C3: minimal validation"]
+    },
+    {
+      "decision": "Caller-supplied idempotency key + gateway-level cache (D1) vs Atlassian-native (D2 — not an option) vs orchestrator-only (D3)",
+      "chosen": "D1 — caller-supplied idempotency_key, gateway in-process dict, 5-minute TTL, applies to createJiraIssue and addCommentToJiraIssue",
+      "rationale": "D1 solves the duplicate-ticket / double-post problem without involving Atlassian. The orchestrator can derive the key from (pipeline_id, plan_node_id) for stable retries. Memory bounded — small dict, short TTL, single-replica gateway. D2 isn't possible (Atlassian doesn't support idempotency keys). D3 pushes the burden onto every consumer (#1557 plan-apply, future skills, manual scripts) and the gateway audit log doesn't help the orchestrator across retries.",
+      "alternatives_rejected": ["D2: Atlassian-native (not an option)", "D3: orchestrator-only"]
+    },
+    {
+      "decision": "Plain-text + flag-based ergonomic input (E1) vs raw ADF passthrough (E2) vs Markdown→ADF (E3)",
+      "chosen": "E1 — wrapper accepts --description / --body / --*-file / --*-stdin plain text; gateway wraps in ADF",
+      "rationale": "E1 keeps agent prompts simple (no ADF construction), mirrors gh wrapper's --body-file ergonomics, and supports multi-line bodies via stdin / file. E2 forces ADF construction into agent code — bug-prone. E3 (Markdown→ADF) introduces a third-party dep with surprising edge cases (tables, code blocks); revisit only if needed.",
+      "alternatives_rejected": ["E2: raw ADF passthrough only", "E3: Markdown→ADF in wrapper"]
+    },
+    {
+      "decision": "Idempotency cache file location",
+      "chosen": "gateway/jira_idempotency.py for v1.1; rename to gateway/idempotency.py only when a second consumer (e.g. Confluence writes) lands",
+      "rationale": "Avoid premature generalisation. Module is small (~150 lines), reuse cost is low when the second consumer arrives."
+    },
+    {
+      "decision": "ADF wrapper file location",
+      "chosen": "gateway/jira_adf.py for v1.1; rename to gateway/atlassian_adf.py if Confluence adopts the same wrapping (Confluence uses storage-format default, so this is unlikely)",
+      "rationale": "Module is tiny (~80 lines). Premature generalisation has higher refactor cost than later rename."
+    },
+    {
+      "decision": "Audit-body redaction policy",
+      "chosen": "Structural-only (field names changed, content lengths, label counts, link type names); never body content; labels values are logged (low PII surface)",
+      "rationale": "Description / comment bodies may contain PII or sensitive context; the audit log is high-stakes and persistent. Labels are typically engineering / project tags, low PII. Refine feedback Q5 confirms.",
+      "subject_to_hitl": "Refine feedback Q5"
+    },
+    {
+      "decision": "Adversarial test file location",
+      "chosen": "Separate test_jira_writes_adversarial.py",
+      "rationale": "Per-route 403 grid (test_jira_routes.py) is already large; mixing in oversized-body / unicode / smuggled-customfield tests doubles its size and obscures the route grid. Separate file gives the adversarial suite its own discoverable home.",
+      "subject_to_hitl": "Refine feedback Q6"
+    }
+  ],
+
+  "complexity": "medium",
+
+  "complexity_justification": "Four narrow per-verb routes added to a well-established pattern, plus a small idempotency cache module and a tiny ADF wrapper helper. Each verb is a self-contained slice (route + client method + body validator + sandbox subcommand + tests) and could be implemented in parallel after a small foundation step (idempotency cache module, ADF wrapper helper, write_audit_context helper). The implementation surface is bounded: ~600 LoC in gateway/ (250-350 in jira_client.py for the four methods, 60-80 in jira_adf.py, 120-160 in jira_idempotency.py, 500-650 in gateway.py for the four routes), ~300-450 in sandbox/scripts/jira for four new subcommands, ~300-500 in tests. The medium rating (vs low) is driven by (a) the large unresolved HITL surface — 19 decisions and 9 feedback questions outstanding at the time of this analysis, each gating a body-schema or audit detail; (b) Atlassian per-instance variation (Epic Link mechanism, link types, custom fields) that needs explicit operator configuration; (c) the idempotency cache and ADF wrapping are net-new gateway modules with their own thread-safety / TTL / unicode test obligations; (d) the cross-project-parent and createIssueLink-idempotency edge cases each have multiple plausible answers and either needs an Atlassian probe or accepts duplicates with documented orchestrator responsibility. Once HITL closes, plan tasks decompose cleanly into per-verb slices.",
+
+  "key_files": [
+    {
+      "path": "gateway/jira_client.py",
+      "change_type": "extend",
+      "lines_affected_estimate": "+250-350",
+      "purpose": "Add create_issue / edit_issue / add_comment / create_issue_link methods; reuse _request unchanged."
+    },
+    {
+      "path": "gateway/jira_adf.py",
+      "change_type": "create",
+      "lines_affected_estimate": "60-80",
+      "purpose": "Plain-text → minimal ADF paragraph wrapping helper."
+    },
+    {
+      "path": "gateway/jira_idempotency.py",
+      "change_type": "create",
+      "lines_affected_estimate": "120-160",
+      "purpose": "In-process gateway-level idempotency cache (TTL 300s, threading.Lock-guarded)."
+    },
+    {
+      "path": "gateway/jira_policy.py",
+      "change_type": "extend",
+      "lines_affected_estimate": "0-80 (HITL-conditional)",
+      "purpose": "Optional link_type_allowlist() and custom_field_allowlist() if refine HITL picks the configurable options."
+    },
+    {
+      "path": "gateway/gateway.py",
+      "change_type": "extend",
+      "lines_affected_estimate": "+500-650",
+      "purpose": "Four new routes (POST /api/v1/jira/ticket/create / edit / comment/add / issue-link/create) + shared write helpers (audit context, error mapping, ADF resolution, idempotency-key validation)."
+    },
+    {
+      "path": "sandbox/scripts/jira",
+      "change_type": "extend",
+      "lines_affected_estimate": "+300-450",
+      "purpose": "Four new subcommands (jira ticket create / edit, jira ticket comment add, jira link create) with --description-file / --body-stdin / --idempotency-key / --no-notify / --return-issue flags."
+    },
+    {
+      "path": "config/context-filters.yaml",
+      "change_type": "extend (HITL-conditional)",
+      "lines_affected_estimate": "0-30",
+      "purpose": "Optional jira.link_types and jira.custom_fields sections per refine decisions 1 and 4."
+    },
+    {
+      "path": "sandbox/agent-config/rules/environment.md",
+      "change_type": "extend",
+      "lines_affected_estimate": "+30-60",
+      "purpose": "Document the four new write subcommands and the ADF-wrapping invariant in the existing Jira wrapper subsection."
+    },
+    {
+      "path": "docs/reference/jira-wrapper.md",
+      "change_type": "extend (or create docs/reference/jira-writes.md per refine HITL Q27)",
+      "lines_affected_estimate": "+150-250",
+      "purpose": "Write-endpoint surface table, per-verb body schema, ADF wrapping rules, idempotency semantics, audit event names, configuration."
+    },
+    {
+      "path": "docs/architecture/network-isolation.md",
+      "change_type": "extend",
+      "lines_affected_estimate": "+5-10",
+      "purpose": "Add the four new /api/v1/jira/* write routes to the private-mode endpoint table."
+    },
+    {
+      "path": "gateway/tests/test_jira_client.py",
+      "change_type": "extend",
+      "lines_affected_estimate": "+250-400",
+      "purpose": "Per-method shape tests for the four write methods (httpx.MockTransport): ADF body assembly, addLabels/removeLabels translation, query construction, 429 surfaces (no auto-retry), 4xx field-level error envelope."
+    },
+    {
+      "path": "gateway/tests/test_jira_routes.py",
+      "change_type": "extend",
+      "lines_affected_estimate": "+400-600",
+      "purpose": "Per-route 200 / 400 / 403 / 503 grid for the four new routes; project-allowlist gating; ticket-allowlist gating; private-mode 403; missing creds 503; audit assertions; route-enumeration regression already covers __egg_requires_private_mode__."
+    },
+    {
+      "path": "gateway/tests/test_jira_idempotency.py",
+      "change_type": "create",
+      "lines_affected_estimate": "150-250",
+      "purpose": "IdempotencyCache hit / miss / TTL expiry / per-key isolation / per-verb isolation / thread-safety."
+    },
+    {
+      "path": "gateway/tests/test_jira_adf.py",
+      "change_type": "create",
+      "lines_affected_estimate": "80-150",
+      "purpose": "wrap_text shape; multi-line splitting; is_adf_dict duck-type; Unicode handling."
+    },
+    {
+      "path": "gateway/tests/test_jira_writes_adversarial.py",
+      "change_type": "create (refine feedback Q6 pending)",
+      "lines_affected_estimate": "200-350",
+      "purpose": "Oversized summary / description / labels; unknown issuetype name; custom-field smuggling; non-allowlisted link type; cross-project parent; malformed idempotency key; unicode in TICKET-KEY; pre-built ADF with disallowed mark types."
+    },
+    {
+      "path": "tests/sandbox/test_jira_wrapper.py",
+      "change_type": "create-or-extend",
+      "lines_affected_estimate": "150-300",
+      "purpose": "Subcommand smoke tests with mocked gateway: every new subcommand produces the expected JSON body and posts to the right route."
+    }
+  ],
+
+  "dependencies": [
+    {
+      "name": "#1556 (v1 read-only Jira gateway)",
+      "kind": "internal",
+      "status": "landed",
+      "reason": "All write extension code reuses #1556's modules verbatim. v1 must remain green; #1924 is purely additive."
+    },
+    {
+      "name": "#1557 (Jira-epic SDLC pipelines)",
+      "kind": "internal",
+      "status": "blocked-on-this-issue",
+      "reason": "#1557 is the primary consumer; its plan-phase apply step calls all four new verbs and its refine-phase apply calls editJiraIssue. The body shapes #1924 ships must match what #1557's apply step expects."
+    },
+    {
+      "name": "Atlassian Cloud Jira REST API v3",
+      "kind": "external",
+      "status": "stable",
+      "endpoints": [
+        "POST /rest/api/3/issue",
+        "PUT /rest/api/3/issue/{issueIdOrKey}?notifyUsers=...&returnIssue=...",
+        "POST /rest/api/3/issue/{issueIdOrKey}/comment",
+        "POST /rest/api/3/issueLink"
+      ],
+      "reason": "Wire format + response shapes inherited from Atlassian; ADF schema is part of the API contract."
+    },
+    {
+      "name": "httpx (httpx.MockTransport)",
+      "kind": "external",
+      "status": "already-used",
+      "reason": "All write tests reuse the v1 mock transport for unit tests; no new test infra."
+    },
+    {
+      "name": "config/context-filters.yaml schema",
+      "kind": "internal",
+      "status": "extend-in-place",
+      "reason": "Optional jira.link_types and jira.custom_fields keys added per HITL outcomes; existing jira.projects unchanged."
+    },
+    {
+      "name": "secrets.env (ATLASSIAN_* / JIRA_* triple)",
+      "kind": "internal",
+      "status": "no-change",
+      "reason": "Same creds used by reads cover writes. No new env-var work in #1924."
+    }
+  ],
+
+  "open_questions_for_plan_phase": [
+    "All 19 refine HITL decisions and 9 feedback questions are unresolved at the time of this analysis. The architectural baseline above lands the recommended option for each axis; if HITL picks a different option, plan tasks should be added/dropped per the slot reservations in proposed_architecture.module_breakdown:",
+    "decision-1 (custom-field exposure) — picks whether jira_policy.py grows custom_field_allowlist() and whether routes accept a customFields map.",
+    "decision-2 (Epic Link mechanism) — picks whether create_issue translates --epic-link to parent.key, customfield_10014, or auto-detects.",
+    "decision-3 (idempotency_key requirement) — picks whether routes 400 on missing key vs warn vs no-cache.",
+    "decision-4 (link type allowlist source) — picks hardcoded {Blocks, Relates} vs jira.link_types yaml vs upstream-passthrough.",
+    "decision-5 (notifyUsers default) — picks default true (Atlassian default) vs false (quiet).",
+    "decision-6 (visibility on comments) — picks v1 hides vs v1 exposes.",
+    "decision-7 (body input format) — picks plain-text only vs ADF passthrough only vs both.",
+    "decision-8 (issuetype identifier) — picks name only vs ID only vs both.",
+    "decision-9 (createIssueLink project allowlist semantics) — picks strict-both vs loose-either vs main+linkable-only.",
+    "decision-10 (per-role write gating) — picks unrestricted vs per-verb-role-allowlist vs defer.",
+    "decision-11 (per-phase write gating) — picks unrestricted vs phase_filter.py extension vs defer.",
+    "decision-12 (createJiraIssue response shape) — picks raw {id,key,self} vs normalised envelope.",
+    "decision-13 (editJiraIssue response shape) — picks {status:updated,key} vs ?returnIssue=true echo.",
+    "decision-14 (idempotency cache scope) — picks in-memory per-process vs persisted (disk/Redis).",
+    "decision-15 (cross-project parent) — picks reject vs accept-and-let-Atlassian-decide.",
+    "decision-16 (createIssueLink comment payload) — picks surface comment field vs require separate addCommentToJiraIssue.",
+    "decision-17 (dry-run mode) — picks ?dry_run=true on each write vs orchestrator-only preview.",
+    "decision-18 (doc home) — picks extend jira-wrapper.md vs new jira-writes.md vs both.",
+    "decision-19 (createIssueLink idempotency, surfaced by reviewer_refine) — picks extend cache vs orchestrator pre-scan vs accept duplicates.",
+    "feedback Q1 (rate-limit policy + audit on 429) — confirm 429 still emits jira_upstream_rate_limited.",
+    "feedback Q2 (body-size caps) — pick numeric limits.",
+    "feedback Q3 (existing-issue probe) — confirm idempotency key alone is sufficient.",
+    "feedback Q4 (sandbox flag ergonomics) — confirm --description / --description-file / --description-stdin shape.",
+    "feedback Q5 (audit body redaction) — confirm structural-only logging; labels / link names exempt.",
+    "feedback Q6 (adversarial test location) — confirm separate test_jira_writes_adversarial.py.",
+    "feedback Q7 (multi-tenant) — confirm v1 stays single-tenant; no further work in #1924.",
+    "feedback Q8 (rollback for batched plan apply) — confirm orchestrator owns rollback; gateway is stateless.",
+    "feedback Q9 (error envelope shape) — pick passthrough _jira_error_from_upstream vs richer field-level surfacing."
+  ],
+
+  "risks_for_risk_analyst": [
+    "Idempotency cache loss on gateway restart — restart inside a 5-minute TTL window, orchestrator retries, second create succeeds at Atlassian → duplicate ticket. Mitigation: (a) document the restart hazard, (b) refine decision-14 may pick persisted cache for multi-replica deployments.",
+    "Method-allowlist split silently regresses if a future maintainer routes a write through validate_jira_api_path — defense-in-depth fails. Mitigation: code review checklist, regression test that asserts the four write client methods do NOT call validate_jira_api_path.",
+    "Custom-field smuggling via the customFields map (refine decision-1 path) — agent sets Security Level / Components / watchers. Mitigation: operator-allowlist option in decision-1 + adversarial test in test_jira_writes_adversarial.py.",
+    "Cross-project parent on createJiraIssue (refine decision-15 path) — agent creates a ticket in project A under an epic in project B, cross-project hierarchy that the operator may not have intended. Mitigation: strict reject default; HITL can loosen.",
+    "createIssueLink duplicates on retry (refine decision-19 path) — Atlassian doesn't dedup identical (inward, outward, type) triples. Mitigation: pick option 1 (extend idempotency cache) for symmetry with create / comment.",
+    "ADF body length explosion in audit log if an agent passes a multi-megabyte description — audit retention cost. Mitigation: cap length per refine feedback Q2; truncate-with-marker in audit context, never the full body.",
+    "Bash wrapper flag-shadowing — --description and --description-file both set; ambiguity. Mitigation: wrapper validates exclusive use client-side and reports the ambiguity before posting.",
+    "Idempotency key collision across pipelines — if two pipelines pick the same key by accident, second caller gets the first's response. Mitigation: cache key includes (verb, project, idempotency_key); document that callers should namespace their keys (e.g., '<pipeline_id>:<plan_node_id>'); test_jira_idempotency covers per-key isolation.",
+    "Plan-apply partial failure leaves Jira in an inconsistent state (refine feedback Q8) — gateway has no transactions; orchestrator must implement compensating actions. Mitigation: clarified in docs and HITL.",
+    "Per-instance Atlassian variation (Epic Link mechanism, link type names, issuetype IDs) means a config change in production requires gateway restart or YAML reload. Mitigation: config/context-filters.yaml is mtime-cached; reload hook covers link_types / custom_fields if added."
+  ],
+
+  "tasks_for_task_planner": [
+    "Foundation: gateway/jira_idempotency.py (IdempotencyCache class, threading.Lock, TTL, lazy eviction).",
+    "Foundation: gateway/jira_adf.py (wrap_text, is_adf_dict).",
+    "Foundation: gateway/jira_client.py — add JiraClient.create_issue / edit_issue / add_comment / create_issue_link methods (each ~50-80 lines).",
+    "Foundation: gateway/gateway.py — add _resolve_adf_or_text, _validate_idempotency_key, _jira_write_audit_context, _jira_write_error_from_upstream helpers.",
+    "Per-verb route 1: POST /api/v1/jira/ticket/create + body validation + audit + idempotency hookup.",
+    "Per-verb route 2: POST /api/v1/jira/ticket/edit + body validation + audit + addLabels/removeLabels translation + notifyUsers.",
+    "Per-verb route 3: POST /api/v1/jira/ticket/comment/add + body validation + audit + idempotency hookup.",
+    "Per-verb route 4: POST /api/v1/jira/issue-link/create + body validation + audit + (link type allowlist per refine decision-4) + (idempotency per refine decision-19).",
+    "Sandbox wrapper: extend sandbox/scripts/jira with the four new subcommands and their flag set.",
+    "HITL-conditional: gateway/jira_policy.py extensions for link_type_allowlist / custom_field_allowlist (only if refine decisions 1 / 4 pick the configurable options).",
+    "HITL-conditional: gateway/phase_filter.py write-verb gate (only if refine decision-11 picks per-phase gating).",
+    "HITL-conditional: per-role write gate inline in gateway.py routes (only if refine decision-10 picks per-role gating).",
+    "Tests: extend gateway/tests/test_jira_client.py with the four write-method shape tests.",
+    "Tests: extend gateway/tests/test_jira_routes.py with the per-route 200/400/403/503 grid for the four new routes.",
+    "Tests: create gateway/tests/test_jira_idempotency.py.",
+    "Tests: create gateway/tests/test_jira_adf.py.",
+    "Tests: create gateway/tests/test_jira_writes_adversarial.py (or merge into routes per refine feedback Q6).",
+    "Tests: create-or-extend tests/sandbox/test_jira_wrapper.py for new subcommands.",
+    "Docs: extend docs/reference/jira-wrapper.md with Write Endpoints section (or create docs/reference/jira-writes.md per refine decision-18).",
+    "Docs: update docs/architecture/network-isolation.md with the four new routes.",
+    "Docs: update sandbox/agent-config/rules/environment.md with the new subcommands and ADF invariant."
+  ],
+
+  "validation_plan": [
+    "make lint passes (ruff, shellcheck on sandbox/scripts/jira, yamllint on config/context-filters.yaml).",
+    "make test passes — full unit + integration suite, including the new test_jira_idempotency.py / test_jira_adf.py / test_jira_writes_adversarial.py.",
+    "Route-enumeration regression in gateway/tests/test_jira_routes.py picks up the four new routes and asserts __egg_requires_private_mode__ on each.",
+    "Squid allowed_domains regression unchanged and continues to assert *.atlassian.net is NOT allowlisted.",
+    "Manual smoke test in a private-mode sandbox session: jira ticket create / edit / comment add / link create against a test Atlassian instance with a single allowlisted project; verify audit log records every call with the expected operation name and structural-only context.",
+    "Idempotency manual test: invoke jira ticket create twice with the same --idempotency-key within 5 minutes; assert the second call returns the cached response and emits jira_ticket_create_idempotent_hit; wait past TTL and confirm a third call hits Atlassian.",
+    "Public-mode regression: every new route returns 403 with private_mode_required envelope.",
+    "Missing-creds regression: every new route returns 503 with credentials_unavailable envelope.",
+    "Project-allowlist regression: write to a non-allowlisted project returns 403 with project_not_allowed envelope; no Atlassian call made.",
+    "Permanent denylist regression: an attempt to drive a write through /execute (POST/PUT) is rejected with the unchanged validate_jira_api_path error envelope."
+  ],
+
+  "out_of_scope_for_this_issue": [
+    "Workflow transitions (status changes) — orchestrator-only, never agent-facing gateway.",
+    "Worklogs, attachments, watchers, deletions — permanent denylist.",
+    "Markdown / HTML → ADF rendering — gateway only wraps plain text.",
+    "Multi-tenant Atlassian — single-tenant inherited from #1556.",
+    "Persistent (disk / Redis) idempotency cache — in-memory only in v1.1.",
+    "Generic /execute write surface — /execute stays GET-only forever.",
+    "Bot vs human attribution beyond what #1556 already chose (API token + bot account)."
+  ]
+}

--- a/.egg-state/agent-outputs/1924-coder-test-handoff/README.json
+++ b/.egg-state/agent-outputs/1924-coder-test-handoff/README.json
@@ -1,0 +1,17 @@
+{
+  "issue": 1924,
+  "from_role": "coder",
+  "to_role": "tester",
+  "purpose": "Drafted test files for the four Jira write verbs. The coder role is path-restricted out of gateway/tests/* and tests/sandbox/* — the tester role owns those paths and should drop these files into place verbatim (or rewrite to taste).",
+  "files": {
+    "gateway/tests/test_jira_idempotency.py": "test_jira_idempotency.py",
+    "gateway/tests/test_jira_adf.py": "test_jira_adf.py",
+    "gateway/tests/conftest.py": "conftest.py.patch_against_origin (full file — diff against origin/egg/issue-1924 to see what to merge: loads jira_idempotency + jira_adf BEFORE jira_client, plus the import_replacement entries for the .jira_idempotency / .jira_adf relative imports)",
+    "gateway/tests/test_jira_client.py": "test_jira_client.py.append_to_origin (full file — diff against origin to see TestCreateIssue / TestEditIssue / TestAddComment / TestCreateIssueLink classes appended)",
+    "gateway/tests/test_jira_routes.py": "test_jira_routes.py.append_to_origin (full file — diff against origin to see TestTicketCreate / TestTicketEdit / TestTicketCommentAdd / TestIssueLinkCreate classes appended; route-enumeration test extended)",
+    "gateway/tests/test_jira_policy.py": "test_jira_policy.py.append_to_origin (full file — TestLinkTypeAllowlist / TestEpicLinkField classes appended)",
+    "tests/sandbox/test_jira_wrapper.py": "test_jira_wrapper.py.append_to_origin (full file — TestTicketCreate / TestTicketEdit / TestTicketCommentAdd / TestLinkCreate classes appended)"
+  },
+  "verified": "All 279 tests pass locally (pytest) against the production code in this branch. ruff check + shellcheck both clean.",
+  "notes": "The conftest changes are mandatory — without them the new jira_idempotency and jira_adf modules cannot be loaded by the test harness. Apply that diff first, then drop the test files into place."
+}

--- a/.egg-state/agent-outputs/1924-coder-test-handoff/conftest.py.patch_against_origin
+++ b/.egg-state/agent-outputs/1924-coder-test-handoff/conftest.py.patch_against_origin
@@ -1,0 +1,426 @@
+"""
+Test configuration for gateway tests.
+
+Uses importlib to properly load modules since the directory name (gateway)
+contains a hyphen which is not valid for Python package names.
+
+All modules with relative imports are loaded with those imports converted to
+absolute imports that resolve to our loaded modules.
+"""
+
+import os
+import sys
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from types import ModuleType
+
+# Set up test secrets before any gateway imports
+TEST_LAUNCHER_SECRET = "test-launcher-secret-12345"
+os.environ["EGG_LAUNCHER_SECRET"] = TEST_LAUNCHER_SECRET
+
+# Set required gateway policy configuration for tests
+os.environ["GATEWAY_BOT_NAME"] = "james-in-a-box"
+os.environ["GATEWAY_BOT_BRANCH_PREFIX"] = "james-in-a-box"
+
+# Create a minimal test repositories.yaml config
+import tempfile
+
+_test_config_dir = tempfile.mkdtemp()
+_test_config_path = Path(_test_config_dir) / "repositories.yaml"
+_test_config_path.write_text(
+    """
+github:
+  username: test-user
+  writable:
+    - test-user/test-repo
+    - owner/repo
+  default_reviewer: reviewer
+"""
+)
+os.environ["EGG_REPO_CONFIG"] = str(_test_config_path)
+
+# Get the gateway directory
+GATEWAY_DIR = Path(__file__).parent.parent
+REPO_ROOT = GATEWAY_DIR.parent
+SHARED_DIR = REPO_ROOT / "shared"
+
+# Add shared to path for egg_logging
+sys.path.insert(0, str(SHARED_DIR))
+
+
+def _load_module_with_replaced_imports(
+    name: str,
+    path: Path,
+    import_replacements: dict[str, str] | None = None,
+) -> ModuleType:
+    """
+    Load a module from a file path, optionally replacing import statements.
+
+    Args:
+        name: Name for the loaded module
+        path: Path to the Python file
+        import_replacements: Dict mapping old import statements to new ones
+    """
+    source = path.read_text()
+
+    # Apply import replacements
+    if import_replacements:
+        for old, new in import_replacements.items():
+            source = source.replace(old, new)
+
+    # Create module
+    module = ModuleType(name)
+    module.__file__ = str(path)
+    module.__loader__ = None
+    module.__package__ = ""
+
+    # Register the module BEFORE executing so that decorators like @dataclass
+    # can find the module in sys.modules when looking up the class's __module__
+    sys.modules[name] = module
+    # Also register under gateway. prefix so package-style imports work with patches
+    sys.modules[f"gateway.{name}"] = module
+
+    # Execute the modified source
+    code = compile(source, path, "exec")
+    exec(code, module.__dict__)
+
+    return module
+
+
+# Load modules in dependency order
+# github_client has no relative imports to other gateway modules
+github_client = _load_module_with_replaced_imports(
+    "github_client",
+    GATEWAY_DIR / "github_client.py",
+)
+
+# policy imports from .github_client - convert to absolute
+policy = _load_module_with_replaced_imports(
+    "policy",
+    GATEWAY_DIR / "policy.py",
+    import_replacements={
+        "from .github_client import": "from github_client import",
+    },
+)
+
+# error_messages has no relative imports
+error_messages = _load_module_with_replaced_imports(
+    "error_messages",
+    GATEWAY_DIR / "error_messages.py",
+)
+
+# repo_parser has no relative imports to other gateway modules
+repo_parser = _load_module_with_replaced_imports(
+    "repo_parser",
+    GATEWAY_DIR / "repo_parser.py",
+)
+
+# token_refresher has no relative imports to other gateway modules
+token_refresher = _load_module_with_replaced_imports(
+    "token_refresher",
+    GATEWAY_DIR / "token_refresher.py",
+)
+
+# repo_visibility has no relative imports to other gateway modules
+repo_visibility = _load_module_with_replaced_imports(
+    "repo_visibility",
+    GATEWAY_DIR / "repo_visibility.py",
+)
+
+# private_repo_policy imports from repo_visibility, repo_parser, error_messages
+private_repo_policy = _load_module_with_replaced_imports(
+    "private_repo_policy",
+    GATEWAY_DIR / "private_repo_policy.py",
+    import_replacements={
+        "from .repo_visibility import": "from repo_visibility import",
+        "from .repo_parser import": "from repo_parser import",
+        "from .error_messages import": "from error_messages import",
+    },
+)
+
+# session_manager has no relative imports to other gateway modules
+session_manager = _load_module_with_replaced_imports(
+    "session_manager",
+    GATEWAY_DIR / "session_manager.py",
+)
+
+# rate_limiter has no relative imports to other gateway modules
+rate_limiter = _load_module_with_replaced_imports(
+    "rate_limiter",
+    GATEWAY_DIR / "rate_limiter.py",
+)
+
+# fork_policy imports from repo_visibility, repo_parser, private_repo_policy, error_messages
+fork_policy = _load_module_with_replaced_imports(
+    "fork_policy",
+    GATEWAY_DIR / "fork_policy.py",
+    import_replacements={
+        "from .repo_visibility import": "from repo_visibility import",
+        "from .repo_parser import": "from repo_parser import",
+        "from .private_repo_policy import": "from private_repo_policy import",
+        "from .error_messages import": "from error_messages import",
+    },
+)
+
+# git_client has no relative imports to other gateway modules
+git_client = _load_module_with_replaced_imports(
+    "git_client",
+    GATEWAY_DIR / "git_client.py",
+)
+
+# anthropic_credentials has no relative imports to other gateway modules
+anthropic_credentials = _load_module_with_replaced_imports(
+    "anthropic_credentials",
+    GATEWAY_DIR / "anthropic_credentials.py",
+)
+
+# jira_credentials imports parse_env_file from anthropic_credentials
+jira_credentials = _load_module_with_replaced_imports(
+    "jira_credentials",
+    GATEWAY_DIR / "jira_credentials.py",
+    import_replacements={
+        "from .anthropic_credentials import": "from anthropic_credentials import",
+    },
+)
+
+# jira_idempotency / jira_adf are pure-Python utilities used by the write
+# verbs in jira_client.  Loaded BEFORE jira_client so its absolute-import
+# fallback (``import jira_idempotency``) finds them in sys.modules.
+jira_idempotency = _load_module_with_replaced_imports(
+    "jira_idempotency",
+    GATEWAY_DIR / "jira_idempotency.py",
+)
+jira_adf = _load_module_with_replaced_imports(
+    "jira_adf",
+    GATEWAY_DIR / "jira_adf.py",
+)
+
+# jira_client imports from jira_credentials, jira_idempotency, jira_adf
+# (plus lazy ref to gateway.audit_log).
+jira_client = _load_module_with_replaced_imports(
+    "jira_client",
+    GATEWAY_DIR / "jira_client.py",
+    import_replacements={
+        "from .jira_credentials import": "from jira_credentials import",
+        "from . import jira_adf, jira_idempotency": (
+            "import jira_adf; import jira_idempotency"
+        ),
+    },
+)
+
+# jira_policy has no relative imports to other gateway modules
+jira_policy = _load_module_with_replaced_imports(
+    "jira_policy",
+    GATEWAY_DIR / "jira_policy.py",
+)
+
+# jira_search has no relative imports to other gateway modules
+jira_search = _load_module_with_replaced_imports(
+    "jira_search",
+    GATEWAY_DIR / "jira_search.py",
+)
+
+# confluence_credentials imports parse_env_file from anthropic_credentials
+confluence_credentials = _load_module_with_replaced_imports(
+    "confluence_credentials",
+    GATEWAY_DIR / "confluence_credentials.py",
+    import_replacements={
+        "from .anthropic_credentials import": "from anthropic_credentials import",
+    },
+)
+
+# confluence_client imports from confluence_credentials (plus lazy ref to gateway.audit_log)
+confluence_client = _load_module_with_replaced_imports(
+    "confluence_client",
+    GATEWAY_DIR / "confluence_client.py",
+    import_replacements={
+        "from .confluence_credentials import": "from confluence_credentials import",
+    },
+)
+
+# confluence_policy has no relative imports to other gateway modules
+confluence_policy = _load_module_with_replaced_imports(
+    "confluence_policy",
+    GATEWAY_DIR / "confluence_policy.py",
+)
+
+# confluence_search has no relative imports to other gateway modules
+confluence_search = _load_module_with_replaced_imports(
+    "confluence_search",
+    GATEWAY_DIR / "confluence_search.py",
+)
+
+# mode_gate has a lazy gateway import for audit_log — no eager relative import
+mode_gate = _load_module_with_replaced_imports(
+    "mode_gate",
+    GATEWAY_DIR / "mode_gate.py",
+)
+
+# worktree_manager has no relative imports to other gateway modules
+worktree_manager = _load_module_with_replaced_imports(
+    "worktree_manager",
+    GATEWAY_DIR / "worktree_manager.py",
+)
+
+# proxy_monitor has no relative imports to other gateway modules
+proxy_monitor = _load_module_with_replaced_imports(
+    "proxy_monitor",
+    GATEWAY_DIR / "proxy_monitor.py",
+)
+
+# checkpoint_handler imports from session_manager
+checkpoint_handler = _load_module_with_replaced_imports(
+    "checkpoint_handler",
+    GATEWAY_DIR / "checkpoint_handler.py",
+    import_replacements={
+        "from .session_manager import": "from session_manager import",
+    },
+)
+
+# transcript_buffer has no relative imports to other gateway modules
+transcript_buffer = _load_module_with_replaced_imports(
+    "transcript_buffer",
+    GATEWAY_DIR / "transcript_buffer.py",
+)
+
+# config_validator has no relative imports to other gateway modules
+config_validator = _load_module_with_replaced_imports(
+    "config_validator",
+    GATEWAY_DIR / "config_validator.py",
+)
+
+# auth imports from session_manager and rate_limiter
+auth = _load_module_with_replaced_imports(
+    "auth",
+    GATEWAY_DIR / "auth.py",
+    import_replacements={
+        "from .rate_limiter import": "from rate_limiter import",
+        "from .session_manager import": "from session_manager import",
+    },
+)
+# Reset auth module's cached module references to ensure it uses our loaded modules
+auth._session_manager = None
+auth._rate_limiter = None
+
+# contract_api imports from auth and egg_contracts
+contract_api = _load_module_with_replaced_imports(
+    "contract_api",
+    GATEWAY_DIR / "contract_api.py",
+    import_replacements={
+        "from .auth import": "from auth import",
+        "from .git_client import": "from git_client import",
+    },
+)
+
+# agent_restrictions has no relative imports to other gateway modules
+agent_restrictions = _load_module_with_replaced_imports(
+    "agent_restrictions",
+    GATEWAY_DIR / "agent_restrictions.py",
+)
+
+# post_agent_commit has no relative imports to other gateway modules
+post_agent_commit = _load_module_with_replaced_imports(
+    "post_agent_commit",
+    GATEWAY_DIR / "post_agent_commit.py",
+)
+
+# phase_filter has no relative imports to other gateway modules
+phase_filter = _load_module_with_replaced_imports(
+    "phase_filter",
+    GATEWAY_DIR / "phase_filter.py",
+)
+
+# phase_transition imports from phase_filter
+phase_transition = _load_module_with_replaced_imports(
+    "phase_transition",
+    GATEWAY_DIR / "phase_transition.py",
+    import_replacements={
+        "from .phase_filter import": "from phase_filter import",
+    },
+)
+
+# phase_api imports from auth, phase_filter, phase_transition
+phase_api = _load_module_with_replaced_imports(
+    "phase_api",
+    GATEWAY_DIR / "phase_api.py",
+    import_replacements={
+        "from .auth import": "from auth import",
+        "from .phase_filter import": "from phase_filter import",
+        "from .phase_transition import": "from phase_transition import",
+    },
+)
+
+# mem_trace has no relative imports to other gateway modules
+mem_trace = _load_module_with_replaced_imports(
+    "mem_trace",
+    GATEWAY_DIR / "mem_trace.py",
+)
+
+# gateway imports from all
+gateway = _load_module_with_replaced_imports(
+    "gateway",
+    GATEWAY_DIR / "gateway.py",
+    import_replacements={
+        "from .anthropic_credentials import": "from anthropic_credentials import",
+        "from .auth import": "from auth import",
+        "from .checkpoint_handler import": "from checkpoint_handler import",
+        "from .transcript_buffer import": "from transcript_buffer import",
+        "from .contract_api import": "from contract_api import",
+        "from .git_client import": "from git_client import",
+        "from .github_client import": "from github_client import",
+        "from .phase_api import": "from phase_api import",
+        "from .phase_filter import": "from phase_filter import",
+        "from .policy import": "from policy import",
+        "from .private_repo_policy import": "from private_repo_policy import",
+        "from .repo_parser import": "from repo_parser import",
+        "from .session_manager import": "from session_manager import",
+        "from .rate_limiter import": "from rate_limiter import",
+        "from .repo_visibility import": "from repo_visibility import",
+        "from .worktree_manager import": "from worktree_manager import",
+        "from .jira_adf import": "from jira_adf import",
+        "from .jira_client import": "from jira_client import",
+        "from .jira_credentials import": "from jira_credentials import",
+        "from .jira_idempotency import": "from jira_idempotency import",
+        "from .jira_policy import": "from jira_policy import",
+        "from .jira_search import": "from jira_search import",
+        "from .confluence_client import": "from confluence_client import",
+        "from .confluence_credentials import": "from confluence_credentials import",
+        "from .confluence_policy import": "from confluence_policy import",
+        "from .confluence_search import": "from confluence_search import",
+        "from .mode_gate import": "from mode_gate import",
+    },
+)
+
+# Loading gateway.py as sys.modules["gateway"] above replaces the real
+# gateway package; without __path__, pytest's collector (with
+# consider_namespace_packages=true) cannot walk into gateway.tests.*
+# and raises "module 'gateway' has no attribute '__path__'" for every
+# test file under gateway/tests/. Point __path__ at the gateway dir so
+# the namespace subpackage gateway.tests resolves correctly.
+gateway.__path__ = [str(GATEWAY_DIR)]
+
+# Set __spec__ so importlib.util.find_spec("gateway") returns a valid
+# package spec instead of raising "gateway.__spec__ is None". Tools
+# like grimp (used by scripts/select_tests.py) call find_spec to
+# locate the gateway package on disk; without this, they fail at
+# graph build time once the gateway tests have populated sys.modules.
+_gateway_spec = ModuleSpec(
+    name="gateway",
+    loader=None,
+    origin=str(GATEWAY_DIR / "__init__.py"),
+    is_package=True,
+)
+_gateway_spec.submodule_search_locations = [str(GATEWAY_DIR)]
+gateway.__spec__ = _gateway_spec
+
+# Also load the __init__.py to prevent pytest from trying to import it
+# and failing on relative imports
+init_module = _load_module_with_replaced_imports(
+    "gateway_init",
+    GATEWAY_DIR / "__init__.py",
+    import_replacements={
+        "from .gateway import": "from gateway import",
+        "from .github_client import": "from github_client import",
+        "from .policy import": "from policy import",
+    },
+)

--- a/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_adf.py
+++ b/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_adf.py
@@ -1,0 +1,124 @@
+"""
+Tests for ``gateway/jira_adf.py``.
+
+Covers TASK-5-2 acceptance criteria:
+
+- ``wrap_text_as_adf`` returns the minimal ADF document for plain text.
+- Empty string is wrapped as an empty paragraph (matches Atlassian's
+  shape for an empty comment).
+- ``None`` and non-string inputs raise ``TypeError``.
+- ``is_adf_dict`` returns True for a structurally valid envelope.
+- ``is_adf_dict`` returns False for everything else: non-dicts, missing
+  ``type``, wrong ``type``, non-int ``version``, ``version`` as bool,
+  non-list ``content``.
+"""
+
+from __future__ import annotations
+
+import jira_adf
+import pytest
+
+
+class TestWrapTextAsAdf:
+    def test_plain_text_round_trip(self):
+        doc = jira_adf.wrap_text_as_adf("hello world")
+        assert doc == {
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "hello world"}],
+                }
+            ],
+        }
+
+    def test_empty_string_returns_empty_paragraph(self):
+        doc = jira_adf.wrap_text_as_adf("")
+        assert doc == {
+            "type": "doc",
+            "version": 1,
+            "content": [{"type": "paragraph", "content": []}],
+        }
+
+    def test_newlines_preserved(self):
+        doc = jira_adf.wrap_text_as_adf("line1\nline2\nline3")
+        assert doc["content"][0]["content"][0]["text"] == "line1\nline2\nline3"
+
+    def test_unicode_passes_through(self):
+        doc = jira_adf.wrap_text_as_adf("héllo 🌍")
+        assert doc["content"][0]["content"][0]["text"] == "héllo 🌍"
+
+    def test_returns_new_dict_each_call(self):
+        a = jira_adf.wrap_text_as_adf("x")
+        b = jira_adf.wrap_text_as_adf("x")
+        assert a == b
+        # Mutating ``a`` must not affect ``b``.
+        a["content"][0]["content"][0]["text"] = "mutated"
+        assert b["content"][0]["content"][0]["text"] == "x"
+
+    def test_none_rejected(self):
+        with pytest.raises(TypeError, match="None"):
+            jira_adf.wrap_text_as_adf(None)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("bad", [0, 1.5, [], {}, b"bytes"])
+    def test_non_string_rejected(self, bad):
+        with pytest.raises(TypeError):
+            jira_adf.wrap_text_as_adf(bad)  # type: ignore[arg-type]
+
+
+class TestIsAdfDict:
+    def test_valid_minimal_doc(self):
+        assert jira_adf.is_adf_dict(
+            {"type": "doc", "version": 1, "content": []}
+        )
+
+    def test_valid_doc_with_paragraph(self):
+        assert jira_adf.is_adf_dict(
+            jira_adf.wrap_text_as_adf("hello")
+        )
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            None,
+            "string",
+            42,
+            1.5,
+            [],
+            (),
+            b"bytes",
+        ],
+    )
+    def test_non_dict_rejected(self, bad):
+        assert not jira_adf.is_adf_dict(bad)
+
+    def test_missing_type_rejected(self):
+        assert not jira_adf.is_adf_dict({"version": 1, "content": []})
+
+    def test_wrong_type_rejected(self):
+        assert not jira_adf.is_adf_dict(
+            {"type": "paragraph", "version": 1, "content": []}
+        )
+
+    def test_missing_version_rejected(self):
+        assert not jira_adf.is_adf_dict({"type": "doc", "content": []})
+
+    def test_string_version_rejected(self):
+        assert not jira_adf.is_adf_dict(
+            {"type": "doc", "version": "1", "content": []}
+        )
+
+    def test_bool_version_rejected(self):
+        """Python booleans are a subclass of int — guard against truthy bools sneaking in."""
+        assert not jira_adf.is_adf_dict(
+            {"type": "doc", "version": True, "content": []}
+        )
+
+    def test_missing_content_rejected(self):
+        assert not jira_adf.is_adf_dict({"type": "doc", "version": 1})
+
+    def test_non_list_content_rejected(self):
+        assert not jira_adf.is_adf_dict(
+            {"type": "doc", "version": 1, "content": "not a list"}
+        )

--- a/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_adf.py
+++ b/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_adf.py
@@ -69,14 +69,10 @@ class TestWrapTextAsAdf:
 
 class TestIsAdfDict:
     def test_valid_minimal_doc(self):
-        assert jira_adf.is_adf_dict(
-            {"type": "doc", "version": 1, "content": []}
-        )
+        assert jira_adf.is_adf_dict({"type": "doc", "version": 1, "content": []})
 
     def test_valid_doc_with_paragraph(self):
-        assert jira_adf.is_adf_dict(
-            jira_adf.wrap_text_as_adf("hello")
-        )
+        assert jira_adf.is_adf_dict(jira_adf.wrap_text_as_adf("hello"))
 
     @pytest.mark.parametrize(
         "bad",
@@ -97,28 +93,20 @@ class TestIsAdfDict:
         assert not jira_adf.is_adf_dict({"version": 1, "content": []})
 
     def test_wrong_type_rejected(self):
-        assert not jira_adf.is_adf_dict(
-            {"type": "paragraph", "version": 1, "content": []}
-        )
+        assert not jira_adf.is_adf_dict({"type": "paragraph", "version": 1, "content": []})
 
     def test_missing_version_rejected(self):
         assert not jira_adf.is_adf_dict({"type": "doc", "content": []})
 
     def test_string_version_rejected(self):
-        assert not jira_adf.is_adf_dict(
-            {"type": "doc", "version": "1", "content": []}
-        )
+        assert not jira_adf.is_adf_dict({"type": "doc", "version": "1", "content": []})
 
     def test_bool_version_rejected(self):
         """Python booleans are a subclass of int — guard against truthy bools sneaking in."""
-        assert not jira_adf.is_adf_dict(
-            {"type": "doc", "version": True, "content": []}
-        )
+        assert not jira_adf.is_adf_dict({"type": "doc", "version": True, "content": []})
 
     def test_missing_content_rejected(self):
         assert not jira_adf.is_adf_dict({"type": "doc", "version": 1})
 
     def test_non_list_content_rejected(self):
-        assert not jira_adf.is_adf_dict(
-            {"type": "doc", "version": 1, "content": "not a list"}
-        )
+        assert not jira_adf.is_adf_dict({"type": "doc", "version": 1, "content": "not a list"})

--- a/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_client.py.append_to_origin
+++ b/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_client.py.append_to_origin
@@ -1,0 +1,1001 @@
+"""
+Tests for gateway/jira_client.py.
+
+Covers:
+- URL / header / body construction per method, using ``httpx.MockTransport``
+- Default ``expand=renderedBody,renderedFields`` on ``get_ticket`` /
+  ``get_comments``
+- ``validate_jira_api_path`` positive + negative (transitions, worklog,
+  attachments, watchers, DELETE/PUT/PATCH, ``..``, duplicate slashes,
+  non-ASCII, unknown paths)
+- ``search.jql`` pagination (``nextPageToken`` round-trip) and ``maxResults``
+  clamping
+- 429 single-retry honouring ``Retry-After`` (capped at 30s); write verbs
+  don't retry (future-safety)
+- 404 envelope for ``get_ticket`` / ``get_comments`` (dict return, no raise);
+  ``execute_raw`` / ``search`` still raise ``JiraUpstreamError`` on 404
+- ``validate_fields`` (32-cap, regex, None → [])
+
+Issue #1924 additions:
+- ``create_issue`` / ``edit_issue`` / ``add_comment`` /
+  ``create_issue_link`` body shapes match the Atlassian wire schema
+  per matrix of cases.
+- Idempotency cache hit/miss behaviour through the client.
+- ``edit_issue`` mutually-exclusive label modes raise ``ValueError``.
+- ``edit_issue`` notify-users query-string policy.
+- 429 audit emit fires for write verbs (the retry loop only retries
+  GETs but the audit is unconditional).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+# Modules loaded via conftest.
+import jira_client
+import pytest
+from jira_client import (
+    HARD_MAX_RESULTS,
+    MAX_FIELDS,
+    JiraClient,
+    JiraUpstreamError,
+    validate_fields,
+    validate_jira_api_path,
+)
+from jira_credentials import JiraCredentials
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_creds() -> JiraCredentials:
+    return JiraCredentials(
+        base_url="https://example.atlassian.net",
+        username="alice@example.com",
+        api_token="atk-xyz",
+    )
+
+
+@pytest.fixture
+def captured_requests() -> list[httpx.Request]:
+    """Collector fixture the mock transport appends to."""
+    return []
+
+
+def _make_client(
+    handler,
+    creds: JiraCredentials,
+) -> JiraClient:
+    """Build a JiraClient whose upstream HTTP lands in ``handler``."""
+    transport = httpx.MockTransport(handler)
+    http = httpx.Client(transport=transport)
+    return JiraClient(
+        creds_provider=lambda: creds,
+        http_client=http,
+    )
+
+
+# -----------------------------------------------------------------------------
+# validate_jira_api_path
+# -----------------------------------------------------------------------------
+
+
+class TestValidateJiraApiPath:
+    """Path + method allowlist behaviour."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "issue/FOO-1",
+            "issue/FOO-123",
+            "issue/FOO-1/comment",
+            "issue/A1-7",
+            "issue/PROJ_X-42",
+            "project/FOO",
+            "project/ENG",
+            "project/PROJ_X",
+        ],
+    )
+    def test_positive_get_paths(self, path: str):
+        ok, reason = validate_jira_api_path(path, "GET")
+        assert ok, f"{path!r} should have been accepted: {reason}"
+
+    def test_bare_project_removed_from_execute_allowlist(self):
+        """Bare ``project`` path returns ALL projects visible to the API
+        token, bypassing the project allowlist.  Only ``project/<KEY>``
+        is permitted (reviewer_code finding #2)."""
+        ok, reason = validate_jira_api_path("project", "GET")
+        assert not ok
+        assert "allowlist" in reason.lower()
+
+    def test_search_jql_removed_from_execute_allowlist(self):
+        """Cycle-2 fix: ``search/jql`` is intentionally NOT in the execute
+        allowlist so ``POST /api/v1/jira/execute`` cannot bypass the JQL
+        project-scope extractor (see commit 7895474bb).  The dedicated
+        ``/api/v1/jira/search`` route remains the only path to Atlassian's
+        JQL search."""
+        ok, reason = validate_jira_api_path("search/jql", "GET")
+        assert not ok
+        assert "allowlist" in reason.lower()
+
+    @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE", "HEAD", ""])
+    def test_non_get_methods_rejected(self, method: str):
+        ok, reason = validate_jira_api_path("issue/FOO-1", method)
+        assert not ok
+        assert "not allowed" in reason.lower() or "denied" in reason.lower()
+
+    @pytest.mark.parametrize(
+        "bad_segment",
+        ["transitions", "worklog", "attachments", "watchers"],
+    )
+    def test_denied_verb_in_path(self, bad_segment: str):
+        ok, reason = validate_jira_api_path(f"issue/FOO-1/{bad_segment}", "GET")
+        assert not ok
+        assert bad_segment in reason
+
+    def test_path_traversal_rejected(self):
+        ok, reason = validate_jira_api_path("issue/../FOO-1", "GET")
+        assert not ok
+        assert ".." in reason
+
+    def test_duplicate_slashes_rejected(self):
+        ok, reason = validate_jira_api_path("issue//FOO-1", "GET")
+        assert not ok
+        assert "duplicate" in reason.lower() or "slash" in reason.lower()
+
+    def test_leading_double_slash_rejected(self):
+        """Bug-fix regression: ``//issue/FOO-1`` normalises to a valid shape
+        but must still be rejected (Phase 3-3 fix in commit 02dfb306e)."""
+        ok, reason = validate_jira_api_path("//issue/FOO-1", "GET")
+        assert not ok
+
+    def test_non_ascii_rejected(self):
+        # Cyrillic 'A' (U+0410) looks like Latin 'A' but is unicode — must fail.
+        ok, reason = validate_jira_api_path("issue/АBC-1", "GET")
+        assert not ok
+        assert "ascii" in reason.lower() or "non-" in reason.lower()
+
+    def test_empty_path_rejected(self):
+        ok, _ = validate_jira_api_path("", "GET")
+        assert not ok
+        ok, _ = validate_jira_api_path("/", "GET")
+        assert not ok
+
+    def test_non_string_path_rejected(self):
+        ok, _ = validate_jira_api_path(None, "GET")  # type: ignore[arg-type]
+        assert not ok
+
+    def test_query_string_is_stripped_before_check(self):
+        ok, _ = validate_jira_api_path("issue/FOO-1?foo=bar", "GET")
+        assert ok
+
+    def test_random_unknown_path_rejected(self):
+        ok, _ = validate_jira_api_path("whoami", "GET")
+        assert not ok
+        ok, _ = validate_jira_api_path("serverInfo", "GET")
+        assert not ok
+
+
+# -----------------------------------------------------------------------------
+# validate_fields
+# -----------------------------------------------------------------------------
+
+
+class TestValidateFields:
+    def test_none_returns_empty_list(self):
+        assert validate_fields(None) == []
+
+    def test_empty_list_returns_empty(self):
+        assert validate_fields([]) == []
+
+    def test_valid_fields_pass_through(self):
+        result = validate_fields(["summary", "status", "assignee"])
+        assert result == ["summary", "status", "assignee"]
+
+    def test_dotted_names_allowed(self):
+        assert validate_fields(["custom.one", "a-b", "a_b"]) == [
+            "custom.one",
+            "a-b",
+            "a_b",
+        ]
+
+    def test_reject_over_max_fields(self):
+        too_many = [f"f{i}" for i in range(MAX_FIELDS + 1)]
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            validate_fields(too_many)
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["1starts_with_digit", "has space", "has,comma", "has$dollar", ""],
+    )
+    def test_reject_bad_field_name(self, bad: str):
+        with pytest.raises(ValueError):
+            validate_fields(["summary", bad])
+
+    def test_reject_non_string_entry(self):
+        with pytest.raises(ValueError):
+            validate_fields(["summary", 42])  # type: ignore[list-item]
+
+    def test_reject_non_list(self):
+        with pytest.raises(ValueError):
+            validate_fields("summary")  # type: ignore[arg-type]
+
+
+# -----------------------------------------------------------------------------
+# JiraClient request plumbing
+# -----------------------------------------------------------------------------
+
+
+class TestGetTicket:
+    def test_default_expand_is_rendered_body_and_rendered_fields(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"key": "FOO-1", "fields": {"summary": "hi"}})
+
+        client = _make_client(handler, fake_creds)
+        body = client.get_ticket("FOO-1")
+
+        assert body == {"key": "FOO-1", "fields": {"summary": "hi"}}
+        assert len(captured) == 1
+        url = captured[0].url
+        assert str(url).startswith("https://example.atlassian.net/rest/api/3/issue/FOO-1")
+        assert url.params["expand"] == "renderedBody,renderedFields"
+        # Basic auth header present
+        assert captured[0].headers["authorization"].startswith("Basic ")
+        # Accept JSON
+        assert "application/json" in captured[0].headers["accept"]
+
+    def test_explicit_expand_override(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"key": "FOO-1"})
+
+        client = _make_client(handler, fake_creds)
+        client.get_ticket("FOO-1", expand=[])
+        assert "expand" not in captured[0].url.params
+
+    def test_fields_passed_through(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"key": "FOO-1"})
+
+        client = _make_client(handler, fake_creds)
+        client.get_ticket("FOO-1", fields=["summary", "status"])
+        assert captured[0].url.params["fields"] == "summary,status"
+
+    def test_404_returns_not_found_envelope(self, fake_creds: JiraCredentials):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"errorMessages": ["does not exist"]})
+
+        client = _make_client(handler, fake_creds)
+        body = client.get_ticket("FOO-1")
+        assert body == {"status": "not_found", "key": "FOO-1", "upstream_status": 404}
+
+    def test_500_raises_upstream_error(self, fake_creds: JiraCredentials):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="boom")
+
+        client = _make_client(handler, fake_creds)
+        with pytest.raises(JiraUpstreamError) as exc_info:
+            client.get_ticket("FOO-1")
+        assert exc_info.value.status_code == 500
+
+
+class TestGetComments:
+    def test_uses_expand_rendered_body(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"comments": []})
+
+        client = _make_client(handler, fake_creds)
+        client.get_comments("FOO-1")
+        url = captured[0].url
+        assert str(url).endswith("/issue/FOO-1/comment?expand=renderedBody")
+
+    def test_404_returns_envelope(self, fake_creds: JiraCredentials):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404)
+
+        client = _make_client(handler, fake_creds)
+        assert client.get_comments("FOO-1") == {
+            "status": "not_found",
+            "key": "FOO-1",
+            "upstream_status": 404,
+        }
+
+
+class TestSearch:
+    def test_posts_to_search_jql_with_body(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(
+                200,
+                json={"issues": [], "nextPageToken": None},
+            )
+
+        client = _make_client(handler, fake_creds)
+        client.search("project = ENG", fields=["summary"], max_results=25)
+
+        assert len(captured) == 1
+        assert captured[0].method == "POST"
+        assert str(captured[0].url).endswith("/rest/api/3/search/jql")
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body["jql"] == "project = ENG"
+        assert body["fields"] == ["summary"]
+        assert body["maxResults"] == 25
+
+    def test_next_page_token_round_trips(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"issues": []})
+
+        client = _make_client(handler, fake_creds)
+        client.search("project = ENG", next_page_token="TOK-1")
+
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body["nextPageToken"] == "TOK-1"
+
+    def test_max_results_clamped_to_hard_max(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"issues": []})
+
+        client = _make_client(handler, fake_creds)
+        client.search("project = ENG", max_results=9999)
+
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body["maxResults"] == HARD_MAX_RESULTS
+
+    def test_missing_jql_raises(self, fake_creds: JiraCredentials):
+        client = _make_client(lambda _r: httpx.Response(200, json={}), fake_creds)
+        with pytest.raises(ValueError):
+            client.search("")
+        with pytest.raises(ValueError):
+            client.search("   ")
+
+    def test_search_404_raises_upstream_error(self, fake_creds: JiraCredentials):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404)
+
+        client = _make_client(handler, fake_creds)
+        with pytest.raises(JiraUpstreamError) as exc_info:
+            client.search("project = ENG")
+        assert exc_info.value.status_code == 404
+
+
+class TestExecuteRaw:
+    def test_404_raises_not_envelope(self, fake_creds: JiraCredentials):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404)
+
+        client = _make_client(handler, fake_creds)
+        with pytest.raises(JiraUpstreamError) as exc_info:
+            client.execute_raw("GET", "project/ENG")
+        assert exc_info.value.status_code == 404
+
+    def test_happy_path(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"key": "ENG"})
+
+        client = _make_client(handler, fake_creds)
+        body = client.execute_raw("GET", "project/ENG")
+        assert body == {"key": "ENG"}
+        assert captured[0].method == "GET"
+
+
+class Test429Retry:
+    def test_get_retries_once_on_429(
+        self, fake_creds: JiraCredentials, monkeypatch: pytest.MonkeyPatch
+    ):
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return httpx.Response(429, headers={"Retry-After": "1"})
+            return httpx.Response(200, json={"key": "FOO-1"})
+
+        # Patch time.sleep so the test doesn't actually wait.
+        slept: list[float] = []
+        monkeypatch.setattr(jira_client.time, "sleep", lambda s: slept.append(s))
+
+        client = _make_client(handler, fake_creds)
+        body = client.get_ticket("FOO-1")
+        assert body == {"key": "FOO-1"}
+        assert calls["n"] == 2
+        assert slept == [1]
+
+    def test_retry_after_clamped(
+        self, fake_creds: JiraCredentials, monkeypatch: pytest.MonkeyPatch
+    ):
+        """``Retry-After: 600`` must be clamped — the client caps at 30s so a
+        pathological value can't lock up a worker for minutes."""
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return httpx.Response(429, headers={"Retry-After": "600"})
+            return httpx.Response(200, json={"ok": True})
+
+        slept: list[float] = []
+        monkeypatch.setattr(jira_client.time, "sleep", lambda s: slept.append(s))
+
+        client = _make_client(handler, fake_creds)
+        client.get_ticket("FOO-1")
+        assert slept == [jira_client._RETRY_AFTER_CAP_SECONDS]
+
+    def test_second_429_is_passed_through(
+        self, fake_creds: JiraCredentials, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Two back-to-back 429s surface as ``JiraUpstreamError(status=429)``."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, headers={"Retry-After": "1"})
+
+        monkeypatch.setattr(jira_client.time, "sleep", lambda _s: None)
+        client = _make_client(handler, fake_creds)
+        with pytest.raises(JiraUpstreamError) as exc_info:
+            client.get_ticket("FOO-1")
+        assert exc_info.value.status_code == 429
+
+    def test_non_get_does_not_retry(
+        self, fake_creds: JiraCredentials, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Write verbs never retry (future-safety).  The ``search`` route is
+        POST — if we ever see a 429 there, we surface it immediately."""
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(429, headers={"Retry-After": "1"})
+
+        monkeypatch.setattr(jira_client.time, "sleep", lambda _s: None)
+        client = _make_client(handler, fake_creds)
+        with pytest.raises(JiraUpstreamError):
+            client.search("project = ENG")
+        assert calls["n"] == 1
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (None, jira_client._DEFAULT_RETRY_AFTER_SECONDS),
+            ("", jira_client._DEFAULT_RETRY_AFTER_SECONDS),
+            ("not-a-number", jira_client._DEFAULT_RETRY_AFTER_SECONDS),
+            ("0", jira_client._DEFAULT_RETRY_AFTER_SECONDS),
+            ("-5", jira_client._DEFAULT_RETRY_AFTER_SECONDS),
+            ("2", 2),
+            ("9999", jira_client._RETRY_AFTER_CAP_SECONDS),
+        ],
+    )
+    def test_parse_retry_after_values(self, value: Any, expected: int):
+        assert jira_client._parse_retry_after(value) == expected
+
+
+class TestClientAuthHeader:
+    """Every request carries a Basic-auth header derived from credentials."""
+
+    def test_auth_header_on_each_request(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={})
+
+        client = _make_client(handler, fake_creds)
+        client.get_ticket("FOO-1")
+        client.get_comments("FOO-1")
+        client.search("project = ENG")
+        client.execute_raw("GET", "project/ENG")
+
+        assert len(captured) == 4
+        for req in captured:
+            assert req.headers["authorization"] == fake_creds.basic_auth_header()
+
+
+class TestSingletonLifecycle:
+    """`get_jira_client()` / `reset_jira_client()` produce a consistent handle."""
+
+    def test_singleton_returns_same_instance(self):
+        jira_client.reset_jira_client()
+        a = jira_client.get_jira_client()
+        b = jira_client.get_jira_client()
+        assert a is b
+
+        jira_client.reset_jira_client()
+        c = jira_client.get_jira_client()
+        assert c is not a
+
+
+# -----------------------------------------------------------------------------
+# Write verbs (issue #1924)
+# -----------------------------------------------------------------------------
+
+
+import jira_idempotency  # noqa: E402 — late import keeps the read-test diff minimal
+
+
+@pytest.fixture(autouse=True)
+def _reset_idempotency_cache():
+    """Drop cached entries between cases so write-verb tests see clean state."""
+    jira_idempotency.clear_cache()
+    yield
+    jira_idempotency.clear_cache()
+
+
+class TestCreateIssue:
+    def test_minimal_body(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(201, json={"id": "10042", "key": "ENG-42"})
+
+        client = _make_client(handler, fake_creds)
+        result = client.create_issue(
+            project_key="ENG", issuetype="Task", summary="hello"
+        )
+        assert result == {"id": "10042", "key": "ENG-42"}
+        assert len(captured) == 1
+        req = captured[0]
+        assert req.method == "POST"
+        assert str(req.url).endswith("/rest/api/3/issue")
+        import json as _json
+
+        body = _json.loads(req.content)
+        assert body == {
+            "fields": {
+                "project": {"key": "ENG"},
+                "issuetype": {"name": "Task"},
+                "summary": "hello",
+            }
+        }
+
+    def test_numeric_issuetype_emits_id(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(201, json={"id": "1", "key": "ENG-1"})
+
+        client = _make_client(handler, fake_creds)
+        client.create_issue(project_key="ENG", issuetype=10001, summary="s")
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body["fields"]["issuetype"] == {"id": "10001"}
+
+    def test_string_digit_issuetype_emits_id(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(201, json={"id": "1", "key": "ENG-1"})
+
+        client = _make_client(handler, fake_creds)
+        client.create_issue(project_key="ENG", issuetype="10001", summary="s")
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body["fields"]["issuetype"] == {"id": "10001"}
+
+    def test_text_description_wrapped_to_adf(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(201, json={"id": "1", "key": "ENG-1"})
+
+        client = _make_client(handler, fake_creds)
+        client.create_issue(
+            project_key="ENG", issuetype="Task", summary="s", description="hi"
+        )
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body["fields"]["description"] == {
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "hi"}],
+                }
+            ],
+        }
+
+    def test_adf_description_passes_through(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(201, json={"id": "1", "key": "ENG-1"})
+
+        adf = {"type": "doc", "version": 1, "content": []}
+        client = _make_client(handler, fake_creds)
+        client.create_issue(
+            project_key="ENG", issuetype="Task", summary="s", description=adf
+        )
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body["fields"]["description"] == adf
+
+    def test_explicit_parent_emits_parent_key(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(201, json={"id": "1", "key": "ENG-1"})
+
+        client = _make_client(handler, fake_creds)
+        client.create_issue(
+            project_key="ENG", issuetype="Task", summary="s", parent="ENG-99"
+        )
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body["fields"]["parent"] == {"key": "ENG-99"}
+
+    def test_epic_link_with_parent_field(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(201, json={"id": "1", "key": "ENG-1"})
+
+        client = _make_client(handler, fake_creds)
+        client.create_issue(
+            project_key="ENG",
+            issuetype="Task",
+            summary="s",
+            epic_link="ENG-9999",
+            epic_link_field="parent",
+        )
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body["fields"]["parent"] == {"key": "ENG-9999"}
+        assert "customfield_10014" not in body["fields"]
+
+    def test_epic_link_with_customfield(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(201, json={"id": "1", "key": "ENG-1"})
+
+        client = _make_client(handler, fake_creds)
+        client.create_issue(
+            project_key="ENG",
+            issuetype="Task",
+            summary="s",
+            epic_link="ENG-9999",
+            epic_link_field="customfield_10014",
+        )
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body["fields"]["customfield_10014"] == "ENG-9999"
+        assert "parent" not in body["fields"]
+
+    def test_unknown_epic_link_field_rejected(self, fake_creds: JiraCredentials):
+        client = _make_client(lambda r: httpx.Response(200, json={}), fake_creds)
+        with pytest.raises(ValueError, match="epic_link_field"):
+            client.create_issue(
+                project_key="ENG",
+                issuetype="Task",
+                summary="s",
+                epic_link="ENG-1",
+                epic_link_field="bogus",
+            )
+
+    def test_idempotency_cache_hit(self, fake_creds: JiraCredentials):
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(201, json={"id": "1", "key": "ENG-1"})
+
+        client = _make_client(handler, fake_creds)
+        a = client.create_issue(
+            project_key="ENG",
+            issuetype="Task",
+            summary="s",
+            idempotency_key="key-1",
+        )
+        b = client.create_issue(
+            project_key="ENG",
+            issuetype="Task",
+            summary="s",
+            idempotency_key="key-1",
+        )
+        assert calls["n"] == 1, "second call must hit cache, not Atlassian"
+        assert a == b
+
+    def test_idempotency_distinct_projects_distinct_entries(self, fake_creds):
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(201, json={"id": "1", "key": "ENG-1"})
+
+        client = _make_client(handler, fake_creds)
+        client.create_issue(
+            project_key="ENG", issuetype="Task", summary="s", idempotency_key="k"
+        )
+        client.create_issue(
+            project_key="DEVOPS", issuetype="Task", summary="s", idempotency_key="k"
+        )
+        assert calls["n"] == 2
+
+    def test_5xx_raises_upstream_error(self, fake_creds: JiraCredentials):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="boom")
+
+        client = _make_client(handler, fake_creds)
+        with pytest.raises(JiraUpstreamError) as exc_info:
+            client.create_issue(project_key="ENG", issuetype="Task", summary="s")
+        assert exc_info.value.status_code == 500
+
+
+class TestEditIssue:
+    def test_replace_mode_emits_fields_labels(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(204)
+
+        client = _make_client(handler, fake_creds)
+        client.edit_issue(key="ENG-1", labels=["a", "b"], notify_users=True)
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body == {"fields": {"labels": ["a", "b"]}}
+
+    def test_incremental_mode_emits_update_block(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(204)
+
+        client = _make_client(handler, fake_creds)
+        client.edit_issue(
+            key="ENG-1",
+            add_labels=["x", "y"],
+            remove_labels=["old"],
+            notify_users=True,
+        )
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body == {
+            "update": {
+                "labels": [
+                    {"add": "x"},
+                    {"add": "y"},
+                    {"remove": "old"},
+                ]
+            }
+        }
+
+    def test_replace_plus_incremental_raises(self, fake_creds: JiraCredentials):
+        client = _make_client(lambda r: httpx.Response(204), fake_creds)
+        with pytest.raises(ValueError, match="not both"):
+            client.edit_issue(key="ENG-1", labels=["a"], add_labels=["b"])
+
+    def test_notify_users_false_appends_query(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(204)
+
+        client = _make_client(handler, fake_creds)
+        client.edit_issue(key="ENG-1", summary="updated")
+        # default notify_users=False
+        assert captured[0].url.params["notifyUsers"] == "false"
+
+    def test_notify_users_true_omits_query(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(204)
+
+        client = _make_client(handler, fake_creds)
+        client.edit_issue(key="ENG-1", summary="updated", notify_users=True)
+        assert "notifyUsers" not in captured[0].url.params
+
+    def test_summary_and_description_in_fields(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(204)
+
+        client = _make_client(handler, fake_creds)
+        client.edit_issue(key="ENG-1", summary="new", description="body")
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body["fields"]["summary"] == "new"
+        assert body["fields"]["description"]["type"] == "doc"
+
+
+class TestAddComment:
+    def test_text_body_wrapped(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(201, json={"id": "c1"})
+
+        client = _make_client(handler, fake_creds)
+        client.add_comment(key="ENG-1", body="hi")
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body["body"]["type"] == "doc"
+        assert body["body"]["content"][0]["content"][0]["text"] == "hi"
+        assert str(captured[0].url).endswith("/rest/api/3/issue/ENG-1/comment")
+
+    def test_adf_body_passthrough(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(201, json={"id": "c1"})
+
+        adf = {"type": "doc", "version": 1, "content": []}
+        client = _make_client(handler, fake_creds)
+        client.add_comment(key="ENG-1", body=adf)
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body["body"] == adf
+
+    def test_idempotency_cache_hit(self, fake_creds: JiraCredentials):
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(201, json={"id": "c1"})
+
+        client = _make_client(handler, fake_creds)
+        client.add_comment(key="ENG-1", body="hi", idempotency_key="k")
+        client.add_comment(key="ENG-1", body="hi", idempotency_key="k")
+        assert calls["n"] == 1
+
+
+class TestCreateIssueLink:
+    def test_basic_body(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(201)
+
+        client = _make_client(handler, fake_creds)
+        client.create_issue_link(
+            link_type="Blocks", inward_key="ENG-1", outward_key="ENG-2"
+        )
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body == {
+            "type": {"name": "Blocks"},
+            "inwardIssue": {"key": "ENG-1"},
+            "outwardIssue": {"key": "ENG-2"},
+        }
+        assert str(captured[0].url).endswith("/rest/api/3/issueLink")
+
+    def test_comment_wrapped_to_adf(self, fake_creds: JiraCredentials):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(201)
+
+        client = _make_client(handler, fake_creds)
+        client.create_issue_link(
+            link_type="Blocks",
+            inward_key="ENG-1",
+            outward_key="ENG-2",
+            comment="reason",
+        )
+        import json as _json
+
+        body = _json.loads(captured[0].content)
+        assert body["comment"]["body"]["type"] == "doc"
+
+    def test_empty_response_returns_empty_dict(self, fake_creds: JiraCredentials):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(201)  # empty body — Atlassian's actual shape
+
+        client = _make_client(handler, fake_creds)
+        result = client.create_issue_link(
+            link_type="Blocks", inward_key="ENG-1", outward_key="ENG-2"
+        )
+        assert result == {}
+
+    def test_idempotency_cached_per_triple(self, fake_creds: JiraCredentials):
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(201)
+
+        client = _make_client(handler, fake_creds)
+        client.create_issue_link(
+            link_type="Blocks",
+            inward_key="ENG-1",
+            outward_key="ENG-2",
+            idempotency_key="k",
+        )
+        client.create_issue_link(
+            link_type="Blocks",
+            inward_key="ENG-1",
+            outward_key="ENG-2",
+            idempotency_key="k",
+        )
+        assert calls["n"] == 1, "same triple + key → cache hit"
+
+    def test_idempotency_distinct_triples_no_alias(self, fake_creds: JiraCredentials):
+        """Same opaque key against two different ``(inward, outward, type)`` triples
+        produces two distinct cache entries (decision-28 alias safety)."""
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(201)
+
+        client = _make_client(handler, fake_creds)
+        client.create_issue_link(
+            link_type="Blocks",
+            inward_key="ENG-1",
+            outward_key="ENG-2",
+            idempotency_key="shared",
+        )
+        client.create_issue_link(
+            link_type="Blocks",
+            inward_key="ENG-3",
+            outward_key="ENG-4",
+            idempotency_key="shared",
+        )
+        client.create_issue_link(
+            link_type="Relates",
+            inward_key="ENG-1",
+            outward_key="ENG-2",
+            idempotency_key="shared",
+        )
+        assert calls["n"] == 3

--- a/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_idempotency.py
+++ b/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_idempotency.py
@@ -1,0 +1,170 @@
+"""
+Tests for ``gateway/jira_idempotency.py``.
+
+Covers TASK-5-1 acceptance criteria:
+
+- Cache hit: same ``(verb, project, key)`` triple returns cached response,
+  ``fn`` invoked exactly once.
+- TTL expiry: an entry past ``IDEMPOTENCY_TTL_SECONDS`` is dropped on
+  lookup and ``fn`` runs again.  We inject ``time.monotonic`` so the
+  test does not actually sleep.
+- Distinct keys: same verb + project, different ``key`` → distinct cache
+  entries.
+- Distinct verbs sharing keys: same opaque ``key`` against different
+  verbs → distinct entries.
+- ``key=None`` bypasses cache entirely.
+- ``canonical_link_id`` produces stable, unique strings per triple.
+- Thread-safety: concurrent calls for different keys do not deadlock and
+  produce the expected number of upstream invocations.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import jira_idempotency
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    jira_idempotency.clear_cache()
+    yield
+    jira_idempotency.clear_cache()
+
+
+def _ok(payload: dict[str, Any], status: int = 200):
+    """Build a zero-arg callable that returns ``(status, payload)`` and counts hits."""
+    state = {"calls": 0}
+
+    def fn():
+        state["calls"] += 1
+        return status, payload
+
+    return fn, state
+
+
+class TestGetOrRun:
+    def test_cache_hit_returns_cached_value(self):
+        fn, state = _ok({"id": "1"})
+        first = jira_idempotency.get_or_run("create", "ENG", "k1", fn)
+        second = jira_idempotency.get_or_run("create", "ENG", "k1", fn)
+        assert first == (200, {"id": "1"})
+        assert second == (200, {"id": "1"})
+        assert state["calls"] == 1, "fn must run exactly once on cache hit"
+
+    def test_distinct_keys_distinct_entries(self):
+        fn, state = _ok({"id": "x"})
+        jira_idempotency.get_or_run("create", "ENG", "k1", fn)
+        jira_idempotency.get_or_run("create", "ENG", "k2", fn)
+        assert state["calls"] == 2
+
+    def test_distinct_verbs_share_key_independent(self):
+        fn, state = _ok({"id": "x"})
+        jira_idempotency.get_or_run("create", "ENG", "shared", fn)
+        jira_idempotency.get_or_run("comment", "ENG", "shared", fn)
+        jira_idempotency.get_or_run("link", "ENG", "shared", fn)
+        assert state["calls"] == 3
+
+    def test_distinct_projects_share_key_independent(self):
+        fn, state = _ok({"id": "x"})
+        jira_idempotency.get_or_run("create", "ENG", "shared", fn)
+        jira_idempotency.get_or_run("create", "DEVOPS", "shared", fn)
+        assert state["calls"] == 2
+
+    def test_none_key_bypasses_cache(self):
+        fn, state = _ok({"id": "x"})
+        jira_idempotency.get_or_run("create", "ENG", None, fn)
+        jira_idempotency.get_or_run("create", "ENG", None, fn)
+        assert state["calls"] == 2, "key=None must always re-run the upstream"
+
+    def test_ttl_expiry_runs_again(self, monkeypatch: pytest.MonkeyPatch):
+        """An entry past TTL is dropped on lookup; ``fn`` runs again."""
+        clock = {"now": 1000.0}
+
+        def fake_now():
+            return clock["now"]
+
+        monkeypatch.setattr(jira_idempotency, "_now", fake_now)
+
+        fn, state = _ok({"id": "x"})
+        jira_idempotency.get_or_run("create", "ENG", "k1", fn)
+        # Advance just shy of TTL — still cached.
+        clock["now"] += jira_idempotency.IDEMPOTENCY_TTL_SECONDS - 1
+        jira_idempotency.get_or_run("create", "ENG", "k1", fn)
+        assert state["calls"] == 1
+        # Cross the TTL boundary.
+        clock["now"] += 2
+        jira_idempotency.get_or_run("create", "ENG", "k1", fn)
+        assert state["calls"] == 2
+
+    def test_failure_not_cached(self):
+        """Exceptions from ``fn`` must not poison the cache — the next retry runs again."""
+        attempts = {"n": 0}
+
+        class Boom(RuntimeError):
+            pass
+
+        def fn():
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise Boom("upstream failure")
+            return 200, {"id": "ok"}
+
+        with pytest.raises(Boom):
+            jira_idempotency.get_or_run("create", "ENG", "k1", fn)
+        result = jira_idempotency.get_or_run("create", "ENG", "k1", fn)
+        assert result == (200, {"id": "ok"})
+        assert attempts["n"] == 2
+
+    def test_status_code_round_trips(self):
+        """The cached entry includes the upstream status code so the route layer
+        can replay it verbatim."""
+        fn, _ = _ok({"id": "x"}, status=201)
+        first = jira_idempotency.get_or_run("create", "ENG", "k1", fn)
+        second = jira_idempotency.get_or_run("create", "ENG", "k1", fn)
+        assert first == (201, {"id": "x"})
+        assert second == (201, {"id": "x"})
+
+
+class TestCanonicalLinkId:
+    def test_stable_format(self):
+        assert (
+            jira_idempotency.canonical_link_id("ENG-1", "ENG-2", "Blocks")
+            == "ENG-1|ENG-2|Blocks"
+        )
+
+    def test_distinct_triples_distinct_ids(self):
+        a = jira_idempotency.canonical_link_id("ENG-1", "ENG-2", "Blocks")
+        b = jira_idempotency.canonical_link_id("ENG-2", "ENG-1", "Blocks")
+        c = jira_idempotency.canonical_link_id("ENG-1", "ENG-2", "Relates")
+        assert len({a, b, c}) == 3, "every distinct triple yields a distinct id"
+
+    def test_link_aliasing_safety(self):
+        """Two callers re-using the same opaque idempotency key against different
+        ``(inward, outward, type)`` triples must NOT alias to the same entry."""
+        fn, state = _ok({"id": "x"})
+        ns_a = jira_idempotency.canonical_link_id("ENG-1", "ENG-2", "Blocks")
+        ns_b = jira_idempotency.canonical_link_id("ENG-3", "ENG-4", "Blocks")
+        jira_idempotency.get_or_run("link", ns_a, "shared-key", fn)
+        jira_idempotency.get_or_run("link", ns_b, "shared-key", fn)
+        assert state["calls"] == 2
+
+
+class TestThreadSafety:
+    def test_distinct_keys_no_deadlock(self):
+        """Spinning 16 threads against distinct keys produces 16 upstream calls
+        and does not deadlock."""
+        fn, state = _ok({"id": "x"})
+
+        def hit(i: int):
+            jira_idempotency.get_or_run("create", "ENG", f"k{i}", fn)
+
+        threads = [threading.Thread(target=hit, args=(i,)) for i in range(16)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+            assert not t.is_alive(), "thread did not finish — deadlock?"
+        assert state["calls"] == 16

--- a/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_idempotency.py
+++ b/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_idempotency.py
@@ -131,8 +131,7 @@ class TestGetOrRun:
 class TestCanonicalLinkId:
     def test_stable_format(self):
         assert (
-            jira_idempotency.canonical_link_id("ENG-1", "ENG-2", "Blocks")
-            == "ENG-1|ENG-2|Blocks"
+            jira_idempotency.canonical_link_id("ENG-1", "ENG-2", "Blocks") == "ENG-1|ENG-2|Blocks"
         )
 
     def test_distinct_triples_distinct_ids(self):

--- a/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_policy.py.append_to_origin
+++ b/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_policy.py.append_to_origin
@@ -1,0 +1,319 @@
+"""
+Tests for gateway/jira_policy.py.
+
+Covers:
+- allowlist round-trip from a tmp ``context-filters.yaml`` using the
+  authoritative ``jira.projects`` key
+- mtime-based reload
+- ``reload_jira_policy()`` forces a re-read
+- fail-closed on missing file, missing ``jira:`` section, malformed YAML,
+  wrong top-level shape, non-list ``projects`` value
+- invalid project keys skipped (non-string, bad shape)
+- ``extract_project_key`` on good / bad / non-string input
+- module-level singleton + ``reset`` helper
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+# Modules loaded via conftest.py.
+import jira_policy
+import pytest
+from jira_policy import (
+    JiraPolicy,
+    extract_project_key,
+    reload_jira_policy,
+    reset_jira_policy,
+)
+from jira_policy import (
+    allowed_projects as allowed_projects_singleton,
+)
+from jira_policy import (
+    is_project_allowed as is_allowed_singleton,
+)
+
+
+@pytest.fixture
+def tmp_yaml(tmp_path: Path) -> Path:
+    return tmp_path / "context-filters.yaml"
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.write_text(content)
+
+
+class TestAllowlistRoundTrip:
+    def test_loads_projects_list(self, tmp_yaml: Path):
+        _write_yaml(
+            tmp_yaml,
+            "jira:\n  projects: [ENG, DEVOPS]\n",
+        )
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_projects() == frozenset({"ENG", "DEVOPS"})
+
+    def test_empty_projects_list_is_empty_set(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "jira:\n  projects: []\n")
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_projects() == frozenset()
+
+    def test_is_project_allowed(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "jira:\n  projects: [ENG]\n")
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.is_project_allowed("ENG") is True
+        assert policy.is_project_allowed("SEC") is False
+        assert policy.is_project_allowed("") is False
+
+    def test_invalid_project_keys_skipped(self, tmp_yaml: Path):
+        _write_yaml(
+            tmp_yaml,
+            "jira:\n  projects: [ENG, lowercase_bad, 'with space', '1starts_with_digit']\n",
+        )
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_projects() == frozenset({"ENG"})
+
+    def test_non_string_entry_skipped(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "jira:\n  projects: [ENG, 42]\n")
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_projects() == frozenset({"ENG"})
+
+
+class TestFailClosed:
+    def test_missing_file(self, tmp_path: Path):
+        policy = JiraPolicy(tmp_path / "does-not-exist.yaml")
+        assert policy.allowed_projects() == frozenset()
+
+    def test_missing_jira_section(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "other: stuff\n")
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_projects() == frozenset()
+
+    def test_jira_section_not_a_mapping(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "jira: not-a-mapping\n")
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_projects() == frozenset()
+
+    def test_projects_missing(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "jira: {}\n")
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_projects() == frozenset()
+
+    def test_projects_not_a_list(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "jira:\n  projects: ENG\n")
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_projects() == frozenset()
+
+    def test_malformed_yaml_does_not_crash(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "jira:\n  projects: [\n")
+        policy = JiraPolicy(tmp_yaml)
+        # Must return a frozenset (not raise).
+        result = policy.allowed_projects()
+        assert result == frozenset()
+
+    def test_top_level_not_mapping(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "- just\n- a\n- list\n")
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_projects() == frozenset()
+
+    def test_empty_file(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "")
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_projects() == frozenset()
+
+
+class TestCacheReload:
+    def test_mtime_change_triggers_reload(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "jira:\n  projects: [ENG]\n")
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_projects() == frozenset({"ENG"})
+
+        # Bump the mtime and rewrite.
+        new_mtime = tmp_yaml.stat().st_mtime + 2
+        _write_yaml(tmp_yaml, "jira:\n  projects: [SEC]\n")
+        os.utime(tmp_yaml, (new_mtime, new_mtime))
+
+        assert policy.allowed_projects() == frozenset({"SEC"})
+
+    def test_reload_clears_cache(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "jira:\n  projects: [ENG]\n")
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_projects() == frozenset({"ENG"})
+
+        # Rewrite WITHOUT changing mtime; cache holds old value.
+        original_mtime = tmp_yaml.stat().st_mtime
+        _write_yaml(tmp_yaml, "jira:\n  projects: [SEC]\n")
+        os.utime(tmp_yaml, (original_mtime, original_mtime))
+        time.sleep(0.001)
+        assert policy.allowed_projects() == frozenset({"ENG"})
+
+        policy.reload()
+        assert policy.allowed_projects() == frozenset({"SEC"})
+
+    def test_file_disappearing_clears_cache(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "jira:\n  projects: [ENG]\n")
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_projects() == frozenset({"ENG"})
+
+        tmp_yaml.unlink()
+        assert policy.allowed_projects() == frozenset()
+
+
+class TestExtractProjectKey:
+    @pytest.mark.parametrize(
+        "ticket, expected",
+        [
+            ("FOO-123", "FOO"),
+            ("ENG-1", "ENG"),
+            ("PROJ_X-42", "PROJ_X"),
+            ("A1B2-9", "A1B2"),
+            ("  ENG-1  ", "ENG"),  # surrounding whitespace tolerated
+        ],
+    )
+    def test_valid_tickets(self, ticket: str, expected: str):
+        assert extract_project_key(ticket) == expected
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "foo",
+            "foo-1",  # lowercase not allowed
+            "FOO",  # missing -<digits>
+            "FOO-",  # missing digits
+            "-123",  # missing project key
+            "FOO-abc",  # non-digit trailing
+        ],
+    )
+    def test_invalid_tickets_return_empty(self, bad: str):
+        assert extract_project_key(bad) == ""
+
+    def test_non_string_returns_empty(self):
+        assert extract_project_key(None) == ""  # type: ignore[arg-type]
+        assert extract_project_key(123) == ""  # type: ignore[arg-type]
+
+
+class TestModuleSingleton:
+    def test_reset_drops_singleton(self, tmp_yaml: Path, monkeypatch):
+        _write_yaml(tmp_yaml, "jira:\n  projects: [ENG]\n")
+        monkeypatch.setattr(jira_policy, "_DEFAULT_CONFIG_PATH", tmp_yaml)
+        reset_jira_policy()
+        first = jira_policy.get_jira_policy()
+        # Point the freshly-created instance at our tmp file.
+        first._config_path = tmp_yaml
+        assert is_allowed_singleton("ENG") is True
+        assert "ENG" in allowed_projects_singleton()
+
+        reset_jira_policy()
+        second = jira_policy.get_jira_policy()
+        assert first is not second
+
+    def test_reload_jira_policy_forces_reread(self, tmp_yaml: Path, monkeypatch):
+        _write_yaml(tmp_yaml, "jira:\n  projects: [ENG]\n")
+        monkeypatch.setattr(jira_policy, "_DEFAULT_CONFIG_PATH", tmp_yaml)
+        reset_jira_policy()
+        policy = jira_policy.get_jira_policy()
+        policy._config_path = tmp_yaml
+        assert allowed_projects_singleton() == frozenset({"ENG"})
+
+        # Rewrite WITHOUT bumping mtime.
+        original_mtime = tmp_yaml.stat().st_mtime
+        _write_yaml(tmp_yaml, "jira:\n  projects: [SEC]\n")
+        os.utime(tmp_yaml, (original_mtime, original_mtime))
+        time.sleep(0.001)
+        # Without reload we still see the old value.
+        assert allowed_projects_singleton() == frozenset({"ENG"})
+
+        reload_jira_policy()
+        assert allowed_projects_singleton() == frozenset({"SEC"})
+
+
+# -----------------------------------------------------------------------------
+# Issue #1924 — link types + epic_link_field
+# -----------------------------------------------------------------------------
+
+
+class TestLinkTypeAllowlist:
+    def test_default_when_absent(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "jira:\n  projects: [ENG]\n")
+        policy = JiraPolicy(tmp_yaml)
+        # Default = ("Blocks", "Relates")
+        assert policy.allowed_link_types() == ("Blocks", "Relates")
+
+    def test_operator_overrides(self, tmp_yaml: Path):
+        _write_yaml(
+            tmp_yaml,
+            "jira:\n  projects: [ENG]\n  link_types: [Blocks, Relates, 'is duplicated by']\n",
+        )
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_link_types() == (
+            "Blocks",
+            "Relates",
+            "is duplicated by",
+        )
+
+    def test_empty_list_means_no_links_allowed(self, tmp_yaml: Path):
+        """Operators can disable linking entirely with ``link_types: []``."""
+        _write_yaml(tmp_yaml, "jira:\n  projects: [ENG]\n  link_types: []\n")
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_link_types() == ()
+
+    def test_malformed_link_types_falls_back_to_default(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "jira:\n  projects: [ENG]\n  link_types: 42\n")
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_link_types() == ("Blocks", "Relates")
+
+    def test_non_string_entries_skipped(self, tmp_yaml: Path):
+        _write_yaml(
+            tmp_yaml,
+            "jira:\n  projects: [ENG]\n  link_types: [Blocks, 42, '']\n",
+        )
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_link_types() == ("Blocks",)
+
+    def test_oversize_entries_skipped(self, tmp_yaml: Path):
+        oversize = "x" * 100  # > 64 char cap
+        _write_yaml(
+            tmp_yaml,
+            f"jira:\n  projects: [ENG]\n  link_types: [Blocks, '{oversize}']\n",
+        )
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.allowed_link_types() == ("Blocks",)
+
+    def test_is_link_type_allowed_helper(self, tmp_yaml: Path, monkeypatch):
+        _write_yaml(tmp_yaml, "jira:\n  projects: [ENG]\n  link_types: [Blocks]\n")
+        monkeypatch.setattr(jira_policy, "_DEFAULT_CONFIG_PATH", tmp_yaml)
+        reset_jira_policy()
+        jira_policy.get_jira_policy()._config_path = tmp_yaml
+        assert jira_policy.is_link_type_allowed("Blocks") is True
+        assert jira_policy.is_link_type_allowed("Relates") is False
+        assert jira_policy.is_link_type_allowed("") is False
+        assert jira_policy.is_link_type_allowed(None) is False  # type: ignore[arg-type]
+
+
+class TestEpicLinkField:
+    def test_default_is_parent(self, tmp_yaml: Path):
+        _write_yaml(tmp_yaml, "jira:\n  projects: [ENG]\n")
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.epic_link_field() == "parent"
+
+    def test_explicit_customfield(self, tmp_yaml: Path):
+        _write_yaml(
+            tmp_yaml,
+            "jira:\n  projects: [ENG]\n  epic_link_field: customfield_10014\n",
+        )
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.epic_link_field() == "customfield_10014"
+
+    @pytest.mark.parametrize(
+        "value",
+        ["unknown", "", 42, "PARENT", "customfield_999"],
+    )
+    def test_malformed_falls_back_to_default(self, tmp_yaml: Path, value):
+        _write_yaml(
+            tmp_yaml,
+            f"jira:\n  projects: [ENG]\n  epic_link_field: {value!r}\n",
+        )
+        policy = JiraPolicy(tmp_yaml)
+        assert policy.epic_link_field() == "parent"

--- a/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_routes.py.append_to_origin
+++ b/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_routes.py.append_to_origin
@@ -1,0 +1,1080 @@
+"""
+Tests for the four ``/api/v1/jira/*`` routes in ``gateway/gateway.py``.
+
+Covers Phase 2 / Task 4-4 acceptance criteria:
+
+- Public mode → 403 on every route, with ``private_mode_required`` audit entry.
+- Private mode + disallowed project → 403 ``*_denied`` / ``*_rejected``.
+- Private mode + allowlisted project + mocked upstream → 200 with body.
+- 404 envelope end-to-end on ``ticket/get`` and ``ticket/comments``.
+- Adversarial JQL suite for ``/search``.
+- ``/execute`` rejection of write methods, denied verbs, path traversal,
+  disallowed projects.
+- Route-enumeration regression: every ``/api/v1/jira/*`` view has
+  ``__egg_requires_private_mode__ = True``.
+- Audit-log assertions include ``session.jira_ticket`` and
+  ``projects_extracted`` for search (and ``ticket`` is NOT emitted on search).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import jira_policy
+import pytest
+import session_manager
+from mode_gate import PRIVATE_MODE_MARKER_ATTR
+from session_manager import SessionValidationResult
+
+# Import the conftest-loaded modules.
+import gateway  # noqa: F401 — registers the app + views
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client():
+    gateway.app.config["TESTING"] = True
+    with gateway.app.test_client() as c:
+        yield c
+
+
+def _patch_session(mode: str):
+    """Return a context manager that patches session validation to yield a
+    session with the given ``mode`` and a representative jira_ticket."""
+    import auth
+
+    mock_session = MagicMock()
+    mock_session.mode = mode
+    mock_session.container_id = "test-container"
+    mock_session.expires_at = None
+    mock_session.pipeline_id = "issue-1556"
+    mock_session.agent_role = "coder"
+    mock_session.jira_ticket = "ENG-123"
+
+    mock_result = SessionValidationResult(valid=True, session=mock_session)
+
+    auth._session_manager = None
+    auth._rate_limiter = None
+    if "gateway.auth" in sys.modules:
+        sys.modules["gateway.auth"]._session_manager = None
+        sys.modules["gateway.auth"]._rate_limiter = None
+
+    current_sm = sys.modules.get("session_manager", session_manager)
+    return patch.object(
+        current_sm,
+        "validate_session_for_request",
+        return_value=mock_result,
+    )
+
+
+@pytest.fixture
+def private_headers():
+    with _patch_session("private"):
+        yield {"Authorization": "Bearer test-private-token"}
+
+
+@pytest.fixture
+def public_headers():
+    with _patch_session("public"):
+        yield {"Authorization": "Bearer test-public-token"}
+
+
+@pytest.fixture
+def allow_eng(monkeypatch):
+    """Force the policy singleton to say ENG is allowlisted."""
+    monkeypatch.setattr(
+        jira_policy,
+        "is_project_allowed",
+        lambda p: p == "ENG",
+    )
+    # Also patch the import in gateway so the route's lookup uses our mock.
+    monkeypatch.setattr(
+        gateway,
+        "is_project_allowed",
+        lambda p: p == "ENG",
+    )
+    monkeypatch.setattr(jira_policy, "allowed_projects", lambda: frozenset({"ENG"}))
+    # `gateway.py` imports `allowed_projects` lazily via `from .jira_policy
+    # import allowed_projects`, so the direct module attribute on jira_policy
+    # (singleton fallback) covers the route's call.
+
+
+@pytest.fixture
+def captured_audit(monkeypatch):
+    """Capture every ``audit_log`` call made by gateway routes."""
+    captured: list[dict[str, Any]] = []
+
+    def _capture(event_type, operation, *, success, details=None):
+        captured.append(
+            {
+                "event_type": event_type,
+                "operation": operation,
+                "success": success,
+                "details": dict(details) if details else {},
+            }
+        )
+
+    monkeypatch.setattr(gateway, "audit_log", _capture)
+    return captured
+
+
+# -----------------------------------------------------------------------------
+# Route enumeration regression (risk R4)
+# -----------------------------------------------------------------------------
+
+
+class TestRouteEnumeration:
+    def test_every_jira_route_has_private_mode_marker(self, client):
+        """Walk ``app.url_map`` for every ``/api/v1/jira/*`` rule and assert
+        each view function carries the private-mode marker.  This catches a
+        future contributor adding a new Jira route without the decorator."""
+        found = 0
+        for rule in gateway.app.url_map.iter_rules():
+            if not rule.rule.startswith("/api/v1/jira/"):
+                continue
+            view = gateway.app.view_functions[rule.endpoint]
+            assert getattr(view, PRIVATE_MODE_MARKER_ATTR, False) is True, (
+                f"Jira route {rule.rule!r} (view={view.__name__}) is missing "
+                f"the @require_private_mode decorator."
+            )
+            found += 1
+        assert found >= 4, f"Expected at least 4 Jira routes; found {found}"
+
+
+# -----------------------------------------------------------------------------
+# /api/v1/jira/ticket/get
+# -----------------------------------------------------------------------------
+
+
+class TestTicketGet:
+    def test_public_mode_returns_403_and_audits(self, client, public_headers, captured_audit):
+        resp = client.post(
+            "/api/v1/jira/ticket/get",
+            headers=public_headers,
+            data=json.dumps({"ticket": "ENG-1"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+        body = json.loads(resp.data)
+        assert "private network mode" in body["message"].lower()
+        # Audit entry from require_private_mode.
+        assert any(a["event_type"] == "private_mode_required" for a in captured_audit)
+
+    def test_invalid_ticket_shape_rejected(self, client, private_headers, captured_audit):
+        resp = client.post(
+            "/api/v1/jira/ticket/get",
+            headers=private_headers,
+            data=json.dumps({"ticket": "lowercase-1"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert any(
+            a["event_type"] == "jira_ticket_get_rejected"
+            and "invalid ticket" in a["details"].get("reason", "").lower()
+            for a in captured_audit
+        )
+
+    def test_disallowed_project_returns_403(
+        self, client, private_headers, captured_audit, monkeypatch
+    ):
+        monkeypatch.setattr(gateway, "is_project_allowed", lambda p: False)
+        resp = client.post(
+            "/api/v1/jira/ticket/get",
+            headers=private_headers,
+            data=json.dumps({"ticket": "SEC-1"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+        body = json.loads(resp.data)
+        # `make_error` stuffs `details` into the `data` field of the response.
+        assert body.get("data", {}).get("project") == "SEC"
+        # Audit entry from _project_not_allowlisted_response.
+        denied = [a for a in captured_audit if a["event_type"] == "jira_ticket_get_denied"]
+        assert denied
+        assert denied[0]["details"]["reason"] == "project not allowlisted"
+
+    def test_happy_path(self, client, private_headers, allow_eng, captured_audit):
+        fake_client = MagicMock()
+        fake_client.get_ticket.return_value = {"key": "ENG-1", "fields": {}}
+        with patch.object(gateway, "get_jira_client", return_value=fake_client):
+            resp = client.post(
+                "/api/v1/jira/ticket/get",
+                headers=private_headers,
+                data=json.dumps({"ticket": "ENG-1"}),
+                content_type="application/json",
+            )
+        assert resp.status_code == 200
+        body = json.loads(resp.data)
+        assert body["data"]["key"] == "ENG-1"
+        fake_client.get_ticket.assert_called_once_with("ENG-1", None)
+
+        success = [a for a in captured_audit if a["event_type"] == "jira_ticket_get"]
+        assert success
+        details = success[0]["details"]
+        assert details["ticket"] == "ENG-1"
+        assert details["project"] == "ENG"
+        assert details["pipeline_id"] == "issue-1556"
+        assert details["agent_role"] == "coder"
+        assert details["jira_ticket"] == "ENG-123"  # session.jira_ticket
+        assert details["not_found"] is False
+
+    def test_not_found_envelope_passes_through_as_200(
+        self, client, private_headers, allow_eng, captured_audit
+    ):
+        fake_client = MagicMock()
+        fake_client.get_ticket.return_value = {
+            "status": "not_found",
+            "key": "ENG-999",
+            "upstream_status": 404,
+        }
+        with patch.object(gateway, "get_jira_client", return_value=fake_client):
+            resp = client.post(
+                "/api/v1/jira/ticket/get",
+                headers=private_headers,
+                data=json.dumps({"ticket": "ENG-999"}),
+                content_type="application/json",
+            )
+        assert resp.status_code == 200
+        body = json.loads(resp.data)
+        assert body["data"] == {
+            "status": "not_found",
+            "key": "ENG-999",
+            "upstream_status": 404,
+        }
+        success = [a for a in captured_audit if a["event_type"] == "jira_ticket_get"]
+        assert success[0]["details"]["not_found"] is True
+
+    def test_invalid_fields_rejected(self, client, private_headers, allow_eng, captured_audit):
+        resp = client.post(
+            "/api/v1/jira/ticket/get",
+            headers=private_headers,
+            data=json.dumps({"ticket": "ENG-1", "fields": ["bad field"]}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert any(a["event_type"] == "jira_ticket_get_rejected" for a in captured_audit)
+
+
+# -----------------------------------------------------------------------------
+# /api/v1/jira/search
+# -----------------------------------------------------------------------------
+
+
+class TestSearch:
+    def test_public_mode_403(self, client, public_headers):
+        resp = client.post(
+            "/api/v1/jira/search",
+            headers=public_headers,
+            data=json.dumps({"jql": "project = ENG"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+
+    def test_missing_jql_400(self, client, private_headers, captured_audit):
+        resp = client.post(
+            "/api/v1/jira/search",
+            headers=private_headers,
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert any(a["event_type"] == "jira_search_rejected" for a in captured_audit)
+
+    @pytest.mark.parametrize(
+        "jql",
+        [
+            "project = ENG OR project = SEC",
+            'project = "ENG"',
+            "PROJECT = ENG",
+            "project = projectsLeadByUser()",
+            "project = ENG /* hack */",
+            "project IN (ENG, SEC)",  # SEC not allowlisted
+            "status = Open",
+            "project = ENG ; drop",
+            'key = "ENG-1"',
+            "project = ЕNG",  # Cyrillic
+        ],
+    )
+    def test_adversarial_jql_rejected(
+        self, client, private_headers, allow_eng, captured_audit, jql: str
+    ):
+        resp = client.post(
+            "/api/v1/jira/search",
+            headers=private_headers,
+            data=json.dumps({"jql": jql}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403, f"expected 403 for {jql!r}"
+        body = json.loads(resp.data)
+        assert "rejected" in body["message"].lower()
+        rejected = [a for a in captured_audit if a["event_type"] == "jira_search_rejected"]
+        assert rejected, f"expected audit entry for {jql!r}"
+        # ``ticket`` must NEVER appear on search audits (Task 2-2 acceptance).
+        assert "ticket" not in rejected[-1]["details"]
+
+    def test_happy_path_clamps_max_results(
+        self, client, private_headers, allow_eng, captured_audit
+    ):
+        fake_client = MagicMock()
+        fake_client.search.return_value = {"issues": [], "nextPageToken": None}
+        with patch.object(gateway, "get_jira_client", return_value=fake_client):
+            resp = client.post(
+                "/api/v1/jira/search",
+                headers=private_headers,
+                data=json.dumps(
+                    {
+                        "jql": "project = ENG AND status = Open",
+                        "maxResults": 99999,
+                        "nextPageToken": "TOK-abc",
+                    }
+                ),
+                content_type="application/json",
+            )
+        assert resp.status_code == 200
+        kwargs = fake_client.search.call_args.kwargs
+        assert kwargs["max_results"] == 100  # clamped
+        assert kwargs["next_page_token"] == "TOK-abc"
+
+        success = [a for a in captured_audit if a["event_type"] == "jira_search"]
+        assert success
+        details = success[0]["details"]
+        assert details["projects_extracted"] == ["ENG"]
+        # Search audits must NOT emit ``ticket``.
+        assert "ticket" not in details
+
+    def test_invalid_max_results_400(self, client, private_headers, allow_eng, captured_audit):
+        resp = client.post(
+            "/api/v1/jira/search",
+            headers=private_headers,
+            data=json.dumps({"jql": "project = ENG", "maxResults": "bad"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert any(a["event_type"] == "jira_search_rejected" for a in captured_audit)
+
+
+# -----------------------------------------------------------------------------
+# /api/v1/jira/ticket/comments
+# -----------------------------------------------------------------------------
+
+
+class TestTicketComments:
+    def test_public_mode_403(self, client, public_headers):
+        resp = client.post(
+            "/api/v1/jira/ticket/comments",
+            headers=public_headers,
+            data=json.dumps({"ticket": "ENG-1"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+
+    def test_disallowed_project_403(self, client, private_headers, captured_audit, monkeypatch):
+        monkeypatch.setattr(gateway, "is_project_allowed", lambda p: False)
+        resp = client.post(
+            "/api/v1/jira/ticket/comments",
+            headers=private_headers,
+            data=json.dumps({"ticket": "SEC-1"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+        denied = [a for a in captured_audit if a["event_type"] == "jira_ticket_comments_denied"]
+        assert denied
+
+    def test_happy_path(self, client, private_headers, allow_eng, captured_audit):
+        fake_client = MagicMock()
+        fake_client.get_comments.return_value = {"comments": [{"id": "1", "body": "hi"}]}
+        with patch.object(gateway, "get_jira_client", return_value=fake_client):
+            resp = client.post(
+                "/api/v1/jira/ticket/comments",
+                headers=private_headers,
+                data=json.dumps({"ticket": "ENG-1"}),
+                content_type="application/json",
+            )
+        assert resp.status_code == 200
+        fake_client.get_comments.assert_called_once_with("ENG-1")
+
+    def test_not_found_envelope(self, client, private_headers, allow_eng, captured_audit):
+        fake_client = MagicMock()
+        fake_client.get_comments.return_value = {
+            "status": "not_found",
+            "key": "ENG-9",
+            "upstream_status": 404,
+        }
+        with patch.object(gateway, "get_jira_client", return_value=fake_client):
+            resp = client.post(
+                "/api/v1/jira/ticket/comments",
+                headers=private_headers,
+                data=json.dumps({"ticket": "ENG-9"}),
+                content_type="application/json",
+            )
+        assert resp.status_code == 200
+        body = json.loads(resp.data)
+        assert body["data"]["status"] == "not_found"
+
+
+# -----------------------------------------------------------------------------
+# /api/v1/jira/execute
+# -----------------------------------------------------------------------------
+
+
+class TestExecute:
+    def test_public_mode_403(self, client, public_headers):
+        resp = client.post(
+            "/api/v1/jira/execute",
+            headers=public_headers,
+            data=json.dumps({"method": "GET", "path": "issue/ENG-1"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+    def test_non_get_methods_rejected(
+        self, client, private_headers, allow_eng, captured_audit, method: str
+    ):
+        resp = client.post(
+            "/api/v1/jira/execute",
+            headers=private_headers,
+            data=json.dumps({"method": method, "path": "issue/ENG-1"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+        denied = [a for a in captured_audit if a["event_type"] == "jira_execute_denied"]
+        assert denied
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "issue/ENG-1/transitions",
+            "issue/ENG-1/worklog",
+            "issue/ENG-1/attachments",
+            "issue/ENG-1/watchers",
+        ],
+    )
+    def test_denied_verb_in_path_rejected(
+        self, client, private_headers, allow_eng, captured_audit, path: str
+    ):
+        resp = client.post(
+            "/api/v1/jira/execute",
+            headers=private_headers,
+            data=json.dumps({"method": "GET", "path": path}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+
+    def test_path_traversal_rejected(self, client, private_headers, allow_eng, captured_audit):
+        resp = client.post(
+            "/api/v1/jira/execute",
+            headers=private_headers,
+            data=json.dumps({"method": "GET", "path": "issue/../FOO-1"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+
+    def test_disallowed_project_rejected(
+        self, client, private_headers, captured_audit, monkeypatch
+    ):
+        monkeypatch.setattr(gateway, "is_project_allowed", lambda p: False)
+        resp = client.post(
+            "/api/v1/jira/execute",
+            headers=private_headers,
+            data=json.dumps({"method": "GET", "path": "issue/SEC-1"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+        denied = [a for a in captured_audit if a["event_type"] == "jira_execute_denied"]
+        assert denied
+        assert denied[-1]["details"]["reason"] == "project not allowlisted"
+
+    def test_happy_path_get(self, client, private_headers, allow_eng, captured_audit):
+        fake_client = MagicMock()
+        fake_client.execute_raw.return_value = {"key": "ENG"}
+        with patch.object(gateway, "get_jira_client", return_value=fake_client):
+            resp = client.post(
+                "/api/v1/jira/execute",
+                headers=private_headers,
+                data=json.dumps(
+                    {
+                        "method": "GET",
+                        "path": "project/ENG",
+                    }
+                ),
+                content_type="application/json",
+            )
+        assert resp.status_code == 200
+        body = json.loads(resp.data)
+        assert body["data"]["key"] == "ENG"
+        # Audit entry for successful execute.
+        success = [a for a in captured_audit if a["event_type"] == "jira_execute"]
+        assert success
+        assert success[0]["details"]["method"] == "GET"
+        assert success[0]["details"]["path"] == "project/ENG"
+        assert success[0]["details"]["project"] == "ENG"
+
+    def test_missing_path_400(self, client, private_headers, captured_audit):
+        resp = client.post(
+            "/api/v1/jira/execute",
+            headers=private_headers,
+            data=json.dumps({"method": "GET"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+
+# -----------------------------------------------------------------------------
+# Issue #1924 — write-verb routes
+# -----------------------------------------------------------------------------
+#
+# Each new route gets the standard 403 grid (public mode → 403, missing
+# creds → 503, non-allowlisted project → 403, malformed body → 400, success
+# path → 2xx with audit assertion) plus the verb-specific adversarial cases
+# called out in the plan: oversized summary, unknown issuetype, custom-field
+# smuggling, cross-project parent reject, etc.
+
+import jira_client as jira_client_module  # noqa: E402
+import jira_idempotency  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_idempotency_cache():
+    jira_idempotency.clear_cache()
+    yield
+    jira_idempotency.clear_cache()
+
+
+@pytest.fixture
+def allow_eng_and_ops(monkeypatch):
+    """Both ENG and DEVOPS are allowlisted — used by cross-project tests."""
+    allow = {"ENG", "DEVOPS"}
+    monkeypatch.setattr(
+        jira_policy, "is_project_allowed", lambda p: p in allow
+    )
+    monkeypatch.setattr(gateway, "is_project_allowed", lambda p: p in allow)
+    monkeypatch.setattr(
+        jira_policy, "allowed_projects", lambda: frozenset(allow)
+    )
+
+
+@pytest.fixture
+def allow_blocks_and_relates(monkeypatch):
+    """Default ``("Blocks", "Relates")`` — assert against this in link tests."""
+    monkeypatch.setattr(
+        gateway,
+        "jira_allowed_link_types",
+        lambda: ("Blocks", "Relates"),
+    )
+
+
+class TestTicketCreate:
+    def test_public_mode_returns_403(self, client, public_headers, captured_audit):
+        resp = client.post(
+            "/api/v1/jira/ticket/create",
+            headers=public_headers,
+            data=json.dumps({"projectKey": "ENG", "issuetype": "Task", "summary": "s"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+        assert any(a["event_type"] == "private_mode_required" for a in captured_audit)
+
+    def test_missing_creds_returns_503(
+        self, client, private_headers, allow_eng, captured_audit
+    ):
+        from jira_credentials import JiraCredentialsUnavailable
+
+        fake_client = MagicMock()
+        fake_client.create_issue.side_effect = JiraCredentialsUnavailable("no creds")
+        with patch.object(gateway, "get_jira_client", return_value=fake_client):
+            resp = client.post(
+                "/api/v1/jira/ticket/create",
+                headers=private_headers,
+                data=json.dumps(
+                    {"projectKey": "ENG", "issuetype": "Task", "summary": "s"}
+                ),
+                content_type="application/json",
+            )
+        assert resp.status_code == 503
+
+    def test_disallowed_project_403(self, client, private_headers, captured_audit, monkeypatch):
+        monkeypatch.setattr(gateway, "is_project_allowed", lambda p: False)
+        resp = client.post(
+            "/api/v1/jira/ticket/create",
+            headers=private_headers,
+            data=json.dumps({"projectKey": "SEC", "issuetype": "Task", "summary": "s"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+        denied = [a for a in captured_audit if a["event_type"] == "jira_ticket_create_denied"]
+        assert denied
+        assert denied[0]["details"]["project"] == "SEC"
+
+    @pytest.mark.parametrize(
+        "body, expected_match",
+        [
+            ({}, "projectKey"),
+            ({"projectKey": "lower"}, "projectKey"),
+            (
+                {"projectKey": "ENG", "issuetype": "Task"},
+                "summary",
+            ),
+            (
+                {"projectKey": "ENG", "issuetype": "Task", "summary": ""},
+                "summary",
+            ),
+        ],
+    )
+    def test_required_field_validation(
+        self,
+        client,
+        private_headers,
+        allow_eng,
+        captured_audit,
+        body,
+        expected_match,
+    ):
+        resp = client.post(
+            "/api/v1/jira/ticket/create",
+            headers=private_headers,
+            data=json.dumps(body),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        body = json.loads(resp.data)
+        assert expected_match.lower() in body["message"].lower()
+
+    def test_summary_too_long(self, client, private_headers, allow_eng, captured_audit):
+        oversized = "x" * (jira_client_module.JIRA_SUMMARY_MAX_CHARS + 1)
+        resp = client.post(
+            "/api/v1/jira/ticket/create",
+            headers=private_headers,
+            data=json.dumps(
+                {"projectKey": "ENG", "issuetype": "Task", "summary": oversized}
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        rejected = [
+            a for a in captured_audit if a["event_type"] == "jira_ticket_create_rejected"
+        ]
+        assert rejected
+        assert "exceeds" in rejected[-1]["details"]["reason"]
+
+    def test_description_too_long(self, client, private_headers, allow_eng, captured_audit):
+        oversized = "x" * (jira_client_module.JIRA_DESCRIPTION_MAX_CHARS + 1)
+        resp = client.post(
+            "/api/v1/jira/ticket/create",
+            headers=private_headers,
+            data=json.dumps(
+                {
+                    "projectKey": "ENG",
+                    "issuetype": "Task",
+                    "summary": "ok",
+                    "description": oversized,
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_custom_field_smuggling_rejected(
+        self, client, private_headers, allow_eng, captured_audit
+    ):
+        """Decision-1: no arbitrary ``customfield_*`` in the body."""
+        resp = client.post(
+            "/api/v1/jira/ticket/create",
+            headers=private_headers,
+            data=json.dumps(
+                {
+                    "projectKey": "ENG",
+                    "issuetype": "Task",
+                    "summary": "ok",
+                    "customfield_10042": "smuggled",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        body = json.loads(resp.data)
+        assert "customfield_10042" in body["message"]
+
+    def test_cross_project_parent_rejected(
+        self, client, private_headers, allow_eng_and_ops, captured_audit
+    ):
+        """Decision-17: parent project must match the new ticket's project."""
+        resp = client.post(
+            "/api/v1/jira/ticket/create",
+            headers=private_headers,
+            data=json.dumps(
+                {
+                    "projectKey": "ENG",
+                    "issuetype": "Task",
+                    "summary": "s",
+                    "parent": "DEVOPS-1",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        body = json.loads(resp.data)
+        assert "parent" in body["message"].lower()
+
+    def test_parent_and_epic_link_mutually_exclusive(
+        self, client, private_headers, allow_eng, captured_audit
+    ):
+        resp = client.post(
+            "/api/v1/jira/ticket/create",
+            headers=private_headers,
+            data=json.dumps(
+                {
+                    "projectKey": "ENG",
+                    "issuetype": "Task",
+                    "summary": "s",
+                    "parent": "ENG-1",
+                    "epicLink": "ENG-2",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_happy_path_emits_envelope(self, client, private_headers, allow_eng, captured_audit):
+        fake_client = MagicMock()
+        fake_client.create_issue.return_value = {"id": "10042", "key": "ENG-42"}
+        fake_client.creds_provider.return_value.base_url = "https://acme.atlassian.net"
+        with patch.object(gateway, "get_jira_client", return_value=fake_client):
+            resp = client.post(
+                "/api/v1/jira/ticket/create",
+                headers=private_headers,
+                data=json.dumps(
+                    {
+                        "projectKey": "ENG",
+                        "issuetype": "Task",
+                        "summary": "Investigate flake",
+                        "description": "details here",
+                        "labels": ["triage"],
+                        "idempotencyKey": "key-1",
+                    }
+                ),
+                content_type="application/json",
+            )
+        assert resp.status_code == 200
+        body = json.loads(resp.data)
+        assert body["data"]["status"] == "created"
+        assert body["data"]["key"] == "ENG-42"
+        assert body["data"]["id"] == "10042"
+        assert body["data"]["browse_url"] == "https://acme.atlassian.net/browse/ENG-42"
+        success = [a for a in captured_audit if a["event_type"] == "jira_ticket_create"]
+        assert success
+        details = success[-1]["details"]
+        assert details["projectKey"] == "ENG"
+        assert details["key"] == "ENG-42"
+        # Body content NOT logged — only lengths.
+        assert "summary" not in details
+        assert "description" not in details
+        assert details["summary_length"] == len("Investigate flake")
+        assert details["description_length"] == len("details here")
+        assert details["labels"] == ["triage"]
+
+    def test_missing_idempotency_emits_warning_audit(
+        self, client, private_headers, allow_eng, captured_audit
+    ):
+        fake_client = MagicMock()
+        fake_client.create_issue.return_value = {"id": "1", "key": "ENG-1"}
+        fake_client.creds_provider.return_value.base_url = "https://x"
+        with patch.object(gateway, "get_jira_client", return_value=fake_client):
+            client.post(
+                "/api/v1/jira/ticket/create",
+                headers=private_headers,
+                data=json.dumps(
+                    {"projectKey": "ENG", "issuetype": "Task", "summary": "s"}
+                ),
+                content_type="application/json",
+            )
+        warning = [
+            a for a in captured_audit
+            if a["event_type"] == "jira_ticket_create_no_idempotency_key"
+        ]
+        assert warning
+
+
+class TestTicketEdit:
+    def test_public_mode_403(self, client, public_headers):
+        resp = client.post(
+            "/api/v1/jira/ticket/edit",
+            headers=public_headers,
+            data=json.dumps({"ticket": "ENG-1", "summary": "x"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+
+    def test_invalid_ticket_400(self, client, private_headers, captured_audit):
+        resp = client.post(
+            "/api/v1/jira/ticket/edit",
+            headers=private_headers,
+            data=json.dumps({"ticket": "lower-1", "summary": "x"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_disallowed_project_403(self, client, private_headers, captured_audit, monkeypatch):
+        monkeypatch.setattr(gateway, "is_project_allowed", lambda p: False)
+        resp = client.post(
+            "/api/v1/jira/ticket/edit",
+            headers=private_headers,
+            data=json.dumps({"ticket": "SEC-1", "summary": "x"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+
+    def test_replace_plus_incremental_400(
+        self, client, private_headers, allow_eng, captured_audit
+    ):
+        resp = client.post(
+            "/api/v1/jira/ticket/edit",
+            headers=private_headers,
+            data=json.dumps(
+                {"ticket": "ENG-1", "labels": ["a"], "addLabels": ["b"]}
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        rejected = [
+            a for a in captured_audit if a["event_type"] == "jira_ticket_edit_rejected"
+        ]
+        assert rejected
+
+    def test_no_op_edit_rejected(
+        self, client, private_headers, allow_eng, captured_audit
+    ):
+        resp = client.post(
+            "/api/v1/jira/ticket/edit",
+            headers=private_headers,
+            data=json.dumps({"ticket": "ENG-1"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_happy_path(self, client, private_headers, allow_eng, captured_audit):
+        fake_client = MagicMock()
+        with patch.object(gateway, "get_jira_client", return_value=fake_client):
+            resp = client.post(
+                "/api/v1/jira/ticket/edit",
+                headers=private_headers,
+                data=json.dumps(
+                    {
+                        "ticket": "ENG-1",
+                        "summary": "new",
+                        "addLabels": ["x"],
+                        "removeLabels": ["y"],
+                    }
+                ),
+                content_type="application/json",
+            )
+        assert resp.status_code == 200
+        body = json.loads(resp.data)
+        assert body["data"] == {"status": "updated", "key": "ENG-1"}
+        # Confirm the underlying call shape.
+        kwargs = fake_client.edit_issue.call_args.kwargs
+        assert kwargs["key"] == "ENG-1"
+        assert kwargs["add_labels"] == ["x"]
+        assert kwargs["remove_labels"] == ["y"]
+        assert kwargs["notify_users"] is False  # default
+        success = [a for a in captured_audit if a["event_type"] == "jira_ticket_edit"]
+        assert success
+        details = success[-1]["details"]
+        assert details["fields_changed"] == ["summary", "addLabels", "removeLabels"]
+
+
+class TestTicketCommentAdd:
+    def test_public_mode_403(self, client, public_headers):
+        resp = client.post(
+            "/api/v1/jira/ticket/comment/add",
+            headers=public_headers,
+            data=json.dumps({"ticket": "ENG-1", "body": "hi"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+
+    def test_disallowed_project_403(self, client, private_headers, captured_audit, monkeypatch):
+        monkeypatch.setattr(gateway, "is_project_allowed", lambda p: False)
+        resp = client.post(
+            "/api/v1/jira/ticket/comment/add",
+            headers=private_headers,
+            data=json.dumps({"ticket": "SEC-1", "body": "hi"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+
+    def test_missing_body_400(self, client, private_headers, allow_eng, captured_audit):
+        resp = client.post(
+            "/api/v1/jira/ticket/comment/add",
+            headers=private_headers,
+            data=json.dumps({"ticket": "ENG-1"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_visibility_field_rejected(self, client, private_headers, allow_eng, captured_audit):
+        """Decision-6: visibility is not exposed in v1."""
+        resp = client.post(
+            "/api/v1/jira/ticket/comment/add",
+            headers=private_headers,
+            data=json.dumps(
+                {
+                    "ticket": "ENG-1",
+                    "body": "hi",
+                    "visibility": {"type": "role", "value": "Admin"},
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        body = json.loads(resp.data)
+        assert "visibility" in body["message"]
+
+    def test_happy_path(self, client, private_headers, allow_eng, captured_audit):
+        fake_client = MagicMock()
+        fake_client.add_comment.return_value = {"id": "c1", "body": {"type": "doc"}}
+        with patch.object(gateway, "get_jira_client", return_value=fake_client):
+            resp = client.post(
+                "/api/v1/jira/ticket/comment/add",
+                headers=private_headers,
+                data=json.dumps(
+                    {"ticket": "ENG-1", "body": "Plan-apply succeeded"}
+                ),
+                content_type="application/json",
+            )
+        assert resp.status_code == 200
+        success = [a for a in captured_audit if a["event_type"] == "jira_comment_add"]
+        assert success
+        details = success[-1]["details"]
+        assert details["ticket"] == "ENG-1"
+        assert details["comment_length"] == len("Plan-apply succeeded")
+        # Body text NOT in audit.
+        assert "body" not in details
+
+
+class TestIssueLinkCreate:
+    def test_public_mode_403(self, client, public_headers):
+        resp = client.post(
+            "/api/v1/jira/issue-link/create",
+            headers=public_headers,
+            data=json.dumps(
+                {"type": "Blocks", "inwardIssue": "ENG-1", "outwardIssue": "ENG-2"}
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+
+    def test_link_type_not_allowlisted_403(
+        self, client, private_headers, allow_eng, allow_blocks_and_relates, captured_audit
+    ):
+        resp = client.post(
+            "/api/v1/jira/issue-link/create",
+            headers=private_headers,
+            data=json.dumps(
+                {
+                    "type": "Bogus",
+                    "inwardIssue": "ENG-1",
+                    "outwardIssue": "ENG-2",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+        denied = [a for a in captured_audit if a["event_type"] == "jira_issue_link_create_denied"]
+        assert denied
+
+    def test_inward_project_not_allowlisted_403(
+        self, client, private_headers, allow_blocks_and_relates, captured_audit, monkeypatch
+    ):
+        monkeypatch.setattr(gateway, "is_project_allowed", lambda p: p == "ENG")
+        resp = client.post(
+            "/api/v1/jira/issue-link/create",
+            headers=private_headers,
+            data=json.dumps(
+                {
+                    "type": "Blocks",
+                    "inwardIssue": "SEC-1",
+                    "outwardIssue": "ENG-2",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+
+    def test_outward_project_not_allowlisted_403(
+        self, client, private_headers, allow_blocks_and_relates, captured_audit, monkeypatch
+    ):
+        monkeypatch.setattr(gateway, "is_project_allowed", lambda p: p == "ENG")
+        resp = client.post(
+            "/api/v1/jira/issue-link/create",
+            headers=private_headers,
+            data=json.dumps(
+                {
+                    "type": "Blocks",
+                    "inwardIssue": "ENG-1",
+                    "outwardIssue": "SEC-2",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+
+    def test_happy_path(
+        self, client, private_headers, allow_eng, allow_blocks_and_relates, captured_audit
+    ):
+        fake_client = MagicMock()
+        fake_client.create_issue_link.return_value = {}
+        with patch.object(gateway, "get_jira_client", return_value=fake_client):
+            resp = client.post(
+                "/api/v1/jira/issue-link/create",
+                headers=private_headers,
+                data=json.dumps(
+                    {
+                        "type": "Blocks",
+                        "inwardIssue": "ENG-1",
+                        "outwardIssue": "ENG-2",
+                        "comment": "explain",
+                    }
+                ),
+                content_type="application/json",
+            )
+        assert resp.status_code == 200
+        body = json.loads(resp.data)
+        assert body["data"] == {
+            "status": "created",
+            "type": "Blocks",
+            "inwardIssue": "ENG-1",
+            "outwardIssue": "ENG-2",
+        }
+        success = [a for a in captured_audit if a["event_type"] == "jira_issue_link_create"]
+        assert success
+        details = success[-1]["details"]
+        assert details["type"] == "Blocks"
+        assert details["comment_present"] is True
+
+
+# -----------------------------------------------------------------------------
+# Route-enumeration regression — extended for #1924
+# -----------------------------------------------------------------------------
+
+
+class TestRouteEnumerationExtended:
+    def test_at_least_eight_jira_routes(self, client):
+        """Issue #1924 brings the total to 8 — 4 read, 4 write."""
+        rules = [
+            r.rule
+            for r in gateway.app.url_map.iter_rules()
+            if r.rule.startswith("/api/v1/jira/")
+        ]
+        assert len(rules) >= 8, f"Expected >=8 Jira routes; found {rules}"
+        # Spot-check the four new ones.
+        assert "/api/v1/jira/ticket/create" in rules
+        assert "/api/v1/jira/ticket/edit" in rules
+        assert "/api/v1/jira/ticket/comment/add" in rules
+        assert "/api/v1/jira/issue-link/create" in rules

--- a/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_wrapper.py.append_to_origin
+++ b/.egg-state/agent-outputs/1924-coder-test-handoff/test_jira_wrapper.py.append_to_origin
@@ -1,0 +1,689 @@
+"""
+Tests for the sandbox ``jira`` CLI wrapper.
+
+Subprocess-invokes the wrapper against a stdlib ``http.server`` mock gateway
+and asserts:
+
+- Each verb constructs the correct request path + JSON body.
+- The ``Authorization: Bearer $EGG_SESSION_TOKEN`` header is always sent.
+- 2xx responses print the ``data`` subtree on stdout and exit 0.
+- Non-2xx responses print an error on stderr and exit non-zero.
+- Missing ``EGG_SESSION_TOKEN`` fails closed.
+- Missing gateway fails closed with the standard error banner.
+
+Note: this file exercises the wrapper directly; the actual route
+enforcement (private-mode gate, project allowlist, etc.) is covered in
+``gateway/tests/test_jira_routes.py``.  The wrapper's only job is to
+translate CLI args into a well-formed ``POST /api/v1/jira/*`` request and
+surface the gateway's response.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# -----------------------------------------------------------------------------
+# Locate the wrapper
+# -----------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CANONICAL = _REPO_ROOT / "sandbox" / "scripts" / "jira"
+
+
+def _locate_wrapper() -> Path:
+    """Return the wrapper path; skip the test if it is not present."""
+    if _CANONICAL.exists():
+        return _CANONICAL
+    pytest.skip(
+        f"sandbox jira wrapper not found at {_CANONICAL}.",
+        allow_module_level=True,
+    )
+
+
+WRAPPER = _locate_wrapper()
+
+
+# -----------------------------------------------------------------------------
+# Mock gateway: a single-thread HTTP server that records every request.
+# -----------------------------------------------------------------------------
+
+
+class _RecordingHandler(BaseHTTPRequestHandler):
+    """HTTP handler that records request path/body/headers and echoes a scripted
+    response supplied by the test via ``server.response_queue``."""
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        # Silence default access-log chatter during tests.
+        pass
+
+    def do_GET(self):  # noqa: N802 — stdlib naming
+        if self.path == "/api/v1/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"status": "ok"}')
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length) if length else b""
+        try:
+            body = json.loads(raw.decode("utf-8")) if raw else None
+        except json.JSONDecodeError:
+            body = raw.decode("utf-8", errors="replace")
+        self.server.recorded.append(  # type: ignore[attr-defined]
+            {
+                "path": self.path,
+                "body": body,
+                "authorization": self.headers.get("Authorization", ""),
+                "content_type": self.headers.get("Content-Type", ""),
+            }
+        )
+        queue = self.server.response_queue  # type: ignore[attr-defined]
+        if queue:
+            response = queue.pop(0)
+        else:
+            response = {"status": 200, "body": {"success": True, "data": {}}}
+        self.send_response(response["status"])
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        payload = response["body"]
+        if isinstance(payload, dict):
+            self.wfile.write(json.dumps(payload).encode("utf-8"))
+        else:
+            self.wfile.write(str(payload).encode("utf-8"))
+
+
+@pytest.fixture
+def mock_gateway():
+    """Spin up a local HTTP server and yield its URL + control handles."""
+    server = HTTPServer(("127.0.0.1", 0), _RecordingHandler)
+    server.recorded = []  # type: ignore[attr-defined]
+    server.response_queue = []  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        _, port = server.server_address
+        yield {
+            "url": f"http://127.0.0.1:{port}",
+            "server": server,
+        }
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
+
+
+def _run_wrapper(
+    mock_gateway: dict,
+    argv: list[str],
+    session_token: str = "test-session-token",
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["GATEWAY_URL"] = mock_gateway["url"]
+    if session_token is None:
+        env.pop("EGG_SESSION_TOKEN", None)
+    else:
+        env["EGG_SESSION_TOKEN"] = session_token
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(WRAPPER), *argv],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Happy-path verbs
+# -----------------------------------------------------------------------------
+
+
+class TestTicketGet:
+    def test_builds_request_and_prints_data(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {
+                "status": 200,
+                "body": {"success": True, "data": {"key": "ENG-1"}},
+            }
+        )
+        proc = _run_wrapper(mock_gateway, ["ticket", "get", "ENG-1"])
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["path"] == "/api/v1/jira/ticket/get"
+        assert rec["body"] == {"ticket": "ENG-1"}
+        assert rec["authorization"] == "Bearer test-session-token"
+        out = json.loads(proc.stdout)
+        assert out == {"key": "ENG-1"}
+
+    def test_fields_flag_forwarded(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {"status": 200, "body": {"success": True, "data": {}}}
+        )
+        proc = _run_wrapper(
+            mock_gateway,
+            ["ticket", "get", "ENG-1", "--fields", "summary,status"],
+        )
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["body"] == {
+            "ticket": "ENG-1",
+            "fields": ["summary", "status"],
+        }
+
+    def test_missing_key_fails(self, mock_gateway):
+        proc = _run_wrapper(mock_gateway, ["ticket", "get"])
+        assert proc.returncode != 0
+        assert "ticket key required" in proc.stderr.lower()
+
+    def test_403_response_prints_error(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {
+                "status": 403,
+                "body": {
+                    "success": False,
+                    "message": "Jira project not allowlisted",
+                    "details": {"project": "SEC"},
+                },
+            }
+        )
+        proc = _run_wrapper(mock_gateway, ["ticket", "get", "SEC-1"])
+        assert proc.returncode != 0
+        assert "not allowlisted" in proc.stderr.lower()
+
+    def test_401_response_prints_auth_hint(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {
+                "status": 401,
+                "body": {
+                    "success": False,
+                    "message": "Unauthorized",
+                },
+            }
+        )
+        proc = _run_wrapper(mock_gateway, ["ticket", "get", "ENG-1"])
+        assert proc.returncode != 0
+        assert "authentication failed" in proc.stderr.lower()
+        assert "session token" in proc.stderr.lower()
+
+    def test_429_response_prints_rate_limit_hint(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {
+                "status": 429,
+                "body": {
+                    "success": False,
+                    "message": "Rate limited",
+                },
+            }
+        )
+        proc = _run_wrapper(mock_gateway, ["ticket", "get", "ENG-1"])
+        assert proc.returncode != 0
+        assert "rate limit exceeded" in proc.stderr.lower()
+
+
+class TestTicketComments:
+    def test_happy_path(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {
+                "status": 200,
+                "body": {"success": True, "data": {"comments": []}},
+            }
+        )
+        proc = _run_wrapper(mock_gateway, ["ticket", "comments", "ENG-1"])
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["path"] == "/api/v1/jira/ticket/comments"
+        assert rec["body"] == {"ticket": "ENG-1"}
+
+    def test_failure(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {
+                "status": 503,
+                "body": {
+                    "success": False,
+                    "message": "Jira credentials not configured on the gateway",
+                },
+            }
+        )
+        proc = _run_wrapper(mock_gateway, ["ticket", "comments", "ENG-1"])
+        assert proc.returncode != 0
+        assert "credentials" in proc.stderr.lower()
+
+
+class TestSearch:
+    def test_happy_path(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {"status": 200, "body": {"success": True, "data": {"issues": []}}}
+        )
+        proc = _run_wrapper(
+            mock_gateway,
+            [
+                "search",
+                "project = ENG",
+                "--max-results",
+                "25",
+                "--fields",
+                "summary",
+                "--next-page-token",
+                "TOK-1",
+            ],
+        )
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["path"] == "/api/v1/jira/search"
+        assert rec["body"] == {
+            "jql": "project = ENG",
+            "fields": ["summary"],
+            "maxResults": 25,
+            "nextPageToken": "TOK-1",
+        }
+
+    def test_non_int_max_results_fails(self, mock_gateway):
+        proc = _run_wrapper(
+            mock_gateway,
+            ["search", "project = ENG", "--max-results", "bad"],
+        )
+        assert proc.returncode != 0
+        assert "--max-results" in proc.stderr.lower() or "integer" in proc.stderr.lower()
+
+    def test_search_403_from_gateway(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {
+                "status": 403,
+                "body": {
+                    "success": False,
+                    "message": "JQL rejected: project under OR",
+                    "details": {"reason": "project under OR"},
+                },
+            }
+        )
+        proc = _run_wrapper(
+            mock_gateway,
+            ["search", "project = ENG OR project = SEC"],
+        )
+        assert proc.returncode != 0
+        assert "rejected" in proc.stderr.lower()
+
+
+class TestExecute:
+    def test_happy_get(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {"status": 200, "body": {"success": True, "data": {"key": "ENG"}}}
+        )
+        proc = _run_wrapper(
+            mock_gateway,
+            ["execute", "GET", "project/ENG"],
+        )
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["path"] == "/api/v1/jira/execute"
+        assert rec["body"] == {"method": "GET", "path": "project/ENG"}
+
+    def test_happy_with_query(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {"status": 200, "body": {"success": True, "data": {}}}
+        )
+        proc = _run_wrapper(
+            mock_gateway,
+            ["execute", "GET", "issue/ENG-1", "--query", "fields=summary,expand=renderedBody"],
+        )
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["body"]["method"] == "GET"
+        assert rec["body"]["path"] == "issue/ENG-1"
+        assert rec["body"]["query"] == {
+            "fields": "summary",
+            "expand": "renderedBody",
+        }
+
+    def test_denied_method_returns_error(self, mock_gateway):
+        """The wrapper forwards any verb; the gateway is the enforcement
+        surface.  We verify the gateway's 403 response is surfaced correctly."""
+        mock_gateway["server"].response_queue.append(
+            {
+                "status": 403,
+                "body": {
+                    "success": False,
+                    "message": "Jira API call rejected: HTTP method 'DELETE' not allowed for Jira",
+                    "details": {"method": "DELETE"},
+                },
+            }
+        )
+        proc = _run_wrapper(
+            mock_gateway,
+            ["execute", "DELETE", "issue/ENG-1"],
+        )
+        assert proc.returncode != 0
+        assert "delete" in proc.stderr.lower() or "not allowed" in proc.stderr.lower()
+
+
+class TestFailClosed:
+    def test_missing_session_token_fails(self, mock_gateway):
+        proc = _run_wrapper(
+            mock_gateway,
+            ["ticket", "get", "ENG-1"],
+            session_token=None,
+        )
+        assert proc.returncode != 0
+        assert "EGG_SESSION_TOKEN" in proc.stderr
+
+    def test_missing_gateway_url_fails(self, tmp_path):
+        env = os.environ.copy()
+        env.pop("GATEWAY_URL", None)
+        env.pop("EGG_SESSION_TOKEN", None)
+        proc = subprocess.run(
+            ["bash", str(WRAPPER), "ticket", "get", "ENG-1"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=10,
+        )
+        assert proc.returncode != 0
+        assert "GATEWAY_URL" in proc.stderr
+
+    def test_gateway_unreachable_fails_closed(self):
+        """If /api/v1/health is unreachable, the wrapper must refuse the call."""
+        # Grab a free port that nothing is listening on.
+        with socket.socket() as s:
+            s.bind(("127.0.0.1", 0))
+            port = s.getsockname()[1]
+        env = os.environ.copy()
+        env["GATEWAY_URL"] = f"http://127.0.0.1:{port}"
+        env["EGG_SESSION_TOKEN"] = "tok"
+        proc = subprocess.run(
+            ["bash", str(WRAPPER), "ticket", "get", "ENG-1"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=10,
+        )
+        assert proc.returncode != 0
+        assert "GATEWAY SIDECAR NOT AVAILABLE" in proc.stderr
+
+
+class TestUsage:
+    def test_help(self, mock_gateway):
+        proc = _run_wrapper(mock_gateway, ["help"])
+        assert proc.returncode == 0
+        assert "jira ticket get" in proc.stderr or "jira ticket get" in proc.stdout
+
+    def test_unknown_verb(self, mock_gateway):
+        proc = _run_wrapper(mock_gateway, ["transition", "ENG-1"])
+        assert proc.returncode != 0
+        assert "unknown" in proc.stderr.lower()
+
+
+# -----------------------------------------------------------------------------
+# Issue #1924 — write verbs
+# -----------------------------------------------------------------------------
+
+
+class TestTicketCreate:
+    def test_minimal(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {"status": 200, "body": {"success": True, "data": {"key": "ENG-1"}}}
+        )
+        proc = _run_wrapper(
+            mock_gateway,
+            [
+                "ticket",
+                "create",
+                "--project",
+                "ENG",
+                "--type",
+                "Task",
+                "--summary",
+                "Investigate flake",
+            ],
+        )
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["path"] == "/api/v1/jira/ticket/create"
+        assert rec["body"] == {
+            "projectKey": "ENG",
+            "issuetype": "Task",
+            "summary": "Investigate flake",
+        }
+
+    def test_required_flags_enforced(self, mock_gateway):
+        proc = _run_wrapper(mock_gateway, ["ticket", "create", "--project", "ENG"])
+        assert proc.returncode != 0
+        assert "required" in proc.stderr.lower()
+
+    def test_description_inline(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {"status": 200, "body": {"success": True, "data": {}}}
+        )
+        proc = _run_wrapper(
+            mock_gateway,
+            [
+                "ticket",
+                "create",
+                "--project",
+                "ENG",
+                "--type",
+                "Task",
+                "--summary",
+                "s",
+                "--description",
+                "details here",
+            ],
+        )
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["body"]["description"] == "details here"
+
+    def test_description_from_file(self, mock_gateway, tmp_path):
+        path = tmp_path / "desc.txt"
+        path.write_text("from-file body\nwith newlines")
+        mock_gateway["server"].response_queue.append(
+            {"status": 200, "body": {"success": True, "data": {}}}
+        )
+        proc = _run_wrapper(
+            mock_gateway,
+            [
+                "ticket",
+                "create",
+                "--project",
+                "ENG",
+                "--type",
+                "Task",
+                "--summary",
+                "s",
+                "--description-file",
+                str(path),
+            ],
+        )
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["body"]["description"] == "from-file body\nwith newlines"
+
+    def test_labels_split(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {"status": 200, "body": {"success": True, "data": {}}}
+        )
+        proc = _run_wrapper(
+            mock_gateway,
+            [
+                "ticket",
+                "create",
+                "--project",
+                "ENG",
+                "--type",
+                "Task",
+                "--summary",
+                "s",
+                "--labels",
+                "alpha,beta,gamma",
+            ],
+        )
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["body"]["labels"] == ["alpha", "beta", "gamma"]
+
+
+class TestTicketEdit:
+    def test_summary_only(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {"status": 200, "body": {"success": True, "data": {}}}
+        )
+        proc = _run_wrapper(
+            mock_gateway,
+            ["ticket", "edit", "ENG-1", "--summary", "new summary"],
+        )
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["path"] == "/api/v1/jira/ticket/edit"
+        assert rec["body"]["ticket"] == "ENG-1"
+        assert rec["body"]["summary"] == "new summary"
+        assert rec["body"]["notifyUsers"] is True  # default no --no-notify
+
+    def test_no_notify_flag(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {"status": 200, "body": {"success": True, "data": {}}}
+        )
+        proc = _run_wrapper(
+            mock_gateway,
+            ["ticket", "edit", "ENG-1", "--summary", "x", "--no-notify"],
+        )
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["body"]["notifyUsers"] is False
+
+    def test_replace_plus_incremental_rejected_clientside(self, mock_gateway):
+        proc = _run_wrapper(
+            mock_gateway,
+            [
+                "ticket",
+                "edit",
+                "ENG-1",
+                "--labels",
+                "a",
+                "--add-labels",
+                "b",
+            ],
+        )
+        assert proc.returncode != 0
+        assert "mutually exclusive" in proc.stderr.lower()
+
+
+class TestTicketCommentAdd:
+    def test_inline_body(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {"status": 200, "body": {"success": True, "data": {}}}
+        )
+        proc = _run_wrapper(
+            mock_gateway,
+            ["ticket", "comment", "add", "ENG-1", "--body", "plan-apply done"],
+        )
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["path"] == "/api/v1/jira/ticket/comment/add"
+        assert rec["body"] == {
+            "ticket": "ENG-1",
+            "body": "plan-apply done",
+        }
+
+    def test_missing_body_fails(self, mock_gateway):
+        proc = _run_wrapper(mock_gateway, ["ticket", "comment", "add", "ENG-1"])
+        assert proc.returncode != 0
+        assert "body" in proc.stderr.lower()
+
+    def test_body_from_stdin(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {"status": 200, "body": {"success": True, "data": {}}}
+        )
+        env = os.environ.copy()
+        env["GATEWAY_URL"] = mock_gateway["url"]
+        env["EGG_SESSION_TOKEN"] = "test-session-token"
+        proc = subprocess.run(
+            [
+                "bash",
+                str(WRAPPER),
+                "ticket",
+                "comment",
+                "add",
+                "ENG-1",
+                "--body-stdin",
+            ],
+            input="from stdin",
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=15,
+        )
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["body"]["body"] == "from stdin"
+
+
+class TestLinkCreate:
+    def test_minimal(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {"status": 200, "body": {"success": True, "data": {}}}
+        )
+        proc = _run_wrapper(
+            mock_gateway,
+            [
+                "link",
+                "create",
+                "--type",
+                "Blocks",
+                "--inward",
+                "ENG-1",
+                "--outward",
+                "ENG-2",
+            ],
+        )
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["path"] == "/api/v1/jira/issue-link/create"
+        assert rec["body"] == {
+            "type": "Blocks",
+            "inwardIssue": "ENG-1",
+            "outwardIssue": "ENG-2",
+        }
+
+    def test_required_flags(self, mock_gateway):
+        proc = _run_wrapper(
+            mock_gateway, ["link", "create", "--type", "Blocks"]
+        )
+        assert proc.returncode != 0
+        assert "required" in proc.stderr.lower()
+
+    def test_with_idempotency_key(self, mock_gateway):
+        mock_gateway["server"].response_queue.append(
+            {"status": 200, "body": {"success": True, "data": {}}}
+        )
+        proc = _run_wrapper(
+            mock_gateway,
+            [
+                "link",
+                "create",
+                "--type",
+                "Blocks",
+                "--inward",
+                "ENG-1",
+                "--outward",
+                "ENG-2",
+                "--idempotency-key",
+                "abc-123",
+            ],
+        )
+        assert proc.returncode == 0, proc.stderr
+        rec = mock_gateway["server"].recorded[-1]
+        assert rec["body"]["idempotencyKey"] == "abc-123"

--- a/.egg-state/agent-outputs/1924-risk_analyst-output.json
+++ b/.egg-state/agent-outputs/1924-risk_analyst-output.json
@@ -1,0 +1,543 @@
+{
+  "schemaVersion": "1.0",
+  "issue": 1924,
+  "phase": "plan",
+  "agent_role": "risk_analyst",
+  "summary": "Risk assessment for #1924 — Jira gateway WRITE-verb extension (createJiraIssue, editJiraIssue, addCommentToJiraIssue, createIssueLink). The change is a bounded extension of #1556's read-only v1 surface and inherits its scaffolding (private-mode gate, project allowlist, gateway-held credentials, structured audit, Squid allowlist). That retires most architectural risk. Residual risk concentrates in five buckets: (1) **write-verb body smuggling** — custom-field, Epic Link, ADF, and link-type body shapes are richer than any v1 read input; a permissive validator lets agents change Security Level / Sprint / watchers / story points; (2) **non-idempotent writes** — Atlassian's REST API has no native idempotency keys and explicitly does NOT dedupe POST /issueLink, so any retry after a transient failure can create duplicate tickets, comments, or links; (3) **method-allowlist drift** — `editJiraIssue` is upstream PUT, which collides with v1's `JIRA_WRITE_VERBS_DENIED = {DELETE, PUT, PATCH}`; the separation between `/execute` (GET-only forever) and dedicated write client methods has to be airtight; (4) **rate-limit blast radius** — Atlassian's March 2026 points-based quotas + per-issue write throttling (`jira-per-issue-on-write`) make a runaway plan-apply much more disruptive than read traffic; (5) **HITL-blocking unresolved decisions** — 19 unresolved decisions and 9 unresolved feedback items from refine cover security-load-bearing choices (custom-field allowlist, idempotency requirement, link-type source, role/phase gating, body-size caps); the implementation cannot start safely until they resolve. Three risks are flagged for human review (R1 custom-field exposure, R7 idempotency policy, R10 phase/role gating). No HIGH-severity unmitigated risks remain after applying the recommended mitigations; six MEDIUM-severity risks require explicit implement-phase action.",
+  "scoring_legend": {
+    "impact": {
+      "low": "User-visible inconvenience; no security/data exposure; recoverable via retry or wrapper override.",
+      "medium": "Functional regression, partial outage, audit-log noise, or duplicate Jira artifacts that an operator can clean up via Jira UI.",
+      "high": "Security boundary breach, credential exposure, project-allowlist bypass, sandbox escape, or pipeline-blocking outage of Jira-coupled phases."
+    },
+    "likelihood": {
+      "low": "Requires multiple independent failures or adversarial intent; not expected in normal operation.",
+      "medium": "Plausible under realistic operator config, agent behavior, or Atlassian upstream churn within 6 months.",
+      "high": "Will occur in routine use unless explicitly mitigated."
+    },
+    "severity": {
+      "low": "Track and document; no implement-phase action required.",
+      "medium": "Implement-phase mitigation required; reviewer must verify mitigation is in place before ACK.",
+      "high": "Block release until mitigation is verified end-to-end (test + audit) and operator runbook updated."
+    }
+  },
+  "risks": [
+    {
+      "id": "R1",
+      "title": "Custom-field smuggling — agent escalates ticket via fields the operator did not intend to expose",
+      "category": "security",
+      "description": "Atlassian's POST /rest/api/3/issue and PUT /rest/api/3/issue/{key} accept an open `fields` map with no per-field allowlist on the upstream side. Agents calling createJiraIssue / editJiraIssue can therefore set fields the operator never intended: Security Level (visibility scoping), Sprint (sprint-board manipulation), Components (alerting), watchers (notification spam), Story Points (planning fraud), Assignee (impersonation by accountId), or arbitrary `customfield_NNNN` values. The refine analysis explicitly flagged this (Open Q1) but the decision is unresolved (decision-1). A pure-passthrough body validator (rejected option C2) would inherit Atlassian's default of accepting anything; the architect's recommended C1 'curated allowlist + opt-in customFields' still depends on which option HITL picks for decision-1.",
+      "affected_components": [
+        "gateway/jira_client.py — new `create_issue`, `edit_issue` methods (body-shape translation)",
+        "gateway/gateway.py — `POST /api/v1/jira/ticket/create`, `POST /api/v1/jira/ticket/edit` route handlers",
+        "config/context-filters.yaml — potential `jira.custom_fields` allowlist (depends on decision-1)",
+        "gateway/tests/test_jira_routes.py — adversarial body grid"
+      ],
+      "impact": "high",
+      "likelihood": "medium",
+      "severity": "high",
+      "mitigations": [
+        "Block until decision-1 resolves. Implementation cannot proceed safely without the operator picking the customField policy.",
+        "If decision-1 = opt-3 (no customFields map): hard-reject any body key not in {summary, description, labels, parent, epicLink} for create; not in {summary, description, labels, addLabels, removeLabels, parent, epicLink, notifyUsers} for edit. This is the safest default.",
+        "If decision-1 = opt-2 (operator-configured allowlist): load `jira.custom_fields: [...]` from config/context-filters.yaml with the same fail-closed mtime-cached pattern as `jira.policy.allowed_projects`. Reject any customfield_NNNN not in the allowlist with a structured 403 (`jira_custom_field_denied`, `field=customfield_NNNN`).",
+        "If decision-1 = opt-1 (generic map): EXPLICITLY denylist {Security, Security Level, securityLevel, components, sprint, customfield_10020 (Sprint), watcher/watches, fixVersions, assignee, reporter, priority, labels-via-customfield} regardless of map content. Document this denylist in code with an Atlassian docs link per field.",
+        "Regardless of decision-1: the adversarial test grid MUST include attempts to set securityLevel, sprint, watchers, assignee, fixVersions through every entry-point (top-level field, customFields map, parent, update block) and assert all are rejected.",
+        "Audit on rejection: emit `jira_<verb>_field_rejected` with `field=<name>` so operator dashboards surface attempted privilege escalation.",
+        "Reviewer MUST trace each accepted field through to the upstream Atlassian docs and confirm it does NOT change visibility, security, or assignment semantics before ACK."
+      ],
+      "rollback": "Reduce `jira.custom_fields` allowlist to empty in config; POST /api/v1/config/reload propagates without restart. Existing tickets are unaffected; new create/edit calls fall back to the curated-only set.",
+      "requires_human_review": true,
+      "human_review_reason": "Custom-field exposure is HITL decision-1; the security implications differ qualitatively across the three options (`opt-1 generic map`, `opt-2 operator allowlist`, `opt-3 closed`). A security reviewer must confirm the chosen option's denylist coverage matches the deployment's Jira project schemas. This cannot be punted to the gateway test grid alone."
+    },
+    {
+      "id": "R2",
+      "title": "Method-allowlist drift — editJiraIssue is upstream PUT, conflicts with permanent denylist",
+      "category": "security",
+      "description": "v1's `JIRA_WRITE_VERBS_DENIED = {transitions, worklog, attachments, watchers, DELETE, PUT, PATCH}` (gateway/jira_client.py line 95–108) lumps the segment denylist with the HTTP-method denylist. `editJiraIssue` is upstream `PUT /rest/api/3/issue/{key}` — the gateway must issue PUT for it to land. The architect's recommendation (option B1, separate /execute path-validator from write-client methods) is correct, but a careless implementation could (a) widen `validate_jira_api_path.ALLOWED_METHODS` to include PUT, which would silently expose any allowlisted GET path family to PUT through `/api/v1/jira/execute`, OR (b) remove PUT from `JIRA_WRITE_VERBS_DENIED` entirely, which would let `transitions`, `worklog`, `attachments`, `watchers` be bypassed via PUT in the future. Either mistake reopens the read-only fence.",
+      "affected_components": [
+        "gateway/jira_client.py — `validate_jira_api_path`, `JIRA_WRITE_VERBS_DENIED`, `_request`",
+        "gateway/jira_client.py — new write methods (`create_issue`, `edit_issue`, `add_comment`, `create_issue_link`)",
+        "gateway/tests/test_jira_client.py — path-validator regression suite",
+        "gateway/tests/test_jira_routes.py — `/execute` anti-bypass test"
+      ],
+      "impact": "high",
+      "likelihood": "low",
+      "severity": "medium",
+      "mitigations": [
+        "Adopt architect option B1: `validate_jira_api_path.ALLOWED_METHODS` STAYS `frozenset({'GET'})` forever. The /execute route NEVER accepts POST, PUT, DELETE, or PATCH.",
+        "New write methods (`create_issue`, `edit_issue`, ...) hard-code their upstream paths and methods in code. They DO NOT call `validate_jira_api_path` — the path is not user-controlled.",
+        "Keep the path-segment denylist (`transitions`, `worklog`, `attachments`, `watchers`) on `validate_jira_api_path`. The write client methods must hardcode paths that don't include those segments, verified by static-string assertion in unit tests.",
+        "Remove PUT/DELETE/PATCH from `JIRA_WRITE_VERBS_DENIED` would be a code-change blocker — keep the constant intact for `/execute`'s benefit. If editJiraIssue's PUT clashes with the constant's name, RENAME the constant to `JIRA_EXECUTE_DENIED_VERBS` to make the scope explicit (preferred), or split into two constants (`JIRA_EXECUTE_DENIED_PATH_SEGMENTS` and `JIRA_EXECUTE_DENIED_METHODS`).",
+        "Add an anti-bypass test: enumerate all `/api/v1/jira/*` routes via app.url_map; assert `/execute` rejects POST and PUT for ALL of them, including the new write paths (create, edit, comment-add, link-create). Use both bare-method and lowercase-method variants.",
+        "Audit on /execute rejection records the rejected method explicitly: `jira_execute_method_denied`, `method=<...>`.",
+        "Reviewer MUST grep the diff for `ALLOWED_METHODS` and confirm only GET appears in the /execute scope."
+      ],
+      "rollback": "If the /execute method allowlist drifts, revert that single hunk; the dedicated write routes continue to serve traffic. If a write method's hardcoded path turns out to include a denylisted segment, hot-patch the path string in jira_client.py and roll the gateway pod.",
+      "requires_human_review": false
+    },
+    {
+      "id": "R3",
+      "title": "Non-idempotent writes — retry after transient failure creates duplicate tickets, comments, or links",
+      "category": "data-integrity",
+      "description": "Atlassian's Jira Cloud REST API does not natively support idempotency keys for any v3 write endpoint. The community thread on idempotent issue creation explicitly confirms there is no native idempotency-key header. POST /rest/api/3/issue, POST /rest/api/3/issue/{key}/comment, and POST /rest/api/3/issueLink all create a NEW resource on every successful call — Atlassian does not deduplicate on (project, summary), (issue, body), or (inward, outward, type) triples. Refine open question Q28 (decision-19) explicitly surfaced that POST /issueLink does not dedupe (inward, outward, type) — a retry after a transient 5xx creates a duplicate link. A network blip, gateway restart, or 5xx-without-Retry-After could cause the orchestrator to re-issue and produce duplicate work-management artifacts that humans must clean up by hand. The architect's option D1 (caller-supplied idempotency_key + 5-minute in-process cache) mitigates retries within the cache window but NOT cross-process or cross-window duplication.",
+      "affected_components": [
+        "gateway/jira_client.py — `create_issue`, `add_comment`, `create_issue_link`",
+        "gateway/idempotency.py (new) — process-local cache, 5-minute TTL, threading lock",
+        "gateway/gateway.py — write route handlers must extract `idempotency_key` from body, key on `(verb, project, idempotency_key)`",
+        "config — possible env-var to expand cache TTL"
+      ],
+      "impact": "medium",
+      "likelihood": "high",
+      "severity": "medium",
+      "mitigations": [
+        "Block until decision-3 (idempotency_key requirement) resolves. The safest default is `opt-1 Required (gateway 400 if missing)` — turns 'orchestrator forgot to pass a key' into a fast-fail rather than a silent duplicate.",
+        "Keep cache scope per-process per architect D1 + decision-14 (opt-1: in-memory, 5-min TTL). Document the trade-off explicitly: gateway restart drops the cache, so an orchestrator retry that crosses a restart can still duplicate. Mitigate via runbook entry.",
+        "For createIssueLink specifically (decision-19): adopt opt-1 — extend the idempotency cache to `create_issue_link` symmetrically with createJiraIssue. Atlassian's 0% native dedup makes this the only safe default.",
+        "Idempotency cache key MUST include the project (or both projects for issueLink) so the same key in different projects doesn't collide. Recommended shape: `(verb, project_key_or_keys, idempotency_key)` → `(timestamp, response_body, status_code)`.",
+        "Cache eviction is lazy on insert (sweep entries older than TTL). Bounded by `MAX_IDEMPOTENCY_ENTRIES` (e.g., 10_000) — drop the oldest if exceeded, with a `jira_idempotency_cache_evicted` audit line.",
+        "On cache HIT, return the SAME response (status code + body) the first call produced, with an `Idempotency-Replayed: true` response header so callers can distinguish 'created now' from 'created earlier'.",
+        "Document explicitly in docs/reference/jira-wrapper.md the orchestrator's responsibility: derive idempotency_key from `(pipeline_id, plan_node_id)` for create; from `(pipeline_id, ticket_key, comment_purpose)` for comments; from `(pipeline_id, inward, outward, type)` for links. STABLE across retries.",
+        "Test coverage: cache HIT, cache MISS, TTL expiry, distinct keys → distinct calls, same key in different verb → distinct calls, same key in different project → distinct calls, oldest-eviction under cap, threading-safe under contention.",
+        "Operator runbook: 'If the gateway restarts mid-plan-apply, the orchestrator MUST treat the in-flight request as ambiguous — query Jira for a ticket matching the idempotency key (stored in a labeled custom field, if one is configured) before re-issuing.'",
+        "Out of scope, document explicitly: existence-probe before create (Open Q18 / feedback-1.Q3) is NOT implemented in v1 — idempotency key is the only safety net."
+      ],
+      "rollback": "Disable the new write routes via gateway-side kill switch (return 503 on `/api/v1/jira/ticket/create`, `/edit`, `/comment/add`, `/issue-link/create`) until idempotency cache bug is patched. Read endpoints unaffected.",
+      "requires_human_review": true,
+      "human_review_reason": "Idempotency policy (decision-3) and createIssueLink dedup (decision-19) are HITL-blocking. The 'opt-2 optional with documented warning' option for decision-3 leaves duplicates as a normal-operation outcome, not an exceptional one. A security/SRE reviewer should confirm the chosen option matches the operator's tolerance for manual Jira cleanup."
+    },
+    {
+      "id": "R4",
+      "title": "Atlassian 2026 points-based rate limits + per-issue write throttling — runaway plan-apply could quota-starve the bot account",
+      "category": "performance",
+      "description": "Per Atlassian's March 2026 rate-limit rollout, Jira Cloud now enforces three concurrent rate-limit systems (cost-based, quota-based, burst-based) plus a NEW `jira-per-issue-on-write` throttle that targets repeated writes to the SAME issue. Per-issue throttling is exactly the pattern #1557's plan-apply will hit — multiple sequential editJiraIssue calls on the parent epic, multiple addCommentToJiraIssue calls during consolidation. API-token traffic (which is what the gateway uses) is NOT exempt from the burst limit. A 100-task plan-apply could exhaust per-issue write quota for the parent epic and stall the entire pipeline. v1's `_request` retry policy is GET-only, so writes never auto-retry — the 429 surfaces immediately to the orchestrator with no auto-backoff.",
+      "affected_components": [
+        "gateway/jira_client.py — `_request` (writes never auto-retry; documented invariant)",
+        "gateway/gateway.py — `_jira_error_from_upstream` for 429 envelope",
+        "Orchestrator plan-apply loop (out of scope but documentation entry needed)"
+      ],
+      "impact": "medium",
+      "likelihood": "medium",
+      "severity": "medium",
+      "mitigations": [
+        "Resolve feedback-1.Q1 (Open Q12): confirm 'no auto-retry on 429 for writes' is correct. The recommended answer is YES — writes never auto-retry. The orchestrator's plan-apply already has its own resume-on-error semantics.",
+        "Surface the `RateLimit-Reason` header (`jira-cost-based`, `jira-quota-based`, `jira-burst-based`, `jira-per-issue-on-write`) in the upstream-error envelope so the orchestrator can branch on the kind of limit hit. `_jira_error_from_upstream` should propagate it as `details.upstream_rate_limit_reason`.",
+        "Surface `Retry-After` on 429 in the error envelope so the orchestrator can sleep before re-issuing.",
+        "Audit on every 429 (write or read) — `jira_upstream_rate_limited` — with `path`, `method`, `rate_limit_reason`, `retry_after`, and the existing session context. Operator dashboards can alarm on per-issue throttles to detect runaway plan-apply.",
+        "Document in docs/reference/jira-wrapper.md the orchestrator's responsibility: implement exponential-backoff-with-jitter on 429, NOT a tight retry loop. Cite Atlassian's official guidance.",
+        "Recommend a per-pipeline write budget (out-of-scope soft-limit at orchestrator layer, NOT in gateway): e.g., abort plan-apply if more than 50 writes hit the same epic in 60 seconds. Implementation deferred to a follow-up issue; document the gap.",
+        "Test: mock a 429 response with each of the four `RateLimit-Reason` values and assert the gateway envelope preserves each.",
+        "Implement-phase reviewer MUST verify writes do NOT call the GET-only retry path inside `_request`."
+      ],
+      "rollback": "Disable write routes (kill switch) so plan-apply falls back to manual Jira UI updates. Read traffic unaffected.",
+      "requires_human_review": false
+    },
+    {
+      "id": "R5",
+      "title": "ADF body-format ambiguity / passthrough lets agents inject unwanted ADF nodes (mention, action, media, embed)",
+      "category": "security",
+      "description": "ADF supports many node types beyond plain text: `mention` (notifies a specific accountId), `media` (embeds files via mediaSingle/mediaInline by mediaId), `inlineCard` / `embedCard` / `blockCard` (URL embeds — could leak referrer to attacker-controlled domains), `action` (interactive button — supported in some surfaces), `taskList` / `decisionList` (state-tracking), `extension` / `bodiedExtension` (third-party macros). If decision-7 picks opt-2 (pre-built ADF passthrough only) or opt-3 (both plain-text and ADF), an agent that controls description/comment text could craft a body that pings users via `mention`, embeds an attacker-controlled URL via `inlineCard`, or invokes a third-party extension. Atlassian's renderer enforces output sanitization for direct XSS, but mention-spam, URL-leak, and extension-trigger are within ADF's documented spec. The recent stored-XSS-in-Jira-Work-Management finding (Snapsec, 2025) shows that fields outside ADF schema (Icon URL) lacked sanitization — implies ADF schema enforcement does NOT extend to all surfaces, but for description/comment bodies the renderer DOES sanitize HTML/JS.",
+      "affected_components": [
+        "gateway/jira_client.py — ADF wrapper (plain-text → minimal ADF doc)",
+        "gateway/gateway.py — body validation in create/edit/comment routes",
+        "config — potential ADF-node allowlist"
+      ],
+      "impact": "medium",
+      "likelihood": "medium",
+      "severity": "medium",
+      "mitigations": [
+        "Block until decision-7 (body input format) resolves. Recommended option is opt-1 (plain text only — gateway wraps to ADF) for the v1 write surface. ADF passthrough is harder to validate.",
+        "If decision-7 = opt-1 (plain-text only): the gateway's ADF wrapper produces ONLY `{type:'doc',version:1,content:[{type:'paragraph',content:[{type:'text',text:S}]}]}` — no other node types. Reject any body that is a dict (not a string).",
+        "If decision-7 = opt-2 or opt-3 (ADF passthrough): walk the ADF tree and reject ADF nodes outside an allowlist: `{doc, paragraph, text, heading, bulletList, orderedList, listItem, codeBlock, blockquote, hardBreak, rule, emoji}`. Explicitly reject `mention`, `media`, `mediaSingle`, `mediaInline`, `inlineCard`, `embedCard`, `blockCard`, `action`, `extension`, `bodiedExtension`. Document the allowlist in code.",
+        "Regardless: cap the serialized ADF JSON at the body-size limit (depends on feedback-1.Q2 / Open Q15). 100 KB is a reasonable upper bound — Atlassian's own per-comment storage cap is roughly 32 KB but is not officially documented.",
+        "Audit log records `description_length`, `comment_length` in characters AND the count of ADF nodes by type — never the body content (per refine open Q20 / feedback-1.Q5). Mention nodes (if accepted) MUST log the targeted accountId so impersonation/spam attempts are visible.",
+        "Test grid: oversized body, nested-deeply ADF (recursive bombing), unknown node type, mention node (rejected or audited), inlineCard with attacker-controlled URL (rejected), extension node (rejected), broken UTF-8, surrogate pairs.",
+        "Reviewer MUST run the adversarial body suite and read the rejection reasons before ACK."
+      ],
+      "rollback": "Force plain-text-only mode via gateway env-var (`EGG_JIRA_ADF_PASSTHROUGH=false`) and reject ADF dicts at the route layer. Existing comments / descriptions unaffected.",
+      "requires_human_review": false
+    },
+    {
+      "id": "R6",
+      "title": "Epic Link mechanism per-instance variation — wrong field for the project type creates orphan tickets",
+      "category": "compatibility",
+      "description": "Atlassian's Jira has two project schemas: classic (team-managed) projects use `customfield_10014` for Epic Link; next-gen (company-managed) projects use the modern `parent.key` hierarchy. The two are not interchangeable — sending `parent.key` to a classic project that uses `customfield_10014` creates a ticket that is NOT linked to the epic, while still succeeding (Atlassian silently drops the unknown field on classic projects, depending on instance config). The orchestrator (#1557 consumer) needs the child ticket linked to the epic; an orphan child blocks the SDLC pipeline that follows. Refine open question Q2 (decision-2) is unresolved.",
+      "affected_components": [
+        "gateway/jira_client.py — `create_issue` body shape, `epicLink` shorthand translation",
+        "gateway/gateway.py — body validator for `epicLink` field",
+        "config/context-filters.yaml — potential per-project Epic Link mechanism config"
+      ],
+      "impact": "medium",
+      "likelihood": "medium",
+      "severity": "medium",
+      "mitigations": [
+        "Block until decision-2 (Epic Link mechanism) resolves. Recommended option is opt-3 (Auto-detect or accept either via `epicLink` shorthand) — turns the gateway into a single agent-facing field that abstracts the upstream split.",
+        "If decision-2 = opt-1 (parent.key only): document that classic-project epics WILL silently fail; operator must migrate to next-gen or use a different gateway. Test: simulating a classic-project create with `parent.key` set asserts a structured warning in the audit log, even if Atlassian succeeds.",
+        "If decision-2 = opt-3 (auto-detect via shorthand): the gateway probes the parent ticket's project type via `GET /rest/api/3/project/{key}` (cached) on first use, then chooses `parent.key` or `customfield_10014`. Cache the projectType per-project per-process to avoid an extra call per create.",
+        "If decision-2 = opt-2 (customfield_10014 only): document that next-gen project epics MUST be created via parent.key elsewhere; this gateway path doesn't support them.",
+        "Body validator MUST reject simultaneous `parent` + `epicLink` (ambiguous intent). Reject either field referencing a ticket key whose project is not in the allowlist.",
+        "Address decision-15 (cross-project parent on createJiraIssue): recommended opt-1 (reject if parent.key project differs from new ticket project). Cross-project parents are a niche feature that mostly creates confusion in pipeline use cases.",
+        "Test: mock GET /project/{key} returning each project type and assert the right field is populated; assert structured rejection on cross-project parent.",
+        "Document in docs/reference/jira-wrapper.md (or the new jira-writes.md, depending on decision-18) the per-instance variation and the chosen mechanism."
+      ],
+      "rollback": "If auto-detect picks the wrong field, operator can override via per-project config in context-filters.yaml (`jira.projects[<KEY>].epic_link_mechanism: parent | customfield_10014`). Hot-reloadable.",
+      "requires_human_review": false
+    },
+    {
+      "id": "R7",
+      "title": "Project-allowlist semantics for createJiraIssue — different gate vector than v1 reads",
+      "category": "security",
+      "description": "v1 reads gate the project-allowlist on the ticket key extracted from the request body (`extract_project_key('FOO-123') = 'FOO'`). createJiraIssue has no ticket key yet — the project-allowlist gate must read `request.body.fields.project.key` (or wherever the validated body schema places it). A naive port of the v1 gate (extract_project_key on a non-ticket field) would return empty and silently allow the create. This is a different code path from every existing route. Refine analysis explicitly named this in Constraints (line 88), but the implementation is brittle.",
+      "affected_components": [
+        "gateway/gateway.py — `POST /api/v1/jira/ticket/create` route handler",
+        "gateway/jira_policy.py — `is_project_allowed` (reused; no change needed)",
+        "gateway/tests/test_jira_routes.py — adversarial create-body tests"
+      ],
+      "impact": "high",
+      "likelihood": "low",
+      "severity": "medium",
+      "mitigations": [
+        "Body validator MUST require a top-level `projectKey: '[A-Z][A-Z0-9_]*'` field on createJiraIssue (mirroring v1's _PROJECT_KEY_RE in jira_policy.py). Reject any create without it as 400 BEFORE running the allowlist gate.",
+        "Project-allowlist gate runs on `body.projectKey` (validated string). Audit on rejection: `jira_ticket_create_denied`, `project=<KEY>`, `reason='project not allowlisted'` — same envelope as v1 reads.",
+        "If decision-1 chooses to expose `customFields` map: the projectKey check still gates allowlist enforcement; customFields cannot smuggle a different project (the project is at top level, not inside customFields).",
+        "Validate the project key is consistent: reject if `body.fields.project.key` (the Atlassian wire shape) is also set AND mismatches the top-level `projectKey`. Prevents an agent from passing a different project to upstream while passing the allowlisted one to the gate.",
+        "Test grid: missing projectKey, projectKey with non-allowlisted value, projectKey-vs-fields.project.key mismatch, projectKey with leading/trailing whitespace, projectKey with unicode homoglyph (use the same homoglyph defense from v1).",
+        "Reviewer MUST trace `is_project_allowed` for createJiraIssue specifically and confirm it does NOT use `extract_project_key`."
+      ],
+      "rollback": "If a bypass is found, hot-patch the route to reject all create calls (return 503 `jira_ticket_create_disabled`) and roll the gateway pod. Read endpoints unaffected.",
+      "requires_human_review": false
+    },
+    {
+      "id": "R8",
+      "title": "createIssueLink project-allowlist semantics — strict-vs-loose decides whether agent can leak ticket existence across projects",
+      "category": "security",
+      "description": "`POST /rest/api/3/issueLink` takes `inwardIssue` and `outwardIssue` keys. If only ONE side needs to be allowlisted (decision-9 opt-2 'loose'), an agent can probe the existence of tickets in the OTHER project by calling createIssueLink and observing 200 (link succeeded → both tickets exist) vs 4xx (one missing). This is a confused-deputy / existence-leak attack: the gateway mediates writes but enables a side-channel read. Strict 'both allowlisted' (decision-9 opt-1) closes the channel; loose 'one allowlisted' (opt-2) opens it. Refine Open Q9 / decision-9 is unresolved.",
+      "affected_components": [
+        "gateway/jira_client.py — `create_issue_link`",
+        "gateway/gateway.py — `POST /api/v1/jira/issue-link/create` route handler",
+        "config/context-filters.yaml — potential `jira.linkable_only_projects: [...]` for opt-3"
+      ],
+      "impact": "medium",
+      "likelihood": "low",
+      "severity": "medium",
+      "mitigations": [
+        "Block until decision-9 (createIssueLink project allowlist semantics) resolves. Strongly recommend opt-1 (strict — both projects must be allowlisted). Closes existence-leak side-channel.",
+        "If decision-9 = opt-1 (strict): both `inwardIssue` and `outwardIssue` must extract to projects in `jira.projects`. Audit on rejection: `jira_issue_link_denied`, `inward_project=<KEY>`, `outward_project=<KEY>`, `reason='one or both projects not allowlisted'`.",
+        "If decision-9 = opt-3 (separate linkable-only list): require new `jira.linkable_only_projects: [...]` in config. The non-allowlisted side must be in the linkable-only list, the other side must be in `jira.projects`. Same fail-closed mtime-cached pattern.",
+        "Reject self-links (inward.key == outward.key) with 400 — Atlassian accepts these but they're meaningless.",
+        "Reject identity link (inward and outward both pointing at the same ticket via different keys, e.g., one resolved by ID and one by key) — rare but possible.",
+        "Test: link across two allowlisted projects, link from allowlisted to non-allowlisted (rejected under opt-1, accepted under opt-2 with audit), link from non-allowlisted to allowlisted (same), self-link (rejected), null inward / null outward (rejected).",
+        "Reviewer MUST run the existence-leak fuzz: attempt to enumerate tickets in a non-allowlisted project by varying inward.key — the gateway should return identical 403 responses regardless of whether the target ticket exists upstream."
+      ],
+      "rollback": "Tighten config (move all `linkable_only_projects` to allowlist or remove them); POST /api/v1/config/reload. Future link calls fail closed.",
+      "requires_human_review": false
+    },
+    {
+      "id": "R9",
+      "title": "Link-type passthrough — agent uses Atlassian-instance link types the operator did not vet",
+      "category": "security",
+      "description": "`POST /rest/api/3/issueLink` accepts `type.name` from the Atlassian instance's link-type table. Common types are `Blocks`, `Relates`, `Cloners`, `Duplicate`, but operators can configure custom link types (`Implements`, `Tests`, `Causes`, etc.) or third-party-app-installed link types with surprising semantics (e.g., a workflow-trigger link type that fires automation). Decision-4 (link-type allowlist source) is unresolved. Accepting any name (decision-4 opt-3) lets an agent invoke a link-type that triggers downstream automation (e.g., Jira Automation rules listening for `Causes` to auto-transition).",
+      "affected_components": [
+        "gateway/jira_client.py — `create_issue_link` body validator",
+        "config/context-filters.yaml — potential `jira.link_types: [...]`"
+      ],
+      "impact": "medium",
+      "likelihood": "low",
+      "severity": "medium",
+      "mitigations": [
+        "Block until decision-4 (link-type allowlist source) resolves. Recommended option is opt-2 (operator-configurable `jira.link_types: [...]` in context-filters.yaml, default `[Blocks, Relates]`).",
+        "If decision-4 = opt-1 (hardcoded): the allowlist is `frozenset({'Blocks', 'Relates'})` in code; widen via PR only.",
+        "If decision-4 = opt-2 (config-allowed): `jira.link_types` defaults to `[Blocks, Relates]` if absent; rejects empty list with audit log line; mtime-cached and reload-able like `jira.projects`.",
+        "If decision-4 = opt-3 (any name): explicitly denylist link types known to trigger Jira Automation rules in common deployments — `Causes`, `Discovers`, plus operator-extensible denylist via config. Document the residual risk.",
+        "Body validator: `type.name` must match `^[A-Za-z][A-Za-z _-]{0,32}$` (Atlassian's name shape). Reject empty / whitespace-only.",
+        "Audit on rejection: `jira_issue_link_type_denied`, `type=<name>`. On acceptance, audit records `type=<name>` so operators can spot unusual link-type usage.",
+        "Test: every option's allowlist boundary; case-sensitivity (Atlassian link-type names are case-sensitive); whitespace; unicode."
+      ],
+      "rollback": "Tighten `jira.link_types` to `[Blocks]` only and reload; new link calls with other types fail closed.",
+      "requires_human_review": false
+    },
+    {
+      "id": "R10",
+      "title": "Per-role and per-phase write gating — agent of a phase/role inappropriate for writes can mutate Jira",
+      "category": "security",
+      "description": "v1 reads have no per-role or per-phase gating beyond the project allowlist (any session calling /api/v1/jira/* with valid auth and an allowlisted project succeeds). Writes are higher-stakes — should a `tester` agent be able to call createJiraIssue? Should `editJiraIssue` only be callable in refine? Decisions 10 (per-role) and 11 (per-phase) are unresolved. Punting them ('opt-3 defer to follow-up') is the architect's likely pick (low-friction v1) but means any role / phase combination with a session token can write to allowlisted Jira projects until a follow-up issue lands.",
+      "affected_components": [
+        "gateway/gateway.py — write route handlers",
+        "gateway/phase_filter.py (potentially extended)",
+        "gateway/role_filter.py (potentially new)",
+        "shared/egg_restrictions/ — role/phase allowlist sources"
+      ],
+      "impact": "medium",
+      "likelihood": "medium",
+      "severity": "medium",
+      "mitigations": [
+        "Block until decision-10 (per-role gating) and decision-11 (per-phase gating) resolve. Recommend BOTH be set to opt-3 (defer to follow-up issue) for v1924, with a documented runbook note that v1 writes are open to any session-authenticated role in any phase, gated only by project allowlist.",
+        "If decisions 10/11 = opt-3 (defer): document the gap explicitly in docs/reference/jira-wrapper.md and link a tracking issue for the follow-up. Operator dashboards must surface caller role/phase per write to enable post-hoc detection of misuse.",
+        "If decision-10 = opt-2 (per-verb role allowlist): config shape `jira.role_allowlist: { ticket_create: [planner, refiner], ticket_edit: [refiner], comment_add: [refiner, planner], issue_link_create: [planner] }`. Default is empty (everything allowed) per opt-3 fallback.",
+        "If decision-11 = opt-2 (per-phase verb allowlist): mirror decision-10's shape but keyed on phase. Both can coexist via AND.",
+        "Audit on every write records `caller_role=<role>` and `caller_phase=<phase>` (already in `_session_jira_context`). Operator runbook: `jq '.events[] | select(.operation | startswith(\"jira_\")) | select(.success==true) | [.caller_role, .caller_phase, .operation] | @csv'` produces a per-write audit table for ad-hoc review.",
+        "Test: each role/phase combination calling each write verb; expected accept/reject matrix."
+      ],
+      "rollback": "If misuse is detected post-merge, hot-patch the role/phase allowlist (or default to refiner+planner only) via gateway env-var, ship, and roll. Existing in-flight writes complete.",
+      "requires_human_review": true,
+      "human_review_reason": "Decision-10 and decision-11 are HITL-blocking. Either choice has security trade-offs — opt-3 (defer) makes v1924 easier to ship but leaves write surface open across roles/phases until a follow-up. A security reviewer should confirm the deferral acceptable for the operator's deployment."
+    },
+    {
+      "id": "R11",
+      "title": "Body-size caps and audit-log explosion — large description / comment bodies blow up audit log and gateway memory",
+      "category": "performance",
+      "description": "Atlassian publishes `summary` cap of 255 chars, but no public cap for `description`, `comment.body`, or label count. A large ADF body (say, 5 MB of markdown serialized to ADF) would (a) be accepted upstream up to Atlassian's storage limit (Atlassian's per-comment internal cap is ~32 KB but undocumented), (b) blow up the gateway's audit log (length recorded but not body), (c) slow the gateway's HTTP serialization, (d) blow up the orchestrator's response-handling memory, and (e) stress Atlassian's per-issue write quota. Refine open question Q15 / feedback-1.Q2 is unresolved.",
+      "affected_components": [
+        "gateway/jira_client.py — body validator pre-flight size check",
+        "gateway/gateway.py — request body parsing (Flask `request.get_json` cap)",
+        "gateway/audit log emitter — confirms structural-only logging"
+      ],
+      "impact": "low",
+      "likelihood": "medium",
+      "severity": "medium",
+      "mitigations": [
+        "Block until feedback-1.Q2 resolves. Recommended caps: `summary` ≤ 255 (matches Atlassian), `description` ≤ 100_000 chars, `comment body` ≤ 32_000 chars (matches Atlassian's undocumented internal limit), `labels` ≤ 32 entries with each ≤ 100 chars (Atlassian's hard limit is 255, but agents shouldn't need that), `customFields` map ≤ 16 keys. All caps are operator-overridable via env-var (`EGG_JIRA_DESCRIPTION_MAX`, etc.) for one-off use cases.",
+        "Validate caps BEFORE making the upstream call. Audit on rejection: `jira_<verb>_body_size_rejected`, `field=<name>`, `length=<int>`, `cap=<int>`.",
+        "Flask `MAX_CONTENT_LENGTH` (request body size cap) set to ~256 KB for /api/v1/jira/* routes — defense-in-depth so a multi-megabyte body cannot reach the JSON parser.",
+        "Audit log body redaction: only `description_length`, `description_node_count`, `description_depth`, `comment_length`, `comment_node_count`, `labels_count`, `labels_total_length`. NEVER the body content (per refine Open Q20 / feedback-1.Q5).",
+        "Test: oversized body (just over cap) rejected with structured 400; deeply-nested ADF rejected on node-count or depth cap; label list at exactly 32 entries accepted, 33 rejected.",
+        "Test: confirm audit log entries do NOT include the body content for a successful write."
+      ],
+      "rollback": "Tighten caps via env-var; agents that hit them get 400 with a clear `cap=<int>` reason. Operators can re-issue via Jira UI."
+    },
+    {
+      "id": "R12",
+      "title": "Sandbox wrapper UX bugs — bash JSON construction with multi-line / shell-special bodies leaks args, drops bytes, or fails",
+      "category": "operational",
+      "description": "v1's sandbox/scripts/jira already uses Python heredocs to build JSON bodies. The write extension grows that wrapper by ~300 lines, including new flags `--description`, `--description-file`, `--description-stdin`, `--body`, `--body-file`, `--body-stdin`, `--labels`, `--add-labels`, `--remove-labels`, `--idempotency-key`, plus a four-way verb dispatch tree. Risks: multi-line bodies passed via `--description \"...\"` are mangled by bash's IFS / quoting; large bodies via stdin run into bash's argv length limits (rare but possible); file paths with spaces break unquoted variables; non-UTF-8 bytes corrupt the Python heredoc.",
+      "affected_components": [
+        "sandbox/scripts/jira",
+        "tests/sandbox/test_jira_wrapper.py"
+      ],
+      "impact": "low",
+      "likelihood": "medium",
+      "severity": "low",
+      "mitigations": [
+        "Resolve feedback-1.Q4 (Open Q19): confirm `--description` / `--description-file` / `--description-stdin` flag set. Recommended: support all three for create/edit; require the same triplet for `comment add` (`--body` / `--body-file` / `--body-stdin`); prefer `--description-file` and `--body-file` in agent prompts (most robust to multi-line content).",
+        "Pass body content through `python3 -c` heredoc with `sys.argv` (already the v1 pattern); never embed body in the bash JSON-build line.",
+        "For `--description-stdin` / `--body-stdin`: read from `sys.stdin.buffer` (binary), validate UTF-8, fail clearly on non-UTF-8.",
+        "All file paths quoted in bash; tests include paths with spaces, paths with newlines (rejected), paths with non-ASCII (accepted, validated UTF-8).",
+        "Test grid: empty body (rejected), multi-line body (preserved), unicode body (preserved), body with embedded JSON-escape sequences (preserved verbatim — agent text is not JSON), body with literal backslashes (preserved).",
+        "Document in sandbox/agent-config/rules/environment.md the recommended flag (`--description-file <path>`) for any body > 1 line."
+      ],
+      "rollback": "Wrapper bug → wrapper-only fix; gateway unchanged. Workaround: agent invokes the gateway via `curl` directly (already supported via `gateway/gateway.py` REST surface)."
+    },
+    {
+      "id": "R13",
+      "title": "PII / sensitive content in description bodies — appears in audit logs only as length, but reaches Atlassian",
+      "category": "data-privacy",
+      "description": "Agent-authored description / comment bodies could contain inadvertent PII (email addresses scraped from the codebase, sandbox tokens, API keys pasted from a debug session, personal names from commit history). Refine open question Q20 (feedback-1.Q5) confirmed audit logs record only structural metadata (length, node counts). But the bodies still reach Atlassian and live in Jira's audit / version history forever. The orchestrator's plan-apply pulls agent text from prompts; an off-prompt agent could write something the operator would not want in Jira.",
+      "affected_components": [
+        "gateway/jira_client.py — body acceptance",
+        "Agent prompts (out of scope for gateway; documentation only)"
+      ],
+      "impact": "medium",
+      "likelihood": "medium",
+      "severity": "medium",
+      "mitigations": [
+        "Confirm feedback-1.Q5 (Open Q20): audit logs record structural metadata only — confirmed.",
+        "Document in docs/reference/jira-wrapper.md and in agent prompts: 'Agent-authored Jira bodies are visible to all Jira users with project access. Do not paste credentials, API tokens, or PII.'",
+        "Consider a future-scope feature (out of v1924): a redaction pre-flight that scans description/comment bodies for known credential patterns (private keys, AWS keys, Anthropic keys, GitHub PATs). Document as a follow-up.",
+        "Audit log records `agent_role`, `pipeline_id`, `caller_phase` per write so post-hoc forensics can identify which agent wrote which body.",
+        "If a credential leak is detected, runbook: (1) revoke the credential; (2) operator manually edits the Jira ticket / deletes the comment; (3) Atlassian audit log retention applies."
+      ],
+      "rollback": "Manual Jira UI cleanup. Gateway cannot redact retroactively."
+    },
+    {
+      "id": "R14",
+      "title": "Issuetype identifier per-instance variation — `Task` name might not exist in operator's Jira",
+      "category": "compatibility",
+      "description": "Atlassian's default issuetypes are `Task`, `Story`, `Bug`, `Epic`, `Sub-task`, but operators can rename them, add new ones, or use numeric IDs. An agent that hardcodes `'issuetype': {'name': 'Task'}` will fail on instances with renamed or non-default issuetype configurations. Refine open question Q8 (decision-8) is unresolved. The architect's recommended C1 schema accepts `issuetype: <NAME from {Task, Story, Bug, Epic, Sub-task} or numeric ID>`, which papers over the variation but doesn't validate against the actual instance.",
+      "affected_components": [
+        "gateway/jira_client.py — `create_issue` body validator",
+        "config/context-filters.yaml — potential `jira.issuetypes: [...]`"
+      ],
+      "impact": "medium",
+      "likelihood": "medium",
+      "severity": "low",
+      "mitigations": [
+        "Block until decision-8 (issuetype identifier) resolves. Recommended option is opt-3 (both name and numeric ID) — most flexible.",
+        "If decision-8 = opt-3 (both): the body validator accepts `issuetype: {name: 'Task'}` OR `issuetype: {id: '10003'}`. Pass-through to upstream.",
+        "Atlassian rejects unknown issuetypes with a 400 + `errorMessages: ['issuetype is required']` — surface that error verbatim via R15's enriched envelope.",
+        "Future-scope (out of v1924): validate against `GET /rest/api/3/issuetype/project?projectId=N` per-project to fail-fast on unknown types. Document as follow-up.",
+        "Document in docs/reference/jira-wrapper.md the issuetype enumeration: 'Use Atlassian default names (Task, Story, Bug, Epic, Sub-task) where possible. For renamed issuetypes, use the numeric ID via `--type-id` instead of `--type`.'"
+      ],
+      "rollback": "Operator overrides issuetype mapping in agent prompts; gateway accepts whatever name/ID the agent passes."
+    },
+    {
+      "id": "R15",
+      "title": "Error-envelope drift — a write 4xx with field-level Atlassian errors gets swallowed by `_jira_error_from_upstream`",
+      "category": "operational",
+      "description": "v1's `_jira_error_from_upstream` (gateway.py line 4311) maps Atlassian 4xx → 4xx, 5xx → 502, with the upstream body in `details.upstream_body`. Atlassian write 4xx responses have a structured `errorMessages: [...]` and `errors: {<field>: <reason>}` shape (e.g., `{'errors': {'parent': 'Field parent cannot be set...'}}`). The current passthrough preserves the body verbatim, so an agent that knows to look at `details.upstream_body.errors` can debug. But a less-sophisticated caller sees a generic 'Jira upstream error 400' and has to dig. Refine feedback-1.Q9 (Open Q26) is unresolved.",
+      "affected_components": [
+        "gateway/gateway.py — `_jira_error_from_upstream`",
+        "docs/reference/jira-wrapper.md — error-envelope shape documentation"
+      ],
+      "impact": "low",
+      "likelihood": "high",
+      "severity": "low",
+      "mitigations": [
+        "Resolve feedback-1.Q9 (Open Q26). Recommended: enrich the envelope with a top-level `field_errors: {<field>: <reason>}` extracted from `errors` if present, plus `error_messages: [<str>]` extracted from `errorMessages`. Keeps the verbatim body in `details.upstream_body` for debug.",
+        "Document the shape in docs/reference/jira-wrapper.md so callers know to check `field_errors` first.",
+        "Test: each Atlassian write 4xx shape (createJiraIssue with missing project, editJiraIssue with invalid field, addCommentToJiraIssue with malformed ADF) preserved through the envelope.",
+        "Audit: each upstream 4xx logs `upstream_status`, `field_errors_keys` (just the field NAMES, not values — Atlassian sometimes includes user-input echoes in error reasons)."
+      ],
+      "rollback": "Revert envelope enrichment if it leaks unintended Atlassian data; fall back to v1's verbatim passthrough. Agents see slightly noisier errors."
+    },
+    {
+      "id": "R16",
+      "title": "private-mode-gate decorator drift — a new write route ships without `@require_private_mode`",
+      "category": "security",
+      "description": "Every `/api/v1/jira/*` route MUST carry `@require_session_auth` and `@require_private_mode`. The gate is one decorator line per route and easy to omit on a follow-up commit. v1's `test_jira_routes.test_all_jira_routes_require_private_mode` walks `app.url_map`, filters by `/api/v1/jira/`, and asserts every view's `__egg_requires_private_mode__` is True. The new write routes inherit this regression test, but only if the route registration matches the test's URL pattern.",
+      "affected_components": [
+        "gateway/gateway.py — write route handlers",
+        "gateway/tests/test_jira_routes.py — route-enumeration regression test"
+      ],
+      "impact": "high",
+      "likelihood": "low",
+      "severity": "medium",
+      "mitigations": [
+        "Confirm `test_all_jira_routes_require_private_mode` enumerates the new routes (`/ticket/create`, `/ticket/edit`, `/ticket/comment/add`, `/issue-link/create`). The pattern in the test must include them.",
+        "Add a CONTRIBUTING note (or extend gateway/README.md): 'New /api/v1/jira/* routes MUST stack @require_session_auth → @require_private_mode → handler.'",
+        "Reviewer MUST run `pytest gateway/tests/test_jira_routes.py -k private_mode` and confirm pass count includes 4 new routes (8 routes total: 4 read + 4 write).",
+        "Audit log records `session_mode` per write call so post-hoc detection catches any accidental public-mode access."
+      ],
+      "rollback": "If a route ships without the gate, hot-patch by adding the decorator and re-deploying the gateway pod. CI catches it pre-merge."
+    },
+    {
+      "id": "R17",
+      "title": "Squid allowlist accidentally widened to include `*.atlassian.net`",
+      "category": "security",
+      "description": "v1's allowed_domains.txt deliberately excludes `*.atlassian.net` — sandboxed agents cannot bypass the gateway and hit Atlassian directly. The write extension's larger surface area might tempt a future maintainer to 'just allow Atlassian' to debug, breaking the gateway-only invariant for both reads AND writes. Mirrors #1556's R5.",
+      "affected_components": [
+        "gateway/allowed_domains.txt",
+        "gateway/tests/test_allowed_domains.py"
+      ],
+      "impact": "high",
+      "likelihood": "low",
+      "severity": "medium",
+      "mitigations": [
+        "Verify `test_allowed_domains.py` asserts `*.atlassian.net` is NOT in allowlist (already covered by v1).",
+        "Comment in `gateway/allowed_domains.txt`: '# Atlassian (Jira AND Confluence) is intentionally NOT here — route through /api/v1/jira/* via the gateway.' (May already exist post-#1931.)",
+        "Implement-phase reviewer must spot-check the comment lands and the test still passes.",
+        "Audit log records destination host on egress denials so an accidental config drift surfaces immediately."
+      ],
+      "rollback": "One-line revert of allowed_domains.txt; CI catches it pre-merge."
+    },
+    {
+      "id": "R18",
+      "title": "Idempotency cache memory unbounded — pathological key generation could OOM the gateway",
+      "category": "performance",
+      "description": "Architect option D1 specifies a 5-minute TTL in-process dict. If an agent generates 10,000 unique idempotency_keys per minute (each cache entry ~1 KB), the cache grows ~50 MB before TTL eviction kicks in. The eviction path is lazy on insert — at high churn the dict could reach hundreds of MB before sweep. Decision-14 (cache scope) implies in-memory but doesn't put a hard cap on entry count.",
+      "affected_components": [
+        "gateway/jira_client.py or gateway/idempotency.py — cache module",
+        "tests for cache eviction under load"
+      ],
+      "impact": "low",
+      "likelihood": "low",
+      "severity": "low",
+      "mitigations": [
+        "Hard cap at `MAX_IDEMPOTENCY_ENTRIES = 10_000`. On insert, if cap reached, evict oldest entry (LRU) and emit `jira_idempotency_cache_evicted` audit line.",
+        "Eager sweep of expired entries every N inserts (where N = 100 or so) so memory stays bounded under high churn.",
+        "Cache value is structurally bounded (just status code + small response body summary, NOT the full Atlassian response if that response is huge — replay returns a synthetic envelope `{status: 'idempotency_replay', cached: true, original_status: <int>}` rather than the full upstream body). Trade-off: clients that need the full body re-issue with a fresh key.",
+        "Test: hammer cache with 10_001 unique keys, assert oldest is evicted, memory growth bounded.",
+        "Document in docs/reference/jira-wrapper.md the memory cap and eviction semantics."
+      ],
+      "rollback": "Tune cap via env-var; in catastrophic OOM, restart gateway pod (cache is per-process, restart drops it cleanly)."
+    },
+    {
+      "id": "R19",
+      "title": "Documentation home unresolved — decision-18 splits between extending jira-wrapper.md or creating jira-writes.md",
+      "category": "operational",
+      "description": "Decision-18 (Open Q27) is unresolved. Where the four new verbs are documented affects discoverability. Splitting docs (option opt-3 'both, high-level in jira-wrapper.md, deep dive in jira-writes.md') is the most reviewer-friendly but doubles the surface to maintain. Inlining (option opt-1) keeps a single page but bloats jira-wrapper.md to ~400 lines. New file (option opt-2) is cleanest but requires updating index links.",
+      "affected_components": [
+        "docs/reference/jira-wrapper.md",
+        "docs/reference/jira-writes.md (potentially new)",
+        "docs/index.md (link update)"
+      ],
+      "impact": "low",
+      "likelihood": "high",
+      "severity": "low",
+      "mitigations": [
+        "Defer to HITL decision-18 resolution. Recommended: opt-1 (extend existing jira-wrapper.md) for minimal documentation surface; the page is currently 174 lines and four new verbs adds ~120 lines, keeping it under 350 — manageable.",
+        "Whichever option HITL picks, doc-updater agent (or implement-phase doc step) ensures docs/index.md and CONTRIBUTING.md links are consistent.",
+        "Reviewer MUST verify the chosen doc layout describes: each new verb's request body, response shape, body-size caps (R11), idempotency requirement (R3), Epic Link mechanism (R6), link-type allowlist (R9), error envelope shape (R15)."
+      ],
+      "rollback": "Re-organize docs in a follow-up PR if the layout proves confusing."
+    }
+  ],
+  "global_rollback_plan": {
+    "level_1_config_only": [
+      "Set `jira.projects: []` in config/context-filters.yaml — fails every Jira call (read AND write) closed; agents see 403 with `jira_<verb>_denied`.",
+      "Set `jira.link_types: []` (if decision-4 = opt-2) — fails every createIssueLink closed.",
+      "POST /api/v1/config/reload — propagates without restart.",
+      "Confirm via grep of audit log: zero `success: true` Jira write events in the next minute."
+    ],
+    "level_2_route_disable": [
+      "Hot-patch gateway to return 503 on `/api/v1/jira/ticket/create`, `/ticket/edit`, `/ticket/comment/add`, `/issue-link/create` (single-file change in gateway.py); roll the gateway pod.",
+      "Read endpoints (`/ticket/get`, `/search`, `/ticket/comments`, `/execute`) continue to serve traffic.",
+      "Plan-apply consumers (#1557) fall back to manual Jira UI updates."
+    ],
+    "level_3_credential_revoke": [
+      "Revoke the Atlassian bot-account API token in Atlassian admin UI.",
+      "Gateway returns 503 on next call (credential loader fails); audit log records the failure mode.",
+      "Both Jira and Confluence go dark together (per #1931 decision-6 shared-creds coupling). Document this as the trade-off of consolidation. Pipeline phases that need either service block on `awaiting_human` until rotation."
+    ],
+    "level_4_full_revert": [
+      "git revert the merge commit; redeploy the gateway image.",
+      "config/context-filters.yaml retains the `jira:` section but no code reads write-specific config (`jira.custom_fields`, `jira.link_types`) — no-op until re-rolled.",
+      "Idempotency cache is per-process — restart drops it; no orphan state.",
+      "Future re-land via a new PR after the issue is identified and patched."
+    ]
+  },
+  "implement_phase_checklist": [
+    "[R1] Custom-field allowlist matches HITL decision-1; adversarial body grid asserts `securityLevel`, `sprint`, `watchers`, `assignee`, `fixVersions` rejected via every entry-point.",
+    "[R2] `validate_jira_api_path.ALLOWED_METHODS == frozenset({'GET'})` confirmed by unit test; new write methods bypass `validate_jira_api_path`; `/execute` anti-bypass test enumerates all write paths and confirms POST/PUT rejected.",
+    "[R3] Idempotency cache: per-(verb, project_key, idempotency_key) keying; 5-minute TTL; threading lock; max 10_000 entries with LRU eviction; replay returns `Idempotency-Replayed: true` header; cache scope matches HITL decision-3 / decision-14 / decision-19.",
+    "[R4] Writes never auto-retry on 429; `_jira_error_from_upstream` surfaces `RateLimit-Reason` and `Retry-After` in the envelope; audit emits `jira_upstream_rate_limited` for 429 on writes.",
+    "[R5] ADF body validation matches HITL decision-7; node-type allowlist enforced; serialized ADF size capped per R11 limits.",
+    "[R6] Epic Link mechanism matches HITL decision-2; cross-project parent rejected (HITL decision-15 = opt-1); body validator rejects simultaneous parent + epicLink.",
+    "[R7] createJiraIssue project-allowlist gate reads `body.projectKey` (not extract_project_key); test grid covers missing / non-allowlisted / mismatched projectKey-vs-fields.project.key.",
+    "[R8] createIssueLink project-allowlist matches HITL decision-9; existence-leak fuzz confirms identical 403 shape regardless of upstream ticket existence.",
+    "[R9] Link-type allowlist matches HITL decision-4; type.name regex bounds; case-sensitivity test passes.",
+    "[R10] Per-role / per-phase gating matches HITL decisions 10 and 11; if deferred, runbook entry documents the gap; audit captures `caller_role` and `caller_phase` per write.",
+    "[R11] Body-size caps match feedback-1.Q2 resolution; Flask `MAX_CONTENT_LENGTH` capped at 256 KB for `/api/v1/jira/*`; audit log records structural metadata only (per feedback-1.Q5).",
+    "[R12] Sandbox wrapper supports `--description` / `--description-file` / `--description-stdin` (and `--body` analogue); multi-line and unicode bodies preserved; tests cover paths-with-spaces.",
+    "[R13] Documentation explicitly warns: agent-authored Jira bodies are visible to all Jira users with project access; do not paste credentials.",
+    "[R14] Issuetype identifier matches HITL decision-8; documentation enumerates Atlassian defaults and recommends numeric ID for renamed issuetypes.",
+    "[R15] Error envelope enriched with `field_errors` and `error_messages` per feedback-1.Q9 resolution; verbatim `details.upstream_body` preserved.",
+    "[R16] `test_all_jira_routes_require_private_mode` covers 4 new write routes; `__egg_requires_private_mode__` confirmed True on each.",
+    "[R17] `gateway/allowed_domains.txt` comment confirms `*.atlassian.net` exclusion is intentional for both Jira AND Confluence.",
+    "[R18] Idempotency cache eviction test passes: 10_001 unique keys → oldest evicted, memory bounded, structured audit on eviction.",
+    "[R19] Documentation home matches HITL decision-18; docs/index.md updated."
+  ],
+  "external_research": {
+    "sources_consulted": [
+      "https://developer.atlassian.com/cloud/jira/platform/rate-limiting/",
+      "https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/",
+      "https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-bulk-operations/",
+      "https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-links/",
+      "https://developer.atlassian.com/cloud/jira/platform/issue-linking-model/",
+      "https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/",
+      "https://developer.atlassian.com/cloud/jira/platform/change-notice-update-in-simultaneous-transitions-issue-api/",
+      "https://community.atlassian.com/forums/Jira-questions/Does-Jira-Rest-API-have-idempotent-create-Jira-ticket-API/qaq-p/2380895",
+      "https://community.atlassian.com/forums/Jira-questions/Clarification-on-Rate-Limiting-for-Jira-REST-API-s-Edit-Issue/qaq-p/2956205",
+      "https://www.atlassian.com/blog/platform/evolving-api-rate-limits",
+      "https://cyberpress.org/stored-xss-flaw-in-jira-work/",
+      "https://jira.atlassian.com/browse/JSDSERVER-6895",
+      "https://jira.atlassian.com/browse/JRACLOUD-77436"
+    ],
+    "key_findings": [
+      "Atlassian's March 2026 points-based rate-limit rollout introduces per-issue write throttling (`jira-per-issue-on-write`) — exactly the pattern #1557's plan-apply will hit with multiple sequential editJiraIssue calls on the parent epic. API-token traffic is NOT exempt from burst limits. Surfacing `RateLimit-Reason` and `Retry-After` in the gateway envelope is mandatory for the orchestrator to back off correctly.",
+      "Jira Cloud REST API v3 has NO native idempotency key for any write endpoint. Atlassian's own documentation explicitly states 'only retry if the API is idempotent' — Jira creates are NOT. POST /rest/api/3/issueLink does NOT dedupe (inward, outward, type) triples; refine open Q28 / decision-19 was correct to surface this. The only mitigation is a gateway-side idempotency cache (architect D1) plus stable orchestrator-derived keys.",
+      "ADF bodies passed through to Atlassian are sanitized on render but the Atlassian Document Format spec includes node types (`mention`, `media`, `inlineCard`, `extension`) that have non-trivial side-effects. Recent stored-XSS findings in Jira Work Management (Snapsec, 2025) prove that fields outside ADF schema can lack sanitization. The safe v1 default is plain-text-only with gateway-side ADF wrapping (architect E1, recommend decision-7 = opt-1).",
+      "Atlassian transition API is moving from 400 → 409 for race conditions. While transitions are explicitly out of scope for #1924, the same 409 pattern may eventually apply to other writes; the gateway should be ready to translate 409 → exposed-via-envelope for the orchestrator to retry-with-backoff."
+    ]
+  },
+  "tasks_satisfied": [],
+  "produced_at": "2026-04-27T19:30:00Z"
+}

--- a/.egg-state/brc-history/1924-plan.json
+++ b/.egg-state/brc-history/1924-plan.json
@@ -1,0 +1,1378 @@
+[
+  {
+    "id": "355256e1-c4a4-4f",
+    "pipeline_id": "issue-1924",
+    "from_role": "overseer",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "Cycle 1 complete. Refine phase BRC consensus confirmed. Plan phase agents launched (architect, task_planner, risk_analyst, reviewer_plan). 8 stale refine-phase alerts classified as noise \u2014 no corrective action required. Monitoring plan phase progression.",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:15:32.127640+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "86167bf8-7b9a-43",
+    "pipeline_id": "issue-1924",
+    "from_role": "overseer",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "Cycle 2 complete. Plan phase healthy \u2014 4 agents running (architect, task_planner, risk_analyst, reviewer_plan), elapsed ~34s. No new alerts. Monitoring.",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT"
+    },
+    "timestamp": "2026-04-27T19:15:51.705704+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "35837d78-50e4-4d",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT"
+    },
+    "timestamp": "2026-04-27T19:17:13.216723+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "ac56f265-941e-47",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:17:24.587462+00:00"
+    },
+    "timestamp": "2026-04-27T19:17:24.624952+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "eb1ad32a-767a-4b",
+    "pipeline_id": "issue-1924",
+    "from_role": "overseer",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "Plan phase nominal \u2014 reviewer_plan active, waiting for CONSENSUS_PROPOSE from architect/task_planner/risk_analyst (151s elapsed). No anomalies detected.",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT"
+    },
+    "timestamp": "2026-04-27T19:17:41.276290+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "a3263597-2358-46",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:17:24.587462+00:00"
+    },
+    "timestamp": "2026-04-27T19:18:24.812262+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "b760ad9e-a1ed-40",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:17:24.587462+00:00"
+    },
+    "timestamp": "2026-04-27T19:19:24.926318+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "a67d86c1-af62-4f",
+    "pipeline_id": "issue-1924",
+    "from_role": "overseer",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "Plan phase cycle 25 \u2014 288s elapsed, all 4 agents running (architect, task_planner, risk_analyst, reviewer_plan). reviewer_plan active and waiting for CONSENSUS_PROPOSE. No producer proposals yet. No detector alerts. Pipeline healthy.",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT"
+    },
+    "timestamp": "2026-04-27T19:20:00.882253+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "4b348f29-6aa2-4b",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:17:24.587462+00:00"
+    },
+    "timestamp": "2026-04-27T19:20:25.161621+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "9736a8bd-5ea8-46",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:17:24.587462+00:00"
+    },
+    "timestamp": "2026-04-27T19:21:25.345268+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "b8d42f38-c2e9-42",
+    "pipeline_id": "issue-1924",
+    "from_role": "task_planner",
+    "to_role": "all",
+    "message_type": "CONSENSUS_PROPOSE",
+    "subject": "Proposal from task_planner",
+    "body": "Plan phase task decomposition for #1924 (Jira gateway write verbs). Six-phase single-PR plan: (1) foundation modules \u2014 idempotency cache + ADF helper; (2) four JiraClient write methods bypassing validate_jira_api_path with hardcoded paths; (3) four /api/v1/jira/* gateway routes with curated body schemas, project allowlist, audit redaction; (4) four sandbox wrapper subcommands with text/file/stdin input ergonomics; (5) tests \u2014 per-route 403 grid extension, idempotency cache, ADF, adversarial bodies; (6) docs \u2014 extend jira-wrapper.md. 26 tasks across coder/tester/documenter roles. Bakes in 19 HITL decision defaults from the architect's recommended approach (A1+B1+C1+D1+E1) so implement can start before all HITL answers land.",
+    "metadata": {
+      "payload": {
+        "summary": "Plan phase task decomposition for #1924 (Jira gateway write verbs). Six-phase single-PR plan: (1) foundation modules \u2014 idempotency cache + ADF helper; (2) four JiraClient write methods bypassing validate_jira_api_path with hardcoded paths; (3) four /api/v1/jira/* gateway routes with curated body schemas, project allowlist, audit redaction; (4) four sandbox wrapper subcommands with text/file/stdin input ergonomics; (5) tests \u2014 per-route 403 grid extension, idempotency cache, ADF, adversarial bodies; (6) docs \u2014 extend jira-wrapper.md. 26 tasks across coder/tester/documenter roles. Bakes in 19 HITL decision defaults from the architect's recommended approach (A1+B1+C1+D1+E1) so implement can start before all HITL answers land.",
+        "attestation": {},
+        "artifacts": [
+          ".egg-state/drafts/1924-plan.md"
+        ],
+        "risk_considered": "",
+        "commit_sha": "5a8e52da5cefcd29800b6296791fdd5a1519048c",
+        "files_changed": [
+          ".egg-state/drafts/1924-plan.md"
+        ],
+        "tests_run": [],
+        "tasks_satisfied": []
+      },
+      "version": 1,
+      "commit_sha": "5a8e52da5cefcd29800b6296791fdd5a1519048c"
+    },
+    "timestamp": "2026-04-27T19:21:49.766188+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "bcb02c6b-69dc-48",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:21:50.317209+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "c95ac50f-1c1e-4a",
+    "pipeline_id": "issue-1924",
+    "from_role": "task_planner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:22:03.270283+00:00"
+    },
+    "timestamp": "2026-04-27T19:22:05.028123+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "271d944c-157e-4f",
+    "pipeline_id": "issue-1924",
+    "from_role": "task_planner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:22:05.151647+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "c699b691-806f-4c",
+    "pipeline_id": "issue-1924",
+    "from_role": "task_planner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:22:07.693396+00:00"
+    },
+    "timestamp": "2026-04-27T19:22:07.768434+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "eae0f8f5-2318-42",
+    "pipeline_id": "issue-1924",
+    "from_role": "task_planner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:22:07.693396+00:00"
+    },
+    "timestamp": "2026-04-27T19:23:07.816325+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "6b873daa-e5a0-49",
+    "pipeline_id": "issue-1924",
+    "from_role": "overseer",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "Plan phase cycle 50 \u2014 486s elapsed. task_planner PROPOSED (6-phase, 26-task plan). reviewer_plan actively reviewing. architect + risk_analyst still preparing proposals. No real alerts (1 calibration-only stale refine-phase stall). BRC progressing normally.",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT"
+    },
+    "timestamp": "2026-04-27T19:23:16.627264+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "48453a3a-ed1b-4d",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:23:35.757504+00:00"
+    },
+    "timestamp": "2026-04-27T19:23:35.794201+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "7ea4b104-c9d5-4f",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:23:45.914636+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "bac873d6-053b-43",
+    "pipeline_id": "issue-1924",
+    "from_role": "task_planner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:22:07.693396+00:00"
+    },
+    "timestamp": "2026-04-27T19:24:07.995116+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "26ce78db-c061-4e",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "task_planner",
+    "message_type": "CONSENSUS_NACK",
+    "subject": "NACK from reviewer_plan for task_planner",
+    "body": "\nReviewed the plan draft section-by-section against the analysis and the existing v1 read-only gateway. The phase decomposition (Foundation \u2192 Client \u2192 Routes \u2192 Wrapper \u2192 Tests \u2192 Docs), choice of A1+B1+C1+D1+E1, and PR scoping are sound. The HITL-defaults table is a useful unblock and most defaults match the analysis. But six items must be tightened before this plan is implementable \u2014 three of them are actively broken or self-contradictory.\n\n### Blocking\n\n1. **Defaults table D2 + TASK-2-1: \"Auto-detect\" emits BOTH `parent.key` AND `customfield_10014` simultaneously \u2014 this is wrong and will 400 upstream.** The analysis (lines 198, 347) and Atlassian's REST docs are explicit: `parent.key` is the next-gen / company-managed field; `customfield_10014` is the classic Epic Link field. They are mutually exclusive per project type. Sending both on a next-gen project returns `400 Field 'customfield_10014' cannot be set, it is not on the appropriate screen, or unknown.`; sending both on classic returns the inverse for `parent`. The plan's `1924-plan.md:55` says \"emit both `parent.key` (next-gen) and `customfield_10014` (classic Epic Link); the wire shape is decided per-instance via `jira_policy` config (default = both)\" \u2014 and TASK-2-1's description (lines 452-454) literally builds both fields. **Fix:** pick a per-instance config knob in `jira_policy` (e.g. `jira.epic_link_field: \"parent\" | \"customfield_10014\"`, default `\"parent\"`) and emit only that field. The architect's option 3 (\"Auto-detect or accept either via the epicLink shorthand\") is one-or-the-other dispatch, not a both-fields shotgun. Add a TASK in Phase 2 or Phase 3-5 to load this knob, and reflect it in the body builder. Also amend the ambiguity in TASK-2-1 between the explicit `parent` arg and the `epic_link` arg \u2014 if both are passed, what wins? Spec it (e.g. \"explicit `parent` overrides `epic_link`; if both set and conflicting, 400 at the route\") rather than letting the second `fields.parent.key=` line clobber the first.\n\n2. **TASK-1-1 / TASK-1-2 acceptance criteria duplicate TASK-5-1 / TASK-5-2 \u2014 same test files owned by two roles.** TASK-1-1 acceptance (lines 396-404) demands `gateway/tests/test_jira_idempotency.py` pass with seven named scenarios. TASK-5-1 (lines 766-779, role: tester) describes \"Create `gateway/tests/test_jira_idempotency.py` covering the cache module from TASK-1-1: \u2026\" \u2014 same file, same scenarios, different role. Same collision for TASK-1-2 \u2194 TASK-5-2 on `test_jira_adf.py`. The implement-phase coder/tester roles will both think they own the file; whichever lands second overwrites. **Fix:** decide explicitly. Either (a) drop the test requirement from TASK-1-1/1-2 acceptance, leaving \"module exists with the API\" as the only criterion and TASK-5-1/5-2 owns the file; or (b) drop TASK-5-1/5-2 entirely and acknowledge in Phase 5's preamble that the foundation tests landed in Phase 1. Option (a) is cleaner because it matches the role assignments.\n\n3. **TASK-3-4 createIssueLink response shape is left for the coder to decide.** The task literal text (lines 636-639): \"Returns Atlassian's response envelope (201 body or `{status: 'created'}` envelope \u2014 choose one and document; default to envelope for consistency with create-issue).\" The analysis (line 54, line 114) is explicit that Atlassian's `POST /rest/api/3/issueLink` returns `201 Created` **with no body in v3**, so \"Atlassian's response envelope\" is empty \u2014 the only viable option is the synthesized envelope. **Fix:** spec the envelope now: `{status: \"created\"}` for parity with `editJiraIssue`'s envelope (`{status: \"updated\", key}`). Decide whether to include the (inward, outward, type) triple in the response so the orchestrator's plan-apply can correlate the call with its retry record \u2014 recommend yes: `{status: \"created\", inwardIssue, outwardIssue, type}`.\n\n4. **TASK-2-2 labels semantics for replace + incremental is also left for the coder.** Lines 488-489: \"replace+incremental rejected (or merged per chosen semantics \u2014 document the choice)\". This is a real semantic decision that affects the route schema validator, the client method body, AND the test grid in TASK-5-3. **Fix:** pick now. Recommendation: **reject as 400 at the route layer** if both `labels` and (`addLabels` or `removeLabels`) are present \u2014 agents pick one mode. Easier to test, less surprising for callers, and aligns with the \"reject malformed body\" theme of C1 validation.\n\n5. **Idempotency cache key for createIssueLink is under-specified.** Cache is keyed `(verb, project, idempotency_key)` per `1924-plan.md:23-25` and TASK-1-1 description. For `create_issue_link`, \"project\" is ambiguous (inward? outward? both?). Two callers re-using the same opaque `idempotency_key` for distinct (inward, outward, type) triples would collide and the second caller would receive the cached response of the first. **Fix:** for `create_issue_link` either (a) compose the cache key as `(\"link\", canonical(inward, outward, type), idempotency_key)` so identical opaque keys never alias different links, or (b) document that the orchestrator MUST derive `idempotency_key` from `(inward_key, outward_key, type)` and the gateway treats it as a black-box. Option (a) is safer because it puts the invariant in the gateway. Update TASK-1-1's `get_or_run` signature accordingly (or add a per-verb wrapper) and add a test scenario for \"same idempotency_key, different link triples \u2192 distinct cache entries\".\n\n6. **429 audit emit on writes (Q12 default = \"yes\") has no implementation hook in the plan.** TASK-5-3 acceptance (line 805) asserts \"429 audit emit on each verb\", but the existing `JiraClient._request` (per the survey) emits `jira_upstream_rate_limited` only inside its retry loop on lines 340-367 \u2014 and writes deliberately skip the retry loop (line 322). None of TASK-2-1..2-4 nor the route-layer tasks add an audit emission for the no-retry 429 path. As written, the test in TASK-5-3 will fail \u2014 there's no code path that emits the audit for write 429s. **Fix:** add an explicit task (or a sub-bullet to TASK-2-5) modifying `_request` to emit `jira_upstream_rate_limited` on EVERY 429 (retry-or-not), guarded by `flask.has_request_context()`. Reflect this in the unit-test surface (TASK-5-3 already lists it; the production code just needs to exist).\n\n### Non-blocking\n\n- **`1924-plan.md:75` Q15 cap reconciliation:** \"comment body \u2264 32 KiB\" matches the description cap, but the analysis (line 100) cites \"no published Atlassian limit\". Confirm the 32 KiB cap is intentional rather than a copy-paste from `description`. Recommend keeping it; just want it explicit in TASK-3-3 comments.\n- **`1924-plan.md:77` Q20 audit redaction conflicts with TASK-3-1 audit description:** Q20 says \"labels logged because they are policy-relevant\", but TASK-3-1 audit details (line 583) say \"label count\". Pick one \u2014 recommend logging label *values* (small enumerated strings, policy-relevant for who-tagged-what audit, matches Q20 default) and add a note in TASK-3-1 acceptance.\n- **TASK-2-2 `notifyUsers` query:** the plan emits `notifyUsers=true` explicitly when `notify_users=True`. Atlassian's default already is `true`; sending the param redundantly is harmless but bloats the URL. Suggest: omit the query param when `notify_users=True`, send `notifyUsers=false` only when False.\n- **Phase 3 intra-phase ordering:** TASK-3-4 (link route) depends on TASK-3-5 (`link_types` config + helper). The plan explicitly says (lines 260-264) \"Within each phase the tasks are independent\". Add a one-line note that TASK-3-5 must land before TASK-3-4 (or merge them into a single task) so the implementer doesn't try them in parallel and break the route.\n- **TASK-3-7:** \"Add a commented `jira.link_types` example block to `config/context-filters.yaml` (or its example file)\". Pick now: edit `config/context-filters.yaml` directly \u2014 that's the file the policy loads, and the survey confirmed the existing `jira:` section (lines 11-24) already lives there. The \"(or its example file)\" hedge invites coder confusion.\n- **TASK-4-1..4-4 `--help`:** the survey didn't confirm the existing `sandbox/scripts/jira` wrapper has per-subcommand `--help` output. The acceptance criteria of all four sandbox tasks reference `--help`. If the v1 wrapper doesn't already support `--help`, that's hidden scope. Add a one-liner to TASK-4-1 confirming the existing dispatcher's `--help` pattern (or noting the addition).\n- **Per-role / per-phase write gating deferred (D10/D11):** plan correctly defers to a follow-up. Add a follow-up issue placeholder reference in the PR body (`Follows: TBD-issue-for-write-gating`) so the deferred work isn't dropped.\n- **TASK-5-4 unicode-in-keys path-traversal:** good adversarial coverage. Suggest also adding a test case for HTTP-method tunnelling via body (e.g. body containing `\"_method\": \"DELETE\"` or similar) \u2014 defensive, since v1 read paths weren't tested for it either.\n- **TASK-5-3 test combinations matrix:** \"all input combinations\" is broad. Add a one-line cap (e.g. \"\u22651 success case per option pair\" or \"named matrix in test docstring\") so the implementer doesn't generate a Cartesian explosion.\n- **`1924-plan.md:233` no live-Atlassian smoke test:** consistent with v1; flag that #1557 (the consumer) will be the integration smoke. Add to PR body's test_plan as \"Integration smoke test deferred to #1557 plan-apply rollout\".\n- **`Risks (deferred to risk_analyst)`:** good division of labour. The plan-only review will not block on risks \u2014 but the rollback claim (\"each phase is independently revertible\") deserves a one-line acceptance check (e.g. \"TASK-X.Y verifies `git revert` of each phase commit leaves the v1 read surface green\"). Currently this claim is unverified.\n",
+    "metadata": {
+      "payload": {
+        "reason": "\nReviewed the plan draft section-by-section against the analysis and the existing v1 read-only gateway. The phase decomposition (Foundation \u2192 Client \u2192 Routes \u2192 Wrapper \u2192 Tests \u2192 Docs), choice of A1+B1+C1+D1+E1, and PR scoping are sound. The HITL-defaults table is a useful unblock and most defaults match the analysis. But six items must be tightened before this plan is implementable \u2014 three of them are actively broken or self-contradictory.\n\n### Blocking\n\n1. **Defaults table D2 + TASK-2-1: \"Auto-detect\" emits BOTH `parent.key` AND `customfield_10014` simultaneously \u2014 this is wrong and will 400 upstream.** The analysis (lines 198, 347) and Atlassian's REST docs are explicit: `parent.key` is the next-gen / company-managed field; `customfield_10014` is the classic Epic Link field. They are mutually exclusive per project type. Sending both on a next-gen project returns `400 Field 'customfield_10014' cannot be set, it is not on the appropriate screen, or unknown.`; sending both on classic returns the inverse for `parent`. The plan's `1924-plan.md:55` says \"emit both `parent.key` (next-gen) and `customfield_10014` (classic Epic Link); the wire shape is decided per-instance via `jira_policy` config (default = both)\" \u2014 and TASK-2-1's description (lines 452-454) literally builds both fields. **Fix:** pick a per-instance config knob in `jira_policy` (e.g. `jira.epic_link_field: \"parent\" | \"customfield_10014\"`, default `\"parent\"`) and emit only that field. The architect's option 3 (\"Auto-detect or accept either via the epicLink shorthand\") is one-or-the-other dispatch, not a both-fields shotgun. Add a TASK in Phase 2 or Phase 3-5 to load this knob, and reflect it in the body builder. Also amend the ambiguity in TASK-2-1 between the explicit `parent` arg and the `epic_link` arg \u2014 if both are passed, what wins? Spec it (e.g. \"explicit `parent` overrides `epic_link`; if both set and conflicting, 400 at the route\") rather than letting the second `fields.parent.key=` line clobber the first.\n\n2. **TASK-1-1 / TASK-1-2 acceptance criteria duplicate TASK-5-1 / TASK-5-2 \u2014 same test files owned by two roles.** TASK-1-1 acceptance (lines 396-404) demands `gateway/tests/test_jira_idempotency.py` pass with seven named scenarios. TASK-5-1 (lines 766-779, role: tester) describes \"Create `gateway/tests/test_jira_idempotency.py` covering the cache module from TASK-1-1: \u2026\" \u2014 same file, same scenarios, different role. Same collision for TASK-1-2 \u2194 TASK-5-2 on `test_jira_adf.py`. The implement-phase coder/tester roles will both think they own the file; whichever lands second overwrites. **Fix:** decide explicitly. Either (a) drop the test requirement from TASK-1-1/1-2 acceptance, leaving \"module exists with the API\" as the only criterion and TASK-5-1/5-2 owns the file; or (b) drop TASK-5-1/5-2 entirely and acknowledge in Phase 5's preamble that the foundation tests landed in Phase 1. Option (a) is cleaner because it matches the role assignments.\n\n3. **TASK-3-4 createIssueLink response shape is left for the coder to decide.** The task literal text (lines 636-639): \"Returns Atlassian's response envelope (201 body or `{status: 'created'}` envelope \u2014 choose one and document; default to envelope for consistency with create-issue).\" The analysis (line 54, line 114) is explicit that Atlassian's `POST /rest/api/3/issueLink` returns `201 Created` **with no body in v3**, so \"Atlassian's response envelope\" is empty \u2014 the only viable option is the synthesized envelope. **Fix:** spec the envelope now: `{status: \"created\"}` for parity with `editJiraIssue`'s envelope (`{status: \"updated\", key}`). Decide whether to include the (inward, outward, type) triple in the response so the orchestrator's plan-apply can correlate the call with its retry record \u2014 recommend yes: `{status: \"created\", inwardIssue, outwardIssue, type}`.\n\n4. **TASK-2-2 labels semantics for replace + incremental is also left for the coder.** Lines 488-489: \"replace+incremental rejected (or merged per chosen semantics \u2014 document the choice)\". This is a real semantic decision that affects the route schema validator, the client method body, AND the test grid in TASK-5-3. **Fix:** pick now. Recommendation: **reject as 400 at the route layer** if both `labels` and (`addLabels` or `removeLabels`) are present \u2014 agents pick one mode. Easier to test, less surprising for callers, and aligns with the \"reject malformed body\" theme of C1 validation.\n\n5. **Idempotency cache key for createIssueLink is under-specified.** Cache is keyed `(verb, project, idempotency_key)` per `1924-plan.md:23-25` and TASK-1-1 description. For `create_issue_link`, \"project\" is ambiguous (inward? outward? both?). Two callers re-using the same opaque `idempotency_key` for distinct (inward, outward, type) triples would collide and the second caller would receive the cached response of the first. **Fix:** for `create_issue_link` either (a) compose the cache key as `(\"link\", canonical(inward, outward, type), idempotency_key)` so identical opaque keys never alias different links, or (b) document that the orchestrator MUST derive `idempotency_key` from `(inward_key, outward_key, type)` and the gateway treats it as a black-box. Option (a) is safer because it puts the invariant in the gateway. Update TASK-1-1's `get_or_run` signature accordingly (or add a per-verb wrapper) and add a test scenario for \"same idempotency_key, different link triples \u2192 distinct cache entries\".\n\n6. **429 audit emit on writes (Q12 default = \"yes\") has no implementation hook in the plan.** TASK-5-3 acceptance (line 805) asserts \"429 audit emit on each verb\", but the existing `JiraClient._request` (per the survey) emits `jira_upstream_rate_limited` only inside its retry loop on lines 340-367 \u2014 and writes deliberately skip the retry loop (line 322). None of TASK-2-1..2-4 nor the route-layer tasks add an audit emission for the no-retry 429 path. As written, the test in TASK-5-3 will fail \u2014 there's no code path that emits the audit for write 429s. **Fix:** add an explicit task (or a sub-bullet to TASK-2-5) modifying `_request` to emit `jira_upstream_rate_limited` on EVERY 429 (retry-or-not), guarded by `flask.has_request_context()`. Reflect this in the unit-test surface (TASK-5-3 already lists it; the production code just needs to exist).\n\n### Non-blocking\n\n- **`1924-plan.md:75` Q15 cap reconciliation:** \"comment body \u2264 32 KiB\" matches the description cap, but the analysis (line 100) cites \"no published Atlassian limit\". Confirm the 32 KiB cap is intentional rather than a copy-paste from `description`. Recommend keeping it; just want it explicit in TASK-3-3 comments.\n- **`1924-plan.md:77` Q20 audit redaction conflicts with TASK-3-1 audit description:** Q20 says \"labels logged because they are policy-relevant\", but TASK-3-1 audit details (line 583) say \"label count\". Pick one \u2014 recommend logging label *values* (small enumerated strings, policy-relevant for who-tagged-what audit, matches Q20 default) and add a note in TASK-3-1 acceptance.\n- **TASK-2-2 `notifyUsers` query:** the plan emits `notifyUsers=true` explicitly when `notify_users=True`. Atlassian's default already is `true`; sending the param redundantly is harmless but bloats the URL. Suggest: omit the query param when `notify_users=True`, send `notifyUsers=false` only when False.\n- **Phase 3 intra-phase ordering:** TASK-3-4 (link route) depends on TASK-3-5 (`link_types` config + helper). The plan explicitly says (lines 260-264) \"Within each phase the tasks are independent\". Add a one-line note that TASK-3-5 must land before TASK-3-4 (or merge them into a single task) so the implementer doesn't try them in parallel and break the route.\n- **TASK-3-7:** \"Add a commented `jira.link_types` example block to `config/context-filters.yaml` (or its example file)\". Pick now: edit `config/context-filters.yaml` directly \u2014 that's the file the policy loads, and the survey confirmed the existing `jira:` section (lines 11-24) already lives there. The \"(or its example file)\" hedge invites coder confusion.\n- **TASK-4-1..4-4 `--help`:** the survey didn't confirm the existing `sandbox/scripts/jira` wrapper has per-subcommand `--help` output. The acceptance criteria of all four sandbox tasks reference `--help`. If the v1 wrapper doesn't already support `--help`, that's hidden scope. Add a one-liner to TASK-4-1 confirming the existing dispatcher's `--help` pattern (or noting the addition).\n- **Per-role / per-phase write gating deferred (D10/D11):** plan correctly defers to a follow-up. Add a follow-up issue placeholder reference in the PR body (`Follows: TBD-issue-for-write-gating`) so the deferred work isn't dropped.\n- **TASK-5-4 unicode-in-keys path-traversal:** good adversarial coverage. Suggest also adding a test case for HTTP-method tunnelling via body (e.g. body containing `\"_method\": \"DELETE\"` or similar) \u2014 defensive, since v1 read paths weren't tested for it either.\n- **TASK-5-3 test combinations matrix:** \"all input combinations\" is broad. Add a one-line cap (e.g. \"\u22651 success case per option pair\" or \"named matrix in test docstring\") so the implementer doesn't generate a Cartesian explosion.\n- **`1924-plan.md:233` no live-Atlassian smoke test:** consistent with v1; flag that #1557 (the consumer) will be the integration smoke. Add to PR body's test_plan as \"Integration smoke test deferred to #1557 plan-apply rollout\".\n- **`Risks (deferred to risk_analyst)`:** good division of labour. The plan-only review will not block on risks \u2014 but the rollback claim (\"each phase is independently revertible\") deserves a one-line acceptance check (e.g. \"TASK-X.Y verifies `git revert` of each phase commit leaves the v1 read surface green\"). Currently this claim is unverified.\n",
+        "artifact_references": [
+          ".egg-state/drafts/1924-plan.md",
+          ".egg-state/drafts/1924-analysis.md",
+          "gateway/jira_client.py",
+          "gateway/jira_policy.py",
+          "gateway/gateway.py",
+          "gateway/tests/test_jira_routes.py",
+          "sandbox/scripts/jira",
+          "config/context-filters.yaml"
+        ]
+      },
+      "reason": "\nReviewed the plan draft section-by-section against the analysis and the existing v1 read-only gateway. The phase decomposition (Foundation \u2192 Client \u2192 Routes \u2192 Wrapper \u2192 Tests \u2192 Docs), choice of A1+B1+C1+D1+E1, and PR scoping are sound. The HITL-defaults table is a useful unblock and most defaults match the analysis. But six items must be tightened before this plan is implementable \u2014 three of them are actively broken or self-contradictory.\n\n### Blocking\n\n1. **Defaults table D2 + TASK-2-1: \"Auto-detect\" emits BOTH `parent.key` AND `customfield_10014` simultaneously \u2014 this is wrong and will 400 upstream.** The analysis (lines 198, 347) and Atlassian's REST docs are explicit: `parent.key` is the next-gen / company-managed field; `customfield_10014` is the classic Epic Link field. They are mutually exclusive per project type. Sending both on a next-gen project returns `400 Field 'customfield_10014' cannot be set, it is not on the appropriate screen, or unknown.`; sending both on classic returns the inverse for `parent`. The plan's `1924-plan.md:55` says \"emit both `parent.key` (next-gen) and `customfield_10014` (classic Epic Link); the wire shape is decided per-instance via `jira_policy` config (default = both)\" \u2014 and TASK-2-1's description (lines 452-454) literally builds both fields. **Fix:** pick a per-instance config knob in `jira_policy` (e.g. `jira.epic_link_field: \"parent\" | \"customfield_10014\"`, default `\"parent\"`) and emit only that field. The architect's option 3 (\"Auto-detect or accept either via the epicLink shorthand\") is one-or-the-other dispatch, not a both-fields shotgun. Add a TASK in Phase 2 or Phase 3-5 to load this knob, and reflect it in the body builder. Also amend the ambiguity in TASK-2-1 between the explicit `parent` arg and the `epic_link` arg \u2014 if both are passed, what wins? Spec it (e.g. \"explicit `parent` overrides `epic_link`; if both set and conflicting, 400 at the route\") rather than letting the second `fields.parent.key=` line clobber the first.\n\n2. **TASK-1-1 / TASK-1-2 acceptance criteria duplicate TASK-5-1 / TASK-5-2 \u2014 same test files owned by two roles.** TASK-1-1 acceptance (lines 396-404) demands `gateway/tests/test_jira_idempotency.py` pass with seven named scenarios. TASK-5-1 (lines 766-779, role: tester) describes \"Create `gateway/tests/test_jira_idempotency.py` covering the cache module from TASK-1-1: \u2026\" \u2014 same file, same scenarios, different role. Same collision for TASK-1-2 \u2194 TASK-5-2 on `test_jira_adf.py`. The implement-phase coder/tester roles will both think they own the file; whichever lands second overwrites. **Fix:** decide explicitly. Either (a) drop the test requirement from TASK-1-1/1-2 acceptance, leaving \"module exists with the API\" as the only criterion and TASK-5-1/5-2 owns the file; or (b) drop TASK-5-1/5-2 entirely and acknowledge in Phase 5's preamble that the foundation tests landed in Phase 1. Option (a) is cleaner because it matches the role assignments.\n\n3. **TASK-3-4 createIssueLink response shape is left for the coder to decide.** The task literal text (lines 636-639): \"Returns Atlassian's response envelope (201 body or `{status: 'created'}` envelope \u2014 choose one and document; default to envelope for consistency with create-issue).\" The analysis (line 54, line 114) is explicit that Atlassian's `POST /rest/api/3/issueLink` returns `201 Created` **with no body in v3**, so \"Atlassian's response envelope\" is empty \u2014 the only viable option is the synthesized envelope. **Fix:** spec the envelope now: `{status: \"created\"}` for parity with `editJiraIssue`'s envelope (`{status: \"updated\", key}`). Decide whether to include the (inward, outward, type) triple in the response so the orchestrator's plan-apply can correlate the call with its retry record \u2014 recommend yes: `{status: \"created\", inwardIssue, outwardIssue, type}`.\n\n4. **TASK-2-2 labels semantics for replace + incremental is also left for the coder.** Lines 488-489: \"replace+incremental rejected (or merged per chosen semantics \u2014 document the choice)\". This is a real semantic decision that affects the route schema validator, the client method body, AND the test grid in TASK-5-3. **Fix:** pick now. Recommendation: **reject as 400 at the route layer** if both `labels` and (`addLabels` or `removeLabels`) are present \u2014 agents pick one mode. Easier to test, less surprising for callers, and aligns with the \"reject malformed body\" theme of C1 validation.\n\n5. **Idempotency cache key for createIssueLink is under-specified.** Cache is keyed `(verb, project, idempotency_key)` per `1924-plan.md:23-25` and TASK-1-1 description. For `create_issue_link`, \"project\" is ambiguous (inward? outward? both?). Two callers re-using the same opaque `idempotency_key` for distinct (inward, outward, type) triples would collide and the second caller would receive the cached response of the first. **Fix:** for `create_issue_link` either (a) compose the cache key as `(\"link\", canonical(inward, outward, type), idempotency_key)` so identical opaque keys never alias different links, or (b) document that the orchestrator MUST derive `idempotency_key` from `(inward_key, outward_key, type)` and the gateway treats it as a black-box. Option (a) is safer because it puts the invariant in the gateway. Update TASK-1-1's `get_or_run` signature accordingly (or add a per-verb wrapper) and add a test scenario for \"same idempotency_key, different link triples \u2192 distinct cache entries\".\n\n6. **429 audit emit on writes (Q12 default = \"yes\") has no implementation hook in the plan.** TASK-5-3 acceptance (line 805) asserts \"429 audit emit on each verb\", but the existing `JiraClient._request` (per the survey) emits `jira_upstream_rate_limited` only inside its retry loop on lines 340-367 \u2014 and writes deliberately skip the retry loop (line 322). None of TASK-2-1..2-4 nor the route-layer tasks add an audit emission for the no-retry 429 path. As written, the test in TASK-5-3 will fail \u2014 there's no code path that emits the audit for write 429s. **Fix:** add an explicit task (or a sub-bullet to TASK-2-5) modifying `_request` to emit `jira_upstream_rate_limited` on EVERY 429 (retry-or-not), guarded by `flask.has_request_context()`. Reflect this in the unit-test surface (TASK-5-3 already lists it; the production code just needs to exist).\n\n### Non-blocking\n\n- **`1924-plan.md:75` Q15 cap reconciliation:** \"comment body \u2264 32 KiB\" matches the description cap, but the analysis (line 100) cites \"no published Atlassian limit\". Confirm the 32 KiB cap is intentional rather than a copy-paste from `description`. Recommend keeping it; just want it explicit in TASK-3-3 comments.\n- **`1924-plan.md:77` Q20 audit redaction conflicts with TASK-3-1 audit description:** Q20 says \"labels logged because they are policy-relevant\", but TASK-3-1 audit details (line 583) say \"label count\". Pick one \u2014 recommend logging label *values* (small enumerated strings, policy-relevant for who-tagged-what audit, matches Q20 default) and add a note in TASK-3-1 acceptance.\n- **TASK-2-2 `notifyUsers` query:** the plan emits `notifyUsers=true` explicitly when `notify_users=True`. Atlassian's default already is `true`; sending the param redundantly is harmless but bloats the URL. Suggest: omit the query param when `notify_users=True`, send `notifyUsers=false` only when False.\n- **Phase 3 intra-phase ordering:** TASK-3-4 (link route) depends on TASK-3-5 (`link_types` config + helper). The plan explicitly says (lines 260-264) \"Within each phase the tasks are independent\". Add a one-line note that TASK-3-5 must land before TASK-3-4 (or merge them into a single task) so the implementer doesn't try them in parallel and break the route.\n- **TASK-3-7:** \"Add a commented `jira.link_types` example block to `config/context-filters.yaml` (or its example file)\". Pick now: edit `config/context-filters.yaml` directly \u2014 that's the file the policy loads, and the survey confirmed the existing `jira:` section (lines 11-24) already lives there. The \"(or its example file)\" hedge invites coder confusion.\n- **TASK-4-1..4-4 `--help`:** the survey didn't confirm the existing `sandbox/scripts/jira` wrapper has per-subcommand `--help` output. The acceptance criteria of all four sandbox tasks reference `--help`. If the v1 wrapper doesn't already support `--help`, that's hidden scope. Add a one-liner to TASK-4-1 confirming the existing dispatcher's `--help` pattern (or noting the addition).\n- **Per-role / per-phase write gating deferred (D10/D11):** plan correctly defers to a follow-up. Add a follow-up issue placeholder reference in the PR body (`Follows: TBD-issue-for-write-gating`) so the deferred work isn't dropped.\n- **TASK-5-4 unicode-in-keys path-traversal:** good adversarial coverage. Suggest also adding a test case for HTTP-method tunnelling via body (e.g. body containing `\"_method\": \"DELETE\"` or similar) \u2014 defensive, since v1 read paths weren't tested for it either.\n- **TASK-5-3 test combinations matrix:** \"all input combinations\" is broad. Add a one-line cap (e.g. \"\u22651 success case per option pair\" or \"named matrix in test docstring\") so the implementer doesn't generate a Cartesian explosion.\n- **`1924-plan.md:233` no live-Atlassian smoke test:** consistent with v1; flag that #1557 (the consumer) will be the integration smoke. Add to PR body's test_plan as \"Integration smoke test deferred to #1557 plan-apply rollout\".\n- **`Risks (deferred to risk_analyst)`:** good division of labour. The plan-only review will not block on risks \u2014 but the rollback claim (\"each phase is independently revertible\") deserves a one-line acceptance check (e.g. \"TASK-X.Y verifies `git revert` of each phase commit leaves the v1 read surface green\"). Currently this claim is unverified.\n",
+      "revision_count": 1
+    },
+    "timestamp": "2026-04-27T19:25:02.952935+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "4c68cbb8-1598-4d",
+    "pipeline_id": "issue-1924",
+    "from_role": "task_planner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:25:03.106495+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "f5bfbde1-b5df-42",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:25:14.198622+00:00"
+    },
+    "timestamp": "2026-04-27T19:25:14.442105+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "cae857e4-d37e-44",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "CONSENSUS_PROPOSE",
+    "subject": "Proposal from architect",
+    "body": "Architecture analysis for #1924 \u2014 bounded write extension of the v1 read-only Jira gateway. Four narrow per-verb routes (POST /api/v1/jira/ticket/create, /ticket/edit, /ticket/comment/add, /issue-link/create) instead of widening /execute; method-allowlist split (validate_jira_api_path keeps ALLOWED_METHODS={'GET'}; write client methods bypass with hardcoded paths so the permanent denylist transitions/worklog/attachments/watchers stays unbreakable); curated per-verb body schemas with project / ticket / size / label-count validation; in-process gateway idempotency cache (TTL 300s, threading.Lock-guarded) for createJiraIssue and addCommentToJiraIssue; plain-text -> minimal ADF paragraph wrapping helper so sandbox agents never construct Atlassian Document Format JSON. New gateway/jira_adf.py and gateway/jira_idempotency.py modules; ~250-350 lines added to jira_client.py for the four write methods; ~500-650 lines in gateway.py for the four routes; ~300-450 lines in sandbox/scripts/jira for the four new subcommands; new test files test_jira_idempotency.py / test_jira_adf.py / test_jira_writes_adversarial.py. Records the architectural slot for every unresolved refine HITL decision so plan tasks can be written deterministically once HITL closes. Output: .egg-state/agent-outputs/1924-architect-output.json (60 KB JSON; problem statement, current-architecture map of reusable v1 building blocks, external Atlassian v3 endpoint shapes, proposed module breakdown with per-route validation, data-flow walkthroughs, design decisions justifying A1+B1+C1+D1+E1, key-files table, dependency list, open-questions slot reservations, risks for risk_analyst, tasks for task_planner, validation plan, out-of-scope list).",
+    "metadata": {
+      "payload": {
+        "summary": "Architecture analysis for #1924 \u2014 bounded write extension of the v1 read-only Jira gateway. Four narrow per-verb routes (POST /api/v1/jira/ticket/create, /ticket/edit, /ticket/comment/add, /issue-link/create) instead of widening /execute; method-allowlist split (validate_jira_api_path keeps ALLOWED_METHODS={'GET'}; write client methods bypass with hardcoded paths so the permanent denylist transitions/worklog/attachments/watchers stays unbreakable); curated per-verb body schemas with project / ticket / size / label-count validation; in-process gateway idempotency cache (TTL 300s, threading.Lock-guarded) for createJiraIssue and addCommentToJiraIssue; plain-text -> minimal ADF paragraph wrapping helper so sandbox agents never construct Atlassian Document Format JSON. New gateway/jira_adf.py and gateway/jira_idempotency.py modules; ~250-350 lines added to jira_client.py for the four write methods; ~500-650 lines in gateway.py for the four routes; ~300-450 lines in sandbox/scripts/jira for the four new subcommands; new test files test_jira_idempotency.py / test_jira_adf.py / test_jira_writes_adversarial.py. Records the architectural slot for every unresolved refine HITL decision so plan tasks can be written deterministically once HITL closes. Output: .egg-state/agent-outputs/1924-architect-output.json (60 KB JSON; problem statement, current-architecture map of reusable v1 building blocks, external Atlassian v3 endpoint shapes, proposed module breakdown with per-route validation, data-flow walkthroughs, design decisions justifying A1+B1+C1+D1+E1, key-files table, dependency list, open-questions slot reservations, risks for risk_analyst, tasks for task_planner, validation plan, out-of-scope list).",
+        "attestation": {},
+        "artifacts": [
+          ".egg-state/agent-outputs/1924-architect-output.json"
+        ],
+        "risk_considered": "",
+        "commit_sha": "42386139b",
+        "files_changed": [
+          ".egg-state/agent-outputs/1924-architect-output.json"
+        ],
+        "tests_run": [],
+        "tasks_satisfied": []
+      },
+      "version": 1,
+      "commit_sha": "42386139b"
+    },
+    "timestamp": "2026-04-27T19:25:32.572327+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "c29a66d6-959a-46",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:25:33.745963+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "b7109c5b-50ef-43",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: PROPOSED",
+    "body": "",
+    "metadata": {
+      "state": "PROPOSED"
+    },
+    "timestamp": "2026-04-27T19:25:43.585699+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "d2ca4f21-7b63-4c",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:25:50.393297+00:00"
+    },
+    "timestamp": "2026-04-27T19:25:50.995903+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "b957dbae-f52d-46",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:25:51.572288+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "aec0128a-77f2-46",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:25:54.941151+00:00"
+    },
+    "timestamp": "2026-04-27T19:25:57.154490+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "cc39671c-dd6c-45",
+    "pipeline_id": "issue-1924",
+    "from_role": "risk_analyst",
+    "to_role": "all",
+    "message_type": "CONSENSUS_PROPOSE",
+    "subject": "Proposal from risk_analyst",
+    "body": "Plan-phase risk assessment for #1924 (Jira gateway writes \u2014 createJiraIssue, editJiraIssue, addCommentToJiraIssue, createIssueLink). 19 risks identified across security, data-integrity, performance, compatibility, data-privacy, and operational categories. Highest-severity risk: R1 custom-field smuggling (HIGH severity, blocked on HITL decision-1) \u2014 agents could set securityLevel/sprint/watchers/assignee via untrusted body fields. Highest-likelihood: R3 non-idempotent writes (Atlassian's v3 REST has no native idempotency key, POST /issueLink does NOT dedupe identical triples). Three risks flagged for human review: R1, R3, R10 (phase/role gating). Six MEDIUM-severity risks require implement-phase mitigation. Implement-phase checklist enumerates 19 verification items keyed by risk ID. External research cites 13 sources including Atlassian's official rate-limiting docs, March 2026 points-based rollout announcement, ADF schema reference, Snapsec stored-XSS finding, and community threads on idempotent issue creation. Output written to .egg-state/agent-outputs/1924-risk_analyst-output.json (543 lines, valid JSON, 19 risks). Risks align with refine analysis (1924-analysis.md) AND with the architect's risks_for_risk_analyst list (10 risks all covered). 19 unresolved HITL decisions and 9 unresolved feedback items are explicitly flagged as implementation blockers.",
+    "metadata": {
+      "payload": {
+        "summary": "Plan-phase risk assessment for #1924 (Jira gateway writes \u2014 createJiraIssue, editJiraIssue, addCommentToJiraIssue, createIssueLink). 19 risks identified across security, data-integrity, performance, compatibility, data-privacy, and operational categories. Highest-severity risk: R1 custom-field smuggling (HIGH severity, blocked on HITL decision-1) \u2014 agents could set securityLevel/sprint/watchers/assignee via untrusted body fields. Highest-likelihood: R3 non-idempotent writes (Atlassian's v3 REST has no native idempotency key, POST /issueLink does NOT dedupe identical triples). Three risks flagged for human review: R1, R3, R10 (phase/role gating). Six MEDIUM-severity risks require implement-phase mitigation. Implement-phase checklist enumerates 19 verification items keyed by risk ID. External research cites 13 sources including Atlassian's official rate-limiting docs, March 2026 points-based rollout announcement, ADF schema reference, Snapsec stored-XSS finding, and community threads on idempotent issue creation. Output written to .egg-state/agent-outputs/1924-risk_analyst-output.json (543 lines, valid JSON, 19 risks). Risks align with refine analysis (1924-analysis.md) AND with the architect's risks_for_risk_analyst list (10 risks all covered). 19 unresolved HITL decisions and 9 unresolved feedback items are explicitly flagged as implementation blockers.",
+        "attestation": {},
+        "artifacts": [
+          ".egg-state/agent-outputs/1924-risk_analyst-output.json"
+        ],
+        "risk_considered": "19 risks identified \u2014 1 HIGH severity (R1 custom-field smuggling), 11 MEDIUM, 7 LOW. Three flagged for human review. Six implementation-blocking HITL decisions tied to specific risks. Rollback plan has four levels (config-only, route disable, credential revoke, full revert) progressively scoped from cheapest to most disruptive. All 10 of the architect's risks_for_risk_analyst items are covered by the assessment (no gap).",
+        "commit_sha": "7821cc4cfb1ec70beac09ed3acaca7eb7728b8e7",
+        "files_changed": [
+          ".egg-state/agent-outputs/1924-risk_analyst-output.json"
+        ],
+        "tests_run": [],
+        "tasks_satisfied": []
+      },
+      "version": 1,
+      "commit_sha": "7821cc4cfb1ec70beac09ed3acaca7eb7728b8e7"
+    },
+    "timestamp": "2026-04-27T19:26:31.768668+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "03ff561c-1010-49",
+    "pipeline_id": "issue-1924",
+    "from_role": "orchestrator",
+    "to_role": "risk_analyst",
+    "message_type": "STATUS",
+    "subject": "Ready to confirm \u2014 all confirm preconditions satisfied",
+    "body": "Your proposal (version 1) is ready to confirm \u2014 all blocking reviews are clear and global confirm preconditions are met. Run `egg-orch consensus confirmed` to confirm.",
+    "metadata": {
+      "ready_to_confirm": true,
+      "version": 1
+    },
+    "timestamp": "2026-04-27T19:26:31.768736+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "d69737cf-fd2e-43",
+    "pipeline_id": "issue-1924",
+    "from_role": "risk_analyst",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT from=reviewer_plan",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:26:47.081812+00:00"
+    },
+    "timestamp": "2026-04-27T19:26:47.117235+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "b6dcd1f0-fd74-40",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:25:54.941151+00:00"
+    },
+    "timestamp": "2026-04-27T19:26:57.471924+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "16f07d54-9c48-43",
+    "pipeline_id": "issue-1924",
+    "from_role": "overseer",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "Plan phase cycle 73 \u2014 742s elapsed. BRC progressing: architect PROPOSED, risk_analyst PROPOSED, reviewer_plan REVIEWING (19 risks identified). task_planner re-working proposal (went WORKING after initial proposal at 6.5min). No real anomalies. Awaiting task_planner re-proposal for full consensus.",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT"
+    },
+    "timestamp": "2026-04-27T19:27:34.100105+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "c217bed2-5d2c-43",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "architect",
+    "message_type": "CONSENSUS_ACK",
+    "subject": "ACK from reviewer_plan for architect",
+    "body": "\nReviewed `1924-architect-output.json` (706 lines) section-by-section against the refine analysis and against `1924-plan.md` from task_planner. The architectural baseline is sound and adheres to every v1 invariant from `#1556`. ACK because the work meets the plan-phase bar: the design choices match the refine analysis verbatim (A1+B1+C1+D1+E1 selected with rationale; permanent denylist preserved; module breakdown is comprehensive; data flows for happy path / non-allowlisted project / public mode / missing creds / idempotent hit are concrete). The HITL slot-reservation pattern (record the slot, defer the bake-in to task_planner) is the right division of labour and means the architect's analysis stays correct under different HITL outcomes.\n\n### What I verified\n\n- **Alignment with analysis** \u2014 every axis cited in `1924-analysis.md` (A/B/C/D/E sub-options) is named and the same recommendation chosen, with explicit `alternatives_rejected`. The architect's `chosen` for D1 (5-min TTL in-memory cache) and B1 (path-validator stays GET-only; write methods bypass) match the analysis recommendation.\n- **Reuse map** (`reusable_infrastructure`, lines 36-92) is exact \u2014 `@require_session_auth` + `@require_private_mode` chain, mtime-cached `JiraPolicy`, `JiraCredentialsManager`, `_request`'s GET-only retry on line 322, route-enumeration regression in `test_jira_routes.py`, sandbox `call_gateway`, doc home. Cross-checked against the v1 code (lines 4365-4759 in `gateway.py`, the `validate_jira_api_path`+`JIRA_WRITE_VERBS_DENIED` block in `jira_client.py:179-236`, etc.) \u2014 every cited line + behaviour is real.\n- **v1 invariants carried forward** (lines 93-102) \u2014 zero sandbox creds, `*.atlassian.net` not in Squid, `/execute` GET-only forever, writes never auto-retry on 429, audit on success/reject \u2014 all correct and align with #1556's contract.\n- **Atlassian endpoint shapes** (lines 106-134) \u2014 `POST /rest/api/3/issue` body fields, `PUT /rest/api/3/issue/{key}?notifyUsers=...`, `POST /rest/api/3/issue/{key}/comment` ADF body, `POST /rest/api/3/issueLink` 201-no-body \u2014 match the v3 docs cited in the analysis.\n- **Module breakdown** (lines 169-368) \u2014 covers `jira_client.py` (extend), new `jira_adf.py`, new `jira_idempotency.py`, `jira_policy.py` (HITL-conditional), `gateway.py` write block, `sandbox/scripts/jira`, `config/context-filters.yaml`, `environment.md`, `jira-wrapper.md`, `network-isolation.md`, and the test surface. Every file has a change_type + lines estimate. Estimates are realistic vs the v1 read block (~485 lines for 4 read routes; ~500-650 for 4 write routes is slightly larger which matches the richer body validation).\n- **Data flow narratives** (lines 369-409) \u2014 five distinct flows (happy create, non-allowlisted project, public mode, missing creds, idempotent hit) with concrete steps; the implementer can write tests directly against these flows.\n- **Validation plan** (lines 684-695) \u2014 covers lint, test, route-enumeration regression, allowed-domains regression, manual smoke, idempotency manual test, public-mode 403, missing-creds 503, project-allowlist 403, permanent-denylist regression. Comprehensive.\n- **Risks** (lines 647-658) \u2014 ten distinct risks, each with mitigation. Useful pickup list for risk_analyst.\n- **Out-of-scope** (lines 697-705) \u2014 clear and matches `#1556`'s permanent denylist + the analysis non-goals.\n\n### Non-blocking\n\n- **`JiraUpstreamWriteError` punted within the architect's own output** (line 179): \"(subclass of existing JiraUpstreamError, OR the existing one extended)\". Low-stakes \u2014 the implementer can pick \u2014 but recommend committing now: subclass it for distinct catch-handling per route. Not worth a NACK because either choice is structurally fine.\n- **`createIssueLink` idempotency option named but not chosen** (line 143-144 + line 289): the architect lists three options for decision-19/Q28 (\"extend cache, scan upstream, accept duplicates\") and observes \"the first is most aligned with create / comment for symmetry\" \u2014 but doesn't actually pick. The task_planner picked option 1 (extend the cache). Architect should align \u2014 the design baseline should reflect what the implementer will build. (This is the kind of mismatch that produces churn during implement.)\n- **Adversarial test file location** (line 363, line 461): architect proposes a separate `test_jira_writes_adversarial.py`. Task_planner's bake-in (Q21 default) puts adversarial cases in the SAME file as the route 403 grid (`test_jira_routes.py`). The two artifacts disagree. Both choices are reasonable; recommend the architect note that the final location follows the task_planner's bake-in (or vice versa) so the implementer doesn't see two contradictory specs. **Suggest:** add a one-line \"Adversarial test file location follows task_planner's HITL-default bake-in (same-file)\" reconciliation note in the architect's `design_decisions` section.\n- **`--return-issue` flag on `jira ticket edit` wrapper** (line 312): the architect's wrapper exposes `--return-issue` which maps to Atlassian's `?returnIssue=true`. But the task_planner baked D14 = \"Envelope `{status: 'updated', key}` (no extra Atlassian call)\". Under that bake-in the `--return-issue` flag is dead \u2014 the route always returns the envelope. Architect should either drop the flag from the wrapper sketch or note that the flag is HITL-conditional and inert under the chosen default.\n- **Doc home hedge** (line 522): \"extend (or create docs/reference/jira-writes.md per refine HITL Q27)\". Task_planner baked D27 = \"Extend `docs/reference/jira-wrapper.md`\". The architect's hedge is fine as a slot reservation, but the picked default should be reflected in the `key_files` purpose line so the implementer doesn't waste time deciding.\n- **Idempotency cache key for `create_issue_link`** (line 142): `(verb, project, idempotency_key)` is well-defined for `create` and `comment` (the project derived from `projectKey` / `extract_project_key(ticket)`), but for `create_issue_link` \"project\" is ambiguous (inward? outward? both?). The architect's analysis doesn't disambiguate \u2014 neither does the task_planner's plan (I flagged this in my task_planner NACK). Suggest adding a one-line clarification: e.g. cache key for link uses canonical `(inward, outward, type)` triple OR documents that orchestrator must namespace the opaque key. This is mostly a task_planner concern but the architect's data-flow doc should at least name the slot.\n- **Per-role / per-phase write gating module** (line 303-304): if HITL picks gating, the architect proposes adding `JIRA_WRITE_VERBS_PER_PHASE` to `gateway/phase_filter.py`. That file is currently file-restriction-only (per the survey, it has `check_file_restrictions` and `check_phase_file_restrictions`); putting Jira-verb-gating there overloads the module's responsibility. Suggest a separate `gateway/jira_phase_filter.py` (or co-locate with `jira_policy.py`) so the file restriction code stays orthogonal.\n- **Audit event taxonomy** (lines 244, 260, 276, 292): architect's per-verb suite (`jira_ticket_create / _rejected / _denied / _upstream_error / _idempotent_hit / jira_upstream_rate_limited`) is more granular than task_planner's tasks specify. Recommend the task_planner adopt this taxonomy or the architect note \"task descriptions may collapse `_rejected` and `_denied` into a single event since both are pre-Atlassian rejections\". Either is fine; the inconsistency just needs a callout.\n- **JiraClient method signature for `add_comment`** (line 177): architect's signature includes `idempotency_response=None` as a parameter \u2014 should be `idempotency_key`, matching the route-layer name (line 270). Looks like a copy-paste from the cache lookup variable. Minor naming consistency fix.\n- **Module size estimates** are realistic but the validation plan should add a one-line cap (e.g. \"no single module grows by >40% beyond its v1 size without splitting\") so implement-phase doesn't end up with a 2000-line `gateway.py` write block.\n- **`docs/architecture/network-isolation.md`** addition (line 354) is a nice catch \u2014 the v1 read routes are listed there; writes inherit the same exception. Confirm the file actually exists before this becomes a task (the survey didn't list it). If not, fold the change into `jira-wrapper.md`.\n\nThe architectural baseline is solid enough to drive plan tasks. None of the non-blocking items above invalidate the design. ACK.\n",
+    "metadata": {
+      "payload": {
+        "artifact_references": [
+          ".egg-state/agent-outputs/1924-architect-output.json",
+          ".egg-state/drafts/1924-analysis.md",
+          ".egg-state/drafts/1924-plan.md",
+          "gateway/jira_client.py",
+          "gateway/jira_policy.py",
+          "gateway/gateway.py",
+          "gateway/tests/test_jira_routes.py",
+          "sandbox/scripts/jira",
+          "config/context-filters.yaml"
+        ],
+        "reason": "\nReviewed `1924-architect-output.json` (706 lines) section-by-section against the refine analysis and against `1924-plan.md` from task_planner. The architectural baseline is sound and adheres to every v1 invariant from `#1556`. ACK because the work meets the plan-phase bar: the design choices match the refine analysis verbatim (A1+B1+C1+D1+E1 selected with rationale; permanent denylist preserved; module breakdown is comprehensive; data flows for happy path / non-allowlisted project / public mode / missing creds / idempotent hit are concrete). The HITL slot-reservation pattern (record the slot, defer the bake-in to task_planner) is the right division of labour and means the architect's analysis stays correct under different HITL outcomes.\n\n### What I verified\n\n- **Alignment with analysis** \u2014 every axis cited in `1924-analysis.md` (A/B/C/D/E sub-options) is named and the same recommendation chosen, with explicit `alternatives_rejected`. The architect's `chosen` for D1 (5-min TTL in-memory cache) and B1 (path-validator stays GET-only; write methods bypass) match the analysis recommendation.\n- **Reuse map** (`reusable_infrastructure`, lines 36-92) is exact \u2014 `@require_session_auth` + `@require_private_mode` chain, mtime-cached `JiraPolicy`, `JiraCredentialsManager`, `_request`'s GET-only retry on line 322, route-enumeration regression in `test_jira_routes.py`, sandbox `call_gateway`, doc home. Cross-checked against the v1 code (lines 4365-4759 in `gateway.py`, the `validate_jira_api_path`+`JIRA_WRITE_VERBS_DENIED` block in `jira_client.py:179-236`, etc.) \u2014 every cited line + behaviour is real.\n- **v1 invariants carried forward** (lines 93-102) \u2014 zero sandbox creds, `*.atlassian.net` not in Squid, `/execute` GET-only forever, writes never auto-retry on 429, audit on success/reject \u2014 all correct and align with #1556's contract.\n- **Atlassian endpoint shapes** (lines 106-134) \u2014 `POST /rest/api/3/issue` body fields, `PUT /rest/api/3/issue/{key}?notifyUsers=...`, `POST /rest/api/3/issue/{key}/comment` ADF body, `POST /rest/api/3/issueLink` 201-no-body \u2014 match the v3 docs cited in the analysis.\n- **Module breakdown** (lines 169-368) \u2014 covers `jira_client.py` (extend), new `jira_adf.py`, new `jira_idempotency.py`, `jira_policy.py` (HITL-conditional), `gateway.py` write block, `sandbox/scripts/jira`, `config/context-filters.yaml`, `environment.md`, `jira-wrapper.md`, `network-isolation.md`, and the test surface. Every file has a change_type + lines estimate. Estimates are realistic vs the v1 read block (~485 lines for 4 read routes; ~500-650 for 4 write routes is slightly larger which matches the richer body validation).\n- **Data flow narratives** (lines 369-409) \u2014 five distinct flows (happy create, non-allowlisted project, public mode, missing creds, idempotent hit) with concrete steps; the implementer can write tests directly against these flows.\n- **Validation plan** (lines 684-695) \u2014 covers lint, test, route-enumeration regression, allowed-domains regression, manual smoke, idempotency manual test, public-mode 403, missing-creds 503, project-allowlist 403, permanent-denylist regression. Comprehensive.\n- **Risks** (lines 647-658) \u2014 ten distinct risks, each with mitigation. Useful pickup list for risk_analyst.\n- **Out-of-scope** (lines 697-705) \u2014 clear and matches `#1556`'s permanent denylist + the analysis non-goals.\n\n### Non-blocking\n\n- **`JiraUpstreamWriteError` punted within the architect's own output** (line 179): \"(subclass of existing JiraUpstreamError, OR the existing one extended)\". Low-stakes \u2014 the implementer can pick \u2014 but recommend committing now: subclass it for distinct catch-handling per route. Not worth a NACK because either choice is structurally fine.\n- **`createIssueLink` idempotency option named but not chosen** (line 143-144 + line 289): the architect lists three options for decision-19/Q28 (\"extend cache, scan upstream, accept duplicates\") and observes \"the first is most aligned with create / comment for symmetry\" \u2014 but doesn't actually pick. The task_planner picked option 1 (extend the cache). Architect should align \u2014 the design baseline should reflect what the implementer will build. (This is the kind of mismatch that produces churn during implement.)\n- **Adversarial test file location** (line 363, line 461): architect proposes a separate `test_jira_writes_adversarial.py`. Task_planner's bake-in (Q21 default) puts adversarial cases in the SAME file as the route 403 grid (`test_jira_routes.py`). The two artifacts disagree. Both choices are reasonable; recommend the architect note that the final location follows the task_planner's bake-in (or vice versa) so the implementer doesn't see two contradictory specs. **Suggest:** add a one-line \"Adversarial test file location follows task_planner's HITL-default bake-in (same-file)\" reconciliation note in the architect's `design_decisions` section.\n- **`--return-issue` flag on `jira ticket edit` wrapper** (line 312): the architect's wrapper exposes `--return-issue` which maps to Atlassian's `?returnIssue=true`. But the task_planner baked D14 = \"Envelope `{status: 'updated', key}` (no extra Atlassian call)\". Under that bake-in the `--return-issue` flag is dead \u2014 the route always returns the envelope. Architect should either drop the flag from the wrapper sketch or note that the flag is HITL-conditional and inert under the chosen default.\n- **Doc home hedge** (line 522): \"extend (or create docs/reference/jira-writes.md per refine HITL Q27)\". Task_planner baked D27 = \"Extend `docs/reference/jira-wrapper.md`\". The architect's hedge is fine as a slot reservation, but the picked default should be reflected in the `key_files` purpose line so the implementer doesn't waste time deciding.\n- **Idempotency cache key for `create_issue_link`** (line 142): `(verb, project, idempotency_key)` is well-defined for `create` and `comment` (the project derived from `projectKey` / `extract_project_key(ticket)`), but for `create_issue_link` \"project\" is ambiguous (inward? outward? both?). The architect's analysis doesn't disambiguate \u2014 neither does the task_planner's plan (I flagged this in my task_planner NACK). Suggest adding a one-line clarification: e.g. cache key for link uses canonical `(inward, outward, type)` triple OR documents that orchestrator must namespace the opaque key. This is mostly a task_planner concern but the architect's data-flow doc should at least name the slot.\n- **Per-role / per-phase write gating module** (line 303-304): if HITL picks gating, the architect proposes adding `JIRA_WRITE_VERBS_PER_PHASE` to `gateway/phase_filter.py`. That file is currently file-restriction-only (per the survey, it has `check_file_restrictions` and `check_phase_file_restrictions`); putting Jira-verb-gating there overloads the module's responsibility. Suggest a separate `gateway/jira_phase_filter.py` (or co-locate with `jira_policy.py`) so the file restriction code stays orthogonal.\n- **Audit event taxonomy** (lines 244, 260, 276, 292): architect's per-verb suite (`jira_ticket_create / _rejected / _denied / _upstream_error / _idempotent_hit / jira_upstream_rate_limited`) is more granular than task_planner's tasks specify. Recommend the task_planner adopt this taxonomy or the architect note \"task descriptions may collapse `_rejected` and `_denied` into a single event since both are pre-Atlassian rejections\". Either is fine; the inconsistency just needs a callout.\n- **JiraClient method signature for `add_comment`** (line 177): architect's signature includes `idempotency_response=None` as a parameter \u2014 should be `idempotency_key`, matching the route-layer name (line 270). Looks like a copy-paste from the cache lookup variable. Minor naming consistency fix.\n- **Module size estimates** are realistic but the validation plan should add a one-line cap (e.g. \"no single module grows by >40% beyond its v1 size without splitting\") so implement-phase doesn't end up with a 2000-line `gateway.py` write block.\n- **`docs/architecture/network-isolation.md`** addition (line 354) is a nice catch \u2014 the v1 read routes are listed there; writes inherit the same exception. Confirm the file actually exists before this becomes a task (the survey didn't list it). If not, fold the change into `jira-wrapper.md`.\n\nThe architectural baseline is solid enough to drive plan tasks. None of the non-blocking items above invalidate the design. ACK.\n"
+      },
+      "version": 1
+    },
+    "timestamp": "2026-04-27T19:27:44.147087+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "a2b2f726-f573-4a",
+    "pipeline_id": "issue-1924",
+    "from_role": "orchestrator",
+    "to_role": "architect",
+    "message_type": "STATUS",
+    "subject": "Ready to confirm \u2014 all confirm preconditions satisfied",
+    "body": "Your proposal (version 1) is ready to confirm \u2014 all blocking reviews are clear and global confirm preconditions are met. Run `egg-orch consensus confirmed` to confirm.",
+    "metadata": {
+      "ready_to_confirm": true,
+      "version": 1
+    },
+    "timestamp": "2026-04-27T19:27:44.147126+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "38cb753c-eafe-49",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:27:44.239838+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "b35f3ecc-07ad-4a",
+    "pipeline_id": "issue-1924",
+    "from_role": "risk_analyst",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT from=reviewer_plan",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:26:47.081812+00:00"
+    },
+    "timestamp": "2026-04-27T19:27:47.312362+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "45a67b7d-c4b8-4c",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:27:48.858721+00:00"
+    },
+    "timestamp": "2026-04-27T19:27:48.940327+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "ac77890b-aaee-4d",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:27:49.043128+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "495ecb04-ec43-4c",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "CONSENSUS_CONFIRMED",
+    "subject": "Confirmed by architect",
+    "body": "",
+    "metadata": {
+      "consensus_reached": false
+    },
+    "timestamp": "2026-04-27T19:27:59.700277+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "986bf5ef-c348-40",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:28:16.953451+00:00"
+    },
+    "timestamp": "2026-04-27T19:28:17.043662+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "db113336-b85f-48",
+    "pipeline_id": "issue-1924",
+    "from_role": "risk_analyst",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT from=reviewer_plan",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:26:47.081812+00:00"
+    },
+    "timestamp": "2026-04-27T19:28:47.568674+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "66823dad-a68f-43",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:28:16.953451+00:00"
+    },
+    "timestamp": "2026-04-27T19:29:17.380942+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "77402267-879d-4b",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "risk_analyst",
+    "message_type": "CONSENSUS_ACK",
+    "subject": "ACK from reviewer_plan for risk_analyst",
+    "body": "\nReviewed `1924-risk_analyst-output.json` (543 lines, 19 risks R1-R19) section-by-section against the refine analysis, the architect's plan-phase analysis, and the task_planner's plan draft. The risk surface is comprehensive, severities are calibrated, mitigations are concrete and actionable, the implement-phase checklist (lines 497-517) maps every risk to a verification step, and the four-level global rollback plan (config-only \u2192 route-disable \u2192 credential-revoke \u2192 full-revert) is realistic. ACK because this meets the plan-phase risk-assessment bar.\n\n### What I verified\n\n- **Risk coverage breadth** \u2014 19 risks across the right categories: security (R1, R2, R5, R7, R8, R9, R10, R16, R17), data-integrity (R3), performance (R4, R11, R18), compatibility (R6, R14), operational (R12, R15, R19), data-privacy (R13). No obvious gap. Notably, R3 (non-idempotent writes), R4 (Atlassian's March 2026 per-issue write throttling), R6 (Epic Link per-instance variation), R8 (createIssueLink existence-leak side channel), and R18 (cache memory unbounded) are all correctly identified as the high-leverage write-specific risks that did NOT exist for the v1 read surface.\n- **Severity calibration** \u2014 0 HIGH after mitigations, 6 MEDIUM, low ones documented but no implement-phase action required. R1 (custom-field smuggling) starts at high/medium \u2192 severity high BEFORE mitigations because the unmitigated path lets agents set `securityLevel`, `assignee`, `sprint` etc.; severity drops to medium after curated allowlist is enforced. R7 (project-allowlist gate vector) impact=high but likelihood=low because the failure mode requires a careless port of v1 reads.\n- **HITL flags** \u2014 three correctly flagged for human review: R1 (custom-field exposure \u2192 decision-1), R3 (idempotency policy \u2192 decision-3 + decision-19), R10 (per-role / per-phase gating \u2192 decision-10 + decision-11). The reasoning column on each (`human_review_reason`) is specific and actionable.\n- **Mitigations are concrete** \u2014 each mitigation is either a code change with file path (e.g., R7's \"Body validator MUST require a top-level `projectKey: '[A-Z][A-Z0-9_]*'` field\"), a config change (R4's `RateLimit-Reason` envelope propagation), a test grid (R5's adversarial body suite), or a runbook entry (R3's \"operator runbook\"). No hand-waving.\n- **Rollback per-risk** \u2014 every risk has a rollback paragraph that names the specific lever (config reload, hot-patch, env-var, credential revoke, full revert). The level-1 rollback (set `jira.projects: []`) is the v1 read pattern and correctly carries forward.\n- **External research** (lines 518-540) is solid: 13 sources cited including Atlassian's 2026 rate-limit rollout docs, the community thread on idempotency, ADF schema reference, and the Snapsec stored-XSS-in-Jira-Work-Management finding (recent and germane). Key findings (lines 534-538) tie each cited source to a specific risk (R3 \u2194 idempotency thread, R4 \u2194 rate-limit rollout, R5 \u2194 ADF + Snapsec finding).\n- **Implement-phase checklist** (lines 497-517) is a one-line-per-risk verification list. The reviewer in implement phase can grep for `[R<N>]` and confirm each. This is reusable artifact value.\n- **Global rollback plan** (lines 473-495) \u2014 level 1-4 is graduated and matches the v1 read rollback plan. Level 3's note that \"Both Jira and Confluence go dark together (per #1931 decision-6 shared-creds coupling)\" is a real cross-issue coupling worth surfacing.\n\n### Non-blocking\n\n- **R6 (Epic Link auto-detect) recommendation conflicts with the task_planner's bake-in.** Risk_analyst (line 175) recommends \"the gateway probes the parent ticket's project type via `GET /rest/api/3/project/{key}` (cached) on first use, then chooses `parent.key` OR `customfield_10014`\" \u2014 i.e., probe-and-pick-one. The task_planner's bake-in (`1924-plan.md:55`) emits BOTH fields simultaneously, which I separately NACKed as broken. **Risk_analyst's interpretation is correct** and I want this called out explicitly: when the task_planner re-proposes addressing my D2 NACK, they should adopt risk_analyst's probe-and-cache approach rather than the both-fields shotgun. Suggest the risk_analyst surface this as an explicit cross-artifact conflict in their next iteration (or in a follow-up note) so the implement-phase coder doesn't see two contradictory specs.\n- **R11 (body-size caps) numbers conflict with the task_planner's bake-in.** Risk_analyst recommends `description \u2264 100,000 chars`; task_planner bakes `description \u2264 32 KiB` (\u224832,768 chars). A 3\u00d7 factor difference. Both are defensible for different operator tolerances. Flag for HITL feedback-1.Q2 pickup; the implement-phase reviewer should not arbitrate.\n- **R5 (ADF passthrough) recommendation conflicts with task_planner's bake-in.** Risk_analyst recommends decision-7 = opt-1 (plain-text only) on security grounds (mention/media/extension nodes). Task_planner baked decision-7 = opt-3 (both). The risk_analyst's case is sound \u2014 passthrough is much harder to validate. Suggest adding the ADF-node allowlist to TASK-3-3's body-validator if the bake-in survives HITL.\n- **R18 (cache memory) surfaces a real gap in the task_planner's plan.** Risk_analyst recommends `MAX_IDEMPOTENCY_ENTRIES = 10_000` with LRU eviction; task_planner's TASK-1-1 (which I separately reviewed) only specifies TTL eviction with no entry-count cap. The risk_analyst is right that TTL-only is unbounded under high churn. The task_planner's plan should adopt this cap when re-proposing.\n- **R15 (error envelope) \u2014 risk_analyst recommends enrichment, task_planner baked verbatim.** Risk_analyst's enriched envelope (`field_errors`, `error_messages`) is the better DX, but the task_planner's bake-in (Q26 default = verbatim passthrough) ships sooner. Note the trade-off; not blocking for v1.\n- **R3 severity is debatable.** Risk_analyst rates impact=medium, likelihood=high \u2192 severity=medium. Given the mitigation (architect D1 cache) is in scope and well-defined, medium is fine. Worth noting that without the cache the severity would be high.\n- **R10 mitigations include a minor file-naming concern.** Risk_analyst (line 266) says \"gateway/role_filter.py (potentially new)\" \u2014 this duplicates the architect's pattern. If decisions 10/11 land on opt-2, recommend co-locating with `jira_policy.py` rather than a new top-level role_filter.py to avoid scattering authorization logic across multiple modules. This is a future-scope concern; currently the recommendation is \"defer to follow-up\" so the file doesn't materialize in this PR.\n- **R16 reviewer-action wording.** \"Reviewer MUST run `pytest gateway/tests/test_jira_routes.py -k private_mode` and confirm pass count includes 4 new routes (8 routes total: 4 read + 4 write).\" This is a hard count \u2014 if a future PR adds a fifth Jira read route, the assertion drifts. Suggest \"\u2265 8 routes\" rather than \"8 routes total\" so the assertion stays valid as the surface grows. (Minor.)\n- **R12 sandbox-wrapper risk has severity=low/likelihood=medium.** That feels right; the v1 wrapper already exercises the heredoc pattern. Just confirming the calibration is reasonable.\n- **R17 (Squid allowlist)** is appropriately a re-flag of #1556's R5 \u2014 defensive duplication is fine.\n- **`tasks_satisfied: []` (line 541)** is empty. For an issue with 19 contract tasks (after task_planner's plan resolves), the risk_analyst's output should eventually link risk-mitigation verifications to specific contract task IDs. Currently TASK-1-1, TASK-3-1, etc. don't exist in the contract yet (the plan is still in BRC), so empty is OK for this iteration \u2014 but flag this as something to populate after task_planner's NACK is addressed and the contract tasks land.\n- **R19 (doc home unresolved) is severity=low/impact=low** which feels right; a doc layout choice should not block release.\n- **No risk addresses the `JiraUpstreamWriteError` vs `JiraUpstreamError` choice** I flagged in the architect's analysis. Not a security issue \u2014 operational only. Skip.\n\n### One observation about coverage\n\nThe risk_analyst's surface does NOT include a risk for \"coder/tester role conflict on test files\" (TASK-1-1 vs TASK-5-1, which I NACKed for task_planner). That's a process risk, not a write-extension risk, so it's reasonable to omit. Just noting that BRC-level process risks are not in scope for the risk_analyst's deliverable.\n\nThe risk_analyst's output is implementable as-is by a careful reviewer + coder. ACK.\n",
+    "metadata": {
+      "payload": {
+        "artifact_references": [
+          ".egg-state/agent-outputs/1924-risk_analyst-output.json",
+          ".egg-state/drafts/1924-analysis.md",
+          ".egg-state/drafts/1924-plan.md",
+          ".egg-state/agent-outputs/1924-architect-output.json",
+          "gateway/jira_client.py",
+          "gateway/jira_policy.py",
+          "gateway/gateway.py",
+          "gateway/tests/test_jira_routes.py"
+        ],
+        "reason": "\nReviewed `1924-risk_analyst-output.json` (543 lines, 19 risks R1-R19) section-by-section against the refine analysis, the architect's plan-phase analysis, and the task_planner's plan draft. The risk surface is comprehensive, severities are calibrated, mitigations are concrete and actionable, the implement-phase checklist (lines 497-517) maps every risk to a verification step, and the four-level global rollback plan (config-only \u2192 route-disable \u2192 credential-revoke \u2192 full-revert) is realistic. ACK because this meets the plan-phase risk-assessment bar.\n\n### What I verified\n\n- **Risk coverage breadth** \u2014 19 risks across the right categories: security (R1, R2, R5, R7, R8, R9, R10, R16, R17), data-integrity (R3), performance (R4, R11, R18), compatibility (R6, R14), operational (R12, R15, R19), data-privacy (R13). No obvious gap. Notably, R3 (non-idempotent writes), R4 (Atlassian's March 2026 per-issue write throttling), R6 (Epic Link per-instance variation), R8 (createIssueLink existence-leak side channel), and R18 (cache memory unbounded) are all correctly identified as the high-leverage write-specific risks that did NOT exist for the v1 read surface.\n- **Severity calibration** \u2014 0 HIGH after mitigations, 6 MEDIUM, low ones documented but no implement-phase action required. R1 (custom-field smuggling) starts at high/medium \u2192 severity high BEFORE mitigations because the unmitigated path lets agents set `securityLevel`, `assignee`, `sprint` etc.; severity drops to medium after curated allowlist is enforced. R7 (project-allowlist gate vector) impact=high but likelihood=low because the failure mode requires a careless port of v1 reads.\n- **HITL flags** \u2014 three correctly flagged for human review: R1 (custom-field exposure \u2192 decision-1), R3 (idempotency policy \u2192 decision-3 + decision-19), R10 (per-role / per-phase gating \u2192 decision-10 + decision-11). The reasoning column on each (`human_review_reason`) is specific and actionable.\n- **Mitigations are concrete** \u2014 each mitigation is either a code change with file path (e.g., R7's \"Body validator MUST require a top-level `projectKey: '[A-Z][A-Z0-9_]*'` field\"), a config change (R4's `RateLimit-Reason` envelope propagation), a test grid (R5's adversarial body suite), or a runbook entry (R3's \"operator runbook\"). No hand-waving.\n- **Rollback per-risk** \u2014 every risk has a rollback paragraph that names the specific lever (config reload, hot-patch, env-var, credential revoke, full revert). The level-1 rollback (set `jira.projects: []`) is the v1 read pattern and correctly carries forward.\n- **External research** (lines 518-540) is solid: 13 sources cited including Atlassian's 2026 rate-limit rollout docs, the community thread on idempotency, ADF schema reference, and the Snapsec stored-XSS-in-Jira-Work-Management finding (recent and germane). Key findings (lines 534-538) tie each cited source to a specific risk (R3 \u2194 idempotency thread, R4 \u2194 rate-limit rollout, R5 \u2194 ADF + Snapsec finding).\n- **Implement-phase checklist** (lines 497-517) is a one-line-per-risk verification list. The reviewer in implement phase can grep for `[R<N>]` and confirm each. This is reusable artifact value.\n- **Global rollback plan** (lines 473-495) \u2014 level 1-4 is graduated and matches the v1 read rollback plan. Level 3's note that \"Both Jira and Confluence go dark together (per #1931 decision-6 shared-creds coupling)\" is a real cross-issue coupling worth surfacing.\n\n### Non-blocking\n\n- **R6 (Epic Link auto-detect) recommendation conflicts with the task_planner's bake-in.** Risk_analyst (line 175) recommends \"the gateway probes the parent ticket's project type via `GET /rest/api/3/project/{key}` (cached) on first use, then chooses `parent.key` OR `customfield_10014`\" \u2014 i.e., probe-and-pick-one. The task_planner's bake-in (`1924-plan.md:55`) emits BOTH fields simultaneously, which I separately NACKed as broken. **Risk_analyst's interpretation is correct** and I want this called out explicitly: when the task_planner re-proposes addressing my D2 NACK, they should adopt risk_analyst's probe-and-cache approach rather than the both-fields shotgun. Suggest the risk_analyst surface this as an explicit cross-artifact conflict in their next iteration (or in a follow-up note) so the implement-phase coder doesn't see two contradictory specs.\n- **R11 (body-size caps) numbers conflict with the task_planner's bake-in.** Risk_analyst recommends `description \u2264 100,000 chars`; task_planner bakes `description \u2264 32 KiB` (\u224832,768 chars). A 3\u00d7 factor difference. Both are defensible for different operator tolerances. Flag for HITL feedback-1.Q2 pickup; the implement-phase reviewer should not arbitrate.\n- **R5 (ADF passthrough) recommendation conflicts with task_planner's bake-in.** Risk_analyst recommends decision-7 = opt-1 (plain-text only) on security grounds (mention/media/extension nodes). Task_planner baked decision-7 = opt-3 (both). The risk_analyst's case is sound \u2014 passthrough is much harder to validate. Suggest adding the ADF-node allowlist to TASK-3-3's body-validator if the bake-in survives HITL.\n- **R18 (cache memory) surfaces a real gap in the task_planner's plan.** Risk_analyst recommends `MAX_IDEMPOTENCY_ENTRIES = 10_000` with LRU eviction; task_planner's TASK-1-1 (which I separately reviewed) only specifies TTL eviction with no entry-count cap. The risk_analyst is right that TTL-only is unbounded under high churn. The task_planner's plan should adopt this cap when re-proposing.\n- **R15 (error envelope) \u2014 risk_analyst recommends enrichment, task_planner baked verbatim.** Risk_analyst's enriched envelope (`field_errors`, `error_messages`) is the better DX, but the task_planner's bake-in (Q26 default = verbatim passthrough) ships sooner. Note the trade-off; not blocking for v1.\n- **R3 severity is debatable.** Risk_analyst rates impact=medium, likelihood=high \u2192 severity=medium. Given the mitigation (architect D1 cache) is in scope and well-defined, medium is fine. Worth noting that without the cache the severity would be high.\n- **R10 mitigations include a minor file-naming concern.** Risk_analyst (line 266) says \"gateway/role_filter.py (potentially new)\" \u2014 this duplicates the architect's pattern. If decisions 10/11 land on opt-2, recommend co-locating with `jira_policy.py` rather than a new top-level role_filter.py to avoid scattering authorization logic across multiple modules. This is a future-scope concern; currently the recommendation is \"defer to follow-up\" so the file doesn't materialize in this PR.\n- **R16 reviewer-action wording.** \"Reviewer MUST run `pytest gateway/tests/test_jira_routes.py -k private_mode` and confirm pass count includes 4 new routes (8 routes total: 4 read + 4 write).\" This is a hard count \u2014 if a future PR adds a fifth Jira read route, the assertion drifts. Suggest \"\u2265 8 routes\" rather than \"8 routes total\" so the assertion stays valid as the surface grows. (Minor.)\n- **R12 sandbox-wrapper risk has severity=low/likelihood=medium.** That feels right; the v1 wrapper already exercises the heredoc pattern. Just confirming the calibration is reasonable.\n- **R17 (Squid allowlist)** is appropriately a re-flag of #1556's R5 \u2014 defensive duplication is fine.\n- **`tasks_satisfied: []` (line 541)** is empty. For an issue with 19 contract tasks (after task_planner's plan resolves), the risk_analyst's output should eventually link risk-mitigation verifications to specific contract task IDs. Currently TASK-1-1, TASK-3-1, etc. don't exist in the contract yet (the plan is still in BRC), so empty is OK for this iteration \u2014 but flag this as something to populate after task_planner's NACK is addressed and the contract tasks land.\n- **R19 (doc home unresolved) is severity=low/impact=low** which feels right; a doc layout choice should not block release.\n- **No risk addresses the `JiraUpstreamWriteError` vs `JiraUpstreamError` choice** I flagged in the architect's analysis. Not a security issue \u2014 operational only. Skip.\n\n### One observation about coverage\n\nThe risk_analyst's surface does NOT include a risk for \"coder/tester role conflict on test files\" (TASK-1-1 vs TASK-5-1, which I NACKed for task_planner). That's a process risk, not a write-extension risk, so it's reasonable to omit. Just noting that BRC-level process risks are not in scope for the risk_analyst's deliverable.\n\nThe risk_analyst's output is implementable as-is by a careful reviewer + coder. ACK.\n"
+      },
+      "version": 1
+    },
+    "timestamp": "2026-04-27T19:29:40.334755+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "c64e3ba5-2e95-46",
+    "pipeline_id": "issue-1924",
+    "from_role": "risk_analyst",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:29:40.428702+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "90771745-7659-4a",
+    "pipeline_id": "issue-1924",
+    "from_role": "orchestrator",
+    "to_role": "risk_analyst",
+    "message_type": "OVERSEER_ALERT",
+    "subject": "BRC confirmation timeout \u2014 call mcp__brc__confirm",
+    "body": "You are PROPOSED and fully ACKed but have not confirmed in 180s. Call `mcp__brc__confirm` now. If it returns `status='pending_acks'`, read `message` for the guard reason and wait on the prerequisite events instead: `CONSENSUS_PROPOSE` if a producer hasn't proposed (`zero_proposal_producers`), `CONSENSUS_ACK` / `CONSENSUS_RE_REVIEW` if a reviewer's ACK is stale or unresolved. Then retry confirm.",
+    "metadata": {
+      "alert_type": "brc_confirmation_timeout",
+      "elapsed_seconds": 180,
+      "source": "health_monitor"
+    },
+    "timestamp": "2026-04-27T19:29:42.932605+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "98ad190a-a540-40",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "CONSENSUS_CONFIRMED",
+    "subject": "Confirmed by reviewer_plan (pending_acks)",
+    "body": "Reviewer reviewer_plan cannot confirm: unresolved NACKs. Wait for these producers to re-propose before confirming: ['task_planner']",
+    "metadata": {
+      "pending_acks": true
+    },
+    "timestamp": "2026-04-27T19:29:46.508131+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "a57a4a59-d4d6-4e",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:29:46.624275+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "17fad84d-661b-45",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:29:50.883617+00:00"
+    },
+    "timestamp": "2026-04-27T19:29:50.975936+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "bd00e94f-3ba7-42",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:29:51.713750+00:00"
+    },
+    "timestamp": "2026-04-27T19:29:51.804768+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "1bfbf8b1-dd8f-49",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:29:51.979309+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "85b99700-6338-4e",
+    "pipeline_id": "issue-1924",
+    "from_role": "risk_analyst",
+    "to_role": "all",
+    "message_type": "CONSENSUS_CONFIRMED",
+    "subject": "Confirmed by risk_analyst",
+    "body": "",
+    "metadata": {
+      "consensus_reached": false
+    },
+    "timestamp": "2026-04-27T19:29:52.477629+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "f01c9e51-a651-44",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:29:52.568307+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "2e401610-0228-48",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:29:56.104233+00:00"
+    },
+    "timestamp": "2026-04-27T19:29:56.179557+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "2303176e-fb2b-4a",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:29:58.783921+00:00"
+    },
+    "timestamp": "2026-04-27T19:29:58.910929+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "2bd9598e-c8ce-42",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:29:59.051210+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "05af9d20-ef3c-48",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:30:02.252335+00:00"
+    },
+    "timestamp": "2026-04-27T19:30:02.328003+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "bb1ab77a-96ab-43",
+    "pipeline_id": "issue-1924",
+    "from_role": "risk_analyst",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:30:04.973077+00:00"
+    },
+    "timestamp": "2026-04-27T19:30:05.055599+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "2f0b7575-e40c-4c",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:29:56.104233+00:00"
+    },
+    "timestamp": "2026-04-27T19:30:56.240767+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "cf1bd472-eefe-41",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:30:02.252335+00:00"
+    },
+    "timestamp": "2026-04-27T19:31:02.578722+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "34482e36-122e-40",
+    "pipeline_id": "issue-1924",
+    "from_role": "risk_analyst",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:30:04.973077+00:00"
+    },
+    "timestamp": "2026-04-27T19:31:05.208821+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "2d0a51ef-b613-48",
+    "pipeline_id": "issue-1924",
+    "from_role": "overseer",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "Plan phase cycle 97 \u2014 968s (~16min). BRC progress: architect CONFIRMED, risk_analyst CONFIRMED, reviewer REVIEWING. task_planner NACKed (at ~19:25), revising for ~7 min. No anomalies \u2014 normal NACK revision cycle. Awaiting task_planner re-proposal to complete consensus.",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT"
+    },
+    "timestamp": "2026-04-27T19:31:18.888592+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "ad3ccdb0-25b3-43",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:30:02.252335+00:00"
+    },
+    "timestamp": "2026-04-27T19:32:02.818395+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "a68c5db5-93fb-43",
+    "pipeline_id": "issue-1924",
+    "from_role": "risk_analyst",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:30:04.973077+00:00"
+    },
+    "timestamp": "2026-04-27T19:32:05.293441+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "04daa963-c6f5-42",
+    "pipeline_id": "issue-1924",
+    "from_role": "task_planner",
+    "to_role": "all",
+    "message_type": "CONSENSUS_PROPOSE",
+    "subject": "Proposal from task_planner",
+    "body": "Revised plan addressing all six blocking issues from reviewer_plan's NACK plus the actionable non-blocking suggestions: (1) D2 epic-link dispatch is now per-instance via `jira.epic_link_field` config knob \u2014 never emits both fields, route 400s on conflicting parent+epicLink; (2) Phase 1 foundations no longer demand test files (Phase 5 tester owns those); (3) createIssueLink synthesizes a `{status, inward, outward, type}` envelope (Atlassian returns 201 with no body); (4) labels replace/incremental modes mutually exclusive \u2014 400 at route, ValueError in client; (5) link idempotency cache composes key as `(link, canonical(inward,outward,type), key)` to prevent aliasing; (6) `_request` 429 audit emit lifted out of the GET-only retry loop so writes also emit. Plus minor fixes: 32 KiB comment-body cap rationale documented, label values logged (not just count) per Q20, notifyUsers query omitted when true, TASK-3-5 ordering note, sandbox `show_usage` pattern confirmed, TASK-5-3 matrix cap, method-tunneling adversarial test, integration-smoke deferred to #1557 in PR body, D10/D11 follow-up placeholder, new TASK-6-3 documenting phase-rollback verification.",
+    "metadata": {
+      "payload": {
+        "summary": "Revised plan addressing all six blocking issues from reviewer_plan's NACK plus the actionable non-blocking suggestions: (1) D2 epic-link dispatch is now per-instance via `jira.epic_link_field` config knob \u2014 never emits both fields, route 400s on conflicting parent+epicLink; (2) Phase 1 foundations no longer demand test files (Phase 5 tester owns those); (3) createIssueLink synthesizes a `{status, inward, outward, type}` envelope (Atlassian returns 201 with no body); (4) labels replace/incremental modes mutually exclusive \u2014 400 at route, ValueError in client; (5) link idempotency cache composes key as `(link, canonical(inward,outward,type), key)` to prevent aliasing; (6) `_request` 429 audit emit lifted out of the GET-only retry loop so writes also emit. Plus minor fixes: 32 KiB comment-body cap rationale documented, label values logged (not just count) per Q20, notifyUsers query omitted when true, TASK-3-5 ordering note, sandbox `show_usage` pattern confirmed, TASK-5-3 matrix cap, method-tunneling adversarial test, integration-smoke deferred to #1557 in PR body, D10/D11 follow-up placeholder, new TASK-6-3 documenting phase-rollback verification.",
+        "attestation": {},
+        "artifacts": [
+          ".egg-state/drafts/1924-plan.md"
+        ],
+        "risk_considered": "",
+        "commit_sha": "42fbb6433519f82749bcdd4ba6ad22ac91882f19",
+        "files_changed": [
+          ".egg-state/drafts/1924-plan.md"
+        ],
+        "tests_run": [],
+        "tasks_satisfied": []
+      },
+      "version": 2,
+      "commit_sha": "42fbb6433519f82749bcdd4ba6ad22ac91882f19"
+    },
+    "timestamp": "2026-04-27T19:32:48.749930+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "4b3e6e25-cb4c-47",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:32:48.793026+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "41c83d41-6e58-40",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:29:56.104233+00:00"
+    },
+    "timestamp": "2026-04-27T19:32:57.518489+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "7b4086f3-3c06-4f",
+    "pipeline_id": "issue-1924",
+    "from_role": "task_planner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:33:00.007016+00:00"
+    },
+    "timestamp": "2026-04-27T19:33:00.062004+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "22c27cc0-2fef-43",
+    "pipeline_id": "issue-1924",
+    "from_role": "risk_analyst",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:30:04.973077+00:00"
+    },
+    "timestamp": "2026-04-27T19:33:05.504896+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "f5cbad8e-7266-41",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:29:56.104233+00:00"
+    },
+    "timestamp": "2026-04-27T19:33:57.666672+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "4f6fb497-47e9-40",
+    "pipeline_id": "issue-1924",
+    "from_role": "task_planner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:33:00.007016+00:00"
+    },
+    "timestamp": "2026-04-27T19:34:00.192007+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "79525cfa-5e30-40",
+    "pipeline_id": "issue-1924",
+    "from_role": "risk_analyst",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:30:04.973077+00:00"
+    },
+    "timestamp": "2026-04-27T19:34:05.829186+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "692ef1b6-0ae7-45",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:29:56.104233+00:00"
+    },
+    "timestamp": "2026-04-27T19:34:57.847092+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "fde43ef1-49f8-48",
+    "pipeline_id": "issue-1924",
+    "from_role": "task_planner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:33:00.007016+00:00"
+    },
+    "timestamp": "2026-04-27T19:35:00.472557+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "1fcb7159-022f-45",
+    "pipeline_id": "issue-1924",
+    "from_role": "risk_analyst",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:30:04.973077+00:00"
+    },
+    "timestamp": "2026-04-27T19:35:06.051185+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "ed3f3dd4-8373-4d",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:29:56.104233+00:00"
+    },
+    "timestamp": "2026-04-27T19:35:57.949279+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "f20d59f1-084d-4a",
+    "pipeline_id": "issue-1924",
+    "from_role": "task_planner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:33:00.007016+00:00"
+    },
+    "timestamp": "2026-04-27T19:36:00.713694+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "72029db6-e47f-41",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "task_planner",
+    "message_type": "CONSENSUS_ACK",
+    "subject": "ACK from reviewer_plan for task_planner",
+    "body": "\nRe-reviewed `1924-plan.md` v2 (commit `42fbb6433`, 1044 lines, +295/-168 vs v1) line-by-line against the six blockers in my NACK and the non-blocking suggestions. Every blocker is addressed cleanly; every actionable non-blocking item is addressed. No new blocking issues introduced. ACK.\n\n### Blocker-by-blocker verification\n\n1. **D2 Epic Link auto-detect (was: emits BOTH parent.key + customfield_10014)** \u2014 FIXED with the strongest version of the fix.\n   - Defaults table line 55: \"Per-instance dispatch via config knob. `JiraPolicy` loads `jira.epic_link_field: 'parent' | 'customfield_10014'` (default `'parent'`). The `epicLink` shorthand emits **only the configured field** \u2014 never both.\"\n   - TASK-2-1 (lines 458-470): `create_issue` signature now takes `epic_link_field` parameter; routes to ONE field, never both. Explicit `parent` wins only when `epicLink` absent.\n   - TASK-3-1 step 6 (line 616-617): route 400s if both `parent` and `epicLink` are present.\n   - TASK-3-5 (lines 717-722): `JiraPolicy` exposes `epic_link_field` property with default `\"parent\"`, fail-closed-on-malformed-enum (warning + fall back to default).\n   - TASK-5-4 (lines 914-915): adversarial test grid asserts \"both `parent` and `epicLink` set \u2192 400\".\n   - This implementation **also matches risk_analyst R6's recommendation** (probe-and-pick-one, never both).\n\n2. **TASK-1-1 / TASK-1-2 vs TASK-5-1 / TASK-5-2 duplicate test ownership** \u2014 FIXED.\n   - TASK-1-1 description (lines 408-410): \"The corresponding test file is owned by TASK-5-1 \u2014 this task's acceptance does **not** require tests to exist; it only requires the module API.\"\n   - TASK-1-1 acceptance (lines 411-417): \"(Test coverage is asserted by TASK-5-1.)\"\n   - Same pattern applied to TASK-1-2 \u2194 TASK-5-2 (lines 432-437).\n   - This is option (a) from my NACK \u2014 the cleaner choice.\n\n3. **TASK-3-4 createIssueLink response shape** \u2014 FIXED exactly as recommended.\n   - TASK-3-4 (lines 693-700): \"Atlassian returns `201 Created` with **no body** in v3, so the route synthesizes a response envelope: `{status: 'created', inwardIssue: <key>, outwardIssue: <key>, type: <name>}`. Including the triple in the response lets the orchestrator's plan-apply correlate the call against its retry record.\"\n   - TASK-5-4 acceptance (lines 922-924) explicitly asserts the envelope shape.\n\n4. **TASK-2-2 labels replace+incremental** \u2014 FIXED with a clean two-layer rejection.\n   - TASK-2-2 (lines 496-505): \"two modes are **mutually exclusive at the client method level**: if both are set, raise `ValueError`. The route layer (TASK-3-2) returns 400 for this case before calling the client.\"\n   - TASK-3-2 (lines 645-647): explicit \"**reject 400 if both `labels` (replace mode) and any of `addLabels` / `removeLabels` (incremental mode) are present**\".\n   - TASK-5-4 (line 916): adversarial grid covers \"**mixed labels mode (replace + incremental) \u2192 400**\".\n\n5. **Idempotency cache key for createIssueLink** \u2014 FIXED (option (a) from my NACK).\n   - TASK-1-1 (lines 397-401): \"For `verb='link'` the caller composes `project` as `canonical(inward, outward, type)` (a stable tuple-string) so identical opaque keys never alias different (inward, outward, type) triples\".\n   - TASK-2-4 (lines 547-555): defines `canonical_link_id(inward_key, outward_key, link_type)` returning `\"<inward>|<outward>|<type>\"` and uses `get_or_run(\"link\", canonical_link_id(...), idempotency_key, ...)`.\n   - TASK-2-4 acceptance (lines 560-562): asserts no aliasing for same opaque key with different triples.\n   - TASK-5-1 (lines 852-855): explicit aliasing test.\n\n6. **429 audit emit on writes** \u2014 FIXED in the right place (`_request`).\n   - TASK-2-5 (lines 579-585): \"**Move the `jira_upstream_rate_limited` audit-emit call out of the GET-only retry loop in `_request`** so it fires on every 429 (writes included), guarded by `flask.has_request_context()`. The retry loop still retries only GET; the audit emit is unconditional on 429.\"\n   - TASK-2-5 acceptance (line 590): \"The 429 audit emit fires for write methods (a new test in TASK-5-3 asserts this).\"\n   - TASK-5-3 (line 896): \"**429 audit emit on each write verb** (asserts the TASK-2-5 audit-emit fix).\"\n\n### Non-blocking items also addressed\n\n- **Q15 32 KiB comment-body cap rationale** \u2014 TASK-3-3 (lines 666-668): \"32 KiB \u2014 chosen to mirror the description cap; Atlassian publishes no upper limit, but 32 KiB bounds audit-log size and covers realistic plan-apply commentary\".\n- **Q20 label values logged (not just count)** \u2014 Defaults table Q20 row (line 77) updated; TASK-3-1 (line 622) \"**label values** (small enumerated strings \u2014 policy-relevant per Q20)\"; TASK-3-2 (lines 651-652) \"label values (when replace), add/remove label values (when incremental)\".\n- **TASK-2-2 `notifyUsers` query omitted when True** \u2014 TASK-2-2 (lines 506-508): \"omit `notifyUsers` entirely when `notify_users=True` (Atlassian's default is true \u2014 do not bloat the URL); send `notifyUsers=false` only when `notify_users=False`\".\n- **Phase 3 intra-phase ordering (TASK-3-5 before TASK-3-4)** \u2014 TASK-3-5 (lines 723-726): \"**Ordering note:** TASK-3-5 must land before TASK-3-4 (issue-link route) because the route depends on `link_type_allowed`. The implementer must commit TASK-3-5 first within Phase 3.\"\n- **TASK-3-7 picks `config/context-filters.yaml` directly** \u2014 TASK-3-7 (line 754): \"Edit `config/context-filters.yaml` directly (the file `JiraPolicy` loads \u2014 survey confirmed the existing `jira:` section lives there).\"\n- **Sandbox wrapper `--help` clarification** \u2014 Phase 4 goal (lines 778-781): \"The existing wrapper has a top-level `show_usage` (line ~350) and no per-subcommand `--help`; the new subcommands extend `show_usage` with their flags rather than introducing a new help-output convention.\" All four sandbox tasks now reference `show_usage` instead of `--help`.\n- **D10/D11 follow-up placeholder in PR body** \u2014 PR description (lines 336-339): \"**Per-role and per-phase write gating (decisions D10/D11) are explicitly deferred to a follow-up issue (to be filed once this PR is merged \u2014 placeholder reference: `Follows: TBD-write-policy`)**\".\n- **HTTP-method tunnelling adversarial test** \u2014 TASK-5-4 (lines 919-920): \"**HTTP-method tunnelling via body** (e.g. `'_method': 'DELETE'` keys, `__proto__` pollution) \u2192 400\".\n- **TASK-5-3 matrix cap** \u2014 TASK-5-3 (lines 884-887): \"Bound the matrix at **\u22651 success case per option pair** and one failure case per validation rule \u2014 write a brief named matrix in each test's docstring rather than generating a Cartesian explosion.\"\n- **Integration smoke deferred to #1557 in PR body** \u2014 Manual section (lines 369-373): \"**Integration smoke against a live Atlassian instance is intentionally deferred to #1557** (Jira-epic SDLC pipelines), which is the first real consumer.\"\n- **Rollback claim verification** \u2014 NEW TASK-6-3 (lines 1005-1024): adds a \"Phase rollback\" doc sub-section AND tasks the implement-phase reviewer with running `git revert --no-commit <phase-N-commit>` on each phase and confirming v1 read tests stay green. Concrete and verifiable.\n\n### Non-blocking \u2014 minor (no change needed)\n\n- **Approach summary line 22-25** still reads \"Cache is keyed by `(verb, project, key)` for ... `createIssueLink`\". Strictly the link verb's cache key uses `canonical(inward, outward, type)` in the `project` slot (per TASK-1-1 lines 397-401). High-level Approach is mildly inconsistent with the canonical-link-id detail buried in the tasks, but the tasks are authoritative \u2014 a coder following TASK-2-4 will not be confused. Optional polish: footnote the Approach with \"(see TASK-2-4 for link-verb cache-key composition)\".\n- **TASK-2-1 client method still accepts both `parent` and `epic_link`** \u2014 the route layer rejects when both are present (TASK-3-1 step 6), so client-level enforcement is belt-and-braces. Currently the client just emits whichever is set; if both are set programmatically (bypassing the route) the second `fields.parent.key=` write clobbers the first. The route gate is the canonical fix; adding a client-level `ValueError` for \"both set\" would be defense-in-depth but is not required since all callers route through the gateway.\n- **TASK-2-4 / TASK-5-1 link-cache aliasing** \u2014 the canonical-link-id is `\"<inward>|<outward>|<type>\"`. If a customer link type ever contains `|` literally, the canonical id collides with another triple. Atlassian's link-type name regex (per risk_analyst R9 mitigation) bounds names to `[A-Za-z][A-Za-z _-]{0,32}` which excludes `|`, so this is safe in practice \u2014 but worth a one-line code comment near `canonical_link_id` noting the chosen separator and the regex bound that protects it.\n\nThe plan v2 is implementable. The HITL bake-ins are clearly tagged with `decision-N` references; the implement-phase coder can swap in the operator's actual answer when HITL closes. Reviewer NACK satisfaction is complete. ACK.\n",
+    "metadata": {
+      "payload": {
+        "artifact_references": [
+          ".egg-state/drafts/1924-plan.md",
+          ".egg-state/drafts/1924-analysis.md",
+          ".egg-state/agent-outputs/1924-architect-output.json",
+          ".egg-state/agent-outputs/1924-risk_analyst-output.json"
+        ],
+        "reason": "\nRe-reviewed `1924-plan.md` v2 (commit `42fbb6433`, 1044 lines, +295/-168 vs v1) line-by-line against the six blockers in my NACK and the non-blocking suggestions. Every blocker is addressed cleanly; every actionable non-blocking item is addressed. No new blocking issues introduced. ACK.\n\n### Blocker-by-blocker verification\n\n1. **D2 Epic Link auto-detect (was: emits BOTH parent.key + customfield_10014)** \u2014 FIXED with the strongest version of the fix.\n   - Defaults table line 55: \"Per-instance dispatch via config knob. `JiraPolicy` loads `jira.epic_link_field: 'parent' | 'customfield_10014'` (default `'parent'`). The `epicLink` shorthand emits **only the configured field** \u2014 never both.\"\n   - TASK-2-1 (lines 458-470): `create_issue` signature now takes `epic_link_field` parameter; routes to ONE field, never both. Explicit `parent` wins only when `epicLink` absent.\n   - TASK-3-1 step 6 (line 616-617): route 400s if both `parent` and `epicLink` are present.\n   - TASK-3-5 (lines 717-722): `JiraPolicy` exposes `epic_link_field` property with default `\"parent\"`, fail-closed-on-malformed-enum (warning + fall back to default).\n   - TASK-5-4 (lines 914-915): adversarial test grid asserts \"both `parent` and `epicLink` set \u2192 400\".\n   - This implementation **also matches risk_analyst R6's recommendation** (probe-and-pick-one, never both).\n\n2. **TASK-1-1 / TASK-1-2 vs TASK-5-1 / TASK-5-2 duplicate test ownership** \u2014 FIXED.\n   - TASK-1-1 description (lines 408-410): \"The corresponding test file is owned by TASK-5-1 \u2014 this task's acceptance does **not** require tests to exist; it only requires the module API.\"\n   - TASK-1-1 acceptance (lines 411-417): \"(Test coverage is asserted by TASK-5-1.)\"\n   - Same pattern applied to TASK-1-2 \u2194 TASK-5-2 (lines 432-437).\n   - This is option (a) from my NACK \u2014 the cleaner choice.\n\n3. **TASK-3-4 createIssueLink response shape** \u2014 FIXED exactly as recommended.\n   - TASK-3-4 (lines 693-700): \"Atlassian returns `201 Created` with **no body** in v3, so the route synthesizes a response envelope: `{status: 'created', inwardIssue: <key>, outwardIssue: <key>, type: <name>}`. Including the triple in the response lets the orchestrator's plan-apply correlate the call against its retry record.\"\n   - TASK-5-4 acceptance (lines 922-924) explicitly asserts the envelope shape.\n\n4. **TASK-2-2 labels replace+incremental** \u2014 FIXED with a clean two-layer rejection.\n   - TASK-2-2 (lines 496-505): \"two modes are **mutually exclusive at the client method level**: if both are set, raise `ValueError`. The route layer (TASK-3-2) returns 400 for this case before calling the client.\"\n   - TASK-3-2 (lines 645-647): explicit \"**reject 400 if both `labels` (replace mode) and any of `addLabels` / `removeLabels` (incremental mode) are present**\".\n   - TASK-5-4 (line 916): adversarial grid covers \"**mixed labels mode (replace + incremental) \u2192 400**\".\n\n5. **Idempotency cache key for createIssueLink** \u2014 FIXED (option (a) from my NACK).\n   - TASK-1-1 (lines 397-401): \"For `verb='link'` the caller composes `project` as `canonical(inward, outward, type)` (a stable tuple-string) so identical opaque keys never alias different (inward, outward, type) triples\".\n   - TASK-2-4 (lines 547-555): defines `canonical_link_id(inward_key, outward_key, link_type)` returning `\"<inward>|<outward>|<type>\"` and uses `get_or_run(\"link\", canonical_link_id(...), idempotency_key, ...)`.\n   - TASK-2-4 acceptance (lines 560-562): asserts no aliasing for same opaque key with different triples.\n   - TASK-5-1 (lines 852-855): explicit aliasing test.\n\n6. **429 audit emit on writes** \u2014 FIXED in the right place (`_request`).\n   - TASK-2-5 (lines 579-585): \"**Move the `jira_upstream_rate_limited` audit-emit call out of the GET-only retry loop in `_request`** so it fires on every 429 (writes included), guarded by `flask.has_request_context()`. The retry loop still retries only GET; the audit emit is unconditional on 429.\"\n   - TASK-2-5 acceptance (line 590): \"The 429 audit emit fires for write methods (a new test in TASK-5-3 asserts this).\"\n   - TASK-5-3 (line 896): \"**429 audit emit on each write verb** (asserts the TASK-2-5 audit-emit fix).\"\n\n### Non-blocking items also addressed\n\n- **Q15 32 KiB comment-body cap rationale** \u2014 TASK-3-3 (lines 666-668): \"32 KiB \u2014 chosen to mirror the description cap; Atlassian publishes no upper limit, but 32 KiB bounds audit-log size and covers realistic plan-apply commentary\".\n- **Q20 label values logged (not just count)** \u2014 Defaults table Q20 row (line 77) updated; TASK-3-1 (line 622) \"**label values** (small enumerated strings \u2014 policy-relevant per Q20)\"; TASK-3-2 (lines 651-652) \"label values (when replace), add/remove label values (when incremental)\".\n- **TASK-2-2 `notifyUsers` query omitted when True** \u2014 TASK-2-2 (lines 506-508): \"omit `notifyUsers` entirely when `notify_users=True` (Atlassian's default is true \u2014 do not bloat the URL); send `notifyUsers=false` only when `notify_users=False`\".\n- **Phase 3 intra-phase ordering (TASK-3-5 before TASK-3-4)** \u2014 TASK-3-5 (lines 723-726): \"**Ordering note:** TASK-3-5 must land before TASK-3-4 (issue-link route) because the route depends on `link_type_allowed`. The implementer must commit TASK-3-5 first within Phase 3.\"\n- **TASK-3-7 picks `config/context-filters.yaml` directly** \u2014 TASK-3-7 (line 754): \"Edit `config/context-filters.yaml` directly (the file `JiraPolicy` loads \u2014 survey confirmed the existing `jira:` section lives there).\"\n- **Sandbox wrapper `--help` clarification** \u2014 Phase 4 goal (lines 778-781): \"The existing wrapper has a top-level `show_usage` (line ~350) and no per-subcommand `--help`; the new subcommands extend `show_usage` with their flags rather than introducing a new help-output convention.\" All four sandbox tasks now reference `show_usage` instead of `--help`.\n- **D10/D11 follow-up placeholder in PR body** \u2014 PR description (lines 336-339): \"**Per-role and per-phase write gating (decisions D10/D11) are explicitly deferred to a follow-up issue (to be filed once this PR is merged \u2014 placeholder reference: `Follows: TBD-write-policy`)**\".\n- **HTTP-method tunnelling adversarial test** \u2014 TASK-5-4 (lines 919-920): \"**HTTP-method tunnelling via body** (e.g. `'_method': 'DELETE'` keys, `__proto__` pollution) \u2192 400\".\n- **TASK-5-3 matrix cap** \u2014 TASK-5-3 (lines 884-887): \"Bound the matrix at **\u22651 success case per option pair** and one failure case per validation rule \u2014 write a brief named matrix in each test's docstring rather than generating a Cartesian explosion.\"\n- **Integration smoke deferred to #1557 in PR body** \u2014 Manual section (lines 369-373): \"**Integration smoke against a live Atlassian instance is intentionally deferred to #1557** (Jira-epic SDLC pipelines), which is the first real consumer.\"\n- **Rollback claim verification** \u2014 NEW TASK-6-3 (lines 1005-1024): adds a \"Phase rollback\" doc sub-section AND tasks the implement-phase reviewer with running `git revert --no-commit <phase-N-commit>` on each phase and confirming v1 read tests stay green. Concrete and verifiable.\n\n### Non-blocking \u2014 minor (no change needed)\n\n- **Approach summary line 22-25** still reads \"Cache is keyed by `(verb, project, key)` for ... `createIssueLink`\". Strictly the link verb's cache key uses `canonical(inward, outward, type)` in the `project` slot (per TASK-1-1 lines 397-401). High-level Approach is mildly inconsistent with the canonical-link-id detail buried in the tasks, but the tasks are authoritative \u2014 a coder following TASK-2-4 will not be confused. Optional polish: footnote the Approach with \"(see TASK-2-4 for link-verb cache-key composition)\".\n- **TASK-2-1 client method still accepts both `parent` and `epic_link`** \u2014 the route layer rejects when both are present (TASK-3-1 step 6), so client-level enforcement is belt-and-braces. Currently the client just emits whichever is set; if both are set programmatically (bypassing the route) the second `fields.parent.key=` write clobbers the first. The route gate is the canonical fix; adding a client-level `ValueError` for \"both set\" would be defense-in-depth but is not required since all callers route through the gateway.\n- **TASK-2-4 / TASK-5-1 link-cache aliasing** \u2014 the canonical-link-id is `\"<inward>|<outward>|<type>\"`. If a customer link type ever contains `|` literally, the canonical id collides with another triple. Atlassian's link-type name regex (per risk_analyst R9 mitigation) bounds names to `[A-Za-z][A-Za-z _-]{0,32}` which excludes `|`, so this is safe in practice \u2014 but worth a one-line code comment near `canonical_link_id` noting the chosen separator and the regex bound that protects it.\n\nThe plan v2 is implementable. The HITL bake-ins are clearly tagged with `decision-N` references; the implement-phase coder can swap in the operator's actual answer when HITL closes. Reviewer NACK satisfaction is complete. ACK.\n"
+      },
+      "version": 2
+    },
+    "timestamp": "2026-04-27T19:36:01.506222+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "bd9b094c-57ab-4a",
+    "pipeline_id": "issue-1924",
+    "from_role": "orchestrator",
+    "to_role": "task_planner",
+    "message_type": "STATUS",
+    "subject": "Ready to confirm \u2014 all confirm preconditions satisfied",
+    "body": "Your proposal (version 2) is ready to confirm \u2014 all blocking reviews are clear and global confirm preconditions are met. Run `egg-orch consensus confirmed` to confirm.",
+    "metadata": {
+      "ready_to_confirm": true,
+      "version": 2
+    },
+    "timestamp": "2026-04-27T19:36:01.507067+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "4782160e-b2b2-40",
+    "pipeline_id": "issue-1924",
+    "from_role": "task_planner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:36:01.602852+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "e8d64c43-3996-45",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_plan",
+    "to_role": "all",
+    "message_type": "CONSENSUS_CONFIRMED",
+    "subject": "Confirmed by reviewer_plan",
+    "body": "",
+    "metadata": {
+      "consensus_reached": false
+    },
+    "timestamp": "2026-04-27T19:36:05.448666+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "621d141d-a2d0-40",
+    "pipeline_id": "issue-1924",
+    "from_role": "architect",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:36:05.901064+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "0ccee75a-68c3-4a",
+    "pipeline_id": "issue-1924",
+    "from_role": "risk_analyst",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:36:05.945990+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "4ddbaf7a-8bdd-4f",
+    "pipeline_id": "issue-1924",
+    "from_role": "task_planner",
+    "to_role": "all",
+    "message_type": "CONSENSUS_CONFIRMED",
+    "subject": "Confirmed by task_planner",
+    "body": "",
+    "metadata": {
+      "consensus_reached": true
+    },
+    "timestamp": "2026-04-27T19:36:06.304904+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "18d7c09a-d319-40",
+    "pipeline_id": "issue-1924",
+    "from_role": "risk_analyst",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T19:36:10.224217+00:00"
+    },
+    "timestamp": "2026-04-27T19:36:10.274350+00:00",
+    "phase": "plan"
+  },
+  {
+    "id": "87bd5fb0-fdae-48",
+    "pipeline_id": "issue-1924",
+    "from_role": "risk_analyst",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T19:36:10.432820+00:00",
+    "phase": "plan"
+  }
+]

--- a/.egg-state/brc-history/1924-plan.md
+++ b/.egg-state/brc-history/1924-plan.md
@@ -1,0 +1,1892 @@
+# BRC Consensus History — plan phase
+
+Generated: 2026-04-27T19:36:10Z
+Pipeline: issue-1924
+
+### [2026-04-27T19:15:32Z] overseer (HEARTBEAT): heartbeat: WORKING
+
+Cycle 1 complete. Refine phase BRC consensus confirmed. Plan phase agents launched (architect, task_planner, risk_analyst, reviewer_plan). 8 stale refine-phase alerts classified as noise — no corrective action required. Monitoring plan phase progression.
+
+````yaml
+id: 355256e1-c4a4-4f
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:15:51Z] overseer (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+Cycle 2 complete. Plan phase healthy — 4 agents running (architect, task_planner, risk_analyst, reviewer_plan), elapsed ~34s. No new alerts. Monitoring.
+
+````yaml
+id: 86167bf8-7b9a-43
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+````
+
+### [2026-04-27T19:17:13Z] reviewer_plan (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+````yaml
+id: 35837d78-50e4-4d
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+````
+
+### [2026-04-27T19:17:24Z] reviewer_plan (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE
+
+````yaml
+id: ac56f265-941e-47
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:17:24.587462+00:00'
+````
+
+### [2026-04-27T19:17:41Z] overseer (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+Plan phase nominal — reviewer_plan active, waiting for CONSENSUS_PROPOSE from architect/task_planner/risk_analyst (151s elapsed). No anomalies detected.
+
+````yaml
+id: eb1ad32a-767a-4b
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+````
+
+### [2026-04-27T19:18:24Z] reviewer_plan (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE
+
+````yaml
+id: a3263597-2358-46
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:17:24.587462+00:00'
+````
+
+### [2026-04-27T19:19:24Z] reviewer_plan (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE
+
+````yaml
+id: b760ad9e-a1ed-40
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:17:24.587462+00:00'
+````
+
+### [2026-04-27T19:20:00Z] overseer (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+Plan phase cycle 25 — 288s elapsed, all 4 agents running (architect, task_planner, risk_analyst, reviewer_plan). reviewer_plan active and waiting for CONSENSUS_PROPOSE. No producer proposals yet. No detector alerts. Pipeline healthy.
+
+````yaml
+id: a67d86c1-af62-4f
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+````
+
+### [2026-04-27T19:20:25Z] reviewer_plan (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE
+
+````yaml
+id: 4b348f29-6aa2-4b
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:17:24.587462+00:00'
+````
+
+### [2026-04-27T19:21:25Z] reviewer_plan (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE
+
+````yaml
+id: 9736a8bd-5ea8-46
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:17:24.587462+00:00'
+````
+
+### [2026-04-27T19:21:49Z] task_planner (CONSENSUS_PROPOSE): Proposal from task_planner
+
+Plan phase task decomposition for #1924 (Jira gateway write verbs). Six-phase single-PR plan: (1) foundation modules — idempotency cache + ADF helper; (2) four JiraClient write methods bypassing validate_jira_api_path with hardcoded paths; (3) four /api/v1/jira/* gateway routes with curated body schemas, project allowlist, audit redaction; (4) four sandbox wrapper subcommands with text/file/stdin input ergonomics; (5) tests — per-route 403 grid extension, idempotency cache, ADF, adversarial bodies; (6) docs — extend jira-wrapper.md. 26 tasks across coder/tester/documenter roles. Bakes in 19 HITL decision defaults from the architect's recommended approach (A1+B1+C1+D1+E1) so implement can start before all HITL answers land.
+
+````yaml
+id: b8d42f38-c2e9-42
+phase: plan
+metadata:
+  payload:
+    summary: "Plan phase task decomposition for #1924 (Jira gateway write verbs).\
+      \ Six-phase single-PR plan: (1) foundation modules \u2014 idempotency cache\
+      \ + ADF helper; (2) four JiraClient write methods bypassing validate_jira_api_path\
+      \ with hardcoded paths; (3) four /api/v1/jira/* gateway routes with curated\
+      \ body schemas, project allowlist, audit redaction; (4) four sandbox wrapper\
+      \ subcommands with text/file/stdin input ergonomics; (5) tests \u2014 per-route\
+      \ 403 grid extension, idempotency cache, ADF, adversarial bodies; (6) docs \u2014\
+      \ extend jira-wrapper.md. 26 tasks across coder/tester/documenter roles. Bakes\
+      \ in 19 HITL decision defaults from the architect's recommended approach (A1+B1+C1+D1+E1)\
+      \ so implement can start before all HITL answers land."
+    attestation: {}
+    artifacts:
+    - .egg-state/drafts/1924-plan.md
+    risk_considered: ''
+    commit_sha: 5a8e52da5cefcd29800b6296791fdd5a1519048c
+    files_changed:
+    - .egg-state/drafts/1924-plan.md
+    tests_run: []
+    tasks_satisfied: []
+  version: 1
+  commit_sha: 5a8e52da5cefcd29800b6296791fdd5a1519048c
+````
+
+### [2026-04-27T19:21:50Z] reviewer_plan (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: bcb02c6b-69dc-48
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:22:05Z] task_planner (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: c95ac50f-1c1e-4a
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:22:03.270283+00:00'
+````
+
+### [2026-04-27T19:22:05Z] task_planner (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 271d944c-157e-4f
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:22:07Z] task_planner (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: c699b691-806f-4c
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:22:07.693396+00:00'
+````
+
+### [2026-04-27T19:23:07Z] task_planner (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: eae0f8f5-2318-42
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:22:07.693396+00:00'
+````
+
+### [2026-04-27T19:23:16Z] overseer (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+Plan phase cycle 50 — 486s elapsed. task_planner PROPOSED (6-phase, 26-task plan). reviewer_plan actively reviewing. architect + risk_analyst still preparing proposals. No real alerts (1 calibration-only stale refine-phase stall). BRC progressing normally.
+
+````yaml
+id: 6b873daa-e5a0-49
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+````
+
+### [2026-04-27T19:23:35Z] reviewer_plan (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE
+
+````yaml
+id: 48453a3a-ed1b-4d
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:23:35.757504+00:00'
+````
+
+### [2026-04-27T19:23:45Z] reviewer_plan (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 7ea4b104-c9d5-4f
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:24:07Z] task_planner (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: bac873d6-053b-43
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:22:07.693396+00:00'
+````
+
+### [2026-04-27T19:25:02Z] reviewer_plan → task_planner (CONSENSUS_NACK): NACK from reviewer_plan for task_planner
+
+
+Reviewed the plan draft section-by-section against the analysis and the existing v1 read-only gateway. The phase decomposition (Foundation → Client → Routes → Wrapper → Tests → Docs), choice of A1+B1+C1+D1+E1, and PR scoping are sound. The HITL-defaults table is a useful unblock and most defaults match the analysis. But six items must be tightened before this plan is implementable — three of them are actively broken or self-contradictory.
+
+### Blocking
+
+1. **Defaults table D2 + TASK-2-1: "Auto-detect" emits BOTH `parent.key` AND `customfield_10014` simultaneously — this is wrong and will 400 upstream.** The analysis (lines 198, 347) and Atlassian's REST docs are explicit: `parent.key` is the next-gen / company-managed field; `customfield_10014` is the classic Epic Link field. They are mutually exclusive per project type. Sending both on a next-gen project returns `400 Field 'customfield_10014' cannot be set, it is not on the appropriate screen, or unknown.`; sending both on classic returns the inverse for `parent`. The plan's `1924-plan.md:55` says "emit both `parent.key` (next-gen) and `customfield_10014` (classic Epic Link); the wire shape is decided per-instance via `jira_policy` config (default = both)" — and TASK-2-1's description (lines 452-454) literally builds both fields. **Fix:** pick a per-instance config knob in `jira_policy` (e.g. `jira.epic_link_field: "parent" | "customfield_10014"`, default `"parent"`) and emit only that field. The architect's option 3 ("Auto-detect or accept either via the epicLink shorthand") is one-or-the-other dispatch, not a both-fields shotgun. Add a TASK in Phase 2 or Phase 3-5 to load this knob, and reflect it in the body builder. Also amend the ambiguity in TASK-2-1 between the explicit `parent` arg and the `epic_link` arg — if both are passed, what wins? Spec it (e.g. "explicit `parent` overrides `epic_link`; if both set and conflicting, 400 at the route") rather than letting the second `fields.parent.key=` line clobber the first.
+
+2. **TASK-1-1 / TASK-1-2 acceptance criteria duplicate TASK-5-1 / TASK-5-2 — same test files owned by two roles.** TASK-1-1 acceptance (lines 396-404) demands `gateway/tests/test_jira_idempotency.py` pass with seven named scenarios. TASK-5-1 (lines 766-779, role: tester) describes "Create `gateway/tests/test_jira_idempotency.py` covering the cache module from TASK-1-1: …" — same file, same scenarios, different role. Same collision for TASK-1-2 ↔ TASK-5-2 on `test_jira_adf.py`. The implement-phase coder/tester roles will both think they own the file; whichever lands second overwrites. **Fix:** decide explicitly. Either (a) drop the test requirement from TASK-1-1/1-2 acceptance, leaving "module exists with the API" as the only criterion and TASK-5-1/5-2 owns the file; or (b) drop TASK-5-1/5-2 entirely and acknowledge in Phase 5's preamble that the foundation tests landed in Phase 1. Option (a) is cleaner because it matches the role assignments.
+
+3. **TASK-3-4 createIssueLink response shape is left for the coder to decide.** The task literal text (lines 636-639): "Returns Atlassian's response envelope (201 body or `{status: 'created'}` envelope — choose one and document; default to envelope for consistency with create-issue)." The analysis (line 54, line 114) is explicit that Atlassian's `POST /rest/api/3/issueLink` returns `201 Created` **with no body in v3**, so "Atlassian's response envelope" is empty — the only viable option is the synthesized envelope. **Fix:** spec the envelope now: `{status: "created"}` for parity with `editJiraIssue`'s envelope (`{status: "updated", key}`). Decide whether to include the (inward, outward, type) triple in the response so the orchestrator's plan-apply can correlate the call with its retry record — recommend yes: `{status: "created", inwardIssue, outwardIssue, type}`.
+
+4. **TASK-2-2 labels semantics for replace + incremental is also left for the coder.** Lines 488-489: "replace+incremental rejected (or merged per chosen semantics — document the choice)". This is a real semantic decision that affects the route schema validator, the client method body, AND the test grid in TASK-5-3. **Fix:** pick now. Recommendation: **reject as 400 at the route layer** if both `labels` and (`addLabels` or `removeLabels`) are present — agents pick one mode. Easier to test, less surprising for callers, and aligns with the "reject malformed body" theme of C1 validation.
+
+5. **Idempotency cache key for createIssueLink is under-specified.** Cache is keyed `(verb, project, idempotency_key)` per `1924-plan.md:23-25` and TASK-1-1 description. For `create_issue_link`, "project" is ambiguous (inward? outward? both?). Two callers re-using the same opaque `idempotency_key` for distinct (inward, outward, type) triples would collide and the second caller would receive the cached response of the first. **Fix:** for `create_issue_link` either (a) compose the cache key as `("link", canonical(inward, outward, type), idempotency_key)` so identical opaque keys never alias different links, or (b) document that the orchestrator MUST derive `idempotency_key` from `(inward_key, outward_key, type)` and the gateway treats it as a black-box. Option (a) is safer because it puts the invariant in the gateway. Update TASK-1-1's `get_or_run` signature accordingly (or add a per-verb wrapper) and add a test scenario for "same idempotency_key, different link triples → distinct cache entries".
+
+6. **429 audit emit on writes (Q12 default = "yes") has no implementation hook in the plan.** TASK-5-3 acceptance (line 805) asserts "429 audit emit on each verb", but the existing `JiraClient._request` (per the survey) emits `jira_upstream_rate_limited` only inside its retry loop on lines 340-367 — and writes deliberately skip the retry loop (line 322). None of TASK-2-1..2-4 nor the route-layer tasks add an audit emission for the no-retry 429 path. As written, the test in TASK-5-3 will fail — there's no code path that emits the audit for write 429s. **Fix:** add an explicit task (or a sub-bullet to TASK-2-5) modifying `_request` to emit `jira_upstream_rate_limited` on EVERY 429 (retry-or-not), guarded by `flask.has_request_context()`. Reflect this in the unit-test surface (TASK-5-3 already lists it; the production code just needs to exist).
+
+### Non-blocking
+
+- **`1924-plan.md:75` Q15 cap reconciliation:** "comment body ≤ 32 KiB" matches the description cap, but the analysis (line 100) cites "no published Atlassian limit". Confirm the 32 KiB cap is intentional rather than a copy-paste from `description`. Recommend keeping it; just want it explicit in TASK-3-3 comments.
+- **`1924-plan.md:77` Q20 audit redaction conflicts with TASK-3-1 audit description:** Q20 says "labels logged because they are policy-relevant", but TASK-3-1 audit details (line 583) say "label count". Pick one — recommend logging label *values* (small enumerated strings, policy-relevant for who-tagged-what audit, matches Q20 default) and add a note in TASK-3-1 acceptance.
+- **TASK-2-2 `notifyUsers` query:** the plan emits `notifyUsers=true` explicitly when `notify_users=True`. Atlassian's default already is `true`; sending the param redundantly is harmless but bloats the URL. Suggest: omit the query param when `notify_users=True`, send `notifyUsers=false` only when False.
+- **Phase 3 intra-phase ordering:** TASK-3-4 (link route) depends on TASK-3-5 (`link_types` config + helper). The plan explicitly says (lines 260-264) "Within each phase the tasks are independent". Add a one-line note that TASK-3-5 must land before TASK-3-4 (or merge them into a single task) so the implementer doesn't try them in parallel and break the route.
+- **TASK-3-7:** "Add a commented `jira.link_types` example block to `config/context-filters.yaml` (or its example file)". Pick now: edit `config/context-filters.yaml` directly — that's the file the policy loads, and the survey confirmed the existing `jira:` section (lines 11-24) already lives there. The "(or its example file)" hedge invites coder confusion.
+- **TASK-4-1..4-4 `--help`:** the survey didn't confirm the existing `sandbox/scripts/jira` wrapper has per-subcommand `--help` output. The acceptance criteria of all four sandbox tasks reference `--help`. If the v1 wrapper doesn't already support `--help`, that's hidden scope. Add a one-liner to TASK-4-1 confirming the existing dispatcher's `--help` pattern (or noting the addition).
+- **Per-role / per-phase write gating deferred (D10/D11):** plan correctly defers to a follow-up. Add a follow-up issue placeholder reference in the PR body (`Follows: TBD-issue-for-write-gating`) so the deferred work isn't dropped.
+- **TASK-5-4 unicode-in-keys path-traversal:** good adversarial coverage. Suggest also adding a test case for HTTP-method tunnelling via body (e.g. body containing `"_method": "DELETE"` or similar) — defensive, since v1 read paths weren't tested for it either.
+- **TASK-5-3 test combinations matrix:** "all input combinations" is broad. Add a one-line cap (e.g. "≥1 success case per option pair" or "named matrix in test docstring") so the implementer doesn't generate a Cartesian explosion.
+- **`1924-plan.md:233` no live-Atlassian smoke test:** consistent with v1; flag that #1557 (the consumer) will be the integration smoke. Add to PR body's test_plan as "Integration smoke test deferred to #1557 plan-apply rollout".
+- **`Risks (deferred to risk_analyst)`:** good division of labour. The plan-only review will not block on risks — but the rollback claim ("each phase is independently revertible") deserves a one-line acceptance check (e.g. "TASK-X.Y verifies `git revert` of each phase commit leaves the v1 read surface green"). Currently this claim is unverified.
+
+
+````yaml
+id: 26ce78db-c061-4e
+phase: plan
+metadata:
+  payload:
+    reason: "\nReviewed the plan draft section-by-section against the analysis and\
+      \ the existing v1 read-only gateway. The phase decomposition (Foundation \u2192\
+      \ Client \u2192 Routes \u2192 Wrapper \u2192 Tests \u2192 Docs), choice of A1+B1+C1+D1+E1,\
+      \ and PR scoping are sound. The HITL-defaults table is a useful unblock and\
+      \ most defaults match the analysis. But six items must be tightened before this\
+      \ plan is implementable \u2014 three of them are actively broken or self-contradictory.\n\
+      \n### Blocking\n\n1. **Defaults table D2 + TASK-2-1: \"Auto-detect\" emits BOTH\
+      \ `parent.key` AND `customfield_10014` simultaneously \u2014 this is wrong and\
+      \ will 400 upstream.** The analysis (lines 198, 347) and Atlassian's REST docs\
+      \ are explicit: `parent.key` is the next-gen / company-managed field; `customfield_10014`\
+      \ is the classic Epic Link field. They are mutually exclusive per project type.\
+      \ Sending both on a next-gen project returns `400 Field 'customfield_10014'\
+      \ cannot be set, it is not on the appropriate screen, or unknown.`; sending\
+      \ both on classic returns the inverse for `parent`. The plan's `1924-plan.md:55`\
+      \ says \"emit both `parent.key` (next-gen) and `customfield_10014` (classic\
+      \ Epic Link); the wire shape is decided per-instance via `jira_policy` config\
+      \ (default = both)\" \u2014 and TASK-2-1's description (lines 452-454) literally\
+      \ builds both fields. **Fix:** pick a per-instance config knob in `jira_policy`\
+      \ (e.g. `jira.epic_link_field: \"parent\" | \"customfield_10014\"`, default\
+      \ `\"parent\"`) and emit only that field. The architect's option 3 (\"Auto-detect\
+      \ or accept either via the epicLink shorthand\") is one-or-the-other dispatch,\
+      \ not a both-fields shotgun. Add a TASK in Phase 2 or Phase 3-5 to load this\
+      \ knob, and reflect it in the body builder. Also amend the ambiguity in TASK-2-1\
+      \ between the explicit `parent` arg and the `epic_link` arg \u2014 if both are\
+      \ passed, what wins? Spec it (e.g. \"explicit `parent` overrides `epic_link`;\
+      \ if both set and conflicting, 400 at the route\") rather than letting the second\
+      \ `fields.parent.key=` line clobber the first.\n\n2. **TASK-1-1 / TASK-1-2 acceptance\
+      \ criteria duplicate TASK-5-1 / TASK-5-2 \u2014 same test files owned by two\
+      \ roles.** TASK-1-1 acceptance (lines 396-404) demands `gateway/tests/test_jira_idempotency.py`\
+      \ pass with seven named scenarios. TASK-5-1 (lines 766-779, role: tester) describes\
+      \ \"Create `gateway/tests/test_jira_idempotency.py` covering the cache module\
+      \ from TASK-1-1: \u2026\" \u2014 same file, same scenarios, different role.\
+      \ Same collision for TASK-1-2 \u2194 TASK-5-2 on `test_jira_adf.py`. The implement-phase\
+      \ coder/tester roles will both think they own the file; whichever lands second\
+      \ overwrites. **Fix:** decide explicitly. Either (a) drop the test requirement\
+      \ from TASK-1-1/1-2 acceptance, leaving \"module exists with the API\" as the\
+      \ only criterion and TASK-5-1/5-2 owns the file; or (b) drop TASK-5-1/5-2 entirely\
+      \ and acknowledge in Phase 5's preamble that the foundation tests landed in\
+      \ Phase 1. Option (a) is cleaner because it matches the role assignments.\n\n\
+      3. **TASK-3-4 createIssueLink response shape is left for the coder to decide.**\
+      \ The task literal text (lines 636-639): \"Returns Atlassian's response envelope\
+      \ (201 body or `{status: 'created'}` envelope \u2014 choose one and document;\
+      \ default to envelope for consistency with create-issue).\" The analysis (line\
+      \ 54, line 114) is explicit that Atlassian's `POST /rest/api/3/issueLink` returns\
+      \ `201 Created` **with no body in v3**, so \"Atlassian's response envelope\"\
+      \ is empty \u2014 the only viable option is the synthesized envelope. **Fix:**\
+      \ spec the envelope now: `{status: \"created\"}` for parity with `editJiraIssue`'s\
+      \ envelope (`{status: \"updated\", key}`). Decide whether to include the (inward,\
+      \ outward, type) triple in the response so the orchestrator's plan-apply can\
+      \ correlate the call with its retry record \u2014 recommend yes: `{status: \"\
+      created\", inwardIssue, outwardIssue, type}`.\n\n4. **TASK-2-2 labels semantics\
+      \ for replace + incremental is also left for the coder.** Lines 488-489: \"\
+      replace+incremental rejected (or merged per chosen semantics \u2014 document\
+      \ the choice)\". This is a real semantic decision that affects the route schema\
+      \ validator, the client method body, AND the test grid in TASK-5-3. **Fix:**\
+      \ pick now. Recommendation: **reject as 400 at the route layer** if both `labels`\
+      \ and (`addLabels` or `removeLabels`) are present \u2014 agents pick one mode.\
+      \ Easier to test, less surprising for callers, and aligns with the \"reject\
+      \ malformed body\" theme of C1 validation.\n\n5. **Idempotency cache key for\
+      \ createIssueLink is under-specified.** Cache is keyed `(verb, project, idempotency_key)`\
+      \ per `1924-plan.md:23-25` and TASK-1-1 description. For `create_issue_link`,\
+      \ \"project\" is ambiguous (inward? outward? both?). Two callers re-using the\
+      \ same opaque `idempotency_key` for distinct (inward, outward, type) triples\
+      \ would collide and the second caller would receive the cached response of the\
+      \ first. **Fix:** for `create_issue_link` either (a) compose the cache key as\
+      \ `(\"link\", canonical(inward, outward, type), idempotency_key)` so identical\
+      \ opaque keys never alias different links, or (b) document that the orchestrator\
+      \ MUST derive `idempotency_key` from `(inward_key, outward_key, type)` and the\
+      \ gateway treats it as a black-box. Option (a) is safer because it puts the\
+      \ invariant in the gateway. Update TASK-1-1's `get_or_run` signature accordingly\
+      \ (or add a per-verb wrapper) and add a test scenario for \"same idempotency_key,\
+      \ different link triples \u2192 distinct cache entries\".\n\n6. **429 audit\
+      \ emit on writes (Q12 default = \"yes\") has no implementation hook in the plan.**\
+      \ TASK-5-3 acceptance (line 805) asserts \"429 audit emit on each verb\", but\
+      \ the existing `JiraClient._request` (per the survey) emits `jira_upstream_rate_limited`\
+      \ only inside its retry loop on lines 340-367 \u2014 and writes deliberately\
+      \ skip the retry loop (line 322). None of TASK-2-1..2-4 nor the route-layer\
+      \ tasks add an audit emission for the no-retry 429 path. As written, the test\
+      \ in TASK-5-3 will fail \u2014 there's no code path that emits the audit for\
+      \ write 429s. **Fix:** add an explicit task (or a sub-bullet to TASK-2-5) modifying\
+      \ `_request` to emit `jira_upstream_rate_limited` on EVERY 429 (retry-or-not),\
+      \ guarded by `flask.has_request_context()`. Reflect this in the unit-test surface\
+      \ (TASK-5-3 already lists it; the production code just needs to exist).\n\n\
+      ### Non-blocking\n\n- **`1924-plan.md:75` Q15 cap reconciliation:** \"comment\
+      \ body \u2264 32 KiB\" matches the description cap, but the analysis (line 100)\
+      \ cites \"no published Atlassian limit\". Confirm the 32 KiB cap is intentional\
+      \ rather than a copy-paste from `description`. Recommend keeping it; just want\
+      \ it explicit in TASK-3-3 comments.\n- **`1924-plan.md:77` Q20 audit redaction\
+      \ conflicts with TASK-3-1 audit description:** Q20 says \"labels logged because\
+      \ they are policy-relevant\", but TASK-3-1 audit details (line 583) say \"label\
+      \ count\". Pick one \u2014 recommend logging label *values* (small enumerated\
+      \ strings, policy-relevant for who-tagged-what audit, matches Q20 default) and\
+      \ add a note in TASK-3-1 acceptance.\n- **TASK-2-2 `notifyUsers` query:** the\
+      \ plan emits `notifyUsers=true` explicitly when `notify_users=True`. Atlassian's\
+      \ default already is `true`; sending the param redundantly is harmless but bloats\
+      \ the URL. Suggest: omit the query param when `notify_users=True`, send `notifyUsers=false`\
+      \ only when False.\n- **Phase 3 intra-phase ordering:** TASK-3-4 (link route)\
+      \ depends on TASK-3-5 (`link_types` config + helper). The plan explicitly says\
+      \ (lines 260-264) \"Within each phase the tasks are independent\". Add a one-line\
+      \ note that TASK-3-5 must land before TASK-3-4 (or merge them into a single\
+      \ task) so the implementer doesn't try them in parallel and break the route.\n\
+      - **TASK-3-7:** \"Add a commented `jira.link_types` example block to `config/context-filters.yaml`\
+      \ (or its example file)\". Pick now: edit `config/context-filters.yaml` directly\
+      \ \u2014 that's the file the policy loads, and the survey confirmed the existing\
+      \ `jira:` section (lines 11-24) already lives there. The \"(or its example file)\"\
+      \ hedge invites coder confusion.\n- **TASK-4-1..4-4 `--help`:** the survey didn't\
+      \ confirm the existing `sandbox/scripts/jira` wrapper has per-subcommand `--help`\
+      \ output. The acceptance criteria of all four sandbox tasks reference `--help`.\
+      \ If the v1 wrapper doesn't already support `--help`, that's hidden scope. Add\
+      \ a one-liner to TASK-4-1 confirming the existing dispatcher's `--help` pattern\
+      \ (or noting the addition).\n- **Per-role / per-phase write gating deferred\
+      \ (D10/D11):** plan correctly defers to a follow-up. Add a follow-up issue placeholder\
+      \ reference in the PR body (`Follows: TBD-issue-for-write-gating`) so the deferred\
+      \ work isn't dropped.\n- **TASK-5-4 unicode-in-keys path-traversal:** good adversarial\
+      \ coverage. Suggest also adding a test case for HTTP-method tunnelling via body\
+      \ (e.g. body containing `\"_method\": \"DELETE\"` or similar) \u2014 defensive,\
+      \ since v1 read paths weren't tested for it either.\n- **TASK-5-3 test combinations\
+      \ matrix:** \"all input combinations\" is broad. Add a one-line cap (e.g. \"\
+      \u22651 success case per option pair\" or \"named matrix in test docstring\"\
+      ) so the implementer doesn't generate a Cartesian explosion.\n- **`1924-plan.md:233`\
+      \ no live-Atlassian smoke test:** consistent with v1; flag that #1557 (the consumer)\
+      \ will be the integration smoke. Add to PR body's test_plan as \"Integration\
+      \ smoke test deferred to #1557 plan-apply rollout\".\n- **`Risks (deferred to\
+      \ risk_analyst)`:** good division of labour. The plan-only review will not block\
+      \ on risks \u2014 but the rollback claim (\"each phase is independently revertible\"\
+      ) deserves a one-line acceptance check (e.g. \"TASK-X.Y verifies `git revert`\
+      \ of each phase commit leaves the v1 read surface green\"). Currently this claim\
+      \ is unverified.\n"
+    artifact_references:
+    - .egg-state/drafts/1924-plan.md
+    - .egg-state/drafts/1924-analysis.md
+    - gateway/jira_client.py
+    - gateway/jira_policy.py
+    - gateway/gateway.py
+    - gateway/tests/test_jira_routes.py
+    - sandbox/scripts/jira
+    - config/context-filters.yaml
+  reason: "\nReviewed the plan draft section-by-section against the analysis and the\
+    \ existing v1 read-only gateway. The phase decomposition (Foundation \u2192 Client\
+    \ \u2192 Routes \u2192 Wrapper \u2192 Tests \u2192 Docs), choice of A1+B1+C1+D1+E1,\
+    \ and PR scoping are sound. The HITL-defaults table is a useful unblock and most\
+    \ defaults match the analysis. But six items must be tightened before this plan\
+    \ is implementable \u2014 three of them are actively broken or self-contradictory.\n\
+    \n### Blocking\n\n1. **Defaults table D2 + TASK-2-1: \"Auto-detect\" emits BOTH\
+    \ `parent.key` AND `customfield_10014` simultaneously \u2014 this is wrong and\
+    \ will 400 upstream.** The analysis (lines 198, 347) and Atlassian's REST docs\
+    \ are explicit: `parent.key` is the next-gen / company-managed field; `customfield_10014`\
+    \ is the classic Epic Link field. They are mutually exclusive per project type.\
+    \ Sending both on a next-gen project returns `400 Field 'customfield_10014' cannot\
+    \ be set, it is not on the appropriate screen, or unknown.`; sending both on classic\
+    \ returns the inverse for `parent`. The plan's `1924-plan.md:55` says \"emit both\
+    \ `parent.key` (next-gen) and `customfield_10014` (classic Epic Link); the wire\
+    \ shape is decided per-instance via `jira_policy` config (default = both)\" \u2014\
+    \ and TASK-2-1's description (lines 452-454) literally builds both fields. **Fix:**\
+    \ pick a per-instance config knob in `jira_policy` (e.g. `jira.epic_link_field:\
+    \ \"parent\" | \"customfield_10014\"`, default `\"parent\"`) and emit only that\
+    \ field. The architect's option 3 (\"Auto-detect or accept either via the epicLink\
+    \ shorthand\") is one-or-the-other dispatch, not a both-fields shotgun. Add a\
+    \ TASK in Phase 2 or Phase 3-5 to load this knob, and reflect it in the body builder.\
+    \ Also amend the ambiguity in TASK-2-1 between the explicit `parent` arg and the\
+    \ `epic_link` arg \u2014 if both are passed, what wins? Spec it (e.g. \"explicit\
+    \ `parent` overrides `epic_link`; if both set and conflicting, 400 at the route\"\
+    ) rather than letting the second `fields.parent.key=` line clobber the first.\n\
+    \n2. **TASK-1-1 / TASK-1-2 acceptance criteria duplicate TASK-5-1 / TASK-5-2 \u2014\
+    \ same test files owned by two roles.** TASK-1-1 acceptance (lines 396-404) demands\
+    \ `gateway/tests/test_jira_idempotency.py` pass with seven named scenarios. TASK-5-1\
+    \ (lines 766-779, role: tester) describes \"Create `gateway/tests/test_jira_idempotency.py`\
+    \ covering the cache module from TASK-1-1: \u2026\" \u2014 same file, same scenarios,\
+    \ different role. Same collision for TASK-1-2 \u2194 TASK-5-2 on `test_jira_adf.py`.\
+    \ The implement-phase coder/tester roles will both think they own the file; whichever\
+    \ lands second overwrites. **Fix:** decide explicitly. Either (a) drop the test\
+    \ requirement from TASK-1-1/1-2 acceptance, leaving \"module exists with the API\"\
+    \ as the only criterion and TASK-5-1/5-2 owns the file; or (b) drop TASK-5-1/5-2\
+    \ entirely and acknowledge in Phase 5's preamble that the foundation tests landed\
+    \ in Phase 1. Option (a) is cleaner because it matches the role assignments.\n\
+    \n3. **TASK-3-4 createIssueLink response shape is left for the coder to decide.**\
+    \ The task literal text (lines 636-639): \"Returns Atlassian's response envelope\
+    \ (201 body or `{status: 'created'}` envelope \u2014 choose one and document;\
+    \ default to envelope for consistency with create-issue).\" The analysis (line\
+    \ 54, line 114) is explicit that Atlassian's `POST /rest/api/3/issueLink` returns\
+    \ `201 Created` **with no body in v3**, so \"Atlassian's response envelope\" is\
+    \ empty \u2014 the only viable option is the synthesized envelope. **Fix:** spec\
+    \ the envelope now: `{status: \"created\"}` for parity with `editJiraIssue`'s\
+    \ envelope (`{status: \"updated\", key}`). Decide whether to include the (inward,\
+    \ outward, type) triple in the response so the orchestrator's plan-apply can correlate\
+    \ the call with its retry record \u2014 recommend yes: `{status: \"created\",\
+    \ inwardIssue, outwardIssue, type}`.\n\n4. **TASK-2-2 labels semantics for replace\
+    \ + incremental is also left for the coder.** Lines 488-489: \"replace+incremental\
+    \ rejected (or merged per chosen semantics \u2014 document the choice)\". This\
+    \ is a real semantic decision that affects the route schema validator, the client\
+    \ method body, AND the test grid in TASK-5-3. **Fix:** pick now. Recommendation:\
+    \ **reject as 400 at the route layer** if both `labels` and (`addLabels` or `removeLabels`)\
+    \ are present \u2014 agents pick one mode. Easier to test, less surprising for\
+    \ callers, and aligns with the \"reject malformed body\" theme of C1 validation.\n\
+    \n5. **Idempotency cache key for createIssueLink is under-specified.** Cache is\
+    \ keyed `(verb, project, idempotency_key)` per `1924-plan.md:23-25` and TASK-1-1\
+    \ description. For `create_issue_link`, \"project\" is ambiguous (inward? outward?\
+    \ both?). Two callers re-using the same opaque `idempotency_key` for distinct\
+    \ (inward, outward, type) triples would collide and the second caller would receive\
+    \ the cached response of the first. **Fix:** for `create_issue_link` either (a)\
+    \ compose the cache key as `(\"link\", canonical(inward, outward, type), idempotency_key)`\
+    \ so identical opaque keys never alias different links, or (b) document that the\
+    \ orchestrator MUST derive `idempotency_key` from `(inward_key, outward_key, type)`\
+    \ and the gateway treats it as a black-box. Option (a) is safer because it puts\
+    \ the invariant in the gateway. Update TASK-1-1's `get_or_run` signature accordingly\
+    \ (or add a per-verb wrapper) and add a test scenario for \"same idempotency_key,\
+    \ different link triples \u2192 distinct cache entries\".\n\n6. **429 audit emit\
+    \ on writes (Q12 default = \"yes\") has no implementation hook in the plan.**\
+    \ TASK-5-3 acceptance (line 805) asserts \"429 audit emit on each verb\", but\
+    \ the existing `JiraClient._request` (per the survey) emits `jira_upstream_rate_limited`\
+    \ only inside its retry loop on lines 340-367 \u2014 and writes deliberately skip\
+    \ the retry loop (line 322). None of TASK-2-1..2-4 nor the route-layer tasks add\
+    \ an audit emission for the no-retry 429 path. As written, the test in TASK-5-3\
+    \ will fail \u2014 there's no code path that emits the audit for write 429s. **Fix:**\
+    \ add an explicit task (or a sub-bullet to TASK-2-5) modifying `_request` to emit\
+    \ `jira_upstream_rate_limited` on EVERY 429 (retry-or-not), guarded by `flask.has_request_context()`.\
+    \ Reflect this in the unit-test surface (TASK-5-3 already lists it; the production\
+    \ code just needs to exist).\n\n### Non-blocking\n\n- **`1924-plan.md:75` Q15\
+    \ cap reconciliation:** \"comment body \u2264 32 KiB\" matches the description\
+    \ cap, but the analysis (line 100) cites \"no published Atlassian limit\". Confirm\
+    \ the 32 KiB cap is intentional rather than a copy-paste from `description`. Recommend\
+    \ keeping it; just want it explicit in TASK-3-3 comments.\n- **`1924-plan.md:77`\
+    \ Q20 audit redaction conflicts with TASK-3-1 audit description:** Q20 says \"\
+    labels logged because they are policy-relevant\", but TASK-3-1 audit details (line\
+    \ 583) say \"label count\". Pick one \u2014 recommend logging label *values* (small\
+    \ enumerated strings, policy-relevant for who-tagged-what audit, matches Q20 default)\
+    \ and add a note in TASK-3-1 acceptance.\n- **TASK-2-2 `notifyUsers` query:**\
+    \ the plan emits `notifyUsers=true` explicitly when `notify_users=True`. Atlassian's\
+    \ default already is `true`; sending the param redundantly is harmless but bloats\
+    \ the URL. Suggest: omit the query param when `notify_users=True`, send `notifyUsers=false`\
+    \ only when False.\n- **Phase 3 intra-phase ordering:** TASK-3-4 (link route)\
+    \ depends on TASK-3-5 (`link_types` config + helper). The plan explicitly says\
+    \ (lines 260-264) \"Within each phase the tasks are independent\". Add a one-line\
+    \ note that TASK-3-5 must land before TASK-3-4 (or merge them into a single task)\
+    \ so the implementer doesn't try them in parallel and break the route.\n- **TASK-3-7:**\
+    \ \"Add a commented `jira.link_types` example block to `config/context-filters.yaml`\
+    \ (or its example file)\". Pick now: edit `config/context-filters.yaml` directly\
+    \ \u2014 that's the file the policy loads, and the survey confirmed the existing\
+    \ `jira:` section (lines 11-24) already lives there. The \"(or its example file)\"\
+    \ hedge invites coder confusion.\n- **TASK-4-1..4-4 `--help`:** the survey didn't\
+    \ confirm the existing `sandbox/scripts/jira` wrapper has per-subcommand `--help`\
+    \ output. The acceptance criteria of all four sandbox tasks reference `--help`.\
+    \ If the v1 wrapper doesn't already support `--help`, that's hidden scope. Add\
+    \ a one-liner to TASK-4-1 confirming the existing dispatcher's `--help` pattern\
+    \ (or noting the addition).\n- **Per-role / per-phase write gating deferred (D10/D11):**\
+    \ plan correctly defers to a follow-up. Add a follow-up issue placeholder reference\
+    \ in the PR body (`Follows: TBD-issue-for-write-gating`) so the deferred work\
+    \ isn't dropped.\n- **TASK-5-4 unicode-in-keys path-traversal:** good adversarial\
+    \ coverage. Suggest also adding a test case for HTTP-method tunnelling via body\
+    \ (e.g. body containing `\"_method\": \"DELETE\"` or similar) \u2014 defensive,\
+    \ since v1 read paths weren't tested for it either.\n- **TASK-5-3 test combinations\
+    \ matrix:** \"all input combinations\" is broad. Add a one-line cap (e.g. \"\u2265\
+    1 success case per option pair\" or \"named matrix in test docstring\") so the\
+    \ implementer doesn't generate a Cartesian explosion.\n- **`1924-plan.md:233`\
+    \ no live-Atlassian smoke test:** consistent with v1; flag that #1557 (the consumer)\
+    \ will be the integration smoke. Add to PR body's test_plan as \"Integration smoke\
+    \ test deferred to #1557 plan-apply rollout\".\n- **`Risks (deferred to risk_analyst)`:**\
+    \ good division of labour. The plan-only review will not block on risks \u2014\
+    \ but the rollback claim (\"each phase is independently revertible\") deserves\
+    \ a one-line acceptance check (e.g. \"TASK-X.Y verifies `git revert` of each phase\
+    \ commit leaves the v1 read surface green\"). Currently this claim is unverified.\n"
+  revision_count: 1
+````
+
+### [2026-04-27T19:25:03Z] task_planner (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 4c68cbb8-1598-4d
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:25:14Z] reviewer_plan (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW
+
+````yaml
+id: f5bfbde1-b5df-42
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:25:14.198622+00:00'
+````
+
+### [2026-04-27T19:25:32Z] architect (CONSENSUS_PROPOSE): Proposal from architect
+
+Architecture analysis for #1924 — bounded write extension of the v1 read-only Jira gateway. Four narrow per-verb routes (POST /api/v1/jira/ticket/create, /ticket/edit, /ticket/comment/add, /issue-link/create) instead of widening /execute; method-allowlist split (validate_jira_api_path keeps ALLOWED_METHODS={'GET'}; write client methods bypass with hardcoded paths so the permanent denylist transitions/worklog/attachments/watchers stays unbreakable); curated per-verb body schemas with project / ticket / size / label-count validation; in-process gateway idempotency cache (TTL 300s, threading.Lock-guarded) for createJiraIssue and addCommentToJiraIssue; plain-text -> minimal ADF paragraph wrapping helper so sandbox agents never construct Atlassian Document Format JSON. New gateway/jira_adf.py and gateway/jira_idempotency.py modules; ~250-350 lines added to jira_client.py for the four write methods; ~500-650 lines in gateway.py for the four routes; ~300-450 lines in sandbox/scripts/jira for the four new subcommands; new test files test_jira_idempotency.py / test_jira_adf.py / test_jira_writes_adversarial.py. Records the architectural slot for every unresolved refine HITL decision so plan tasks can be written deterministically once HITL closes. Output: .egg-state/agent-outputs/1924-architect-output.json (60 KB JSON; problem statement, current-architecture map of reusable v1 building blocks, external Atlassian v3 endpoint shapes, proposed module breakdown with per-route validation, data-flow walkthroughs, design decisions justifying A1+B1+C1+D1+E1, key-files table, dependency list, open-questions slot reservations, risks for risk_analyst, tasks for task_planner, validation plan, out-of-scope list).
+
+````yaml
+id: cae857e4-d37e-44
+phase: plan
+metadata:
+  payload:
+    summary: "Architecture analysis for #1924 \u2014 bounded write extension of the\
+      \ v1 read-only Jira gateway. Four narrow per-verb routes (POST /api/v1/jira/ticket/create,\
+      \ /ticket/edit, /ticket/comment/add, /issue-link/create) instead of widening\
+      \ /execute; method-allowlist split (validate_jira_api_path keeps ALLOWED_METHODS={'GET'};\
+      \ write client methods bypass with hardcoded paths so the permanent denylist\
+      \ transitions/worklog/attachments/watchers stays unbreakable); curated per-verb\
+      \ body schemas with project / ticket / size / label-count validation; in-process\
+      \ gateway idempotency cache (TTL 300s, threading.Lock-guarded) for createJiraIssue\
+      \ and addCommentToJiraIssue; plain-text -> minimal ADF paragraph wrapping helper\
+      \ so sandbox agents never construct Atlassian Document Format JSON. New gateway/jira_adf.py\
+      \ and gateway/jira_idempotency.py modules; ~250-350 lines added to jira_client.py\
+      \ for the four write methods; ~500-650 lines in gateway.py for the four routes;\
+      \ ~300-450 lines in sandbox/scripts/jira for the four new subcommands; new test\
+      \ files test_jira_idempotency.py / test_jira_adf.py / test_jira_writes_adversarial.py.\
+      \ Records the architectural slot for every unresolved refine HITL decision so\
+      \ plan tasks can be written deterministically once HITL closes. Output: .egg-state/agent-outputs/1924-architect-output.json\
+      \ (60 KB JSON; problem statement, current-architecture map of reusable v1 building\
+      \ blocks, external Atlassian v3 endpoint shapes, proposed module breakdown with\
+      \ per-route validation, data-flow walkthroughs, design decisions justifying\
+      \ A1+B1+C1+D1+E1, key-files table, dependency list, open-questions slot reservations,\
+      \ risks for risk_analyst, tasks for task_planner, validation plan, out-of-scope\
+      \ list)."
+    attestation: {}
+    artifacts:
+    - .egg-state/agent-outputs/1924-architect-output.json
+    risk_considered: ''
+    commit_sha: 42386139b
+    files_changed:
+    - .egg-state/agent-outputs/1924-architect-output.json
+    tests_run: []
+    tasks_satisfied: []
+  version: 1
+  commit_sha: 42386139b
+````
+
+### [2026-04-27T19:25:33Z] reviewer_plan (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: c29a66d6-959a-46
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:25:43Z] architect (HEARTBEAT): heartbeat: PROPOSED
+
+````yaml
+id: b7109c5b-50ef-43
+phase: plan
+metadata:
+  state: PROPOSED
+````
+
+### [2026-04-27T19:25:50Z] architect (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT
+
+````yaml
+id: d2ca4f21-7b63-4c
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:25:50.393297+00:00'
+````
+
+### [2026-04-27T19:25:51Z] architect (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: b957dbae-f52d-46
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:25:57Z] architect (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: aec0128a-77f2-46
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:25:54.941151+00:00'
+````
+
+### [2026-04-27T19:26:31Z] risk_analyst (CONSENSUS_PROPOSE): Proposal from risk_analyst
+
+Plan-phase risk assessment for #1924 (Jira gateway writes — createJiraIssue, editJiraIssue, addCommentToJiraIssue, createIssueLink). 19 risks identified across security, data-integrity, performance, compatibility, data-privacy, and operational categories. Highest-severity risk: R1 custom-field smuggling (HIGH severity, blocked on HITL decision-1) — agents could set securityLevel/sprint/watchers/assignee via untrusted body fields. Highest-likelihood: R3 non-idempotent writes (Atlassian's v3 REST has no native idempotency key, POST /issueLink does NOT dedupe identical triples). Three risks flagged for human review: R1, R3, R10 (phase/role gating). Six MEDIUM-severity risks require implement-phase mitigation. Implement-phase checklist enumerates 19 verification items keyed by risk ID. External research cites 13 sources including Atlassian's official rate-limiting docs, March 2026 points-based rollout announcement, ADF schema reference, Snapsec stored-XSS finding, and community threads on idempotent issue creation. Output written to .egg-state/agent-outputs/1924-risk_analyst-output.json (543 lines, valid JSON, 19 risks). Risks align with refine analysis (1924-analysis.md) AND with the architect's risks_for_risk_analyst list (10 risks all covered). 19 unresolved HITL decisions and 9 unresolved feedback items are explicitly flagged as implementation blockers.
+
+````yaml
+id: cc39671c-dd6c-45
+phase: plan
+metadata:
+  payload:
+    summary: "Plan-phase risk assessment for #1924 (Jira gateway writes \u2014 createJiraIssue,\
+      \ editJiraIssue, addCommentToJiraIssue, createIssueLink). 19 risks identified\
+      \ across security, data-integrity, performance, compatibility, data-privacy,\
+      \ and operational categories. Highest-severity risk: R1 custom-field smuggling\
+      \ (HIGH severity, blocked on HITL decision-1) \u2014 agents could set securityLevel/sprint/watchers/assignee\
+      \ via untrusted body fields. Highest-likelihood: R3 non-idempotent writes (Atlassian's\
+      \ v3 REST has no native idempotency key, POST /issueLink does NOT dedupe identical\
+      \ triples). Three risks flagged for human review: R1, R3, R10 (phase/role gating).\
+      \ Six MEDIUM-severity risks require implement-phase mitigation. Implement-phase\
+      \ checklist enumerates 19 verification items keyed by risk ID. External research\
+      \ cites 13 sources including Atlassian's official rate-limiting docs, March\
+      \ 2026 points-based rollout announcement, ADF schema reference, Snapsec stored-XSS\
+      \ finding, and community threads on idempotent issue creation. Output written\
+      \ to .egg-state/agent-outputs/1924-risk_analyst-output.json (543 lines, valid\
+      \ JSON, 19 risks). Risks align with refine analysis (1924-analysis.md) AND with\
+      \ the architect's risks_for_risk_analyst list (10 risks all covered). 19 unresolved\
+      \ HITL decisions and 9 unresolved feedback items are explicitly flagged as implementation\
+      \ blockers."
+    attestation: {}
+    artifacts:
+    - .egg-state/agent-outputs/1924-risk_analyst-output.json
+    risk_considered: "19 risks identified \u2014 1 HIGH severity (R1 custom-field\
+      \ smuggling), 11 MEDIUM, 7 LOW. Three flagged for human review. Six implementation-blocking\
+      \ HITL decisions tied to specific risks. Rollback plan has four levels (config-only,\
+      \ route disable, credential revoke, full revert) progressively scoped from cheapest\
+      \ to most disruptive. All 10 of the architect's risks_for_risk_analyst items\
+      \ are covered by the assessment (no gap)."
+    commit_sha: 7821cc4cfb1ec70beac09ed3acaca7eb7728b8e7
+    files_changed:
+    - .egg-state/agent-outputs/1924-risk_analyst-output.json
+    tests_run: []
+    tasks_satisfied: []
+  version: 1
+  commit_sha: 7821cc4cfb1ec70beac09ed3acaca7eb7728b8e7
+````
+
+### [2026-04-27T19:26:31Z] orchestrator → risk_analyst (STATUS): Ready to confirm — all confirm preconditions satisfied
+
+Your proposal (version 1) is ready to confirm — all blocking reviews are clear and global confirm preconditions are met. Run `egg-orch consensus confirmed` to confirm.
+
+````yaml
+id: 03ff561c-1010-49
+phase: plan
+metadata:
+  ready_to_confirm: true
+  version: 1
+````
+
+### [2026-04-27T19:26:47Z] risk_analyst (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT from=reviewer_plan
+
+````yaml
+id: d69737cf-fd2e-43
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:26:47.081812+00:00'
+````
+
+### [2026-04-27T19:26:57Z] architect (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: b6dcd1f0-fd74-40
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:25:54.941151+00:00'
+````
+
+### [2026-04-27T19:27:34Z] overseer (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+Plan phase cycle 73 — 742s elapsed. BRC progressing: architect PROPOSED, risk_analyst PROPOSED, reviewer_plan REVIEWING (19 risks identified). task_planner re-working proposal (went WORKING after initial proposal at 6.5min). No real anomalies. Awaiting task_planner re-proposal for full consensus.
+
+````yaml
+id: 16f07d54-9c48-43
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+````
+
+### [2026-04-27T19:27:44Z] reviewer_plan → architect (CONSENSUS_ACK): ACK from reviewer_plan for architect
+
+
+Reviewed `1924-architect-output.json` (706 lines) section-by-section against the refine analysis and against `1924-plan.md` from task_planner. The architectural baseline is sound and adheres to every v1 invariant from `#1556`. ACK because the work meets the plan-phase bar: the design choices match the refine analysis verbatim (A1+B1+C1+D1+E1 selected with rationale; permanent denylist preserved; module breakdown is comprehensive; data flows for happy path / non-allowlisted project / public mode / missing creds / idempotent hit are concrete). The HITL slot-reservation pattern (record the slot, defer the bake-in to task_planner) is the right division of labour and means the architect's analysis stays correct under different HITL outcomes.
+
+### What I verified
+
+- **Alignment with analysis** — every axis cited in `1924-analysis.md` (A/B/C/D/E sub-options) is named and the same recommendation chosen, with explicit `alternatives_rejected`. The architect's `chosen` for D1 (5-min TTL in-memory cache) and B1 (path-validator stays GET-only; write methods bypass) match the analysis recommendation.
+- **Reuse map** (`reusable_infrastructure`, lines 36-92) is exact — `@require_session_auth` + `@require_private_mode` chain, mtime-cached `JiraPolicy`, `JiraCredentialsManager`, `_request`'s GET-only retry on line 322, route-enumeration regression in `test_jira_routes.py`, sandbox `call_gateway`, doc home. Cross-checked against the v1 code (lines 4365-4759 in `gateway.py`, the `validate_jira_api_path`+`JIRA_WRITE_VERBS_DENIED` block in `jira_client.py:179-236`, etc.) — every cited line + behaviour is real.
+- **v1 invariants carried forward** (lines 93-102) — zero sandbox creds, `*.atlassian.net` not in Squid, `/execute` GET-only forever, writes never auto-retry on 429, audit on success/reject — all correct and align with #1556's contract.
+- **Atlassian endpoint shapes** (lines 106-134) — `POST /rest/api/3/issue` body fields, `PUT /rest/api/3/issue/{key}?notifyUsers=...`, `POST /rest/api/3/issue/{key}/comment` ADF body, `POST /rest/api/3/issueLink` 201-no-body — match the v3 docs cited in the analysis.
+- **Module breakdown** (lines 169-368) — covers `jira_client.py` (extend), new `jira_adf.py`, new `jira_idempotency.py`, `jira_policy.py` (HITL-conditional), `gateway.py` write block, `sandbox/scripts/jira`, `config/context-filters.yaml`, `environment.md`, `jira-wrapper.md`, `network-isolation.md`, and the test surface. Every file has a change_type + lines estimate. Estimates are realistic vs the v1 read block (~485 lines for 4 read routes; ~500-650 for 4 write routes is slightly larger which matches the richer body validation).
+- **Data flow narratives** (lines 369-409) — five distinct flows (happy create, non-allowlisted project, public mode, missing creds, idempotent hit) with concrete steps; the implementer can write tests directly against these flows.
+- **Validation plan** (lines 684-695) — covers lint, test, route-enumeration regression, allowed-domains regression, manual smoke, idempotency manual test, public-mode 403, missing-creds 503, project-allowlist 403, permanent-denylist regression. Comprehensive.
+- **Risks** (lines 647-658) — ten distinct risks, each with mitigation. Useful pickup list for risk_analyst.
+- **Out-of-scope** (lines 697-705) — clear and matches `#1556`'s permanent denylist + the analysis non-goals.
+
+### Non-blocking
+
+- **`JiraUpstreamWriteError` punted within the architect's own output** (line 179): "(subclass of existing JiraUpstreamError, OR the existing one extended)". Low-stakes — the implementer can pick — but recommend committing now: subclass it for distinct catch-handling per route. Not worth a NACK because either choice is structurally fine.
+- **`createIssueLink` idempotency option named but not chosen** (line 143-144 + line 289): the architect lists three options for decision-19/Q28 ("extend cache, scan upstream, accept duplicates") and observes "the first is most aligned with create / comment for symmetry" — but doesn't actually pick. The task_planner picked option 1 (extend the cache). Architect should align — the design baseline should reflect what the implementer will build. (This is the kind of mismatch that produces churn during implement.)
+- **Adversarial test file location** (line 363, line 461): architect proposes a separate `test_jira_writes_adversarial.py`. Task_planner's bake-in (Q21 default) puts adversarial cases in the SAME file as the route 403 grid (`test_jira_routes.py`). The two artifacts disagree. Both choices are reasonable; recommend the architect note that the final location follows the task_planner's bake-in (or vice versa) so the implementer doesn't see two contradictory specs. **Suggest:** add a one-line "Adversarial test file location follows task_planner's HITL-default bake-in (same-file)" reconciliation note in the architect's `design_decisions` section.
+- **`--return-issue` flag on `jira ticket edit` wrapper** (line 312): the architect's wrapper exposes `--return-issue` which maps to Atlassian's `?returnIssue=true`. But the task_planner baked D14 = "Envelope `{status: 'updated', key}` (no extra Atlassian call)". Under that bake-in the `--return-issue` flag is dead — the route always returns the envelope. Architect should either drop the flag from the wrapper sketch or note that the flag is HITL-conditional and inert under the chosen default.
+- **Doc home hedge** (line 522): "extend (or create docs/reference/jira-writes.md per refine HITL Q27)". Task_planner baked D27 = "Extend `docs/reference/jira-wrapper.md`". The architect's hedge is fine as a slot reservation, but the picked default should be reflected in the `key_files` purpose line so the implementer doesn't waste time deciding.
+- **Idempotency cache key for `create_issue_link`** (line 142): `(verb, project, idempotency_key)` is well-defined for `create` and `comment` (the project derived from `projectKey` / `extract_project_key(ticket)`), but for `create_issue_link` "project" is ambiguous (inward? outward? both?). The architect's analysis doesn't disambiguate — neither does the task_planner's plan (I flagged this in my task_planner NACK). Suggest adding a one-line clarification: e.g. cache key for link uses canonical `(inward, outward, type)` triple OR documents that orchestrator must namespace the opaque key. This is mostly a task_planner concern but the architect's data-flow doc should at least name the slot.
+- **Per-role / per-phase write gating module** (line 303-304): if HITL picks gating, the architect proposes adding `JIRA_WRITE_VERBS_PER_PHASE` to `gateway/phase_filter.py`. That file is currently file-restriction-only (per the survey, it has `check_file_restrictions` and `check_phase_file_restrictions`); putting Jira-verb-gating there overloads the module's responsibility. Suggest a separate `gateway/jira_phase_filter.py` (or co-locate with `jira_policy.py`) so the file restriction code stays orthogonal.
+- **Audit event taxonomy** (lines 244, 260, 276, 292): architect's per-verb suite (`jira_ticket_create / _rejected / _denied / _upstream_error / _idempotent_hit / jira_upstream_rate_limited`) is more granular than task_planner's tasks specify. Recommend the task_planner adopt this taxonomy or the architect note "task descriptions may collapse `_rejected` and `_denied` into a single event since both are pre-Atlassian rejections". Either is fine; the inconsistency just needs a callout.
+- **JiraClient method signature for `add_comment`** (line 177): architect's signature includes `idempotency_response=None` as a parameter — should be `idempotency_key`, matching the route-layer name (line 270). Looks like a copy-paste from the cache lookup variable. Minor naming consistency fix.
+- **Module size estimates** are realistic but the validation plan should add a one-line cap (e.g. "no single module grows by >40% beyond its v1 size without splitting") so implement-phase doesn't end up with a 2000-line `gateway.py` write block.
+- **`docs/architecture/network-isolation.md`** addition (line 354) is a nice catch — the v1 read routes are listed there; writes inherit the same exception. Confirm the file actually exists before this becomes a task (the survey didn't list it). If not, fold the change into `jira-wrapper.md`.
+
+The architectural baseline is solid enough to drive plan tasks. None of the non-blocking items above invalidate the design. ACK.
+
+
+````yaml
+id: c217bed2-5d2c-43
+phase: plan
+metadata:
+  payload:
+    artifact_references:
+    - .egg-state/agent-outputs/1924-architect-output.json
+    - .egg-state/drafts/1924-analysis.md
+    - .egg-state/drafts/1924-plan.md
+    - gateway/jira_client.py
+    - gateway/jira_policy.py
+    - gateway/gateway.py
+    - gateway/tests/test_jira_routes.py
+    - sandbox/scripts/jira
+    - config/context-filters.yaml
+    reason: "\nReviewed `1924-architect-output.json` (706 lines) section-by-section\
+      \ against the refine analysis and against `1924-plan.md` from task_planner.\
+      \ The architectural baseline is sound and adheres to every v1 invariant from\
+      \ `#1556`. ACK because the work meets the plan-phase bar: the design choices\
+      \ match the refine analysis verbatim (A1+B1+C1+D1+E1 selected with rationale;\
+      \ permanent denylist preserved; module breakdown is comprehensive; data flows\
+      \ for happy path / non-allowlisted project / public mode / missing creds / idempotent\
+      \ hit are concrete). The HITL slot-reservation pattern (record the slot, defer\
+      \ the bake-in to task_planner) is the right division of labour and means the\
+      \ architect's analysis stays correct under different HITL outcomes.\n\n### What\
+      \ I verified\n\n- **Alignment with analysis** \u2014 every axis cited in `1924-analysis.md`\
+      \ (A/B/C/D/E sub-options) is named and the same recommendation chosen, with\
+      \ explicit `alternatives_rejected`. The architect's `chosen` for D1 (5-min TTL\
+      \ in-memory cache) and B1 (path-validator stays GET-only; write methods bypass)\
+      \ match the analysis recommendation.\n- **Reuse map** (`reusable_infrastructure`,\
+      \ lines 36-92) is exact \u2014 `@require_session_auth` + `@require_private_mode`\
+      \ chain, mtime-cached `JiraPolicy`, `JiraCredentialsManager`, `_request`'s GET-only\
+      \ retry on line 322, route-enumeration regression in `test_jira_routes.py`,\
+      \ sandbox `call_gateway`, doc home. Cross-checked against the v1 code (lines\
+      \ 4365-4759 in `gateway.py`, the `validate_jira_api_path`+`JIRA_WRITE_VERBS_DENIED`\
+      \ block in `jira_client.py:179-236`, etc.) \u2014 every cited line + behaviour\
+      \ is real.\n- **v1 invariants carried forward** (lines 93-102) \u2014 zero sandbox\
+      \ creds, `*.atlassian.net` not in Squid, `/execute` GET-only forever, writes\
+      \ never auto-retry on 429, audit on success/reject \u2014 all correct and align\
+      \ with #1556's contract.\n- **Atlassian endpoint shapes** (lines 106-134) \u2014\
+      \ `POST /rest/api/3/issue` body fields, `PUT /rest/api/3/issue/{key}?notifyUsers=...`,\
+      \ `POST /rest/api/3/issue/{key}/comment` ADF body, `POST /rest/api/3/issueLink`\
+      \ 201-no-body \u2014 match the v3 docs cited in the analysis.\n- **Module breakdown**\
+      \ (lines 169-368) \u2014 covers `jira_client.py` (extend), new `jira_adf.py`,\
+      \ new `jira_idempotency.py`, `jira_policy.py` (HITL-conditional), `gateway.py`\
+      \ write block, `sandbox/scripts/jira`, `config/context-filters.yaml`, `environment.md`,\
+      \ `jira-wrapper.md`, `network-isolation.md`, and the test surface. Every file\
+      \ has a change_type + lines estimate. Estimates are realistic vs the v1 read\
+      \ block (~485 lines for 4 read routes; ~500-650 for 4 write routes is slightly\
+      \ larger which matches the richer body validation).\n- **Data flow narratives**\
+      \ (lines 369-409) \u2014 five distinct flows (happy create, non-allowlisted\
+      \ project, public mode, missing creds, idempotent hit) with concrete steps;\
+      \ the implementer can write tests directly against these flows.\n- **Validation\
+      \ plan** (lines 684-695) \u2014 covers lint, test, route-enumeration regression,\
+      \ allowed-domains regression, manual smoke, idempotency manual test, public-mode\
+      \ 403, missing-creds 503, project-allowlist 403, permanent-denylist regression.\
+      \ Comprehensive.\n- **Risks** (lines 647-658) \u2014 ten distinct risks, each\
+      \ with mitigation. Useful pickup list for risk_analyst.\n- **Out-of-scope**\
+      \ (lines 697-705) \u2014 clear and matches `#1556`'s permanent denylist + the\
+      \ analysis non-goals.\n\n### Non-blocking\n\n- **`JiraUpstreamWriteError` punted\
+      \ within the architect's own output** (line 179): \"(subclass of existing JiraUpstreamError,\
+      \ OR the existing one extended)\". Low-stakes \u2014 the implementer can pick\
+      \ \u2014 but recommend committing now: subclass it for distinct catch-handling\
+      \ per route. Not worth a NACK because either choice is structurally fine.\n\
+      - **`createIssueLink` idempotency option named but not chosen** (line 143-144\
+      \ + line 289): the architect lists three options for decision-19/Q28 (\"extend\
+      \ cache, scan upstream, accept duplicates\") and observes \"the first is most\
+      \ aligned with create / comment for symmetry\" \u2014 but doesn't actually pick.\
+      \ The task_planner picked option 1 (extend the cache). Architect should align\
+      \ \u2014 the design baseline should reflect what the implementer will build.\
+      \ (This is the kind of mismatch that produces churn during implement.)\n- **Adversarial\
+      \ test file location** (line 363, line 461): architect proposes a separate `test_jira_writes_adversarial.py`.\
+      \ Task_planner's bake-in (Q21 default) puts adversarial cases in the SAME file\
+      \ as the route 403 grid (`test_jira_routes.py`). The two artifacts disagree.\
+      \ Both choices are reasonable; recommend the architect note that the final location\
+      \ follows the task_planner's bake-in (or vice versa) so the implementer doesn't\
+      \ see two contradictory specs. **Suggest:** add a one-line \"Adversarial test\
+      \ file location follows task_planner's HITL-default bake-in (same-file)\" reconciliation\
+      \ note in the architect's `design_decisions` section.\n- **`--return-issue`\
+      \ flag on `jira ticket edit` wrapper** (line 312): the architect's wrapper exposes\
+      \ `--return-issue` which maps to Atlassian's `?returnIssue=true`. But the task_planner\
+      \ baked D14 = \"Envelope `{status: 'updated', key}` (no extra Atlassian call)\"\
+      . Under that bake-in the `--return-issue` flag is dead \u2014 the route always\
+      \ returns the envelope. Architect should either drop the flag from the wrapper\
+      \ sketch or note that the flag is HITL-conditional and inert under the chosen\
+      \ default.\n- **Doc home hedge** (line 522): \"extend (or create docs/reference/jira-writes.md\
+      \ per refine HITL Q27)\". Task_planner baked D27 = \"Extend `docs/reference/jira-wrapper.md`\"\
+      . The architect's hedge is fine as a slot reservation, but the picked default\
+      \ should be reflected in the `key_files` purpose line so the implementer doesn't\
+      \ waste time deciding.\n- **Idempotency cache key for `create_issue_link`**\
+      \ (line 142): `(verb, project, idempotency_key)` is well-defined for `create`\
+      \ and `comment` (the project derived from `projectKey` / `extract_project_key(ticket)`),\
+      \ but for `create_issue_link` \"project\" is ambiguous (inward? outward? both?).\
+      \ The architect's analysis doesn't disambiguate \u2014 neither does the task_planner's\
+      \ plan (I flagged this in my task_planner NACK). Suggest adding a one-line clarification:\
+      \ e.g. cache key for link uses canonical `(inward, outward, type)` triple OR\
+      \ documents that orchestrator must namespace the opaque key. This is mostly\
+      \ a task_planner concern but the architect's data-flow doc should at least name\
+      \ the slot.\n- **Per-role / per-phase write gating module** (line 303-304):\
+      \ if HITL picks gating, the architect proposes adding `JIRA_WRITE_VERBS_PER_PHASE`\
+      \ to `gateway/phase_filter.py`. That file is currently file-restriction-only\
+      \ (per the survey, it has `check_file_restrictions` and `check_phase_file_restrictions`);\
+      \ putting Jira-verb-gating there overloads the module's responsibility. Suggest\
+      \ a separate `gateway/jira_phase_filter.py` (or co-locate with `jira_policy.py`)\
+      \ so the file restriction code stays orthogonal.\n- **Audit event taxonomy**\
+      \ (lines 244, 260, 276, 292): architect's per-verb suite (`jira_ticket_create\
+      \ / _rejected / _denied / _upstream_error / _idempotent_hit / jira_upstream_rate_limited`)\
+      \ is more granular than task_planner's tasks specify. Recommend the task_planner\
+      \ adopt this taxonomy or the architect note \"task descriptions may collapse\
+      \ `_rejected` and `_denied` into a single event since both are pre-Atlassian\
+      \ rejections\". Either is fine; the inconsistency just needs a callout.\n- **JiraClient\
+      \ method signature for `add_comment`** (line 177): architect's signature includes\
+      \ `idempotency_response=None` as a parameter \u2014 should be `idempotency_key`,\
+      \ matching the route-layer name (line 270). Looks like a copy-paste from the\
+      \ cache lookup variable. Minor naming consistency fix.\n- **Module size estimates**\
+      \ are realistic but the validation plan should add a one-line cap (e.g. \"no\
+      \ single module grows by >40% beyond its v1 size without splitting\") so implement-phase\
+      \ doesn't end up with a 2000-line `gateway.py` write block.\n- **`docs/architecture/network-isolation.md`**\
+      \ addition (line 354) is a nice catch \u2014 the v1 read routes are listed there;\
+      \ writes inherit the same exception. Confirm the file actually exists before\
+      \ this becomes a task (the survey didn't list it). If not, fold the change into\
+      \ `jira-wrapper.md`.\n\nThe architectural baseline is solid enough to drive\
+      \ plan tasks. None of the non-blocking items above invalidate the design. ACK.\n"
+  version: 1
+````
+
+### [2026-04-27T19:27:44Z] orchestrator → architect (STATUS): Ready to confirm — all confirm preconditions satisfied
+
+Your proposal (version 1) is ready to confirm — all blocking reviews are clear and global confirm preconditions are met. Run `egg-orch consensus confirmed` to confirm.
+
+````yaml
+id: a2b2f726-f573-4a
+phase: plan
+metadata:
+  ready_to_confirm: true
+  version: 1
+````
+
+### [2026-04-27T19:27:44Z] architect (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 38cb753c-eafe-49
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:27:47Z] risk_analyst (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT from=reviewer_plan
+
+````yaml
+id: b35f3ecc-07ad-4a
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:26:47.081812+00:00'
+````
+
+### [2026-04-27T19:27:48Z] reviewer_plan (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW
+
+````yaml
+id: 45a67b7d-c4b8-4c
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:27:48.858721+00:00'
+````
+
+### [2026-04-27T19:27:49Z] reviewer_plan (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: ac77890b-aaee-4d
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:27:59Z] architect (CONSENSUS_CONFIRMED): Confirmed by architect
+
+````yaml
+id: 495ecb04-ec43-4c
+phase: plan
+metadata:
+  consensus_reached: false
+````
+
+### [2026-04-27T19:28:17Z] architect (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: 986bf5ef-c348-40
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:28:16.953451+00:00'
+````
+
+### [2026-04-27T19:28:47Z] risk_analyst (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT from=reviewer_plan
+
+````yaml
+id: db113336-b85f-48
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:26:47.081812+00:00'
+````
+
+### [2026-04-27T19:29:17Z] architect (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: 66823dad-a68f-43
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:28:16.953451+00:00'
+````
+
+### [2026-04-27T19:29:40Z] reviewer_plan → risk_analyst (CONSENSUS_ACK): ACK from reviewer_plan for risk_analyst
+
+
+Reviewed `1924-risk_analyst-output.json` (543 lines, 19 risks R1-R19) section-by-section against the refine analysis, the architect's plan-phase analysis, and the task_planner's plan draft. The risk surface is comprehensive, severities are calibrated, mitigations are concrete and actionable, the implement-phase checklist (lines 497-517) maps every risk to a verification step, and the four-level global rollback plan (config-only → route-disable → credential-revoke → full-revert) is realistic. ACK because this meets the plan-phase risk-assessment bar.
+
+### What I verified
+
+- **Risk coverage breadth** — 19 risks across the right categories: security (R1, R2, R5, R7, R8, R9, R10, R16, R17), data-integrity (R3), performance (R4, R11, R18), compatibility (R6, R14), operational (R12, R15, R19), data-privacy (R13). No obvious gap. Notably, R3 (non-idempotent writes), R4 (Atlassian's March 2026 per-issue write throttling), R6 (Epic Link per-instance variation), R8 (createIssueLink existence-leak side channel), and R18 (cache memory unbounded) are all correctly identified as the high-leverage write-specific risks that did NOT exist for the v1 read surface.
+- **Severity calibration** — 0 HIGH after mitigations, 6 MEDIUM, low ones documented but no implement-phase action required. R1 (custom-field smuggling) starts at high/medium → severity high BEFORE mitigations because the unmitigated path lets agents set `securityLevel`, `assignee`, `sprint` etc.; severity drops to medium after curated allowlist is enforced. R7 (project-allowlist gate vector) impact=high but likelihood=low because the failure mode requires a careless port of v1 reads.
+- **HITL flags** — three correctly flagged for human review: R1 (custom-field exposure → decision-1), R3 (idempotency policy → decision-3 + decision-19), R10 (per-role / per-phase gating → decision-10 + decision-11). The reasoning column on each (`human_review_reason`) is specific and actionable.
+- **Mitigations are concrete** — each mitigation is either a code change with file path (e.g., R7's "Body validator MUST require a top-level `projectKey: '[A-Z][A-Z0-9_]*'` field"), a config change (R4's `RateLimit-Reason` envelope propagation), a test grid (R5's adversarial body suite), or a runbook entry (R3's "operator runbook"). No hand-waving.
+- **Rollback per-risk** — every risk has a rollback paragraph that names the specific lever (config reload, hot-patch, env-var, credential revoke, full revert). The level-1 rollback (set `jira.projects: []`) is the v1 read pattern and correctly carries forward.
+- **External research** (lines 518-540) is solid: 13 sources cited including Atlassian's 2026 rate-limit rollout docs, the community thread on idempotency, ADF schema reference, and the Snapsec stored-XSS-in-Jira-Work-Management finding (recent and germane). Key findings (lines 534-538) tie each cited source to a specific risk (R3 ↔ idempotency thread, R4 ↔ rate-limit rollout, R5 ↔ ADF + Snapsec finding).
+- **Implement-phase checklist** (lines 497-517) is a one-line-per-risk verification list. The reviewer in implement phase can grep for `[R<N>]` and confirm each. This is reusable artifact value.
+- **Global rollback plan** (lines 473-495) — level 1-4 is graduated and matches the v1 read rollback plan. Level 3's note that "Both Jira and Confluence go dark together (per #1931 decision-6 shared-creds coupling)" is a real cross-issue coupling worth surfacing.
+
+### Non-blocking
+
+- **R6 (Epic Link auto-detect) recommendation conflicts with the task_planner's bake-in.** Risk_analyst (line 175) recommends "the gateway probes the parent ticket's project type via `GET /rest/api/3/project/{key}` (cached) on first use, then chooses `parent.key` OR `customfield_10014`" — i.e., probe-and-pick-one. The task_planner's bake-in (`1924-plan.md:55`) emits BOTH fields simultaneously, which I separately NACKed as broken. **Risk_analyst's interpretation is correct** and I want this called out explicitly: when the task_planner re-proposes addressing my D2 NACK, they should adopt risk_analyst's probe-and-cache approach rather than the both-fields shotgun. Suggest the risk_analyst surface this as an explicit cross-artifact conflict in their next iteration (or in a follow-up note) so the implement-phase coder doesn't see two contradictory specs.
+- **R11 (body-size caps) numbers conflict with the task_planner's bake-in.** Risk_analyst recommends `description ≤ 100,000 chars`; task_planner bakes `description ≤ 32 KiB` (≈32,768 chars). A 3× factor difference. Both are defensible for different operator tolerances. Flag for HITL feedback-1.Q2 pickup; the implement-phase reviewer should not arbitrate.
+- **R5 (ADF passthrough) recommendation conflicts with task_planner's bake-in.** Risk_analyst recommends decision-7 = opt-1 (plain-text only) on security grounds (mention/media/extension nodes). Task_planner baked decision-7 = opt-3 (both). The risk_analyst's case is sound — passthrough is much harder to validate. Suggest adding the ADF-node allowlist to TASK-3-3's body-validator if the bake-in survives HITL.
+- **R18 (cache memory) surfaces a real gap in the task_planner's plan.** Risk_analyst recommends `MAX_IDEMPOTENCY_ENTRIES = 10_000` with LRU eviction; task_planner's TASK-1-1 (which I separately reviewed) only specifies TTL eviction with no entry-count cap. The risk_analyst is right that TTL-only is unbounded under high churn. The task_planner's plan should adopt this cap when re-proposing.
+- **R15 (error envelope) — risk_analyst recommends enrichment, task_planner baked verbatim.** Risk_analyst's enriched envelope (`field_errors`, `error_messages`) is the better DX, but the task_planner's bake-in (Q26 default = verbatim passthrough) ships sooner. Note the trade-off; not blocking for v1.
+- **R3 severity is debatable.** Risk_analyst rates impact=medium, likelihood=high → severity=medium. Given the mitigation (architect D1 cache) is in scope and well-defined, medium is fine. Worth noting that without the cache the severity would be high.
+- **R10 mitigations include a minor file-naming concern.** Risk_analyst (line 266) says "gateway/role_filter.py (potentially new)" — this duplicates the architect's pattern. If decisions 10/11 land on opt-2, recommend co-locating with `jira_policy.py` rather than a new top-level role_filter.py to avoid scattering authorization logic across multiple modules. This is a future-scope concern; currently the recommendation is "defer to follow-up" so the file doesn't materialize in this PR.
+- **R16 reviewer-action wording.** "Reviewer MUST run `pytest gateway/tests/test_jira_routes.py -k private_mode` and confirm pass count includes 4 new routes (8 routes total: 4 read + 4 write)." This is a hard count — if a future PR adds a fifth Jira read route, the assertion drifts. Suggest "≥ 8 routes" rather than "8 routes total" so the assertion stays valid as the surface grows. (Minor.)
+- **R12 sandbox-wrapper risk has severity=low/likelihood=medium.** That feels right; the v1 wrapper already exercises the heredoc pattern. Just confirming the calibration is reasonable.
+- **R17 (Squid allowlist)** is appropriately a re-flag of #1556's R5 — defensive duplication is fine.
+- **`tasks_satisfied: []` (line 541)** is empty. For an issue with 19 contract tasks (after task_planner's plan resolves), the risk_analyst's output should eventually link risk-mitigation verifications to specific contract task IDs. Currently TASK-1-1, TASK-3-1, etc. don't exist in the contract yet (the plan is still in BRC), so empty is OK for this iteration — but flag this as something to populate after task_planner's NACK is addressed and the contract tasks land.
+- **R19 (doc home unresolved) is severity=low/impact=low** which feels right; a doc layout choice should not block release.
+- **No risk addresses the `JiraUpstreamWriteError` vs `JiraUpstreamError` choice** I flagged in the architect's analysis. Not a security issue — operational only. Skip.
+
+### One observation about coverage
+
+The risk_analyst's surface does NOT include a risk for "coder/tester role conflict on test files" (TASK-1-1 vs TASK-5-1, which I NACKed for task_planner). That's a process risk, not a write-extension risk, so it's reasonable to omit. Just noting that BRC-level process risks are not in scope for the risk_analyst's deliverable.
+
+The risk_analyst's output is implementable as-is by a careful reviewer + coder. ACK.
+
+
+````yaml
+id: 77402267-879d-4b
+phase: plan
+metadata:
+  payload:
+    artifact_references:
+    - .egg-state/agent-outputs/1924-risk_analyst-output.json
+    - .egg-state/drafts/1924-analysis.md
+    - .egg-state/drafts/1924-plan.md
+    - .egg-state/agent-outputs/1924-architect-output.json
+    - gateway/jira_client.py
+    - gateway/jira_policy.py
+    - gateway/gateway.py
+    - gateway/tests/test_jira_routes.py
+    reason: "\nReviewed `1924-risk_analyst-output.json` (543 lines, 19 risks R1-R19)\
+      \ section-by-section against the refine analysis, the architect's plan-phase\
+      \ analysis, and the task_planner's plan draft. The risk surface is comprehensive,\
+      \ severities are calibrated, mitigations are concrete and actionable, the implement-phase\
+      \ checklist (lines 497-517) maps every risk to a verification step, and the\
+      \ four-level global rollback plan (config-only \u2192 route-disable \u2192 credential-revoke\
+      \ \u2192 full-revert) is realistic. ACK because this meets the plan-phase risk-assessment\
+      \ bar.\n\n### What I verified\n\n- **Risk coverage breadth** \u2014 19 risks\
+      \ across the right categories: security (R1, R2, R5, R7, R8, R9, R10, R16, R17),\
+      \ data-integrity (R3), performance (R4, R11, R18), compatibility (R6, R14),\
+      \ operational (R12, R15, R19), data-privacy (R13). No obvious gap. Notably,\
+      \ R3 (non-idempotent writes), R4 (Atlassian's March 2026 per-issue write throttling),\
+      \ R6 (Epic Link per-instance variation), R8 (createIssueLink existence-leak\
+      \ side channel), and R18 (cache memory unbounded) are all correctly identified\
+      \ as the high-leverage write-specific risks that did NOT exist for the v1 read\
+      \ surface.\n- **Severity calibration** \u2014 0 HIGH after mitigations, 6 MEDIUM,\
+      \ low ones documented but no implement-phase action required. R1 (custom-field\
+      \ smuggling) starts at high/medium \u2192 severity high BEFORE mitigations because\
+      \ the unmitigated path lets agents set `securityLevel`, `assignee`, `sprint`\
+      \ etc.; severity drops to medium after curated allowlist is enforced. R7 (project-allowlist\
+      \ gate vector) impact=high but likelihood=low because the failure mode requires\
+      \ a careless port of v1 reads.\n- **HITL flags** \u2014 three correctly flagged\
+      \ for human review: R1 (custom-field exposure \u2192 decision-1), R3 (idempotency\
+      \ policy \u2192 decision-3 + decision-19), R10 (per-role / per-phase gating\
+      \ \u2192 decision-10 + decision-11). The reasoning column on each (`human_review_reason`)\
+      \ is specific and actionable.\n- **Mitigations are concrete** \u2014 each mitigation\
+      \ is either a code change with file path (e.g., R7's \"Body validator MUST require\
+      \ a top-level `projectKey: '[A-Z][A-Z0-9_]*'` field\"), a config change (R4's\
+      \ `RateLimit-Reason` envelope propagation), a test grid (R5's adversarial body\
+      \ suite), or a runbook entry (R3's \"operator runbook\"). No hand-waving.\n\
+      - **Rollback per-risk** \u2014 every risk has a rollback paragraph that names\
+      \ the specific lever (config reload, hot-patch, env-var, credential revoke,\
+      \ full revert). The level-1 rollback (set `jira.projects: []`) is the v1 read\
+      \ pattern and correctly carries forward.\n- **External research** (lines 518-540)\
+      \ is solid: 13 sources cited including Atlassian's 2026 rate-limit rollout docs,\
+      \ the community thread on idempotency, ADF schema reference, and the Snapsec\
+      \ stored-XSS-in-Jira-Work-Management finding (recent and germane). Key findings\
+      \ (lines 534-538) tie each cited source to a specific risk (R3 \u2194 idempotency\
+      \ thread, R4 \u2194 rate-limit rollout, R5 \u2194 ADF + Snapsec finding).\n\
+      - **Implement-phase checklist** (lines 497-517) is a one-line-per-risk verification\
+      \ list. The reviewer in implement phase can grep for `[R<N>]` and confirm each.\
+      \ This is reusable artifact value.\n- **Global rollback plan** (lines 473-495)\
+      \ \u2014 level 1-4 is graduated and matches the v1 read rollback plan. Level\
+      \ 3's note that \"Both Jira and Confluence go dark together (per #1931 decision-6\
+      \ shared-creds coupling)\" is a real cross-issue coupling worth surfacing.\n\
+      \n### Non-blocking\n\n- **R6 (Epic Link auto-detect) recommendation conflicts\
+      \ with the task_planner's bake-in.** Risk_analyst (line 175) recommends \"the\
+      \ gateway probes the parent ticket's project type via `GET /rest/api/3/project/{key}`\
+      \ (cached) on first use, then chooses `parent.key` OR `customfield_10014`\"\
+      \ \u2014 i.e., probe-and-pick-one. The task_planner's bake-in (`1924-plan.md:55`)\
+      \ emits BOTH fields simultaneously, which I separately NACKed as broken. **Risk_analyst's\
+      \ interpretation is correct** and I want this called out explicitly: when the\
+      \ task_planner re-proposes addressing my D2 NACK, they should adopt risk_analyst's\
+      \ probe-and-cache approach rather than the both-fields shotgun. Suggest the\
+      \ risk_analyst surface this as an explicit cross-artifact conflict in their\
+      \ next iteration (or in a follow-up note) so the implement-phase coder doesn't\
+      \ see two contradictory specs.\n- **R11 (body-size caps) numbers conflict with\
+      \ the task_planner's bake-in.** Risk_analyst recommends `description \u2264\
+      \ 100,000 chars`; task_planner bakes `description \u2264 32 KiB` (\u224832,768\
+      \ chars). A 3\xD7 factor difference. Both are defensible for different operator\
+      \ tolerances. Flag for HITL feedback-1.Q2 pickup; the implement-phase reviewer\
+      \ should not arbitrate.\n- **R5 (ADF passthrough) recommendation conflicts with\
+      \ task_planner's bake-in.** Risk_analyst recommends decision-7 = opt-1 (plain-text\
+      \ only) on security grounds (mention/media/extension nodes). Task_planner baked\
+      \ decision-7 = opt-3 (both). The risk_analyst's case is sound \u2014 passthrough\
+      \ is much harder to validate. Suggest adding the ADF-node allowlist to TASK-3-3's\
+      \ body-validator if the bake-in survives HITL.\n- **R18 (cache memory) surfaces\
+      \ a real gap in the task_planner's plan.** Risk_analyst recommends `MAX_IDEMPOTENCY_ENTRIES\
+      \ = 10_000` with LRU eviction; task_planner's TASK-1-1 (which I separately reviewed)\
+      \ only specifies TTL eviction with no entry-count cap. The risk_analyst is right\
+      \ that TTL-only is unbounded under high churn. The task_planner's plan should\
+      \ adopt this cap when re-proposing.\n- **R15 (error envelope) \u2014 risk_analyst\
+      \ recommends enrichment, task_planner baked verbatim.** Risk_analyst's enriched\
+      \ envelope (`field_errors`, `error_messages`) is the better DX, but the task_planner's\
+      \ bake-in (Q26 default = verbatim passthrough) ships sooner. Note the trade-off;\
+      \ not blocking for v1.\n- **R3 severity is debatable.** Risk_analyst rates impact=medium,\
+      \ likelihood=high \u2192 severity=medium. Given the mitigation (architect D1\
+      \ cache) is in scope and well-defined, medium is fine. Worth noting that without\
+      \ the cache the severity would be high.\n- **R10 mitigations include a minor\
+      \ file-naming concern.** Risk_analyst (line 266) says \"gateway/role_filter.py\
+      \ (potentially new)\" \u2014 this duplicates the architect's pattern. If decisions\
+      \ 10/11 land on opt-2, recommend co-locating with `jira_policy.py` rather than\
+      \ a new top-level role_filter.py to avoid scattering authorization logic across\
+      \ multiple modules. This is a future-scope concern; currently the recommendation\
+      \ is \"defer to follow-up\" so the file doesn't materialize in this PR.\n- **R16\
+      \ reviewer-action wording.** \"Reviewer MUST run `pytest gateway/tests/test_jira_routes.py\
+      \ -k private_mode` and confirm pass count includes 4 new routes (8 routes total:\
+      \ 4 read + 4 write).\" This is a hard count \u2014 if a future PR adds a fifth\
+      \ Jira read route, the assertion drifts. Suggest \"\u2265 8 routes\" rather\
+      \ than \"8 routes total\" so the assertion stays valid as the surface grows.\
+      \ (Minor.)\n- **R12 sandbox-wrapper risk has severity=low/likelihood=medium.**\
+      \ That feels right; the v1 wrapper already exercises the heredoc pattern. Just\
+      \ confirming the calibration is reasonable.\n- **R17 (Squid allowlist)** is\
+      \ appropriately a re-flag of #1556's R5 \u2014 defensive duplication is fine.\n\
+      - **`tasks_satisfied: []` (line 541)** is empty. For an issue with 19 contract\
+      \ tasks (after task_planner's plan resolves), the risk_analyst's output should\
+      \ eventually link risk-mitigation verifications to specific contract task IDs.\
+      \ Currently TASK-1-1, TASK-3-1, etc. don't exist in the contract yet (the plan\
+      \ is still in BRC), so empty is OK for this iteration \u2014 but flag this as\
+      \ something to populate after task_planner's NACK is addressed and the contract\
+      \ tasks land.\n- **R19 (doc home unresolved) is severity=low/impact=low** which\
+      \ feels right; a doc layout choice should not block release.\n- **No risk addresses\
+      \ the `JiraUpstreamWriteError` vs `JiraUpstreamError` choice** I flagged in\
+      \ the architect's analysis. Not a security issue \u2014 operational only. Skip.\n\
+      \n### One observation about coverage\n\nThe risk_analyst's surface does NOT\
+      \ include a risk for \"coder/tester role conflict on test files\" (TASK-1-1\
+      \ vs TASK-5-1, which I NACKed for task_planner). That's a process risk, not\
+      \ a write-extension risk, so it's reasonable to omit. Just noting that BRC-level\
+      \ process risks are not in scope for the risk_analyst's deliverable.\n\nThe\
+      \ risk_analyst's output is implementable as-is by a careful reviewer + coder.\
+      \ ACK.\n"
+  version: 1
+````
+
+### [2026-04-27T19:29:40Z] risk_analyst (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: c64e3ba5-2e95-46
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:29:42Z] orchestrator → risk_analyst (OVERSEER_ALERT): BRC confirmation timeout — call mcp__brc__confirm
+
+You are PROPOSED and fully ACKed but have not confirmed in 180s. Call `mcp__brc__confirm` now. If it returns `status='pending_acks'`, read `message` for the guard reason and wait on the prerequisite events instead: `CONSENSUS_PROPOSE` if a producer hasn't proposed (`zero_proposal_producers`), `CONSENSUS_ACK` / `CONSENSUS_RE_REVIEW` if a reviewer's ACK is stale or unresolved. Then retry confirm.
+
+````yaml
+id: 90771745-7659-4a
+phase: plan
+metadata:
+  alert_type: brc_confirmation_timeout
+  elapsed_seconds: 180
+  source: health_monitor
+````
+
+### [2026-04-27T19:29:46Z] reviewer_plan (CONSENSUS_CONFIRMED): Confirmed by reviewer_plan (pending_acks)
+
+Reviewer reviewer_plan cannot confirm: unresolved NACKs. Wait for these producers to re-propose before confirming: ['task_planner']
+
+````yaml
+id: 98ad190a-a540-40
+phase: plan
+metadata:
+  pending_acks: true
+````
+
+### [2026-04-27T19:29:46Z] architect (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: a57a4a59-d4d6-4e
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:29:50Z] architect (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: 17fad84d-661b-45
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:29:50.883617+00:00'
+````
+
+### [2026-04-27T19:29:51Z] reviewer_plan (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT
+
+````yaml
+id: bd00e94f-3ba7-42
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:29:51.713750+00:00'
+````
+
+### [2026-04-27T19:29:51Z] reviewer_plan (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 1bfbf8b1-dd8f-49
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:29:52Z] risk_analyst (CONSENSUS_CONFIRMED): Confirmed by risk_analyst
+
+````yaml
+id: 85b99700-6338-4e
+phase: plan
+metadata:
+  consensus_reached: false
+````
+
+### [2026-04-27T19:29:52Z] architect (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: f01c9e51-a651-44
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:29:56Z] architect (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: 2e401610-0228-48
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:29:56.104233+00:00'
+````
+
+### [2026-04-27T19:29:58Z] reviewer_plan (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT
+
+````yaml
+id: 2303176e-fb2b-4a
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:29:58.783921+00:00'
+````
+
+### [2026-04-27T19:29:59Z] reviewer_plan (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 2bd9598e-c8ce-42
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:30:02Z] reviewer_plan (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT
+
+````yaml
+id: 05af9d20-ef3c-48
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:30:02.252335+00:00'
+````
+
+### [2026-04-27T19:30:05Z] risk_analyst (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: bb1ab77a-96ab-43
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:30:04.973077+00:00'
+````
+
+### [2026-04-27T19:30:56Z] architect (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: 2f0b7575-e40c-4c
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:29:56.104233+00:00'
+````
+
+### [2026-04-27T19:31:02Z] reviewer_plan (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT
+
+````yaml
+id: cf1bd472-eefe-41
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:30:02.252335+00:00'
+````
+
+### [2026-04-27T19:31:05Z] risk_analyst (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: 34482e36-122e-40
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:30:04.973077+00:00'
+````
+
+### [2026-04-27T19:31:18Z] overseer (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+Plan phase cycle 97 — 968s (~16min). BRC progress: architect CONFIRMED, risk_analyst CONFIRMED, reviewer REVIEWING. task_planner NACKed (at ~19:25), revising for ~7 min. No anomalies — normal NACK revision cycle. Awaiting task_planner re-proposal to complete consensus.
+
+````yaml
+id: 2d0a51ef-b613-48
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+````
+
+### [2026-04-27T19:32:02Z] reviewer_plan (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT
+
+````yaml
+id: ad3ccdb0-25b3-43
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:30:02.252335+00:00'
+````
+
+### [2026-04-27T19:32:05Z] risk_analyst (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: a68c5db5-93fb-43
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:30:04.973077+00:00'
+````
+
+### [2026-04-27T19:32:48Z] task_planner (CONSENSUS_PROPOSE): Proposal from task_planner
+
+Revised plan addressing all six blocking issues from reviewer_plan's NACK plus the actionable non-blocking suggestions: (1) D2 epic-link dispatch is now per-instance via `jira.epic_link_field` config knob — never emits both fields, route 400s on conflicting parent+epicLink; (2) Phase 1 foundations no longer demand test files (Phase 5 tester owns those); (3) createIssueLink synthesizes a `{status, inward, outward, type}` envelope (Atlassian returns 201 with no body); (4) labels replace/incremental modes mutually exclusive — 400 at route, ValueError in client; (5) link idempotency cache composes key as `(link, canonical(inward,outward,type), key)` to prevent aliasing; (6) `_request` 429 audit emit lifted out of the GET-only retry loop so writes also emit. Plus minor fixes: 32 KiB comment-body cap rationale documented, label values logged (not just count) per Q20, notifyUsers query omitted when true, TASK-3-5 ordering note, sandbox `show_usage` pattern confirmed, TASK-5-3 matrix cap, method-tunneling adversarial test, integration-smoke deferred to #1557 in PR body, D10/D11 follow-up placeholder, new TASK-6-3 documenting phase-rollback verification.
+
+````yaml
+id: 04daa963-c6f5-42
+phase: plan
+metadata:
+  payload:
+    summary: "Revised plan addressing all six blocking issues from reviewer_plan's\
+      \ NACK plus the actionable non-blocking suggestions: (1) D2 epic-link dispatch\
+      \ is now per-instance via `jira.epic_link_field` config knob \u2014 never emits\
+      \ both fields, route 400s on conflicting parent+epicLink; (2) Phase 1 foundations\
+      \ no longer demand test files (Phase 5 tester owns those); (3) createIssueLink\
+      \ synthesizes a `{status, inward, outward, type}` envelope (Atlassian returns\
+      \ 201 with no body); (4) labels replace/incremental modes mutually exclusive\
+      \ \u2014 400 at route, ValueError in client; (5) link idempotency cache composes\
+      \ key as `(link, canonical(inward,outward,type), key)` to prevent aliasing;\
+      \ (6) `_request` 429 audit emit lifted out of the GET-only retry loop so writes\
+      \ also emit. Plus minor fixes: 32 KiB comment-body cap rationale documented,\
+      \ label values logged (not just count) per Q20, notifyUsers query omitted when\
+      \ true, TASK-3-5 ordering note, sandbox `show_usage` pattern confirmed, TASK-5-3\
+      \ matrix cap, method-tunneling adversarial test, integration-smoke deferred\
+      \ to #1557 in PR body, D10/D11 follow-up placeholder, new TASK-6-3 documenting\
+      \ phase-rollback verification."
+    attestation: {}
+    artifacts:
+    - .egg-state/drafts/1924-plan.md
+    risk_considered: ''
+    commit_sha: 42fbb6433519f82749bcdd4ba6ad22ac91882f19
+    files_changed:
+    - .egg-state/drafts/1924-plan.md
+    tests_run: []
+    tasks_satisfied: []
+  version: 2
+  commit_sha: 42fbb6433519f82749bcdd4ba6ad22ac91882f19
+````
+
+### [2026-04-27T19:32:48Z] reviewer_plan (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 4b3e6e25-cb4c-47
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:32:57Z] architect (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: 41c83d41-6e58-40
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:29:56.104233+00:00'
+````
+
+### [2026-04-27T19:33:00Z] task_planner (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: 7b4086f3-3c06-4f
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:33:00.007016+00:00'
+````
+
+### [2026-04-27T19:33:05Z] risk_analyst (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: 22c27cc0-2fef-43
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:30:04.973077+00:00'
+````
+
+### [2026-04-27T19:33:57Z] architect (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: f5cbad8e-7266-41
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:29:56.104233+00:00'
+````
+
+### [2026-04-27T19:34:00Z] task_planner (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: 4f6fb497-47e9-40
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:33:00.007016+00:00'
+````
+
+### [2026-04-27T19:34:05Z] risk_analyst (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: 79525cfa-5e30-40
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:30:04.973077+00:00'
+````
+
+### [2026-04-27T19:34:57Z] architect (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: 692ef1b6-0ae7-45
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:29:56.104233+00:00'
+````
+
+### [2026-04-27T19:35:00Z] task_planner (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: fde43ef1-49f8-48
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:33:00.007016+00:00'
+````
+
+### [2026-04-27T19:35:06Z] risk_analyst (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: 1fcb7159-022f-45
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:30:04.973077+00:00'
+````
+
+### [2026-04-27T19:35:57Z] architect (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: ed3f3dd4-8373-4d
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:29:56.104233+00:00'
+````
+
+### [2026-04-27T19:36:00Z] task_planner (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: f20d59f1-084d-4a
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:33:00.007016+00:00'
+````
+
+### [2026-04-27T19:36:01Z] reviewer_plan → task_planner (CONSENSUS_ACK): ACK from reviewer_plan for task_planner
+
+
+Re-reviewed `1924-plan.md` v2 (commit `42fbb6433`, 1044 lines, +295/-168 vs v1) line-by-line against the six blockers in my NACK and the non-blocking suggestions. Every blocker is addressed cleanly; every actionable non-blocking item is addressed. No new blocking issues introduced. ACK.
+
+### Blocker-by-blocker verification
+
+1. **D2 Epic Link auto-detect (was: emits BOTH parent.key + customfield_10014)** — FIXED with the strongest version of the fix.
+   - Defaults table line 55: "Per-instance dispatch via config knob. `JiraPolicy` loads `jira.epic_link_field: 'parent' | 'customfield_10014'` (default `'parent'`). The `epicLink` shorthand emits **only the configured field** — never both."
+   - TASK-2-1 (lines 458-470): `create_issue` signature now takes `epic_link_field` parameter; routes to ONE field, never both. Explicit `parent` wins only when `epicLink` absent.
+   - TASK-3-1 step 6 (line 616-617): route 400s if both `parent` and `epicLink` are present.
+   - TASK-3-5 (lines 717-722): `JiraPolicy` exposes `epic_link_field` property with default `"parent"`, fail-closed-on-malformed-enum (warning + fall back to default).
+   - TASK-5-4 (lines 914-915): adversarial test grid asserts "both `parent` and `epicLink` set → 400".
+   - This implementation **also matches risk_analyst R6's recommendation** (probe-and-pick-one, never both).
+
+2. **TASK-1-1 / TASK-1-2 vs TASK-5-1 / TASK-5-2 duplicate test ownership** — FIXED.
+   - TASK-1-1 description (lines 408-410): "The corresponding test file is owned by TASK-5-1 — this task's acceptance does **not** require tests to exist; it only requires the module API."
+   - TASK-1-1 acceptance (lines 411-417): "(Test coverage is asserted by TASK-5-1.)"
+   - Same pattern applied to TASK-1-2 ↔ TASK-5-2 (lines 432-437).
+   - This is option (a) from my NACK — the cleaner choice.
+
+3. **TASK-3-4 createIssueLink response shape** — FIXED exactly as recommended.
+   - TASK-3-4 (lines 693-700): "Atlassian returns `201 Created` with **no body** in v3, so the route synthesizes a response envelope: `{status: 'created', inwardIssue: <key>, outwardIssue: <key>, type: <name>}`. Including the triple in the response lets the orchestrator's plan-apply correlate the call against its retry record."
+   - TASK-5-4 acceptance (lines 922-924) explicitly asserts the envelope shape.
+
+4. **TASK-2-2 labels replace+incremental** — FIXED with a clean two-layer rejection.
+   - TASK-2-2 (lines 496-505): "two modes are **mutually exclusive at the client method level**: if both are set, raise `ValueError`. The route layer (TASK-3-2) returns 400 for this case before calling the client."
+   - TASK-3-2 (lines 645-647): explicit "**reject 400 if both `labels` (replace mode) and any of `addLabels` / `removeLabels` (incremental mode) are present**".
+   - TASK-5-4 (line 916): adversarial grid covers "**mixed labels mode (replace + incremental) → 400**".
+
+5. **Idempotency cache key for createIssueLink** — FIXED (option (a) from my NACK).
+   - TASK-1-1 (lines 397-401): "For `verb='link'` the caller composes `project` as `canonical(inward, outward, type)` (a stable tuple-string) so identical opaque keys never alias different (inward, outward, type) triples".
+   - TASK-2-4 (lines 547-555): defines `canonical_link_id(inward_key, outward_key, link_type)` returning `"<inward>|<outward>|<type>"` and uses `get_or_run("link", canonical_link_id(...), idempotency_key, ...)`.
+   - TASK-2-4 acceptance (lines 560-562): asserts no aliasing for same opaque key with different triples.
+   - TASK-5-1 (lines 852-855): explicit aliasing test.
+
+6. **429 audit emit on writes** — FIXED in the right place (`_request`).
+   - TASK-2-5 (lines 579-585): "**Move the `jira_upstream_rate_limited` audit-emit call out of the GET-only retry loop in `_request`** so it fires on every 429 (writes included), guarded by `flask.has_request_context()`. The retry loop still retries only GET; the audit emit is unconditional on 429."
+   - TASK-2-5 acceptance (line 590): "The 429 audit emit fires for write methods (a new test in TASK-5-3 asserts this)."
+   - TASK-5-3 (line 896): "**429 audit emit on each write verb** (asserts the TASK-2-5 audit-emit fix)."
+
+### Non-blocking items also addressed
+
+- **Q15 32 KiB comment-body cap rationale** — TASK-3-3 (lines 666-668): "32 KiB — chosen to mirror the description cap; Atlassian publishes no upper limit, but 32 KiB bounds audit-log size and covers realistic plan-apply commentary".
+- **Q20 label values logged (not just count)** — Defaults table Q20 row (line 77) updated; TASK-3-1 (line 622) "**label values** (small enumerated strings — policy-relevant per Q20)"; TASK-3-2 (lines 651-652) "label values (when replace), add/remove label values (when incremental)".
+- **TASK-2-2 `notifyUsers` query omitted when True** — TASK-2-2 (lines 506-508): "omit `notifyUsers` entirely when `notify_users=True` (Atlassian's default is true — do not bloat the URL); send `notifyUsers=false` only when `notify_users=False`".
+- **Phase 3 intra-phase ordering (TASK-3-5 before TASK-3-4)** — TASK-3-5 (lines 723-726): "**Ordering note:** TASK-3-5 must land before TASK-3-4 (issue-link route) because the route depends on `link_type_allowed`. The implementer must commit TASK-3-5 first within Phase 3."
+- **TASK-3-7 picks `config/context-filters.yaml` directly** — TASK-3-7 (line 754): "Edit `config/context-filters.yaml` directly (the file `JiraPolicy` loads — survey confirmed the existing `jira:` section lives there)."
+- **Sandbox wrapper `--help` clarification** — Phase 4 goal (lines 778-781): "The existing wrapper has a top-level `show_usage` (line ~350) and no per-subcommand `--help`; the new subcommands extend `show_usage` with their flags rather than introducing a new help-output convention." All four sandbox tasks now reference `show_usage` instead of `--help`.
+- **D10/D11 follow-up placeholder in PR body** — PR description (lines 336-339): "**Per-role and per-phase write gating (decisions D10/D11) are explicitly deferred to a follow-up issue (to be filed once this PR is merged — placeholder reference: `Follows: TBD-write-policy`)**".
+- **HTTP-method tunnelling adversarial test** — TASK-5-4 (lines 919-920): "**HTTP-method tunnelling via body** (e.g. `'_method': 'DELETE'` keys, `__proto__` pollution) → 400".
+- **TASK-5-3 matrix cap** — TASK-5-3 (lines 884-887): "Bound the matrix at **≥1 success case per option pair** and one failure case per validation rule — write a brief named matrix in each test's docstring rather than generating a Cartesian explosion."
+- **Integration smoke deferred to #1557 in PR body** — Manual section (lines 369-373): "**Integration smoke against a live Atlassian instance is intentionally deferred to #1557** (Jira-epic SDLC pipelines), which is the first real consumer."
+- **Rollback claim verification** — NEW TASK-6-3 (lines 1005-1024): adds a "Phase rollback" doc sub-section AND tasks the implement-phase reviewer with running `git revert --no-commit <phase-N-commit>` on each phase and confirming v1 read tests stay green. Concrete and verifiable.
+
+### Non-blocking — minor (no change needed)
+
+- **Approach summary line 22-25** still reads "Cache is keyed by `(verb, project, key)` for ... `createIssueLink`". Strictly the link verb's cache key uses `canonical(inward, outward, type)` in the `project` slot (per TASK-1-1 lines 397-401). High-level Approach is mildly inconsistent with the canonical-link-id detail buried in the tasks, but the tasks are authoritative — a coder following TASK-2-4 will not be confused. Optional polish: footnote the Approach with "(see TASK-2-4 for link-verb cache-key composition)".
+- **TASK-2-1 client method still accepts both `parent` and `epic_link`** — the route layer rejects when both are present (TASK-3-1 step 6), so client-level enforcement is belt-and-braces. Currently the client just emits whichever is set; if both are set programmatically (bypassing the route) the second `fields.parent.key=` write clobbers the first. The route gate is the canonical fix; adding a client-level `ValueError` for "both set" would be defense-in-depth but is not required since all callers route through the gateway.
+- **TASK-2-4 / TASK-5-1 link-cache aliasing** — the canonical-link-id is `"<inward>|<outward>|<type>"`. If a customer link type ever contains `|` literally, the canonical id collides with another triple. Atlassian's link-type name regex (per risk_analyst R9 mitigation) bounds names to `[A-Za-z][A-Za-z _-]{0,32}` which excludes `|`, so this is safe in practice — but worth a one-line code comment near `canonical_link_id` noting the chosen separator and the regex bound that protects it.
+
+The plan v2 is implementable. The HITL bake-ins are clearly tagged with `decision-N` references; the implement-phase coder can swap in the operator's actual answer when HITL closes. Reviewer NACK satisfaction is complete. ACK.
+
+
+````yaml
+id: 72029db6-e47f-41
+phase: plan
+metadata:
+  payload:
+    artifact_references:
+    - .egg-state/drafts/1924-plan.md
+    - .egg-state/drafts/1924-analysis.md
+    - .egg-state/agent-outputs/1924-architect-output.json
+    - .egg-state/agent-outputs/1924-risk_analyst-output.json
+    reason: "\nRe-reviewed `1924-plan.md` v2 (commit `42fbb6433`, 1044 lines, +295/-168\
+      \ vs v1) line-by-line against the six blockers in my NACK and the non-blocking\
+      \ suggestions. Every blocker is addressed cleanly; every actionable non-blocking\
+      \ item is addressed. No new blocking issues introduced. ACK.\n\n### Blocker-by-blocker\
+      \ verification\n\n1. **D2 Epic Link auto-detect (was: emits BOTH parent.key\
+      \ + customfield_10014)** \u2014 FIXED with the strongest version of the fix.\n\
+      \   - Defaults table line 55: \"Per-instance dispatch via config knob. `JiraPolicy`\
+      \ loads `jira.epic_link_field: 'parent' | 'customfield_10014'` (default `'parent'`).\
+      \ The `epicLink` shorthand emits **only the configured field** \u2014 never\
+      \ both.\"\n   - TASK-2-1 (lines 458-470): `create_issue` signature now takes\
+      \ `epic_link_field` parameter; routes to ONE field, never both. Explicit `parent`\
+      \ wins only when `epicLink` absent.\n   - TASK-3-1 step 6 (line 616-617): route\
+      \ 400s if both `parent` and `epicLink` are present.\n   - TASK-3-5 (lines 717-722):\
+      \ `JiraPolicy` exposes `epic_link_field` property with default `\"parent\"`,\
+      \ fail-closed-on-malformed-enum (warning + fall back to default).\n   - TASK-5-4\
+      \ (lines 914-915): adversarial test grid asserts \"both `parent` and `epicLink`\
+      \ set \u2192 400\".\n   - This implementation **also matches risk_analyst R6's\
+      \ recommendation** (probe-and-pick-one, never both).\n\n2. **TASK-1-1 / TASK-1-2\
+      \ vs TASK-5-1 / TASK-5-2 duplicate test ownership** \u2014 FIXED.\n   - TASK-1-1\
+      \ description (lines 408-410): \"The corresponding test file is owned by TASK-5-1\
+      \ \u2014 this task's acceptance does **not** require tests to exist; it only\
+      \ requires the module API.\"\n   - TASK-1-1 acceptance (lines 411-417): \"(Test\
+      \ coverage is asserted by TASK-5-1.)\"\n   - Same pattern applied to TASK-1-2\
+      \ \u2194 TASK-5-2 (lines 432-437).\n   - This is option (a) from my NACK \u2014\
+      \ the cleaner choice.\n\n3. **TASK-3-4 createIssueLink response shape** \u2014\
+      \ FIXED exactly as recommended.\n   - TASK-3-4 (lines 693-700): \"Atlassian\
+      \ returns `201 Created` with **no body** in v3, so the route synthesizes a response\
+      \ envelope: `{status: 'created', inwardIssue: <key>, outwardIssue: <key>, type:\
+      \ <name>}`. Including the triple in the response lets the orchestrator's plan-apply\
+      \ correlate the call against its retry record.\"\n   - TASK-5-4 acceptance (lines\
+      \ 922-924) explicitly asserts the envelope shape.\n\n4. **TASK-2-2 labels replace+incremental**\
+      \ \u2014 FIXED with a clean two-layer rejection.\n   - TASK-2-2 (lines 496-505):\
+      \ \"two modes are **mutually exclusive at the client method level**: if both\
+      \ are set, raise `ValueError`. The route layer (TASK-3-2) returns 400 for this\
+      \ case before calling the client.\"\n   - TASK-3-2 (lines 645-647): explicit\
+      \ \"**reject 400 if both `labels` (replace mode) and any of `addLabels` / `removeLabels`\
+      \ (incremental mode) are present**\".\n   - TASK-5-4 (line 916): adversarial\
+      \ grid covers \"**mixed labels mode (replace + incremental) \u2192 400**\".\n\
+      \n5. **Idempotency cache key for createIssueLink** \u2014 FIXED (option (a)\
+      \ from my NACK).\n   - TASK-1-1 (lines 397-401): \"For `verb='link'` the caller\
+      \ composes `project` as `canonical(inward, outward, type)` (a stable tuple-string)\
+      \ so identical opaque keys never alias different (inward, outward, type) triples\"\
+      .\n   - TASK-2-4 (lines 547-555): defines `canonical_link_id(inward_key, outward_key,\
+      \ link_type)` returning `\"<inward>|<outward>|<type>\"` and uses `get_or_run(\"\
+      link\", canonical_link_id(...), idempotency_key, ...)`.\n   - TASK-2-4 acceptance\
+      \ (lines 560-562): asserts no aliasing for same opaque key with different triples.\n\
+      \   - TASK-5-1 (lines 852-855): explicit aliasing test.\n\n6. **429 audit emit\
+      \ on writes** \u2014 FIXED in the right place (`_request`).\n   - TASK-2-5 (lines\
+      \ 579-585): \"**Move the `jira_upstream_rate_limited` audit-emit call out of\
+      \ the GET-only retry loop in `_request`** so it fires on every 429 (writes included),\
+      \ guarded by `flask.has_request_context()`. The retry loop still retries only\
+      \ GET; the audit emit is unconditional on 429.\"\n   - TASK-2-5 acceptance (line\
+      \ 590): \"The 429 audit emit fires for write methods (a new test in TASK-5-3\
+      \ asserts this).\"\n   - TASK-5-3 (line 896): \"**429 audit emit on each write\
+      \ verb** (asserts the TASK-2-5 audit-emit fix).\"\n\n### Non-blocking items\
+      \ also addressed\n\n- **Q15 32 KiB comment-body cap rationale** \u2014 TASK-3-3\
+      \ (lines 666-668): \"32 KiB \u2014 chosen to mirror the description cap; Atlassian\
+      \ publishes no upper limit, but 32 KiB bounds audit-log size and covers realistic\
+      \ plan-apply commentary\".\n- **Q20 label values logged (not just count)** \u2014\
+      \ Defaults table Q20 row (line 77) updated; TASK-3-1 (line 622) \"**label values**\
+      \ (small enumerated strings \u2014 policy-relevant per Q20)\"; TASK-3-2 (lines\
+      \ 651-652) \"label values (when replace), add/remove label values (when incremental)\"\
+      .\n- **TASK-2-2 `notifyUsers` query omitted when True** \u2014 TASK-2-2 (lines\
+      \ 506-508): \"omit `notifyUsers` entirely when `notify_users=True` (Atlassian's\
+      \ default is true \u2014 do not bloat the URL); send `notifyUsers=false` only\
+      \ when `notify_users=False`\".\n- **Phase 3 intra-phase ordering (TASK-3-5 before\
+      \ TASK-3-4)** \u2014 TASK-3-5 (lines 723-726): \"**Ordering note:** TASK-3-5\
+      \ must land before TASK-3-4 (issue-link route) because the route depends on\
+      \ `link_type_allowed`. The implementer must commit TASK-3-5 first within Phase\
+      \ 3.\"\n- **TASK-3-7 picks `config/context-filters.yaml` directly** \u2014 TASK-3-7\
+      \ (line 754): \"Edit `config/context-filters.yaml` directly (the file `JiraPolicy`\
+      \ loads \u2014 survey confirmed the existing `jira:` section lives there).\"\
+      \n- **Sandbox wrapper `--help` clarification** \u2014 Phase 4 goal (lines 778-781):\
+      \ \"The existing wrapper has a top-level `show_usage` (line ~350) and no per-subcommand\
+      \ `--help`; the new subcommands extend `show_usage` with their flags rather\
+      \ than introducing a new help-output convention.\" All four sandbox tasks now\
+      \ reference `show_usage` instead of `--help`.\n- **D10/D11 follow-up placeholder\
+      \ in PR body** \u2014 PR description (lines 336-339): \"**Per-role and per-phase\
+      \ write gating (decisions D10/D11) are explicitly deferred to a follow-up issue\
+      \ (to be filed once this PR is merged \u2014 placeholder reference: `Follows:\
+      \ TBD-write-policy`)**\".\n- **HTTP-method tunnelling adversarial test** \u2014\
+      \ TASK-5-4 (lines 919-920): \"**HTTP-method tunnelling via body** (e.g. `'_method':\
+      \ 'DELETE'` keys, `__proto__` pollution) \u2192 400\".\n- **TASK-5-3 matrix\
+      \ cap** \u2014 TASK-5-3 (lines 884-887): \"Bound the matrix at **\u22651 success\
+      \ case per option pair** and one failure case per validation rule \u2014 write\
+      \ a brief named matrix in each test's docstring rather than generating a Cartesian\
+      \ explosion.\"\n- **Integration smoke deferred to #1557 in PR body** \u2014\
+      \ Manual section (lines 369-373): \"**Integration smoke against a live Atlassian\
+      \ instance is intentionally deferred to #1557** (Jira-epic SDLC pipelines),\
+      \ which is the first real consumer.\"\n- **Rollback claim verification** \u2014\
+      \ NEW TASK-6-3 (lines 1005-1024): adds a \"Phase rollback\" doc sub-section\
+      \ AND tasks the implement-phase reviewer with running `git revert --no-commit\
+      \ <phase-N-commit>` on each phase and confirming v1 read tests stay green. Concrete\
+      \ and verifiable.\n\n### Non-blocking \u2014 minor (no change needed)\n\n- **Approach\
+      \ summary line 22-25** still reads \"Cache is keyed by `(verb, project, key)`\
+      \ for ... `createIssueLink`\". Strictly the link verb's cache key uses `canonical(inward,\
+      \ outward, type)` in the `project` slot (per TASK-1-1 lines 397-401). High-level\
+      \ Approach is mildly inconsistent with the canonical-link-id detail buried in\
+      \ the tasks, but the tasks are authoritative \u2014 a coder following TASK-2-4\
+      \ will not be confused. Optional polish: footnote the Approach with \"(see TASK-2-4\
+      \ for link-verb cache-key composition)\".\n- **TASK-2-1 client method still\
+      \ accepts both `parent` and `epic_link`** \u2014 the route layer rejects when\
+      \ both are present (TASK-3-1 step 6), so client-level enforcement is belt-and-braces.\
+      \ Currently the client just emits whichever is set; if both are set programmatically\
+      \ (bypassing the route) the second `fields.parent.key=` write clobbers the first.\
+      \ The route gate is the canonical fix; adding a client-level `ValueError` for\
+      \ \"both set\" would be defense-in-depth but is not required since all callers\
+      \ route through the gateway.\n- **TASK-2-4 / TASK-5-1 link-cache aliasing**\
+      \ \u2014 the canonical-link-id is `\"<inward>|<outward>|<type>\"`. If a customer\
+      \ link type ever contains `|` literally, the canonical id collides with another\
+      \ triple. Atlassian's link-type name regex (per risk_analyst R9 mitigation)\
+      \ bounds names to `[A-Za-z][A-Za-z _-]{0,32}` which excludes `|`, so this is\
+      \ safe in practice \u2014 but worth a one-line code comment near `canonical_link_id`\
+      \ noting the chosen separator and the regex bound that protects it.\n\nThe plan\
+      \ v2 is implementable. The HITL bake-ins are clearly tagged with `decision-N`\
+      \ references; the implement-phase coder can swap in the operator's actual answer\
+      \ when HITL closes. Reviewer NACK satisfaction is complete. ACK.\n"
+  version: 2
+````
+
+### [2026-04-27T19:36:01Z] orchestrator → task_planner (STATUS): Ready to confirm — all confirm preconditions satisfied
+
+Your proposal (version 2) is ready to confirm — all blocking reviews are clear and global confirm preconditions are met. Run `egg-orch consensus confirmed` to confirm.
+
+````yaml
+id: bd9b094c-57ab-4a
+phase: plan
+metadata:
+  ready_to_confirm: true
+  version: 2
+````
+
+### [2026-04-27T19:36:01Z] task_planner (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 4782160e-b2b2-40
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:36:05Z] reviewer_plan (CONSENSUS_CONFIRMED): Confirmed by reviewer_plan
+
+````yaml
+id: e8d64c43-3996-45
+phase: plan
+metadata:
+  consensus_reached: false
+````
+
+### [2026-04-27T19:36:05Z] architect (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 621d141d-a2d0-40
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:36:05Z] risk_analyst (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 0ccee75a-68c3-4a
+phase: plan
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T19:36:06Z] task_planner (CONSENSUS_CONFIRMED): Confirmed by task_planner
+
+````yaml
+id: 4ddbaf7a-8bdd-4f
+phase: plan
+metadata:
+  consensus_reached: true
+````
+
+### [2026-04-27T19:36:10Z] risk_analyst (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: 18d7c09a-d319-40
+phase: plan
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T19:36:10.224217+00:00'
+````
+
+### [2026-04-27T19:36:10Z] risk_analyst (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 87bd5fb0-fdae-48
+phase: plan
+metadata:
+  state: WORKING
+````

--- a/.egg-state/brc-history/1924-refine.json
+++ b/.egg-state/brc-history/1924-refine.json
@@ -1,0 +1,681 @@
+[
+  {
+    "id": "3a84cf4d-39c9-41",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_refine",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_ON_ROLE",
+    "body": "Reviewer prepared; waiting for refiner CONSENSUS_PROPOSE on issue-1924 refine analysis.",
+    "metadata": {
+      "state": "WAITING_ON_ROLE",
+      "waiting_on": "refiner"
+    },
+    "timestamp": "2026-04-27T18:39:38.463968+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "792f39d4-2925-46",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_refine",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:49.699886+00:00"
+    },
+    "timestamp": "2026-04-27T18:39:49.755933+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "a2191044-014b-4a",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_ON_ROLE",
+    "body": "",
+    "metadata": {
+      "state": "WAITING_ON_ROLE",
+      "waiting_on": "refiner"
+    },
+    "timestamp": "2026-04-27T18:39:51.959453+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "004119c6-55f1-46",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:56.065969+00:00"
+    },
+    "timestamp": "2026-04-27T18:39:56.168141+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "54d0d6a9-0462-48",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_refine",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:49.699886+00:00"
+    },
+    "timestamp": "2026-04-27T18:40:49.840868+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "4681c40b-8f83-4c",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:56.065969+00:00"
+    },
+    "timestamp": "2026-04-27T18:40:56.518882+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "19595b88-5534-43",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_refine",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:49.699886+00:00"
+    },
+    "timestamp": "2026-04-27T18:41:50.269411+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "376cde0f-b5bc-47",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:56.065969+00:00"
+    },
+    "timestamp": "2026-04-27T18:41:56.811849+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "e90efc6f-ff75-43",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_refine",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:49.699886+00:00"
+    },
+    "timestamp": "2026-04-27T18:42:50.517973+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "a0e6b8ab-7e51-44",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:56.065969+00:00"
+    },
+    "timestamp": "2026-04-27T18:42:57.082939+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "090f569a-899b-45",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_refine",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:49.699886+00:00"
+    },
+    "timestamp": "2026-04-27T18:43:50.791667+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "381f10ce-83ba-44",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:56.065969+00:00"
+    },
+    "timestamp": "2026-04-27T18:43:57.248483+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "af31b6be-fa95-40",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_refine",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:49.699886+00:00"
+    },
+    "timestamp": "2026-04-27T18:44:51.080868+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "8faba815-1d84-4a",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:56.065969+00:00"
+    },
+    "timestamp": "2026-04-27T18:44:57.476084+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "0b1df359-5fc9-48",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_refine",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:49.699886+00:00"
+    },
+    "timestamp": "2026-04-27T18:45:51.359634+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "d65ac9bf-a375-40",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:56.065969+00:00"
+    },
+    "timestamp": "2026-04-27T18:45:57.717695+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "502b494b-1df2-4b",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_refine",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:49.699886+00:00"
+    },
+    "timestamp": "2026-04-27T18:46:51.622361+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "f4b3a035-e3e9-47",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:56.065969+00:00"
+    },
+    "timestamp": "2026-04-27T18:46:58.205012+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "f29796d6-14f3-42",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_refine",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:49.699886+00:00"
+    },
+    "timestamp": "2026-04-27T18:47:51.869769+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "d65bd3f4-b746-4d",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:56.065969+00:00"
+    },
+    "timestamp": "2026-04-27T18:47:58.520544+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "1fd3b76b-805e-4d",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_refine",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:49.699886+00:00"
+    },
+    "timestamp": "2026-04-27T18:48:52.631717+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "5295741e-de98-45",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE from=refiner",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:39:56.065969+00:00"
+    },
+    "timestamp": "2026-04-27T18:48:58.719079+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "3c69b6c7-22c3-49",
+    "pipeline_id": "issue-1924",
+    "from_role": "refiner",
+    "to_role": "all",
+    "message_type": "CONSENSUS_PROPOSE",
+    "subject": "Proposal from refiner",
+    "body": "Refine analysis drafted for #1924 (Jira gateway writes). Surveys the existing v1 read-only surface delivered by #1556 (gateway/jira_client.py, gateway/jira_policy.py, gateway/jira_credentials.py, sandbox/scripts/jira), enumerates the four target Atlassian write endpoints (POST /issue, PUT /issue/{key}, POST /issue/{key}/comment, POST /issueLink) with their wire shapes, and recommends four dedicated narrow gateway routes (POST /api/v1/jira/ticket/create | edit | comment/add | issue-link/create) plus a per-route body schema, ADF wrapping helper, gateway-side idempotency cache, and a clean separation between the GET-only /execute passthrough and write client methods. Permanent denylist (transitions/worklog/attachments/watchers/DELETE) preserved. Surfaces 18 multiple-choice HITL decisions (custom-field allowlist, Epic Link mechanism, idempotency policy, link-type allowlist, role/phase gating, response shapes, dry-run, docs home) and 9 free-form feedback questions (rate-limit policy, body size caps, existence probe, wrapper flags, audit redaction, test layout, multi-tenant hooks, rollback responsibility, error envelope shape). Complexity: medium. Draft committed as 27ac5b150 and ready for reviewer_refine + reviewer_agent_design review.",
+    "metadata": {
+      "payload": {
+        "summary": "Refine analysis drafted for #1924 (Jira gateway writes). Surveys the existing v1 read-only surface delivered by #1556 (gateway/jira_client.py, gateway/jira_policy.py, gateway/jira_credentials.py, sandbox/scripts/jira), enumerates the four target Atlassian write endpoints (POST /issue, PUT /issue/{key}, POST /issue/{key}/comment, POST /issueLink) with their wire shapes, and recommends four dedicated narrow gateway routes (POST /api/v1/jira/ticket/create | edit | comment/add | issue-link/create) plus a per-route body schema, ADF wrapping helper, gateway-side idempotency cache, and a clean separation between the GET-only /execute passthrough and write client methods. Permanent denylist (transitions/worklog/attachments/watchers/DELETE) preserved. Surfaces 18 multiple-choice HITL decisions (custom-field allowlist, Epic Link mechanism, idempotency policy, link-type allowlist, role/phase gating, response shapes, dry-run, docs home) and 9 free-form feedback questions (rate-limit policy, body size caps, existence probe, wrapper flags, audit redaction, test layout, multi-tenant hooks, rollback responsibility, error envelope shape). Complexity: medium. Draft committed as 27ac5b150 and ready for reviewer_refine + reviewer_agent_design review.",
+        "attestation": {},
+        "artifacts": [
+          ".egg-state/drafts/1924-analysis.md"
+        ],
+        "risk_considered": "Open questions are extensive (27 in total) \u2014 risk of overload for human reviewer, but each captures a real decision the plan phase needs (custom-field allowlist scope, Epic Link mechanism, idempotency model, link-type allowlist, role/phase gating). Skipping any of them would force plan to hardcode an assumption. The recommended approach (A1+B1+C1+D1+E1) is conservative and additive \u2014 preserves all v1 invariants and matches the v1 verb-noun pattern, so risk of plan-phase rework is low.",
+        "commit_sha": "27ac5b1507c105481c83189b444a282985d6663f",
+        "files_changed": [
+          ".egg-state/drafts/1924-analysis.md"
+        ],
+        "tests_run": [],
+        "tasks_satisfied": []
+      },
+      "version": 1,
+      "commit_sha": "27ac5b1507c105481c83189b444a282985d6663f"
+    },
+    "timestamp": "2026-04-27T18:49:23.902407+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "828afce9-a872-45",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_refine",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T18:49:24.136259+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "d1bfa1f7-b51f-40",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T18:49:24.143794+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "b57bef08-32a7-4e",
+    "pipeline_id": "issue-1924",
+    "from_role": "refiner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:49:30.687479+00:00"
+    },
+    "timestamp": "2026-04-27T18:49:32.445734+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "789f5cc5-45f7-44",
+    "pipeline_id": "issue-1924",
+    "from_role": "refiner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T18:49:32.539356+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "2cd01155-55e3-48",
+    "pipeline_id": "issue-1924",
+    "from_role": "refiner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:49:35.833475+00:00"
+    },
+    "timestamp": "2026-04-27T18:49:35.896669+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "a9615c2f-982f-46",
+    "pipeline_id": "issue-1924",
+    "from_role": "refiner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:49:35.833475+00:00"
+    },
+    "timestamp": "2026-04-27T18:50:36.118849+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "a9df1124-5af8-41",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "refiner",
+    "message_type": "CONSENSUS_ACK",
+    "subject": "ACK from reviewer_agent_design for refiner",
+    "body": "\nReviewed `.egg-state/drafts/1924-analysis.md` end-to-end (522 lines) against the agent-mode design rubric (`docs/guides/agent-mode-design.md`). No agent-mode anti-patterns found. The recommended design (A1+B1+C1+D1+E1) actually *strengthens* agent-mode properties on several axes:\n\n**What the design gets right (agent-mode lens):**\n\n- **Sandbox-enforced security, not prompt-level.** Every hard invariant (project allowlist, `@require_private_mode`, `@require_session_auth`, body-shape validation, permanent `transitions/worklog/attachments/watchers/DELETE` denylist, zero credentials in sandbox) lives in gateway code. Nothing relies on instructing the agent \"don't do X.\" Matches `docs/guides/agent-mode-design.md` \"infra-level constraints beat config-level allowlists\" (which the doc itself quotes from #1556's body).\n- **Per-verb narrow routes (A1) over generic dispatcher (A2).** Picking four per-verb routes with per-verb audit operation names + per-verb body validators is the agent-friendlier choice: each verb has a tight, reasoned-about surface, and `/execute`'s GET-only invariant cannot be widened by a write-side mistake. The A2 rejection rationale (lines 152\u2013157) explicitly cites \"verb allowlist by construction\" \u2014 the right primitive to preserve.\n- **B1 method-allowlist split.** Keeping `validate_jira_api_path` GET-only and letting the dedicated write-client methods hardcode their own paths/methods is the cleanest separation. A future maintainer cannot accidentally widen `/execute` into write territory by editing one config knob (B2's failure mode, correctly rejected at line 184\u2013190).\n- **Plain-text \u2192 ADF wrapping in the gateway (E1, C1).** This is wire-format adaptation, not a post-processing pipeline \u2014 the agent expresses intent in the natural format (`--description \"...\"`), and the gateway adapts to Atlassian's wire shape. It removes a class of bug (agents constructing ADF JSON in bash heredocs) without re-interpreting the agent's output to take new actions. Mirrors the established `gh pr create --body-file` ergonomics from the existing `gh` wrapper, so agents get a consistent affordance across tools.\n- **Curated field allowlist (C1).** Rejecting C2 passthrough is correct. Pure passthrough would let agents smuggle `Security Level`, `Components`, `Sprint`, watchers, etc. into write bodies \u2014 exactly the \"config-level allowlist beaten by infra-level constraint\" pattern. The explicit `customFields` opt-in map (with operator allowlist as Open Q1) keeps the dangerous surface gated by config, not by agent restraint.\n- **No structured-output-for-humans issue.** The gateway's response envelope (`{key, id, browse_url, status}` etc.) is consumed by orchestrator/sandbox code, never rendered to a human. Open Q13/Q14 surfacing the envelope shape is appropriate.\n- **No LLM-API anti-patterns.** This isn't LLM code \u2014 `EGG200` and `EGG201` (model-id / direct-Anthropic-API rules) don't apply, and the analysis doesn't introduce any LLM call sites.\n- **No excessive pre-fetching.** Existing-issue probe before create (Open Q18) is correctly *surfaced as an open question* rather than prescribed. If the human picks \"yes, probe,\" that's an explicit operator choice, not a baked-in fragility.\n- **Idempotency cache (D1) is caller-supplied keys, not magic.** The orchestrator can derive `(pipeline_id, plan_node_id)` keys; the gateway is a transparent dedup layer with bounded memory. No agent prompt mentions idempotency \u2014 the contract is at the API, where it belongs.\n- **Open Q10/Q11 (per-role / per-phase write gating).** Both proposed via `gateway/phase_filter.py` style, i.e. enforced at the gateway layer if adopted. Even when the question is \"should we constrain agents,\" the answer mechanism is sandbox-enforced. Correct framing.\n\n**Borderline items I deliberately did not flag:**\n\n- Open Q24 (`?dry_run=true`) could in principle become a \"preview API the agent re-parses\" anti-pattern, but the analysis frames it as orchestrator-side preview ergonomics, and the recommended path leaves it open for human decision. Not a current concern.\n- The plain-text-vs-ADF accept-both option (E1 + Open Q7) introduces a small dual-path; the gateway code complexity is fine for the agent ergonomics it buys, and the design is consistent (gateway always sends ADF upstream).\n\nNo blocking items. Approving for the agent-design dimension.\n",
+    "metadata": {
+      "payload": {
+        "artifact_references": [
+          ".egg-state/drafts/1924-analysis.md"
+        ],
+        "reason": "\nReviewed `.egg-state/drafts/1924-analysis.md` end-to-end (522 lines) against the agent-mode design rubric (`docs/guides/agent-mode-design.md`). No agent-mode anti-patterns found. The recommended design (A1+B1+C1+D1+E1) actually *strengthens* agent-mode properties on several axes:\n\n**What the design gets right (agent-mode lens):**\n\n- **Sandbox-enforced security, not prompt-level.** Every hard invariant (project allowlist, `@require_private_mode`, `@require_session_auth`, body-shape validation, permanent `transitions/worklog/attachments/watchers/DELETE` denylist, zero credentials in sandbox) lives in gateway code. Nothing relies on instructing the agent \"don't do X.\" Matches `docs/guides/agent-mode-design.md` \"infra-level constraints beat config-level allowlists\" (which the doc itself quotes from #1556's body).\n- **Per-verb narrow routes (A1) over generic dispatcher (A2).** Picking four per-verb routes with per-verb audit operation names + per-verb body validators is the agent-friendlier choice: each verb has a tight, reasoned-about surface, and `/execute`'s GET-only invariant cannot be widened by a write-side mistake. The A2 rejection rationale (lines 152\u2013157) explicitly cites \"verb allowlist by construction\" \u2014 the right primitive to preserve.\n- **B1 method-allowlist split.** Keeping `validate_jira_api_path` GET-only and letting the dedicated write-client methods hardcode their own paths/methods is the cleanest separation. A future maintainer cannot accidentally widen `/execute` into write territory by editing one config knob (B2's failure mode, correctly rejected at line 184\u2013190).\n- **Plain-text \u2192 ADF wrapping in the gateway (E1, C1).** This is wire-format adaptation, not a post-processing pipeline \u2014 the agent expresses intent in the natural format (`--description \"...\"`), and the gateway adapts to Atlassian's wire shape. It removes a class of bug (agents constructing ADF JSON in bash heredocs) without re-interpreting the agent's output to take new actions. Mirrors the established `gh pr create --body-file` ergonomics from the existing `gh` wrapper, so agents get a consistent affordance across tools.\n- **Curated field allowlist (C1).** Rejecting C2 passthrough is correct. Pure passthrough would let agents smuggle `Security Level`, `Components`, `Sprint`, watchers, etc. into write bodies \u2014 exactly the \"config-level allowlist beaten by infra-level constraint\" pattern. The explicit `customFields` opt-in map (with operator allowlist as Open Q1) keeps the dangerous surface gated by config, not by agent restraint.\n- **No structured-output-for-humans issue.** The gateway's response envelope (`{key, id, browse_url, status}` etc.) is consumed by orchestrator/sandbox code, never rendered to a human. Open Q13/Q14 surfacing the envelope shape is appropriate.\n- **No LLM-API anti-patterns.** This isn't LLM code \u2014 `EGG200` and `EGG201` (model-id / direct-Anthropic-API rules) don't apply, and the analysis doesn't introduce any LLM call sites.\n- **No excessive pre-fetching.** Existing-issue probe before create (Open Q18) is correctly *surfaced as an open question* rather than prescribed. If the human picks \"yes, probe,\" that's an explicit operator choice, not a baked-in fragility.\n- **Idempotency cache (D1) is caller-supplied keys, not magic.** The orchestrator can derive `(pipeline_id, plan_node_id)` keys; the gateway is a transparent dedup layer with bounded memory. No agent prompt mentions idempotency \u2014 the contract is at the API, where it belongs.\n- **Open Q10/Q11 (per-role / per-phase write gating).** Both proposed via `gateway/phase_filter.py` style, i.e. enforced at the gateway layer if adopted. Even when the question is \"should we constrain agents,\" the answer mechanism is sandbox-enforced. Correct framing.\n\n**Borderline items I deliberately did not flag:**\n\n- Open Q24 (`?dry_run=true`) could in principle become a \"preview API the agent re-parses\" anti-pattern, but the analysis frames it as orchestrator-side preview ergonomics, and the recommended path leaves it open for human decision. Not a current concern.\n- The plain-text-vs-ADF accept-both option (E1 + Open Q7) introduces a small dual-path; the gateway code complexity is fine for the agent ergonomics it buys, and the design is consistent (gateway always sends ADF upstream).\n\nNo blocking items. Approving for the agent-design dimension.\n"
+      },
+      "version": 1
+    },
+    "timestamp": "2026-04-27T18:50:42.331209+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "8f340b8f-e95d-4e",
+    "pipeline_id": "issue-1924",
+    "from_role": "refiner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T18:50:42.441156+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "5f51212e-7665-4e",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "CONSENSUS_CONFIRMED",
+    "subject": "Confirmed by reviewer_agent_design",
+    "body": "",
+    "metadata": {
+      "consensus_reached": false
+    },
+    "timestamp": "2026-04-27T18:50:46.621096+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "e6800920-07bc-4b",
+    "pipeline_id": "issue-1924",
+    "from_role": "refiner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT from=reviewer_refine",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:50:50.951072+00:00"
+    },
+    "timestamp": "2026-04-27T18:50:51.027301+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "423cf167-4e04-43",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:50:51.896329+00:00"
+    },
+    "timestamp": "2026-04-27T18:50:52.129457+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "6398bc94-e81b-4d",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T18:50:52.306994+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "96d2e1cf-5ff9-45",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:51:02.962405+00:00"
+    },
+    "timestamp": "2026-04-27T18:51:03.084613+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "1fbbef92-bf26-43",
+    "pipeline_id": "issue-1924",
+    "from_role": "refiner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT from=reviewer_refine",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:50:50.951072+00:00"
+    },
+    "timestamp": "2026-04-27T18:51:51.250132+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "e78dfc1a-aa7f-46",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WAITING_FOR_EVENT",
+    "body": "wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT",
+    "metadata": {
+      "state": "WAITING_FOR_EVENT",
+      "since": "2026-04-27T18:51:02.962405+00:00"
+    },
+    "timestamp": "2026-04-27T18:52:03.312846+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "e76cfca9-e91c-45",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_refine",
+    "to_role": "refiner",
+    "message_type": "CONSENSUS_ACK",
+    "subject": "ACK from reviewer_refine for refiner",
+    "body": "\n## Refine Review \u2014 issue #1924 (Jira gateway write operations)\n\n**Verdict: ACK.** The analysis is comprehensive, accurate, and well-anchored to the existing #1556 v1 surface. All 27 open questions are registered as HITL contract items (18 decisions + 9 feedback). The recommended A1+B1+C1+D1+E1 design preserves every v1 invariant. Section-by-section findings below; non-blocking nits only.\n\n### 1. Problem Understanding \u2014 strong\n\nThe framing is precise: the four verbs (`createJiraIssue`, `editJiraIssue`, `addCommentToJiraIssue`, `createIssueLink`) are exactly what #1557's plan-apply step needs (refine\u2192epic Description sink, plan\u2192child create + cross-link + consolidation comments). The \"permanent denylist preserved\" point at line 87 correctly nails the security boundary that distinguishes #1924 from #1556's \"future-scope\" carve-out.\n\n### 2. Research Quality \u2014 strong, code citations verified\n\nI cross-checked the file/line claims against the source:\n- `JIRA_WRITE_VERBS_DENIED` at `gateway/jira_client.py:95-108` \u2713 (analysis cites it correctly as covering `transitions/worklog/attachments/watchers` plus `DELETE/PUT/PATCH`).\n- `ALLOWED_METHODS = frozenset({\"GET\"})` at line 89 \u2713.\n- `JIRA_API_ALLOWED_PATHS` regex extension point at line 120 \u2713.\n- `validate_jira_api_path` at line 179 \u2713.\n- The \"Retry is GET-only \u2026 future-safety if someone widens ALLOWED_METHODS\" docstring at lines 308-311; pivot `retryable = method.upper() == \"GET\"` at line 322. Analysis cites 322-331 \u2014 accurate.\n- The v1 read routes `/api/v1/jira/ticket/get`, `/search`, `/ticket/comments`, `/execute` exist at lines 4365/4448/4572/4634 \u2713.\n- All referenced building blocks (`auth.py require_session_auth`, `mode_gate.py @require_private_mode`, `jira_policy.py JiraPolicy`, `jira_credentials.py JiraCredentialsManager`, `sandbox/scripts/jira`) exist as cited.\n\n### 3. Options Analysis \u2014 five axes, well-reasoned\n\nThe five-axis split (endpoint shape / method-allowlist separation / body validation / idempotency / wrapper UX) covers the design space cleanly. Every option carries explicit pros/cons; rejections are stated (\"**Rejected**\") rather than implied. Particular strengths:\n- **A1 vs A2** correctly identifies that generalizing `/execute` would couple read and write invariants \u2014 agree with reject.\n- **B1 vs B2** keeps `validate_jira_api_path`'s contract narrow and leverages the path validator only against user-supplied paths, while writes hardcode their paths in client methods. Right call.\n- **D1 idempotency cache** is the right shape for the orchestrator's retry pattern; D2 is correctly noted as not viable (Atlassian doesn't support idempotency keys natively).\n- **C1 curated body validation** correctly identifies the custom-field smuggling risk (Security Level / Components / watchers / Sprint).\n\n### 4. Constraints \u2014 comprehensive, threat model is implicit\n\nSecurity/architectural block at lines 82-93 is tight. The \"project allowlist gate is `request.body.fields.project.key` for create, ticket key for edit/comment/link\" detail (line 88) is exactly the right level of specificity for a refine doc. The `/execute` GET-only invariant is preserved by construction (line 87). Idempotency, ADF handling, per-instance Jira customization (Epic Link mechanism), and rate-limit policy are each surfaced under Operational. External Atlassian REST docs are linked.\n\n### 5. Open Questions \u2014 all 27 registered, well-scoped\n\nVerified against `.egg-state/contracts/issue-1924.json`:\n- 18 contract decisions (decision-1..decision-18) map cleanly to Q1-Q11, Q13, Q14, Q16, Q17, Q23, Q24, Q27 \u2014 multiple-choice questions.\n- 9 feedback items (Q1..Q9 in the feedback block) map to Q12, Q15, Q18, Q19, Q20, Q21, Q22, Q25, Q26 \u2014 open-ended questions.\n\nEach question is specific and actionable. No prose-only questions floating without a contract entry.\n\n### 6. Recommendation Quality \u2014 concrete and grounded\n\nThe recommendation table at lines 313-318 names each new route, its Atlassian endpoint, its audit operation name, and the relevant policy gate per verb. It follows from the options analysis (A1+B1+C1+D1+E1). Test surface (per-route 403 grid, route-enumeration regression update, idempotency test file, sandbox-wrapper smoke tests, adversarial bodies) and documentation home are listed. Complexity assessment (medium, ~1,200 LoC) is reasonable.\n\n### 7. HITL Decision Registration \u2014 fully compliant\n\nEvery open question is registered. No assumptions silently baked in beyond the explicit recommendation.\n\n### Non-blocking \u2014 items the planner should be aware of\n\n- **`.../ticket/comment/add` route name (line 317).** The recommendation pairs the singular noun with an `/add` action suffix, which departs from the v1 plural-noun style (`/ticket/comments`) and the `gh` wrapper's noun-action shape (`/api/v1/gh/pr/create`). Two acceptable resolutions: (a) match the create style \u2014 `POST /api/v1/jira/ticket/comment/create`; (b) keep `/comment/add` and document the deliberate divergence. Either way, fix the inconsistency at plan time so the operator-facing surface is uniform.\n\n- **`createIssueLink` idempotency dismissal (D1, line 239).** The analysis says links are \"naturally unique per `inward+outward+type`,\" but Atlassian's `POST /rest/api/3/issueLink` will happily create duplicate link records with the same triple \u2014 Atlassian assigns each link its own ID and does not de-dup. If the orchestrator retries a `createIssueLink` after a transient 5xx, the second call will create a second link. Recommend the planner either (i) extend the idempotency-key + cache to `createIssueLink` for symmetry, or (ii) document explicitly that the orchestrator's plan-apply must scan existing `inwardIssue` links before retrying link creation, or (iii) add a 28th open question. Surface this as a coverage gap to plan.\n\n- **Recommendation table preempts Q4 (line 318).** \"link `type.name` against a configurable allowlist (default `Blocks`, `Relates`)\" assumes the operator-configurable path. The plan should treat this as contingent on the human's answer to decision-4 (hardcoded vs config vs any).\n\n- **Cross-project parent (Q17) and createIssueLink cross-project (Q9) overlap conceptually.** Both ask \"can a write reference an off-allowlist project?\" Distinct enough to keep separate, but the planner should answer them consistently \u2014 accepting cross-project on one and rejecting on the other would be surprising.\n\n- **Idempotency-cache TTL = 5 minutes** is a reasonable default but is not yet a contract decision \u2014 the orchestrator's actual retry window for write failures should drive this. Decision-14 (\"Idempotency cache scope\") covers in-memory-vs-persistent but not the TTL itself; planner may want to size the TTL after the orchestrator side is sketched.\n\n- **Bot account / token attribution.** Constraints mention Atlassian's recommendation against API tokens for production integrations carries through from #1556 (line 117), but the doc doesn't restate that a dedicated bot Atlassian account is required for clean attribution on writes. Worth restating in the plan's Implementation Notes so the operator doesn't accidentally point the gateway at a personal token.\n\n- **Audit redaction of label values (Q20 \u2192 feedback Q5).** The \"log only structural metadata\" stance is right for descriptions/comments, but labels themselves are often the point of an audit (\"agent added `wontfix`\" \u2014 useful) and short. Worth explicitly carving labels out of the redaction rule when Q20 is answered.\n\n- **Test file path `tests/sandbox/test_jira_wrapper.py`.** The pattern matches existing `tests/sandbox/test_confluence_wrapper.py`, so the proposed location is right.\n\nNone of these are refine-blocking \u2014 the human reviewer has the surface area and the planner has enough material to draft the implementation plan after Q1-Q27 resolve.\n",
+    "metadata": {
+      "payload": {
+        "artifact_references": [
+          ".egg-state/drafts/1924-analysis.md",
+          ".egg-state/contracts/issue-1924.json",
+          "gateway/jira_client.py",
+          "gateway/gateway.py",
+          "gateway/tests/test_jira_routes.py",
+          "sandbox/scripts/jira"
+        ],
+        "reason": "\n## Refine Review \u2014 issue #1924 (Jira gateway write operations)\n\n**Verdict: ACK.** The analysis is comprehensive, accurate, and well-anchored to the existing #1556 v1 surface. All 27 open questions are registered as HITL contract items (18 decisions + 9 feedback). The recommended A1+B1+C1+D1+E1 design preserves every v1 invariant. Section-by-section findings below; non-blocking nits only.\n\n### 1. Problem Understanding \u2014 strong\n\nThe framing is precise: the four verbs (`createJiraIssue`, `editJiraIssue`, `addCommentToJiraIssue`, `createIssueLink`) are exactly what #1557's plan-apply step needs (refine\u2192epic Description sink, plan\u2192child create + cross-link + consolidation comments). The \"permanent denylist preserved\" point at line 87 correctly nails the security boundary that distinguishes #1924 from #1556's \"future-scope\" carve-out.\n\n### 2. Research Quality \u2014 strong, code citations verified\n\nI cross-checked the file/line claims against the source:\n- `JIRA_WRITE_VERBS_DENIED` at `gateway/jira_client.py:95-108` \u2713 (analysis cites it correctly as covering `transitions/worklog/attachments/watchers` plus `DELETE/PUT/PATCH`).\n- `ALLOWED_METHODS = frozenset({\"GET\"})` at line 89 \u2713.\n- `JIRA_API_ALLOWED_PATHS` regex extension point at line 120 \u2713.\n- `validate_jira_api_path` at line 179 \u2713.\n- The \"Retry is GET-only \u2026 future-safety if someone widens ALLOWED_METHODS\" docstring at lines 308-311; pivot `retryable = method.upper() == \"GET\"` at line 322. Analysis cites 322-331 \u2014 accurate.\n- The v1 read routes `/api/v1/jira/ticket/get`, `/search`, `/ticket/comments`, `/execute` exist at lines 4365/4448/4572/4634 \u2713.\n- All referenced building blocks (`auth.py require_session_auth`, `mode_gate.py @require_private_mode`, `jira_policy.py JiraPolicy`, `jira_credentials.py JiraCredentialsManager`, `sandbox/scripts/jira`) exist as cited.\n\n### 3. Options Analysis \u2014 five axes, well-reasoned\n\nThe five-axis split (endpoint shape / method-allowlist separation / body validation / idempotency / wrapper UX) covers the design space cleanly. Every option carries explicit pros/cons; rejections are stated (\"**Rejected**\") rather than implied. Particular strengths:\n- **A1 vs A2** correctly identifies that generalizing `/execute` would couple read and write invariants \u2014 agree with reject.\n- **B1 vs B2** keeps `validate_jira_api_path`'s contract narrow and leverages the path validator only against user-supplied paths, while writes hardcode their paths in client methods. Right call.\n- **D1 idempotency cache** is the right shape for the orchestrator's retry pattern; D2 is correctly noted as not viable (Atlassian doesn't support idempotency keys natively).\n- **C1 curated body validation** correctly identifies the custom-field smuggling risk (Security Level / Components / watchers / Sprint).\n\n### 4. Constraints \u2014 comprehensive, threat model is implicit\n\nSecurity/architectural block at lines 82-93 is tight. The \"project allowlist gate is `request.body.fields.project.key` for create, ticket key for edit/comment/link\" detail (line 88) is exactly the right level of specificity for a refine doc. The `/execute` GET-only invariant is preserved by construction (line 87). Idempotency, ADF handling, per-instance Jira customization (Epic Link mechanism), and rate-limit policy are each surfaced under Operational. External Atlassian REST docs are linked.\n\n### 5. Open Questions \u2014 all 27 registered, well-scoped\n\nVerified against `.egg-state/contracts/issue-1924.json`:\n- 18 contract decisions (decision-1..decision-18) map cleanly to Q1-Q11, Q13, Q14, Q16, Q17, Q23, Q24, Q27 \u2014 multiple-choice questions.\n- 9 feedback items (Q1..Q9 in the feedback block) map to Q12, Q15, Q18, Q19, Q20, Q21, Q22, Q25, Q26 \u2014 open-ended questions.\n\nEach question is specific and actionable. No prose-only questions floating without a contract entry.\n\n### 6. Recommendation Quality \u2014 concrete and grounded\n\nThe recommendation table at lines 313-318 names each new route, its Atlassian endpoint, its audit operation name, and the relevant policy gate per verb. It follows from the options analysis (A1+B1+C1+D1+E1). Test surface (per-route 403 grid, route-enumeration regression update, idempotency test file, sandbox-wrapper smoke tests, adversarial bodies) and documentation home are listed. Complexity assessment (medium, ~1,200 LoC) is reasonable.\n\n### 7. HITL Decision Registration \u2014 fully compliant\n\nEvery open question is registered. No assumptions silently baked in beyond the explicit recommendation.\n\n### Non-blocking \u2014 items the planner should be aware of\n\n- **`.../ticket/comment/add` route name (line 317).** The recommendation pairs the singular noun with an `/add` action suffix, which departs from the v1 plural-noun style (`/ticket/comments`) and the `gh` wrapper's noun-action shape (`/api/v1/gh/pr/create`). Two acceptable resolutions: (a) match the create style \u2014 `POST /api/v1/jira/ticket/comment/create`; (b) keep `/comment/add` and document the deliberate divergence. Either way, fix the inconsistency at plan time so the operator-facing surface is uniform.\n\n- **`createIssueLink` idempotency dismissal (D1, line 239).** The analysis says links are \"naturally unique per `inward+outward+type`,\" but Atlassian's `POST /rest/api/3/issueLink` will happily create duplicate link records with the same triple \u2014 Atlassian assigns each link its own ID and does not de-dup. If the orchestrator retries a `createIssueLink` after a transient 5xx, the second call will create a second link. Recommend the planner either (i) extend the idempotency-key + cache to `createIssueLink` for symmetry, or (ii) document explicitly that the orchestrator's plan-apply must scan existing `inwardIssue` links before retrying link creation, or (iii) add a 28th open question. Surface this as a coverage gap to plan.\n\n- **Recommendation table preempts Q4 (line 318).** \"link `type.name` against a configurable allowlist (default `Blocks`, `Relates`)\" assumes the operator-configurable path. The plan should treat this as contingent on the human's answer to decision-4 (hardcoded vs config vs any).\n\n- **Cross-project parent (Q17) and createIssueLink cross-project (Q9) overlap conceptually.** Both ask \"can a write reference an off-allowlist project?\" Distinct enough to keep separate, but the planner should answer them consistently \u2014 accepting cross-project on one and rejecting on the other would be surprising.\n\n- **Idempotency-cache TTL = 5 minutes** is a reasonable default but is not yet a contract decision \u2014 the orchestrator's actual retry window for write failures should drive this. Decision-14 (\"Idempotency cache scope\") covers in-memory-vs-persistent but not the TTL itself; planner may want to size the TTL after the orchestrator side is sketched.\n\n- **Bot account / token attribution.** Constraints mention Atlassian's recommendation against API tokens for production integrations carries through from #1556 (line 117), but the doc doesn't restate that a dedicated bot Atlassian account is required for clean attribution on writes. Worth restating in the plan's Implementation Notes so the operator doesn't accidentally point the gateway at a personal token.\n\n- **Audit redaction of label values (Q20 \u2192 feedback Q5).** The \"log only structural metadata\" stance is right for descriptions/comments, but labels themselves are often the point of an audit (\"agent added `wontfix`\" \u2014 useful) and short. Worth explicitly carving labels out of the redaction rule when Q20 is answered.\n\n- **Test file path `tests/sandbox/test_jira_wrapper.py`.** The pattern matches existing `tests/sandbox/test_confluence_wrapper.py`, so the proposed location is right.\n\nNone of these are refine-blocking \u2014 the human reviewer has the surface area and the planner has enough material to draft the implementation plan after Q1-Q27 resolve.\n"
+      },
+      "version": 1
+    },
+    "timestamp": "2026-04-27T18:52:17.277093+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "c3f87e9a-cf28-40",
+    "pipeline_id": "issue-1924",
+    "from_role": "orchestrator",
+    "to_role": "refiner",
+    "message_type": "STATUS",
+    "subject": "Ready to confirm \u2014 all confirm preconditions satisfied",
+    "body": "Your proposal (version 1) is ready to confirm \u2014 all blocking reviews are clear and global confirm preconditions are met. Run `egg-orch consensus confirmed` to confirm.",
+    "metadata": {
+      "ready_to_confirm": true,
+      "version": 1
+    },
+    "timestamp": "2026-04-27T18:52:17.277126+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "26f24a2d-e828-48",
+    "pipeline_id": "issue-1924",
+    "from_role": "refiner",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T18:52:17.359845+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "48e1945d-79c5-4a",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_refine",
+    "to_role": "all",
+    "message_type": "CONSENSUS_CONFIRMED",
+    "subject": "Confirmed by reviewer_refine",
+    "body": "",
+    "metadata": {
+      "consensus_reached": false
+    },
+    "timestamp": "2026-04-27T18:52:28.186426+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "e6d78193-00b0-42",
+    "pipeline_id": "issue-1924",
+    "from_role": "refiner",
+    "to_role": "all",
+    "message_type": "CONSENSUS_CONFIRMED",
+    "subject": "Confirmed by refiner",
+    "body": "",
+    "metadata": {
+      "consensus_reached": true
+    },
+    "timestamp": "2026-04-27T18:52:28.685139+00:00",
+    "phase": "refine"
+  },
+  {
+    "id": "5a5ec7be-d322-49",
+    "pipeline_id": "issue-1924",
+    "from_role": "reviewer_agent_design",
+    "to_role": "all",
+    "message_type": "HEARTBEAT",
+    "subject": "heartbeat: WORKING",
+    "body": "wait_loop exited",
+    "metadata": {
+      "state": "WORKING"
+    },
+    "timestamp": "2026-04-27T18:52:28.699494+00:00",
+    "phase": "refine"
+  }
+]

--- a/.egg-state/brc-history/1924-refine.md
+++ b/.egg-state/brc-history/1924-refine.md
@@ -1,0 +1,803 @@
+# BRC Consensus History — refine phase
+
+Generated: 2026-04-27T18:52:28Z
+Pipeline: issue-1924
+
+### [2026-04-27T18:39:38Z] reviewer_refine (HEARTBEAT): heartbeat: WAITING_ON_ROLE
+
+Reviewer prepared; waiting for refiner CONSENSUS_PROPOSE on issue-1924 refine analysis.
+
+````yaml
+id: 3a84cf4d-39c9-41
+phase: refine
+metadata:
+  state: WAITING_ON_ROLE
+  waiting_on: refiner
+````
+
+### [2026-04-27T18:39:49Z] reviewer_refine (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: 792f39d4-2925-46
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:49.699886+00:00'
+````
+
+### [2026-04-27T18:39:51Z] reviewer_agent_design (HEARTBEAT): heartbeat: WAITING_ON_ROLE
+
+````yaml
+id: a2191044-014b-4a
+phase: refine
+metadata:
+  state: WAITING_ON_ROLE
+  waiting_on: refiner
+````
+
+### [2026-04-27T18:39:56Z] reviewer_agent_design (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: 004119c6-55f1-46
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:56.065969+00:00'
+````
+
+### [2026-04-27T18:40:49Z] reviewer_refine (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: 54d0d6a9-0462-48
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:49.699886+00:00'
+````
+
+### [2026-04-27T18:40:56Z] reviewer_agent_design (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: 4681c40b-8f83-4c
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:56.065969+00:00'
+````
+
+### [2026-04-27T18:41:50Z] reviewer_refine (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: 19595b88-5534-43
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:49.699886+00:00'
+````
+
+### [2026-04-27T18:41:56Z] reviewer_agent_design (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: 376cde0f-b5bc-47
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:56.065969+00:00'
+````
+
+### [2026-04-27T18:42:50Z] reviewer_refine (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: e90efc6f-ff75-43
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:49.699886+00:00'
+````
+
+### [2026-04-27T18:42:57Z] reviewer_agent_design (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: a0e6b8ab-7e51-44
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:56.065969+00:00'
+````
+
+### [2026-04-27T18:43:50Z] reviewer_refine (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: 090f569a-899b-45
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:49.699886+00:00'
+````
+
+### [2026-04-27T18:43:57Z] reviewer_agent_design (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: 381f10ce-83ba-44
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:56.065969+00:00'
+````
+
+### [2026-04-27T18:44:51Z] reviewer_refine (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: af31b6be-fa95-40
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:49.699886+00:00'
+````
+
+### [2026-04-27T18:44:57Z] reviewer_agent_design (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: 8faba815-1d84-4a
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:56.065969+00:00'
+````
+
+### [2026-04-27T18:45:51Z] reviewer_refine (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: 0b1df359-5fc9-48
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:49.699886+00:00'
+````
+
+### [2026-04-27T18:45:57Z] reviewer_agent_design (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: d65ac9bf-a375-40
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:56.065969+00:00'
+````
+
+### [2026-04-27T18:46:51Z] reviewer_refine (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: 502b494b-1df2-4b
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:49.699886+00:00'
+````
+
+### [2026-04-27T18:46:58Z] reviewer_agent_design (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: f4b3a035-e3e9-47
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:56.065969+00:00'
+````
+
+### [2026-04-27T18:47:51Z] reviewer_refine (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: f29796d6-14f3-42
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:49.699886+00:00'
+````
+
+### [2026-04-27T18:47:58Z] reviewer_agent_design (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: d65bd3f4-b746-4d
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:56.065969+00:00'
+````
+
+### [2026-04-27T18:48:52Z] reviewer_refine (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: 1fd3b76b-805e-4d
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:49.699886+00:00'
+````
+
+### [2026-04-27T18:48:58Z] reviewer_agent_design (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE from=refiner
+
+````yaml
+id: 5295741e-de98-45
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:39:56.065969+00:00'
+````
+
+### [2026-04-27T18:49:23Z] refiner (CONSENSUS_PROPOSE): Proposal from refiner
+
+Refine analysis drafted for #1924 (Jira gateway writes). Surveys the existing v1 read-only surface delivered by #1556 (gateway/jira_client.py, gateway/jira_policy.py, gateway/jira_credentials.py, sandbox/scripts/jira), enumerates the four target Atlassian write endpoints (POST /issue, PUT /issue/{key}, POST /issue/{key}/comment, POST /issueLink) with their wire shapes, and recommends four dedicated narrow gateway routes (POST /api/v1/jira/ticket/create | edit | comment/add | issue-link/create) plus a per-route body schema, ADF wrapping helper, gateway-side idempotency cache, and a clean separation between the GET-only /execute passthrough and write client methods. Permanent denylist (transitions/worklog/attachments/watchers/DELETE) preserved. Surfaces 18 multiple-choice HITL decisions (custom-field allowlist, Epic Link mechanism, idempotency policy, link-type allowlist, role/phase gating, response shapes, dry-run, docs home) and 9 free-form feedback questions (rate-limit policy, body size caps, existence probe, wrapper flags, audit redaction, test layout, multi-tenant hooks, rollback responsibility, error envelope shape). Complexity: medium. Draft committed as 27ac5b150 and ready for reviewer_refine + reviewer_agent_design review.
+
+````yaml
+id: 3c69b6c7-22c3-49
+phase: refine
+metadata:
+  payload:
+    summary: 'Refine analysis drafted for #1924 (Jira gateway writes). Surveys the
+      existing v1 read-only surface delivered by #1556 (gateway/jira_client.py, gateway/jira_policy.py,
+      gateway/jira_credentials.py, sandbox/scripts/jira), enumerates the four target
+      Atlassian write endpoints (POST /issue, PUT /issue/{key}, POST /issue/{key}/comment,
+      POST /issueLink) with their wire shapes, and recommends four dedicated narrow
+      gateway routes (POST /api/v1/jira/ticket/create | edit | comment/add | issue-link/create)
+      plus a per-route body schema, ADF wrapping helper, gateway-side idempotency
+      cache, and a clean separation between the GET-only /execute passthrough and
+      write client methods. Permanent denylist (transitions/worklog/attachments/watchers/DELETE)
+      preserved. Surfaces 18 multiple-choice HITL decisions (custom-field allowlist,
+      Epic Link mechanism, idempotency policy, link-type allowlist, role/phase gating,
+      response shapes, dry-run, docs home) and 9 free-form feedback questions (rate-limit
+      policy, body size caps, existence probe, wrapper flags, audit redaction, test
+      layout, multi-tenant hooks, rollback responsibility, error envelope shape).
+      Complexity: medium. Draft committed as 27ac5b150 and ready for reviewer_refine
+      + reviewer_agent_design review.'
+    attestation: {}
+    artifacts:
+    - .egg-state/drafts/1924-analysis.md
+    risk_considered: "Open questions are extensive (27 in total) \u2014 risk of overload\
+      \ for human reviewer, but each captures a real decision the plan phase needs\
+      \ (custom-field allowlist scope, Epic Link mechanism, idempotency model, link-type\
+      \ allowlist, role/phase gating). Skipping any of them would force plan to hardcode\
+      \ an assumption. The recommended approach (A1+B1+C1+D1+E1) is conservative and\
+      \ additive \u2014 preserves all v1 invariants and matches the v1 verb-noun pattern,\
+      \ so risk of plan-phase rework is low."
+    commit_sha: 27ac5b1507c105481c83189b444a282985d6663f
+    files_changed:
+    - .egg-state/drafts/1924-analysis.md
+    tests_run: []
+    tasks_satisfied: []
+  version: 1
+  commit_sha: 27ac5b1507c105481c83189b444a282985d6663f
+````
+
+### [2026-04-27T18:49:24Z] reviewer_refine (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 828afce9-a872-45
+phase: refine
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T18:49:24Z] reviewer_agent_design (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: d1bfa1f7-b51f-40
+phase: refine
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T18:49:32Z] refiner (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: b57bef08-32a7-4e
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:49:30.687479+00:00'
+````
+
+### [2026-04-27T18:49:32Z] refiner (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 789f5cc5-45f7-44
+phase: refine
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T18:49:35Z] refiner (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: 2cd01155-55e3-48
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:49:35.833475+00:00'
+````
+
+### [2026-04-27T18:50:36Z] refiner (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT
+
+````yaml
+id: a9615c2f-982f-46
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:49:35.833475+00:00'
+````
+
+### [2026-04-27T18:50:42Z] reviewer_agent_design → refiner (CONSENSUS_ACK): ACK from reviewer_agent_design for refiner
+
+
+Reviewed `.egg-state/drafts/1924-analysis.md` end-to-end (522 lines) against the agent-mode design rubric (`docs/guides/agent-mode-design.md`). No agent-mode anti-patterns found. The recommended design (A1+B1+C1+D1+E1) actually *strengthens* agent-mode properties on several axes:
+
+**What the design gets right (agent-mode lens):**
+
+- **Sandbox-enforced security, not prompt-level.** Every hard invariant (project allowlist, `@require_private_mode`, `@require_session_auth`, body-shape validation, permanent `transitions/worklog/attachments/watchers/DELETE` denylist, zero credentials in sandbox) lives in gateway code. Nothing relies on instructing the agent "don't do X." Matches `docs/guides/agent-mode-design.md` "infra-level constraints beat config-level allowlists" (which the doc itself quotes from #1556's body).
+- **Per-verb narrow routes (A1) over generic dispatcher (A2).** Picking four per-verb routes with per-verb audit operation names + per-verb body validators is the agent-friendlier choice: each verb has a tight, reasoned-about surface, and `/execute`'s GET-only invariant cannot be widened by a write-side mistake. The A2 rejection rationale (lines 152–157) explicitly cites "verb allowlist by construction" — the right primitive to preserve.
+- **B1 method-allowlist split.** Keeping `validate_jira_api_path` GET-only and letting the dedicated write-client methods hardcode their own paths/methods is the cleanest separation. A future maintainer cannot accidentally widen `/execute` into write territory by editing one config knob (B2's failure mode, correctly rejected at line 184–190).
+- **Plain-text → ADF wrapping in the gateway (E1, C1).** This is wire-format adaptation, not a post-processing pipeline — the agent expresses intent in the natural format (`--description "..."`), and the gateway adapts to Atlassian's wire shape. It removes a class of bug (agents constructing ADF JSON in bash heredocs) without re-interpreting the agent's output to take new actions. Mirrors the established `gh pr create --body-file` ergonomics from the existing `gh` wrapper, so agents get a consistent affordance across tools.
+- **Curated field allowlist (C1).** Rejecting C2 passthrough is correct. Pure passthrough would let agents smuggle `Security Level`, `Components`, `Sprint`, watchers, etc. into write bodies — exactly the "config-level allowlist beaten by infra-level constraint" pattern. The explicit `customFields` opt-in map (with operator allowlist as Open Q1) keeps the dangerous surface gated by config, not by agent restraint.
+- **No structured-output-for-humans issue.** The gateway's response envelope (`{key, id, browse_url, status}` etc.) is consumed by orchestrator/sandbox code, never rendered to a human. Open Q13/Q14 surfacing the envelope shape is appropriate.
+- **No LLM-API anti-patterns.** This isn't LLM code — `EGG200` and `EGG201` (model-id / direct-Anthropic-API rules) don't apply, and the analysis doesn't introduce any LLM call sites.
+- **No excessive pre-fetching.** Existing-issue probe before create (Open Q18) is correctly *surfaced as an open question* rather than prescribed. If the human picks "yes, probe," that's an explicit operator choice, not a baked-in fragility.
+- **Idempotency cache (D1) is caller-supplied keys, not magic.** The orchestrator can derive `(pipeline_id, plan_node_id)` keys; the gateway is a transparent dedup layer with bounded memory. No agent prompt mentions idempotency — the contract is at the API, where it belongs.
+- **Open Q10/Q11 (per-role / per-phase write gating).** Both proposed via `gateway/phase_filter.py` style, i.e. enforced at the gateway layer if adopted. Even when the question is "should we constrain agents," the answer mechanism is sandbox-enforced. Correct framing.
+
+**Borderline items I deliberately did not flag:**
+
+- Open Q24 (`?dry_run=true`) could in principle become a "preview API the agent re-parses" anti-pattern, but the analysis frames it as orchestrator-side preview ergonomics, and the recommended path leaves it open for human decision. Not a current concern.
+- The plain-text-vs-ADF accept-both option (E1 + Open Q7) introduces a small dual-path; the gateway code complexity is fine for the agent ergonomics it buys, and the design is consistent (gateway always sends ADF upstream).
+
+No blocking items. Approving for the agent-design dimension.
+
+
+````yaml
+id: a9df1124-5af8-41
+phase: refine
+metadata:
+  payload:
+    artifact_references:
+    - .egg-state/drafts/1924-analysis.md
+    reason: "\nReviewed `.egg-state/drafts/1924-analysis.md` end-to-end (522 lines)\
+      \ against the agent-mode design rubric (`docs/guides/agent-mode-design.md`).\
+      \ No agent-mode anti-patterns found. The recommended design (A1+B1+C1+D1+E1)\
+      \ actually *strengthens* agent-mode properties on several axes:\n\n**What the\
+      \ design gets right (agent-mode lens):**\n\n- **Sandbox-enforced security, not\
+      \ prompt-level.** Every hard invariant (project allowlist, `@require_private_mode`,\
+      \ `@require_session_auth`, body-shape validation, permanent `transitions/worklog/attachments/watchers/DELETE`\
+      \ denylist, zero credentials in sandbox) lives in gateway code. Nothing relies\
+      \ on instructing the agent \"don't do X.\" Matches `docs/guides/agent-mode-design.md`\
+      \ \"infra-level constraints beat config-level allowlists\" (which the doc itself\
+      \ quotes from #1556's body).\n- **Per-verb narrow routes (A1) over generic dispatcher\
+      \ (A2).** Picking four per-verb routes with per-verb audit operation names +\
+      \ per-verb body validators is the agent-friendlier choice: each verb has a tight,\
+      \ reasoned-about surface, and `/execute`'s GET-only invariant cannot be widened\
+      \ by a write-side mistake. The A2 rejection rationale (lines 152\u2013157) explicitly\
+      \ cites \"verb allowlist by construction\" \u2014 the right primitive to preserve.\n\
+      - **B1 method-allowlist split.** Keeping `validate_jira_api_path` GET-only and\
+      \ letting the dedicated write-client methods hardcode their own paths/methods\
+      \ is the cleanest separation. A future maintainer cannot accidentally widen\
+      \ `/execute` into write territory by editing one config knob (B2's failure mode,\
+      \ correctly rejected at line 184\u2013190).\n- **Plain-text \u2192 ADF wrapping\
+      \ in the gateway (E1, C1).** This is wire-format adaptation, not a post-processing\
+      \ pipeline \u2014 the agent expresses intent in the natural format (`--description\
+      \ \"...\"`), and the gateway adapts to Atlassian's wire shape. It removes a\
+      \ class of bug (agents constructing ADF JSON in bash heredocs) without re-interpreting\
+      \ the agent's output to take new actions. Mirrors the established `gh pr create\
+      \ --body-file` ergonomics from the existing `gh` wrapper, so agents get a consistent\
+      \ affordance across tools.\n- **Curated field allowlist (C1).** Rejecting C2\
+      \ passthrough is correct. Pure passthrough would let agents smuggle `Security\
+      \ Level`, `Components`, `Sprint`, watchers, etc. into write bodies \u2014 exactly\
+      \ the \"config-level allowlist beaten by infra-level constraint\" pattern. The\
+      \ explicit `customFields` opt-in map (with operator allowlist as Open Q1) keeps\
+      \ the dangerous surface gated by config, not by agent restraint.\n- **No structured-output-for-humans\
+      \ issue.** The gateway's response envelope (`{key, id, browse_url, status}`\
+      \ etc.) is consumed by orchestrator/sandbox code, never rendered to a human.\
+      \ Open Q13/Q14 surfacing the envelope shape is appropriate.\n- **No LLM-API\
+      \ anti-patterns.** This isn't LLM code \u2014 `EGG200` and `EGG201` (model-id\
+      \ / direct-Anthropic-API rules) don't apply, and the analysis doesn't introduce\
+      \ any LLM call sites.\n- **No excessive pre-fetching.** Existing-issue probe\
+      \ before create (Open Q18) is correctly *surfaced as an open question* rather\
+      \ than prescribed. If the human picks \"yes, probe,\" that's an explicit operator\
+      \ choice, not a baked-in fragility.\n- **Idempotency cache (D1) is caller-supplied\
+      \ keys, not magic.** The orchestrator can derive `(pipeline_id, plan_node_id)`\
+      \ keys; the gateway is a transparent dedup layer with bounded memory. No agent\
+      \ prompt mentions idempotency \u2014 the contract is at the API, where it belongs.\n\
+      - **Open Q10/Q11 (per-role / per-phase write gating).** Both proposed via `gateway/phase_filter.py`\
+      \ style, i.e. enforced at the gateway layer if adopted. Even when the question\
+      \ is \"should we constrain agents,\" the answer mechanism is sandbox-enforced.\
+      \ Correct framing.\n\n**Borderline items I deliberately did not flag:**\n\n\
+      - Open Q24 (`?dry_run=true`) could in principle become a \"preview API the agent\
+      \ re-parses\" anti-pattern, but the analysis frames it as orchestrator-side\
+      \ preview ergonomics, and the recommended path leaves it open for human decision.\
+      \ Not a current concern.\n- The plain-text-vs-ADF accept-both option (E1 + Open\
+      \ Q7) introduces a small dual-path; the gateway code complexity is fine for\
+      \ the agent ergonomics it buys, and the design is consistent (gateway always\
+      \ sends ADF upstream).\n\nNo blocking items. Approving for the agent-design\
+      \ dimension.\n"
+  version: 1
+````
+
+### [2026-04-27T18:50:42Z] refiner (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 8f340b8f-e95d-4e
+phase: refine
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T18:50:46Z] reviewer_agent_design (CONSENSUS_CONFIRMED): Confirmed by reviewer_agent_design
+
+````yaml
+id: 5f51212e-7665-4e
+phase: refine
+metadata:
+  consensus_reached: false
+````
+
+### [2026-04-27T18:50:51Z] refiner (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT from=reviewer_refine
+
+````yaml
+id: e6800920-07bc-4b
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:50:50.951072+00:00'
+````
+
+### [2026-04-27T18:50:52Z] reviewer_agent_design (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT
+
+````yaml
+id: 423cf167-4e04-43
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:50:51.896329+00:00'
+````
+
+### [2026-04-27T18:50:52Z] reviewer_agent_design (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 6398bc94-e81b-4d
+phase: refine
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T18:51:03Z] reviewer_agent_design (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT
+
+````yaml
+id: 96d2e1cf-5ff9-45
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:51:02.962405+00:00'
+````
+
+### [2026-04-27T18:51:51Z] refiner (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT from=reviewer_refine
+
+````yaml
+id: 1fbbef92-bf26-43
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:50:50.951072+00:00'
+````
+
+### [2026-04-27T18:52:03Z] reviewer_agent_design (HEARTBEAT): heartbeat: WAITING_FOR_EVENT
+
+wait_loop blocked on CONSENSUS_PROPOSE,CONSENSUS_RE_REVIEW,CONSENSUS_CONFIRMED,OVERSEER_ALERT
+
+````yaml
+id: e78dfc1a-aa7f-46
+phase: refine
+metadata:
+  state: WAITING_FOR_EVENT
+  since: '2026-04-27T18:51:02.962405+00:00'
+````
+
+### [2026-04-27T18:52:17Z] reviewer_refine → refiner (CONSENSUS_ACK): ACK from reviewer_refine for refiner
+
+
+## Refine Review — issue #1924 (Jira gateway write operations)
+
+**Verdict: ACK.** The analysis is comprehensive, accurate, and well-anchored to the existing #1556 v1 surface. All 27 open questions are registered as HITL contract items (18 decisions + 9 feedback). The recommended A1+B1+C1+D1+E1 design preserves every v1 invariant. Section-by-section findings below; non-blocking nits only.
+
+### 1. Problem Understanding — strong
+
+The framing is precise: the four verbs (`createJiraIssue`, `editJiraIssue`, `addCommentToJiraIssue`, `createIssueLink`) are exactly what #1557's plan-apply step needs (refine→epic Description sink, plan→child create + cross-link + consolidation comments). The "permanent denylist preserved" point at line 87 correctly nails the security boundary that distinguishes #1924 from #1556's "future-scope" carve-out.
+
+### 2. Research Quality — strong, code citations verified
+
+I cross-checked the file/line claims against the source:
+- `JIRA_WRITE_VERBS_DENIED` at `gateway/jira_client.py:95-108` ✓ (analysis cites it correctly as covering `transitions/worklog/attachments/watchers` plus `DELETE/PUT/PATCH`).
+- `ALLOWED_METHODS = frozenset({"GET"})` at line 89 ✓.
+- `JIRA_API_ALLOWED_PATHS` regex extension point at line 120 ✓.
+- `validate_jira_api_path` at line 179 ✓.
+- The "Retry is GET-only … future-safety if someone widens ALLOWED_METHODS" docstring at lines 308-311; pivot `retryable = method.upper() == "GET"` at line 322. Analysis cites 322-331 — accurate.
+- The v1 read routes `/api/v1/jira/ticket/get`, `/search`, `/ticket/comments`, `/execute` exist at lines 4365/4448/4572/4634 ✓.
+- All referenced building blocks (`auth.py require_session_auth`, `mode_gate.py @require_private_mode`, `jira_policy.py JiraPolicy`, `jira_credentials.py JiraCredentialsManager`, `sandbox/scripts/jira`) exist as cited.
+
+### 3. Options Analysis — five axes, well-reasoned
+
+The five-axis split (endpoint shape / method-allowlist separation / body validation / idempotency / wrapper UX) covers the design space cleanly. Every option carries explicit pros/cons; rejections are stated ("**Rejected**") rather than implied. Particular strengths:
+- **A1 vs A2** correctly identifies that generalizing `/execute` would couple read and write invariants — agree with reject.
+- **B1 vs B2** keeps `validate_jira_api_path`'s contract narrow and leverages the path validator only against user-supplied paths, while writes hardcode their paths in client methods. Right call.
+- **D1 idempotency cache** is the right shape for the orchestrator's retry pattern; D2 is correctly noted as not viable (Atlassian doesn't support idempotency keys natively).
+- **C1 curated body validation** correctly identifies the custom-field smuggling risk (Security Level / Components / watchers / Sprint).
+
+### 4. Constraints — comprehensive, threat model is implicit
+
+Security/architectural block at lines 82-93 is tight. The "project allowlist gate is `request.body.fields.project.key` for create, ticket key for edit/comment/link" detail (line 88) is exactly the right level of specificity for a refine doc. The `/execute` GET-only invariant is preserved by construction (line 87). Idempotency, ADF handling, per-instance Jira customization (Epic Link mechanism), and rate-limit policy are each surfaced under Operational. External Atlassian REST docs are linked.
+
+### 5. Open Questions — all 27 registered, well-scoped
+
+Verified against `.egg-state/contracts/issue-1924.json`:
+- 18 contract decisions (decision-1..decision-18) map cleanly to Q1-Q11, Q13, Q14, Q16, Q17, Q23, Q24, Q27 — multiple-choice questions.
+- 9 feedback items (Q1..Q9 in the feedback block) map to Q12, Q15, Q18, Q19, Q20, Q21, Q22, Q25, Q26 — open-ended questions.
+
+Each question is specific and actionable. No prose-only questions floating without a contract entry.
+
+### 6. Recommendation Quality — concrete and grounded
+
+The recommendation table at lines 313-318 names each new route, its Atlassian endpoint, its audit operation name, and the relevant policy gate per verb. It follows from the options analysis (A1+B1+C1+D1+E1). Test surface (per-route 403 grid, route-enumeration regression update, idempotency test file, sandbox-wrapper smoke tests, adversarial bodies) and documentation home are listed. Complexity assessment (medium, ~1,200 LoC) is reasonable.
+
+### 7. HITL Decision Registration — fully compliant
+
+Every open question is registered. No assumptions silently baked in beyond the explicit recommendation.
+
+### Non-blocking — items the planner should be aware of
+
+- **`.../ticket/comment/add` route name (line 317).** The recommendation pairs the singular noun with an `/add` action suffix, which departs from the v1 plural-noun style (`/ticket/comments`) and the `gh` wrapper's noun-action shape (`/api/v1/gh/pr/create`). Two acceptable resolutions: (a) match the create style — `POST /api/v1/jira/ticket/comment/create`; (b) keep `/comment/add` and document the deliberate divergence. Either way, fix the inconsistency at plan time so the operator-facing surface is uniform.
+
+- **`createIssueLink` idempotency dismissal (D1, line 239).** The analysis says links are "naturally unique per `inward+outward+type`," but Atlassian's `POST /rest/api/3/issueLink` will happily create duplicate link records with the same triple — Atlassian assigns each link its own ID and does not de-dup. If the orchestrator retries a `createIssueLink` after a transient 5xx, the second call will create a second link. Recommend the planner either (i) extend the idempotency-key + cache to `createIssueLink` for symmetry, or (ii) document explicitly that the orchestrator's plan-apply must scan existing `inwardIssue` links before retrying link creation, or (iii) add a 28th open question. Surface this as a coverage gap to plan.
+
+- **Recommendation table preempts Q4 (line 318).** "link `type.name` against a configurable allowlist (default `Blocks`, `Relates`)" assumes the operator-configurable path. The plan should treat this as contingent on the human's answer to decision-4 (hardcoded vs config vs any).
+
+- **Cross-project parent (Q17) and createIssueLink cross-project (Q9) overlap conceptually.** Both ask "can a write reference an off-allowlist project?" Distinct enough to keep separate, but the planner should answer them consistently — accepting cross-project on one and rejecting on the other would be surprising.
+
+- **Idempotency-cache TTL = 5 minutes** is a reasonable default but is not yet a contract decision — the orchestrator's actual retry window for write failures should drive this. Decision-14 ("Idempotency cache scope") covers in-memory-vs-persistent but not the TTL itself; planner may want to size the TTL after the orchestrator side is sketched.
+
+- **Bot account / token attribution.** Constraints mention Atlassian's recommendation against API tokens for production integrations carries through from #1556 (line 117), but the doc doesn't restate that a dedicated bot Atlassian account is required for clean attribution on writes. Worth restating in the plan's Implementation Notes so the operator doesn't accidentally point the gateway at a personal token.
+
+- **Audit redaction of label values (Q20 → feedback Q5).** The "log only structural metadata" stance is right for descriptions/comments, but labels themselves are often the point of an audit ("agent added `wontfix`" — useful) and short. Worth explicitly carving labels out of the redaction rule when Q20 is answered.
+
+- **Test file path `tests/sandbox/test_jira_wrapper.py`.** The pattern matches existing `tests/sandbox/test_confluence_wrapper.py`, so the proposed location is right.
+
+None of these are refine-blocking — the human reviewer has the surface area and the planner has enough material to draft the implementation plan after Q1-Q27 resolve.
+
+
+````yaml
+id: e76cfca9-e91c-45
+phase: refine
+metadata:
+  payload:
+    artifact_references:
+    - .egg-state/drafts/1924-analysis.md
+    - .egg-state/contracts/issue-1924.json
+    - gateway/jira_client.py
+    - gateway/gateway.py
+    - gateway/tests/test_jira_routes.py
+    - sandbox/scripts/jira
+    reason: "\n## Refine Review \u2014 issue #1924 (Jira gateway write operations)\n\
+      \n**Verdict: ACK.** The analysis is comprehensive, accurate, and well-anchored\
+      \ to the existing #1556 v1 surface. All 27 open questions are registered as\
+      \ HITL contract items (18 decisions + 9 feedback). The recommended A1+B1+C1+D1+E1\
+      \ design preserves every v1 invariant. Section-by-section findings below; non-blocking\
+      \ nits only.\n\n### 1. Problem Understanding \u2014 strong\n\nThe framing is\
+      \ precise: the four verbs (`createJiraIssue`, `editJiraIssue`, `addCommentToJiraIssue`,\
+      \ `createIssueLink`) are exactly what #1557's plan-apply step needs (refine\u2192\
+      epic Description sink, plan\u2192child create + cross-link + consolidation comments).\
+      \ The \"permanent denylist preserved\" point at line 87 correctly nails the\
+      \ security boundary that distinguishes #1924 from #1556's \"future-scope\" carve-out.\n\
+      \n### 2. Research Quality \u2014 strong, code citations verified\n\nI cross-checked\
+      \ the file/line claims against the source:\n- `JIRA_WRITE_VERBS_DENIED` at `gateway/jira_client.py:95-108`\
+      \ \u2713 (analysis cites it correctly as covering `transitions/worklog/attachments/watchers`\
+      \ plus `DELETE/PUT/PATCH`).\n- `ALLOWED_METHODS = frozenset({\"GET\"})` at line\
+      \ 89 \u2713.\n- `JIRA_API_ALLOWED_PATHS` regex extension point at line 120 \u2713\
+      .\n- `validate_jira_api_path` at line 179 \u2713.\n- The \"Retry is GET-only\
+      \ \u2026 future-safety if someone widens ALLOWED_METHODS\" docstring at lines\
+      \ 308-311; pivot `retryable = method.upper() == \"GET\"` at line 322. Analysis\
+      \ cites 322-331 \u2014 accurate.\n- The v1 read routes `/api/v1/jira/ticket/get`,\
+      \ `/search`, `/ticket/comments`, `/execute` exist at lines 4365/4448/4572/4634\
+      \ \u2713.\n- All referenced building blocks (`auth.py require_session_auth`,\
+      \ `mode_gate.py @require_private_mode`, `jira_policy.py JiraPolicy`, `jira_credentials.py\
+      \ JiraCredentialsManager`, `sandbox/scripts/jira`) exist as cited.\n\n### 3.\
+      \ Options Analysis \u2014 five axes, well-reasoned\n\nThe five-axis split (endpoint\
+      \ shape / method-allowlist separation / body validation / idempotency / wrapper\
+      \ UX) covers the design space cleanly. Every option carries explicit pros/cons;\
+      \ rejections are stated (\"**Rejected**\") rather than implied. Particular strengths:\n\
+      - **A1 vs A2** correctly identifies that generalizing `/execute` would couple\
+      \ read and write invariants \u2014 agree with reject.\n- **B1 vs B2** keeps\
+      \ `validate_jira_api_path`'s contract narrow and leverages the path validator\
+      \ only against user-supplied paths, while writes hardcode their paths in client\
+      \ methods. Right call.\n- **D1 idempotency cache** is the right shape for the\
+      \ orchestrator's retry pattern; D2 is correctly noted as not viable (Atlassian\
+      \ doesn't support idempotency keys natively).\n- **C1 curated body validation**\
+      \ correctly identifies the custom-field smuggling risk (Security Level / Components\
+      \ / watchers / Sprint).\n\n### 4. Constraints \u2014 comprehensive, threat model\
+      \ is implicit\n\nSecurity/architectural block at lines 82-93 is tight. The \"\
+      project allowlist gate is `request.body.fields.project.key` for create, ticket\
+      \ key for edit/comment/link\" detail (line 88) is exactly the right level of\
+      \ specificity for a refine doc. The `/execute` GET-only invariant is preserved\
+      \ by construction (line 87). Idempotency, ADF handling, per-instance Jira customization\
+      \ (Epic Link mechanism), and rate-limit policy are each surfaced under Operational.\
+      \ External Atlassian REST docs are linked.\n\n### 5. Open Questions \u2014 all\
+      \ 27 registered, well-scoped\n\nVerified against `.egg-state/contracts/issue-1924.json`:\n\
+      - 18 contract decisions (decision-1..decision-18) map cleanly to Q1-Q11, Q13,\
+      \ Q14, Q16, Q17, Q23, Q24, Q27 \u2014 multiple-choice questions.\n- 9 feedback\
+      \ items (Q1..Q9 in the feedback block) map to Q12, Q15, Q18, Q19, Q20, Q21,\
+      \ Q22, Q25, Q26 \u2014 open-ended questions.\n\nEach question is specific and\
+      \ actionable. No prose-only questions floating without a contract entry.\n\n\
+      ### 6. Recommendation Quality \u2014 concrete and grounded\n\nThe recommendation\
+      \ table at lines 313-318 names each new route, its Atlassian endpoint, its audit\
+      \ operation name, and the relevant policy gate per verb. It follows from the\
+      \ options analysis (A1+B1+C1+D1+E1). Test surface (per-route 403 grid, route-enumeration\
+      \ regression update, idempotency test file, sandbox-wrapper smoke tests, adversarial\
+      \ bodies) and documentation home are listed. Complexity assessment (medium,\
+      \ ~1,200 LoC) is reasonable.\n\n### 7. HITL Decision Registration \u2014 fully\
+      \ compliant\n\nEvery open question is registered. No assumptions silently baked\
+      \ in beyond the explicit recommendation.\n\n### Non-blocking \u2014 items the\
+      \ planner should be aware of\n\n- **`.../ticket/comment/add` route name (line\
+      \ 317).** The recommendation pairs the singular noun with an `/add` action suffix,\
+      \ which departs from the v1 plural-noun style (`/ticket/comments`) and the `gh`\
+      \ wrapper's noun-action shape (`/api/v1/gh/pr/create`). Two acceptable resolutions:\
+      \ (a) match the create style \u2014 `POST /api/v1/jira/ticket/comment/create`;\
+      \ (b) keep `/comment/add` and document the deliberate divergence. Either way,\
+      \ fix the inconsistency at plan time so the operator-facing surface is uniform.\n\
+      \n- **`createIssueLink` idempotency dismissal (D1, line 239).** The analysis\
+      \ says links are \"naturally unique per `inward+outward+type`,\" but Atlassian's\
+      \ `POST /rest/api/3/issueLink` will happily create duplicate link records with\
+      \ the same triple \u2014 Atlassian assigns each link its own ID and does not\
+      \ de-dup. If the orchestrator retries a `createIssueLink` after a transient\
+      \ 5xx, the second call will create a second link. Recommend the planner either\
+      \ (i) extend the idempotency-key + cache to `createIssueLink` for symmetry,\
+      \ or (ii) document explicitly that the orchestrator's plan-apply must scan existing\
+      \ `inwardIssue` links before retrying link creation, or (iii) add a 28th open\
+      \ question. Surface this as a coverage gap to plan.\n\n- **Recommendation table\
+      \ preempts Q4 (line 318).** \"link `type.name` against a configurable allowlist\
+      \ (default `Blocks`, `Relates`)\" assumes the operator-configurable path. The\
+      \ plan should treat this as contingent on the human's answer to decision-4 (hardcoded\
+      \ vs config vs any).\n\n- **Cross-project parent (Q17) and createIssueLink cross-project\
+      \ (Q9) overlap conceptually.** Both ask \"can a write reference an off-allowlist\
+      \ project?\" Distinct enough to keep separate, but the planner should answer\
+      \ them consistently \u2014 accepting cross-project on one and rejecting on the\
+      \ other would be surprising.\n\n- **Idempotency-cache TTL = 5 minutes** is a\
+      \ reasonable default but is not yet a contract decision \u2014 the orchestrator's\
+      \ actual retry window for write failures should drive this. Decision-14 (\"\
+      Idempotency cache scope\") covers in-memory-vs-persistent but not the TTL itself;\
+      \ planner may want to size the TTL after the orchestrator side is sketched.\n\
+      \n- **Bot account / token attribution.** Constraints mention Atlassian's recommendation\
+      \ against API tokens for production integrations carries through from #1556\
+      \ (line 117), but the doc doesn't restate that a dedicated bot Atlassian account\
+      \ is required for clean attribution on writes. Worth restating in the plan's\
+      \ Implementation Notes so the operator doesn't accidentally point the gateway\
+      \ at a personal token.\n\n- **Audit redaction of label values (Q20 \u2192 feedback\
+      \ Q5).** The \"log only structural metadata\" stance is right for descriptions/comments,\
+      \ but labels themselves are often the point of an audit (\"agent added `wontfix`\"\
+      \ \u2014 useful) and short. Worth explicitly carving labels out of the redaction\
+      \ rule when Q20 is answered.\n\n- **Test file path `tests/sandbox/test_jira_wrapper.py`.**\
+      \ The pattern matches existing `tests/sandbox/test_confluence_wrapper.py`, so\
+      \ the proposed location is right.\n\nNone of these are refine-blocking \u2014\
+      \ the human reviewer has the surface area and the planner has enough material\
+      \ to draft the implementation plan after Q1-Q27 resolve.\n"
+  version: 1
+````
+
+### [2026-04-27T18:52:17Z] orchestrator → refiner (STATUS): Ready to confirm — all confirm preconditions satisfied
+
+Your proposal (version 1) is ready to confirm — all blocking reviews are clear and global confirm preconditions are met. Run `egg-orch consensus confirmed` to confirm.
+
+````yaml
+id: c3f87e9a-cf28-40
+phase: refine
+metadata:
+  ready_to_confirm: true
+  version: 1
+````
+
+### [2026-04-27T18:52:17Z] refiner (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 26f24a2d-e828-48
+phase: refine
+metadata:
+  state: WORKING
+````
+
+### [2026-04-27T18:52:28Z] reviewer_refine (CONSENSUS_CONFIRMED): Confirmed by reviewer_refine
+
+````yaml
+id: 48e1945d-79c5-4a
+phase: refine
+metadata:
+  consensus_reached: false
+````
+
+### [2026-04-27T18:52:28Z] refiner (CONSENSUS_CONFIRMED): Confirmed by refiner
+
+````yaml
+id: e6d78193-00b0-42
+phase: refine
+metadata:
+  consensus_reached: true
+````
+
+### [2026-04-27T18:52:28Z] reviewer_agent_design (HEARTBEAT): heartbeat: WORKING
+
+wait_loop exited
+
+````yaml
+id: 5a5ec7be-d322-49
+phase: refine
+metadata:
+  state: WORKING
+````

--- a/.egg-state/contracts/issue-1924.json
+++ b/.egg-state/contracts/issue-1924.json
@@ -596,6 +596,18 @@
       "resolved_by": null,
       "resolved_at": null,
       "debounce_until": null
+    },
+    {
+      "id": "decision-20",
+      "question": "Open feedback request feedback-1",
+      "type": "hitl",
+      "phase": null,
+      "options": [],
+      "resolved": true,
+      "resolution": "{\"action\": \"submit_feedback\", \"answers\": {\"Q1\": \"Confirmed: no auto-retry on 429 for writes (matches v1 _request which restricts retry to GET). Yes \u2014 writes should still emit a jira_upstream_rate_limited audit on 429. Since the dedicated write client methods bypass _request's retry loop, the audit must fire from the write methods themselves (operation = jira_ticket_create / jira_ticket_edit / jira_comment_add / jira_issue_link_create) so 429s are still recorded.\", \"Q2\": \"summary: 255 chars (Atlassian default). description: 32 KB (32768 chars). labels: max 30 entries, each up to 50 chars. comment body: 32 KB. customFields map: max 32 entries (matches MAX_FIELDS in v1).\", \"Q3\": \"Idempotency key is sufficient for v1; no existing-issue probe. The idempotency cache (D1) covers the realistic retry window (transient 5xx within minutes); a probe would add upstream latency and a second failure surface for marginal benefit.\", \"Q4\": \"Confirmed: --description / --description-file / --description-stdin (and analogous --body / --body-file / --body-stdin for comment) match expected agent ergonomics. Mirrors gh wrapper conventions.\", \"Q5\": \"Yes \u2014 log only structural metadata (field names present, content lengths, label counts). Labels and link type names ARE loggable (operator-controlled, low-PII). Body content (summary, description, comment body) is NEVER logged verbatim.\", \"Q6\": \"Separate test_jira_writes_adversarial.py for adversarial body tests (oversized fields, custom-field smuggling, unknown issuetype, non-allowlisted link type). The per-route 403 grid stays in test_jira_routes.py.\", \"Q7\": \"Confirmed \u2014 v1 stays single-tenant exactly as #1556 left it. No multi-tenant work in #1924.\", \"Q8\": \"Confirmed \u2014 rollback / compensation is the orchestrator's responsibility. The gateway implements no transactions or compensating actions.\", \"Q9\": \"Reuse _jira_error_from_upstream verbatim for v1. Richer field-level error shapes are a follow-up if #1557 needs them.\"}}",
+      "resolved_by": "human",
+      "resolved_at": "2026-04-27T19:20:00.874308Z",
+      "debounce_until": null
     }
   ],
   "workflow_owner": null,

--- a/.egg-state/contracts/issue-1924.json
+++ b/.egg-state/contracts/issue-1924.json
@@ -9,15 +9,1502 @@
   "current_phase": "refine",
   "acceptance_criteria": [],
   "phases": [],
-  "decisions": [],
+  "decisions": [
+    {
+      "id": "decision-1",
+      "question": "Custom field exposure scope (Open Q1) \u2014 Beyond summary/description/labels/parent/epicLink, do we expose a generic customFields map in the create/edit body, and under what allowlist?",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Generic customFields map (any customfield_NNNN, only structural validation)",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "Operator-configured customField allowlist (config/context-filters.yaml: jira.custom_fields: [...])",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "No customFields map; only summary/description/labels/parent/epicLink shorthand exposed in v1",
+          "description": null
+        },
+        {
+          "id": "opt-4",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-2",
+      "question": "Epic Link mechanism (Open Q2) \u2014 How should the gateway place new tickets under an epic?",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "parent.key only (next-gen / company-managed)",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "customfield_10014 only (classic / team-managed)",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Auto-detect or accept either via the epicLink shorthand",
+          "description": null
+        },
+        {
+          "id": "opt-4",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-3",
+      "question": "idempotency_key requirement for createJiraIssue / addCommentToJiraIssue (Open Q3)",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Required (gateway 400 if missing)",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "Optional with documented warning",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Not implemented \u2014 caller responsibility",
+          "description": null
+        },
+        {
+          "id": "opt-4",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-4",
+      "question": "Link type allowlist source for createIssueLink (Open Q4)",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Hardcoded {Blocks, Relates}",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "config/context-filters.yaml jira.link_types: [...] (operator-configurable)",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Accept any name upstream Jira recognizes",
+          "description": null
+        },
+        {
+          "id": "opt-4",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-5",
+      "question": "notifyUsers default for editJiraIssue (Open Q5) \u2014 when caller doesn't specify, what should the gateway send to Atlassian?",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "true (Atlassian default \u2014 sends email)",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "false (quiet update; opt-in to notify)",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-6",
+      "question": "addCommentToJiraIssue visibility field (Open Q6) \u2014 should v1 expose role/group visibility restrictions on comments?",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Hide entirely in v1",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "Expose role/group restrictions",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-7",
+      "question": "Body input format for description / comment (Open Q7) \u2014 what shape do agents send?",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Plain text only (gateway wraps to ADF)",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "Pre-built ADF dict only (passthrough)",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Both \u2014 accept whichever the caller passes",
+          "description": null
+        },
+        {
+          "id": "opt-4",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-8",
+      "question": "Issuetype identifier accepted by createJiraIssue (Open Q8)",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Name only (Task / Story / Bug / Epic / Sub-task)",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "Numeric ID only",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Both",
+          "description": null
+        },
+        {
+          "id": "opt-4",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-9",
+      "question": "createIssueLink project allowlist semantics (Open Q9)",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Both inwardIssue and outwardIssue projects must be allowlisted (strict)",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "Only one needs to be allowlisted (loose)",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "One in main allowlist, the other in a separate 'linkable-only' config list",
+          "description": null
+        },
+        {
+          "id": "opt-4",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-10",
+      "question": "Per-role write gating (Open Q10) \u2014 should specific agent roles be the only ones allowed to call write verbs?",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Unrestricted within allowlisted projects",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "Per-verb role allowlist (e.g., refiner=editJiraIssue, planner=createJiraIssue/createIssueLink)",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Defer to a follow-up issue",
+          "description": null
+        },
+        {
+          "id": "opt-4",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-11",
+      "question": "Phase gating for writes (Open Q11) \u2014 restrict per SDLC phase?",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Unrestricted across phases",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "Per-phase verb allowlist via gateway/phase_filter.py",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Defer to a follow-up issue",
+          "description": null
+        },
+        {
+          "id": "opt-4",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-12",
+      "question": "createJiraIssue response shape (Open Q13)",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Atlassian raw {id, key, self}",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "Normalized envelope {key, id, browse_url, status: 'created'}",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-13",
+      "question": "editJiraIssue response shape (Open Q14)",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Envelope {status: 'updated', key} (no extra Atlassian call)",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "Echo post-edit ticket via Atlassian ?returnIssue=true (extra read latency)",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-14",
+      "question": "Idempotency cache scope (Open Q16)",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "In-memory per-gateway-process, 5-minute TTL",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "Persisted (disk or Redis) for multi-replica deployments",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-15",
+      "question": "Cross-project parent on createJiraIssue (Open Q17)",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Reject if parent.key project differs from new ticket project",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "Accept; let Atlassian decide",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-16",
+      "question": "createIssueLink optional comment payload (Open Q23)",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Surface via 'comment' field in body",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "Require a separate addCommentToJiraIssue call",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-17",
+      "question": "Dry-run / validation mode (Open Q24) \u2014 expose ?dry_run=true on each write route?",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Expose ?dry_run=true on each write route",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "Live calls only; orchestrator handles preview",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-18",
+      "question": "Documentation home for new write verbs (Open Q27)",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Extend existing docs/reference/jira-wrapper.md",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "New docs/reference/jira-writes.md plus link from jira-wrapper.md",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Both \u2014 high-level in jira-wrapper.md, deep dive in jira-writes.md",
+          "description": null
+        },
+        {
+          "id": "opt-4",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    },
+    {
+      "id": "decision-19",
+      "question": "createIssueLink idempotency (Open Q28, surfaced by reviewer_refine) \u2014 Atlassian's POST /rest/api/3/issueLink does not dedupe identical (inward, outward, type) triples; a retry after a transient 5xx creates a duplicate link. How should the gateway / orchestrator handle this?",
+      "type": "hitl",
+      "phase": "refine",
+      "options": [
+        {
+          "id": "opt-1",
+          "label": "Extend the idempotency-key + cache (D1) to createIssueLink for symmetry with createJiraIssue / addCommentToJiraIssue",
+          "description": null
+        },
+        {
+          "id": "opt-2",
+          "label": "Document that orchestrator's plan-apply must scan existing inwardIssue links before retrying createIssueLink",
+          "description": null
+        },
+        {
+          "id": "opt-3",
+          "label": "Accept duplicates; orchestrator de-dups separately as a follow-up",
+          "description": null
+        },
+        {
+          "id": "opt-4",
+          "label": "Other (explain in reply)",
+          "description": null
+        }
+      ],
+      "resolved": false,
+      "resolution": null,
+      "resolved_by": null,
+      "resolved_at": null,
+      "debounce_until": null
+    }
+  ],
   "workflow_owner": null,
-  "audit_log": [],
+  "audit_log": [
+    {
+      "timestamp": "2026-04-27T18:47:08.876582Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.0",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-1",
+        "question": "Custom field exposure scope (Open Q1) \u2014 Beyond summary/description/labels/parent/epicLink, do we expose a generic customFields map in the create/edit body, and under what allowlist?",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Generic customFields map (any customfield_NNNN, only structural validation)",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "Operator-configured customField allowlist (config/context-filters.yaml: jira.custom_fields: [...])",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "No customFields map; only summary/description/labels/parent/epicLink shorthand exposed in v1",
+            "description": null
+          },
+          {
+            "id": "opt-4",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: Custom field exposure scope (Open Q1) \u2014 Beyond sum...",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:47:08.919462Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.1",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-2",
+        "question": "Epic Link mechanism (Open Q2) \u2014 How should the gateway place new tickets under an epic?",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "parent.key only (next-gen / company-managed)",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "customfield_10014 only (classic / team-managed)",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Auto-detect or accept either via the epicLink shorthand",
+            "description": null
+          },
+          {
+            "id": "opt-4",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: Epic Link mechanism (Open Q2) \u2014 How should the gat...",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:47:08.949490Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.2",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-3",
+        "question": "idempotency_key requirement for createJiraIssue / addCommentToJiraIssue (Open Q3)",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Required (gateway 400 if missing)",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "Optional with documented warning",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Not implemented \u2014 caller responsibility",
+            "description": null
+          },
+          {
+            "id": "opt-4",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: idempotency_key requirement for createJiraIssue / ...",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:47:08.977044Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.3",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-4",
+        "question": "Link type allowlist source for createIssueLink (Open Q4)",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Hardcoded {Blocks, Relates}",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "config/context-filters.yaml jira.link_types: [...] (operator-configurable)",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Accept any name upstream Jira recognizes",
+            "description": null
+          },
+          {
+            "id": "opt-4",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: Link type allowlist source for createIssueLink (Op...",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:47:23.735954Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.4",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-5",
+        "question": "notifyUsers default for editJiraIssue (Open Q5) \u2014 when caller doesn't specify, what should the gateway send to Atlassian?",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "true (Atlassian default \u2014 sends email)",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "false (quiet update; opt-in to notify)",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: notifyUsers default for editJiraIssue (Open Q5) \u2014 ...",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:47:23.800084Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.5",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-6",
+        "question": "addCommentToJiraIssue visibility field (Open Q6) \u2014 should v1 expose role/group visibility restrictions on comments?",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Hide entirely in v1",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "Expose role/group restrictions",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: addCommentToJiraIssue visibility field (Open Q6) \u2014...",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:47:23.878921Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.6",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-7",
+        "question": "Body input format for description / comment (Open Q7) \u2014 what shape do agents send?",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Plain text only (gateway wraps to ADF)",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "Pre-built ADF dict only (passthrough)",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Both \u2014 accept whichever the caller passes",
+            "description": null
+          },
+          {
+            "id": "opt-4",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: Body input format for description / comment (Open ...",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:47:23.927158Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.7",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-8",
+        "question": "Issuetype identifier accepted by createJiraIssue (Open Q8)",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Name only (Task / Story / Bug / Epic / Sub-task)",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "Numeric ID only",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Both",
+            "description": null
+          },
+          {
+            "id": "opt-4",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: Issuetype identifier accepted by createJiraIssue (...",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:47:35.262347Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.8",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-9",
+        "question": "createIssueLink project allowlist semantics (Open Q9)",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Both inwardIssue and outwardIssue projects must be allowlisted (strict)",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "Only one needs to be allowlisted (loose)",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "One in main allowlist, the other in a separate 'linkable-only' config list",
+            "description": null
+          },
+          {
+            "id": "opt-4",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: createIssueLink project allowlist semantics (Open ...",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:47:35.297315Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.9",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-10",
+        "question": "Per-role write gating (Open Q10) \u2014 should specific agent roles be the only ones allowed to call write verbs?",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Unrestricted within allowlisted projects",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "Per-verb role allowlist (e.g., refiner=editJiraIssue, planner=createJiraIssue/createIssueLink)",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Defer to a follow-up issue",
+            "description": null
+          },
+          {
+            "id": "opt-4",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: Per-role write gating (Open Q10) \u2014 should specific...",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:47:35.333351Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.10",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-11",
+        "question": "Phase gating for writes (Open Q11) \u2014 restrict per SDLC phase?",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Unrestricted across phases",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "Per-phase verb allowlist via gateway/phase_filter.py",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Defer to a follow-up issue",
+            "description": null
+          },
+          {
+            "id": "opt-4",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: Phase gating for writes (Open Q11) \u2014 restrict per ...",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:47:35.368078Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.11",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-12",
+        "question": "createJiraIssue response shape (Open Q13)",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Atlassian raw {id, key, self}",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "Normalized envelope {key, id, browse_url, status: 'created'}",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: createJiraIssue response shape (Open Q13)",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:47:44.604321Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.12",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-13",
+        "question": "editJiraIssue response shape (Open Q14)",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Envelope {status: 'updated', key} (no extra Atlassian call)",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "Echo post-edit ticket via Atlassian ?returnIssue=true (extra read latency)",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: editJiraIssue response shape (Open Q14)",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:47:44.637675Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.13",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-14",
+        "question": "Idempotency cache scope (Open Q16)",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "In-memory per-gateway-process, 5-minute TTL",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "Persisted (disk or Redis) for multi-replica deployments",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: Idempotency cache scope (Open Q16)",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:47:44.669371Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.14",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-15",
+        "question": "Cross-project parent on createJiraIssue (Open Q17)",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Reject if parent.key project differs from new ticket project",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "Accept; let Atlassian decide",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: Cross-project parent on createJiraIssue (Open Q17)",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:47:44.706894Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.15",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-16",
+        "question": "createIssueLink optional comment payload (Open Q23)",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Surface via 'comment' field in body",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "Require a separate addCommentToJiraIssue call",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: createIssueLink optional comment payload (Open Q23...",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:48:03.382780Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.16",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-17",
+        "question": "Dry-run / validation mode (Open Q24) \u2014 expose ?dry_run=true on each write route?",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Expose ?dry_run=true on each write route",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "Live calls only; orchestrator handles preview",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: Dry-run / validation mode (Open Q24) \u2014 expose ?dry...",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:48:03.425931Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.17",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-18",
+        "question": "Documentation home for new write verbs (Open Q27)",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Extend existing docs/reference/jira-wrapper.md",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "New docs/reference/jira-writes.md plus link from jira-wrapper.md",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Both \u2014 high-level in jira-wrapper.md, deep dive in jira-writes.md",
+            "description": null
+          },
+          {
+            "id": "opt-4",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: Documentation home for new write verbs (Open Q27)",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:48:03.564386Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "feedback",
+      "old_value": null,
+      "new_value": {
+        "id": "feedback-1",
+        "phase": "refine",
+        "questions": [
+          {
+            "id": "Q1",
+            "question": "Open Q12 \u2014 write rate-limit policy: confirm 'no auto-retry on 429 for writes' is correct (matches v1 _request); should writes still emit jira_upstream_rate_limited audit on 429?",
+            "answer": null
+          },
+          {
+            "id": "Q2",
+            "question": "Open Q15 \u2014 body size caps: pick numeric limits for summary (default 255 from Atlassian), description, labels (count + per-label length), comment body, customFields map size.",
+            "answer": null
+          },
+          {
+            "id": "Q3",
+            "question": "Open Q18 \u2014 existing-issue probe before create / edit: is the idempotency key sufficient, or do we add a 'is there already a ticket matching this' safety check?",
+            "answer": null
+          },
+          {
+            "id": "Q4",
+            "question": "Open Q19 \u2014 sandbox wrapper input flags: confirm --description / --description-file / --description-stdin (and the analogous comment body flags) match expected agent ergonomics.",
+            "answer": null
+          },
+          {
+            "id": "Q5",
+            "question": "Open Q20 \u2014 audit body redaction: confirm we log only structural metadata (field names, content lengths, label counts) and never body content; any exceptions (labels, link type names)?",
+            "answer": null
+          },
+          {
+            "id": "Q6",
+            "question": "Open Q21 \u2014 adversarial body tests location: same file as the route 403 grid, or a separate test_jira_writes_adversarial.py?",
+            "answer": null
+          },
+          {
+            "id": "Q7",
+            "question": "Open Q22 \u2014 multi-tenant hooks: confirm v1 stays single-tenant exactly as #1556 left it, with no further work in #1924?",
+            "answer": null
+          },
+          {
+            "id": "Q8",
+            "question": "Open Q25 \u2014 failure recovery for batched plan apply: confirm rollback is the orchestrator's responsibility (gateway implements no transactions or compensating actions).",
+            "answer": null
+          },
+          {
+            "id": "Q9",
+            "question": "Open Q26 \u2014 error envelope for write upstream errors: reuse _jira_error_from_upstream verbatim, or surface field-level Atlassian error messages (e.g., 'Field parent cannot be set...') in a richer shape?",
+            "answer": null
+          }
+        ],
+        "submitted": false,
+        "submitted_by": null,
+        "submitted_at": null,
+        "comment_id": null,
+        "debounce_until": null
+      },
+      "reason": "Created feedback request with 9 question(s)",
+      "checkpoint_id": null
+    },
+    {
+      "timestamp": "2026-04-27T18:52:27.964849Z",
+      "actor": "egg",
+      "role": "implementer",
+      "action": "update",
+      "field_path": "decisions.18",
+      "old_value": null,
+      "new_value": {
+        "id": "decision-19",
+        "question": "createIssueLink idempotency (Open Q28, surfaced by reviewer_refine) \u2014 Atlassian's POST /rest/api/3/issueLink does not dedupe identical (inward, outward, type) triples; a retry after a transient 5xx creates a duplicate link. How should the gateway / orchestrator handle this?",
+        "type": "hitl",
+        "phase": "refine",
+        "options": [
+          {
+            "id": "opt-1",
+            "label": "Extend the idempotency-key + cache (D1) to createIssueLink for symmetry with createJiraIssue / addCommentToJiraIssue",
+            "description": null
+          },
+          {
+            "id": "opt-2",
+            "label": "Document that orchestrator's plan-apply must scan existing inwardIssue links before retrying createIssueLink",
+            "description": null
+          },
+          {
+            "id": "opt-3",
+            "label": "Accept duplicates; orchestrator de-dups separately as a follow-up",
+            "description": null
+          },
+          {
+            "id": "opt-4",
+            "label": "Other (explain in reply)",
+            "description": null
+          }
+        ],
+        "resolved": false,
+        "resolution": null,
+        "resolved_by": null,
+        "resolved_at": null,
+        "debounce_until": null
+      },
+      "reason": "Created HITL decision: createIssueLink idempotency (Open Q28, surfaced by...",
+      "checkpoint_id": null
+    }
+  ],
   "refine_review_cycles": 0,
   "refine_review_feedback": "",
   "plan_review_cycles": 0,
   "plan_review_feedback": "",
   "pr": null,
-  "feedback": null,
+  "feedback": {
+    "id": "feedback-1",
+    "phase": "refine",
+    "questions": [
+      {
+        "id": "Q1",
+        "question": "Open Q12 \u2014 write rate-limit policy: confirm 'no auto-retry on 429 for writes' is correct (matches v1 _request); should writes still emit jira_upstream_rate_limited audit on 429?",
+        "answer": null
+      },
+      {
+        "id": "Q2",
+        "question": "Open Q15 \u2014 body size caps: pick numeric limits for summary (default 255 from Atlassian), description, labels (count + per-label length), comment body, customFields map size.",
+        "answer": null
+      },
+      {
+        "id": "Q3",
+        "question": "Open Q18 \u2014 existing-issue probe before create / edit: is the idempotency key sufficient, or do we add a 'is there already a ticket matching this' safety check?",
+        "answer": null
+      },
+      {
+        "id": "Q4",
+        "question": "Open Q19 \u2014 sandbox wrapper input flags: confirm --description / --description-file / --description-stdin (and the analogous comment body flags) match expected agent ergonomics.",
+        "answer": null
+      },
+      {
+        "id": "Q5",
+        "question": "Open Q20 \u2014 audit body redaction: confirm we log only structural metadata (field names, content lengths, label counts) and never body content; any exceptions (labels, link type names)?",
+        "answer": null
+      },
+      {
+        "id": "Q6",
+        "question": "Open Q21 \u2014 adversarial body tests location: same file as the route 403 grid, or a separate test_jira_writes_adversarial.py?",
+        "answer": null
+      },
+      {
+        "id": "Q7",
+        "question": "Open Q22 \u2014 multi-tenant hooks: confirm v1 stays single-tenant exactly as #1556 left it, with no further work in #1924?",
+        "answer": null
+      },
+      {
+        "id": "Q8",
+        "question": "Open Q25 \u2014 failure recovery for batched plan apply: confirm rollback is the orchestrator's responsibility (gateway implements no transactions or compensating actions).",
+        "answer": null
+      },
+      {
+        "id": "Q9",
+        "question": "Open Q26 \u2014 error envelope for write upstream errors: reuse _jira_error_from_upstream verbatim, or surface field-level Atlassian error messages (e.g., 'Field parent cannot be set...') in a richer shape?",
+        "answer": null
+      }
+    ],
+    "submitted": false,
+    "submitted_by": null,
+    "submitted_at": null,
+    "comment_id": null,
+    "debounce_until": null
+  },
   "phase_configs": null,
   "agent_executions": []
 }

--- a/.egg-state/contracts/issue-1924.json
+++ b/.egg-state/contracts/issue-1924.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.0",
+  "issue": {
+    "number": 1924,
+    "title": "Issue #1924",
+    "url": "https://github.com/jwbron/egg/issues/1924"
+  },
+  "pipeline_id": "issue-1924",
+  "current_phase": "refine",
+  "acceptance_criteria": [],
+  "phases": [],
+  "decisions": [],
+  "workflow_owner": null,
+  "audit_log": [],
+  "refine_review_cycles": 0,
+  "refine_review_feedback": "",
+  "plan_review_cycles": 0,
+  "plan_review_feedback": "",
+  "pr": null,
+  "feedback": null,
+  "phase_configs": null,
+  "agent_executions": []
+}

--- a/.egg-state/drafts/1924-analysis.md
+++ b/.egg-state/drafts/1924-analysis.md
@@ -1,0 +1,522 @@
+# Analysis: Add write operations to Jira gateway (create/update/comment/link)
+
+> Issue: #1924 | Phase: refine
+
+## Problem Statement
+
+Issue [#1556](https://github.com/jwbron/egg/issues/1556) landed the v1 read-only Jira gateway: sandboxed agents can fetch tickets, search via JQL, and read comments through `/api/v1/jira/*`, with Atlassian credentials held exclusively in the gateway, project allowlist enforcement, private-mode-only access, conservative JQL scope extraction, and structured audit logging. Writes were explicitly future-scope.
+
+Issue [#1557](https://github.com/jwbron/egg/issues/1557) (Jira-epic SDLC pipelines) is now blocked on those writes. The refine phase needs to push the agent-authored analysis to the **epic's Description field** (`editJiraIssue`); the plan phase needs to create **child tickets under an epic** with parent / Epic Link set (`createJiraIssue`), update existing children when scope shifts (`editJiraIssue`), drop comments pointing at survivors during consolidation (`addCommentToJiraIssue`), and wire cross-task dependency edges (`createIssueLink`).
+
+#1924 is the **bounded write extension** of #1556. It must:
+
+1. Add four narrow write verbs: `createJiraIssue`, `editJiraIssue`, `addCommentToJiraIssue`, `createIssueLink`.
+2. Inherit every v1 invariant: private-mode only, project allowlist, gateway-held credentials, structured audit, fail-closed on missing config.
+3. Keep transitions, worklogs, attachments, and deletions **permanently denied** at the path / method validator (matching #1556's `JIRA_WRITE_VERBS_DENIED`). The write extension does **not** widen that escape hatch.
+4. Land as a **pure extension** of the existing modules (`gateway/jira_client.py`, `gateway/jira_policy.py`, `gateway/gateway.py` route layer, `sandbox/scripts/jira`, `gateway/tests/test_jira_*`) — no re-architecting.
+5. Preserve the zero-credential invariant: Atlassian creds never enter the sandbox; the new sandbox wrapper subcommands shell to the gateway over `EGG_SESSION_TOKEN`.
+
+This analysis surveys the existing v1 surface, enumerates each new verb's Atlassian shape, names the design choices that need a human answer, and recommends an approach that keeps the surface tight, auditable, and reusable for #1557.
+
+## Current Behavior
+
+### v1 read surface (delivered by #1556)
+
+The gateway exposes four read routes, all decorated with `@require_session_auth` + `@require_private_mode`:
+
+| Route | Atlassian endpoint | Notes |
+|-------|-------------------|-------|
+| `POST /api/v1/jira/ticket/get` | `GET /rest/api/3/issue/{key}` | Default `expand=renderedBody,renderedFields`; 404 envelope; field allowlist (≤32 entries). |
+| `POST /api/v1/jira/search` | `POST /rest/api/3/search/jql` | Static JQL scope extractor (`gateway/jira_search.py`); cursor pagination via `nextPageToken`; `maxResults` clamped to 100. |
+| `POST /api/v1/jira/ticket/comments` | `GET /rest/api/3/issue/{key}/comment` | 404 envelope; `expand=renderedBody`. |
+| `POST /api/v1/jira/execute` | passthrough | Regex-allowlisted, GET-only, never writes. |
+
+Key building blocks the write extension reuses verbatim:
+
+| Mechanism | File | Role |
+|-----------|------|------|
+| Per-container session auth | `gateway/auth.py` `require_session_auth` | Loads `Session` (`session_mode`, `pipeline_id`, `agent_role`, `jira_ticket`) into `g`. |
+| Mode gate | `gateway/mode_gate.py` `@require_private_mode` | Stamps `__egg_requires_private_mode__ = True`; route-enumeration test in `test_jira_routes.py` proves every Jira route carries it. |
+| Project allowlist | `gateway/jira_policy.py` (`JiraPolicy`) | Mtime-cached YAML from `config/context-filters.yaml` (`jira.projects: [...]`); fail-closed on empty/malformed. |
+| Credential injection | `gateway/jira_credentials.py` (`JiraCredentialsManager`) | `ATLASSIAN_*` preferred / `JIRA_*` fallback; mtime-cached; raises `JiraCredentialsUnavailable` → 503. |
+| Path / method validator | `gateway/jira_client.py` `validate_jira_api_path` + `JIRA_WRITE_VERBS_DENIED` | Hard denylist for `transitions`, `worklog`, `attachments`, `watchers`, and HTTP `DELETE`/`PUT`/`PATCH`. |
+| HTTPX wrapper | `gateway/jira_client.py` `JiraClient._request` | Basic auth + 429 retry **only on GET**; non-GET methods get one-shot semantics (deliberately future-safe per `JiraClient._request` lines 322–331). |
+| Audit | `gateway/gateway.py` `audit_log` + `_session_jira_context` | Uniform `event_type="gateway_operation"` with per-verb operation name and session context (`pipeline_id`, `agent_role`, `jira_ticket`). |
+| Sandbox wrapper | `sandbox/scripts/jira` | Bash → gateway POST; `EGG_SESSION_TOKEN` Bearer auth; gateway-health pre-check; verb dispatch. |
+
+### Atlassian REST API v3 shapes the write extension must front
+
+| Verb | Atlassian endpoint | Method | Body shape (abridged) | Response |
+|------|-------------------|--------|------------------------|----------|
+| Create issue | `POST /rest/api/3/issue` | POST | `{"fields": {"project": {"key":"FOO"}, "issuetype": {"name":"Task"}, "summary": "...", "description": ADF, "labels":[...], "parent":{"key":"FOO-1"} or "customfield_10014":"FOO-1"}}` | `{"id": "...", "key": "FOO-123", "self": "..."}` |
+| Update issue | `PUT /rest/api/3/issue/{key}` | PUT | `{"fields": {"summary":"...", "description": ADF, "labels":["a","b"]}, "update": {"labels": [{"add":"x"},{"remove":"y"}]}}` | `204 No Content` (no body) |
+| Add comment | `POST /rest/api/3/issue/{key}/comment` | POST | `{"body": ADF, "visibility": {...}}` | full comment object |
+| Create issue link | `POST /rest/api/3/issueLink` | POST | `{"type": {"name":"Blocks"}, "inwardIssue": {"key":"FOO-1"}, "outwardIssue": {"key":"FOO-2"}, "comment": {...optional}}` | `201 Created` (no body in v3) |
+
+Two facts shape the design:
+
+- **Method denylist conflict.** v1's `JIRA_WRITE_VERBS_DENIED` lumps HTTP `DELETE`/`PUT`/`PATCH` with the path-segment denylist (`transitions`, `worklog`, `attachments`, `watchers`). `editJiraIssue` is `PUT` upstream — we cannot keep the method denylist verbatim for writes. We need a clean separation between (a) the `/execute` passthrough's method allowlist (stays GET-only forever — never bypasses dedicated routes) and (b) the per-route method permissions (POST/PUT for the dedicated write routes only).
+- **ADF body format.** Description and comment bodies are Atlassian Document Format JSON, not plain text. Wire format is `{"type":"doc","version":1,"content":[{"type":"paragraph","content":[{"type":"text","text":"..."}]}]}`. Bash-string construction of ADF in `sandbox/scripts/jira` is awkward; the wrapper needs an ergonomic input path.
+
+### What #1556's v1 left "future-safe" for writes
+
+The v1 architect notes (visible in `jira_client.py` lines 30–31, 86–108, and the `JIRA_WRITE_VERBS_DENIED` comment) explicitly anticipated writes:
+
+- `_request()` retries 429 only for GET, matching the issue's "writes never auto-retry" invariant.
+- `JIRA_API_ALLOWED_PATHS` is the regex extension point — write paths (`issue` for create, `issue/<KEY>` for edit, `issue/<KEY>/comment` for comment-create, `issueLink` for link-create) need new patterns or, preferably, **dedicated narrow handlers that skip the generic path validator entirely** because each write verb has a tighter shape than a regex captures.
+- `JIRA_WRITE_VERBS_DENIED` was framed as "permanent" — `transitions`, `worklog`, `attachments`, `watchers`, `DELETE`. We keep the segment denylist permanent. We loosen the method denylist **only inside the dedicated write client methods**; `/execute` and `validate_jira_api_path` stay GET-only.
+
+### #1557's exact ask of #1924
+
+From [#1557's body](https://github.com/jwbron/egg/issues/1557):
+
+- **Refine sink** — `editJiraIssue` to write the refined analysis to the epic's Description field. Single-field update.
+- **Plan sink, fresh epic** — `createJiraIssue` with parent / Epic Link to place each plan-node child under the epic.
+- **Plan sink, reassess** — mix of `editJiraIssue` (scope changes), `createJiraIssue` (net-new), `addCommentToJiraIssue` (consolidation survivors point at the merged-away keys), and `createIssueLink` for cross-task dependency edges.
+- **Won't-Done transitions** — explicitly out of scope for #1924; the orchestrator does these directly with its own creds (transitions never touch the agent-facing gateway).
+
+That ask is satisfied by exactly the four verbs in this issue.
+
+## Constraints
+
+**Security / architectural (hard invariants — no exceptions):**
+
+- **Zero credentials in the sandbox.** Atlassian creds live only in the gateway. New write routes follow the same `creds_provider=get_jira_credentials` pattern.
+- **Private-mode only.** Every new write route gets `@require_session_auth` + `@require_private_mode`. The route-enumeration regression test in `test_jira_routes.py` must extend to assert `__egg_requires_private_mode__` on each new route.
+- **`*.atlassian.net` stays out of the Squid allowlist** so containers cannot bypass the gateway via direct REST. v1's regression test in `test_allowed_domains.py` continues to enforce this.
+- **Permanent denylist preserved.** `transitions`, `worklog`, `attachments`, `watchers`, `DELETE` remain rejected by `validate_jira_api_path`. The write client methods bypass the path validator (they hardcode their own paths), but the `/execute` passthrough stays GET-only forever.
+- **Project allowlist enforced on every write call.** For `createJiraIssue`, the gate is `request.body.fields.project.key` (not a ticket key — the ticket doesn't exist yet). For `editJiraIssue` / `addCommentToJiraIssue` / `createIssueLink`, the gate is the ticket key(s) parsed from the request, exactly as in v1 read paths.
+- **Verb allowlist by construction.** New writes are per-verb routes — one Python handler per Atlassian verb. No generic "issue update via /execute" path.
+- **Body shape validation is a hard gate.** Each write route runs request-body validation (shape + size + field allowlist) before calling Atlassian. Pass-through of arbitrary `fields` dicts is a security risk (custom fields may grant escalation; see Open Questions).
+- **Audit on success and on rejection.** Every write call emits an audit record, including rejected calls (with reason). For reject cases, no Atlassian call is made.
+- **Writes never auto-retry on 429** (already true in `JiraClient._request`). A failed write surfaces the 429 to the caller; the caller's idempotency story (see below) decides what to do.
+
+**Operational:**
+
+- **Idempotency is the new sharp edge.** A retried `createJiraIssue` could create duplicate tickets; a retried `addCommentToJiraIssue` could double-post. v1 GETs are naturally idempotent; writes are not. The pipeline orchestrator (or the agent caller) must be responsible for "did this already succeed?" reasoning, OR the gateway grows an idempotency-key cache. (See Open Questions.)
+- **Per-instance Jira customization** — Epic Link mechanism varies per project (legacy `customfield_10014` Epic Link vs. `parent.key` next-gen hierarchy). The gateway must not encode a single hardcoded customfield ID; either (a) the caller specifies the field shape directly, or (b) the gateway has an instance-level config knob.
+- **ADF handling.** Comments and descriptions are ADF JSON. Bash construction of ADF is painful; sandbox wrapper needs ergonomic input (plain-text → ADF wrapping, or stdin/file reading, or both).
+- **Test strategy unchanged.** `httpx.MockTransport` already used for read endpoints handles writes too. Per-route 403 grid extends naturally.
+- **Write audit retention.** Writes are higher-stakes than reads; audit records must persist to the same sink with no truncation. Body content (description/comment) is **not** logged verbatim — only length and structural metadata (number of fields, label count). Avoid leaking PII.
+- **Rate limits** — Atlassian's per-user write quota is tighter than the read quota. The gateway should surface 429s without retrying writes; the orchestrator can re-issue at its discretion with idempotency keys.
+
+**Dependencies / coupling:**
+
+- **#1556 must remain green.** The write extension is purely additive: new files are isolated; modifications to `gateway.py` and `jira_client.py` add functions/routes without altering existing ones (the only edit to existing code is the path/method validator's separation between `/execute` enforcement and write-path enforcement).
+- **#1557 is a hard consumer.** Its plan-phase apply step calls all four new verbs. Its refine-phase apply calls `editJiraIssue` for the epic Description. Whatever shape the gateway exposes here, #1557's apply step has to match exactly.
+- **No bash → bin/jira-cli detour.** Writes stay REST-only via the existing wrapper, same as reads.
+
+**External (Atlassian):**
+
+- Issue creation REST docs: [POST /rest/api/3/issue](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-post). Body uses `fields` (replace) and `update` (add/remove). The `parent` field is the modern hierarchy; `customfield_10014` (Epic Link) is legacy and only on classic projects.
+- Issue edit: [PUT /rest/api/3/issue/{issueIdOrKey}](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-put). Returns 204; supports `?notifyUsers=false` to suppress email; supports `?returnIssue=true` to get the post-edit body. Both flags relevant.
+- Add comment: [POST /rest/api/3/issue/{issueIdOrKey}/comment](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-post). Supports comment visibility restriction (role/group). Probably out of scope for v1.1 writes.
+- Create link: [POST /rest/api/3/issueLink](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-links/#api-rest-api-3-issuelink-post). Link type names are per-instance (`Blocks`, `Relates`, `Cloners`, `Duplicate`, …). The endpoint accepts an optional `comment` payload to drop a comment on the inward issue at link time.
+- Available link types come from [GET /rest/api/3/issueLinkType](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-link-types/) — useful for v1 validation if we need to gate `type.name` against a known set without hardcoding.
+- ADF schema: [Atlassian Document Format reference](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/). Minimal valid doc is `{"type":"doc","version":1,"content":[]}`.
+- Atlassian's recommendation against API tokens for production integrations applies equally to writes; #1556 chose API token + bot account for clean attribution and that decision carries through.
+
+## Options Considered
+
+The five biggest design axes are: (1) endpoint surface shape, (2) method-allowlist separation, (3) request-body validation depth, (4) idempotency, and (5) sandbox wrapper UX for ADF. Each has a clear recommendation; the open questions below name the residual decisions for the human.
+
+### Endpoint surface shape
+
+#### A1. Four dedicated narrow routes, no `/execute` involvement — **preferred**
+
+**Approach**: New routes mirroring the v1 verb-noun shape:
+
+- `POST /api/v1/jira/ticket/create` → upstream `POST /rest/api/3/issue`
+- `POST /api/v1/jira/ticket/edit` → upstream `PUT /rest/api/3/issue/{key}`
+- `POST /api/v1/jira/ticket/comment/add` → upstream `POST /rest/api/3/issue/{key}/comment`
+- `POST /api/v1/jira/issue-link/create` → upstream `POST /rest/api/3/issueLink`
+
+`/api/v1/jira/execute` stays GET-only. The new routes call new `JiraClient` methods (`create_issue`, `edit_issue`, `add_comment`, `create_issue_link`) that bypass `validate_jira_api_path` and hardcode their upstream paths.
+
+**Pros**:
+- Each verb has its own audit operation name, its own body validator, its own per-route test grid.
+- `/execute`'s GET-only invariant is preserved by construction (no risk of method-list creep).
+- Path validator stays read-only; the permanent segment denylist (`transitions`, `worklog`, `attachments`, `watchers`) is unchanged.
+- Mirrors `gh` wrapper structure (`/api/v1/gh/pr/create`, `/api/v1/gh/pr/comment`, etc.) — operators see the same convention.
+- Future writes (visibility-restricted comments, link-deletion if ever in scope) drop in as additional narrow routes.
+
+**Cons**:
+- Four new routes to write, test, and document — but each is small (≤120 lines including audit and validation).
+
+#### A2. Generalize `/execute` to allow whitelisted write paths
+
+**Approach**: Add `POST` and `PUT` to `ALLOWED_METHODS`, expand `JIRA_API_ALLOWED_PATHS` to include `^issue$`, `^issue/<KEY>$`, `^issue/<KEY>/comment$`, `^issueLink$`. Send writes through `/execute`.
+
+**Pros**: Single endpoint to extend; less code.
+
+**Cons**:
+- Defeats the "verb allowlist by construction" principle. Body validation now lives in a generic dispatcher, not a per-verb handler.
+- Audit operation name collapses to `jira_execute` for everything — coarse-grained logs.
+- Couples `/execute`'s read-only invariant to the write-verb logic. One mistake widens both.
+- Per-verb tests harder; more state in the dispatcher.
+- **Rejected.**
+
+#### A3. RESTful HTTP-method paths (`POST /api/v1/jira/ticket`, `PUT /api/v1/jira/ticket/<KEY>`, …)
+
+**Approach**: One path per resource, multiple methods.
+
+**Pros**: HTTP-purist.
+
+**Cons**:
+- Inconsistent with v1 (everything is `POST` regardless of upstream verb).
+- Bash wrapper has to deduce the right method per command — more error-prone.
+- Audit naming collapses unless we add per-method operation suffixes anyway.
+- **Rejected** for inconsistency with the rest of the gateway.
+
+### Method-allowlist separation
+
+#### B1. Split the allowlist into "execute-passthrough" vs "write-client" — **preferred**
+
+**Approach**:
+- `validate_jira_api_path` (used by `/execute`) keeps `ALLOWED_METHODS = {"GET"}`. Path-segment denylist is unchanged.
+- Each write `JiraClient` method (`create_issue`, etc.) issues its hardcoded method (`POST`/`PUT`) directly through `_request`. They bypass the path validator entirely because the path is fixed in code, not user-supplied.
+- The path-segment denylist (`transitions`, `worklog`, `attachments`, `watchers`) still applies to **paths within write client methods** — verified by hardcoding paths that don't include any of these segments.
+
+**Pros**: Clean separation. No code path can reach `transitions` etc. The path validator's contract stays narrow.
+
+**Cons**: None significant.
+
+#### B2. Widen `validate_jira_api_path` to know about write methods
+
+**Approach**: Add `POST`/`PUT` to `ALLOWED_METHODS`, gate them with method-specific allowed-path tables.
+
+**Pros**: Single source of method+path truth.
+
+**Cons**: Couples `/execute` exposure to write-method config. A future maintainer who widens `ALLOWED_METHODS` for a read use case accidentally exposes a write surface. **Rejected**.
+
+### Request-body validation depth
+
+#### C1. Curated field allowlist + structural validation — **preferred**
+
+**Approach**: Each write route validates its body against an explicit schema:
+
+- **createJiraIssue body**: `{ projectKey: <ALLOWED-KEY>, issuetype: <NAME from {Task, Story, Bug, Epic, Sub-task} or numeric ID>, summary: <str ≤ 255>, description?: <ADF dict | str>, labels?: <list[str ≤ 25]>, parent?: { key: <TICKET-KEY> }, epicLink?: <TICKET-KEY> }` plus an optional `customFields: { customfield_NNNN: <value> }` map keyed by validated field IDs.
+- **editJiraIssue body**: `{ ticket: <TICKET-KEY in allowlist>, summary?, description?: <ADF | str>, labels?: <list[str]>, addLabels?: <list[str]>, removeLabels?: <list[str]>, customFields?: {...}, notifyUsers?: bool (default true) }`. Translated to Atlassian's `fields` + `update` body shape inside the client.
+- **addCommentToJiraIssue body**: `{ ticket: <TICKET-KEY in allowlist>, body: <ADF | str> }` (visibility intentionally not exposed in v1).
+- **createIssueLink body**: `{ type: <NAME from allowlist>, inwardIssue: <TICKET-KEY in allowlist>, outwardIssue: <TICKET-KEY in allowlist>, comment?: <ADF | str> }`.
+
+The gateway translates plain-text `description`/`body` to ADF using a minimal paragraph wrapper (`{type:"doc",version:1,content:[{type:"paragraph",content:[{type:"text",text:S}]}]}`), and accepts pre-built ADF dicts pass-through. No HTML or Markdown parsing in v1.
+
+**Pros**:
+- Tight body shape; rejects garbage at the route layer before any Atlassian call.
+- Custom fields explicitly opt-in (via the `customFields` map and `epicLink` shorthand) — agents can't accidentally smuggle in `Security Level`, `Components`, or other escalation-prone fields.
+- ADF wrapping makes the bash wrapper trivial — agents pass `--description "Some text"` and the gateway handles the JSON.
+- `notifyUsers` exposed as a single bool so agents can suppress email storms during plan-apply.
+
+**Cons**:
+- More schema code than a passthrough.
+- Choice of issuetype name vs ID has per-instance variation (some instances use ID).
+
+#### C2. Pure passthrough of Atlassian's body
+
+**Approach**: Forward whatever body the agent sends.
+
+**Pros**: Maximum flexibility.
+
+**Cons**:
+- Agents can set arbitrary custom fields, including `Security Level`, `Components`, `Sprint`, watchers — fields the operator may not have intended to expose.
+- ADF burden falls on bash wrapper.
+- No invariant on summary length, label cap, etc.
+- **Rejected** as too permissive for v1.
+
+#### C3. Minimal validation (project + ticket + length only)
+
+**Approach**: Validate just the project allowlist and a hard length cap; pass everything else through.
+
+**Pros**: Less code.
+
+**Cons**: Same custom-field exposure risk as C2. **Rejected**.
+
+### Idempotency for create / comment
+
+#### D1. Caller-supplied idempotency key + gateway-level dedup cache (in-memory, TTL ≤ 5 min) — **preferred**
+
+**Approach**: Each `createJiraIssue` and `addCommentToJiraIssue` request may include `idempotency_key: <opaque-string>` in the body. The gateway maintains a per-process in-memory dict keyed by `(verb, project, idempotency_key)` → `(timestamp, response)` with a 5-minute TTL. A duplicate request inside the window short-circuits to the cached response. `editJiraIssue` and `createIssueLink` are not idempotency-keyed (edit is naturally idempotent on a stable ticket; link is unique per `inward+outward+type`).
+
+The TTL is short to keep memory bounded and to reflect the realistic retry window (orchestrator retries within seconds of a transient 5xx, not hours later).
+
+**Pros**:
+- Solves the "duplicate ticket on retry" problem without involving Atlassian.
+- Caller-controlled key — the orchestrator can derive it from `(pipeline_id, plan_node_id)` for stable retries.
+- Falls back gracefully: missing key → no dedup, behavior identical to v1's read paths.
+- Memory bounded (small dict, short TTL, one process — gateway runs single-replica per session).
+
+**Cons**:
+- New gateway state. Must be cleared on gateway restart (acceptable — restarts are rare and short retry windows mean little surface).
+- Cache eviction logic to write and test.
+
+#### D2. Atlassian-native idempotency
+
+**Approach**: Atlassian's REST API does not natively support idempotency keys. **Not an option.**
+
+#### D3. Orchestrator-only responsibility — gateway is stateless
+
+**Approach**: Document non-idempotency. Orchestrator is responsible for "did I already create this ticket?" via its own state.
+
+**Pros**: Simplest gateway code.
+
+**Cons**:
+- Pushes the burden onto every consumer. #1557's plan-apply is one consumer; future ones (impact-analysis skill, manual scripts, future SDLC phases) all repeat the same logic.
+- Gateway audit log already records "created FOO-N" but the orchestrator doesn't necessarily see the audit log between retries.
+- Easier to ship in v1, harder to retrofit later.
+
+### Sandbox wrapper UX for ADF
+
+#### E1. Plain-text + flag-based ergonomic input (`--summary`, `--description`, `--description-file`, `--labels a,b`) — **preferred**
+
+**Approach**: New `sandbox/scripts/jira` subcommands:
+
+```
+jira ticket create --project KEY --type Task --summary "..." [--description "..."|--description-file path|--description-stdin] [--labels a,b] [--parent FOO-1] [--epic-link FOO-2] [--idempotency-key K]
+jira ticket edit  TICKET [--summary "..."] [--description "..."|--description-file path] [--labels a,b] [--add-labels x] [--remove-labels y] [--no-notify]
+jira ticket comment add TICKET [--body "..."|--body-file path|--body-stdin] [--idempotency-key K]
+jira link create --type Blocks --inward FOO-1 --outward FOO-2 [--comment "..."] [--idempotency-key K]
+```
+
+The wrapper builds the JSON request body with Python (already used in v1 wrapper) and posts to the gateway. Body content arrives as plain text; the gateway wraps it in ADF.
+
+**Pros**:
+- Agent ergonomics: no ADF construction in agent code.
+- File / stdin path supports multi-line descriptions naturally.
+- Aligns with `gh pr create --body-file` ergonomics from the existing `gh` wrapper.
+
+**Cons**:
+- Wrapper is bigger than v1's. Manageable (≤500 LoC bash + Python heredocs).
+
+#### E2. Raw ADF passthrough only
+
+**Approach**: Wrapper accepts only pre-built ADF JSON.
+
+**Pros**: Smaller wrapper.
+
+**Cons**: Pushes ADF construction into agent prompts / code. Painful and bug-prone.
+
+#### E3. Markdown → ADF in the wrapper
+
+**Approach**: Agent passes Markdown; wrapper converts.
+
+**Pros**: Familiar input shape.
+
+**Cons**: Markdown → ADF is a non-trivial library dependency (e.g., `mdx_to_adf`) with surprising edge cases (tables, code blocks). Wrap in v1.x if needed.
+
+## Recommended Approach
+
+**Adopt A1 + B1 + C1 + D1 + E1.** The combined design preserves every v1 invariant, keeps `/execute` GET-only, names a per-verb route per Atlassian write, validates request bodies up front, solves idempotency at the gateway, and makes the sandbox wrapper agent-friendly.
+
+Concretely the surface becomes:
+
+| New gateway route | Atlassian endpoint | Audit operation | Notes |
+|---|---|---|---|
+| `POST /api/v1/jira/ticket/create` | `POST /rest/api/3/issue` | `jira_ticket_create` | projectKey-allowlisted; idempotency-keyed; ADF wrapping; returns Atlassian's `{id, key, self}`. |
+| `POST /api/v1/jira/ticket/edit` | `PUT /rest/api/3/issue/{key}` | `jira_ticket_edit` | ticket-allowlisted; supports `notifyUsers=false`; translates `addLabels`/`removeLabels` to Atlassian `update` block. |
+| `POST /api/v1/jira/ticket/comment/add` | `POST /rest/api/3/issue/{key}/comment` | `jira_comment_add` | ticket-allowlisted; idempotency-keyed; ADF wrapping; **no visibility restriction in v1**. |
+| `POST /api/v1/jira/issue-link/create` | `POST /rest/api/3/issueLink` | `jira_issue_link_create` | both `inwardIssue` and `outwardIssue` projects allowlisted; link `type.name` against a configurable allowlist (default `Blocks`, `Relates`). |
+
+Permanent denylist unchanged (`transitions`, `worklog`, `attachments`, `watchers`, `DELETE`). `/execute` stays GET-only forever. `validate_jira_api_path` is unchanged.
+
+`JiraClient` gains four methods: `create_issue`, `edit_issue`, `add_comment`, `create_issue_link`. They use `_request` directly with hardcoded paths; they do **not** auto-retry on 429 (already enforced by `_request` for non-GET). They translate the route-layer body schema to Atlassian's wire shape (e.g., `addLabels`/`removeLabels` → `update.labels: [{add},{remove}]`).
+
+Idempotency cache lives in `gateway/jira_client.py` (or a thin `gateway/idempotency.py` if a Confluence write surface in the future would reuse it). Module-level dict, threading lock, 5-minute TTL, evicted lazily.
+
+`sandbox/scripts/jira` grows the four new subcommands per E1, sharing the `call_gateway` helper. The wrapper validates flag presence client-side; semantic validation lives at the gateway.
+
+Tests:
+
+- `gateway/tests/test_jira_client.py` — per-method shape tests with `httpx.MockTransport`, ADF wrapping, label-update translation, idempotency hit/miss.
+- `gateway/tests/test_jira_routes.py` — per-route 403 grid (public mode → 403; missing creds → 503; non-allowlisted project / ticket → 403; malformed body → 400; success path → 2xx with audit assertions). **Route-enumeration regression** updated to include the four new routes.
+- `gateway/tests/test_jira_idempotency.py` — new file; cache hit, TTL expiry, distinct keys, distinct verbs sharing keys.
+- `tests/sandbox/test_jira_wrapper.py` — new subcommand smoke tests (mocked gateway).
+- Adversarial body tests: oversized summary/description, custom-field smuggling, unknown issuetype, non-allowlisted link type.
+
+Documentation:
+
+- Extend `docs/reference/jira-wrapper.md` with the four new verbs and ADF wrapping rules.
+- Update `config/context-filters.yaml` documentation if a link-type allowlist is added (Open Question 5).
+
+## Open Questions
+
+> Every question below MUST be registered as a contract decision or feedback item — see commands at end of section. Any item not registered is invisible to the human reviewer.
+
+1. **Custom field exposure scope.** Beyond `summary`, `description`, `labels`, `parent`, and an `epicLink` shorthand, do we expose a generic `customFields: {customfield_NNNN: value}` map in the create / edit body, and if so under what allowlist? (Risk: agents could set `Security Level`, `Sprint`, `Components`, watchers, story points, etc.)
+
+2. **Epic Link mechanism.** Use `parent.key` (next-gen / company-managed projects) only, `customfield_10014` (Epic Link, classic / team-managed) only, or auto-detect / accept either via the `epicLink` shorthand?
+
+3. **Idempotency key requirement.** Should `idempotency_key` be **required** for `createJiraIssue` and `addCommentToJiraIssue`, or **optional with a documented warning**?
+
+4. **Link type allowlist source.** Hardcode the v1 allowed `type.name` set (`Blocks`, `Relates`), pull from a new `config/context-filters.yaml` `jira.link_types: [...]` section (operator-configurable), or accept any name the upstream Jira instance recognizes?
+
+5. **`notifyUsers` default.** When the caller of `editJiraIssue` doesn't pass `notifyUsers`, should the gateway default to `true` (Atlassian's default — sends email) or `false` (matches automation-style "quiet" updates)?
+
+6. **`addCommentToJiraIssue` visibility.** v1 hides the `visibility` field entirely. Should v1 expose role/group visibility restrictions, or defer until a concrete consumer needs it?
+
+7. **Body input format for description / comment.** Accept plain text (gateway wraps to ADF), accept pre-built ADF dicts (passthrough), or both?
+
+8. **Issuetype identifier.** Accept issuetype by **name** (`"Task"`), by **numeric ID** (Atlassian's stable identifier), or both?
+
+9. **createIssueLink project allowlist semantics.** Require **both** `inwardIssue` and `outwardIssue` projects to be allowlisted (strict, prevents existence-leak), require **only one** (looser, allows linking to "external" projects the agent can read about), or one with the other in a separate "linkable-only" config list?
+
+10. **Per-role write gating.** Should writes be restricted to specific agent roles (e.g., orchestrator-only, or `refiner` for description edits and `planner` for ticket creation), or unrestricted within an allowlisted project?
+
+11. **Phase gating for writes.** Should writes only be callable in specific SDLC phases (refine for description edits, plan for ticket creation), enforced via the existing `gateway/phase_filter.py` style, or unrestricted?
+
+12. **Write rate-limit policy.** Agree on "no auto-retry on 429 for writes" (matches v1's `_request` already)? Confirm whether a 429 on a write should still emit `jira_upstream_rate_limited` audit (currently only emitted from inside `_request`'s retry loop, which writes skip)?
+
+13. **`createJiraIssue` response shape.** Return Atlassian's raw `{id, key, self}` body, OR a normalized envelope (`{key, id, browse_url, status: "created"}`)? Affects #1557's plan-draft mapping format.
+
+14. **`editJiraIssue` response shape.** Atlassian returns 204 (no body). Return `{status: "updated", key}` envelope, or echo back the post-edit ticket via Atlassian's `?returnIssue=true` flag (extra read latency, but caller has the new state)?
+
+15. **Body-size limits.** Pick caps for `summary` (Atlassian limit is 255), `description` length (Atlassian has no published limit but huge bodies waste audit log + memory), `labels` count and per-label length (Atlassian: 255 chars, no count limit), `comment body` length, and `customFields` map size.
+
+16. **Idempotency cache scope.** Per-gateway-process (in-memory, TTL 5 min) — confirm; or persist to disk / Redis for multi-replica gateway deployments? (egg currently runs single-replica gateway per session; in-memory is plausibly sufficient.)
+
+17. **Cross-project parent.** Reject `parent.key` whose project differs from the new ticket's project (strict — Atlassian sometimes allows cross-project epics, sometimes not), or accept and let Atlassian decide?
+
+18. **Existing-issue probe before create / edit.** For idempotency-keyed retries, do we need to also do an existence check (`is there already a ticket with summary "Foo" in project ENG"`) for safety, or is the idempotency key sufficient?
+
+19. **Sandbox wrapper input ergonomics.** Confirm flags: `--description`, `--description-file`, `--description-stdin` for create / edit; analogous for comment body. Any of these you specifically want or don't want?
+
+20. **Audit body redaction.** Confirm: log only structural metadata (field names changed, content lengths, label counts), never body content. Any exception (e.g., labels — usually safe to log)?
+
+21. **Test coverage requirements.** Should the per-route 403 grid include adversarial bodies (oversized summary, unknown issuetype, custom-field smuggling, unicode in keys) as part of the same file, or a separate `test_jira_writes_adversarial.py`?
+
+22. **Multi-tenant hooks.** v1 reads are single-tenant (one Atlassian site). Writes inherit that. Confirm we leave the multi-tenant seam exactly where #1556 left it, with no further work in #1924?
+
+23. **`createIssueLink` comment payload.** Atlassian allows attaching a comment when creating a link. Surface that in v1 (via `comment` field in body), or require a separate `addCommentToJiraIssue` call?
+
+24. **Dry-run / validation mode.** Do we expose a `?dry_run=true` parameter that validates the body and policy gates without calling Atlassian, useful during plan-phase preview? Or is the gateway always live, and the orchestrator does its own preview?
+
+25. **Failure recovery for batched plan apply.** The orchestrator's plan-apply step calls many writes in sequence (create N children, edit M, link K). The gateway is stateless. Confirm: rollback is the orchestrator's responsibility; the gateway will not implement transactions or compensating actions.
+
+26. **Error envelope for write upstream errors.** Reuse `_jira_error_from_upstream` (passes 4xx through as 4xx, 5xx as 502)? Or richer error mapping for known write-failure modes (e.g., 400 with `errorMessages: ["Field 'parent' cannot be set ..."]` — surface the field name to the caller)?
+
+27. **Documentation home.** Where do the new verbs live in docs — extend `docs/reference/jira-wrapper.md`, add a new `docs/reference/jira-writes.md`, or both?
+
+To register these:
+
+```bash
+# Multiple-choice questions (markdown checkbox surface)
+egg-contract add-decision \
+  --question "Custom field exposure scope (Open Q1)" \
+  --options "Generic customFields map (any customfield_NNNN, only structural validation)" \
+            "Operator-configured customField allowlist (config/context-filters.yaml: jira.custom_fields: [...])" \
+            "No customFields map; only summary/description/labels/parent/epicLink shorthand exposed in v1"
+
+egg-contract add-decision \
+  --question "Epic Link mechanism (Open Q2)" \
+  --options "parent.key only (next-gen / company-managed)" \
+            "customfield_10014 only (classic / team-managed)" \
+            "Auto-detect or accept either via the epicLink shorthand"
+
+egg-contract add-decision \
+  --question "idempotency_key requirement for createJiraIssue / addCommentToJiraIssue (Open Q3)" \
+  --options "Required (gateway 400 if missing)" \
+            "Optional with documented warning" \
+            "Not implemented — caller responsibility"
+
+egg-contract add-decision \
+  --question "Link type allowlist source (Open Q4)" \
+  --options "Hardcoded {Blocks, Relates}" \
+            "config/context-filters.yaml jira.link_types: [...]" \
+            "Accept any name upstream Jira recognizes"
+
+egg-contract add-decision \
+  --question "notifyUsers default for editJiraIssue (Open Q5)" \
+  --options "true (Atlassian default — sends email)" \
+            "false (quiet update; opt-in to notify)"
+
+egg-contract add-decision \
+  --question "addCommentToJiraIssue visibility field (Open Q6)" \
+  --options "Hide entirely in v1" \
+            "Expose role/group restrictions"
+
+egg-contract add-decision \
+  --question "Body input format for description / comment (Open Q7)" \
+  --options "Plain text only (gateway wraps to ADF)" \
+            "Pre-built ADF dict only (passthrough)" \
+            "Both — accept whichever the caller passes"
+
+egg-contract add-decision \
+  --question "Issuetype identifier accepted by createJiraIssue (Open Q8)" \
+  --options "Name only (Task / Story / Bug / Epic / Sub-task)" \
+            "Numeric ID only" \
+            "Both"
+
+egg-contract add-decision \
+  --question "createIssueLink project allowlist semantics (Open Q9)" \
+  --options "Both inwardIssue and outwardIssue projects must be allowlisted (strict)" \
+            "Only one needs to be allowlisted (loose)" \
+            "One in main allowlist, the other in a separate 'linkable-only' config list"
+
+egg-contract add-decision \
+  --question "Per-role write gating (Open Q10)" \
+  --options "Unrestricted within allowlisted projects" \
+            "Per-verb role allowlist (e.g., refiner=editJiraIssue, planner=createJiraIssue/createIssueLink)" \
+            "Defer to a follow-up issue"
+
+egg-contract add-decision \
+  --question "Phase gating for writes (Open Q11)" \
+  --options "Unrestricted across phases" \
+            "Per-phase verb allowlist via gateway/phase_filter.py" \
+            "Defer to a follow-up issue"
+
+egg-contract add-decision \
+  --question "createJiraIssue response shape (Open Q13)" \
+  --options "Atlassian raw {id, key, self}" \
+            "Normalized envelope {key, id, browse_url, status: 'created'}"
+
+egg-contract add-decision \
+  --question "editJiraIssue response shape (Open Q14)" \
+  --options "Envelope {status: 'updated', key} (no extra Atlassian call)" \
+            "Echo post-edit ticket via Atlassian ?returnIssue=true (extra read latency)"
+
+egg-contract add-decision \
+  --question "Idempotency cache scope (Open Q16)" \
+  --options "In-memory per-gateway-process, 5-minute TTL" \
+            "Persisted (disk or Redis) for multi-replica deployments"
+
+egg-contract add-decision \
+  --question "Cross-project parent on createJiraIssue (Open Q17)" \
+  --options "Reject if parent.key project differs from new ticket project" \
+            "Accept; let Atlassian decide"
+
+egg-contract add-decision \
+  --question "createIssueLink optional comment payload (Open Q23)" \
+  --options "Surface via 'comment' field in body" \
+            "Require a separate addCommentToJiraIssue call"
+
+egg-contract add-decision \
+  --question "Dry-run / validation mode (Open Q24)" \
+  --options "Expose ?dry_run=true on each write route" \
+            "Live calls only; orchestrator handles preview"
+
+egg-contract add-decision \
+  --question "Documentation home for new write verbs (Open Q27)" \
+  --options "Extend existing docs/reference/jira-wrapper.md" \
+            "New docs/reference/jira-writes.md plus link from jira-wrapper.md" \
+            "Both — high-level in jira-wrapper.md, deep dive in jira-writes.md"
+
+# Open-ended questions
+egg-contract add-feedback \
+  --question "Open Q12 — write rate-limit policy: confirm 'no auto-retry on 429 for writes' is correct (matches v1 _request); should writes still emit jira_upstream_rate_limited audit on 429?" \
+  --question "Open Q15 — body size caps: pick numeric limits for summary (default 255 from Atlassian), description, labels (count + per-label length), comment body, customFields map size." \
+  --question "Open Q18 — existing-issue probe before create / edit: is the idempotency key sufficient, or do we add a 'is there already a ticket matching this' safety check?" \
+  --question "Open Q19 — sandbox wrapper input flags: confirm --description / --description-file / --description-stdin (and the analogous comment body flags) match expected agent ergonomics." \
+  --question "Open Q20 — audit body redaction: confirm we log only structural metadata (field names, content lengths, label counts) and never body content; any exceptions (labels, link type names)?" \
+  --question "Open Q21 — adversarial body tests location: same file as the route 403 grid, or a separate test_jira_writes_adversarial.py?" \
+  --question "Open Q22 — multi-tenant hooks: confirm v1 stays single-tenant exactly as #1556 left it, with no further work in #1924?" \
+  --question "Open Q25 — failure recovery for batched plan apply: confirm rollback is the orchestrator's responsibility (gateway implements no transactions or compensating actions)." \
+  --question "Open Q26 — error envelope for write upstream errors: reuse _jira_error_from_upstream verbatim, or surface field-level Atlassian error messages (e.g., 'Field parent cannot be set...') in a richer shape?"
+```
+
+## Complexity Assessment
+
+**medium** — four narrow per-verb routes added to a well-established pattern, plus a small idempotency cache and ADF wrapping helper. Each verb is a self-contained slice (route + client method + body validator + sandbox subcommand + tests) and could be implemented in parallel after a small foundation step (method-allowlist separation, idempotency cache module, ADF wrapper helper). The implementation surface is bounded (~1,200 LoC total: ~600 in `gateway/`, ~300 in `sandbox/scripts/jira`, ~300 in tests + docs), but the open-question count is large because each new verb has its own per-instance Atlassian quirks (Epic Link mechanism, link types, custom fields) that need explicit human decisions before plan can write tasks.
+
+---
+
+*Authored-by: egg*

--- a/.egg-state/drafts/1924-plan.md
+++ b/.egg-state/drafts/1924-plan.md
@@ -52,7 +52,7 @@ coder agent then. The defaults are:
 | Decision | Default chosen |
 |----------|----------------|
 | D1 — Custom fields | **No customFields map** in v1; only `summary` / `description` / `labels` / `parent` / `epicLink` shorthand. |
-| D2 — Epic Link | **Auto-detect**: accept the `epicLink` shorthand and, when present, emit both `parent.key` (next-gen) **and** `customfield_10014` (classic Epic Link); the wire shape is decided per-instance via `jira_policy` config (default = both). |
+| D2 — Epic Link | **Per-instance dispatch via config knob.** `JiraPolicy` loads `jira.epic_link_field: "parent" \| "customfield_10014"` (default `"parent"`). The `epicLink` shorthand emits **only the configured field** — never both — because Atlassian rejects the un-configured field as `cannot be set, it is not on the appropriate screen, or unknown`. If a caller passes both an explicit `parent` and `epicLink`, the route returns 400 (conflicting fields); explicit `parent` wins only when `epicLink` is absent. |
 | D3 — `idempotency_key` | **Optional, with documented warning** for createJiraIssue / addCommentToJiraIssue / createIssueLink. |
 | D4 — Link-type allowlist source | **Operator-configurable** via `config/context-filters.yaml jira.link_types: [...]`; default `["Blocks", "Relates"]`. |
 | D5 — `notifyUsers` default | **`false`** (quiet update — opt-in to notify) for editJiraIssue. |
@@ -71,10 +71,10 @@ coder agent then. The defaults are:
 | D27 — Documentation home | **Extend `docs/reference/jira-wrapper.md`** (single source of truth). |
 | D28 — `createIssueLink` idempotency | **Extend the idempotency cache** (D1) to `createIssueLink` for symmetry. |
 | Q12 — 429 audit on writes | **Yes** — emit `jira_upstream_rate_limited` audit on any 429, including writes. |
-| Q15 — Body size caps | summary ≤ 255, description ≤ 32 KiB, comment body ≤ 32 KiB, labels count ≤ 30 with each ≤ 255 chars, customFields map disabled (per D1). |
+| Q15 — Body size caps | summary ≤ 255 (Atlassian limit), description ≤ 32 KiB, comment body ≤ 32 KiB (chosen to mirror description; Atlassian publishes no comment-body limit, but 32 KiB is generous for plan-apply commentary and bounds audit-log size), labels count ≤ 30 with each ≤ 255 chars, customFields map disabled (per D1). |
 | Q18 — Existing-issue probe | **No** — idempotency key is sufficient; orchestrator owns higher-level dedup. |
 | Q19 — Wrapper input flags | Confirmed `--description` / `--description-file` / `--description-stdin` (and analogous `--body*` for comments). |
-| Q20 — Audit body redaction | Log only structural metadata (field-names changed, content lengths, label count, link-type name). Body content never logged; labels logged because they are policy-relevant. |
+| Q20 — Audit body redaction | Log structural metadata (field-names changed, content lengths) **and label values** (small enumerated strings; policy-relevant for who-tagged-what audit) **and link-type name**. Body content (description / comment) is never logged — only its length. |
 | Q21 — Adversarial body tests | **Same file** as the route 403 grid (`test_jira_routes.py`) for grep-by-route convenience; only split if the file exceeds 2000 LoC. |
 | Q22 — Multi-tenant hooks | **Single-tenant** in v1, no multi-tenant work in #1924. |
 | Q25 — Failure recovery | **Orchestrator's responsibility**; gateway implements no transactions or compensating actions. |
@@ -333,11 +333,14 @@ pr:
     (`transitions`, `worklog`, `attachments`, `watchers`, `DELETE`)
     is unchanged, and `/execute` stays GET-only. Agents gain the
     minimum surface needed for #1557's plan-apply: create issue,
-    edit issue, add comment, create issue link. Per-role and
-    per-phase write gating are explicitly deferred to a follow-up
-    issue; #1924 is the surface, not the policy. Body content is
-    never written to audit logs (only structural metadata — field
-    names, content lengths, label counts, link-type name).
+    edit issue, add comment, create issue link. **Per-role and
+    per-phase write gating (decisions D10/D11) are explicitly
+    deferred to a follow-up issue (to be filed once this PR is
+    merged — placeholder reference: `Follows: TBD-write-policy`)**;
+    #1924 is the surface, not the policy. Body content
+    (description, comment) is never written to audit logs — only
+    structural metadata (field names changed, content lengths,
+    label values, link-type name).
   test_plan: |
     - Automated:
       - `make test` runs every gateway and sandbox test, including
@@ -356,13 +359,18 @@ pr:
         routes (public mode → 403, missing creds → 503,
         non-allowlisted project → 403, malformed body → 400, success
         path → 2xx with audit assertion).
-      - Reviewer runs `./sandbox/scripts/jira ticket create --help`
-        and the analogous `--help` for the other three new
-        subcommands and confirms the flag set matches the
-        wrapper-input plan.
+      - Reviewer runs `./sandbox/scripts/jira --help` (the
+        existing top-level `show_usage`) and confirms that the
+        four new subcommands appear with the expected flags.
+        Per-subcommand `--help` is not part of the existing
+        wrapper convention.
       - Reviewer skims `docs/reference/jira-wrapper.md` write-verbs
         section for accuracy.
-      - No live Atlassian call is required.
+      - **Integration smoke against a live Atlassian instance is
+        intentionally deferred to #1557** (Jira-epic SDLC pipelines),
+        which is the first real consumer. v1 read verbs landed
+        without a live smoke test for the same reason and the
+        precedent stands.
   manual_steps: |
     Pre-merge:
       - If the operator wants link types beyond the default
@@ -386,22 +394,27 @@ phases:
           Add `gateway/jira_idempotency.py`. The module exposes
           `get_or_run(verb: str, project: str, key: str | None,
           fn: Callable[[], tuple[int, dict]])` and `clear_cache()`.
-          Internal storage is a module-level dict keyed by
-          `(verb, project, key)` mapping to `(monotonic_seconds,
-          status_code, response_json)` with a 5-min TTL constant.
-          Eviction is lazy at lookup time; a threading lock guards
-          mutations. When `key is None` the cache is bypassed and
-          `fn()` runs unconditionally. Locks in decision-3 (optional
-          key) and decision-14 (in-memory, 5-min TTL).
+          For `verb="link"` the caller composes `project` as
+          `canonical(inward, outward, type)` (a stable
+          tuple-string) so identical opaque keys never alias
+          different (inward, outward, type) triples — see
+          decision-28 default. Internal storage is a module-level
+          dict keyed by `(verb, project, key)` mapping to
+          `(monotonic_seconds, status_code, response_json)` with a
+          5-min TTL constant. Eviction is lazy at lookup time; a
+          threading lock guards mutations. When `key is None` the
+          cache is bypassed and `fn()` runs unconditionally.
+          Locks in decision-3 (optional key) and decision-14
+          (in-memory, 5-min TTL). The corresponding test file is
+          owned by TASK-5-1 — this task's acceptance does **not**
+          require tests to exist; it only requires the module API.
         acceptance: |-
-          File `gateway/jira_idempotency.py` exists with the API
-          above. Unit tests in
-          `gateway/tests/test_jira_idempotency.py` cover: cache miss
-          calls fn once and stores the result; cache hit short-circuits
-          fn; distinct keys store distinct entries; distinct verbs
-          can share a key; TTL expiry forces fn to re-run; missing key
-          bypasses the cache; concurrent access is race-safe under the
-          lock. `make lint` and `make test` pass.
+          File `gateway/jira_idempotency.py` exists exporting
+          `get_or_run`, `clear_cache`, and a public TTL constant
+          named `IDEMPOTENCY_TTL_SECONDS`. The module imports
+          cleanly (`python -c "import gateway.jira_idempotency"`).
+          `make lint` passes. (Test coverage is asserted by
+          TASK-5-1.)
         role: coder
         files:
           - gateway/jira_idempotency.py
@@ -415,16 +428,13 @@ phases:
           returning True when `value` is a dict with
           `type=="doc"`, `version` integer, and `content` list. The
           module has no httpx / Flask coupling; it is pure-Python and
-          unit-testable in isolation.
+          unit-testable in isolation. The corresponding test file is
+          owned by TASK-5-2.
         acceptance: |-
-          File `gateway/jira_adf.py` exists with the API above. Unit
-          tests in `gateway/tests/test_jira_adf.py` cover: plain text
-          wraps to the expected shape; empty string wraps to a doc
-          with an empty paragraph; multi-line text wraps to a single
-          paragraph (no Markdown / paragraph splitting in v1);
-          `is_adf_dict` returns True on a real Atlassian sample and
-          False on plain dict / list / str. `make lint` and
-          `make test` pass.
+          File `gateway/jira_adf.py` exists exporting
+          `wrap_text_as_adf` and `is_adf_dict`. The module imports
+          cleanly. `make lint` passes. (Test coverage is asserted
+          by TASK-5-2.)
         role: coder
         files:
           - gateway/jira_adf.py
@@ -443,26 +453,37 @@ phases:
           Add `JiraClient.create_issue(*, project_key: str,
           issuetype: str | int, summary: str, description: str | dict
           | None = None, labels: list[str] | None = None, parent: str
-          | None = None, epic_link: str | None = None, idempotency_key:
-          str | None = None) -> dict`. The method builds the
-          Atlassian body (`fields.project.key=project_key`,
-          `fields.issuetype.{name|id}` based on type of issuetype,
+          | None = None, epic_link: str | None = None,
+          epic_link_field: str = "parent", idempotency_key: str | None
+          = None) -> dict`. The method builds the Atlassian body —
+          `fields.project.key=project_key`, `fields.issuetype.name`
+          (when `isinstance(issuetype, str)`) or
+          `fields.issuetype.id` (when `int` or numeric str),
           `fields.summary`, `fields.description=ADF` (wrap text or
-          accept dict), `fields.labels`, `fields.parent.key=parent`,
-          `fields.customfield_10014=epic_link` AND
-          `fields.parent.key=epic_link` per decision-2 auto-detect
-          default). It calls `_request("POST", "issue", body=body)`
-          via the existing client and consults `jira_idempotency`
-          when `idempotency_key` is provided. Returns the parsed
-          Atlassian response (`{id, key, self}`); the route layer
-          translates to the normalized envelope.
+          accept dict), `fields.labels`. Epic-link dispatch
+          (decision-2 default — see Approach table): if `parent` is
+          provided it goes verbatim to `fields.parent.key`. If
+          `epic_link` is provided, it is routed to
+          `fields.parent.key` when `epic_link_field == "parent"`
+          and to `fields.customfield_10014` when
+          `epic_link_field == "customfield_10014"` — never both.
+          The route-layer schema rejects (400) any request that
+          carries both `parent` and `epicLink` (handled in TASK-3-1,
+          not in the client). Calls
+          `_request("POST", "issue", body=body)` and consults
+          `jira_idempotency` when `idempotency_key` is provided.
+          Returns the parsed Atlassian response (`{id, key, self}`);
+          the route layer translates to the normalized envelope.
         acceptance: |-
-          The method exists and is exported in `__all__`. Unit tests
-          in `gateway/tests/test_jira_client.py` use
-          `httpx.MockTransport` to assert the wire body shape exactly
-          matches the Atlassian schema for all combinations of
-          inputs (with/without parent, with/without epic_link,
-          issuetype as name vs ID). `make lint` and `make test` pass.
+          The method exists and is exported in `__all__`. Unit
+          tests in `gateway/tests/test_jira_client.py` use
+          `httpx.MockTransport` to assert the wire body shape
+          exactly matches the Atlassian schema for the named
+          matrix of cases: explicit parent only; epic_link with
+          `epic_link_field="parent"`; epic_link with
+          `epic_link_field="customfield_10014"`; issuetype as name
+          string; issuetype as numeric ID; idempotency hit/miss.
+          `make lint` and `make test` pass.
         role: coder
         files:
           - gateway/jira_client.py
@@ -472,24 +493,27 @@ phases:
           = None, description: str | dict | None = None, labels:
           list[str] | None = None, add_labels: list[str] | None = None,
           remove_labels: list[str] | None = None, notify_users: bool =
-          False) -> None`. The method builds Atlassian's
-          `{"fields": {...}, "update": {"labels": [{"add": x}, ...,
-          {"remove": y}, ...]}}` body — `labels` (replace) and
-          `add_labels` / `remove_labels` (incremental) are mutually
-          coherent (replace overrides increments). It calls
-          `_request("PUT", f"issue/{key}",
-          query={"notifyUsers": "false" if not notify_users else
-          "true"}, body=body)`. No idempotency cache (edit is
-          naturally idempotent). Decision-5 default
-          (`notify_users=False`) is encoded here.
+          False) -> None`. The method builds Atlassian's body in
+          two modes: **replace mode** (`labels` provided) emits
+          `{"fields": {"labels": [...]}}`; **incremental mode**
+          (`add_labels` / `remove_labels` provided) emits
+          `{"update": {"labels": [{"add": x}, ..., {"remove": y},
+          ...]}}`. The two modes are **mutually exclusive at the
+          client method level**: if both are set, raise
+          `ValueError`. The route layer (TASK-3-2) returns 400 for
+          this case before calling the client. Query-param policy:
+          omit `notifyUsers` entirely when `notify_users=True`
+          (Atlassian's default is true — do not bloat the URL); send
+          `notifyUsers=false` only when `notify_users=False`
+          (decision-5 default).
         acceptance: |-
           The method exists. Unit tests in
           `gateway/tests/test_jira_client.py` assert the body shape
-          for: replace-only, incremental-only,
-          replace+incremental rejected (or merged per chosen
-          semantics — document the choice), and that
-          `notifyUsers=false` is the default query param. `make lint`
-          and `make test` pass.
+          for: replace-only; incremental-only; combined replace +
+          incremental raises ValueError; `notifyUsers=false` query
+          string when `notify_users=False`; query string absent
+          when `notify_users=True`. `make lint` and `make test`
+          pass.
         role: coder
         files:
           - gateway/jira_client.py
@@ -520,34 +544,53 @@ phases:
           body. When `comment` is provided, ADF-wraps and adds it
           under `comment` (decision-23 default). Consults
           `jira_idempotency` when `idempotency_key` is provided
-          (decision-28 default — link verb cached). Calls
-          `_request("POST", "issueLink", body=body)`.
+          (decision-28 default — link verb cached). The cache key
+          composition is **`get_or_run("link",
+          canonical_link_id(inward_key, outward_key, link_type),
+          idempotency_key, ...)`** where `canonical_link_id` is
+          a stable string `"<inward>|<outward>|<type>"` (define
+          this helper near the method). This ensures two callers
+          re-using the same opaque `idempotency_key` for distinct
+          (inward, outward, type) triples never alias to the same
+          cache entry. Calls `_request("POST", "issueLink",
+          body=body)`.
         acceptance: |-
-          The method exists. Unit tests assert the body shape with
-          and without comment, idempotency cache hit/miss, and that
-          the path is hardcoded (no custom-path injection
-          possible). `make lint` and `make test` pass.
+          The method exists. Unit tests assert: body shape with
+          and without comment; idempotency cache hit/miss for the
+          same (inward, outward, type) triple; same opaque
+          `idempotency_key` against two different triples → two
+          distinct cache entries (no aliasing); the path is
+          hardcoded (no custom-path injection possible). `make
+          lint` and `make test` pass.
         role: coder
         files:
           - gateway/jira_client.py
       - id: TASK-2-5
         description: |-
-          Update the docstring at the top of
-          `gateway/jira_client.py` and the comment block above
-          `validate_jira_api_path` to clarify that the validator's
-          `ALLOWED_METHODS={"GET"}` constraint applies **only** to
-          the `/execute` passthrough; the four new write methods
-          bypass it because their paths are hardcoded. Cite the
-          permanent denylist (`transitions`, `worklog`,
-          `attachments`, `watchers`, `DELETE`/`PUT`/`PATCH` on
-          `/execute`) and confirm it is unchanged. Update `__all__`
-          to export the four new methods if needed.
+          Three small touch-ups in `gateway/jira_client.py`:
+          (1) update the docstring at the top of the module and
+          the comment block above `validate_jira_api_path` to
+          clarify that the validator's `ALLOWED_METHODS={"GET"}`
+          constraint applies **only** to the `/execute`
+          passthrough; the four new write methods bypass it
+          because their paths are hardcoded. Cite the permanent
+          denylist (`transitions`, `worklog`, `attachments`,
+          `watchers`, `DELETE`/`PUT`/`PATCH` on `/execute`) and
+          confirm it is unchanged. (2) **Move the
+          `jira_upstream_rate_limited` audit-emit call out of the
+          GET-only retry loop in `_request`** so it fires on
+          every 429 (writes included), guarded by
+          `flask.has_request_context()`. The retry loop still
+          retries only GET; the audit emit is unconditional on
+          429. This implements the Q12 default. (3) Update
+          `__all__` to export the four new methods.
         acceptance: |-
           The docstring + comment are present and reflect the B1
-          design. A grep for `JIRA_WRITE_VERBS_DENIED` in the
-          codebase shows no new bypass; the denylist remains
-          enforced for `/execute`. `make lint` and `make test`
-          pass.
+          design. The 429 audit emit fires for write methods (a
+          new test in TASK-5-3 asserts this). A grep for
+          `JIRA_WRITE_VERBS_DENIED` in the codebase shows no new
+          bypass; the denylist remains enforced for `/execute`.
+          `make lint` and `make test` pass.
         role: coder
         files:
           - gateway/jira_client.py
@@ -570,18 +613,23 @@ phases:
           (2) field allowlist (reject any custom fields per
           decision-1), (3) size caps (Q15), (4) `JiraPolicy`
           allowlist on `projectKey`, (5) cross-project parent reject
-          (decision-17), (6) ADF wrap of text description. Calls
-          `JiraClient.create_issue(...)`. Audit on success/reject
-          with operation `jira_ticket_create` and structural metadata
-          only (field names, content lengths, label count). Returns
-          the normalized envelope `{key, id, browse_url, status:
-          "created"}` (decision-13). Decorators:
-          `@require_session_auth` + `@require_private_mode`.
+          (decision-17), (6) reject if both `parent` and `epicLink`
+          are present (per blocker-1 fix), (7) ADF wrap of text
+          description. Calls `JiraClient.create_issue(...)` (passes
+          `epic_link_field=jira_policy.epic_link_field`). Audit on
+          success/reject with operation `jira_ticket_create` and
+          structural metadata: field names changed, summary length,
+          description length, **label values** (small enumerated
+          strings — policy-relevant per Q20), `epic_link_field` used.
+          Body content (summary text, description text) is NEVER
+          logged — only its length. Returns the normalized envelope
+          `{key, id, browse_url, status: "created"}` (decision-13).
+          Decorators: `@require_session_auth` + `@require_private_mode`.
         acceptance: |-
           The route exists, decorated, and reachable. Audit log
-          fields match the redaction policy (no `summary` or
-          `description` body content; only lengths). The route
-          appears in the route-enumeration regression in
+          fields match the redaction policy (label values logged;
+          summary / description bodies never logged — only lengths).
+          The route appears in the route-enumeration regression in
           `test_jira_routes.py`. `make lint` and `make test` pass.
         role: coder
         files:
@@ -594,27 +642,36 @@ phases:
           removeLabels?: list[str], notifyUsers?: bool (default
           false per decision-5)}`. Validation: ticket-key format,
           `JiraPolicy` allowlist on the parsed project, no custom
-          fields, size caps. Calls
+          fields, size caps, **reject 400 if both `labels` (replace
+          mode) and any of `addLabels` / `removeLabels` (incremental
+          mode) are present** (per blocker-4 fix). Calls
           `JiraClient.edit_issue(...)`. Audit operation
-          `jira_ticket_edit`. Returns
-          `{status: "updated", key}` (decision-14).
+          `jira_ticket_edit` with structural metadata: field names
+          changed, summary/description lengths, label values (when
+          replace), add/remove label values (when incremental).
+          Returns `{status: "updated", key}` (decision-14).
         acceptance: |-
           Route exists, decorated, in route-enumeration regression.
-          Audit shape matches Q20 redaction. `make lint` and `make
-          test` pass.
+          Mixed labels mode returns 400 (asserted in TASK-5-4
+          adversarial grid). Audit shape matches Q20 redaction.
+          `make lint` and `make test` pass.
         role: coder
         files:
           - gateway/gateway.py
       - id: TASK-3-3
         description: |-
           Add `POST /api/v1/jira/ticket/comment/add`. Body schema:
-          `{ticket: TICKET-KEY, body: str | ADF (≤32 KiB),
+          `{ticket: TICKET-KEY, body: str | ADF (≤32 KiB —
+          chosen to mirror the description cap; Atlassian publishes
+          no upper limit, but 32 KiB bounds audit-log size and
+          covers realistic plan-apply commentary),
           idempotencyKey?: str}`. Visibility is rejected if
-          present (decision-6). Validation: ticket-key,
-          allowlist, size cap, ADF wrap. Calls
+          present (decision-6). Validation: ticket-key, allowlist,
+          size cap, ADF wrap. Calls
           `JiraClient.add_comment(...)`. Audit operation
-          `jira_comment_add`. Returns the Atlassian comment
-          object verbatim.
+          `jira_comment_add` with structural metadata (body length
+          only — body content NEVER logged). Returns the Atlassian
+          comment object verbatim.
         acceptance: |-
           Route exists, decorated, in route-enumeration regression.
           Body content not in audit log; only lengths. `make lint`
@@ -633,35 +690,50 @@ phases:
           allowlist (decision-4), ticket-key format, ADF wrap if
           comment present. Calls
           `JiraClient.create_issue_link(...)`. Audit operation
-          `jira_issue_link_create`. Returns Atlassian's response
-          envelope (`201` body or `{status: "created"}` envelope —
-          choose one and document; default to envelope for
-          consistency with create-issue).
+          `jira_issue_link_create`. Atlassian returns `201 Created`
+          with **no body** in v3, so the route synthesizes a
+          response envelope:
+          `{status: "created", inwardIssue: <key>, outwardIssue:
+          <key>, type: <name>}`. Including the triple in the
+          response lets the orchestrator's plan-apply correlate
+          the call against its retry record. (Decision-23 default
+          — comment surfaced via `comment` field in body.)
         acceptance: |-
           Route exists, decorated, in route-enumeration regression.
           Strict project allowlist enforced for both inward and
-          outward. Link-type allowlist enforced. `make lint` and
-          `make test` pass.
+          outward. Link-type allowlist enforced. Response envelope
+          shape matches the spec above (asserted in TASK-5-4
+          success test). `make lint` and `make test` pass.
         role: coder
         files:
           - gateway/gateway.py
       - id: TASK-3-5
         description: |-
-          Extend `gateway/jira_policy.py` with optional
-          `link_types: list[str]` loaded from
-          `config/context-filters.yaml` `jira.link_types: [...]`,
-          defaulting to `["Blocks", "Relates"]` when missing
-          (decision-4 default). Mtime-cache shared with the rest of
-          `JiraPolicy`. Add `link_type_allowed(name: str) -> bool`
-          helper.
+          Extend `gateway/jira_policy.py` with two optional config
+          knobs loaded from `config/context-filters.yaml`:
+          (a) `jira.link_types: list[str]`, default
+          `["Blocks", "Relates"]` (decision-4 default), exposed via
+          `link_type_allowed(name: str) -> bool`; and
+          (b) `jira.epic_link_field: "parent" | "customfield_10014"`,
+          default `"parent"` (decision-2 default), exposed via
+          `epic_link_field` property. Both knobs use the existing
+          mtime-cache; both fail-closed-on-malformed (e.g. unknown
+          enum value for `epic_link_field` raises a startup
+          warning and falls back to default `"parent"`).
+          **Ordering note:** TASK-3-5 must land before TASK-3-4
+          (issue-link route) because the route depends on
+          `link_type_allowed`. The implementer must commit
+          TASK-3-5 first within Phase 3.
         acceptance: |-
-          `JiraPolicy` exposes `link_types` and
-          `link_type_allowed`. Unit tests in
-          `gateway/tests/test_jira_policy.py` cover: missing
-          `jira.link_types` falls back to defaults; explicit list
-          overrides; case-sensitivity matches Atlassian (link
-          type names are case-sensitive). `make lint` and `make
-          test` pass.
+          `JiraPolicy` exposes `link_types`,
+          `link_type_allowed(name)`, and `epic_link_field`. Unit
+          tests in `gateway/tests/test_jira_policy.py` cover:
+          missing `jira.link_types` → defaults; explicit list
+          overrides; missing `jira.epic_link_field` → defaults to
+          `"parent"`; explicit valid value → override; explicit
+          invalid value → fall back to default with warning;
+          case-sensitivity matches Atlassian (link type names
+          are case-sensitive). `make lint` and `make test` pass.
         role: coder
         files:
           - gateway/jira_policy.py
@@ -679,16 +751,19 @@ phases:
           - gateway/gateway.py
       - id: TASK-3-7
         description: |-
-          Add a commented `jira.link_types` example block to
-          `config/context-filters.yaml` (or its example file)
-          documenting the new optional key with the default
-          `["Blocks", "Relates"]` value. The actual policy default
-          lives in code (TASK-3-5); this is a discoverability
-          touch-up so operators see the knob in the example.
+          Edit `config/context-filters.yaml` directly (the file
+          `JiraPolicy` loads — survey confirmed the existing
+          `jira:` section lives there). Add commented example
+          blocks for both new optional keys with their defaults:
+          `# jira.link_types: [Blocks, Relates]   # default if
+          omitted` and `# jira.epic_link_field: parent   #
+          default; alternative "customfield_10014"`. The actual
+          policy defaults live in code (TASK-3-5); this is a
+          discoverability touch-up so operators see the knobs.
         acceptance: |-
-          The example yaml file mentions the new optional key with
-          a comment block. `make lint` passes (no schema break in
-          the YAML).
+          `config/context-filters.yaml` mentions both new optional
+          keys with comment blocks. `make lint` passes (no schema
+          break in the YAML).
         role: coder
         files:
           - config/context-filters.yaml
@@ -700,6 +775,10 @@ phases:
       the gateway routes, with agent-friendly text input flags
       (description / body file/stdin) and idempotency-key
       passthrough. Atlassian credentials never enter the sandbox.
+      The existing wrapper has a top-level `show_usage` (line ~350)
+      and no per-subcommand `--help`; the new subcommands extend
+      `show_usage` with their flags rather than introducing a new
+      help-output convention.
     tasks:
       - id: TASK-4-1
         description: |-
@@ -712,8 +791,9 @@ phases:
           client-side; gateway returns the normalized envelope.
         acceptance: |-
           Subcommand exists and is reachable from the existing
-          `jira` dispatch. `--help` prints the flag list. `make
-          lint` (shellcheck) passes.
+          `jira` dispatch. `show_usage` (line ~350) is updated
+          to include the new flags. `make lint` (shellcheck)
+          passes.
         role: coder
         files:
           - sandbox/scripts/jira
@@ -724,10 +804,10 @@ phases:
           [--remove-labels y] [--no-notify]`. POST to
           `/api/v1/jira/ticket/edit`.
         acceptance: |-
-          Subcommand exists, `--help` prints flags, mutually
-          exclusive `--description` / `--description-file` /
-          `--description-stdin` enforced client-side. `make lint`
-          passes.
+          Subcommand exists, `show_usage` includes the new flags,
+          mutually exclusive `--description` /
+          `--description-file` / `--description-stdin` enforced
+          client-side. `make lint` passes.
         role: coder
         files:
           - sandbox/scripts/jira
@@ -738,7 +818,7 @@ phases:
           to `/api/v1/jira/ticket/comment/add`.
         acceptance: |-
           Subcommand exists, exclusive body flags enforced,
-          `--help` accurate. `make lint` passes.
+          `show_usage` updated. `make lint` passes.
         role: coder
         files:
           - sandbox/scripts/jira
@@ -749,7 +829,7 @@ phases:
           [--idempotency-key K]`. POST to
           `/api/v1/jira/issue-link/create`.
         acceptance: |-
-          Subcommand exists, `--help` accurate. `make lint`
+          Subcommand exists, `show_usage` updated. `make lint`
           passes.
         role: coder
         files:
@@ -769,11 +849,15 @@ phases:
           expiry (inject monotonic clock); distinct keys; distinct
           verbs sharing a key; missing-key bypass; threading-lock
           race-safety using `concurrent.futures.ThreadPoolExecutor`
-          with N concurrent calls.
+          with N concurrent calls; **link cache aliasing test —
+          same opaque `idempotency_key` against two different
+          `(inward, outward, type)` triples must produce two
+          distinct cache entries** (decision-28 + blocker-5 fix).
         acceptance: |-
           File exists with named tests covering each scenario
-          above. Coverage of `gateway/jira_idempotency.py` is
-          ≥95% by line. `make test` passes.
+          above (including the link-aliasing case). Coverage of
+          `gateway/jira_idempotency.py` is ≥95% by line. `make
+          test` passes.
         role: tester
         files:
           - gateway/tests/test_jira_idempotency.py
@@ -797,16 +881,26 @@ phases:
           Extend `gateway/tests/test_jira_client.py` with per-method
           tests for `create_issue`, `edit_issue`, `add_comment`,
           `create_issue_link`. Use `httpx.MockTransport` to assert
-          wire-body shapes match Atlassian schema for all input
-          combinations: `parent` only, `epic_link` only, both
-          (auto-detect emits both fields), name-vs-ID issuetype,
-          replace labels, incremental add/remove labels,
-          notify_users false vs true, ADF passthrough vs text wrap,
-          idempotency hit/miss, 429 audit emit on each verb.
+          wire-body shapes match Atlassian schema. Bound the
+          matrix at **≥1 success case per option pair** and one
+          failure case per validation rule — write a brief named
+          matrix in each test's docstring rather than generating
+          a Cartesian explosion. Required cases: `parent` only;
+          `epic_link` with `epic_link_field="parent"`;
+          `epic_link` with `epic_link_field="customfield_10014"`;
+          name-vs-ID issuetype; replace labels; incremental
+          add/remove labels; combined replace+incremental raises
+          ValueError at the client level (route-layer 400 in
+          TASK-5-4); notify_users false vs true (query-param
+          present vs absent); ADF passthrough vs text wrap;
+          idempotency hit/miss; **429 audit emit on each write
+          verb** (asserts the TASK-2-5 audit-emit fix).
         acceptance: |-
-          New test functions added, all named after the verb under
-          test. Coverage of the four new client methods ≥95% by
-          line. `make test` passes.
+          New test functions added, all named after the verb
+          under test. Each test has a named matrix in its
+          docstring listing the cases it covers. Coverage of the
+          four new client methods ≥95% by line. `make test`
+          passes.
         role: tester
         files:
           - gateway/tests/test_jira_client.py
@@ -817,17 +911,24 @@ phases:
           covers: public mode → 403; missing creds → 503;
           non-allowlisted project → 403; malformed body → 400;
           oversized summary / description / labels → 400; unknown
-          issuetype → 400; cross-project parent → 400; custom-field
-          smuggling → 400; non-allowlisted link-type → 400;
-          unicode-in-keys path-traversal attempt → 400; success
-          path → 2xx with audit body assertion (no body content
-          logged). Update the route-enumeration regression to
-          include the four new routes (assert
+          issuetype → 400; cross-project parent → 400; **both
+          `parent` and `epicLink` set → 400** (per blocker-1
+          fix); **mixed labels mode (replace + incremental) → 400**
+          (per blocker-4 fix); custom-field smuggling → 400;
+          non-allowlisted link-type → 400; unicode-in-keys
+          path-traversal attempt → 400; **HTTP-method tunnelling
+          via body** (e.g. `"_method": "DELETE"` keys, `__proto__`
+          pollution) → 400; success path → 2xx with audit body
+          assertion (no body content logged); **issue-link
+          response envelope shape** (decision-23 / blocker-3 fix —
+          assert `{status, inwardIssue, outwardIssue, type}`).
+          Update the route-enumeration regression to include the
+          four new routes (assert
           `__egg_requires_private_mode__` on each).
         acceptance: |-
-          The 403 grid covers every cell above for each of the
-          four new routes. The route-enumeration regression now
-          includes four extra routes and asserts the
+          The 403/400 grid covers every cell above for each of
+          the four new routes. The route-enumeration regression
+          now includes four extra routes and asserts the
           private-mode flag. `make test` passes.
         role: tester
         files:
@@ -898,6 +999,32 @@ phases:
           Either the index is updated, or the task is documented
           as a no-op (with a brief justification) in the
           implement-phase commit message. `make lint` passes.
+        role: documenter
+        files:
+          - docs/reference/jira-wrapper.md
+      - id: TASK-6-3
+        description: |-
+          Add a "Phase rollback" sub-section to the new
+          "Write verbs" doc spelling out that each phase is
+          independently revertible — reverting Phase 6 (docs)
+          alone is harmless; reverting Phase 5 (tests) alone
+          is harmless; reverting Phase 4 (sandbox wrapper) leaves
+          gateway routes inert from the agent's perspective;
+          reverting Phase 3 (routes) leaves JiraClient methods
+          callable only from the gateway process; reverting
+          Phase 2 (client) makes the routes return 500 if hit;
+          reverting Phase 1 (foundations) breaks Phase 2. The
+          BRC implement-phase reviewer is asked to verify by
+          running `git revert --no-commit <phase-N-commit>` on
+          each phase and confirming the v1 read tests
+          (`pytest gateway/tests/test_jira_routes.py
+          gateway/tests/test_jira_client.py
+          gateway/tests/test_allowed_domains.py`) stay green
+          before discarding the revert. This is a one-time
+          implement-phase verification, not a CI gate.
+        acceptance: |-
+          The "Phase rollback" sub-section exists with the
+          ordering above. `make lint` passes.
         role: documenter
         files:
           - docs/reference/jira-wrapper.md

--- a/.egg-state/drafts/1924-plan.md
+++ b/.egg-state/drafts/1924-plan.md
@@ -1,0 +1,916 @@
+# Plan: Add write operations to Jira gateway (create/update/comment/link)
+
+> Issue: [#1924](https://github.com/jwbron/egg/issues/1924) | Phase: plan
+> Single PR — phases organise commits inside the same workflow.
+
+## Approach
+
+Implement the bounded write extension recommended by the architect
+analysis (`A1 + B1 + C1 + D1 + E1`):
+
+- **A1 — four dedicated narrow routes** under `/api/v1/jira/*`, one per
+  Atlassian write verb. `/api/v1/jira/execute` stays GET-only forever.
+- **B1 — split the method allowlist**. `validate_jira_api_path` keeps
+  `ALLOWED_METHODS={"GET"}`; the new `JiraClient` write methods bypass
+  the validator and call `_request` directly with hardcoded paths.
+  Path-segment denylist (`transitions`, `worklog`, `attachments`,
+  `watchers`, `DELETE`/`PUT`/`PATCH` on `/execute`) stays unchanged.
+- **C1 — curated body schema with field allowlist**, rejecting
+  arbitrary `fields:` passthrough. ADF wrapping for plain-text
+  `description`/`comment` bodies; raw ADF dicts pass through.
+- **D1 — caller-supplied idempotency key + in-process cache** (5-min
+  TTL, per-process). Cache is keyed by `(verb, project, key)` for
+  `createJiraIssue` / `addCommentToJiraIssue` / `createIssueLink` (the
+  link verb gets cached too because Atlassian does not dedupe identical
+  `(inward, outward, type)` triples — see Open Q28). `editJiraIssue` is
+  naturally idempotent and skips the cache.
+- **E1 — agent-friendly sandbox wrapper** with `--summary`,
+  `--description`, `--description-file`, `--description-stdin`,
+  `--labels a,b`, `--parent`, `--epic-link`, `--add-labels`,
+  `--remove-labels`, `--no-notify`, `--idempotency-key`, etc. Bash
+  subcommands shell out to the existing `call_gateway` helper.
+
+The work decomposes into six phases inside a single PR. Phases 1 and 2
+are the shared foundation (idempotency cache, ADF helper, method
+allowlist split, JiraClient write methods); Phase 3 is the four
+gateway routes; Phase 4 is the sandbox wrapper; Phase 5 is tests;
+Phase 6 is documentation. Each phase commits independently so review
+can be targeted (e.g., reviewing just the gateway routes without
+re-reading the foundation), and the BRC reviewer can replay
+phase-by-phase if needed.
+
+### HITL defaults baked into this plan
+
+Nineteen HITL decisions and nine feedback questions from the refine
+phase remained unresolved at plan-time. To unblock implementation we
+**bake in the architect's recommended defaults** (matching the
+"Recommended Approach" in `1924-analysis.md`); if the human answers
+the contract differently before implement starts, the affected task
+acceptance criteria and small slices of code will be updated by the
+coder agent then. The defaults are:
+
+| Decision | Default chosen |
+|----------|----------------|
+| D1 — Custom fields | **No customFields map** in v1; only `summary` / `description` / `labels` / `parent` / `epicLink` shorthand. |
+| D2 — Epic Link | **Auto-detect**: accept the `epicLink` shorthand and, when present, emit both `parent.key` (next-gen) **and** `customfield_10014` (classic Epic Link); the wire shape is decided per-instance via `jira_policy` config (default = both). |
+| D3 — `idempotency_key` | **Optional, with documented warning** for createJiraIssue / addCommentToJiraIssue / createIssueLink. |
+| D4 — Link-type allowlist source | **Operator-configurable** via `config/context-filters.yaml jira.link_types: [...]`; default `["Blocks", "Relates"]`. |
+| D5 — `notifyUsers` default | **`false`** (quiet update — opt-in to notify) for editJiraIssue. |
+| D6 — Comment visibility | **Hidden in v1** (no `visibility` field exposed). |
+| D7 — Body input format | **Both** — plain text gets wrapped to ADF; pre-built ADF dicts pass through. |
+| D8 — Issuetype identifier | **Both** name (`"Task"`) and numeric ID. |
+| D9 — `createIssueLink` allowlist | **Strict** — both `inwardIssue` and `outwardIssue` projects must be allowlisted. |
+| D10 — Per-role write gating | **Defer** to a follow-up issue (unrestricted within allowlisted projects in v1). |
+| D11 — Phase gating | **Defer** to a follow-up issue (unrestricted across phases in v1). |
+| D13 — `createJiraIssue` response | **Normalized envelope** `{key, id, browse_url, status: "created"}`. |
+| D14 — `editJiraIssue` response | **Envelope** `{status: "updated", key}` (no extra Atlassian call). |
+| D16 — Idempotency cache scope | **In-memory per-gateway-process, 5-min TTL**. |
+| D17 — Cross-project parent | **Reject** if `parent.key` project differs from the new ticket's project. |
+| D23 — `createIssueLink` comment | **Surface via `comment` field** in body (single round-trip; idempotent with link cache). |
+| D24 — Dry-run mode | **Live calls only** — orchestrator handles preview. |
+| D27 — Documentation home | **Extend `docs/reference/jira-wrapper.md`** (single source of truth). |
+| D28 — `createIssueLink` idempotency | **Extend the idempotency cache** (D1) to `createIssueLink` for symmetry. |
+| Q12 — 429 audit on writes | **Yes** — emit `jira_upstream_rate_limited` audit on any 429, including writes. |
+| Q15 — Body size caps | summary ≤ 255, description ≤ 32 KiB, comment body ≤ 32 KiB, labels count ≤ 30 with each ≤ 255 chars, customFields map disabled (per D1). |
+| Q18 — Existing-issue probe | **No** — idempotency key is sufficient; orchestrator owns higher-level dedup. |
+| Q19 — Wrapper input flags | Confirmed `--description` / `--description-file` / `--description-stdin` (and analogous `--body*` for comments). |
+| Q20 — Audit body redaction | Log only structural metadata (field-names changed, content lengths, label count, link-type name). Body content never logged; labels logged because they are policy-relevant. |
+| Q21 — Adversarial body tests | **Same file** as the route 403 grid (`test_jira_routes.py`) for grep-by-route convenience; only split if the file exceeds 2000 LoC. |
+| Q22 — Multi-tenant hooks | **Single-tenant** in v1, no multi-tenant work in #1924. |
+| Q25 — Failure recovery | **Orchestrator's responsibility**; gateway implements no transactions or compensating actions. |
+| Q26 — Error envelope | **Reuse `_jira_error_from_upstream` verbatim** for v1. Field-level Atlassian error surfacing is a follow-up. |
+
+Each task that locks in one of these defaults references the relevant
+`decision-N` ID in its description so the implementor knows where to
+look if the HITL answer changes.
+
+## Phase Breakdown
+
+### Phase 1 — Foundation modules
+
+Two small reusable building blocks land first so later phases can
+import them.
+
+- `gateway/jira_idempotency.py` — module-level dict keyed by
+  `(verb, project, idempotency_key)` → `(monotonic_ts, response_json,
+  status_code)`, threading lock, lazy eviction at lookup time, 5-min
+  TTL constant. Exposes `get_or_run(verb, project, key, fn)` and
+  `clear_cache()` (for tests).
+- `gateway/jira_adf.py` — `wrap_text_as_adf(text)` returns the minimal
+  `{"type": "doc", "version": 1, "content": [paragraph...]}` shape;
+  `is_adf_dict(value)` used by routes to decide between wrap and
+  passthrough.
+
+Both modules are pure-Python utilities; they have unit tests but no
+Flask / httpx coupling.
+
+### Phase 2 — JiraClient write methods + method-allowlist separation
+
+Extend `gateway/jira_client.py` only — no changes to existing methods.
+
+- Add a comment block above `validate_jira_api_path` reaffirming that
+  the validator is **execute-passthrough only** and that write
+  client methods bypass it; cite the rationale (B1 in plan).
+- Add `JiraClient.create_issue(*, project_key, issuetype, summary,
+  description, labels, parent, epic_link, idempotency_key)` that
+  builds the Atlassian body, calls `_request("POST", "issue", body=b)`
+  with hardcoded path, and returns the parsed response. The method
+  consults `jira_idempotency` only when `idempotency_key` is set.
+- Add `JiraClient.edit_issue(*, key, summary, description, labels,
+  add_labels, remove_labels, notify_users)` that sets `update.labels`
+  add/remove pairs and `fields.*` for replace fields, calling
+  `_request("PUT", f"issue/{key}", query={"notifyUsers": "false"} if
+  not notify_users else None)`.
+- Add `JiraClient.add_comment(*, key, body, idempotency_key)` calling
+  `_request("POST", f"issue/{key}/comment", body=body)`.
+- Add `JiraClient.create_issue_link(*, link_type, inward_key,
+  outward_key, comment, idempotency_key)` calling
+  `_request("POST", "issueLink", body=body)`.
+- Implement `_jira_error_from_upstream` reuse in the four new methods
+  (or, if it already lives in `gateway.py`, leave the route layer to
+  translate `JiraUpstreamError`).
+- Update the `__all__` list at the bottom of `jira_client.py`.
+
+### Phase 3 — Gateway routes + body validation
+
+Four new Flask routes in `gateway/gateway.py`, each decorated with
+`@require_session_auth` + `@require_private_mode`. Each route:
+
+1. Parses + validates the body schema (size caps + field allowlist;
+   reject custom-field smuggling; reject cross-project parent).
+2. Resolves the project allowlist via `JiraPolicy` (from the body's
+   `projectKey` for create, from `key` / `inwardIssue` / `outwardIssue`
+   for the rest; both projects strict on link).
+3. Wraps text bodies as ADF (or accepts ADF passthrough).
+4. Calls the corresponding `JiraClient` method.
+5. Emits `audit_log` with operation name (`jira_ticket_create`,
+   `jira_ticket_edit`, `jira_comment_add`, `jira_issue_link_create`),
+   structural metadata (field names changed, content lengths, label
+   counts, link-type name), and policy outcome (allow / deny / 429).
+6. Returns the agreed response envelope.
+
+The route docstring at the top of `gateway.py` (lines 20–24) gets four
+new entries.
+
+`gateway/jira_policy.py` may grow a `link_types: list[str]` field
+(default `["Blocks", "Relates"]`) loaded from
+`config/context-filters.yaml jira.link_types: [...]`.
+
+### Phase 4 — Sandbox wrapper subcommands
+
+`sandbox/scripts/jira` grows four new subcommands:
+
+```
+jira ticket create   --project KEY --type Task --summary "..." \
+                     [--description "..."|--description-file P|--description-stdin] \
+                     [--labels a,b] [--parent FOO-1] [--epic-link FOO-2] \
+                     [--idempotency-key K]
+jira ticket edit     TICKET [--summary "..."] [--description …] \
+                     [--labels a,b] [--add-labels x] [--remove-labels y] \
+                     [--no-notify]
+jira ticket comment  add TICKET [--body "..."|--body-file P|--body-stdin] \
+                     [--idempotency-key K]
+jira link create     --type Blocks --inward FOO-1 --outward FOO-2 \
+                     [--comment "..."] [--idempotency-key K]
+```
+
+Argument parsing reuses the existing bash + Python heredoc pattern.
+Pre-flight gateway-health check is unchanged.
+
+### Phase 5 — Tests
+
+Test surface (each task names the new test functions and the file):
+
+- `gateway/tests/test_jira_client.py` — per-method shape (request body
+  matches Atlassian wire shape), ADF wrapping, label-update
+  translation, idempotency hit/miss, 429 audit on write.
+- `gateway/tests/test_jira_routes.py` — per-route 403 grid (public mode
+  → 403; missing creds → 503; non-allowlisted project → 403; malformed
+  body → 400; success path → 2xx with audit assertion). Adversarial
+  body cases (oversized summary, unknown issuetype, custom-field
+  smuggling, cross-project parent reject) live alongside the success
+  paths in the same file. Route-enumeration regression updated to
+  include the four new routes.
+- `gateway/tests/test_jira_idempotency.py` — new file covering cache
+  hit, TTL expiry (using monotonic-clock injection), distinct keys,
+  distinct verbs sharing keys, race-safe via the threading lock.
+- `gateway/tests/test_jira_adf.py` — new file covering ADF wrap of
+  plain text, ADF passthrough, structural validation of malformed
+  ADF input.
+- `gateway/tests/test_jira_policy.py` — extend with `link_types`
+  config loading and fail-closed behaviour.
+- `tests/sandbox/test_jira_wrapper.py` — extend with subcommand smoke
+  tests against a mocked gateway (success path + flag-validation
+  errors).
+
+### Phase 6 — Documentation
+
+- Extend `docs/reference/jira-wrapper.md` with a "Write verbs" section
+  documenting each subcommand, ADF wrapping rules, idempotency-key
+  semantics, the link-type allowlist, and audit-log redaction.
+- Update `config/context-filters.yaml` (or its surrounding docs) for
+  the new optional `jira.link_types` key.
+- Update `docs/reference/sandbox-tools.md` if it indexes Jira verbs.
+
+## Test Strategy
+
+- **Automated:**
+  - All gateway test files above run via `make test` (pytest under
+    `.venv`).
+  - Sandbox wrapper smoke tests run via the same target.
+  - The `test_allowed_domains.py` regression — `*.atlassian.net` not
+    in the Squid allowlist — must continue to pass unchanged.
+  - The route-enumeration regression in `test_jira_routes.py` covers
+    each new route's `__egg_requires_private_mode__` flag.
+- **Manual:**
+  - Reviewer sanity-checks the four new routes by reading
+    `test_jira_routes.py` 403 grid line-by-line.
+  - Reviewer skims the new sandbox subcommands' bash help output
+    (`./sandbox/scripts/jira ticket create --help`) for typos /
+    missing flags.
+  - No live-Atlassian smoke test is required (the existing v1 read
+    integration test is mock-only); however, the operator running
+    #1557 may dry-run the apply step against a sandbox Jira project.
+
+## Manual Steps (Pre/Post-Merge)
+
+- **Pre-merge:**
+  - If the operator wants to gate link types beyond the default
+    `["Blocks", "Relates"]`, add `jira.link_types: [...]` to
+    `config/context-filters.yaml` before deploy.
+- **Post-merge:**
+  - None required. The new routes are inert until an agent or the
+    orchestrator calls them. #1557 (Jira-epic SDLC pipelines) is the
+    first real consumer and ships separately.
+
+## Dependencies / Ordering
+
+```
+Phase 1 (foundations) ──► Phase 2 (JiraClient writes)
+                          │
+                          ├──► Phase 3 (gateway routes)
+                          │       │
+                          │       └──► Phase 4 (sandbox wrapper)
+                          │
+                          └──► Phase 5 (tests, can begin partway through P2/P3/P4)
+
+Phase 6 (docs) — last; depends on the final shape of P3 and P4.
+```
+
+Within each phase the tasks are independent (e.g., the four
+`JiraClient` methods can be drafted in any order) but each depends on
+the foundation modules from Phase 1. Phase 5 can begin alongside
+Phase 2 / 3 / 4 once the relevant slice has landed; the BRC reviewer
+will see them committed together.
+
+```yaml
+# yaml-tasks
+pr:
+  title: |-
+    Add bounded Jira write verbs to the gateway (create/edit/comment/link)
+  description: |
+    Issue [#1556](https://github.com/jwbron/egg/issues/1556) shipped the
+    v1 read-only Jira gateway. Issue
+    [#1557](https://github.com/jwbron/egg/issues/1557) (Jira-epic SDLC
+    pipelines) is now blocked on the **write** counterpart: refine
+    needs to push agent-authored analysis into the epic Description,
+    plan needs to create child tickets under an epic and wire
+    cross-task links, and reassessment needs to drop comments and edit
+    scope. This PR is the bounded write extension that unblocks #1557.
+
+    **Changes:**
+
+    1. **Four new gateway routes** under `/api/v1/jira/*` — `ticket/create`
+       (`POST /rest/api/3/issue`), `ticket/edit` (`PUT
+       /rest/api/3/issue/{key}`), `ticket/comment/add` (`POST
+       /rest/api/3/issue/{key}/comment`), and `issue-link/create`
+       (`POST /rest/api/3/issueLink`). Each is decorated with
+       `@require_session_auth` + `@require_private_mode` and emits a
+       distinct audit operation name. `/api/v1/jira/execute` stays
+       GET-only forever.
+    2. **Four new `JiraClient` methods** (`create_issue`, `edit_issue`,
+       `add_comment`, `create_issue_link`) that bypass
+       `validate_jira_api_path` (their paths are hardcoded) and use
+       `_request` directly — preserving the v1 invariant that writes
+       never auto-retry on 429.
+    3. **Per-verb body schema** — every write route validates a tight
+       schema (project / ticket allowlisted, summary ≤ 255 chars,
+       description ≤ 32 KiB, labels ≤ 30 × 255 chars, link type in the
+       configurable allowlist). Custom fields are not exposed in v1;
+       only `summary` / `description` / `labels` / `parent` /
+       `epicLink` shorthand is accepted.
+    4. **ADF wrapping helper** (`gateway/jira_adf.py`) so callers can
+       send plain text and the gateway wraps it in Atlassian Document
+       Format; pre-built ADF dicts pass through.
+    5. **Idempotency cache** (`gateway/jira_idempotency.py`) — a
+       per-gateway-process in-memory dict with a 5-minute TTL, keyed
+       by `(verb, project, idempotency_key)`. Applies to
+       `create_issue`, `add_comment`, and `create_issue_link` (the
+       link verb is included because Atlassian does not dedupe
+       identical `(inward, outward, type)` triples).
+    6. **Sandbox wrapper subcommands** (`sandbox/scripts/jira ticket
+       create | edit | comment add | link create`) with
+       `--description` / `--description-file` / `--description-stdin`
+       (and analogous `--body*` flags for comments) and
+       `--idempotency-key`. The wrapper builds the JSON request body
+       and shells to the gateway over `EGG_SESSION_TOKEN`; Atlassian
+       credentials never enter the sandbox.
+    7. **Tests** — per-route 403 grid extended to the four new routes;
+       new `test_jira_idempotency.py` and `test_jira_adf.py`;
+       adversarial body cases (oversized summary, unknown issuetype,
+       custom-field smuggling, cross-project parent reject) live in
+       the same file as the route success paths for grep-by-route
+       convenience. The route-enumeration regression in
+       `test_jira_routes.py` is updated to include the new routes.
+    8. **Docs** — `docs/reference/jira-wrapper.md` gains a "Write
+       verbs" section documenting each subcommand, ADF wrapping rules,
+       idempotency semantics, link-type allowlist, and audit-log
+       redaction.
+
+    **Impact:** The v1 read-only invariants are preserved verbatim —
+    `*.atlassian.net` stays out of the Squid allowlist, Atlassian
+    credentials remain gateway-only, the permanent denylist
+    (`transitions`, `worklog`, `attachments`, `watchers`, `DELETE`)
+    is unchanged, and `/execute` stays GET-only. Agents gain the
+    minimum surface needed for #1557's plan-apply: create issue,
+    edit issue, add comment, create issue link. Per-role and
+    per-phase write gating are explicitly deferred to a follow-up
+    issue; #1924 is the surface, not the policy. Body content is
+    never written to audit logs (only structural metadata — field
+    names, content lengths, label counts, link-type name).
+  test_plan: |
+    - Automated:
+      - `make test` runs every gateway and sandbox test, including
+        the new `test_jira_idempotency.py`, `test_jira_adf.py`, and
+        the extended `test_jira_routes.py` 403 grid.
+      - `make lint` covers the new modules.
+      - The existing `test_allowed_domains.py` regression continues to
+        pass — `*.atlassian.net` is still not in the Squid allowlist.
+      - The route-enumeration regression in `test_jira_routes.py` now
+        asserts `__egg_requires_private_mode__` on each of the four
+        new routes.
+      - `make security` runs bandit / safety / trivy on the new code.
+    - Manual:
+      - Reviewer reads the per-route 403 grid in
+        `test_jira_routes.py` to confirm coverage of the four new
+        routes (public mode → 403, missing creds → 503,
+        non-allowlisted project → 403, malformed body → 400, success
+        path → 2xx with audit assertion).
+      - Reviewer runs `./sandbox/scripts/jira ticket create --help`
+        and the analogous `--help` for the other three new
+        subcommands and confirms the flag set matches the
+        wrapper-input plan.
+      - Reviewer skims `docs/reference/jira-wrapper.md` write-verbs
+        section for accuracy.
+      - No live Atlassian call is required.
+  manual_steps: |
+    Pre-merge:
+      - If the operator wants link types beyond the default
+        `["Blocks", "Relates"]`, add a `jira.link_types: [...]` block
+        to `config/context-filters.yaml` before deploy. (Optional —
+        the default is fine for most installations.)
+    Post-merge:
+      - None. The new routes are inert until #1557 (Jira-epic SDLC
+        pipelines) ships; until then the orchestrator and agents do
+        not call them.
+phases:
+  - id: 1
+    name: |-
+      Foundation modules
+    goal: |-
+      Land the two reusable utilities that later phases import: an
+      in-process idempotency cache and an ADF wrapper helper.
+    tasks:
+      - id: TASK-1-1
+        description: |-
+          Add `gateway/jira_idempotency.py`. The module exposes
+          `get_or_run(verb: str, project: str, key: str | None,
+          fn: Callable[[], tuple[int, dict]])` and `clear_cache()`.
+          Internal storage is a module-level dict keyed by
+          `(verb, project, key)` mapping to `(monotonic_seconds,
+          status_code, response_json)` with a 5-min TTL constant.
+          Eviction is lazy at lookup time; a threading lock guards
+          mutations. When `key is None` the cache is bypassed and
+          `fn()` runs unconditionally. Locks in decision-3 (optional
+          key) and decision-14 (in-memory, 5-min TTL).
+        acceptance: |-
+          File `gateway/jira_idempotency.py` exists with the API
+          above. Unit tests in
+          `gateway/tests/test_jira_idempotency.py` cover: cache miss
+          calls fn once and stores the result; cache hit short-circuits
+          fn; distinct keys store distinct entries; distinct verbs
+          can share a key; TTL expiry forces fn to re-run; missing key
+          bypasses the cache; concurrent access is race-safe under the
+          lock. `make lint` and `make test` pass.
+        role: coder
+        files:
+          - gateway/jira_idempotency.py
+      - id: TASK-1-2
+        description: |-
+          Add `gateway/jira_adf.py`. The module exposes
+          `wrap_text_as_adf(text: str) -> dict` returning the minimal
+          ADF doc shape `{"type":"doc","version":1,"content":
+          [{"type":"paragraph","content":[{"type":"text",
+          "text":<text>}]}]}` and `is_adf_dict(value: object) -> bool`
+          returning True when `value` is a dict with
+          `type=="doc"`, `version` integer, and `content` list. The
+          module has no httpx / Flask coupling; it is pure-Python and
+          unit-testable in isolation.
+        acceptance: |-
+          File `gateway/jira_adf.py` exists with the API above. Unit
+          tests in `gateway/tests/test_jira_adf.py` cover: plain text
+          wraps to the expected shape; empty string wraps to a doc
+          with an empty paragraph; multi-line text wraps to a single
+          paragraph (no Markdown / paragraph splitting in v1);
+          `is_adf_dict` returns True on a real Atlassian sample and
+          False on plain dict / list / str. `make lint` and
+          `make test` pass.
+        role: coder
+        files:
+          - gateway/jira_adf.py
+  - id: 2
+    name: |-
+      JiraClient write methods + method-allowlist separation
+    goal: |-
+      Extend `gateway/jira_client.py` with four new write methods that
+      bypass `validate_jira_api_path`, hardcoding their upstream paths
+      so the path-segment denylist (transitions / worklog /
+      attachments / watchers) cannot be reached by construction. The
+      `/execute` validator stays GET-only.
+    tasks:
+      - id: TASK-2-1
+        description: |-
+          Add `JiraClient.create_issue(*, project_key: str,
+          issuetype: str | int, summary: str, description: str | dict
+          | None = None, labels: list[str] | None = None, parent: str
+          | None = None, epic_link: str | None = None, idempotency_key:
+          str | None = None) -> dict`. The method builds the
+          Atlassian body (`fields.project.key=project_key`,
+          `fields.issuetype.{name|id}` based on type of issuetype,
+          `fields.summary`, `fields.description=ADF` (wrap text or
+          accept dict), `fields.labels`, `fields.parent.key=parent`,
+          `fields.customfield_10014=epic_link` AND
+          `fields.parent.key=epic_link` per decision-2 auto-detect
+          default). It calls `_request("POST", "issue", body=body)`
+          via the existing client and consults `jira_idempotency`
+          when `idempotency_key` is provided. Returns the parsed
+          Atlassian response (`{id, key, self}`); the route layer
+          translates to the normalized envelope.
+        acceptance: |-
+          The method exists and is exported in `__all__`. Unit tests
+          in `gateway/tests/test_jira_client.py` use
+          `httpx.MockTransport` to assert the wire body shape exactly
+          matches the Atlassian schema for all combinations of
+          inputs (with/without parent, with/without epic_link,
+          issuetype as name vs ID). `make lint` and `make test` pass.
+        role: coder
+        files:
+          - gateway/jira_client.py
+      - id: TASK-2-2
+        description: |-
+          Add `JiraClient.edit_issue(*, key: str, summary: str | None
+          = None, description: str | dict | None = None, labels:
+          list[str] | None = None, add_labels: list[str] | None = None,
+          remove_labels: list[str] | None = None, notify_users: bool =
+          False) -> None`. The method builds Atlassian's
+          `{"fields": {...}, "update": {"labels": [{"add": x}, ...,
+          {"remove": y}, ...]}}` body — `labels` (replace) and
+          `add_labels` / `remove_labels` (incremental) are mutually
+          coherent (replace overrides increments). It calls
+          `_request("PUT", f"issue/{key}",
+          query={"notifyUsers": "false" if not notify_users else
+          "true"}, body=body)`. No idempotency cache (edit is
+          naturally idempotent). Decision-5 default
+          (`notify_users=False`) is encoded here.
+        acceptance: |-
+          The method exists. Unit tests in
+          `gateway/tests/test_jira_client.py` assert the body shape
+          for: replace-only, incremental-only,
+          replace+incremental rejected (or merged per chosen
+          semantics — document the choice), and that
+          `notifyUsers=false` is the default query param. `make lint`
+          and `make test` pass.
+        role: coder
+        files:
+          - gateway/jira_client.py
+      - id: TASK-2-3
+        description: |-
+          Add `JiraClient.add_comment(*, key: str, body: str | dict,
+          idempotency_key: str | None = None) -> dict`. ADF-wrap text
+          / passthrough dict via `gateway/jira_adf.py`. Calls
+          `_request("POST", f"issue/{key}/comment", body={"body":
+          adf})`. Consults `jira_idempotency` when
+          `idempotency_key` is provided. Visibility field is
+          intentionally not exposed (decision-6 default).
+        acceptance: |-
+          The method exists. Unit tests assert the wire shape for
+          plain-text body (gets ADF-wrapped), pre-built ADF (passes
+          through), and idempotency cache hit/miss. `make lint` and
+          `make test` pass.
+        role: coder
+        files:
+          - gateway/jira_client.py
+      - id: TASK-2-4
+        description: |-
+          Add `JiraClient.create_issue_link(*, link_type: str,
+          inward_key: str, outward_key: str, comment: str | dict |
+          None = None, idempotency_key: str | None = None) -> dict`.
+          Builds `{"type": {"name": link_type}, "inwardIssue":
+          {"key": inward_key}, "outwardIssue": {"key": outward_key}}`
+          body. When `comment` is provided, ADF-wraps and adds it
+          under `comment` (decision-23 default). Consults
+          `jira_idempotency` when `idempotency_key` is provided
+          (decision-28 default — link verb cached). Calls
+          `_request("POST", "issueLink", body=body)`.
+        acceptance: |-
+          The method exists. Unit tests assert the body shape with
+          and without comment, idempotency cache hit/miss, and that
+          the path is hardcoded (no custom-path injection
+          possible). `make lint` and `make test` pass.
+        role: coder
+        files:
+          - gateway/jira_client.py
+      - id: TASK-2-5
+        description: |-
+          Update the docstring at the top of
+          `gateway/jira_client.py` and the comment block above
+          `validate_jira_api_path` to clarify that the validator's
+          `ALLOWED_METHODS={"GET"}` constraint applies **only** to
+          the `/execute` passthrough; the four new write methods
+          bypass it because their paths are hardcoded. Cite the
+          permanent denylist (`transitions`, `worklog`,
+          `attachments`, `watchers`, `DELETE`/`PUT`/`PATCH` on
+          `/execute`) and confirm it is unchanged. Update `__all__`
+          to export the four new methods if needed.
+        acceptance: |-
+          The docstring + comment are present and reflect the B1
+          design. A grep for `JIRA_WRITE_VERBS_DENIED` in the
+          codebase shows no new bypass; the denylist remains
+          enforced for `/execute`. `make lint` and `make test`
+          pass.
+        role: coder
+        files:
+          - gateway/jira_client.py
+  - id: 3
+    name: |-
+      Gateway routes + body validation + audit
+    goal: |-
+      Land the four new Flask routes, each with curated body schema,
+      project / ticket allowlist enforcement, ADF wrapping, JiraClient
+      dispatch, and structured audit (no body content logged).
+    tasks:
+      - id: TASK-3-1
+        description: |-
+          Add `POST /api/v1/jira/ticket/create` to
+          `gateway/gateway.py`. Body schema: `{projectKey: str,
+          issuetype: str | int, summary: str (≤255), description?:
+          str | ADF (≤32 KiB), labels?: list[str] (≤30 × 255 chars),
+          parent?: TICKET-KEY, epicLink?: TICKET-KEY,
+          idempotencyKey?: str}`. Validation order: (1) JSON parse,
+          (2) field allowlist (reject any custom fields per
+          decision-1), (3) size caps (Q15), (4) `JiraPolicy`
+          allowlist on `projectKey`, (5) cross-project parent reject
+          (decision-17), (6) ADF wrap of text description. Calls
+          `JiraClient.create_issue(...)`. Audit on success/reject
+          with operation `jira_ticket_create` and structural metadata
+          only (field names, content lengths, label count). Returns
+          the normalized envelope `{key, id, browse_url, status:
+          "created"}` (decision-13). Decorators:
+          `@require_session_auth` + `@require_private_mode`.
+        acceptance: |-
+          The route exists, decorated, and reachable. Audit log
+          fields match the redaction policy (no `summary` or
+          `description` body content; only lengths). The route
+          appears in the route-enumeration regression in
+          `test_jira_routes.py`. `make lint` and `make test` pass.
+        role: coder
+        files:
+          - gateway/gateway.py
+      - id: TASK-3-2
+        description: |-
+          Add `POST /api/v1/jira/ticket/edit`. Body schema:
+          `{ticket: TICKET-KEY, summary?: str ≤255, description?: str
+          | ADF ≤32 KiB, labels?: list[str], addLabels?: list[str],
+          removeLabels?: list[str], notifyUsers?: bool (default
+          false per decision-5)}`. Validation: ticket-key format,
+          `JiraPolicy` allowlist on the parsed project, no custom
+          fields, size caps. Calls
+          `JiraClient.edit_issue(...)`. Audit operation
+          `jira_ticket_edit`. Returns
+          `{status: "updated", key}` (decision-14).
+        acceptance: |-
+          Route exists, decorated, in route-enumeration regression.
+          Audit shape matches Q20 redaction. `make lint` and `make
+          test` pass.
+        role: coder
+        files:
+          - gateway/gateway.py
+      - id: TASK-3-3
+        description: |-
+          Add `POST /api/v1/jira/ticket/comment/add`. Body schema:
+          `{ticket: TICKET-KEY, body: str | ADF (≤32 KiB),
+          idempotencyKey?: str}`. Visibility is rejected if
+          present (decision-6). Validation: ticket-key,
+          allowlist, size cap, ADF wrap. Calls
+          `JiraClient.add_comment(...)`. Audit operation
+          `jira_comment_add`. Returns the Atlassian comment
+          object verbatim.
+        acceptance: |-
+          Route exists, decorated, in route-enumeration regression.
+          Body content not in audit log; only lengths. `make lint`
+          and `make test` pass.
+        role: coder
+        files:
+          - gateway/gateway.py
+      - id: TASK-3-4
+        description: |-
+          Add `POST /api/v1/jira/issue-link/create`. Body schema:
+          `{type: str (in jira_policy.link_types allowlist),
+          inwardIssue: TICKET-KEY, outwardIssue: TICKET-KEY,
+          comment?: str | ADF, idempotencyKey?: str}`. Validation:
+          both inward and outward project allowlisted (strict —
+          decision-9), link type in the operator-configurable
+          allowlist (decision-4), ticket-key format, ADF wrap if
+          comment present. Calls
+          `JiraClient.create_issue_link(...)`. Audit operation
+          `jira_issue_link_create`. Returns Atlassian's response
+          envelope (`201` body or `{status: "created"}` envelope —
+          choose one and document; default to envelope for
+          consistency with create-issue).
+        acceptance: |-
+          Route exists, decorated, in route-enumeration regression.
+          Strict project allowlist enforced for both inward and
+          outward. Link-type allowlist enforced. `make lint` and
+          `make test` pass.
+        role: coder
+        files:
+          - gateway/gateway.py
+      - id: TASK-3-5
+        description: |-
+          Extend `gateway/jira_policy.py` with optional
+          `link_types: list[str]` loaded from
+          `config/context-filters.yaml` `jira.link_types: [...]`,
+          defaulting to `["Blocks", "Relates"]` when missing
+          (decision-4 default). Mtime-cache shared with the rest of
+          `JiraPolicy`. Add `link_type_allowed(name: str) -> bool`
+          helper.
+        acceptance: |-
+          `JiraPolicy` exposes `link_types` and
+          `link_type_allowed`. Unit tests in
+          `gateway/tests/test_jira_policy.py` cover: missing
+          `jira.link_types` falls back to defaults; explicit list
+          overrides; case-sensitivity matches Atlassian (link
+          type names are case-sensitive). `make lint` and `make
+          test` pass.
+        role: coder
+        files:
+          - gateway/jira_policy.py
+      - id: TASK-3-6
+        description: |-
+          Update the `gateway/gateway.py` module docstring (lines
+          20-24) to list the four new write routes alongside the
+          existing read routes, with policy notes (private-mode,
+          allowlist, idempotency-keyed where applicable).
+        acceptance: |-
+          The docstring lists the four new routes. `make lint`
+          passes.
+        role: coder
+        files:
+          - gateway/gateway.py
+      - id: TASK-3-7
+        description: |-
+          Add a commented `jira.link_types` example block to
+          `config/context-filters.yaml` (or its example file)
+          documenting the new optional key with the default
+          `["Blocks", "Relates"]` value. The actual policy default
+          lives in code (TASK-3-5); this is a discoverability
+          touch-up so operators see the knob in the example.
+        acceptance: |-
+          The example yaml file mentions the new optional key with
+          a comment block. `make lint` passes (no schema break in
+          the YAML).
+        role: coder
+        files:
+          - config/context-filters.yaml
+  - id: 4
+    name: |-
+      Sandbox wrapper subcommands
+    goal: |-
+      Extend `sandbox/scripts/jira` with four new subcommands matching
+      the gateway routes, with agent-friendly text input flags
+      (description / body file/stdin) and idempotency-key
+      passthrough. Atlassian credentials never enter the sandbox.
+    tasks:
+      - id: TASK-4-1
+        description: |-
+          Add `jira ticket create --project KEY --type Task
+          --summary "..." [--description "..."|--description-file P|
+          --description-stdin] [--labels a,b] [--parent FOO-1]
+          [--epic-link FOO-2] [--idempotency-key K]`. Build the
+          JSON body in the existing Python heredoc and POST to
+          `/api/v1/jira/ticket/create`. Validate flag presence
+          client-side; gateway returns the normalized envelope.
+        acceptance: |-
+          Subcommand exists and is reachable from the existing
+          `jira` dispatch. `--help` prints the flag list. `make
+          lint` (shellcheck) passes.
+        role: coder
+        files:
+          - sandbox/scripts/jira
+      - id: TASK-4-2
+        description: |-
+          Add `jira ticket edit TICKET [--summary "..."]
+          [--description ...] [--labels a,b] [--add-labels x]
+          [--remove-labels y] [--no-notify]`. POST to
+          `/api/v1/jira/ticket/edit`.
+        acceptance: |-
+          Subcommand exists, `--help` prints flags, mutually
+          exclusive `--description` / `--description-file` /
+          `--description-stdin` enforced client-side. `make lint`
+          passes.
+        role: coder
+        files:
+          - sandbox/scripts/jira
+      - id: TASK-4-3
+        description: |-
+          Add `jira ticket comment add TICKET [--body "..."|
+          --body-file P|--body-stdin] [--idempotency-key K]`. POST
+          to `/api/v1/jira/ticket/comment/add`.
+        acceptance: |-
+          Subcommand exists, exclusive body flags enforced,
+          `--help` accurate. `make lint` passes.
+        role: coder
+        files:
+          - sandbox/scripts/jira
+      - id: TASK-4-4
+        description: |-
+          Add `jira link create --type Blocks --inward FOO-1
+          --outward FOO-2 [--comment "..."]
+          [--idempotency-key K]`. POST to
+          `/api/v1/jira/issue-link/create`.
+        acceptance: |-
+          Subcommand exists, `--help` accurate. `make lint`
+          passes.
+        role: coder
+        files:
+          - sandbox/scripts/jira
+  - id: 5
+    name: |-
+      Tests
+    goal: |-
+      Land the test surface that locks in policy invariants, ADF
+      wrapping, idempotency cache, per-route 403 grid, and adversarial
+      bodies.
+    tasks:
+      - id: TASK-5-1
+        description: |-
+          Create `gateway/tests/test_jira_idempotency.py` covering
+          the cache module from TASK-1-1: cache miss / hit; TTL
+          expiry (inject monotonic clock); distinct keys; distinct
+          verbs sharing a key; missing-key bypass; threading-lock
+          race-safety using `concurrent.futures.ThreadPoolExecutor`
+          with N concurrent calls.
+        acceptance: |-
+          File exists with named tests covering each scenario
+          above. Coverage of `gateway/jira_idempotency.py` is
+          ≥95% by line. `make test` passes.
+        role: tester
+        files:
+          - gateway/tests/test_jira_idempotency.py
+      - id: TASK-5-2
+        description: |-
+          Create `gateway/tests/test_jira_adf.py` covering the
+          ADF helper from TASK-1-2: plain text wrap; empty string
+          wrap; multi-line text (single paragraph in v1);
+          `is_adf_dict` true on real Atlassian samples; `is_adf_dict`
+          false on plain dicts, lists, strings, and dicts missing
+          required keys.
+        acceptance: |-
+          File exists with named tests. Coverage of
+          `gateway/jira_adf.py` is ≥95% by line. `make test`
+          passes.
+        role: tester
+        files:
+          - gateway/tests/test_jira_adf.py
+      - id: TASK-5-3
+        description: |-
+          Extend `gateway/tests/test_jira_client.py` with per-method
+          tests for `create_issue`, `edit_issue`, `add_comment`,
+          `create_issue_link`. Use `httpx.MockTransport` to assert
+          wire-body shapes match Atlassian schema for all input
+          combinations: `parent` only, `epic_link` only, both
+          (auto-detect emits both fields), name-vs-ID issuetype,
+          replace labels, incremental add/remove labels,
+          notify_users false vs true, ADF passthrough vs text wrap,
+          idempotency hit/miss, 429 audit emit on each verb.
+        acceptance: |-
+          New test functions added, all named after the verb under
+          test. Coverage of the four new client methods ≥95% by
+          line. `make test` passes.
+        role: tester
+        files:
+          - gateway/tests/test_jira_client.py
+      - id: TASK-5-4
+        description: |-
+          Extend `gateway/tests/test_jira_routes.py` with the
+          per-route 403 grid for the four new routes. Each route
+          covers: public mode → 403; missing creds → 503;
+          non-allowlisted project → 403; malformed body → 400;
+          oversized summary / description / labels → 400; unknown
+          issuetype → 400; cross-project parent → 400; custom-field
+          smuggling → 400; non-allowlisted link-type → 400;
+          unicode-in-keys path-traversal attempt → 400; success
+          path → 2xx with audit body assertion (no body content
+          logged). Update the route-enumeration regression to
+          include the four new routes (assert
+          `__egg_requires_private_mode__` on each).
+        acceptance: |-
+          The 403 grid covers every cell above for each of the
+          four new routes. The route-enumeration regression now
+          includes four extra routes and asserts the
+          private-mode flag. `make test` passes.
+        role: tester
+        files:
+          - gateway/tests/test_jira_routes.py
+      - id: TASK-5-5
+        description: |-
+          Extend `gateway/tests/test_jira_policy.py` with tests
+          for the new `link_types` config knob from TASK-3-5:
+          missing key → defaults to `["Blocks", "Relates"]`;
+          explicit list overrides; mtime-cache invalidates on
+          file change; case-sensitive lookup. Also assert
+          fail-closed when the config file is malformed (existing
+          v1 invariant).
+        acceptance: |-
+          New tests pass. Coverage of `link_types` branch in
+          `JiraPolicy` is ≥95%. `make test` passes.
+        role: tester
+        files:
+          - gateway/tests/test_jira_policy.py
+      - id: TASK-5-6
+        description: |-
+          Extend `tests/sandbox/test_jira_wrapper.py` with smoke
+          tests for the four new subcommands against a mocked
+          gateway: success path; mutually-exclusive body flags
+          rejected; missing required flag rejected; output JSON
+          piped to stdout. Run the wrapper via subprocess so the
+          shell flag-parsing is exercised end-to-end.
+        acceptance: |-
+          New tests added and passing. `make test` passes.
+        role: tester
+        files:
+          - tests/sandbox/test_jira_wrapper.py
+  - id: 6
+    name: |-
+      Documentation
+    goal: |-
+      Land the user-facing docs for the new write verbs (per
+      decision-27 default — extend the existing wrapper doc).
+    tasks:
+      - id: TASK-6-1
+        description: |-
+          Extend `docs/reference/jira-wrapper.md` with a "Write
+          verbs" section documenting each subcommand
+          (create / edit / comment add / link create), the body
+          schema accepted by the gateway, ADF wrapping rules,
+          idempotency-key semantics (optional with documented
+          warning per decision-3), the `jira.link_types` config
+          knob, the audit-log redaction rules (Q20 — only
+          structural metadata logged), and the cross-project
+          parent reject (decision-17). Cross-link from the v1
+          read-verbs section.
+        acceptance: |-
+          The "Write verbs" section exists and covers each verb
+          end-to-end. Markdown lints clean (`make lint`). The
+          existing v1 read section is untouched.
+        role: documenter
+        files:
+          - docs/reference/jira-wrapper.md
+      - id: TASK-6-2
+        description: |-
+          If `docs/reference/sandbox-tools.md` (or equivalent
+          index of sandbox verbs) exists, add the four new
+          `jira ticket create | edit | comment add | link create`
+          subcommands to the list with one-line summaries.
+          Otherwise this task is a no-op and should be marked as
+          such in the implement-phase commit message.
+        acceptance: |-
+          Either the index is updated, or the task is documented
+          as a no-op (with a brief justification) in the
+          implement-phase commit message. `make lint` passes.
+        role: documenter
+        files:
+          - docs/reference/jira-wrapper.md
+```
+
+## Risks (deferred to risk_analyst)
+
+The risk analyst peer is producing a separate risk assessment for this
+phase. The plan above is structured so each phase is independently
+revertible (`git revert <phase-N-commit>`) without breaking the v1
+read surface, and so the BRC reviewer can NACK any single phase
+without forcing a full re-plan.
+
+---
+
+*Authored-by: egg (task_planner)*

--- a/config/context-filters.yaml
+++ b/config/context-filters.yaml
@@ -9,10 +9,10 @@
 # missing entirely) blocks every call until an operator adds entries.
 
 jira:
-  # Atlassian Jira project keys agents are allowed to read through the
-  # /api/v1/jira/* endpoints.  Project keys must match the Atlassian shape:
-  # uppercase letter followed by letters / digits / underscore (e.g. ENG,
-  # DEVOPS, MOBILE_V2).  Case-sensitive.
+  # Atlassian Jira project keys agents are allowed to read AND write
+  # through the /api/v1/jira/* endpoints.  Project keys must match the
+  # Atlassian shape: uppercase letter followed by letters / digits /
+  # underscore (e.g. ENG, DEVOPS, MOBILE_V2).  Case-sensitive.
   #
   # Example:
   #   projects: ["ENG", "DEVOPS"]
@@ -20,8 +20,28 @@ jira:
   # Any ticket whose project is not on this list returns HTTP 403 with
   # `jira_*_denied` in the gateway audit log.  JQL searches must be
   # statically provable as scoped to the listed projects — see
-  # gateway/jira_search.py for the exact acceptance rules.
+  # gateway/jira_search.py for the exact acceptance rules.  The same
+  # allowlist gates writes (#1924): create / edit / comment / link.
   projects: []
+
+  # Atlassian link-type names allowed by /api/v1/jira/issue-link/create
+  # (issue #1924).  Optional.  Defaults to ["Blocks", "Relates"] when
+  # omitted.  Atlassian link-type names are case-sensitive — `blocks`
+  # is rejected.  An empty list disables the verb entirely (fail-closed).
+  #
+  # Example:
+  #   link_types: ["Blocks", "Relates", "is duplicated by"]
+  # link_types: ["Blocks", "Relates"]
+
+  # Epic-link placement (issue #1924, decision-2).  Atlassian has two
+  # mechanisms for placing a ticket under an epic depending on the
+  # project type:
+  #   - "parent"               — next-gen / company-managed (default)
+  #   - "customfield_10014"    — classic / team-managed
+  # When `epicLink` is supplied to /api/v1/jira/ticket/create, the
+  # gateway emits ONLY the configured field — never both.  Leave unset
+  # to keep the default ("parent").
+  # epic_link_field: "parent"
 
 confluence:
   # Atlassian Confluence space keys agents are allowed to read through the

--- a/docs/reference/jira-wrapper.md
+++ b/docs/reference/jira-wrapper.md
@@ -1,12 +1,17 @@
 # Jira Wrapper Reference
 
-> Gateway REST surface that gives sandboxed agents **read-only** access to Jira. Mirrors the `/api/v1/gh/*` pattern: Atlassian credentials live in the gateway, the sandbox posts session-authenticated JSON, and every call is funneled through a private-mode gate, a project allowlist, and structured audit logs.
+> Gateway REST surface that gives sandboxed agents bounded read **and write** access to Jira. Mirrors the `/api/v1/gh/*` pattern: Atlassian credentials live in the gateway, the sandbox posts session-authenticated JSON, and every call is funneled through a private-mode gate, a project allowlist, and structured audit logs.
 
-v1 is read-only. Write verbs (`ticket create`, `ticket update`, `comment create`) are scoped as a follow-up and drop in as three additional narrow routes under the same decorators and policy plumbing — no re-architecting. Transitions, worklogs, attachments, watchers, deletions, and `PUT` / `PATCH` / `DELETE` methods are **permanently out of scope** and are enforced at the path validator.
+The gateway exposes two surface families:
+
+- **Read verbs** (v1, [#1556](https://github.com/jwbron/egg/issues/1556)): `ticket get`, `ticket comments`, `search`, and the GET-only `execute` passthrough.
+- **Write verbs** (v1.1, [#1924](https://github.com/jwbron/egg/issues/1924)): `ticket create`, `ticket edit`, `ticket comment add`, and `issue-link create` — see [Write verbs](#write-verbs) below.
+
+Transitions, worklogs, attachments, watchers, deletions, and `PUT` / `PATCH` / `DELETE` methods on `/execute` are **permanently out of scope** and are enforced at the path validator. The write surface bypasses `/execute` entirely (each verb is its own narrow route with a hardcoded upstream path), so the GET-only `/execute` invariant is preserved by construction.
 
 ## Endpoint surface
 
-All four routes are `POST /api/v1/jira/...`, require a session token via `@require_session_auth`, and are gated by `@require_private_mode` (from `gateway/mode_gate.py`). In public mode every route returns 403 `private_mode_required` **before** any upstream call — no Atlassian credential is loaded and no network egress happens.
+All routes are `POST /api/v1/jira/...`, require a session token via `@require_session_auth`, and are gated by `@require_private_mode` (from `gateway/mode_gate.py`). In public mode every route returns 403 `private_mode_required` **before** any upstream call — no Atlassian credential is loaded and no network egress happens.
 
 | Endpoint | Purpose | Upstream |
 |----------|---------|----------|
@@ -14,6 +19,10 @@ All four routes are `POST /api/v1/jira/...`, require a session token via `@requi
 | `POST /api/v1/jira/search` | JQL search with conservative static project-scope extraction | `POST /rest/api/3/search/jql` |
 | `POST /api/v1/jira/ticket/comments` | Read comments for a ticket, default `expand=renderedBody,renderedFields` | `GET /rest/api/3/issue/{key}/comment` |
 | `POST /api/v1/jira/execute` | GET-only regex-allowlisted passthrough | `GET /rest/api/3/...` |
+| `POST /api/v1/jira/ticket/create` | [Write] Create a ticket; supports `parent` / `epicLink` shorthand and idempotency-key dedup | `POST /rest/api/3/issue` |
+| `POST /api/v1/jira/ticket/edit` | [Write] Update a ticket's `summary` / `description` / `labels` (replace or add/remove) | `PUT /rest/api/3/issue/{key}` |
+| `POST /api/v1/jira/ticket/comment/add` | [Write] Add a comment; ADF wrap on plain text; idempotency-key dedup | `POST /rest/api/3/issue/{key}/comment` |
+| `POST /api/v1/jira/issue-link/create` | [Write] Create a typed link (`Blocks` / `Relates` / operator-allowlisted) between two tickets | `POST /rest/api/3/issueLink` |
 
 ### `POST /api/v1/jira/ticket/get`
 
@@ -151,23 +160,275 @@ Atlassian stores ticket and comment bodies in [Atlassian Document Format](https:
 
 The gateway's `JiraClient.get_ticket` and `JiraClient.get_comments` therefore default to `expand=renderedBody,renderedFields`, so `fields.description.renderedBody` contains HTML the agent can parse directly. Callers may override `expand` by passing a different value via the `fields` parameter; the default exists so the common case "just read me this ticket" works without additional ceremony.
 
+## Write verbs
+
+The four write verbs ([#1924](https://github.com/jwbron/egg/issues/1924)) extend the v1 read surface with a **bounded** mutation surface — just enough for the SDLC pipeline to push agent-authored analysis into an epic Description, create child tickets under an epic, drop comments, and wire cross-task links ([#1557](https://github.com/jwbron/egg/issues/1557) is the first consumer). Every write inherits the v1 invariants: private-mode-only, project allowlist, audit-on-every-call, and Atlassian credentials never leave the gateway.
+
+The write verbs **do not** extend `/api/v1/jira/execute`. Each has its own narrow route with a hardcoded upstream path — the `/execute` regex allowlist stays GET-only forever. The `JiraClient` write methods bypass the `validate_jira_api_path` validator (their paths are constants, not caller input), but the path-segment denylist (`transitions`, `worklog`, `attachments`, `watchers`, plus `DELETE` / `PUT` / `PATCH` on `/execute`) is unchanged.
+
+### Sandbox wrapper subcommands
+
+The sandbox wrapper (`sandbox/scripts/jira`) gains four new subcommands. Each shells to the matching gateway route over `EGG_SESSION_TOKEN`; Atlassian credentials never enter the sandbox.
+
+```text
+jira ticket create   --project KEY --type Task --summary "..."
+                     [--description "..." | --description-file PATH | --description-stdin]
+                     [--labels a,b]
+                     [--parent FOO-1] [--epic-link FOO-2]
+                     [--idempotency-key K]
+
+jira ticket edit     TICKET
+                     [--summary "..."]
+                     [--description "..." | --description-file PATH | --description-stdin]
+                     [--labels a,b]                # replace mode (mutually exclusive with add/remove)
+                     [--add-labels x] [--remove-labels y]   # incremental mode
+                     [--no-notify]
+
+jira ticket comment add TICKET
+                     [--body "..." | --body-file PATH | --body-stdin]
+                     [--idempotency-key K]
+
+jira link create     --type Blocks --inward FOO-1 --outward FOO-2
+                     [--comment "..."]
+                     [--idempotency-key K]
+```
+
+The `--description-*` / `--body-*` flag groups are mutually exclusive — pass at most one. Mixing replace-mode `--labels` with incremental `--add-labels` / `--remove-labels` is rejected client-side and (as a defence in depth) at the gateway with HTTP 400.
+
+### `POST /api/v1/jira/ticket/create`
+
+**Request body:**
+```json
+{
+  "projectKey": "ENG",
+  "issuetype": "Task",                       // or numeric ID
+  "summary": "Investigate flaky pipeline",   // required, ≤ 255 chars
+  "description": "Plain text or ADF dict",   // optional, ≤ 32 KiB
+  "labels": ["triage", "p2"],                // optional, ≤ 30 entries × ≤ 255 chars each
+  "parent": "ENG-1234",                      // optional; used for next-gen / company-managed parent
+  "epicLink": "ENG-9999",                    // optional; routed per jira.epic_link_field
+  "idempotencyKey": "create-eng-2026-04-27-001"  // optional, see Idempotency below
+}
+```
+
+**Validation:**
+
+1. JSON parse, then field allowlist — only the keys above are accepted; any unknown field (including `customfield_*` smuggling) is rejected 400. Custom fields are not exposed in v1.
+2. Size caps: `summary` ≤ 255 chars (matches Atlassian's hard limit), `description` ≤ 32 KiB, `labels` ≤ 30 entries with each ≤ 255 chars.
+3. `projectKey` must be in `jira.projects` (otherwise 403 `jira_ticket_create_denied`, reason `"project not allowlisted"`).
+4. **Cross-project parent reject.** If `parent.<key>` is from a different project than `projectKey`, the request is rejected 400. The gateway will not implicitly widen the project allowlist via a parent reference.
+5. **`parent` and `epicLink` are mutually exclusive.** Passing both returns 400 — Atlassian's two epic-link mechanisms cannot be set simultaneously and the gateway refuses to silently choose.
+6. Plain-text `description` is wrapped to ADF; an ADF dict (i.e. `{"type": "doc", "version": 1, "content": [...]}`) passes through verbatim.
+
+**Epic-link dispatch.** Atlassian has two mechanisms for placing a ticket under an epic, depending on the project type:
+
+- Next-gen / company-managed: `parent.key`.
+- Classic / team-managed: `customfield_10014`.
+
+The gateway selects between them via `jira.epic_link_field` in `config/context-filters.yaml` (default `"parent"`). When `epicLink` is supplied, the gateway emits **only** the configured field — never both — because Atlassian rejects the un-configured field with `cannot be set, it is not on the appropriate screen, or unknown`. If you pass an explicit `parent`, it goes through verbatim regardless of the config knob.
+
+**Response:** normalized envelope (always 200 on success):
+```json
+{
+  "key": "ENG-4242",
+  "id": "10042",
+  "browse_url": "https://acme.atlassian.net/browse/ENG-4242",
+  "status": "created"
+}
+```
+
+### `POST /api/v1/jira/ticket/edit`
+
+**Request body:**
+```json
+{
+  "ticket": "ENG-4242",
+  "summary": "...",                  // optional, ≤ 255 chars
+  "description": "...",              // optional, str or ADF dict, ≤ 32 KiB
+  "labels": ["a", "b"],              // optional REPLACE mode
+  "addLabels": ["new"],              // optional INCREMENTAL mode
+  "removeLabels": ["old"],           // optional INCREMENTAL mode
+  "notifyUsers": false               // optional, default false (quiet update)
+}
+```
+
+**Validation:**
+
+1. `ticket` must match `^[A-Z][A-Z0-9_]*-\d+$` and its project must be in `jira.projects`.
+2. Field allowlist + size caps as above.
+3. **Replace and incremental label modes are mutually exclusive.** If `labels` is set together with any of `addLabels` / `removeLabels`, the request is rejected 400 — Atlassian's update body cannot express both at once and the gateway refuses to silently pick a winner.
+4. `notifyUsers` defaults to `false` (decision-5). When `false`, the gateway adds `?notifyUsers=false` to the upstream URL; when `true`, the query param is omitted (Atlassian's default is to notify, so `notifyUsers=true` would just bloat the URL).
+
+**Response:**
+```json
+{ "status": "updated", "key": "ENG-4242" }
+```
+
+The gateway does not synthesize an extra read after the edit — if you need the post-edit ticket, follow with `POST /api/v1/jira/ticket/get`.
+
+### `POST /api/v1/jira/ticket/comment/add`
+
+**Request body:**
+```json
+{
+  "ticket": "ENG-4242",
+  "body": "Plan-apply succeeded — ticket linked to epic ENG-9999.",
+  "idempotencyKey": "comment-eng-4242-plan-apply-2026-04-27"
+}
+```
+
+`body` may also be an ADF dict for rich formatting. Cap is 32 KiB (mirrors `description` — Atlassian publishes no upper limit, but 32 KiB bounds audit-log size and easily covers realistic plan-apply commentary).
+
+**Visibility is intentionally not exposed in v1.** The Atlassian `visibility` field (project-role / group restrictions on a comment) is rejected 400 if present in the body. Comments are public to anyone with read access to the ticket.
+
+**Response:** the Atlassian comment object verbatim.
+
+### `POST /api/v1/jira/issue-link/create`
+
+**Request body:**
+```json
+{
+  "type": "Blocks",
+  "inwardIssue": "ENG-1234",
+  "outwardIssue": "ENG-5678",
+  "comment": "Optional explanation",
+  "idempotencyKey": "link-eng-1234-blocks-eng-5678"
+}
+```
+
+**Validation:**
+
+1. `type` must be in the operator-configurable `jira.link_types` allowlist (default `["Blocks", "Relates"]`). Atlassian link-type names are case-sensitive — `blocks` will be rejected.
+2. **Both** `inwardIssue` and `outwardIssue` projects must be in `jira.projects` (strict — decision-9). The gateway will not link tickets across the allowlist boundary even when the operator has read access to both projects.
+3. `comment`, when provided, is ADF-wrapped and surfaced via the body's `comment` field — a single round-trip rather than two (decision-23). Idempotency cache covers the link too, so the comment cannot be duplicated by retries.
+
+**Response.** Atlassian returns `201 Created` with no body for `POST /rest/api/3/issueLink`. The gateway therefore synthesizes a stable response envelope:
+```json
+{
+  "status": "created",
+  "inwardIssue": "ENG-1234",
+  "outwardIssue": "ENG-5678",
+  "type": "Blocks"
+}
+```
+
+Including the triple in the response lets the orchestrator's plan-apply correlate the call against its retry record.
+
+### Atlassian Document Format (ADF) wrapping
+
+Atlassian stores ticket descriptions and comment bodies as a JSON tree ([Atlassian Document Format](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/)), not plain text or HTML. Agents almost always work with plain text, so the gateway's write verbs accept either:
+
+- **Plain text** — wrapped to a single-paragraph ADF document by `gateway/jira_adf.py:wrap_text_as_adf`.
+- **ADF dict** — passes through verbatim. The gateway recognizes ADF via `is_adf_dict`: a dict with `type == "doc"`, an integer `version`, and a list `content`.
+
+Any other shape (string, list, dict missing required keys) is rejected 400 with a validation error.
+
+### Idempotency keys
+
+`createJiraIssue`, `addCommentToJiraIssue`, and `createIssueLink` accept an optional `idempotencyKey`. When supplied, the gateway caches the upstream response in an in-memory per-process map (`gateway/jira_idempotency.py`) for **5 minutes**. A second call with the same `(verb, project, idempotencyKey)` triple within the TTL returns the cached response without re-hitting Atlassian. Without the key, every call is dispatched fresh.
+
+The cache lives in the gateway process. If the gateway is restarted, the cache is lost — the orchestrator owns higher-level retry semantics and must be prepared for transient duplicates after a restart.
+
+`editJiraIssue` is naturally idempotent (a PUT against the same key with the same body is a no-op) and does not accept `idempotencyKey`.
+
+**Link-cache aliasing safety.** For `createIssueLink`, the cache key is composed as `(verb="link", canonical_link_id(inward, outward, type), idempotencyKey)`. Two callers re-using the same opaque `idempotencyKey` against different `(inwardIssue, outwardIssue, type)` triples produce **distinct** cache entries — no aliasing across triples.
+
+**Optional with documented warning (decision-3).** Omitting `idempotencyKey` is not an error, but at-least-once retry semantics are then the caller's responsibility. The gateway logs a `jira_<verb>_no_idempotency_key` audit entry when the key is omitted so operators can spot agents that retry without dedup.
+
+### Audit-log redaction
+
+Every write call emits a structured audit entry with operation `jira_ticket_create` / `jira_ticket_edit` / `jira_comment_add` / `jira_issue_link_create`. The redaction rules (Q20 default):
+
+| What is logged | What is **not** logged |
+|----------------|------------------------|
+| Operation name, caller identity, pipeline / contract context | Description text |
+| Project key, ticket key (where applicable) | Comment body text |
+| Field names changed | Summary text |
+| Content lengths (`summary_length`, `description_length`, `comment_length`) | |
+| Label values (small enumerated strings — policy-relevant for who-tagged-what audit) | |
+| Link-type name (e.g. `"Blocks"`) | |
+| Epic-link field used (`"parent"` vs `"customfield_10014"`) | |
+| Outcome (`allowed` / `denied` / 429) | |
+
+The rationale: structural metadata is enough for the operator to reconstruct what changed, and labels are short enumerated strings that operators legitimately need for audit ("who tagged this incident `p0`?"). Free-text body content is treated as customer-impacting data and never written to disk.
+
+**429 audit on writes.** Per Q12 default, every Atlassian 429 emits a `jira_upstream_rate_limited` audit entry — including writes. The retry loop in `JiraClient._request` still retries only GETs (writes never auto-retry, to preserve the v1 invariant), but the audit emit is unconditional on 429. Operators can therefore alert on rate-limit pressure across reads and writes uniformly.
+
+### Configuration knobs
+
+`config/context-filters.yaml` gains two optional keys under `jira:`. Both have sensible defaults; both fail closed on malformed input.
+
+```yaml
+jira:
+  projects: [ENG, DEVOPS]
+  # Optional. Default ["Blocks", "Relates"]. Atlassian link-type names
+  # are case-sensitive.
+  link_types: ["Blocks", "Relates"]
+  # Optional. Default "parent". Selects which Atlassian field carries
+  # the epic relationship for the `epicLink` shorthand. Use
+  # "customfield_10014" for classic / team-managed projects.
+  epic_link_field: "parent"
+```
+
+Both knobs are reloaded on `POST /api/v1/config/reload` and on file mtime change. Invalid values (unknown enum for `epic_link_field`, non-list for `link_types`) trigger a startup warning and fall back to the default — the gateway does not crash.
+
+### Error cases (write surface)
+
+In addition to the [shared error cases](#error-cases) above:
+
+| HTTP | Condition | Audit event |
+|------|-----------|-------------|
+| 400 | Unknown field in body (e.g. `customfield_*` smuggling) | `jira_<verb>_rejected`, reason `"unknown field"` |
+| 400 | Both `parent` and `epicLink` set on create | `jira_ticket_create_rejected`, reason `"parent and epicLink mutually exclusive"` |
+| 400 | Both replace `labels` and incremental `addLabels` / `removeLabels` set on edit | `jira_ticket_edit_rejected`, reason `"label modes mutually exclusive"` |
+| 400 | Cross-project `parent` (parent's project ≠ new ticket's `projectKey`) | `jira_ticket_create_rejected`, reason `"cross-project parent"` |
+| 400 | Oversized `summary` / `description` / `labels` count | `jira_<verb>_rejected`, reason names the cap |
+| 400 | Unknown issuetype | `jira_ticket_create_rejected`, reason `"unknown issuetype"` |
+| 400 | `comment` body shape is neither plain text nor a valid ADF dict | `jira_<verb>_rejected`, reason `"invalid body shape"` |
+| 400 | `visibility` field present on comment | `jira_comment_add_rejected`, reason `"visibility not supported"` |
+| 403 | Either side of `createIssueLink` not in `jira.projects` | `jira_issue_link_create_denied`, reason `"project not allowlisted"` |
+| 403 | Link `type` not in `jira.link_types` | `jira_issue_link_create_denied`, reason `"link type not allowlisted"` |
+| 503 | Atlassian credentials not configured | `jira_credentials_unavailable` |
+| *upstream* | Atlassian 4xx/5xx other than rate-limit | Upstream status passed through, `jira_upstream_error` |
+
+### Phase rollback
+
+The implementation lands as six commits inside a single PR (foundation modules → JiraClient methods → gateway routes → sandbox wrapper → tests → docs). Each phase is independently revertible without breaking the v1 read surface — the BRC implement-phase reviewer should verify by running `git revert --no-commit <phase-N-commit>` on each phase and confirming that `pytest gateway/tests/test_jira_routes.py gateway/tests/test_jira_client.py gateway/tests/test_allowed_domains.py` stays green before discarding the revert.
+
+| Reverting … | Effect |
+|-------------|--------|
+| Phase 6 (this doc) | Harmless. The runtime is unchanged; only the user-facing reference disappears. |
+| Phase 5 (tests) | Harmless. The runtime is unchanged; coverage drops on the four new modules. |
+| Phase 4 (sandbox wrapper) | Gateway routes remain reachable from any HTTP client with the session token, but the sandbox `jira` CLI loses the `ticket create` / `ticket edit` / `ticket comment add` / `link create` subcommands. Agents lose the friendly surface; the gateway is otherwise inert. |
+| Phase 3 (gateway routes) | The four `/api/v1/jira/...` write routes return 404. `JiraClient` write methods exist on the class but are not callable from outside the gateway process. |
+| Phase 2 (`JiraClient` writes) | The four routes return 500 if hit (`AttributeError` on missing methods). The route-enumeration regression in `test_jira_routes.py` will start failing — revert Phase 3 alongside Phase 2. |
+| Phase 1 (foundations: idempotency cache + ADF wrapper) | Phase 2 does not import; revert Phase 2 alongside Phase 1. The v1 read surface is unaffected — read verbs do not depend on `jira_idempotency.py` or `jira_adf.py`. |
+
+This is a one-time implement-phase verification, not a CI gate. The phase ordering is documented here so operators have a written record of how to peel the surface back if a downstream issue forces a partial rollback.
+
+### Cross-references
+
+- [Read verbs](#endpoint-surface) — the v1 read surface this section extends.
+- [Project-allowlist semantics](#project-allowlist-semantics) — `jira.projects`, the hard policy boundary that the write verbs inherit verbatim.
+- [`not_found` envelope](#not_found-envelope) — write verbs do **not** use this envelope; an Atlassian 404 on edit / comment-add / issue-link surfaces as `JiraUpstreamError` and is translated to the upstream status.
+
 ## Future-verb extension points
 
-The v1 shape is deliberately the base case for the follow-up write verbs (not in this ticket):
+The bounded write surface above is intentionally narrow. Several adjacent capabilities were considered and explicitly **deferred** rather than silently dropped:
 
-- **`POST /api/v1/jira/ticket/create`** — new narrow route. Adds `POST /rest/api/3/issue` to `validate_jira_api_path` (POST-allowed list keyed to the same project-allowlist gate). `JiraClient.create_ticket(project, issuetype, fields)` added; existing `_request` 429-retry does not retry writes (already enforced for future safety).
-- **`POST /api/v1/jira/ticket/update`** — new narrow route. Adds `POST /rest/api/3/issue/{key}` (Atlassian's edit endpoint is POST, not PUT). `JiraClient.update_ticket(key, fields)`.
-- **`POST /api/v1/jira/comment/create`** — new narrow route. Adds `POST /rest/api/3/issue/{key}/comment`. `JiraClient.add_comment(key, body)`.
+- **Per-role write gating** (decision-D10). Within an allowlisted project, every authenticated agent can call every write verb. Per-role policy (e.g. only `coder` can create tickets, only `reviewer_*` can comment) is a follow-up. Filed: TBD-write-policy.
+- **Per-phase write gating** (decision-D11). Writes are accepted from any phase. Restricting to e.g. plan-only `createIssue` is a follow-up under the same write-policy umbrella.
+- **Generic `customFields` map** (decision-D1). Only the curated `summary` / `description` / `labels` / `parent` / `epicLink` shorthand is exposed in v1.1. Operators with downstream Jira integrations needing arbitrary custom-field writes should file a follow-up.
+- **Transitions, worklogs, attachments, watchers, deletions** — permanently out of scope. The path validator's denylist refuses these even on `/execute`, even if a future verb tried to widen the surface.
+- **Per-verb rate-limit config** (`jira.rate_limits:`) and `EGG_JIRA_ENABLED` kill-switch — deferred from the original v1 read scope; still deferred. Both are beyond v1.1; this section calls them out so reviewers don't search the codebase for them.
 
-All three land under the same `@require_session_auth` → `@require_private_mode` → project-allowlist chain. None of them extends the `/execute` passthrough — the regex allowlist there stays GET-only. The `JIRA_WRITE_VERBS_DENIED` frozenset permanently refuses `transitions`, `worklog`, `attachments`, `watchers`, `DELETE`, `PUT`, and `PATCH` at the path validator, even in the write-verb follow-up.
-
-**Deferred to v1.1 (explicit, not silently dropped):** per-verb rate-limit config under `jira.rate_limits:` and an `EGG_JIRA_ENABLED` kill-switch env var. Both are beyond v1 scope; this section calls them out so reviewers don't search the codebase for them.
+The `JIRA_WRITE_VERBS_DENIED` frozenset permanently refuses `transitions`, `worklog`, `attachments`, `watchers`, `DELETE`, `PUT`, and `PATCH` at the path validator. The four write verbs above sidestep the validator by hardcoding their upstream paths — they cannot reach the denylisted segments by construction.
 
 ## Related documentation
 
 - [Credential Injection — Atlassian / Jira](../architecture/credential-injection.md#atlassian--jira) — where credentials live, mtime refresh, zero-credential invariant
 - [Network Isolation — Gateway REST API](../architecture/network-isolation.md#gateway-rest-api) — endpoint summary and Squid allowlist exclusion
 - [Sandbox environment rules](../../sandbox/agent-config/rules/environment.md) — `jira` wrapper verbs, `EGG_JIRA_TICKET` semantics
-- Gateway source: `gateway/jira_credentials.py`, `gateway/jira_client.py`, `gateway/jira_policy.py`, `gateway/mode_gate.py`
+- Gateway source: `gateway/jira_credentials.py`, `gateway/jira_client.py`, `gateway/jira_policy.py`, `gateway/jira_idempotency.py`, `gateway/jira_adf.py`, `gateway/mode_gate.py`
 - Sandbox wrapper: `sandbox/scripts/jira`
 - Config: `config/context-filters.yaml`, `config/secrets.template.env`

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -17,10 +17,14 @@ Endpoints:
     POST /api/v1/gh/pr/edit     - Edit PR (policy: pr_ownership)
     POST /api/v1/gh/pr/close    - Close PR (policy: pr_ownership)
     POST /api/v1/gh/execute     - Generic gh command (policy: filtered)
-    POST /api/v1/jira/ticket/get       - Read Jira issue (policy: private-mode, project allowlist)
-    POST /api/v1/jira/search           - JQL search (policy: private-mode, statically project-scoped)
-    POST /api/v1/jira/ticket/comments  - Read Jira issue comments (policy: private-mode, project allowlist)
-    POST /api/v1/jira/execute          - Generic read-only Jira REST call (policy: private-mode, allowlisted path)
+    POST /api/v1/jira/ticket/get          - Read Jira issue (policy: private-mode, project allowlist)
+    POST /api/v1/jira/search              - JQL search (policy: private-mode, statically project-scoped)
+    POST /api/v1/jira/ticket/comments     - Read Jira issue comments (policy: private-mode, project allowlist)
+    POST /api/v1/jira/execute             - Generic read-only Jira REST call (policy: private-mode, allowlisted path)
+    POST /api/v1/jira/ticket/create       - Create a new Jira issue (policy: private-mode, project allowlist, body schema)
+    POST /api/v1/jira/ticket/edit         - Edit an existing Jira issue (policy: private-mode, project allowlist, body schema)
+    POST /api/v1/jira/ticket/comment/add  - Add a comment to a Jira issue (policy: private-mode, project allowlist, body schema)
+    POST /api/v1/jira/issue-link/create   - Create an issue-link between two Jira issues (policy: private-mode, both projects allowlisted, link-type allowlist)
     POST /api/v1/confluence/page/get             - Read Confluence page (policy: private-mode, space allowlist)
     POST /api/v1/confluence/page/descendants     - List page descendants (policy: private-mode, space allowlist)
     POST /api/v1/confluence/page/footer-comments - Read page footer comments (policy: private-mode, space allowlist)
@@ -146,6 +150,12 @@ try:
         validate_gh_api_path,
     )
     from .jira_client import (
+        DEFAULT_JIRA_LINK_TYPES,
+        JIRA_COMMENT_MAX_CHARS,
+        JIRA_DESCRIPTION_MAX_CHARS,
+        JIRA_LABEL_MAX_CHARS,
+        JIRA_LABEL_MAX_COUNT,
+        JIRA_SUMMARY_MAX_CHARS,
         JiraCredentialsUnavailable,
         JiraUpstreamError,
         get_jira_client,
@@ -156,10 +166,17 @@ try:
     )
     from .jira_credentials import reload_jira_credentials
     from .jira_policy import (
+        allowed_link_types as jira_allowed_link_types,
+    )
+    from .jira_policy import (
+        epic_link_field as jira_epic_link_field,
+    )
+    from .jira_policy import (
         extract_project_key,
         is_project_allowed,
         reload_jira_policy,
     )
+    from .jira_adf import is_adf_dict as is_jira_adf_dict
     from .jira_search import extract_search_projects
     from .mode_gate import require_private_mode
     from .phase_filter import (
@@ -283,6 +300,12 @@ except ImportError:
         extract_search_spaces,
     )
     from jira_client import (  # type: ignore[no-redef, import-untyped]
+        DEFAULT_JIRA_LINK_TYPES,
+        JIRA_COMMENT_MAX_CHARS,
+        JIRA_DESCRIPTION_MAX_CHARS,
+        JIRA_LABEL_MAX_CHARS,
+        JIRA_LABEL_MAX_COUNT,
+        JIRA_SUMMARY_MAX_CHARS,
         JiraCredentialsUnavailable,
         JiraUpstreamError,
         get_jira_client,
@@ -295,9 +318,18 @@ except ImportError:
         reload_jira_credentials,
     )
     from jira_policy import (  # type: ignore[no-redef, import-untyped]
+        allowed_link_types as jira_allowed_link_types,
+    )
+    from jira_policy import (  # type: ignore[no-redef]
+        epic_link_field as jira_epic_link_field,
+    )
+    from jira_policy import (  # type: ignore[no-redef]
         extract_project_key,
         is_project_allowed,
         reload_jira_policy,
+    )
+    from jira_adf import (  # type: ignore[no-redef, import-untyped]
+        is_adf_dict as is_jira_adf_dict,
     )
     from jira_search import (  # type: ignore[no-redef, import-untyped]
         extract_search_projects,
@@ -4758,6 +4790,1141 @@ def jira_execute() -> tuple[Response, int] | Response:
         },
     )
     return make_success("Jira API call executed", body)
+
+
+# -----------------------------------------------------------------------------
+# Jira write verbs (issue #1924)
+# -----------------------------------------------------------------------------
+#
+# Four narrow routes — one per Atlassian write verb — extending the v1
+# read-only surface with a bounded mutation surface.  Each route:
+#
+# 1. Validates the body schema (size caps + field allowlist; reject custom-
+#    field smuggling via the strict allowlist; reject cross-project parent).
+# 2. Resolves the project allowlist via ``JiraPolicy``.
+# 3. ADF-wraps plain-text rich-text fields (or accepts ADF dicts).
+# 4. Calls the corresponding ``JiraClient`` write method.
+# 5. Emits an audit record with structural metadata only (no body content).
+# 6. Returns the agreed response envelope.
+#
+# Per architect decision-1 the v1 surface does NOT expose a generic
+# ``customFields`` map.  Adding a custom field means adding a new shorthand
+# (like the existing ``epicLink``) and re-reviewing the policy.
+#
+# Per architect decision-10/11 the v1 surface does NOT gate writes by agent
+# role or pipeline phase — those are deferred to a follow-up issue once the
+# real consumer (#1557) lands.
+
+# Atlassian link-type names: printable, ≤ 64 chars (matches policy loader).
+_JIRA_LINK_TYPE_RE = re.compile(r"^[\w\s-]{1,64}$")
+
+
+def _validate_jira_label(value: Any) -> str:
+    """Reject labels that fail Atlassian's character / length constraints.
+
+    Returns the trimmed string on success, or raises ``ValueError`` with an
+    actionable message.  Atlassian rejects whitespace inside labels — the
+    web UI replaces spaces with hyphens — so we surface that as a 400
+    rather than letting the upstream return a confusing error.
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"label must be a string, got {type(value).__name__}")
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("label must not be empty")
+    if len(cleaned) > JIRA_LABEL_MAX_CHARS:
+        raise ValueError(f"label exceeds {JIRA_LABEL_MAX_CHARS} chars")
+    if any(ch.isspace() for ch in cleaned):
+        raise ValueError("label must not contain whitespace")
+    return cleaned
+
+
+def _validate_jira_label_list(value: Any, *, name: str) -> list[str]:
+    """Validate a list-of-labels payload field.  Empty list is fine."""
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be a list of strings")
+    if len(value) > JIRA_LABEL_MAX_COUNT:
+        raise ValueError(f"{name} exceeds {JIRA_LABEL_MAX_COUNT} entries")
+    cleaned: list[str] = []
+    for entry in value:
+        cleaned.append(_validate_jira_label(entry))
+    return cleaned
+
+
+def _validate_jira_richtext(
+    value: Any, *, name: str, max_chars: int
+) -> str | dict[str, Any]:
+    """Validate a description / comment field — text or ADF passthrough.
+
+    Returns the original string (with length-checked, non-empty preserved)
+    or the ADF dict unchanged.  ``None`` is rejected — the caller decides
+    whether the field is optional and skips this helper accordingly.
+    """
+    if isinstance(value, str):
+        if len(value) > max_chars:
+            raise ValueError(f"{name} exceeds {max_chars} chars")
+        return value
+    if is_jira_adf_dict(value):
+        # ADF size — bound the JSON serialization so an attacker cannot
+        # smuggle a 100 MiB description by pre-wrapping it in ADF.
+        encoded = json.dumps(value)
+        if len(encoded) > max_chars:
+            raise ValueError(f"{name} exceeds {max_chars} chars (ADF size)")
+        return value
+    raise ValueError(
+        f"{name} must be a string or a valid ADF document dict"
+    )
+
+
+def _audit_jira_write(
+    *,
+    event_type: str,
+    operation: str,
+    success: bool,
+    details: dict[str, Any],
+) -> None:
+    """Audit-log helper that always merges in session context.
+
+    Routes use this so the redaction grid (Q20 default) is centralised:
+    the only callers are this module and tests should never see the raw
+    ``audit_log`` for write events.
+    """
+    payload: dict[str, Any] = dict(details)
+    payload.update(_session_jira_context())
+    audit_log(event_type, operation, success=success, details=payload)
+
+
+# Body field allowlists — anything outside these sets gets a 400 with a
+# named violation.  We keep them as module-level constants so the four
+# routes share the policy and the test suite can introspect the
+# enumeration directly.
+
+_JIRA_TICKET_CREATE_ALLOWED_FIELDS: frozenset[str] = frozenset(
+    {
+        "projectKey",
+        "issuetype",
+        "summary",
+        "description",
+        "labels",
+        "parent",
+        "epicLink",
+        "idempotencyKey",
+    }
+)
+
+_JIRA_TICKET_EDIT_ALLOWED_FIELDS: frozenset[str] = frozenset(
+    {
+        "ticket",
+        "summary",
+        "description",
+        "labels",
+        "addLabels",
+        "removeLabels",
+        "notifyUsers",
+    }
+)
+
+_JIRA_COMMENT_ADD_ALLOWED_FIELDS: frozenset[str] = frozenset(
+    {
+        "ticket",
+        "body",
+        "idempotencyKey",
+    }
+)
+
+_JIRA_LINK_CREATE_ALLOWED_FIELDS: frozenset[str] = frozenset(
+    {
+        "type",
+        "inwardIssue",
+        "outwardIssue",
+        "comment",
+        "idempotencyKey",
+    }
+)
+
+
+def _reject_unknown_fields(
+    body: dict[str, Any],
+    *,
+    allowed: frozenset[str],
+    operation: str,
+) -> str | None:
+    """Return a 400-error reason if ``body`` contains a field not in ``allowed``.
+
+    Returning ``None`` means the body passed.  The caller emits the audit
+    record + 400 response from the returned reason; this helper is silent.
+    """
+    extras = sorted(set(body.keys()) - allowed)
+    if extras:
+        return (
+            f"unknown field(s) for {operation}: {', '.join(repr(k) for k in extras)}"
+        )
+    return None
+
+
+def _validate_idempotency_key(value: Any) -> str | None:
+    """Validate ``idempotencyKey`` body field.
+
+    Atlassian-side caps don't apply (the key never reaches Atlassian) but a
+    pathological 1 MiB key would bloat audit logs and the cache, so we
+    cap the length here.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("idempotencyKey must be a string")
+    if not value or len(value) > 128:
+        raise ValueError("idempotencyKey must be 1..128 chars")
+    return value
+
+
+@app.route("/api/v1/jira/ticket/create", methods=["POST"])
+@require_session_auth
+@require_private_mode
+def jira_ticket_create() -> tuple[Response, int] | Response:
+    """Create a new Jira issue.
+
+    Request body::
+
+        {
+          "projectKey": "ENG",
+          "issuetype": "Task",                       // or numeric id
+          "summary": "Investigate flaky pipeline",   // required, ≤ 255 chars
+          "description": "...",                      // optional, str or ADF
+          "labels": ["a", "b"],                      // optional
+          "parent": "ENG-1234",                      // optional
+          "epicLink": "ENG-9999",                    // optional
+          "idempotencyKey": "..."                    // optional
+        }
+
+    Per architect decision-1 the body **must not** carry arbitrary
+    ``customfield_*`` keys; the field allowlist rejects them with 400.
+    """
+    op = "jira_ticket_create"
+    data = request.get_json(silent=True) or {}
+
+    if not isinstance(data, dict):
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "body must be an object"},
+        )
+        return make_error("body must be an object", status_code=400)
+
+    extras = _reject_unknown_fields(
+        data, allowed=_JIRA_TICKET_CREATE_ALLOWED_FIELDS, operation=op
+    )
+    if extras is not None:
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": extras},
+        )
+        return make_error(extras, status_code=400)
+
+    project_key = data.get("projectKey")
+    issuetype = data.get("issuetype")
+    summary = data.get("summary")
+    description = data.get("description")
+    labels = data.get("labels")
+    parent = data.get("parent")
+    epic_link = data.get("epicLink")
+    idempotency_key = data.get("idempotencyKey")
+
+    # Project key shape — uppercase letter + alnum/_.
+    if not isinstance(project_key, str) or not re.fullmatch(r"[A-Z][A-Z0-9_]*", project_key):
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "projectKey shape invalid", "projectKey": project_key},
+        )
+        return make_error("projectKey is required and must be a Jira project key", status_code=400)
+
+    # Allowlist gate.
+    if not is_project_allowed(project_key):
+        return _project_not_allowlisted_response(
+            event=f"{op}_denied",
+            ticket=None,
+            project=project_key,
+            reason="project not allowlisted",
+        )
+
+    # issuetype required.
+    if not isinstance(issuetype, (str, int)) or isinstance(issuetype, bool):
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "issuetype must be a string name or numeric id"},
+        )
+        return make_error("issuetype must be a string name or numeric id", status_code=400)
+    if isinstance(issuetype, str) and not issuetype.strip():
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "issuetype must not be empty"},
+        )
+        return make_error("issuetype must not be empty", status_code=400)
+
+    # Summary required, capped.
+    if not isinstance(summary, str) or not summary.strip():
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "summary required"},
+        )
+        return make_error("summary is required", status_code=400)
+    if len(summary) > JIRA_SUMMARY_MAX_CHARS:
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={
+                "reason": f"summary exceeds {JIRA_SUMMARY_MAX_CHARS} chars",
+                "summary_length": len(summary),
+            },
+        )
+        return make_error(
+            f"summary exceeds {JIRA_SUMMARY_MAX_CHARS} chars",
+            status_code=400,
+        )
+
+    # Description optional.
+    cleaned_description: str | dict[str, Any] | None = None
+    if description is not None:
+        try:
+            cleaned_description = _validate_jira_richtext(
+                description,
+                name="description",
+                max_chars=JIRA_DESCRIPTION_MAX_CHARS,
+            )
+        except ValueError as exc:
+            _audit_jira_write(
+                event_type=f"{op}_rejected",
+                operation=op,
+                success=False,
+                details={"reason": str(exc)},
+            )
+            return make_error(str(exc), status_code=400)
+
+    # Labels optional.
+    cleaned_labels: list[str] | None = None
+    if labels is not None:
+        try:
+            cleaned_labels = _validate_jira_label_list(labels, name="labels")
+        except ValueError as exc:
+            _audit_jira_write(
+                event_type=f"{op}_rejected",
+                operation=op,
+                success=False,
+                details={"reason": str(exc)},
+            )
+            return make_error(str(exc), status_code=400)
+
+    # Parent / epicLink — at most one (route-level reject).
+    if parent is not None and epic_link is not None:
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "parent and epicLink are mutually exclusive"},
+        )
+        return make_error(
+            "parent and epicLink are mutually exclusive — pass at most one",
+            status_code=400,
+        )
+
+    if parent is not None:
+        if not isinstance(parent, str) or not _JIRA_TICKET_KEY_RE.fullmatch(parent):
+            _audit_jira_write(
+                event_type=f"{op}_rejected",
+                operation=op,
+                success=False,
+                details={"reason": "parent must be a Jira ticket key"},
+            )
+            return make_error(
+                "parent must be a Jira ticket key (e.g. 'FOO-1')", status_code=400
+            )
+        parent_project = extract_project_key(parent)
+        # Cross-project parent reject (decision-17): the new ticket is in
+        # ``project_key`` and the parent is in ``parent_project`` — refuse
+        # the implicit allowlist widening.
+        if parent_project != project_key:
+            _audit_jira_write(
+                event_type=f"{op}_rejected",
+                operation=op,
+                success=False,
+                details={
+                    "reason": "parent project differs from projectKey",
+                    "projectKey": project_key,
+                    "parent_project": parent_project,
+                    "parent": parent,
+                },
+            )
+            return make_error(
+                "parent must belong to the same project as projectKey",
+                status_code=400,
+            )
+
+    if epic_link is not None:
+        if not isinstance(epic_link, str) or not _JIRA_TICKET_KEY_RE.fullmatch(epic_link):
+            _audit_jira_write(
+                event_type=f"{op}_rejected",
+                operation=op,
+                success=False,
+                details={"reason": "epicLink must be a Jira ticket key"},
+            )
+            return make_error(
+                "epicLink must be a Jira ticket key (e.g. 'FOO-1')", status_code=400
+            )
+        # Allowlist gate the epic key too — epics live in their own project,
+        # which must also be allowlisted.
+        epic_project = extract_project_key(epic_link)
+        if not is_project_allowed(epic_project):
+            return _project_not_allowlisted_response(
+                event=f"{op}_denied",
+                ticket=epic_link,
+                project=epic_project,
+                reason="epic project not allowlisted",
+                extra={"projectKey": project_key},
+            )
+
+    # Idempotency key.
+    try:
+        cleaned_idem_key = _validate_idempotency_key(idempotency_key)
+    except ValueError as exc:
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": str(exc)},
+        )
+        return make_error(str(exc), status_code=400)
+
+    # All checks passed — make the upstream call.
+    try:
+        upstream = get_jira_client().create_issue(
+            project_key=project_key,
+            issuetype=issuetype,
+            summary=summary,
+            description=cleaned_description,
+            labels=cleaned_labels,
+            parent=parent,
+            epic_link=epic_link,
+            epic_link_field=jira_epic_link_field(),
+            idempotency_key=cleaned_idem_key,
+        )
+    except JiraCredentialsUnavailable as exc:
+        return _jira_not_configured_error(exc)
+    except JiraUpstreamError as exc:
+        _audit_jira_write(
+            event_type=f"{op}_upstream_error",
+            operation=op,
+            success=False,
+            details={
+                "projectKey": project_key,
+                "upstream_status": exc.status_code,
+            },
+        )
+        return _jira_error_from_upstream(exc)
+
+    new_key = upstream.get("key") if isinstance(upstream, dict) else None
+    new_id = upstream.get("id") if isinstance(upstream, dict) else None
+
+    # Build the normalized envelope (decision-13).  ``browse_url`` is the
+    # canonical Atlassian web URL; the gateway derives it from the
+    # configured base URL so the orchestrator can drop it straight into a
+    # PR description / Slack notification.
+    browse_url: str | None = None
+    if new_key:
+        try:
+            base = get_jira_client().creds_provider().base_url
+            browse_url = f"{base.rstrip('/')}/browse/{new_key}"
+        except Exception:  # pragma: no cover — defensive
+            browse_url = None
+
+    envelope: dict[str, Any] = {"status": "created"}
+    if new_key:
+        envelope["key"] = new_key
+    if new_id:
+        envelope["id"] = new_id
+    if browse_url:
+        envelope["browse_url"] = browse_url
+
+    # Idempotency-key absent → emit a no-key audit so operators can spot
+    # agents that retry without dedup (decision-3 documented warning).
+    if cleaned_idem_key is None:
+        _audit_jira_write(
+            event_type="jira_ticket_create_no_idempotency_key",
+            operation=op,
+            success=True,
+            details={"projectKey": project_key},
+        )
+
+    fields_changed = ["summary"]
+    if cleaned_description is not None:
+        fields_changed.append("description")
+    if cleaned_labels is not None:
+        fields_changed.append("labels")
+    if parent is not None:
+        fields_changed.append("parent")
+    if epic_link is not None:
+        fields_changed.append("epicLink")
+
+    _audit_jira_write(
+        event_type=op,
+        operation=op,
+        success=True,
+        details={
+            "projectKey": project_key,
+            "key": new_key,
+            "issuetype": issuetype if isinstance(issuetype, str) else f"id:{issuetype}",
+            "summary_length": len(summary),
+            "description_length": (
+                None
+                if description is None
+                else (
+                    len(description)
+                    if isinstance(description, str)
+                    else len(json.dumps(cleaned_description))
+                )
+            ),
+            "label_count": len(cleaned_labels) if cleaned_labels is not None else 0,
+            "labels": cleaned_labels or [],
+            "fields_changed": fields_changed,
+            "parent": parent,
+            "epic_link": epic_link,
+            "epic_link_field": jira_epic_link_field() if epic_link is not None else None,
+            "idempotency_key_present": cleaned_idem_key is not None,
+        },
+    )
+
+    return make_success("Jira ticket created", envelope)
+
+
+@app.route("/api/v1/jira/ticket/edit", methods=["POST"])
+@require_session_auth
+@require_private_mode
+def jira_ticket_edit() -> tuple[Response, int] | Response:
+    """Edit an existing Jira issue.
+
+    Request body::
+
+        {
+          "ticket": "ENG-4242",
+          "summary": "...",          // optional
+          "description": "...",      // optional, str or ADF
+          "labels": ["a", "b"],      // optional REPLACE mode
+          "addLabels": ["new"],      // optional INCREMENTAL mode
+          "removeLabels": ["old"],   // optional INCREMENTAL mode
+          "notifyUsers": false       // optional, defaults to false
+        }
+    """
+    op = "jira_ticket_edit"
+    data = request.get_json(silent=True) or {}
+
+    if not isinstance(data, dict):
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "body must be an object"},
+        )
+        return make_error("body must be an object", status_code=400)
+
+    extras = _reject_unknown_fields(
+        data, allowed=_JIRA_TICKET_EDIT_ALLOWED_FIELDS, operation=op
+    )
+    if extras is not None:
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": extras},
+        )
+        return make_error(extras, status_code=400)
+
+    ticket = data.get("ticket")
+    summary = data.get("summary")
+    description = data.get("description")
+    labels = data.get("labels")
+    add_labels = data.get("addLabels")
+    remove_labels = data.get("removeLabels")
+    notify_users = data.get("notifyUsers", False)
+
+    if not isinstance(ticket, str) or not _JIRA_TICKET_KEY_RE.fullmatch(ticket):
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "invalid ticket shape", "ticket": ticket},
+        )
+        return make_error(
+            "Invalid ticket key (expected e.g. 'FOO-123')",
+            status_code=400,
+        )
+
+    project = extract_project_key(ticket)
+    if not is_project_allowed(project):
+        return _project_not_allowlisted_response(
+            event=f"{op}_denied",
+            ticket=ticket,
+            project=project,
+            reason="project not allowlisted",
+        )
+
+    # Mutually-exclusive label modes.
+    if labels is not None and (add_labels is not None or remove_labels is not None):
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={
+                "reason": "labels (replace) and addLabels/removeLabels (incremental) are mutually exclusive",
+                "ticket": ticket,
+            },
+        )
+        return make_error(
+            "Pass either 'labels' OR 'addLabels'/'removeLabels', not both",
+            status_code=400,
+        )
+
+    cleaned_summary: str | None = None
+    if summary is not None:
+        if not isinstance(summary, str) or not summary.strip():
+            _audit_jira_write(
+                event_type=f"{op}_rejected",
+                operation=op,
+                success=False,
+                details={"reason": "summary must be non-empty when provided"},
+            )
+            return make_error("summary must be non-empty when provided", status_code=400)
+        if len(summary) > JIRA_SUMMARY_MAX_CHARS:
+            _audit_jira_write(
+                event_type=f"{op}_rejected",
+                operation=op,
+                success=False,
+                details={"reason": f"summary exceeds {JIRA_SUMMARY_MAX_CHARS} chars"},
+            )
+            return make_error(
+                f"summary exceeds {JIRA_SUMMARY_MAX_CHARS} chars", status_code=400
+            )
+        cleaned_summary = summary
+
+    cleaned_description: str | dict[str, Any] | None = None
+    if description is not None:
+        try:
+            cleaned_description = _validate_jira_richtext(
+                description,
+                name="description",
+                max_chars=JIRA_DESCRIPTION_MAX_CHARS,
+            )
+        except ValueError as exc:
+            _audit_jira_write(
+                event_type=f"{op}_rejected",
+                operation=op,
+                success=False,
+                details={"reason": str(exc), "ticket": ticket},
+            )
+            return make_error(str(exc), status_code=400)
+
+    cleaned_labels: list[str] | None = None
+    if labels is not None:
+        try:
+            cleaned_labels = _validate_jira_label_list(labels, name="labels")
+        except ValueError as exc:
+            _audit_jira_write(
+                event_type=f"{op}_rejected",
+                operation=op,
+                success=False,
+                details={"reason": str(exc), "ticket": ticket},
+            )
+            return make_error(str(exc), status_code=400)
+
+    cleaned_add: list[str] | None = None
+    if add_labels is not None:
+        try:
+            cleaned_add = _validate_jira_label_list(add_labels, name="addLabels")
+        except ValueError as exc:
+            _audit_jira_write(
+                event_type=f"{op}_rejected",
+                operation=op,
+                success=False,
+                details={"reason": str(exc), "ticket": ticket},
+            )
+            return make_error(str(exc), status_code=400)
+
+    cleaned_remove: list[str] | None = None
+    if remove_labels is not None:
+        try:
+            cleaned_remove = _validate_jira_label_list(remove_labels, name="removeLabels")
+        except ValueError as exc:
+            _audit_jira_write(
+                event_type=f"{op}_rejected",
+                operation=op,
+                success=False,
+                details={"reason": str(exc), "ticket": ticket},
+            )
+            return make_error(str(exc), status_code=400)
+
+    # No-op guard: the route requires *some* change.
+    if (
+        cleaned_summary is None
+        and cleaned_description is None
+        and cleaned_labels is None
+        and not cleaned_add
+        and not cleaned_remove
+    ):
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={
+                "reason": "edit body must mutate at least one field",
+                "ticket": ticket,
+            },
+        )
+        return make_error(
+            "edit body must mutate at least one field "
+            "(summary, description, labels, addLabels, or removeLabels)",
+            status_code=400,
+        )
+
+    if not isinstance(notify_users, bool):
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "notifyUsers must be a boolean", "ticket": ticket},
+        )
+        return make_error("notifyUsers must be a boolean", status_code=400)
+
+    try:
+        get_jira_client().edit_issue(
+            key=ticket,
+            summary=cleaned_summary,
+            description=cleaned_description,
+            labels=cleaned_labels,
+            add_labels=cleaned_add,
+            remove_labels=cleaned_remove,
+            notify_users=notify_users,
+        )
+    except JiraCredentialsUnavailable as exc:
+        return _jira_not_configured_error(exc)
+    except JiraUpstreamError as exc:
+        _audit_jira_write(
+            event_type=f"{op}_upstream_error",
+            operation=op,
+            success=False,
+            details={
+                "ticket": ticket,
+                "project": project,
+                "upstream_status": exc.status_code,
+            },
+        )
+        return _jira_error_from_upstream(exc)
+
+    fields_changed: list[str] = []
+    if cleaned_summary is not None:
+        fields_changed.append("summary")
+    if cleaned_description is not None:
+        fields_changed.append("description")
+    if cleaned_labels is not None:
+        fields_changed.append("labels")
+    if cleaned_add is not None:
+        fields_changed.append("addLabels")
+    if cleaned_remove is not None:
+        fields_changed.append("removeLabels")
+
+    _audit_jira_write(
+        event_type=op,
+        operation=op,
+        success=True,
+        details={
+            "ticket": ticket,
+            "project": project,
+            "fields_changed": fields_changed,
+            "summary_length": len(cleaned_summary) if cleaned_summary is not None else 0,
+            "description_length": (
+                0
+                if cleaned_description is None
+                else (
+                    len(cleaned_description)
+                    if isinstance(cleaned_description, str)
+                    else len(json.dumps(cleaned_description))
+                )
+            ),
+            "labels": cleaned_labels or [],
+            "add_labels": cleaned_add or [],
+            "remove_labels": cleaned_remove or [],
+            "notify_users": notify_users,
+        },
+    )
+
+    return make_success("Jira ticket updated", {"status": "updated", "key": ticket})
+
+
+@app.route("/api/v1/jira/ticket/comment/add", methods=["POST"])
+@require_session_auth
+@require_private_mode
+def jira_ticket_comment_add() -> tuple[Response, int] | Response:
+    """Add a comment to a Jira issue.
+
+    Request body::
+
+        {
+          "ticket": "ENG-4242",
+          "body": "Plain text or ADF dict",
+          "idempotencyKey": "..."
+        }
+    """
+    op = "jira_comment_add"
+    data = request.get_json(silent=True) or {}
+
+    if not isinstance(data, dict):
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "body must be an object"},
+        )
+        return make_error("body must be an object", status_code=400)
+
+    extras = _reject_unknown_fields(
+        data, allowed=_JIRA_COMMENT_ADD_ALLOWED_FIELDS, operation=op
+    )
+    if extras is not None:
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": extras},
+        )
+        return make_error(extras, status_code=400)
+
+    ticket = data.get("ticket")
+    body_value = data.get("body")
+    idempotency_key = data.get("idempotencyKey")
+
+    if not isinstance(ticket, str) or not _JIRA_TICKET_KEY_RE.fullmatch(ticket):
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "invalid ticket shape", "ticket": ticket},
+        )
+        return make_error(
+            "Invalid ticket key (expected e.g. 'FOO-123')", status_code=400
+        )
+
+    project = extract_project_key(ticket)
+    if not is_project_allowed(project):
+        return _project_not_allowlisted_response(
+            event=f"{op}_denied",
+            ticket=ticket,
+            project=project,
+            reason="project not allowlisted",
+        )
+
+    if body_value is None:
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "body required", "ticket": ticket},
+        )
+        return make_error("body is required", status_code=400)
+
+    try:
+        cleaned_body = _validate_jira_richtext(
+            body_value, name="body", max_chars=JIRA_COMMENT_MAX_CHARS
+        )
+    except ValueError as exc:
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": str(exc), "ticket": ticket},
+        )
+        return make_error(str(exc), status_code=400)
+
+    try:
+        cleaned_idem_key = _validate_idempotency_key(idempotency_key)
+    except ValueError as exc:
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": str(exc), "ticket": ticket},
+        )
+        return make_error(str(exc), status_code=400)
+
+    try:
+        upstream = get_jira_client().add_comment(
+            key=ticket, body=cleaned_body, idempotency_key=cleaned_idem_key
+        )
+    except JiraCredentialsUnavailable as exc:
+        return _jira_not_configured_error(exc)
+    except JiraUpstreamError as exc:
+        _audit_jira_write(
+            event_type=f"{op}_upstream_error",
+            operation=op,
+            success=False,
+            details={
+                "ticket": ticket,
+                "project": project,
+                "upstream_status": exc.status_code,
+            },
+        )
+        return _jira_error_from_upstream(exc)
+
+    if cleaned_idem_key is None:
+        _audit_jira_write(
+            event_type="jira_comment_add_no_idempotency_key",
+            operation=op,
+            success=True,
+            details={"ticket": ticket, "project": project},
+        )
+
+    body_length = (
+        len(cleaned_body) if isinstance(cleaned_body, str) else len(json.dumps(cleaned_body))
+    )
+
+    _audit_jira_write(
+        event_type=op,
+        operation=op,
+        success=True,
+        details={
+            "ticket": ticket,
+            "project": project,
+            "comment_length": body_length,
+            "comment_id": (
+                upstream.get("id") if isinstance(upstream, dict) else None
+            ),
+            "idempotency_key_present": cleaned_idem_key is not None,
+        },
+    )
+
+    return make_success("Jira comment added", upstream if isinstance(upstream, dict) else {})
+
+
+@app.route("/api/v1/jira/issue-link/create", methods=["POST"])
+@require_session_auth
+@require_private_mode
+def jira_issue_link_create() -> tuple[Response, int] | Response:
+    """Create a Jira issue link between two tickets.
+
+    Request body::
+
+        {
+          "type": "Blocks",
+          "inwardIssue": "ENG-1234",
+          "outwardIssue": "ENG-5678",
+          "comment": "Optional explanation",
+          "idempotencyKey": "..."
+        }
+    """
+    op = "jira_issue_link_create"
+    data = request.get_json(silent=True) or {}
+
+    if not isinstance(data, dict):
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "body must be an object"},
+        )
+        return make_error("body must be an object", status_code=400)
+
+    extras = _reject_unknown_fields(
+        data, allowed=_JIRA_LINK_CREATE_ALLOWED_FIELDS, operation=op
+    )
+    if extras is not None:
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": extras},
+        )
+        return make_error(extras, status_code=400)
+
+    link_type = data.get("type")
+    inward = data.get("inwardIssue")
+    outward = data.get("outwardIssue")
+    comment_body = data.get("comment")
+    idempotency_key = data.get("idempotencyKey")
+
+    # Link-type validation — shape + allowlist.
+    if not isinstance(link_type, str) or not _JIRA_LINK_TYPE_RE.fullmatch(link_type):
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "type must be a printable string ≤ 64 chars"},
+        )
+        return make_error(
+            "type must be a printable Atlassian link-type name", status_code=400
+        )
+    allowed_types = jira_allowed_link_types()
+    if link_type not in allowed_types:
+        _audit_jira_write(
+            event_type=f"{op}_denied",
+            operation=op,
+            success=False,
+            details={
+                "reason": "link type not allowlisted",
+                "type": link_type,
+                "allowed": list(allowed_types),
+            },
+        )
+        return make_error(
+            "Jira link type not allowlisted",
+            status_code=403,
+            details={"type": link_type, "allowed": list(allowed_types)},
+        )
+
+    if not isinstance(inward, str) or not _JIRA_TICKET_KEY_RE.fullmatch(inward):
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "inwardIssue must be a Jira ticket key"},
+        )
+        return make_error(
+            "inwardIssue must be a Jira ticket key", status_code=400
+        )
+    if not isinstance(outward, str) or not _JIRA_TICKET_KEY_RE.fullmatch(outward):
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": "outwardIssue must be a Jira ticket key"},
+        )
+        return make_error(
+            "outwardIssue must be a Jira ticket key", status_code=400
+        )
+
+    inward_project = extract_project_key(inward)
+    outward_project = extract_project_key(outward)
+
+    # Strict — both projects allowlisted (decision-9).
+    if not is_project_allowed(inward_project):
+        return _project_not_allowlisted_response(
+            event=f"{op}_denied",
+            ticket=inward,
+            project=inward_project,
+            reason="inward project not allowlisted",
+            extra={"type": link_type, "outwardIssue": outward},
+        )
+    if not is_project_allowed(outward_project):
+        return _project_not_allowlisted_response(
+            event=f"{op}_denied",
+            ticket=outward,
+            project=outward_project,
+            reason="outward project not allowlisted",
+            extra={"type": link_type, "inwardIssue": inward},
+        )
+
+    cleaned_comment: str | dict[str, Any] | None = None
+    if comment_body is not None:
+        try:
+            cleaned_comment = _validate_jira_richtext(
+                comment_body, name="comment", max_chars=JIRA_COMMENT_MAX_CHARS
+            )
+        except ValueError as exc:
+            _audit_jira_write(
+                event_type=f"{op}_rejected",
+                operation=op,
+                success=False,
+                details={"reason": str(exc)},
+            )
+            return make_error(str(exc), status_code=400)
+
+    try:
+        cleaned_idem_key = _validate_idempotency_key(idempotency_key)
+    except ValueError as exc:
+        _audit_jira_write(
+            event_type=f"{op}_rejected",
+            operation=op,
+            success=False,
+            details={"reason": str(exc)},
+        )
+        return make_error(str(exc), status_code=400)
+
+    try:
+        get_jira_client().create_issue_link(
+            link_type=link_type,
+            inward_key=inward,
+            outward_key=outward,
+            comment=cleaned_comment,
+            idempotency_key=cleaned_idem_key,
+        )
+    except JiraCredentialsUnavailable as exc:
+        return _jira_not_configured_error(exc)
+    except JiraUpstreamError as exc:
+        _audit_jira_write(
+            event_type=f"{op}_upstream_error",
+            operation=op,
+            success=False,
+            details={
+                "type": link_type,
+                "inwardIssue": inward,
+                "outwardIssue": outward,
+                "upstream_status": exc.status_code,
+            },
+        )
+        return _jira_error_from_upstream(exc)
+
+    if cleaned_idem_key is None:
+        _audit_jira_write(
+            event_type="jira_issue_link_create_no_idempotency_key",
+            operation=op,
+            success=True,
+            details={
+                "type": link_type,
+                "inwardIssue": inward,
+                "outwardIssue": outward,
+            },
+        )
+
+    _audit_jira_write(
+        event_type=op,
+        operation=op,
+        success=True,
+        details={
+            "type": link_type,
+            "inwardIssue": inward,
+            "outwardIssue": outward,
+            "inward_project": inward_project,
+            "outward_project": outward_project,
+            "comment_present": cleaned_comment is not None,
+            "comment_length": (
+                None
+                if cleaned_comment is None
+                else (
+                    len(cleaned_comment)
+                    if isinstance(cleaned_comment, str)
+                    else len(json.dumps(cleaned_comment))
+                )
+            ),
+            "idempotency_key_present": cleaned_idem_key is not None,
+        },
+    )
+
+    return make_success(
+        "Jira issue link created",
+        {
+            "status": "created",
+            "type": link_type,
+            "inwardIssue": inward,
+            "outwardIssue": outward,
+        },
+    )
 
 
 # =============================================================================

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -149,8 +149,8 @@ try:
         resolve_gh_api_template_variables,
         validate_gh_api_path,
     )
+    from .jira_adf import is_adf_dict as is_jira_adf_dict
     from .jira_client import (
-        DEFAULT_JIRA_LINK_TYPES,
         JIRA_COMMENT_MAX_CHARS,
         JIRA_DESCRIPTION_MAX_CHARS,
         JIRA_LABEL_MAX_CHARS,
@@ -176,7 +176,6 @@ try:
         is_project_allowed,
         reload_jira_policy,
     )
-    from .jira_adf import is_adf_dict as is_jira_adf_dict
     from .jira_search import extract_search_projects
     from .mode_gate import require_private_mode
     from .phase_filter import (
@@ -299,8 +298,10 @@ except ImportError:
     from confluence_search import (  # type: ignore[no-redef, import-untyped]
         extract_search_spaces,
     )
+    from jira_adf import (  # type: ignore[no-redef, import-untyped]
+        is_adf_dict as is_jira_adf_dict,
+    )
     from jira_client import (  # type: ignore[no-redef, import-untyped]
-        DEFAULT_JIRA_LINK_TYPES,
         JIRA_COMMENT_MAX_CHARS,
         JIRA_DESCRIPTION_MAX_CHARS,
         JIRA_LABEL_MAX_CHARS,
@@ -327,9 +328,6 @@ except ImportError:
         extract_project_key,
         is_project_allowed,
         reload_jira_policy,
-    )
-    from jira_adf import (  # type: ignore[no-redef, import-untyped]
-        is_adf_dict as is_jira_adf_dict,
     )
     from jira_search import (  # type: ignore[no-redef, import-untyped]
         extract_search_projects,

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -4849,9 +4849,7 @@ def _validate_jira_label_list(value: Any, *, name: str) -> list[str]:
     return cleaned
 
 
-def _validate_jira_richtext(
-    value: Any, *, name: str, max_chars: int
-) -> str | dict[str, Any]:
+def _validate_jira_richtext(value: Any, *, name: str, max_chars: int) -> str | dict[str, Any]:
     """Validate a description / comment field — text or ADF passthrough.
 
     Returns the original string (with length-checked, non-empty preserved)
@@ -4869,9 +4867,7 @@ def _validate_jira_richtext(
         if len(encoded) > max_chars:
             raise ValueError(f"{name} exceeds {max_chars} chars (ADF size)")
         return value
-    raise ValueError(
-        f"{name} must be a string or a valid ADF document dict"
-    )
+    raise ValueError(f"{name} must be a string or a valid ADF document dict")
 
 
 def _audit_jira_write(
@@ -4954,9 +4950,7 @@ def _reject_unknown_fields(
     """
     extras = sorted(set(body.keys()) - allowed)
     if extras:
-        return (
-            f"unknown field(s) for {operation}: {', '.join(repr(k) for k in extras)}"
-        )
+        return f"unknown field(s) for {operation}: {', '.join(repr(k) for k in extras)}"
     return None
 
 
@@ -5010,9 +5004,7 @@ def jira_ticket_create() -> tuple[Response, int] | Response:
         )
         return make_error("body must be an object", status_code=400)
 
-    extras = _reject_unknown_fields(
-        data, allowed=_JIRA_TICKET_CREATE_ALLOWED_FIELDS, operation=op
-    )
+    extras = _reject_unknown_fields(data, allowed=_JIRA_TICKET_CREATE_ALLOWED_FIELDS, operation=op)
     if extras is not None:
         _audit_jira_write(
             event_type=f"{op}_rejected",
@@ -5145,9 +5137,7 @@ def jira_ticket_create() -> tuple[Response, int] | Response:
                 success=False,
                 details={"reason": "parent must be a Jira ticket key"},
             )
-            return make_error(
-                "parent must be a Jira ticket key (e.g. 'FOO-1')", status_code=400
-            )
+            return make_error("parent must be a Jira ticket key (e.g. 'FOO-1')", status_code=400)
         parent_project = extract_project_key(parent)
         # Cross-project parent reject (decision-17): the new ticket is in
         # ``project_key`` and the parent is in ``parent_project`` — refuse
@@ -5177,9 +5167,7 @@ def jira_ticket_create() -> tuple[Response, int] | Response:
                 success=False,
                 details={"reason": "epicLink must be a Jira ticket key"},
             )
-            return make_error(
-                "epicLink must be a Jira ticket key (e.g. 'FOO-1')", status_code=400
-            )
+            return make_error("epicLink must be a Jira ticket key (e.g. 'FOO-1')", status_code=400)
         # Allowlist gate the epic key too — epics live in their own project,
         # which must also be allowlisted.
         epic_project = extract_project_key(epic_link)
@@ -5335,9 +5323,7 @@ def jira_ticket_edit() -> tuple[Response, int] | Response:
         )
         return make_error("body must be an object", status_code=400)
 
-    extras = _reject_unknown_fields(
-        data, allowed=_JIRA_TICKET_EDIT_ALLOWED_FIELDS, operation=op
-    )
+    extras = _reject_unknown_fields(data, allowed=_JIRA_TICKET_EDIT_ALLOWED_FIELDS, operation=op)
     if extras is not None:
         _audit_jira_write(
             event_type=f"{op}_rejected",
@@ -5409,9 +5395,7 @@ def jira_ticket_edit() -> tuple[Response, int] | Response:
                 success=False,
                 details={"reason": f"summary exceeds {JIRA_SUMMARY_MAX_CHARS} chars"},
             )
-            return make_error(
-                f"summary exceeds {JIRA_SUMMARY_MAX_CHARS} chars", status_code=400
-            )
+            return make_error(f"summary exceeds {JIRA_SUMMARY_MAX_CHARS} chars", status_code=400)
         cleaned_summary = summary
 
     cleaned_description: str | dict[str, Any] | None = None
@@ -5593,9 +5577,7 @@ def jira_ticket_comment_add() -> tuple[Response, int] | Response:
         )
         return make_error("body must be an object", status_code=400)
 
-    extras = _reject_unknown_fields(
-        data, allowed=_JIRA_COMMENT_ADD_ALLOWED_FIELDS, operation=op
-    )
+    extras = _reject_unknown_fields(data, allowed=_JIRA_COMMENT_ADD_ALLOWED_FIELDS, operation=op)
     if extras is not None:
         _audit_jira_write(
             event_type=f"{op}_rejected",
@@ -5616,9 +5598,7 @@ def jira_ticket_comment_add() -> tuple[Response, int] | Response:
             success=False,
             details={"reason": "invalid ticket shape", "ticket": ticket},
         )
-        return make_error(
-            "Invalid ticket key (expected e.g. 'FOO-123')", status_code=400
-        )
+        return make_error("Invalid ticket key (expected e.g. 'FOO-123')", status_code=400)
 
     project = extract_project_key(ticket)
     if not is_project_allowed(project):
@@ -5701,9 +5681,7 @@ def jira_ticket_comment_add() -> tuple[Response, int] | Response:
             "ticket": ticket,
             "project": project,
             "comment_length": body_length,
-            "comment_id": (
-                upstream.get("id") if isinstance(upstream, dict) else None
-            ),
+            "comment_id": (upstream.get("id") if isinstance(upstream, dict) else None),
             "idempotency_key_present": cleaned_idem_key is not None,
         },
     )
@@ -5739,9 +5717,7 @@ def jira_issue_link_create() -> tuple[Response, int] | Response:
         )
         return make_error("body must be an object", status_code=400)
 
-    extras = _reject_unknown_fields(
-        data, allowed=_JIRA_LINK_CREATE_ALLOWED_FIELDS, operation=op
-    )
+    extras = _reject_unknown_fields(data, allowed=_JIRA_LINK_CREATE_ALLOWED_FIELDS, operation=op)
     if extras is not None:
         _audit_jira_write(
             event_type=f"{op}_rejected",
@@ -5765,9 +5741,7 @@ def jira_issue_link_create() -> tuple[Response, int] | Response:
             success=False,
             details={"reason": "type must be a printable string ≤ 64 chars"},
         )
-        return make_error(
-            "type must be a printable Atlassian link-type name", status_code=400
-        )
+        return make_error("type must be a printable Atlassian link-type name", status_code=400)
     allowed_types = jira_allowed_link_types()
     if link_type not in allowed_types:
         _audit_jira_write(
@@ -5793,9 +5767,7 @@ def jira_issue_link_create() -> tuple[Response, int] | Response:
             success=False,
             details={"reason": "inwardIssue must be a Jira ticket key"},
         )
-        return make_error(
-            "inwardIssue must be a Jira ticket key", status_code=400
-        )
+        return make_error("inwardIssue must be a Jira ticket key", status_code=400)
     if not isinstance(outward, str) or not _JIRA_TICKET_KEY_RE.fullmatch(outward):
         _audit_jira_write(
             event_type=f"{op}_rejected",
@@ -5803,9 +5775,7 @@ def jira_issue_link_create() -> tuple[Response, int] | Response:
             success=False,
             details={"reason": "outwardIssue must be a Jira ticket key"},
         )
-        return make_error(
-            "outwardIssue must be a Jira ticket key", status_code=400
-        )
+        return make_error("outwardIssue must be a Jira ticket key", status_code=400)
 
     inward_project = extract_project_key(inward)
     outward_project = extract_project_key(outward)

--- a/gateway/jira_adf.py
+++ b/gateway/jira_adf.py
@@ -1,0 +1,116 @@
+"""
+Atlassian Document Format (ADF) helpers for Jira write verbs.
+
+Atlassian Cloud's REST API v3 expects rich-text fields (``description``,
+``comment.body``) to be serialised as ADF — a JSON document tree, not a plain
+string or wiki markup.  Agents typically only have plain text to send, so the
+gateway transparently wraps it in the minimal ADF document shape.  Callers
+that already speak ADF (e.g. an orchestrator that built a structured comment
+with bullet lists) can pass a pre-built dict and we will leave it alone.
+
+Implements decision-7 (accept both plain text and ADF dicts) from the
+architect analysis for issue [#1924](https://github.com/jwbron/egg/issues/1924).
+
+This module is intentionally pure-Python — no httpx, no Flask, no Atlassian
+credentials.  It is unit-testable in isolation and imported by both
+``gateway/jira_client.py`` (the write methods) and ``gateway/gateway.py`` (the
+route-layer body validators).
+
+ADF reference: https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def wrap_text_as_adf(text: str) -> dict[str, Any]:
+    """Return the minimal ADF document that renders ``text`` as a single paragraph.
+
+    Atlassian rejects ADF documents whose ``content`` array is empty (the
+    paragraph node must contain at least one child), so the empty-string case
+    is wrapped as an empty paragraph with no text node.  This matches the
+    shape Atlassian sends back when a user posts an empty comment via the
+    web UI.
+
+    Newlines in the input are preserved as-is inside a single text node;
+    ADF treats text nodes opaquely.  Callers that want hard line breaks
+    (separate paragraphs, ``hardBreak`` nodes) should pre-build the ADF dict
+    themselves and pass it through ``is_adf_dict``.
+
+    Args:
+        text: Plain-text body to wrap.  ``None`` is rejected (callers should
+            pass an empty string for "no description").
+
+    Returns:
+        A new dict each call (callers may mutate it without contaminating
+        future calls).
+    """
+    if text is None:
+        raise TypeError("wrap_text_as_adf requires a string, got None")
+    if not isinstance(text, str):
+        raise TypeError(f"wrap_text_as_adf requires a string, got {type(text).__name__}")
+
+    if text == "":
+        # Empty paragraph — Atlassian renders this as a blank line, matching
+        # what the web UI emits for an empty body.
+        return {
+            "type": "doc",
+            "version": 1,
+            "content": [{"type": "paragraph", "content": []}],
+        }
+
+    return {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": text}],
+            }
+        ],
+    }
+
+
+def is_adf_dict(value: Any) -> bool:
+    """Return True iff ``value`` looks like a structurally-valid ADF document.
+
+    Catches the common cases — top-level dict, ``type=="doc"``, integer
+    ``version``, list-shaped ``content`` — without doing a full schema walk
+    (Atlassian validates the rest server-side).  Callers use this to decide
+    between "wrap this plain text" and "pass this dict through unchanged".
+
+    Specifically rejects:
+
+    - Non-dicts (strings, lists, numbers, ``None``).
+    - Dicts missing ``type`` or with ``type != "doc"``.
+    - Dicts whose ``version`` is missing or not an integer (booleans count
+      as ints in Python; we reject them explicitly because ``True``/``False``
+      are never valid ADF version values).
+    - Dicts whose ``content`` is missing or not a list.
+
+    Args:
+        value: Any candidate value from a request body.
+
+    Returns:
+        ``True`` if the value's outer envelope matches ADF; ``False`` otherwise.
+    """
+    if not isinstance(value, dict):
+        return False
+    if value.get("type") != "doc":
+        return False
+    version = value.get("version")
+    # Reject booleans even though ``bool`` is a subclass of ``int`` in Python —
+    # ``{"version": True}`` is structurally suspicious and should not be
+    # treated as a valid ADF doc.
+    if isinstance(version, bool) or not isinstance(version, int):
+        return False
+    if not isinstance(value.get("content"), list):
+        return False
+    return True
+
+
+__all__ = [
+    "is_adf_dict",
+    "wrap_text_as_adf",
+]

--- a/gateway/jira_client.py
+++ b/gateway/jira_client.py
@@ -1,12 +1,14 @@
 """
 Jira REST API client for the gateway sidecar.
 
-Provides a thin, read-only wrapper around the Atlassian Cloud REST API v3.
-All traffic originates from the gateway (never from the sandbox) and is
+Provides a thin, policy-enforced wrapper around the Atlassian Cloud REST API
+v3.  All traffic originates from the gateway (never from the sandbox) and is
 authenticated with Basic auth using credentials loaded from
 ``gateway/jira_credentials.py``.
 
 Public surface (used by ``/api/v1/jira/*`` routes in ``gateway.py``):
+
+Read verbs (issue [#1556](https://github.com/jwbron/egg/issues/1556) — v1):
 
 - ``JiraClient.get_ticket(key, fields=None)`` — ``GET /rest/api/3/issue/{key}``
   with ``expand=renderedBody,renderedFields`` by default so agents receive the
@@ -17,20 +19,36 @@ Public surface (used by ``/api/v1/jira/*`` routes in ``gateway.py``):
 - ``JiraClient.execute_raw(method, path, query=None, body=None)`` — passthrough
   used by ``/api/v1/jira/execute`` for read-only API endpoints.
 
+Write verbs (issue [#1924](https://github.com/jwbron/egg/issues/1924) — v1.1):
+
+- ``JiraClient.create_issue(...)`` — ``POST /rest/api/3/issue``.
+- ``JiraClient.edit_issue(...)`` — ``PUT /rest/api/3/issue/{key}``.
+- ``JiraClient.add_comment(...)`` — ``POST /rest/api/3/issue/{key}/comment``.
+- ``JiraClient.create_issue_link(...)`` — ``POST /rest/api/3/issueLink``.
+
 Path safety:
 
 - ``validate_jira_api_path(path, method)`` enforces a regex allowlist of the
-  read-only REST paths permitted by v1.  Write verbs (``DELETE``/``PUT``/
-  ``PATCH``) and path fragments in ``JIRA_WRITE_VERBS_DENIED``
-  (``transitions``, ``worklog``, ``attachments``, ``watchers``) are rejected
-  unconditionally.  See refine-phase constraints.
+  read-only REST paths permitted by ``/api/v1/jira/execute``.  Its
+  ``ALLOWED_METHODS={"GET"}`` constraint applies **only** to that
+  passthrough — it is not consulted by the write methods listed above,
+  whose paths are hardcoded inside the methods (so the path-segment
+  denylist cannot be reached by construction).  Write verbs
+  (``DELETE``/``PUT``/``PATCH``) on ``/execute`` and path fragments in
+  ``JIRA_WRITE_VERBS_DENIED`` (``transitions``, ``worklog``,
+  ``attachments``, ``watchers``) are rejected unconditionally — see refine
+  / architect cycle.
 
-429 handling (refine Q5, architect D7):
+429 handling:
 
 - GET requests retry at most once on HTTP 429, honoring ``Retry-After`` up to
-  30s.  Write verbs never retry (future-safety).
+  30s.  Write verbs never retry (future-safety: a retried POST can create
+  duplicate Jira issues).
+- ``jira_upstream_rate_limited`` is emitted on every 429 — including writes
+  — so the audit trail covers operator-visible rate-limit incidents.  The
+  retry loop only retries GETs; the audit emit is unconditional.
 
-404 envelope (refine Q8, architect D8):
+404 envelope:
 
 - ``get_ticket`` and ``get_comments`` translate upstream 404 into a structured
   ``{"status": "not_found", "key": key, "upstream_status": 404}`` dict so the
@@ -42,6 +60,13 @@ Field validation:
 - ``validate_fields`` caps the list at 32 entries and requires each to match
   ``^[a-zA-Z_][a-zA-Z0-9_.-]*$`` — applied at the route layer before calling
   the client.
+
+Idempotency (write verbs):
+
+- ``create_issue``, ``add_comment``, and ``create_issue_link`` consult the
+  in-process cache in ``gateway/jira_idempotency.py`` when the caller passes
+  ``idempotency_key``.  ``edit_issue`` is naturally idempotent and bypasses
+  the cache.
 """
 
 from __future__ import annotations
@@ -76,6 +101,15 @@ except ImportError:
         get_jira_credentials,
     )
 
+# Idempotency cache + ADF wrapper helpers — added in #1924.  The conftest in
+# ``gateway/tests`` loads modules with absolute imports, so we mirror the
+# ``jira_credentials`` two-step import dance here.
+try:
+    from . import jira_adf, jira_idempotency
+except ImportError:
+    import jira_adf  # type: ignore[no-redef, import-untyped]
+    import jira_idempotency  # type: ignore[no-redef, import-untyped]
+
 logger = get_logger("gateway.jira-client")
 
 
@@ -83,9 +117,17 @@ logger = get_logger("gateway.jira-client")
 # Constants & validation helpers
 # -----------------------------------------------------------------------------
 
-# Allowed HTTP methods for Jira REST calls in v1.  Kept tight on purpose:
-# the gateway is a read-only fence today, and new verbs should be added
-# deliberately (and reviewed against the write-verb denylist below).
+# Allowed HTTP methods for the ``/api/v1/jira/execute`` passthrough.  Stays
+# GET-only forever — the write verbs added in
+# [#1924](https://github.com/jwbron/egg/issues/1924) live on dedicated routes
+# (``/api/v1/jira/ticket/create``, ``ticket/edit``, ``ticket/comment/add``,
+# ``issue-link/create``) whose paths are hardcoded inside their corresponding
+# ``JiraClient`` write methods.  Those methods bypass
+# ``validate_jira_api_path`` because their paths are construction-time
+# constants — there is no caller-supplied path that could smuggle in a
+# denied verb segment (``transitions``, ``worklog``, ``attachments``,
+# ``watchers``).  Adding new write verbs in the future means adding a new
+# narrow route + ``JiraClient`` method — *not* widening this set.
 ALLOWED_METHODS: frozenset[str] = frozenset({"GET"})
 
 # Paths / HTTP verbs that are permanently out of scope for the wrapper.
@@ -162,6 +204,37 @@ _DEFAULT_RETRY_AFTER_SECONDS: int = 1
 
 # Single-request timeout for upstream Jira calls.
 _DEFAULT_TIMEOUT_SECONDS: float = 30.0
+
+# -----------------------------------------------------------------------------
+# Write-verb body caps (issue #1924, Q15 default)
+# -----------------------------------------------------------------------------
+#
+# These bounds keep audit-log entries small and protect against memory
+# exhaustion if a misbehaving caller sends a 100 MiB description.  They are
+# enforced at the route layer (``gateway/gateway.py``) so the rejection
+# happens before we touch the client; the constants are exported here so
+# tests and callers can refer to them by name.
+
+# Atlassian summary field hard limit.
+JIRA_SUMMARY_MAX_CHARS: int = 255
+
+# Description / comment body — generous enough for plan-apply commentary,
+# small enough to bound audit-log size.  Atlassian publishes no comment-body
+# limit in the v3 docs but mirrors the description constraint server-side
+# under Cloud's modern editor.
+JIRA_DESCRIPTION_MAX_CHARS: int = 32 * 1024
+JIRA_COMMENT_MAX_CHARS: int = 32 * 1024
+
+# Labels — Atlassian rejects labels above 255 chars; 30 distinct labels per
+# write covers the realistic "list every component this ticket touches"
+# case without giving a misbehaving caller free rein.
+JIRA_LABEL_MAX_COUNT: int = 30
+JIRA_LABEL_MAX_CHARS: int = 255
+
+# Default link-type allowlist (decision-4).  Operators may extend this list
+# via ``config/context-filters.yaml jira.link_types: [...]``; the default
+# covers the most common SDLC use cases (blocks / relates).
+DEFAULT_JIRA_LINK_TYPES: tuple[str, ...] = ("Blocks", "Relates")
 
 
 class JiraUpstreamError(RuntimeError):
@@ -472,6 +545,320 @@ class JiraClient:
         _raise_for_status(response, path)
         return _safe_json(response, path)
 
+    # -- Write verbs (issue #1924) ------------------------------------------
+    #
+    # These methods bypass ``validate_jira_api_path`` — their REST paths are
+    # construction-time constants (``"issue"``, ``"issue/<key>"``,
+    # ``"issue/<key>/comment"``, ``"issueLink"``) so the path-segment
+    # denylist (``transitions``, ``worklog``, ``attachments``, ``watchers``)
+    # cannot be reached by construction.  They build the Atlassian-shaped
+    # body dict, ADF-wrap rich-text fields, and consult
+    # ``jira_idempotency.get_or_run`` when the caller passes
+    # ``idempotency_key``.
+
+    def create_issue(
+        self,
+        *,
+        project_key: str,
+        issuetype: str | int,
+        summary: str,
+        description: str | dict[str, Any] | None = None,
+        labels: list[str] | None = None,
+        parent: str | None = None,
+        epic_link: str | None = None,
+        epic_link_field: str = "parent",
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a new Jira issue.
+
+        Builds the Atlassian REST body — ``fields.project.key=project_key``,
+        ``fields.issuetype.{name|id}``, ``fields.summary``,
+        ``fields.description=ADF`` (text wrapped, dict passed through),
+        ``fields.labels``, and either ``fields.parent.key`` or
+        ``fields.customfield_10014`` for epic-link dispatch (decision-2
+        default).
+
+        Args:
+            project_key: Atlassian project key (e.g. ``"ENG"``) the new
+                ticket belongs to.
+            issuetype: Either a name (``"Task"``) or numeric ID
+                (``10001``).  Strings that parse as ints are treated as
+                IDs, matching Atlassian's wire shape (``{"id": "10001"}``).
+            summary: Required, ≤ ``JIRA_SUMMARY_MAX_CHARS`` chars (route
+                layer enforces; method does not re-check).
+            description: Optional rich-text body.  Plain strings are wrapped
+                via ``jira_adf.wrap_text_as_adf``; dicts that pass
+                ``jira_adf.is_adf_dict`` go through unchanged.  ``None``
+                omits the field entirely.
+            labels: Optional list of label strings.  ``None`` omits.
+            parent: Optional parent ticket key.  When set, emits
+                ``fields.parent={"key": parent}``.
+            epic_link: Optional epic ticket key.  When set, routed via
+                ``epic_link_field`` (decision-2): ``"parent"`` →
+                ``fields.parent.key``; ``"customfield_10014"`` →
+                ``fields.customfield_10014``.  Never both.
+            epic_link_field: ``"parent"`` (next-gen / company-managed
+                projects, default) or ``"customfield_10014"`` (classic /
+                team-managed).  Loaded from ``JiraPolicy.epic_link_field``
+                at the route layer.
+            idempotency_key: Optional caller-supplied dedup token.  When
+                present, the cache in ``jira_idempotency`` is consulted
+                before issuing the upstream call.
+
+        Returns:
+            Atlassian's parsed response dict (typically
+            ``{"id", "key", "self"}`` — the route layer wraps it in the
+            ``{key, id, browse_url, status: "created"}`` envelope).
+
+        Raises:
+            JiraUpstreamError: On any non-2xx upstream status.
+            ValueError: If ``epic_link_field`` is unknown.
+        """
+        if epic_link_field not in ("parent", "customfield_10014"):
+            raise ValueError(
+                f"epic_link_field must be 'parent' or 'customfield_10014', "
+                f"got {epic_link_field!r}"
+            )
+
+        fields: dict[str, Any] = {
+            "project": {"key": project_key},
+            "issuetype": _build_issuetype_field(issuetype),
+            "summary": summary,
+        }
+        if description is not None:
+            fields["description"] = _coerce_adf(description)
+        if labels:
+            fields["labels"] = list(labels)
+
+        # Epic-link dispatch.  ``parent`` provided explicitly always wins
+        # for ``fields.parent`` — the route layer rejects calls that pass
+        # both ``parent`` AND ``epic_link`` so we never end up emitting two
+        # conflicting fields here.
+        if parent is not None:
+            fields["parent"] = {"key": parent}
+        if epic_link is not None:
+            if epic_link_field == "parent":
+                fields["parent"] = {"key": epic_link}
+            else:  # customfield_10014
+                fields["customfield_10014"] = epic_link
+
+        request_body: dict[str, Any] = {"fields": fields}
+
+        def _do_call() -> tuple[int, dict[str, Any]]:
+            response = self._request("POST", "issue", body=request_body)
+            _raise_for_status(response, "issue")
+            return response.status_code, _safe_json(response, "issue")
+
+        _, body = jira_idempotency.get_or_run(
+            "create",
+            project_key,
+            idempotency_key,
+            _do_call,
+        )
+        return body
+
+    def edit_issue(
+        self,
+        *,
+        key: str,
+        summary: str | None = None,
+        description: str | dict[str, Any] | None = None,
+        labels: list[str] | None = None,
+        add_labels: list[str] | None = None,
+        remove_labels: list[str] | None = None,
+        notify_users: bool = False,
+    ) -> None:
+        """Edit an existing Jira issue (``PUT /rest/api/3/issue/{key}``).
+
+        Two label modes — mutually exclusive at the method level:
+
+        - **Replace mode**: pass ``labels=[...]`` to overwrite the entire
+          list.  Emits ``{"fields": {"labels": [...]}}``.
+        - **Incremental mode**: pass ``add_labels=[...]`` and / or
+          ``remove_labels=[...]`` to mutate the existing list.  Emits
+          ``{"update": {"labels": [{"add": "x"}, ..., {"remove": "y"},
+          ...]}}``.
+
+        Combining ``labels`` with either ``add_labels`` / ``remove_labels``
+        raises ``ValueError`` — the route layer (Phase 3) returns 400 for
+        the same case before calling this method.
+
+        Atlassian defaults ``notifyUsers`` to ``true``; we omit the query
+        parameter entirely in that case to keep the URL clean.  When
+        ``notify_users=False`` we explicitly send ``notifyUsers=false`` —
+        decision-5 default for SDLC writes.
+
+        Args:
+            key: Ticket key to edit.
+            summary: New summary, or ``None`` to leave unchanged.
+            description: New description (text or ADF dict), or ``None`` to
+                leave unchanged.
+            labels: Replace-mode label list.
+            add_labels: Incremental add list.
+            remove_labels: Incremental remove list.
+            notify_users: Whether Atlassian should email watchers
+                (default: ``False`` per decision-5).
+
+        Returns:
+            ``None`` — Atlassian responds with HTTP 204 No Content on
+            success.
+
+        Raises:
+            ValueError: If both replace-mode and incremental-mode label
+                arguments are supplied.
+            JiraUpstreamError: On any non-2xx upstream status.
+        """
+        replace_mode = labels is not None
+        incremental_mode = (add_labels is not None) or (remove_labels is not None)
+        if replace_mode and incremental_mode:
+            raise ValueError(
+                "edit_issue: pass either 'labels' (replace mode) OR "
+                "'add_labels' / 'remove_labels' (incremental mode), not both"
+            )
+
+        body: dict[str, Any] = {}
+        fields_block: dict[str, Any] = {}
+        if summary is not None:
+            fields_block["summary"] = summary
+        if description is not None:
+            fields_block["description"] = _coerce_adf(description)
+        if replace_mode:
+            fields_block["labels"] = list(labels) if labels else []
+        if fields_block:
+            body["fields"] = fields_block
+
+        if incremental_mode:
+            label_ops: list[dict[str, str]] = []
+            for label in add_labels or []:
+                label_ops.append({"add": label})
+            for label in remove_labels or []:
+                label_ops.append({"remove": label})
+            body["update"] = {"labels": label_ops}
+
+        # Empty body — caller asked for a no-op edit.  We could short-circuit
+        # but Atlassian itself rejects empty edits with 400, so let the
+        # upstream surface the error rather than silently succeeding.
+
+        query: dict[str, Any] | None = None
+        if not notify_users:
+            query = {"notifyUsers": "false"}
+
+        response = self._request("PUT", f"issue/{key}", query=query, body=body)
+        _raise_for_status(response, f"issue/{key}")
+        # 204 No Content on success — no body to parse.
+
+    def add_comment(
+        self,
+        *,
+        key: str,
+        body: str | dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        """Add a comment to an existing Jira issue.
+
+        ``body`` can be plain text (auto-wrapped to ADF) or a pre-built ADF
+        dict (passed through).  Visibility (``visibility.type``,
+        ``visibility.value``) is intentionally not exposed — decision-6
+        default for v1.
+
+        Args:
+            key: Ticket key the comment lands on.
+            body: Comment body — plain string or ADF dict.
+            idempotency_key: Optional dedup token; cached in
+                ``jira_idempotency`` under
+                ``("comment", key, idempotency_key)``.
+
+        Returns:
+            Atlassian's parsed response dict for the new comment (id,
+            author, created, body, etc.).
+
+        Raises:
+            JiraUpstreamError: On any non-2xx upstream status.
+        """
+        request_body = {"body": _coerce_adf(body)}
+
+        def _do_call() -> tuple[int, dict[str, Any]]:
+            response = self._request("POST", f"issue/{key}/comment", body=request_body)
+            _raise_for_status(response, f"issue/{key}/comment")
+            return response.status_code, _safe_json(response, f"issue/{key}/comment")
+
+        # Cache key namespace = ticket key.  Two callers re-using the same
+        # opaque idempotency key against different tickets do not collide.
+        _, response_body = jira_idempotency.get_or_run(
+            "comment",
+            key,
+            idempotency_key,
+            _do_call,
+        )
+        return response_body
+
+    def create_issue_link(
+        self,
+        *,
+        link_type: str,
+        inward_key: str,
+        outward_key: str,
+        comment: str | dict[str, Any] | None = None,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a Jira issue link between two tickets.
+
+        Atlassian does NOT dedupe identical ``(inward, outward, type)``
+        triples — the same call repeated five times creates five identical
+        links.  Decision-28 mandates we extend the idempotency cache to
+        this verb so the gateway-side cache is the dedup boundary.
+
+        Args:
+            link_type: Atlassian link-type name (``"Blocks"``, ``"Relates"``,
+                etc.).  The route-layer schema validates this against the
+                operator-configurable allowlist (decision-4).
+            inward_key: Ticket key on the inward side of the link.
+            outward_key: Ticket key on the outward side of the link.
+            comment: Optional comment to attach to the link, surfaced via
+                Atlassian's ``comment`` field on ``issueLink`` (decision-23
+                — single round-trip with idempotency).
+            idempotency_key: Optional dedup token; cached under
+                ``("link", canonical_link_id(inward, outward, type),
+                idempotency_key)`` so two callers re-using the same opaque
+                key against different triples never alias.
+
+        Returns:
+            Atlassian's parsed response dict.  In practice
+            ``POST /rest/api/3/issueLink`` returns 201 with an empty body;
+            ``_safe_json`` wraps that as ``{}`` so the route layer can
+            still build a structured envelope.
+
+        Raises:
+            JiraUpstreamError: On any non-2xx upstream status.
+        """
+        body: dict[str, Any] = {
+            "type": {"name": link_type},
+            "inwardIssue": {"key": inward_key},
+            "outwardIssue": {"key": outward_key},
+        }
+        if comment is not None:
+            body["comment"] = {"body": _coerce_adf(comment)}
+
+        def _do_call() -> tuple[int, dict[str, Any]]:
+            response = self._request("POST", "issueLink", body=body)
+            _raise_for_status(response, "issueLink")
+            # ``POST /rest/api/3/issueLink`` returns 201 with an empty body;
+            # ``_safe_json`` raises on empty responses, so handle that here.
+            if not response.content:
+                return response.status_code, {}
+            return response.status_code, _safe_json(response, "issueLink")
+
+        cache_namespace = jira_idempotency.canonical_link_id(
+            inward_key, outward_key, link_type
+        )
+        _, response_body = jira_idempotency.get_or_run(
+            "link",
+            cache_namespace,
+            idempotency_key,
+            _do_call,
+        )
+        return response_body
+
 
 # -----------------------------------------------------------------------------
 # Helpers & module-level singleton
@@ -481,6 +868,46 @@ class JiraClient:
 def _not_found_envelope(key: str) -> dict[str, Any]:
     """Canonical ``not_found`` envelope used by ticket-read endpoints."""
     return {"status": "not_found", "key": key, "upstream_status": 404}
+
+
+def _coerce_adf(value: str | dict[str, Any]) -> dict[str, Any]:
+    """Return ADF — wrap a plain string, pass through a valid ADF dict.
+
+    Anything else raises ``ValueError``; the route layer body-validates
+    these inputs first, so this is a defence-in-depth check.
+    """
+    if isinstance(value, str):
+        return jira_adf.wrap_text_as_adf(value)
+    if jira_adf.is_adf_dict(value):
+        return value
+    raise ValueError(
+        "rich-text body must be a string or a valid ADF document dict"
+    )
+
+
+def _build_issuetype_field(issuetype: str | int) -> dict[str, str]:
+    """Translate an issuetype into the Atlassian wire shape.
+
+    - Integer (or all-digit string) → ``{"id": "<n>"}``.
+    - Non-numeric string → ``{"name": <s>}``.
+
+    Raises ``ValueError`` for empty / wrong-typed inputs so the route
+    layer sees a clean 400 instead of a 500 from Atlassian.
+    """
+    if isinstance(issuetype, bool):
+        # ``bool`` is a subclass of ``int`` — explicitly reject before the
+        # numeric branch below claims it.
+        raise ValueError("issuetype must be a string name or numeric id")
+    if isinstance(issuetype, int):
+        return {"id": str(issuetype)}
+    if isinstance(issuetype, str):
+        cleaned = issuetype.strip()
+        if not cleaned:
+            raise ValueError("issuetype must not be empty")
+        if cleaned.isdigit():
+            return {"id": cleaned}
+        return {"name": cleaned}
+    raise ValueError("issuetype must be a string name or numeric id")
 
 
 def _raise_for_status(response: httpx.Response, path: str) -> None:
@@ -551,9 +978,15 @@ def reset_jira_client() -> None:
 __all__ = [
     "ALLOWED_METHODS",
     "DEFAULT_EXPAND",
+    "DEFAULT_JIRA_LINK_TYPES",
     "DEFAULT_MAX_RESULTS",
     "HARD_MAX_RESULTS",
     "JIRA_API_ALLOWED_PATHS",
+    "JIRA_COMMENT_MAX_CHARS",
+    "JIRA_DESCRIPTION_MAX_CHARS",
+    "JIRA_LABEL_MAX_CHARS",
+    "JIRA_LABEL_MAX_COUNT",
+    "JIRA_SUMMARY_MAX_CHARS",
     "JIRA_WRITE_VERBS_DENIED",
     "JiraClient",
     "JiraCredentials",

--- a/gateway/jira_client.py
+++ b/gateway/jira_client.py
@@ -616,8 +616,7 @@ class JiraClient:
         """
         if epic_link_field not in ("parent", "customfield_10014"):
             raise ValueError(
-                f"epic_link_field must be 'parent' or 'customfield_10014', "
-                f"got {epic_link_field!r}"
+                f"epic_link_field must be 'parent' or 'customfield_10014', got {epic_link_field!r}"
             )
 
         fields: dict[str, Any] = {
@@ -848,9 +847,7 @@ class JiraClient:
                 return response.status_code, {}
             return response.status_code, _safe_json(response, "issueLink")
 
-        cache_namespace = jira_idempotency.canonical_link_id(
-            inward_key, outward_key, link_type
-        )
+        cache_namespace = jira_idempotency.canonical_link_id(inward_key, outward_key, link_type)
         _, response_body = jira_idempotency.get_or_run(
             "link",
             cache_namespace,
@@ -880,9 +877,7 @@ def _coerce_adf(value: str | dict[str, Any]) -> dict[str, Any]:
         return jira_adf.wrap_text_as_adf(value)
     if jira_adf.is_adf_dict(value):
         return value
-    raise ValueError(
-        "rich-text body must be a string or a valid ADF document dict"
-    )
+    raise ValueError("rich-text body must be a string or a valid ADF document dict")
 
 
 def _build_issuetype_field(issuetype: str | int) -> dict[str, str]:

--- a/gateway/jira_idempotency.py
+++ b/gateway/jira_idempotency.py
@@ -1,0 +1,157 @@
+"""
+In-process idempotency cache for Jira write verbs.
+
+Implements decision-3 (optional ``idempotency_key``) and decision-16 (in-memory
+per-gateway-process, 5-minute TTL) from the architect analysis for issue
+[#1924](https://github.com/jwbron/egg/issues/1924).
+
+Atlassian Cloud has no native idempotency-key header for the v3 REST API, so
+when a caller (e.g. an SDLC agent retrying after a network blip) issues the
+same logical write twice, Atlassian happily creates two tickets / posts two
+comments / wires two duplicate links.  This cache shields the gateway against
+short-lived retries: a successful write is remembered for ``IDEMPOTENCY_TTL_SECONDS``,
+and any subsequent call with the same ``(verb, project, idempotency_key)``
+triple within that window returns the cached response without touching
+Atlassian.
+
+Scope:
+
+- Per-gateway-process — explicitly NOT a Redis / cross-instance cache.  v1
+  ships a single gateway sidecar per host so this is sufficient (Q22:
+  multi-tenant deferred).
+- 5-minute TTL — long enough to absorb retry storms after a transient
+  upstream error, short enough that the orchestrator owns higher-level
+  dedup (Q18).
+- Lazy eviction at lookup — entries past their TTL are removed when the
+  next caller probes for the same key.  No background thread.
+- Thread-safe via a module-level ``_lock``.
+
+Cache key composition:
+
+- ``createJiraIssue`` and ``addCommentToJiraIssue`` use ``(verb, project_key,
+  idempotency_key)``.  The project key narrows the namespace so two callers
+  re-using the same opaque key against different projects do not collide.
+- ``createIssueLink`` uses ``(verb="link", canonical_link_id(inward, outward,
+  type), idempotency_key)`` (decision-28).  Distinct ``(inward, outward,
+  type)`` triples never alias to the same cache entry even if callers reuse
+  the same opaque key.
+
+Public API:
+
+- ``get_or_run(verb, project, key, fn)`` — lookup-or-compute.  When ``key`` is
+  ``None`` the cache is bypassed entirely and ``fn()`` runs unconditionally,
+  matching the "optional with documented warning" decision.
+- ``clear_cache()`` — drop all entries.  Used by tests.
+- ``IDEMPOTENCY_TTL_SECONDS`` — public 5-minute TTL constant.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+
+# Public TTL — 5 minutes.  Tuned per architect analysis (decision-16).
+IDEMPOTENCY_TTL_SECONDS: int = 5 * 60
+
+# Internal storage: ``(verb, project, key)`` -> ``(monotonic_ts, status_code,
+# response_json)``.  ``status_code`` is included so cached entries can be
+# replayed verbatim by the route layer (return body + status as if Atlassian
+# answered again).
+_CacheKey = tuple[str, str, str]
+_CacheEntry = tuple[float, int, dict[str, Any]]
+_cache: dict[_CacheKey, _CacheEntry] = {}
+_lock = threading.Lock()
+
+
+def _now() -> float:
+    """Return the current monotonic clock reading.
+
+    Wrapped in a helper so tests can patch ``time.monotonic`` via
+    ``monkeypatch.setattr`` and exercise TTL expiry deterministically.
+    """
+    return time.monotonic()
+
+
+def get_or_run(
+    verb: str,
+    project: str,
+    key: str | None,
+    fn: Callable[[], tuple[int, dict[str, Any]]],
+) -> tuple[int, dict[str, Any]]:
+    """Return a cached ``(status_code, response_json)`` if one exists, else run ``fn``.
+
+    Args:
+        verb: A short identifier for the write verb (e.g. ``"create"``,
+            ``"comment"``, ``"link"``).  Combined with ``project`` and
+            ``key`` to form the cache key.
+        project: A namespace string — typically the Atlassian project key
+            (``"ENG"``).  For ``createIssueLink`` callers should pass
+            ``canonical_link_id(inward, outward, type)`` (a stable triple
+            string) so distinct triples never alias to the same opaque key.
+        key: Caller-supplied idempotency token.  ``None`` disables the
+            cache entirely and ``fn()`` runs unconditionally.
+        fn: A zero-arg callable that performs the upstream call and returns
+            ``(status_code, response_json)``.  Only invoked on a miss.
+
+    Returns:
+        ``(status_code, response_json)`` either fetched from cache or freshly
+        produced by ``fn``.
+
+    Notes:
+        ``fn`` exceptions are NOT cached — a failed upstream call leaves the
+        cache empty, so the next retry runs the function again.  This is a
+        deliberate choice: caching errors would force the caller to wait out
+        the TTL after an outage.
+    """
+    if key is None:
+        return fn()
+
+    cache_key: _CacheKey = (verb, project, key)
+    now = _now()
+
+    with _lock:
+        entry = _cache.get(cache_key)
+        if entry is not None:
+            ts, status, body = entry
+            if now - ts <= IDEMPOTENCY_TTL_SECONDS:
+                return status, body
+            # Stale — drop it and fall through to recompute.
+            del _cache[cache_key]
+
+    # Cache miss (or stale).  Run outside the lock so concurrent calls for
+    # different keys do not block each other.  A small thundering-herd window
+    # exists for the same key; the worst case is two upstream calls and the
+    # second writer overwrites the first cached entry — both responses are
+    # successful so the user-visible behaviour matches Atlassian's at-most-once
+    # semantics anyway.
+    status_code, response = fn()
+    with _lock:
+        _cache[cache_key] = (_now(), status_code, response)
+    return status_code, response
+
+
+def clear_cache() -> None:
+    """Drop every cached entry.  Used by tests to isolate cases."""
+    with _lock:
+        _cache.clear()
+
+
+def canonical_link_id(inward_key: str, outward_key: str, link_type: str) -> str:
+    """Build a stable namespace string for ``createIssueLink`` cache keys.
+
+    Returns ``"<inward>|<outward>|<type>"``.  Two different
+    ``(inward, outward, type)`` triples never collide because the separator
+    (``|``) is illegal in Jira ticket keys (``[A-Z][A-Z0-9_]*-\\d+``) and in
+    Jira link-type names (Atlassian rejects pipes in link-type names).
+    """
+    return f"{inward_key}|{outward_key}|{link_type}"
+
+
+__all__ = [
+    "IDEMPOTENCY_TTL_SECONDS",
+    "canonical_link_id",
+    "clear_cache",
+    "get_or_run",
+]

--- a/gateway/jira_policy.py
+++ b/gateway/jira_policy.py
@@ -2,24 +2,32 @@
 Jira project-allowlist loader.
 
 Reads the ``jira:`` section of ``config/context-filters.yaml`` (or whatever
-``EGG_CONTEXT_FILTERS_PATH`` points at) and exposes three helpers the Jira
-routes compose:
+``EGG_CONTEXT_FILTERS_PATH`` points at) and exposes helpers the Jira routes
+compose:
 
 - ``allowed_projects()`` — current ``frozenset[str]`` of allowlisted keys.
 - ``is_project_allowed(key)`` — simple membership test.
 - ``extract_project_key(ticket_key)`` — ``"FOO-123" -> "FOO"``.
+- ``allowed_link_types()`` — current ``tuple[str, ...]`` of link-type names
+  (issue [#1924](https://github.com/jwbron/egg/issues/1924), decision-4).
+- ``epic_link_field()`` — ``"parent"`` (default) or ``"customfield_10014"``,
+  driving epic-link dispatch in ``createJiraIssue`` (decision-2).
 
 Expected YAML shape:
 
     jira:
       projects: ["ENG", "DEVOPS"]
+      link_types: ["Blocks", "Relates"]    # optional; defaults to ["Blocks", "Relates"]
+      epic_link_field: "parent"            # optional; "parent" or "customfield_10014"
 
 Fail-closed semantics:
 
-- Missing file → empty set (no project allowed).
-- Missing ``jira:`` section → empty set.
-- Malformed YAML → empty set, and the parse error is logged once per load
-  cycle (not re-raised — a bad config file must not crash the gateway).
+- Missing file → empty project set + default link types + ``parent``.
+- Missing ``jira:`` section → empty project set + default link types +
+  ``parent``.
+- Malformed YAML → fail closed (empty set), and the parse error is logged
+  once per load cycle (not re-raised — a bad config file must not crash the
+  gateway).
 
 Cache invalidation mirrors ``anthropic_credentials.py``: an ``st_mtime``
 check fires on every access, and ``reload_jira_policy()`` forces a clear so
@@ -62,6 +70,25 @@ _DEFAULT_CONFIG_PATH = Path(
 _PROJECT_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
 _TICKET_KEY_RE = re.compile(r"^([A-Z][A-Z0-9_]*)-(\d+)$")
 
+# Default link types when the operator does not configure ``jira.link_types``.
+# Matches the v1.1 default in ``gateway/jira_client.DEFAULT_JIRA_LINK_TYPES``;
+# duplicated here so importers do not have to round-trip through jira_client.
+_DEFAULT_LINK_TYPES: tuple[str, ...] = ("Blocks", "Relates")
+
+# Allowed values for ``jira.epic_link_field`` — the two real Atlassian
+# placement modes for the new-issue epic-link shorthand.  See
+# ``gateway/jira_client.JiraClient.create_issue`` for how the dispatch
+# resolves ``epic_link`` to either ``fields.parent.key`` or
+# ``fields.customfield_10014`` (never both).
+_EPIC_LINK_FIELDS: frozenset[str] = frozenset({"parent", "customfield_10014"})
+_DEFAULT_EPIC_LINK_FIELD: str = "parent"
+
+# Link-type names that Atlassian rejects for being unhealthy: empty,
+# whitespace-only, or excessively long.  We mirror the project-key
+# validation philosophy — fail closed at load time so a typo in
+# ``context-filters.yaml`` never silently widens the policy.
+_LINK_TYPE_MAX_CHARS: int = 64
+
 
 class JiraPolicy:
     """Thread-safe, mtime-caching loader for the Jira project allowlist."""
@@ -69,12 +96,18 @@ class JiraPolicy:
     def __init__(self, config_path: Path | None = None):
         self._config_path = config_path or _DEFAULT_CONFIG_PATH
         self._projects: frozenset[str] = frozenset()
+        self._link_types: tuple[str, ...] = _DEFAULT_LINK_TYPES
+        self._epic_link_field: str = _DEFAULT_EPIC_LINK_FIELD
         self._cached_mtime: float = 0
         self._lock = threading.Lock()
         self._loaded: bool = False
 
-    def allowed_projects(self) -> frozenset[str]:
-        """Return the current allowlist, reloading if the file changed."""
+    def _ensure_loaded(self) -> None:
+        """Refresh from disk if the file changed; called under no lock.
+
+        Returns silently — the call sites pull whichever attribute they
+        need after this primes the cache.
+        """
         try:
             current_mtime = self._config_path.stat().st_mtime
         except OSError:
@@ -86,16 +119,22 @@ class JiraPolicy:
                         path=str(self._config_path),
                     )
                 self._projects = frozenset()
+                self._link_types = _DEFAULT_LINK_TYPES
+                self._epic_link_field = _DEFAULT_EPIC_LINK_FIELD
                 self._cached_mtime = 0
                 self._loaded = True
-            return self._projects
+            return
 
         with self._lock:
             if (not self._loaded) or current_mtime != self._cached_mtime:
                 self._load()
                 self._cached_mtime = current_mtime
                 self._loaded = True
-            return self._projects
+
+    def allowed_projects(self) -> frozenset[str]:
+        """Return the current allowlist, reloading if the file changed."""
+        self._ensure_loaded()
+        return self._projects
 
     def is_project_allowed(self, project_key: str) -> bool:
         """Return True iff ``project_key`` is in the allowlist."""
@@ -103,12 +142,24 @@ class JiraPolicy:
             return False
         return project_key in self.allowed_projects()
 
+    def allowed_link_types(self) -> tuple[str, ...]:
+        """Return the operator-configured link-type allowlist (decision-4)."""
+        self._ensure_loaded()
+        return self._link_types
+
+    def epic_link_field(self) -> str:
+        """Return ``"parent"`` (default) or ``"customfield_10014"`` (decision-2)."""
+        self._ensure_loaded()
+        return self._epic_link_field
+
     def reload(self) -> None:
         """Force the next ``allowed_projects()`` to re-read from disk."""
         with self._lock:
             self._cached_mtime = 0
             self._loaded = False
             self._projects = frozenset()
+            self._link_types = _DEFAULT_LINK_TYPES
+            self._epic_link_field = _DEFAULT_EPIC_LINK_FIELD
 
     def _load(self) -> None:
         """Load the allowlist from YAML (called under the lock)."""
@@ -146,43 +197,101 @@ class JiraPolicy:
         jira_section = parsed.get("jira")
         if not isinstance(jira_section, dict):
             self._projects = frozenset()
+            self._link_types = _DEFAULT_LINK_TYPES
+            self._epic_link_field = _DEFAULT_EPIC_LINK_FIELD
             return
 
         projects_raw = jira_section.get("projects")
         if projects_raw is None:
             self._projects = frozenset()
-            return
-        if not isinstance(projects_raw, list):
+        elif not isinstance(projects_raw, list):
             logger.error(
                 "jira.projects must be a list — failing closed",
                 path=str(self._config_path),
                 type=type(projects_raw).__name__,
             )
             self._projects = frozenset()
-            return
+        else:
+            cleaned: set[str] = set()
+            for entry in projects_raw:
+                if not isinstance(entry, str):
+                    logger.warning(
+                        "Ignoring non-string entry in jira.projects",
+                        entry=repr(entry),
+                    )
+                    continue
+                key = entry.strip()
+                if not _PROJECT_KEY_RE.fullmatch(key):
+                    logger.warning(
+                        "Ignoring invalid Jira project key in jira.projects",
+                        entry=repr(entry),
+                    )
+                    continue
+                cleaned.add(key)
+            self._projects = frozenset(cleaned)
 
-        cleaned: set[str] = set()
-        for entry in projects_raw:
-            if not isinstance(entry, str):
-                logger.warning(
-                    "Ignoring non-string entry in jira.projects",
-                    entry=repr(entry),
-                )
-                continue
-            key = entry.strip()
-            if not _PROJECT_KEY_RE.fullmatch(key):
-                logger.warning(
-                    "Ignoring invalid Jira project key in jira.projects",
-                    entry=repr(entry),
-                )
-                continue
-            cleaned.add(key)
+        # Link-type allowlist (decision-4).  Optional — default to the
+        # built-in pair when absent or malformed.
+        link_types_raw = jira_section.get("link_types")
+        if link_types_raw is None:
+            self._link_types = _DEFAULT_LINK_TYPES
+        elif not isinstance(link_types_raw, list):
+            logger.error(
+                "jira.link_types must be a list — falling back to default",
+                path=str(self._config_path),
+                type=type(link_types_raw).__name__,
+            )
+            self._link_types = _DEFAULT_LINK_TYPES
+        else:
+            cleaned_links: list[str] = []
+            for entry in link_types_raw:
+                if not isinstance(entry, str):
+                    logger.warning(
+                        "Ignoring non-string entry in jira.link_types",
+                        entry=repr(entry),
+                    )
+                    continue
+                name = entry.strip()
+                if not name or len(name) > _LINK_TYPE_MAX_CHARS:
+                    logger.warning(
+                        "Ignoring out-of-bounds entry in jira.link_types",
+                        entry=repr(entry),
+                    )
+                    continue
+                # Atlassian link-type names are arbitrary unicode but we
+                # restrict to printable characters so audit logs remain
+                # clean.
+                if not all(ch.isprintable() for ch in name):
+                    logger.warning(
+                        "Ignoring non-printable entry in jira.link_types",
+                        entry=repr(entry),
+                    )
+                    continue
+                cleaned_links.append(name)
+            # Preserve operator order so audit logs read predictably; an
+            # empty list means "no link types allowed" (fail-closed).
+            self._link_types = tuple(cleaned_links)
 
-        self._projects = frozenset(cleaned)
+        # Epic-link field (decision-2).
+        epic_field_raw = jira_section.get("epic_link_field")
+        if epic_field_raw is None:
+            self._epic_link_field = _DEFAULT_EPIC_LINK_FIELD
+        elif not isinstance(epic_field_raw, str) or epic_field_raw not in _EPIC_LINK_FIELDS:
+            logger.error(
+                "jira.epic_link_field must be 'parent' or 'customfield_10014' — falling back to default",
+                path=str(self._config_path),
+                value=repr(epic_field_raw),
+            )
+            self._epic_link_field = _DEFAULT_EPIC_LINK_FIELD
+        else:
+            self._epic_link_field = epic_field_raw
+
         logger.info(
             "Jira project allowlist loaded",
             path=str(self._config_path),
             count=len(self._projects),
+            link_types=list(self._link_types),
+            epic_link_field=self._epic_link_field,
         )
 
 
@@ -226,6 +335,23 @@ def is_project_allowed(project_key: str) -> bool:
     return get_jira_policy().is_project_allowed(project_key)
 
 
+def allowed_link_types() -> tuple[str, ...]:
+    """Convenience accessor — ``JiraPolicy.allowed_link_types()`` via singleton."""
+    return get_jira_policy().allowed_link_types()
+
+
+def is_link_type_allowed(link_type: str) -> bool:
+    """Return True iff ``link_type`` is in the configured allowlist."""
+    if not isinstance(link_type, str) or not link_type:
+        return False
+    return link_type in allowed_link_types()
+
+
+def epic_link_field() -> str:
+    """Convenience accessor — ``JiraPolicy.epic_link_field()`` via singleton."""
+    return get_jira_policy().epic_link_field()
+
+
 def reload_jira_policy() -> None:
     """Force the next allowlist access to re-read from disk.
 
@@ -244,9 +370,12 @@ def reset_jira_policy() -> None:
 
 __all__ = [
     "JiraPolicy",
+    "allowed_link_types",
     "allowed_projects",
+    "epic_link_field",
     "extract_project_key",
     "get_jira_policy",
+    "is_link_type_allowed",
     "is_project_allowed",
     "reload_jira_policy",
     "reset_jira_policy",

--- a/sandbox/scripts/jira
+++ b/sandbox/scripts/jira
@@ -10,11 +10,33 @@
 # - JQL scope extraction prevents cross-project data access
 #
 # Verbs:
-#   jira ticket get <KEY> [--fields f1,f2]
-#   jira ticket comments <KEY>
-#   jira search <JQL> [--max-results N] [--fields f1,f2] [--next-page-token TOK]
-#   jira execute <METHOD> <PATH> [--query key=val,key2=val2]
-#   jira help
+#   Read (issue #1556 — v1):
+#     jira ticket get <KEY> [--fields f1,f2]
+#     jira ticket comments <KEY>
+#     jira search <JQL> [--max-results N] [--fields f1,f2] [--next-page-token TOK]
+#     jira execute <METHOD> <PATH> [--query key=val,key2=val2]
+#
+#   Write (issue #1924):
+#     jira ticket create   --project KEY --type Task --summary "..."
+#                          [--description "..." | --description-file PATH | --description-stdin]
+#                          [--labels a,b]
+#                          [--parent FOO-1] [--epic-link FOO-2]
+#                          [--idempotency-key K]
+#     jira ticket edit     <KEY>
+#                          [--summary "..."]
+#                          [--description "..." | --description-file PATH | --description-stdin]
+#                          [--labels a,b]                  # replace mode
+#                          [--add-labels x] [--remove-labels y]   # incremental
+#                          [--no-notify]
+#     jira ticket comment add <KEY>
+#                          [--body "..." | --body-file PATH | --body-stdin]
+#                          [--idempotency-key K]
+#     jira link create     --type Blocks --inward FOO-1 --outward FOO-2
+#                          [--comment "..."]
+#                          [--idempotency-key K]
+#
+#   Help:
+#     jira help
 #
 
 set -euo pipefail
@@ -76,7 +98,7 @@ show_usage() {
     cat << 'EOF'
 Usage: jira <command> [options]
 
-Commands:
+Read commands:
   jira ticket get <KEY> [--fields f1,f2]
       Fetch a Jira ticket by key (e.g. ENG-123).
 
@@ -88,6 +110,32 @@ Commands:
 
   jira execute <METHOD> <PATH> [--query key=val,key2=val2]
       Execute a raw read-only Jira REST API call through the gateway.
+
+Write commands (issue #1924):
+  jira ticket create --project KEY --type Task --summary "..."
+                     [--description "..." | --description-file PATH | --description-stdin]
+                     [--labels a,b] [--parent FOO-1] [--epic-link FOO-2]
+                     [--idempotency-key K]
+      Create a new Jira ticket (decision-13: returns key, id, browse_url).
+
+  jira ticket edit <KEY> [--summary "..."]
+                         [--description "..." | --description-file PATH | --description-stdin]
+                         [--labels a,b]                       # replace mode
+                         [--add-labels x] [--remove-labels y] # incremental
+                         [--no-notify]
+      Edit an existing Jira ticket. Replace and incremental label modes
+      are mutually exclusive.
+
+  jira ticket comment add <KEY>
+                          [--body "..." | --body-file PATH | --body-stdin]
+                          [--idempotency-key K]
+      Add a comment to a Jira ticket. Body may be plain text (auto-wrapped
+      to ADF) or pre-built ADF JSON loaded from --body-file / --body-stdin.
+
+  jira link create --type Blocks --inward FOO-1 --outward FOO-2
+                   [--comment "..."] [--idempotency-key K]
+      Create a Jira issue link between two tickets. Both projects must be
+      allowlisted; link type must be in jira.link_types.
 
   jira help
       Show this usage information.
@@ -159,6 +207,52 @@ else:
 " "$tmpfile" "$http_code"
 
     return $?
+}
+
+# --- Body-source helpers (write verbs) ---
+#
+# The write verbs accept three mutually exclusive ways to supply the
+# description / comment body:
+#
+#   --description "...inline..."
+#   --description-file PATH        (slurp the file)
+#   --description-stdin            (read from STDIN)
+#
+# The same trio applies to comments (--body, --body-file, --body-stdin).
+# This helper resolves the trio for a given flag prefix and exits on
+# conflict / missing input.
+#
+# Usage: resolve_body_source <flag-prefix> <inline> <file_path> <stdin_flag>
+# Returns: the resolved body on stdout, or exits non-zero on error.
+resolve_body_source() {
+    local prefix="$1" inline="$2" file_path="$3" stdin_flag="$4"
+    local sources=0
+    [ -n "$inline" ] && sources=$((sources + 1))
+    [ -n "$file_path" ] && sources=$((sources + 1))
+    [ "$stdin_flag" = "1" ] && sources=$((sources + 1))
+
+    if [ "$sources" -gt 1 ]; then
+        echo "ERROR: --${prefix}, --${prefix}-file, and --${prefix}-stdin are mutually exclusive" >&2
+        exit 1
+    fi
+    if [ -n "$inline" ]; then
+        printf '%s' "$inline"
+        return 0
+    fi
+    if [ -n "$file_path" ]; then
+        if [ ! -f "$file_path" ]; then
+            echo "ERROR: --${prefix}-file: '$file_path' not found" >&2
+            exit 1
+        fi
+        cat "$file_path"
+        return 0
+    fi
+    if [ "$stdin_flag" = "1" ]; then
+        cat
+        return 0
+    fi
+    # No source — caller decides whether the field is optional.
+    return 0
 }
 
 # --- Verb handlers ---
@@ -312,6 +406,292 @@ print(json.dumps(body))
     call_gateway "/api/v1/jira/execute" "$payload"
 }
 
+handle_ticket_create() {
+    shift  # consume "create"
+    local project="" type="" summary=""
+    local desc_inline="" desc_file="" desc_stdin=0
+    local labels="" parent="" epic_link="" idempotency_key=""
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --project)
+                shift; project="${1:-}"; shift || true
+                ;;
+            --type)
+                shift; type="${1:-}"; shift || true
+                ;;
+            --summary)
+                shift; summary="${1:-}"; shift || true
+                ;;
+            --description)
+                shift; desc_inline="${1:-}"; shift || true
+                ;;
+            --description-file)
+                shift; desc_file="${1:-}"; shift || true
+                ;;
+            --description-stdin)
+                desc_stdin=1; shift
+                ;;
+            --labels)
+                shift; labels="${1:-}"; shift || true
+                ;;
+            --parent)
+                shift; parent="${1:-}"; shift || true
+                ;;
+            --epic-link)
+                shift; epic_link="${1:-}"; shift || true
+                ;;
+            --idempotency-key)
+                shift; idempotency_key="${1:-}"; shift || true
+                ;;
+            *)
+                echo "ERROR: Unknown flag '$1' for 'jira ticket create'" >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    if [ -z "$project" ] || [ -z "$type" ] || [ -z "$summary" ]; then
+        echo "ERROR: --project, --type, and --summary are required" >&2
+        exit 1
+    fi
+
+    local description
+    description=$(resolve_body_source "description" "$desc_inline" "$desc_file" "$desc_stdin")
+
+    local payload
+    payload=$(DESCRIPTION="$description" python3 -c "
+import json, os, sys
+
+body = {
+    'projectKey': sys.argv[1],
+    'issuetype': sys.argv[2],
+    'summary': sys.argv[3],
+}
+description = os.environ.get('DESCRIPTION', '')
+have_desc = sys.argv[4] == '1'
+labels = sys.argv[5]
+parent = sys.argv[6]
+epic_link = sys.argv[7]
+idempotency_key = sys.argv[8]
+
+if have_desc:
+    body['description'] = description
+if labels:
+    body['labels'] = [s.strip() for s in labels.split(',') if s.strip()]
+if parent:
+    body['parent'] = parent
+if epic_link:
+    body['epicLink'] = epic_link
+if idempotency_key:
+    body['idempotencyKey'] = idempotency_key
+print(json.dumps(body))
+" "$project" "$type" "$summary" \
+    "$([ -n "$desc_inline$desc_file" ] || [ "$desc_stdin" = "1" ] && echo 1 || echo 0)" \
+    "$labels" "$parent" "$epic_link" "$idempotency_key")
+
+    call_gateway "/api/v1/jira/ticket/create" "$payload"
+}
+
+handle_ticket_edit() {
+    shift  # consume "edit"
+    if [ $# -lt 1 ]; then
+        echo "ERROR: Ticket key required. Usage: jira ticket edit <KEY> [...]" >&2
+        exit 1
+    fi
+    local ticket="$1"
+    shift
+
+    local summary="" labels="" add_labels="" remove_labels=""
+    local desc_inline="" desc_file="" desc_stdin=0
+    local notify_users=1   # default true; --no-notify flips to 0
+    local explicit_summary=0 explicit_labels=0 explicit_add=0 explicit_remove=0
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --summary)
+                shift; summary="${1:-}"; explicit_summary=1; shift || true
+                ;;
+            --description)
+                shift; desc_inline="${1:-}"; shift || true
+                ;;
+            --description-file)
+                shift; desc_file="${1:-}"; shift || true
+                ;;
+            --description-stdin)
+                desc_stdin=1; shift
+                ;;
+            --labels)
+                shift; labels="${1:-}"; explicit_labels=1; shift || true
+                ;;
+            --add-labels)
+                shift; add_labels="${1:-}"; explicit_add=1; shift || true
+                ;;
+            --remove-labels)
+                shift; remove_labels="${1:-}"; explicit_remove=1; shift || true
+                ;;
+            --no-notify)
+                notify_users=0; shift
+                ;;
+            *)
+                echo "ERROR: Unknown flag '$1' for 'jira ticket edit'" >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    if [ "$explicit_labels" = "1" ] && { [ "$explicit_add" = "1" ] || [ "$explicit_remove" = "1" ]; }; then
+        echo "ERROR: --labels (replace mode) and --add-labels/--remove-labels (incremental) are mutually exclusive" >&2
+        exit 1
+    fi
+
+    local description
+    description=$(resolve_body_source "description" "$desc_inline" "$desc_file" "$desc_stdin")
+
+    local payload
+    payload=$(DESCRIPTION="$description" python3 -c "
+import json, os, sys
+
+body = {'ticket': sys.argv[1]}
+have_summary = sys.argv[2] == '1'
+have_labels = sys.argv[3] == '1'
+have_add = sys.argv[4] == '1'
+have_remove = sys.argv[5] == '1'
+have_desc = sys.argv[6] == '1'
+notify = sys.argv[7] == '1'
+
+if have_summary:
+    body['summary'] = sys.argv[8]
+if have_desc:
+    body['description'] = os.environ.get('DESCRIPTION', '')
+if have_labels:
+    body['labels'] = [s.strip() for s in sys.argv[9].split(',') if s.strip()]
+if have_add:
+    body['addLabels'] = [s.strip() for s in sys.argv[10].split(',') if s.strip()]
+if have_remove:
+    body['removeLabels'] = [s.strip() for s in sys.argv[11].split(',') if s.strip()]
+body['notifyUsers'] = notify
+print(json.dumps(body))
+" "$ticket" \
+    "$explicit_summary" "$explicit_labels" "$explicit_add" "$explicit_remove" \
+    "$([ -n "$desc_inline$desc_file" ] || [ "$desc_stdin" = "1" ] && echo 1 || echo 0)" \
+    "$notify_users" \
+    "$summary" "$labels" "$add_labels" "$remove_labels")
+
+    call_gateway "/api/v1/jira/ticket/edit" "$payload"
+}
+
+handle_ticket_comment_add() {
+    shift  # consume "add"
+    if [ $# -lt 1 ]; then
+        echo "ERROR: Ticket key required. Usage: jira ticket comment add <KEY> [...]" >&2
+        exit 1
+    fi
+    local ticket="$1"
+    shift
+
+    local body_inline="" body_file="" body_stdin=0 idempotency_key=""
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --body)
+                shift; body_inline="${1:-}"; shift || true
+                ;;
+            --body-file)
+                shift; body_file="${1:-}"; shift || true
+                ;;
+            --body-stdin)
+                body_stdin=1; shift
+                ;;
+            --idempotency-key)
+                shift; idempotency_key="${1:-}"; shift || true
+                ;;
+            *)
+                echo "ERROR: Unknown flag '$1' for 'jira ticket comment add'" >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    if [ -z "$body_inline" ] && [ -z "$body_file" ] && [ "$body_stdin" != "1" ]; then
+        echo "ERROR: comment body is required (--body, --body-file, or --body-stdin)" >&2
+        exit 1
+    fi
+
+    local body_text
+    body_text=$(resolve_body_source "body" "$body_inline" "$body_file" "$body_stdin")
+
+    local payload
+    payload=$(BODY_TEXT="$body_text" python3 -c "
+import json, os, sys
+
+out = {
+    'ticket': sys.argv[1],
+    'body': os.environ.get('BODY_TEXT', ''),
+}
+idempotency_key = sys.argv[2]
+if idempotency_key:
+    out['idempotencyKey'] = idempotency_key
+print(json.dumps(out))
+" "$ticket" "$idempotency_key")
+
+    call_gateway "/api/v1/jira/ticket/comment/add" "$payload"
+}
+
+handle_link_create() {
+    shift  # consume "create"
+    local link_type="" inward="" outward="" comment="" idempotency_key=""
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --type)
+                shift; link_type="${1:-}"; shift || true
+                ;;
+            --inward)
+                shift; inward="${1:-}"; shift || true
+                ;;
+            --outward)
+                shift; outward="${1:-}"; shift || true
+                ;;
+            --comment)
+                shift; comment="${1:-}"; shift || true
+                ;;
+            --idempotency-key)
+                shift; idempotency_key="${1:-}"; shift || true
+                ;;
+            *)
+                echo "ERROR: Unknown flag '$1' for 'jira link create'" >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    if [ -z "$link_type" ] || [ -z "$inward" ] || [ -z "$outward" ]; then
+        echo "ERROR: --type, --inward, and --outward are required" >&2
+        exit 1
+    fi
+
+    local payload
+    payload=$(python3 -c "
+import json, sys
+
+body = {
+    'type': sys.argv[1],
+    'inwardIssue': sys.argv[2],
+    'outwardIssue': sys.argv[3],
+}
+comment = sys.argv[4]
+idempotency_key = sys.argv[5]
+if comment:
+    body['comment'] = comment
+if idempotency_key:
+    body['idempotencyKey'] = idempotency_key
+print(json.dumps(body))
+" "$link_type" "$inward" "$outward" "$comment" "$idempotency_key")
+
+    call_gateway "/api/v1/jira/issue-link/create" "$payload"
+}
+
 # --- Main dispatch ---
 
 if [ $# -lt 1 ]; then
@@ -323,7 +703,7 @@ case "$1" in
     ticket)
         shift
         if [ $# -lt 1 ]; then
-            echo "ERROR: Missing ticket subcommand. Usage: jira ticket get|comments <KEY>" >&2
+            echo "ERROR: Missing ticket subcommand. Usage: jira ticket get|comments|create|edit|comment <KEY>" >&2
             exit 1
         fi
         case "$1" in
@@ -333,8 +713,22 @@ case "$1" in
             comments)
                 handle_ticket_comments "$@"
                 ;;
+            create)
+                handle_ticket_create "$@"
+                ;;
+            edit)
+                handle_ticket_edit "$@"
+                ;;
+            comment)
+                shift  # consume "comment"
+                if [ $# -lt 1 ] || [ "$1" != "add" ]; then
+                    echo "ERROR: Missing 'add' subcommand. Usage: jira ticket comment add <KEY> [...]" >&2
+                    exit 1
+                fi
+                handle_ticket_comment_add "$@"
+                ;;
             *)
-                echo "ERROR: Unknown ticket subcommand '$1'. Use: get, comments" >&2
+                echo "ERROR: Unknown ticket subcommand '$1'. Use: get, comments, create, edit, comment" >&2
                 exit 1
                 ;;
         esac
@@ -347,12 +741,20 @@ case "$1" in
         shift
         handle_execute "$@"
         ;;
+    link)
+        shift
+        if [ $# -lt 1 ] || [ "$1" != "create" ]; then
+            echo "ERROR: Missing 'create' subcommand. Usage: jira link create --type ... --inward ... --outward ..." >&2
+            exit 1
+        fi
+        handle_link_create "$@"
+        ;;
     help|--help|-h)
         show_usage
         exit 0
         ;;
     *)
-        echo "ERROR: Unknown command '$1'. Use: ticket, search, execute, help" >&2
+        echo "ERROR: Unknown command '$1'. Use: ticket, search, execute, link, help" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
Resumes work on #1924 from the prior pipeline (cancelled before Phase 5 landed).

## Status

Phases 1–4 and 6 from the plan are already coded on this branch:

- **Phase 1** (foundation): `gateway/jira_idempotency.py`, `gateway/jira_adf.py`
- **Phase 2** (`JiraClient` writes): `create_issue`, `edit_issue`, `add_comment`, `create_issue_link` + 429-audit relocation
- **Phase 3** (gateway routes): four new `/api/v1/jira/*` routes with body schema, ADF wrap, audit
- **Phase 4** (sandbox wrappers): `jira ticket create | edit | comment add | link create` subcommands
- **Phase 6** (docs): `docs/reference/jira-wrapper.md` "Write verbs" section + `config/context-filters.yaml` knobs

**Missing — Phase 5 (tests).** The prior pipeline handed off test scaffolding to the tester role at `.egg-state/agent-outputs/1924-coder-test-handoff/` but did not land the tests. This PR is being driven through `babysit_pr` (BRC coder + reviewer) to land the test suite + address any reviewer concerns.

## Plan + analysis

Full prior-run artifacts on this branch:

- `.egg-state/drafts/1924-plan.md` — 6-phase plan with 25 named tasks (`yaml-tasks` appendix)
- `.egg-state/drafts/1924-analysis.md` — refine-phase analysis
- Decided design and acceptance criteria are also in the issue body (#1924).

## Test plan

Phase 5 acceptance criteria from the plan:

- `gateway/tests/test_jira_idempotency.py` — cache hit/miss, TTL expiry, threading-lock race, link-cache aliasing
- `gateway/tests/test_jira_adf.py` — wrap_text_as_adf + is_adf_dict coverage
- `gateway/tests/test_jira_client.py` — per-method wire-shape tests + 429 audit on writes
- `gateway/tests/test_jira_routes.py` — per-route 403/400 grid for the four new routes + route-enumeration regression
- `gateway/tests/test_jira_policy.py` — link_types and epic_link_field config knobs
- `tests/sandbox/test_jira_wrapper.py` — subcommand smoke tests against mocked gateway

`make lint`, `make test`, `make security` must all pass; existing v1 read tests (`test_allowed_domains.py`, etc.) must remain green.

Closes #1924.