### PR TITLE
docs(agent-rules): steer producers to register_open_question over overseer_alert

### DIFF
--- a/sandbox/agent-config/rules/contract.md
+++ b/sandbox/agent-config/rules/contract.md
@@ -33,7 +33,7 @@ the contract verbs that iteration-1 left as Bash-only:
 - `mcp__phase__complete_phase` — Prefer this over `egg-contract complete-phase`. Transitions phase status to "complete" (downstream `phase_complete` signal fires).
 - `mcp__sdlc__verify_criterion` — Prefer this over `egg-contract verify-criterion`. Marks an acceptance criterion verified; **REVIEWER role only** (the gateway rejects non-REVIEWER writers — no in-process re-check).
 - `mcp__task__complete` — Prefer this over `egg-contract complete-task`. Marks a contract task complete and optionally links a commit.
-- `mcp__sdlc__register_open_question` — Prefer this over `egg-contract add-decision`. Creates a HITL multiple-choice decision.
+- `mcp__sdlc__register_open_question` — Prefer this over `egg-contract add-decision`. Creates a HITL multiple-choice decision. **Available to every role, not just refiner/planner** — coders should call this when reviewer NACKs name an architectural scope question the operator (not the coder) must decide. See [`mission.md`](mission.md) → "HITL Decisions vs. Operational Alerts" for the producer-side checklist; do NOT file an `OVERSEER_ALERT` for this.
 - `mcp__sdlc__request_feedback` — Prefer this over `egg-contract add-feedback`. Creates an open-ended HITL feedback request.
 
 A new no-CLI tool also lives in the contract surface:

--- a/sandbox/agent-config/rules/mission.md
+++ b/sandbox/agent-config/rules/mission.md
@@ -169,6 +169,17 @@ egg-orch progress emit --step "applying fix" --state blocked --blocker "missing 
 
 Emit progress when: starting/completing major steps, encountering blockers, during long-running operations. Progress events supplement heartbeats — they tell the orchestrator *what* you're doing, not just that you're alive.
 
+### HITL Decisions vs. Operational Alerts
+
+When you hit a NACK that names an **architectural scope question** the operator must decide — not a code-level fix you can make — register a HITL decision. Do **NOT** file an `OVERSEER_ALERT` for this; alerts are informational broadcasts, not decision gates.
+
+- **`mcp__sdlc__register_open_question`** — for **decisions blocking your re-propose**. Writes to the contract, surfaces in `pending_decisions`, and is resolvable via `/sdlc` / `provide_input`. Reference the returned decision id in your re-propose summary so reviewers and the operator can correlate.
+- **`mcp__progress__overseer_alert`** — for **runtime anomalies**: stalls, ambiguous failures, agent-loop, heartbeat gaps. Informational broadcast only — no contract write, no HITL gate. The operator may or may not see it depending on tooling.
+
+**Checklist before re-proposing after NACKs:** do any of these NACKs require an operator scope decision (not just a code change I can make)? If yes, register a multi-choice HITL question and reference the decision id in your next propose. If no, fix the code and re-propose. The OCC barrier blocks the re-propose either way; the question is whether the operator gets a contract-tracked surface to resolve from.
+
+Note: the `unmediated-disagreement` anomaly type on `overseer_alert` is for **observers** (overseer / mediator) to flag that no one is adjudicating a disagreement. Producers facing reviewer disagreement on a scope question should `register_open_question` instead — that is the right surface, not an alert.
+
 ### Handling Agent Failures
 
 If you receive an `AGENT_FAILED` message about another agent:

--- a/sandbox/agent-config/rules/mission.md
+++ b/sandbox/agent-config/rules/mission.md
@@ -178,7 +178,7 @@ Whenever you identify an **architectural scope question** the operator (not you)
 
 **Checklist (any time, not just at re-propose):** is what's blocking me an operator scope decision (not a code change I can make)? If yes, register a multi-choice HITL question and reference the decision id when I next surface state (propose, proposal summary, comment). If no, fix the code and proceed.
 
