### PR TITLE
Fix #2345: route _sync_pipeline_decisions_to_contract through main state store

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -13066,6 +13066,7 @@ def _populate_contract_from_plan(
 
 def _sync_pipeline_decisions_to_contract(
     repo_path: Path,
+    worktree_repo_path: Path,
     pipeline_id: str,
     pipeline_mode: str = "issue",
     issue_number: int | None = None,
@@ -13080,6 +13081,12 @@ def _sync_pipeline_decisions_to_contract(
     choices, not process-control gates).  Skips decisions already present
     in the contract (matched by question text) to avoid duplicates on
     re-runs after HITL revision cycles.
+
+    Args:
+        repo_path: Orchestrator's main repo path — root for the state
+            store that owns pipeline records.
+        worktree_repo_path: Pipeline's per-run worktree path — root for
+            the contract under ``<worktree>/.egg-state/contracts/``.
     """
     try:
         from egg_contracts.loader import load_contract, save_contract
@@ -13088,14 +13095,20 @@ def _sync_pipeline_decisions_to_contract(
         logger.warning("egg_contracts not available, skipping decision sync")
         return
 
-    # Load pipeline to get its decisions
+    # Load pipeline from the orchestrator's state store, NOT the per-run
+    # worktree.  Pipeline records live under ``repo_path``'s persistent
+    # state-store worktree; the per-run worktree has none.  Conflating
+    # the two silently no-op'd this helper for every issue-mode pipeline
+    # since #950 (#2345).
     store = get_state_store(repo_path)
     try:
         pipeline = store.load_pipeline(pipeline_id)
-    except Exception:
+    except Exception as exc:
         logger.warning(
-            "Pipeline not found, skipping decision sync",
+            "decision_sync_pipeline_load_failed",
             pipeline_id=pipeline_id,
+            state_store_repo_path=str(repo_path),
+            error=str(exc),
         )
         return
 
@@ -13111,7 +13124,7 @@ def _sync_pipeline_decisions_to_contract(
         return
 
     try:
-        contract = load_contract(pipeline_id, repo_path)
+        contract = load_contract(pipeline_id, worktree_repo_path)
     except Exception:
         logger.warning(
             "Contract not found, skipping decision sync",
@@ -13161,7 +13174,7 @@ def _sync_pipeline_decisions_to_contract(
         synced_count += 1
 
     if synced_count > 0:
-        save_contract(contract, repo_path)
+        save_contract(contract, worktree_repo_path)
         logger.info(
             "Synced pipeline decisions to contract",
             pipeline_id=pipeline_id,
@@ -14993,7 +15006,11 @@ def _run_pipeline(
             if current_phase.value in _HITL_GATE_PHASES:
                 try:
                     _sync_pipeline_decisions_to_contract(
-                        worktree_repo_path, pipeline_id, pipeline_mode, pipeline.issue_number
+                        repo_path,
+                        worktree_repo_path,
+                        pipeline_id,
+                        pipeline_mode,
+                        pipeline.issue_number,
                     )
                 except Exception as sync_err:
                     logger.warning(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -13068,8 +13068,6 @@ def _sync_pipeline_decisions_to_contract(
     repo_path: Path,
     worktree_repo_path: Path,
     pipeline_id: str,
-    pipeline_mode: str = "issue",
-    issue_number: int | None = None,
 ) -> None:
     """Sync resolved non-phase-gate pipeline decisions to the contract.
 
@@ -15009,8 +15007,6 @@ def _run_pipeline(
                         repo_path,
                         worktree_repo_path,
                         pipeline_id,
-                        pipeline_mode,
-                        pipeline.issue_number,
                     )
                 except Exception as sync_err:
                     logger.warning(

--- a/orchestrator/tests/test_hitl_revision.py
+++ b/orchestrator/tests/test_hitl_revision.py
@@ -1075,6 +1075,7 @@ class TestSyncPipelineDecisionsToContract:
         ):
             _sync_pipeline_decisions_to_contract(
                 repo_path=Path("/fake/repo"),
+                worktree_repo_path=Path("/fake/worktree"),
                 pipeline_id="test-pipeline",
                 pipeline_mode="issue",
             )
@@ -1142,6 +1143,7 @@ class TestSyncPipelineDecisionsToContract:
         ):
             _sync_pipeline_decisions_to_contract(
                 repo_path=Path("/fake/repo"),
+                worktree_repo_path=Path("/fake/worktree"),
                 pipeline_id="test-pipeline",
             )
 
@@ -1193,11 +1195,68 @@ class TestSyncPipelineDecisionsToContract:
         ):
             _sync_pipeline_decisions_to_contract(
                 repo_path=Path("/fake/repo"),
+                worktree_repo_path=Path("/fake/worktree"),
                 pipeline_id="test-pipeline",
             )
 
         # All decisions deduplicated — save should not be called
         mock_save.assert_not_called()
