### PR TITLE
Fix #2311: cross-process flock for shared bare-repo git ops

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -66,12 +66,13 @@ WORKDIR /app
 # Copy gateway code
 COPY gateway/*.py ./
 
-# Copy shared modules (egg_logging for logging, egg_config for config parsing, egg_contracts for contract API, egg_restrictions for agent role enforcement, egg_health for health tracking)
+# Copy shared modules (egg_logging for logging, egg_config for config parsing, egg_contracts for contract API, egg_restrictions for agent role enforcement, egg_health for health tracking, egg_git for cross-process git locking)
 COPY shared/egg_logging/ ./egg_logging/
 COPY shared/egg_config/ ./egg_config/
 COPY shared/egg_contracts/ ./egg_contracts/
 COPY shared/egg_restrictions/ ./egg_restrictions/
 COPY shared/egg_health/ ./egg_health/
+COPY shared/egg_git/ ./egg_git/
 
 # Copy config module (repo_config needed by github_client for user mode)
 # Copy to both /config/ (for package-style imports) and /app/ (for PYTHONPATH)

--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -1338,6 +1338,119 @@ class TestWorktreeManagerConcurrency:
             assert git_file.is_file(), f"{cid}: .git should be a file"
             assert git_file.read_text().strip().startswith("gitdir:")
 
+    def test_concurrent_create_worktree_with_sibling_state_writes(self, git_repo):
+        """Concurrent worktree creates do not lose ``.git/config`` lock races to
+        a sibling process running state-store-style git operations on the
+        same bare repo (#2311).
+
+        The pre-#2311 gateway only serialised worktree creates inside its
+        own process; a separate process (the orchestrator's state-store)
+        could write to ``.git/config`` between the gateway's claim and
+        commit of ``.git/config.lock``, and ``git worktree add`` would
+        fail with ``could not lock config file .git/config: File exists``.
+        With the cross-process flock, both sides cooperatively serialise
+        on a shared sentinel inside ``.git/`` — ``git worktree add`` no
+        longer races.
+        """
+        import os as _os
+        import subprocess as _sp
+        import sys as _sys
+        import textwrap
+        import threading
+
+        worktree_base, repos_base, repo_dir = git_repo
+        manager = WorktreeManager(worktree_base=worktree_base, repos_base=repos_base)
+
+        # Sibling subprocess: bursts of ``git config`` writes guarded by
+        # ``bare_repo_lock`` — i.e. the same lock the gateway acquires.
+        # Each write goes through ``.git/config.lock``, the same file that
+        # ``git worktree add`` claims when it sets ``branch.<x>.remote``.
+        ready_sentinel = repo_dir / ".contender-ready"
+        contender_script = textwrap.dedent(
+            f"""
+            import subprocess, sys, time
+            sys.path.insert(0, {str(Path(__file__).resolve().parent.parent.parent / "shared")!r})
+            from egg_git.cross_process_lock import bare_repo_lock
+
+            repo = {str(repo_dir)!r}
+            open({str(ready_sentinel)!r}, "w").close()
+            deadline = time.monotonic() + 8
+            i = 0
+            while time.monotonic() < deadline:
+                with bare_repo_lock(repo):
+                    subprocess.run(
+                        ["git", "-C", repo, "config",
+                         f"egg.statetest{{i}}", str(i)],
+                        check=False, capture_output=True,
+                    )
+                i += 1
+            """
+        )
+        contender = _sp.Popen(
+            [_sys.executable, "-c", contender_script],
+            env={**_os.environ, "PYTHONUNBUFFERED": "1"},
+            stdout=_sp.PIPE,
+            stderr=_sp.PIPE,
+        )
+
+        try:
+            # Wait for the contender to start running before launching
+            # threads so the race window actually overlaps.
+            import time as _time
+
+            deadline = _time.monotonic() + 5
+            while not ready_sentinel.exists() and _time.monotonic() < deadline:
+                if contender.poll() is not None:
+                    out, err = contender.communicate(timeout=1)
+                    pytest.fail(
+                        f"contender exited early rc={contender.returncode}: "
+                        f"stdout={out!r} stderr={err!r}"
+                    )
+                _time.sleep(0.01)
+            assert ready_sentinel.exists(), "contender did not signal readiness"
+
+            results: dict[str, object] = {}
+            container_ids = [f"container-{i}" for i in range(6)]
+            barrier = threading.Barrier(len(container_ids))
+
+            def create(cid: str) -> None:
+                try:
+                    barrier.wait(timeout=10)
+                    # ``assigned_branch`` triggers ``_configure_push_upstream``,
+                    # which writes ``branch.<x>.remote`` / ``branch.<x>.merge``
+                    # into ``.git/config``.  That is the same write that races
+                    # ``.git/config.lock`` in #2311.
+                    results[cid] = manager.create_worktree(
+                        "test-repo",
+                        cid,
+                        assigned_branch="egg/issue-2311-target",
+                    )
+                except Exception as exc:
+                    results[cid] = exc
+
+            threads = [threading.Thread(target=create, args=(cid,)) for cid in container_ids]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=60)
+        finally:
+            contender.terminate()
+            try:
+                contender.wait(timeout=5)
+            except _sp.TimeoutExpired:
+                contender.kill()
+                contender.wait(timeout=2)
+
+        for cid in container_ids:
+            assert cid in results, f"Thread for {cid} did not finish"
+            info = results[cid]
+            if isinstance(info, Exception):
+                # Surface the exact error message — the regression
+                # signature is ``could not lock config file .git/config``.
+                pytest.fail(f"{cid} failed: {info!r}")
+            assert isinstance(info, WorktreeInfo)
+            assert info.worktree_path.exists()
+
 
 class TestRunGitWorktreeAddRetry:
     """Tests for _run_git_worktree_add retry logic on index.lock contention."""

--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -1377,10 +1377,12 @@ class TestWorktreeManagerConcurrency:
             deadline = time.monotonic() + 8
             i = 0
             while time.monotonic() < deadline:
+                # Reuse a single key — same race surface on
+                # ``.git/config.lock`` without bloating ``.git/config``
+                # with thousands of distinct keys over the test window.
                 with bare_repo_lock(repo):
                     subprocess.run(
-                        ["git", "-C", repo, "config",
-                         f"egg.statetest{{i}}", str(i)],
+                        ["git", "-C", repo, "config", "egg.statetest", str(i)],
                         check=False, capture_output=True,
                     )
                 i += 1

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -29,7 +29,9 @@ _shared_path = Path(__file__).parent.parent.parent / "shared"
 if _shared_path.exists():
     sys.path.insert(0, str(_shared_path))
 import contextlib
+from collections.abc import Generator
 
+from egg_git.cross_process_lock import bare_repo_lock
 from egg_logging import get_logger
 
 # Import git_cmd helper
@@ -319,23 +321,26 @@ class WorktreeManager:
             # Ensure ownership is correct (may have been created with different uid/gid)
             self._chown_recursive(worktree_path, uid, gid)
             self._chown_single(worktree_path.parent, uid, gid)
-            # Re-apply push upstream config in case the assigned branch
-            # changed across calls (idempotent when unchanged).
-            self._configure_push_upstream(main_repo, branch_name, assigned_branch)
-            # Reset HEAD to a known-good ref so we don't inherit a stale
-            # left-over HEAD from a prior pipeline that collided on
-            # ``container_id`` (deterministic pipeline_id can collide when
-            # the same issue is resubmitted — see #2222).  Without this,
-            # the new pipeline's first push hits non-fast-forward and
-            # the reconcile path can absorb upstream main commits onto
-            # the pipeline branch.
-            self._reset_reused_worktree_to_safe_ref(
-                worktree_path=worktree_path,
-                main_repo=main_repo,
-                container_id=container_id,
-                assigned_branch=assigned_branch,
-                base_branch=base_branch,
-            )
+            # Re-apply push upstream config and reset to a safe ref under
+            # the per-repo lock — both write to ``.git/config`` (and the
+            # latter to ``.git/index``), and concurrent callers without
+            # the lock race on ``.git/config.lock`` (#2311).
+            with self._get_repo_lock(repo_name):
+                self._configure_push_upstream(main_repo, branch_name, assigned_branch)
+                # Reset HEAD to a known-good ref so we don't inherit a stale
+                # left-over HEAD from a prior pipeline that collided on
+                # ``container_id`` (deterministic pipeline_id can collide when
+                # the same issue is resubmitted — see #2222).  Without this,
+                # the new pipeline's first push hits non-fast-forward and
+                # the reconcile path can absorb upstream main commits onto
+                # the pipeline branch.
+                self._reset_reused_worktree_to_safe_ref(
+                    worktree_path=worktree_path,
+                    main_repo=main_repo,
+                    container_id=container_id,
+                    assigned_branch=assigned_branch,
+                    base_branch=base_branch,
+                )
             # Return info about existing worktree
             return WorktreeInfo(
                 container_id=container_id,
@@ -496,8 +501,11 @@ class WorktreeManager:
         # Point the per-worktree local branch at the assigned remote branch
         # so `git push` resolves to a refspec the gateway will accept
         # (#1809).  Must happen before returning so the sandbox's push
-        # client sees the config on its first push.
-        self._configure_push_upstream(main_repo, branch_name, assigned_branch)
+        # client sees the config on its first push.  Held under the
+        # per-repo lock so the ``.git/config`` write does not race the
+        # state-store's commits in the orchestrator pod (#2311).
+        with self._get_repo_lock(repo_name):
+            self._configure_push_upstream(main_repo, branch_name, assigned_branch)
 
         # Find the actual git dir (git names it based on worktree basename)
         git_dir = self._find_worktree_git_dir(main_repo, worktree_path)
@@ -584,12 +592,27 @@ class WorktreeManager:
             git_dir=self._find_worktree_git_dir(main_repo, worktree_path),
         )
 
-    def _get_repo_lock(self, repo_name: str) -> threading.Lock:
-        """Get or create a per-repo lock for serializing git operations."""
+    @contextlib.contextmanager
+    def _get_repo_lock(self, repo_name: str) -> Generator[None]:
+        """Hold the per-repo lock for serializing git operations.
+
+        Combines two layers:
+
+        * A per-repo ``threading.Lock`` for in-process serialization (the
+          original #1857 / #1863 fix).
+        * ``bare_repo_lock`` for cross-process serialization against the
+          orchestrator's state-store, which runs git from a different pod
+          but shares the same hostPath-mounted bare repo (#2311).  Without
+          this, parallel ``git worktree add`` calls race the state-store's
+          commits on ``.git/config.lock`` and fail with ``could not lock
+          config file .git/config: File exists``.
+        """
         with self._repo_locks_guard:
             if repo_name not in self._repo_locks:
                 self._repo_locks[repo_name] = threading.Lock()
-            return self._repo_locks[repo_name]
+            thread_lock = self._repo_locks[repo_name]
+        with thread_lock, bare_repo_lock(self.repos_base / repo_name):
+            yield
 
     def _configure_push_upstream(
         self,

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -693,7 +693,11 @@ class WorktreeManager:
         """
         # Best-effort fetch so the remote-tracking refs are current; if
         # this fails we still attempt the reset against whatever local
-        # state we have.
+        # state we have.  This runs inside the cross-process lock (the
+        # caller holds it across this whole method) so the timeout
+        # caps how long every other state-store commit / worktree
+        # create on this repo can be blocked by a slow remote — keep
+        # it tight.
         try:
             subprocess.run(
                 git_cmd("fetch", "origin"),
@@ -701,7 +705,7 @@ class WorktreeManager:
                 capture_output=True,
                 text=True,
                 check=False,
-                timeout=120,
+                timeout=30,
             )
         except (subprocess.TimeoutExpired, OSError) as exc:
             logger.warning(

--- a/orchestrator/state_store.py
+++ b/orchestrator/state_store.py
@@ -29,6 +29,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, ClassVar, Literal
 
+from egg_git.cross_process_lock import lock_path_for_repo
 from models import Pipeline, PipelineMode, PipelinePhase, PipelineStatus
 from pydantic import ValidationError
 
@@ -153,8 +154,17 @@ class StateStore:
 
     @property
     def _lock_path(self) -> Path:
-        """Lock file for cross-process git serialization."""
-        return self._worktree_dir.parent / ".git-ops.lock"
+        """Lock file for cross-process git serialization.
+
+        Located inside the bare repo's ``.git/`` directory so the same
+        sentinel inode is visible to the gateway pod, which mounts the
+        repo from the same hostPath.  Until #2311, the lock lived under
+        ``self._worktree_dir.parent`` — a pod-local ``emptyDir`` — so the
+        gateway and orchestrator never actually synchronised, and a
+        ``git worktree add`` could race a state-store commit on
+        ``.git/config.lock`` and fail.
+        """
+        return lock_path_for_repo(self.repo_path)
 
     @classmethod
     def _get_flock_fd(cls, lock_path: Path) -> int:

--- a/orchestrator/tests/test_state_store.py
+++ b/orchestrator/tests/test_state_store.py
@@ -1109,7 +1109,10 @@ class TestRunGitLocking:
         store = StateStore(tmp_path, worktree_dir=worktree_dir)
         store._worktree = worktree_dir
 
-        lock_file = tmp_path / ".git-ops.lock"
+        # Lock file lives inside the bare repo's .git/ so the gateway pod
+        # (which mounts /home/egg/repos/ from the same hostPath) sees the
+        # same inode and flock serialises both processes (#2311).
+        lock_file = tmp_path / ".git" / ".egg-cross-process.lock"
         assert not lock_file.exists()
 
         with store._git_op():

--- a/shared/egg_git/__init__.py
+++ b/shared/egg_git/__init__.py
@@ -4,8 +4,11 @@ Git utilities for egg.
 Provides common git operations that can be reused across processors and tasks.
 """
 
+from .cross_process_lock import bare_repo_lock, lock_path_for_repo
 from .default_branch import get_default_branch
 
 __all__ = [
+    "bare_repo_lock",
     "get_default_branch",
+    "lock_path_for_repo",
 ]

--- a/shared/egg_git/cross_process_lock.py
+++ b/shared/egg_git/cross_process_lock.py
@@ -1,0 +1,116 @@
+"""Cross-process serialization for git operations on a shared bare repo.
+
+The gateway pod and orchestrator pod both run git against the same shared
+bare repo at ``/home/egg/repos/<repo>/.git`` (the same hostPath is mounted
+into each pod).  A ``threading.Lock`` only synchronises calls inside one
+process — nothing stops the gateway's ``git worktree add`` from racing the
+orchestrator's state-store commit on ``.git/config.lock`` (#2311).
+
+This module wraps that file with an ``fcntl.flock`` so both processes
+serialise on the same inode.  The lock file lives at
+``<repo_path>/.git/.egg-cross-process.lock`` — inside the resource being
+protected, on the shared mount, so any process that can run git against
+the repo can also see and acquire the lock.
+
+Reentrancy: nested ``with bare_repo_lock(repo)`` blocks in the same
+process do not block — the inner acquisitions just bump a depth counter.
+This matches the orchestrator state-store's existing pattern, where a
+compound operation (e.g. ``add → commit``) holds the lock across several
+inner ``_run_git`` calls.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import os
+import threading
+from collections.abc import Generator
+from pathlib import Path
+from typing import Final
+
+LOCK_FILENAME: Final = ".egg-cross-process.lock"
+
+
+def lock_path_for_repo(repo_path: Path | str) -> Path:
+    """Return the cross-process lock path for ``repo_path``.
+
+    The path is ``<repo_path>/.git/<LOCK_FILENAME>``.  ``repo_path`` must
+    be the main repo (with ``.git`` as a directory).  Worktree paths
+    (where ``.git`` is a file) are not valid arguments — callers should
+    resolve to the main repo first.
+    """
+    return Path(repo_path) / ".git" / LOCK_FILENAME
+
+
+class _RepoLockState:
+    __slots__ = ("rlock", "fd", "depth")
+
+    def __init__(self, fd: int) -> None:
+        self.rlock = threading.RLock()
+        self.fd = fd
+        # Nesting depth, only mutated while ``rlock`` is held.
+        self.depth = 0
+
+
+# Per-process state, keyed by stringified repo path.  Each entry owns a
+# long-lived file descriptor on the lock file plus a reentrant thread
+# lock so multiple threads in this process queue locally rather than all
+# bouncing on the kernel's flock queue.
+_state_lock = threading.Lock()
+_per_repo_state: dict[str, _RepoLockState] = {}
+
+
+def _get_state(repo_path: Path) -> _RepoLockState:
+    key = str(repo_path)
+    with _state_lock:
+        state = _per_repo_state.get(key)
+        if state is None:
+            lock_path = lock_path_for_repo(repo_path)
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+            state = _RepoLockState(fd=fd)
+            _per_repo_state[key] = state
+        return state
+
+
+@contextlib.contextmanager
+def bare_repo_lock(repo_path: Path | str) -> Generator[None]:
+    """Hold the cross-process bare-repo lock for ``repo_path``.
+
+    Acquires, in order, a reentrant in-process thread lock and an
+    ``fcntl.flock`` ``LOCK_EX`` on a sentinel file under ``.git/``.
+    Releases both on exit.  Reentrant within a single process via a
+    depth counter — only the outermost caller actually issues the
+    ``flock`` syscall.
+    """
+    state = _get_state(Path(repo_path))
+    state.rlock.acquire()
+    try:
+        if state.depth == 0:
+            fcntl.flock(state.fd, fcntl.LOCK_EX)
+        state.depth += 1
+        try:
+            yield
+        finally:
+            state.depth -= 1
+            if state.depth == 0:
+                fcntl.flock(state.fd, fcntl.LOCK_UN)
+    finally:
+        state.rlock.release()
+
+
+def reset_for_tests() -> None:
+    """Drop the per-repo state cache.  Test-only.
+
+    Closes every cached file descriptor and clears the registry so a
+    fresh test run starts from a clean slate.  Calling this while a
+    lock is held in another thread is undefined behaviour.
+    """
+    with _state_lock:
+        for state in _per_repo_state.values():
+            try:
+                os.close(state.fd)
+            except OSError:
+                pass
+        _per_repo_state.clear()

--- a/shared/egg_git/cross_process_lock.py
+++ b/shared/egg_git/cross_process_lock.py
@@ -62,7 +62,15 @@ _per_repo_state: dict[str, _RepoLockState] = {}
 
 
 def _get_state(repo_path: Path) -> _RepoLockState:
-    key = str(repo_path)
+    # Resolve so two equivalent path forms (abs vs rel, with/without
+    # trailing slash, symlinks) hit the same cache entry.  flock keys
+    # on the inode regardless, but a single fd avoids redundant state
+    # and a self-deadlock risk if a future caller relies on RLock
+    # reentrancy across forms.
+    try:
+        key = str(repo_path.resolve())
+    except OSError:
+        key = str(repo_path)
     with _state_lock:
         state = _per_repo_state.get(key)
         if state is None:

--- a/shared/tests/test_cross_process_lock.py
+++ b/shared/tests/test_cross_process_lock.py
@@ -96,7 +96,7 @@ def test_serialises_across_processes(tmp_path: Path) -> None:
         with bare_repo_lock({str(tmp_path)!r}):
             # Signal "lock held" by writing to a sentinel file.
             open({str(tmp_path / "held")!r}, "w").close()
-            time.sleep(0.5)
+            time.sleep(1.0)
         """
     )
 
@@ -121,7 +121,8 @@ def test_serialises_across_processes(tmp_path: Path) -> None:
             proc.kill()
             proc.wait(timeout=2)
 
-    # The child held the lock for ~0.5s after writing the sentinel; the
-    # parent should have waited at least most of that time.  Allow a
-    # generous slack for scheduler jitter on busy CI hosts.
-    assert wait > 0.2, f"parent acquired lock too quickly ({wait:.3f}s) — flock did not block"
+    # The child held the lock for ~1.0s after writing the sentinel; the
+    # parent should have waited at least half that time.  The 0.5s slack
+    # absorbs the parent's sentinel-detection latency (the polling loop
+    # ticks every 10ms) plus scheduler jitter on busy CI hosts.
+    assert wait > 0.5, f"parent acquired lock too quickly ({wait:.3f}s) — flock did not block"

--- a/shared/tests/test_cross_process_lock.py
+++ b/shared/tests/test_cross_process_lock.py
@@ -1,0 +1,127 @@
+"""Tests for ``egg_git.cross_process_lock``.
+
+Covers the per-repo flock primitive that synchronises git operations
+between the gateway and orchestrator pods on a shared bare repo (#2311).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+from pathlib import Path
+
+import pytest
+from egg_git.cross_process_lock import (
+    LOCK_FILENAME,
+    bare_repo_lock,
+    lock_path_for_repo,
+    reset_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    yield
+    reset_for_tests()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A directory with an empty ``.git/`` so the lock file can land."""
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+def test_lock_path_lives_inside_dot_git(tmp_path: Path) -> None:
+    assert lock_path_for_repo(tmp_path) == tmp_path / ".git" / LOCK_FILENAME
+
+
+def test_acquiring_creates_lock_file(repo: Path) -> None:
+    expected = repo / ".git" / LOCK_FILENAME
+    assert not expected.exists()
+    with bare_repo_lock(repo):
+        assert expected.exists()
+
+
+def test_reentrant_within_process(repo: Path) -> None:
+    # Three nested ``with`` blocks must not deadlock — only the outermost
+    # actually issues an ``flock`` syscall.
+    with bare_repo_lock(repo):
+        with bare_repo_lock(repo):
+            with bare_repo_lock(repo):
+                pass
+
+
+def test_threads_in_one_process_serialise(repo: Path) -> None:
+    in_section: list[bool] = []
+    overlap = threading.Event()
+
+    def hold(duration: float) -> None:
+        with bare_repo_lock(repo):
+            if any(in_section):
+                overlap.set()
+            in_section.append(True)
+            try:
+                time.sleep(duration)
+            finally:
+                in_section.pop()
+
+    threads = [threading.Thread(target=hold, args=(0.05,)) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert not overlap.is_set(), "threads observed each other inside the lock"
+
+
+def test_serialises_across_processes(tmp_path: Path) -> None:
+    """A subprocess holding the lock blocks the parent until it releases.
+
+    Without flock-on-shared-inode (the #2311 fix), the parent would
+    proceed immediately and the assertion below would fail by a wide
+    margin.
+    """
+    (tmp_path / ".git").mkdir()
+
+    holder_script = textwrap.dedent(
+        f"""
+        import sys, time
+        sys.path.insert(0, {str(Path(__file__).resolve().parent.parent)!r})
+        from egg_git.cross_process_lock import bare_repo_lock
+        with bare_repo_lock({str(tmp_path)!r}):
+            # Signal "lock held" by writing to a sentinel file.
+            open({str(tmp_path / "held")!r}, "w").close()
+            time.sleep(0.5)
+        """
+    )
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", holder_script],
+        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+    )
+
+    try:
+        # Wait until the child has actually acquired the lock.
+        deadline = time.monotonic() + 5
+        while not (tmp_path / "held").exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert (tmp_path / "held").exists(), "child never signalled lock acquisition"
+
+        start = time.monotonic()
+        with bare_repo_lock(tmp_path):
+            wait = time.monotonic() - start
+        proc.wait(timeout=5)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=2)
+
+    # The child held the lock for ~0.5s after writing the sentinel; the
+    # parent should have waited at least most of that time.  Allow a
+    # generous slack for scheduler jitter on busy CI hosts.
+    assert wait > 0.2, f"parent acquired lock too quickly ({wait:.3f}s) — flock did not block"


### PR DESCRIPTION
## Summary
- Adds `egg_git.cross_process_lock.bare_repo_lock` — a reentrant `fcntl.flock` on a sentinel inside the bare repo's `.git/`, visible to both gateway and orchestrator pods (they share `/home/egg/repos/` via hostPath).
- Wires it into the gateway's `WorktreeManager._get_repo_lock`, alongside the existing per-process `threading.Lock`. Extends the lock to also cover the post-`worktree add` `_configure_push_upstream` and `_reset_reused_worktree_to_safe_ref` calls, which also write to `.git/config`.
- Moves the orchestrator state-store's flock sentinel from the pod-local `/home/egg/.egg-state/.git-ops.lock` to the shared `<repo>/.git/.egg-cross-process.lock` so its existing `fcntl.flock` and the gateway's flock cooperate on a single inode.

Closes #2311.

## Why
The gateway's `git worktree add` was racing the orchestrator state-store's commits on `.git/config.lock`. Each side had its own in-process lock, and the state-store's flock lived in a pod-local `emptyDir`, so they never synchronised. Failure mode (verbatim from the issue):

```
error: could not lock config file .git/config: File exists
error: unable to write upstream branch configuration
```

`#1857` / `#1863` closed the in-process race; this PR closes the cross-process one.

## Test plan
- [x] `make test` (16 020 passed, 41 skipped, 75 deselected)
- [x] New `shared/tests/test_cross_process_lock.py` covers reentrancy, in-process serialisation, and cross-process serialisation via subprocess.
- [x] New gateway regression test `test_concurrent_create_worktree_with_sibling_state_writes` spawns 6 concurrent worktree creates while a sibling subprocess hammers `git config`. With the fix removed it reproduces the `.git/config.lock` failure 4/5 runs; with the fix it's clean 8/8.