-**Registering is necessary but not sufficient to unblock.** The OCC barrier on re-propose clears only after reviewers re-ACK; that requires the operator to resolve the decision *and* you to update the proposal per the resolution. The full unblock path is: `register_open_question` → operator resolves via `/sdlc` → you fix per the resolution → reviewers re-ACK → OCC clears. Without the decision, the operator has no contract-tracked surface to resolve from at all — that is the value-add, not auto-unblocking.
+**Registering is necessary but not sufficient to unblock.** The OCC (optimistic concurrency control) barrier on re-propose clears only after reviewers re-ACK; that requires the operator to resolve the decision *and* you to update the proposal per the resolution. The full unblock path is: `register_open_question` → operator resolves via `/sdlc` → you fix per the resolution → reviewers re-ACK → OCC clears. Without the decision, the operator has no contract-tracked surface to resolve from at all — that is the value-add, not auto-unblocking.
 
 Note: the `unmediated-disagreement` anomaly type on `overseer_alert` is for **observers** (overseer / mediator) to flag that no one is adjudicating a disagreement. Producers facing reviewer disagreement on a scope question should `register_open_question` instead — that is the right surface, not an alert.
 

--- a/sandbox/agent-config/rules/mission.md
+++ b/sandbox/agent-config/rules/mission.md
@@ -171,12 +171,14 @@ Emit progress when: starting/completing major steps, encountering blockers, duri
 
 ### HITL Decisions vs. Operational Alerts
 
-When you hit a NACK that names an **architectural scope question** the operator must decide — not a code-level fix you can make — register a HITL decision. Do **NOT** file an `OVERSEER_ALERT` for this; alerts are informational broadcasts, not decision gates.
+Whenever you identify an **architectural scope question** the operator (not you) must decide — whether you spotted it proactively during planning, hit it as a NACK from a reviewer, or recognized it mid-implementation — register a HITL decision. Do **NOT** file an `OVERSEER_ALERT` for this; alerts are informational broadcasts, not decision gates.
 
-- **`mcp__sdlc__register_open_question`** — for **decisions blocking your re-propose**. Writes to the contract, surfaces in `pending_decisions`, and is resolvable via `/sdlc` / `provide_input`. Reference the returned decision id in your re-propose summary so reviewers and the operator can correlate.
+- **`mcp__sdlc__register_open_question`** — for **decisions blocking forward progress**. Writes to the contract, surfaces in `pending_decisions`, and is resolvable via `/sdlc` / `provide_input`. Reference the returned decision id in your next propose / proposal-summary so reviewers and the operator can correlate.
 - **`mcp__progress__overseer_alert`** — for **runtime anomalies**: stalls, ambiguous failures, agent-loop, heartbeat gaps. Informational broadcast only — no contract write, no HITL gate. The operator may or may not see it depending on tooling.
 
-**Checklist before re-proposing after NACKs:** do any of these NACKs require an operator scope decision (not just a code change I can make)? If yes, register a multi-choice HITL question and reference the decision id in your next propose. If no, fix the code and re-propose. The OCC barrier blocks the re-propose either way; the question is whether the operator gets a contract-tracked surface to resolve from.
+**Checklist (any time, not just at re-propose):** is what's blocking me an operator scope decision (not a code change I can make)? If yes, register a multi-choice HITL question and reference the decision id when I next surface state (propose, proposal summary, comment). If no, fix the code and proceed.
+
+**Registering is necessary but not sufficient to unblock.** The OCC barrier on re-propose clears only after reviewers re-ACK; that requires the operator to resolve the decision *and* you to update the proposal per the resolution. The full unblock path is: `register_open_question` → operator resolves via `/sdlc` → you fix per the resolution → reviewers re-ACK → OCC clears. Without the decision, the operator has no contract-tracked surface to resolve from at all — that is the value-add, not auto-unblocking.
 
 Note: the `unmediated-disagreement` anomaly type on `overseer_alert` is for **observers** (overseer / mediator) to flag that no one is adjudicating a disagreement. Producers facing reviewer disagreement on a scope question should `register_open_question` instead — that is the right surface, not an alert.
 

