### PR TITLE
Fix #2338 (b2): pre-flight tester attestation in mcp__brc__propose

### DIFF
--- a/sandbox/egg_agent_tools/handlers/brc.py
+++ b/sandbox/egg_agent_tools/handlers/brc.py
@@ -89,6 +89,91 @@ def _resolve_head_sha() -> str:
         raise HandlerError("'commit_sha' not provided and could not resolve HEAD") from exc
 
 
+def _validate_tester_attestation_pre_flight(attestation: dict[str, Any]) -> None:
+    """Catch missing tester attestation fields at the handler boundary (#2338).
+
+    Mirrors the orchestrator's strict-mode tester checks
+    (``orchestrator/attestation_schemas.py:_validate_strict``) so a
+    misconfigured proposal fails locally with an actionable HandlerError
+    instead of going on the wire and bouncing back as a 400 on the next
+    retry. The orchestrator's check stays — this is pre-flight validation,
+    not a replacement.
+
+    The attestation's ``tests_run`` is the *count* of tests run (an
+    ``int``), not the propose-tool's top-level ``tests_run`` (a
+    ``list[str]`` of test identifiers). When tests genuinely cannot run
+    (e.g. private-network mode blocking module downloads), set
+    ``tests_execution_blocked=True`` with a non-empty
+    ``tests_execution_blocked_reason``.
+
+    Raises ``HandlerError`` when the attestation would fail strict-mode
+    validation; passes silently otherwise. Relaxed-mode pipelines accept
+    an empty payload — this validator is a no-op for them, since the
+    orchestrator's strict-mode check is the only gate that fires.
+    """
+    blocked_raw = attestation.get("tests_execution_blocked", False)
+    blocked = bool(blocked_raw) if blocked_raw is not False else False
+
+    if blocked:
+        reason = (attestation.get("tests_execution_blocked_reason") or "").strip()
+        if not reason:
+            raise HandlerError(
+                "Tester attestation: 'tests_execution_blocked' is true but "
+                "'tests_execution_blocked_reason' is empty. Populate "
+                "attestation.tests_execution_blocked_reason with why tests "
+                "could not run (e.g. 'private-network mode blocked package "
+                "downloads'), then retry."
+            )
+        # Mutual-exclusion guard: blocked pipelines must not also report
+        # tests_run > 0 — pick one and stick with it.
+        try:
+            tests_run_int = int(attestation.get("tests_run", 0) or 0)
+        except TypeError, ValueError:
+            tests_run_int = 0
+        if tests_run_int > 0:
+            raise HandlerError(
+                "Tester attestation: tests_execution_blocked=true conflicts "
+                "with tests_run > 0. If some tests ran, set "
+                "tests_execution_blocked=false and report the count and "
+                "checks_passed normally."
+            )
+        return
+
+    # Non-blocked path — strict mode requires tests_run > 0 and
+    # checks_passed populated.
+    try:
+        tests_run_int = int(attestation.get("tests_run", 0) or 0)
+    except (TypeError, ValueError) as exc:
+        raise HandlerError(
+            "Tester attestation: 'tests_run' must be an integer count of "
+            "tests executed (e.g. 42). Got "
+            f"{attestation.get('tests_run')!r}. Note: this is the "
+            "attestation field, distinct from the propose tool's top-level "
+            "tests_run argument (which carries test *identifiers* as a "
+            "list of strings)."
+        ) from exc
+    if tests_run_int <= 0:
+        raise HandlerError(
+            "Tester attestation requires tests_run > 0 (the integer count "
+            "of tests executed). If tests genuinely could not run, set "
+            "tests_execution_blocked=true with a non-empty "
+            "tests_execution_blocked_reason instead. Pass these as fields "
+            "on the propose tool's `attestation` dict — e.g. "
+            "attestation={'tests_run': 42, 'checks_passed': "
+            "['lint', 'test']}."
+        )
+
+    checks_passed = attestation.get("checks_passed") or []
+    if not isinstance(checks_passed, list) or not checks_passed:
+        raise HandlerError(
+            "Tester attestation requires checks_passed to list the "
+            "configured checks that actually passed (e.g. "
+            "['lint', 'test']). Only include checks that passed — do NOT "
+            "include checks that failed. Empty list is rejected when "
+            "tests_execution_blocked is false."
+        )
+
+
 def brc_propose(req: dict[str, Any]) -> dict[str, Any]:
     """Send a CONSENSUS_PROPOSE signal.
 
@@ -99,9 +184,18 @@ def brc_propose(req: dict[str, Any]) -> dict[str, Any]:
         risk_considered (str): risk summary.
         commit_sha (str): commit SHA; defaults to ``git rev-parse HEAD``.
         files_changed (list[str])
-        tests_run (list[str])
+        tests_run (list[str]): test *identifiers* executed (e.g. test
+            node IDs). Distinct from the attestation's ``tests_run``
+            field, which is an integer count of tests executed (see
+            ``attestation`` below).
         tasks (list[str]): tasks_satisfied
-        attestation (dict): attestation payload.
+        attestation (dict): role-specific attestation payload. For the
+            ``tester`` role under strict mode, requires either
+            ``tests_run > 0`` (integer) and a non-empty ``checks_passed``
+            list, or ``tests_execution_blocked=true`` with a non-empty
+            ``tests_execution_blocked_reason``. Pre-flight validated by
+            this handler so misconfigurations fail locally rather than
+            bouncing off the orchestrator as 400 (#2338).
         changed_artifacts (list[str]): optional re-proposal delta.
         raw_payload (dict): pre-built payload dict — every key is
             forwarded verbatim to the orchestrator.  Structured
@@ -154,6 +248,15 @@ def brc_propose(req: dict[str, Any]) -> dict[str, Any]:
             ),
         }
     )
+    # Pre-flight role-specific attestation validation (#2338). Mirrors
+    # the orchestrator's strict-mode checks so misconfigurations fail
+    # at the handler boundary with an actionable HandlerError instead
+    # of going on the wire and bouncing back as a 400. Strict-mode-only
+    # — the orchestrator gates this; relaxed-mode pipelines won't reach
+    # the strict validator and aren't disrupted by pre-flight here.
+    if role == "tester" and isinstance(payload.get("attestation"), dict):
+        _validate_tester_attestation_pre_flight(payload["attestation"])
+
     data: dict[str, Any] = {
         "signal_type": "consensus_propose",
         "agent_role": role,

--- a/sandbox/egg_agent_tools/handlers/brc.py
+++ b/sandbox/egg_agent_tools/handlers/brc.py
@@ -122,22 +122,86 @@ def _coerce_attestation_bool(value: Any, *, field: str) -> bool:
     )
 
 
+def _coerce_attestation_int(value: Any, *, field: str) -> int:
+    """Coerce a JSON-ish value to int, matching Pydantic v2's lax rules.
+
+    Used for ``tests_run`` so pre-flight's verdict matches the
+    orchestrator's Pydantic parse step. The strict-mode rule logic only
+    runs *after* Pydantic has parsed the payload into a typed model;
+    payloads that fail parsing (lists, unparseable strings,
+    non-integer-valued floats) raise ``ValidationError`` and never
+    reach ``_validate_strict``. Without this helper, pre-flight's
+    blocked branch would silently swallow a bad ``tests_run`` and let
+    the request go on the wire — which is exactly what the orchestrator
+    rejects at parse time.
+
+    Accepts: ``int`` (incl. ``bool``, since ``bool`` is an ``int``
+    subclass and Pydantic v2 lax-mode accepts it), ``float`` only when
+    ``is_integer()`` is true, and ``str`` only when stripping yields a
+    parseable integer. Rejects everything else with ``HandlerError``.
+    """
+    if isinstance(value, bool):
+        # bool is an int subclass; Pydantic v2 lax mode accepts True/False
+        # for an int field (coerces to 1/0).
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not value.is_integer():
+            raise HandlerError(
+                f"Tester attestation: '{field}' must be an integer count "
+                f"of tests executed (e.g. 42). Got {value!r}, a "
+                "non-integer float — Pydantic only accepts integer-valued "
+                "floats here."
+            )
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError as exc:
+            raise HandlerError(
+                f"Tester attestation: '{field}' must be an integer count "
+                f"of tests executed (e.g. 42). Got {value!r}, an "
+                "unparseable string. Note: this is the attestation field, "
+                "distinct from the propose tool's top-level tests_run "
+                "argument (which carries test *identifiers* as a list of "
+                "strings)."
+            ) from exc
+    raise HandlerError(
+        f"Tester attestation: '{field}' must be an integer count of "
+        f"tests executed (e.g. 42). Got {value!r}. Note: this is the "
+        "attestation field, distinct from the propose tool's top-level "
+        "tests_run argument (which carries test *identifiers* as a "
+        "list of strings)."
+    )
+
+
 def _validate_tester_attestation_pre_flight(attestation: dict[str, Any]) -> None:
-    """Catch missing tester attestation fields at the handler boundary (#2338).
+    """Catch missing / malformed tester attestation at the handler boundary (#2338).
 
-    Mirrors the orchestrator's strict-mode tester checks
-    (``orchestrator/attestation_schemas.py:_validate_strict``) so a
-    misconfigured proposal fails locally with an actionable HandlerError
-    instead of going on the wire and bouncing back as a 400 on the next
-    retry. The orchestrator's check stays — this is pre-flight validation,
-    not a replacement.
+    Pre-flight has two layers, both mirroring the orchestrator:
 
-    The attestation's ``tests_run`` is the *count* of tests run (an
-    ``int``), not the propose-tool's top-level ``tests_run`` (a
-    ``list[str]`` of test identifiers). When tests genuinely cannot run
-    (e.g. private-network mode blocking module downloads), set
-    ``tests_execution_blocked=True`` with a non-empty
-    ``tests_execution_blocked_reason``.
+    1. **Type checks** that mirror Pydantic v2's parse step on
+       ``TesterAttestation`` (``orchestrator/attestation_schemas.py``).
+       Runs unconditionally — a payload that would fail
+       ``model_cls(**attestation_data)`` (e.g. ``tests_run="abc"``,
+       ``tests_run=["t1"]``, ``tests_run=0.5``, ``checks_passed="lint"``)
+       fails pre-flight with the same verdict, regardless of whether
+       ``tests_execution_blocked`` is true. This catches divergence #1
+       from PR #2344's re-review: the orchestrator's Pydantic parse
+       rejects bad types in both branches, so pre-flight must too.
+    2. **Strict-mode rule logic** that mirrors ``_validate_strict``
+       (the post-Pydantic checks). Branches on the parsed
+       ``tests_execution_blocked`` value to enforce the
+       ``tests_run > 0 + checks_passed populated`` requirement (or the
+       blocked-with-reason alternative).
+
+    Failures raise ``HandlerError`` with an actionable message
+    naming the field, the common cause, and the expected format —
+    including a callout disambiguating the attestation's ``tests_run``
+    (integer count) from the propose tool's top-level ``tests_run``
+    (list of test identifiers). The orchestrator's check stays — this
+    is defense-in-depth, not a replacement.
 
     Pre-flight enforces strict-mode rules unconditionally, regardless of
     the pipeline's ``attestation_strictness`` setting. The handler has no
@@ -149,15 +213,38 @@ def _validate_tester_attestation_pre_flight(attestation: dict[str, Any]) -> None
     the canonical "tester forgot to populate attestation.tests_run" case
     from #2338 is the same misconfiguration in both modes, so failing
     fast with an actionable error is better UX than letting an empty
-    payload silently slip past in relaxed mode. Raises ``HandlerError``
-    on any divergence; passes silently when the orchestrator's strict
-    validator would also accept the payload.
+    payload silently slip past in relaxed mode.
+
+    Invariant: pre-flight verdict (accept / raise) must match
+    ``validate_attestation(role="tester", strictness=STRICT)`` for every
+    payload. Enforced by
+    ``test_handlers_brc.py::TestPreFlightMirrorsOrchestrator``; if you
+    tighten one side, tighten both.
     """
+    # Layer 1 — type checks that mirror Pydantic's parse step. Runs
+    # unconditionally. A payload that would bounce off
+    # ``model_cls(**attestation_data)`` bounces off pre-flight first
+    # with a friendlier message.
     blocked = _coerce_attestation_bool(
         attestation.get("tests_execution_blocked", False),
         field="tests_execution_blocked",
     )
+    tests_run_int = _coerce_attestation_int(
+        attestation.get("tests_run", 0),
+        field="tests_run",
+    )
+    checks_passed = attestation.get("checks_passed", [])
+    if not isinstance(checks_passed, list):
+        # Pydantic rejects ``checks_passed`` if it isn't a list of
+        # strings. Mirror the type check unconditionally; the
+        # populated-ness check below only runs in non-blocked mode
+        # (Pydantic-parsed empty list is fine when blocked).
+        raise HandlerError(
+            "Tester attestation: 'checks_passed' must be a list of strings "
+            f"(e.g. ['lint', 'test']). Got {checks_passed!r}."
+        )
 
+    # Layer 2 — strict-mode rule logic that mirrors _validate_strict.
     if blocked:
         reason = (attestation.get("tests_execution_blocked_reason") or "").strip()
         if not reason:
@@ -170,10 +257,6 @@ def _validate_tester_attestation_pre_flight(attestation: dict[str, Any]) -> None
             )
         # Mutual-exclusion guard: blocked pipelines must not also report
         # tests_run > 0 — pick one and stick with it.
