### PR TITLE
docs(CLAUDE.md): point agents at make test, not raw pytest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,13 @@ make lint-fix      # Auto-fix lint issues
 make security      # Run security scans (bandit, safety, trivy)
 ```
 
-**Use `make test`, not raw `pytest`/`.venv/bin/pytest`.** It narrows to the tests your diff actually touches (transitively, via static imports), so you don't have to guess which suites to run. Reach for direct `pytest` only when you need a flag the wrapper doesn't expose. See [docs/guides/testing.md](docs/guides/testing.md) for the narrowing model and `make test-all` escape hatch.
+**Use `make test`, not raw `pytest`/`.venv/bin/pytest`.** `make test` is changeset-aware — it narrows to the tests your diff actually touches (transitively, via static imports), so you don't have to guess which suites to run. It also picks up `.venv/bin/pytest` automatically, so the venv's pinned versions are what runs. Reach for direct `pytest` only when you need a flag the wrapper doesn't expose, and even then **invoke it from the venv** (`.venv/bin/pytest …`) — the system `pytest` won't have the project's deps. See [docs/guides/testing.md](docs/guides/testing.md) for the narrowing model and `make test-all` escape hatch.
 
 ## Python Environment
 
-If `.venv` is absent, run `make deps` to install all dependencies. This installs `uv` if needed and creates a `.venv` with all dev dependencies. Always use the `.venv` for project-specific Python usage such as tests and linting.
+This project requires a `.venv` for all Python tooling — pytest, ruff, mypy, etc. `make` targets resolve to `.venv/bin/<tool>` automatically, so following the "use `make test` / `make lint`" guidance above keeps you in the venv without thinking about it. If you ever invoke a Python tool directly, prefix it with `.venv/bin/` (e.g. `.venv/bin/pytest`, `.venv/bin/ruff`) — never the system binary.
+
+If `.venv` is absent, run `make deps` to install everything. This installs `uv` if needed and creates a `.venv` with all dev dependencies.
 
 ## Repo Layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,10 +9,13 @@ make help          # List all targets
 make deps          # Install all dependencies (installs uv + venv)
 make setup         # Install dependencies + pre-commit hooks
 make lint          # Run all linters (Python, Shell, YAML, Dockerfile)
-make test          # Run full test suite
+make test          # Changeset-aware: tests reachable from the diff (inner-loop default)
+make test-all      # Full suite — CI ground truth; updates LKG baseline on green
 make lint-fix      # Auto-fix lint issues
 make security      # Run security scans (bandit, safety, trivy)
 ```
+
+**Use `make test`, not raw `pytest`/`.venv/bin/pytest`.** It narrows to the tests your diff actually touches (transitively, via static imports), so you don't have to guess which suites to run. Reach for direct `pytest` only when you need a flag the wrapper doesn't expose. See [docs/guides/testing.md](docs/guides/testing.md) for the narrowing model and `make test-all` escape hatch.
 
 ## Python Environment
 

--- a/gateway/CLAUDE.md
+++ b/gateway/CLAUDE.md
@@ -7,7 +7,4 @@ Policy-enforcement sidecar that sits between agents and GitHub. Validates git/gh
 
 ## Testing
 
-```bash
-make test                     # Full suite from repo root
-pytest gateway/tests/         # Gateway tests only
-```
+Run `make test` from the repo root — it's changeset-aware and selects only the tests reachable from your diff. `make test-all` runs the full suite. See [docs/guides/testing.md](../docs/guides/testing.md) and the root [CLAUDE.md](../CLAUDE.md#quick-reference). Avoid invoking `pytest` directly: you'll skip the narrowing and may hit venv-PATH issues.

--- a/orchestrator/CLAUDE.md
+++ b/orchestrator/CLAUDE.md
@@ -9,7 +9,4 @@ Central coordination engine for SDLC pipelines. Manages agent lifecycle, phase t
 
 ## Testing
 
-```bash
-make test                           # Full suite from repo root
-pytest orchestrator/tests/          # Orchestrator tests only
-```
+Run `make test` from the repo root — it's changeset-aware and selects only the tests reachable from your diff. `make test-all` runs the full suite. See [docs/guides/testing.md](../docs/guides/testing.md) and the root [CLAUDE.md](../CLAUDE.md#quick-reference). Avoid invoking `pytest` directly: you'll skip the narrowing and may hit venv-PATH issues.

--- a/sandbox/CLAUDE.md
+++ b/sandbox/CLAUDE.md
@@ -8,7 +8,4 @@ Untrusted agent container. Provides the isolated execution environment where Cla
 
 ## Testing
 
-```bash
-make test                      # Full suite from repo root
-pytest sandbox/tests/          # Sandbox tests only
-```
+Run `make test` from the repo root — it's changeset-aware and selects only the tests reachable from your diff. `make test-all` runs the full suite. See [docs/guides/testing.md](../docs/guides/testing.md) and the root [CLAUDE.md](../CLAUDE.md#quick-reference). Avoid invoking `pytest` directly: you'll skip the narrowing and may hit venv-PATH issues.


### PR DESCRIPTION
## Summary

- The Quick Reference in `CLAUDE.md` described `make test` as "Run full test suite", which is wrong — `make test` is changeset-aware (narrowed to tests reachable from the diff via static imports). Fix the description, add `make test-all` for the full-suite case, and add an explicit "use `make test`, not raw `pytest`" line so agents don't reach for `.venv/bin/pytest` and miss the narrowing (or hit venv-PATH issues when the venv isn't fully synced yet).
- Apply the same fix to the per-component CLAUDE.md files in `gateway/`, `orchestrator/`, and `sandbox/`, which carried the same misleading hint.
- Links the canonical [docs/guides/testing.md](https://github.com/jwbron/egg/blob/main/docs/guides/testing.md) for the full narrowing model so the CLAUDE.md hint stays terse.

Motivation: an agent (me) ran `.venv/bin/pytest` directly during PR #2209, exactly because the existing CLAUDE.md hint encouraged it. Closing that loophole at the source.

## Test plan

- [x] No code changes — docs only. Pre-commit hooks pass.
- [ ] Spot-read each updated CLAUDE.md to confirm the new wording renders correctly.