### PR TITLE
Fix #2332: narrow bare_repo_lock window in store_checkpoint_v2

### DIFF
--- a/gateway/checkpoint_handler.py
+++ b/gateway/checkpoint_handler.py
@@ -949,30 +949,42 @@ class CheckpointHandler:
                                         error=str(exc),
                                     )
                                     raise
-                        self._run_git(
-                            repo_path,
-                            [
-                                "worktree",
-                                "add",
-                                "--detach",
-                                str(temp_path),
-                                CHECKPOINT_BRANCH,
-                            ],
-                        )
+                        # Cross-process flock only around the bare-repo
+                        # `.git/` writer (#2332). State-store races on
+                        # `.git/config.lock` come from `worktree add`,
+                        # not from fetch — so the flock window is just
+                        # this call.
+                        with bare_repo_lock(repo_path):
+                            self._run_git(
+                                repo_path,
+                                [
+                                    "worktree",
+                                    "add",
+                                    "--detach",
+                                    str(temp_path),
+                                    CHECKPOINT_BRANCH,
+                                ],
+                            )
                     else:
                         # Delete any stale local branch before creating orphan.
                         # The branch may exist locally from a different remote
                         # (e.g., checkpoints were previously stored in the source
                         # repo before migrating to an external checkpoint repo).
