### PR TITLE
fix(test): keep make test changeset-aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,16 @@ Thumbs.db
 # Per-machine runtime telemetry written by the overseer; otherwise
 # leaves `git status` dirty after every local pipeline run and trips
 # the selector's "non-.py change" fallback into running the full suite.
+# Tracked test fixtures (test-00{2,3,4}-oversight.jsonl) are unaffected
+# — .gitignore only hides untracked paths.
 .egg-state/oversight/agent-timing.json
 .egg-state/oversight/agent-timing.json.lock
+.egg-state/oversight/*-oversight.jsonl
+.egg-state/oversight/*-health-summary.md
+.egg-state/oversight/filed-issues.jsonl
+.egg-state/oversight/filed-issues.jsonl.lock
+# `save_agent_timing` writes via `tempfile.NamedTemporaryFile(prefix=".<name>.", suffix=".tmp")`
+# and only `os.replace`s on the happy path; a SIGKILL mid-write leaves
+# a leftover tmp file alongside the target.
+.egg-state/oversight/.agent-timing.json.*.tmp
+.egg-state/oversight/.filed-issues.jsonl.*.tmp

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ Thumbs.db
 .egg-state/oversight/filed-issues.jsonl.lock
 # `save_agent_timing` writes via `tempfile.NamedTemporaryFile(prefix=".<name>.", suffix=".tmp")`
 # and only `os.replace`s on the happy path; a SIGKILL mid-write leaves
-# a leftover tmp file alongside the target.
+# a leftover tmp file alongside the target.  `append_filed_issue` uses
+# plain `open(p, "a")` + `fsync` (no rename pattern), so there's no
+# matching tmp leftover to ignore for that file.
 .egg-state/oversight/.agent-timing.json.*.tmp
-.egg-state/oversight/.filed-issues.jsonl.*.tmp

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,9 @@ Thumbs.db
 .egg-state/last-known-good/
 .egg-state/selection/
 .egg-state/grimp-cache/
+
+# Per-machine runtime telemetry written by the overseer; otherwise
+# leaves `git status` dirty after every local pipeline run and trips
+# the selector's "non-.py change" fallback into running the full suite.
+.egg-state/oversight/agent-timing.json
+.egg-state/oversight/agent-timing.json.lock

--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ test: sync-venv-if-uv
 	@echo "==> Running narrowed unit tests (changeset-aware; see docs/guides/testing.md)..."
 	@selected_file=$$(mktemp); \
 	PYTEST_ARGS_RAW="$(PYTEST_ARGS)" \
-		$(PYTHON) scripts/select_tests.py >"$$selected_file"; \
+		env -u PYTHONPATH $(PYTHON) scripts/select_tests.py >"$$selected_file"; \
 	selector_rc=$$?; \
 	if [ "$$selector_rc" -ne 0 ]; then \
 		echo "select-tests: selector exited $$selector_rc; running full suite as fallback"; \
@@ -325,7 +325,7 @@ test: sync-venv-if-uv
 	t1=$$(date +%s%N); \
 	rm -f "$$selected_file"; \
 	pytest_ms=$$(( (t1 - t0) / 1000000 )); \
-	$(PYTHON) scripts/select_tests.py --patch-selection-json --head "$$head_sha" --pytest-ms "$$pytest_ms" || true; \
+	env -u PYTHONPATH $(PYTHON) scripts/select_tests.py --patch-selection-json --head "$$head_sha" --pytest-ms "$$pytest_ms" || true; \
 	exit $$pytest_rc
 
 ## Full-suite escape hatch (issue #1973).  Runs the historical
@@ -346,7 +346,7 @@ test-all: sync-venv-if-uv  ## Run the full unit-test suite + record LKG on green
 	@$(PYTEST) tests/ gateway/tests/ orchestrator/tests/ shared/tests/ -v -m "not functional" $(PYTEST_ARGS); \
 	pytest_rc=$$?; \
 	if [ "$$pytest_rc" -eq 0 ]; then \
-		$(PYTHON) scripts/select_tests.py --record-good \
+		env -u PYTHONPATH $(PYTHON) scripts/select_tests.py --record-good \
 			|| echo "select-tests: --record-good failed; LKG not updated"; \
 	else \
 		echo "select-tests: pytest failed; LKG not updated"; \
@@ -361,7 +361,7 @@ test-all: sync-venv-if-uv  ## Run the full unit-test suite + record LKG on green
 ## input.
 test-record-good:
 	@echo "==> Recording HEAD as Last-Known-Good baseline (issue #1973)..."
-	@$(PYTHON) scripts/select_tests.py --record-good
+	@env -u PYTHONPATH $(PYTHON) scripts/select_tests.py --record-good
 
 smoketest-long-poll: export PYTHONPATH := shared:gateway:orchestrator
 smoketest-long-poll: venv  ## Smoke-test the long-poll / event-driven wait infrastructure

--- a/scripts/select_tests.py
+++ b/scripts/select_tests.py
@@ -726,17 +726,20 @@ def build_graph(repo_root: Path | None = None, packages: tuple[str, ...] = PACKA
         #
         # Asymmetry note: an externally-set ``PYTHONPATH=shared:...``
         # makes grimp abort with ``NotATopLevelModule: shared.egg_agent``
-        # because ``shared/`` lands at sys.path[0] (egg_agent then
-        # resolves as a bare top-level package, conflicting with
-        # ``shared.egg_agent`` registered in PACKAGES).  These internal
-        # ``sys.path.insert(0, ...)`` calls do NOT trip the same bug
-        # because each insert at 0 reverses the iteration order, so
-        # ``root`` ends up at sys.path[0] and ``root/shared`` further
-        # back — Python finds ``shared.egg_agent`` via the regular
-        # namespace package mechanism before it would find a bare
-        # ``egg_agent``.  ``main()`` also pops ``PYTHONPATH`` from the
-        # environment as defense-in-depth in case a future grimp
-        # release becomes more sensitive to either path's presence.
+        # because ``egg_agent`` becomes reachable as both
+        # ``shared.egg_agent`` (registered in PACKAGES) and a bare
+        # top-level ``egg_agent`` via ``shared/``.  The defense-in-depth
+        # scrub at the top of ``main()`` (``_strip_pythonpath_from_sys_path``)
+        # removes any PYTHONPATH-derived entries from sys.path before
+        # grimp is imported, so the internal ``sys.path.insert(0, ...)``
+        # calls below cannot collide with one Python added at startup.
+        # Empirically the internal injection of ``root/shared`` does
+        # not trigger the same ``NotATopLevelModule`` failure, but the
+        # mechanism for that asymmetry is not fully understood — a
+        # future grimp release could become more sensitive.  If that
+        # ever happens, the right move is to stop injecting the
+        # subpackage source roots here and instead rely on the same
+        # ``PACKAGES`` registration grimp already uses.
         added_paths: list[str] = []
         for entry in (
             str(root),

--- a/scripts/select_tests.py
+++ b/scripts/select_tests.py
@@ -723,6 +723,20 @@ def build_graph(repo_root: Path | None = None, packages: tuple[str, ...] = PACKA
         #                                  (matches `tests/conftest.py:15`).
         #   - root / "config"            — `import host_config` etc.
         #                                  (matches `tests/conftest.py:16`).
+        #
+        # Asymmetry note: an externally-set ``PYTHONPATH=shared:...``
+        # makes grimp abort with ``NotATopLevelModule: shared.egg_agent``
+        # because ``shared/`` lands at sys.path[0] (egg_agent then
+        # resolves as a bare top-level package, conflicting with
+        # ``shared.egg_agent`` registered in PACKAGES).  These internal
+        # ``sys.path.insert(0, ...)`` calls do NOT trip the same bug
+        # because each insert at 0 reverses the iteration order, so
+        # ``root`` ends up at sys.path[0] and ``root/shared`` further
+        # back — Python finds ``shared.egg_agent`` via the regular
+        # namespace package mechanism before it would find a bare
+        # ``egg_agent``.  ``main()`` also pops ``PYTHONPATH`` from the
+        # environment as defense-in-depth in case a future grimp
+        # release becomes more sensitive to either path's presence.
         added_paths: list[str] = []
         for entry in (
             str(root),
@@ -1551,6 +1565,38 @@ def _main_inner(argv: list[str] | None = None) -> int:
     return _run_narrow_or_fallback(repo_root)
 
 
+def _strip_pythonpath_from_sys_path() -> None:
+    """Pop ``PYTHONPATH`` from the env AND remove its entries from
+    ``sys.path``.
+
+    A ``PYTHONPATH=shared:gateway:orchestrator`` (the value the Makefile
+    exports for pytest) leaves ``shared/`` at the head of ``sys.path``,
+    which causes grimp's ``build_graph`` to abort with
+    ``NotATopLevelModule: shared.egg_agent`` — ``egg_agent`` becomes
+    reachable as a bare top-level package via ``shared/`` AND as
+    ``shared.egg_agent`` via the namespace package, and grimp refuses
+    the ambiguity.  Python has already resolved the env var to absolute
+    paths and prepended them to sys.path at interpreter startup, so
+    just popping the env var is not enough — we also strip the
+    resolved entries from sys.path.
+    """
+    pythonpath = os.environ.pop("PYTHONPATH", None)
+    if not pythonpath:
+        return
+    for entry in pythonpath.split(os.pathsep):
+        if not entry:
+            continue
+        # Python prepends the resolved absolute path; try both forms.
+        candidates = {entry}
+        try:
+            candidates.add(str(Path(entry).resolve()))
+        except OSError:
+            pass
+        for candidate in candidates:
+            while candidate in sys.path:
+                sys.path.remove(candidate)
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point with the **fail-open** wrapper.
 
@@ -1572,6 +1618,19 @@ def main(argv: list[str] | None = None) -> int:
     exit 0 instead.  TASK-5-2 includes a regression test that locks
     this behaviour.
     """
+    # Defense-in-depth: a `PYTHONPATH` containing source roots like
+    # `shared` makes subpackages reachable as both `shared.egg_agent`
+    # and bare `egg_agent`, which causes grimp to abort the graph
+    # build with `NotATopLevelModule`.  The Makefile already strips
+    # the env via `env -u PYTHONPATH`, but anyone invoking the
+    # script directly (or any future caller that forgets the
+    # wrapper) gets the same protection here.
+    #
+    # Popping the env var alone is not enough — Python has already
+    # prepended the PYTHONPATH entries to sys.path at interpreter
+    # startup (resolved to absolute paths), and grimp inspects
+    # sys.path directly during `build_graph`.  Scrub both.
+    _strip_pythonpath_from_sys_path()
     try:
         return _main_inner(argv)
     except SystemExit:

--- a/tests/tools/test_select_tests_fallbacks.py
+++ b/tests/tools/test_select_tests_fallbacks.py
@@ -512,15 +512,24 @@ def test_strip_pythonpath_no_op_when_unset(monkeypatch: pytest.MonkeyPatch) -> N
     assert sys.path == snapshot
 
 
-def test_subprocess_with_leaked_pythonpath_does_not_abort_graph(real_git, tmp_path: Path) -> None:
+def test_subprocess_with_leaked_pythonpath_does_not_abort_graph() -> None:
     """End-to-end contract: setting ``PYTHONPATH=shared:gateway:orchestrator``
     in the child env (mimicking the Makefile pre-fix) MUST NOT cause
-    grimp to abort with ``NotATopLevelModule`` against the real repo.
+    grimp's ``build_graph`` to abort with ``NotATopLevelModule``.
 
-    Runs against ``REPO_ROOT`` so PACKAGES (which includes
-    ``shared.egg_agent``) actually overlaps with the leaked
-    ``shared/`` entry.  Skips when grimp isn't installed because the
-    bug is a grimp-specific failure mode.
+    Drives ``--why`` against a real test path so the selector actually
+    reaches ``build_graph`` (the ``--full-suite`` short-circuits before
+    grimp is touched and would let the regression slip through silently).
+    ``explain_why`` calls ``build_graph`` immediately; under the bug it
+    logs ``select-tests: --why: graph build failed: NotATopLevelModule:``
+    on stderr, and with the strip in ``main()`` neither marker appears.
+
+    ``--why`` is purely read-only — no canary counter bump, no selection
+    record write — so this test has no effect on subsequent ``make test``
+    runs in the same checkout.
+
+    Skips when grimp isn't installed because the bug is a grimp-specific
+    failure mode.
     """
     pytest.importorskip("grimp")
     env = os.environ.copy()
@@ -528,7 +537,12 @@ def test_subprocess_with_leaked_pythonpath_does_not_abort_graph(real_git, tmp_pa
     env.pop("EGG_AGENT_ROLE", None)
     env["PYTHONPATH"] = "shared:gateway:orchestrator"
     proc = subprocess.run(
-        [find_python(), str(SELECTOR_PATH), "--full-suite"],
+        [
+            find_python(),
+            str(SELECTOR_PATH),
+            "--why",
+            "tests/test_python_syntax.py",
+        ],
         cwd=str(REPO_ROOT),
         capture_output=True,
         text=True,
@@ -536,19 +550,19 @@ def test_subprocess_with_leaked_pythonpath_does_not_abort_graph(real_git, tmp_pa
         env=env,
         timeout=60,
     )
-    # --full-suite avoids needing a synthetic git history but still
-    # exercises main()'s strip before any further setup.  The bug
-    # would surface as `graph build failed: NotATopLevelModule` on
-    # stderr from a subsequent narrow-mode invocation; with --full-suite
-    # we instead assert the strip itself didn't blow up and the
-    # selector returns the canonical test-root list.
+    # Fail-open contract guarantees rc==0; assert it explicitly so a
+    # different non-zero exit (e.g. an unhandled exception escaping the
+    # wrapper) doesn't go unnoticed.
     assert proc.returncode == 0, (
         f"selector exited {proc.returncode} with leaked PYTHONPATH\n"
         f"stdout: {proc.stdout!r}\nstderr: {proc.stderr!r}"
     )
-    out = proc.stdout.splitlines()
-    for d in selector.TEST_ROOT_DIRS:
-        assert d in out, f"missing {d} in stdout: {out!r}"
+    # The two buggy stderr signatures: grimp's exception class name and
+    # the explain_why fail-open log line that wraps it.  Either appearing
+    # means PYTHONPATH leaked through the strip and into build_graph.
     assert "NotATopLevelModule" not in proc.stderr, (
         f"PYTHONPATH leaked into grimp despite the strip:\n{proc.stderr!r}"
+    )
+    assert "graph build failed" not in proc.stderr, (
+        f"build_graph aborted (likely from PYTHONPATH leak):\n{proc.stderr!r}"
     )

--- a/tests/tools/test_select_tests_fallbacks.py
+++ b/tests/tools/test_select_tests_fallbacks.py
@@ -16,11 +16,13 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from tests.tools._select_tests_helpers import (
+    REPO_ROOT,
     SELECTOR_PATH,
     _git,
     commit_file,
@@ -465,3 +467,88 @@ def test_fail_open_subprocess_grimp_unavailable(
         or "selector exception" in proc.stderr
         or "trigger=" in proc.stderr  # any explicit trigger
     ), f"no fallback trigger logged on stderr: {proc.stderr!r}"
+
+
+# ----------------------------------------------------------------------
+# PYTHONPATH leak — the Makefile exports `PYTHONPATH=shared:gateway:orchestrator`
+# for pytest, which previously also reached `select_tests.py`.  With
+# `shared/` on sys.path, grimp's `build_graph` aborts with
+# `NotATopLevelModule: shared.egg_agent` and the selector silently
+# fell back to the full suite.  The two regression cases below pin
+# both the helper and the end-to-end contract.
+# ----------------------------------------------------------------------
+
+
+def test_strip_pythonpath_pops_env_and_sys_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_strip_pythonpath_from_sys_path`` MUST remove PYTHONPATH from
+    ``os.environ`` AND strip its entries from ``sys.path`` (both raw
+    and ``Path.resolve()`` forms — Python prepends the resolved
+    absolute path at interpreter startup, but a sloppy caller could
+    inject the raw form too)."""
+    raw = "shared:gateway:orchestrator"
+    monkeypatch.setenv("PYTHONPATH", raw)
+    raw_entries = raw.split(os.pathsep)
+    resolved_entries = [str(Path(e).resolve()) for e in raw_entries]
+    # Inject both forms at the head of sys.path, then assert they're
+    # all gone after the strip.
+    original_path = list(sys.path)
+    try:
+        for entry in [*resolved_entries, *raw_entries]:
+            sys.path.insert(0, entry)
+        selector._strip_pythonpath_from_sys_path()
+        assert "PYTHONPATH" not in os.environ
+        for entry in [*raw_entries, *resolved_entries]:
+            assert entry not in sys.path, f"{entry!r} still on sys.path"
+    finally:
+        sys.path[:] = original_path
+
+
+def test_strip_pythonpath_no_op_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No PYTHONPATH → no env mutation, no sys.path mutation."""
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    snapshot = list(sys.path)
+    selector._strip_pythonpath_from_sys_path()
+    assert "PYTHONPATH" not in os.environ
+    assert sys.path == snapshot
+
+
+def test_subprocess_with_leaked_pythonpath_does_not_abort_graph(real_git, tmp_path: Path) -> None:
+    """End-to-end contract: setting ``PYTHONPATH=shared:gateway:orchestrator``
+    in the child env (mimicking the Makefile pre-fix) MUST NOT cause
+    grimp to abort with ``NotATopLevelModule`` against the real repo.
+
+    Runs against ``REPO_ROOT`` so PACKAGES (which includes
+    ``shared.egg_agent``) actually overlaps with the leaked
+    ``shared/`` entry.  Skips when grimp isn't installed because the
+    bug is a grimp-specific failure mode.
+    """
+    pytest.importorskip("grimp")
+    env = os.environ.copy()
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env.pop("EGG_AGENT_ROLE", None)
+    env["PYTHONPATH"] = "shared:gateway:orchestrator"
+    proc = subprocess.run(
+        [find_python(), str(SELECTOR_PATH), "--full-suite"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=60,
+    )
+    # --full-suite avoids needing a synthetic git history but still
+    # exercises main()'s strip before any further setup.  The bug
+    # would surface as `graph build failed: NotATopLevelModule` on
+    # stderr from a subsequent narrow-mode invocation; with --full-suite
+    # we instead assert the strip itself didn't blow up and the
+    # selector returns the canonical test-root list.
+    assert proc.returncode == 0, (
+        f"selector exited {proc.returncode} with leaked PYTHONPATH\n"
+        f"stdout: {proc.stdout!r}\nstderr: {proc.stderr!r}"
+    )
+    out = proc.stdout.splitlines()
+    for d in selector.TEST_ROOT_DIRS:
+        assert d in out, f"missing {d} in stdout: {out!r}"
+    assert "NotATopLevelModule" not in proc.stderr, (
+        f"PYTHONPATH leaked into grimp despite the strip:\n{proc.stderr!r}"
+    )


### PR DESCRIPTION
## Summary

Two bugs were silently widening every `make test` invocation to the full suite regardless of the diff:

- **Untracked runtime telemetry.** The overseer writes per-machine state to `.egg-state/oversight/agent-timing.json{,.lock}`. Those paths weren't gitignored, so any local pipeline run leaves `git status` dirty; `select_tests.py` feeds porcelain output into its diff and the "non-.py change" catch-all (`scripts/select_tests.py:1086-1088`) then forces the full suite. Fix: gitignore the two files.
- **Leaked `PYTHONPATH` breaks the grimp graph build.** `test`/`test-all` export `PYTHONPATH=shared:gateway:orchestrator` for pytest, but the env var also reaches `select_tests.py`. With `shared/` on the path, subpackages like `shared.egg_agent` are reachable as top-level `egg_agent`, so grimp aborts with `NotATopLevelModule:`. The script's fail-open at `scripts/select_tests.py:1297-1300` then skips narrowing entirely and emits the full suite. Fix: wrap the three `select_tests.py` invocations with `env -u PYTHONPATH`; pytest still gets the original `PYTHONPATH`.

Before (clean tree, with the leftover untracked telemetry):
```
select-tests: graph build failed: NotATopLevelModule:
select-tests: full suite 4 tests (trigger=non-.py change)
```

After (clean tree):
```
select-tests: full suite 270 tests (trigger=empty diff)
```

The remaining `empty diff` trigger is by design (`select_tests.py:1033-1035`); narrowing now actually engages whenever there's a diff to narrow against.

## Test plan
- [ ] `make test` on a clean tree — selector emits 270 test modules and the graph build succeeds (no `graph build failed:` line).
- [ ] `touch foo.py && make test` — selector narrows via the import graph rather than the non-.py fallback.
- [ ] Spot-check that pytest still resolves imports under all four test roots (the test target's own `PYTHONPATH` export is unchanged).