### PR TITLE
Fix #2372: exempt synthetic slice integration pushes from role-path allowlist

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -1507,12 +1507,20 @@ def git_push() -> tuple[Response, int] | Response:
     # Note: Only configured roles are checked. The SYSTEM role is typically NOT
     # blocked because SYSTEM never makes git pushes - it only initializes contracts
     # via the contract API. The gateway itself runs without a role context.
+    #
+    # Infrastructure pushes (checkpoint branches, pipeline-state, and synthetic-
+    # session slice integration-branch creation pushes; see is_infrastructure_push
+    # above) are exempt: the changed-files diff against `main` would otherwise pull
+    # in every file modified on the parent branch's history (drafts, contracts,
+    # brc-history, ...) and falsely block a logical no-op branch-creation push
+    # (#2372).  The downstream anchor/phase/agent-restriction checks already gate
+    # on `not is_infrastructure_push`; this gate makes the role check symmetric.
     session_role = None
     changed_files = None  # May be populated by role check, reused by phase check
     if hasattr(g, "session") and g.session:
         session_role = getattr(g.session, "agent_role", None)
 
-    if session_role:
+    if session_role and not is_infrastructure_push:
         # Get the list of files being pushed
         changed_files, check_error = get_changed_files_in_push(exec_path, remote, branch)
 

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -1510,11 +1510,17 @@ def git_push() -> tuple[Response, int] | Response:
     #
     # Infrastructure pushes (checkpoint branches, pipeline-state, and synthetic-
     # session slice integration-branch creation pushes; see is_infrastructure_push
-    # above) are exempt: the changed-files diff against `main` would otherwise pull
-    # in every file modified on the parent branch's history (drafts, contracts,
-    # brc-history, ...) and falsely block a logical no-op branch-creation push
-    # (#2372).  The downstream anchor/phase/agent-restriction checks already gate
-    # on `not is_infrastructure_push`; this gate makes the role check symmetric.
+    # above) are exempt for two distinct reasons:
+    #   1. ``egg/checkpoints/v2`` and ``egg/pipeline-state`` are orphan/disjoint-
+    #      history branches written by orchestrator infrastructure, not agent
+    #      BRC pushes, so role-based file restrictions don't conceptually apply.
+    #   2. Synthetic-session slice integration-branch creation pushes (#2368)
+    #      diff against `main` because the target ref doesn't exist yet, which
+    #      would otherwise pull in every file modified on the parent branch's
+    #      history (drafts, contracts, brc-history, ...) and falsely block a
+    #      logical no-op branch-creation push (#2372).
+    # The downstream anchor/phase/agent-restriction checks already gate on
+    # `not is_infrastructure_push`; this gate makes the role check symmetric.
     session_role = None
     changed_files = None  # May be populated by role check, reused by phase check
     if hasattr(g, "session") and g.session:

--- a/gateway/tests/test_pipeline_push_block.py
+++ b/gateway/tests/test_pipeline_push_block.py
@@ -907,3 +907,116 @@ class TestSliceIntegrationBranchExemption:
                 assert infra_events, (
                     "Expected push_infrastructure_exempt with exempt_type=slice_integration_branch"
                 )
