### PR TITLE
Fix #2200: unblock detached-HEAD BRC pushes via SHA + symbolic-ref

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -1156,7 +1156,13 @@ def git_push() -> tuple[Response, int] | Response:
                 "commit_sha push requires consensus_push=true",
                 status_code=400,
             )
-        if not re.fullmatch(r"[0-9a-f]{7,64}", commit_sha):
+        # Require a full SHA (40 = SHA-1, 64 = SHA-256). Abbreviated SHAs
+        # (7-39 chars) can resolve ambiguously on the gateway side; the
+        # helper always emits the full output of ``git rev-parse HEAD`` so
+        # there is no legitimate caller of the shorter range. The explicit
+        # ``isinstance`` guard turns a non-string payload into a clean 400
+        # rather than a 500 from ``re.fullmatch``.
+        if not isinstance(commit_sha, str) or not re.fullmatch(r"[0-9a-f]{40,64}", commit_sha):
             audit_log(
                 "push_blocked",
                 "git_push",
@@ -1167,7 +1173,7 @@ def git_push() -> tuple[Response, int] | Response:
                 },
             )
             return make_error(
-                f"Invalid commit_sha {commit_sha!r}: must be 7-64 hex chars",
+                f"Invalid commit_sha {commit_sha!r}: must be 40-64 hex chars",
                 status_code=400,
             )
         session = getattr(g, "session", None)
@@ -1187,6 +1193,21 @@ def git_push() -> tuple[Response, int] | Response:
                 status_code=400,
             )
         refspec = f"{commit_sha}:refs/heads/{assigned}"
+        # Distinct audit event so post-incident review can distinguish a
+        # gateway-constructed refspec (commit_sha path) from an
+        # agent-supplied refspec; both flow through the same downstream
+        # ``push_*`` audit events and would otherwise be indistinguishable.
+        audit_log(
+            "push_via_commit_sha",
+            "git_push",
+            success=True,
+            details={
+                "repo_path": repo_path,
+                "commit_sha": commit_sha,
+                "assigned_branch": assigned,
+                "constructed_refspec": refspec,
+            },
+        )
 
     # Validate repo_path to prevent path traversal attacks
     path_valid, path_error = validate_repo_path(repo_path)
@@ -2222,10 +2243,16 @@ def git_execute() -> tuple[Response, int] | Response:
             )
         else:
             allowed_refs = {f"refs/heads/{assigned}"}
-            if isinstance(container_id, str) and container_id:
+            # Defense in depth: scope the per-role local work branch from
+            # ``session.container_id`` (canonical, set by the orchestrator at
+            # session registration), not ``data.get("container_id")`` which
+            # is agent-supplied.  Mirrors the ``update-ref`` guard above which
+            # also ignores the request-body container_id.
+            session_container_id = getattr(session, "container_id", None)
+            if isinstance(session_container_id, str) and session_container_id:
                 # Per-role local work branch (`egg/{container_id}/work`)
                 # — see worktree_manager._create_or_reuse_worktree.
-                allowed_refs.add(f"refs/heads/egg/{container_id}/work")
+                allowed_refs.add(f"refs/heads/egg/{session_container_id}/work")
             if positional[1] not in allowed_refs:
                 denial_reason = (
                     f"git symbolic-ref target '{positional[1]}' is not allowed. "

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -1114,7 +1114,8 @@ def git_push() -> tuple[Response, int] | Response:
             "repo_path": "/path/to/repo",
             "remote": "origin",
             "refspec": "branch-name",
-            "force": false
+            "force": false,
+            "commit_sha": "<40-hex>",   # alternative to refspec; consensus pushes only
         }
 
     Policy: branch_ownership
@@ -1128,9 +1129,64 @@ def git_push() -> tuple[Response, int] | Response:
     refspec = data.get("refspec", "")
     force = data.get("force", False)
     container_id = data.get("container_id")
+    commit_sha = data.get("commit_sha", "")
 
     if not repo_path:
         return make_error("Missing repo_path")
+
+    # Detached-HEAD-tolerant consensus push (#2200): when the agent's HEAD
+    # is detached (post-rebase or otherwise), the helper cannot read
+    # ``git branch --show-current`` and instead supplies ``commit_sha``.
+    # The gateway derives the refspec server-side from the session's
+    # assigned branch.  This is strictly tighter than an agent-supplied
+    # refspec because the existing ``push_target_enforcement`` block
+    # below already requires ``branch == session.assigned_branch``.
+    if commit_sha and not refspec:
+        if not data.get("consensus_push"):
+            audit_log(
+                "push_blocked",
+                "git_push",
+                success=False,
+                details={
+                    "repo_path": repo_path,
+                    "reason": "commit_sha push requires consensus_push=true",
+                },
+            )
+            return make_error(
+                "commit_sha push requires consensus_push=true",
+                status_code=400,
+            )
+        if not re.fullmatch(r"[0-9a-f]{7,64}", commit_sha):
+            audit_log(
+                "push_blocked",
+                "git_push",
+                success=False,
+                details={
+                    "repo_path": repo_path,
+                    "reason": f"Invalid commit_sha {commit_sha!r}",
+                },
+            )
+            return make_error(
+                f"Invalid commit_sha {commit_sha!r}: must be 7-64 hex chars",
+                status_code=400,
+            )
+        session = getattr(g, "session", None)
+        assigned = getattr(session, "assigned_branch", None) if session else None
+        if not isinstance(assigned, str) or not assigned:
+            audit_log(
+                "push_blocked",
+                "git_push",
+                success=False,
+                details={
+                    "repo_path": repo_path,
+                    "reason": "commit_sha push requires a pipeline session with assigned_branch",
+                },
+            )
+            return make_error(
+                "commit_sha push requires a pipeline session with an assigned branch",
+                status_code=400,
+            )
+        refspec = f"{commit_sha}:refs/heads/{assigned}"
 
     # Validate repo_path to prevent path traversal attacks
     path_valid, path_error = validate_repo_path(repo_path)