-                        self._run_git(
-                            repo_path,
-                            ["branch", "-D", CHECKPOINT_BRANCH],
-                            check=False,
-                        )
-                        self._run_git(
-                            repo_path,
-                            ["worktree", "add", "--detach", str(temp_path)],
-                        )
+                        # Both the `branch -D` and `worktree add` write under
+                        # the bare repo's `.git/`, so they share one flock
+                        # window. `checkout --orphan` and `rm -rf .` run
+                        # inside the temp worktree and don't touch the bare
+                        # repo's config, so they stay outside the flock.
+                        with bare_repo_lock(repo_path):
+                            self._run_git(
+                                repo_path,
+                                ["branch", "-D", CHECKPOINT_BRANCH],
+                                check=False,
+                            )
+                            self._run_git(
+                                repo_path,
+                                ["worktree", "add", "--detach", str(temp_path)],
+                            )
                         self._run_git(
                             str(temp_path),
                             ["checkout", "--orphan", CHECKPOINT_BRANCH],
@@ -1077,19 +1089,23 @@ class CheckpointHandler:
                     return True
 
                 finally:
-                    self._run_git(
-                        repo_path,
-                        ["worktree", "remove", "--force", str(temp_path)],
-                        check=False,
-                    )
-                    # Drop any stale .git/worktrees/<basename> entry so a
-                    # failed remove (or a failed worktree add) doesn't
-                    # leak across attempts.
-                    self._run_git(
-                        repo_path,
-                        ["worktree", "prune"],
-                        check=False,
-                    )
+                    # Worktree cleanup writes under the bare repo's
+                    # `.git/worktrees/`, so it shares the cross-process
+                    # flock with `worktree add` (#2332).
+                    with bare_repo_lock(repo_path):
+                        self._run_git(
+                            repo_path,
+                            ["worktree", "remove", "--force", str(temp_path)],
+                            check=False,
+                        )
+                        # Drop any stale .git/worktrees/<basename> entry so a
+                        # failed remove (or a failed worktree add) doesn't
+                        # leak across attempts.
+                        self._run_git(
+                            repo_path,
+                            ["worktree", "prune"],
+                            check=False,
+                        )
 
         except Exception as e:
             logger.error(
@@ -1341,24 +1357,26 @@ _repo_locks_guard = threading.Lock()
 
 @contextlib.contextmanager
 def _get_repo_lock(repo_path: str) -> Generator[None]:
-    """Hold the per-repo lock for serializing checkpoint git operations.
+    """Hold the per-process per-repo lock for the whole checkpoint op.
 
-    Combines two layers, mirroring ``WorktreeManager._get_repo_lock``:
+    In-process serialization only (#2069). Cross-process serialization
+    against the orchestrator's state-store on ``.git/config.lock``
+    (#2311) is handled with narrower ``bare_repo_lock`` windows around
+    the specific git operations that touch the bare repo's ``.git/``
+    (worktree add, worktree remove/prune) — see #2332.
 
-    * A per-repo ``threading.Lock`` for in-process serialization (#2069).
-    * ``bare_repo_lock`` for cross-process serialization against the
-      orchestrator's state-store, which runs git from a different pod
-      but shares the same hostPath-mounted bare repo (#2311).  Without
-      this, a checkpoint store's ``git worktree add`` can race a
-      state-store commit on ``.git/config.lock`` and fail with
-      ``could not lock config file .git/config: File exists``.
+    Holding the cross-process flock for the entire op would block every
+    state-store commit and other gateway worktree op against the same
+    bare repo for up to ~135s under fetch-retry pathology, which is
+    much wider than necessary: fetch, the in-temp-worktree commit, and
+    the push do not race the state-store on ``.git/config.lock``.
     """
     with _repo_locks_guard:
         thread_lock = _repo_locks.get(repo_path)
         if thread_lock is None:
             thread_lock = threading.Lock()
             _repo_locks[repo_path] = thread_lock
-    with thread_lock, bare_repo_lock(repo_path):
+    with thread_lock:
         yield
 
 

--- a/gateway/tests/test_checkpoint_handler.py
+++ b/gateway/tests/test_checkpoint_handler.py
@@ -36,6 +36,10 @@ def _stub_bare_repo_lock(monkeypatch):
     is covered by ``shared/tests/test_cross_process_lock.py`` and the
     worktree integration test — here we only need ``_get_repo_lock``'s
     in-process serialization to work.
+
+    Tests that need to observe ``bare_repo_lock`` acquire/release order
+    (e.g. #2332's regression that the flock is *not* held across the
+    fetch-retry window) override this with their own recording stand-in.
     """
     import checkpoint_handler
 
@@ -853,6 +857,77 @@ class TestStoreCheckpointV2Concurrency:
         assert max_in_flight >= 2, (
             "Expected concurrent execution across different repos, "
             f"saw max_in_flight={max_in_flight}"
+        )
+
+    def test_bare_repo_lock_not_held_across_fetch_retry(self, monkeypatch):
+        """Cross-process flock is released around the fetch-retry window.
+
+        Regression for #2332. Holding ``bare_repo_lock`` across the
+        fetch's 3 × 45s retry window blocks every state-store commit
+        and other gateway worktree op against the same bare repo.
+        Fetch doesn't write ``.git/config``, so it doesn't need
+        cross-process serialization — the flock should only wrap the
+        ops that touch the bare repo's ``.git/`` (worktree add,
+        worktree remove/prune).
+        """
+        import checkpoint_handler
+
+        checkpoint_handler._repo_locks.clear()
+
+        flock_depth = [0]
+        # Per-call list of (git_args, depth_at_entry).
+        observations: list[tuple[list[str], int]] = []
+
+        @contextlib.contextmanager
+        def recording_flock(_repo_path):
+            flock_depth[0] += 1
+            try:
+                yield
+            finally:
+                flock_depth[0] -= 1
+
+        monkeypatch.setattr(checkpoint_handler, "bare_repo_lock", recording_flock)
+        monkeypatch.setattr(checkpoint_handler.time, "sleep", lambda _s: None)
+
+        handler = checkpoint_handler.CheckpointHandler(github_token="test-token")
+
+        fetch_attempts = [0]
+
+        def track_run_git(cwd, args, **kwargs):
+            observations.append((list(args), flock_depth[0]))
+            if args[:1] == ["fetch"]:
+                fetch_attempts[0] += 1
+                # Fail the first two fetches to drive the retry loop;
+                # let the third succeed so the rest of the op runs.
+                if fetch_attempts[0] < 3:
+                    raise checkpoint_handler.CheckpointError("simulated fetch failure")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        handler._run_git = track_run_git
+        handler._branch_exists = MagicMock(return_value=True)
+
+        result = handler.store_checkpoint_v2(self._make_checkpoint(), "/fake/repo")
+        assert result is True
+
+        fetch_observations = [depth for args, depth in observations if args[:1] == ["fetch"]]
+        assert len(fetch_observations) == 3, (
+            f"Expected 3 fetch attempts, observed {len(fetch_observations)}"
+        )
+        assert all(d == 0 for d in fetch_observations), (
+            f"bare_repo_lock must not be held during fetch retry, saw depths {fetch_observations}"
+        )
+
+        # Sanity: `worktree add` and the cleanup `worktree remove` /
+        # `worktree prune` must run *under* the flock — that's the
+        # whole point of keeping the flock at all.
+        worktree_observations = [
+            (args[:2], depth)
+            for args, depth in observations
+            if args[:2] in (["worktree", "add"], ["worktree", "remove"], ["worktree", "prune"])
+        ]
+        assert worktree_observations, "Expected worktree git ops to be observed"
+        assert all(depth >= 1 for _args, depth in worktree_observations), (
+            f"Worktree ops must run under bare_repo_lock, saw {worktree_observations}"
         )
 
 


### PR DESCRIPTION
Closes #2332.

## Summary

- Reduce `_get_repo_lock` to the per-process `threading.Lock` only (the #2069 serializer); drop `bare_repo_lock` from the broad wrap.
- In `store_checkpoint_v2`, add narrow `bare_repo_lock(repo_path)` windows around the bare-repo `.git/`-touching git ops:
  - branch-exists path: `worktree add`
  - first-run path: `branch -D` + `worktree add` (the subsequent `checkout --orphan` / `rm -rf .` run *inside the temp worktree* and stay outside the flock)
  - cleanup `finally`: `worktree remove --force` + `worktree prune`
- Fetch (and its 3 × 45s retry loop), the in-temp-worktree commit, the push, and its non-fast-forward rebase-fetch all run **outside** the flock — they don't write `.git/config` and so don't race the state-store on `.git/config.lock`.

## Why

PR #2330 mirrored `WorktreeManager`'s pattern and held the cross-process flock for the entire `store_checkpoint_v2`, including the up-to-135s fetch-retry window. Under fetch-timeout pathology that blocks **every** orchestrator state-store commit and **every** other gateway worktree op against the same bare repo. The reviewer flagged this as a "Not for this PR" deferral; the trade-off is meaningfully different from `WorktreeManager`, whose entire op is short-running git commands.

The narrow scope is what the original #2311 race actually requires: state-store collisions on `.git/config.lock` come from `worktree add`, not from fetch.

## Test plan

- [x] `gateway/tests/test_checkpoint_handler.py` — all 83 tests pass, including the existing concurrency tests (`test_concurrent_stores_on_same_repo_serialized` still observes `max_in_flight == 1` because the broad `threading.Lock` is unchanged).
- [x] New regression test `test_bare_repo_lock_not_held_across_fetch_retry`: records `bare_repo_lock` acquire/release depth, drives 3 fetch attempts via simulated transient failures, asserts depth is 0 during every fetch attempt and ≥ 1 during every `worktree add` / `worktree remove` / `worktree prune` call.
- [x] `gateway/tests/test_checkpoint_inter_agent.py`, `gateway/tests/test_checkpoint_read.py`, `shared/tests/test_cross_process_lock.py` — pass.
- [x] `ruff check` + `ruff format` clean.
- [ ] CI green.

## Acceptance criteria (from issue)

- [x] `store_checkpoint_v2` no longer holds `bare_repo_lock` across the fetch-retry window.
- [x] `worktree add` and other operations writing to `.git/` in the bare repo remain serialised cross-process.
- [x] Existing test coverage continues to pass; regression test asserts the lock is not held across the fetch-retry window.
- [x] No regression of #2311 — `worktree add` still runs under the flock, which is exactly the call that races state-store on `.git/config.lock`.