-        try:
-            tests_run_int = int(attestation.get("tests_run", 0) or 0)
-        except TypeError, ValueError:
-            tests_run_int = 0
         if tests_run_int > 0:
             raise HandlerError(
                 "Tester attestation: tests_execution_blocked=true conflicts "
@@ -184,23 +267,12 @@ def _validate_tester_attestation_pre_flight(attestation: dict[str, Any]) -> None
         return
 
     # Non-blocked path — strict mode requires tests_run > 0 and
-    # checks_passed populated.
-    try:
-        tests_run_int = int(attestation.get("tests_run", 0) or 0)
-    except (TypeError, ValueError) as exc:
-        raise HandlerError(
-            "Tester attestation: 'tests_run' must be an integer count of "
-            "tests executed (e.g. 42). Got "
-            f"{attestation.get('tests_run')!r}. Note: this is the "
-            "attestation field, distinct from the propose tool's top-level "
-            "tests_run argument (which carries test *identifiers* as a "
-            "list of strings)."
-        ) from exc
-    # Mirror the orchestrator: only ``tests_run == 0`` is rejected.
-    # Negative counts slip past Pydantic (no constraint on the int field)
-    # and the strict validator's ``elif instance.tests_run == 0`` check,
-    # so pre-flight intentionally lets them pass too. If we tighten one
-    # side, tighten both — see the cross-check tests in
+    # checks_passed populated. Mirror the orchestrator: only
+    # ``tests_run == 0`` is rejected. Negative counts slip past
+    # Pydantic (no constraint on the int field) and the strict
+    # validator's ``elif instance.tests_run == 0`` check, so pre-flight
+    # intentionally lets them pass too. If we tighten one side, tighten
+    # both — see the cross-check tests in
     # ``test_handlers_brc.py::TestPreFlightMirrorsOrchestrator``.
     if tests_run_int == 0:
         raise HandlerError(
@@ -213,8 +285,7 @@ def _validate_tester_attestation_pre_flight(attestation: dict[str, Any]) -> None
             "['lint', 'test']}."
         )
 
-    checks_passed = attestation.get("checks_passed") or []
-    if not isinstance(checks_passed, list) or not checks_passed:
+    if not checks_passed:
         raise HandlerError(
             "Tester attestation requires checks_passed to list the "
             "configured checks that actually passed (e.g. "

--- a/sandbox/egg_agent_tools/handlers/brc.py
+++ b/sandbox/egg_agent_tools/handlers/brc.py
@@ -215,11 +215,36 @@ def _validate_tester_attestation_pre_flight(attestation: dict[str, Any]) -> None
     fast with an actionable error is better UX than letting an empty
     payload silently slip past in relaxed mode.
 
-    Invariant: pre-flight verdict (accept / raise) must match
-    ``validate_attestation(role="tester", strictness=STRICT)`` for every
-    payload. Enforced by
+    Invariant: pre-flight verdict (accept / raise) mirrors
+    ``validate_attestation(role="tester", strictness=STRICT)`` for the
+    canonical #2338 footguns — empty payload, missing/zero/non-int
+    ``tests_run``, missing/empty/non-list/non-string-item
+    ``checks_passed``, and the lax bool/int string forms Pydantic v2
+    accepts. Enforced by
     ``test_handlers_brc.py::TestPreFlightMirrorsOrchestrator``; if you
-    tighten one side, tighten both.
+    tighten one side on a covered rule, tighten both.
+
+    Known inverse-direction divergences (pre-flight is stricter than
+    the orchestrator on these — agents see a friendlier HandlerError
+    locally instead of the orchestrator accepting an obscure type):
+
+    - ``checks_passed`` as a tuple (Pydantic coerces to list).
+    - ``tests_execution_blocked`` as ``0.0``/``1.0`` float, ``b"true"``
+      bytes, or other Pydantic-lax bool inputs not in
+      ``_BOOL_TRUE_STRINGS`` / ``_BOOL_FALSE_STRINGS``.
+    - ``tests_run`` as a stringified non-integer float (e.g. ``"1.0"``)
+      — Pydantic v2 accepts via float-then-int; pre-flight requires
+      the string to parse straight to int.
+
+    JSON-deserialised payloads from the wire don't produce these types
+    in practice (no tuples, no bytes), so the worst case is a clearer
+    error on the producer side. The orchestrator's strict validator
+    stays as defense-in-depth for any payload that does slip through.
+
+    Known same-direction divergence (academic, both reject in
+    practice): ``tests_run = 1e20`` — Pydantic v2's int field has
+    overflow protection, ``int(1e20)`` does not. Producers don't
+    construct counts this large.
     """
     # Layer 1 — type checks that mirror Pydantic's parse step. Runs
     # unconditionally. A payload that would bounce off
@@ -242,6 +267,17 @@ def _validate_tester_attestation_pre_flight(attestation: dict[str, Any]) -> None
         raise HandlerError(
             "Tester attestation: 'checks_passed' must be a list of strings "
             f"(e.g. ['lint', 'test']). Got {checks_passed!r}."
+        )
+    # Item-type check: Pydantic's ``list[str]`` field rejects payloads
+    # like ``checks_passed=[1, 2, 3]`` — exactly the #2338 footgun
+    # shape (agent forgets to stringify). Without this, pre-flight
+    # accepts and the request bounces off the orchestrator as a 400.
+    bad_items = [item for item in checks_passed if not isinstance(item, str)]
+    if bad_items:
+        raise HandlerError(
+            "Tester attestation: 'checks_passed' items must be strings "
+            f"(e.g. ['lint', 'test']). Got non-string items: {bad_items!r}. "
+            "Stringify check identifiers before passing them in."
         )
 
     # Layer 2 — strict-mode rule logic that mirrors _validate_strict.

--- a/sandbox/egg_agent_tools/handlers/brc.py
+++ b/sandbox/egg_agent_tools/handlers/brc.py
@@ -89,6 +89,39 @@ def _resolve_head_sha() -> str:
         raise HandlerError("'commit_sha' not provided and could not resolve HEAD") from exc
 
 
+# Pydantic v2's lax bool coercion accepts these string forms (case-insensitive).
+# Mirrored here so pre-flight matches the orchestrator's parse step on
+# tests_execution_blocked — see _coerce_attestation_bool below.
+_BOOL_TRUE_STRINGS = frozenset({"true", "yes", "on", "1", "t", "y"})
+_BOOL_FALSE_STRINGS = frozenset({"false", "no", "off", "0", "f", "n"})
+
+
+def _coerce_attestation_bool(value: Any, *, field: str) -> bool:
+    """Coerce a JSON-ish value to bool, matching Pydantic v2's lax rules.
+
+    Used for ``tests_execution_blocked`` so pre-flight's verdict matches
+    the orchestrator's Pydantic parse step. Without this, a string like
+    ``"false"`` is truthy under Python's ``bool()`` (non-empty string)
+    but parses to ``False`` in Pydantic — pre-flight would reject a
+    payload the orchestrator would accept.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _BOOL_TRUE_STRINGS:
+            return True
+        if normalized in _BOOL_FALSE_STRINGS:
+            return False
+    raise HandlerError(
+        f"Tester attestation: '{field}' must be a bool (got {value!r}). "
+        "Pass true/false, or one of the string forms 'true'/'false'/"
+        "'yes'/'no'/'on'/'off'/'1'/'0'."
+    )
+
+
 def _validate_tester_attestation_pre_flight(attestation: dict[str, Any]) -> None:
     """Catch missing tester attestation fields at the handler boundary (#2338).
 
@@ -106,13 +139,24 @@ def _validate_tester_attestation_pre_flight(attestation: dict[str, Any]) -> None
     ``tests_execution_blocked=True`` with a non-empty
     ``tests_execution_blocked_reason``.
 
-    Raises ``HandlerError`` when the attestation would fail strict-mode
-    validation; passes silently otherwise. Relaxed-mode pipelines accept
-    an empty payload — this validator is a no-op for them, since the
-    orchestrator's strict-mode check is the only gate that fires.
+    Pre-flight enforces strict-mode rules unconditionally, regardless of
+    the pipeline's ``attestation_strictness`` setting. The handler has no
+    cheap way to read tracker strictness from the sandbox, and a relaxed
+    pipeline that has been reconstructed post-restart
+    (``orchestrator/peer_consensus.py`` keeps reconstructed trackers in
+    ``RELAXED`` for the rest of their lifetime) will see pre-flight reject
+    proposals the orchestrator would have accepted. That is acceptable:
+    the canonical "tester forgot to populate attestation.tests_run" case
+    from #2338 is the same misconfiguration in both modes, so failing
+    fast with an actionable error is better UX than letting an empty
+    payload silently slip past in relaxed mode. Raises ``HandlerError``
+    on any divergence; passes silently when the orchestrator's strict
+    validator would also accept the payload.
     """
-    blocked_raw = attestation.get("tests_execution_blocked", False)
-    blocked = bool(blocked_raw) if blocked_raw is not False else False
+    blocked = _coerce_attestation_bool(
+        attestation.get("tests_execution_blocked", False),
+        field="tests_execution_blocked",
+    )
 
     if blocked:
         reason = (attestation.get("tests_execution_blocked_reason") or "").strip()
@@ -152,7 +196,13 @@ def _validate_tester_attestation_pre_flight(attestation: dict[str, Any]) -> None
             "tests_run argument (which carries test *identifiers* as a "
             "list of strings)."
         ) from exc
-    if tests_run_int <= 0:
+    # Mirror the orchestrator: only ``tests_run == 0`` is rejected.
+    # Negative counts slip past Pydantic (no constraint on the int field)
+    # and the strict validator's ``elif instance.tests_run == 0`` check,
+    # so pre-flight intentionally lets them pass too. If we tighten one
+    # side, tighten both — see the cross-check tests in
+    # ``test_handlers_brc.py::TestPreFlightMirrorsOrchestrator``.
+    if tests_run_int == 0:
         raise HandlerError(
             "Tester attestation requires tests_run > 0 (the integer count "
             "of tests executed). If tests genuinely could not run, set "

--- a/sandbox/egg_agent_tools/tools/brc.py
+++ b/sandbox/egg_agent_tools/tools/brc.py
@@ -37,7 +37,12 @@ _PROPOSE_SCHEMA: dict[str, Any] = {
         "tests_run": {
             "type": "array",
             "items": {"type": "string"},
-            "description": "Test identifiers executed",
+            "description": (
+                "Test *identifiers* executed (e.g. pytest node IDs). "
+                "Distinct from `attestation.tests_run`, which is an "
+                "integer count of tests run for strict-mode "
+                "validation."
+            ),
         },
         "tasks": {
             "type": "array",
@@ -46,7 +51,17 @@ _PROPOSE_SCHEMA: dict[str, Any] = {
         },
         "attestation": {
             "type": "object",
-            "description": "Optional attestation payload forwarded to the orchestrator",
+            "description": (
+                "Role-specific attestation payload forwarded to the "
+                "orchestrator. For the `tester` role under strict mode, "
+                "must include either (a) `tests_run` > 0 (integer count) "
+                "and a non-empty `checks_passed` list (e.g. "
+                "['lint', 'test']), or (b) `tests_execution_blocked`=true "
+                "with a non-empty `tests_execution_blocked_reason`. The "
+                "handler validates these pre-flight (#2338) so a "
+                "misconfigured payload fails locally with an actionable "
+                "error rather than as a 400 from the orchestrator."
+            ),
         },
         "changed_artifacts": {
             "type": "array",

--- a/tests/sandbox/egg_agent_tools/test_handlers_brc.py
+++ b/tests/sandbox/egg_agent_tools/test_handlers_brc.py
@@ -369,6 +369,45 @@ class TestPreFlightMirrorsOrchestrator:
             },
             # String "true" without reason — both reject.
             {"tests_execution_blocked": "true"},
+            # --- Pydantic parse-step type checks (PR #2344 re-review) ---
+            # Bad tests_run type (unparseable string) — Pydantic rejects in
+            # both modes; pre-flight now mirrors via _coerce_attestation_int.
+            {"tests_run": "abc", "checks_passed": ["test"]},
+            {
+                "tests_execution_blocked": True,
+                "tests_execution_blocked_reason": "x",
+                "tests_run": "abc",
+            },
+            # Bad tests_run type (list) — same.
+            {"tests_run": ["t1", "t2"], "checks_passed": ["test"]},
+            {
+                "tests_execution_blocked": True,
+                "tests_execution_blocked_reason": "x",
+                "tests_run": ["t1", "t2"],
+            },
+            # Non-integer-valued float — Pydantic rejects (only int-like
+            # floats coerce to int); pre-flight mirrors.
+            {"tests_run": 0.5, "checks_passed": ["test"]},
+            {
+                "tests_execution_blocked": True,
+                "tests_execution_blocked_reason": "x",
+                "tests_run": 0.5,
+            },
+            # Integer-valued float — Pydantic accepts (2.0 → 2); pre-flight
+            # mirrors via float.is_integer() in the coercion helper.
+            {"tests_run": 2.0, "checks_passed": ["test"]},
+            # Parseable integer string — Pydantic accepts; pre-flight mirrors.
+            {"tests_run": "42", "checks_passed": ["test"]},
+            # Non-list checks_passed — Pydantic rejects (list[str] field) in
+            # both blocked and non-blocked modes; pre-flight mirrors with
+            # an unconditional isinstance(..., list) check above the
+            # branch split.
+            {"tests_run": 5, "checks_passed": "lint"},
+            {
+                "tests_execution_blocked": True,
+                "tests_execution_blocked_reason": "x",
+                "checks_passed": "lint",
+            },
         ],
     )
     def test_pre_flight_matches_orchestrator(self, attestation: dict):

--- a/tests/sandbox/egg_agent_tools/test_handlers_brc.py
+++ b/tests/sandbox/egg_agent_tools/test_handlers_brc.py
@@ -289,6 +289,15 @@ class TestBrcProposeTesterAttestationPreFlight:
         with pytest.raises(HandlerError, match="must be a bool"):
             self._propose_tester({"tests_execution_blocked": ["maybe"]})
 
+    def test_non_string_checks_passed_items_rejected(self):
+        """``checks_passed=[1, 2, 3]`` is the same #2338 footgun shape
+        as the canonical empty-attestation case — the agent forgot to
+        stringify check identifiers. Pydantic's ``list[str]`` field
+        rejects this; pre-flight catches it first with a message that
+        names the bad items."""
+        with pytest.raises(HandlerError, match="must be strings"):
+            self._propose_tester({"tests_run": 5, "checks_passed": [1, 2, 3]})
+
 
 class TestPreFlightMirrorsOrchestrator:
     """Cross-check: pre-flight and orchestrator's strict validator agree.
@@ -408,6 +417,19 @@ class TestPreFlightMirrorsOrchestrator:
                 "tests_execution_blocked_reason": "x",
                 "checks_passed": "lint",
             },
+            # Non-string items in checks_passed — Pydantic's list[str] field
+            # rejects this (the operationally-relevant #2338 footgun shape
+            # flagged in the second re-review). Pre-flight now mirrors with
+            # an explicit item-type check.
+            {"tests_run": 5, "checks_passed": [1, 2, 3]},
+            {
+                "tests_execution_blocked": True,
+                "tests_execution_blocked_reason": "x",
+                "checks_passed": [1, 2, 3],
+            },
+            # Mixed string + non-string items — pre-flight should still
+            # reject (Pydantic does too).
+            {"tests_run": 5, "checks_passed": ["lint", 42, "test"]},
         ],
     )
     def test_pre_flight_matches_orchestrator(self, attestation: dict):

--- a/tests/sandbox/egg_agent_tools/test_handlers_brc.py
+++ b/tests/sandbox/egg_agent_tools/test_handlers_brc.py
@@ -105,6 +105,137 @@ class TestBrcPropose:
                 brc.brc_propose({"pipeline_id": "p", "role": "coder", "summary": "x" * 60})
 
 
+class TestBrcProposeTesterAttestationPreFlight:
+    """Pre-flight tester-attestation validation in ``brc_propose`` (#2338).
+
+    Mirrors the orchestrator's strict-mode tester checks but runs at the
+    handler boundary so misconfigurations fail locally with an actionable
+    HandlerError rather than as a 400 bouncing off the orchestrator.
+    """
+
+    def _propose_tester(self, attestation: dict):
+        with (
+            patch(
+                "egg_agent_tools.handlers.brc.orchestrator_request",
+                return_value=_ok_response(),
+            ),
+            patch(
+                "egg_agent_tools.handlers.brc._resolve_head_sha",
+                return_value="abc1234",
+            ),
+        ):
+            return brc.brc_propose(
+                {
+                    "pipeline_id": "pipe-1",
+                    "role": "tester",
+                    "summary": "x" * 60,
+                    "attestation": attestation,
+                }
+            )
+
+    def test_missing_tests_run_rejected_pre_flight(self):
+        """Empty / missing tests_run is rejected at handler boundary."""
+        with pytest.raises(HandlerError, match="tests_run > 0"):
+            self._propose_tester({})
+
+    def test_zero_tests_run_rejected(self):
+        with pytest.raises(HandlerError, match="tests_run > 0"):
+            self._propose_tester({"tests_run": 0, "checks_passed": ["test"]})
+
+    def test_non_integer_tests_run_rejected(self):
+        with pytest.raises(HandlerError, match="must be an integer"):
+            self._propose_tester({"tests_run": "many", "checks_passed": ["test"]})
+
+    def test_missing_checks_passed_rejected(self):
+        with pytest.raises(HandlerError, match="checks_passed"):
+            self._propose_tester({"tests_run": 5})
+
+    def test_empty_checks_passed_rejected(self):
+        with pytest.raises(HandlerError, match="checks_passed"):
+            self._propose_tester({"tests_run": 5, "checks_passed": []})
+
+    def test_happy_path_passes_pre_flight(self):
+        resp = self._propose_tester({"tests_run": 42, "checks_passed": ["lint", "test"]})
+        assert resp["ok"] is True
+
+    def test_blocked_with_reason_passes(self):
+        """tests_execution_blocked=true with a reason is accepted —
+        no tests_run / checks_passed required for blocked pipelines."""
+        resp = self._propose_tester(
+            {
+                "tests_execution_blocked": True,
+                "tests_execution_blocked_reason": (
+                    "private-network mode blocked package downloads"
+                ),
+            }
+        )
+        assert resp["ok"] is True
+
+    def test_blocked_without_reason_rejected(self):
+        with pytest.raises(HandlerError, match="tests_execution_blocked_reason"):
+            self._propose_tester({"tests_execution_blocked": True})
+
+    def test_blocked_with_tests_run_conflict(self):
+        """blocked=true + tests_run > 0 is contradictory."""
+        with pytest.raises(HandlerError, match="conflicts with tests_run"):
+            self._propose_tester(
+                {
+                    "tests_execution_blocked": True,
+                    "tests_execution_blocked_reason": "x",
+                    "tests_run": 5,
+                }
+            )
+
+    def test_other_roles_skip_validator(self):
+        """Coder / documenter etc. should not be subject to tester
+        attestation requirements — pre-flight only fires on role=tester."""
+        with (
+            patch(
+                "egg_agent_tools.handlers.brc.orchestrator_request",
+                return_value=_ok_response(),
+            ),
+            patch(
+                "egg_agent_tools.handlers.brc._resolve_head_sha",
+                return_value="abc",
+            ),
+        ):
+            resp = brc.brc_propose(
+                {
+                    "pipeline_id": "pipe-1",
+                    "role": "coder",
+                    "summary": "x" * 60,
+                    "attestation": {},  # empty — would fail tester pre-flight
+                }
+            )
+        assert resp["ok"] is True
+
+    def test_omitted_attestation_treated_as_empty_and_rejected(self):
+        """Caller that omits ``attestation`` entirely defaults to ``{}``,
+        which fails strict-mode pre-flight — the canonical "tester
+        forgot to populate" scenario from #2338. The handler surfaces
+        the same actionable error the orchestrator would have returned
+        as a 400."""
+        with (
+            patch(
+                "egg_agent_tools.handlers.brc.orchestrator_request",
+                return_value=_ok_response(),
+            ),
+            patch(
+                "egg_agent_tools.handlers.brc._resolve_head_sha",
+                return_value="abc",
+            ),
+        ):
+            with pytest.raises(HandlerError, match="tests_run > 0"):
+                brc.brc_propose(
+                    {
+                        "pipeline_id": "pipe-1",
+                        "role": "tester",
+                        "summary": "x" * 60,
+                        # No attestation — defaults to {} and fails pre-flight.
+                    }
+                )
+
+
 class TestBrcAck:
     def test_happy_path(self):
         with patch(

--- a/tests/sandbox/egg_agent_tools/test_handlers_brc.py
+++ b/tests/sandbox/egg_agent_tools/test_handlers_brc.py
@@ -15,6 +15,10 @@ import pytest
 ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(ROOT / "sandbox"))
 sys.path.insert(0, str(ROOT / "shared"))
+# Orchestrator path is needed for the cross-check tests that import
+# ``attestation_schemas.validate_attestation`` and assert pre-flight
+# verdicts agree with the strict-mode orchestrator validator.
+sys.path.insert(0, str(ROOT / "orchestrator"))
 
 from egg_agent_tools.handlers import brc  # noqa: E402
 from egg_agent_tools.handlers.errors import GatewayError, HandlerError  # noqa: E402
@@ -234,6 +238,148 @@ class TestBrcProposeTesterAttestationPreFlight:
                         # No attestation — defaults to {} and fails pre-flight.
                     }
                 )
+
+    # --- Coverage-gap cases flagged in the PR review --------------------
+
+    def test_non_list_checks_passed_rejected(self):
+        """``checks_passed`` as a non-list (string) trips the
+        ``isinstance(..., list)`` guard. The orchestrator's Pydantic
+        parse step also rejects this, so pre-flight catches it first
+        with a friendlier message."""
+        with pytest.raises(HandlerError, match="checks_passed"):
+            self._propose_tester({"tests_run": 5, "checks_passed": "lint"})
+
+    def test_negative_tests_run_passes_pre_flight(self):
+        """The orchestrator's ``_validate_strict`` only rejects
+        ``tests_run == 0`` (negative ints slip past Pydantic's plain
+        ``int`` field). Pre-flight intentionally mirrors that — see the
+        cross-check test below."""
+        resp = self._propose_tester({"tests_run": -1, "checks_passed": ["test"]})
+        assert resp["ok"] is True
+
+    def test_string_false_tests_execution_blocked_passes_through(self):
+        """Pydantic v2 coerces the string ``"false"`` to ``False``, so
+        the orchestrator routes a payload like
+        ``{"tests_execution_blocked": "false", "tests_run": 5,
+        "checks_passed": ["t"]}`` into the non-blocked branch and
+        accepts it. Pre-flight uses ``_coerce_attestation_bool`` to
+        match — without it, ``bool("false")`` is truthy and pre-flight
+        would wrongly demand a reason."""
+        resp = self._propose_tester(
+            {
+                "tests_execution_blocked": "false",
+                "tests_run": 5,
+                "checks_passed": ["test"],
+            }
+        )
+        assert resp["ok"] is True
+
+    def test_string_true_tests_execution_blocked_requires_reason(self):
+        """Symmetric to the previous: string ``"true"`` is coerced to
+        ``True``, so pre-flight enters the blocked branch and demands
+        a reason — same verdict the orchestrator would reach."""
+        with pytest.raises(HandlerError, match="tests_execution_blocked_reason"):
+            self._propose_tester({"tests_execution_blocked": "true"})
+
+    def test_unparseable_tests_execution_blocked_rejected(self):
+        """Values neither bool-like nor recognized strings (e.g. a
+        list) are rejected pre-flight with a coercion error. Pydantic
+        would also reject these — pre-flight just surfaces the message
+        before the request hits the wire."""
+        with pytest.raises(HandlerError, match="must be a bool"):
+            self._propose_tester({"tests_execution_blocked": ["maybe"]})
+
+
+class TestPreFlightMirrorsOrchestrator:
+    """Cross-check: pre-flight and orchestrator's strict validator agree.
+
+    The pre-flight docstring claims it "mirrors the orchestrator's
+    strict-mode tester checks." This class enforces that as an
+    invariant rather than a docstring claim — every payload runs
+    through both validators, and the verdicts (accept / reject) must
+    match. If someone tightens one side and not the other, one of these
+    parametrized cases fails. See PR #2344 review feedback.
+    """
+
+    @staticmethod
+    def _orchestrator_verdict(attestation: dict) -> bool:
+        """Return True if the orchestrator's strict validator would
+        accept the payload, False if it raises. Catches ``ValueError``
+        — pydantic.ValidationError inherits from ValueError in v2, and
+        ``_validate_strict`` raises ``ValueError`` directly."""
+        from attestation_schemas import AttestationStrictness, validate_attestation
+
+        try:
+            validate_attestation(
+                "tester",
+                attestation,
+                AttestationStrictness.STRICT,
+                is_producer=True,
+            )
+        except ValueError:
+            return False
+        return True
+
+    @staticmethod
+    def _pre_flight_verdict(attestation: dict) -> bool:
+        """Return True if pre-flight accepts (passes silently), False
+        if it raises ``HandlerError``."""
+        try:
+            brc._validate_tester_attestation_pre_flight(attestation)
+        except HandlerError:
+            return False
+        return True
+
+    @pytest.mark.parametrize(
+        "attestation",
+        [
+            # Empty payload — both reject.
+            {},
+            # Missing checks_passed — both reject.
+            {"tests_run": 5},
+            # Missing tests_run — both reject.
+            {"checks_passed": ["test"]},
+            # Zero tests_run — both reject.
+            {"tests_run": 0, "checks_passed": ["test"]},
+            # Empty checks_passed list — both reject.
+            {"tests_run": 5, "checks_passed": []},
+            # Blocked without reason — both reject.
+            {"tests_execution_blocked": True},
+            # Blocked + tests_run > 0 — both reject (mutual exclusion).
+            {
+                "tests_execution_blocked": True,
+                "tests_execution_blocked_reason": "x",
+                "tests_run": 5,
+            },
+            # Happy path — both accept.
+            {"tests_run": 42, "checks_passed": ["lint", "test"]},
+            # Blocked with reason — both accept.
+            {
+                "tests_execution_blocked": True,
+                "tests_execution_blocked_reason": "private-network mode",
+            },
+            # Negative tests_run — both accept (Pydantic has no constraint,
+            # _validate_strict only rejects == 0; pre-flight mirrors).
+            {"tests_run": -3, "checks_passed": ["test"]},
+            # String "false" for tests_execution_blocked — both accept.
+            {
+                "tests_execution_blocked": "false",
+                "tests_run": 1,
+                "checks_passed": ["test"],
+            },
+            # String "true" without reason — both reject.
+            {"tests_execution_blocked": "true"},
+        ],
+    )
+    def test_pre_flight_matches_orchestrator(self, attestation: dict):
+        pre_flight = self._pre_flight_verdict(attestation)
+        orchestrator = self._orchestrator_verdict(attestation)
+        assert pre_flight == orchestrator, (
+            f"Verdict divergence for {attestation!r}: "
+            f"pre-flight={'accept' if pre_flight else 'reject'}, "
+            f"orchestrator={'accept' if orchestrator else 'reject'}. "
+            "Pre-flight must mirror the orchestrator's strict validator."
+        )
 
 
 class TestBrcAck:


### PR DESCRIPTION
## Summary

Closes #2338 (part b2). Companion to #2343 (a1+a2).

In the issue's incident, the tester proposed without populating `attestation.tests_run` and got back `Tester attestation requires tests_run > 0 in strict mode (status 400)` from the orchestrator after the request was on the wire. Two retries + ~30 seconds of self-correction later, the tester figured out which field to populate. The fix:

- Add `_validate_tester_attestation_pre_flight` in `sandbox/egg_agent_tools/handlers/brc.py` that mirrors the orchestrator's strict-mode tester checks and runs before the request leaves the sandbox.
- Failures surface as `HandlerError` with an actionable message that names the field, the common cause, and the expected format — including a callout disambiguating `attestation.tests_run` (integer count) from the propose tool's top-level `tests_run` (list of test identifiers). The fact that two distinct fields share a name is its own usability problem; the error message at least tells the agent which one needs populating.
- Update the propose tool's `attestation` schema description to surface the per-role expectations at tool-call time, not just after a failed propose.

The orchestrator's strict-mode check stays — pre-flight is defense-in-depth, not a replacement. Other roles (coder, documenter) skip the validator unconditionally; pre-flight only fires when `role=tester`, including when `attestation` is omitted (defaults to `{}`, which is the canonical "tester forgot to populate" case from the issue).

## Key changes

- `sandbox/egg_agent_tools/handlers/brc.py`: new `_validate_tester_attestation_pre_flight` invoked from `brc_propose` when `role=tester`. Updated `brc_propose` docstring to document the new pre-flight contract.
- `sandbox/egg_agent_tools/tools/brc.py`: `attestation` and `tests_run` schema descriptions updated with per-role expectations.
- `tests/sandbox/egg_agent_tools/test_handlers_brc.py`: 11 new tests covering the validator's positive and negative paths (zero / non-integer / missing tests_run, missing / empty checks_passed, blocked + reason happy path, blocked without reason, blocked + tests_run conflict, other-roles skip, omitted-attestation rejection).

## Test Plan

- Targeted: `pytest tests/sandbox/egg_agent_tools/test_handlers_brc.py orchestrator/tests/test_peer_consensus_integration.py orchestrator/tests/test_producer_push_consensus.py orchestrator/tests/test_brc_phase_propagation.py orchestrator/tests/test_brc_content_validation.py` — all green locally (309 passed).

## Manual Steps

None.

## Pipeline Context

Issue: #2338