### PR TITLE
Fix #2340: thread planner-authored pr.* into terminal slice's PR

### DIFF
--- a/docs/architecture/slice-dag.md
+++ b/docs/architecture/slice-dag.md
@@ -426,16 +426,59 @@ on the correct tracker.
 ## Stacked-PR creation
 
 `GatewayClient.create_slice_pr(pipeline_id, repo, *, slice_id, slice_name,
-slice_tasks, head, base, ...)` opens one PR per slice with:
+slice_tasks, head, base, program_title=None, program_description=None,
+program_test_plan=None, program_manual_steps=None,
+terminal_slice_id=None, ...)` opens one PR per slice with two body
+shapes:
 
-- **Title**: `"slice {slice_id}: {slice_name}"` truncated to 70 chars.
-- **Body**: the slice name, a bulleted list of tasks (each truncated to
-  300 chars), and a footer naming the slice ID, pipeline, and base.
+- **Non-terminal slices** (no `program_title`) — title is
+  `"slice {slice_id}: {slice_name}"` truncated to 70 chars; body lists
+  the slice's tasks (each truncated to 300 chars), optionally followed
+  by a one-line pointer to `terminal_slice_id` so reviewers can jump
+  to the umbrella PR; footer names the slice ID, pipeline, and base.
+- **Terminal slice** (`program_title` set, sourced from the planner's
+  `# yaml-tasks` `pr` block) — title is the human-authored
+  `contract.pr.title` (still capped to 70 chars); body opens with a
+  `> Program-level umbrella PR — terminal slice of pipeline …`
+  banner and renders `contract.pr.description` /
+  `pr.test_plan` (under `## Test Plan`) / `pr.manual_steps` (under
+  `## Manual Steps`) so the umbrella PR carries the program-level
+  reviewer narrative; the slice-context footer survives so the chain
+  position stays legible.
 
