### PR TITLE
Fix #2244: scope EGG_REPO_PATH in overseer tests

### DIFF
--- a/.egg-state/oversight/test-002-oversight.jsonl
+++ b/.egg-state/oversight/test-002-oversight.jsonl
@@ -1,6 +1,0 @@
-{"timestamp": "2026-03-17T18:34:43.047831+00:00", "pipeline_id": "test-002", "event": "action_executed", "action": "nudge", "agent_role": "coder", "message": "Please check your progress.", "priority": "low"}
-{"timestamp": "2026-03-17T18:38:17.905656+00:00", "pipeline_id": "test-002", "event": "action_executed", "action": "nudge", "agent_role": "coder", "message": "Please check your progress.", "priority": "low"}
-{"timestamp": "2026-03-17T18:43:44.250547+00:00", "pipeline_id": "test-002", "event": "action_executed", "action": "nudge", "agent_role": "coder", "message": "Please check your progress.", "priority": "low"}
-{"timestamp": "2026-03-17T18:44:16.661561+00:00", "pipeline_id": "test-002", "event": "action_executed", "action": "nudge", "agent_role": "coder", "message": "Please check your progress.", "priority": "low"}
-{"timestamp": "2026-03-17T18:45:54.152468+00:00", "pipeline_id": "test-002", "event": "action_executed", "action": "nudge", "agent_role": "coder", "message": "Please check your progress.", "priority": "low"}
-{"timestamp": "2026-03-17T18:51:13.874649+00:00", "pipeline_id": "test-002", "event": "action_executed", "action": "nudge", "agent_role": "coder", "message": "Please check your progress.", "priority": "low"}

--- a/.egg-state/oversight/test-003-oversight.jsonl
+++ b/.egg-state/oversight/test-003-oversight.jsonl
@@ -1,6 +1,0 @@
-{"timestamp": "2026-03-17T18:34:43.048900+00:00", "pipeline_id": "test-003", "event": "action_executed", "action": "nudge", "agent_role": "coder", "message": "Please check your progress.", "priority": "low"}
-{"timestamp": "2026-03-17T18:38:17.906488+00:00", "pipeline_id": "test-003", "event": "action_executed", "action": "nudge", "agent_role": "coder", "message": "Please check your progress.", "priority": "low"}
-{"timestamp": "2026-03-17T18:43:44.251518+00:00", "pipeline_id": "test-003", "event": "action_executed", "action": "nudge", "agent_role": "coder", "message": "Please check your progress.", "priority": "low"}
-{"timestamp": "2026-03-17T18:44:16.662461+00:00", "pipeline_id": "test-003", "event": "action_executed", "action": "nudge", "agent_role": "coder", "message": "Please check your progress.", "priority": "low"}
-{"timestamp": "2026-03-17T18:45:54.153457+00:00", "pipeline_id": "test-003", "event": "action_executed", "action": "nudge", "agent_role": "coder", "message": "Please check your progress.", "priority": "low"}
-{"timestamp": "2026-03-17T18:51:13.875694+00:00", "pipeline_id": "test-003", "event": "action_executed", "action": "nudge", "agent_role": "coder", "message": "Please check your progress.", "priority": "low"}

--- a/.egg-state/oversight/test-004-oversight.jsonl
+++ b/.egg-state/oversight/test-004-oversight.jsonl
@@ -1,6 +1,0 @@
-{"timestamp": "2026-03-17T18:34:43.049730+00:00", "pipeline_id": "test-004", "event": "action_executed", "action": "hitl", "agent_role": "coder", "message": "Redirects exhausted", "priority": "high"}
-{"timestamp": "2026-03-17T18:38:17.907463+00:00", "pipeline_id": "test-004", "event": "action_executed", "action": "hitl", "agent_role": "coder", "message": "Redirects exhausted", "priority": "high"}
-{"timestamp": "2026-03-17T18:43:44.252326+00:00", "pipeline_id": "test-004", "event": "action_executed", "action": "hitl", "agent_role": "coder", "message": "Redirects exhausted", "priority": "high"}
-{"timestamp": "2026-03-17T18:44:16.663489+00:00", "pipeline_id": "test-004", "event": "action_executed", "action": "hitl", "agent_role": "coder", "message": "Redirects exhausted", "priority": "high"}
-{"timestamp": "2026-03-17T18:45:54.154262+00:00", "pipeline_id": "test-004", "event": "action_executed", "action": "hitl", "agent_role": "coder", "message": "Redirects exhausted", "priority": "high"}
-{"timestamp": "2026-03-17T18:51:13.876583+00:00", "pipeline_id": "test-004", "event": "action_executed", "action": "hitl", "agent_role": "coder", "message": "Redirects exhausted", "priority": "high"}

