### PR TITLE
Install pyyaml in action composite for host Python orchestration

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -86,6 +86,10 @@ runs:
       with:
         python-version: "3.14"
 
+    - name: Install Python orchestration dependencies
+      shell: bash
+      run: python3 -m pip install --disable-pip-version-check pyyaml
+
     - name: Run egg
       id: run
       shell: bash


### PR DESCRIPTION
## Summary

- #2279 added `actions/setup-python@v5` to pin host Python to 3.14, but `setup-python` provides a clean interpreter with no project deps. The orchestration command `python3 -c "from egg_lib.gha_exec import gha_exec; ..."` transitively imports `shared/egg_config/config.py`, which `import yaml`s and exits with `Error: PyYAML is required`. Observed on PR #2268's `egg-reviewer-review` job ([run](https://github.com/jwbron/egg/actions/runs/25132997884/job/73665066251?pr=2268)).
- Add a minimal `pip install pyyaml` step after setup-python in `action/action.yml`. PyYAML is the only non-stdlib dep on the `gha_exec → egg_config` import path (verified by walking imports across `sandbox/egg_lib/*.py` and `shared/egg_config/*.py`), so this is tighter than the `uv sync --extra dev` pattern used in test/lint workflows.

## Test plan

- [ ] Re-run the failing `egg-reviewer-review` job on PR #2268 (or push a new commit to it) once this lands and confirm it gets past `=== Step 3: Python orchestration ===` without the PyYAML error.
- [ ] Spot-check that other action invocations (autofixer, conflict, doc-updater, etc.) still succeed — they share the same composite.