@@ -2125,6 +2181,55 @@ def git_execute() -> tuple[Response, int] | Response:
                 denial_reason = (
                     f"git update-ref target '{positional[0]}' is not allowed. "
                     f"Only '{expected_ref}' (your assigned branch) may be updated."
+                )
+        if denial_reason is not None:
+            audit_log(
+                "git_execute_blocked",
+                operation,
+                success=False,
+                details={
+                    "repo_path": repo_path,
+                    "git_args": validated_args,
+                    "container_id": container_id,
+                    "assigned_branch": assigned,
+                    "reason": denial_reason,
+                },
+            )
+            return make_error(denial_reason, status_code=403)
+
+    # SECURITY: Scope `git symbolic-ref HEAD <ref>` to the agent's own
+    # assigned or local per-role branch.  symbolic-ref is the canonical
+    # reattach primitive when a worktree ends up on detached HEAD (e.g.
+    # post-rebase, see issue #2200).  Restricted to the two-positional
+    # form `symbolic-ref HEAD <ref>` — read forms (one-arg) and the
+    # delete form (`-d`) are rejected because they do not participate
+    # in the recovery flow.
+    if operation == "symbolic-ref":
+        session = getattr(g, "session", None)
+        assigned = getattr(session, "assigned_branch", None) if session else None
+        positional = [a for a in validated_args if not a.startswith("-")]
+        denial_reason = None
+        if not isinstance(assigned, str) or not assigned:
+            denial_reason = (
+                "git symbolic-ref is only allowed in pipeline sessions with an assigned branch."
+            )
+        elif len(positional) != 2:
+            denial_reason = "git symbolic-ref must be of the form `git symbolic-ref HEAD <ref>`."
+        elif positional[0] != "HEAD":
+            denial_reason = (
+                f"git symbolic-ref source '{positional[0]}' is not allowed. "
+                f"Only HEAD may be retargeted."
+            )
+        else:
+            allowed_refs = {f"refs/heads/{assigned}"}
+            if isinstance(container_id, str) and container_id:
+                # Per-role local work branch (`egg/{container_id}/work`)
+                # — see worktree_manager._create_or_reuse_worktree.
+                allowed_refs.add(f"refs/heads/egg/{container_id}/work")
+            if positional[1] not in allowed_refs:
+                denial_reason = (
+                    f"git symbolic-ref target '{positional[1]}' is not allowed. "
+                    f"Allowed targets: {sorted(allowed_refs)}."
                 )
         if denial_reason is not None:
             audit_log(

--- a/gateway/git_client.py
+++ b/gateway/git_client.py
@@ -872,6 +872,21 @@ GIT_ALLOWED_COMMANDS: dict[str, dict[str, list[str]]] = {
     "update-ref": {
         "allowed_flags": [],
     },
+    # symbolic-ref is the canonical reattach primitive when an agent ends up
+    # on detached HEAD (e.g. after a `git rebase` against an advanced
+    # upstream silently leaves the worktree detached).  Restricted to the
+    # two-arg form (`symbolic-ref HEAD <ref>`) and further scoped in
+    # gateway.py to the session's assigned branch or the per-role local
+    # work branch.  Lower-level than `switch`/`checkout`: rewrites HEAD's
+    # symref but does not change branch contents.  Pairs with the
+    # already-allowed `git reset --hard <on-lineage>` to advance the
+    # local branch when needed.  ``-d``/``--delete``/``--short``/``-q``
+    # are intentionally absent: deletion is not a recovery primitive and
+    # the printed-output forms have no use in scripted recovery.
+    # Issue #2200.
+    "symbolic-ref": {
+        "allowed_flags": [],
+    },
 }
 
 # Per-subcommand flag normalization: map short flags to long form for consistent

--- a/gateway/tests/test_push_by_sha.py
+++ b/gateway/tests/test_push_by_sha.py
@@ -283,3 +283,146 @@ class TestCommitShaPush:
         cmd = push_invocations[0]
         assert "egg/issue-2200" in cmd
         assert not any(":refs/heads/" in arg for arg in cmd)
+
+    def test_refspec_takes_precedence_when_both_supplied(self, client):
+        """When refspec and commit_sha are both supplied, refspec wins.
+
+        Pins the current ``if commit_sha and not refspec:`` short-circuit so a
+        future refactor cannot quietly flip which input takes precedence.
+        """
+        session = _make_session()
+        captured: list[list[str]] = []
+        patches = _push_context(session, captured)
+        sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+        ):
+            response = _post(
+                client,
+                {
+                    "repo_path": "/home/egg/repos/test-repo",
+                    "remote": "origin",
+                    "refspec": "egg/issue-2200",
+                    "commit_sha": sha,
+                    "consensus_push": True,
+                },
+            )
+        assert response.status_code == 200, response.data
+        push_invocations = [c for c in captured if "push" in c and "--no-verify" in c]
+        assert len(push_invocations) == 1
+        cmd = push_invocations[0]
+        # The plain refspec passes through; the SHA-derived form must NOT appear.
+        assert "egg/issue-2200" in cmd
+        assert not any(arg.startswith(f"{sha}:") for arg in cmd)
+
+    def test_commit_sha_non_string_rejected_clean_400(self, client):
+        """A non-string commit_sha must produce a clean 400, not a 500.
+
+        Pre-fix, the path was ``re.fullmatch(r"...", commit_sha)`` with no
+        ``isinstance`` guard — a JSON ``"commit_sha": 123`` payload was
+        truthy, slipped past the ``if commit_sha`` check, and raised
+        ``TypeError`` from ``re.fullmatch``.
+        """
+        session = _make_session()
+        captured: list[list[str]] = []
+        patches = _push_context(session, captured)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+        ):
+            response = _post(
+                client,
+                {
+                    "repo_path": "/home/egg/repos/test-repo",
+                    "remote": "origin",
+                    "commit_sha": 123,
+                    "consensus_push": True,
+                },
+            )
+        assert response.status_code == 400, response.data
+        body = json.loads(response.data)
+        assert "commit_sha" in body.get("message", "")
+
+    def test_commit_sha_abbreviated_rejected(self, client):
+        """A 7-char abbreviated SHA is rejected — only full SHAs (40-64) are valid.
+
+        Abbreviated SHAs can resolve ambiguously on the gateway side.  The
+        helper always emits the full output of ``git rev-parse HEAD`` so the
+        7-39 range has no legitimate caller.
+        """
+        session = _make_session()
+        captured: list[list[str]] = []
+        patches = _push_context(session, captured)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+        ):
+            response = _post(
+                client,
+                {
+                    "repo_path": "/home/egg/repos/test-repo",
+                    "remote": "origin",
+                    "commit_sha": "abcdef0",
+                    "consensus_push": True,
+                },
+            )
+        assert response.status_code == 400, response.data
+        body = json.loads(response.data)
+        assert "commit_sha" in body.get("message", "")
+
+    def test_commit_sha_private_mode_unaffected(self, client):
+        """Private-mode sessions can use the SHA path the same as public.
+
+        The SHA→refspec construction happens before the private-repo policy
+        check; the constructed refspec then flows through every downstream
+        gate (private-repo policy, branch ownership, file restrictions) the
+        same as an agent-supplied refspec.
+        """
+        session = _make_session()
+        session.mode = "private"
+        captured: list[list[str]] = []
+        patches = _push_context(session, captured)
+        sha = "cafebabecafebabecafebabecafebabecafebabe"
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+        ):
+            response = _post(
+                client,
+                {
+                    "repo_path": "/home/egg/repos/test-repo",
+                    "remote": "origin",
+                    "commit_sha": sha,
+                    "consensus_push": True,
+                },
+            )
+        assert response.status_code == 200, response.data
+        push_invocations = [c for c in captured if "push" in c and "--no-verify" in c]
+        assert len(push_invocations) == 1
+        cmd = push_invocations[0]
+        assert f"{sha}:refs/heads/egg/issue-2200" in cmd

