### PR TITLE
Fix #2357: route start_pipeline recovery's phase-gate persistence through the worktree

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -16608,14 +16608,18 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                         worktree_repo_path = _resolve_pipeline_worktree_path(pipeline, repo_path)
                         if worktree_repo_path == repo_path:
                             # No materialised worktree — recovery degrades to
-                            # the pre-fix shape (contract write no-ops via
-                            # ContractNotFoundError, draft append skipped).
-                            # Surface this so operators can correlate missing
-                            # next-phase context with worktree-cleanup races.
+                            # the pre-fix shape (contract write typically
+                            # no-ops via ContractNotFoundError, draft append
+                            # skipped). The contract write *may* succeed if
+                            # the orchestrator's main repo happens to carry a
+                            # contract for this pipeline, but it would land
+                            # against the wrong tree. Surface this either way
+                            # so operators can correlate missing next-phase
+                            # context with worktree-cleanup races.
                             logger.warning(
                                 "No materialised worktree found for phase gate "
                                 "persistence; falling back to main repo path. "
-                                "Contract write will silently no-op.",
+                                "Contract write may silently no-op.",
                                 pipeline_id=pipeline_id,
                                 phase=pipeline.current_phase.value,
                             )

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -16594,9 +16594,20 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                         phase_execution.completed_at = datetime.now(UTC)
 
                     # Persist phase gate resolution so next-phase agents see it.  #1295
+                    #
+                    # The contract and phase draft both live under the
+                    # per-pipeline worktree (``<worktree>/.egg-state/``),
+                    # not the orchestrator's main repo. Resolve the
+                    # worktree explicitly here — the inline path inside
+                    # ``_run_pipeline`` already has ``worktree_repo_path``
+                    # in scope, but this recovery branch only has the
+                    # main ``repo_path``. Passing ``repo_path`` would
+                    # silently no-op the contract write and draft append
+                    # (#2357, same shape as #2345).
                     if phase_gate_decisions:
