### PR TITLE
fix(orchestrator): create HITL decision when consensus is incomplete on container exit (#2203)

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9263,6 +9263,42 @@ def _format_nack_summary(nack_details: list[dict]) -> str:
     )
 
 
+def _incomplete_consensus_decision_text(
+    final_consensus: dict,
+    container_failure_count: int,
+) -> tuple[str, str]:
+    """Build (question, log_suffix) for incomplete-consensus HITL escalation.
+
+    Distinguishes the two failure modes — unresolved NACKs vs. agents that
+    never confirmed — so the operator sees actionable detail in `/sdlc`.
+    """
+    nacks = final_consensus.get("unresolved_nacks", []) or []
+    blocking = final_consensus.get("blocking_agents", []) or []
+    if container_failure_count:
+        prefix = f"{container_failure_count} container(s) exited with non-zero code; "
+    else:
+        prefix = "All containers exited; "
+    if nacks:
+        summary = _format_nack_summary(nacks)
+        question = (
+            f"{prefix}consensus incomplete with {len(nacks)} unresolved NACK(s): "
+            f"{summary}. Committed work is preserved on the per-role branch — "
+            f"'Retry phase' restarts with artifacts intact. How to proceed?"
+        )
+        log_suffix = f"\n--- INCOMPLETE CONSENSUS / UNRESOLVED NACKs ({len(nacks)}) ---\n{summary}"
+    else:
+        agent_list = ", ".join(blocking) if blocking else "unknown"
+        question = (
+            f"{prefix}consensus incomplete; agents never confirmed: {agent_list}. "
+            f"Committed work is preserved on the per-role branch — "
+            f"'Retry phase' restarts with artifacts intact. How to proceed?"
+        )
+        log_suffix = (
+            f"\n--- INCOMPLETE CONSENSUS / NO CONFIRMATION ---\nblocking_agents={agent_list}"
+        )
+    return question, log_suffix
+
+
 def _handle_brc_consensus_timeout(
     pipeline: Pipeline,
     pipeline_id: str,
@@ -10135,6 +10171,35 @@ def _run_concurrent_phase(
                     _stop_running_containers()
                     return 0, combined_logs
 
+                # Incomplete consensus + container failures: surface an HITL
+                # decision so the operator can drive recovery (issue #2203).
+                # Without this, the phase fails terminally with no signal —
+                # the agent's committed work is still on the per-role branch
+                # and `restart_phase` would recover, but the operator has no
+                # way to know that without out-of-band investigation.
+                failure_count = sum(1 for info in exited_containers.values() if info.exit_code != 0)
+                question, log_suffix = _incomplete_consensus_decision_text(
+                    final_consensus, container_failure_count=failure_count
+                )
+                logger.warning(
+                    "Incomplete consensus with container failures — escalating to HITL",
+                    pipeline_id=pipeline_id,
+                    failure_count=failure_count,
+                    blocking_agents=final_consensus.get("blocking_agents", []),
+                    nack_count=len(final_consensus.get("unresolved_nacks", []) or []),
+                )
+                try:
+                    pipeline.add_decision(
+                        question=question,
+                        options=["Retry phase", "Accept current state", "Abort phase"],
+                        phase=pipeline.current_phase,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to create incomplete-consensus HITL decision (has_failures path)",
+                        exc_info=True,
+                    )
+                combined_logs += log_suffix
                 return 1, combined_logs
 
             # Before returning success, check the BRC approval matrix for
@@ -10179,11 +10244,30 @@ def _run_concurrent_phase(
                 final_consensus = {"is_complete": False}
 
             if not final_consensus.get("is_complete"):
+                # Symmetric to the has_failures path: clean exits with no
+                # consensus also need an HITL decision so the operator can
+                # drive recovery (issue #2203).
+                question, log_suffix = _incomplete_consensus_decision_text(
+                    final_consensus, container_failure_count=0
+                )
                 logger.warning(
-                    "All containers exited cleanly but consensus not reached",
+                    "All containers exited cleanly but consensus not reached — escalating to HITL",
                     pipeline_id=pipeline_id,
                     elapsed_seconds=round(elapsed, 1),
+                    blocking_agents=final_consensus.get("blocking_agents", []),
                 )
+                try:
+                    pipeline.add_decision(
+                        question=question,
+                        options=["Retry phase", "Accept current state", "Abort phase"],
+                        phase=pipeline.current_phase,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to create incomplete-consensus HITL decision (clean-exit path)",
+                        exc_info=True,
+                    )
+                combined_logs += log_suffix
                 return 1, combined_logs
 
             # Consensus confirmed on clean exit — mirror the has_failures

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9302,7 +9302,7 @@ def _incomplete_consensus_decision_text(
 def _persist_hitl_decision(
     pipeline_id: str,
     pipeline: Pipeline,
-    store,
+    store: StateStore,
     *,
     question: str,
     options: list[str],
@@ -9314,10 +9314,14 @@ def _persist_hitl_decision(
     of `_run_concurrent_phase` reloads the pipeline fresh from disk before
     writing FAILED, so any in-memory decision is silently dropped — the
     on-disk state (which `/sdlc` reads via `pipeline.get_pending_decisions()`)
-    never sees it.  This helper mirrors `DecisionQueue.queue_decision()` and
-    the HITL-gate write at pipelines.py:13080-13089: load → mutate → save
-    under the reentrant pipeline state lock.  The in-memory `pipeline`
-    argument is also synced so callers observe consistent state.
+    never sees it.  This helper mirrors the *persistence half* of
+    `DecisionQueue.queue_decision()` and the HITL-gate write at
+    pipelines.py:13080-13089: load → mutate → save under the reentrant
+    pipeline state lock.  Note: it intentionally does **not** invoke
+    `_notify_handlers` — no production code currently registers a
+    `DecisionHandler` and `/sdlc` reads from disk on each request, so
+    notifications are not needed for the issue-2203 path.  The in-memory
+    `pipeline` argument is also synced so callers observe consistent state.
 
     Returns the created decision, or None if persistence failed (logged;
     callers should not raise — losing an HITL decision is bad but losing
@@ -9332,7 +9336,9 @@ def _persist_hitl_decision(
                 phase=phase or disk_pipeline.current_phase,
             )
             store.save_pipeline(disk_pipeline)
-        pipeline.decisions = disk_pipeline.decisions
+        # Defensive copy: avoid sharing the list reference with the
+        # disk-loaded copy, which is local and goes out of scope.
+        pipeline.decisions = list(disk_pipeline.decisions)
         return decision
     except Exception:
         logger.warning(
@@ -9349,7 +9355,7 @@ def _handle_brc_consensus_timeout(
     pipeline_id: str,
     consensus_timeout: float,
     blocking_agents: list[str],
-    store,
+    store: StateStore,
 ) -> None:
     # Extracted from _run_concurrent_phase so k3s-style top-level-module
     # layouts (and tests) can exercise this path in isolation — issue #1783.

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9299,11 +9299,57 @@ def _incomplete_consensus_decision_text(
     return question, log_suffix
 
 
+def _persist_hitl_decision(
+    pipeline_id: str,
+    pipeline: Pipeline,
+    store,
+    *,
+    question: str,
+    options: list[str],
+    phase: PipelinePhase | None = None,
+):
+    """Create and persist an HITL decision under the pipeline state lock.
+
+    `pipeline.add_decision()` only mutates an in-memory object.  The caller
+    of `_run_concurrent_phase` reloads the pipeline fresh from disk before
+    writing FAILED, so any in-memory decision is silently dropped — the
+    on-disk state (which `/sdlc` reads via `pipeline.get_pending_decisions()`)
+    never sees it.  This helper mirrors `DecisionQueue.queue_decision()` and
+    the HITL-gate write at pipelines.py:13080-13089: load → mutate → save
+    under the reentrant pipeline state lock.  The in-memory `pipeline`
+    argument is also synced so callers observe consistent state.
+
+    Returns the created decision, or None if persistence failed (logged;
+    callers should not raise — losing an HITL decision is bad but losing
+    the rest of the cleanup path is worse).
+    """
+    try:
+        with get_pipeline_state_lock(pipeline_id):
+            disk_pipeline = store.load_pipeline(pipeline_id)
+            decision = disk_pipeline.add_decision(
+                question=question,
+                options=options,
+                phase=phase or disk_pipeline.current_phase,
+            )
+            store.save_pipeline(disk_pipeline)
+        pipeline.decisions = disk_pipeline.decisions
+        return decision
+    except Exception:
+        logger.warning(
+            "Failed to persist HITL decision",
+            pipeline_id=pipeline_id,
+            question=question[:100],
+            exc_info=True,
+        )
+        return None
+
+
 def _handle_brc_consensus_timeout(
     pipeline: Pipeline,
     pipeline_id: str,
     consensus_timeout: float,
     blocking_agents: list[str],
+    store,
 ) -> None:
     # Extracted from _run_concurrent_phase so k3s-style top-level-module
     # layouts (and tests) can exercise this path in isolation — issue #1783.
@@ -9339,21 +9385,17 @@ def _handle_brc_consensus_timeout(
         and _brc_timeout_result is not None
         and _brc_timeout_result.get("action") == "escalate"
     ):
-        try:
-            pipeline.add_decision(
-                question=(
-                    f"BRC consensus failure: critical reviewers unconfirmed after "
-                    f"{int(consensus_timeout / 60)} minutes. How to proceed?"
-                ),
-                options=["Continue waiting", "Accept current state", "Abort phase"],
-                phase=pipeline.current_phase,
-            )
-        except Exception as decision_err:
-            logger.error(
-                "Failed to queue HITL decision after BRC escalation — pipeline will stall",
-                pipeline_id=pipeline_id,
-                error=str(decision_err),
-            )
+        _persist_hitl_decision(
+            pipeline_id,
+            pipeline,
+            store,
+            question=(
+                f"BRC consensus failure: critical reviewers unconfirmed after "
+                f"{int(consensus_timeout / 60)} minutes. How to proceed?"
+            ),
+            options=["Continue waiting", "Accept current state", "Abort phase"],
+            phase=pipeline.current_phase,
+        )
     elif not _brc_handled:
         if _emit_event is not None:
             _emit_event(
@@ -9364,21 +9406,17 @@ def _handle_brc_consensus_timeout(
                     "blocking_agents": blocking_agents,
                 },
             )
-        try:
-            pipeline.add_decision(
-                question=(
-                    f"Consensus not reached after {int(consensus_timeout / 60)} minutes. "
-                    f"How to proceed?"
-                ),
-                options=["Continue waiting", "Accept current state", "Abort phase"],
-                phase=pipeline.current_phase,
-            )
-        except Exception as decision_err:
-            logger.error(
-                "Failed to queue HITL decision after consensus timeout — pipeline will stall",
-                pipeline_id=pipeline_id,
-                error=str(decision_err),
-            )
+        _persist_hitl_decision(
+            pipeline_id,
+            pipeline,
+            store,
+            question=(
+                f"Consensus not reached after {int(consensus_timeout / 60)} minutes. "
+                f"How to proceed?"
+            ),
+            options=["Continue waiting", "Accept current state", "Abort phase"],
+            phase=pipeline.current_phase,
+        )
 
 
 def _run_concurrent_phase(
@@ -9961,23 +9999,20 @@ def _run_concurrent_phase(
         #    the next poll iteration.  "Abort phase" triggers pipeline
         #    cancellation via a separate control path.
         if consensus.get("has_objections") and not objection_decision_created:
-            try:
-                pipeline.add_decision(
-                    question="Agent(s) objecting to phase completion. How to proceed?",
-                    options=["Override objections", "Wait for resolution", "Abort phase"],
-                    phase=pipeline.current_phase,
-                )
+            decision = _persist_hitl_decision(
+                pipeline_id,
+                pipeline,
+                store,
+                question="Agent(s) objecting to phase completion. How to proceed?",
+                options=["Override objections", "Wait for resolution", "Abort phase"],
+                phase=pipeline.current_phase,
+            )
+            if decision is not None:
                 objection_decision_created = True
                 logger.info(
                     "Objection detected, HITL decision created",
                     pipeline_id=pipeline_id,
                     blocking_agents=consensus.get("blocking_agents", []),
-                )
-            except Exception as e:
-                logger.warning(
-                    "Failed to create objection HITL decision",
-                    pipeline_id=pipeline_id,
-                    error=str(e),
                 )
 
         # 3b. RC3: Stall demotion for dual-role agents.
@@ -10113,20 +10148,17 @@ def _run_concurrent_phase(
                             nack_count=len(nack_details),
                             nack_summary=nack_summary,
                         )
-                        try:
-                            pipeline.add_decision(
-                                question=(
-                                    f"Consensus reached but {len(nack_details)} NACK(s) "
-                                    f"remain unresolved: {nack_summary}. How to proceed?"
-                                ),
-                                options=["Retry phase", "Accept current state", "Abort phase"],
-                                phase=pipeline.current_phase,
-                            )
-                        except Exception:
-                            logger.warning(
-                                "Failed to create NACK escalation decision (step 5 has_failures path)",
-                                exc_info=True,
-                            )
+                        _persist_hitl_decision(
+                            pipeline_id,
+                            pipeline,
+                            store,
+                            question=(
+                                f"Consensus reached but {len(nack_details)} NACK(s) "
+                                f"remain unresolved: {nack_summary}. How to proceed?"
+                            ),
+                            options=["Retry phase", "Accept current state", "Abort phase"],
+                            phase=pipeline.current_phase,
+                        )
                         combined_logs += (
                             f"\n--- UNRESOLVED NACKs ({len(nack_details)}) ---\n{nack_summary}"
                         )
@@ -10177,6 +10209,14 @@ def _run_concurrent_phase(
                 # the agent's committed work is still on the per-role branch
                 # and `restart_phase` would recover, but the operator has no
                 # way to know that without out-of-band investigation.
+                #
+                # If an objection HITL was created earlier in the polling loop
+                # this is intentionally a *second* pending decision: it
+                # carries different options ("Retry phase" / "Accept current
+                # state" / "Abort phase" vs the objection set) and conveys a
+                # different operator action.  The test
+                # `test_objection_dedup_distinct_from_incomplete_consensus_hitl`
+                # locks in the two-decision UX.
                 failure_count = sum(1 for info in exited_containers.values() if info.exit_code != 0)
                 question, log_suffix = _incomplete_consensus_decision_text(
                     final_consensus, container_failure_count=failure_count
@@ -10188,17 +10228,14 @@ def _run_concurrent_phase(
                     blocking_agents=final_consensus.get("blocking_agents", []),
                     nack_count=len(final_consensus.get("unresolved_nacks", []) or []),
                 )
-                try:
-                    pipeline.add_decision(
-                        question=question,
-                        options=["Retry phase", "Accept current state", "Abort phase"],
-                        phase=pipeline.current_phase,
-                    )
-                except Exception:
-                    logger.warning(
-                        "Failed to create incomplete-consensus HITL decision (has_failures path)",
-                        exc_info=True,
-                    )
+                _persist_hitl_decision(
+                    pipeline_id,
+                    pipeline,
+                    store,
+                    question=question,
+                    options=["Retry phase", "Accept current state", "Abort phase"],
+                    phase=pipeline.current_phase,
+                )
                 combined_logs += log_suffix
                 return 1, combined_logs
 
@@ -10215,17 +10252,17 @@ def _run_concurrent_phase(
                     nack_count=len(nack_details),
                     nack_summary=nack_summary,
                 )
-                try:
-                    pipeline.add_decision(
-                        question=(
-                            f"All agents exited but {len(nack_details)} NACK(s) remain "
-                            f"unresolved: {nack_summary}. How to proceed?"
-                        ),
-                        options=["Retry phase", "Accept current state", "Abort phase"],
-                        phase=pipeline.current_phase,
-                    )
-                except Exception:
-                    logger.warning("Failed to create NACK escalation decision", exc_info=True)
+                _persist_hitl_decision(
+                    pipeline_id,
+                    pipeline,
+                    store,
+                    question=(
+                        f"All agents exited but {len(nack_details)} NACK(s) remain "
+                        f"unresolved: {nack_summary}. How to proceed?"
+                    ),
+                    options=["Retry phase", "Accept current state", "Abort phase"],
+                    phase=pipeline.current_phase,
+                )
                 combined_logs += f"\n--- UNRESOLVED NACKs ({len(nack_details)}) ---\n{nack_summary}"
                 return 1, combined_logs
 
@@ -10256,17 +10293,14 @@ def _run_concurrent_phase(
                     elapsed_seconds=round(elapsed, 1),
                     blocking_agents=final_consensus.get("blocking_agents", []),
                 )
-                try:
-                    pipeline.add_decision(
-                        question=question,
-                        options=["Retry phase", "Accept current state", "Abort phase"],
-                        phase=pipeline.current_phase,
-                    )
-                except Exception:
-                    logger.warning(
-                        "Failed to create incomplete-consensus HITL decision (clean-exit path)",
-                        exc_info=True,
-                    )
+                _persist_hitl_decision(
+                    pipeline_id,
+                    pipeline,
+                    store,
+                    question=question,
+                    options=["Retry phase", "Accept current state", "Abort phase"],
+                    phase=pipeline.current_phase,
+                )
                 combined_logs += log_suffix
                 return 1, combined_logs
 
@@ -10300,6 +10334,7 @@ def _run_concurrent_phase(
                 pipeline_id,
                 consensus_timeout,
                 consensus.get("blocking_agents", []),
+                store,
             )
 
             # Fall back: event-driven wait for remaining containers.
@@ -10448,20 +10483,17 @@ def _run_concurrent_phase(
                             nack_count=len(nack_details),
                             nack_summary=nack_summary,
                         )
-                        try:
-                            pipeline.add_decision(
-                                question=(
-                                    f"Consensus reached after timeout but {len(nack_details)} NACK(s) "
-                                    f"remain unresolved: {nack_summary}. How to proceed?"
-                                ),
-                                options=["Retry phase", "Accept current state", "Abort phase"],
-                                phase=pipeline.current_phase,
-                            )
-                        except Exception:
-                            logger.warning(
-                                "Failed to create NACK escalation decision (timeout path)",
-                                exc_info=True,
-                            )
+                        _persist_hitl_decision(
+                            pipeline_id,
+                            pipeline,
+                            store,
+                            question=(
+                                f"Consensus reached after timeout but {len(nack_details)} NACK(s) "
+                                f"remain unresolved: {nack_summary}. How to proceed?"
+                            ),
+                            options=["Retry phase", "Accept current state", "Abort phase"],
+                            phase=pipeline.current_phase,
+                        )
                         combined_logs += (
                             f"\n--- UNRESOLVED NACKs ({len(nack_details)}) ---\n{nack_summary}"
                         )

--- a/orchestrator/tests/test_brc_nack_iteration.py
+++ b/orchestrator/tests/test_brc_nack_iteration.py
@@ -325,7 +325,7 @@ class TestPollingLoopWithNacks:
     def test_containers_exit_without_nacks_returns_failure_without_consensus(
         self, MockExecutor, mock_prompt, mock_lock, mock_monotonic, mock_sleep
     ):
-        """All containers exit code 0, no NACKs but no consensus -> returns (1, ...)."""
+        """Clean exit, no NACKs, no consensus -> failure + HITL decision (#2203)."""
         from routes.pipelines import _run_concurrent_phase
 
         mock_monotonic.return_value = 0.0
@@ -360,17 +360,235 @@ class TestPollingLoopWithNacks:
         mock_lock.return_value.__enter__ = MagicMock(return_value=None)
         mock_lock.return_value.__exit__ = MagicMock(return_value=False)
 
-        exit_code, logs = _run_concurrent_phase(
-            pipeline_id="issue-999",
-            pipeline=pipeline,
-            phase="implement",
-            spawner=mock_spawner,
-            store=mock_store,
-            **_CALL_ARGS,
+        mock_add_decision = MagicMock(return_value=MagicMock(id="dec-1"))
+        with patch.object(type(pipeline), "add_decision", mock_add_decision):
+            exit_code, logs = _run_concurrent_phase(
+                pipeline_id="issue-999",
+                pipeline=pipeline,
+                phase="implement",
+                spawner=mock_spawner,
+                store=mock_store,
+                **_CALL_ARGS,
+            )
+
+        # Issue #1581: clean exit without consensus must return failure.
+        assert exit_code == 1
+        # Issue #2203: it must also surface an HITL decision so the
+        # operator can drive recovery without out-of-band investigation.
+        mock_add_decision.assert_called_once()
+        call_kwargs = mock_add_decision.call_args.kwargs
+        assert "coder" in call_kwargs["question"]
+        assert call_kwargs["options"] == [
+            "Retry phase",
+            "Accept current state",
+            "Abort phase",
+        ]
+        assert "INCOMPLETE CONSENSUS" in logs
+
+
+class TestIncompleteConsensusWithFailures:
+    """Issue #2203: container failures + incomplete consensus must create
+    an HITL decision rather than failing the phase silently."""
+
+    @patch("routes.pipelines.time.sleep")
+    @patch("routes.pipelines.time.monotonic")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
+    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
+    def test_failure_with_unresolved_nacks_creates_hitl_decision(
+        self, MockExecutor, mock_prompt, mock_lock, mock_monotonic, mock_sleep
+    ):
+        """Container exit-1 + incomplete consensus + unresolved NACKs."""
+        from routes.pipelines import _run_concurrent_phase
+
+        mock_monotonic.return_value = 0.0
+
+        executions = [
+            _make_execution(AgentRole.CODER, "coder-1"),
+            _make_execution(AgentRole.REVIEWER_CODE, "reviewer-1"),
+        ]
+
+        container_infos = {
+            "coder-1": ContainerInfo(
+                container_id="coder-1",
+                container_name="issue-999-coder",
+                status=ContainerStatus.EXITED,
+                exit_code=1,
+                exited_at=datetime.now(UTC),
+            ),
+            "reviewer-1": ContainerInfo(
+                container_id="reviewer-1",
+                container_name="issue-999-reviewer_code",
+                status=ContainerStatus.EXITED,
+                exit_code=0,
+                exited_at=datetime.now(UTC),
+            ),
+        }
+
+        pipeline, mock_store, mock_spawner, mock_docker = _base_mocks(
+            executions, container_infos=container_infos
         )
 
-        # Issue #1581: clean exit without consensus must return failure
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        mock_executor_instance.check_consensus.return_value = {
+            "is_complete": False,
+            "has_objections": False,
+            "has_unresolved_nacks": True,
+            "unresolved_nacks": [
+                {
+                    "reviewer": "reviewer_code",
+                    "producer": "coder",
+                    "reason": "Run-loop wire-up missing",
+                    "version": 2,
+                },
+            ],
+            "blocking_agents": ["coder"],
+        }
+        MockExecutor.return_value = mock_executor_instance
+
+        mock_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_add_decision = MagicMock(return_value=MagicMock(id="dec-1"))
+        with patch.object(type(pipeline), "add_decision", mock_add_decision):
+            exit_code, logs = _run_concurrent_phase(
+                pipeline_id="issue-999",
+                pipeline=pipeline,
+                phase="implement",
+                spawner=mock_spawner,
+                store=mock_store,
+                **_CALL_ARGS,
+            )
+
         assert exit_code == 1
+        mock_add_decision.assert_called_once()
+        call_kwargs = mock_add_decision.call_args.kwargs
+        assert "Run-loop wire-up missing" in call_kwargs["question"]
+        assert "1 container(s) exited with non-zero" in call_kwargs["question"]
+        assert call_kwargs["options"] == [
+            "Retry phase",
+            "Accept current state",
+            "Abort phase",
+        ]
+        assert "INCOMPLETE CONSENSUS / UNRESOLVED NACKs" in logs
+
+    @patch("routes.pipelines.time.sleep")
+    @patch("routes.pipelines.time.monotonic")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
+    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
+    def test_failure_no_nacks_blocking_agents_creates_hitl_decision(
+        self, MockExecutor, mock_prompt, mock_lock, mock_monotonic, mock_sleep
+    ):
+        """Container exit-1, no NACKs, but agents never confirmed."""
+        from routes.pipelines import _run_concurrent_phase
+
+        mock_monotonic.return_value = 0.0
+
+        executions = [_make_execution(AgentRole.CODER, "coder-1")]
+        container_infos = {
+            "coder-1": ContainerInfo(
+                container_id="coder-1",
+                container_name="issue-999-coder",
+                status=ContainerStatus.EXITED,
+                exit_code=1,
+                exited_at=datetime.now(UTC),
+            ),
+        }
+
+        pipeline, mock_store, mock_spawner, mock_docker = _base_mocks(
+            executions, container_infos=container_infos
+        )
+
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        mock_executor_instance.check_consensus.return_value = {
+            "is_complete": False,
+            "has_objections": False,
+            "has_unresolved_nacks": False,
+            "unresolved_nacks": [],
+            "blocking_agents": ["coder", "reviewer_code"],
+        }
+        MockExecutor.return_value = mock_executor_instance
+
+        mock_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_add_decision = MagicMock(return_value=MagicMock(id="dec-1"))
+        with patch.object(type(pipeline), "add_decision", mock_add_decision):
+            exit_code, logs = _run_concurrent_phase(
+                pipeline_id="issue-999",
+                pipeline=pipeline,
+                phase="implement",
+                spawner=mock_spawner,
+                store=mock_store,
+                **_CALL_ARGS,
+            )
+
+        assert exit_code == 1
+        mock_add_decision.assert_called_once()
+        call_kwargs = mock_add_decision.call_args.kwargs
+        assert "coder" in call_kwargs["question"]
+        assert "reviewer_code" in call_kwargs["question"]
+        assert "never confirmed" in call_kwargs["question"]
+        assert "INCOMPLETE CONSENSUS / NO CONFIRMATION" in logs
+
+    @patch("routes.pipelines.time.sleep")
+    @patch("routes.pipelines.time.monotonic")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
+    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
+    def test_add_decision_failure_does_not_break_return(
+        self, MockExecutor, mock_prompt, mock_lock, mock_monotonic, mock_sleep
+    ):
+        """If add_decision raises, the phase still returns (1, ...) cleanly."""
+        from routes.pipelines import _run_concurrent_phase
+
+        mock_monotonic.return_value = 0.0
+
+        executions = [_make_execution(AgentRole.CODER, "coder-1")]
+        container_infos = {
+            "coder-1": ContainerInfo(
+                container_id="coder-1",
+                container_name="issue-999-coder",
+                status=ContainerStatus.EXITED,
+                exit_code=1,
+                exited_at=datetime.now(UTC),
+            ),
+        }
+
+        pipeline, mock_store, mock_spawner, mock_docker = _base_mocks(
+            executions, container_infos=container_infos
+        )
+
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        mock_executor_instance.check_consensus.return_value = {
+            "is_complete": False,
+            "has_objections": False,
+            "has_unresolved_nacks": False,
+            "unresolved_nacks": [],
+            "blocking_agents": ["coder"],
+        }
+        MockExecutor.return_value = mock_executor_instance
+
+        mock_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_add_decision = MagicMock(side_effect=RuntimeError("decision store down"))
+        with patch.object(type(pipeline), "add_decision", mock_add_decision):
+            exit_code, logs = _run_concurrent_phase(
+                pipeline_id="issue-999",
+                pipeline=pipeline,
+                phase="implement",
+                spawner=mock_spawner,
+                store=mock_store,
+                **_CALL_ARGS,
+            )
+
+        assert exit_code == 1
+        mock_add_decision.assert_called_once()
 
 
 class TestTimeoutWithNacks:

--- a/orchestrator/tests/test_brc_nack_iteration.py
+++ b/orchestrator/tests/test_brc_nack_iteration.py
@@ -195,14 +195,36 @@ def _make_phase_execution():
     )
 
 
+def _make_real_store(pipeline):
+    """MagicMock store that round-trips a real Pipeline through load/save.
+
+    Preserves the MagicMock surface for tests that already inspect call
+    history while making ``load`` return the latest persisted state and
+    ``save`` update it.  The HITL persistence path the issue #2208
+    review flagged is then observable through
+    ``store.load_pipeline(...).decisions`` after ``_run_concurrent_phase``
+    returns — and a missing ``save_pipeline`` call would be visible
+    because the held Pipeline is intentionally a *different object* from
+    the in-memory ``pipeline`` argument.
+    """
+    holder = {"pipeline": pipeline}
+    store = MagicMock()
+    store.load_pipeline.side_effect = lambda _pid: holder["pipeline"]
+
+    def _save(p):
+        holder["pipeline"] = p
+
+    store.save_pipeline.side_effect = _save
+    return store
+
+
 def _base_mocks(executions, container_infos=None):
     pipeline = _make_concurrent_pipeline()
-    phase_exec = _make_phase_execution()
-
-    mock_store = MagicMock()
-    mock_pipeline_state = MagicMock()
-    mock_pipeline_state.get_phase_execution.return_value = phase_exec
-    mock_store.load_pipeline.return_value = mock_pipeline_state
+    # Disk-side pipeline mirrors the in-memory one but is a distinct
+    # object; tests assert HITL decisions land on this side, mirroring
+    # what /sdlc reads from disk.
+    disk_pipeline = _make_concurrent_pipeline()
+    mock_store = _make_real_store(disk_pipeline)
 
     mock_docker = MagicMock()
 
@@ -360,29 +382,33 @@ class TestPollingLoopWithNacks:
         mock_lock.return_value.__enter__ = MagicMock(return_value=None)
         mock_lock.return_value.__exit__ = MagicMock(return_value=False)
 
-        mock_add_decision = MagicMock(return_value=MagicMock(id="dec-1"))
-        with patch.object(type(pipeline), "add_decision", mock_add_decision):
-            exit_code, logs = _run_concurrent_phase(
-                pipeline_id="issue-999",
-                pipeline=pipeline,
-                phase="implement",
-                spawner=mock_spawner,
-                store=mock_store,
-                **_CALL_ARGS,
-            )
+        exit_code, logs = _run_concurrent_phase(
+            pipeline_id="issue-999",
+            pipeline=pipeline,
+            phase="implement",
+            spawner=mock_spawner,
+            store=mock_store,
+            **_CALL_ARGS,
+        )
 
         # Issue #1581: clean exit without consensus must return failure.
         assert exit_code == 1
         # Issue #2203: it must also surface an HITL decision so the
         # operator can drive recovery without out-of-band investigation.
-        mock_add_decision.assert_called_once()
-        call_kwargs = mock_add_decision.call_args.kwargs
-        assert "coder" in call_kwargs["question"]
-        assert call_kwargs["options"] == [
+        # Assert via the on-disk pipeline (round-tripped through
+        # save_pipeline/load_pipeline) — a missing save in
+        # `_persist_hitl_decision` would surface here.
+        disk_decisions = mock_store.load_pipeline("issue-999").decisions
+        assert len(disk_decisions) == 1
+        decision = disk_decisions[0]
+        assert "coder" in decision.question
+        assert decision.options == [
             "Retry phase",
             "Accept current state",
             "Abort phase",
         ]
+        # The in-memory `pipeline` arg is also synced for caller consistency.
+        assert len(pipeline.decisions) == 1
         assert "INCOMPLETE CONSENSUS" in logs
 
 
@@ -450,27 +476,31 @@ class TestIncompleteConsensusWithFailures:
         mock_lock.return_value.__enter__ = MagicMock(return_value=None)
         mock_lock.return_value.__exit__ = MagicMock(return_value=False)
 
-        mock_add_decision = MagicMock(return_value=MagicMock(id="dec-1"))
-        with patch.object(type(pipeline), "add_decision", mock_add_decision):
-            exit_code, logs = _run_concurrent_phase(
-                pipeline_id="issue-999",
-                pipeline=pipeline,
-                phase="implement",
-                spawner=mock_spawner,
-                store=mock_store,
-                **_CALL_ARGS,
-            )
+        exit_code, logs = _run_concurrent_phase(
+            pipeline_id="issue-999",
+            pipeline=pipeline,
+            phase="implement",
+            spawner=mock_spawner,
+            store=mock_store,
+            **_CALL_ARGS,
+        )
 
         assert exit_code == 1
-        mock_add_decision.assert_called_once()
-        call_kwargs = mock_add_decision.call_args.kwargs
-        assert "Run-loop wire-up missing" in call_kwargs["question"]
-        assert "1 container(s) exited with non-zero" in call_kwargs["question"]
-        assert call_kwargs["options"] == [
+        # Assert against the on-disk pipeline so a missing save_pipeline
+        # would fail the test (issue #2208 review): `add_decision` on the
+        # in-memory ref alone is not enough — `/sdlc` reads the persisted
+        # state.
+        disk_decisions = mock_store.load_pipeline("issue-999").decisions
+        assert len(disk_decisions) == 1
+        decision = disk_decisions[0]
+        assert "Run-loop wire-up missing" in decision.question
+        assert "1 container(s) exited with non-zero" in decision.question
+        assert decision.options == [
             "Retry phase",
             "Accept current state",
             "Abort phase",
         ]
+        assert len(pipeline.decisions) == 1
         assert "INCOMPLETE CONSENSUS / UNRESOLVED NACKs" in logs
 
     @patch("routes.pipelines.time.sleep")
@@ -515,23 +545,23 @@ class TestIncompleteConsensusWithFailures:
         mock_lock.return_value.__enter__ = MagicMock(return_value=None)
         mock_lock.return_value.__exit__ = MagicMock(return_value=False)
 
-        mock_add_decision = MagicMock(return_value=MagicMock(id="dec-1"))
-        with patch.object(type(pipeline), "add_decision", mock_add_decision):
-            exit_code, logs = _run_concurrent_phase(
-                pipeline_id="issue-999",
-                pipeline=pipeline,
-                phase="implement",
-                spawner=mock_spawner,
-                store=mock_store,
-                **_CALL_ARGS,
-            )
+        exit_code, logs = _run_concurrent_phase(
+            pipeline_id="issue-999",
+            pipeline=pipeline,
+            phase="implement",
+            spawner=mock_spawner,
+            store=mock_store,
+            **_CALL_ARGS,
+        )
 
         assert exit_code == 1
-        mock_add_decision.assert_called_once()
-        call_kwargs = mock_add_decision.call_args.kwargs
-        assert "coder" in call_kwargs["question"]
-        assert "reviewer_code" in call_kwargs["question"]
-        assert "never confirmed" in call_kwargs["question"]
+        disk_decisions = mock_store.load_pipeline("issue-999").decisions
+        assert len(disk_decisions) == 1
+        decision = disk_decisions[0]
+        assert "coder" in decision.question
+        assert "reviewer_code" in decision.question
+        assert "never confirmed" in decision.question
+        assert len(pipeline.decisions) == 1
         assert "INCOMPLETE CONSENSUS / NO CONFIRMATION" in logs
 
     @patch("routes.pipelines.time.sleep")
@@ -539,10 +569,12 @@ class TestIncompleteConsensusWithFailures:
     @patch("routes.pipelines.get_pipeline_state_lock")
     @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
     @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
-    def test_add_decision_failure_does_not_break_return(
+    def test_persistence_failure_does_not_break_return(
         self, MockExecutor, mock_prompt, mock_lock, mock_monotonic, mock_sleep
     ):
-        """If add_decision raises, the phase still returns (1, ...) cleanly."""
+        """If the store raises during HITL persistence, the phase still
+        returns (1, ...) cleanly — losing the decision is bad, but losing
+        the rest of the cleanup path is worse."""
         from routes.pipelines import _run_concurrent_phase
 
         mock_monotonic.return_value = 0.0
@@ -576,8 +608,19 @@ class TestIncompleteConsensusWithFailures:
         mock_lock.return_value.__enter__ = MagicMock(return_value=None)
         mock_lock.return_value.__exit__ = MagicMock(return_value=False)
 
-        mock_add_decision = MagicMock(side_effect=RuntimeError("decision store down"))
-        with patch.object(type(pipeline), "add_decision", mock_add_decision):
+        # Make save_pipeline raise — _persist_hitl_decision must swallow
+        # the exception and return None, leaving the phase free to fail
+        # the rest of its cleanup path normally.
+        original_save = mock_store.save_pipeline
+        save_calls = {"count": 0}
+
+        def boom(pipeline):
+            save_calls["count"] += 1
+            raise RuntimeError("decision store down")
+
+        mock_store.save_pipeline = boom
+
+        try:
             exit_code, logs = _run_concurrent_phase(
                 pipeline_id="issue-999",
                 pipeline=pipeline,
@@ -586,9 +629,13 @@ class TestIncompleteConsensusWithFailures:
                 store=mock_store,
                 **_CALL_ARGS,
             )
+        finally:
+            mock_store.save_pipeline = original_save
 
         assert exit_code == 1
-        mock_add_decision.assert_called_once()
+        # Persistence was attempted at least once; the decision is lost
+        # (logged) but the phase still returned cleanly.
+        assert save_calls["count"] >= 1
 
 
 class TestTimeoutWithNacks:

--- a/orchestrator/tests/test_brc_nack_iteration.py
+++ b/orchestrator/tests/test_brc_nack_iteration.py
@@ -198,21 +198,25 @@ def _make_phase_execution():
 def _make_real_store(pipeline):
     """MagicMock store that round-trips a real Pipeline through load/save.
 
-    Preserves the MagicMock surface for tests that already inspect call
-    history while making ``load`` return the latest persisted state and
-    ``save`` update it.  The HITL persistence path the issue #2208
-    review flagged is then observable through
-    ``store.load_pipeline(...).decisions`` after ``_run_concurrent_phase``
-    returns — and a missing ``save_pipeline`` call would be visible
-    because the held Pipeline is intentionally a *different object* from
-    the in-memory ``pipeline`` argument.
+    Serializes on save and deserializes on load via Pydantic's
+    ``model_dump_json`` / ``model_validate_json`` so a missing
+    ``save_pipeline`` call after an in-place mutation surfaces as a
+    failed assertion: the in-memory mutation is invisible to the next
+    ``load_pipeline`` because the held state is the JSON snapshot from
+    the last save.  This is the round-trip fidelity the issue #2208
+    re-review asked for — verifying the *persistence* path, not just
+    that ``add_decision`` was called.
+
+    Preserves the MagicMock surface (``load_pipeline.call_count``,
+    ``save_pipeline.call_args_list``) for tests that inspect call
+    history.
     """
-    holder = {"pipeline": pipeline}
+    holder = {"json": pipeline.model_dump_json()}
     store = MagicMock()
-    store.load_pipeline.side_effect = lambda _pid: holder["pipeline"]
+    store.load_pipeline.side_effect = lambda _pid: Pipeline.model_validate_json(holder["json"])
 
     def _save(p):
-        holder["pipeline"] = p
+        holder["json"] = p.model_dump_json()
 
     store.save_pipeline.side_effect = _save
     return store

--- a/orchestrator/tests/test_consensus_polling.py
+++ b/orchestrator/tests/test_consensus_polling.py
@@ -452,11 +452,24 @@ class TestObjectionHandling:
                 **_CALL_ARGS,
             )
 
-        # add_decision called exactly once despite multiple polls with objections
-        mock_add_decision.assert_called_once()
-        call_args = mock_add_decision.call_args
-        question = call_args[1].get("question", call_args[0][0] if call_args[0] else "")
-        assert "objecting" in question.lower()
+        # The objection HITL is created exactly once despite multiple polls
+        # with objections (the deduplication this test is really about).
+        # Issue #2203 added a separate incomplete-consensus HITL that also
+        # fires when containers exit cleanly without consensus closing —
+        # that's a distinct decision and is expected here.
+        objection_calls = [
+            c
+            for c in mock_add_decision.call_args_list
+            if "objecting" in c.kwargs.get("question", "").lower()
+        ]
+        assert len(objection_calls) == 1
+        incomplete_calls = [
+            c
+            for c in mock_add_decision.call_args_list
+            if "INCOMPLETE CONSENSUS" in c.kwargs.get("question", "")
+            or "consensus incomplete" in c.kwargs.get("question", "")
+        ]
+        assert len(incomplete_calls) == 1
 
 
 class TestContainerExitFallback:

--- a/orchestrator/tests/test_consensus_polling.py
+++ b/orchestrator/tests/test_consensus_polling.py
@@ -64,6 +64,30 @@ def _make_phase_execution():
     )
 
 
+def _make_real_store(pipeline):
+    """MagicMock store that round-trips a real Pipeline through load/save.
+
+    Preserves the MagicMock surface (``load_pipeline.call_count``,
+    ``save_pipeline.call_args_list``) for tests that already inspect
+    call history, while ``load`` returns the latest persisted state
+    and ``save`` updates it.  This lets HITL persistence be observed
+    through ``store.load_pipeline(...).decisions`` after
+    ``_run_concurrent_phase`` returns — the round-trip the issue #2208
+    review asked for.  The held Pipeline is intentionally distinct from
+    the ``pipeline`` argument passed to the function under test so a
+    missing ``save_pipeline`` call would fail the assertion.
+    """
+    holder = {"pipeline": pipeline}
+    store = MagicMock()
+    store.load_pipeline.side_effect = lambda _pid: holder["pipeline"]
+
+    def _save(p):
+        holder["pipeline"] = p
+
+    store.save_pipeline.side_effect = _save
+    return store
+
+
 def _base_mocks(executions, container_infos=None):
     """Create common mocks for the consensus polling tests.
 
@@ -73,12 +97,11 @@ def _base_mocks(executions, container_infos=None):
             Defaults to RUNNING status for all containers.
     """
     pipeline = _make_concurrent_pipeline()
-    phase_exec = _make_phase_execution()
-
-    mock_store = MagicMock()
-    mock_pipeline_state = MagicMock()
-    mock_pipeline_state.get_phase_execution.return_value = phase_exec
-    mock_store.load_pipeline.return_value = mock_pipeline_state
+    # Disk-side pipeline mirrors the in-memory one but is a distinct
+    # object; tests assert HITL decisions land on this side, mirroring
+    # what /sdlc reads from disk.
+    disk_pipeline = _make_concurrent_pipeline()
+    mock_store = _make_real_store(disk_pipeline)
 
     mock_docker = MagicMock()
 
@@ -389,10 +412,12 @@ class TestObjectionHandling:
     @patch("routes.pipelines.get_pipeline_state_lock")
     @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
     @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
-    def test_objection_creates_hitl_decision_once(
+    def test_objection_dedup_distinct_from_incomplete_consensus_hitl(
         self, MockExecutor, mock_prompt, mock_lock, mock_monotonic, mock_sleep
     ):
-        """When has_objections=True, a HITL decision is created only once."""
+        """The objection HITL is created exactly once despite repeated polls
+        with ``has_objections=True``; it's a distinct decision from the
+        incomplete-consensus HITL that fires once at exit (issue #2203)."""
         poll_count = [0]
 
         def _monotonic():
@@ -441,35 +466,32 @@ class TestObjectionHandling:
         mock_lock.return_value.__enter__ = MagicMock(return_value=None)
         mock_lock.return_value.__exit__ = MagicMock(return_value=False)
 
-        mock_add_decision = MagicMock(return_value=MagicMock(id="dec-1"))
-        with patch.object(type(pipeline), "add_decision", mock_add_decision):
-            _run_concurrent_phase(
-                pipeline_id="issue-999",
-                pipeline=pipeline,
-                phase="implement",
-                spawner=mock_spawner,
-                store=mock_store,
-                **_CALL_ARGS,
-            )
+        _run_concurrent_phase(
+            pipeline_id="issue-999",
+            pipeline=pipeline,
+            phase="implement",
+            spawner=mock_spawner,
+            store=mock_store,
+            **_CALL_ARGS,
+        )
 
-        # The objection HITL is created exactly once despite multiple polls
-        # with objections (the deduplication this test is really about).
-        # Issue #2203 added a separate incomplete-consensus HITL that also
-        # fires when containers exit cleanly without consensus closing —
-        # that's a distinct decision and is expected here.
-        objection_calls = [
-            c
-            for c in mock_add_decision.call_args_list
-            if "objecting" in c.kwargs.get("question", "").lower()
+        # Read the persisted (round-tripped) decisions to verify what
+        # ``/sdlc`` would actually see.  Issue #2208 review pointed out
+        # that asserting only on ``add_decision`` call shape masks
+        # missing-save bugs.
+        disk_decisions = mock_store.load_pipeline("issue-999").decisions
+        objection_decisions = [d for d in disk_decisions if "objecting" in d.question.lower()]
+        # Deduplication: only one objection HITL despite repeated polls.
+        assert len(objection_decisions) == 1
+        # Plus exactly one incomplete-consensus HITL fired at exit
+        # (clean-exit-without-consensus path, issue #2203).
+        incomplete_decisions = [
+            d for d in disk_decisions if "consensus incomplete" in d.question.lower()
         ]
-        assert len(objection_calls) == 1
-        incomplete_calls = [
-            c
-            for c in mock_add_decision.call_args_list
-            if "INCOMPLETE CONSENSUS" in c.kwargs.get("question", "")
-            or "consensus incomplete" in c.kwargs.get("question", "")
-        ]
-        assert len(incomplete_calls) == 1
+        assert len(incomplete_decisions) == 1
+        # The two decisions carry different option lists — they convey
+        # different operator actions and are intentionally distinct.
+        assert objection_decisions[0].options != incomplete_decisions[0].options
 
 
 class TestContainerExitFallback:
@@ -922,10 +944,11 @@ class TestFailedRecovery:
         pipeline, mock_store, mock_spawner, mock_docker = _base_mocks(executions)
 
         # Simulate the reconciliation thread marking the pipeline FAILED.
-        # load_pipeline returns a mock with status=FAILED for the recovery check.
-        mock_pipeline_state = mock_store.load_pipeline.return_value
-        mock_pipeline_state.status = PipelineStatus.FAILED
-        mock_pipeline_state.error = "Container exited unexpectedly"
+        # The in-memory _InMemoryStore holds a real Pipeline; mutate its
+        # status so subsequent load_pipeline() calls observe FAILED.
+        disk_pipeline = mock_store.load_pipeline("issue-999")
+        disk_pipeline.status = PipelineStatus.FAILED
+        disk_pipeline.error = "Container exited unexpectedly"
 
         def _check_consensus():
             poll_count[0] += 1
@@ -984,9 +1007,9 @@ class TestFailedRecovery:
         executions = [_make_execution(AgentRole.CODER, "coder-1")]
         pipeline, mock_store, mock_spawner, mock_docker = _base_mocks(executions)
 
-        # Pipeline is RUNNING (normal state) — recovery should not trigger.
-        mock_pipeline_state = mock_store.load_pipeline.return_value
-        mock_pipeline_state.status = PipelineStatus.RUNNING
+        # Pipeline is RUNNING (normal state, from _make_concurrent_pipeline)
+        # — recovery should not trigger.
+        assert mock_store.load_pipeline("issue-999").status == PipelineStatus.RUNNING
 
         mock_executor_instance = MagicMock()
         mock_executor_instance.spawn_all.return_value = executions
@@ -1068,7 +1091,10 @@ class TestUpdateAgentsCompleteContainerCleanup:
                 )
             )
 
-        mock_store.load_pipeline.return_value = real_pipeline
+        # Override the in-memory store's held pipeline so subsequent
+        # load_pipeline() calls observe the test's pre-populated state
+        # (containers + agents).  Saves continue to update the holder.
+        mock_store.load_pipeline.side_effect = lambda _pid: real_pipeline
 
         mock_executor_instance = MagicMock()
         mock_executor_instance.spawn_all.return_value = executions

--- a/orchestrator/tests/test_consensus_polling.py
+++ b/orchestrator/tests/test_consensus_polling.py
@@ -67,22 +67,25 @@ def _make_phase_execution():
 def _make_real_store(pipeline):
     """MagicMock store that round-trips a real Pipeline through load/save.
 
+    Serializes on save and deserializes on load via Pydantic's
+    ``model_dump_json`` / ``model_validate_json`` so a missing
+    ``save_pipeline`` call after an in-place mutation surfaces as a
+    failed assertion: the in-memory mutation is invisible to the next
+    ``load_pipeline`` because the held state is the JSON snapshot from
+    the last save.  This is the round-trip fidelity the issue #2208
+    re-review asked for — verifying the *persistence* path, not just
+    that ``add_decision`` was called.
+
     Preserves the MagicMock surface (``load_pipeline.call_count``,
-    ``save_pipeline.call_args_list``) for tests that already inspect
-    call history, while ``load`` returns the latest persisted state
-    and ``save`` updates it.  This lets HITL persistence be observed
-    through ``store.load_pipeline(...).decisions`` after
-    ``_run_concurrent_phase`` returns — the round-trip the issue #2208
-    review asked for.  The held Pipeline is intentionally distinct from
-    the ``pipeline`` argument passed to the function under test so a
-    missing ``save_pipeline`` call would fail the assertion.
+    ``save_pipeline.call_args_list``) for tests that inspect call
+    history.
     """
-    holder = {"pipeline": pipeline}
+    holder = {"json": pipeline.model_dump_json()}
     store = MagicMock()
-    store.load_pipeline.side_effect = lambda _pid: holder["pipeline"]
+    store.load_pipeline.side_effect = lambda _pid: Pipeline.model_validate_json(holder["json"])
 
     def _save(p):
-        holder["pipeline"] = p
+        holder["json"] = p.model_dump_json()
 
     store.save_pipeline.side_effect = _save
     return store
@@ -944,11 +947,12 @@ class TestFailedRecovery:
         pipeline, mock_store, mock_spawner, mock_docker = _base_mocks(executions)
 
         # Simulate the reconciliation thread marking the pipeline FAILED.
-        # The in-memory _InMemoryStore holds a real Pipeline; mutate its
-        # status so subsequent load_pipeline() calls observe FAILED.
+        # The store round-trips through JSON, so mutate then save back to
+        # update the held snapshot.
         disk_pipeline = mock_store.load_pipeline("issue-999")
         disk_pipeline.status = PipelineStatus.FAILED
         disk_pipeline.error = "Container exited unexpectedly"
+        mock_store.save_pipeline(disk_pipeline)
 
         def _check_consensus():
             poll_count[0] += 1
@@ -985,11 +989,15 @@ class TestFailedRecovery:
         # and _update_agents_complete.  The extra lock (vs 2 in normal case)
         # proves recovery ran.
         assert mock_lock.call_count == 3
-        # Verify save_pipeline was called to persist recovery.
+        # Verify save_pipeline was called to persist recovery.  The first
+        # save is the test's own setup (writing FAILED to the holder); the
+        # recovery save is the next one — find it by status.
         save_calls = mock_store.save_pipeline.call_args_list
-        assert len(save_calls) >= 1
-        recovered = save_calls[0][0][0]  # first save is from recovery
-        assert recovered.status == PipelineStatus.RUNNING
+        recovered = next(
+            (call[0][0] for call in save_calls if call[0][0].status == PipelineStatus.RUNNING),
+            None,
+        )
+        assert recovered is not None, "recovery save not found"
         assert recovered.error is None
 
     @patch("routes.pipelines.time.sleep")

--- a/orchestrator/tests/test_pipelines_routes.py
+++ b/orchestrator/tests/test_pipelines_routes.py
@@ -20,6 +20,20 @@ def pipeline():
     return p
 
 
+def _make_store(pipeline):
+    """MagicMock store whose load/save round-trip the in-memory pipeline.
+
+    `_persist_hitl_decision` does load → mutate → save. Returning the
+    same pipeline from `load_pipeline` keeps the test assertions on
+    `pipeline.decisions` working without inventing a separate disk-side
+    Pipeline (issue #2208 review asked HITL writes go through the store).
+    """
+    store = MagicMock()
+    store.load_pipeline.side_effect = lambda _pid: pipeline
+    store.save_pipeline.side_effect = lambda _p: None
+    return store
+
+
 class TestHandleBrcConsensusTimeout:
     """The timeout handler must reach add_decision under k3s's module layout.
 
@@ -30,12 +44,14 @@ class TestHandleBrcConsensusTimeout:
 
     @patch("routes.pipelines._emit_event")
     def test_no_brc_tracker_queues_hitl_decision(self, mock_emit, pipeline):
+        store = _make_store(pipeline)
         with patch("peer_consensus.get_peer_consensus_tracker", return_value=None):
             _handle_brc_consensus_timeout(
                 pipeline,
                 pipeline.id,
                 consensus_timeout=1800.0,
                 blocking_agents=["reviewer_code"],
+                store=store,
             )
 
         assert len(pipeline.decisions) == 1
@@ -51,6 +67,7 @@ class TestHandleBrcConsensusTimeout:
 
     @patch("routes.pipelines._emit_event")
     def test_brc_escalate_queues_hitl_decision(self, mock_emit, pipeline):
+        store = _make_store(pipeline)
         tracker = MagicMock()
         tracker.handle_timeout.return_value = {"action": "escalate"}
         tracker.is_timeout_handled.return_value = True
@@ -61,6 +78,7 @@ class TestHandleBrcConsensusTimeout:
                 pipeline.id,
                 consensus_timeout=1800.0,
                 blocking_agents=[],
+                store=store,
             )
 
         assert len(pipeline.decisions) == 1
@@ -69,6 +87,7 @@ class TestHandleBrcConsensusTimeout:
 
     @patch("routes.pipelines._emit_event")
     def test_brc_handled_without_escalate_no_decision(self, mock_emit, pipeline):
+        store = _make_store(pipeline)
         tracker = MagicMock()
         tracker.handle_timeout.return_value = {"action": "proceed"}
         tracker.is_timeout_handled.return_value = True
@@ -79,6 +98,7 @@ class TestHandleBrcConsensusTimeout:
                 pipeline.id,
                 consensus_timeout=1800.0,
                 blocking_agents=[],
+                store=store,
             )
 
         assert len(pipeline.decisions) == 0
@@ -90,6 +110,7 @@ class TestHandleBrcConsensusTimeout:
         # Regression test for issue #1783: bare relative import raised
         # ImportError under k3s, and the outer except caught it but the
         # HITL decision must still be created via the fallback path.
+        store = _make_store(pipeline)
         with patch(
             "peer_consensus.get_peer_consensus_tracker",
             side_effect=ImportError("simulated k3s import failure"),
@@ -99,6 +120,7 @@ class TestHandleBrcConsensusTimeout:
                 pipeline.id,
                 consensus_timeout=1800.0,
                 blocking_agents=["reviewer_code"],
+                store=store,
             )
 
         # The warning log records the import failure
@@ -123,6 +145,10 @@ class TestHandleBrcConsensusTimeout:
     def test_add_decision_failure_is_logged_not_swallowed(self, mock_emit, mock_logger, pipeline):
         # Covers the issue #1783 second-order bug: the except Exception: pass
         # at the old decision-queue call sites hid stall-causing failures.
+        # Post-#2208 review: persistence routes through `_persist_hitl_decision`,
+        # which catches and logs at WARNING with exc_info so the original
+        # traceback survives — still not swallowed.
+        store = _make_store(pipeline)
         with (
             patch("peer_consensus.get_peer_consensus_tracker", return_value=None),
             patch.object(Pipeline, "add_decision", side_effect=RuntimeError("boom")),
@@ -132,10 +158,17 @@ class TestHandleBrcConsensusTimeout:
                 pipeline.id,
                 consensus_timeout=1800.0,
                 blocking_agents=[],
+                store=store,
             )
 
-        error_calls = list(mock_logger.error.call_args_list)
-        assert error_calls, "add_decision failure must be logged at ERROR"
-        _, kwargs = error_calls[0]
+        # `_persist_hitl_decision` logs the failure with exc_info so the
+        # traceback is preserved rather than swallowed.
+        warning_calls = [
+            call
+            for call in mock_logger.warning.call_args_list
+            if call.args and "Failed to persist HITL decision" in call.args[0]
+        ]
+        assert warning_calls, "add_decision failure must be logged with exc_info"
+        _, kwargs = warning_calls[0]
         assert kwargs.get("pipeline_id") == pipeline.id
-        assert "boom" in kwargs.get("error", "")
+        assert kwargs.get("exc_info") is True


### PR DESCRIPTION
## Summary

- When all containers exited and BRC consensus was incomplete, the implement phase failed terminally with no HITL decision. The operator had to investigate out-of-band to discover that `restart_phase` would recover the pipeline (committed work is preserved on the per-role branch).
- Both the `has_failures` and clean-exit incomplete-consensus paths now create an HITL decision with options `["Retry phase", "Accept current state", "Abort phase"]`, mirroring the existing branch-A pattern at `pipelines.py:10081`.
- A new helper `_incomplete_consensus_decision_text` distinguishes the two underlying causes — unresolved NACKs vs. agents that never confirmed — so the operator sees actionable detail in `/sdlc`.

## Why it was wrong

Per #2203:
1. The agent's work is intact on the per-role branch.
2. The reviewers' NACKs (or blocking agents) carry actionable signal.
3. `restart_phase` already exists and works — the operator just needed to be told.

## Test plan

- [x] 3 new tests in `test_brc_nack_iteration.py::TestIncompleteConsensusWithFailures`:
  - `test_failure_with_unresolved_nacks_creates_hitl_decision` — primary bug scenario from issue-2137 (container exit-1 + unresolved NACKs).
  - `test_failure_no_nacks_blocking_agents_creates_hitl_decision` — same shape but blocking on missing confirmations.
  - `test_add_decision_failure_does_not_break_return` — defensive: `add_decision` raising must not break the `(1, logs)` return.
- [x] Updated `test_containers_exit_without_nacks_returns_failure_without_consensus` (the symmetric clean-exit path) to assert the HITL decision is created.
- [x] Updated `test_objection_creates_hitl_decision_once` — the objection HITL is still created exactly once across polls; the new incomplete-consensus HITL fires once at exit. Both behaviors are now asserted.
- [x] `make lint` (ruff check + ruff format) clean on changed files.
- [x] `pytest orchestrator/tests/test_brc_nack_iteration.py orchestrator/tests/test_consensus_polling.py orchestrator/tests/test_concurrent_executor.py orchestrator/tests/test_consensus_race_on_exit.py orchestrator/tests/test_consensus_timeout_recheck.py orchestrator/tests/test_producer_push_consensus.py` — all pass.
- [ ] End-to-end verification on a live pipeline with a producer container exiting non-zero before consensus closes.

## Out of scope

- The decision-registration UX gap from issue-2137 (agent filed `OVERSEER_ALERT` instead of HITL `register_open_question`) — separate ticket (#2204).
- Distinguishing exit-1 root causes (routine NACK exit vs. real crash) — both should reach HITL.

Fixes #2203