--- a/gateway/tests/test_push_by_sha.py
+++ b/gateway/tests/test_push_by_sha.py
@@ -1,0 +1,285 @@
+"""Tests for the detached-HEAD-tolerant push-by-SHA path (#2200).
+
+When a BRC producer agent ends up on detached HEAD (e.g. after
+``git rebase origin/<assigned>`` advances HEAD without reattaching the
+local branch), it cannot read ``git branch --show-current`` and the
+existing helper used to bail with ``"could not determine current
+branch for push"`` — trapping the agent with no way to publish its
+proposal.  The fix lets the helper send ``commit_sha`` instead of
+``refspec``; the gateway derives the refspec server-side from the
+session's assigned branch.
+
+Covers:
+- ``commit_sha`` push without ``consensus_push=true`` is rejected (400).
+- ``commit_sha`` push with malformed SHA is rejected (400).
+- ``commit_sha`` push without an assigned branch is rejected (400).
+- ``commit_sha`` push with a valid SHA + assigned branch builds the
+  ``<sha>:refs/heads/<assigned>`` refspec server-side and reaches the
+  push subprocess unchanged.
+- Existing refspec-based pushes are unaffected (commit_sha is optional).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+import session_manager
+from policy import PolicyResult
+from private_repo_policy import PrivateRepoPolicyResult
+from session_manager import SessionValidationResult
+
+import gateway
+
+
+@pytest.fixture
+def client():
+    gateway.app.config["TESTING"] = True
+    with gateway.app.test_client() as client:
+        yield client
+
+
+def _make_session(
+    pipeline_id: str | None = "issue-2200",
+    assigned_branch: str | None = "egg/issue-2200",
+) -> MagicMock:
+    s = MagicMock()
+    s.mode = "public"
+    s.container_id = "issue-2200-coder"
+    s.expires_at = None
+    s.agent_role = "coder"
+    s.phase = "implement"
+    s.pipeline_id = pipeline_id
+    s.assigned_branch = assigned_branch
+    return s
+
+
+def _push_context(mock_session: MagicMock, captured_cmd: list[list[str]]):
+    """Mock everything around the push handler so we can observe the final ``git push``."""
+    import auth
+
+    mock_result = SessionValidationResult(valid=True, session=mock_session)
+    mock_policy_result = PrivateRepoPolicyResult(
+        allowed=True,
+        reason="Test mode",
+        visibility="public",
+    )
+
+    auth._session_manager = None
+    auth._rate_limiter = None
+    if "gateway.auth" in sys.modules:
+        sys.modules["gateway.auth"]._session_manager = None
+        sys.modules["gateway.auth"]._rate_limiter = None
+
+    current_sm = sys.modules.get("session_manager", session_manager)
+
+    def run_side_effect(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("args", [])
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        if "remote" in cmd and "get-url" in cmd:
+            result.stdout = "https://github.com/owner/repo.git\n"
+        elif "ls-remote" in cmd:
+            result.stdout = ""
+        elif "push" in cmd:
+            captured_cmd.append(list(cmd))
+            result.stdout = "Everything up-to-date\n"
+        elif "diff" in cmd:
+            result.stdout = ""
+        else:
+            result.stdout = ""
+        return result
+
+    return (
+        patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+        patch.object(gateway, "check_private_repo_access", return_value=mock_policy_result),
+        patch("subprocess.run", side_effect=run_side_effect),
+        patch.object(
+            gateway,
+            "get_policy_engine",
+            return_value=MagicMock(
+                check_branch_ownership=MagicMock(
+                    return_value=PolicyResult(
+                        allowed=True,
+                        reason="OK",
+                        details={"branch": "egg/issue-2200"},
+                    )
+                ),
+            ),
+        ),
+        patch.object(gateway, "get_token_for_repo", return_value=("test-token", "bot", "")),
+        patch.object(gateway, "get_changed_files_in_push", return_value=([], None)),
+        patch.object(
+            gateway,
+            "check_file_restrictions",
+            return_value=MagicMock(allowed=True, blocked=False),
+        ),
+        patch.object(
+            gateway,
+            "check_agent_restrictions",
+            return_value=MagicMock(allowed=True, blocked=False),
+        ),
+    )
+
+
+def _post(client, payload: dict) -> object:
+    return client.post(
+        "/api/v1/git/push",
+        headers={"Authorization": "Bearer test-session-token"},
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+class TestCommitShaPush:
+    def test_commit_sha_without_consensus_marker_rejected(self, client):
+        """commit_sha push must require consensus_push=true (defense in depth)."""
+        session = _make_session()
+        captured: list[list[str]] = []
+        patches = _push_context(session, captured)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+        ):
+            response = _post(
+                client,
+                {
+                    "repo_path": "/home/egg/repos/test-repo",
+                    "remote": "origin",
+                    "commit_sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                },
+            )
+        assert response.status_code == 400
+        body = json.loads(response.data)
+        assert "consensus_push" in body.get("message", "")
+
+    def test_commit_sha_invalid_format_rejected(self, client):
+        """Non-hex / wrong-length commit_sha must be rejected before any subprocess work."""
+        session = _make_session()
+        captured: list[list[str]] = []
+        patches = _push_context(session, captured)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+        ):
+            response = _post(
+                client,
+                {
+                    "repo_path": "/home/egg/repos/test-repo",
+                    "remote": "origin",
+                    "commit_sha": "not-a-sha",
+                    "consensus_push": True,
+                },
+            )
+        assert response.status_code == 400
+        body = json.loads(response.data)
+        assert "commit_sha" in body.get("message", "")
+
+    def test_commit_sha_without_assigned_branch_rejected(self, client):
+        """A session without assigned_branch cannot use the SHA path (no target)."""
+        session = _make_session(pipeline_id=None, assigned_branch=None)
+        captured: list[list[str]] = []
+        patches = _push_context(session, captured)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+        ):
+            response = _post(
+                client,
+                {
+                    "repo_path": "/home/egg/repos/test-repo",
+                    "remote": "origin",
+                    "commit_sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                    "consensus_push": True,
+                },
+            )
+        assert response.status_code == 400
+        body = json.loads(response.data)
+        assert "assigned branch" in body.get("message", "").lower()
+
+    def test_commit_sha_builds_refspec_server_side(self, client):
+        """A valid commit_sha + assigned_branch produces ``<sha>:refs/heads/<assigned>``."""
+        session = _make_session()
+        captured: list[list[str]] = []
+        patches = _push_context(session, captured)
+        sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+        ):
+            response = _post(
+                client,
+                {
+                    "repo_path": "/home/egg/repos/test-repo",
+                    "remote": "origin",
+                    "commit_sha": sha,
+                    "consensus_push": True,
+                },
+            )
+        assert response.status_code == 200, response.data
+        # Find the actual `git push` invocation in the captured commands.
+        push_invocations = [c for c in captured if "push" in c and "--no-verify" in c]
+        assert len(push_invocations) == 1, push_invocations
+        cmd = push_invocations[0]
+        # The constructed refspec must be <sha>:refs/heads/<assigned>.
+        expected_refspec = f"{sha}:refs/heads/egg/issue-2200"
+        assert expected_refspec in cmd, (cmd, expected_refspec)
+
+    def test_refspec_path_unaffected(self, client):
+        """Existing refspec-based pushes still work — commit_sha is purely additive."""
+        session = _make_session()
+        captured: list[list[str]] = []
+        patches = _push_context(session, captured)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+        ):
+            response = _post(
+                client,
+                {
+                    "repo_path": "/home/egg/repos/test-repo",
+                    "remote": "origin",
+                    "refspec": "egg/issue-2200",
+                    "consensus_push": True,
+                },
+            )
+        assert response.status_code == 200, response.data
+        push_invocations = [c for c in captured if "push" in c and "--no-verify" in c]
+        assert len(push_invocations) == 1
+        # No SHA-style refspec should appear; the original refspec passes through.
+        cmd = push_invocations[0]
+        assert "egg/issue-2200" in cmd
+        assert not any(":refs/heads/" in arg for arg in cmd)

--- a/gateway/tests/test_symbolic_ref_recovery.py
+++ b/gateway/tests/test_symbolic_ref_recovery.py
@@ -236,3 +236,36 @@ class TestSymbolicRefScope:
             assert response.status_code == 400
             data = json.loads(response.data)
             assert "--short" in data.get("message", "")
+
+    def test_symbolic_ref_request_container_id_does_not_widen_scope(self, client):
+        """An attacker-supplied ``container_id`` in the request body cannot
+        widen the symbolic-ref scope past the session's own per-role branch.
+
+        Defense in depth: the allowlist is computed from
+        ``session.container_id`` (canonical, set by the orchestrator at
+        session registration), not ``data.get("container_id")``.  Mismatched
+        values reach the same gate as any other unrelated target — 403.
+        """
+        session = _make_session("egg/issue-2200", container_id="issue-2200-coder")
+        headers, mock_result, mock_policy, current_sm = _setup_auth(session)
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+        ):
+            # Request claims a different container_id than the session holds.
+            response = _execute(
+                client,
+                headers,
+                ["HEAD", "refs/heads/egg/other-pipeline-coder/work"],
+                container_id="other-pipeline-coder",
+            )
+            assert response.status_code == 403, response.data
+            data = json.loads(response.data)
+            msg = data.get("message", "")
+            # The attempted target must appear in the denial; the allowed set
+            # must reflect the session's container_id, not the request's.
+            assert "refs/heads/egg/other-pipeline-coder/work" in msg
+            assert "refs/heads/egg/issue-2200-coder/work" in msg

--- a/gateway/tests/test_symbolic_ref_recovery.py
+++ b/gateway/tests/test_symbolic_ref_recovery.py
@@ -1,0 +1,238 @@
+"""Tests for the symbolic-ref reattach primitive (issue #2200).
+
+``git symbolic-ref HEAD <ref>`` is the canonical low-level reattach
+primitive: it rewrites HEAD's symref without changing branch contents,
+so it does not need the broader ``switch``/``checkout`` allowance that
+pipeline sessions intentionally deny.
+
+Covers:
+- ``symbolic-ref HEAD refs/heads/<assigned>`` is allowed.
+- ``symbolic-ref HEAD refs/heads/egg/<container_id>/work`` (the per-role
+  local work branch) is allowed.
+- Other ``symbolic-ref`` targets are rejected with 403.
+- Sessions without an assigned branch cannot use ``symbolic-ref``.
+- Read forms (one-arg) are rejected.
+- Disallowed flags (``-d``, ``--short``, ``-q``) are rejected by the
+  allowlist.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import auth
+import pytest
+import session_manager as session_manager_module
+from private_repo_policy import PrivateRepoPolicyResult
+from session_manager import SessionValidationResult
+
+import gateway
+
+
+@pytest.fixture
+def client():
+    gateway.app.config["TESTING"] = True
+    with gateway.app.test_client() as client:
+        yield client
+
+
+def _make_session(assigned_branch, container_id="issue-2200-coder"):
+    s = MagicMock()
+    s.mode = "private"
+    s.container_id = container_id
+    s.expires_at = None
+    s.phase = "implement"
+    s.agent_role = "coder"
+    s.assigned_branch = assigned_branch
+    s.pipeline_id = "issue-2200" if assigned_branch else None
+    s.last_branch = assigned_branch
+    s.checkpoint_repo = None
+    s.last_repo_path = None
+    return s
+
+
+def _setup_auth(session):
+    mock_result = SessionValidationResult(valid=True, session=session)
+    mock_policy_result = PrivateRepoPolicyResult(
+        allowed=True,
+        reason="Test mode",
+        visibility="public",
+    )
+    auth._session_manager = None
+    auth._rate_limiter = None
+    if "gateway.auth" in sys.modules:
+        sys.modules["gateway.auth"]._session_manager = None
+        sys.modules["gateway.auth"]._rate_limiter = None
+    current_sm = sys.modules.get("session_manager", session_manager_module)
+    return (
+        {"Authorization": "Bearer test-session-token"},
+        mock_result,
+        mock_policy_result,
+        current_sm,
+    )
+
+
+def _execute(client, headers, args, container_id="issue-2200-coder"):
+    return client.post(
+        "/api/v1/git/execute",
+        json={
+            "repo_path": "/home/egg/repos/myrepo",
+            "operation": "symbolic-ref",
+            "args": args,
+            "container_id": container_id,
+        },
+        headers=headers,
+    )
+
+
+class TestSymbolicRefScope:
+    @pytest.fixture
+    def auth_with_branch(self):
+        return _setup_auth(_make_session("egg/issue-2200"))
+
+    @pytest.fixture
+    def auth_without_branch(self):
+        return _setup_auth(_make_session(None))
+
+    def test_symbolic_ref_to_assigned_branch_allowed(self, client, auth_with_branch):
+        """symbolic-ref HEAD refs/heads/<assigned> reaches subprocess."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+            patch.object(gateway, "map_container_path_to_worktree", return_value="/worktree/path"),
+            patch("gateway.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            response = _execute(
+                client,
+                headers,
+                ["HEAD", "refs/heads/egg/issue-2200"],
+            )
+            assert response.status_code == 200, response.data
+
+    def test_symbolic_ref_to_local_work_branch_allowed(self, client, auth_with_branch):
+        """The per-role local work branch (egg/<container_id>/work) is allowed."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+            patch.object(gateway, "map_container_path_to_worktree", return_value="/worktree/path"),
+            patch("gateway.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            response = _execute(
+                client,
+                headers,
+                ["HEAD", "refs/heads/egg/issue-2200-coder/work"],
+            )
+            assert response.status_code == 200, response.data
+
+    def test_symbolic_ref_to_main_blocked(self, client, auth_with_branch):
+        """Targets outside the agent's assigned/local pair are rejected with 403."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+        ):
+            response = _execute(client, headers, ["HEAD", "refs/heads/main"])
+            assert response.status_code == 403
+            data = json.loads(response.data)
+            msg = data.get("message", "")
+            assert "refs/heads/main" in msg
+            assert "egg/issue-2200" in msg
+
+    def test_symbolic_ref_non_head_source_blocked(self, client, auth_with_branch):
+        """The source must be literal HEAD; retargeting other symrefs is denied."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+        ):
+            response = _execute(
+                client,
+                headers,
+                ["FETCH_HEAD", "refs/heads/egg/issue-2200"],
+            )
+            assert response.status_code == 403
+            data = json.loads(response.data)
+            assert "Only HEAD" in data.get("message", "")
+
+    def test_symbolic_ref_read_form_blocked(self, client, auth_with_branch):
+        """The read form (`symbolic-ref HEAD`) — one positional — is rejected.
+
+        The agent already has ``git rev-parse --abbrev-ref HEAD`` for that.
+        Allowing the read form would just enlarge the surface area without
+        improving recovery flow.
+        """
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+        ):
+            response = _execute(client, headers, ["HEAD"])
+            assert response.status_code == 403
+            data = json.loads(response.data)
+            assert "symbolic-ref HEAD" in data.get("message", "")
+
+    def test_symbolic_ref_with_no_assigned_branch_blocked(self, client, auth_without_branch):
+        """Sessions without assigned_branch cannot use symbolic-ref at all."""
+        headers, mock_result, mock_policy, current_sm = auth_without_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+        ):
+            response = _execute(client, headers, ["HEAD", "refs/heads/main"])
+            assert response.status_code == 403
+            data = json.loads(response.data)
+            assert "pipeline session" in data.get("message", "").lower()
+
+    def test_symbolic_ref_delete_flag_blocked_by_allowlist(self, client, auth_with_branch):
+        """-d (delete symref) is not in allowed_flags and is rejected during arg validation."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+        ):
+            response = _execute(client, headers, ["-d", "HEAD"])
+            assert response.status_code == 400
+            data = json.loads(response.data)
+            assert "-d" in data.get("message", "")
+
+    def test_symbolic_ref_short_flag_blocked_by_allowlist(self, client, auth_with_branch):
+        """--short (print short form) is not in allowed_flags."""
+        headers, mock_result, mock_policy, current_sm = auth_with_branch
+
+        with (
+            patch.object(current_sm, "validate_session_for_request", return_value=mock_result),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy),
+            patch.object(gateway, "audit_log"),
+            patch.object(gateway, "validate_repo_path", return_value=(True, "")),
+        ):
+            response = _execute(client, headers, ["--short", "HEAD"])
+            assert response.status_code == 400
+            data = json.loads(response.data)
+            assert "--short" in data.get("message", "")

--- a/sandbox/egg_agent_tools/push.py
+++ b/sandbox/egg_agent_tools/push.py
@@ -84,39 +84,56 @@ def consensus_push() -> tuple[int, str | None]:
     except (subprocess.CalledProcessError, FileNotFoundError):
         branch = ""
 
-    if not branch:
-        msg = "could not determine current branch for push"
-        print(f"Error: {msg}", file=sys.stderr)
-        return 1, msg
+    payload_data: dict[str, object] = {
+        "repo_path": repo_path,
+        "remote": "origin",
+        "force": False,
+        "container_id": container_id,
+        "consensus_push": True,
+    }
 
-    # Retarget to the assigned pipeline branch when on a per-agent work
-    # branch (shared logic with ``cli_push``).
-    retarget = _retarget_refspec(branch)
-    if retarget:
-        refspec = retarget
+    if branch:
+        # Retarget to the assigned pipeline branch when on a per-agent work
+        # branch (shared logic with ``cli_push``).
+        retarget = _retarget_refspec(branch)
+        if retarget:
+            refspec = retarget
+        else:
+            try:
+                tracking = subprocess.check_output(
+                    ["git", "config", f"branch.{branch}.merge"],
+                    text=True,
+                    cwd=repo_path or None,
+                    stderr=subprocess.DEVNULL,
+                ).strip()
+                remote_branch = tracking.removeprefix("refs/heads/")
+                refspec = f"{branch}:{remote_branch}" if remote_branch != branch else branch
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                refspec = branch
+        payload_data["refspec"] = refspec
     else:
+        # Detached HEAD (post-rebase, after manual checkout-by-sha, etc.).
+        # Push by SHA instead — the gateway resolves the assigned branch
+        # from the session and constructs the refspec server-side. See
+        # issue #2200: when the worktree was on detached HEAD the helper
+        # used to bail with "could not determine current branch", trapping
+        # the agent with no way to publish its BRC proposal.
         try:
-            tracking = subprocess.check_output(
-                ["git", "config", f"branch.{branch}.merge"],
+            commit_sha = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"],
                 text=True,
                 cwd=repo_path or None,
                 stderr=subprocess.DEVNULL,
             ).strip()
-            remote_branch = tracking.removeprefix("refs/heads/")
-            refspec = f"{branch}:{remote_branch}" if remote_branch != branch else branch
         except (subprocess.CalledProcessError, FileNotFoundError):
-            refspec = branch
+            commit_sha = ""
+        if not commit_sha:
+            msg = "could not determine HEAD commit for push"
+            print(f"Error: {msg}", file=sys.stderr)
+            return 1, msg
+        payload_data["commit_sha"] = commit_sha
 
-    payload = json.dumps(
-        {
-            "repo_path": repo_path,
-            "remote": "origin",
-            "refspec": refspec,
-            "force": False,
-            "container_id": container_id,
-            "consensus_push": True,
-        }
-    ).encode()
+    payload = json.dumps(payload_data).encode()
 
     req = urllib.request.Request(
         f"{gateway_url}/api/v1/git/push",

--- a/tests/sandbox/test_consensus_push_detached.py
+++ b/tests/sandbox/test_consensus_push_detached.py
@@ -1,0 +1,145 @@
+"""Tests for the detached-HEAD fallback in ``consensus_push`` (#2200).
+
+When ``git branch --show-current`` returns empty (detached HEAD), the
+helper used to bail out with ``"could not determine current branch
+for push"``.  That trapped BRC producer agents that ended up detached
+after a rebase.  The fix falls back to ``git rev-parse HEAD`` and
+sends a ``commit_sha`` field; the gateway derives the refspec from
+the session's assigned branch.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).parent.parent.parent
+for _p in (
+    str(_PROJECT_ROOT / "sandbox"),
+    str(_PROJECT_ROOT / "shared"),
+):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from egg_agent_tools.push import consensus_push  # noqa: E402
+
+
+class _FakeResponse:
+    """Minimal urlopen response stand-in that supports the context manager protocol."""
+
+    def __init__(self, body: dict):
+        self._body = json.dumps(body).encode()
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *exc) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _check_output_factory(branch_value: str, head_sha: str = "deadbeef" * 5):
+    """Build a check_output stub that returns ``branch_value`` for --show-current.
+
+    Other git invocations (rev-parse HEAD, config branch.X.merge) are
+    served from a small lookup table.  ``CalledProcessError`` is raised
+    for unmatched commands so the test fails loudly rather than silently.
+    """
+
+    import subprocess as _subprocess
+
+    def stub(cmd, *args, **kwargs):
+        if cmd[:3] == ["git", "branch", "--show-current"]:
+            return f"{branch_value}\n"
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return f"{head_sha}\n"
+        if cmd[:2] == ["git", "config"] and cmd[2].startswith("branch."):
+            # No tracking config — let the helper fall back to plain branch.
+            raise _subprocess.CalledProcessError(1, cmd)
+        raise _subprocess.CalledProcessError(1, cmd)
+
+    return stub
+
+
+@pytest.fixture
+def gateway_env(monkeypatch):
+    monkeypatch.setenv("GATEWAY_URL", "http://gateway.test")
+    monkeypatch.setenv("EGG_SESSION_TOKEN", "test-token")
+    monkeypatch.setenv("CONTAINER_ID", "issue-2200-coder")
+    monkeypatch.setenv("EGG_REPO_PATH", "/repo")
+    # No EGG_BRANCH set — we want the helper to use its non-retarget path
+    # so the test exercises the SHA fallback cleanly.
+    monkeypatch.delenv("EGG_BRANCH", raising=False)
+
+
+class TestConsensusPushDetachedHead:
+    def test_detached_head_falls_back_to_commit_sha(self, gateway_env):
+        """Empty branch + valid HEAD sends commit_sha in the payload (no refspec)."""
+        captured: list[bytes] = []
+
+        def fake_urlopen(req, timeout=120):
+            captured.append(req.data)
+            return _FakeResponse({"data": {"stdout": "ok\n", "stderr": ""}})
+
+        with (
+            patch(
+                "egg_agent_tools.push.subprocess.check_output",
+                side_effect=_check_output_factory(branch_value="", head_sha="cafef00d" * 5),
+            ),
+            patch("egg_agent_tools.push.urllib.request.urlopen", side_effect=fake_urlopen),
+        ):
+            rc, err = consensus_push()
+
+        assert rc == 0, err
+        assert len(captured) == 1
+        payload = json.loads(captured[0])
+        assert payload.get("consensus_push") is True
+        assert payload.get("commit_sha") == "cafef00d" * 5
+        # The helper must NOT send a refspec when on detached HEAD — that
+        # is the gateway's job (it derives <sha>:refs/heads/<assigned>
+        # from the session) and sending both would invite drift.
+        assert "refspec" not in payload
+
+    def test_detached_head_no_sha_returns_error(self, gateway_env):
+        """If both branch and HEAD lookups fail, the helper returns an error."""
+
+        def stub(cmd, *args, **kwargs):
+            import subprocess as _subprocess
+
+            raise _subprocess.CalledProcessError(1, cmd)
+
+        with (
+            patch("egg_agent_tools.push.subprocess.check_output", side_effect=stub),
+        ):
+            rc, err = consensus_push()
+        assert rc == 1
+        assert err is not None
+        assert "HEAD" in err
+
+    def test_attached_head_still_sends_refspec(self, gateway_env):
+        """Attached-HEAD path is unchanged: refspec built client-side, no commit_sha."""
+        captured: list[bytes] = []
+
+        def fake_urlopen(req, timeout=120):
+            captured.append(req.data)
+            return _FakeResponse({"data": {"stdout": "ok\n", "stderr": ""}})
+
+        with (
+            patch(
+                "egg_agent_tools.push.subprocess.check_output",
+                side_effect=_check_output_factory(branch_value="egg/issue-2200"),
+            ),
+            patch("egg_agent_tools.push.urllib.request.urlopen", side_effect=fake_urlopen),
+        ):
+            rc, err = consensus_push()
+
+        assert rc == 0, err
+        payload = json.loads(captured[0])
+        assert "refspec" in payload
+        assert "commit_sha" not in payload


