### PR TITLE
Fix #2232: wait-status launcher in skills/sdlc/bin (no host setup)

### DIFF
--- a/docs/reference/agent-wait-patterns.md
+++ b/docs/reference/agent-wait-patterns.md
@@ -642,7 +642,10 @@ Hosts invoke this via the SDLC skill's launcher,
 beyond `make deps` ([#2232](https://github.com/jwbron/egg/issues/2232)).
 The launcher's default URL (`http://localhost:9849`) relies on the
 `hostPort: 9849` binding in
-`k8s/overlays/local/patches/orchestrator-volumes.yaml`.
+`k8s/overlays/local/patches/orchestrator-volumes.yaml`. The bare
+`egg-orch pipeline wait-status` invocation shown above is the
+in-sandbox / unit-test entry point; host callers should always go
+through the launcher.
 
 The CLI loops `GET /api/v1/pipelines/<id>/status/wait?wait=25`,
 threading the cursor between successive calls. Stdout is **JSON-lines**
@@ -653,7 +656,7 @@ threading the cursor between successive calls. Stdout is **JSON-lines**
 | `0` | Pipeline reached terminal state (`complete` / `failed` / `cancelled`) or terminal-event wire value (`pipeline.completed` / `pipeline.failed` / `pipeline.cancelled`). |
 | `1` | `--max-iterations` cap hit (test harnesses only — default loops forever). |
 | `2` | Transient error budget exceeded (5xx / connection errors after backoff). Caller should retry. |
-| `3` | Permanent error (4xx, malformed cursor, unknown pipeline). Caller should surface to user, not retry. |
+| `3` | Permanent error (4xx, malformed cursor, unknown pipeline). Caller should surface to user, not retry. The `skills/sdlc/bin/wait-status` launcher also exits 3 on env-setup failures (missing `.venv/bin/python` or `sandbox/bin/egg-orch`); both signals collapse to "don't retry" from the caller's perspective. |
 
 Each emitted JSON line is a stable subset of the route's Path-A
 envelope:
@@ -860,8 +863,9 @@ render_full_dashboard(last_status)
 last_cursor = ""   # no cursor yet — first wait-status snaps to tip
 
 # blocking wait via Bash; emits one JSON line per event, exits on terminal.
-# Hosts call this through the SDLC skill's launcher (skills/sdlc/bin/wait-status, #2232).
-egg-orch pipeline wait-status $TASK_ID --since "$last_cursor" \
+# Host-side callers use the SDLC skill's launcher (#2232); it wraps
+# `egg-orch pipeline wait-status` with PYTHONPATH and EGG_ORCHESTRATOR_URL.
+skills/sdlc/bin/wait-status $TASK_ID --since "$last_cursor" \
   | while IFS= read -r line; do
       cursor=$(jq -r .cursor <<< "$line")
       trigger=$(jq -r .trigger <<< "$line")

--- a/docs/reference/agent-wait-patterns.md
+++ b/docs/reference/agent-wait-patterns.md
@@ -636,6 +636,14 @@ re-fetching the full envelope when needed.
 egg-orch pipeline wait-status <pipeline_id> [--since <cursor>]
 ```
 
+Hosts invoke this via the SDLC skill's launcher,
+`skills/sdlc/bin/wait-status`, which sets `PYTHONPATH` and
+`EGG_ORCHESTRATOR_URL` so no host-side configuration is required
+beyond `make deps` ([#2232](https://github.com/jwbron/egg/issues/2232)).
+The launcher's default URL (`http://localhost:9849`) relies on the
+`hostPort: 9849` binding in
+`k8s/overlays/local/patches/orchestrator-volumes.yaml`.
+
 The CLI loops `GET /api/v1/pipelines/<id>/status/wait?wait=25`,
 threading the cursor between successive calls. Stdout is **JSON-lines**
 — one line per pipeline-relevant event. The process exits with:
@@ -851,7 +859,8 @@ last_status = $(egg-orch pipeline status $TASK_ID --json)
 render_full_dashboard(last_status)
 last_cursor = ""   # no cursor yet — first wait-status snaps to tip
 
-# blocking wait via Bash; emits one JSON line per event, exits on terminal
+# blocking wait via Bash; emits one JSON line per event, exits on terminal.
+# Hosts call this through the SDLC skill's launcher (skills/sdlc/bin/wait-status, #2232).
 egg-orch pipeline wait-status $TASK_ID --since "$last_cursor" \
   | while IFS= read -r line; do
       cursor=$(jq -r .cursor <<< "$line")

--- a/k8s/overlays/local/patches/orchestrator-volumes.yaml
+++ b/k8s/overlays/local/patches/orchestrator-volumes.yaml
@@ -25,10 +25,20 @@ spec:
           # Claude Code's MCP config (http://localhost:9850/mcp) works
           # without kubectl port-forward. Local-dev only; production
           # k8s should use a Service/Ingress.
+          #
+          # The orchestrator API (9849) gets the same treatment so the
+          # SDLC skill's wait-status launcher
+          # (skills/sdlc/bin/wait-status) can default
+          # EGG_ORCHESTRATOR_URL=http://localhost:9849 — keep both in
+          # sync.
           ports:
             - name: mcp
               containerPort: 9850
               hostPort: 9850
+              protocol: TCP
+            - name: api
+              containerPort: 9849
+              hostPort: 9849
               protocol: TCP
           env:
             - name: EGG_REPO_PATH

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -316,13 +316,13 @@ Drive the pipeline through one Bash invocation per quiet stretch. On entry:
 
 1. **First poll** — call the `get_status(task_id)` MCP tool to render the initial dashboard. `get_status` returns the full snapshot. It does **not** return a `cursor`; the cursor is produced by `wait-status` only. Cache the snapshot in conversation context as `last_status`. Initialize `last_cursor = ""` (empty — the first `wait-status` call snaps to the tip of both event sources).
 
-2. **Blocking wait** — invoke the canonical Bash idiom:
+2. **Blocking wait** — invoke the canonical Bash idiom (run from the repo root):
 
    ```bash
-   egg-orch pipeline wait-status <task_id> --since "<last_cursor>"
+   skills/sdlc/bin/wait-status <task_id> --since "<last_cursor>"
    ```
 
-   The CLI loops the orchestrator's `/status/wait` route server-side, threading the cursor between calls. Stdout is **JSON-lines** — one line per pipeline-relevant event. The CLI is silent on `no_change`, so the LLM only wakes when something happened. Exit codes:
+   The launcher wraps `sandbox/bin/egg-orch pipeline wait-status`, setting `PYTHONPATH` and `EGG_ORCHESTRATOR_URL` so no host-side configuration is required beyond `make deps`. It loops the orchestrator's `/status/wait` route server-side, threading the cursor between calls. Stdout is **JSON-lines** — one line per pipeline-relevant event. The CLI is silent on `no_change`, so the LLM only wakes when something happened. Exit codes:
 
    | Exit code | Meaning | Skill action |
    |-----------|---------|--------------|
@@ -987,7 +987,7 @@ All orchestrator and gateway interactions use the MCP tool surface. Never call R
 |------|---------|
 | `submit_task` | Submit a new pipeline task |
 | `get_status` | One-shot status snapshot (no cursor) — use for first poll and after `provide_input` |
-| `egg-orch pipeline wait-status` (Bash) | Long-poll for status changes; emits JSON-lines on stdout, threading the opaque cursor between calls. Replaces the prior `wait_for_status_change` MCP tool (#2211). |
+| `skills/sdlc/bin/wait-status` (Bash) | Long-poll for status changes; emits JSON-lines on stdout, threading the opaque cursor between calls. Host-side launcher around `sandbox/bin/egg-orch pipeline wait-status`. Replaces the prior `wait_for_status_change` MCP tool (#2211). |
 | `provide_input` | Respond to HITL decisions (serialize JSON payload as string) |
 | `list_tasks` | List tasks for a repository |
 | `cancel_task` | Cancel a running task |
@@ -1002,12 +1002,12 @@ All orchestrator and gateway interactions use the MCP tool surface. Never call R
 | `list_checkpoints` | Browse prior agent session transcripts (gateway-backed) |
 | `search_checkpoints` | Search checkpoint metadata for keywords (gateway-backed) |
 
-**Polling protocol:** First poll uses `get_status(task_id)` (MCP). Every subsequent quiet stretch uses one Bash invocation: `egg-orch pipeline wait-status <task_id> --since "<last_cursor>"`. See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the full envelope contract and trigger allowlist.
+**Polling protocol:** First poll uses `get_status(task_id)` (MCP). Every subsequent quiet stretch uses one Bash invocation: `skills/sdlc/bin/wait-status <task_id> --since "<last_cursor>"`. See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the full envelope contract and trigger allowlist.
 
 ## Critical Rules
 
 - **Always use MCP tools** — never call orchestrator/gateway APIs or CLIs directly
-- **First poll uses `get_status(task_id)` (MCP); every subsequent quiet stretch uses `egg-orch pipeline wait-status <task_id> --since "<last_cursor>"` (Bash)** — thread the `cursor` from each emitted JSON-line into the next Bash invocation's `--since`. The first `wait-status` call after the `get_status` snapshot uses an empty `--since` (route snaps to tip); `get_status` itself does NOT return a cursor. See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the trigger allowlist, envelope, and exit-code contract.
+- **First poll uses `get_status(task_id)` (MCP); every subsequent quiet stretch uses `skills/sdlc/bin/wait-status <task_id> --since "<last_cursor>"` (Bash)** — thread the `cursor` from each emitted JSON-line into the next Bash invocation's `--since`. The first `wait-status` call after the `get_status` snapshot uses an empty `--since` (route snaps to tip); `get_status` itself does NOT return a cursor. See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the trigger allowlist, envelope, and exit-code contract.
 - **Read each emitted JSON-line as it arrives.** The CLI is silent on `no_change` — it only emits when something happened. Re-fetch the full snapshot via `get_status` whenever the dashboard needs fields not on the JSON-line (running_agents, completed_agents, recent_messages, enriched pending_decisions).
 - **Always serialize JSON payloads as strings** for `provide_input` — the `response` parameter is a string, not an object. Pass `'{"action": "approve"}'` not `{"action": "approve"}`
 - **Never skip HITL** — always present decisions to the user and wait for their response
@@ -1296,13 +1296,13 @@ Drive the pipeline through one Bash invocation per quiet stretch. On entry:
 
 1. **First poll** — call the `get_status(task_id)` MCP tool to render the initial dashboard and cache the snapshot as `last_status`. `get_status` does not return a `cursor`; the cursor is produced by `wait-status` only. Initialize `last_cursor = ""` (empty — the first `wait-status` call snaps to the tip).
 
-2. **Blocking wait** — invoke the canonical Bash idiom:
+2. **Blocking wait** — invoke the canonical Bash idiom (run from the repo root):
 
    ```bash
-   egg-orch pipeline wait-status <task_id> --since "<last_cursor>"
+   skills/sdlc/bin/wait-status <task_id> --since "<last_cursor>"
    ```
 
-   The CLI loops `/status/wait` server-side, threading the cursor between calls. Stdout is **JSON-lines** — one line per pipeline-relevant event, silent on `no_change`. Exit codes:
+   The launcher wraps `sandbox/bin/egg-orch pipeline wait-status` and loops `/status/wait` server-side, threading the cursor between calls. Stdout is **JSON-lines** — one line per pipeline-relevant event, silent on `no_change`. Exit codes:
 
    | Exit code | Meaning | Skill action |
    |-----------|---------|--------------|
@@ -1432,7 +1432,7 @@ Phase: <phase where failure occurred>
 
 ## Short Flow Critical Rules
 
-- **Always use MCP tools for state-query operations** (`submit_task`, `get_status` for the first poll and one-shot snapshots, `provide_input`, `cancel_task`) — never call orchestrator APIs directly. **For blocking waits use the Bash CLI** `egg-orch pipeline wait-status` (issue #2211) — the MCP transport caps tool calls below typical quiet-phase intervals, so an MCP-driven wait would burn an LLM turn on every cap-elapsed return. Thread the JSON-line `cursor` into the next Bash invocation's `--since`. See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the contract.
+- **Always use MCP tools for state-query operations** (`submit_task`, `get_status` for the first poll and one-shot snapshots, `provide_input`, `cancel_task`) — never call orchestrator APIs directly. **For blocking waits use the Bash launcher** `skills/sdlc/bin/wait-status` (host-side wrapper around `egg-orch pipeline wait-status`, issue #2211) — the MCP transport caps tool calls below typical quiet-phase intervals, so an MCP-driven wait would burn an LLM turn on every cap-elapsed return. Thread the JSON-line `cursor` into the next Bash invocation's `--since`. See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the contract.
 - **Always serialize JSON payloads as strings** for `provide_input`
 - **Always pass `config`** with `{"start_phase": "implement", "hitl_gates": false, "overseer_enabled": true}` when calling `submit_task`
 - **Auto-approve phase gates** — this is a no-HITL flow; if a gate appears, approve it automatically and inform the user

--- a/skills/sdlc/bin/wait-status
+++ b/skills/sdlc/bin/wait-status
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Host-side launcher for `egg-orch pipeline wait-status`. Lets the SDLC
+# skill drive its quiet-stretch monitoring loop without `make deps`-time
+# setup beyond the venv.
+#
+# Defaults EGG_ORCHESTRATOR_URL to http://localhost:9849. That endpoint
+# is exposed by `hostPort: 9849` in
+# k8s/overlays/local/patches/orchestrator-volumes.yaml — keep both in
+# sync.
+#
+# Issue: https://github.com/jwbron/egg/issues/2232
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+VENV_PYTHON="$REPO_ROOT/.venv/bin/python"
+if [[ ! -x "$VENV_PYTHON" ]]; then
+    echo "wait-status: $VENV_PYTHON not found — run 'make deps' first" >&2
+    exit 3
+fi
+
+EGG_ORCH_SCRIPT="$REPO_ROOT/sandbox/bin/egg-orch"
+if [[ ! -e "$EGG_ORCH_SCRIPT" ]]; then
+    echo "wait-status: $EGG_ORCH_SCRIPT not found" >&2
+    exit 3
+fi
+
+export PYTHONPATH="$REPO_ROOT/sandbox:$REPO_ROOT/shared${PYTHONPATH:+:$PYTHONPATH}"
+export EGG_ORCHESTRATOR_URL="${EGG_ORCHESTRATOR_URL:-http://localhost:9849}"
+
+exec "$VENV_PYTHON" "$EGG_ORCH_SCRIPT" pipeline wait-status "$@"

--- a/skills/sdlc/bin/wait-status
+++ b/skills/sdlc/bin/wait-status
@@ -12,8 +12,9 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../../.." && pwd)"
 
 VENV_PYTHON="$REPO_ROOT/.venv/bin/python"
 if [[ ! -x "$VENV_PYTHON" ]]; then


### PR DESCRIPTION
## Summary

- New `skills/sdlc/bin/wait-status` launcher resolves `<repo>/.venv/bin/python`, sets `PYTHONPATH=sandbox:shared`, defaults `EGG_ORCHESTRATOR_URL=http://localhost:9849`, and execs `sandbox/bin/egg-orch pipeline wait-status "$@"`.
- `k8s/overlays/local/patches/orchestrator-volumes.yaml` adds `hostPort: 9849` next to the existing `hostPort: 9850` so the orchestrator API gets host-bound the same way the MCP port already is. Cross-link comments keep the binding and the launcher default in sync.
- SDLC skill (`skills/sdlc/SKILL.md`) and the §7 host-side waits doc now invoke the launcher path; the underlying `egg-orch pipeline wait-status` CLI is unchanged.

Closes #2232.

## Why

Without this, the very first `wait-status` invocation from the host fails with `command not found` and the skill silently falls back to MCP `get_status(wait=N)` polling — exactly the LLM-turn-burning loop that #2211 was meant to remove. The fix piggybacks on the existing local-overlay pattern that already exposes the MCP port to localhost.

## Test plan

- [ ] `make deps` in a fresh checkout, then `skills/sdlc/bin/wait-status --help` prints argparse usage with no PYTHONPATH/URL setup. (Verified locally via the main `.venv`: launcher resolves, sets env, execs the CLI, `--help` lands.)
- [ ] After `make deploy` with the local overlay, `curl -s http://localhost:9849/api/v1/health` returns 200 (i.e. hostPort 9849 is bound).
- [ ] Run a pipeline, then from the repo root: `skills/sdlc/bin/wait-status <task_id> --since ""` — emits a JSON-line on the first event and silences on `no_change`, matching the §7 contract.
- [ ] `EGG_ORCHESTRATOR_URL=http://10.43.36.88:9849 skills/sdlc/bin/wait-status <task_id> --since ""` — env override still wins (regression check on the resolution order).
- [ ] `make lint` and `make test` clean.