### PR TITLE
fix(gateway,orchestrator): surface per-repo worktree creation errors in logs (#2186)

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -6178,6 +6178,41 @@ def _cleanup_stale_pack_files(exec_path: str) -> None:
         )
 
 
+def _cleanup_empty_container_dir(container_id: str) -> None:
+    """Best-effort removal of an orphan container worktree directory.
+
+    Called from the total-failure branch of worktree_create.  Only acts
+    when the directory is actually empty — if any per-repo subdir is
+    present (partial failure with leftover state), we leave it for an
+    operator-driven prune so we don't accidentally drop in-progress
+    work.  See #2186.
+    """
+    target = WORKTREE_BASE_DIR / container_id
+    try:
+        if not target.exists():
+            return
+        if any(target.iterdir()):
+            logger.warning(
+                "Skipping orphan container dir cleanup: not empty",
+                container_id=container_id,
+                path=str(target),
+            )
+            return
+        target.rmdir()
+        logger.info(
+            "Removed empty orphan container worktree dir",
+            container_id=container_id,
+            path=str(target),
+        )
+    except OSError as e:
+        logger.warning(
+            "Failed to clean orphan container dir",
+            container_id=container_id,
+            path=str(target),
+            error=str(e),
+        )
+
+
 @app.route("/api/v1/worktree/create", methods=["POST"])
 @require_launcher_auth
 def worktree_create() -> tuple[Response, int] | Response:
@@ -6241,11 +6276,11 @@ def worktree_create() -> tuple[Response, int] | Response:
         else:
             repo_name = repo
 
+        effective_branch = base_branch or manager.resolve_default_branch(repo_name)
         try:
             # Resolve the default branch per-repo when no explicit base is given.
             # This ensures repos with non-standard default branches (e.g., master)
             # are handled correctly.  See #860.
-            effective_branch = base_branch or manager.resolve_default_branch(repo_name)
             info = manager.create_worktree(
                 repo_name=repo_name,
                 container_id=container_id,
@@ -6256,14 +6291,48 @@ def worktree_create() -> tuple[Response, int] | Response:
             )
             # Translate container path to host path for egg launcher mount sources
             worktrees[repo_name] = translate_to_host_path(str(info.worktree_path))
-        except ValueError as e:
-            errors.append(f"{repo_name}: {e}")
-        except RuntimeError as e:
+        except (ValueError, RuntimeError) as e:
+            # Capture full traceback so operators can diagnose without
+            # re-instrumenting the gateway.  See #2186.
+            logger.exception(
+                "worktree_create per-repo failure",
+                repo_name=repo_name,
+                container_id=container_id,
+                base_branch=effective_branch,
+                assigned_branch=assigned_branch,
+                error_type=type(e).__name__,
+            )
             errors.append(f"{repo_name}: {e}")
         except Exception as e:
+            logger.exception(
+                "worktree_create unexpected per-repo failure",
+                repo_name=repo_name,
+                container_id=container_id,
+                base_branch=effective_branch,
+                assigned_branch=assigned_branch,
+                error_type=type(e).__name__,
+            )
             errors.append(f"{repo_name}: unexpected error - {e}")
 
     if errors and not worktrees:
+        # Total failure: surface aggregate errors in logs + audit, then
+        # best-effort clean up the empty container directory so retries
+        # aren't blocked by stale state.  See #2186.
+        logger.error(
+            "worktree_create failed for all repos",
+            container_id=container_id,
+            errors=errors,
+        )
+        audit_log(
+            "worktrees_create_failed",
+            "worktree_create",
+            success=False,
+            details={
+                "container_id": container_id,
+                "errors": errors,
+            },
+        )
+        _cleanup_empty_container_dir(container_id)
         return make_error(
             "Failed to create any worktrees",
             status_code=500,

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -197,6 +197,7 @@ try:
         WorktreeManager,
         get_active_docker_containers,
         startup_cleanup,
+        validate_identifier,
     )
 except ImportError:
     from agent_restrictions import (  # type: ignore[no-redef, import-untyped]
@@ -338,6 +339,7 @@ except ImportError:
         WorktreeManager,
         get_active_docker_containers,
         startup_cleanup,
+        validate_identifier,
     )
 
 # Import repo_config for user mode support
@@ -6186,9 +6188,38 @@ def _cleanup_empty_container_dir(container_id: str) -> None:
     present (partial failure with leftover state), we leave it for an
     operator-driven prune so we don't accidentally drop in-progress
     work.  See #2186.