-The human-authored `pr.title` / `pr.description` / `pr.test_plan` block
-from the plan's `# yaml-tasks` remains the source of truth for the
-**terminal slice** (the chain's tip). Sibling roots and intermediate
-slices ship with the auto-generated copy.
+The implement-phase run loop (`_run_implement_phase_slices` in
+`orchestrator/routes/pipelines.py`) selects the terminal slice and
+threads the kwargs:
+
+1. Compute `depended_on = {dep for slice in contract.slices for dep in slice.dependencies}`.
+2. `terminal_ids = [s.id for s in contract.slices if s.id not in depended_on]`.
+3. `chosen_terminal = terminal_ids[-1]` (last in declared order — see
+   the multi-terminal forest note below).
+4. For the terminal slice: pass `program_*` from `contract.pr`,
+   `terminal_slice_id=None`.
+5. For every non-terminal slice: pass `program_*=None`,
+   `terminal_slice_id=chosen_terminal` **only if** `contract.pr.title`
+   is non-empty. When the contract has no program block (older
+   contracts, or `_populate_contract_from_plan` did not run), the
+   pointer is suppressed so reviewers are not directed to a PR with
+   no umbrella content.
+
+### Multi-terminal-forest pointer caveat
+
+The slice DAG is a forest (≤1 DAG parent per slice — see
+[Forest Validation](#plan-parser--forest-validation)) and a
+multi-tree forest can have multiple terminal slices, one per tree.
+The current behaviour picks `terminal_ids[-1]` (last declared) as
+`chosen_terminal` and points **every** non-terminal across **every**
+tree at it. This means non-terminal leaves in non-chosen trees carry
+a pointer to a PR that lives in a different subtree of the chain. The
+choice is deliberate (arbitrary but stable, deterministic across
+parallel slice runs) and matches the simplification the issue asks
+for, but operators reviewing a multi-tree pipeline should not be
+surprised by the cross-tree pointer. A future refinement could
+choose per-tree terminals and emit `terminal_slice_id` only within
+the slice's own tree; until then the umbrella PR remains a single
+roll-up at `chosen_terminal`.
 
 ## Stacked-PR rebase reconciler
 

--- a/docs/architecture/slice-dag.md
+++ b/docs/architecture/slice-dag.md
@@ -437,7 +437,7 @@ shapes:
   by a one-line pointer to `terminal_slice_id` so reviewers can jump
   to the umbrella PR; footer names the slice ID, pipeline, and base.
 - **Terminal slice** (`program_title` set, sourced from the planner's
-  `# yaml-tasks` `pr` block) — title is the human-authored
+  `# yaml-tasks` `pr` block) — title is the planner-authored
   `contract.pr.title` (still capped to 70 chars); body opens with a
   `> Program-level umbrella PR — terminal slice of pipeline …`
   banner and renders `contract.pr.description` /

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1211,37 +1211,88 @@ class GatewayClient:
         agent_role: str | None = None,
         mode: Literal["public", "private"] = "public",
         draft: bool = False,
+        program_title: str | None = None,
+        program_description: str | None = None,
+        program_test_plan: str | None = None,
+        program_manual_steps: str | None = None,
+        terminal_slice_id: str | None = None,
     ) -> str | None:
         """Open a PR for one slice in a stacked-PR chain.
 
-        Title is deterministic: ``slice {slice_id}: {slice_name}``
-        truncated to 70 chars (matches the existing PR-title
-        guidance). Body lists the slice's tasks as bullets, each
-        truncated to 300 chars per #2137 plan TASK-5-1. The
-        human-authored ``pr.title`` / ``pr.description`` /
-        ``pr.test_plan`` block from the plan's yaml-tasks remains
-        the source of truth for the *terminal* slice (the chain's
-        tip) — the implement phase aggregates it there. Sibling
-        roots and intermediate slices ship with the auto-generated
-        copy this helper produces.
+        Two body shapes:
+
+        * **Terminal slice** (caller passes ``program_title`` from the
+          contract's ``pr`` block): the PR carries the human-authored
+          title / description / test plan / manual steps the planner
+          authored, plus a banner marking it as the program-level
+          umbrella for the chain. This is the reviewer-facing
+          narrative for the whole pipeline.
+        * **Non-terminal slice** (no ``program_title``): deterministic
+          ``slice {slice_id}: {slice_name}`` title, bulleted task list
+          body. When ``terminal_slice_id`` is supplied, the body also
+          carries a pointer to the terminal slice so reviewers can
+          jump to the umbrella PR.
+
+        Both shapes always end with a footer naming the slice and the
+        branch it stacks onto, so the slice's role in the chain stays
+        legible in the PR view.
         """
-        title = f"slice {slice_id}: {slice_name}".strip()
+        has_program_block = bool(program_title and program_title.strip())
+
+        if has_program_block:
+            assert program_title is not None  # narrowed for the type checker
+            title = program_title.strip()
+        else:
+            title = f"slice {slice_id}: {slice_name}".strip()
         if len(title) > 70:
             title = title[:67] + "..."
 
-        body_lines: list[str] = [slice_name]
-        if slice_tasks:
+        body_lines: list[str] = []
+
+        if has_program_block:
+            body_lines.append(
+                f"> **Program-level umbrella PR — terminal slice of pipeline `{pipeline_id}`.**"
+            )
+            body_lines.append(
+                "> Roll-up of the slice-PR chain; the planner's narrative below covers "
+                "the whole program, not just this slice."
+            )
             body_lines.append("")
-            body_lines.append("Tasks in this slice:")
-            for task in slice_tasks:
-                desc = task.get("description") or task.get("id") or ""
-                desc = " ".join(desc.split())  # collapse whitespace
-                if len(desc) > 300:
-                    desc = desc[:297] + "..."
-                task_id = task.get("id") or ""
-                bullet_prefix = f"- {task_id}: " if task_id else "- "
-                body_lines.append(f"{bullet_prefix}{desc}")
-        body_lines.append("")
+            if program_description and program_description.strip():
+                body_lines.append(program_description.strip())
+                body_lines.append("")
+            if program_test_plan and program_test_plan.strip():
+                body_lines.append("## Test Plan")
+                body_lines.append("")
+                body_lines.append(program_test_plan.strip())
+                body_lines.append("")
+            if program_manual_steps and program_manual_steps.strip():
+                body_lines.append("## Manual Steps")
+                body_lines.append("")
+                body_lines.append(program_manual_steps.strip())
+                body_lines.append("")
+        else:
+            body_lines.append(slice_name)
+            if slice_tasks:
+                body_lines.append("")
+                body_lines.append("Tasks in this slice:")
+                for task in slice_tasks:
+                    desc = task.get("description") or task.get("id") or ""
+                    desc = " ".join(desc.split())  # collapse whitespace
+                    if len(desc) > 300:
+                        desc = desc[:297] + "..."
+                    task_id = task.get("id") or ""
+                    bullet_prefix = f"- {task_id}: " if task_id else "- "
+                    body_lines.append(f"{bullet_prefix}{desc}")
+            if terminal_slice_id:
+                body_lines.append("")
+                body_lines.append(
+                    f"Part of pipeline `{pipeline_id}`; the terminal slice "
+                    f"`{terminal_slice_id}`'s PR carries the program-level "
+                    "narrative (description, test plan, manual steps)."
+                )
+            body_lines.append("")
+
         body_lines.append(
             f"Slice {slice_id} of pipeline {pipeline_id}. Stacked on top of `{base}`."
         )

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1222,11 +1222,11 @@ class GatewayClient:
         Two body shapes:
 
         * **Terminal slice** (caller passes ``program_title`` from the
-          contract's ``pr`` block): the PR carries the human-authored
-          title / description / test plan / manual steps the planner
-          authored, plus a banner marking it as the program-level
-          umbrella for the chain. This is the reviewer-facing
-          narrative for the whole pipeline.
+          contract's ``pr`` block): the PR carries the planner-authored
+          title / description / test plan / manual steps, plus a
+          banner marking it as the program-level umbrella for the
+          chain. This is the reviewer-facing narrative for the whole
+          pipeline.
         * **Non-terminal slice** (no ``program_title``): deterministic
           ``slice {slice_id}: {slice_name}`` title, bulleted task list
           body. When ``terminal_slice_id`` is supplied, the body also

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1240,7 +1240,7 @@ class GatewayClient:
         has_program_block = bool(program_title and program_title.strip())
 
         if has_program_block:
-            assert program_title is not None  # narrowed for the type checker
+            assert program_title is not None  # implied by has_program_block
             title = program_title.strip()
         else:
             title = f"slice {slice_id}: {slice_name}".strip()

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -10960,9 +10960,15 @@ def _run_implement_phase_slices(
                             # lands on exactly one PR.  When the
                             # forest has multiple terminal slices we
                             # take the last one in declared order —
-                            # arbitrary but stable.
+                            # arbitrary but stable. For multi-tree
+                            # forests this means non-terminal slices
+                            # in non-chosen trees point at a leaf
+                            # outside their own subtree; see the
+                            # "Stacked-PR creation" section of
+                            # ``docs/architecture/slice-dag.md`` for
+                            # the rationale.
                             depended_on: set[str] = {
-                                dep for s in contract_post.slices for dep in (s.dependencies or [])
+                                dep for s in contract_post.slices for dep in s.dependencies
                             }
                             terminal_ids = [
                                 s.id for s in contract_post.slices if s.id not in depended_on
@@ -10970,6 +10976,26 @@ def _run_implement_phase_slices(
                             chosen_terminal = terminal_ids[-1] if terminal_ids else None
                             is_terminal = slice_id == chosen_terminal
                             program_pr = contract_post.pr if is_terminal else None
+                            # Only point non-terminal slices at the
+                            # terminal when the umbrella will actually
+                            # carry a program-level narrative.
+                            # ``create_slice_pr`` upgrades to the
+                            # human-authored shape only when
+                            # ``program_title`` is non-empty, so a
+                            # ``contract.pr`` with a missing/empty
+                            # title yields the auto-generated body on
+                            # the terminal — and the pointer would
+                            # mislead reviewers who follow it.
+                            umbrella_has_program_block = bool(
+                                contract_post.pr
+                                and contract_post.pr.title
+                                and contract_post.pr.title.strip()
+                            )
+                            terminal_pointer = (
+                                None
+                                if is_terminal or not umbrella_has_program_block
+                                else chosen_terminal
+                            )
                             slice_pr_data = {
                                 "slice_name": slice_obj.name or slice_id,
                                 "slice_tasks": [
@@ -10984,7 +11010,7 @@ def _run_implement_phase_slices(
                                 "program_manual_steps": (
                                     program_pr.manual_steps if program_pr else None
                                 ),
-                                "terminal_slice_id": (None if is_terminal else chosen_terminal),
+                                "terminal_slice_id": terminal_pointer,
                             }
                 except Exception as load_err:  # noqa: BLE001
                     logger.warning(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -10956,7 +10956,7 @@ def _run_implement_phase_slices(
                             # so non-terminal slices can point at it
                             # ("see <terminal-slice-id>'s PR for the
                             # umbrella narrative") and so the
-                            # human-authored ``contract.pr`` block
+                            # planner-authored ``contract.pr`` block
                             # lands on exactly one PR.  When the
                             # forest has multiple terminal slices we
                             # take the last one in declared order —
@@ -10980,7 +10980,7 @@ def _run_implement_phase_slices(
                             # terminal when the umbrella will actually
                             # carry a program-level narrative.
                             # ``create_slice_pr`` upgrades to the
-                            # human-authored shape only when
+                            # planner-authored shape only when
                             # ``program_title`` is non-empty, so a
                             # ``contract.pr`` with a missing/empty
                             # title yields the auto-generated body on

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -10950,12 +10950,41 @@ def _run_implement_phase_slices(
                             None,
                         )
                         if slice_obj is not None and pipeline.repo:
+                            # Identify the terminal slice(s) of the
+                            # forest: any slice no other slice lists
+                            # as a dependency. Pick a single terminal
+                            # so non-terminal slices can point at it
+                            # ("see <terminal-slice-id>'s PR for the
+                            # umbrella narrative") and so the
+                            # human-authored ``contract.pr`` block
+                            # lands on exactly one PR.  When the
+                            # forest has multiple terminal slices we
+                            # take the last one in declared order —
+                            # arbitrary but stable.
+                            depended_on: set[str] = {
+                                dep for s in contract_post.slices for dep in (s.dependencies or [])
+                            }
+                            terminal_ids = [
+                                s.id for s in contract_post.slices if s.id not in depended_on
+                            ]
+                            chosen_terminal = terminal_ids[-1] if terminal_ids else None
+                            is_terminal = slice_id == chosen_terminal
+                            program_pr = contract_post.pr if is_terminal else None
                             slice_pr_data = {
                                 "slice_name": slice_obj.name or slice_id,
                                 "slice_tasks": [
                                     {"id": t.id, "description": t.description}
                                     for t in (slice_obj.tasks or [])
                                 ],
+                                "program_title": (program_pr.title if program_pr else None),
+                                "program_description": (
+                                    program_pr.description if program_pr else None
+                                ),
+                                "program_test_plan": (program_pr.test_plan if program_pr else None),
+                                "program_manual_steps": (
+                                    program_pr.manual_steps if program_pr else None
+                                ),
+                                "terminal_slice_id": (None if is_terminal else chosen_terminal),
                             }
                 except Exception as load_err:  # noqa: BLE001
                     logger.warning(
@@ -10979,6 +11008,11 @@ def _run_implement_phase_slices(
                             issue_number=issue_number,
                             agent_role="coder",
                             mode=gateway_mode,  # type: ignore[arg-type]
+                            program_title=slice_pr_data["program_title"],
+                            program_description=slice_pr_data["program_description"],
+                            program_test_plan=slice_pr_data["program_test_plan"],
+                            program_manual_steps=slice_pr_data["program_manual_steps"],
+                            terminal_slice_id=slice_pr_data["terminal_slice_id"],
                         )
                     except Exception as pr_err:  # noqa: BLE001
                         logger.error(

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -1341,6 +1341,117 @@ class TestCreatePR:
             assert call_kwargs.kwargs.get("phase") == "pr" or call_kwargs[1].get("phase") == "pr"
 
 
+class TestCreateSlicePR:
+    """Body / title composition for create_slice_pr (#2340)."""
+
+    def _capture(self, gateway_client):
+        """Patch create_pr to capture (title, body) and return a dummy URL."""
+        captured: dict[str, str] = {}
+
+        def _fake_create_pr(*, title: str, body: str, **_kwargs: object) -> str:
+            captured["title"] = title
+            captured["body"] = body
+            return "https://example/pr/1"
+
+        return captured, patch.object(gateway_client, "create_pr", side_effect=_fake_create_pr)
+
+    def test_non_terminal_slice_uses_auto_generated_title_and_body(self, gateway_client):
+        """Without program_title the helper still emits the deterministic
+        ``slice <id>: <name>`` title and the bulleted task body."""
+        captured, ctx = self._capture(gateway_client)
+        with ctx:
+            gateway_client.create_slice_pr(
+                pipeline_id="issue-42",
+                repo="owner/repo",
+                slice_id="slice-1",
+                slice_name="Pattern adoption",
+                slice_tasks=[{"id": "task-1-1", "description": "Add the barrel re-export"}],
+                head="egg/issue-42/slice-1",
+                base="egg/issue-42",
+            )
+        assert captured["title"] == "slice slice-1: Pattern adoption"
+        assert "Pattern adoption" in captured["body"]
+        assert "Tasks in this slice:" in captured["body"]
+        assert "- task-1-1: Add the barrel re-export" in captured["body"]
+        assert "Slice slice-1 of pipeline issue-42" in captured["body"]
+        # No program-umbrella banner / pointer when neither field is set.
+        assert "Program-level umbrella PR" not in captured["body"]
+        assert "terminal slice" not in captured["body"]
+
+    def test_non_terminal_slice_with_terminal_pointer_includes_pointer_line(self, gateway_client):
+        """When ``terminal_slice_id`` is supplied (and program_title is not)
+        the body adds a pointer to the umbrella PR's slice without
+        upgrading to the human-authored shape."""
+        captured, ctx = self._capture(gateway_client)
+        with ctx:
+            gateway_client.create_slice_pr(
+                pipeline_id="issue-42",
+                repo="owner/repo",
+                slice_id="slice-1",
+                slice_name="Pattern adoption",
+                slice_tasks=None,
+                head="egg/issue-42/slice-1",
+                base="egg/issue-42",
+                terminal_slice_id="slice-3",
+            )
+        assert captured["title"] == "slice slice-1: Pattern adoption"
+        assert "`slice-3`" in captured["body"]
+        assert "program-level narrative" in captured["body"]
+        assert "Program-level umbrella PR" not in captured["body"]
+
+    def test_terminal_slice_uses_program_title_and_human_authored_body(self, gateway_client):
+        """When ``program_title`` is set the helper emits the human-authored
+        title + description / test plan / manual steps body, prefixed with
+        the umbrella banner so reviewers can tell the PR is program-level."""
+        captured, ctx = self._capture(gateway_client)
+        with ctx:
+            gateway_client.create_slice_pr(
+                pipeline_id="issue-42",
+                repo="owner/repo",
+                slice_id="slice-3",
+                slice_name="Apply the ratchet",
+                slice_tasks=[{"id": "task-3-1", "description": "Bump the allowlist"}],
+                head="egg/issue-42/slice-3",
+                base="egg/issue-42/slice-2",
+                program_title="Decompose oversize files; ratchet allowlist",
+                program_description="The lint added in #2250 caps Python files at 1500 lines.",
+                program_test_plan="- Automated: make lint and make test-all green.",
+                program_manual_steps="Pre-merge (terminal slice only): verify seam tables.",
+            )
+        assert captured["title"] == "Decompose oversize files; ratchet allowlist"
+        body = captured["body"]
+        assert "Program-level umbrella PR" in body
+        assert "issue-42" in body
+        assert "The lint added in #2250" in body
+        assert "## Test Plan" in body
+        assert "make lint" in body
+        assert "## Manual Steps" in body
+        assert "seam tables" in body
+        # Slice-context footer survives so reviewers still see chain position.
+        assert "Slice slice-3 of pipeline issue-42" in body
+        # No "see <terminal-slice-id>'s PR" pointer on the terminal PR itself.
+        assert "program-level narrative" not in body
+
+    def test_terminal_slice_truncates_long_program_title_to_70_chars(self, gateway_client):
+        """Title-length cap is symmetric for human-authored titles so the
+        existing PR-title guidance still holds."""
+        captured, ctx = self._capture(gateway_client)
+        long_title = "A" * 90
+        with ctx:
+            gateway_client.create_slice_pr(
+                pipeline_id="issue-42",
+                repo="owner/repo",
+                slice_id="slice-3",
+                slice_name="Tip",
+                slice_tasks=None,
+                head="egg/issue-42/slice-3",
+                base="egg/issue-42/slice-2",
+                program_title=long_title,
+            )
+        assert len(captured["title"]) == 70
+        assert captured["title"].endswith("...")
+
+
 class TestSelfIpResolution:
     """Tests for self_ip property used in temporary session registration."""
 

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -1381,7 +1381,7 @@ class TestCreateSlicePR:
     def test_non_terminal_slice_with_terminal_pointer_includes_pointer_line(self, gateway_client):
         """When ``terminal_slice_id`` is supplied (and program_title is not)
         the body adds a pointer to the umbrella PR's slice without
-        upgrading to the human-authored shape."""
+        upgrading to the planner-authored shape."""
         captured, ctx = self._capture(gateway_client)
         with ctx:
             gateway_client.create_slice_pr(
@@ -1399,8 +1399,8 @@ class TestCreateSlicePR:
         assert "program-level narrative" in captured["body"]
         assert "Program-level umbrella PR" not in captured["body"]
 
-    def test_terminal_slice_uses_program_title_and_human_authored_body(self, gateway_client):
-        """When ``program_title`` is set the helper emits the human-authored
+    def test_terminal_slice_uses_program_title_and_planner_authored_body(self, gateway_client):
+        """When ``program_title`` is set the helper emits the planner-authored
         title + description / test plan / manual steps body, prefixed with
         the umbrella banner so reviewers can tell the PR is program-level."""
         captured, ctx = self._capture(gateway_client)
@@ -1433,7 +1433,7 @@ class TestCreateSlicePR:
         assert "program-level narrative" not in body
 
     def test_terminal_slice_truncates_long_program_title_to_70_chars(self, gateway_client):
-        """Title-length cap is symmetric for human-authored titles so the
+        """Title-length cap is symmetric for planner-authored titles so the
         existing PR-title guidance still holds."""
         captured, ctx = self._capture(gateway_client)
         long_title = "A" * 90

--- a/orchestrator/tests/test_slice_run_loop_integration.py
+++ b/orchestrator/tests/test_slice_run_loop_integration.py
@@ -759,6 +759,60 @@ class TestRunImplementPhaseSlices:
             assert kwargs["program_manual_steps"] is None
             assert kwargs["terminal_slice_id"] == "slice-3"
 
+    def test_non_terminal_pointer_suppressed_when_contract_pr_missing(
+        self,
+    ) -> None:
+        """When ``contract.pr`` is missing (older contracts, or
+        ``_populate_contract_from_plan`` did not run), the umbrella PR
+        won't carry a program-level narrative — so non-terminal slices
+        must not point at it. Otherwise the pointer line "the terminal
+        slice <id>'s PR carries the program-level narrative" would
+        direct reviewers to a PR with the auto-generated body and no
+        narrative.
+        """
+        pipeline = _make_pipeline()
+        root = _make_slice("slice-1", tasks=[_make_task("task-1-1")])
+        middle = _make_slice("slice-2", deps=["slice-1"], tasks=[_make_task("task-2-1")])
+        terminal = _make_slice("slice-3", deps=["slice-2"], tasks=[_make_task("task-3-1")])
+        contract = _make_contract(slices=[root, middle, terminal])
+        contract.pr = None
+
+        with (
+            patch("egg_contracts.loader.load_contract", return_value=contract),
+            patch("egg_contracts.loader.save_contract"),
+            patch("routes.pipelines._start_stacked_pr_reconciler") as mock_start_recon,
+            patch("routes.pipelines._run_concurrent_phase", return_value=(0, "ok")),
+            patch("orchestrator.peer_consensus.remove_peer_consensus_tracker"),
+        ):
+            mock_start_recon.return_value = (MagicMock(), threading.Event())
+            spawner = self._make_spawner()
+            exit_code, _ = _run_implement_phase_slices(
+                pipeline_id=pipeline.id,
+                pipeline=pipeline,
+                spawner=spawner,
+                repo_volumes={},
+                gateway_mode="public",
+                repos=["owner/repo"],
+                sandbox_env={},
+                store=MagicMock(),
+                certs_volume=None,
+                worktree_repo_path=Path("/tmp/x"),
+            )
+        assert exit_code == 0
+        pr_calls_by_slice = {
+            c.kwargs["slice_id"]: c.kwargs for c in spawner.gateway.create_slice_pr.call_args_list
+        }
+        assert set(pr_calls_by_slice) == {"slice-1", "slice-2", "slice-3"}
+        # Every slice — terminal and non-terminal — gets None for the
+        # pointer when the umbrella has no program-level content.
+        for slice_id in ("slice-1", "slice-2", "slice-3"):
+            kwargs = pr_calls_by_slice[slice_id]
+            assert kwargs["program_title"] is None
+            assert kwargs["program_description"] is None
+            assert kwargs["program_test_plan"] is None
+            assert kwargs["program_manual_steps"] is None
+            assert kwargs["terminal_slice_id"] is None
+
     def test_single_slice_path_skips_pr_when_repo_unset(self) -> None:
         """If pipeline.repo is empty the loop must not attempt create_slice_pr."""
         pipeline = _make_pipeline()

--- a/orchestrator/tests/test_slice_run_loop_integration.py
+++ b/orchestrator/tests/test_slice_run_loop_integration.py
@@ -51,6 +51,7 @@ sys.modules.setdefault("docker.types", MagicMock())
 from egg_contracts.models import (  # noqa: E402
     Contract,
     IssueInfo,
+    PRMetadata,
     Slice,
     SliceStatus,
     Task,
@@ -689,6 +690,74 @@ class TestRunImplementPhaseSlices:
         assert fake_event.is_set(), "stop_event must be set on slice-loop exit"
         # Thread.join is invoked with a bounded timeout to avoid blocking.
         fake_thread.join.assert_called_once()
+
+    def test_terminal_slice_pr_carries_program_metadata_non_terminal_does_not(
+        self,
+    ) -> None:
+        """#2340: program-level ``contract.pr`` is threaded only into the
+        terminal slice's PR; non-terminal slices stay deterministic and
+        carry a pointer to the terminal slice's PR.
+
+        Forest: slice-1 (root) → slice-2 (intermediate) → slice-3 (terminal).
+        slice-3 is the unique slice no other slice depends on; it should
+        receive ``program_title`` / ``program_description`` /
+        ``program_test_plan`` / ``program_manual_steps`` from
+        ``contract.pr``. slice-1 and slice-2 should receive ``None`` for
+        each program-* kwarg and ``terminal_slice_id="slice-3"``.
+        """
+        pipeline = _make_pipeline()
+        root = _make_slice("slice-1", tasks=[_make_task("task-1-1")])
+        middle = _make_slice("slice-2", deps=["slice-1"], tasks=[_make_task("task-2-1")])
+        terminal = _make_slice("slice-3", deps=["slice-2"], tasks=[_make_task("task-3-1")])
+        contract = _make_contract(slices=[root, middle, terminal])
+        contract.pr = PRMetadata(
+            title="Decompose oversize files; ratchet allowlist",
+            description="The lint added in #2250 caps Python files at 1500 lines...",
+            test_plan="- Automated: make lint and make test-all green on every slice.",
+            manual_steps="Pre-merge (terminal slice only): verify seam tables.",
+        )
+
+        with (
+            patch("egg_contracts.loader.load_contract", return_value=contract),
+            patch("egg_contracts.loader.save_contract"),
+            patch("routes.pipelines._start_stacked_pr_reconciler") as mock_start_recon,
+            patch("routes.pipelines._run_concurrent_phase", return_value=(0, "ok")),
+            patch("orchestrator.peer_consensus.remove_peer_consensus_tracker"),
+        ):
+            mock_start_recon.return_value = (MagicMock(), threading.Event())
+            spawner = self._make_spawner()
+            exit_code, _ = _run_implement_phase_slices(
+                pipeline_id=pipeline.id,
+                pipeline=pipeline,
+                spawner=spawner,
+                repo_volumes={},
+                gateway_mode="public",
+                repos=["owner/repo"],
+                sandbox_env={},
+                store=MagicMock(),
+                certs_volume=None,
+                worktree_repo_path=Path("/tmp/x"),
+            )
+        assert exit_code == 0
+        pr_calls_by_slice = {
+            c.kwargs["slice_id"]: c.kwargs for c in spawner.gateway.create_slice_pr.call_args_list
+        }
+        assert set(pr_calls_by_slice) == {"slice-1", "slice-2", "slice-3"}
+
+        terminal_kwargs = pr_calls_by_slice["slice-3"]
+        assert terminal_kwargs["program_title"] == "Decompose oversize files; ratchet allowlist"
+        assert terminal_kwargs["program_description"].startswith("The lint added in #2250")
+        assert "make lint" in terminal_kwargs["program_test_plan"]
+        assert "seam tables" in terminal_kwargs["program_manual_steps"]
+        assert terminal_kwargs["terminal_slice_id"] is None
+
+        for non_terminal_id in ("slice-1", "slice-2"):
+            kwargs = pr_calls_by_slice[non_terminal_id]
+            assert kwargs["program_title"] is None
+            assert kwargs["program_description"] is None
+            assert kwargs["program_test_plan"] is None
+            assert kwargs["program_manual_steps"] is None
+            assert kwargs["terminal_slice_id"] == "slice-3"
 
     def test_single_slice_path_skips_pr_when_repo_unset(self) -> None:
         """If pipeline.repo is empty the loop must not attempt create_slice_pr."""


### PR DESCRIPTION
## Summary

- `GatewayClient.create_slice_pr` (`orchestrator/gateway_client.py`) now accepts `program_title` / `program_description` / `program_test_plan` / `program_manual_steps` / `terminal_slice_id` kwargs. When `program_title` is set the helper emits the planner-authored title and a description / test plan / manual steps body prefixed with a `> Program-level umbrella PR — terminal slice of pipeline …` banner; when `terminal_slice_id` is set on a non-terminal slice, the body adds a one-line pointer to that slice. Both shapes still end with the existing `Slice <id> of pipeline <id>. Stacked on top of <base>.` footer.
- The slice run loop (`orchestrator/routes/pipelines.py`) now identifies the forest's terminal slice (any slice no other slice depends on; multi-terminal forests pick the last declared, arbitrary but stable) and threads `contract.pr.*` into `create_slice_pr` for that slice. Non-terminal slices receive `terminal_slice_id` and `None` for the program-* fields, preserving today's deterministic copy.
- Closes #2340.

## Why

The helper's docstring claimed the implement phase aggregated the planner-authored `pr` block at the terminal slice, but no code did so — `create_slice_pr` had no parameter for it and the call site never read `contract.pr`. For multi-slice plans like #2261 the program-level reviewer narrative (description, cross-cutting test plan, manual steps) appeared in zero PRs even though `_populate_contract_from_plan` had populated it correctly on `contract.pr`.

## Test plan

- [x] New `TestRunImplementPhaseSlices.test_terminal_slice_pr_carries_program_metadata_non_terminal_does_not` exercises a 3-slice chain (slice-1 → slice-2 → slice-3): slice-3 receives `program_*` kwargs from `contract.pr`; slice-1 and slice-2 receive `terminal_slice_id="slice-3"` and `None` for program-*.
- [x] New `TestCreateSlicePR` in `test_gateway_client.py` covers the helper's body composition directly: auto-generated shape (no kwargs), pointer-line shape (`terminal_slice_id` only), planner-authored shape (`program_title` + body fields), and the 70-char title cap on long planner-authored titles.
- [x] `make lint` clean.
- [x] `.venv/bin/pytest orchestrator/tests/test_slice_run_loop_integration.py orchestrator/tests/test_gateway_client.py` — 112 passed.

## Adjacent

- Issue #2336 is the analogous problem on the legacy monolithic `_auto_create_pr` path; that helper already reads `contract.pr.*` via `_build_pr_body` so the legacy path is unaffected by this change.
- Issue #2337 (slice-DAG implement phase exits after slice-1) is a separate run-loop bug; this PR doesn't touch that codepath.
