### PR TITLE
Fix #2355: derive push-denied hint from blocked path category

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -1809,14 +1809,22 @@ def git_push() -> tuple[Response, int] | Response:
                         "blocked_reason": anchor_result.blocked_reason,
                     },
                 )
+                anchor_details: dict[str, Any] = {
+                    "agent_anchor_id": session_anchor_id,
+                    "blocked_files": anchor_result.blocked_files,
+                    "blocked_reason": anchor_result.blocked_reason,
+                }
+                # Anchor-write violations bypass check_file_restrictions (the
+                # role-level coder blocklist exempts .egg-state/agent-anchors/),
+                # so they need their own derive_hint call to deliver the
+                # orchestrator-API guidance from BLOCKED_HINTS. See #2355.
+                anchor_hint = _derive_push_denied_hint(anchor_result.blocked_files)
+                if anchor_hint is not None:
+                    anchor_details["hint"] = anchor_hint
                 return make_error(
                     f"Push denied: {anchor_result.message}",
                     status_code=403,
-                    details={
-                        "agent_anchor_id": session_anchor_id,
-                        "blocked_files": anchor_result.blocked_files,
-                        "blocked_reason": anchor_result.blocked_reason,
-                    },
+                    details=anchor_details,
                 )
 
     # SECURITY: Check phase-based file restrictions for local mode sessions.

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -70,6 +70,7 @@ if _shared_path.exists():
     sys.path.insert(0, str(_shared_path))
 from egg_health import HealthTracker
 from egg_logging import get_logger
+from egg_restrictions.hints import derive_hint as _derive_push_denied_hint
 
 # Module-level health tracker. Updated every time the /api/v1/health
 # endpoint is evaluated so callers can distinguish "healthy since process
@@ -1555,15 +1556,22 @@ def git_push() -> tuple[Response, int] | Response:
                     "blocked_reason": restriction_result.blocked_reason,
                 },
             )
+            details: dict[str, Any] = {
+                "role": session_role,
+                "blocked_files": restriction_result.blocked_files,
+                "blocked_reason": restriction_result.blocked_reason,
+            }
+            # Derive the hint from the blocked path's category so non-contract
+            # violations (CI workflows, anchors, role-scope mismatches) get
+            # actionable guidance instead of the legacy contract-only hint.
+            # See #2355.
+            hint = _derive_push_denied_hint(restriction_result.blocked_files)
+            if hint is not None:
+                details["hint"] = hint
             return make_error(
                 f"Push denied: {restriction_result.message}. {restriction_result.blocked_reason}",
                 status_code=403,
-                details={
-                    "role": session_role,
-                    "blocked_files": restriction_result.blocked_files,
-                    "blocked_reason": restriction_result.blocked_reason,
-                    "hint": "Use egg-contract CLI commands to update contract state.",
-                },
+                details=details,
             )
 
     # Agent-role file restrictions (#2039 restricted-path rejection).

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -1431,6 +1431,11 @@ class TestGitPush:
             assert "Push denied" in data["message"]
             assert data["data"]["agent_anchor_id"] == expected_anchor_id
             assert anchor_file in data["data"]["blocked_files"]
+            # #2355: anchor-write 403 carries the orchestrator-API hint derived
+            # from the blocked path category. The role-level path skips this
+            # check via the coder block_exempt_patterns carve-out, so without
+            # the explicit derive_hint call here the field would be missing.
+            assert "mcp__sdlc__update_anchor" in data["data"]["hint"]
 
     def test_push_allowed_for_own_anchor_write(self, client):
         """Push allowed when agent writes to its own anchor file."""

--- a/shared/egg_restrictions/__init__.py
+++ b/shared/egg_restrictions/__init__.py
@@ -12,6 +12,7 @@ from .checker import (
     get_agent_pattern,
     validate_agent_push,
 )
