### PR TITLE
Fix #2177: serialize _ensure_worktree to close concurrent-recovery race

### DIFF
--- a/orchestrator/state_store.py
+++ b/orchestrator/state_store.py
@@ -226,115 +226,128 @@ class StateStore:
                 f"the state store."
             )
 
-        # Clean up stale admin dir for THIS worktree only (e.g., from crashes).
-        # IMPORTANT: Do NOT use `git worktree prune` — the orchestrator cannot
-        # see the gateway's worktree paths (different bind mounts), so prune
-        # would incorrectly remove admin dirs for active gateway worktrees,
-        # breaking all container git operations.
-        #
-        # This early call covers the wt-gone case: the worktree directory was
-        # wiped (e.g., state volume reset) but the admin dir under
-        # `<repo>/.git/worktrees/` survived.  The forced call later in this
-        # method (line ~259) covers the wt-broken case: the worktree directory
-        # is on disk but rev-parse rejects it.
-        self._remove_stale_admin_dir()
-
-        wt = self._worktree_dir
-
-        if wt.exists():
-            # Validate against `git rev-parse` rather than relying on the
-            # presence of `wt/.git`.  The `.git` link can be missing or
-            # broken (e.g., the matching admin dir under
-            # `<repo>/.git/worktrees/...` was orphaned by a crash) while
-            # the worktree directory itself still sits on disk.  In that
-            # state, falling through to `git worktree add` below would
-            # fail with `'<wt>' already exists` and strand the pipeline
-            # on `request_changes` re-runs (#2140).  Probe with rev-parse
-            # and only treat the worktree as healthy when git agrees.
+        # Serialize the entire worktree bring-up sequence under the same
+        # reentrant RLock + flock that ``_run_git`` uses.  Without this,
+        # concurrent callers (state-store probe, pipeline driver thread,
+        # ``/api/v1/health``) race between detect-failure → cleanup →
+        # retry inside ``_add_worktree_with_branch_recovery`` and surface
+        # misleading one-shot 500s on whichever arrived second (#2177).
+        # The same root cause produced #2234's ENOENT race.  ``_git_op``
+        # is reentrant via ``_flock_depth``, so nested ``_run_git`` calls
+        # compose without deadlock.  Cost: lock window grows from "one
+        # git command" to "the worktree-bring-up sequence" — tens of ms
+        # in steady state; the cold-start ``_restore_from_remote`` fetch
+        # is the longest case, runs at most once per repo per process.
+        with self._git_op():
+            # Clean up stale admin dir for THIS worktree only (e.g., from crashes).
+            # IMPORTANT: Do NOT use `git worktree prune` — the orchestrator cannot
+            # see the gateway's worktree paths (different bind mounts), so prune
+            # would incorrectly remove admin dirs for active gateway worktrees,
+            # breaking all container git operations.
             #
-            # One retry covers transient git contention (e.g., concurrent
-            # _commit_statefiles_to_worktree holding a lock on the shared
-            # .git directory).  See #1396.
-            healthy = False
-            for _attempt in range(2):
-                result = self._run_git("rev-parse", "--is-inside-work-tree", cwd=wt, check=False)
-                if result.returncode == 0:
-                    healthy = True
-                    break
-                if _attempt == 0:
-                    time.sleep(0.1)
-            if healthy:
-                return wt
+            # This early call covers the wt-gone case: the worktree directory was
+            # wiped (e.g., state volume reset) but the admin dir under
+            # `<repo>/.git/worktrees/` survived.  The forced call later in this
+            # method covers the wt-broken case: the worktree directory
+            # is on disk but rev-parse rejects it.
+            self._remove_stale_admin_dir()
 
-            logger.warning(
-                "Worktree validation failed, recreating: worktree=%s returncode=%s",
-                str(wt),
-                result.returncode,
-            )
-            try:
-                shutil.rmtree(wt)
-            except FileNotFoundError:
-                # Concurrent caller (e.g. the state-store probe at
-                # ``state_store_probe.py``, a sibling pipeline thread, or
-                # the ``/api/v1/health`` probe) already cleaned up the
-                # worktree between our ``wt.exists()`` check and this
-                # rmtree.  ``_ensure_worktree`` is invoked from many
-                # threads concurrently and is not wrapped in
-                # ``_git_op()``, so the TOCTOU window is real.  ENOENT
-                # here is exactly the post-state we wanted — fall
-                # through to recreate.  Issue #2234.
-                pass
-            except OSError as exc:
-                raise GitOperationError(
-                    f"Failed to remove stale state worktree at {wt}: {exc}"
-                ) from exc
-            # Force-remove the admin dir too — the matching wt directory
-            # was just removed, but `_remove_stale_admin_dir` checks
-            # `wt.exists()` before deleting, so call the forced variant
-            # to guarantee `git worktree add` won't refuse.
-            self._remove_stale_admin_dir(force=True)
+            wt = self._worktree_dir
+
             if wt.exists():
