### PR TITLE
file-size lint: drop per-file baselines from allowlist

### DIFF
--- a/scripts/check-file-sizes.py
+++ b/scripts/check-file-sizes.py
@@ -18,20 +18,21 @@ Test files are exempt -- parametrized cases legitimately push line counts
 past these caps and decomposing them mechanically would hurt readability.
 
 Files already over the hard cap on day one are listed in
-``scripts/file-size-allowlist.yaml`` with their line and byte baselines.
-The lint allows allowlisted files to stay over the cap, but rejects further
-growth past the recorded baseline -- decomposition follow-ups land as the
-file shrinks. Removing a file from the allowlist (or letting it grow under
-the cap) is encouraged as cleanup proceeds.
+``scripts/file-size-allowlist.yaml``. The lint allows allowlisted files to
+stay over the cap regardless of size; per-file size baselines were dropped
+because every unrelated PR that touched one of these files needed a
+baseline bump in the allowlist, conflicting with every other in-flight PR.
+Removing a file from the allowlist (or letting it drop under the cap) is
+encouraged as decomposition proceeds.
 
 Usage:
     scripts/check-file-sizes.py
-    scripts/check-file-sizes.py --update-allowlist  # rewrite baselines
+    scripts/check-file-sizes.py --update-allowlist  # add over-cap files
     scripts/check-file-sizes.py --list              # report all files
 
 Exit codes:
     0  no violations