--- a/sandbox/agent-config/rules/orchestrator.md
+++ b/sandbox/agent-config/rules/orchestrator.md
@@ -51,7 +51,7 @@ Progress + overseer (iter-2 added the overseer surface):
 - `mcp__progress__emit` — Prefer this over `egg-orch progress emit`. Emit a structured progress event (step/state/detail/blocker).
 - `mcp__progress__signal_error` — Prefer this over `egg-orch signal error`. Signal a recoverable / unrecoverable error.
 - `mcp__progress__heartbeat` — Prefer this over `egg-orch signal heartbeat`. Send a coarse-grained heartbeat.
-- `mcp__progress__overseer_alert` — Prefer this over `egg-orch overseer alert`. Broadcast an `OVERSEER_ALERT` to all agents in the pipeline.
+- `mcp__progress__overseer_alert` — Prefer this over `egg-orch overseer alert`. Broadcast an `OVERSEER_ALERT` to all agents in the pipeline. **Producers blocked by reviewer NACKs (or proactive scope questions) on operator-decidable architectural choices — use `mcp__sdlc__register_open_question`, not this. Alerts are informational; decisions are HITL gates. See [`mission.md`](mission.md) → "HITL Decisions vs. Operational Alerts".**
 - `mcp__progress__query_status` — Prefer this over `egg-orch pipeline status`. Read structured pipeline status (agent matrix, BRC phase, blocked roles). Note: the MCP tool lives in the `progress` namespace per decision-5; the CLI lives in the `pipeline` subcommand subtree (decision-17 keeps the drift-gate symmetric with `overseer_alert`).
 
 No-CLI BRC introspection (iteration 1 + 2):