### PR DESCRIPTION
## Summary
- Gateway push endpoint (`/api/v1/git/push`) now accepts `commit_sha` as an alternative to `refspec` for `consensus_push=true` requests; the refspec `<sha>:refs/heads/<assigned>` is constructed server-side from the session's assigned branch — strictly tighter than trusting an agent-supplied refspec.
- `consensus_push` helper falls back to `git rev-parse HEAD` + `commit_sha` when `git branch --show-current` is empty, so a detached HEAD no longer traps the producer.
- `git symbolic-ref HEAD <ref>` is now in the gateway allowlist as a low-level reattach primitive, scoped to the session's assigned branch or per-role local work branch (`egg/<container_id>/work`). Pairs with the already-allowed `git reset --hard <on-lineage>` for any manual recovery flow.

Together these address the no-exit trap in #2200: a per-role producer that needed to rebase to incorporate recent main commits and ended up on detached HEAD had no gateway-allowed path to publish its BRC proposal — every recovery knob (`switch`, `checkout`, `update-ref` against the local branch, `egg-orch consensus propose --push`) was either denied or bailed on the empty-branch check.

## Test plan
- [x] `pytest gateway/tests/test_push_by_sha.py gateway/tests/test_symbolic_ref_recovery.py` — new tests for the gateway-side commit_sha path and the symbolic-ref guard
- [x] `pytest tests/sandbox/test_consensus_push_detached.py` — new tests for the helper's detached-HEAD fallback
- [x] `pytest gateway/tests/` — full gateway suite (3099 tests pass; pre-commit hooks include ruff + format checks, all clean)
- [ ] CI: full lint + monorepo-narrowed test suite

## Notes
- Out of scope (filed separately if needed): root cause of why rebase detached HEAD in the first place; the worktree directory-ref collision between `refs/heads/<assigned>` and `refs/heads/<assigned>/<role>/work`. The recovery primitives added here fire regardless of the trigger, so the trap stops blocking BRC progress today.
- Approach (4) + (1) from the issue's suggested fixes; details in the PR plan thread.