-    1  one or more files exceed caps or grew past their allowlist baseline
+    1  one or more non-allowlisted files exceed the hard cap
 """
 
 from __future__ import annotations
@@ -63,13 +64,6 @@ class Caps:
 
 
 @dataclass(frozen=True)
-class Baseline:
-    lines: int
-    bytes: int
-    issue: str | None = None
-
-
-@dataclass(frozen=True)
 class FileStats:
     path: Path
     lines: int
@@ -79,7 +73,9 @@ class FileStats:
 @dataclass
 class Config:
     caps: Caps
-    baselines: dict[str, Baseline]
+    # path -> optional tracking issue. Membership is what gates the lint;
+    # the issue field is documentation only.
+    allowlist: dict[str, str | None]
 
 
 def load_config(path: Path | None = None) -> Config:
@@ -95,15 +91,14 @@ def load_config(path: Path | None = None) -> Config:
         soft_bytes=int(caps_raw["soft_bytes"]),
     )
     files_raw: dict[str, Any] = raw.get("files") or {}
-    baselines = {
-        rel: Baseline(
-            lines=int(entry["lines"]),
-            bytes=int(entry["bytes"]),
-            issue=(str(entry["issue"]) if entry.get("issue") is not None else None),
-        )
-        for rel, entry in files_raw.items()
-    }
-    return Config(caps=caps, baselines=baselines)
+    allowlist: dict[str, str | None] = {}
+    for rel, entry in files_raw.items():
+        if isinstance(entry, dict):
+            issue = entry.get("issue")
+            allowlist[rel] = str(issue) if issue is not None else None
+        else:
+            allowlist[rel] = None
+    return Config(caps=caps, allowlist=allowlist)
 
 
 def is_test_file(rel: Path) -> bool:
@@ -146,37 +141,24 @@ def evaluate(
     errors: list[str] = []
     warnings: list[str] = []
     caps = config.caps
-    baseline = config.baselines.get(rel)
+    in_allowlist = rel in config.allowlist
 
     over_hard_lines = stats.lines > caps.hard_lines
     over_hard_bytes = stats.bytes > caps.hard_bytes
 
     if over_hard_lines or over_hard_bytes:
-        if baseline is None:
+        if not in_allowlist:
             errors.append(
                 f"{rel}: {stats.lines} lines / {stats.bytes} bytes exceeds hard cap "
                 f"({caps.hard_lines} lines / {caps.hard_bytes} bytes). "
                 "Decompose the file or, if you cannot in this PR, add it to "
                 "scripts/file-size-allowlist.yaml with a tracking issue."
             )
-        else:
-            if stats.lines > baseline.lines:
-                errors.append(
-                    f"{rel}: {stats.lines} lines exceeds allowlist baseline "
-                    f"({baseline.lines}). Reduce the file or open a separate PR "
-                    "raising the baseline with justification."
-                )
-            if stats.bytes > baseline.bytes:
-                errors.append(
-                    f"{rel}: {stats.bytes} bytes exceeds allowlist baseline "
-                    f"({baseline.bytes}). Reduce the file or open a separate PR "
-                    "raising the baseline with justification."
-                )
         return errors, warnings
 
     # Soft warnings are skipped for allowlisted files -- they're already
     # tracked for decomposition.
-    if baseline is not None:
+    if in_allowlist:
         return errors, warnings
 
     if stats.lines > caps.soft_lines:
@@ -207,18 +189,17 @@ def check_all(repo_root: Path = REPO_ROOT) -> tuple[list[str], list[str], list[s
         errors.extend(file_errors)
         warnings.extend(file_warnings)
 
-    stale = sorted(rel for rel in config.baselines if rel not in seen)
+    stale = sorted(rel for rel in config.allowlist if rel not in seen)
     return errors, warnings, stale
 
 
-def write_allowlist(config: Config, baselines: dict[str, Baseline]) -> None:
-    """Rewrite the allowlist file preserving caps + sorted baselines."""
+def write_allowlist(config: Config, allowlist: dict[str, str | None]) -> None:
+    """Rewrite the allowlist file preserving caps + sorted entries."""
 
-    def _entry(b: Baseline) -> dict[str, Any]:
-        out: dict[str, Any] = {"lines": b.lines, "bytes": b.bytes}
-        if b.issue is not None:
-            out["issue"] = b.issue
-        return out
+    def _entry(issue: str | None) -> Any:
+        if issue is None:
+            return None
+        return {"issue": issue}
 
     payload: dict[str, Any] = {
         "caps": {
@@ -227,32 +208,29 @@ def write_allowlist(config: Config, baselines: dict[str, Baseline]) -> None:
             "soft_lines": config.caps.soft_lines,
             "soft_bytes": config.caps.soft_bytes,
         },
-        "files": {rel: _entry(b) for rel, b in sorted(baselines.items())},
+        "files": {rel: _entry(issue) for rel, issue in sorted(allowlist.items())},
     }
     ALLOWLIST_PATH.write_text(yaml.safe_dump(payload, sort_keys=False))
 
 
 def update_allowlist(repo_root: Path = REPO_ROOT) -> int:
-    """Refresh allowlist baselines from current file sizes.
+    """Sync the allowlist with the current set of over-cap files.
 
-    The ``issue:`` tracking field on each existing entry is carried forward;
-    losing it would drop the link between the file and its decomposition
-    follow-up.
+    Adds over-cap files not yet listed (with no issue link) and drops
+    entries for files that have shrunk under the cap or no longer exist.
+    The ``issue:`` tracking field on each existing entry is carried
+    forward; losing it would drop the link between the file and its
+    decomposition follow-up.
     """
     config = load_config()
-    new_baselines: dict[str, Baseline] = {}
+    new_allowlist: dict[str, str | None] = {}
     for path in iter_source_files(repo_root):
         rel = str(path.relative_to(repo_root))
         stats = measure(path)
         if stats.lines > config.caps.hard_lines or stats.bytes > config.caps.hard_bytes:
-            existing = config.baselines.get(rel)
-            new_baselines[rel] = Baseline(
-                lines=stats.lines,
-                bytes=stats.bytes,
-                issue=existing.issue if existing is not None else None,
-            )
-    write_allowlist(config, new_baselines)
-    print(f"Wrote {len(new_baselines)} entries to {ALLOWLIST_PATH.name}")
+            new_allowlist[rel] = config.allowlist.get(rel)
+    write_allowlist(config, new_allowlist)
+    print(f"Wrote {len(new_allowlist)} entries to {ALLOWLIST_PATH.name}")
     return 0
 
 
@@ -274,7 +252,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--update-allowlist",
         action="store_true",