--- a/sandbox/agent-config/rules/overseer.md
+++ b/sandbox/agent-config/rules/overseer.md
@@ -110,7 +110,7 @@ Each `--once` call to the monitoring script (`/opt/egg-runtime/sandbox/overseer_
 **Your responsibilities** when reading the script's output:
 1. **Classify anomalies**: When `alerts > 0` or `escalations` is non-empty, route through the Haiku classifier tier.
 2. **Decide whether to escalate**: Route classified results through the Sonnet/Opus decision tier. The decision is "alert or keep watching," not "what to do about it."
-3. **Emit `OVERSEER_ALERT`**: Use `egg-orch overseer alert ...` for any anomaly that needs human attention. Do not attempt corrective actions on the pipeline itself.
+3. **Emit `OVERSEER_ALERT`**: Use `egg-orch overseer alert ...` for any anomaly that needs human attention. Do not attempt corrective actions on the pipeline itself. Note: this is the **observer** surface — when the overseer flags `unmediated-disagreement`, that is correct (no one is adjudicating). Producers facing the same disagreement should instead use `mcp__sdlc__register_open_question` to create a contract-tracked HITL gate; see [`mission.md`](mission.md) → "HITL Decisions vs. Operational Alerts" for the role distinction.
 4. **Track self-monitoring**: Record LLM call costs and message volume.
 
 ## Haiku/Sonnet Split

--- a/sandbox/egg_agent_tools/handlers/progress.py
+++ b/sandbox/egg_agent_tools/handlers/progress.py
@@ -158,6 +158,13 @@ def progress_overseer_alert(req: dict[str, Any]) -> dict[str, Any]:
             include stuck-phase-transition, agent-heartbeat-stall,
             agent-loop, orchestrator-consensus-silent,
             unauthorized-overseer-action, unmediated-disagreement).
+            ``unmediated-disagreement`` is for observers (overseer /
+            mediator) flagging that no one is adjudicating a
+            disagreement; producers blocked by reviewer NACKs that
+            name an operator-decidable scope question should call
+            ``mcp__sdlc__register_open_question`` instead so the
+            decision lands in ``pending_decisions`` (HITL gate)
+            rather than as an informational alert.
         priority (str): required — one of ``low``/``medium``/``high``.
         summary (str): required — one-line description.
         detail (str): optional longer description / observed evidence.

--- a/sandbox/egg_agent_tools/tools/progress.py
+++ b/sandbox/egg_agent_tools/tools/progress.py
@@ -65,7 +65,13 @@ _OVERSEER_ALERT_SCHEMA: dict[str, Any] = {
             "description": (
                 "Anomaly type (free text). Known types: stuck-phase-transition, "
                 "agent-heartbeat-stall, agent-loop, orchestrator-consensus-silent, "
-                "unauthorized-overseer-action, unmediated-disagreement."
+                "unauthorized-overseer-action, unmediated-disagreement. NOTE: "
+                "`unmediated-disagreement` is for OBSERVERS (overseer/mediator) "
+                "flagging that no one is adjudicating a disagreement. If you are "
+                "a producer blocked by reviewer NACKs that name an architectural "
+                "scope question for the operator, use "
+                "`mcp__sdlc__register_open_question` instead -- it creates a "
+                "contract-tracked HITL gate; this alert is informational only."
             ),
         },
         "priority": {

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -3151,7 +3151,13 @@ def create_parser() -> argparse.ArgumentParser:
             "Anomaly type -- intentionally free-text so new types can emerge "
             "without CLI changes. Known types: stuck-phase-transition, "
             "agent-heartbeat-stall, agent-loop, orchestrator-consensus-silent, "
-            "unauthorized-overseer-action, unmediated-disagreement"
+            "unauthorized-overseer-action, unmediated-disagreement. NOTE: "
+            "'unmediated-disagreement' is for observers (overseer/mediator) "
+            "flagging that no one is adjudicating; producers blocked by "
+            "reviewer NACKs naming an operator-decidable scope question "
+            "should use 'egg-contract add-decision' / "
+            "'mcp__sdlc__register_open_question' instead -- alerts are "
+            "informational, decisions are HITL gates."
         ),
     )
     ov_alert.add_argument(


### PR DESCRIPTION
## Summary

Closes the producer-side mis-framing described in #2204: implement-phase coders blocked by reviewer NACKs on architectural-scope questions were filing `mcp__progress__overseer_alert(anomaly=unmediated-disagreement)` instead of `mcp__sdlc__register_open_question`. Alerts are informational broadcasts; decisions land in `pending_decisions` and are resolvable through the standard HITL surface (`/sdlc`, `provide_input`).

This PR addresses suggestions (1)–(3) from the issue. Suggestion (4) (orchestrator-side enforcement) is intentionally skipped — it overlaps with the orchestrator-side fix in #2203.

## Changes

- **`sandbox/agent-config/rules/mission.md`**: new "HITL Decisions vs. Operational Alerts" section with the producer-side checklist for picking between `register_open_question` and `overseer_alert`. Lives next to the existing structured-progress and BRC sections, where producers are most likely to look when handling NACKs.
- **`sandbox/agent-config/rules/contract.md`**: reframe `register_open_question` as available to every role (not just refiner/planner) and cross-link mission.md. Adds an explicit "do NOT file an `OVERSEER_ALERT` for this" pointer.
- **`sandbox/egg_agent_tools/tools/progress.py`** + **`sandbox/egg_agent_tools/handlers/progress.py`** + **`sandbox/egg_lib/orch_cli.py`**: clarify the `unmediated-disagreement` anomaly description so producers are redirected to `register_open_question`. The enum value stays valid because the overseer's mediator-boundary playbook (overseer.md:323) still uses it legitimately — the overseer is observation-only and forbidden from contract writes.

## What we deliberately did NOT do

- Did not remove the `unmediated-disagreement` anomaly value (overseer.md:323 needs it).
- Did not add orchestrator-side auto-creation of `pending_decisions` from alert-with-decision-id pattern matching. That's brittle and overlaps with #2203's HITL-on-incomplete-consensus fix.
- Did not modify overseer.md — its use of `unmediated-disagreement` is correct given the observation-only role.

## Test plan

- [x] `pytest sandbox/tests/test_overseer_alert_cli.py` — parser/schema tests pass; the 9 failing tests fail identically on main (pre-existing network-resolution issue, not caused by this PR).
- [x] `ruff check` clean on all edited Python files.
- [x] Pre-commit hooks pass (ruff, format, trailing-whitespace, eof).
- [ ] Real-world: next pipeline that hits a NACK-on-scope-question in implement should produce a `pending_decisions` entry instead of an `OVERSEER_ALERT`. (The fix is prompt-side, so verification requires a live pipeline — recommend monitoring the next implement-phase incident.)

Refs #2204. Companion to #2203 (orchestrator-side hole).