### PR TITLE
Fix #2354: thread contract.pr.deferred_actions into umbrella slice PR

### DIFF
--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1219,7 +1219,7 @@ class GatewayClient:
         program_description: str | None = None,
         program_test_plan: str | None = None,
         program_manual_steps: str | None = None,
-        program_deferred_actions: list[Any] | None = None,
+        program_deferred_actions: list[dict[str, str]] | None = None,
         terminal_slice_id: str | None = None,
     ) -> str | None:
         """Open a PR for one slice in a stacked-PR chain.
@@ -1233,15 +1233,26 @@ class GatewayClient:
           chain. When ``program_deferred_actions`` is non-empty, the
           body also includes the ``## ⚠️ Pre-merge Obligations`` (and,
           when applicable, ``## ✅ Resolved within this PR``) section
-          carrying conditional-ACK obligations from
-          ``contract.pr.deferred_actions`` (#2354). This is the
-          reviewer-facing narrative for the whole pipeline.
+          carrying conditional-ACK obligations (#2354). The section
+          is rendered immediately after the program description and
+          *before* ``## Test Plan`` so the merge-blocking banner is
+          visible without scrolling past pipeline metadata — same
+          placement as the legacy ``_auto_create_pr`` path. The
+          caller is expected to pass the *normalized* obligation
+          shape produced by
+          ``routes.pipelines._collect_pre_merge_obligations`` (a list
+          of ``{reviewer, condition, resolved_in_diff}`` dicts), which
+          carries both the contract source and the live-tracker
+          fallback so this path stays at parity with the legacy
+          single-PR renderer.
         * **Non-terminal slice** (no ``program_title``): deterministic
           ``slice {slice_id}: {slice_name}`` title, bulleted task list
           body. When ``terminal_slice_id`` is supplied, the body also
           carries a pointer to the terminal slice so reviewers can
-          jump to the umbrella PR. ``program_deferred_actions`` is
-          ignored on this shape — obligations belong on the umbrella.
+          jump to the umbrella PR. ``program_deferred_actions`` MUST
+          be ``None`` on this shape — obligations belong on the
+          umbrella, and the assertion below fails fast on caller
+          mistakes (#2354 review nit).
 
         Both shapes always end with a footer naming the slice and the
         branch it stacks onto, so the slice's role in the chain stays
@@ -1271,6 +1282,26 @@ class GatewayClient:
             if program_description and program_description.strip():
                 body_lines.append(program_description.strip())
                 body_lines.append("")
+            # Render Pre-merge Obligations / Resolved-within-PR *before*
+            # ``## Test Plan`` so the merge-blocking banner is visible
+            # without scrolling past plan/steps. Same placement as the
+            # legacy ``_auto_create_pr`` path (see
+            # ``routes/pipelines.py::_build_pr_body``); the renderer is
+            # the same shared module so both paths stay byte-identical
+            # (#2354 review).
+            if program_deferred_actions:
+                try:
+                    from pr_obligations import render_obligations_section_from_normalized
+                except ImportError:
+                    from orchestrator.pr_obligations import (  # type: ignore[no-redef]
+                        render_obligations_section_from_normalized,
+                    )
+                obligations_section = render_obligations_section_from_normalized(
+                    program_deferred_actions
+                )
+                if obligations_section:
+                    body_lines.append(obligations_section)
+                    body_lines.append("")
             if program_test_plan and program_test_plan.strip():
                 body_lines.append("## Test Plan")
                 body_lines.append("")
@@ -1281,23 +1312,15 @@ class GatewayClient:
                 body_lines.append("")
                 body_lines.append(program_manual_steps.strip())
                 body_lines.append("")
-            if program_deferred_actions:
-                # Render the same Pre-merge Obligations / Resolved-within-PR
-                # sections the legacy ``_auto_create_pr`` path emits via
-                # ``_build_pre_merge_obligations_section`` (#2354). Shared
-                # markdown composer lives in ``orchestrator.pr_obligations``
-                # so both paths stay byte-identical.
-                try:
-                    from pr_obligations import render_obligations_section
-                except ImportError:
-                    from orchestrator.pr_obligations import (  # type: ignore[no-redef]
-                        render_obligations_section,
-                    )
-                obligations_section = render_obligations_section(program_deferred_actions)
-                if obligations_section:
-                    body_lines.append(obligations_section)
-                    body_lines.append("")
         else:
+            # Defensive: obligations belong only on the umbrella. Failing
+            # fast here catches a caller wiring ``program_deferred_actions``
+            # through to a non-terminal slice (#2354 review nit) instead
+            # of silently dropping it.
+            assert program_deferred_actions is None, (
+                "program_deferred_actions must be None on non-terminal slices; "
+                "obligations belong on the umbrella PR only"
+            )
             body_lines.append(slice_name)
             if slice_tasks:
                 body_lines.append("")

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1317,10 +1317,19 @@ class GatewayClient:
             # fast here catches a caller wiring ``program_deferred_actions``
             # through to a non-terminal slice (#2354 review nit) instead
             # of silently dropping it.
-            assert program_deferred_actions is None, (
-                "program_deferred_actions must be None on non-terminal slices; "
-                "obligations belong on the umbrella PR only"
-            )
+            #
+            # Guarded on ``program_title is None`` rather than
+            # ``has_program_block`` so a whitespace-only ``program_title``
+            # (which ``PRMetadata.title`` allows under its current
+            # ``min_length=1`` validator) doesn't masquerade as a slice
+            # routing error here — that's a different bug and should
+            # surface as such, not as a spurious AssertionError on the
+            # umbrella PR creation path (#2354 review observation B).
+            if program_title is None:
+                assert program_deferred_actions is None, (
+                    "program_deferred_actions must be None on non-terminal slices; "
+                    "obligations belong on the umbrella PR only"
+                )
             body_lines.append(slice_name)
             if slice_tasks:
                 body_lines.append("")

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1219,6 +1219,7 @@ class GatewayClient:
         program_description: str | None = None,
         program_test_plan: str | None = None,
         program_manual_steps: str | None = None,
+        program_deferred_actions: list[Any] | None = None,
         terminal_slice_id: str | None = None,
     ) -> str | None:
         """Open a PR for one slice in a stacked-PR chain.
@@ -1229,13 +1230,18 @@ class GatewayClient:
           contract's ``pr`` block): the PR carries the planner-authored
           title / description / test plan / manual steps, plus a
           banner marking it as the program-level umbrella for the