-        help="Rewrite scripts/file-size-allowlist.yaml from current file sizes.",
+        help="Sync scripts/file-size-allowlist.yaml with current over-cap files.",
     )
     parser.add_argument(
         "--list",

--- a/scripts/file-size-allowlist.yaml
+++ b/scripts/file-size-allowlist.yaml
@@ -1,17 +1,18 @@
 # Allowlist for scripts/check-file-sizes.py.
 #
-# Each entry grandfathers a Python source file at the line and byte count it
-# had when added here. The lint allows files in this list to remain over the
-# global cap, but rejects any further growth past the recorded baselines.
+# Each entry grandfathers a Python source file so the lint allows it to
+# remain over the global cap. Allowlisted files may grow freely -- the
+# allowlist's only role is to say "this file is exempt from the global
+# size cap." Decompose listed files in follow-up PRs and remove them from
+# the allowlist when they drop back under the global cap.
 #
-# Decompose listed files in follow-up PRs and remove them from the allowlist
-# when they drop back under the global cap. New files are NOT eligible — add
-# only files that pre-date the lint or whose decomposition is already tracked
-# as a separate issue.
+# Per-file size baselines were dropped because every unrelated PR that
+# touched one of these files needed a baseline bump here, which conflicted
+# with every other in-flight PR.
 #
 # Schema:
 #   caps: { hard_lines, hard_bytes, soft_lines, soft_bytes }
-#   files: { <repo-relative path>: { lines: int, bytes: int, issue: str|null } }
+#   files: { <repo-relative path>: null | { issue: str } }
 caps:
   hard_lines: 1500
   hard_bytes: 100000
@@ -20,62 +21,32 @@ caps:
 
 files:
   orchestrator/routes/pipelines.py:
-    lines: 15593
-    bytes: 681405
     issue: "2248"
   gateway/gateway.py:
-    lines: 9754
-    bytes: 373121
     issue: "2248"
   sandbox/egg_lib/orch_cli.py:
-    lines: 3512
-    bytes: 127924
     issue: "2248"
   orchestrator/mcp_tools.py:
-    lines: 2817
-    bytes: 118448
     issue: "2248"
   orchestrator/gateway_client.py:
-    lines: 2392
-    bytes: 88655
     issue: "2248"
   shared/egg_contracts/checkpoint_cli.py:
-    lines: 2233
-    bytes: 81972
     issue: "2248"
   sandbox/entrypoint.py:
-    lines: 2109
-    bytes: 85051
     issue: "2248"
   gateway/worktree_manager.py:
-    lines: 2090
-    bytes: 83664
     issue: "2248"
   gateway/git_client.py:
-    lines: 2032
-    bytes: 66936
     issue: "2248"
   orchestrator/overseer/monitor.py:
-    lines: 2005
-    bytes: 83921
     issue: "2248"
   orchestrator/peer_consensus.py:
-    lines: 2003
-    bytes: 85965
     issue: "2248"
   orchestrator/routes/signals.py:
-    lines: 1986
-    bytes: 74042
     issue: "2248"
   gateway/checkpoint_handler.py:
-    lines: 1655
-    bytes: 61597
     issue: "2248"
   scripts/select_tests.py:
-    lines: 1875
-    bytes: 75206
     issue: "2248"
   orchestrator/routes/deployment.py:
-    lines: 1604
-    bytes: 56130
     issue: "2248"

--- a/tests/scripts/test_check_file_sizes.py
+++ b/tests/scripts/test_check_file_sizes.py
@@ -20,7 +20,6 @@ sys.modules["check_file_sizes"] = _mod
 _spec.loader.exec_module(_mod)
 
 Caps = _mod.Caps
-Baseline = _mod.Baseline
 Config = _mod.Config
 FileStats = _mod.FileStats
 evaluate = _mod.evaluate
@@ -39,7 +38,7 @@ def caps() -> Caps:
 
 @pytest.fixture
 def empty_config(caps: Caps) -> Config:
-    return Config(caps=caps, baselines={})
+    return Config(caps=caps, allowlist={})
 
 
 def _stats(lines: int, bts: int, name: str = "x.py") -> FileStats:
@@ -80,28 +79,24 @@ class TestEvaluate:
         assert errors == []
         assert len(warnings) == 2
 
-    def test_allowlisted_at_baseline_passes(self, caps: Caps) -> None:
-        config = Config(caps=caps, baselines={"big.py": Baseline(lines=2000, bytes=80_000)})
+    def test_allowlisted_over_hard_cap_passes(self, caps: Caps) -> None:
+        config = Config(caps=caps, allowlist={"big.py": "2248"})
         errors, warnings = evaluate(_stats(2000, 80_000), "big.py", config)
         assert errors == []
         assert warnings == []
 
-    def test_allowlisted_growth_in_lines_fails(self, caps: Caps) -> None:
-        config = Config(caps=caps, baselines={"big.py": Baseline(lines=2000, bytes=80_000)})
-        errors, _ = evaluate(_stats(2001, 80_000), "big.py", config)
-        assert len(errors) == 1
-        assert "exceeds allowlist baseline" in errors[0]
+    def test_allowlisted_growth_is_allowed(self, caps: Caps) -> None:
+        """Allowlisted files may grow freely -- removing the baseline check
+        is the whole point of dropping per-file lines/bytes from the YAML."""
+        config = Config(caps=caps, allowlist={"big.py": "2248"})
+        errors, warnings = evaluate(_stats(50_000, 5_000_000), "big.py", config)
+        assert errors == []
+        assert warnings == []
 
-    def test_allowlisted_growth_in_bytes_fails(self, caps: Caps) -> None:
-        config = Config(caps=caps, baselines={"big.py": Baseline(lines=2000, bytes=80_000)})
-        errors, _ = evaluate(_stats(2000, 80_001), "big.py", config)
-        assert len(errors) == 1
-        assert "exceeds allowlist baseline" in errors[0]
-
-    def test_allowlisted_shrinkage_passes(self, caps: Caps) -> None:
-        """Cleanup that drops the file is fine even if still over hard cap."""
-        config = Config(caps=caps, baselines={"big.py": Baseline(lines=2000, bytes=80_000)})
-        errors, warnings = evaluate(_stats(1900, 79_000), "big.py", config)
+    def test_allowlisted_with_no_issue_link_still_allowed(self, caps: Caps) -> None:
+        """Membership alone gates the lint; the issue field is documentation."""
+        config = Config(caps=caps, allowlist={"big.py": None})
+        errors, warnings = evaluate(_stats(2000, 80_000), "big.py", config)
         assert errors == []
         assert warnings == []
 
@@ -110,7 +105,7 @@ class TestEvaluate:
 
         It should not produce a soft-cap warning for an allowlisted file.
         """
-        config = Config(caps=caps, baselines={"big.py": Baseline(lines=2000, bytes=80_000)})
+        config = Config(caps=caps, allowlist={"big.py": "2248"})
         errors, warnings = evaluate(_stats(900, 30_000), "big.py", config)
         assert errors == []
         assert warnings == []
@@ -201,13 +196,11 @@ class TestYamlRoundTrip:
               soft_bytes: 60000
             files:
               foo/bar.py:
-                lines: 2000
-                bytes: 80000
                 issue: "2248"
             """,
         )
         config = load_config(path)