+
+    Defense-in-depth: validate `container_id` and verify the resolved
+    path stays under `WORKTREE_BASE_DIR` before any filesystem mutation.
+    `worktree_create` already validates at the route boundary, but a
+    raw `..`-bearing identifier reaching `Path / container_id` would
+    otherwise let `rmdir(2)` follow the literal path and unlink an
+    empty directory adjacent to the base dir.
     """
+    try:
+        validate_identifier(container_id, "container_id")
+    except ValueError as e:
+        logger.warning(
+            "Skipping orphan container dir cleanup: invalid container_id",
+            container_id=container_id,
+            error=str(e),
+        )
+        return
+
     target = WORKTREE_BASE_DIR / container_id
     try:
+        # Resolve and verify containment as a second line of defense
+        # against any future caller that bypasses validate_identifier.
+        base_resolved = WORKTREE_BASE_DIR.resolve()
+        target_resolved = target.resolve(strict=False)
+        if target_resolved != base_resolved and base_resolved not in target_resolved.parents:
+            logger.warning(
+                "Skipping orphan container dir cleanup: outside base dir",
+                container_id=container_id,
+                resolved=str(target_resolved),
+                base=str(base_resolved),
+            )
+            return
         if not target.exists():
             return
         if any(target.iterdir()):
@@ -6259,6 +6290,18 @@ def worktree_create() -> tuple[Response, int] | Response:
     if not repos:
         return make_error("Missing repos list")
 
+    # Validate container_id at the route boundary so every downstream
+    # filesystem touch (including the post-failure cleanup helper) is
+    # safe.  Without this, a `..`-bearing container_id would reach
+    # `_cleanup_empty_container_dir` after `manager.create_worktree`
+    # raised ValueError into the per-repo `errors[]` list, letting
+    # `rmdir(2)` follow the literal path out of WORKTREE_BASE_DIR.
+    # See #2186 review feedback.
+    try:
+        validate_identifier(container_id, "container_id")
+    except ValueError as e:
+        return make_error(str(e))
+
     # Validate uid/gid if provided
     if uid is not None and (not isinstance(uid, int) or uid < 0):
         return make_error("Invalid uid: must be a non-negative integer")
@@ -6276,11 +6319,18 @@ def worktree_create() -> tuple[Response, int] | Response:
         else:
             repo_name = repo
 
-        effective_branch = base_branch or manager.resolve_default_branch(repo_name)
+        # Pre-bind so the except clauses below can reference
+        # effective_branch even if resolve_default_branch raises (e.g.,
+        # OSError if the git binary is missing).  See #2186 review
+        # feedback — previously hoisted out of the try, which let
+        # resolve_default_branch failures bypass the per-repo errors[]
+        # safety net entirely.
+        effective_branch = base_branch
         try:
             # Resolve the default branch per-repo when no explicit base is given.
             # This ensures repos with non-standard default branches (e.g., master)
             # are handled correctly.  See #860.
+            effective_branch = base_branch or manager.resolve_default_branch(repo_name)
             info = manager.create_worktree(
                 repo_name=repo_name,
                 container_id=container_id,

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -5167,6 +5167,53 @@ class TestWorktreeCreateFailureLogging:
             assert response.status_code == 500
             mock_cleanup.assert_called_once_with("test-container")
 
+    def test_cleanup_rejects_path_traversal(self, tmp_path):
+        """_cleanup_empty_container_dir refuses container_ids containing
+        path-traversal (`..`) so a bypass of the route-level validation
+        cannot rmdir directories outside WORKTREE_BASE_DIR.
+
+        Without this guard, `Path(base) / "../sibling"` would let
+        `rmdir(2)` follow the literal path and unlink an empty directory
+        adjacent to the base dir.  See #2186 review feedback.
+        """
+        base = tmp_path / "base"
+        base.mkdir()
+        sibling = tmp_path / "sibling"
+        sibling.mkdir()  # empty — would otherwise be rmdir-able
+
+        with patch.object(gateway, "WORKTREE_BASE_DIR", base):
+            gateway._cleanup_empty_container_dir("../sibling")
+
+        # The sibling directory must still exist — the helper must
+        # refuse the traversed identifier before any filesystem mutation.
+        assert sibling.exists(), (
+            "Path-traversal container_id reached rmdir; cleanup must "
+            "reject `..`-bearing identifiers before touching the filesystem."
+        )
+
+    def test_route_rejects_path_traversal_container_id(self, client, launcher_auth_headers):
+        """worktree_create validates container_id at the route boundary
+        and returns a 400 for `..`-bearing identifiers, before any
+        per-repo work runs.  See #2186 review feedback."""
+        with patch.object(gateway, "get_worktree_manager") as mock_worktree:
+            response = client.post(
+                "/api/v1/worktree/create",
+                headers=launcher_auth_headers,
+                data=json.dumps(
+                    {
+                        "container_id": "../escape",
+                        "repos": ["owner/repo"],
+                    }
+                ),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 400
+            body = json.loads(response.data)
+            assert "path traversal" in body["message"].lower()
+            # No per-repo work should have started.
+            mock_worktree.return_value.create_worktree.assert_not_called()
+
 
 class TestSessionDeleteByContainerWorktreeCleanup:
     """Tests for DELETE /api/v1/sessions/by-container/<container_id> worktree cleanup."""

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -4960,6 +4960,214 @@ class TestWorktreeCreateEndpointResolution:
             assert base == "origin/develop"
 
 
+class TestWorktreeCreateFailureLogging:
+    """Tests for worktree_create's failure-path observability and cleanup.
+
+    See #2186 — prior to this fix the 500 branch returned the per-repo
+    error list only in the HTTP response body, with no logger.error or
+    audit_log entry, so operators reading only logs were blind to the
+    actual cause.
+    """
+
+    def test_per_repo_failure_logs_with_traceback(self, client, launcher_auth_headers):
+        """Each per-repo exception is captured via logger.exception so the
+        traceback survives.  The response still returns the per-repo
+        message in errors[]."""
+        with (
+            patch.object(gateway, "get_worktree_manager") as mock_worktree,
+            patch.object(gateway, "logger") as mock_logger,
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "_cleanup_empty_container_dir"),
+        ):
+            mock_wt_manager = mock_worktree.return_value
+            mock_wt_manager.resolve_default_branch.return_value = "origin/main"
+            mock_wt_manager.create_worktree.side_effect = ValueError("branch already exists")
+
+            response = client.post(
+                "/api/v1/worktree/create",
+                headers=launcher_auth_headers,
+                data=json.dumps(
+                    {
+                        "container_id": "test-container",
+                        "repos": ["owner/repo"],
+                    }
+                ),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 500
+            body = json.loads(response.data)
+            assert body["data"]["errors"] == ["repo: branch already exists"]
+
+            # Per-repo logger.exception call carries structured fields
+            mock_logger.exception.assert_called_once()
+            exc_kwargs = mock_logger.exception.call_args.kwargs
+            assert exc_kwargs["repo_name"] == "repo"
+            assert exc_kwargs["container_id"] == "test-container"
+            assert exc_kwargs["error_type"] == "ValueError"
+
+    def test_unexpected_exception_logs_with_traceback(self, client, launcher_auth_headers):
+        """The broad `except Exception` path also routes through
+        logger.exception so unexpected failures aren't silently
+        string-coerced."""
+        with (
+            patch.object(gateway, "get_worktree_manager") as mock_worktree,
+            patch.object(gateway, "logger") as mock_logger,
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "_cleanup_empty_container_dir"),
+        ):
+            mock_wt_manager = mock_worktree.return_value
+            mock_wt_manager.resolve_default_branch.return_value = "origin/main"
+            mock_wt_manager.create_worktree.side_effect = OSError("disk full")
+
+            response = client.post(
+                "/api/v1/worktree/create",
+                headers=launcher_auth_headers,
+                data=json.dumps(
+                    {
+                        "container_id": "test-container",
+                        "repos": ["owner/repo"],
+                    }
+                ),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 500
+            mock_logger.exception.assert_called_once()
+            exc_kwargs = mock_logger.exception.call_args.kwargs
+            assert exc_kwargs["error_type"] == "OSError"
+
+    def test_500_branch_emits_audit_log_failure(self, client, launcher_auth_headers):
+        """Total failure must call audit_log with success=False so the
+        operator's audit stream records the event symmetric to the
+        success branch."""
+        mock_audit = MagicMock()
+        with (
+            patch.object(gateway, "get_worktree_manager") as mock_worktree,
+            patch.object(gateway, "audit_log", mock_audit),
+            patch.object(gateway, "_cleanup_empty_container_dir"),
+        ):
+            mock_wt_manager = mock_worktree.return_value
+            mock_wt_manager.resolve_default_branch.return_value = "origin/main"
+            mock_wt_manager.create_worktree.side_effect = RuntimeError("boom")
+
+            response = client.post(
+                "/api/v1/worktree/create",
+                headers=launcher_auth_headers,
+                data=json.dumps(
+                    {
+                        "container_id": "test-container",
+                        "repos": ["owner/repo-a", "owner/repo-b"],
+                    }
+                ),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 500
+            mock_audit.assert_called_once()
+            args, kwargs = mock_audit.call_args
+            # Positional: (event_type, operation, ...) plus success kwarg
+            assert args[0] == "worktrees_create_failed"
+            assert args[1] == "worktree_create"
+            assert kwargs["success"] is False
+            details = kwargs["details"]
+            assert details["container_id"] == "test-container"
+            assert "repo-a: boom" in details["errors"]
+            assert "repo-b: boom" in details["errors"]
+
+    def test_500_branch_logs_error_with_aggregated_errors(self, client, launcher_auth_headers):
+        """Total failure emits a logger.error with the aggregate errors
+        list so non-audit log readers also see the cause."""
+        with (
+            patch.object(gateway, "get_worktree_manager") as mock_worktree,
+            patch.object(gateway, "logger") as mock_logger,
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "_cleanup_empty_container_dir"),
+        ):
+            mock_wt_manager = mock_worktree.return_value
+            mock_wt_manager.resolve_default_branch.return_value = "origin/main"
+            mock_wt_manager.create_worktree.side_effect = ValueError("nope")
+
+            response = client.post(
+                "/api/v1/worktree/create",
+                headers=launcher_auth_headers,
+                data=json.dumps(
+                    {
+                        "container_id": "test-container",
+                        "repos": ["owner/repo"],
+                    }
+                ),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 500
+            mock_logger.error.assert_called_once()
+            err_kwargs = mock_logger.error.call_args.kwargs
+            assert err_kwargs["container_id"] == "test-container"
+            assert err_kwargs["errors"] == ["repo: nope"]
+
+    def test_cleanup_removes_empty_container_dir(self, tmp_path):
+        """_cleanup_empty_container_dir rmdir's an empty container
+        directory so retries aren't blocked by stale state."""
+        target = tmp_path / "container-xyz"
+        target.mkdir()
+
+        with patch.object(gateway, "WORKTREE_BASE_DIR", tmp_path):
+            gateway._cleanup_empty_container_dir("container-xyz")
+
+        assert not target.exists()
+
+    def test_cleanup_skips_non_empty_container_dir(self, tmp_path):
+        """_cleanup_empty_container_dir leaves a non-empty container
+        directory alone — partial state from per-repo failures might
+        contain in-progress work the operator wants to triage."""
+        target = tmp_path / "container-xyz"
+        target.mkdir()
+        (target / "leftover-repo").mkdir()
+
+        with patch.object(gateway, "WORKTREE_BASE_DIR", tmp_path):
+            gateway._cleanup_empty_container_dir("container-xyz")
+
+        assert target.exists()
+        assert (target / "leftover-repo").exists()
+
+    def test_cleanup_no_op_when_dir_absent(self, tmp_path):
+        """_cleanup_empty_container_dir is a safe no-op when the
+        directory doesn't exist (e.g., manager.create_worktree failed
+        before it was even created)."""
+        with patch.object(gateway, "WORKTREE_BASE_DIR", tmp_path):
+            # Should not raise.
+            gateway._cleanup_empty_container_dir("never-existed")
+
+    def test_cleanup_invoked_on_total_failure(self, client, launcher_auth_headers):
+        """The 500 branch wires through to _cleanup_empty_container_dir
+        with the request's container_id."""
+        mock_cleanup = MagicMock()
+        with (
+            patch.object(gateway, "get_worktree_manager") as mock_worktree,
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "_cleanup_empty_container_dir", mock_cleanup),
+        ):
+            mock_wt_manager = mock_worktree.return_value
+            mock_wt_manager.resolve_default_branch.return_value = "origin/main"
+            mock_wt_manager.create_worktree.side_effect = RuntimeError("boom")
+
+            response = client.post(
+                "/api/v1/worktree/create",
+                headers=launcher_auth_headers,
+                data=json.dumps(
+                    {
+                        "container_id": "test-container",
+                        "repos": ["owner/repo"],
+                    }
+                ),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 500
+            mock_cleanup.assert_called_once_with("test-container")
+
+
 class TestSessionDeleteByContainerWorktreeCleanup:
     """Tests for DELETE /api/v1/sessions/by-container/<container_id> worktree cleanup."""
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -11564,9 +11564,21 @@ def _run_pipeline(
                     except GatewayError as gw_err:
                         is_transient = gw_err.status_code is None or gw_err.status_code >= 500
                         if not is_transient or wt_attempt == wt_max_attempts:
+                            # Surface gw_err.details so per-repo failures
+                            # captured by the gateway aren't dropped.  See
+                            # #2186.
+                            logger.error(
+                                "Worktree creation failed permanently",
+                                pipeline_id=pipeline_id,
+                                attempts=wt_attempt,
+                                status_code=gw_err.status_code,
+                                error_message=gw_err.message,
+                                details=gw_err.details,
+                            )
                             raise RuntimeError(
                                 f"Failed to create worktrees for pipeline {pipeline_id} "
-                                f"after {wt_max_attempts} attempts: {gw_err}"
+                                f"after {wt_max_attempts} attempts: "
+                                f"{gw_err.message} (details: {gw_err.details})"
                             ) from gw_err
                         logger.warning(
                             "Worktree creation failed, retrying",
@@ -11574,6 +11586,7 @@ def _run_pipeline(
                             attempt=wt_attempt,
                             max_attempts=wt_max_attempts,
                             error=str(gw_err),
+                            details=gw_err.details,
                         )
                         time.sleep(wt_backoff)
                         wt_backoff *= 2

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -11575,10 +11575,13 @@ def _run_pipeline(
                                 error_message=gw_err.message,
                                 details=gw_err.details,
                             )
+                            detail_suffix = (
+                                f" (details: {gw_err.details})" if gw_err.details else ""
+                            )
                             raise RuntimeError(
                                 f"Failed to create worktrees for pipeline {pipeline_id} "
                                 f"after {wt_max_attempts} attempts: "
-                                f"{gw_err.message} (details: {gw_err.details})"
+                                f"{gw_err.message}{detail_suffix}"
                             ) from gw_err
                         logger.warning(
                             "Worktree creation failed, retrying",

--- a/orchestrator/tests/test_pipeline_worktree_failure_logging.py
+++ b/orchestrator/tests/test_pipeline_worktree_failure_logging.py
@@ -1,0 +1,305 @@
+"""Regression tests for #2186 — worktree-creation failure logging.
+
+When the gateway returns 500 from POST /api/v1/worktree/create with a
+populated `details.errors` payload, the orchestrator's retry loop in
+`routes/pipelines.py` must surface those per-repo errors in its own
+logs.  Prior to #2186 the loop logged only `str(gw_err)` (the bare
+message) and the wrapped `RuntimeError` discarded `gw_err.details`
+entirely, leaving operators with no diagnostic when pipelines failed
+at worktree creation.
+"""
+
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+# Mock docker before importing modules that depend on it
+sys.modules.setdefault("docker", MagicMock())
+sys.modules.setdefault("docker.errors", MagicMock())
+sys.modules.setdefault("docker.types", MagicMock())
+
+from gateway_client import GatewayError
+from models import Pipeline, PipelinePhase, PipelineStatus
+
+
+def _make_running_pipeline():
+    pipeline = Pipeline(
+        id="issue-42",
+        issue_number=42,
+        repo="owner/repo",
+        branch="egg/issue-42",
+        mode="issue",
+        status=PipelineStatus.RUNNING,
+        current_phase=PipelinePhase.REFINE,
+        network_mode="public",
+    )
+    pipeline.contract_synced = True
+    execution = pipeline.get_phase_execution(PipelinePhase.REFINE)
+    execution.status = PipelineStatus.RUNNING
+    execution.started_at = datetime.now(UTC)
+    return pipeline
+
+
+_COMMON_PATCHES = [
+    "routes.pipelines._emit_pipeline_event",
+    "routes.pipelines.get_container_spawner",
+    "routes.pipelines.get_state_store",
+    "routes.pipelines._spawn_and_wait",
+    "routes.pipelines.get_pipeline_state_lock",
+    "routes.pipelines._build_phase_prompt",
+    "routes.pipelines._read_phase_draft",
+    "routes.pipelines.report_pipeline_status",
+]
+
+
+def _setup(
+    mock_report,
+    mock_read_draft,
+    mock_build_prompt,
+    mock_state_lock,
+    mock_spawn_wait,
+    mock_get_store,
+    mock_get_spawner,
+    mock_emit,
+    pipeline,
+    create_worktrees_side_effect,
+):
+    mock_store = MagicMock()
+    mock_store.load_pipeline.return_value = pipeline
+    mock_store.repo_path = Path("/repo")
+    mock_get_store.return_value = mock_store
+
+    mock_gateway = MagicMock()
+    mock_gateway.create_worktrees.side_effect = create_worktrees_side_effect
+
+    mock_spawner = MagicMock()
+    mock_spawner.gateway = mock_gateway
+    mock_get_spawner.return_value = mock_spawner
+
+    mock_spawn_wait.return_value = (1, "error log")
+
+    mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
+    mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+    mock_build_prompt.return_value = "test prompt"
+    mock_read_draft.return_value = None
+
+    return mock_store, mock_gateway
+
+
+class TestWorktreeFailureLogsGatewayDetails:
+    """The orchestrator's retry loop must log gw_err.details on the
+    final-attempt failure so per-repo error text from the gateway
+    survives in the orchestrator log stream.  See #2186."""
+
+    @patch(_COMMON_PATCHES[7])
+    @patch(_COMMON_PATCHES[6])
+    @patch(_COMMON_PATCHES[5])
+    @patch(_COMMON_PATCHES[4])
+    @patch(_COMMON_PATCHES[3])
+    @patch(_COMMON_PATCHES[2])
+    @patch(_COMMON_PATCHES[1])
+    @patch(_COMMON_PATCHES[0])
+    def test_final_failure_logs_error_with_details(
+        self,
+        mock_emit,
+        mock_get_spawner,
+        mock_get_store,
+        mock_spawn_wait,
+        mock_state_lock,
+        mock_build_prompt,
+        mock_read_draft,
+        mock_report,
+    ):
+        from routes.pipelines import _run_pipeline
+
+        pipeline = _make_running_pipeline()
+        # Every attempt fails with a transient 500 carrying per-repo errors.
+        gw_err = GatewayError(
+            "Failed to create any worktrees",
+            status_code=500,
+            details={"errors": ["egg: branch already exists"]},
+        )
+        _setup(
+            mock_report,
+            mock_read_draft,
+            mock_build_prompt,
+            mock_state_lock,
+            mock_spawn_wait,
+            mock_get_store,
+            mock_get_spawner,
+            mock_emit,
+            pipeline,
+            create_worktrees_side_effect=gw_err,
+        )
+
+        with (
+            patch.dict(os.environ, {"EGG_HOST_REPO_MAP": '{"repo": "/host/repo"}'}, clear=False),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("routes.pipelines.logger") as mock_logger,
+            # Skip the retry sleep to keep the test fast.
+            patch("routes.pipelines.time.sleep"),
+        ):
+            _run_pipeline("issue-42", Path("/repo"))
+
+        # The final-failure logger.error must include gw_err.details.
+        permanent_calls = [
+            c
+            for c in mock_logger.error.call_args_list
+            if c.args and c.args[0] == "Worktree creation failed permanently"
+        ]
+        assert permanent_calls, (
+            "Expected logger.error('Worktree creation failed permanently', ...), "
+            f"got: {mock_logger.error.call_args_list}"
+        )
+        kwargs = permanent_calls[0].kwargs
+        assert kwargs["details"] == {"errors": ["egg: branch already exists"]}
+        assert kwargs["status_code"] == 500
+        assert kwargs["pipeline_id"] == "issue-42"
+        # The logger renames the GatewayError's message field to
+        # 'error_message' because 'message' collides with LogRecord's
+        # reserved key.
+        assert kwargs["error_message"] == "Failed to create any worktrees"
+
+    @patch(_COMMON_PATCHES[7])
+    @patch(_COMMON_PATCHES[6])
+    @patch(_COMMON_PATCHES[5])
+    @patch(_COMMON_PATCHES[4])
+    @patch(_COMMON_PATCHES[3])
+    @patch(_COMMON_PATCHES[2])
+    @patch(_COMMON_PATCHES[1])
+    @patch(_COMMON_PATCHES[0])
+    def test_retry_warning_includes_details(
+        self,
+        mock_emit,
+        mock_get_spawner,
+        mock_get_store,
+        mock_spawn_wait,
+        mock_state_lock,
+        mock_build_prompt,
+        mock_read_draft,
+        mock_report,
+    ):
+        """Transient retry warnings also carry gw_err.details so
+        intermediate failures are diagnosable, not just the final
+        raise."""
+        from routes.pipelines import _run_pipeline
+
+        pipeline = _make_running_pipeline()
+        gw_err = GatewayError(
+            "Failed to create any worktrees",
+            status_code=500,
+            details={"errors": ["egg: transient lock contention"]},
+        )
+        _setup(
+            mock_report,
+            mock_read_draft,
+            mock_build_prompt,
+            mock_state_lock,
+            mock_spawn_wait,
+            mock_get_store,
+            mock_get_spawner,
+            mock_emit,
+            pipeline,
+            create_worktrees_side_effect=gw_err,
+        )
+
+        with (
+            patch.dict(os.environ, {"EGG_HOST_REPO_MAP": '{"repo": "/host/repo"}'}, clear=False),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("routes.pipelines.logger") as mock_logger,
+            patch("routes.pipelines.time.sleep"),
+        ):
+            _run_pipeline("issue-42", Path("/repo"))
+
+        retry_calls = [
+            c
+            for c in mock_logger.warning.call_args_list
+            if c.args and c.args[0] == "Worktree creation failed, retrying"
+        ]
+        assert retry_calls, (
+            f"Expected at least one retry warning, got: {mock_logger.warning.call_args_list}"
+        )
+        # Every retry warning must carry the per-repo details.
+        for c in retry_calls:
+            assert c.kwargs.get("details") == {"errors": ["egg: transient lock contention"]}
+
+    @patch(_COMMON_PATCHES[7])
+    @patch(_COMMON_PATCHES[6])
+    @patch(_COMMON_PATCHES[5])
+    @patch(_COMMON_PATCHES[4])
+    @patch(_COMMON_PATCHES[3])
+    @patch(_COMMON_PATCHES[2])
+    @patch(_COMMON_PATCHES[1])
+    @patch(_COMMON_PATCHES[0])
+    def test_runtime_error_message_includes_details(
+        self,
+        mock_emit,
+        mock_get_spawner,
+        mock_get_store,
+        mock_spawn_wait,
+        mock_state_lock,
+        mock_build_prompt,
+        mock_read_draft,
+        mock_report,
+    ):
+        """The wrapped RuntimeError message must include gw_err.details
+        so any traceback consumer (Sentry, structured stderr) sees the
+        per-repo errors, not just the bare gateway message."""
+        from routes.pipelines import _run_pipeline
+
+        pipeline = _make_running_pipeline()
+        gw_err = GatewayError(
+            "Failed to create any worktrees",
+            status_code=500,
+            details={"errors": ["egg: ENOENT /repos/egg"]},
+        )
+        # Patch get_state_store to capture the failure_message that's
+        # written when the worktree-creation RuntimeError propagates.
+        captured_errors: list[str] = []
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_store.repo_path = Path("/repo")
+
+        def _save_pipeline(p, **kwargs):
+            if getattr(p, "error", None):
+                captured_errors.append(p.error)
+
+        mock_store.save_pipeline.side_effect = _save_pipeline
+        mock_get_store.return_value = mock_store
+
+        mock_gateway = MagicMock()
+        mock_gateway.create_worktrees.side_effect = gw_err
+        mock_spawner = MagicMock()
+        mock_spawner.gateway = mock_gateway
+        mock_get_spawner.return_value = mock_spawner
+
+        mock_spawn_wait.return_value = (1, "error log")
+        mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
+        mock_build_prompt.return_value = "test prompt"
+        mock_read_draft.return_value = None
+
+        with (
+            patch.dict(os.environ, {"EGG_HOST_REPO_MAP": '{"repo": "/host/repo"}'}, clear=False),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("routes.pipelines.time.sleep"),
+        ):
+            _run_pipeline("issue-42", Path("/repo"))
+
+        # At least one captured error string includes both the gateway
+        # message and the per-repo details payload.
+        assert any(
+            "Failed to create any worktrees" in e and "egg: ENOENT /repos/egg" in e
+            for e in captured_errors
+        ), f"Expected pipeline.error to embed gw_err.details; got: {captured_errors}"


### PR DESCRIPTION
## Summary

Closes #2186 by making worktree-creation failures visible in logs on both the gateway and the orchestrator side, plus best-effort cleanup of orphan container worktree directories so retries aren't blocked by stale state.

Before this change, the gateway's `worktree_create` 500 branch returned per-repo `errors[]` only in the HTTP response body — no `audit_log`, no `logger.error` — and the orchestrator's retry loop in `routes/pipelines.py` wrapped `GatewayError` into a `RuntimeError` using only `str(gw_err)`, dropping `gw_err.details` entirely. The result: `Failed to create any worktrees` with no diagnosable cause anywhere in the logs.

### Gateway (`gateway/gateway.py`)
- Each per-repo `except` clause now uses `logger.exception(...)` with structured fields (`repo_name`, `container_id`, `base_branch`, `assigned_branch`, `error_type`) so tracebacks survive instead of being string-coerced.
- The 500-return branch now emits both a `logger.error` and an `audit_log("worktrees_create_failed", ..., success=False, ...)` mirroring the success-branch audit entry.
- New helper `_cleanup_empty_container_dir(container_id)` rmdir's an *empty* container worktree directory after total failure. Conservative on purpose: if any per-repo subdir is present (partial state), it logs a warning and leaves the dir alone. Per-repo cleanup inside `worktree_manager.create_worktree` is intentionally deferred — see "Out of scope" below.

### Orchestrator (`orchestrator/routes/pipelines.py`)
- The retry-loop's transient-warning and final `logger.error` now include `gw_err.details`.
- The wrapped `RuntimeError` message now embeds `gw_err.details` so Sentry / structured-stderr consumers see the per-repo errors.
- Renamed the structured-log kwarg `message` → `error_message` to avoid `LogRecord`'s reserved-key collision (the egg structured logger raised `KeyError: "Attempt to overwrite 'message' in LogRecord"` until this was fixed — caught by the new orchestrator test that exercises the real logger).

### Tests
- `gateway/tests/test_gateway.py::TestWorktreeCreateFailureLogging` — 8 tests covering per-repo log emission, audit_log on 500, error log content, and the three cleanup branches (empty dir removed, non-empty dir preserved, missing dir no-op, plus the wiring from the 500 branch).
- `orchestrator/tests/test_pipeline_worktree_failure_logging.py` — 3 tests covering final-failure `logger.error` content, retry-warning `details` propagation, and `gw_err.details` embedded in the captured `pipeline.error`.

All 11 new tests pass. Existing `TestWorktreeCreateEndpointResolution` tests still pass.

## Out of scope (intentional follow-ups)

- **Identifying the actual root cause of the failing worktree creation in the original repro.** Gated on this PR landing + a redeploy. Once gateway logs surface the real per-repo error, file a follow-up. Hypothesis from the issue is multi-repo `EGG_REPO_PATH` analogous to #2184's `commit_authorship` fix, but speculatively patching `worktree_manager.create_worktree` now would risk fixing a phantom problem.
- **Per-repo cleanup inside `worktree_manager.create_worktree`.** If the captured failure shows the per-repo subdir is left in a partial state, that's the right place to add a try/finally rollback. Today's helper only handles the empty-parent-dir case to avoid accidentally rm'ing in-progress state.
- **Overriding `GatewayError.__str__` to include `details`.** Tempting (would auto-propagate to every call site) but broader blast radius; deferred unless we see other call sites with the same loss-of-info pattern.

## Test plan

- [x] New gateway tests pass (`pytest gateway/tests/test_gateway.py::TestWorktreeCreateFailureLogging`)
- [x] New orchestrator tests pass (`pytest orchestrator/tests/test_pipeline_worktree_failure_logging.py`)
- [x] Existing `TestWorktreeCreateEndpointResolution` tests still pass
- [ ] Post-merge: redeploy and re-run the issue's repro (`submit_task(repo='jwbron/egg', issue_number=1924, branch='egg/issue-1924', ...)`) and confirm the gateway logs now name the actual per-repo failure
- [ ] Post-merge: confirm orphan `/home/egg/.egg-worktrees/<container_id>` dirs are no longer left behind on total failure (when empty)
- [ ] Post-merge: confirm orchestrator `logger.error("Worktree creation failed permanently", ...)` contains `details=...` with per-repo errors