+
+    def test_synthetic_slice_branch_skips_role_path_allowlist(self, client):
+        """Role-based path-allowlist check is bypassed for synthetic slice pushes (#2372).
+
+        ``create_slice_integration_branch`` pushes
+        ``parent:refs/heads/egg/<base>/slice-N`` with ``agent_role="coder"``.
+        ``get_changed_files_in_push`` falls back to a ``main``-based diff
+        when the target ref doesn't exist yet, surfacing every file
+        modified on the parent branch's history (drafts, contracts,
+        brc-history) — none of which ``coder`` can write.  The role
+        check at gateway/gateway.py must skip this branch-creation push
+        the same way the anchor/phase/agent-restriction checks already
+        do, otherwise a logical no-op push gets falsely blocked.
+
+        Mock ``check_file_restrictions`` to return ``allowed=False`` so
+        the test fails loudly if the gate ever regresses, and assert
+        that ``get_changed_files_in_push`` is never even called for an
+        infrastructure push.
+        """
+        session = _make_session(synthetic=True, assigned_branch="egg/issue-2261-v3/slice-2")
+        patches = _push_context(session)
+        forbidden_files = [
+            ".egg-state/brc-history/issue-2261-v3-2026-04-30.jsonl",
+            ".egg-state/contracts/issue-2261-v3.json",
+            ".egg-state/drafts/issue-2261-v3-plan.md",
+        ]
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            # Override patches[5] (get_changed_files_in_push) and patches[6]
+            # (check_file_restrictions) so the role check would 403 if it ran.
+            patch.object(
+                gateway,
+                "get_changed_files_in_push",
+                MagicMock(return_value=(forbidden_files, None)),
+            ) as mock_changed_files,
+            patch.object(
+                gateway,
+                "check_file_restrictions",
+                MagicMock(
+                    return_value=MagicMock(
+                        allowed=False,
+                        blocked_files=forbidden_files,
+                        blocked_reason="Role 'coder' cannot modify .egg-state/brc-history/...",
+                        message="Path allowlist violation",
+                    )
+                ),
+            ) as mock_check_restrictions,
+            patches[7],
+        ):
+            response = _do_push(
+                client,
+                refspec="egg/issue-2261-v3:refs/heads/egg/issue-2261-v3/slice-2",
+            )
+            assert response.status_code == 200, (
+                f"Synthetic slice integration push must bypass the role-based "
+                f"path allowlist (#2372). Got {response.status_code}: {response.data!r}"
+            )
+            mock_changed_files.assert_not_called()
+            mock_check_restrictions.assert_not_called()
+
+    def test_role_path_allowlist_still_enforced_for_non_infrastructure_pushes(self, client):
+        """Regression guard: the gate added in #2372 must NOT weaken the role
+        check for ordinary (non-infrastructure) pushes.
+
+        Use a non-pipeline session so the pipeline-session and push-target
+        enforcers don't fire first; the role check should still 403 with
+        ``push_denied_protected_files`` when ``check_file_restrictions``
+        rejects the diff.
+        """
+        session = _make_session(
+            role="coder",
+            pipeline_id=None,
+            assigned_branch="egg/some-branch",
+            synthetic=False,
+        )
+        patches = _push_context(session)
+        forbidden_files = [".egg-state/contracts/some.json"]
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patch.object(
+                gateway,
+                "get_changed_files_in_push",
+                MagicMock(return_value=(forbidden_files, None)),
+            ),
+            patch.object(
+                gateway,
+                "check_file_restrictions",
+                MagicMock(
+                    return_value=MagicMock(
+                        allowed=False,
+                        blocked_files=forbidden_files,
+                        blocked_reason="Role 'coder' cannot modify .egg-state/contracts/...",
+                        message="Path allowlist violation",
+                    )
+                ),
+            ),
+            patches[7],
+        ):
+            response = _do_push(client, refspec="egg/some-branch")
+            assert response.status_code == 403, (
+                f"Non-infrastructure pushes must still hit the role path-allowlist "
+                f"check. Got {response.status_code}: {response.data!r}"
+            )
+            data = json.loads(response.data)
+            assert "Path allowlist violation" in data["message"]


### PR DESCRIPTION
## Summary

- Closes #2372. The role-based path-allowlist check at `gateway/gateway.py:1515` was the only file-restriction gate not keyed on `is_infrastructure_push`. After #2370 exempted synthetic-session slice integration-branch pushes from the pipeline-session push block, the next gate in the chain — the role check — fired on a logical no-op branch-creation push because `get_changed_files_in_push` falls back to a `main`-based diff when the target ref doesn't exist yet, surfacing the parent branch's full history (drafts, contracts, brc-history). None of those paths are writable by the `coder` role, so all 15 slice integration-branch creations on `issue-2261-v3` failed with `Push denied: Role 'coder' cannot modify: .egg-state/brc-history/...`.
- The fix adds `not is_infrastructure_push` to the role check gate, mirroring the existing gates on the anchor (l.1785), phase (l.1822), and agent-restriction (l.1580) checks. Because `is_slice_integration_push=True` already promotes `is_infrastructure_push=True` (l.1316-1318), this only widens the exemption surface for pushes that already cleared the launcher-secret + slice-shape regex.
- Adds two tests in `gateway/tests/test_pipeline_push_block.py::TestSliceIntegrationBranchExemption`:
  - `test_synthetic_slice_branch_skips_role_path_allowlist` — synthetic slice push with would-be-blocked changed_files returns 200, and asserts `get_changed_files_in_push` / `check_file_restrictions` are never called (verifies the gate, not just a happy-path mock).
  - `test_role_path_allowlist_still_enforced_for_non_infrastructure_pushes` — regression guard: a non-pipeline session pushing forbidden files still returns 403 with the path-allowlist error.

Option 1 from the issue (smallest, symmetric with #2370). Options 2 (branch-creation-only detection) and 3 (new orchestrator-infra role) are not pursued here — option 2 touches security-critical attribution code; option 3 adds role configuration for a single call site. Neither is justified for closing this regression.

## Test plan

- [x] `.venv/bin/pytest gateway/tests/test_pipeline_push_block.py` — 31 passed (29 existing + 2 new).
- [x] `.venv/bin/pytest gateway/tests/` — 3167 passed.
- [x] `make test` — 81182 passed; 1 unrelated failure + 2 unrelated errors are pre-existing local-environment artifacts (stale `integration_tests/deployment_validation/__pycache__`, port-binding conflict).
- [x] `make lint` clean for the changed files (`gateway/gateway.py`, `gateway/tests/test_pipeline_push_block.py`).
- [ ] Post-deploy operational step (separate from this PR): `mcp__egg__advance_phase target_phase=implement force=true` for pipeline `issue-2261-v3` to retry the slice loop.

## Refs

- #2368 — slice integration-branch creation; introduced the synthetic exemption shape.
- #2370 — exempted synthetic-session pushes from the pipeline-session push block. This PR closes the third gate in the same chain.
- #2220 — implement-phase slice DAG.