-        assert config.baselines["foo/bar.py"].issue == "2248"
+        assert config.allowlist["foo/bar.py"] == "2248"
 
     def test_load_handles_missing_issue_field(self, tmp_path: Path) -> None:
         path = self._yaml(
@@ -219,15 +212,35 @@ class TestYamlRoundTrip:
               soft_lines: 800
               soft_bytes: 60000
             files:
-              foo/bar.py:
-                lines: 2000
-                bytes: 80000
+              foo/bar.py: {}
             """,
         )
         config = load_config(path)
-        assert config.baselines["foo/bar.py"].issue is None
+        assert config.allowlist["foo/bar.py"] is None
 
-    def test_load_handles_null_issue_field(self, tmp_path: Path) -> None:
+    def test_load_handles_null_entry(self, tmp_path: Path) -> None:
+        """An entry with no value at all is just a path -- the bare-key
+        form keeps the YAML maximally compact when there's no issue link."""
+        path = self._yaml(
+            tmp_path,
+            """
+            caps:
+              hard_lines: 1500
+              hard_bytes: 100000
+              soft_lines: 800
+              soft_bytes: 60000
+            files:
+              foo/bar.py:
+            """,
+        )
+        config = load_config(path)
+        assert "foo/bar.py" in config.allowlist
+        assert config.allowlist["foo/bar.py"] is None
+
+    def test_load_ignores_legacy_lines_bytes(self, tmp_path: Path) -> None:
+        """Legacy YAMLs with lines/bytes keys still load -- the lint just
+        ignores the now-defunct fields. This protects branches that haven't
+        rebased onto the simplified schema yet."""
         path = self._yaml(
             tmp_path,
             """
@@ -240,40 +253,33 @@ class TestYamlRoundTrip:
               foo/bar.py:
                 lines: 2000
                 bytes: 80000
-                issue: null
+                issue: "2248"
             """,
         )
         config = load_config(path)
-        assert config.baselines["foo/bar.py"].issue is None
+        assert config.allowlist["foo/bar.py"] == "2248"
 
     def test_write_emits_issue_when_present(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caps: Caps
     ) -> None:
         out = tmp_path / "out.yaml"
         monkeypatch.setattr(_mod, "ALLOWLIST_PATH", out)
-        config = Config(caps=caps, baselines={})
-        baselines = {"foo/bar.py": Baseline(lines=2000, bytes=80_000, issue="2248")}
-        write_allowlist(config, baselines)
+        config = Config(caps=caps, allowlist={})
+        write_allowlist(config, {"foo/bar.py": "2248"})
         loaded = yaml.safe_load(out.read_text())
-        assert loaded["files"]["foo/bar.py"] == {
-            "lines": 2000,
-            "bytes": 80_000,
-            "issue": "2248",
-        }
+        assert loaded["files"]["foo/bar.py"] == {"issue": "2248"}
 
     def test_write_omits_issue_when_absent(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caps: Caps
     ) -> None:
         out = tmp_path / "out.yaml"
         monkeypatch.setattr(_mod, "ALLOWLIST_PATH", out)
-        config = Config(caps=caps, baselines={})
-        baselines = {"foo/bar.py": Baseline(lines=2000, bytes=80_000)}
-        write_allowlist(config, baselines)
+        config = Config(caps=caps, allowlist={})
+        write_allowlist(config, {"foo/bar.py": None})
         loaded = yaml.safe_load(out.read_text())
-        # No `issue:` key emitted when the baseline has none -- avoids
-        # littering new entries with `issue: null`.
-        assert loaded["files"]["foo/bar.py"] == {"lines": 2000, "bytes": 80_000}
-        assert "issue" not in loaded["files"]["foo/bar.py"]
+        # Bare key (null value) when there's no issue link -- avoids
+        # littering the YAML with `issue: null` placeholders.
+        assert loaded["files"]["foo/bar.py"] is None
 
     def test_round_trip_preserves_issue(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caps: Caps
@@ -281,15 +287,15 @@ class TestYamlRoundTrip:
         """Regression: --update-allowlist must not silently drop issue links."""
         out = tmp_path / "out.yaml"
         monkeypatch.setattr(_mod, "ALLOWLIST_PATH", out)
-        config = Config(caps=caps, baselines={})
+        config = Config(caps=caps, allowlist={})
         original = {
-            "a.py": Baseline(lines=2000, bytes=80_000, issue="2248"),
-            "b.py": Baseline(lines=2500, bytes=90_000, issue="9999"),
-            "c.py": Baseline(lines=1800, bytes=70_000),  # no issue
+            "a.py": "2248",
+            "b.py": "9999",
+            "c.py": None,
         }
         write_allowlist(config, original)
         reloaded = load_config(out)
-        assert reloaded.baselines == original
+        assert reloaded.allowlist == original
 
     def test_update_allowlist_carries_issue_forward(
         self,
@@ -304,9 +310,8 @@ class TestYamlRoundTrip:
         big = repo_root / "orchestrator" / "big.py"
         big.write_text("x = 1\n" * 50)
 
-        # Seed deliberately stale line/byte values so the post-update
-        # assertion only passes when update_allowlist genuinely re-measures
-        # from the live file (rather than silently preserving the seed).
+        # Seed deliberately stale line/byte values so we also confirm that
+        # legacy fields don't trip up loading or get re-emitted on write.
         allowlist = tmp_path / "allowlist.yaml"
         allowlist.write_text(
             textwrap.dedent(
@@ -331,9 +336,79 @@ class TestYamlRoundTrip:
         capsys.readouterr()  # discard the "Wrote N entries" print
 
         reloaded = load_config(allowlist)
-        entry = reloaded.baselines["orchestrator/big.py"]
-        assert entry.issue == "2248"
-        # And the line/byte counts were refreshed from the live file —
-        # not preserved from the stale seed values above.
-        assert entry.lines == 50
-        assert entry.bytes == len(big.read_bytes())
+        assert reloaded.allowlist["orchestrator/big.py"] == "2248"
+        # Legacy lines/bytes keys are not re-emitted on write.
+        raw = yaml.safe_load(allowlist.read_text())
+        entry = raw["files"]["orchestrator/big.py"]
+        assert entry == {"issue": "2248"}
+
+    def test_update_allowlist_adds_new_over_cap_file(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A newly oversize file not yet listed gets added with no issue."""
+        repo_root = tmp_path / "repo"
+        (repo_root / "orchestrator").mkdir(parents=True)
+        big = repo_root / "orchestrator" / "new_big.py"
+        big.write_text("x = 1\n" * 50)
+
+        allowlist = tmp_path / "allowlist.yaml"
+        allowlist.write_text(
+            textwrap.dedent(
+                """
+                caps:
+                  hard_lines: 10
+                  hard_bytes: 1000000
+                  soft_lines: 5
+                  soft_bytes: 500000
+                files: {}
+                """
+            )
+        )
+        monkeypatch.setattr(_mod, "ALLOWLIST_PATH", allowlist)
+
+        rc = update_allowlist(repo_root)
+        assert rc == 0
+        capsys.readouterr()
+
+        reloaded = load_config(allowlist)
+        assert "orchestrator/new_big.py" in reloaded.allowlist
+        assert reloaded.allowlist["orchestrator/new_big.py"] is None
+
+    def test_update_allowlist_drops_now_under_cap_file(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A file that has shrunk under the cap is dropped from the allowlist."""
+        repo_root = tmp_path / "repo"
+        (repo_root / "orchestrator").mkdir(parents=True)
+        small = repo_root / "orchestrator" / "small.py"
+        small.write_text("x = 1\n")
+
+        allowlist = tmp_path / "allowlist.yaml"
+        allowlist.write_text(
+            textwrap.dedent(
+                """
+                caps:
+                  hard_lines: 10
+                  hard_bytes: 1000000
+                  soft_lines: 5
+                  soft_bytes: 500000
+                files:
+                  orchestrator/small.py:
+                    issue: "2248"
+                """
+            )
+        )
+        monkeypatch.setattr(_mod, "ALLOWLIST_PATH", allowlist)
+
+        rc = update_allowlist(repo_root)
+        assert rc == 0
+        capsys.readouterr()
+
+        reloaded = load_config(allowlist)
+        assert "orchestrator/small.py" not in reloaded.allowlist


### PR DESCRIPTION
## Summary

- Drop `lines:` and `bytes:` baselines from each entry in `scripts/file-size-allowlist.yaml`. Membership in the allowlist alone now exempts a file from the global cap; allowlisted files may grow freely.
- Simplify `scripts/check-file-sizes.py` to match. `load_config` tolerates legacy `lines:`/`bytes:` keys so branches that haven't rebased still load, but `write_allowlist` drops them on output. `--update-allowlist` now syncs membership (add over-cap files, drop now-under-cap ones), carrying the `issue:` link forward.

## Why

Every PR that touches an allowlisted file had to bump that file's baseline numbers in the YAML. Every such bump conflicted with every other concurrent PR touching the same file. Six open PRs hit this same conflict at once today.

The baselines were intended to prevent further growth of grandfathered files, but the merge-conflict tax across cross-PR rebases outweighed the regression-prevention value. Decomposition for these files is tracked under #2248; size regressions on them are a known accepted state until that work lands.

## Test plan

- [x] `make lint-custom` passes (`scripts/check-file-sizes.py` exits 0, soft-cap warnings only)
- [x] `pytest tests/scripts/test_check_file_sizes.py` — 31 passed (including new tests for legacy-format loading, round-trip issue preservation, and update-allowlist add/drop)
- [x] `ruff check` and `ruff format --check` clean
- [x] `mypy` clean
- [x] `yamllint` clean