### PR TITLE
Fix #2336: distinguish resolved vs open conditional-ACK obligations

### DIFF
--- a/docs/reference/conditional-ack.md
+++ b/docs/reference/conditional-ack.md
@@ -42,19 +42,34 @@ The same surface is available via the `mcp__brc__ack` MCP tool — pass `pre_mer
 
 A conditional NACK is rejected at the schema layer — the combination is nonsensical because NACK already blocks the producer, leaving nothing to defer.
 
+### Marking an obligation resolved within the PR (#2336)
+
+Obligations sometimes get satisfied inside the same PR's diff after the initial conditional ACK landed — for example, a reviewer attaches "verify the tester committed the patch-path rewrite" and the tester subsequently lands that commit. Re-ACK with `--pre-merge-condition-resolved-in-diff <sha>` to record the resolving commit:
+
+```bash
+egg-orch consensus ack tester issue-42 \
+  --files-reviewed tests/tools/_select_tests_helpers.py \
+  --reason "Patch-path rewrite is correct" \
+  --pre-merge-condition "Verify make test-all is green against the merged branch state" \
+  --pre-merge-condition-resolved-in-diff 2c319626a
+```
+
+The PR-body renderer demotes resolved obligations from the merge-blocking `## ⚠️ Pre-merge Obligations` section to a `## ✅ Resolved within this PR` subsection, with a link to the satisfying commit. The merge-blocking banner only fires when at least one obligation is still open. The flag requires `--pre-merge-condition`; a resolution SHA on a plain ACK is rejected at the boundary.
+
 ## How obligations are tracked
 
 - **Live tracker.** `record_ack` stores the condition on the approval-matrix edge for the current proposal version ([`orchestrator/approval_matrix.py`](../../orchestrator/approval_matrix.py)).
 - **Version scoping.** `get_pre_merge_conditions()` returns only conditions attached to each producer's *current* proposal version. If a producer re-proposes, the reviewer's prior conditional ACK is dropped until they re-attach the obligation to the new version.
-- **NACK clears it.** A NACK or `invalidate_ack` clears any condition on that edge — there is no such thing as a lingering conditional NACK.
-- **Contract persistence.** When the human approves obligations via the HITL gate, they are written to `contract.pr.deferred_actions` (`PRMetadata.deferred_actions`, a `list[str]`), so they survive tracker teardown between phase close and PR creation. The PR body renderer prefers this field over the live tracker.
+- **NACK clears it.** A NACK or `invalidate_ack` clears any condition (and any resolution SHA) on that edge — there is no such thing as a lingering conditional NACK.
+- **Resolution scoping.** A `--pre-merge-condition-resolved-in-diff` SHA travels with the obligation: it is cleared on NACK / re-propose / invalidate, and a re-ACK without the flag explicitly returns the obligation to the open list.
+- **Contract persistence.** When the human approves obligations via the HITL gate, they are written to `contract.pr.deferred_actions` (`PRMetadata.deferred_actions`, a `list[DeferredAction]`), so they survive tracker teardown between phase close and PR creation. Each entry carries `reviewer`, `condition`, and an optional `resolved_in_diff` SHA. Legacy `list[str]` entries from pre-#2336 contracts still load — they are coerced to `DeferredAction` with the reviewer parsed from the `<reviewer>: <condition>` prefix. The PR body renderer prefers this field over the live tracker.
 
 ## Where obligations surface
 
