### PR TITLE
Fix #2210: stop K8s monitor from escalating clean BRC exits to pipeline FAILED

### DIFF
--- a/orchestrator/kubernetes_monitor.py
+++ b/orchestrator/kubernetes_monitor.py
@@ -570,14 +570,32 @@ class KubernetesMonitor:
                                 exit_code=None,
                                 exited_at=now,
                             )
-                        logger.warning(
-                            "Reconciliation: pod terminated, marking agent FAILED",
-                            pipeline_id=pipeline_id,
-                            container_id=agent.container_id,
-                            agent_role=str(agent.role),
-                            exit_code=actual_exit_code,
-                            pod_gone=pod_gone,
-                        )
+                        # 143 in a RUNNING phase reaches this branch
+                        # (the non-RUNNING-phase carve-out at L527 only
+                        # skips when the phase has already moved past
+                        # RUNNING).  ``_reconcile_pod_state`` →
+                        # ``_classify_exit`` will mark such an agent
+                        # COMPLETE, not FAILED, so log accordingly
+                        # rather than asserting "marking agent FAILED".
+                        is_clean = actual_exit_code in (0, 143)
+                        if is_clean:
+                            logger.info(
+                                "Reconciliation: pod terminated cleanly, marking agent COMPLETE",
+                                pipeline_id=pipeline_id,
+                                container_id=agent.container_id,
+                                agent_role=str(agent.role),
+                                exit_code=actual_exit_code,
+                                pod_gone=pod_gone,
+                            )
+                        else:
+                            logger.warning(
+                                "Reconciliation: pod terminated, marking agent FAILED",
+                                pipeline_id=pipeline_id,
+                                container_id=agent.container_id,
+                                agent_role=str(agent.role),
+                                exit_code=actual_exit_code,
+                                pod_gone=pod_gone,
+                            )
                         _reconcile_pod_state(store, observed_info)
                     else:
                         logger.debug(

--- a/orchestrator/kubernetes_monitor.py
+++ b/orchestrator/kubernetes_monitor.py
@@ -729,10 +729,13 @@ class KubernetesMonitor:
                             completed_container_ids.add(agent.container_id)
 
                 # Synthetically mark containers EXITED (exit_code=0) so
-                # _reconcile_pod_state doesn't flip the pipeline to FAILED
-                # when the pods are deleted below.  Mirrors the normal
+                # the periodic reconciler treats them as clean exits when
+                # the pods are deleted below.  Mirrors the normal
                 # _update_agents_complete path in routes/pipelines.py
-                # (see #1294).
+                # (see #1294).  As of #2210 the reconciler no longer
+                # escalates pipeline.status itself, but matching the
+                # clean-exit shape here still keeps the agent/container
+                # records consistent with the recovery decision.
                 pods_to_stop: list[str] = []
                 for ci in phase_exec.containers:
                     if (
@@ -883,13 +886,51 @@ def get_kubernetes_monitor() -> KubernetesMonitor:
     return _kubernetes_monitor
 
 
+def _classify_exit(exit_code: int | None) -> tuple[bool, str]:
+    """Classify a container exit code as clean or failed.
+
+    Returns ``(is_clean, error_message)``.
+
+    - exit_code 0 (normal exit) and 143 (SIGTERM, orchestrator-initiated
+      stop) are treated as clean — these are the post-BRC and
+      teardown-shutdown cases respectively.
+    - Anything else is a failure; the error string includes the actual
+      exit code so observers can distinguish OOM, crash, etc.
+
+    Sub-record reconciliation only — the pipeline-level decision about
+    whether the pipeline itself has failed lives in the BRC poll loop
+    (see ``orchestrator/routes/pipelines.py::_run_concurrent_phase``),
+    which has consensus context this monitor lacks.  See #2210.
+    """
+    if exit_code in (0, 143):
+        return True, ""
+    code_repr = "unknown" if exit_code is None else str(exit_code)
+    return (
+        False,
+        f"Pod exited with code {code_repr} — detected by Kubernetes runtime monitor",
+    )
+
+
 def _reconcile_pod_state(store: Any, container_info: ContainerInfo) -> bool:
     """Update pipeline state for a single pod that has exited.
 
     Scans pipelines for a container matching the given container_info
-    and reconciles stale RUNNING agent/container records.  On RUNNING
-    pipelines the pipeline itself is also marked FAILED; on terminal or
-    AWAITING_HUMAN pipelines only the sub-records are updated.
+    and reconciles stale RUNNING agent/container records based on the
+    pod's exit code:
+
+    - exit_code 0 / 143 → agent COMPLETE, container EXITED (clean exit
+      after BRC protocol work, or orchestrator-initiated SIGTERM).
+    - any other exit code → agent FAILED with the code in the error
+      string, container FAILED.
+
+    The pipeline's own ``status`` is never mutated here.  That decision
+    belongs to the BRC poll loop in
+    ``orchestrator/routes/pipelines.py::_run_concurrent_phase``, which
+    has full consensus context.  See #2210 for why making that call
+    from here was wrong: the K8s monitor cannot tell a clean post-BRC
+    exit apart from a crash without consulting consensus state, so it
+    used to escalate the pipeline to FAILED on agents that had finished
+    their protocol obligations and exited 0.
 
     Args:
         store: StateStore instance
@@ -948,6 +989,8 @@ def _reconcile_pod_state(store: Any, container_info: ContainerInfo) -> bool:
                     if a.status == AgentExecutionStatus.COMPLETE and a.container_id
                 }
 
+                is_clean_exit, agent_error = _classify_exit(container_info.exit_code)
+
                 for ci in phase_execution.containers:
                     if (
                         ci.container_id == container_info.container_id
@@ -960,23 +1003,22 @@ def _reconcile_pod_state(store: Any, container_info: ContainerInfo) -> bool:
                                 container_id=ci.container_id[:12],
                             )
                             continue
-                        if (
-                            container_info.exit_code == 143
-                            and phase_execution.status != PipelineStatus.RUNNING
-                        ):
+                        if is_clean_exit:
                             logger.info(
-                                "Runtime reconciliation: SIGTERM (143) during "
-                                "completed phase, skipping FAILED reconciliation",
+                                "Runtime reconciliation: pod exited cleanly, marking EXITED",
                                 pipeline_id=pipeline_id,
                                 container_id=container_info.container_id[:12],
+                                exit_code=container_info.exit_code,
                             )
-                            continue
-                        logger.warning(
-                            "Runtime reconciliation: pod exited, marking FAILED",
-                            pipeline_id=pipeline_id,
-                            container_id=container_info.container_id,
-                        )
-                        ci.status = ContainerStatus.FAILED
+                            ci.status = ContainerStatus.EXITED
+                        else:
+                            logger.warning(
+                                "Runtime reconciliation: pod exited with non-zero code, marking FAILED",
+                                pipeline_id=pipeline_id,
+                                container_id=container_info.container_id,
+                                exit_code=container_info.exit_code,
+                            )
+                            ci.status = ContainerStatus.FAILED
                         ci.exit_code = (
                             container_info.exit_code if container_info.exit_code is not None else -1
                         )
@@ -988,36 +1030,33 @@ def _reconcile_pod_state(store: Any, container_info: ContainerInfo) -> bool:
                         agent.status == AgentExecutionStatus.RUNNING
                         and agent.container_id == container_info.container_id
                     ):
-                        if (
-                            container_info.exit_code == 143
-                            and phase_execution.status != PipelineStatus.RUNNING
-                        ):
-                            continue
-                        logger.warning(
-                            "Runtime reconciliation: agent pod exited, marking FAILED",
-                            pipeline_id=pipeline_id,
-                            agent_role=str(agent.role),
-                            container_id=container_info.container_id,
-                        )
-                        agent.status = AgentExecutionStatus.FAILED
+                        if is_clean_exit:
+                            logger.info(
+                                "Runtime reconciliation: agent pod exited cleanly, marking COMPLETE",
+                                pipeline_id=pipeline_id,
+                                agent_role=str(agent.role),
+                                container_id=container_info.container_id,
+                                exit_code=container_info.exit_code,
+                            )
+                            agent.status = AgentExecutionStatus.COMPLETE
+                        else:
+                            logger.warning(
+                                "Runtime reconciliation: agent pod exited with non-zero code, marking FAILED",
+                                pipeline_id=pipeline_id,
+                                agent_role=str(agent.role),
+                                container_id=container_info.container_id,
+                                exit_code=container_info.exit_code,
+                            )
+                            agent.status = AgentExecutionStatus.FAILED
+                            agent.error = agent_error
                         agent.completed_at = datetime.now(UTC)
-                        agent.error = (
-                            "Pod exited unexpectedly during execution — "
-                            "detected by Kubernetes runtime monitor"
-                        )
                         changed = True
 
             if changed:
-                # Only escalate the pipeline's own status when it was
-                # still RUNNING. Terminal states (FAILED/COMPLETE/
-                # CANCELLED) and AWAITING_HUMAN stay as-is — we only
-                # reconciled stale records underneath them.
-                if pipeline.status == PipelineStatus.RUNNING:
-                    pipeline.status = PipelineStatus.FAILED
-                    pipeline.error = (
-                        "Pipeline marked FAILED: agent pod exited unexpectedly "
-                        "during execution. Restart via POST /pipelines/{id}/start."
-                    )
+                # The K8s monitor never mutates pipeline.status here.
+                # Pipeline-level FAILED decisions belong to the BRC poll
+                # loop, which has consensus context (#2210).  Sub-record
+                # updates above are sufficient for this layer.
                 try:
                     store.save_pipeline(
                         pipeline,

--- a/orchestrator/kubernetes_monitor.py
+++ b/orchestrator/kubernetes_monitor.py
@@ -546,6 +546,30 @@ class KubernetesMonitor:
                             break
 
                     if matching_ci is not None:
+                        # Build the ContainerInfo we hand to
+                        # ``_reconcile_pod_state`` from the *live* pod
+                        # observation, not from the stored record.  The
+                        # stored ``matching_ci`` still has
+                        # ``exit_code=None`` for an agent that was
+                        # RUNNING up to this sweep, so the reconciler's
+                        # ``_classify_exit`` would only see "code
+                        # unknown" and never reach its clean-exit branch
+                        # — losing the actual exit code in the saved
+                        # error string and miscategorising
+                        # sweep-detected clean exits.  When the pod is
+                        # gone (PodNotFoundError) we fall back to a
+                        # synthesised record; the exit code is
+                        # genuinely unknown in that case.  See #2210.
+                        if info is not None:
+                            observed_info = info
+                        else:
+                            observed_info = ContainerInfo(
+                                container_id=agent.container_id,
+                                container_name=matching_ci.container_name,
+                                status=ContainerStatus.REMOVED,
+                                exit_code=None,
+                                exited_at=now,
+                            )
                         logger.warning(
                             "Reconciliation: pod terminated, marking agent FAILED",
                             pipeline_id=pipeline_id,
@@ -554,7 +578,7 @@ class KubernetesMonitor:
                             exit_code=actual_exit_code,
                             pod_gone=pod_gone,
                         )
-                        _reconcile_pod_state(store, matching_ci)
+                        _reconcile_pod_state(store, observed_info)
                     else:
                         logger.debug(
                             "Stale agent has no matching ContainerInfo",
@@ -728,14 +752,16 @@ class KubernetesMonitor:
                         if agent.container_id:
                             completed_container_ids.add(agent.container_id)
 
-                # Synthetically mark containers EXITED (exit_code=0) so
-                # the periodic reconciler treats them as clean exits when
-                # the pods are deleted below.  Mirrors the normal
-                # _update_agents_complete path in routes/pipelines.py
-                # (see #1294).  As of #2210 the reconciler no longer
-                # escalates pipeline.status itself, but matching the
-                # clean-exit shape here still keeps the agent/container
-                # records consistent with the recovery decision.
+                # Synthetically mark containers EXITED (exit_code=0) for
+                # state-shape consistency: the stored record matches
+                # what a normal clean exit would have written, mirroring
+                # the _update_agents_complete path in
+                # routes/pipelines.py (see #1294).  This is purely
+                # cosmetic / observability — the periodic reconciler
+                # already skips these agents because they are now
+                # COMPLETE (the sweep at line 451-454 only reconciles
+                # ``agent.status == RUNNING``), and as of #2210 the
+                # reconciler does not mutate pipeline.status anyway.
                 pods_to_stop: list[str] = []
                 for ci in phase_exec.containers:
                     if (
@@ -1090,7 +1116,11 @@ def create_pipeline_reconciliation_handler(repo_path: str) -> EventHandler:
     """Create handler that updates pipeline state when pods exit.
 
     Only FAILED events trigger reconciliation — STOPPED (exit code 0)
-    represents a graceful exit and should not mark pipelines as failed.
+    is a graceful exit that needs no sub-record correction.  Since
+    #2210 this handler never mutates ``pipeline.status``; it only
+    reconciles agent + container records via ``_reconcile_pod_state``.
+    Pipeline-level FAILED decisions belong to the BRC poll loop, which
+    has consensus context.
 
     Args:
         repo_path: Path to the repository (for StateStore access)

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9706,7 +9706,10 @@ def _run_concurrent_phase(
                 pass
 
         with _logs_lock:
-            if final_info.exit_code != 0:
+            # 143 (SIGTERM) is orchestrator-initiated teardown, not a
+            # failure — match the K8s monitor's classifier (#2210) so
+            # the two layers don't disagree about what 143 means.
+            if final_info.exit_code not in (0, 143):
                 has_failures[0] = True
             all_logs.append(
                 f"--- {exec_info.role.value} (exit={final_info.exit_code}) ---\n{container_logs}"
@@ -9728,7 +9731,7 @@ def _run_concurrent_phase(
                     for agent in pe.agents:
                         if agent.container_id == exec_info.container_id:
                             agent.completed_at = datetime.now(UTC)
-                            if final_info.exit_code == 0:
+                            if final_info.exit_code in (0, 143):
                                 agent.status = StateAgentStatus.COMPLETE
                             else:
                                 agent.status = StateAgentStatus.FAILED
@@ -10023,8 +10026,12 @@ def _run_concurrent_phase(
                 exited_containers[exec_info.container_id] = info
                 _record_container_exit(exec_info, info)
 
-                # Handle non-zero exit as agent failure
-                if info.exit_code != 0:
+                # Handle non-clean exit as agent failure.  0 = normal,
+                # 143 = orchestrator-initiated SIGTERM (#2210) — both
+                # are classified as clean here to match the K8s monitor's
+                # _classify_exit, so the two layers can't race to write
+                # contradictory agent.status values.
+                if info.exit_code not in (0, 143):
                     try:
                         executor.handle_agent_failure(
                             role=exec_info.role.value,
@@ -10037,14 +10044,15 @@ def _run_concurrent_phase(
                             error=str(e),
                         )
                 else:
-                    # Clean exit (code 0): the consensus wrapper inside the
-                    # container handles restarts if the agent didn't signal
-                    # READY. We do NOT auto-register READY here — agents
-                    # must explicitly participate in consensus.
+                    # Clean exit (0 or 143): the consensus wrapper inside
+                    # the container handles restarts if the agent didn't
+                    # signal READY. We do NOT auto-register READY here —
+                    # agents must explicitly participate in consensus.
                     logger.info(
                         "Container exited cleanly, wrapper handles consensus",
                         pipeline_id=pipeline_id,
                         role=exec_info.role.value,
+                        exit_code=info.exit_code,
                     )
 
         # 5. All containers exited — fall back to exit-code-based result

--- a/orchestrator/tests/test_container_monitor.py
+++ b/orchestrator/tests/test_container_monitor.py
@@ -605,7 +605,14 @@ class TestPeriodicReconciliation:
     """Tests for the _reconciliation_loop background thread."""
 
     def test_detects_stale_container_in_current_phase(self):
-        """Loop detects a stale container in the current phase and reconciles it."""
+        """Loop detects a stale container in the current phase and reconciles it.
+
+        #2210: the sweep now hands ``_reconcile_pod_state`` the live
+        observation of the pod (with the actual exit code), not the
+        stored ``ContainerInfo`` whose ``exit_code`` is ``None`` while
+        the agent is RUNNING.  This test asserts both the container_id
+        plumbing and that a real exit_code reaches the reconciler.
+        """
         container_id = "stale_abc"
         pipeline = _make_pipeline_with_running_agent(container_id)
         store = _make_store(pipeline)
@@ -614,6 +621,13 @@ class TestPeriodicReconciliation:
         # No live containers — the agent's container is missing
         mock_docker.list_containers.return_value = []
         mock_docker.list_jobs.return_value = []
+        mock_docker.get_container_info.return_value = ContainerInfo(
+            container_id=container_id,
+            container_name="job-stale",
+            status=ContainerStatus.FAILED,
+            exit_code=137,
+            exited_at=datetime.now(UTC),
+        )
 
         monitor = ContainerMonitor(docker_client=mock_docker, check_interval=1)
 
@@ -624,11 +638,13 @@ class TestPeriodicReconciliation:
 
             _run_one_reconciliation_sweep(monitor)
 
-            # Should have called _reconcile with the matching ContainerInfo
+            # Should have called _reconcile with the live observed
+            # ContainerInfo, not the stored record.
             mock_reconcile.assert_called()
             call_args = mock_reconcile.call_args
             assert call_args[0][0] is store
             assert call_args[0][1].container_id == container_id
+            assert call_args[0][1].exit_code == 137
 
     def test_reconciles_stale_records_on_complete_pipeline(self):
         """Loop reconciles COMPLETE pipelines that have stale RUNNING records (#1840)."""

--- a/orchestrator/tests/test_container_monitor.py
+++ b/orchestrator/tests/test_container_monitor.py
@@ -120,8 +120,14 @@ def _make_container_info(container_id: str, exit_code: int = 1) -> ContainerInfo
 class TestReconcileContainerState:
     """Tests for the _reconcile_container_state helper."""
 
-    def test_marks_pipeline_failed_when_container_exits(self):
-        """A RUNNING pipeline whose container exits is marked FAILED."""
+    def test_reconciles_records_without_escalating_pipeline(self):
+        """A RUNNING pipeline whose container exits gets sub-records reconciled.
+
+        #2210: pipeline.status is no longer mutated by this path — that
+        decision belongs to the BRC poll loop which has consensus context.
+        The agent + container records still get the failure recorded so
+        observers can see what happened.
+        """
         container_id = "dead_container_xyz"
         pipeline = _make_pipeline_with_running_agent(container_id)
         store = _make_store(pipeline)
@@ -130,8 +136,9 @@ class TestReconcileContainerState:
         result = _reconcile_container_state(store, exited_info)
 
         assert result is True
-        assert pipeline.status == PipelineStatus.FAILED
-        assert pipeline.error is not None
+        # Pipeline.status preserved.
+        assert pipeline.status == PipelineStatus.RUNNING
+        assert pipeline.error is None
         store.save_pipeline.assert_called_once_with(
             pipeline,
             expected_version=pipeline.version,
@@ -251,10 +258,11 @@ class TestReconcileContainerState:
         assert result is False
 
     def test_reconciles_running_container_in_completed_phase(self):
-        """A RUNNING agent in a COMPLETE phase with an exited container is marked FAILED.
+        """A RUNNING agent in a COMPLETE phase with an exited container is reconciled.
 
         Reviewers run inside phases already marked complete. The reconciler
-        must still scan completed phases for exited containers.
+        must still scan completed phases for exited containers and update
+        the agent record, but it must not escalate the pipeline (#2210).
         """
         container_id = "reviewer_dead_xyz"
         pipeline = _make_pipeline_with_running_agent(container_id)
@@ -268,7 +276,8 @@ class TestReconcileContainerState:
         result = _reconcile_container_state(store, exited_info)
 
         assert result is True
-        assert pipeline.status == PipelineStatus.FAILED
+        # Pipeline status preserved — only sub-records reconciled.
+        assert pipeline.status == PipelineStatus.RUNNING
         agent = phase.agents[0]
         assert agent.status == AgentExecutionStatus.FAILED
         assert agent.completed_at is not None
@@ -303,17 +312,19 @@ class TestReconcileContainerState:
         # Agent should still be COMPLETE (not overwritten to FAILED)
         assert phase.agents[0].status == AgentExecutionStatus.COMPLETE
 
-    def test_sigterm_143_skips_reconciliation_when_phase_complete(self):
-        """SIGTERM (exit 143) during a completed phase is benign (issue #1405).
+    def test_sigterm_143_marks_agent_complete_regardless_of_phase_status(self):
+        """SIGTERM (exit 143) is treated as a clean exit regardless of phase status.
 
-        When the orchestrator kills agent containers during a phase transition,
-        containers exit with code 143. If the phase has already completed
-        successfully, the reconciler should NOT mark the pipeline as FAILED.
+        #2210: under the new classifier, 143 is always a clean exit
+        (orchestrator-initiated stop).  The agent flips to COMPLETE,
+        the container to EXITED, pipeline.status is untouched.  The
+        prior "143 only counts as clean during phase teardown" carve-
+        out is gone — that distinction was a workaround for the
+        K8s-monitor escalation bug, not a real semantic difference.
         """
         container_id = "sigterm_phase_done_xyz"
         pipeline = _make_pipeline_with_running_agent(container_id)
         phase = pipeline.get_phase_execution(PipelinePhase.IMPLEMENT)
-        # Phase has completed successfully before containers were killed
         phase.status = PipelineStatus.COMPLETE
 
         store = _make_store(pipeline)
@@ -321,17 +332,21 @@ class TestReconcileContainerState:
 
         result = _reconcile_container_state(store, exited_info)
 
-        # SIGTERM during completed phase should not mark as FAILED
-        assert result is False
-        assert pipeline.status == PipelineStatus.RUNNING  # Unchanged
+        assert result is True
+        assert pipeline.status == PipelineStatus.RUNNING
         agent = phase.agents[0]
-        assert agent.status == AgentExecutionStatus.RUNNING  # Unchanged
+        assert agent.status == AgentExecutionStatus.COMPLETE
+        ci = phase.containers[0]
+        assert ci.status == ContainerStatus.EXITED
 
     def test_sigterm_143_reconciles_when_phase_still_running(self):
-        """SIGTERM (exit 143) during a still-running phase IS a failure.
+        """SIGTERM (exit 143) during a still-running phase: agent COMPLETE, pipeline preserved.
 
-        If the phase is still RUNNING when a container exits with 143, this
-        is an unexpected termination and should be treated as a real failure.
+        #2210: SIGTERM is orchestrator-initiated and treated as clean
+        regardless of phase state.  The reconciler updates the agent
+        record but does not escalate the pipeline.  If 143 ever
+        represents a genuine failure, the BRC poll loop's
+        consensus-aware path catches that on the next tick.
         """
         container_id = "sigterm_running_phase_xyz"
         pipeline = _make_pipeline_with_running_agent(container_id)
@@ -344,9 +359,11 @@ class TestReconcileContainerState:
 
         result = _reconcile_container_state(store, exited_info)
 
-        # SIGTERM during running phase IS a failure
         assert result is True
-        assert pipeline.status == PipelineStatus.FAILED
+        # Pipeline.status preserved — RUNNING.
+        assert pipeline.status == PipelineStatus.RUNNING
+        agent = phase.agents[0]
+        assert agent.status == AgentExecutionStatus.COMPLETE
 
 
 # ---------------------------------------------------------------------------
@@ -359,7 +376,11 @@ class TestCreatePipelineReconciliationHandler:
 
     @patch("state_store.get_state_store")
     def test_handler_calls_reconcile_on_failed_event(self, mock_get_store):
-        """Handler processes FAILED events (non-zero exit)."""
+        """Handler processes FAILED events: agent record reconciled, pipeline preserved.
+
+        #2210: the handler still fires on FAILED events, but the resulting
+        reconciliation no longer escalates pipeline.status.
+        """
         container_id = "dead_container"
         pipeline = _make_pipeline_with_running_agent(container_id)
         store = _make_store(pipeline)
@@ -372,7 +393,10 @@ class TestCreatePipelineReconciliationHandler:
         )
         handler(event)
 
-        assert pipeline.status == PipelineStatus.FAILED
+        # Pipeline.status preserved — agent record reconciled separately.
+        assert pipeline.status == PipelineStatus.RUNNING
+        phase = pipeline.get_phase_execution(PipelinePhase.IMPLEMENT)
+        assert phase.agents[0].status == AgentExecutionStatus.FAILED
 
     @patch("state_store.get_state_store")
     def test_handler_ignores_started_event(self, mock_get_store):

--- a/orchestrator/tests/test_kubernetes_monitor.py
+++ b/orchestrator/tests/test_kubernetes_monitor.py
@@ -520,8 +520,13 @@ class TestReconcilePodState:
         store.load_pipeline.return_value = pipeline
         return store
 
-    def test_reconcile_marks_pipeline_failed(self):
-        """_reconcile_pod_state marks the pipeline as FAILED."""
+    def test_reconcile_crash_exit_marks_agent_failed_preserves_pipeline_running(self):
+        """Non-zero exit reconciles agent + container records but never touches pipeline.status.
+
+        #2210: pipeline-level FAILED decisions belong to the BRC poll loop,
+        which has consensus context.  The K8s monitor only reconciles
+        sub-records; it must not escalate the pipeline itself.
+        """
         from kubernetes_monitor import _reconcile_pod_state
         from models import (
             AgentExecution,
@@ -536,7 +541,7 @@ class TestReconcilePodState:
             container_id="uid-1",
             container_name="job-1",
             status=ContainerStatus.FAILED,
-            exit_code=1,
+            exit_code=137,
             exited_at=datetime(2024, 1, 15, 13, 0, 0, tzinfo=UTC),
         )
 
@@ -576,7 +581,149 @@ class TestReconcilePodState:
         assert result is True
         store.save_pipeline.assert_called_once()
         saved_pipeline = store.save_pipeline.call_args[0][0]
-        assert saved_pipeline.status == PipelineStatus.FAILED
+        # Sub-records reconciled.
+        assert saved_pipeline.phases["implement"].agents[0].status == AgentExecutionStatus.FAILED
+        assert saved_pipeline.phases["implement"].containers[0].status == ContainerStatus.FAILED
+        # Pipeline.status untouched — RUNNING preserved.
+        assert saved_pipeline.status == PipelineStatus.RUNNING
+        assert saved_pipeline.error is None
+        # Error message includes the actual exit code so observers can tell
+        # OOM / crash apart from clean exits.
+        assert "137" in saved_pipeline.phases["implement"].agents[0].error
+
+    def test_reconcile_clean_exit_marks_agent_complete_preserves_pipeline_running(self):
+        """exit_code 0 → agent COMPLETE, container EXITED, pipeline RUNNING preserved.
+
+        #2210: this is the BRC-clean-exit case.  Reviewers / producers
+        legitimately exit 0 after sending CONSENSUS_ACK / PROPOSE; before
+        the BRC poll loop reconciles them, the K8s monitor used to mis-
+        classify the clean exit as a failure and escalate the pipeline.
+        """
+        from kubernetes_monitor import _reconcile_pod_state
+        from models import (
+            AgentExecution,
+            AgentExecutionStatus,
+            PhaseExecution,
+            Pipeline,
+            PipelinePhase,
+            PipelineStatus,
+        )
+
+        container_info = ContainerInfo(
+            container_id="uid-1",
+            container_name="job-1",
+            status=ContainerStatus.EXITED,
+            exit_code=0,
+            exited_at=datetime(2024, 1, 15, 13, 0, 0, tzinfo=UTC),
+        )
+
+        agent = AgentExecution(
+            role="reviewer_code",
+            status=AgentExecutionStatus.RUNNING,
+            container_id="uid-1",
+        )
+        ci = ContainerInfo(
+            container_id="uid-1",
+            container_name="job-1",
+            status=ContainerStatus.RUNNING,
+        )
+        phase_exec = PhaseExecution(
+            phase=PipelinePhase.IMPLEMENT,
+            status=PipelineStatus.RUNNING,
+            agents=[agent],
+            containers=[ci],
+        )
+        pipeline = Pipeline(
+            id="pipe-1",
+            issue_number=1,
+            repo="owner/repo",
+            status=PipelineStatus.RUNNING,
+            current_phase=PipelinePhase.IMPLEMENT,
+            phases={"implement": phase_exec},
+        )
+
+        store = self._make_mock_store(pipeline)
+
+        with patch("state_store.get_pipeline_state_lock") as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock()
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = _reconcile_pod_state(store, container_info)
+
+        assert result is True
+        saved_pipeline = store.save_pipeline.call_args[0][0]
+        assert saved_pipeline.phases["implement"].agents[0].status == AgentExecutionStatus.COMPLETE
+        assert saved_pipeline.phases["implement"].agents[0].error is None
+        assert saved_pipeline.phases["implement"].containers[0].status == ContainerStatus.EXITED
+        assert saved_pipeline.phases["implement"].containers[0].exit_code == 0
+        # Pipeline.status untouched.
+        assert saved_pipeline.status == PipelineStatus.RUNNING
+        assert saved_pipeline.error is None
+
+    def test_reconcile_sigterm_exit_marks_agent_complete(self):
+        """exit_code 143 (SIGTERM) is treated as clean — orchestrator-initiated stop.
+
+        #2210: SIGTERM during phase teardown is expected, not a failure.
+        The previous carve-out only applied when the phase had already
+        transitioned out of RUNNING; with the new classifier, 143 is
+        clean regardless of phase status.
+        """
+        from kubernetes_monitor import _reconcile_pod_state
+        from models import (
+            AgentExecution,
+            AgentExecutionStatus,
+            PhaseExecution,
+            Pipeline,
+            PipelinePhase,
+            PipelineStatus,
+        )
+
+        container_info = ContainerInfo(
+            container_id="uid-1",
+            container_name="job-1",
+            status=ContainerStatus.EXITED,
+            exit_code=143,
+            exited_at=datetime(2024, 1, 15, 13, 0, 0, tzinfo=UTC),
+        )
+
+        agent = AgentExecution(
+            role="documenter",
+            status=AgentExecutionStatus.RUNNING,
+            container_id="uid-1",
+        )
+        ci = ContainerInfo(
+            container_id="uid-1",
+            container_name="job-1",
+            status=ContainerStatus.RUNNING,
+        )
+        phase_exec = PhaseExecution(
+            phase=PipelinePhase.IMPLEMENT,
+            status=PipelineStatus.RUNNING,
+            agents=[agent],
+            containers=[ci],
+        )
+        pipeline = Pipeline(
+            id="pipe-1",
+            issue_number=1,
+            repo="owner/repo",
+            status=PipelineStatus.RUNNING,
+            current_phase=PipelinePhase.IMPLEMENT,
+            phases={"implement": phase_exec},
+        )
+
+        store = self._make_mock_store(pipeline)
+
+        with patch("state_store.get_pipeline_state_lock") as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock()
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = _reconcile_pod_state(store, container_info)
+
+        assert result is True
+        saved_pipeline = store.save_pipeline.call_args[0][0]
+        assert saved_pipeline.phases["implement"].agents[0].status == AgentExecutionStatus.COMPLETE
+        assert saved_pipeline.phases["implement"].containers[0].status == ContainerStatus.EXITED
+        assert saved_pipeline.status == PipelineStatus.RUNNING
 
     def test_reconcile_skips_completed_agents(self):
         """_reconcile_pod_state skips pods whose agent is COMPLETE."""
@@ -1102,9 +1249,18 @@ class TestReconciliationSweep:
         call_kwargs = mock_k8s_client.list_jobs.call_args
         assert call_kwargs.kwargs["label_selector"] == f"{LABEL_ORCHESTRATOR}=true"
 
-    def test_terminated_pod_marks_failed(self, monitor, mock_k8s_client):
-        """A pod with exited_at set and non-zero exit is reconciled."""
-        from models import PipelineStatus
+    def test_terminated_pod_reconciles_records_without_escalating_pipeline(
+        self, monitor, mock_k8s_client
+    ):
+        """A non-zero pod exit reconciles agent + container records but never escalates pipeline.
+
+        #2210: the periodic sweep delegates to _reconcile_pod_state for
+        non-clean exits.  The agent record flips to FAILED and the
+        container record flips to FAILED, but the pipeline's own
+        status stays RUNNING — that decision belongs to the BRC poll
+        loop with consensus context.
+        """
+        from models import AgentExecutionStatus, PipelineStatus
 
         mock_k8s_client.list_containers.return_value = []
         mock_k8s_client.list_jobs.return_value = []
@@ -1129,11 +1285,22 @@ class TestReconciliationSweep:
 
         store.save_pipeline.assert_called_once()
         saved = store.save_pipeline.call_args[0][0]
-        assert saved.status == PipelineStatus.FAILED
+        assert saved.phases["implement"].agents[0].status == AgentExecutionStatus.FAILED
+        assert saved.phases["implement"].containers[0].status == ContainerStatus.FAILED
+        # Pipeline.status untouched — RUNNING preserved.
+        assert saved.status == PipelineStatus.RUNNING
+        assert saved.error is None
 
-    def test_missing_pod_marks_failed(self, monitor, mock_k8s_client):
-        """A pod that has been deleted (PodNotFoundError) is reconciled."""
-        from models import PipelineStatus
+    def test_missing_pod_reconciles_records_without_escalating_pipeline(
+        self, monitor, mock_k8s_client
+    ):
+        """A deleted pod (PodNotFoundError) reconciles records, leaves pipeline RUNNING.
+
+        #2210: same contract as the terminated-pod path — the K8s monitor
+        cannot tell whether a missing pod represents a crash or a clean
+        BRC exit, so it must not be the one to fail the pipeline.
+        """
+        from models import AgentExecutionStatus, PipelineStatus
 
         mock_k8s_client.list_containers.return_value = []
         mock_k8s_client.list_jobs.return_value = []
@@ -1152,7 +1319,10 @@ class TestReconciliationSweep:
 
         store.save_pipeline.assert_called_once()
         saved = store.save_pipeline.call_args[0][0]
-        assert saved.status == PipelineStatus.FAILED
+        assert saved.phases["implement"].agents[0].status == AgentExecutionStatus.FAILED
+        # Pipeline.status untouched.
+        assert saved.status == PipelineStatus.RUNNING
+        assert saved.error is None
 
     def test_sweep_reconciles_stale_records_on_failed_pipeline(self, monitor, mock_k8s_client):
         """Periodic sweep cleans up stale RUNNING records on FAILED pipelines.


### PR DESCRIPTION
## Summary

- The K8s runtime monitor's pod-exit reconciliation marked every pod-exit as a pipeline-level FAILED, regardless of exit code. Agents that exited cleanly (0) post-BRC — reviewers after CONSENSUS_ACK, producers after PROPOSE — were misclassified as failures, poisoning the pipeline even though their work was already on the branch and the BRC poll loop would have closed consensus on its next tick.
- Root cause is layering: the K8s monitor was making pipeline-level decisions without consensus context, racing the BRC poll loop in `_run_concurrent_phase` (which already classifies exits correctly and has consensus state).
- This PR removes the pipeline-level FAILED escalation from the K8s monitor. It now only reconciles sub-records (agent + container), classifying exits as 0/143 → `COMPLETE` (clean BRC exit or orchestrator-initiated SIGTERM) or anything else → `FAILED` with the actual exit code in the error string. Pipeline-level FAILED decisions remain with the BRC poll loop, which has consensus context.

## Why this is the right layer for the fix

`orchestrator/routes/pipelines.py::_run_concurrent_phase` already does the consensus-aware exit classification on every tick (`_record_container_exit`, `handle_agent_failure`). The K8s monitor's escalation was redundant when the loop was alive and incorrect when it raced ahead. Adding consensus checks into the K8s monitor (issue #2210's "fix #1") would have hard-coded the wrong layering — two paths racing to make the same decision. Removing the K8s-monitor escalation (issue's "fix #3") gives a single consensus-aware decider.

## What changed

`orchestrator/kubernetes_monitor.py`
- New `_classify_exit(exit_code)` helper: 0/143 → clean, else → failed with code-in-error.
- `_reconcile_pod_state` uses it for both the container loop and the agent loop.
- The pipeline.status mutation block (and its canned "exited unexpectedly" error) is removed.
- The 143/non-RUNNING-phase carve-outs are removed (subsumed by the new classifier).
- Comment at the aggressive-recovery synthetic-EXITED path is updated to reflect the new contract.

`orchestrator/tests/test_kubernetes_monitor.py`
- Replaced `test_reconcile_marks_pipeline_failed` with three coverage cases: crash exit (records updated, pipeline RUNNING preserved, exit code in error), clean exit (agent COMPLETE, container EXITED, pipeline RUNNING preserved), SIGTERM (same shape as clean exit).
- Updated periodic-sweep tests (`test_terminated_pod_*`, `test_missing_pod_*`) to assert records-updated/pipeline-preserved.
- Existing FAILED/AWAITING_HUMAN preservation tests unchanged — they already encode the right contract.

`orchestrator/tests/test_container_monitor.py`
- Same shape of edits: the re-exported `_reconcile_container_state` and `create_pipeline_reconciliation_handler` tests now assert records-updated, pipeline status preserved.
- The "143 only counts as clean during phase teardown" test is reframed: 143 is now always treated as a clean exit (orchestrator-initiated stop). The prior carve-out was a workaround for the bug being fixed.

## Out of scope

- Companion issues #2203, #2204, #2205 are distinct paths and not bundled.
- The "external FAILED recovery" paths in `routes/pipelines.py` (`9856-9887`, `10100-10119`) become mostly dead code with this fix. Left in place as defense-in-depth; remove in a follow-up if desired.

## Test plan

- [x] `pytest orchestrator/tests/test_kubernetes_monitor.py` — 59 passed
- [x] `pytest orchestrator/tests/test_container_monitor.py` — passed
- [x] Full orchestrator suite: `pytest orchestrator/tests/` — 4882 passed, 1 skipped, 0 failures
- [x] `ruff check` + `ruff format --check` on all changed files — clean
- [ ] Verify in a real pipeline that clean BRC exits no longer poison the pipeline (requires live deployment — note in PR for reviewer)

Closes #2210.