### PR TITLE
Fix #2205: preserve per-role exit info on PhaseExecution.agent_exits

### DIFF
--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -264,6 +264,27 @@ class CycleTiming(BaseModel):
     )
 
 
+class AgentExitInfo(BaseModel):
+    """Per-role exit record preserved across phase failure cleanup.
+
+    Captured when a container exits during concurrent BRC execution, so
+    operators can triage which role failed and what it said last even after
+    container cleanup. See issue #2205.
+    """
+
+    role: AgentRole = Field(..., description="Agent role that exited")
+    exit_code: int = Field(..., description="Container exit code")
+    last_lines: list[str] = Field(
+        default_factory=list,
+        description="Tail of container stdout/stderr (up to 200 lines)",
+    )
+    terminated_at: datetime = Field(..., description="When the container exit was observed")
+    container_id: str | None = Field(
+        default=None,
+        description="Container ID at time of exit (may be unresolvable post-cleanup)",
+    )
+
+
 class PhaseExecution(BaseModel):
     """State of a single phase execution."""
 
@@ -294,6 +315,14 @@ class PhaseExecution(BaseModel):
     phase_start_sha: str | None = Field(
         default=None,
         description="Branch tip SHA at phase start, for completion signal verification",
+    )
+    agent_exits: list[AgentExitInfo] = Field(
+        default_factory=list,
+        description=(
+            "Per-role exit records from concurrent BRC execution. Populated by "
+            "_record_container_exit. Survives container cleanup so failure triage "
+            "remains possible. See issue #2205."
+        ),
     )
 
 

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -265,15 +265,26 @@ class CycleTiming(BaseModel):
 
 
 class AgentExitInfo(BaseModel):
-    """Per-role exit record preserved across phase failure cleanup.
+    """Frozen-at-exit snapshot preserved across phase failure cleanup.
 
     Captured when a container exits during concurrent BRC execution, so
     operators can triage which role failed and what it said last even after