+                        worktree_repo_path = _resolve_pipeline_worktree_path(pipeline, repo_path)
                         _persist_phase_gate_resolution(
-                            repo_path,
+                            worktree_repo_path,
                             pipeline_id,
                             phase_gate_decisions[0],
                             pipeline.current_phase.value,
@@ -16607,7 +16618,7 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                         # include the contract/draft changes.
                         try:
                             _commit_statefiles_to_worktree(
-                                repo_path,
+                                worktree_repo_path,
                                 f"Persist HITL resolution after {pipeline.current_phase.value} phase gate",
                                 pipeline_identifier=_pipeline_identifier(
                                     pipeline.issue_number, pipeline_id
@@ -16627,7 +16638,7 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                                 _spawner = _get_spawner()
                                 _spawner.gateway.push_worktree_branch(
                                     pipeline_id=pipeline_id,
-                                    repo_path=str(repo_path),
+                                    repo_path=str(worktree_repo_path),
                                     branch=pipeline.branch,
                                     mode=_gw_mode,
                                     base_branch=pipeline.base_branch,

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -16606,6 +16606,19 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                     # (#2357, same shape as #2345).
                     if phase_gate_decisions:
                         worktree_repo_path = _resolve_pipeline_worktree_path(pipeline, repo_path)
+                        if worktree_repo_path == repo_path:
+                            # No materialised worktree — recovery degrades to
+                            # the pre-fix shape (contract write no-ops via
+                            # ContractNotFoundError, draft append skipped).
+                            # Surface this so operators can correlate missing
+                            # next-phase context with worktree-cleanup races.
+                            logger.warning(
+                                "No materialised worktree found for phase gate "
+                                "persistence; falling back to main repo path. "
+                                "Contract write will silently no-op.",
+                                pipeline_id=pipeline_id,
+                                phase=pipeline.current_phase.value,
+                            )
                         _persist_phase_gate_resolution(
                             worktree_repo_path,
                             pipeline_id,
@@ -16625,15 +16638,22 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                                 ),
                                 pipeline_id=pipeline_id,
                             )
-                        except subprocess.CalledProcessError as git_err:
+                        except Exception as git_err:
+                            # Catch broadly: see #2219.  The helper raises
+                            # ``TimeoutExpired`` and ``OSError`` paths that a
+                            # ``CalledProcessError``-only handler did not catch.
                             logger.warning(
                                 "Failed to commit statefiles after phase gate resolution (continuing)",
                                 pipeline_id=pipeline_id,
                                 error=str(git_err),
                             )
 
-                        # Push if this repo tracks a remote branch
-                        if pipeline.branch:
+                        # Push if this repo tracks a remote branch and a
+                        # worktree was materialised. Mirrors the inline
+                        # path's guard at pipelines.py:16044 — pushing from
+                        # the orchestrator's main repo would target the
+                        # wrong working tree.
+                        if pipeline.branch and worktree_repo_path != repo_path:
                             try:
                                 _spawner = _get_spawner()
                                 _spawner.gateway.push_worktree_branch(

--- a/orchestrator/tests/test_start_pipeline.py
+++ b/orchestrator/tests/test_start_pipeline.py
@@ -611,6 +611,66 @@ class TestStartAwaitingHumanPipeline:
         mock_remove_tracker.assert_called_once_with("issue-42")
         mock_evaluator.clear.assert_called_once_with("issue-42")
 
+    @patch("routes.pipelines.get_pipeline_state_lock", side_effect=_noop_lock)
+    @patch("routes.pipelines._run_pipeline")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_recovery_routes_phase_gate_persistence_through_worktree(
+        self, mock_get_repo, mock_resolve, mock_run, mock_lock, client
+    ):
+        """Regression for #2357.
+
+        The contract and phase draft both live under the per-pipeline
+        worktree (``<worktree>/.egg-state/``), not the orchestrator's
+        main repo. When the AWAITING_HUMAN recovery branch persists a
+        phase gate resolution, it must resolve the worktree path and
+        forward it to ``_persist_phase_gate_resolution``,
+        ``_commit_statefiles_to_worktree``, and ``push_worktree_branch``
+        — same shape as the #2345 conflation in
+        ``_sync_pipeline_decisions_to_contract``.
+        """
+        pipeline = _make_awaiting_pipeline(
+            phase=PipelinePhase.REFINE,
+            resolution='{"action": "approve", "context": "Use adapter pattern"}',
+        )
+        _setup_mocks(mock_get_repo, mock_resolve, pipeline)
+
+        worktree_path = Path("/home/egg/.egg-worktrees/issue-42/repo")
+        mock_spawner = MagicMock()
+
+        with (
+            patch(
+                "routes.pipelines._resolve_pipeline_worktree_path",
+                return_value=worktree_path,
+            ) as mock_resolve_wt,
+            patch("routes.pipelines._persist_phase_gate_resolution") as mock_persist,
+            patch("routes.pipelines._commit_statefiles_to_worktree") as mock_commit,
+            patch("routes.pipelines._get_spawner", return_value=mock_spawner),
+        ):
+            resp = client.post("/api/v1/pipelines/issue-42/start")
+
+        assert resp.status_code == 200
+
+        mock_resolve_wt.assert_called_once_with(pipeline, Path("/repo"))
+
+        persist_args, _ = mock_persist.call_args
+        assert persist_args[0] == worktree_path, (
+            f"_persist_phase_gate_resolution must be called with the "
+            f"worktree path, got {persist_args[0]}"
+        )
+
+        commit_args, _ = mock_commit.call_args
+        assert commit_args[0] == worktree_path, (
+            f"_commit_statefiles_to_worktree must be called with the "
+            f"worktree path, got {commit_args[0]}"
+        )
+
+        push_kwargs = mock_spawner.gateway.push_worktree_branch.call_args.kwargs
+        assert push_kwargs["repo_path"] == str(worktree_path), (
+            f"push_worktree_branch must be called with the worktree path, "
+            f"got {push_kwargs['repo_path']}"
+        )
+
 
 # -----------------------------------------------------------------------------
 # Issue #1556 — Jira ticket plumbing

--- a/orchestrator/tests/test_start_pipeline.py
+++ b/orchestrator/tests/test_start_pipeline.py
@@ -671,6 +671,92 @@ class TestStartAwaitingHumanPipeline:
             f"got {push_kwargs['repo_path']}"
         )
 
+    @patch("routes.pipelines.get_pipeline_state_lock", side_effect=_noop_lock)
+    @patch("routes.pipelines._run_pipeline")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_recovery_phase_gate_commit_swallows_timeout(
+        self, mock_get_repo, mock_resolve, mock_run, mock_lock, client
+    ):
+        """Recovery's commit handler must catch broad exceptions (#2219, follow-up to #2357).
+
+        ``_commit_statefiles_to_worktree`` calls ``subprocess.run(...,
+        timeout=30)`` which can raise ``TimeoutExpired`` or ``OSError``.
+        Pre-fix the recovery branch's narrow
+        ``except subprocess.CalledProcessError`` was unreachable because
+        ``repo_path`` short-circuited the helper at its ``state_dir.exists()``
+        guard. Now that the helper actually executes git against the
+        worktree, the narrow handler would let those exceptions escape
+        as a 500. Mirror the inline path's broadened handler.
+        """
+        import subprocess
+
+        pipeline = _make_awaiting_pipeline(
+            phase=PipelinePhase.REFINE,
+            resolution='{"action": "approve"}',
+        )
+        _setup_mocks(mock_get_repo, mock_resolve, pipeline)
+
+        worktree_path = Path("/home/egg/.egg-worktrees/issue-42/repo")
+
+        with (
+            patch(
+                "routes.pipelines._resolve_pipeline_worktree_path",
+                return_value=worktree_path,
+            ),
+            patch("routes.pipelines._persist_phase_gate_resolution"),
+            patch(
+                "routes.pipelines._commit_statefiles_to_worktree",
+                side_effect=subprocess.TimeoutExpired(cmd="git commit", timeout=30),
+            ),
+            patch("routes.pipelines._get_spawner", return_value=MagicMock()),
+        ):
+            resp = client.post("/api/v1/pipelines/issue-42/start")
+
+        assert resp.status_code == 200, (
+            "TimeoutExpired from _commit_statefiles_to_worktree must be "
+            "caught and logged, not propagate as a 500"
+        )
+
+    @patch("routes.pipelines.get_pipeline_state_lock", side_effect=_noop_lock)
+    @patch("routes.pipelines._run_pipeline")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_recovery_skips_push_when_worktree_resolves_to_main_repo(
+        self, mock_get_repo, mock_resolve, mock_run, mock_lock, client
+    ):
+        """When no worktree is materialised, recovery must skip the push.
+
+        ``_resolve_pipeline_worktree_path`` falls back to the supplied
+        path when no worktree directory exists (e.g. cleaned up between
+        AWAITING_HUMAN entry and recovery, or after an orchestrator
+        restart). Pushing the orchestrator's main repo would target the
+        wrong working tree — mirror the inline path's
+        ``worktree_repo_path != repo_path`` guard at pipelines.py:16044.
+        """
+        pipeline = _make_awaiting_pipeline(
+            phase=PipelinePhase.REFINE,
+            resolution='{"action": "approve"}',
+        )
+        _setup_mocks(mock_get_repo, mock_resolve, pipeline)
+
+        repo_path = Path("/repo")  # matches _setup_mocks
+        mock_spawner = MagicMock()
+
+        with (
+            patch(
+                "routes.pipelines._resolve_pipeline_worktree_path",
+                return_value=repo_path,  # fallback case: no worktree found
+            ),
+            patch("routes.pipelines._persist_phase_gate_resolution"),
+            patch("routes.pipelines._commit_statefiles_to_worktree"),
+            patch("routes.pipelines._get_spawner", return_value=mock_spawner),
+        ):
+            resp = client.post("/api/v1/pipelines/issue-42/start")
+
+        assert resp.status_code == 200
+        mock_spawner.gateway.push_worktree_branch.assert_not_called()
+
 
 # -----------------------------------------------------------------------------
 # Issue #1556 — Jira ticket plumbing


### PR DESCRIPTION
## Summary

- ``_persist_phase_gate_resolution`` writes to the contract under ``<worktree>/.egg-state/contracts/`` and appends the HITL Resolution section to the phase draft. Both need the per-pipeline worktree path. The inline call inside ``_run_pipeline`` (pipelines.py:16016) passes ``worktree_repo_path`` correctly; the AWAITING_HUMAN recovery branch in ``start_pipeline`` (pipelines.py:16598) was passing the orchestrator's main ``repo_path`` — same shape as the #2345 conflation.
- When the polling thread died after a human resolved a phase gate, the contract write silently no-op'd (``load_contract`` raises ``ContractNotFoundError``, swallowed by the helper's broad ``except Exception``) and the draft append skipped (path doesn't exist on the main repo). The adjacent ``_commit_statefiles_to_worktree`` and ``gateway.push_worktree_branch`` calls were also wrong. Next-phase agents never saw the human's decision.

## Audit findings (#2357 ACs)

Other ``egg_contracts.loader`` and ``get_state_store`` call sites in ``orchestrator/routes/pipelines.py`` are correct:

- ``_pull_contract_from_source_branch`` (pipelines.py:4274), ``_render_contract_tasks`` (pipelines.py:4711), ``_populate_contract_from_plan`` (pipelines.py:13390): param is named ``repo_path`` but every caller passes ``worktree_repo_path``. Internally consistent — misleading name only, refactor out of scope per the issue.
- ``_sync_pipeline_decisions_to_contract`` (pipelines.py:13575): split correctly in #2350.
- All 9 ``get_state_store(...)`` sites receive the orchestrator main path from ``get_repo_path()`` / ``store.repo_path`` / ``_resolve_pipeline``'s ``base_path``.

## Fix

In ``start_pipeline``'s recovery block (around pipelines.py:16596), resolve the worktree path with ``_resolve_pipeline_worktree_path(pipeline, repo_path)`` and forward it to ``_persist_phase_gate_resolution``, ``_commit_statefiles_to_worktree``, and ``gateway.push_worktree_branch``. Mirrors the pattern used in ``_persist_phase_brc_history`` (pipelines.py:7371).

## Test plan

- [x] Added ``test_recovery_routes_phase_gate_persistence_through_worktree`` parallel to ``test_sync_routes_paths_to_state_store_and_contract_separately``. Drives the recovery branch with a mocked worktree-path resolver and asserts all three call sites receive the worktree path.
- [x] Verified the test fails on the pre-fix code.
- [x] ``make test`` — 2193 passed.
- [x] ``make lint`` — clean.

Closes #2357.