-                # Defensive: rmtree returned without raising but the
-                # directory persists (e.g., a sub-mount).  Refuse to
-                # call `git worktree add` over it.
-                raise GitOperationError(
-                    f"State worktree at {wt} could not be removed; "
-                    "refusing to recreate over existing directory"
+                # Validate against `git rev-parse` rather than relying on the
+                # presence of `wt/.git`.  The `.git` link can be missing or
+                # broken (e.g., the matching admin dir under
+                # `<repo>/.git/worktrees/...` was orphaned by a crash) while
+                # the worktree directory itself still sits on disk.  In that
+                # state, falling through to `git worktree add` below would
+                # fail with `'<wt>' already exists` and strand the pipeline
+                # on `request_changes` re-runs (#2140).  Probe with rev-parse
+                # and only treat the worktree as healthy when git agrees.
+                #
+                # One retry covers transient git contention (e.g., concurrent
+                # _commit_statefiles_to_worktree holding a lock on the shared
+                # .git directory).  See #1396.
+                healthy = False
+                for _attempt in range(2):
+                    result = self._run_git(
+                        "rev-parse", "--is-inside-work-tree", cwd=wt, check=False
+                    )
+                    if result.returncode == 0:
+                        healthy = True
+                        break
+                    if _attempt == 0:
+                        time.sleep(0.1)
+                if healthy:
+                    return wt
+
+                logger.warning(
+                    "Worktree validation failed, recreating: worktree=%s returncode=%s",
+                    str(wt),
+                    result.returncode,
                 )
+                try:
+                    shutil.rmtree(wt)
+                except FileNotFoundError:
+                    # Defensive: with the ``_git_op`` wrap above, the
+                    # cross-thread/process race that produced #2234 is
+                    # closed.  Keep tolerating ENOENT anyway — the
+                    # post-state is what we wanted, and an external
+                    # actor (operator cleanup, container restart between
+                    # the ``wt.exists()`` check and this rmtree) can
+                    # still produce it.
+                    pass
+                except OSError as exc:
+                    raise GitOperationError(
+                        f"Failed to remove stale state worktree at {wt}: {exc}"
+                    ) from exc
+                # Force-remove the admin dir too — the matching wt directory
+                # was just removed, but `_remove_stale_admin_dir` checks
+                # `wt.exists()` before deleting, so call the forced variant
+                # to guarantee `git worktree add` won't refuse.
+                self._remove_stale_admin_dir(force=True)
+                if wt.exists():
+                    # Defensive: rmtree returned without raising but the
+                    # directory persists (e.g., a sub-mount).  Refuse to
+                    # call `git worktree add` over it.
+                    raise GitOperationError(
+                        f"State worktree at {wt} could not be removed; "
+                        "refusing to recreate over existing directory"
+                    )
 
-        wt.parent.mkdir(parents=True, exist_ok=True)
+            wt.parent.mkdir(parents=True, exist_ok=True)
 
-        # Try to restore from remote if the local branch doesn't exist yet.
-        # This enables cross-host recovery when the local state volume is lost.
-        if not self._state_branch_exists():
-            self._restore_from_remote()
+            # Try to restore from remote if the local branch doesn't exist yet.
+            # This enables cross-host recovery when the local state volume is lost.
+            if not self._state_branch_exists():
+                self._restore_from_remote()
 
-        if self._state_branch_exists():
-            self._add_worktree_with_branch_recovery(wt)
-        else:
-            # First run: create orphan branch
-            # Wrap in try/except to clean up on partial failure
-            try:
-                self._run_git("worktree", "add", "--detach", str(wt))
-                self._run_git("checkout", "--orphan", STATE_BRANCH, cwd=wt)
-                self._run_git("rm", "-rf", "--cached", ".", cwd=wt, check=False)
-                # Remove inherited files from working directory
-                for item in wt.iterdir():
-                    if item.name == ".git":
-                        continue
-                    if item.is_dir():
-                        shutil.rmtree(item)
-                    else:
-                        item.unlink()
-            except (GitOperationError, OSError):
-                # Clean up partial worktree on failure to avoid broken state.
-                # Catch both GitOperationError (git command failures) and OSError
-                # (filesystem errors during file cleanup like permission denied).
-                shutil.rmtree(wt, ignore_errors=True)
-                self._remove_stale_admin_dir()
-                raise
+            if self._state_branch_exists():
+                self._add_worktree_with_branch_recovery(wt)
+            else:
+                # First run: create orphan branch
+                # Wrap in try/except to clean up on partial failure
+                try:
+                    self._run_git("worktree", "add", "--detach", str(wt))
+                    self._run_git("checkout", "--orphan", STATE_BRANCH, cwd=wt)
+                    self._run_git("rm", "-rf", "--cached", ".", cwd=wt, check=False)
+                    # Remove inherited files from working directory
+                    for item in wt.iterdir():
+                        if item.name == ".git":
+                            continue
+                        if item.is_dir():
+                            shutil.rmtree(item)
+                        else:
+                            item.unlink()
+                except (GitOperationError, OSError):
+                    # Clean up partial worktree on failure to avoid broken state.
+                    # Catch both GitOperationError (git command failures) and OSError
+                    # (filesystem errors during file cleanup like permission denied).
+                    shutil.rmtree(wt, ignore_errors=True)
+                    self._remove_stale_admin_dir()
+                    raise
 
-        return wt
+            return wt
 
     def _remove_stale_admin_dir(self, force: bool = False) -> None:
         """Remove the git admin dir for the state worktree if it's stale.
@@ -401,32 +414,41 @@ class StateStore:
         because the orchestrator pod cannot see the gateway's worktree
         paths (different bind mounts) and prune would incorrectly
         remove their admin dirs (see ``_remove_stale_admin_dir``).
+
+        The body runs under ``_git_op`` so the detect-failure → cleanup
+        → retry sequence is atomic against concurrent callers.  Without
+        this, two callers raced and the loser saw a misleading 500
+        because the admin dir was already cleaned by the winner (#2177).
+        ``_git_op`` is reentrant; ``_ensure_worktree`` already holds it
+        when calling this method, and the inner ``_run_git`` calls
+        nest on the same lock.
         """
-        try:
-            self._run_git("worktree", "add", str(wt), STATE_BRANCH)
-            return
-        except GitOperationError as exc:
-            match = self._BRANCH_IN_USE_PATTERN.search(str(exc))
-            if not match:
-                raise
-            stale_path = Path(match.group(1))
-            if stale_path.exists():
-                # A live worktree genuinely holds the branch.  Refuse to
-                # touch it; surface the original error.
-                raise
-            removed = self._remove_admin_dir_for_path(stale_path)
-            if not removed:
-                logger.warning(
-                    "Branch %s held by prunable worktree at %s but no admin dir matched",
-                    STATE_BRANCH,
+        with self._git_op():
+            try:
+                self._run_git("worktree", "add", str(wt), STATE_BRANCH)
+                return
+            except GitOperationError as exc:
+                match = self._BRANCH_IN_USE_PATTERN.search(str(exc))
+                if not match:
+                    raise
+                stale_path = Path(match.group(1))
+                if stale_path.exists():
+                    # A live worktree genuinely holds the branch.  Refuse to
+                    # touch it; surface the original error.
+                    raise
+                removed = self._remove_admin_dir_for_path(stale_path)
+                if not removed:
+                    logger.warning(
+                        "Branch %s held by prunable worktree at %s but no admin dir matched",
+                        STATE_BRANCH,
+                        stale_path,
+                    )
+                    raise
+                logger.info(
+                    "Cleared stale admin dir for prunable worktree; retrying add: path=%s",
                     stale_path,
                 )
-                raise
-            logger.info(
-                "Cleared stale admin dir for prunable worktree; retrying add: path=%s",
-                stale_path,
-            )
-            self._run_git("worktree", "add", str(wt), STATE_BRANCH)
+                self._run_git("worktree", "add", str(wt), STATE_BRANCH)
 
     def _remove_admin_dir_for_path(self, target_wt_path: Path) -> bool:
         """Remove the admin dir whose ``gitdir`` references ``target_wt_path``.

--- a/orchestrator/tests/test_state_store.py
+++ b/orchestrator/tests/test_state_store.py
@@ -7,6 +7,7 @@ Note: Git operations are mocked since git init is not available in the sandbox.
 import os
 import shutil
 import subprocess
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1867,6 +1868,100 @@ class TestBranchHeldByPrunableWorktree:
         assert not admin_dir.exists()
         # Calling again — nothing left to remove.
         assert store._remove_admin_dir_for_path(unrelated_path) is False
+
+    def test_concurrent_callers_serialize_through_git_op(self, tmp_path):
+        """Two callers entering ``_ensure_worktree`` concurrently must
+        both succeed.  Pre-fix (#2177), the recovery sequence
+        ``worktree add`` (fail) → ``_remove_admin_dir_for_path`` →
+        ``worktree add`` (retry) released ``_git_op`` between the
+        inner ``_run_git`` calls, so the loser found the admin dir
+        already cleaned (returned False) and re-raised the original
+        ``GitOperationError`` as a misleading one-shot 500.  Wrapping
+        the bring-up sequence in ``_git_op`` makes the loser block on
+        the lock and observe a healthy worktree on entry."""
+        store_seed, wt = self._make_store(tmp_path)
+
+        # Wedge state: admin dir for a vanished path holds the branch.
+        stale_path = tmp_path / "old-pipeline-worktree"
+        admin_dir = store_seed.repo_path / ".git" / "worktrees" / "old-pipeline-worktree"
+        admin_dir.mkdir(parents=True)
+        (admin_dir / "gitdir").write_text(f"{stale_path}/.git\n")
+
+        add_call_count = {"n": 0}
+        depth_when_removing_admin: list[int] = []
+        counter_lock = threading.Lock()
+        errors: list[BaseException] = []
+        results: list = []
+
+        def fake_run(*args, check=True, cwd=None):
+            if args[:2] == ("worktree", "add"):
+                with counter_lock:
+                    add_call_count["n"] += 1
+                    is_first = add_call_count["n"] == 1
+                if is_first:
+                    raise GitOperationError(
+                        f"Git command failed: fatal: 'egg/pipeline-state' "
+                        f"is already used by worktree at '{stale_path}'\n"
+                    )
+                # Retry: materialize wt so subsequent rev-parse + the
+                # other thread's wt.exists() probe both observe a
+                # healthy worktree.
+                wt.mkdir(parents=True, exist_ok=True)
+                (wt / ".git").touch()
+                return MagicMock(stdout="", returncode=0)
+            if args[:2] == ("rev-parse", "--is-inside-work-tree"):
+                return MagicMock(
+                    stdout="",
+                    returncode=0 if (wt / ".git").exists() else 1,
+                )
+            if args[:2] == ("rev-parse", "--verify"):
+                return MagicMock(stdout="", returncode=0)
+            return MagicMock(stdout="", returncode=0)
+
+        original_remove = StateStore._remove_admin_dir_for_path
+
+        def tracked_remove(self, target_path):
+            # _flock_depth > 0 proves the recovery is running under
+            # the cross-process lock — i.e., the loser cannot squeeze
+            # in between our failing add and our retry.
+            depth_when_removing_admin.append(StateStore._flock_depth)
+            return original_remove(self, target_path)
+
+        def caller():
+            try:
+                s = StateStore(store_seed.repo_path, worktree_dir=wt)
+                results.append(s._ensure_worktree())
+            except BaseException as exc:
+                errors.append(exc)
+
+        with (
+            patch.object(StateStore, "_run_git", side_effect=fake_run),
+            patch.object(
+                StateStore,
+                "_remove_admin_dir_for_path",
+                tracked_remove,
+            ),
+        ):
+            threads = [threading.Thread(target=caller) for _ in range(2)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        assert errors == [], f"concurrent callers must not raise: {errors}"
+        assert results == [wt, wt]
+        # Exactly one fail+retry pair across both threads — the loser
+        # never re-entered the recovery path; it observed the wt as
+        # healthy under the lock and short-circuited.
+        assert add_call_count["n"] == 2, (
+            f"expected one fail + one retry, got {add_call_count['n']} adds"
+        )
+        # The recovery removed the admin dir while holding the lock.
+        assert depth_when_removing_admin, "recovery never ran"
+        assert all(d > 0 for d in depth_when_removing_admin), (
+            f"_remove_admin_dir_for_path ran outside _git_op: depths={depth_when_removing_admin}"
+        )
+        assert not admin_dir.exists()
 
 
 class TestEnsureWorktreeRepoPathGuard:

--- a/orchestrator/tests/test_state_store.py
+++ b/orchestrator/tests/test_state_store.py
@@ -1921,9 +1921,12 @@ class TestBranchHeldByPrunableWorktree:
         original_remove = StateStore._remove_admin_dir_for_path
 
         def tracked_remove(self, target_path):
-            # _flock_depth > 0 proves the recovery is running under
-            # the cross-process lock — i.e., the loser cannot squeeze
-            # in between our failing add and our retry.
+            # _flock_depth >= 2 proves *both* wraps are in place: the
+            # outer one in _ensure_worktree (depth 1) and the inner one
+            # in _add_worktree_with_branch_recovery (depth 2).  A weaker
+            # ``> 0`` assertion would still pass if a future refactor
+            # dropped the outer wrap and left only the inner one — and
+            # that would re-open the #2177 race.
             depth_when_removing_admin.append(StateStore._flock_depth)
             return original_remove(self, target_path)
 
@@ -1957,9 +1960,14 @@ class TestBranchHeldByPrunableWorktree:
             f"expected one fail + one retry, got {add_call_count['n']} adds"
         )
         # The recovery removed the admin dir while holding the lock.
+        # Depth must be >= 2: the outer wrap in _ensure_worktree
+        # contributes 1, and the inner wrap in
+        # _add_worktree_with_branch_recovery contributes another.  A
+        # weaker ``> 0`` check would still pass with only the inner
+        # wrap present, which would re-open the #2177 race.
         assert depth_when_removing_admin, "recovery never ran"
-        assert all(d > 0 for d in depth_when_removing_admin), (
-            f"_remove_admin_dir_for_path ran outside _git_op: depths={depth_when_removing_admin}"
+        assert all(d >= 2 for d in depth_when_removing_admin), (
+            f"_remove_admin_dir_for_path ran without both _git_op wraps: depths={depth_when_removing_admin}"
         )
         assert not admin_dir.exists()
 


### PR DESCRIPTION
## Summary

- Wrap `_ensure_worktree` (and `_add_worktree_with_branch_recovery` for defense-in-depth) in `self._git_op()` so the worktree bring-up sequence is atomic against concurrent callers.
- Closes the race in #2177: pre-fix, the recovery `worktree add` (fail) → `_remove_admin_dir_for_path` → `worktree add` (retry) released the lock between inner `_run_git` calls, so the loser found the admin dir already cleaned by the winner, returned False, and re-raised a misleading one-shot 500 even though the system had self-healed.
- Same root cause as the ENOENT race fixed defensively in #2235 (#2234) — the `_ensure_worktree` body simply wasn't covered by `_git_op`. Updated the `FileNotFoundError` comment now that the race window is closed (defensive only).

## Why this shape

The [issue comment from @jwbron](https://github.com/jwbron/egg/issues/2177#issuecomment-4340550648) outlined the structural fix and confirmed the lock composes safely:

- `_git_op` is reentrant (RLock + `_flock_depth`), so nested `_run_git` calls inside the wrapped block re-enter without deadlock.
- The cold-start `_restore_from_remote` fetch is the longest operation under the lock — runs at most once per repo per process.
- Lock window grows from "one git command" to "the worktree bring-up sequence" — tens of ms in steady state.

Three current concurrent callers (state-store probe, pipeline driver thread polling `wait_for_decision`, `/api/v1/health`) collapse into a serialized critical section.

## Test plan

- [x] `make lint` clean
- [x] New regression test `test_concurrent_callers_serialize_through_git_op` under `TestBranchHeldByPrunableWorktree` runs two threads through `_ensure_worktree` against the wedge state and asserts:
  1. Neither thread raises `GitOperationError`.
  2. Recovery happens exactly once across both callers (one fail + one retry).
  3. `_remove_admin_dir_for_path` runs while `_flock_depth > 0` — proves the previously-leaky window is now covered.
- [x] Existing `TestBranchHeldByPrunableWorktree` cases still pass.
- [x] `make test` — 15,777 passed. The 3 failures (`tests/llm/claude/test_runner.py::TestRunAgentAsync`) are pre-existing on `origin/main` (Python 3.14 `asyncio.get_event_loop()` incompatibility) and unrelated to this change.

Closes #2177.