+from .hints import BLOCKED_HINTS, derive_hint
 from .patterns import (
     AGENT_PATTERNS,
     AgentFilePattern,
@@ -23,7 +24,9 @@ __all__ = [
     "AgentRestrictionResult",
     "AgentRole",
     "AGENT_PATTERNS",
+    "BLOCKED_HINTS",
     "check_agent_file_access",
+    "derive_hint",
     "get_agent_pattern",
     "validate_agent_push",
 ]

--- a/shared/egg_restrictions/hints.py
+++ b/shared/egg_restrictions/hints.py
@@ -1,0 +1,103 @@
+"""Actionable hints for path-restricted git push denials.
+
+When the gateway rejects a push because a file violates the pushing role's
+write boundary, the response carries a ``hint`` field meant to point the
+operator at the right remediation channel. The mapping below is keyed on
+the *blocked path's category* (not the role), so the same hint applies
+regardless of which role attempted the push — every role blocked from
+``.egg-state/contracts/`` should be told about the egg-contract CLI, not
+just the implementer.
+
+Patterns are evaluated top-to-bottom against
+``AgentFilePattern.matches_pattern``; the first row whose glob matches at
+least one blocked path wins. The list is therefore ordered most-specific
+first. Order matters where prefixes overlap — the
+``.egg-state/agent-anchors/`` row must appear above any broader
+``.egg-state/`` row.
+"""
+
+from __future__ import annotations
+
+from .patterns import AgentFilePattern
+
+__all__ = ["BLOCKED_HINTS", "derive_hint"]
+
+
+BLOCKED_HINTS: list[tuple[str, str]] = [
+    (
+        ".egg-state/contracts/",
+        "Use egg-contract CLI commands to update contract state.",
+    ),
+    (
+        ".egg-state/agent-anchors/",
+        "Anchor writes go through the orchestrator API (`mcp__sdlc__update_anchor`), not git push.",
+    ),
+    (
+        ".egg-state/drafts/",
+        "These directories are owned by a different agent role for this phase.",
+    ),
+    (
+        ".egg-state/reviews/",
+        "These directories are owned by a different agent role for this phase.",
+    ),
+    (
+        ".github/",
+        "These paths are owned by infrastructure; ask a human reviewer to merge changes here.",
+    ),
+    (
+        "docs/",
+        "Documentation changes belong to the documenter role.",
+    ),
+    (
+        "**/*.md",
+        "Documentation changes belong to the documenter role.",
+    ),
+    (
+        "**/README.md",
+        "Documentation changes belong to the documenter role.",
+    ),
+    (
+        "tests/",
+        "Test changes belong to the tester role.",
+    ),
+    (
+        "test/",
+        "Test changes belong to the tester role.",
+    ),
+    (
+        "**/tests/",
+        "Test changes belong to the tester role.",
+    ),
+    (
+        "**/test/",
+        "Test changes belong to the tester role.",
+    ),
+    (
+        "**/test_*.py",
+        "Test changes belong to the tester role.",
+    ),
+    (
+        "**/*_test.py",
+        "Test changes belong to the tester role.",
+    ),
+    (
+        "**/conftest.py",
+        "Test changes belong to the tester role.",
+    ),
+]
+
+
+def derive_hint(blocked_files: list[str]) -> str | None:
+    """Pick the first hint whose glob matches any of ``blocked_files``.
+
+    Returns ``None`` when no row matches; callers should fall back to the
+    role-scope ``blocked_reason`` already carried on the error response
+    rather than substituting a misleading default.
+    """
+    if not blocked_files:
+        return None
+    for pattern, hint in BLOCKED_HINTS:
+        for path in blocked_files:
+            if AgentFilePattern.matches_pattern(path, pattern):
+                return hint
+    return None

--- a/shared/egg_restrictions/hints.py
+++ b/shared/egg_restrictions/hints.py
@@ -10,10 +10,10 @@ just the implementer.
 
 Patterns are evaluated top-to-bottom against
 ``AgentFilePattern.matches_pattern``; the first row whose glob matches at
-least one blocked path wins. The list is therefore ordered most-specific
-first. Order matters where prefixes overlap — the
-``.egg-state/agent-anchors/`` row must appear above any broader
-``.egg-state/`` row.
+least one blocked path wins. The list is ordered most-specific first so
+that if a future broader pattern (e.g. a catch-all ``.egg-state/`` row) is
+added at the end, it does not shadow the specific anchors / contracts /
+drafts / reviews hints above it.
 """
 
 from __future__ import annotations
@@ -48,22 +48,17 @@ BLOCKED_HINTS: list[tuple[str, str]] = [
         "docs/",
         "Documentation changes belong to the documenter role.",
     ),
+    # `**/*.md` covers any depth, including top-level (e.g. `README.md`). A
+    # narrower `**/README.md` row would always be shadowed here, so it's
+    # omitted.
     (
         "**/*.md",
         "Documentation changes belong to the documenter role.",
     ),
-    (
-        "**/README.md",
-        "Documentation changes belong to the documenter role.",
-    ),
-    (
-        "tests/",
-        "Test changes belong to the tester role.",
-    ),
-    (
-        "test/",
-        "Test changes belong to the tester role.",
-    ),
+    # Test directory globs. The `**/<dir>/` form matches both top-level
+    # (`tests/foo.py`) and nested (`gateway/tests/foo.py`) paths via the
+    # path-segment match in `AgentFilePattern.matches_pattern`, so bare
+    # `tests/` / `test/` rows would be redundant.
     (
         "**/tests/",
         "Test changes belong to the tester role.",
@@ -72,6 +67,7 @@ BLOCKED_HINTS: list[tuple[str, str]] = [
         "**/test/",
         "Test changes belong to the tester role.",
     ),
+    # Python test file globs.
     (
         "**/test_*.py",
         "Test changes belong to the tester role.",
@@ -82,6 +78,48 @@ BLOCKED_HINTS: list[tuple[str, str]] = [
     ),
     (
         "**/conftest.py",
+        "Test changes belong to the tester role.",
+    ),
+    # Go test file globs (mirror TESTER_PATTERNS in patterns.py).
+    (
+        "**/*_test.go",
+        "Test changes belong to the tester role.",
+    ),
+    (
+        "**/test_*.go",
+        "Test changes belong to the tester role.",
+    ),
+    # JS/TS test file globs (mirror TESTER_PATTERNS in patterns.py).
+    (
+        "**/*.test.ts",
+        "Test changes belong to the tester role.",
+    ),
+    (
+        "**/*.test.tsx",
+        "Test changes belong to the tester role.",
+    ),
+    (
+        "**/*.test.js",
+        "Test changes belong to the tester role.",
+    ),
+    (
+        "**/*.test.jsx",
+        "Test changes belong to the tester role.",
+    ),
+    (
+        "**/*.spec.ts",
+        "Test changes belong to the tester role.",
+    ),
+    (
+        "**/*.spec.tsx",
+        "Test changes belong to the tester role.",
+    ),
+    (
+        "**/*.spec.js",
+        "Test changes belong to the tester role.",
+    ),
+    (
+        "**/*.spec.jsx",
         "Test changes belong to the tester role.",
     ),
 ]

--- a/shared/tests/test_egg_restrictions_hints.py
+++ b/shared/tests/test_egg_restrictions_hints.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from egg_restrictions import BLOCKED_HINTS, derive_hint
+from egg_restrictions.patterns import AgentFilePattern
 
 
 def test_no_blocked_files_returns_none() -> None:
@@ -28,12 +29,26 @@ def test_unmatched_path_returns_none() -> None:
         ("docs/index.md", "documenter role"),
         ("README.md", "documenter role"),
         ("orchestrator/foo/README.md", "documenter role"),
+        # Test directory globs — `**/<dir>/` covers top-level and nested.
         ("tests/test_foo.py", "tester role"),
         ("test/test_foo.py", "tester role"),
         ("gateway/tests/test_gateway.py", "tester role"),
+        # Python test file globs.
         ("orchestrator/test_foo.py", "tester role"),
         ("orchestrator/foo_test.py", "tester role"),
         ("conftest.py", "tester role"),
+        # Go test file globs.
+        ("internal/foo_test.go", "tester role"),
+        ("internal/test_foo.go", "tester role"),
+        # JS/TS test file globs (Jest / Vitest conventions).
+        ("frontend/foo.test.ts", "tester role"),
+        ("frontend/foo.test.tsx", "tester role"),
+        ("frontend/foo.test.js", "tester role"),
+        ("frontend/foo.test.jsx", "tester role"),
+        ("frontend/foo.spec.ts", "tester role"),
+        ("frontend/foo.spec.tsx", "tester role"),
+        ("frontend/foo.spec.js", "tester role"),
+        ("frontend/foo.spec.jsx", "tester role"),
     ],
 )
 def test_each_category_yields_its_hint(blocked_path: str, expected_substring: str) -> None:
@@ -50,13 +65,23 @@ def test_first_match_wins_when_multiple_files_blocked() -> None:
     assert "egg-contract CLI" in hint
 
 
-def test_anchors_outranks_generic_egg_state_prefix() -> None:
-    # The agent-anchors row must appear above any broader .egg-state/ row so
-    # an anchor-write denial gets the orchestrator-API hint, not (e.g.) the
-    # contract or drafts hint.
-    hint = derive_hint([".egg-state/agent-anchors/coder.json"])
-    assert hint is not None
-    assert "mcp__sdlc__update_anchor" in hint
+def test_anchor_pattern_does_not_match_sibling_egg_state_paths() -> None:
+    # The `.egg-state/agent-anchors/` row is a sibling-prefix to the
+    # contracts/drafts/reviews rows — none of the four patterns should match
+    # an anchor path except the anchor row itself. Without this property,
+    # ordering of the four rows in BLOCKED_HINTS would matter; with it, the
+    # anchor row's relative position is irrelevant for anchor-only paths.
+    anchor_path = ".egg-state/agent-anchors/coder.json"
+    sibling_patterns = [
+        ".egg-state/contracts/",
+        ".egg-state/drafts/",
+        ".egg-state/reviews/",
+    ]
+    for pattern in sibling_patterns:
+        assert not AgentFilePattern.matches_pattern(anchor_path, pattern), (
+            f"sibling pattern {pattern!r} should not match anchor path"
+        )
+    assert AgentFilePattern.matches_pattern(anchor_path, ".egg-state/agent-anchors/")
 
 
 def test_blocked_hints_table_is_well_formed() -> None:

--- a/shared/tests/test_egg_restrictions_hints.py
+++ b/shared/tests/test_egg_restrictions_hints.py
@@ -1,0 +1,67 @@
+"""Tests for egg_restrictions.hints — push-denial hint derivation (#2355)."""
+
+from __future__ import annotations
+
+import pytest
+from egg_restrictions import BLOCKED_HINTS, derive_hint
+
+
+def test_no_blocked_files_returns_none() -> None:
+    assert derive_hint([]) is None
+
+
+def test_unmatched_path_returns_none() -> None:
+    # No row in BLOCKED_HINTS covers a top-level source file under gateway/,
+    # so the helper falls back to None — caller uses blocked_reason instead.
+    assert derive_hint(["gateway/foo.py"]) is None
+
+
+@pytest.mark.parametrize(
+    ("blocked_path", "expected_substring"),
+    [
+        (".egg-state/contracts/foo.json", "egg-contract CLI"),
+        (".egg-state/agent-anchors/coder.json", "mcp__sdlc__update_anchor"),
+        (".egg-state/drafts/plan.md", "different agent role"),
+        (".egg-state/reviews/code.md", "different agent role"),
+        (".github/workflows/ci.yml", "owned by infrastructure"),
+        (".github/CODEOWNERS", "owned by infrastructure"),
+        ("docs/index.md", "documenter role"),
+        ("README.md", "documenter role"),
+        ("orchestrator/foo/README.md", "documenter role"),
+        ("tests/test_foo.py", "tester role"),
+        ("test/test_foo.py", "tester role"),
+        ("gateway/tests/test_gateway.py", "tester role"),
+        ("orchestrator/test_foo.py", "tester role"),
+        ("orchestrator/foo_test.py", "tester role"),
+        ("conftest.py", "tester role"),
+    ],
+)
+def test_each_category_yields_its_hint(blocked_path: str, expected_substring: str) -> None:
+    hint = derive_hint([blocked_path])
+    assert hint is not None
+    assert expected_substring in hint
+
+
+def test_first_match_wins_when_multiple_files_blocked() -> None:
+    # The contracts row is listed before the .github row, so when a single
+    # push violates both, the contracts hint is returned.
+    hint = derive_hint([".github/workflows/ci.yml", ".egg-state/contracts/foo.json"])
+    assert hint is not None
+    assert "egg-contract CLI" in hint
+
+
+def test_anchors_outranks_generic_egg_state_prefix() -> None:
+    # The agent-anchors row must appear above any broader .egg-state/ row so
+    # an anchor-write denial gets the orchestrator-API hint, not (e.g.) the
+    # contract or drafts hint.
+    hint = derive_hint([".egg-state/agent-anchors/coder.json"])
+    assert hint is not None
+    assert "mcp__sdlc__update_anchor" in hint
+
+
+def test_blocked_hints_table_is_well_formed() -> None:
+    # Every entry is a (glob, hint) pair with non-empty strings.
+    assert BLOCKED_HINTS, "BLOCKED_HINTS should not be empty"
+    for pattern, hint in BLOCKED_HINTS:
+        assert pattern, "patterns must be non-empty"
+        assert hint, "hints must be non-empty"


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `"Use egg-contract CLI commands to update contract state."` hint at `gateway/gateway.py:1565` with one derived from the blocked path's category, so non-contract violations (CI workflows, anchor writes, role-scope mismatches) get actionable guidance instead.
- Adds `shared/egg_restrictions/hints.py` with an ordered `(glob, hint)` table and a `derive_hint(blocked_files)` helper. Keyed on the path category — not the role — so the same hint applies to every role blocked from a given prefix.
- When no row matches, the gateway omits the `hint` field; the role-specific `blocked_reason` improved in PR #2342 carries the fallback framing.

Hint table mirrors the issue's proposal:

| Path category | Hint |
|---|---|
| `.egg-state/contracts/` | `Use egg-contract CLI commands to update contract state.` |
| `.egg-state/agent-anchors/` | `Anchor writes go through the orchestrator API (mcp__sdlc__update_anchor), not git push.` |
| `.egg-state/drafts/`, `.egg-state/reviews/` | `These directories are owned by a different agent role for this phase.` |
| `.github/` | `These paths are owned by infrastructure; ask a human reviewer to merge changes here.` |
| `docs/`, `**/*.md` | `Documentation changes belong to the documenter role.` |
| `tests/`, `**/test_*.py`, etc. | `Test changes belong to the tester role.` |
| (no match) | hint omitted; `blocked_reason` carries role-scope context |

## Design choice

The issue floats two shapes — per-pattern overrides on `AgentFilePattern` (Option 1) vs. a lookup table colocated with the gateway (Option 2). I went with a third hybrid: a sibling module `shared/egg_restrictions/hints.py`. The hint depends on the blocked path's category, not the pushing role, so per-role overrides on `AgentFilePattern` would force every role to redeclare the same hints (drift waiting to happen). Co-locating with `patterns.py` keeps the boundary vocabulary in one package and is trivially unit-testable.

## Test plan

- [x] `make test` from repo root — 16,254 passed, 41 skipped (full pre-existing suite).
- [x] New unit tests in `shared/tests/test_egg_restrictions_hints.py` — 20 cases covering each category row, no-match fallback, empty list, first-match precedence, and an anchors-vs-egg-state ordering guard.
- [x] `ruff check` and `ruff format --check` clean on touched files.
- [x] Verified no existing tests pin on the legacy `"Use egg-contract..."` string.

Closes #2355.