### PR TITLE
Pin host Python to 3.14 in action composite

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -81,6 +81,11 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.14"
+
     - name: Run egg
       id: run
       shell: bash


### PR DESCRIPTION
## Summary

Action runs are failing on `main` with `NameError: name 'ValidationResult' is not defined` (e.g. [run 25132261675](https://github.com/jwbron/egg/actions/runs/25132261675/job/73661418221)).

`action/entrypoint.sh` runs `python3 -c "from egg_lib.gha_exec import gha_exec; ..."` directly on the runner host. The chain transitively imports `shared/egg_config/base.py`, which contains class-body self-references like:

```python
class ValidationResult:
    @classmethod
    def valid(cls, warnings: list[str] | None = None) -> ValidationResult:
        ...
```

Those work only under PEP 649 (Python 3.14). #2257 pinned 3.14 across CI, pyproject, and runtime images but missed the action — `ubuntu-latest`'s default `python3` is 3.12, so import fails at class-body evaluation.

Add `actions/setup-python@v5` with `python-version: "3.14"` to the composite action, matching the same pattern used in `test.yml`, `lint.yml`, `test-e2e.yml`, and `test-integration.yml`. Repro on local 3.11 fails with the same NameError; on 3.14 the import succeeds.

## Test plan

- [ ] CI passes (test-action.yml exercises the composite action)
- [ ] Next on-review-feedback / autofix run on a PR completes "Step 3: Python orchestration" without the NameError