-    container cleanup. See issue #2205.
+    container cleanup. Field overlap with `AgentExecution` (role,
+    container_id) and `ContainerInfo` (exit_code, exited_at) is intentional:
+    those live structures may be mutated or removed during cleanup, while
+    this snapshot is immutable history. Only `last_lines` is genuinely new.
+    See issue #2205.
     """
 
     role: AgentRole = Field(..., description="Agent role that exited")
-    exit_code: int = Field(..., description="Container exit code")
+    exit_code: int | None = Field(
+        ...,
+        description=(
+            "Container exit code. None when the pod-phase race surfaces "
+            "an exit before container_statuses[0].state.terminated is "
+            "populated (matches ContainerInfo.exit_code)."
+        ),
+    )
     last_lines: list[str] = Field(
         default_factory=list,
         description="Tail of container stdout/stderr (up to 200 lines)",
@@ -319,9 +330,10 @@ class PhaseExecution(BaseModel):
     agent_exits: list[AgentExitInfo] = Field(
         default_factory=list,
         description=(
-            "Per-role exit records from concurrent BRC execution. Populated by "
-            "_record_container_exit. Survives container cleanup so failure triage "
-            "remains possible. See issue #2205."
+            "Frozen-at-exit snapshots from concurrent BRC execution. Populated "
+            "by _record_container_exit and never mutated afterwards — use this "
+            "for post-mortem triage. The live agents/containers lists are the "
+            "source of truth while the phase is running. See issue #2205."
         ),
     )
 

--- a/orchestrator/routes/phases.py
+++ b/orchestrator/routes/phases.py
@@ -206,6 +206,9 @@ def get_current_phase(pipeline_id: str) -> tuple[Response, int]:
                         }
                         for ct in phase_execution.cycle_timings
                     ],
+                    "agent_exits": [
+                        ae.model_dump(mode="json") for ae in phase_execution.agent_exits
+                    ],
                 },
             },
         )

--- a/orchestrator/routes/phases.py
+++ b/orchestrator/routes/phases.py
@@ -196,15 +196,7 @@ def get_current_phase(pipeline_id: str) -> tuple[Response, int]:
                     "review_cycles": phase_execution.review_cycles,
                     "hitl_review_cycles": phase_execution.hitl_review_cycles,
                     "cycle_timings": [
-                        {
-                            "cycle": ct.cycle,
-                            "started_at": ct.started_at.isoformat() if ct.started_at else None,
-                            "completed_at": ct.completed_at.isoformat()
-                            if ct.completed_at
-                            else None,
-                            "commit_sha": ct.commit_sha,
-                        }
-                        for ct in phase_execution.cycle_timings
+                        ct.model_dump(mode="json") for ct in phase_execution.cycle_timings
                     ],
                     "agent_exits": [
                         ae.model_dump(mode="json") for ae in phase_execution.agent_exits

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9737,11 +9737,19 @@ def _run_concurrent_phase(
                                 agent.error = f"Container exited with code {final_info.exit_code}"
                             break
 
+                    # Cap each tail line at 4096 chars: containers that print
+                    # large JSON blobs on one line could otherwise persist
+                    # multi-MB lines into pipeline state on every chatty exit.
+                    last_lines = (
+                        [ln[:4096] for ln in container_logs.splitlines()[-200:]]
+                        if container_logs
+                        else []
+                    )
                     pe.agent_exits.append(
                         AgentExitInfo(
                             role=exec_info.role,
                             exit_code=final_info.exit_code,
-                            last_lines=container_logs.splitlines()[-200:] if container_logs else [],
+                            last_lines=last_lines,
                             terminated_at=datetime.now(UTC),
                             container_id=exec_info.container_id,
                         )

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -69,6 +69,7 @@ try:
     from ..kubernetes_spawner import KubernetesSpawnError, get_kubernetes_spawner
     from ..models import (
         AgentExecutionStatus,
+        AgentExitInfo,
         AgentRole,
         AggregatedReviewResult,
         ContainerStatus,
@@ -114,6 +115,7 @@ except ImportError:
     )
     from models import (  # type: ignore
         AgentExecutionStatus,
+        AgentExitInfo,
         AgentRole,
         AggregatedReviewResult,
         ContainerStatus,
@@ -9734,6 +9736,16 @@ def _run_concurrent_phase(
                                 agent.status = StateAgentStatus.FAILED
                                 agent.error = f"Container exited with code {final_info.exit_code}"
                             break
+
+                    pe.agent_exits.append(
+                        AgentExitInfo(
+                            role=exec_info.role,
+                            exit_code=final_info.exit_code,
+                            last_lines=container_logs.splitlines()[-200:] if container_logs else [],
+                            terminated_at=datetime.now(UTC),
+                            container_id=exec_info.container_id,
+                        )
+                    )
 
                     store.save_pipeline(pip)
             except Exception as track_err:

--- a/orchestrator/tests/test_agent_exits_recorded.py
+++ b/orchestrator/tests/test_agent_exits_recorded.py
@@ -1,0 +1,265 @@
+"""Tests for issue #2205: per-role exit info preserved on PhaseExecution.
+
+`_record_container_exit` (the per-container exit hook in
+`_run_concurrent_phase`'s polling loop) must append an `AgentExitInfo` to
+`phase_execution.agent_exits` so failure triage survives container cleanup.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from models import (
+    AgentExecution,
+    AgentExecutionStatus,
+    AgentRole,
+    ContainerInfo,
+    ContainerStatus,
+    PhaseExecution,
+    Pipeline,
+    PipelineConfig,
+    PipelinePhase,
+    PipelineStatus,
+)
+from routes.pipelines import _run_concurrent_phase
+
+
+def _make_concurrent_pipeline() -> Pipeline:
+    config = PipelineConfig()
+    config.concurrent_execution = True
+    config.max_concurrent_agents = 4
+    config.consensus_timeout_minutes = 30
+    return Pipeline(
+        id="issue-2205",
+        issue_number=2205,
+        repo="owner/repo",
+        branch="egg/issue-2205",
+        status=PipelineStatus.RUNNING,
+        current_phase=PipelinePhase.IMPLEMENT,
+        config=config,
+    )
+
+
+def _make_execution(role: AgentRole, container_id: str) -> AgentExecution:
+    return AgentExecution(
+        role=role,
+        status=AgentExecutionStatus.RUNNING,
+        container_id=container_id,
+        started_at=datetime.now(UTC),
+    )
+
+
+_CALL_ARGS = {
+    "repo_volumes": {},
+    "gateway_mode": "public",
+    "repos": ["owner/repo"],
+    "sandbox_env": {},
+    "certs_volume": None,
+    "worktree_repo_path": Path("/tmp/test-repo"),
+}
+
+
+def _setup(container_infos: dict[str, ContainerInfo], executions: list[AgentExecution]):
+    """Build the shared scaffolding and expose the PhaseExecution for assertions."""
+    pipeline = _make_concurrent_pipeline()
+    phase_exec = PhaseExecution(
+        phase=PipelinePhase.IMPLEMENT,
+        status=PipelineStatus.RUNNING,
+    )
+
+    mock_store = MagicMock()
+    mock_pipeline_state = MagicMock()
+    mock_pipeline_state.get_phase_execution.return_value = phase_exec
+    mock_store.load_pipeline.return_value = mock_pipeline_state
+
+    mock_docker = MagicMock()
+    mock_docker.get_container_info.side_effect = lambda cid: container_infos[cid]
+
+    mock_spawner = MagicMock()
+    mock_spawner.backend = mock_docker
+    mock_spawner.docker = mock_docker
+    mock_spawner.create_concurrent_spawn_fn.return_value = MagicMock()
+
+    return pipeline, mock_store, mock_spawner, mock_docker, phase_exec
+
+
+class TestAgentExitsRecorded:
+    """`_record_container_exit` populates `PhaseExecution.agent_exits`."""
+
+    @patch("routes.pipelines.time.sleep")
+    @patch("routes.pipelines.time.monotonic")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
+    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
+    def test_nonzero_exit_records_role_code_and_log_tail(
+        self, MockExecutor, mock_prompt, mock_lock, mock_monotonic, mock_sleep
+    ):
+        """A non-zero container exit appends an AgentExitInfo with the log tail."""
+        mock_monotonic.return_value = 0.0
+
+        executions = [_make_execution(AgentRole.CODER, "coder-1")]
+        container_infos = {
+            "coder-1": ContainerInfo(
+                container_id="coder-1",
+                container_name="issue-2205-coder",
+                status=ContainerStatus.FAILED,
+                exit_code=1,
+                exited_at=datetime.now(UTC),
+            ),
+        }
+
+        pipeline, mock_store, mock_spawner, mock_docker, phase_exec = _setup(
+            container_infos, executions
+        )
+        mock_docker.get_container_logs.return_value = "line one\nline two\nline three"
+
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        mock_executor_instance.check_consensus.return_value = {
+            "is_complete": False,
+            "has_objections": False,
+            "blocking_agents": ["coder"],
+        }
+        MockExecutor.return_value = mock_executor_instance
+
+        mock_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        _run_concurrent_phase(
+            pipeline_id="issue-2205",
+            pipeline=pipeline,
+            phase="implement",
+            spawner=mock_spawner,
+            store=mock_store,
+            **_CALL_ARGS,
+        )
+
+        assert len(phase_exec.agent_exits) == 1
+        info = phase_exec.agent_exits[0]
+        assert info.role == AgentRole.CODER
+        assert info.exit_code == 1
+        assert info.last_lines == ["line one", "line two", "line three"]
+        assert info.container_id == "coder-1"
+        assert info.terminated_at is not None
+
+    @patch("routes.pipelines.time.sleep")
+    @patch("routes.pipelines.time.monotonic")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
+    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
+    def test_clean_exit_records_empty_log_tail(
+        self, MockExecutor, mock_prompt, mock_lock, mock_monotonic, mock_sleep
+    ):
+        """exit_code=0 still produces an AgentExitInfo (last_lines empty by design)."""
+        mock_monotonic.return_value = 0.0
+
+        executions = [_make_execution(AgentRole.CODER, "coder-1")]
+        container_infos = {
+            "coder-1": ContainerInfo(
+                container_id="coder-1",
+                container_name="issue-2205-coder",
+                status=ContainerStatus.EXITED,
+                exit_code=0,
+                exited_at=datetime.now(UTC),
+            ),
+        }
+
+        pipeline, mock_store, mock_spawner, mock_docker, phase_exec = _setup(
+            container_infos, executions
+        )
+
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        mock_executor_instance.check_consensus.return_value = {
+            "is_complete": False,
+            "has_objections": False,
+            "blocking_agents": ["coder"],
+        }
+        MockExecutor.return_value = mock_executor_instance
+
+        mock_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        _run_concurrent_phase(
+            pipeline_id="issue-2205",
+            pipeline=pipeline,
+            phase="implement",
+            spawner=mock_spawner,
+            store=mock_store,
+            **_CALL_ARGS,
+        )
+
+        assert len(phase_exec.agent_exits) == 1
+        info = phase_exec.agent_exits[0]
+        assert info.role == AgentRole.CODER
+        assert info.exit_code == 0
+        # Clean exits don't fetch logs (no IO on healthy containers).
+        assert info.last_lines == []
+
+    @patch("routes.pipelines.time.sleep")
+    @patch("routes.pipelines.time.monotonic")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
+    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
+    def test_per_role_exit_records_in_chronological_order(
+        self, MockExecutor, mock_prompt, mock_lock, mock_monotonic, mock_sleep
+    ):
+        """Multiple containers each get their own AgentExitInfo, in observation order."""
+        mock_monotonic.return_value = 0.0
+
+        executions = [
+            _make_execution(AgentRole.CODER, "coder-1"),
+            _make_execution(AgentRole.TESTER, "tester-1"),
+        ]
+        container_infos = {
+            "coder-1": ContainerInfo(
+                container_id="coder-1",
+                container_name="issue-2205-coder",
+                status=ContainerStatus.FAILED,
+                exit_code=1,
+                exited_at=datetime.now(UTC),
+            ),
+            "tester-1": ContainerInfo(
+                container_id="tester-1",
+                container_name="issue-2205-tester",
+                status=ContainerStatus.EXITED,
+                exit_code=0,
+                exited_at=datetime.now(UTC),
+            ),
+        }
+
+        pipeline, mock_store, mock_spawner, mock_docker, phase_exec = _setup(
+            container_infos, executions
+        )
+        mock_docker.get_container_logs.return_value = "boom"
+
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        mock_executor_instance.check_consensus.return_value = {
+            "is_complete": False,
+            "has_objections": False,
+            "blocking_agents": ["coder", "tester"],
+        }
+        MockExecutor.return_value = mock_executor_instance
+
+        mock_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        _run_concurrent_phase(
+            pipeline_id="issue-2205",
+            pipeline=pipeline,
+            phase="implement",
+            spawner=mock_spawner,
+            store=mock_store,
+            **_CALL_ARGS,
+        )
+
+        assert len(phase_exec.agent_exits) == 2
+        roles = {ae.role for ae in phase_exec.agent_exits}
+        assert roles == {AgentRole.CODER, AgentRole.TESTER}
+        coder = next(ae for ae in phase_exec.agent_exits if ae.role == AgentRole.CODER)
+        tester = next(ae for ae in phase_exec.agent_exits if ae.role == AgentRole.TESTER)
+        assert coder.exit_code == 1
+        assert tester.exit_code == 0
+        assert coder.last_lines == ["boom"]
+        assert tester.last_lines == []

--- a/orchestrator/tests/test_agent_exits_recorded.py
+++ b/orchestrator/tests/test_agent_exits_recorded.py
@@ -141,6 +141,9 @@ class TestAgentExitsRecorded:
         assert info.last_lines == ["line one", "line two", "line three"]
         assert info.container_id == "coder-1"
         assert info.terminated_at is not None
+        # PR's value proposition is "survives container teardown" —
+        # so the in-memory mutation must reach the store.
+        assert mock_store.save_pipeline.called
 
     @patch("routes.pipelines.time.sleep")
     @patch("routes.pipelines.time.monotonic")
@@ -195,6 +198,7 @@ class TestAgentExitsRecorded:
         assert info.exit_code == 0
         # Clean exits don't fetch logs (no IO on healthy containers).
         assert info.last_lines == []
+        assert mock_store.save_pipeline.called
 
     @patch("routes.pipelines.time.sleep")
     @patch("routes.pipelines.time.monotonic")
@@ -255,11 +259,99 @@ class TestAgentExitsRecorded:
         )
 
         assert len(phase_exec.agent_exits) == 2
