### PR TITLE
Fix #2055: delete_remote_branch authenticates with launcher secret

### DIFF
--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -139,6 +139,8 @@ def _classify_push_stderr(stderr: str) -> str:
         return "shallow_clone"
     if "already exists" in s:
         return "branch_exists"
+    if "remote ref does not exist" in s:
+        return "already_deleted"
     return "push_rejected"
 
 
@@ -1074,68 +1076,30 @@ class GatewayClient:
         repo_path: str,
         branch: str,
         mode: Literal["public", "private"] = "public",
-    ) -> bool:
-        """Delete a remote branch using a temporary session.
+    ) -> PushResult:
+        """Delete a remote branch with launcher auth (orchestrator-trusted).
 
-        Best-effort operation used to clean up worktree branches from the
-        remote when a pipeline is deleted. Registers a temp session, pushes
-        a deletion refspec (`:branch`), then cleans up the session.
+        Sends a deletion refspec (``:branch``) through the same
+        ``_do_push`` path used by ``push_worktree_branch``.  Authenticates
+        with the launcher secret rather than a sandbox session token: the
+        orchestrator is on the privileged side of the trust boundary, and
+        the gateway's pipeline-push enforcement (#2028) was 403'ing the
+        old temp-session shape, so cleanup silently no-op'd and shared
+        ``egg/<pipeline-id>`` branches accumulated on origin (#2055).
 
-        Args:
-            pipeline_id: Pipeline ID (used as container_id for the temp session)
-            repo_path: Path to a repo directory (for the push endpoint)
-            branch: Remote branch name to delete
-
-        Returns:
-            True if deletion succeeded, False otherwise
+        Returns ``PushResult`` so callers can distinguish ``already_deleted``
+        (the desired state — branch absent on remote) from real failures
+        (``permission_denied``, ``network``, etc.).  ``PushResult`` is
+        truthy on success so existing ``if delete_remote_branch(...):``
+        callers keep working.
         """
-        temp_container_id = f"{pipeline_id}-branch-cleanup-{branch.replace('/', '-')}"
-        session_token: str | None = None
-        try:
-            session = self.register_session(
-                container_id=temp_container_id,
-                container_ip=self.self_ip,
-                mode=mode,
-                pipeline_id=pipeline_id,
-                branch=branch,
-            )
-            session_token = session.session_token
-
-            # Push with empty source = delete remote branch.
-            # Do NOT include container_id — repo_path is already the
-            # resolved path; the synthetic container_id has no real
-            # worktree and would trigger a "worktree not found" error.
-            self._make_request(
-                "/api/v1/git/push",
-                method="POST",
-                data={
-                    "repo_path": repo_path,
-                    "remote": "origin",
-                    "refspec": f":{branch}",
-                },
-                bearer_token=session_token,
-            )
-
-            logger.info(
-                "Deleted remote branch",
-                pipeline_id=pipeline_id,
-                branch=branch,
-            )
-            return True
-        except Exception as e:
-            logger.warning(
-                "Best-effort remote branch deletion failed",
-                pipeline_id=pipeline_id,
-                branch=branch,
-                error=str(e),
-            )
-            return False
-        finally:
-            if session_token:
-                try:
-                    self.delete_session(session_token)
-                except Exception:
-                    pass
+        return self._do_push(
+            pipeline_id=pipeline_id,
+            repo_path=repo_path,
+            branch=branch,
+            mode=mode,
+            refspec=f":{branch}",
+        )
 
     def create_pr(
         self,

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1134,10 +1134,11 @@ class GatewayClient:
 
         Raises:
             GatewayError: On request failure. Unlike push_worktree_branch/
-                delete_remote_branch/fetch_worktree_branch (which catch errors
-                internally and return bool), this method lets errors propagate
-                so the caller can decide whether a failed PR creation should
-                abort the phase.
+                delete_remote_branch (which catch errors internally and
+                return PushResult — truthy on success) or
+                fetch_worktree_branch (which returns bool), this method
+                lets errors propagate so the caller can decide whether a
+                failed PR creation should abort the phase.
         """
         temp_container_id = f"{pipeline_id}-auto-pr"
         session_token: str | None = None

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2076,8 +2076,22 @@ def _cleanup_remote_branches(
 
     deleted = 0
     for branch in sorted(branches):
-        if gateway_client.delete_remote_branch(pipeline_id, repo_path_str, branch, mode=mode):
+        result = gateway_client.delete_remote_branch(pipeline_id, repo_path_str, branch, mode=mode)
+        # ``already_deleted`` means the desired state (branch absent on
+        # remote) is satisfied — count it as success rather than churning a
+        # warning every time a pipeline is cleaned up before any branch was
+        # ever pushed.
+        category = getattr(result, "category", None)
+        if result or category == "already_deleted":
             deleted += 1
+        else:
+            logger.warning(
+                "Remote branch deletion failed during pipeline cleanup",
+                pipeline_id=pipeline_id,
+                branch=branch,
+                category=category,
+                detail=getattr(result, "detail", None),
+            )
 
     if deleted:
         logger.info(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2081,16 +2081,15 @@ def _cleanup_remote_branches(
         # remote) is satisfied — count it as success rather than churning a
         # warning every time a pipeline is cleaned up before any branch was
         # ever pushed.
-        category = getattr(result, "category", None)
-        if result or category == "already_deleted":
+        if result or result.category == "already_deleted":
             deleted += 1
         else:
             logger.warning(
                 "Remote branch deletion failed during pipeline cleanup",
                 pipeline_id=pipeline_id,
                 branch=branch,
-                category=category,
-                detail=getattr(result, "detail", None),
+                category=result.category,
+                detail=result.detail,
             )
 
     if deleted:

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -1165,19 +1165,26 @@ class TestPushWorktreeBranch:
 
 
 class TestDeleteRemoteBranch:
-    """Tests for delete_remote_branch method."""
+    """Tests for delete_remote_branch method.
+
+    Post-#2055: deletion goes through ``_do_push`` with launcher auth
+    (no temp-session ceremony).  The pipeline-push enforcement that
+    blocked the prior shape (#2028) exempts launcher-auth requests.
+    """
 
     def test_delete_remote_branch_success(self, gateway_client, mock_gateway_server):
-        """Test successful deletion of a remote branch."""
+        """Successful deletion returns a truthy ``PushResult``."""
         result = gateway_client.delete_remote_branch(
             pipeline_id="issue-42",
             repo_path="/home/egg/.egg-worktrees/issue-42/repo",
             branch="egg/container-abc123/work",
         )
-        assert result is True
+        assert isinstance(result, PushResult)
+        assert result.ok is True
+        assert bool(result) is True
 
     def test_delete_remote_branch_gateway_unreachable(self):
-        """Test deletion fails gracefully when gateway is unreachable."""
+        """Transport failure surfaces as a falsy ``PushResult`` with category."""
         client = GatewayClient(
             gateway_host="localhost",
             gateway_port=19999,
@@ -1190,35 +1197,50 @@ class TestDeleteRemoteBranch:
             repo_path="/some/path",
             branch="egg/container-abc123/work",
         )
-        assert result is False
+        assert isinstance(result, PushResult)
+        assert result.ok is False
+        assert result.category in ("gateway_unreachable", "gateway_error", "unknown")
+        assert bool(result) is False
 
-    def test_delete_remote_branch_cleans_up_session(self, gateway_client, mock_gateway_server):
-        """Test that temp session is cleaned up after deletion."""
-        with patch.object(gateway_client, "delete_session") as mock_delete:
-            gateway_client.delete_remote_branch(
-                pipeline_id="issue-42",
-                repo_path="/some/path",
-                branch="egg/container-abc123/work",
-            )
-            # Session should be cleaned up
-            mock_delete.assert_called_once_with("test-token-12345")
+    def test_delete_remote_branch_uses_launcher_auth(self, gateway_client, mock_gateway_server):
+        """Pin the trust-boundary fix: deletion authenticates with the
+        launcher secret (not a session token), so it bypasses the
+        gateway's pipeline-push enforcement (#2028, #2055)."""
+        captured: dict = {}
 
-    def test_delete_remote_branch_registers_session_with_branch(
-        self, gateway_client, mock_gateway_server
-    ):
-        """Test that register_session is called with branch so gateway assigns correct branch."""
-        with patch.object(
-            gateway_client, "register_session", wraps=gateway_client.register_session
-        ) as mock_reg:
-            gateway_client.delete_remote_branch(
-                pipeline_id="issue-42",
-                repo_path="/some/path",
-                branch="egg/container-abc123/work",
-            )
-            mock_reg.assert_called_once()
-            call_kwargs = mock_reg.call_args
-            registered_branch = call_kwargs.kwargs["branch"]
-            assert registered_branch == "egg/container-abc123/work"
+        original = gateway_client._make_request
+
+        def spy(endpoint, *args, **kwargs):
+            if endpoint == "/api/v1/git/push":
+                captured["use_launcher_auth"] = kwargs.get("use_launcher_auth")
+                captured["bearer_token"] = kwargs.get("bearer_token")
+                captured["data"] = kwargs.get("data")
+            return original(endpoint, *args, **kwargs)
+
+        with patch.object(gateway_client, "_make_request", side_effect=spy):
+            with patch.object(gateway_client, "register_session") as mock_reg:
+                gateway_client.delete_remote_branch(
+                    pipeline_id="issue-42",
+                    repo_path="/some/path",
+                    branch="egg/container-abc123/work",
+                )
+                # No temp session — the orchestrator authenticates directly.
+                mock_reg.assert_not_called()
+
+        assert captured["use_launcher_auth"] is True
+        assert captured["bearer_token"] is None
+        assert captured["data"]["refspec"] == ":egg/container-abc123/work"
+
+    def test_delete_remote_branch_already_deleted_classifier(self):
+        """``remote ref does not exist`` stderr classifies as ``already_deleted``."""
+        # Direct classifier check — keeps the test independent of HTTP
+        # plumbing while pinning the category callers depend on to
+        # distinguish desired-state-already from real failures.
+        category = _classify_push_stderr(
+            "error: unable to delete 'egg/container-abc/work': remote ref does not exist\n"
+            "error: failed to push some refs to 'origin'"
+        )
+        assert category == "already_deleted"
 
 
 class TestFetchWorktreeBranch:

--- a/orchestrator/tests/test_pipelines_api.py
+++ b/orchestrator/tests/test_pipelines_api.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
+from gateway_client import PushResult
 from models import (
     AgentExecution,
     AgentExecutionStatus,
@@ -95,7 +96,7 @@ class TestDeletePipelineBranchCleanup:
         mock_spawner_fn.return_value = mock_spawner
 
         mock_gw = MagicMock()
-        mock_gw.delete_remote_branch.return_value = True
+        mock_gw.delete_remote_branch.return_value = PushResult(ok=True)
         mock_gw_fn.return_value = mock_gw
 
         response = client.delete("/api/v1/pipelines/test-pipeline")
@@ -143,7 +144,7 @@ class TestDeletePipelineBranchCleanup:
         mock_spawner_fn.return_value = mock_spawner
 
         mock_gw = MagicMock()
-        mock_gw.delete_remote_branch.return_value = True
+        mock_gw.delete_remote_branch.return_value = PushResult(ok=True)
         mock_gw_fn.return_value = mock_gw
 
         response = client.delete("/api/v1/pipelines/issue-1973")
@@ -170,7 +171,9 @@ class TestDeletePipelineBranchCleanup:
         mock_spawner_fn.return_value = mock_spawner
 
         mock_gw = MagicMock()
-        mock_gw.delete_remote_branch.return_value = False
+        mock_gw.delete_remote_branch.return_value = PushResult(
+            ok=False, category="network", detail="connection refused"
+        )
         mock_gw_fn.return_value = mock_gw
 
         response = client.delete("/api/v1/pipelines/test-pipeline")
@@ -245,7 +248,7 @@ class TestDeletePipelineBranchCleanup:
         mock_spawner_fn.return_value = mock_spawner
 
         mock_gw = MagicMock()
-        mock_gw.delete_remote_branch.return_value = True
+        mock_gw.delete_remote_branch.return_value = PushResult(ok=True)
         mock_gw_fn.return_value = mock_gw
 
         response = client.delete("/api/v1/pipelines/test-pipeline")
@@ -257,6 +260,43 @@ class TestDeletePipelineBranchCleanup:
             for call in mock_gw.delete_remote_branch.call_args_list
         }
         assert called_branches == {"egg/test", "egg/container-shared/work"}
+
+    @patch("routes.pipelines.get_gateway_client")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    def test_delete_pipeline_treats_already_deleted_as_success(
+        self, mock_resolve, mock_spawner_fn, mock_gw_fn, client
+    ):
+        """``already_deleted`` is the desired state — cleanup must not warn
+        or treat it as a failure when a branch was never pushed (#2055)."""
+        pipeline = _make_pipeline_with_containers("test-pipeline")
+
+        mock_store = MagicMock()
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        mock_spawner.cleanup_pipeline.return_value = 0
+        mock_spawner_fn.return_value = mock_spawner
+
+        mock_gw = MagicMock()
+        mock_gw.delete_remote_branch.return_value = PushResult(
+            ok=False,
+            category="already_deleted",
+            detail="error: unable to delete: remote ref does not exist",
+        )
+        mock_gw_fn.return_value = mock_gw
+
+        with patch("routes.pipelines.logger") as mock_logger:
+            response = client.delete("/api/v1/pipelines/test-pipeline")
+            assert response.status_code == 200
+
+            # No "deletion failed" warnings — the desired state is satisfied.
+            for call in mock_logger.warning.call_args_list:
+                assert "Remote branch deletion failed" not in (call.args[0] if call.args else "")
+
+            # And the success-summary log records all branches as deleted.
+            info_messages = [call.args[0] for call in mock_logger.info.call_args_list if call.args]
+            assert "Cleaned up remote branches" in info_messages
 
     @patch("routes.pipelines.get_gateway_client")
     @patch("routes.pipelines.get_container_spawner")
@@ -1006,7 +1046,7 @@ class TestRuntimeStateLeakageOnBranchReuse:
         mock_spawner_fn.return_value = mock_spawner
 
         mock_gw = MagicMock()
-        mock_gw.delete_remote_branch.return_value = True
+        mock_gw.delete_remote_branch.return_value = PushResult(ok=True)
         mock_gw_fn.return_value = mock_gw
 
         with patch("routes.pipelines._clear_pipeline_runtime_state") as mock_clear:


### PR DESCRIPTION
## Summary

- `GatewayClient.delete_remote_branch` was silently no-op'ing since #2028: its temp-session shape set `pipeline_id` on the session, the gateway's pipeline-push enforcement 403'd the deletion, the broad `except Exception` swallowed the error, and shared `egg/<pipeline-id>` branches accumulated on `origin` — silently re-opening #2014.
- Switch to launcher auth (same architectural fix #2051 applied to `_do_push`) by delegating to `_do_push` with a `:branch` deletion refspec. The gateway already exempts launcher-authenticated requests from the pipeline-push block.
- Return `PushResult` instead of a bare bool so callers can distinguish `already_deleted` (the desired state when a branch was never pushed) from real failures. The cleanup helper in `routes/pipelines.py` now logs structured warnings on real failures and counts `already_deleted` as success.

## Test plan

- [x] `make test` — full changeset-aware suite passes (3571 tests).
- [x] `make lint` — clean.
- [x] New unit test pins the trust-boundary fix: `delete_remote_branch` uses `use_launcher_auth=True` and does not call `register_session`.
- [x] New unit test pins the `already_deleted` classifier on `remote ref does not exist`.
- [x] New integration test pins cleanup helper behavior: `already_deleted` does not produce "deletion failed" warnings.
- [ ] Manual verification: cancel a pipeline with `cleanup=true` and confirm `egg/<pipeline-id>` is deleted on `origin` (no `push_denied_pipeline_session` audit-log entry).

Closes #2055.