-          chain. This is the reviewer-facing narrative for the whole
-          pipeline.
+          chain. When ``program_deferred_actions`` is non-empty, the
+          body also includes the ``## ⚠️ Pre-merge Obligations`` (and,
+          when applicable, ``## ✅ Resolved within this PR``) section
+          carrying conditional-ACK obligations from
+          ``contract.pr.deferred_actions`` (#2354). This is the
+          reviewer-facing narrative for the whole pipeline.
         * **Non-terminal slice** (no ``program_title``): deterministic
           ``slice {slice_id}: {slice_name}`` title, bulleted task list
           body. When ``terminal_slice_id`` is supplied, the body also
           carries a pointer to the terminal slice so reviewers can
-          jump to the umbrella PR.
+          jump to the umbrella PR. ``program_deferred_actions`` is
+          ignored on this shape — obligations belong on the umbrella.
 
         Both shapes always end with a footer naming the slice and the
         branch it stacks onto, so the slice's role in the chain stays
@@ -1275,6 +1281,22 @@ class GatewayClient:
                 body_lines.append("")
                 body_lines.append(program_manual_steps.strip())
                 body_lines.append("")
+            if program_deferred_actions:
+                # Render the same Pre-merge Obligations / Resolved-within-PR
+                # sections the legacy ``_auto_create_pr`` path emits via
+                # ``_build_pre_merge_obligations_section`` (#2354). Shared
+                # markdown composer lives in ``orchestrator.pr_obligations``
+                # so both paths stay byte-identical.
+                try:
+                    from pr_obligations import render_obligations_section
+                except ImportError:
+                    from orchestrator.pr_obligations import (  # type: ignore[no-redef]
+                        render_obligations_section,
+                    )
+                obligations_section = render_obligations_section(program_deferred_actions)
+                if obligations_section:
+                    body_lines.append(obligations_section)
+                    body_lines.append("")
         else:
             body_lines.append(slice_name)
             if slice_tasks:

--- a/orchestrator/pr_obligations.py
+++ b/orchestrator/pr_obligations.py
@@ -1,0 +1,160 @@
+"""Render the "Pre-merge Obligations" PR-body section from ``DeferredAction``.
+
+Shared between the legacy ``_auto_create_pr`` path
+(``orchestrator/routes/pipelines.py::_build_pre_merge_obligations_section``)
+and the slice-DAG umbrella PR path
+(``orchestrator/gateway_client.py::create_slice_pr``) so both surface the
+same conditional-ACK obligations under the same merge-blocking banner
+(#2354).
+
+Pure with respect to the obligation list: no orchestrator runtime or
+``peer_consensus`` tracker access lives here. Callers that want the
+tracker fallback (the legacy path) wrap this module's
+:func:`render_obligations_section` with their own collection logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_deferred_actions(
+    deferred_actions: list[Any] | None,
+) -> list[dict[str, str]]:
+    """Normalize ``DeferredAction`` objects (or legacy strings) into dicts.
+
+    Returns a list of ``{reviewer, condition, resolved_in_diff}`` dicts.
+    Whitespace-only conditions are dropped — the renderer would emit an
+    empty bullet otherwise. Legacy ``str`` entries (pre-#2336 contract
+    shape) are parsed with the same ``"reviewer: condition"`` split the
+    ``PRMetadata.deferred_actions`` field validator uses, so callers that
+    skip the validator (unit tests building inputs by hand) still
+    produce the expected shape.
+    """
+    if not deferred_actions:
+        return []
+
+    normalized: list[dict[str, str]] = []
+    for entry in deferred_actions:
+        reviewer = getattr(entry, "reviewer", None)
+        condition = getattr(entry, "condition", None)
+        resolved = getattr(entry, "resolved_in_diff", None)
+        if condition is None and isinstance(entry, str):
+            text = entry.strip()
+            if not text:
+                continue
+            head, sep, tail = text.partition(": ")
+            if sep and tail.strip():
+                reviewer, condition = head.strip(), tail.strip()
+            else:
+                reviewer, condition = "", text
+            resolved = ""
+        condition_text = (condition or "").strip()
+        if not condition_text:
+            continue
+        normalized.append(
+            {
+                "reviewer": (reviewer or "").strip(),
+                "condition": condition_text,
+                "resolved_in_diff": (resolved or "").strip(),
+            }
+        )
+    return normalized
+
+
+def _format_obligation_bullet(
+    obligation: dict[str, str],
+    resolved: bool,
+) -> list[str]:
+    """Format a single obligation as a markdown bullet (multi-line aware)."""
+    reviewer = obligation["reviewer"] or "unknown"
+    # ``strip()`` before ``splitlines()`` so a leading/trailing newline doesn't
+    # produce an empty first line ("- **reviewer** — " with nothing after the
+    # em-dash). The collector filters whitespace-only conditions, but a
+    # ``"\nreal text"`` value would otherwise slip through with an empty
+    # first line (#2336 review).
+    condition = obligation["condition"].strip()
+    first, *rest = condition.splitlines()
+    bullet = f"- **{reviewer}** — {first}"
+    lines = [bullet]
+    for extra in rest:
+        lines.append(f"  {extra}")
+    if resolved and obligation["resolved_in_diff"]:
+        # Bare SHA (no backticks) so GitHub auto-links it to the commit page
+        # in the rendered PR body — code-span text is not auto-linked.
+        lines.append(f"  - Resolved in {obligation['resolved_in_diff']}")
+    return lines
+
+
+def render_obligations_section(
+    deferred_actions: list[Any] | None,
+) -> str:
+    """Compose the PR-body Pre-merge / Resolved obligations markdown.
+
+    ``deferred_actions`` may contain ``DeferredAction`` Pydantic objects
+    or legacy ``str`` entries (handled defensively by
+    :func:`normalize_deferred_actions`). Returns the empty string when no
+    obligations remain after normalization, so callers can
+    unconditionally append the result to a PR body.
+
+    Each obligation is classified as **open** or **resolved** (#2336):
+
+    * Open obligations (no ``resolved_in_diff``) render under a merge-blocking
+      "Pre-merge Obligations" banner — a human must act before merging.
+    * Resolved obligations (the reviewer marked them satisfied within the same
+      PR's diff) render under a "Resolved within this PR" subsection with a
+      pointer to the satisfying commit. They do not block merge.
+    """
+    return render_obligations_section_from_normalized(normalize_deferred_actions(deferred_actions))
+
+
+def render_obligations_section_from_normalized(
+    obligations: list[dict[str, str]],
+) -> str:
+    """Compose the markdown from already-normalized obligation dicts.
+
+    Used by callers (the legacy ``_build_pre_merge_obligations_section``
+    in ``routes/pipelines.py``) that collect obligations from multiple
+    sources — contract list + live consensus tracker — and need to merge
+    them before rendering.
+    """
+    if not obligations:
+        return ""
+
+    open_obligations = [o for o in obligations if not o["resolved_in_diff"]]
+    resolved_obligations = [o for o in obligations if o["resolved_in_diff"]]
+
+    sections: list[str] = []
+
+    if open_obligations:
+        lines: list[str] = [
+            "## ⚠️ Pre-merge Obligations",
+            "",
+            "The reviewers below issued a **conditional ACK** — the work is "
+            "approved, but a human must perform the listed action before "
+            "merging. Do **not** merge this PR until every obligation is "
+            "complete.",
+            "",
+        ]
+        for o in open_obligations:
+            lines.extend(_format_obligation_bullet(o, resolved=False))
+        sections.append("\n".join(lines))
+
+    if resolved_obligations:
+        # When the only obligations on the PR are already-satisfied ones, this
+        # subsection stands on its own — there's no "do not merge" banner to
+        # contradict (#2336). Reviewers still get a record of what was
+        # promised and what diff resolved it.
+        lines = [
+            "## ✅ Resolved within this PR",
+            "",
+            "The reviewers below issued a **conditional ACK** and later "
+            "marked the obligation satisfied within this PR's diff. Listed "
+            "for the audit trail; no merge action required.",
+            "",
+        ]
+        for o in resolved_obligations:
+            lines.extend(_format_obligation_bullet(o, resolved=True))
+        sections.append("\n".join(lines))
+
+    return "\n\n".join(sections)

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7417,58 +7417,22 @@ def _build_pre_merge_obligations_section(
        no deferred_actions — either because the gate landed before
        tracker teardown, or the gate was never required.
 
-    Each obligation is classified as **open** or **resolved** (#2336):
-
-    * Open obligations (no ``resolved_in_diff``) render under a merge-blocking
-      "Pre-merge Obligations" banner — a human must act before merging.
-    * Resolved obligations (the reviewer marked them satisfied within the same
-      PR's diff) render under a "Resolved within this PR" subsection with a
-      pointer to the satisfying commit. They do not block merge.
+    The markdown composition (open vs. resolved sections, banner copy) is
+    delegated to :mod:`orchestrator.pr_obligations` so the slice-DAG
+    umbrella PR path (``GatewayClient.create_slice_pr``) renders the same
+    section from the same input shape (#2354).
 
     Returns an empty string if neither source yields obligations, so callers
     can unconditionally append the result to the PR body.
     """
+    try:
+        from pr_obligations import render_obligations_section_from_normalized
+    except ImportError:
+        from ..pr_obligations import (  # type: ignore[import-not-found,no-redef]
+            render_obligations_section_from_normalized,
+        )
     obligations = _collect_pre_merge_obligations(pipeline_id, contract_deferred_actions)
-    if not obligations:
-        return ""
-
-    open_obligations = [o for o in obligations if not o["resolved_in_diff"]]
-    resolved_obligations = [o for o in obligations if o["resolved_in_diff"]]
-
-    sections: list[str] = []
-
-    if open_obligations:
-        lines: list[str] = [
-            "## ⚠️ Pre-merge Obligations",
-            "",
-            "The reviewers below issued a **conditional ACK** — the work is "
-            "approved, but a human must perform the listed action before "
-            "merging. Do **not** merge this PR until every obligation is "
-            "complete.",
-            "",
-        ]
-        for o in open_obligations:
-            lines.extend(_format_obligation_bullet(o, resolved=False))
-        sections.append("\n".join(lines))
-
-    if resolved_obligations:
-        # When the only obligations on the PR are already-satisfied ones, this
-        # subsection stands on its own — there's no "do not merge" banner to
-        # contradict (#2336). Reviewers still get a record of what was
-        # promised and what diff resolved it.
-        lines = [
-            "## ✅ Resolved within this PR",
-            "",
-            "The reviewers below issued a **conditional ACK** and later "
-            "marked the obligation satisfied within this PR's diff. Listed "
-            "for the audit trail; no merge action required.",
-            "",
-        ]
-        for o in resolved_obligations:
-            lines.extend(_format_obligation_bullet(o, resolved=True))
-        sections.append("\n".join(lines))
-
-    return "\n\n".join(sections)
+    return render_obligations_section_from_normalized(obligations)
 
 
 def _collect_pre_merge_obligations(
@@ -7480,39 +7444,15 @@ def _collect_pre_merge_obligations(
     Returns a list of ``{reviewer, condition, resolved_in_diff}`` dicts. The
     contract source takes precedence over the live tracker when present.
     """
-    if contract_deferred_actions:
-        normalized: list[dict[str, str]] = []
-        for entry in contract_deferred_actions:
-            # ``DeferredAction`` (Pydantic) — the post-#2336 shape.
-            reviewer = getattr(entry, "reviewer", None)
-            condition = getattr(entry, "condition", None)
-            resolved = getattr(entry, "resolved_in_diff", None)
-            if condition is None and isinstance(entry, str):
-                # Defensive: a caller passed a legacy string list directly
-                # without going through the field validator (e.g. a unit test
-                # that constructs the input by hand). Parse it the same way
-                # the validator would.
-                text = entry.strip()
-                if not text:
-                    continue
-                head, sep, tail = text.partition(": ")
-                if sep and tail.strip():
-                    reviewer, condition = head.strip(), tail.strip()
-                else:
-                    reviewer, condition = "", text
-                resolved = ""
-            condition_text = (condition or "").strip()
-            if not condition_text:
-                continue
-            normalized.append(
-                {
-                    "reviewer": (reviewer or "").strip(),
-                    "condition": condition_text,
-                    "resolved_in_diff": (resolved or "").strip(),
-                }
-            )
-        if normalized:
-            return normalized
+    try:
+        from pr_obligations import normalize_deferred_actions
+    except ImportError:
+        from ..pr_obligations import (  # type: ignore[import-not-found,no-redef]
+            normalize_deferred_actions,
+        )
+    normalized = normalize_deferred_actions(contract_deferred_actions)
+    if normalized:
+        return normalized
 
     # Tier 2 — live tracker (pre-#2004 path; kept so conditions still
     # render if the HITL gate hasn't resolved yet, e.g. under force=true).
@@ -7533,43 +7473,19 @@ def _collect_pre_merge_obligations(
         )
         return []
 
-    normalized = []
+    tracker_normalized: list[dict[str, str]] = []
     for c in conditions:
         condition = str(c.get("condition", "")).strip()
         if not condition:
             continue
-        normalized.append(
+        tracker_normalized.append(
             {
                 "reviewer": str(c.get("reviewer", "") or "").strip(),
                 "condition": condition,
                 "resolved_in_diff": str(c.get("resolved_in_diff", "") or "").strip(),
             }
         )
-    return normalized
-
-
-def _format_obligation_bullet(
-    obligation: dict[str, str],
-    resolved: bool,
-) -> list[str]:
-    """Format a single obligation as a markdown bullet (multi-line aware)."""
-    reviewer = obligation["reviewer"] or "unknown"
-    # ``strip()`` before splitlines so a leading/trailing newline doesn't
-    # produce an empty first line ("- **reviewer** — " with nothing after the
-    # em-dash). The collector filters whitespace-only conditions but a
-    # ``"\nreal text"`` value would otherwise slip through with an empty
-    # first line (#2336 review).
-    condition = obligation["condition"].strip()
-    first, *rest = condition.splitlines()
-    bullet = f"- **{reviewer}** — {first}"
-    lines = [bullet]
-    for extra in rest:
-        lines.append(f"  {extra}")
-    if resolved and obligation["resolved_in_diff"]:
-        # Bare SHA (no backticks) so GitHub auto-links it to the commit page
-        # in the rendered PR body — code-span text is not auto-linked.
-        lines.append(f"  - Resolved in {obligation['resolved_in_diff']}")
-    return lines
+    return tracker_normalized
 
 
 def _build_brc_history_link_line(
@@ -11322,6 +11238,16 @@ def _run_implement_phase_slices(
                                 "program_manual_steps": (
                                     program_pr.manual_steps if program_pr else None
                                 ),
+                                # Snapshot the obligations list under the
+                                # state lock alongside the rest of the
+                                # program-* fields. Threaded into
+                                # ``create_slice_pr`` only for the
+                                # terminal slice; non-terminal slices
+                                # receive ``None`` so the umbrella is the
+                                # single place reviewers see them (#2354).
+                                "program_deferred_actions": (
+                                    list(program_pr.deferred_actions) if program_pr else None
+                                ),
                                 "terminal_slice_id": terminal_pointer,
                             }
                 except Exception as load_err:  # noqa: BLE001
@@ -11350,6 +11276,7 @@ def _run_implement_phase_slices(
                             program_description=slice_pr_data["program_description"],
                             program_test_plan=slice_pr_data["program_test_plan"],
                             program_manual_steps=slice_pr_data["program_manual_steps"],
+                            program_deferred_actions=slice_pr_data["program_deferred_actions"],
                             terminal_slice_id=slice_pr_data["terminal_slice_id"],
                         )
                     except Exception as pr_err:  # noqa: BLE001

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7443,6 +7443,24 @@ def _collect_pre_merge_obligations(
 
     Returns a list of ``{reviewer, condition, resolved_in_diff}`` dicts. The
     contract source takes precedence over the live tracker when present.
+
+    .. note::
+
+       The tracker fallback is functionally a no-op when called from the
+       slice-DAG umbrella path (``_run_one_slice_inner`` →
+       ``create_slice_pr``). ``get_peer_consensus_tracker(pipeline_id)``
+       returns the **pipeline-level** tracker, but slice-mode BRC
+       consensus runs on per-slice trackers keyed
+       ``{pipeline_id}/{slice_id}`` (see ``peer_consensus._tracker_key``)
+       — so any slice-BRC ACK obligations are written to the per-slice
+       tracker and the pipeline-level tracker won't see them. In
+       practice ``contract.pr.deferred_actions`` (populated by
+       ``_persist_deferred_actions`` when HITL resolves) is therefore the
+       only effective source for the slice umbrella PR. The fallback is
+       still wired in for call-shape parity with the legacy
+       ``_auto_create_pr`` path so future changes (e.g. aggregating
+       slice obligations onto the pipeline tracker) get parity for
+       free — see PR #2382 review observation A.
     """
     try:
         from pr_obligations import normalize_deferred_actions

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -11245,9 +11245,23 @@ def _run_implement_phase_slices(
                                 # terminal slice; non-terminal slices
                                 # receive ``None`` so the umbrella is the
                                 # single place reviewers see them (#2354).
+                                #
+                                # Collect via ``_collect_pre_merge_obligations``
+                                # rather than passing raw ``DeferredAction``
+                                # objects so the umbrella picks up the live
+                                # peer_consensus tracker fallback when the
+                                # contract list is empty — exact parity with
+                                # the legacy ``_auto_create_pr`` path
+                                # (#2354 review item 2).
                                 "program_deferred_actions": (
-                                    list(program_pr.deferred_actions) if program_pr else None
-                                ),
+                                    _collect_pre_merge_obligations(
+                                        pipeline_id,
+                                        list(program_pr.deferred_actions),
+                                    )
+                                    or None
+                                )
+                                if program_pr
+                                else None,
                                 "terminal_slice_id": terminal_pointer,
                             }
                 except Exception as load_err:  # noqa: BLE001

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -1453,17 +1453,12 @@ class TestCreateSlicePR:
 
     def test_terminal_slice_renders_program_deferred_actions(self, gateway_client):
         """#2354: when the terminal slice receives ``program_deferred_actions``
-        from ``contract.pr.deferred_actions``, the umbrella PR body carries
-        the same Pre-merge Obligations section the legacy ``_auto_create_pr``
-        path emits — so reviewers don't have to discover obligations
-        out-of-band."""
-
-        class _DA:
-            def __init__(self, condition, reviewer="", resolved_in_diff=""):
-                self.condition = condition
-                self.reviewer = reviewer
-                self.resolved_in_diff = resolved_in_diff
-
+        (already-normalized list of ``{reviewer, condition, resolved_in_diff}``
+        dicts produced by ``_collect_pre_merge_obligations``), the umbrella
+        PR body carries the same Pre-merge Obligations section the legacy
+        ``_auto_create_pr`` path emits — so reviewers don't have to discover
+        obligations out-of-band. Asserts the section sits *before*
+        ``## Test Plan`` (#2354 review item 1)."""
         captured, ctx = self._capture(gateway_client)
         with ctx:
             gateway_client.create_slice_pr(
@@ -1476,16 +1471,19 @@ class TestCreateSlicePR:
                 base="egg/issue-42/slice-2",
                 program_title="Decompose oversize files",
                 program_description="Description.",
+                program_test_plan="- Automated: make test-all green.",
+                program_manual_steps="Verify seam tables.",
                 program_deferred_actions=[
-                    _DA(
-                        condition="git mv legacy/x new/x before merge",
-                        reviewer="coder",
-                    ),
-                    _DA(
-                        condition="verify tests green against merged state",
-                        reviewer="reviewer_contract",
-                        resolved_in_diff="2c319626a",
-                    ),
+                    {
+                        "reviewer": "coder",
+                        "condition": "git mv legacy/x new/x before merge",
+                        "resolved_in_diff": "",
+                    },
+                    {
+                        "reviewer": "reviewer_contract",
+                        "condition": "verify tests green against merged state",
+                        "resolved_in_diff": "2c319626a",
+                    },
                 ],
             )
         body = captured["body"]
@@ -1493,8 +1491,14 @@ class TestCreateSlicePR:
         assert "- **coder** — git mv legacy/x new/x before merge" in body
         assert "## ✅ Resolved within this PR" in body
         assert "Resolved in 2c319626a" in body
-        # The obligations section sits before the slice-context footer
-        # (so reviewers see it without scrolling past pipeline metadata).
+        # Obligations sit *before* ``## Test Plan`` so the merge-blocking
+        # banner is visible without scrolling past plan/steps. The original
+        # placement (after Test Plan / Manual Steps) defeated the warning's
+        # visibility intent — see PR #2382 review item 1.
+        assert body.index("## ⚠️ Pre-merge Obligations") < body.index("## Test Plan")
+        assert body.index("## ⚠️ Pre-merge Obligations") < body.index("## Manual Steps")
+        # And before the slice-context footer (so reviewers see it without
+        # scrolling past pipeline metadata).
         assert body.index("## ⚠️ Pre-merge Obligations") < body.index(
             "Slice slice-3 of pipeline issue-42"
         )
@@ -1518,20 +1522,42 @@ class TestCreateSlicePR:
         assert "Pre-merge Obligations" not in captured["body"]
         assert "Resolved within this PR" not in captured["body"]
 
-    def test_non_terminal_slice_ignores_program_deferred_actions(self, gateway_client):
-        """Defensive: even if a caller mistakenly threads
-        ``program_deferred_actions`` to a non-terminal slice (no
-        ``program_title``), the body stays auto-generated. Obligations
-        belong on the umbrella, not on every PR in the chain."""
-
-        class _DA:
-            def __init__(self, condition, reviewer=""):
-                self.condition = condition
-                self.reviewer = reviewer
-                self.resolved_in_diff = ""
-
+    def test_terminal_slice_with_empty_deferred_actions_list_omits_section(self, gateway_client):
+        """The realistic production case is ``contract.pr`` populated with
+        ``deferred_actions=[]`` (no obligations), not ``None``. The
+        ``_collect_pre_merge_obligations`` snapshot in
+        ``_run_one_slice_inner`` returns ``None`` only when there's nothing
+        to render, but a defensive ``[]`` should also short-circuit cleanly
+        — same merge-block visibility behaviour as the ``None`` case
+        (#2354 review item 4)."""
         captured, ctx = self._capture(gateway_client)
         with ctx:
+            gateway_client.create_slice_pr(
+                pipeline_id="issue-42",
+                repo="owner/repo",
+                slice_id="slice-3",
+                slice_name="Apply the ratchet",
+                slice_tasks=None,
+                head="egg/issue-42/slice-3",
+                base="egg/issue-42/slice-2",
+                program_title="Decompose oversize files",
+                program_test_plan="- Automated: make test-all green.",
+                program_deferred_actions=[],
+            )
+        body = captured["body"]
+        assert "Pre-merge Obligations" not in body
+        assert "Resolved within this PR" not in body
+        # Test plan is unaffected by the empty obligations list.
+        assert "## Test Plan" in body
+
+    def test_non_terminal_slice_with_program_deferred_actions_raises(self, gateway_client):
+        """Wiring ``program_deferred_actions`` to a non-terminal slice (no
+        ``program_title``) is a caller mistake — the umbrella is the only
+        place obligations belong. Failing fast catches the regression
+        instead of silently dropping the obligations
+        (#2354 review nit)."""
+        captured, ctx = self._capture(gateway_client)
+        with ctx, pytest.raises(AssertionError, match="program_deferred_actions must be None"):
             gateway_client.create_slice_pr(
                 pipeline_id="issue-42",
                 repo="owner/repo",
@@ -1540,13 +1566,10 @@ class TestCreateSlicePR:
                 slice_tasks=[{"id": "task-1-1", "description": "do X"}],
                 head="egg/issue-42/slice-1",
                 base="egg/issue-42",
-                program_deferred_actions=[_DA(condition="do X", reviewer="r1")],
+                program_deferred_actions=[
+                    {"reviewer": "r1", "condition": "do X", "resolved_in_diff": ""},
+                ],
             )
-        # Auto-generated title (no program_title) — body should not carry
-        # the obligations section.
-        assert captured["title"].startswith("slice slice-1:")
-        assert "Pre-merge Obligations" not in captured["body"]
-        assert "Resolved within this PR" not in captured["body"]
 
 
 class TestSelfIpResolution:

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -1451,6 +1451,103 @@ class TestCreateSlicePR:
         assert len(captured["title"]) == 70
         assert captured["title"].endswith("...")
 
+    def test_terminal_slice_renders_program_deferred_actions(self, gateway_client):
+        """#2354: when the terminal slice receives ``program_deferred_actions``
+        from ``contract.pr.deferred_actions``, the umbrella PR body carries
+        the same Pre-merge Obligations section the legacy ``_auto_create_pr``
+        path emits — so reviewers don't have to discover obligations
+        out-of-band."""
+
+        class _DA:
+            def __init__(self, condition, reviewer="", resolved_in_diff=""):
+                self.condition = condition
+                self.reviewer = reviewer
+                self.resolved_in_diff = resolved_in_diff
+
+        captured, ctx = self._capture(gateway_client)
+        with ctx:
+            gateway_client.create_slice_pr(
+                pipeline_id="issue-42",
+                repo="owner/repo",
+                slice_id="slice-3",
+                slice_name="Apply the ratchet",
+                slice_tasks=None,
+                head="egg/issue-42/slice-3",
+                base="egg/issue-42/slice-2",
+                program_title="Decompose oversize files",
+                program_description="Description.",
+                program_deferred_actions=[
+                    _DA(
+                        condition="git mv legacy/x new/x before merge",
+                        reviewer="coder",
+                    ),
+                    _DA(
+                        condition="verify tests green against merged state",
+                        reviewer="reviewer_contract",
+                        resolved_in_diff="2c319626a",
+                    ),
+                ],
+            )
+        body = captured["body"]
+        assert "## ⚠️ Pre-merge Obligations" in body
+        assert "- **coder** — git mv legacy/x new/x before merge" in body
+        assert "## ✅ Resolved within this PR" in body
+        assert "Resolved in 2c319626a" in body
+        # The obligations section sits before the slice-context footer
+        # (so reviewers see it without scrolling past pipeline metadata).
+        assert body.index("## ⚠️ Pre-merge Obligations") < body.index(
+            "Slice slice-3 of pipeline issue-42"
+        )
+
+    def test_terminal_slice_with_no_deferred_actions_omits_section(self, gateway_client):
+        """When the contract carries no obligations the body must not emit
+        an empty Pre-merge Obligations heading."""
+        captured, ctx = self._capture(gateway_client)
+        with ctx:
+            gateway_client.create_slice_pr(
+                pipeline_id="issue-42",
+                repo="owner/repo",
+                slice_id="slice-3",
+                slice_name="Apply the ratchet",
+                slice_tasks=None,
+                head="egg/issue-42/slice-3",
+                base="egg/issue-42/slice-2",
+                program_title="Decompose oversize files",
+                program_deferred_actions=None,
+            )
+        assert "Pre-merge Obligations" not in captured["body"]
+        assert "Resolved within this PR" not in captured["body"]
+
+    def test_non_terminal_slice_ignores_program_deferred_actions(self, gateway_client):
+        """Defensive: even if a caller mistakenly threads
+        ``program_deferred_actions`` to a non-terminal slice (no
+        ``program_title``), the body stays auto-generated. Obligations
+        belong on the umbrella, not on every PR in the chain."""
+
+        class _DA:
+            def __init__(self, condition, reviewer=""):
+                self.condition = condition
+                self.reviewer = reviewer
+                self.resolved_in_diff = ""
+
+        captured, ctx = self._capture(gateway_client)
+        with ctx:
+            gateway_client.create_slice_pr(
+                pipeline_id="issue-42",
+                repo="owner/repo",
+                slice_id="slice-1",
+                slice_name="Pattern adoption",
+                slice_tasks=[{"id": "task-1-1", "description": "do X"}],
+                head="egg/issue-42/slice-1",
+                base="egg/issue-42",
+                program_deferred_actions=[_DA(condition="do X", reviewer="r1")],
+            )
+        # Auto-generated title (no program_title) — body should not carry
+        # the obligations section.
+        assert captured["title"].startswith("slice slice-1:")
+        assert "Pre-merge Obligations" not in captured["body"]
+        assert "Resolved within this PR" not in captured["body"]
+
 
 class TestSelfIpResolution:
     """Tests for self_ip property used in temporary session registration."""

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -1571,6 +1571,33 @@ class TestCreateSlicePR:
                 ],
             )
 
+    def test_whitespace_program_title_does_not_trigger_assertion(self, gateway_client):
+        """``PRMetadata.title`` validates with ``min_length=1`` but does not
+        ``.strip()`` — so a whitespace-only title (e.g. ``" "``) currently
+        passes contract validation. The non-terminal-slice assertion must
+        guard on ``program_title is None`` rather than on
+        ``has_program_block`` (truthy after strip), so a whitespace-only
+        title doesn't spuriously masquerade as a slice routing error
+        (#2354 review observation B). The whitespace-title bug, if any, is
+        for ``PRMetadata`` to catch — not the slice PR builder."""
+        captured, ctx = self._capture(gateway_client)
+        # Should NOT raise AssertionError — program_title is not None,
+        # so the routing-error guard does not fire.
+        with ctx:
+            gateway_client.create_slice_pr(
+                pipeline_id="issue-42",
+                repo="owner/repo",
+                slice_id="slice-1",
+                slice_name="Pattern adoption",
+                slice_tasks=[{"id": "task-1-1", "description": "do X"}],
+                head="egg/issue-42/slice-1",
+                base="egg/issue-42",
+                program_title=" ",
+                program_deferred_actions=[
+                    {"reviewer": "r1", "condition": "do X", "resolved_in_diff": ""},
+                ],
+            )
+
 
 class TestSelfIpResolution:
     """Tests for self_ip property used in temporary session registration."""

--- a/orchestrator/tests/test_pr_obligations.py
+++ b/orchestrator/tests/test_pr_obligations.py
@@ -1,0 +1,131 @@
+"""Unit tests for ``orchestrator.pr_obligations`` (#2354).
+
+The renderer is shared between the legacy ``_auto_create_pr`` path
+(``routes/pipelines.py``) and the slice-DAG umbrella PR path
+(``gateway_client.create_slice_pr``). These tests pin the markdown
+shape so neither caller can drift independently of the other.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+from pr_obligations import (
+    normalize_deferred_actions,
+    render_obligations_section,
+    render_obligations_section_from_normalized,
+)
+
+
+# Lightweight stand-in for ``DeferredAction`` to avoid importing the
+# full pydantic model in a unit test (the renderer reads via
+# ``getattr`` so any object with the three attrs works).
+class _DA:
+    def __init__(
+        self,
+        condition: str,
+        reviewer: str = "",
+        resolved_in_diff: str = "",
+    ) -> None:
+        self.condition = condition
+        self.reviewer = reviewer
+        self.resolved_in_diff = resolved_in_diff
+
+
+class TestRenderObligationsSection:
+    def test_empty_input_returns_empty_string(self) -> None:
+        assert render_obligations_section(None) == ""
+        assert render_obligations_section([]) == ""
+
+    def test_open_obligation_renders_merge_blocking_banner(self) -> None:
+        section = render_obligations_section(
+            [_DA(condition="git mv legacy/x new/x before merge", reviewer="coder")]
+        )
+        assert "## ⚠️ Pre-merge Obligations" in section
+        assert "Do **not** merge this PR until every obligation is complete" in section
+        assert "- **coder** — git mv legacy/x new/x before merge" in section
+        # No resolved-in-diff section when nothing is resolved.
+        assert "Resolved within this PR" not in section
+
+    def test_resolved_obligation_renders_under_resolved_subsection(self) -> None:
+        section = render_obligations_section(
+            [
+                _DA(
+                    condition="verify make test-all green against merged state",
+                    reviewer="reviewer_contract",
+                    resolved_in_diff="2c319626a",
+                )
+            ]
+        )
+        # No merge-blocking banner when *only* resolved obligations are present.
+        assert "## ⚠️ Pre-merge Obligations" not in section
+        assert "## ✅ Resolved within this PR" in section
+        assert "no merge action required" in section
+        assert "- **reviewer_contract** — verify make test-all green" in section
+        # Bare SHA (not in backticks) so GitHub auto-links it.
+        assert "Resolved in 2c319626a" in section
+        assert "`2c319626a`" not in section
+
+    def test_mixed_open_and_resolved_renders_both_sections(self) -> None:
+        section = render_obligations_section(
+            [
+                _DA(condition="open work", reviewer="r1"),
+                _DA(condition="closed work", reviewer="r2", resolved_in_diff="abc123"),
+            ]
+        )
+        # Both banners present; open first (merge-blocking, more urgent).
+        assert section.index("## ⚠️ Pre-merge Obligations") < section.index(
+            "## ✅ Resolved within this PR"
+        )
+        assert "- **r1** — open work" in section
+        assert "- **r2** — closed work" in section
+        assert "Resolved in abc123" in section
+
+    def test_legacy_string_entry_is_parsed(self) -> None:
+        section = render_obligations_section(["coder: git mv legacy/x new/x before merge"])
+        assert "- **coder** — git mv legacy/x new/x before merge" in section
+
+    def test_legacy_string_without_reviewer_falls_back_to_unknown(self) -> None:
+        section = render_obligations_section(["bare condition with no reviewer"])
+        assert "- **unknown** — bare condition with no reviewer" in section
+
+    def test_whitespace_only_condition_is_dropped(self) -> None:
+        # All inputs whitespace-only → no obligations → empty section.
+        assert render_obligations_section([_DA(condition="   ", reviewer="r1")]) == ""
+        assert render_obligations_section(["   "]) == ""
+
+    def test_multiline_condition_indents_continuation_lines(self) -> None:
+        section = render_obligations_section(
+            [_DA(condition="line one\nline two\nline three", reviewer="r1")]
+        )
+        assert "- **r1** — line one" in section
+        assert "  line two" in section
+        assert "  line three" in section
+
+
+class TestNormalizeDeferredActions:
+    def test_strips_whitespace_around_fields(self) -> None:
+        normalized = normalize_deferred_actions(
+            [_DA(condition="  do X  ", reviewer="  r1  ", resolved_in_diff=" abc ")]
+        )
+        assert normalized == [{"reviewer": "r1", "condition": "do X", "resolved_in_diff": "abc"}]
+
+    def test_legacy_str_with_reviewer_prefix_is_split(self) -> None:
+        normalized = normalize_deferred_actions(["coder: do X"])
+        assert normalized == [{"reviewer": "coder", "condition": "do X", "resolved_in_diff": ""}]
+
+
+class TestRenderFromNormalized:
+    def test_directly_consumable_dict_input(self) -> None:
+        section = render_obligations_section_from_normalized(
+            [{"reviewer": "r1", "condition": "do X", "resolved_in_diff": ""}]
+        )
+        assert "- **r1** — do X" in section
+
+    def test_empty_normalized_list_returns_empty_string(self) -> None:
+        assert render_obligations_section_from_normalized([]) == ""

--- a/orchestrator/tests/test_slice_run_loop_integration.py
+++ b/orchestrator/tests/test_slice_run_loop_integration.py
@@ -825,11 +825,17 @@ class TestRunImplementPhaseSlices:
         actions = terminal_kwargs["program_deferred_actions"]
         assert actions is not None
         assert len(actions) == 2
-        # Pydantic objects survive the snapshot — caller passes them
-        # straight to ``create_slice_pr``, which delegates to
-        # ``pr_obligations.render_obligations_section``.
-        assert actions[0].condition.startswith("git mv legacy/x new/x")
-        assert actions[1].resolved_in_diff == "2c319626a"
+        # The snapshot passes through ``_collect_pre_merge_obligations`` so
+        # the gateway receives the *normalized* shape (list of
+        # ``{reviewer, condition, resolved_in_diff}`` dicts) — same shape
+        # the legacy ``_auto_create_pr`` path uses, which lets the umbrella
+        # pick up the live peer_consensus tracker fallback when the
+        # contract list is empty (#2354 review item 2).
+        assert actions[0]["condition"].startswith("git mv legacy/x new/x")
+        assert actions[0]["reviewer"] == "coder"
+        assert actions[0]["resolved_in_diff"] == ""
+        assert actions[1]["resolved_in_diff"] == "2c319626a"
+        assert actions[1]["reviewer"] == "reviewer_contract"
 
         for non_terminal_id in ("slice-1", "slice-2"):
             kwargs = pr_calls_by_slice[non_terminal_id]

--- a/orchestrator/tests/test_slice_run_loop_integration.py
+++ b/orchestrator/tests/test_slice_run_loop_integration.py
@@ -50,6 +50,7 @@ sys.modules.setdefault("docker.types", MagicMock())
 
 from egg_contracts.models import (  # noqa: E402
     Contract,
+    DeferredAction,
     IssueInfo,
     PRMetadata,
     Slice,
@@ -763,6 +764,77 @@ class TestRunImplementPhaseSlices:
             assert kwargs["program_manual_steps"] is None
             assert kwargs["terminal_slice_id"] == "slice-3"
 
+    def test_terminal_slice_pr_carries_program_deferred_actions(
+        self,
+    ) -> None:
+        """#2354: ``contract.pr.deferred_actions`` (conditional-ACK
+        obligations persisted by ``_persist_deferred_actions``) reach the
+        umbrella PR via the terminal slice only. Non-terminal slices
+        receive ``None`` so the obligations section appears exactly once
+        across the chain — same locality rule as the rest of
+        ``contract.pr.*`` (#2340 / #2351)."""
+        pipeline = _make_pipeline()
+        root = _make_slice("slice-1", tasks=[_make_task("task-1-1")])
+        middle = _make_slice("slice-2", deps=["slice-1"], tasks=[_make_task("task-2-1")])
+        terminal = _make_slice("slice-3", deps=["slice-2"], tasks=[_make_task("task-3-1")])
+        contract = _make_contract(slices=[root, middle, terminal])
+        contract.pr = PRMetadata(
+            title="Decompose oversize files; ratchet allowlist",
+            description="Description.",
+            test_plan="Test plan.",
+            manual_steps="Manual steps.",
+            deferred_actions=[
+                DeferredAction(
+                    reviewer="coder",
+                    condition="git mv legacy/x new/x before merge",
+                ),
+                DeferredAction(
+                    reviewer="reviewer_contract",
+                    condition="verify make test-all green",
+                    resolved_in_diff="2c319626a",
+                ),
+            ],
+        )
+
+        with (
+            patch("egg_contracts.loader.load_contract", return_value=contract),
+            patch("egg_contracts.loader.save_contract"),
+            patch("routes.pipelines._start_stacked_pr_reconciler") as mock_start_recon,
+            patch("routes.pipelines._run_concurrent_phase", return_value=(0, "ok")),
+            patch("orchestrator.peer_consensus.remove_peer_consensus_tracker"),
+        ):
+            mock_start_recon.return_value = (MagicMock(), threading.Event())
+            spawner = self._make_spawner()
+            exit_code, _ = _run_implement_phase_slices(
+                pipeline_id=pipeline.id,
+                pipeline=pipeline,
+                spawner=spawner,
+                repo_volumes={},
+                gateway_mode="public",
+                repos=["owner/repo"],
+                sandbox_env={},
+                store=MagicMock(),
+                certs_volume=None,
+                worktree_repo_path=Path("/tmp/x"),
+            )
+        assert exit_code == 0
+        pr_calls_by_slice = {
+            c.kwargs["slice_id"]: c.kwargs for c in spawner.gateway.create_slice_pr.call_args_list
+        }
+        terminal_kwargs = pr_calls_by_slice["slice-3"]
+        actions = terminal_kwargs["program_deferred_actions"]
+        assert actions is not None
+        assert len(actions) == 2
+        # Pydantic objects survive the snapshot — caller passes them
+        # straight to ``create_slice_pr``, which delegates to
+        # ``pr_obligations.render_obligations_section``.
+        assert actions[0].condition.startswith("git mv legacy/x new/x")
+        assert actions[1].resolved_in_diff == "2c319626a"
+
+        for non_terminal_id in ("slice-1", "slice-2"):
+            kwargs = pr_calls_by_slice[non_terminal_id]
+            assert kwargs["program_deferred_actions"] is None
+
     def test_non_terminal_pointer_suppressed_when_contract_pr_missing(
         self,
     ) -> None:
@@ -815,6 +887,7 @@ class TestRunImplementPhaseSlices:
             assert kwargs["program_description"] is None
             assert kwargs["program_test_plan"] is None
             assert kwargs["program_manual_steps"] is None
+            assert kwargs["program_deferred_actions"] is None
             assert kwargs["terminal_slice_id"] is None
 
     def test_single_slice_path_skips_pr_when_repo_unset(self) -> None:


### PR DESCRIPTION
## Summary

- `orchestrator/pr_obligations.py` (new) — extracts the markdown composer for the `## ⚠️ Pre-merge Obligations` / `## ✅ Resolved within this PR` sections so the legacy `_auto_create_pr` path and the slice-DAG umbrella PR path render byte-identical output.
- `routes/pipelines.py` — `_build_pre_merge_obligations_section` and `_collect_pre_merge_obligations` now delegate composition to the shared module, keeping the live-tracker fallback for the legacy path.
- `orchestrator/gateway_client.py` — `create_slice_pr` accepts `program_deferred_actions: list[Any] | None`. When non-empty *and* `program_title` is set (terminal-slice umbrella shape), the body emits the obligations section before the slice-context footer.
- `_run_implement_phase_slices` snapshots `contract.pr.deferred_actions` under the per-pipeline state lock and threads it into `create_slice_pr` for the terminal slice only — non-terminal slices receive `None` so reviewers see the obligations exactly once across the chain.

## Why

PR #2351 threaded `contract.pr.title` / `description` / `test_plan` / `manual_steps` onto the terminal slice's umbrella PR but missed `deferred_actions`. When a slice gets a conditional ACK whose continuation persists obligations to `contract.pr.deferred_actions` via `_persist_deferred_actions` (`orchestrator/routes/decisions.py:294`), the human merging the stack had no way to see them on the PR.

The legacy monolithic path already renders these via `_render_pre_merge_obligations`; this PR brings the slice-DAG umbrella PR to parity by sharing the same renderer.

Closes #2354.

## Test plan

- [x] New `orchestrator/tests/test_pr_obligations.py` (12 tests) pins the markdown shape: empty/None input, open-only, resolved-only, mixed, legacy `list[str]` entries, whitespace-condition drop, multiline-condition indent.
- [x] New `TestCreateSlicePR` cases in `test_gateway_client.py`:
  - terminal slice with mixed open + resolved obligations renders both sections, in order, before the slice-context footer
  - terminal slice with `program_deferred_actions=None` omits the section
  - non-terminal slice (no `program_title`) ignores `program_deferred_actions` defensively
- [x] New `TestRunImplementPhaseSlices.test_terminal_slice_pr_carries_program_deferred_actions` exercises a 3-slice chain seeded with one open + one resolved obligation; asserts the terminal slice's call kwargs carry the full list and non-terminal slices receive `None`. The companion `test_non_terminal_pointer_suppressed_when_contract_pr_missing` test now also asserts `program_deferred_actions is None` on every slice.
- [x] All 75 existing `test_conditional_ack*.py` tests still pass — the legacy renderer's behavior is unchanged.
- [x] `make lint` clean.
- [x] `make test` (changeset-aware): 3692 passed in 6:19.

## Adjacent

- #2351 — original umbrella-PR threading work (this PR is the deferred-actions follow-up).
- #2336 — already landed the `resolved_in_diff` field on `DeferredAction`; the shared renderer keys on it for the open vs. resolved split.