-        roles = {ae.role for ae in phase_exec.agent_exits}
-        assert roles == {AgentRole.CODER, AgentRole.TESTER}
-        coder = next(ae for ae in phase_exec.agent_exits if ae.role == AgentRole.CODER)
-        tester = next(ae for ae in phase_exec.agent_exits if ae.role == AgentRole.TESTER)
+        # The polling loop iterates `active_executions` in order and calls
+        # `_record_container_exit` synchronously, so the recorded order
+        # mirrors the spawn order — coder first, tester second.
+        assert [ae.role for ae in phase_exec.agent_exits] == [
+            AgentRole.CODER,
+            AgentRole.TESTER,
+        ]
+        coder, tester = phase_exec.agent_exits
         assert coder.exit_code == 1
         assert tester.exit_code == 0
         assert coder.last_lines == ["boom"]
         assert tester.last_lines == []
+        # Each recorded exit triggered a persistence call.
+        assert mock_store.save_pipeline.call_count >= 2
+
+    @patch("routes.pipelines.time.sleep")
+    @patch("routes.pipelines.time.monotonic")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
+    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
+    def test_none_exit_code_is_recorded_not_dropped(
+        self, MockExecutor, mock_prompt, mock_lock, mock_monotonic, mock_sleep
+    ):
+        """Pod-phase race: status FAILED but exit_code=None must still record.
+
+        ContainerInfo.exit_code is `int | None`, and the k8s path leaves it
+        None when `container_statuses[0].state.terminated` hasn't populated
+        yet. Reviewer flagged that an `int`-only AgentExitInfo would raise
+        ValidationError under the broad except, drop the agent_status
+        update, and leave the agent stuck as RUNNING. AgentExitInfo accepts
+        None; the agent must be marked FAILED and the snapshot persisted.
+        """
+        mock_monotonic.return_value = 0.0
+
+        executions = [_make_execution(AgentRole.CODER, "coder-1")]
+        container_infos = {
+            "coder-1": ContainerInfo(
+                container_id="coder-1",
+                container_name="issue-2205-coder",
+                status=ContainerStatus.FAILED,
+                exit_code=None,
+                exited_at=datetime.now(UTC),
+            ),
+        }
+
+        pipeline, mock_store, mock_spawner, mock_docker, phase_exec = _setup(
+            container_infos, executions
+        )
+        # Pre-populate the live agents/containers so we can assert the
+        # in-lock mutations that previously got rolled back on ValidationError.
+        phase_exec.containers.append(
+            ContainerInfo(
+                container_id="coder-1",
+                container_name="issue-2205-coder",
+                status=ContainerStatus.RUNNING,
+            )
+        )
+        phase_exec.agents.append(
+            AgentExecution(
+                role=AgentRole.CODER,
+                status=AgentExecutionStatus.RUNNING,
+                container_id="coder-1",
+                started_at=datetime.now(UTC),
+            )
+        )
+
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        mock_executor_instance.check_consensus.return_value = {
+            "is_complete": False,
+            "has_objections": False,
+            "blocking_agents": ["coder"],
+        }
+        MockExecutor.return_value = mock_executor_instance
+
+        mock_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        _run_concurrent_phase(
+            pipeline_id="issue-2205",
+            pipeline=pipeline,
+            phase="implement",
+            spawner=mock_spawner,
+            store=mock_store,
+            **_CALL_ARGS,
+        )
+
+        assert len(phase_exec.agent_exits) == 1
+        info = phase_exec.agent_exits[0]
+        assert info.role == AgentRole.CODER
+        assert info.exit_code is None
+        # The pre-existing failure-marking code must reach persistence
+        # (the original bug: ValidationError swallowed by the broad except
+        # caused save_pipeline to never run).
+        assert phase_exec.agents[0].status == AgentExecutionStatus.FAILED
+        assert mock_store.save_pipeline.called