-- **`egg-orch consensus status`** — prints a `Pending pre-merge obligations:` subsection listing each `reviewer → producer: condition` line while the pipeline is still live. No subsection is printed when the list is empty.
-- **`complete_phase` HITL gate** — when any conditions are live, `complete_phase` queues a `choice` HITL decision before allowing the phase to close (see [HITL gate at phase completion](#hitl-gate-at-phase-completion)).
-- **Auto-created PR body** — a ⚠️-headed `## Pre-merge Obligations` section appears directly after the description, listing each active obligation so the merger sees it before scrolling to the diff.
-- **`CONSENSUS_ACK_RECEIVED` event** — the condition is included on the event payload and the `handle_ack` return value, so downstream consumers (e.g. HITL gates) can act on it.
+- **`egg-orch consensus status`** — prints a `Pending pre-merge obligations:` subsection for open obligations and a `Resolved within this PR:` subsection (with the satisfying SHA) for any that the reviewer marked resolved. No subsection is printed when its list is empty.
+- **`complete_phase` HITL gate** — when any obligations are live, `complete_phase` queues a `choice` HITL decision before allowing the phase to close (see [HITL gate at phase completion](#hitl-gate-at-phase-completion)). Resolution status is preserved through approval so the renderer downstream can demote resolved entries.
+- **Auto-created PR body** — a ⚠️-headed `## Pre-merge Obligations` section appears directly after the description, listing only **open** obligations so the merger sees actionable items before scrolling to the diff. Already-resolved obligations render under a ✅-headed `## Resolved within this PR` subsection that does not carry the merge-blocking banner.
+- **`CONSENSUS_ACK_RECEIVED` event** — the condition (and `pre_merge_condition_resolved_in_diff` when set) is included on the event payload and the `handle_ack` return value, so downstream consumers (e.g. HITL gates) can act on it.
 
 ## HITL gate at phase completion
 
@@ -79,12 +94,12 @@ The gate is skipped when `force=true` is passed to `complete_phase`, so operator
 
 ## Pointers
 
-- Schema: [`orchestrator/attestation_schemas.py`](../../orchestrator/attestation_schemas.py) — `ReviewPayload.pre_merge_condition`.
-- Matrix: [`orchestrator/approval_matrix.py`](../../orchestrator/approval_matrix.py) — `ApprovalEntry.pre_merge_condition`, `get_pre_merge_conditions()`.
+- Schema: [`orchestrator/attestation_schemas.py`](../../orchestrator/attestation_schemas.py) — `ReviewPayload.pre_merge_condition`, `ReviewPayload.pre_merge_condition_resolved_in_diff`.
+- Matrix: [`orchestrator/approval_matrix.py`](../../orchestrator/approval_matrix.py) — `ApprovalEntry.pre_merge_condition`, `ApprovalEntry.pre_merge_condition_resolved_in_diff`, `get_pre_merge_conditions()`.
 - Tracker: [`orchestrator/peer_consensus.py`](../../orchestrator/peer_consensus.py) — `handle_ack`, `get_pre_merge_conditions()`, `evaluate()`.
 - HITL gate: [`orchestrator/routes/phases.py`](../../orchestrator/routes/phases.py) — `_ensure_conditional_ack_gate`, `CONDITIONAL_ACK_OPTIONS`.
 - Gate dispatch: [`orchestrator/routes/decisions.py`](../../orchestrator/routes/decisions.py) — `_handle_conditional_ack_gate`.
 - PR body: [`orchestrator/routes/pipelines.py`](../../orchestrator/routes/pipelines.py) — `_build_pre_merge_obligations_section`.
-- Contract: [`shared/egg_contracts/models.py`](../../shared/egg_contracts/models.py) — `PRMetadata.deferred_actions`.
+- Contract: [`shared/egg_contracts/models.py`](../../shared/egg_contracts/models.py) — `PRMetadata.deferred_actions`, `DeferredAction`.
 - CLI: [`sandbox/egg_lib/orch_cli.py`](../../sandbox/egg_lib/orch_cli.py) — `cmd_consensus_ack`, `cmd_consensus_status`.
 - Related: [Concurrent Execution: Reviewer verdict variants](../guides/concurrent-execution.md#reviewer-verdict-variants), [HITL Decisions](../hitl-decisions.md), [Orchestrator CLI](orchestrator-cli.md), [Reviewer Sync](../../shared/prompts/REVIEWER-SYNC.md).

--- a/orchestrator/approval_matrix.py
+++ b/orchestrator/approval_matrix.py
@@ -39,6 +39,12 @@ class ApprovalEntry:
     # Optional human-facing obligation attached to a conditional ACK (#1998).
     # Empty string for unconditional ACKs. Cleared on NACK and on re-propose.
     pre_merge_condition: str = ""
+    # SHA that satisfied the obligation within the same PR's diff (#2336). When
+    # non-empty, the renderer demotes this entry from the merge-blocking
+    # "Pre-merge Obligations" section to a "Resolved within this PR"
+    # subsection — the obligation was met in-pipeline and the merger no longer
+    # needs to act. Cleared on NACK and on re-propose alongside the condition.
+    pre_merge_condition_resolved_in_diff: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -52,6 +58,7 @@ class ApprovalEntry:
             "timestamp": self.timestamp.isoformat() if self.timestamp else None,
             "ack_commit_sha": self.ack_commit_sha,
             "pre_merge_condition": self.pre_merge_condition,
+            "pre_merge_condition_resolved_in_diff": (self.pre_merge_condition_resolved_in_diff),
         }
 
 
@@ -98,6 +105,7 @@ class ApprovalMatrix:
         artifact_refs: list[str] | None = None,
         commit_sha: str = "",
         pre_merge_condition: str = "",
+        pre_merge_condition_resolved_in_diff: str = "",
     ) -> ApprovalEntry:
         """Record an ACK from a reviewer for a producer's proposal.
 
@@ -106,6 +114,14 @@ class ApprovalMatrix:
         old/path new/path`` before merging". Empty string means an
         unconditional ACK. The condition is scoped to this (reviewer, producer,
         version) edge and is cleared on NACK and re-propose.
+
+        ``pre_merge_condition_resolved_in_diff`` (optional, issue #2336) is the
+        commit SHA — typically observed by the reviewer between their initial
+        conditional ACK and a re-ACK on the current proposal — that satisfied
+        the obligation within the same PR's diff. When non-empty, the PR-body
+        renderer moves the obligation out of the merge-blocking section and
+        into a "Resolved within this PR" subsection. Only meaningful when
+        ``pre_merge_condition`` is also non-empty; ignored otherwise.
         """
         key = (reviewer, producer)
         entry = self._entries.get(key)
@@ -121,7 +137,14 @@ class ApprovalMatrix:
         entry.reason = ""
         entry.timestamp = datetime.now(UTC)
         entry.ack_commit_sha = commit_sha
-        entry.pre_merge_condition = (pre_merge_condition or "").strip()
+        normalized_condition = (pre_merge_condition or "").strip()
+        entry.pre_merge_condition = normalized_condition
+        # Resolution is meaningless without an obligation — drop it if the
+        # caller passes a SHA on a plain (non-conditional) ACK.
+        normalized_resolution = (pre_merge_condition_resolved_in_diff or "").strip()
+        entry.pre_merge_condition_resolved_in_diff = (
+            normalized_resolution if normalized_condition else ""
+        )
         return entry
 
     def record_nack(
@@ -147,6 +170,7 @@ class ApprovalMatrix:
         # A NACK supersedes any prior conditional ACK on this edge — the
         # producer must re-propose, so any deferred obligation is moot (#1998).
         entry.pre_merge_condition = ""
+        entry.pre_merge_condition_resolved_in_diff = ""
 
         # Increment revision count for this edge
         self._revision_counts[key] = self._revision_counts.get(key, 0) + 1
@@ -238,6 +262,7 @@ class ApprovalMatrix:
             # that ACK goes with it (#1998). The reviewer must re-ACK to
             # re-attach a condition if they still want one.
             entry.pre_merge_condition = ""
+            entry.pre_merge_condition_resolved_in_diff = ""
             return True
         return False
 
@@ -318,10 +343,13 @@ class ApprovalMatrix:
         dropped — the producer has re-proposed and the reviewer hasn't
         re-asserted the obligation on the new version.
 
-        Returns a list of dicts: ``{reviewer, producer, condition, version}``,
-        one per active conditional ACK. Callers (e.g. the PR-body builder,
-        HITL gate) surface these to humans so merge-time obligations aren't
-        silently dropped (#1998).
+        Returns a list of dicts: ``{reviewer, producer, condition, version,
+        resolved_in_diff}``, one per active conditional ACK. ``resolved_in_diff``
+        is the empty string for open obligations and the satisfying commit SHA
+        when the reviewer marked the obligation resolved within the same PR
+        (#2336). Callers (PR-body builder, HITL gate, live-status renderer)
+        use it to demote resolved obligations out of the merge-blocking
+        section.
         """
         conditions: list[dict[str, Any]] = []
         for (reviewer, producer), entry in self._entries.items():
@@ -340,6 +368,7 @@ class ApprovalMatrix:
                     "producer": producer,
                     "condition": entry.pre_merge_condition,
                     "version": entry.version,
+                    "resolved_in_diff": entry.pre_merge_condition_resolved_in_diff,
                 }
             )
         return conditions
@@ -409,6 +438,9 @@ class ApprovalMatrix:
                     ),
                     ack_commit_sha=entry_data.get("ack_commit_sha", ""),
                     pre_merge_condition=entry_data.get("pre_merge_condition", ""),
+                    pre_merge_condition_resolved_in_diff=entry_data.get(
+                        "pre_merge_condition_resolved_in_diff", ""
+                    ),
                 )
 
         for key_str, count in data.get("revision_counts", {}).items():

--- a/orchestrator/attestation_schemas.py
+++ b/orchestrator/attestation_schemas.py
@@ -170,6 +170,19 @@ class ReviewPayload(BaseModel):
             "an unconditional ACK."
         ),
     )
+    pre_merge_condition_resolved_in_diff: str = Field(
+        default="",
+        max_length=200,
+        description=(
+            "Optional commit SHA that satisfied ``pre_merge_condition`` within "
+            "the same PR's diff (issue #2336). Set this on a re-ACK when the "
+            "obligation has been met in-pipeline since your initial conditional "
+            "ACK — the PR-body renderer demotes resolved obligations out of "
+            "the merge-blocking section so reviewers don't see boilerplate "
+            "'do not merge' text on busywork. Only meaningful when "
+            "``pre_merge_condition`` is also non-empty."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_artifact_references(self) -> ReviewPayload:
@@ -198,6 +211,23 @@ class ReviewPayload(BaseModel):
             raise ValueError(
                 "pre_merge_condition is only valid on ACK verdicts (conditional ACK); "
                 "NACK already blocks the producer"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_resolution_requires_condition(self) -> ReviewPayload:
+        """Reject a resolution SHA without an accompanying obligation.
+
+        ``pre_merge_condition_resolved_in_diff`` only makes sense when the ACK
+        also carries a ``pre_merge_condition`` to resolve (#2336). A resolution
+        SHA on a plain ACK has nothing to attach to and would be silently
+        dropped downstream — fail loudly at the boundary instead.
+        """
+        if self.pre_merge_condition_resolved_in_diff and not self.pre_merge_condition:
+            raise ValueError(
+                "pre_merge_condition_resolved_in_diff requires a non-empty "
+                "pre_merge_condition; a resolution SHA has nothing to resolve "
+                "on a plain ACK"
             )
         return self
 

--- a/orchestrator/attestation_schemas.py
+++ b/orchestrator/attestation_schemas.py
@@ -173,6 +173,7 @@ class ReviewPayload(BaseModel):
     pre_merge_condition_resolved_in_diff: str = Field(
         default="",
         max_length=200,
+        pattern=r"^[A-Fa-f0-9]{0,200}$",
         description=(
             "Optional commit SHA that satisfied ``pre_merge_condition`` within "
             "the same PR's diff (issue #2336). Set this on a re-ACK when the "
@@ -180,7 +181,8 @@ class ReviewPayload(BaseModel):
             "ACK — the PR-body renderer demotes resolved obligations out of "
             "the merge-blocking section so reviewers don't see boilerplate "
             "'do not merge' text on busywork. Only meaningful when "
-            "``pre_merge_condition`` is also non-empty."
+            "``pre_merge_condition`` is also non-empty. Hex-only to prevent "
+            "newline injection bending the rendered PR-body markdown."
         ),
     )
 

--- a/orchestrator/peer_consensus.py
+++ b/orchestrator/peer_consensus.py
@@ -435,6 +435,7 @@ class PeerConsensusTracker:
                 artifact_refs=review.artifact_references,
                 commit_sha=proposal_commit_sha,
                 pre_merge_condition=review.pre_merge_condition,
+                pre_merge_condition_resolved_in_diff=(review.pre_merge_condition_resolved_in_diff),
             )
 
             # Transition reviewer to REVIEWING
@@ -455,8 +456,11 @@ class PeerConsensusTracker:
             # Use the normalized value (record_ack strips whitespace) so the
             # event stream is consistent with persisted matrix state.
             normalized_condition = (review.pre_merge_condition or "").strip()
+            normalized_resolution = (review.pre_merge_condition_resolved_in_diff or "").strip()
             if normalized_condition:
                 event_data["pre_merge_condition"] = normalized_condition
+                if normalized_resolution:
+                    event_data["pre_merge_condition_resolved_in_diff"] = normalized_resolution
 
             emit_event(
                 EventType.CONSENSUS_ACK_RECEIVED,
@@ -474,6 +478,8 @@ class PeerConsensusTracker:
             }
             if normalized_condition:
                 result["pre_merge_condition"] = normalized_condition
+                if normalized_resolution:
+                    result["pre_merge_condition_resolved_in_diff"] = normalized_resolution
             return result
 
     def handle_nack(

--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -241,7 +241,7 @@ def _persist_deferred_actions(
             load_contract,
             save_contract,
         )
-        from egg_contracts.models import PRMetadata
+        from egg_contracts.models import DeferredAction, PRMetadata
     except ImportError:
         logger.warning(
             "egg_contracts unavailable; cannot persist deferred_actions",
@@ -267,14 +267,21 @@ def _persist_deferred_actions(
         )
         return
 
-    new_lines: list[str] = []
+    new_actions: list[DeferredAction] = []
     for c in conditions:
         reviewer = str(c.get("reviewer", "")).strip() or "unknown"
         condition = str(c.get("condition", "")).strip()
         if not condition:
             continue
-        new_lines.append(f"{reviewer}: {condition}")
-    if not new_lines:
+        resolved_in_diff = str(c.get("resolved_in_diff", "")).strip()
+        new_actions.append(
+            DeferredAction(
+                reviewer=reviewer,
+                condition=condition,
+                resolved_in_diff=resolved_in_diff,
+            )
+        )
+    if not new_actions:
         return
 
     # PR metadata may be absent (e.g. on babysit pipelines with
@@ -285,12 +292,20 @@ def _persist_deferred_actions(
             title=(contract.issue.title if contract.issue else "Pipeline deferred actions"),
         )
 
-    existing = set(contract.pr.deferred_actions)
-    merged = list(contract.pr.deferred_actions)
-    for line in new_lines:
-        if line not in existing:
-            merged.append(line)
-            existing.add(line)
+    # Dedupe by (reviewer, condition) so re-resolving the same gate doesn't
+    # double-list. A later call that adds a ``resolved_in_diff`` for an
+    # already-persisted obligation upgrades the existing entry in place.
+    merged: list[DeferredAction] = list(contract.pr.deferred_actions)
+    by_key: dict[tuple[str, str], DeferredAction] = {(a.reviewer, a.condition): a for a in merged}
+    for action in new_actions:
+        key = (action.reviewer, action.condition)
+        existing = by_key.get(key)
+        if existing is None:
+            merged.append(action)
+            by_key[key] = action
+        elif action.resolved_in_diff and not existing.resolved_in_diff:
+            # Upgrade open → resolved; preserve list ordering.
+            existing.resolved_in_diff = action.resolved_in_diff
     contract.pr.deferred_actions = merged
 
     try:

--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -295,6 +295,18 @@ def _persist_deferred_actions(
     # Dedupe by (reviewer, condition) so re-resolving the same gate doesn't
     # double-list. A later call that adds a ``resolved_in_diff`` for an
     # already-persisted obligation upgrades the existing entry in place.
+    #
+    # Dedup is intentionally one-way (#2336 review):
+    #   - SHA-replaces-SHA: an existing resolution is *not* overwritten
+    #     by a later resolution for the same ``(reviewer, condition)``.
+    #     Once a reviewer marks an obligation resolved, the recorded SHA
+    #     is sticky.
+    #   - Resolved → open downgrade: a later open-only entry does *not*
+    #     clear ``resolved_in_diff``. This matches the pre-existing
+    #     append-only design of contract-persisted obligations (#2004).
+    # Both cases are edge cases driven by NACK / re-propose / reviewer
+    # re-ACK cycles; the live tracker remains the source of truth for
+    # in-flight state and is preferred by the renderer at Tier 2.
     merged: list[DeferredAction] = list(contract.pr.deferred_actions)
     by_key: dict[tuple[str, str], DeferredAction] = {(a.reviewer, a.condition): a for a in merged}
     for action in new_actions:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7388,14 +7388,21 @@ def _format_obligation_bullet(
 ) -> list[str]:
     """Format a single obligation as a markdown bullet (multi-line aware)."""
     reviewer = obligation["reviewer"] or "unknown"
-    condition = obligation["condition"]
+    # ``strip()`` before splitlines so a leading/trailing newline doesn't
+    # produce an empty first line ("- **reviewer** — " with nothing after the
+    # em-dash). The collector filters whitespace-only conditions but a
+    # ``"\nreal text"`` value would otherwise slip through with an empty
+    # first line (#2336 review).
+    condition = obligation["condition"].strip()
     first, *rest = condition.splitlines()
     bullet = f"- **{reviewer}** — {first}"
     lines = [bullet]
     for extra in rest:
         lines.append(f"  {extra}")
     if resolved and obligation["resolved_in_diff"]:
-        lines.append(f"  - Resolved in `{obligation['resolved_in_diff']}`")
+        # Bare SHA (no backticks) so GitHub auto-links it to the commit page
+        # in the rendered PR body — code-span text is not auto-linked.
+        lines.append(f"  - Resolved in {obligation['resolved_in_diff']}")
     return lines
 
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7236,47 +7236,117 @@ def _persist_phase_brc_history(
 
 def _build_pre_merge_obligations_section(
     pipeline_id: str,
-    contract_deferred_actions: list[str] | None = None,
+    contract_deferred_actions: list[Any] | None = None,
 ) -> str:
     """Render the "Pre-merge Obligations" section from active conditional ACKs.
 
     Two sources, in order of preference:
 
-    1. ``contract_deferred_actions`` — strings previously persisted to
-       ``contract.pr.deferred_actions`` when a human approved the
-       conditional-ACK HITL gate (#2004). This is the durable path:
-       the tracker may have been torn down by the time PR creation
-       runs, and the contract survives.
+    1. ``contract_deferred_actions`` — ``DeferredAction`` objects (or legacy
+       strings) previously persisted to ``contract.pr.deferred_actions`` when
+       a human approved the conditional-ACK HITL gate (#2004). This is the
+       durable path: the tracker may have been torn down by the time PR
+       creation runs, and the contract survives.
     2. The live consensus tracker (#1998). Used when the contract has
        no deferred_actions — either because the gate landed before
        tracker teardown, or the gate was never required.
 
-    Returns an empty string if neither source yields conditions, so
-    callers can unconditionally append the result to the PR body.
+    Each obligation is classified as **open** or **resolved** (#2336):
+
+    * Open obligations (no ``resolved_in_diff``) render under a merge-blocking
+      "Pre-merge Obligations" banner — a human must act before merging.
+    * Resolved obligations (the reviewer marked them satisfied within the same
+      PR's diff) render under a "Resolved within this PR" subsection with a
+      pointer to the satisfying commit. They do not block merge.
+
+    Returns an empty string if neither source yields obligations, so callers
+    can unconditionally append the result to the PR body.
     """
-    # Tier 1 — contract.pr.deferred_actions (persisted across teardown).
+    obligations = _collect_pre_merge_obligations(pipeline_id, contract_deferred_actions)
+    if not obligations:
+        return ""
+
+    open_obligations = [o for o in obligations if not o["resolved_in_diff"]]
+    resolved_obligations = [o for o in obligations if o["resolved_in_diff"]]
+
+    sections: list[str] = []
+
+    if open_obligations:
+        lines: list[str] = [
+            "## ⚠️ Pre-merge Obligations",
+            "",
+            "The reviewers below issued a **conditional ACK** — the work is "
+            "approved, but a human must perform the listed action before "
+            "merging. Do **not** merge this PR until every obligation is "
+            "complete.",
+            "",
+        ]
+        for o in open_obligations:
+            lines.extend(_format_obligation_bullet(o, resolved=False))
+        sections.append("\n".join(lines))
+
+    if resolved_obligations:
+        # When the only obligations on the PR are already-satisfied ones, this
+        # subsection stands on its own — there's no "do not merge" banner to
+        # contradict (#2336). Reviewers still get a record of what was
+        # promised and what diff resolved it.
+        lines = [
+            "## ✅ Resolved within this PR",
+            "",
+            "The reviewers below issued a **conditional ACK** and later "
+            "marked the obligation satisfied within this PR's diff. Listed "
+            "for the audit trail; no merge action required.",
+            "",
+        ]
+        for o in resolved_obligations:
+            lines.extend(_format_obligation_bullet(o, resolved=True))
+        sections.append("\n".join(lines))
+
+    return "\n\n".join(sections)
+
+
+def _collect_pre_merge_obligations(
+    pipeline_id: str,
+    contract_deferred_actions: list[Any] | None,
+) -> list[dict[str, str]]:
+    """Normalize obligations from contract or live tracker into a uniform shape.
+
+    Returns a list of ``{reviewer, condition, resolved_in_diff}`` dicts. The
+    contract source takes precedence over the live tracker when present.
+    """
     if contract_deferred_actions:
-        bullets = []
+        normalized: list[dict[str, str]] = []
         for entry in contract_deferred_actions:
-            text = entry.strip()
-            if not text:
+            # ``DeferredAction`` (Pydantic) — the post-#2336 shape.
+            reviewer = getattr(entry, "reviewer", None)
+            condition = getattr(entry, "condition", None)
+            resolved = getattr(entry, "resolved_in_diff", None)
+            if condition is None and isinstance(entry, str):
+                # Defensive: a caller passed a legacy string list directly
+                # without going through the field validator (e.g. a unit test
+                # that constructs the input by hand). Parse it the same way
+                # the validator would.
+                text = entry.strip()
+                if not text:
+                    continue
+                head, sep, tail = text.partition(": ")
+                if sep and tail.strip():
+                    reviewer, condition = head.strip(), tail.strip()
+                else:
+                    reviewer, condition = "", text
+                resolved = ""
+            condition_text = (condition or "").strip()
+            if not condition_text:
                 continue
-            first, *rest = text.splitlines()
-            bullets.append(f"- {first}")
-            bullets.extend(f"  {line}" for line in rest)
-        if bullets:
-            return "\n".join(
-                [
-                    "## ⚠️ Pre-merge Obligations",
-                    "",
-                    "The reviewers below issued a **conditional ACK** — the "
-                    "work is approved, but a human must perform the listed "
-                    "action before merging. Do **not** merge this PR until "
-                    "every obligation is complete.",
-                    "",
-                    *bullets,
-                ]
+            normalized.append(
+                {
+                    "reviewer": (reviewer or "").strip(),
+                    "condition": condition_text,
+                    "resolved_in_diff": (resolved or "").strip(),
+                }
             )
+        if normalized:
+            return normalized
 
     # Tier 2 — live tracker (pre-#2004 path; kept so conditions still
     # render if the HITL gate hasn't resolved yet, e.g. under force=true).
@@ -7286,7 +7356,7 @@ def _build_pre_merge_obligations_section(
         from ..peer_consensus import get_peer_consensus_tracker  # type: ignore[import-not-found]
     tracker = get_peer_consensus_tracker(pipeline_id)
     if tracker is None:
-        return ""
+        return []
     try:
         conditions = tracker.get_pre_merge_conditions()
     except Exception as e:  # defensive — never block PR creation on this
@@ -7295,35 +7365,38 @@ def _build_pre_merge_obligations_section(
             pipeline_id=pipeline_id,
             error=str(e),
         )
-        return ""
-    if not conditions:
-        return ""
+        return []
 
-    lines = [
-        "## ⚠️ Pre-merge Obligations",
-        "",
-        "The reviewers below issued a **conditional ACK** — the work is "
-        "approved, but a human must perform the listed action before "
-        "merging. Do **not** merge this PR until every obligation is "
-        "complete.",
-        "",
-    ]
+    normalized = []
     for c in conditions:
-        reviewer = c.get("reviewer", "unknown")
         condition = str(c.get("condition", "")).strip()
         if not condition:
             continue
-        # Indent multi-line conditions under the bullet so they stay
-        # visually grouped in rendered markdown.
-        first, *rest = condition.splitlines()
-        lines.append(f"- **{reviewer}** — {first}")
-        for extra in rest:
-            lines.append(f"  {extra}")
-    # If every condition was whitespace-only, no bullets were added — return
-    # empty to avoid rendering a header with zero items (#1998 review).
-    if len(lines) == 4:
-        return ""
-    return "\n".join(lines)
+        normalized.append(
+            {
+                "reviewer": str(c.get("reviewer", "") or "").strip(),
+                "condition": condition,
+                "resolved_in_diff": str(c.get("resolved_in_diff", "") or "").strip(),
+            }
+        )
+    return normalized
+
+
+def _format_obligation_bullet(
+    obligation: dict[str, str],
+    resolved: bool,
+) -> list[str]:
+    """Format a single obligation as a markdown bullet (multi-line aware)."""
+    reviewer = obligation["reviewer"] or "unknown"
+    condition = obligation["condition"]
+    first, *rest = condition.splitlines()
+    bullet = f"- **{reviewer}** — {first}"
+    lines = [bullet]
+    for extra in rest:
+        lines.append(f"  {extra}")
+    if resolved and obligation["resolved_in_diff"]:
+        lines.append(f"  - Resolved in `{obligation['resolved_in_diff']}`")
+    return lines
 
 
 def _build_brc_history_link_line(
@@ -7453,7 +7526,7 @@ def _build_pr_body(
     pr_description: str | None = None
     pr_test_plan: str = ""
     pr_manual_steps: str = ""
-    pr_deferred_actions: list[str] = []
+    pr_deferred_actions: list[Any] = []
     issue_title: str | None = None
     plan_draft_warnings: list[str] = []
     plan_draft_path: str | None = None
@@ -8466,6 +8539,13 @@ def _build_brc_preamble(
                 '--pre-merge-condition "A human must `git mv legacy/x '
                 'new/x` before merging — agents cannot push renames through"\n'
                 "   ```\n"
+                "\n"
+                "   If an obligation you attached earlier was satisfied "
+                "within the same PR's diff (e.g. another producer landed the "
+                "commit you required), re-ACK with "
+                "`--pre-merge-condition-resolved-in-diff <sha>` so the "
+                "PR-body renderer demotes it to a 'Resolved within this PR' "
+                "subsection instead of a merge-blocker (#2336).\n"
                 "\n"
                 "   `--reason` must be ≥50 chars of substantive content. "
                 "Boilerplate like 'lgtm' or 'no issues' will be rejected.\n"

--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -1189,6 +1189,19 @@ def handle_consensus_ack_signal(
         if condition_error:
             return make_error_response(condition_error, 400)
 
+    # A resolution SHA without an obligation has nothing to resolve (#2336);
+    # reject at the boundary so downstream code can assume the invariant.
+    pre_merge_condition_resolved_in_diff = (
+        payload.get("pre_merge_condition_resolved_in_diff") or ""
+    ).strip()
+    if pre_merge_condition_resolved_in_diff and not pre_merge_condition:
+        return make_error_response(
+            "pre_merge_condition_resolved_in_diff requires a non-empty "
+            "pre_merge_condition; a resolution SHA has nothing to resolve "
+            "on a plain ACK",
+            400,
+        )
+
     try:
         from peer_consensus import get_peer_consensus_tracker
     except ImportError:

--- a/orchestrator/tests/test_brc_content_validation.py
+++ b/orchestrator/tests/test_brc_content_validation.py
@@ -872,6 +872,39 @@ class TestAckPreMergeConditionValidation:
         assert status_code == 200
         tracker.handle_ack.assert_called_once()
 
+    def test_resolution_without_condition_returns_400(self, app):
+        """A resolution SHA on a plain ACK is rejected at the boundary (#2336).
+
+        ``handle_consensus_ack_signal`` rejects the request with HTTP 400
+        before reaching the tracker so the invariant downstream code relies
+        on (resolution implies obligation) is enforced at the perimeter.
+        """
+        response, status_code, tracker = self._ack_with_payload(
+            app,
+            {
+                "reason": _SUBSTANTIVE_REASON,
+                "pre_merge_condition_resolved_in_diff": "abc1234",
+            },
+        )
+        assert status_code == 400
+        data = json.loads(response.data)
+        assert "pre_merge_condition_resolved_in_diff" in data["message"]
+        assert "requires" in data["message"]
+        tracker.handle_ack.assert_not_called()
+
+    def test_resolution_with_condition_passes(self, app):
+        """Resolution SHA alongside an obligation passes through to the tracker (#2336)."""
+        _, status_code, tracker = self._ack_with_payload(
+            app,
+            {
+                "reason": _SUBSTANTIVE_REASON,
+                "pre_merge_condition": _SUBSTANTIVE_CONDITION,
+                "pre_merge_condition_resolved_in_diff": "abc1234",
+            },
+        )
+        assert status_code == 200
+        tracker.handle_ack.assert_called_once()
+
 
 # ============================================================================
 # Handler integration tests — NACK

--- a/orchestrator/tests/test_conditional_ack.py
+++ b/orchestrator/tests/test_conditional_ack.py
@@ -61,6 +61,35 @@ class TestReviewPayloadCondition:
                 pre_merge_condition="do something",
             )
 
+    def test_resolution_without_condition_rejected(self):
+        """A resolution SHA on a plain ACK has nothing to attach to (#2336)."""
+        with pytest.raises(ValueError, match="requires a non-empty"):
+            ReviewPayload(
+                verdict="ACK",
+                artifact_references=["src/a.py"],
+                pre_merge_condition_resolved_in_diff="abc1234",
+            )
+
+    def test_resolution_with_condition_accepted(self):
+        """A resolution SHA alongside an obligation is the supported shape (#2336)."""
+        payload = ReviewPayload(
+            verdict="ACK",
+            artifact_references=["src/a.py"],
+            pre_merge_condition="verify migration in prod",
+            pre_merge_condition_resolved_in_diff="abc1234",
+        )
+        assert payload.pre_merge_condition_resolved_in_diff == "abc1234"
+
+    def test_resolution_rejects_non_hex_characters(self):
+        """SHA shape validation prevents newline injection bending PR markdown (#2336)."""
+        with pytest.raises(ValueError):
+            ReviewPayload(
+                verdict="ACK",
+                artifact_references=["src/a.py"],
+                pre_merge_condition="verify migration in prod",
+                pre_merge_condition_resolved_in_diff="abc1234\n## Injected heading",
+            )
+
 
 # --- Matrix ----------------------------------------------------------------
 

--- a/orchestrator/tests/test_conditional_ack_hitl_gate.py
+++ b/orchestrator/tests/test_conditional_ack_hitl_gate.py
@@ -453,6 +453,7 @@ class TestPrRenderPrefersContract:
     """PR body renderer tier-1 is contract.pr.deferred_actions (#2004)."""
 
     def test_contract_lines_take_precedence_over_tracker(self, graph):
+        from egg_contracts.models import DeferredAction
         from routes import pipelines as p
 
         tracker = _make_tracker(graph, condition="stale tracker-only condition")
@@ -463,11 +464,17 @@ class TestPrRenderPrefersContract:
         ):
             section = p._build_pre_merge_obligations_section(
                 "pipeline-x",
-                contract_deferred_actions=["reviewer_code: git mv durable/X new/X"],
+                contract_deferred_actions=[
+                    DeferredAction(
+                        reviewer="reviewer_code",
+                        condition="git mv durable/X new/X",
+                    )
+                ],
             )
 
         assert "Pre-merge Obligations" in section
-        assert "reviewer_code: git mv durable/X new/X" in section
+        assert "reviewer_code" in section
+        assert "git mv durable/X new/X" in section
         # Tracker-only condition must not appear — contract wins.
         assert "stale tracker-only condition" not in section
 
@@ -515,3 +522,266 @@ class TestPrRenderPrefersContract:
             section = p._build_pre_merge_obligations_section("pipeline-x")
 
         assert "git mv foo bar" in section
+
+    def test_legacy_string_entries_still_render(self):
+        """Pre-#2336 contracts persisted ``list[str]``; renderer still loads them."""
+        from routes import pipelines as p
+
+        with patch(
+            "peer_consensus.get_peer_consensus_tracker",
+            return_value=None,
+        ):
+            section = p._build_pre_merge_obligations_section(
+                "pipeline-x",
+                contract_deferred_actions=["reviewer_code: git mv durable/X new/X"],
+            )
+
+        assert "Pre-merge Obligations" in section
+        # Legacy string is parsed into reviewer + condition and rendered with
+        # the same bullet shape as a structured DeferredAction.
+        assert "reviewer_code" in section
+        assert "git mv durable/X new/X" in section
+
+
+class TestPrRenderResolvedObligations:
+    """Resolved obligations move out of the merge-blocking section (#2336)."""
+
+    def test_resolved_obligation_renders_under_resolved_section_only(self):
+        from egg_contracts.models import DeferredAction
+        from routes import pipelines as p
+
+        with patch(
+            "peer_consensus.get_peer_consensus_tracker",
+            return_value=None,
+        ):
+            section = p._build_pre_merge_obligations_section(
+                "pipeline-x",
+                contract_deferred_actions=[
+                    DeferredAction(
+                        reviewer="reviewer_code",
+                        condition="git mv legacy/x new/x before merge",
+                        resolved_in_diff="2c319626a",
+                    )
+                ],
+            )
+
+        # All-resolved → no merge-blocking banner anywhere.
+        assert "Pre-merge Obligations" not in section
+        assert "Do **not** merge" not in section
+        # Resolved subsection present, with SHA pointer.
+        assert "Resolved within this PR" in section
+        assert "git mv legacy/x new/x" in section
+        assert "2c319626a" in section
+
+    def test_mixed_open_and_resolved_renders_both_sections(self):
+        from egg_contracts.models import DeferredAction
+        from routes import pipelines as p
+
+        with patch(
+            "peer_consensus.get_peer_consensus_tracker",
+            return_value=None,
+        ):
+            section = p._build_pre_merge_obligations_section(
+                "pipeline-x",
+                contract_deferred_actions=[
+                    DeferredAction(
+                        reviewer="reviewer_code",
+                        condition="open obligation X",
+                    ),
+                    DeferredAction(
+                        reviewer="reviewer_contract",
+                        condition="resolved obligation Y",
+                        resolved_in_diff="abc1234",
+                    ),
+                ],
+            )
+
+        # Open section + banner.
+        assert "## ⚠️ Pre-merge Obligations" in section
+        assert "Do **not** merge" in section
+        assert "open obligation X" in section
+        # Resolved section.
+        assert "## ✅ Resolved within this PR" in section
+        assert "resolved obligation Y" in section
+        assert "abc1234" in section
+        # Open section appears first (merge-blocking is the higher-priority
+        # signal for the merger).
+        assert section.find("## ⚠️ Pre-merge Obligations") < section.find(
+            "## ✅ Resolved within this PR"
+        )
+
+    def test_resolved_via_live_tracker(self, graph):
+        """Tier-2 (live tracker) also surfaces resolutions (#2336)."""
+        from routes import pipelines as p
+
+        tracker = PeerConsensusTracker("pipeline-x", graph, cooldown_seconds=0)
+        tracker.register_agent("coder")
+        tracker.register_agent("reviewer_code")
+        tracker.register_agent("reviewer_contract")
+        tracker.handle_propose(
+            "coder",
+            {"summary": "impl", "artifacts": ["src/a.py"], "commit_sha": "abc"},
+        )
+        tracker.handle_ack(
+            "reviewer_code",
+            "coder",
+            {
+                "artifact_references": ["src/a.py"],
+                "pre_merge_condition": "verify tester landed patch-path rewrite",
+                "pre_merge_condition_resolved_in_diff": "2c319626a",
+            },
+        )
+
+        with patch(
+            "peer_consensus.get_peer_consensus_tracker",
+            return_value=tracker,
+        ):
+            section = p._build_pre_merge_obligations_section(
+                "pipeline-x",
+                contract_deferred_actions=[],
+            )
+
+        assert "Resolved within this PR" in section
+        assert "2c319626a" in section
+        assert "Pre-merge Obligations" not in section
+
+
+class TestApprovalMatrixResolvedField:
+    """ApprovalEntry round-trips ``pre_merge_condition_resolved_in_diff`` (#2336)."""
+
+    def test_record_ack_stores_resolution(self, graph):
+        from approval_matrix import ApprovalMatrix
+
+        matrix = ApprovalMatrix(graph)
+        version = matrix.record_proposal("coder")
+        entry = matrix.record_ack(
+            "reviewer_code",
+            "coder",
+            version,
+            artifact_refs=["src/a.py"],
+            pre_merge_condition="verify migration in prod",
+            pre_merge_condition_resolved_in_diff="abc1234",
+        )
+        assert entry.pre_merge_condition == "verify migration in prod"
+        assert entry.pre_merge_condition_resolved_in_diff == "abc1234"
+
+    def test_resolution_dropped_without_condition(self, graph):
+        """A resolution SHA on a plain ACK has nothing to attach to."""
+        from approval_matrix import ApprovalMatrix
+
+        matrix = ApprovalMatrix(graph)
+        version = matrix.record_proposal("coder")
+        entry = matrix.record_ack(
+            "reviewer_code",
+            "coder",
+            version,
+            artifact_refs=["src/a.py"],
+            pre_merge_condition="",
+            pre_merge_condition_resolved_in_diff="abc1234",
+        )
+        assert entry.pre_merge_condition == ""
+        assert entry.pre_merge_condition_resolved_in_diff == ""
+
+    def test_nack_clears_resolution(self, graph):
+        from approval_matrix import ApprovalMatrix
+
+        matrix = ApprovalMatrix(graph)
+        version = matrix.record_proposal("coder")
+        matrix.record_ack(
+            "reviewer_code",
+            "coder",
+            version,
+            artifact_refs=["src/a.py"],
+            pre_merge_condition="verify migration in prod",
+            pre_merge_condition_resolved_in_diff="abc1234",
+        )
+        matrix.record_nack(
+            "reviewer_code",
+            "coder",
+            version,
+            reason="found a bug",
+            artifact_refs=["src/a.py"],
+        )
+        entry = matrix._entries[("reviewer_code", "coder")]
+        assert entry.pre_merge_condition == ""
+        assert entry.pre_merge_condition_resolved_in_diff == ""
+
+    def test_get_pre_merge_conditions_includes_resolution(self, graph):
+        from approval_matrix import ApprovalMatrix
+
+        matrix = ApprovalMatrix(graph)
+        version = matrix.record_proposal("coder")
+        matrix.record_ack(
+            "reviewer_code",
+            "coder",
+            version,
+            artifact_refs=["src/a.py"],
+            pre_merge_condition="verify migration in prod",
+            pre_merge_condition_resolved_in_diff="abc1234",
+        )
+        conditions = matrix.get_pre_merge_conditions()
+        assert len(conditions) == 1
+        assert conditions[0]["resolved_in_diff"] == "abc1234"
+
+    def test_serialization_round_trip_preserves_resolution(self, graph):
+        from approval_matrix import ApprovalMatrix
+
+        matrix = ApprovalMatrix(graph)
+        version = matrix.record_proposal("coder")
+        matrix.record_ack(
+            "reviewer_code",
+            "coder",
+            version,
+            artifact_refs=["src/a.py"],
+            pre_merge_condition="verify migration in prod",
+            pre_merge_condition_resolved_in_diff="abc1234",
+        )
+        data = matrix.to_dict()
+        # Carry proposal_versions through so the from_dict re-hydration
+        # can answer "what's the latest version?".
+        data.setdefault("proposal_versions", {"coder": version})
+        restored = ApprovalMatrix.from_dict(data, graph)
+        entry = restored._entries[("reviewer_code", "coder")]
+        assert entry.pre_merge_condition_resolved_in_diff == "abc1234"
+
+
+class TestDeferredActionLegacyMigration:
+    """``PRMetadata.deferred_actions`` accepts legacy ``list[str]`` input (#2336)."""
+
+    def test_legacy_string_promoted_to_deferred_action(self):
+        from egg_contracts.models import PRMetadata
+
+        meta = PRMetadata(
+            title="t",
+            deferred_actions=["reviewer_code: git mv legacy/x new/x"],
+        )
+        assert len(meta.deferred_actions) == 1
+        action = meta.deferred_actions[0]
+        assert action.reviewer == "reviewer_code"
+        assert action.condition == "git mv legacy/x new/x"
+        assert action.resolved_in_diff == ""
+
+    def test_structured_input_passes_through(self):
+        from egg_contracts.models import DeferredAction, PRMetadata
+
+        meta = PRMetadata(
+            title="t",
+            deferred_actions=[
+                DeferredAction(
+                    reviewer="reviewer_code",
+                    condition="verify migration",
+                    resolved_in_diff="abc1234",
+                )
+            ],
+        )
+        assert meta.deferred_actions[0].resolved_in_diff == "abc1234"
+
+    def test_legacy_string_without_separator_treated_as_unknown_reviewer(self):
+        from egg_contracts.models import PRMetadata
+
+        meta = PRMetadata(
+            title="t",
+            deferred_actions=["raw obligation text with no reviewer prefix"],
+        )
+        assert meta.deferred_actions[0].reviewer == ""
+        assert meta.deferred_actions[0].condition == ("raw obligation text with no reviewer prefix")

--- a/sandbox/egg_agent_tools/handlers/brc.py
+++ b/sandbox/egg_agent_tools/handlers/brc.py
@@ -205,6 +205,13 @@ def brc_ack(req: dict[str, Any]) -> dict[str, Any]:
             as a dedicated "Pre-merge Obligations" section on the auto-created
             PR so the merger sees it instead of skimming past a prose note in
             the ACK reason (#1998).
+        pre_merge_condition_resolved_in_diff (str): optional commit SHA. Set
+            on a re-ACK when ``pre_merge_condition`` has been satisfied within
+            the same PR's diff since the initial conditional ACK — the PR-body
+            renderer demotes resolved obligations to a "Resolved within this
+            PR" subsection so reviewers don't see merge-blocking boilerplate
+            on busywork (#2336). Only meaningful alongside a non-empty
+            ``pre_merge_condition``.
         pipeline_id, role: overrides.
     """
     pid = _require_pipeline_id(req)
@@ -225,6 +232,9 @@ def brc_ack(req: dict[str, Any]) -> dict[str, Any]:
     pre_merge_condition = req.get("pre_merge_condition") or ""
     if pre_merge_condition:
         payload["pre_merge_condition"] = pre_merge_condition
+        resolved_in_diff = req.get("pre_merge_condition_resolved_in_diff") or ""
+        if resolved_in_diff:
+            payload["pre_merge_condition_resolved_in_diff"] = resolved_in_diff
 
     data = {
         "signal_type": "consensus_ack",

--- a/sandbox/egg_agent_tools/handlers/brc.py
+++ b/sandbox/egg_agent_tools/handlers/brc.py
@@ -230,11 +230,14 @@ def brc_ack(req: dict[str, Any]) -> dict[str, Any]:
         "ack_version": ack_version,
     }
     pre_merge_condition = req.get("pre_merge_condition") or ""
+    resolved_in_diff = req.get("pre_merge_condition_resolved_in_diff") or ""
+    # Thread both fields through unconditionally so the signal-layer
+    # validator can reject a resolution-without-condition request rather
+    # than silently dropping the SHA at the MCP boundary (#2336 review).
     if pre_merge_condition:
         payload["pre_merge_condition"] = pre_merge_condition
-        resolved_in_diff = req.get("pre_merge_condition_resolved_in_diff") or ""
-        if resolved_in_diff:
-            payload["pre_merge_condition_resolved_in_diff"] = resolved_in_diff
+    if resolved_in_diff:
+        payload["pre_merge_condition_resolved_in_diff"] = resolved_in_diff
 
     data = {
         "signal_type": "consensus_ack",

--- a/sandbox/egg_agent_tools/tools/brc.py
+++ b/sandbox/egg_agent_tools/tools/brc.py
@@ -101,6 +101,18 @@ _ACK_SCHEMA: dict[str, Any] = {
                 "auto-created PR. Leave empty for an unconditional ACK."
             ),
         },
+        "pre_merge_condition_resolved_in_diff": {
+            "type": "string",
+            "description": (
+                "Optional commit SHA (issue #2336). Set this on a re-ACK "
+                "when the obligation in `pre_merge_condition` has been "
+                "satisfied within the same PR's diff since your initial "
+                "conditional ACK — the PR-body renderer demotes resolved "
+                "obligations from the merge-blocking section to a "
+                "'Resolved within this PR' subsection. Only meaningful "
+                "alongside a non-empty `pre_merge_condition`."
+            ),
+        },
         "pipeline_id": {"type": "string"},
         "role": {"type": "string"},
     },

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -2260,13 +2260,26 @@ def cmd_consensus_ack(args: argparse.Namespace) -> int:
 
     pid = require_pipeline_id(args)
     role = _require_role(args)
+    pre_merge_condition = getattr(args, "pre_merge_condition", "") or ""
+    pre_merge_condition_resolved_in_diff = (
+        getattr(args, "pre_merge_condition_resolved_in_diff", "") or ""
+    )
+    if pre_merge_condition_resolved_in_diff and not pre_merge_condition:
+        print(
+            "error: --pre-merge-condition-resolved-in-diff requires "
+            "--pre-merge-condition; a resolution SHA has nothing to resolve "
+            "on a plain ACK",
+            file=sys.stderr,
+        )
+        return 2
     req = {
         "pipeline_id": pid,
         "role": role,
         "producer_role": args.producer_role,
         "reason": args.reason,
         "files_reviewed": list(args.files_reviewed or []),
-        "pre_merge_condition": getattr(args, "pre_merge_condition", "") or "",
+        "pre_merge_condition": pre_merge_condition,
+        "pre_merge_condition_resolved_in_diff": pre_merge_condition_resolved_in_diff,
         "ack_version": args.ack_version,
     }
     try:
@@ -2282,9 +2295,14 @@ def cmd_consensus_ack(args: argparse.Namespace) -> int:
         print_json(resp.get("signal", {}))
         return 0
     if req["pre_merge_condition"]:
+        suffix = (
+            f"; resolved in {req['pre_merge_condition_resolved_in_diff']}"
+            if req["pre_merge_condition_resolved_in_diff"]
+            else ""
+        )
         print(
             f"Conditional ACK sent by {role} for {args.producer_role} "
-            f"(obligation: {req['pre_merge_condition']})"
+            f"(obligation: {req['pre_merge_condition']}{suffix})"
         )
     else:
         print(f"ACK sent by {role} for {args.producer_role}")
@@ -2434,12 +2452,23 @@ def cmd_consensus_status(args: argparse.Namespace) -> int:
 
     conditions = consensus.get("pre_merge_conditions") or []
     if conditions:
-        print("\nPending pre-merge obligations:")
-        for cond in conditions:
-            reviewer = cond.get("reviewer", "?")
-            producer = cond.get("producer", "?")
-            text = cond.get("condition", "")
-            print(f"  {reviewer} → {producer}: {text}")
+        open_conditions = [c for c in conditions if not (c.get("resolved_in_diff") or "")]
+        resolved_conditions = [c for c in conditions if (c.get("resolved_in_diff") or "")]
+        if open_conditions:
+            print("\nPending pre-merge obligations:")
+            for cond in open_conditions:
+                reviewer = cond.get("reviewer", "?")
+                producer = cond.get("producer", "?")
+                text = cond.get("condition", "")
+                print(f"  {reviewer} → {producer}: {text}")
+        if resolved_conditions:
+            print("\nResolved within this PR:")
+            for cond in resolved_conditions:
+                reviewer = cond.get("reviewer", "?")
+                producer = cond.get("producer", "?")
+                text = cond.get("condition", "")
+                sha = cond.get("resolved_in_diff", "")
+                print(f"  {reviewer} → {producer}: {text} [resolved in {sha}]")
 
     return 0
 
@@ -3074,6 +3103,19 @@ def create_parser() -> argparse.ArgumentParser:
             "approved but the named action must be performed by a human "
             "before merging (e.g. 'git mv old/path new/path'). Surfaces as "
             "a Pre-merge Obligations section on the auto-created PR."
+        ),
+    )
+    cons_ack.add_argument(
+        "--pre-merge-condition-resolved-in-diff",
+        dest="pre_merge_condition_resolved_in_diff",
+        default="",
+        help=(
+            "Optional: commit SHA that satisfied --pre-merge-condition within "
+            "the same PR's diff (#2336). Use on a re-ACK when the obligation "
+            "has been met in-pipeline since the initial conditional ACK — the "
+            "PR-body renderer moves the obligation out of the merge-blocking "
+            "section and into a 'Resolved within this PR' subsection. Requires "
+            "--pre-merge-condition."
         ),
     )
     _add_json_flag(cons_ack)

--- a/sandbox/tests/test_brc_cli_args.py
+++ b/sandbox/tests/test_brc_cli_args.py
@@ -153,6 +153,73 @@ class TestAckConditionalFlag:
         assert args.pre_merge_condition == "A human must `git mv legacy/x new/x` before merge"
 
 
+class TestAckResolvedInDiffFlag:
+    """--pre-merge-condition-resolved-in-diff marks an obligation resolved (#2336)."""
+
+    def test_resolved_in_diff_defaults_to_empty(self):
+        """Omitting the flag yields an empty resolution (still open)."""
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "consensus",
+                "ack",
+                "coder",
+                "issue-42",
+                "--files-reviewed",
+                "src/a.py",
+                "--reason",
+                "All looks good, reviewed a.py and confirmed auth flow is correct",
+                "--ack-version",
+                "1",
+            ]
+        )
+        assert getattr(args, "pre_merge_condition_resolved_in_diff", "") == ""
+
+    def test_resolved_in_diff_parses(self):
+        """--pre-merge-condition-resolved-in-diff captures the resolving SHA."""
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "consensus",
+                "ack",
+                "coder",
+                "issue-42",
+                "--files-reviewed",
+                "src/a.py",
+                "--reason",
+                "Re-ACK after the tester landed the patch-path commit",
+                "--pre-merge-condition",
+                "Verify tester landed patch-path rewrite before merge",
+                "--pre-merge-condition-resolved-in-diff",
+                "2c319626a",
+                "--ack-version",
+                "2",
+            ]
+        )
+        assert args.pre_merge_condition_resolved_in_diff == "2c319626a"
+
+    def test_resolved_without_condition_exits_2(self, capsys):
+        """A resolution SHA on a plain ACK is rejected with exit code 2 (#2336)."""
+        from egg_lib.orch_cli import cmd_consensus_ack
+
+        args = argparse.Namespace(
+            pipeline_id="issue-42",
+            role="reviewer_code",
+            producer_role="coder",
+            reason="Reviewed src/a.py: logic is correct, tests cover all branches",
+            files_reviewed=["src/a.py"],
+            ack_version=1,
+            pre_merge_condition="",
+            pre_merge_condition_resolved_in_diff="abc1234",
+            json=False,
+        )
+        rc = cmd_consensus_ack(args)
+        captured = capsys.readouterr()
+        assert rc == 2
+        assert "--pre-merge-condition-resolved-in-diff" in captured.err
+        assert "requires" in captured.err
+
+
 # ---------------------------------------------------------------------------
 # ACK/NACK: --ack-version / --nack-version are required (#2142)
 # ---------------------------------------------------------------------------

--- a/sandbox/tests/test_consensus_status_render.py
+++ b/sandbox/tests/test_consensus_status_render.py
@@ -101,3 +101,111 @@ class TestStatusRendersConditions:
         out = capsys.readouterr().out
         assert rc == 0
         assert "Pending pre-merge obligations" not in out
+
+
+class TestStatusRendersResolvedSubsection:
+    """``Resolved within this PR:`` subsection covers #2336 reviewer-resolved obligations."""
+
+    def test_resolved_only_renders_resolved_subsection(self, capsys):
+        """All-resolved should not print a Pending subsection."""
+        fake_state = {
+            "consensus": {
+                "is_complete": True,
+                "agents": {
+                    "coder": {"producer_phase": "CONFIRMED", "confirmed": True},
+                    "reviewer_code": {"reviewer_phase": "CONFIRMED", "confirmed": True},
+                },
+                "blocking_agents": [],
+                "pre_merge_conditions": [
+                    {
+                        "reviewer": "reviewer_code",
+                        "producer": "coder",
+                        "condition": "verify tester landed patch-path rewrite",
+                        "version": 2,
+                        "resolved_in_diff": "2c319626a",
+                    }
+                ],
+            }
+        }
+        with patch(
+            "egg_agent_tools.handlers.brc.brc_get_state",
+            return_value=fake_state,
+        ):
+            rc = cmd_consensus_status(_make_args())
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Resolved within this PR:" in out
+        assert "verify tester landed patch-path rewrite" in out
+        assert "2c319626a" in out
+        assert "Pending pre-merge obligations:" not in out
+
+    def test_mixed_open_and_resolved_renders_both_subsections(self, capsys):
+        """Both subsections appear when the tracker carries a mix (#2336)."""
+        fake_state = {
+            "consensus": {
+                "is_complete": False,
+                "agents": {
+                    "coder": {"producer_phase": "CONFIRMED", "confirmed": True},
+                    "reviewer_code": {"reviewer_phase": "CONFIRMED", "confirmed": True},
+                },
+                "blocking_agents": [],
+                "pre_merge_conditions": [
+                    {
+                        "reviewer": "reviewer_code",
+                        "producer": "coder",
+                        "condition": "open obligation X",
+                        "version": 1,
+                    },
+                    {
+                        "reviewer": "reviewer_contract",
+                        "producer": "coder",
+                        "condition": "resolved obligation Y",
+                        "version": 1,
+                        "resolved_in_diff": "abc1234",
+                    },
+                ],
+            }
+        }
+        with patch(
+            "egg_agent_tools.handlers.brc.brc_get_state",
+            return_value=fake_state,
+        ):
+            rc = cmd_consensus_status(_make_args())
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Pending pre-merge obligations:" in out
+        assert "open obligation X" in out
+        assert "Resolved within this PR:" in out
+        assert "resolved obligation Y" in out
+        assert "abc1234" in out
+
+    def test_empty_string_resolution_treated_as_open(self, capsys):
+        """An empty-string ``resolved_in_diff`` keeps the obligation in the Pending bucket."""
+        fake_state = {
+            "consensus": {
+                "is_complete": False,
+                "agents": {
+                    "coder": {"producer_phase": "CONFIRMED", "confirmed": True},
+                },
+                "blocking_agents": [],
+                "pre_merge_conditions": [
+                    {
+                        "reviewer": "reviewer_code",
+                        "producer": "coder",
+                        "condition": "still-open obligation",
+                        "version": 1,
+                        "resolved_in_diff": "",
+                    }
+                ],
+            }
+        }
+        with patch(
+            "egg_agent_tools.handlers.brc.brc_get_state",
+            return_value=fake_state,
+        ):
+            rc = cmd_consensus_status(_make_args())
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Pending pre-merge obligations:" in out
+        assert "still-open obligation" in out
+        assert "Resolved within this PR:" not in out

--- a/shared/egg_contracts/__init__.py
+++ b/shared/egg_contracts/__init__.py
@@ -149,6 +149,7 @@ from .models import (
     Decision,
     DecisionOption,
     DecisionType,
+    DeferredAction,
     Feedback,
     FeedbackQuestion,
     HumanReviewMechanism,
@@ -246,6 +247,7 @@ __all__ = [
     "Decision",
     "DecisionOption",
     "DecisionType",
+    "DeferredAction",
     "HumanReviewMechanism",
     "PhaseConfig",
     # Roles

--- a/shared/egg_contracts/models.py
+++ b/shared/egg_contracts/models.py
@@ -340,12 +340,14 @@ class DeferredAction(BaseModel):
     resolved_in_diff: str = Field(
         default="",
         max_length=200,
+        pattern=r"^[A-Fa-f0-9]{0,200}$",
         description=(
             "Commit SHA that satisfied the obligation within the same PR's "
             "diff. Empty string means the obligation is still open and will "
             "render under the merge-blocking 'Pre-merge Obligations' section. "
             "When non-empty, the obligation moves to a 'Resolved within this "
-            "PR' subsection (#2336)."
+            "PR' subsection (#2336). Hex-only to prevent newline injection "
+            "bending the rendered PR-body markdown."
         ),
     )
 

--- a/shared/egg_contracts/models.py
+++ b/shared/egg_contracts/models.py
@@ -318,6 +318,38 @@ class Decision(BaseModel):
     debounce_until: datetime | None = Field(default=None, description="Debounce expiration")
 
 
+class DeferredAction(BaseModel):
+    """A single pre-merge obligation persisted from a conditional ACK.
+
+    Replaces the free-form ``list[str]`` shape used in #2004 so the renderer
+    can distinguish open obligations (which still merge-block) from
+    obligations the reviewer marked resolved within the same PR's diff
+    (#2336). Legacy ``list[str]`` entries still load — see the field
+    validator on ``PRMetadata.deferred_actions``.
+    """
+
+    reviewer: str = Field(
+        default="",
+        description="Reviewer role that issued the conditional ACK (may be empty for legacy entries).",
+    )
+    condition: str = Field(
+        ...,
+        min_length=1,
+        description="The obligation text the reviewer attached to their ACK.",
+    )
+    resolved_in_diff: str = Field(
+        default="",
+        max_length=200,
+        description=(
+            "Commit SHA that satisfied the obligation within the same PR's "
+            "diff. Empty string means the obligation is still open and will "
+            "render under the merge-blocking 'Pre-merge Obligations' section. "
+            "When non-empty, the obligation moves to a 'Resolved within this "
+            "PR' subsection (#2336)."
+        ),
+    )
+
+
 class PRMetadata(BaseModel):
     """Planner-generated PR metadata: title, description, test plan, and manual steps."""
 
@@ -331,17 +363,49 @@ class PRMetadata(BaseModel):
         default="",
         description="Manual pre/post-merge steps (migrations, config changes, etc.)",
     )
-    deferred_actions: list[str] = Field(
+    deferred_actions: list[DeferredAction] = Field(
         default_factory=list,
         description=(
             "Durable record of pre-merge obligations from conditional ACKs "
-            "(#1998/#2004). Each entry is a human-readable line (e.g. "
-            "'reviewer_code: git mv legacy/x new/x'). Written when the 3-way "
-            "HITL gate at complete_phase resolves as approve+accept, so "
-            "obligations survive tracker teardown between phase close and "
-            "PR creation."
+            "(#1998/#2004/#2336). Written when the 3-way HITL gate at "
+            "complete_phase resolves as approve+accept, so obligations "
+            "survive tracker teardown between phase close and PR creation. "
+            "Each entry carries the reviewer, the obligation text, and an "
+            "optional ``resolved_in_diff`` SHA when the reviewer marked the "
+            "obligation satisfied within the same PR's diff."
         ),
     )
+
+    @field_validator("deferred_actions", mode="before")
+    @classmethod
+    def _coerce_legacy_deferred_actions(cls, value: Any) -> Any:
+        """Accept legacy ``list[str]`` shape (#2004) by promoting to ``DeferredAction``.
+
+        Pre-#2336 contracts persisted obligations as ``"<reviewer>: <condition>"``
+        strings. Treat those as open obligations with the reviewer parsed
+        from the prefix when present.
+        """
+        if not isinstance(value, list):
+            return value
+        coerced: list[Any] = []
+        for entry in value:
+            if isinstance(entry, str):
+                # Legacy format: "<reviewer>: <condition>". Split on first
+                # ": " to recover the reviewer; fall back to the whole string
+                # as ``condition`` if no separator is present.
+                reviewer, sep, condition = entry.partition(": ")
+                if sep and condition.strip():
+                    coerced.append(
+                        {
+                            "reviewer": reviewer.strip(),
+                            "condition": condition.strip(),
+                        }
+                    )
+                elif entry.strip():
+                    coerced.append({"reviewer": "", "condition": entry.strip()})
+            else:
+                coerced.append(entry)
+        return coerced
 
 
 class CheckDefinition(BaseModel):

--- a/shared/prompts/code-review-criteria.md
+++ b/shared/prompts/code-review-criteria.md
@@ -89,6 +89,8 @@ Concurrent BRC reviewers can attach `--pre-merge-condition "…"` to an ACK to r
 - **NACK** — blocking issues the producer can address. Examples: a logic bug, a missing test for a regression, a security flaw, a broken end-to-end path. Do **not** downgrade a NACK into a conditional ACK to unblock the pipeline — a conditional ACK is not a soft NACK. If the producer could fix it, NACK instead.
 - **Plain ACK with non-blocking note** — the work is correct and merge-safe as-is. Optional suggestions (style nits, naming ideas, defense-in-depth additions) belong under a "Non-blocking" subsection of the `--reason`, not as a pre-merge condition.
 
+If an obligation you attached earlier gets satisfied within the same PR's diff (e.g. another producer lands the commit you required), re-ACK with `--pre-merge-condition-resolved-in-diff <sha>`. The PR-body renderer demotes resolved obligations to a "Resolved within this PR" subsection so the merger does not see merge-blocking boilerplate on busywork (#2336). Do **not** delete the obligation by re-ACKing with an empty `--pre-merge-condition` to "tidy up" — the resolution-in-diff field is the audit trail.
+
 This section is BRC-only. PR reviewers and sequential SDLC reviewers have no conditional-ACK analogue (see `REVIEWER-SYNC.md`).
 
 ### Skip


### PR DESCRIPTION
## Summary

- Adds `pre_merge_condition_resolved_in_diff` end-to-end so reviewers can mark a conditional-ACK obligation as satisfied within the same PR's diff.
- The PR-body renderer now splits obligations: `## ⚠️ Pre-merge Obligations` (with the merge-block banner) for open ones, `## ✅ Resolved within this PR` (no merge-block banner, links the satisfying commit) for resolved ones. The banner only fires when at least one is still open.
- Persists structured `DeferredAction` objects to `contract.pr.deferred_actions`, with a `field_validator` that loads legacy `list[str]` contracts.

Closes #2336.

## Why

Reviewers had no slot to record "this got satisfied" — see PR #2335, where the reviewer typed `(Status: tester landed commit 2c319626a satisfying this — manual re-verification before merge still required.)` *inside the condition string*. The renderer transcribed the whole thing under a "Do **not** merge" banner — turning busywork into apparent merge blockers.

## Design choice

Picked the resolution-flag shape over the prerequisite/merge-verification split. Rationale: PR #2335's actual obligation mixes both kinds in one sentence, so forcing reviewers to pre-classify into two slots makes the schema fight reality. A resolution flag is orthogonal to obligation kind, and a future structural split can layer on top.

Resolution comes from the reviewer at re-ACK time — they're the source of truth for "this got satisfied," and the orchestrator just records and renders without semantic interpretation. CLI/tool boundary rejects a resolution SHA without an accompanying obligation; the schema enforces the same invariant via a Pydantic `model_validator`.

## What changed

**Schema/persistence**
- `orchestrator/approval_matrix.py` — ApprovalEntry gains the new field; `record_ack` accepts it; NACK / invalidate / re-propose clear it alongside the condition.
- `orchestrator/attestation_schemas.py` — `ReviewPayload` field + validator (resolution requires a condition).
- `orchestrator/peer_consensus.py` — threads through to ApprovalMatrix and onto the `CONSENSUS_ACK_RECEIVED` event + `handle_ack` return.
- `orchestrator/routes/signals.py` — boundary validation in `handle_consensus_ack_signal`.
- `shared/egg_contracts/models.py` — new `DeferredAction` Pydantic model; `PRMetadata.deferred_actions` becomes `list[DeferredAction]` with a `field_validator` that accepts legacy `list[str]` entries (parses the `<reviewer>: <condition>` prefix).
- `orchestrator/routes/decisions.py::_persist_deferred_actions` — writes structured entries, deduplicates by `(reviewer, condition)`, upgrades open → resolved when the same gate re-resolves with a new SHA.

**Renderer**
- `orchestrator/routes/pipelines.py::_build_pre_merge_obligations_section` — split into a normalizing collector + per-section formatter. Both Tier 1 (contract) and Tier 2 (live tracker) are demoted into the same shape, then bucketed by resolution status.

**Surfaces (the cross-system sync list from `REVIEWER-SYNC.md`)**
- `sandbox/egg_agent_tools/tools/brc.py` — ACK JSON schema field.
- `sandbox/egg_agent_tools/handlers/brc.py` — request → payload threading.
- `sandbox/egg_lib/orch_cli.py` — `--pre-merge-condition-resolved-in-diff` CLI flag, boundary validation, `consensus status` renderer split into Pending / Resolved within this PR.

**Docs/prompts**
- `docs/reference/conditional-ack.md` — new "Marking an obligation resolved within the PR" section, updated lifecycle, pointer table.
- `shared/prompts/code-review-criteria.md` — short note for BRC reviewers on when to re-ACK with the flag.
- BRC preamble in `_build_brc_preamble()` mentions the resolution path.

## Test plan

Targeted tests pass (220+ assertions across the touched surfaces, including new coverage for):
- ApprovalEntry stores / clears / serializes the new field
- Resolution dropped on a plain ACK
- NACK clears resolution alongside condition
- `get_pre_merge_conditions` includes the resolution
- `DeferredAction` round-trips legacy strings (with and without `<reviewer>: ` prefix) and structured input
- Renderer: all-resolved omits merge-blocking banner; mixed open+resolved renders both sections in priority order; tier-2 (live tracker) surfaces resolutions
- Existing tier-1/tier-2 precedence and whitespace-handling tests still pass after format normalization

```
.venv/bin/pytest \
  orchestrator/tests/test_conditional_ack.py \
  orchestrator/tests/test_conditional_ack_hitl_gate.py \
  orchestrator/tests/test_short_flow_contract_population.py \
  orchestrator/tests/test_brc_content_validation.py \
  orchestrator/tests/test_pipeline_role_to_reviewer_type_mapping.py \
  orchestrator/tests/test_peer_consensus_integration.py \
  orchestrator/tests/test_producer_push_consensus.py \
  orchestrator/tests/test_removal_validation_1165.py \
  sandbox/tests/test_brc_cli_args.py \
  sandbox/tests/test_consensus_status_render.py
# 421 passed
```

`make lint` clean.

- [ ] Visual check of an actual PR body with mixed open/resolved obligations on a live pipeline
- [ ] Verify legacy contracts on `egg/...` branches still load (load existing contract on a finished pipeline locally)

## Out of scope

- Automatic detection of satisfying commits (issue notes this is fuzzy). Resolution stays reviewer-driven.
- Splitting obligation shape into prerequisite + merge-verification (Shape 2 in #2336). The flag is orthogonal so future structural split layers on top.