+
+    def test_sync_routes_paths_to_state_store_and_contract_separately(self):
+        """Regression for #2345.
+
+        Pipeline records live under the orchestrator's main repo path; the
+        contract lives under the per-pipeline worktree.  Verify the helper
+        routes ``repo_path`` to ``get_state_store`` and
+        ``worktree_repo_path`` to ``load_contract`` / ``save_contract``.
+        """
+        from datetime import datetime
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from egg_contracts.models import Contract
+        from models import Pipeline
+        from routes.pipelines import _sync_pipeline_decisions_to_contract
+
+        pipeline = Pipeline(
+            id="test-pipeline",
+            repo="owner/repo",
+            decisions=[
+                self._make_pipeline_decision(
+                    question="Which database?",
+                    options=["PostgreSQL", "MongoDB"],
+                    decision_type="choice",
+                    status="resolved",
+                    resolution="PostgreSQL",
+                ),
+            ],
+        )
+        pipeline.decisions[0].resolved_at = datetime(2026, 4, 30, 4, 41, 11)
+
+        contract = Contract(pipeline_id="test-pipeline", decisions=[])
+
+        repo_path = Path("/home/egg/repos/egg")
+        worktree_repo_path = Path("/home/egg/.egg-worktrees/test-pipeline/egg")
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+
+        with (
+            patch("routes.pipelines.get_state_store", return_value=mock_store) as mock_get_store,
+            patch("egg_contracts.loader.load_contract", return_value=contract) as mock_load,
+            patch("egg_contracts.loader.save_contract") as mock_save,
+        ):
+            _sync_pipeline_decisions_to_contract(
+                repo_path=repo_path,
+                worktree_repo_path=worktree_repo_path,
+                pipeline_id="test-pipeline",
+            )
+
+        mock_get_store.assert_called_once_with(repo_path)
+        load_args, _ = mock_load.call_args
+        assert load_args[1] == worktree_repo_path
+        save_args, _ = mock_save.call_args
+        assert save_args[1] == worktree_repo_path
 
 
 class TestInlineRequestChangesStateReset:

--- a/orchestrator/tests/test_hitl_revision.py
+++ b/orchestrator/tests/test_hitl_revision.py
@@ -1077,7 +1077,6 @@ class TestSyncPipelineDecisionsToContract:
                 repo_path=Path("/fake/repo"),
                 worktree_repo_path=Path("/fake/worktree"),
                 pipeline_id="test-pipeline",
-                pipeline_mode="issue",
             )
 
         # --- Verify ---


### PR DESCRIPTION
## Summary

- `_sync_pipeline_decisions_to_contract` was loading the pipeline via `get_state_store(repo_path).load_pipeline(...)` where `repo_path` is the per-run worktree path. Pipeline records live under the orchestrator's main state store, not the worktree, so `load_pipeline` raised every time and the helper logged `Pipeline not found, skipping decision sync` and returned. Silent no-op for every issue-mode pipeline since #950.
- Visible only because `_handle_resolve_decision` writes resolutions inline to the contract during normal HITL flow. Out-of-band resolutions (`provide_input` on stale decisions, force-advance scenarios) and dropped inline writes are the cases this safety-net was supposed to cover.

## Fix

- Split the helper's single `repo_path` arg into `repo_path` (orchestrator-side, used for `get_state_store`) and `worktree_repo_path` (used for `load_contract` / `save_contract` since the contract lives under `<worktree>/.egg-state/contracts/`).
- Updated the single prod call site in `_run_pipeline` to pass both — `repo_path` was already in scope.
- Reworded the recovery-path warning to `decision_sync_pipeline_load_failed` with the resolved state-store path and exception text, per the issue's AC.

## Out of scope

The issue's "Adjacent" note (sweep `routes/pipelines.py` for other helpers with the same `repo_path`-conflated shape) is left for a follow-up — `_populate_contract_from_plan` is the most likely candidate but worth its own audit pass.

## Test plan

- [x] Added regression test `test_sync_routes_paths_to_state_store_and_contract_separately` asserting `get_state_store` is called with `repo_path` and contract I/O with `worktree_repo_path`.
- [x] Updated the three existing `test_sync_end_to_end_*` tests for the new signature (they already mocked the dependencies; just pass distinct paths now).
- [x] `make test` — 2106 passed.
- [x] `make lint` — clean.

Closes #2345.