--- a/orchestrator/tests/test_models.py
+++ b/orchestrator/tests/test_models.py
@@ -371,6 +371,23 @@ class TestAgentExitInfo:
         assert restored.last_lines == ["a", "b", "c"]
         assert restored.container_id == "cid-9"
 
+    def test_exit_code_none_accepted(self):
+        """exit_code=None is valid (matches ContainerInfo.exit_code).
+
+        The k8s path leaves exit_code=None during pod-phase races where
+        status is FAILED but container_statuses[0].state.terminated hasn't
+        populated yet. AgentExitInfo must not reject this.
+        """
+        now = datetime.now(UTC)
+        info = AgentExitInfo(
+            role=AgentRole.CODER,
+            exit_code=None,
+            terminated_at=now,
+        )
+        assert info.exit_code is None
+        restored = AgentExitInfo(**info.model_dump())
+        assert restored.exit_code is None
+
 
 class TestPipelineConfig:
     """Tests for PipelineConfig model."""

--- a/orchestrator/tests/test_models.py
+++ b/orchestrator/tests/test_models.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from models import (
     AgentExecution,
     AgentExecutionStatus,
+    AgentExitInfo,
     AgentRole,
     ContainerInfo,
     ContainerStatus,
@@ -278,6 +279,97 @@ class TestPhaseExecution:
         assert data["phase_start_sha"] is None
         restored = PhaseExecution(**data)
         assert restored.phase_start_sha is None
+
+    def test_agent_exits_defaults_to_empty_list(self):
+        """agent_exits defaults to an empty list (issue #2205)."""
+        phase = PhaseExecution(phase=PipelinePhase.IMPLEMENT)
+        assert phase.agent_exits == []
+
+    def test_agent_exits_appends_records(self):
+        """agent_exits accepts AgentExitInfo records, preserving order."""
+        now = datetime.now(UTC)
+        phase = PhaseExecution(phase=PipelinePhase.IMPLEMENT)
+        phase.agent_exits.append(
+            AgentExitInfo(
+                role=AgentRole.CODER,
+                exit_code=0,
+                terminated_at=now,
+            )
+        )
+        phase.agent_exits.append(
+            AgentExitInfo(
+                role=AgentRole.TESTER,
+                exit_code=1,
+                last_lines=["traceback line 1", "traceback line 2"],
+                terminated_at=now,
+                container_id="abc123",
+            )
+        )
+        assert [ae.role for ae in phase.agent_exits] == [AgentRole.CODER, AgentRole.TESTER]
+        assert phase.agent_exits[1].exit_code == 1
+        assert phase.agent_exits[1].last_lines == ["traceback line 1", "traceback line 2"]
+        assert phase.agent_exits[1].container_id == "abc123"
+
+    def test_agent_exits_round_trip(self):
+        """agent_exits serializes and rehydrates through model_dump."""
+        now = datetime.now(UTC)
+        phase = PhaseExecution(
+            phase=PipelinePhase.IMPLEMENT,
+            agent_exits=[
+                AgentExitInfo(
+                    role=AgentRole.CODER,
+                    exit_code=1,
+                    last_lines=["line a", "line b"],
+                    terminated_at=now,
+                    container_id="cid-1",
+                ),
+            ],
+        )
+        data = phase.model_dump(mode="json")
+        assert len(data["agent_exits"]) == 1
+        assert data["agent_exits"][0]["role"] == AgentRole.CODER.value
+        assert data["agent_exits"][0]["exit_code"] == 1
+        assert data["agent_exits"][0]["last_lines"] == ["line a", "line b"]
+        assert data["agent_exits"][0]["container_id"] == "cid-1"
+
+        restored = PhaseExecution(**phase.model_dump())
+        assert len(restored.agent_exits) == 1
+        assert restored.agent_exits[0].role == AgentRole.CODER
+        assert restored.agent_exits[0].exit_code == 1
+
+
+class TestAgentExitInfo:
+    """Tests for AgentExitInfo (issue #2205)."""
+
+    def test_minimal(self):
+        """exit_code and role are required, last_lines defaults to []."""
+        now = datetime.now(UTC)
+        info = AgentExitInfo(
+            role=AgentRole.TESTER,
+            exit_code=1,
+            terminated_at=now,
+        )
+        assert info.role == AgentRole.TESTER
+        assert info.exit_code == 1
+        assert info.last_lines == []
+        assert info.container_id is None
+
+    def test_full(self):
+        """All fields populated round-trip."""
+        now = datetime.now(UTC)
+        info = AgentExitInfo(
+            role=AgentRole.CODER,
+            exit_code=137,
+            last_lines=["a", "b", "c"],
+            terminated_at=now,
+            container_id="cid-9",
+        )
+        data = info.model_dump(mode="json")
+        restored = AgentExitInfo(**info.model_dump())
+        assert data["exit_code"] == 137
+        assert restored.role == AgentRole.CODER
+        assert restored.last_lines == ["a", "b", "c"]
+        assert restored.container_id == "cid-9"
 
 
 class TestPipelineConfig:


### PR DESCRIPTION
## Summary

- Adds `AgentExitInfo` (role, exit_code, last_lines, terminated_at, container_id) and an `agent_exits` list on `PhaseExecution`. `_record_container_exit` appends to it inside the existing pipeline state lock so the record is atomic with the agent-status update and survives the failure path's container teardown — operators can answer "which container exited non-zero, and why?" without out-of-band log access.
- Records all exits (clean and failed). `last_lines` is empty for `exit_code=0` because the existing code only fetches logs on non-zero exit, which is the right tradeoff (no IO on healthy containers); the structured record still lets operators correlate exits across roles.
- Surfaces through `GET /pipelines/<id>` (full `model_dump`) and the curated `GET /pipelines/<id>/phase` response so MCP `get_pipeline_snapshot` and `get_phase` both expose it after cleanup.

This is **fix 1 only** from #2205 (the smallest-blast-radius change). Fixes 2 (50–100 line per-role tail in the failure message) and 3 (defer container removal) are intentional follow-ups.

Companion issues are independent:
- #2203 — orchestrator-side HITL decision on incomplete-consensus failure
- #2204 — promote `register_open_question` over `overseer_alert`

Fixes #2205 (partial — see above).

## Test plan

- [x] `pytest orchestrator/tests/test_models.py` — schema round-trip for `AgentExitInfo` and `PhaseExecution.agent_exits`.
- [x] `pytest orchestrator/tests/test_agent_exits_recorded.py` — `_record_container_exit` populates `agent_exits` for non-zero exit (with log tail), clean exit (empty `last_lines`), and multiple roles in chronological order.
- [x] Regression: `pytest orchestrator/tests/test_consensus_polling.py orchestrator/tests/test_consensus_complete_with_failures.py orchestrator/tests/test_concurrent_phases.py orchestrator/tests/test_consensus_race_on_exit.py` — 48 tests pass.
- [x] `ruff check` + `ruff format --check` clean on changed files.