### PR TITLE
Fix #2222: stop pipeline branch eating main commits + carrying stale prior-run history

### DIFF
--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -652,6 +652,118 @@ class TestWorktreeManagerDockerGitDir:
         if result.returncode == 0:
             assert not result.stdout.strip().startswith("refs/heads/egg/")
 
+    def test_worktree_reuse_resets_to_safe_remote_ref(self, tmp_path):
+        """When a valid worktree is reused, the helper resets HEAD to a
+        known-good remote ref so a stale local HEAD from a prior pipeline
+        run on the same container_id (deterministic ID collision, see
+        #2222) doesn't get inherited.
+
+        Reproduction of the pre-fix shape:
+        - First create_worktree creates the worktree at origin/main.
+        - Test simulates yesterday's pipeline by adding a local-only
+          commit on top of the worktree HEAD.
+        - Second create_worktree (same container_id, with
+          assigned_branch=egg/issue-99 which exists on origin) must
+          reset HEAD to origin/egg/issue-99 — discarding the stale local
+          commit.
+        """
+        import subprocess as sp
+
+        env = {
+            **__import__("os").environ,
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        }
+
+        # Bare origin remote with main + a feature branch.
+        origin = tmp_path / "origin.git"
+        sp.run(["git", "init", "--bare", "-b", "main", str(origin)], check=True)
+
+        seed = tmp_path / "seed"
+        seed.mkdir()
+        sp.run(["git", "init", "-b", "main"], cwd=seed, check=True)
+        sp.run(["git", "remote", "add", "origin", str(origin)], cwd=seed, check=True)
+        sp.run(["git", "config", "user.email", "t@t"], cwd=seed, check=True)
+        sp.run(["git", "config", "user.name", "test"], cwd=seed, check=True)
+        (seed / "README.md").write_text("init\n")
+        sp.run(["git", "add", "."], cwd=seed, check=True)
+        sp.run(["git", "commit", "-m", "init"], cwd=seed, check=True, env=env)
+        sp.run(["git", "push", "origin", "main"], cwd=seed, check=True)
+        sp.run(["git", "checkout", "-b", "egg/issue-99"], cwd=seed, check=True)
+        (seed / "feature.md").write_text("feature\n")
+        sp.run(["git", "add", "."], cwd=seed, check=True)
+        sp.run(["git", "commit", "-m", "feature"], cwd=seed, check=True, env=env)
+        sp.run(["git", "push", "origin", "egg/issue-99"], cwd=seed, check=True)
+        feature_sha = sp.run(
+            ["git", "rev-parse", "HEAD"], cwd=seed, capture_output=True, text=True, check=True
+        ).stdout.strip()
+
+        # repos_base hosts a clone of the bare origin so create_worktree
+        # has somewhere to ``git worktree add`` from.
+        repos_base = tmp_path / "repos"
+        repos_base.mkdir()
+        repo_dir = repos_base / "test-repo"
+        sp.run(["git", "clone", str(origin), str(repo_dir)], check=True)
+        sp.run(["git", "config", "user.email", "t@t"], cwd=repo_dir, check=True)
+        sp.run(["git", "config", "user.name", "test"], cwd=repo_dir, check=True)
+        sp.run(["git", "fetch", "origin", "egg/issue-99"], cwd=repo_dir, check=True)
+
+        worktree_base = tmp_path / "worktrees"
+        manager = WorktreeManager(worktree_base=worktree_base, repos_base=repos_base)
+
+        # First creation — bind the worktree to origin/egg/issue-99.
+        info1 = manager.create_worktree(
+            "test-repo",
+            "issue-99-coder",
+            assigned_branch="egg/issue-99",
+        )
+        wt_path = info1.worktree_path
+        sp.run(
+            ["git", "-C", str(wt_path), "reset", "--hard", "origin/egg/issue-99"],
+            check=True,
+        )
+
+        # Simulate yesterday's pipeline leaving a local-only commit on top
+        # of origin/egg/issue-99.  Without the reset on reuse, the new
+        # pipeline would inherit this HEAD.
+        (wt_path / "stale_local.md").write_text("yesterday's leftover\n")
+        sp.run(["git", "-C", str(wt_path), "add", "."], check=True)
+        sp.run(
+            ["git", "-C", str(wt_path), "commit", "-m", "stale local-only"],
+            check=True,
+            env=env,
+        )
+        stale_head = sp.run(
+            ["git", "-C", str(wt_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert stale_head != feature_sha, "precondition: stale HEAD must differ from origin tip"
+
+        # Reuse: second create_worktree with the same container_id.
+        info2 = manager.create_worktree(
+            "test-repo",
+            "issue-99-coder",
+            assigned_branch="egg/issue-99",
+        )
+        assert info2.worktree_path == wt_path
+
+        # After reuse, HEAD must be back at origin/egg/issue-99 — the
+        # stale local commit has been discarded.
+        head_after = sp.run(
+            ["git", "-C", str(wt_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert head_after == feature_sha, (
+            f"reuse should reset HEAD to origin/egg/issue-99 ({feature_sha}); "
+            f"got {head_after} (still on stale local commit)"
+        )
+
     def test_create_worktree_reapplies_upstream_on_reuse(self, git_repo):
         """When a valid worktree is reused, upstream config is re-applied.
 

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -322,6 +322,20 @@ class WorktreeManager:
             # Re-apply push upstream config in case the assigned branch
             # changed across calls (idempotent when unchanged).
             self._configure_push_upstream(main_repo, branch_name, assigned_branch)
+            # Reset HEAD to a known-good ref so we don't inherit a stale
+            # left-over HEAD from a prior pipeline that collided on
+            # ``container_id`` (deterministic pipeline_id can collide when
+            # the same issue is resubmitted — see #2222).  Without this,
+            # the new pipeline's first push hits non-fast-forward and
+            # the reconcile path can absorb upstream main commits onto
+            # the pipeline branch.
+            self._reset_reused_worktree_to_safe_ref(
+                worktree_path=worktree_path,
+                main_repo=main_repo,
+                container_id=container_id,
+                assigned_branch=assigned_branch,
+                base_branch=base_branch,
+            )
             # Return info about existing worktree
             return WorktreeInfo(
                 container_id=container_id,
@@ -621,6 +635,109 @@ class WorktreeManager:
                     stderr=result.stderr.strip(),
                 )
                 return
+
+    def _reset_reused_worktree_to_safe_ref(
+        self,
+        worktree_path: Path,
+        main_repo: Path,
+        container_id: str,
+        assigned_branch: str | None,
+        base_branch: str,
+    ) -> None:
+        """Hard-reset a reused worktree to a known-good remote ref.
+
+        Picks the ref in this order:
+
+        1. ``origin/{assigned_branch}`` if ``assigned_branch`` is set and
+           resolvable.  This is the pipeline's own branch tip — by the
+           time we reach this code the orchestrator's create-pipeline
+           stale-branch check (#2222 Phase 3a) has already refused
+           re-submits where ``origin/{assigned_branch}`` carries
+           prior-pipeline commits, so a reset to it discards only
+           container-local state.
+        2. ``origin/{base_branch}`` if ``base_branch != "HEAD"`` and
+           resolvable.  Used when the assigned branch hasn't been
+           pushed yet (fresh pipeline, first agent) so there is no
+           remote tip to reset to.
+        3. No-op if neither resolves — preserves prior behaviour rather
+           than risk leaving the worktree in an undefined state.
+
+        Best-effort: any git failure is logged and swallowed so a
+        transient hiccup doesn't break worktree reuse.  The downstream
+        orchestrator-side ``_sync_worktree_with_remote`` and
+        ``_rebase_pipeline_branch_onto_base`` provide a second line of
+        defence.
+        """
+        # Best-effort fetch so the remote-tracking refs are current; if
+        # this fails we still attempt the reset against whatever local
+        # state we have.
+        try:
+            subprocess.run(
+                git_cmd("fetch", "origin"),
+                cwd=worktree_path,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=120,
+            )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            logger.warning(
+                "Fetch before worktree-reuse reset failed (continuing)",
+                container_id=container_id,
+                worktree_path=str(worktree_path),
+                error=str(exc),
+            )
+
+        target_ref: str | None = None
+        candidates: list[str] = []
+        if assigned_branch:
+            candidates.append(f"origin/{assigned_branch}")
+        if base_branch and base_branch != "HEAD":
+            candidates.append(f"origin/{base_branch}")
+        for candidate in candidates:
+            verify = subprocess.run(
+                git_cmd("rev-parse", "--verify", candidate),
+                cwd=worktree_path,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if verify.returncode == 0:
+                target_ref = candidate
+                break
+
+        if target_ref is None:
+            logger.info(
+                "Worktree reuse: no remote ref to reset to (preserving HEAD)",
+                container_id=container_id,
+                worktree_path=str(worktree_path),
+                assigned_branch=assigned_branch,
+                base_branch=base_branch,
+            )
+            return
+
+        reset = subprocess.run(
+            git_cmd("reset", "--hard", target_ref),
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if reset.returncode != 0:
+            logger.warning(
+                "Worktree reuse: reset to safe ref failed (continuing)",
+                container_id=container_id,
+                worktree_path=str(worktree_path),
+                target_ref=target_ref,
+                stderr=reset.stderr.strip(),
+            )
+            return
+        logger.info(
+            "Worktree reuse: reset HEAD to safe remote ref",
+            container_id=container_id,
+            worktree_path=str(worktree_path),
+            target_ref=target_ref,
+        )
 
     def _run_git_worktree_add(
         self,

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1417,6 +1417,67 @@ class GatewayClient:
                 except Exception:
                     pass
 
+    def get_remote_branch_sha(
+        self,
+        pipeline_id: str,
+        repo_path: str,
+        ref: str,
+        mode: Literal["public", "private"] = "public",
+    ) -> str | None:
+        """Resolve a remote ref to its commit SHA via ``git ls-remote``.
+
+        Returns the SHA string when the ref exists on origin, or ``None``
+        when it doesn't (or when the gateway request fails).  Used by
+        ``create_pipeline`` to detect stale-pipeline-branch state on
+        re-submit (#2222): if ``origin/egg/issue-N`` resolves to a
+        different SHA than ``origin/<base_branch>``, the branch carries
+        prior-pipeline commits and starting on top of it would inherit
+        them — so refuse with a hint to ``cancel_task(cleanup=true)``.
+        """
+        temp_container_id = f"{pipeline_id}-state-ls-remote-sha"
+        session_token: str | None = None
+        try:
+            session = self.register_session(
+                container_id=temp_container_id,
+                container_ip=self.self_ip,
+                mode=mode,
+                pipeline_id=pipeline_id,
+            )
+            session_token = session.session_token
+
+            result = self._make_request(
+                "/api/v1/git/fetch",
+                method="POST",
+                data={
+                    "repo_path": repo_path,
+                    "remote": "origin",
+                    "operation": "ls-remote",
+                    "args": ["--heads", ref],
+                },
+                bearer_token=session_token,
+            )
+
+            stdout = result.get("data", {}).get("stdout", "")
+            if not stdout.strip():
+                return None
+            # ``git ls-remote`` output: ``<sha>\trefs/heads/<branch>``
+            sha = stdout.split()[0].strip()
+            return sha or None
+        except Exception as e:
+            logger.warning(
+                "ls-remote sha lookup failed",
+                pipeline_id=pipeline_id,
+                ref=ref,
+                error=str(e),
+            )
+            return None
+        finally:
+            if session_token:
+                try:
+                    self.delete_session(session_token)
+                except Exception:
+                    pass
+
     def get_repo_visibility(self, repo: str) -> str | None:
         """Query repo visibility from gateway.
 
@@ -1479,6 +1540,29 @@ def _rebase_with_agent_output_autoresolve(
     ``reconcile_rebase_conflict``, ``reconcile_rebase_failed``).
     """
     rebase_cmd = _build_rebase_cmd(git_base, branch, base_branch)
+    if rebase_cmd is None:
+        # ``base_branch`` was supplied but ``origin/{base_branch}`` is not
+        # resolvable in the worktree — most likely because the upstream
+        # best-effort fetch silently failed.  Surface the failure rather
+        # than fall back to the plain ``git rebase origin/{branch}`` form,
+        # which would replay every commit between the stale ``origin/
+        # {branch}`` tip and HEAD onto the stale tip — including upstream
+        # main commits that landed since.  See #2222.
+        logger.error(
+            "Push reconcile: origin/{base_branch} not resolvable — refusing unsafe rebase fallback",
+            pipeline_id=pipeline_id,
+            branch=branch,
+            base_branch=base_branch,
+        )
+        return PushResult(
+            ok=False,
+            category="reconcile_base_unavailable",
+            detail=(
+                f"origin/{base_branch} could not be resolved in the worktree; "
+                "refusing the plain `git rebase origin/{branch}` fallback "
+                "(would absorb upstream main commits — see #2222)"
+            ),
+        )
     try:
         rebase_result = subprocess.run(
             rebase_cmd,
@@ -1660,31 +1744,46 @@ def _build_rebase_cmd(
     git_base: list[str],
     branch: str,
     base_branch: str | None,
-) -> list[str]:
+) -> list[str] | None:
     """Construct the ``git rebase`` argv for the push-reconcile path.
 
-    When ``base_branch`` is set and ``origin/{base_branch}`` resolves in
-    the worktree, return the ``--onto origin/{branch} origin/{base_branch}``
-    form so only ``origin/{base_branch}..HEAD`` commits are replayed.
-    Otherwise return the plain ``git rebase origin/{branch}`` form
-    (pre-#1976 behavior) — used as a safe fallback when the base branch
-    is unknown or unavailable locally.
+    Three cases:
+
+    * ``base_branch`` is ``None`` (legacy callers that don't thread the
+      pipeline's base): return the plain ``git rebase origin/{branch}``
+      form.  This preserves pre-#1976 behaviour for any call site that
+      still doesn't know the base branch.
+    * ``base_branch`` is set and ``origin/{base_branch}`` resolves: return
+      the ``--onto origin/{branch} origin/{base_branch}`` form so only
+      ``origin/{base_branch}..HEAD`` commits are replayed.
+    * ``base_branch`` is set but ``origin/{base_branch}`` does NOT resolve
+      (the upstream best-effort fetch silently failed earlier, or rev-parse
+      timed out): return ``None``.  The caller must surface this as a
+      ``reconcile_base_unavailable`` failure rather than fall back to the
+      plain form — that fallback is the contamination vector behind #2222.
+      With HEAD at current main and ``origin/{branch}`` stuck on a stale
+      snapshot, the plain form replays merge-base..HEAD (i.e. all the
+      upstream main commits that landed since the stale snapshot) on top
+      of the stale tip, producing a PR full of duplicate-by-content
+      commits with rewritten SHAs.
     """
-    if base_branch:
-        base_ref = f"origin/{base_branch}"
-        try:
-            verify = subprocess.run(
-                [*git_base, "rev-parse", "--verify", base_ref],
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=10,
-            )
-        except subprocess.TimeoutExpired:
-            verify = None
-        if verify and verify.returncode == 0:
-            return [*git_base, "rebase", "--onto", f"origin/{branch}", base_ref]
-    return [*git_base, "rebase", f"origin/{branch}"]
+    if base_branch is None:
+        return [*git_base, "rebase", f"origin/{branch}"]
+
+    base_ref = f"origin/{base_branch}"
+    try:
+        verify = subprocess.run(
+            [*git_base, "rev-parse", "--verify", base_ref],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        verify = None
+    if verify and verify.returncode == 0:
+        return [*git_base, "rebase", "--onto", f"origin/{branch}", base_ref]
+    return None
 
 
 def _abort_rebase_best_effort(

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1559,7 +1559,7 @@ def _rebase_with_agent_output_autoresolve(
             category="reconcile_base_unavailable",
             detail=(
                 f"origin/{base_branch} could not be resolved in the worktree; "
-                "refusing the plain `git rebase origin/{branch}` fallback "
+                f"refusing the plain `git rebase origin/{branch}` fallback "
                 "(would absorb upstream main commits — see #2222)"
             ),
         )

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -1430,10 +1430,62 @@ def create_pipeline() -> tuple[Response, int]:
                         details={"reason": "branch_exists", "branch": branch},
                     )
                 else:
+                    # No active pipeline, but the branch may carry commits
+                    # from a prior failed/cancelled run.  Inheriting that
+                    # state was the precondition for #2222 (stale
+                    # pipeline-branch tip + advanced main → contaminated
+                    # PR via the push-reconcile fallback).  Compare the
+                    # branch tip to the configured base; only a fresh
+                    # branch (tip == base) is safe to silently reuse.
+                    _resolved_base = base_branch or "main"
+                    _branch_sha = gw.get_remote_branch_sha(
+                        pipeline_id=pipeline_id or f"branch-check-{uuid4().hex[:8]}",
+                        repo_path=str(repo_path),
+                        ref=f"refs/heads/{branch}",
+                    )
+                    _base_sha = gw.get_remote_branch_sha(
+                        pipeline_id=pipeline_id or f"branch-check-{uuid4().hex[:8]}",
+                        repo_path=str(repo_path),
+                        ref=f"refs/heads/{_resolved_base}",
+                    )
+                    if _branch_sha and _base_sha and _branch_sha != _base_sha:
+                        logger.warning(
+                            "Branch exists with prior-pipeline commits — refusing reuse (#2222)",
+                            branch=branch,
+                            base_branch=_resolved_base,
+                            branch_sha=_branch_sha,
+                            base_sha=_base_sha,
+                        )
+                        cleanup_hint = (
+                            f" Run cancel_task(task_id='{pipeline_id}', cleanup=true) "
+                            "to delete the stale branch and pipeline state, then "
+                            "resubmit."
+                            if pipeline_id
+                            else (
+                                " Delete the stale branch and any associated "
+                                "pipeline state, then resubmit."
+                            )
+                        )
+                        return make_error_response(
+                            f"Branch '{branch}' exists with commits from a prior "
+                            f"pipeline run (tip {_branch_sha[:8]} != "
+                            f"origin/{_resolved_base} {_base_sha[:8]}). Starting a "
+                            "new pipeline on top of it would inherit that history.",
+                            status_code=409,
+                            details={
+                                "reason": "stale_branch",
+                                "branch": branch,
+                                "branch_sha": _branch_sha,
+                                "base_sha": _base_sha,
+                                "hint": cleanup_hint.strip(),
+                            },
+                        )
                     logger.info(
                         "Branch exists but no active pipeline — allowing reuse",
                         branch=branch,
                         pipeline_id=pipeline_id,
+                        branch_sha=_branch_sha,
+                        base_sha=_base_sha,
                     )
         except Exception as e:
             # Non-fatal — if we can't reach the gateway, let creation proceed
@@ -5478,7 +5530,7 @@ def _rebase_pipeline_branch_onto_base(
         return
 
     # Step 4: Confirm reset-to-origin/<branch> is lossless before we
-    # overwrite HEAD.  Two real worktree states satisfy this:
+    # overwrite HEAD.  Three worktree states are handled:
     #
     #   (a) Preserved-worktree resume (#2098 canonical): the orchestrator-
     #       side worktree was kept across a cancel/resubmit, so HEAD
@@ -5491,24 +5543,38 @@ def _rebase_pipeline_branch_onto_base(
     #       from origin/<base>.  HEAD == origin/<base>; resetting to
     #       origin/<branch> discards no unique commits because every
     #       commit on origin/<base> is preserved as the rebase target.
-    #
-    # If HEAD is on neither ref, something unexpected lives on it and
-    # we defer to the existing push-reconcile path rather than blow it
-    # away.  An ahead-of-base check would have wrongly skipped (a); a
-    # branch-only ancestry check would have wrongly skipped (b).
+    #   (c) Confused-HEAD resume (#2222): the worktree carries a local-
+    #       only commit (e.g. a half-pushed statefiles commit) on top of
+    #       a stale origin/<branch> tip — HEAD is on neither ref.  The
+    #       previous behaviour was to "defer to push-reconcile", but the
+    #       reconcile path's _build_rebase_cmd fallback is the
+    #       contamination producer in #2222.  Recover by hard-resetting
+    #       to origin/<base>: any local-only work is dropped (it would
+    #       be re-created by agents on the next phase, vastly preferable
+    #       to a contaminated PR).
     def _head_on(ref: str) -> bool:
         result = _run_git(["merge-base", "--is-ancestor", "HEAD", ref], timeout=10)
         return result is not None and result.returncode == 0
 
     if not (_head_on(f"origin/{pipeline_branch}") or _head_on(f"origin/{base_branch}")):
-        logger.info(
-            "rebase-on-resume: HEAD on neither origin/<branch> nor origin/<base> — skipping",
+        logger.warning(
+            "rebase-on-resume: HEAD on neither origin/<branch> nor origin/<base> — "
+            "resetting to origin/<base> to avoid push-reconcile contamination (#2222)",
             pipeline_id=pipeline_id,
             branch=pipeline_branch,
             base_branch=base_branch,
             behind_base=behind_count,
         )
-        return
+        recovery_reset = _run_git(["reset", "--hard", f"origin/{base_branch}"], timeout=30)
+        if recovery_reset is None or recovery_reset.returncode != 0:
+            logger.warning(
+                "rebase-on-resume: recovery reset to origin/<base> failed, skipping",
+                pipeline_id=pipeline_id,
+                branch=pipeline_branch,
+                base_branch=base_branch,
+                stderr=(recovery_reset.stderr.strip() if recovery_reset is not None else None),
+            )
+            return
 
     logger.info(
         "rebase-on-resume: pipeline branch is behind base, attempting rebase",

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -1437,7 +1437,14 @@ def create_pipeline() -> tuple[Response, int]:
                     # PR via the push-reconcile fallback).  Compare the
                     # branch tip to the configured base; only a fresh
                     # branch (tip == base) is safe to silently reuse.
-                    _resolved_base = base_branch or "main"
+                    #
+                    # Resolve the default branch via ``_detect_default_branch``
+                    # rather than hardcoding ``"main"`` so repos whose default
+                    # is ``master`` / ``develop`` still get the stale-branch
+                    # check (otherwise the ``origin/main`` lookup returns
+                    # ``None``, the guard falls through, and the precondition
+                    # check is silently disabled).
+                    _resolved_base = base_branch or _detect_default_branch(repo_path)
                     _branch_sha = gw.get_remote_branch_sha(
                         pipeline_id=pipeline_id or f"branch-check-{uuid4().hex[:8]}",
                         repo_path=str(repo_path),
@@ -1448,6 +1455,23 @@ def create_pipeline() -> tuple[Response, int]:
                         repo_path=str(repo_path),
                         ref=f"refs/heads/{_resolved_base}",
                     )
+                    # When either lookup returns ``None`` the stale-branch
+                    # check is bypassed.  ``get_remote_branch_sha`` swallows
+                    # transient gateway errors and returns ``None`` (same
+                    # value it returns when the ref legitimately doesn't
+                    # exist), so we surface a warning here to make the
+                    # silent skip visible to operators investigating a
+                    # post-merge contamination — rather than letting the
+                    # precondition fix vanish behind a transient hiccup.
+                    if _branch_sha is None or _base_sha is None:
+                        logger.warning(
+                            "Stale-branch check skipped: SHA lookup returned None "
+                            "(transient gateway error or ref missing — see #2222)",
+                            branch=branch,
+                            base_branch=_resolved_base,
+                            branch_sha=_branch_sha,
+                            base_sha=_base_sha,
+                        )
                     if _branch_sha and _base_sha and _branch_sha != _base_sha:
                         logger.warning(
                             "Branch exists with prior-pipeline commits — refusing reuse (#2222)",
@@ -5565,6 +5589,15 @@ def _rebase_pipeline_branch_onto_base(
             base_branch=base_branch,
             behind_base=behind_count,
         )
+        # Step 4a: hard-reset to ``origin/<base>`` first.  Note that step 5
+        # immediately overwrites HEAD again with ``reset --hard
+        # origin/<branch>`` in the success path, so this reset's effect on
+        # HEAD is short-lived — its purpose is to act as a safe-state floor:
+        # if step 5 itself fails (network blip, ref vanishes), we leave the
+        # worktree on a known-good ref (``origin/<base>``) instead of the
+        # ambiguous pre-recovery state that prompted the rescue.  Don't
+        # "simplify" by dropping this — the back-to-back hard resets are
+        # intentional.
         recovery_reset = _run_git(["reset", "--hard", f"origin/{base_branch}"], timeout=30)
         if recovery_reset is None or recovery_reset.returncode != 0:
             logger.warning(

--- a/orchestrator/tests/test_pipelines_api.py
+++ b/orchestrator/tests/test_pipelines_api.py
@@ -626,6 +626,101 @@ class TestCreatePipelineJiraAndQualifier:
     @patch("routes.pipelines.get_gateway_client")
     @patch("routes.pipelines.get_state_store")
     @patch("routes.pipelines.get_repo_path")
+    def test_create_pipeline_rejects_stale_branch_with_no_active_pipeline(
+        self, mock_repo_path, mock_get_store, mock_gw_client, client
+    ):
+        """409 when the target branch exists, no active pipeline holds it,
+        but the branch tip differs from origin/<base_branch> — i.e. it
+        carries commits from a prior failed/cancelled pipeline run.
+        Starting on top of those would inherit the stale history and
+        reproduce the contamination shape of #2222.
+        """
+        mock_repo_path.return_value = Path("/home/egg/repos/webapp")
+        mock_gw = MagicMock()
+        mock_gw.ls_remote_branch.return_value = True
+        # Branch SHA differs from base SHA — prior-pipeline commits sit on top.
+        mock_gw.get_remote_branch_sha.side_effect = lambda **kwargs: (
+            "deadbeefcafef00d" * 2 + "00000000"
+            if "egg/" in kwargs["ref"]
+            else "feedfacefeedface" * 2 + "00000000"
+        )
+        mock_gw_client.return_value = mock_gw
+
+        # No active pipeline (terminal state).
+        mock_store = MagicMock()
+        mock_store.pipeline_exists.return_value = True
+        existing = Pipeline(
+            id="issue-2137",
+            repo="Khan/webapp",
+            status=PipelineStatus.CANCELLED,
+        )
+        mock_store.load_pipeline.return_value = existing
+        mock_get_store.return_value = mock_store
+
+        response = client.post(
+            "/api/v1/pipelines",
+            json={
+                "pipeline_id": "issue-2137",
+                "repo": "Khan/webapp",
+                "branch": "egg/issue-2137",
+                "base_branch": "main",
+                "issue_number": 2137,
+            },
+        )
+        assert response.status_code == 409
+        body = response.get_json()
+        assert body["details"]["reason"] == "stale_branch"
+        assert body["details"]["branch"] == "egg/issue-2137"
+        assert "cancel_task" in body["details"]["hint"]
+        assert "cleanup=true" in body["details"]["hint"]
+
+    @patch("routes.pipelines.get_gateway_client")
+    @patch("routes.pipelines.get_state_store")
+    @patch("routes.pipelines.get_repo_path")
+    def test_create_pipeline_allows_reuse_when_branch_at_base(
+        self, mock_repo_path, mock_get_store, mock_gw_client, client
+    ):
+        """When the target branch exists with no active pipeline AND its
+        tip matches origin/<base_branch>, allow reuse — that's a fresh
+        branch off base with no inherited state.
+        """
+        mock_repo_path.return_value = Path("/home/egg/repos/webapp")
+        mock_gw = MagicMock()
+        mock_gw.ls_remote_branch.return_value = True
+        # Both refs resolve to the same SHA — fresh-from-base.
+        same_sha = "abc123def456" * 3 + "abcd"
+        mock_gw.get_remote_branch_sha.return_value = same_sha
+        mock_gw_client.return_value = mock_gw
+
+        mock_store = MagicMock()
+        mock_store.pipeline_exists.return_value = True
+        existing = Pipeline(
+            id="issue-2137",
+            repo="Khan/webapp",
+            status=PipelineStatus.COMPLETE,
+        )
+        mock_store.load_pipeline.return_value = existing
+        mock_pipeline = MagicMock()
+        mock_pipeline.id = "issue-2137"
+        mock_pipeline.model_dump.return_value = {"id": "issue-2137"}
+        mock_store.create_pipeline.return_value = mock_pipeline
+        mock_get_store.return_value = mock_store
+
+        response = client.post(
+            "/api/v1/pipelines",
+            json={
+                "pipeline_id": "issue-2137",
+                "repo": "Khan/webapp",
+                "branch": "egg/issue-2137",
+                "base_branch": "main",
+                "issue_number": 2137,
+            },
+        )
+        assert response.status_code == 200
+
+    @patch("routes.pipelines.get_gateway_client")
+    @patch("routes.pipelines.get_state_store")
+    @patch("routes.pipelines.get_repo_path")
     def test_branch_check_failure_does_not_block_creation(
         self, mock_repo_path, mock_get_store, mock_gw_client, client
     ):

--- a/orchestrator/tests/test_pipelines_api.py
+++ b/orchestrator/tests/test_pipelines_api.py
@@ -717,6 +717,11 @@ class TestCreatePipelineJiraAndQualifier:
             },
         )
         assert response.status_code == 200
+        # A 200 alone is consistent with several short-circuit paths
+        # through ``create_pipeline``; assert the request actually
+        # reached creation so a future regression that returns 200
+        # without persisting the pipeline can't quietly pass this test.
+        mock_store.create_pipeline.assert_called_once()
 
     @patch("routes.pipelines.get_gateway_client")
     @patch("routes.pipelines.get_state_store")

--- a/orchestrator/tests/test_rebase_pipeline_branch.py
+++ b/orchestrator/tests/test_rebase_pipeline_branch.py
@@ -118,15 +118,17 @@ class TestRebasePipelineBranchOntoBase:
             assert mock_run.call_count == 3
             spawner.gateway.push_worktree_branch.assert_not_called()
 
-    def test_skips_when_head_on_neither_branch_nor_base(self):
-        """HEAD carries commits on neither origin/<branch> nor origin/<base>
-        — defer to push reconcile rather than blow away unpublished work.
+    def test_recovers_when_head_on_neither_branch_nor_base(self):
+        """HEAD on neither origin/<branch> nor origin/<base> — reset to
+        origin/<base> and proceed rather than defer to push-reconcile.
 
-        Both supported resume paths land HEAD on one of those refs:
-        preserved-worktree → ancestor of origin/<branch> (state-file
-        commits already pushed); fresh-worktree → ancestor of
-        origin/<base> (recreated from base).  Only when *neither* holds
-        does HEAD carry truly unpublished commits worth preserving.
+        Previously this case skipped, on the theory that HEAD carried
+        "truly unpublished work" worth preserving.  In practice (#2222)
+        the next orchestrator push hit the unsafe ``_build_rebase_cmd``
+        fallback and absorbed upstream main commits onto the pipeline
+        branch.  Discarding a confused-HEAD's local-only commits is
+        recoverable (agents recreate them on the next phase); a
+        contaminated PR is not.
         """
         spawner = _make_spawner()
         with patch("routes.pipelines.subprocess.run") as mock_run:
@@ -136,9 +138,33 @@ class TestRebasePipelineBranchOntoBase:
                 _result(stdout="70\n"),  # 70 commits behind base
                 _result(returncode=1),  # is-ancestor: HEAD NOT on origin/<branch>
                 _result(returncode=1),  # is-ancestor: HEAD NOT on origin/<base>
+                _result(returncode=0),  # recovery reset --hard origin/<base>
+                _result(returncode=0),  # reset --hard origin/<branch>
+                _result(returncode=0),  # rebase succeeds
             ]
             _call(spawner)
-            assert mock_run.call_count == 5
+            assert mock_run.call_count == 8
+            spawner.gateway.push_worktree_branch.assert_called_once()
+            push_kwargs = spawner.gateway.push_worktree_branch.call_args.kwargs
+            assert push_kwargs["force"] is True
+
+    def test_skips_when_head_recovery_reset_to_base_fails(self):
+        """If even the recovery reset to origin/<base> fails, skip rather
+        than risk corruption.  Same best-effort posture as the existing
+        reset-to-branch failure handling.
+        """
+        spawner = _make_spawner()
+        with patch("routes.pipelines.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                _result(returncode=0),  # rev-parse origin/<branch>
+                _result(returncode=0),  # rev-parse origin/<base>
+                _result(stdout="70\n"),  # 70 commits behind base
+                _result(returncode=1),  # is-ancestor: HEAD NOT on origin/<branch>
+                _result(returncode=1),  # is-ancestor: HEAD NOT on origin/<base>
+                _result(returncode=128, stderr="reset failed"),  # recovery reset fails
+            ]
+            _call(spawner)
+            assert mock_run.call_count == 6
             spawner.gateway.push_worktree_branch.assert_not_called()
 
     def test_proceeds_when_head_is_ancestor_of_base(self):

--- a/orchestrator/tests/test_reconcile_and_push_pr_branch.py
+++ b/orchestrator/tests/test_reconcile_and_push_pr_branch.py
@@ -604,13 +604,23 @@ class TestPushWorktreeBranchReconcile:
         )
 
         # No upstream-main commit ended up duplicated into the worktree's
-        # local history (the contamination shape from #2222).
+        # local history (the contamination shape from #2222).  The worktree
+        # was cut from ``origin/main`` and so already contains the original
+        # upstream commit objects at their original SHAs — those are not
+        # contamination.  Contamination is a *new* commit with a different
+        # SHA that carries the same patch-id (rebase-replay artefact).
         upstream_patch_ids = {_patch_id_of(seed, sha) for sha in upstream_shas}
+        upstream_sha_set = set(upstream_shas)
         log = _git(work, "log", "--format=%H", "HEAD").stdout.strip()
-        local_patch_ids = {_patch_id_of(work, sha) for sha in log.splitlines() if sha.strip()}
-        duplicates = local_patch_ids & upstream_patch_ids
-        assert not duplicates, (
-            f"worktree contains duplicate-by-content commits of upstream main: {duplicates}"
+        contaminating = [
+            sha
+            for sha in log.splitlines()
+            if sha.strip()
+            and sha not in upstream_sha_set
+            and _patch_id_of(work, sha) in upstream_patch_ids
+        ]
+        assert not contaminating, (
+            f"worktree contains duplicate-by-content commits of upstream main: {contaminating}"
         )
 
     def test_rebase_fails_closed_when_base_unverifiable(self, tmp_path):

--- a/orchestrator/tests/test_reconcile_and_push_pr_branch.py
+++ b/orchestrator/tests/test_reconcile_and_push_pr_branch.py
@@ -491,13 +491,143 @@ class TestPushWorktreeBranchReconcile:
             f"expected 2 branch-only commits, got {len(branch_only_shas)}: {branch_only_shas}"
         )
 
-    def test_rebase_with_base_branch_falls_back_when_base_missing(self, tmp_path):
-        """When ``origin/{base_branch}`` is not resolvable locally (e.g. the
-        base-branch fetch failed and the tracking ref was never created),
-        the rebase falls back to the plain ``git rebase origin/{branch}``
-        form rather than erroring out.
+    def test_rebase_does_not_contaminate_when_base_fetch_silently_failed(self, tmp_path):
+        """End-to-end regression for #2222.
+
+        Reproduces the production shape:
+
+        - ``origin/egg/issue-N`` is stuck at an old main snapshot (yesterday's
+          aborted pipeline left it there).
+        - ``main`` has advanced by several upstream commits since.
+        - The local worktree is fresh off current main + an agent commit.
+        - The local ``origin/main`` remote-tracking ref is *missing* — the
+          best-effort base-branch fetch in ``_reconcile_and_retry_push``
+          can fail silently (logged-and-continued; see gateway_client.py
+          lines 1006-1031), leaving the rebase helper unable to verify it.
+
+        Before the #2222 fix this caused ``_build_rebase_cmd`` to fall
+        back to ``git rebase origin/egg/issue-N``, which from
+        HEAD-at-current-main replayed every upstream main commit onto
+        the stale tip — producing duplicate-by-content commits with new
+        SHAs in the eventual PR diff.  After the fix the rebase helper
+        returns ``reconcile_base_unavailable`` and the worktree HEAD is
+        unchanged, so no contamination is possible.
         """
-        client = _make_client([False, True])
+        # Bare "origin" remote.
+        origin = tmp_path / "origin.git"
+        subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)], check=True)
+
+        # Seed main + push the stale pipeline branch tip.
+        seed = tmp_path / "seed"
+        seed.mkdir()
+        _git_init(seed, str(origin))
+        (seed / "README.md").write_text("initial\n")
+        _git(seed, "add", "README.md")
+        _git(seed, "commit", "-m", "initial main commit")
+        _git(seed, "push", "origin", "main")
+
+        _git(seed, "checkout", "-b", "egg/issue-2137")
+        (seed / "stale_contract.md").write_text("yesterday's run\n")
+        _git(seed, "add", "stale_contract.md")
+        _git(seed, "commit", "-m", "Initialize SDLC contract for #2137")
+        _git(seed, "push", "origin", "egg/issue-2137")
+
+        # Main advances by 3 upstream commits since the stale tip.
+        _git(seed, "checkout", "main")
+        upstream_shas = []
+        for i in range(3):
+            (seed / f"upstream_{i}.md").write_text(f"upstream work {i}\n")
+            _git(seed, "add", f"upstream_{i}.md")
+            _git(seed, "commit", "-m", f"Fix #{200 + i}: upstream landing {i}")
+            upstream_shas.append(_git(seed, "rev-parse", "HEAD").stdout.strip())
+        _git(seed, "push", "origin", "main")
+
+        # Today's worktree: cut from current main, with an agent commit.
+        # Critically: do NOT fetch origin/main into this worktree's
+        # remote-tracking refs — simulating the silent base-fetch failure
+        # path described in gateway_client.py lines 1006-1031.
+        work = tmp_path / "work"
+        work.mkdir()
+        _git_init(work, str(origin))
+        _git(work, "fetch", "origin", "main")
+        _git(work, "checkout", "-b", "egg/issue-2137-work", "origin/main")
+        (work / "agent_work.md").write_text("today's agent work\n")
+        _git(work, "add", "agent_work.md")
+        _git(work, "commit", "-m", "implement: agent commit on top of fresh main")
+        head_before = _git(work, "rev-parse", "HEAD").stdout.strip()
+
+        # Fetch only ``egg/issue-2137`` (so the stale-tip ref exists locally),
+        # then explicitly drop the ``origin/main`` ref to simulate the
+        # silent-fetch-failure precondition.
+        _git(work, "fetch", "origin", "egg/issue-2137")
+        try:
+            _git(work, "update-ref", "-d", "refs/remotes/origin/main")
+        except subprocess.CalledProcessError:
+            pass
+
+        verify_main = subprocess.run(
+            ["git", "-C", str(work), "rev-parse", "--verify", "origin/main"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert verify_main.returncode != 0, (
+            "precondition failed: origin/main should not be resolvable in this worktree"
+        )
+
+        git_base = [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            f"safe.directory={work}",
+            "-C",
+            str(work),
+        ]
+        result = _rebase_with_agent_output_autoresolve(
+            git_base=git_base,
+            pipeline_id="issue-2137",
+            branch="egg/issue-2137",
+            base_branch="main",
+        )
+
+        # The rebase must refuse rather than fall back to the unsafe form.
+        assert result.ok is False, "rebase should fail-closed when origin/main is missing"
+        assert result.category == "reconcile_base_unavailable", (
+            f"unexpected category: {result.category}"
+        )
+
+        # HEAD must be untouched — no contamination possible.
+        head_after = _git(work, "rev-parse", "HEAD").stdout.strip()
+        assert head_before == head_after, (
+            f"HEAD changed during failed rebase: {head_before} -> {head_after}"
+        )
+
+        # No upstream-main commit ended up duplicated into the worktree's
+        # local history (the contamination shape from #2222).
+        upstream_patch_ids = {_patch_id_of(seed, sha) for sha in upstream_shas}
+        log = _git(work, "log", "--format=%H", "HEAD").stdout.strip()
+        local_patch_ids = {_patch_id_of(work, sha) for sha in log.splitlines() if sha.strip()}
+        duplicates = local_patch_ids & upstream_patch_ids
+        assert not duplicates, (
+            f"worktree contains duplicate-by-content commits of upstream main: {duplicates}"
+        )
+
+    def test_rebase_fails_closed_when_base_unverifiable(self, tmp_path):
+        """When ``base_branch`` is provided but ``origin/{base_branch}`` is
+        not resolvable locally (e.g. the base-branch fetch failed silently
+        and the tracking ref was never created), the reconcile path fails
+        closed with ``reconcile_base_unavailable`` rather than falling back
+        to the plain ``git rebase origin/{branch}`` form.
+
+        The plain fallback is the contamination producer in #2222: from
+        HEAD-at-current-main with a stale ``origin/{branch}`` it replays
+        all the upstream main commits between the stale tip and HEAD onto
+        the stale tip, producing a PR full of duplicate-by-content
+        commits.  Surfacing the failure forces the operator to retry once
+        the base ref is healthy rather than silently producing a broken PR.
+        """
+        client = _make_client([False])  # only the initial push runs
         with patch(
             "gateway_client.subprocess.run",
             side_effect=[
@@ -506,7 +636,6 @@ class TestPushWorktreeBranchReconcile:
                     returncode=1, stderr="couldn't find remote ref"
                 ),  # fetch origin {base_branch} fails
                 _run_result(returncode=128, stderr="unknown revision"),  # rev-parse verify fails
-                _run_result(),  # rebase (plain form)
             ],
         ) as mock_run:
             ok = client.push_worktree_branch(
@@ -516,7 +645,13 @@ class TestPushWorktreeBranchReconcile:
                 base_branch="main",
             )
 
-        assert ok.ok is True
-        rebase_cmd = mock_run.call_args_list[3].args[0]
-        assert "rebase" in rebase_cmd and "--onto" not in rebase_cmd
-        assert "origin/egg/issue-42" in rebase_cmd
+        assert ok.ok is False
+        assert ok.category == "reconcile_base_unavailable"
+        assert "origin/main" in (ok.detail or "")
+        # Critically: no ``rebase`` call landed on the worktree.
+        all_cmds = [c.args[0] for c in mock_run.call_args_list]
+        assert not any("rebase" in c for c in all_cmds), (
+            f"unexpected rebase invocation in {all_cmds}"
+        )
+        # And the retry push was never attempted.
+        assert client._do_push.call_count == 1


### PR DESCRIPTION
## Summary

Fixes #2222 (Phases 1–3 of the plan).  The fix PR for issue-2137 (#2220) shipped a borked diff: 65 commits ahead of main, with ~30 of those being rebased copies of upstream main commits absorbed into the pipeline branch's linear history.  Two preconditions had to hold for the bug to surface; this PR closes both.

**Producer fix (Phase 2):**
- ``orchestrator/gateway_client.py:_build_rebase_cmd`` now fails closed when ``base_branch`` is set but ``origin/<base>`` cannot be verified.  Previously it silently fell back to the plain ``git rebase origin/<branch>`` form, which from HEAD-at-current-main with a stale ``origin/<branch>`` replayed every upstream main commit onto the stale tip — the contamination shape from #2222.  The reconcile path now surfaces ``reconcile_base_unavailable`` instead.
- ``_rebase_pipeline_branch_onto_base`` step 4 no longer defers to push-reconcile when HEAD is on neither ``origin/<branch>`` nor ``origin/<base>``; it now hard-resets to ``origin/<base>`` and proceeds.  Local-only commits are recoverable (agents recreate them); a contaminated PR is not.

**Precondition fix (Phase 3):**
- ``create_pipeline`` now refuses 409 with ``reason: stale_branch`` when the target branch exists with no active pipeline but its tip differs from ``origin/<base_branch>`` — pointing the operator at ``cancel_task(cleanup=true)``.  Adds ``GatewayClient.get_remote_branch_sha`` to support the comparison.
- ``gateway/worktree_manager.create_worktree`` reuse path now hard-resets HEAD to ``origin/<assigned_branch>`` (or ``origin/<base_branch>``) before returning the existing worktree, so a deterministic ``pipeline_id`` collision cannot inherit yesterday's HEAD.

Phase 4 (gateway policy on agent ``git rebase`` against base, end-of-pipeline rebase, divergence alerting) is tracked separately at #2224.

## Test plan

- [x] ``make lint`` — passes after format
- [ ] ``make test`` (changeset-aware) — please verify in CI
- [x] Regression test ``test_rebase_does_not_contaminate_when_base_fetch_silently_failed`` reproduces the #2222 shape with a real repo and asserts no upstream-main commits land as duplicates after the fix.
- [x] ``test_rebase_fails_closed_when_base_unverifiable`` covers the new ``reconcile_base_unavailable`` category.
- [x] ``test_recovers_when_head_on_neither_branch_nor_base`` and ``test_skips_when_head_recovery_reset_to_base_fails`` cover the new step-4 behaviour.
- [x] ``test_create_pipeline_rejects_stale_branch_with_no_active_pipeline`` + ``test_create_pipeline_allows_reuse_when_branch_at_base`` cover Phase 3a.
- [x] ``test_worktree_reuse_resets_to_safe_remote_ref`` covers Phase 3b.

## Closes / refs

Closes #2222.  Follow-up: #2224.