--- a/.gitignore
+++ b/.gitignore
@@ -70,8 +70,6 @@ Thumbs.db
 # Per-machine runtime telemetry written by the overseer; otherwise
 # leaves `git status` dirty after every local pipeline run and trips
 # the selector's "non-.py change" fallback into running the full suite.
-# Tracked test fixtures (test-00{2,3,4}-oversight.jsonl) are unaffected
-# — .gitignore only hides untracked paths.
 .egg-state/oversight/agent-timing.json
 .egg-state/oversight/agent-timing.json.lock
 .egg-state/oversight/*-oversight.jsonl

--- a/orchestrator/tests/test_overseer_alert_isolation.py
+++ b/orchestrator/tests/test_overseer_alert_isolation.py
@@ -40,6 +40,21 @@ except (ImportError, ModuleNotFoundError) as exc:
 
 
 # ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _scope_egg_repo_path(monkeypatch, tmp_path):
+    """Scope EGG_REPO_PATH to tmp_path for every test in this file.
+
+    See test_overseer_monitor.py for the full rationale (#2244): without
+    this, OverseerMonitor writes oversight JSONLs into the real repo.
+    """
+    monkeypatch.setenv("EGG_REPO_PATH", str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/orchestrator/tests/test_overseer_monitor.py
+++ b/orchestrator/tests/test_overseer_monitor.py
@@ -44,6 +44,23 @@ except (ImportError, ModuleNotFoundError) as exc:
 
 
 # ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _scope_egg_repo_path(monkeypatch, tmp_path):
+    """Scope EGG_REPO_PATH to tmp_path for every test in this file.
+
+    OverseerMonitor.__init__ resolves _oversight_dir from EGG_REPO_PATH and
+    writes JSONL records to {EGG_REPO_PATH}/.egg-state/oversight/{pipeline_id}-oversight.jsonl
+    via _log_oversight_event. Without this scoping the writes land in the
+    real repo, dirtying tracked content and blocking `git rebase` (#2244).
+    """
+    monkeypatch.setenv("EGG_REPO_PATH", str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #2244.

`OverseerMonitor.__init__` resolves `_oversight_dir` from `EGG_REPO_PATH` and `_log_oversight_event` appends JSONL records there. `test_overseer_monitor.py` (59 instantiations) and `test_overseer_alert_isolation.py` (2) constructed real `OverseerMonitor`s without scoping `EGG_REPO_PATH`, so writes landed in the real repo's `.egg-state/oversight/`.

Three of those `pipeline_id`s (`test-002`, `test-003`, `test-004`) collided with files actually tracked in the repo. During a phase, `make test` dirtied tracked content; when a producer's `mcp__brc__propose` push was rejected as non-fast-forward (race with a co-producer), the followup `git rebase` refused to proceed because of the dirty tracked files. Per the post-mortem in #2244, this cost ~5 min per occurrence and triggered up to twice per phase.

- Add an autouse fixture in both files that `monkeypatch.setenv("EGG_REPO_PATH", str(tmp_path))` — covers all 61 sites without per-test edits.
- `git rm` the three stale tracked fixture files (verified no readers anywhere in `**/*.py`/`**/*.md`/`**/*.yaml`).
- Drop the now-stale "Tracked test fixtures are unaffected" comment from `.gitignore:73-74`.

The two pre-existing `patch.dict(os.environ, {"EGG_REPO_PATH": "/fake/repo"})` blocks in `test_overseer_monitor.py` (lines 749, 817) are preserved and continue to work — `patch.dict` saves and restores the prior value set by the autouse fixture.

The optional structural backstop suggested in the issue (refusing in `__init__` to point `_jsonl_path` at an already-tracked file) is intentionally **not** in this PR — keeping scope to what the issue author committed to.

## Test plan

- [x] `.venv/bin/pytest orchestrator/tests/test_overseer_monitor.py orchestrator/tests/test_overseer_alert_isolation.py` — 136 passed
- [x] `.venv/bin/pytest orchestrator/tests/ -k overseer` — 385 passed
- [x] After the run, `.egg-state/oversight/` does not exist in the worktree (writes correctly redirected to `tmp_path`)
- [x] Pre-commit hooks (ruff, ruff-format, trim trailing whitespace, EOF fixer) all pass