### PR TITLE
fix(orchestrator): resolve EGG_REPO_PATH for commit-authorship under multi-repo

### DIFF
--- a/orchestrator/commit_authorship_store.py
+++ b/orchestrator/commit_authorship_store.py
@@ -490,6 +490,43 @@ _singleton: CommitAuthorshipStore | None = None
 _singleton_lock = threading.Lock()
 
 
+def _resolve_authorship_repo_path() -> Path:
+    """Resolve ``EGG_REPO_PATH`` to a single git repo for the authorship store.
+
+    The authorship store keeps a single shared shard tree across all repos
+    (sharded by pipeline_id, with ``repo`` recorded as advisory metadata
+    on each entry — see ``register``).  It needs exactly one git repo
+    whose state branch can host that tree.
+
+    ``EGG_REPO_PATH`` may point at:
+
+    1. A single git repo (e.g. ``/home/egg/repos/egg``) — use it directly.
+    2. A parent directory containing several repos (e.g. ``/home/egg/repos``
+       with ``egg/``, ``actions/``, …) — pick one, preferring the ``egg``
+       repo by name (the orchestrator's own repo, where pipeline state
+       conventionally lives).  Falls back to the first repo alphabetically
+       when ``egg`` is absent so the failure mode is deterministic in
+       hand-rolled deployments.
+    3. A non-existent or non-repo path — return the env value verbatim and
+       let ``StateStore`` raise its own actionable error from
+       ``_ensure_worktree`` (the defensive fallback added alongside this
+       multi-repo fix).
+
+    Empty / unset ``EGG_REPO_PATH`` keeps the historical default
+    ``/home/egg/repos/egg`` for backwards compatibility with single-repo
+    deployments that never set the env var.
+    """
+    from state_store import discover_repo_paths  # type: ignore[import-not-found]
+
+    env_path = Path(os.environ.get("EGG_REPO_PATH", "/home/egg/repos/egg"))
+    repos: list[Path] = discover_repo_paths(env_path)
+    if len(repos) == 0:
+        return env_path
+    if len(repos) == 1:
+        return repos[0]
+    return next((r for r in repos if r.name == "egg"), repos[0])
+
+
 def get_store(state_store: StateStore | None = None) -> CommitAuthorshipStore:
     """Return a process-wide singleton backed by the state store.
 
@@ -505,7 +542,7 @@ def get_store(state_store: StateStore | None = None) -> CommitAuthorshipStore:
                 # module graph at import time.
                 from state_store import StateStore as _SS  # type: ignore[import-not-found]
 
-                repo_path = Path(os.environ.get("EGG_REPO_PATH", "/home/egg/repos/egg"))
+                repo_path = _resolve_authorship_repo_path()
                 _singleton = CommitAuthorshipStore(state_store=_SS(repo_path=repo_path))
             else:
                 _singleton = CommitAuthorshipStore(state_store=state_store)

--- a/orchestrator/commit_authorship_store.py
+++ b/orchestrator/commit_authorship_store.py
@@ -498,7 +498,13 @@ def _resolve_authorship_repo_path() -> Path:
     on each entry — see ``register``).  It needs exactly one git repo
     whose state branch can host that tree.
 
-    ``EGG_REPO_PATH`` may point at:
+    ``EGG_AUTHORSHIP_REPO`` (optional) explicitly names the repo path or
+    repo directory name to use.  When set, it bypasses ``EGG_REPO_PATH``
+    discovery entirely — useful for forked / renamed deployments where
+    the default ``egg``-name preference would silently pick the wrong
+    repo.
+
+    ``EGG_REPO_PATH`` may otherwise point at:
 
     1. A single git repo (e.g. ``/home/egg/repos/egg``) — use it directly.
     2. A parent directory containing several repos (e.g. ``/home/egg/repos``
@@ -508,9 +514,9 @@ def _resolve_authorship_repo_path() -> Path:
        when ``egg`` is absent so the failure mode is deterministic in
        hand-rolled deployments.
     3. A non-existent or non-repo path — return the env value verbatim and
-       let ``StateStore`` raise its own actionable error from
-       ``_ensure_worktree`` (the defensive fallback added alongside this
-       multi-repo fix).
+       let ``get_state_store`` raise its own actionable error
+       (the defensive ``_ensure_worktree`` guard catches direct
+       ``StateStore`` constructions that bypass this resolver).
 
     Empty / unset ``EGG_REPO_PATH`` keeps the historical default
     ``/home/egg/repos/egg`` for backwards compatibility with single-repo
@@ -519,6 +525,18 @@ def _resolve_authorship_repo_path() -> Path:
     from state_store import discover_repo_paths  # type: ignore[import-not-found]
 
     env_path = Path(os.environ.get("EGG_REPO_PATH", "/home/egg/repos/egg"))
+
+    # Explicit override wins over discovery — handles forked / renamed
+    # deployments where the alphabetical fallback would pick the wrong
+    # repo.  Accepts either an absolute path or a repo name relative to
+    # ``EGG_REPO_PATH``.
+    override = os.environ.get("EGG_AUTHORSHIP_REPO", "").strip()
+    if override:
+        override_path = Path(override)
+        if override_path.is_absolute():
+            return override_path
+        return env_path / override
+
     repos: list[Path] = discover_repo_paths(env_path)
     if len(repos) == 0:
         return env_path
@@ -540,10 +558,21 @@ def get_store(state_store: StateStore | None = None) -> CommitAuthorshipStore:
             if state_store is None:
                 # Late import to avoid pulling in the full state_store
                 # module graph at import time.
-                from state_store import StateStore as _SS  # type: ignore[import-not-found]
+                #
+                # Route through ``get_state_store`` so the worktree path
+                # matches the rest of the orchestrator (multi-repo
+                # deployments derive ``pipeline-worktree-<name>`` from
+                # the repo dir name — see ``state_store.get_state_store``).
+                # Constructing ``StateStore`` directly would fall back to
+                # the default ``pipeline-worktree`` path and conflict with
+                # ``unified_sse`` / ``routes/health`` over the
+                # ``egg/pipeline-state`` branch.
+                from state_store import (  # type: ignore[import-not-found]
+                    get_state_store as _get_state_store,
+                )
 
                 repo_path = _resolve_authorship_repo_path()
-                _singleton = CommitAuthorshipStore(state_store=_SS(repo_path=repo_path))
+                _singleton = CommitAuthorshipStore(state_store=_get_state_store(repo_path))
             else:
                 _singleton = CommitAuthorshipStore(state_store=state_store)
         return _singleton

--- a/orchestrator/state_store.py
+++ b/orchestrator/state_store.py
@@ -207,6 +207,25 @@ class StateStore:
 
     def _ensure_worktree(self) -> Path:
         """Create or validate the persistent state worktree."""
+        # Fail-fast guard: every code path below runs `git` from
+        # ``self.repo_path``. If that path is not itself a git repository
+        # (e.g., a deployment sets ``EGG_REPO_PATH=/home/egg/repos`` — a
+        # parent dir containing several repos — and a caller constructs
+        # ``StateStore`` directly without going through
+        # :func:`get_state_store`'s multi-repo discovery), git walks up
+        # to the mount point and produces an opaque "not a git repository"
+        # error from inside `git worktree add`. Catch that case here and
+        # raise an actionable error naming the offending env var.
+        if not (self.repo_path / ".git").exists():
+            raise StateStoreError(
+                f"StateStore.repo_path is not a git repository: {self.repo_path}. "
+                f"This usually means EGG_REPO_PATH points at a parent directory "
+                f"containing multiple repos rather than a single repo. Use "
+                f"`get_state_store(repo_path)` (which calls `discover_repo_paths`) "
+                f"to resolve the parent to a specific repo before constructing "
+                f"the state store."
+            )
+
         # Clean up stale admin dir for THIS worktree only (e.g., from crashes).
         # IMPORTANT: Do NOT use `git worktree prune` — the orchestrator cannot
         # see the gateway's worktree paths (different bind mounts), so prune

--- a/orchestrator/tests/test_commit_authorship_store.py
+++ b/orchestrator/tests/test_commit_authorship_store.py
@@ -554,3 +554,71 @@ class TestFactory:
         store = CommitAuthorshipStore(worktree_dir=worktree)
         store.register(_VALID_SHA, "coder", "issue-1882")
         assert worktree.exists()
+
+
+class TestResolveAuthorshipRepoPath:
+    """``_resolve_authorship_repo_path`` must handle the three shapes
+    ``EGG_REPO_PATH`` takes in the wild: single repo, parent dir with
+    multiple child repos, and missing/non-existent path."""
+
+    def test_single_git_repo(self, tmp_path: Path, monkeypatch):
+        """``EGG_REPO_PATH`` pointing at a single repo returns that repo."""
+        from commit_authorship_store import _resolve_authorship_repo_path
+
+        repo = tmp_path / "single"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        monkeypatch.setenv("EGG_REPO_PATH", str(repo))
+
+        assert _resolve_authorship_repo_path() == repo
+
+    def test_parent_dir_prefers_egg_repo(self, tmp_path: Path, monkeypatch):
+        """Parent dir with multiple repos picks ``egg`` by name when present."""
+        from commit_authorship_store import _resolve_authorship_repo_path
+
+        parent = tmp_path / "repos"
+        parent.mkdir()
+        for name in ("actions", "egg", "zzz"):
+            child = parent / name
+            child.mkdir()
+            (child / ".git").mkdir()
+        monkeypatch.setenv("EGG_REPO_PATH", str(parent))
+
+        assert _resolve_authorship_repo_path() == parent / "egg"
+
+    def test_parent_dir_falls_back_to_first_alpha(self, tmp_path: Path, monkeypatch):
+        """When ``egg`` is absent, fall back to the first repo alphabetically
+        so deployments without an ``egg`` repo get a deterministic choice."""
+        from commit_authorship_store import _resolve_authorship_repo_path
+
+        parent = tmp_path / "repos"
+        parent.mkdir()
+        for name in ("alpha", "beta"):
+            child = parent / name
+            child.mkdir()
+            (child / ".git").mkdir()
+        monkeypatch.setenv("EGG_REPO_PATH", str(parent))
+
+        assert _resolve_authorship_repo_path() == parent / "alpha"
+
+    def test_non_existent_path_returns_env_value(self, tmp_path: Path, monkeypatch):
+        """Non-existent path is returned verbatim — ``StateStore`` will
+        raise the actionable error when ``_ensure_worktree`` runs."""
+        from commit_authorship_store import _resolve_authorship_repo_path
+
+        missing = tmp_path / "nope"
+        monkeypatch.setenv("EGG_REPO_PATH", str(missing))
+
+        assert _resolve_authorship_repo_path() == missing
+
+    def test_parent_dir_with_no_repos_returns_env_value(self, tmp_path: Path, monkeypatch):
+        """Parent dir whose children are not git repos is returned
+        verbatim — ``StateStore`` will raise on access."""
+        from commit_authorship_store import _resolve_authorship_repo_path
+
+        parent = tmp_path / "non-repos"
+        parent.mkdir()
+        (parent / "not-a-repo").mkdir()  # No .git inside.
+        monkeypatch.setenv("EGG_REPO_PATH", str(parent))
+
+        assert _resolve_authorship_repo_path() == parent

--- a/orchestrator/tests/test_commit_authorship_store.py
+++ b/orchestrator/tests/test_commit_authorship_store.py
@@ -622,3 +622,126 @@ class TestResolveAuthorshipRepoPath:
         monkeypatch.setenv("EGG_REPO_PATH", str(parent))
 
         assert _resolve_authorship_repo_path() == parent
+
+    def test_unset_env_uses_historical_default(self, monkeypatch):
+        """Unset ``EGG_REPO_PATH`` falls back to ``/home/egg/repos/egg``
+        for back-compat with single-repo deployments that never set it."""
+        from commit_authorship_store import _resolve_authorship_repo_path
+
+        monkeypatch.delenv("EGG_REPO_PATH", raising=False)
+        monkeypatch.delenv("EGG_AUTHORSHIP_REPO", raising=False)
+
+        # The default path almost certainly does not exist on the test
+        # host, so the resolver returns it verbatim per the documented
+        # non-existent-path branch.  The assertion locks in the default.
+        assert _resolve_authorship_repo_path() == Path("/home/egg/repos/egg")
+
+    def test_authorship_repo_override_absolute_path(self, tmp_path: Path, monkeypatch):
+        """``EGG_AUTHORSHIP_REPO`` as absolute path bypasses
+        ``EGG_REPO_PATH`` discovery entirely — useful for forked /
+        renamed deployments where the alphabetical fallback would pick
+        the wrong repo."""
+        from commit_authorship_store import _resolve_authorship_repo_path
+
+        parent = tmp_path / "repos"
+        parent.mkdir()
+        for name in ("alpha", "egg", "zzz"):
+            child = parent / name
+            child.mkdir()
+            (child / ".git").mkdir()
+        monkeypatch.setenv("EGG_REPO_PATH", str(parent))
+        # Override picks `zzz` even though `egg` would normally win.
+        monkeypatch.setenv("EGG_AUTHORSHIP_REPO", str(parent / "zzz"))
+
+        assert _resolve_authorship_repo_path() == parent / "zzz"
+
+    def test_authorship_repo_override_relative_name(self, tmp_path: Path, monkeypatch):
+        """``EGG_AUTHORSHIP_REPO`` as a relative name resolves under
+        ``EGG_REPO_PATH`` so operators can write ``EGG_AUTHORSHIP_REPO=myfork``
+        without repeating the parent path."""
+        from commit_authorship_store import _resolve_authorship_repo_path
+
+        parent = tmp_path / "repos"
+        parent.mkdir()
+        for name in ("alpha", "egg", "myfork"):
+            child = parent / name
+            child.mkdir()
+            (child / ".git").mkdir()
+        monkeypatch.setenv("EGG_REPO_PATH", str(parent))
+        monkeypatch.setenv("EGG_AUTHORSHIP_REPO", "myfork")
+
+        assert _resolve_authorship_repo_path() == parent / "myfork"
+
+
+class TestGetStoreUsesGetStateStore:
+    """Regression for #2184: ``get_store()`` must route through
+    ``state_store.get_state_store`` so the worktree path matches what
+    ``unified_sse``/``routes/health``/``routes/signals`` use.
+
+    Constructing ``StateStore`` directly fell back to the default
+    ``pipeline-worktree`` path while the rest of the orchestrator picked
+    ``pipeline-worktree-egg`` in multi-repo mode — both then raced to
+    ``git worktree add`` the same ``egg/pipeline-state`` branch and one
+    side wedged with ``branch already in use``.
+    """
+
+    def test_multi_repo_converges_on_per_repo_worktree(self, tmp_path: Path, monkeypatch):
+        """In multi-repo mode, ``get_store()`` and ``get_state_store(egg)``
+        agree on ``pipeline-worktree-<repo_name>`` so they share — not
+        clash — over the state branch.
+        """
+        # Stub out StateStore — we don't want real git to run.  We only
+        # need to observe the ``worktree_dir`` argument the factory
+        # passes in.
+        import state_store as ss_mod  # type: ignore[import-not-found]
+
+        captured: dict[str, Path | None] = {}
+
+        class _StubStateStore:
+            def __init__(self, repo_path, worktree_dir=None):
+                self.repo_path = repo_path
+                self._worktree_dir = worktree_dir
+                captured["repo_path"] = repo_path
+                captured["worktree_dir"] = worktree_dir
+
+            def commit_state_to_branch(self, *args, **kwargs):
+                return None
+
+        monkeypatch.setattr(ss_mod, "StateStore", _StubStateStore)
+
+        # Build a parent dir with two sibling repos so multi-repo mode
+        # kicks in (a single child repo intentionally falls back to the
+        # default path — see ``state_store.get_state_store``).
+        parent = tmp_path / "repos"
+        parent.mkdir()
+        for name in ("actions", "egg"):
+            child = parent / name
+            child.mkdir()
+            (child / ".git").mkdir()
+
+        state_dir = tmp_path / "egg-state"
+        monkeypatch.setenv("EGG_REPO_PATH", str(parent))
+        monkeypatch.setenv("EGG_STATE_DIR", str(state_dir))
+        monkeypatch.delenv("EGG_AUTHORSHIP_REPO", raising=False)
+
+        # First, observe what ``get_state_store`` picks for the egg repo
+        # — this is what ``unified_sse`` / health probes use.
+        ss_mod.get_state_store(parent / "egg")
+        expected_worktree = state_dir / "pipeline-worktree-egg"
+        assert captured["repo_path"] == parent / "egg"
+        assert captured["worktree_dir"] == expected_worktree
+
+        # Now drive the authorship-store factory and confirm it picks
+        # the *same* worktree path — i.e., it routes through
+        # ``get_state_store`` rather than constructing ``StateStore``
+        # directly with the default ``pipeline-worktree``.
+        captured.clear()
+        from commit_authorship_store import get_store
+
+        get_store()
+        assert captured["repo_path"] == parent / "egg"
+        assert captured["worktree_dir"] == expected_worktree, (
+            "commit-authorship store must converge on the per-repo worktree "
+            "path that the rest of the orchestrator uses; otherwise both "
+            "sides race over the egg/pipeline-state branch."
+        )

--- a/orchestrator/tests/test_state_store.py
+++ b/orchestrator/tests/test_state_store.py
@@ -1844,15 +1844,23 @@ class TestEnsureWorktreeRepoPathGuard:
         assert str(parent) in msg
 
     def test_repo_path_with_dot_git_passes_guard(self, tmp_path, mock_git):
-        """``repo_path`` with a ``.git`` dir clears the guard and reaches
-        the existing worktree-add path (mocked)."""
+        """``repo_path`` with a ``.git`` dir clears the guard.
+
+        With ``mock_git`` returning success for every git invocation and
+        the worktree dir present on disk, ``_ensure_worktree`` takes the
+        ``rev-parse --is-inside-work-tree`` healthy fast path and returns
+        without reaching the orphan-branch logic.  That is fine for this
+        test — the only assertion is that the new fail-fast guard does
+        not trigger when ``.git`` is present; orphan-branch behaviour is
+        covered by other tests in this module.
+        """
         repo_path = tmp_path / "repo"
         repo_path.mkdir()
         (repo_path / ".git").mkdir()
-        store = StateStore(repo_path, worktree_dir=tmp_path / "wt")
-        # Should not raise — falls through to mocked git operations.
-        # The mocked `_run_git` returns success, so the orphan-branch
-        # branch runs and tries to iterate the worktree dir; create it
-        # so iterdir() doesn't blow up.
-        (tmp_path / "wt").mkdir(parents=True, exist_ok=True)
-        store._ensure_worktree()
+        wt = tmp_path / "wt"
+        wt.mkdir(parents=True, exist_ok=True)
+        store = StateStore(repo_path, worktree_dir=wt)
+
+        # Should not raise — guard passes, fast path returns the
+        # healthy worktree.
+        assert store._ensure_worktree() == wt

--- a/orchestrator/tests/test_state_store.py
+++ b/orchestrator/tests/test_state_store.py
@@ -1816,3 +1816,43 @@ class TestBranchHeldByPrunableWorktree:
         assert not admin_dir.exists()
         # Calling again — nothing left to remove.
         assert store._remove_admin_dir_for_path(unrelated_path) is False
+
+
+class TestEnsureWorktreeRepoPathGuard:
+    """Regression: ``_ensure_worktree`` must reject a non-repo
+    ``repo_path`` with an actionable error instead of letting ``git
+    worktree add`` produce an opaque "not a git repository" failure.
+
+    Repro case: a deployment sets ``EGG_REPO_PATH`` to a parent dir
+    containing several repos and a caller constructs ``StateStore``
+    directly (bypassing ``get_state_store``'s multi-repo discovery)."""
+
+    def test_non_repo_path_raises_actionable_error(self, tmp_path):
+        """``repo_path`` without a ``.git`` entry raises StateStoreError
+        naming ``EGG_REPO_PATH`` so operators can fix the env var."""
+        parent = tmp_path / "repos-parent"
+        parent.mkdir()
+        # No `.git` under parent — it's a parent of repos, not a repo.
+        store = StateStore(parent, worktree_dir=tmp_path / "wt")
+
+        with pytest.raises(StateStoreError) as exc_info:
+            store._ensure_worktree()
+
+        msg = str(exc_info.value)
+        assert "not a git repository" in msg
+        assert "EGG_REPO_PATH" in msg
+        assert str(parent) in msg
+
+    def test_repo_path_with_dot_git_passes_guard(self, tmp_path, mock_git):
+        """``repo_path`` with a ``.git`` dir clears the guard and reaches
+        the existing worktree-add path (mocked)."""
+        repo_path = tmp_path / "repo"
+        repo_path.mkdir()
+        (repo_path / ".git").mkdir()
+        store = StateStore(repo_path, worktree_dir=tmp_path / "wt")
+        # Should not raise — falls through to mocked git operations.
+        # The mocked `_run_git` returns success, so the orphan-branch
+        # branch runs and tries to iterate the worktree dir; create it
+        # so iterdir() doesn't blow up.
+        (tmp_path / "wt").mkdir(parents=True, exist_ok=True)
+        store._ensure_worktree()


### PR DESCRIPTION
## Summary

- Crash repro: any new orchestrator pod starts with `EGG_REPO_PATH=/home/egg/repos` (parent dir, not a git repo). The first `POST /api/v1/commit-authorship/register` after startup hits `commit_authorship_store.get_store()`, which constructs `StateStore(repo_path=Path(EGG_REPO_PATH))` directly, lazily calls `_ensure_worktree`, and runs `git worktree add --detach …` from `/home/egg/repos`. Git walks up to `/home/egg`, finds no `.git`, and 500s with `fatal: not a git repository (or any parent up to mount point /home/egg)`.
- **Proper fix** — new `_resolve_authorship_repo_path` uses `discover_repo_paths` to handle both shapes `EGG_REPO_PATH` takes in deployments: single repo (use directly) or parent containing several repos (prefer `egg`, fall back to first alphabetically for determinism). The shared authorship shard tree continues to live in a single state branch on that resolved repo; the per-entry `repo` field remains advisory metadata.
- **Defensive fallback** — `StateStore._ensure_worktree` now fails fast with an actionable `StateStoreError` naming `EGG_REPO_PATH` when `repo_path` is not a git repo, instead of bubbling git's opaque "not a git repository" string. Catches future callers that bypass `get_state_store`'s multi-repo discovery.

## How discovered

Surfaced when running `babysit_pr` against a fresh PR. The orchestrator pod's `commit_authorship` singleton initialized lazily on first `register` call and 500'd. `register-bulk` then 200'd by accident — its per-item exception handler swallowed each `_ensure_worktree` failure individually (also visible in the same log run as `Worktree validation failed, recreating: worktree=/home/egg/.egg-state/pipeline-worktree-actions`, which is a *different* state store created via the multi-repo-aware `get_state_store` path).

## Test plan

- [x] New `TestResolveAuthorshipRepoPath` (5 cases): single repo, parent with `egg`, parent without `egg` (deterministic alpha fallback), non-existent path, parent with non-repo children.
- [x] New `TestEnsureWorktreeRepoPathGuard` (2 cases): non-repo `repo_path` raises actionable error naming `EGG_REPO_PATH`; valid `.git` path passes the guard.
- [x] `pytest orchestrator/tests/test_state_store.py orchestrator/tests/test_commit_authorship_store.py` — all 155 pass locally.
- [x] `ruff check` and `ruff format --check` clean on all four changed files.
- [ ] CI green.
- [ ] After merge: confirm orchestrator can run `babysit_pr` end-to-end without a 500 on the first `commit-authorship/register`.