### PR TITLE
Fix #2247: allow `git checkout HEAD -- <path>` in pipeline sessions

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -2307,7 +2307,8 @@ def git_execute() -> tuple[Response, int] | Response:
             return make_error(
                 f"Branch switching is not allowed in pipeline sessions. "
                 f"You are locked to branch '{assigned}'. "
-                f"Use 'git checkout -- <file>' to restore files instead.",
+                f"Use 'git checkout [<commit-ish>] -- <file>' to restore files instead "
+                f"(e.g. 'git checkout HEAD -- <file>' or 'git checkout <sha> -- <file>').",
                 status_code=403,
             )
 

--- a/gateway/git_client.py
+++ b/gateway/git_client.py
@@ -1819,14 +1819,15 @@ def is_branch_switch(operation: str, args: list[str]) -> bool:
     Returns True when the command would switch the active branch (e.g.
     ``git checkout other-branch``, ``git checkout -b new``).  Returns False
     for file-level operations (``git checkout -- file.txt``,
-    ``git checkout HEAD -- file``).
+    ``git checkout HEAD -- file``, ``git checkout main -- file``).
 
     Only meaningful for ``checkout`` and ``switch`` operations; returns
     False for everything else.
 
     The heuristic:
-    * If ``--`` separator is present, everything after it is a pathspec
-      → NOT a branch switch if there are no positional args before ``--``.
+    * If ``--`` separator is present, everything after it is a pathspec and
+      anything before it is a commit-ish source for the file restore
+      (``HEAD``, ``HEAD~1``, a sha, a branch name) — NOT a branch switch.
     * ``switch`` always operates on branches, so any invocation of
       ``switch`` is considered a branch switch.
     * ``checkout`` with ``-b``/``-B`` or ``--orphan`` is a branch switch.
@@ -1857,18 +1858,17 @@ def is_branch_switch(operation: str, args: list[str]) -> bool:
             continue
         positional_before_dd.append(arg)
 
-    # If there's a positional arg before -- it's treated as a branch ref.
-    # Known false positive: ``checkout HEAD -- file.txt`` classifies HEAD as
-    # a branch ref.  In practice, pipeline agents use ``checkout -- file.txt``
-    # instead, and the branch lock only fires for pipeline sessions.
-    if positional_before_dd and not has_double_dash:
+    # ``--`` separates a commit-ish source from pathspecs; the form
+    # ``checkout [<tree-ish>] -- <pathspec>`` restores files without
+    # switching branches, regardless of whether a tree-ish is present.
+    if has_double_dash:
+        return False
+
+    # No ``--``: any positional arg is a branch/ref to switch to.
+    if positional_before_dd:
         return True
 
-    # If there's a positional arg before -- AND after, the first is branch
-    if positional_before_dd and has_double_dash:
-        return True
-
-    # No positional args before -- → file checkout (e.g., checkout -- file.txt)
+    # No positional args, no ``--`` → bare checkout, no-op.
     return False
 
 

--- a/gateway/tests/test_branch_switch.py
+++ b/gateway/tests/test_branch_switch.py
@@ -71,8 +71,8 @@ class TestIsBranchSwitchCheckoutBranch:
         assert is_branch_switch("checkout", ["origin/main"]) is True
 
     def test_checkout_branch_with_double_dash_and_files(self):
-        """checkout branch -- file is a branch switch (positional before --)."""
-        assert is_branch_switch("checkout", ["main", "--", "file.txt"]) is True
+        """checkout <tree-ish> -- file restores from <tree-ish>; not a branch switch."""
+        assert is_branch_switch("checkout", ["main", "--", "file.txt"]) is False
 
 
 class TestIsBranchSwitchCheckoutFiles:
@@ -105,8 +105,16 @@ class TestIsBranchSwitchEdgeCases:
     """Edge cases for the branch switch detection heuristic."""
 
     def test_checkout_head_double_dash_file(self):
-        """checkout HEAD -- file.txt: HEAD is a positional before -- so it's a branch switch."""
-        assert is_branch_switch("checkout", ["HEAD", "--", "file.txt"]) is True
+        """checkout HEAD -- file.txt restores from HEAD; not a branch switch."""
+        assert is_branch_switch("checkout", ["HEAD", "--", "file.txt"]) is False
+
+    def test_checkout_head_relative_double_dash_file(self):
+        """checkout HEAD~1 -- file.txt restores from a commit-ish; not a branch switch."""
+        assert is_branch_switch("checkout", ["HEAD~1", "--", "file.txt"]) is False
+
+    def test_checkout_sha_double_dash_file(self):
+        """checkout <sha> -- file.txt restores from a commit-ish; not a branch switch."""
+        assert is_branch_switch("checkout", ["abc1234", "--", "file.txt"]) is False
 
     def test_checkout_unknown_flags_ignored(self):
         """Unknown flags are skipped, positional still detected."""

--- a/gateway/tests/test_branch_switch.py
+++ b/gateway/tests/test_branch_switch.py
@@ -70,10 +70,6 @@ class TestIsBranchSwitchCheckoutBranch:
     def test_checkout_remote_branch(self):
         assert is_branch_switch("checkout", ["origin/main"]) is True
 
-    def test_checkout_branch_with_double_dash_and_files(self):
-        """checkout <tree-ish> -- file restores from <tree-ish>; not a branch switch."""
-        assert is_branch_switch("checkout", ["main", "--", "file.txt"]) is False
-
 
 class TestIsBranchSwitchCheckoutFiles:
     """File-targeting checkouts are NOT branch switches."""
@@ -115,6 +111,10 @@ class TestIsBranchSwitchEdgeCases:
     def test_checkout_sha_double_dash_file(self):
         """checkout <sha> -- file.txt restores from a commit-ish; not a branch switch."""
         assert is_branch_switch("checkout", ["abc1234", "--", "file.txt"]) is False
+
+    def test_checkout_branch_with_double_dash_and_files(self):
+        """checkout <tree-ish> -- file restores from <tree-ish>; not a branch switch."""
+        assert is_branch_switch("checkout", ["main", "--", "file.txt"]) is False
 
     def test_checkout_unknown_flags_ignored(self):
         """Unknown flags are skipped, positional still detected."""


### PR DESCRIPTION
## Summary
- `is_branch_switch` (`gateway/git_client.py`) classified any positional arg before `--` as a branch ref, so `git checkout HEAD -- file.txt` (and `<sha>` / `<branch>` variants) were rejected in pipeline sessions, contradicting the function's docstring. Agents fell back to multi-step recovery chains (`status`/`awk`/`stash`/`diff`) when one command would have done.
- When `--` is present, the leading positional is a commit-ish source for a file restore (HEAD, HEAD~N, sha, branch name) and does not switch the active branch. Return False in that case, refresh the docstring, and add `HEAD~1` / `<sha>` regression coverage.
- Flipped the two tests that pinned the buggy behavior (`test_checkout_branch_with_double_dash_and_files`, `test_checkout_head_double_dash_file`).

Fixes #2247.

## Test plan
- [ ] `make test` (or `make test-all`) passes locally on the gateway suite.
- [ ] `git checkout HEAD -- file.txt` succeeds inside a pipeline session.
- [ ] `git checkout main` is still blocked in a pipeline session.