### PR TITLE
Fix #2219: stop implement→PR auto-advance from silently wedging

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -12077,7 +12077,10 @@ def _run_pipeline(
                         ),
                         pipeline_id=pipeline_id,
                     )
-                except subprocess.CalledProcessError as git_err:
+                except Exception as git_err:
+                    # Catch broadly so TimeoutExpired/OSError also produce
+                    # an explicit FAILED state rather than silently
+                    # propagating to the outer handler (#2219).
                     logger.error(
                         "Failed to commit initial statefiles — aborting pipeline",
                         pipeline_id=pipeline_id,
@@ -12574,7 +12577,8 @@ def _run_pipeline(
                             ),
                             pipeline_id=pipeline_id,
                         )
-                    except subprocess.CalledProcessError as git_err:
+                    except Exception as git_err:
+                        # Catch broadly: see #2219.
                         logger.warning(
                             "Pre-PR statefile commit failed (continuing)",
                             pipeline_id=pipeline_id,
@@ -12956,13 +12960,27 @@ def _run_pipeline(
             # ensures _populate_contract_from_plan can read agent-produced
             # draft files that only exist on the remote.
             if pipeline.branch and worktree_repo_path != repo_path:
-                _sync_worktree_with_remote(
-                    spawner,
-                    pipeline_id,
-                    worktree_repo_path,
-                    gateway_mode=gateway_mode,
-                    base_branch=pipeline.base_branch,
-                )
+                # Best-effort: a sync failure must not strand the
+                # auto-advance.  Without this guard, a gateway HTTP error
+                # or git subprocess failure inside the helper propagates
+                # to the outer Exception handler and (if marking FAILED
+                # also fails) leaves the pipeline wedged with phase
+                # COMPLETE but no successor (#2219).
+                try:
+                    _sync_worktree_with_remote(
+                        spawner,
+                        pipeline_id,
+                        worktree_repo_path,
+                        gateway_mode=gateway_mode,
+                        base_branch=pipeline.base_branch,
+                    )
+                except Exception as sync_err:
+                    logger.warning(
+                        "Failed to sync worktree with remote after phase (continuing)",
+                        pipeline_id=pipeline_id,
+                        phase=current_phase.value,
+                        error=str(sync_err),
+                    )
 
             # After plan phase: populate contract with task structure.
             # NOTE: worktree_repo_path is used for both draft reads and
@@ -13029,7 +13047,12 @@ def _run_pipeline(
                     pipeline_identifier=_pipeline_identifier(pipeline.issue_number, pipeline_id),
                     pipeline_id=pipeline_id,
                 )
-            except subprocess.CalledProcessError as git_err:
+            except Exception as git_err:
+                # Catch broadly: the helper does ``subprocess.run(check=True,
+                # timeout=30)`` which can raise ``TimeoutExpired`` (not a
+                # CalledProcessError) and ``glob.glob`` which can raise
+                # ``OSError``.  A narrow ``except`` here let either escape
+                # to the outer handler and stranded the pipeline (#2219).
                 logger.warning(
                     "Failed to commit statefiles after phase (continuing)",
                     pipeline_id=pipeline_id,
@@ -13396,7 +13419,10 @@ def _run_pipeline(
                         ),
                         pipeline_id=pipeline_id,
                     )
-                except subprocess.CalledProcessError as git_err:
+                except Exception as git_err:
+                    # Catch broadly: see #2219.  The helper raises
+                    # ``TimeoutExpired`` and ``OSError`` paths that a
+                    # ``CalledProcessError``-only handler did not catch.
                     logger.warning(
                         "Failed to commit statefiles after phase gate resolution (continuing)",
                         pipeline_id=pipeline_id,
@@ -13669,8 +13695,19 @@ def _run_pipeline(
                     message=f"Pipeline failed: {str(e)[:100]}",
                 )
                 _emit_pipeline_event(pipeline, "pipeline.failed")
-        except Exception:
-            pass
+        except Exception as fail_err:
+            # If FAILED-marking itself fails (state-store contention, lock
+            # timeout, etc.), the pipeline stays at ``running`` with no
+            # error recorded — exactly the silent-wedge symptom in #2219.
+            # Log so the next occurrence is visible in the orchestrator
+            # log instead of vanishing.
+            logger.error(
+                "Failed to mark pipeline FAILED after exception",
+                pipeline_id=pipeline_id,
+                original_error=str(e),
+                mark_error=str(fail_err),
+                exc_info=True,
+            )
     finally:
         # Stop health monitor polling and unsubscribe from events
         if health_monitor_timer is not None:

--- a/orchestrator/tests/test_advance_phase_thread.py
+++ b/orchestrator/tests/test_advance_phase_thread.py
@@ -367,10 +367,15 @@ class TestPostBrcBandSwallowsErrors:
         # the broader handler.  Find every call to the helper and assert
         # the immediately-following ``except`` clause is ``Exception``.
         call_sites = list(re.finditer(r"_commit_statefiles_to_worktree\(", source))
-        # Two known call sites: post-phase commit, post-HITL-resolution
-        # commit. If a third is added, this count must be revisited.
-        assert len(call_sites) >= 2, (
-            f"Expected ≥2 _commit_statefiles_to_worktree call sites, found {len(call_sites)}"
+        # Four known call sites in ``_run_pipeline``: initial statefile
+        # commit, pre-PR commit, post-phase commit, post-HITL-resolution
+        # commit.  Pin the count so a future move/delete is caught
+        # rather than silently degrading coverage.
+        assert len(call_sites) == 4, (
+            f"Expected 4 _commit_statefiles_to_worktree call sites in "
+            f"_run_pipeline, found {len(call_sites)}.  If a call was "
+            f"intentionally added/removed, update this count and the "
+            f"comment above."
         )
         for match in call_sites:
             # Look at the next ~500 chars for the matching except clause.
@@ -398,9 +403,17 @@ class TestPostBrcBandSwallowsErrors:
         source = self._run_pipeline_source()
         # The outer Exception handler's inner try/except must NOT end in
         # a bare ``pass`` — it must log so future occurrences are visible.
-        # Match the structural shape near "Failed to mark pipeline FAILED"
-        # which is the new log line, OR a continued absence of bare-pass.
-        assert "Failed to mark pipeline FAILED after exception" in source, (
-            "Outer Exception handler must log when FAILED-marking itself "
-            "fails so silent wedges (#2219) become visible in the log."
+        # Match the structural shape: ``except Exception as fail_err:``
+        # immediately followed (within ~500 chars, indentation-tolerant)
+        # by the new log line.  This pins the assertion to the invariant
+        # rather than just any occurrence of the string.
+        assert re.search(
+            r"except\s+Exception\s+as\s+fail_err:[\s\S]{0,500}?"
+            r"Failed to mark pipeline FAILED after exception",
+            source,
+        ), (
+            "Outer Exception handler must log inside an "
+            "``except Exception as fail_err:`` block when FAILED-marking "
+            "itself fails so silent wedges (#2219) become visible in the "
+            "log."
         )

--- a/orchestrator/tests/test_advance_phase_thread.py
+++ b/orchestrator/tests/test_advance_phase_thread.py
@@ -313,3 +313,94 @@ class TestAutoAdvanceRespawnsThread:
             "The auto-advance block must not update the dying thread's "
             "health monitor — the new thread builds its own."
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests for #2219: post-BRC band must not strand the pipeline on
+# best-effort sub-call failures.  The implement→PR auto-advance silently
+# wedged when an exception escaped one of the post-phase helpers and the
+# outer FAILED-marking handler then failed silently.
+# ---------------------------------------------------------------------------
+
+
+class TestPostBrcBandSwallowsErrors:
+    """Verify the band between BRC return and auto-advance never propagates
+    a sub-call exception out of ``_run_pipeline``.
+
+    Source-inspection assertions in the same style as
+    ``TestAutoAdvanceRespawnsThread`` — full behavioural coverage would
+    need a phase-loop harness, but these guarantee the structural
+    invariants that close the wedge in #2219.
+    """
+
+    def _run_pipeline_source(self) -> str:
+        from routes import pipelines
+
+        return inspect.getsource(pipelines._run_pipeline)
+
+    def test_sync_worktree_with_remote_is_wrapped(self):
+        """``_sync_worktree_with_remote`` was unwrapped — a gateway HTTP
+        error or git failure inside it propagated to the outer Exception
+        handler and (when FAILED-marking also failed) stranded the pipeline.
+        """
+        source = self._run_pipeline_source()
+        # The post-phase call site (after BRC return) must sit inside a
+        # ``try`` whose ``except`` matches ``Exception`` so any failure
+        # mode is swallowed with a warning rather than killing the thread.
+        # Indentation-tolerant: ``\s+`` between ``try:`` and the call.
+        assert re.search(
+            r"try:\s*\n\s*_sync_worktree_with_remote\(",
+            source,
+        ), (
+            "_sync_worktree_with_remote(...) call after BRC return must be "
+            "wrapped in try/except so a sub-call failure can't strand the "
+            "pipeline (#2219)."
+        )
+
+    def test_commit_statefiles_handler_catches_broadly(self):
+        """``_commit_statefiles_to_worktree`` raises ``TimeoutExpired`` and
+        ``OSError`` paths that a ``CalledProcessError``-only ``except``
+        does not catch.  The fix broadens the handler to ``Exception``.
+        """
+        source = self._run_pipeline_source()
+        # Both call sites (post-phase and post-HITL-resolution) must use
+        # the broader handler.  Find every call to the helper and assert
+        # the immediately-following ``except`` clause is ``Exception``.
+        call_sites = list(re.finditer(r"_commit_statefiles_to_worktree\(", source))
+        # Two known call sites: post-phase commit, post-HITL-resolution
+        # commit. If a third is added, this count must be revisited.
+        assert len(call_sites) >= 2, (
+            f"Expected ≥2 _commit_statefiles_to_worktree call sites, found {len(call_sites)}"
+        )
+        for match in call_sites:
+            # Look at the next ~500 chars for the matching except clause.
+            window = source[match.end() : match.end() + 500]
+            except_match = re.search(r"except\s+([^\s:]+)", window)
+            assert except_match is not None, (
+                f"_commit_statefiles_to_worktree call at offset "
+                f"{match.start()} has no matching except clause"
+            )
+            caught = except_match.group(1)
+            assert caught == "Exception", (
+                f"_commit_statefiles_to_worktree call at offset "
+                f"{match.start()} catches {caught!r}, but must catch "
+                f"Exception so TimeoutExpired/OSError can't strand the "
+                f"pipeline (#2219)."
+            )
+
+    def test_failed_marking_handler_logs_on_failure(self):
+        """If the FAILED-marking step itself raises (state-store
+        contention, lock timeout), the original ``except Exception: pass``
+        silently dropped both errors — the thread died and the pipeline
+        stayed ``running`` with no error recorded.  The handler must log
+        instead.
+        """
+        source = self._run_pipeline_source()
+        # The outer Exception handler's inner try/except must NOT end in
+        # a bare ``pass`` — it must log so future occurrences are visible.
+        # Match the structural shape near "Failed to mark pipeline FAILED"
+        # which is the new log line, OR a continued absence of bare-pass.
+        assert "Failed to mark pipeline FAILED after exception" in source, (
+            "Outer Exception handler must log when FAILED-marking itself "
+            "fails so silent wedges (#2219) become visible in the log."
+        )


### PR DESCRIPTION
## Summary

Fixes #2219.

The implement→PR auto-advance silently wedged when an exception escaped one of the post-phase helpers in `_run_pipeline` and the outer FAILED-marking handler then failed silently. Pipeline stayed `running` with phase COMPLETE, no successor, no error recorded.

Three small, targeted fixes:

- **Wrap `_sync_worktree_with_remote`** at the post-phase call site in `try/except Exception` (was completely unguarded). A gateway HTTP error or git subprocess failure inside it could escape to the outer Exception handler.
- **Broaden four `_commit_statefiles_to_worktree` handlers** from `subprocess.CalledProcessError` to `Exception`. The helper does `subprocess.run(check=True, timeout=30)` (raises `TimeoutExpired`, not `CalledProcessError`) and `glob.glob` (raises `OSError`) — narrow handlers let either escape.
- **Make the outer FAILED-marking failure audible.** `except Exception: pass` → `logger.error("Failed to mark pipeline FAILED after exception", original_error=..., mark_error=..., exc_info=True)`. Future occurrences become visible in the orchestrator log instead of vanishing.

Three new source-inspection tests in `TestPostBrcBandSwallowsErrors` match the existing pattern in `test_advance_phase_thread.py`.

Out of scope (per analysis on the issue thread):
- `wedged_no_successor` watchdog alert (issue's option 1)
- defensive auto-advance retry (issue's option 3)

Both are good follow-ups but not needed if this targeted fix closes the actual bug. Should ship only if the wedge fires again after this lands.

## Test plan
- [x] `.venv/bin/pytest orchestrator/tests/test_advance_phase_thread.py -v` — 12 passed
- [x] `.venv/bin/pytest orchestrator/tests/test_advance_phase_populate_on_plan_exit.py orchestrator/tests/test_diagnostic_logging_1633.py orchestrator/tests/test_short_flow_contract_population.py` — 52 passed (regression check on adjacent suites)
- [x] `.venv/bin/ruff check` on changed files — clean
- [ ] CI green