### PR TITLE
Fix #2356: consolidate three pattern matchers onto canonical match_pattern

### DIFF
--- a/gateway/phase_filter.py
+++ b/gateway/phase_filter.py
@@ -24,7 +24,8 @@ if _shared_path.exists() and str(_shared_path) not in sys.path:
     sys.path.insert(0, str(_shared_path))
 
 from egg_contracts.models import PipelinePhase as PipelinePhase
-from egg_restrictions.patterns import AGENT_PATTERNS, AgentFilePattern
+from egg_restrictions.matchers import match_pattern
+from egg_restrictions.patterns import AGENT_PATTERNS
 
 
 class OperationType(StrEnum):
@@ -64,10 +65,11 @@ class FileRestriction:
     via git push. This is used to protect sensitive files like SDLC contracts
     that should only be modified through dedicated APIs.
 
-    Glob patterns (``**/*.md``, ``**/tests/``) are matched via the same
-    matcher used by ``AgentFilePattern`` so the gateway's early-reject
-    layer behaves consistently with the per-commit attribution layer
-    (#1903).
+    Glob patterns (``**/*.md``, ``**/tests/``) are matched via the
+    canonical ``egg_restrictions.matchers.match_pattern`` so the
+    gateway's early-reject layer behaves consistently with the per-commit
+    attribution layer (#1903) and the phase-level / role-definition
+    layers (#2356).
     """
 
     role: str
@@ -101,11 +103,11 @@ class FileRestriction:
             # Paths that escape the repository are always blocked
             return True
 
-        if not any(AgentFilePattern.matches_pattern(normalized, p) for p in self.blocked_patterns):
+        if not any(match_pattern(normalized, p) for p in self.blocked_patterns):
             return False
         # Block-exempt carve-outs (e.g. ``.egg-state/agent-outputs/``
         # under coder's ``.egg-state/`` block).
-        if any(AgentFilePattern.matches_pattern(normalized, p) for p in self.block_exempt_patterns):
+        if any(match_pattern(normalized, p) for p in self.block_exempt_patterns):
             return False
         return True
 
@@ -206,17 +208,18 @@ class PhaseFileRestriction:
 
         # Check blocked patterns first (explicit blocks take priority)
         for pattern in self.blocked_patterns:
-            if self._matches_pattern(normalized, pattern):
+            if match_pattern(normalized, pattern):
                 return False, f"File '{file_path}' matches blocked pattern '{pattern}'"
 
         # If allowed_patterns is defined and non-empty, file must match one
         if self.allowed_patterns:
-            # Special case: "*" means allow everything
+            # Special case: "*" means allow everything (short-circuit so
+            # the PR phase doesn't pay per-file fnmatch cost).
             if "*" in self.allowed_patterns:
                 return True, "All files allowed"
 
             for pattern in self.allowed_patterns:
-                if self._matches_pattern(normalized, pattern):
+                if match_pattern(normalized, pattern):
                     return (
                         True,
                         f"File '{file_path}' matches allowed pattern '{pattern}'",
@@ -241,28 +244,6 @@ class PhaseFileRestriction:
         if normalized.startswith("../") or normalized.startswith("/"):
             raise ValueError(f"Invalid path escapes repository: {file_path}")
         return normalized
-
-    @staticmethod
-    def _matches_pattern(file_path: str, pattern: str) -> bool:
-        """Check if a file path matches a glob-like pattern.
-
-        Supports:
-        - Exact prefix match (e.g., ".egg-state/contracts/" matches ".egg-state/contracts/foo.json")
-        - Wildcard suffix match (e.g., ".egg-state/drafts/*analysis*" matches "*-analysis.md")
-        - Full wildcard ("*" matches everything)
-        """
-        if pattern == "*":
-            return True
-
-        # If pattern ends with *, use fnmatch for glob matching
-        if "*" in pattern:
-            return fnmatch.fnmatch(file_path, pattern)
-
-        # Otherwise, use prefix matching (for directory patterns)
-        if pattern.endswith("/"):
-            return file_path.startswith(pattern)
-
-        return file_path.startswith(pattern)
 
 
 @dataclass

--- a/gateway/tests/test_agent_restrictions_patterns.py
+++ b/gateway/tests/test_agent_restrictions_patterns.py
@@ -3,7 +3,9 @@
 Covers:
 - AgentFilePattern.can_write() pattern matching logic
 - _normalize_path() path traversal prevention
-- matches_pattern() glob-style matching (prefix, wildcard, **)
+- match_pattern() glob-style matching (prefix, wildcard, **) — the
+  canonical matcher in :mod:`egg_restrictions.matchers` shared by all
+  per-role / phase / role-definition layers (#2356).
 - All 12 agent role permission matrices
 - check_agent_file_access() and validate_agent_push() entry points
 - Blocked patterns taking precedence over allowed patterns (security)
@@ -20,6 +22,7 @@ from agent_restrictions import (
     get_agent_pattern,
     validate_agent_push,
 )
+from egg_restrictions.matchers import match_pattern
 
 
 class TestNormalizePath:
@@ -63,53 +66,50 @@ class TestNormalizePath:
         assert result == "src/app.py"
 
 
-class TestMatchesPattern:
-    """Tests for AgentFilePattern.matches_pattern()."""
+class TestMatchPattern:
+    """Tests for the canonical ``match_pattern`` matcher (#2356)."""
 
     def test_exact_match(self):
-        assert AgentFilePattern.matches_pattern("Makefile", "Makefile") is True
+        assert match_pattern("Makefile", "Makefile") is True
 
     def test_prefix_directory_match(self):
-        assert AgentFilePattern.matches_pattern("docs/guide.md", "docs/") is True
+        assert match_pattern("docs/guide.md", "docs/") is True
 
     def test_prefix_no_match(self):
-        assert AgentFilePattern.matches_pattern("src/docs/guide.md", "docs/") is False
+        assert match_pattern("src/docs/guide.md", "docs/") is False
 
     def test_nested_prefix_match(self):
-        assert AgentFilePattern.matches_pattern("docs/guides/setup.md", "docs/") is True
+        assert match_pattern("docs/guides/setup.md", "docs/") is True
 
     def test_directory_itself(self):
         """Pattern 'docs/' should match path 'docs' (directory itself)."""
-        assert AgentFilePattern.matches_pattern("docs", "docs/") is True
+        assert match_pattern("docs", "docs/") is True
 
     def test_wildcard_extension(self):
-        assert AgentFilePattern.matches_pattern("file.py", "*.py") is True
+        assert match_pattern("file.py", "*.py") is True
 
     def test_wildcard_extension_no_match(self):
-        assert AgentFilePattern.matches_pattern("file.js", "*.py") is False
+        assert match_pattern("file.js", "*.py") is False
 
     def test_double_wildcard_py(self):
-        assert AgentFilePattern.matches_pattern("src/deep/module.py", "**/*.py") is True
+        assert match_pattern("src/deep/module.py", "**/*.py") is True
 
     def test_double_wildcard_at_root(self):
-        assert AgentFilePattern.matches_pattern("module.py", "**/*.py") is True
+        assert match_pattern("module.py", "**/*.py") is True
 
     def test_double_wildcard_with_prefix(self):
-        assert AgentFilePattern.matches_pattern("tests/unit/test_foo.py", "**/test_*.py") is True
+        assert match_pattern("tests/unit/test_foo.py", "**/test_*.py") is True
 
     def test_fnmatch_in_pattern(self):
-        assert AgentFilePattern.matches_pattern("test_foo.py", "test_*.py") is True
+        assert match_pattern("test_foo.py", "test_*.py") is True
 
     def test_prefix_match_with_egg_state(self):
         assert (
-            AgentFilePattern.matches_pattern(
-                ".egg-state/agent-outputs/out.json", ".egg-state/agent-outputs/"
-            )
-            is True
+            match_pattern(".egg-state/agent-outputs/out.json", ".egg-state/agent-outputs/") is True
         )
 
     def test_leading_dot_slash_normalized(self):
-        assert AgentFilePattern.matches_pattern("./src/app.py", "./src/") is True
+        assert match_pattern("./src/app.py", "./src/") is True
 
 
 class TestCanWrite:
@@ -443,12 +443,12 @@ class TestCoderBlocklistComplement1901:
 
     def test_blocks_traversal_via_can_write(self, pattern):
         # The path-traversal guard lives in _normalize_path via can_write;
-        # asserting at the can_write level (NOT matches_pattern) per TASK-5-2.
+        # asserting at the can_write level (NOT match_pattern) per TASK-5-2.
         assert pattern.can_write("../../etc/passwd") is False
 
 
-class TestMatchesPatternFix1901:
-    """TASK-5-2 (#1901): regression coverage for the matches_pattern fix.
+class TestMatchPatternFix1901:
+    """TASK-5-2 (#1901): regression coverage for the matcher fix.
 
     Before #1901 the ** branch fell through to fnmatch-on-basename, which
     incorrectly returned False for nested files under a directory pattern
@@ -457,25 +457,25 @@ class TestMatchesPatternFix1901:
 
     def test_nested_dir_under_double_star(self):
         """gateway/tests/__init__.py matches **/tests/ — the bug fix."""
-        assert AgentFilePattern.matches_pattern("gateway/tests/__init__.py", "**/tests/") is True
+        assert match_pattern("gateway/tests/__init__.py", "**/tests/") is True
 
     def test_unrelated_file_under_double_star_dir(self):
         """src/foo.py must NOT match **/tests/ — guards against over-match."""
-        assert AgentFilePattern.matches_pattern("src/foo.py", "**/tests/") is False
+        assert match_pattern("src/foo.py", "**/tests/") is False
 
     def test_top_level_tests_under_double_star(self):
         """tests/conftest.py matches **/tests/ — ** must accept zero segments."""
-        assert AgentFilePattern.matches_pattern("tests/conftest.py", "**/tests/") is True
+        assert match_pattern("tests/conftest.py", "**/tests/") is True
 
     def test_double_star_extension_pattern_unchanged(self):
         """Regression: **/*.py still matches files anywhere — file-name
         pattern semantics must not be touched by the directory-pattern fix."""
-        assert AgentFilePattern.matches_pattern("pkg/bar.py", "**/*.py") is True
+        assert match_pattern("pkg/bar.py", "**/*.py") is True
 
     def test_leaf_file_named_like_dir_does_not_match(self):
         """src/tests.py is a Python file named 'tests' — NOT inside a tests/
         directory, so **/tests/ must not match it."""
-        assert AgentFilePattern.matches_pattern("src/tests.py", "**/tests/") is False
+        assert match_pattern("src/tests.py", "**/tests/") is False
 
 
 class TestNoAllowedPatternsDeniesAll1901:

--- a/gateway/tests/test_phase_filter_restrictions.py
+++ b/gateway/tests/test_phase_filter_restrictions.py
@@ -12,6 +12,7 @@ Covers:
 """
 
 import pytest
+from egg_restrictions.matchers import match_pattern
 from phase_filter import (
     FileRestriction,
     FileRestrictionResult,
@@ -119,31 +120,29 @@ class TestPhaseFileRestrictionNormalizePath:
             PhaseFileRestriction._normalize_path("/etc/passwd")
 
 
-class TestPhaseFileRestrictionMatchesPattern:
-    """Tests for PhaseFileRestriction._matches_pattern()."""
+class TestPhaseFileRestrictionMatcher:
+    """Tests for the canonical matcher used by ``PhaseFileRestriction`` (#2356).
+
+    Pre-#2356 ``PhaseFileRestriction`` carried its own private
+    ``_matches_pattern`` static method. It now delegates to
+    :func:`egg_restrictions.matchers.match_pattern`, which is a strict
+    superset — every pre-existing pattern in
+    ``_get_default_phase_file_restrictions`` (fnmatch-style globs and
+    directory prefixes) keeps matching the same paths.
+    """
 
     def test_star_matches_everything(self):
-        assert PhaseFileRestriction._matches_pattern("anything.py", "*") is True
+        assert match_pattern("anything.py", "*") is True
 
     def test_directory_prefix_match(self):
-        assert (
-            PhaseFileRestriction._matches_pattern(
-                ".egg-state/contracts/123.json", ".egg-state/contracts/"
-            )
-            is True
-        )
+        assert match_pattern(".egg-state/contracts/123.json", ".egg-state/contracts/") is True
 
     def test_directory_prefix_no_match(self):
-        assert (
-            PhaseFileRestriction._matches_pattern("src/contracts/123.json", ".egg-state/contracts/")
-            is False
-        )
+        assert match_pattern("src/contracts/123.json", ".egg-state/contracts/") is False
 
     def test_fnmatch_glob(self):
         assert (
-            PhaseFileRestriction._matches_pattern(
-                ".egg-state/drafts/644-analysis.md", ".egg-state/drafts/*analysis*"
-            )
+            match_pattern(".egg-state/drafts/644-analysis.md", ".egg-state/drafts/*analysis*")
             is True
         )
 

--- a/shared/egg_contracts/agent_roles.py
+++ b/shared/egg_contracts/agent_roles.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
+from egg_restrictions.matchers import match_pattern
+
 from .roles import Role
 
 
@@ -121,7 +123,7 @@ class FileAccessPattern:
         if not self.allowed_read:
             return True  # Empty list means all files readable
 
-        return any(self._matches_pattern(file_path, pattern) for pattern in self.allowed_read)
+        return any(match_pattern(file_path, pattern) for pattern in self.allowed_read)
 
     def can_write(self, file_path: str) -> bool:
         """Check if the agent can write to this file.
@@ -133,44 +135,14 @@ class FileAccessPattern:
             True if the file can be written
         """
         # Check blocked patterns first
-        if any(self._matches_pattern(file_path, pattern) for pattern in self.blocked_write):
+        if any(match_pattern(file_path, pattern) for pattern in self.blocked_write):
             return False
 
         # If no allowed patterns, block all writes
         if not self.allowed_write:
             return False
 
-        return any(self._matches_pattern(file_path, pattern) for pattern in self.allowed_write)
-
-    @staticmethod
-    def _matches_pattern(file_path: str, pattern: str) -> bool:
-        """Check if a file path matches a glob-like pattern.
-
-        Supports:
-        - Exact match: "foo/bar.py"
-        - Prefix match: "foo/" (matches any file under foo/)
-        - Wildcard: "*.py" (matches files ending in .py)
-        - Double wildcard: "**/*.py" (matches .py files at any depth)
-
-        Args:
-            file_path: Path to check
-            pattern: Pattern to match against
-
-        Returns:
-            True if the path matches the pattern
-        """
-        import fnmatch
-
-        # Normalize paths
-        file_path = file_path.lstrip("./")
-        pattern = pattern.lstrip("./")
-
-        # Prefix match (directory pattern)
-        if pattern.endswith("/"):
-            return file_path.startswith(pattern) or file_path + "/" == pattern
-
-        # Use fnmatch for wildcard matching
-        return fnmatch.fnmatch(file_path, pattern)
+        return any(match_pattern(file_path, pattern) for pattern in self.allowed_write)
 
 
 @dataclass

--- a/shared/egg_restrictions/__init__.py
+++ b/shared/egg_restrictions/__init__.py
@@ -4,19 +4,32 @@ Shared agent file restriction patterns and checking logic.
 This package provides role-based file access patterns and validation
 functions used by the gateway and other components to enforce agent
 file access boundaries.
+
+The package's public API is re-exported lazily via :pep:`562`
+``__getattr__`` because :mod:`egg_restrictions.patterns` depends on
+:mod:`egg_contracts.agent_roles`, which in turn depends on the
+cycle-free :mod:`egg_restrictions.matchers` (#2356). Eager re-exports
+from ``.patterns`` would re-enter ``egg_contracts`` mid-import and
+raise ``ImportError: partially initialized module``.
 """
 
-from .checker import (
-    AgentRestrictionResult,
-    check_agent_file_access,
-    get_agent_pattern,
-    validate_agent_push,
-)
-from .patterns import (
-    AGENT_PATTERNS,
-    AgentFilePattern,
-    AgentRole,
-)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .checker import (
+        AgentRestrictionResult,
+        check_agent_file_access,
+        get_agent_pattern,
+        validate_agent_push,
+    )
+    from .matchers import match_pattern
+    from .patterns import (
+        AGENT_PATTERNS,
+        AgentFilePattern,
+        AgentRole,
+    )
 
 __all__ = [
     "AgentFilePattern",
@@ -25,5 +38,33 @@ __all__ = [
     "AGENT_PATTERNS",
     "check_agent_file_access",
     "get_agent_pattern",
+    "match_pattern",
     "validate_agent_push",
 ]
+
+_CHECKER_NAMES = frozenset(
+    {
+        "AgentRestrictionResult",
+        "check_agent_file_access",
+        "get_agent_pattern",
+        "validate_agent_push",
+    }
+)
+_PATTERNS_NAMES = frozenset({"AGENT_PATTERNS", "AgentFilePattern", "AgentRole"})
+_MATCHERS_NAMES = frozenset({"match_pattern"})
+
+
+def __getattr__(name: str) -> Any:
+    if name in _CHECKER_NAMES:
+        from . import checker
+
+        return getattr(checker, name)
+    if name in _PATTERNS_NAMES:
+        from . import patterns
+
+        return getattr(patterns, name)
+    if name in _MATCHERS_NAMES:
+        from . import matchers
+
+        return getattr(matchers, name)
+    raise AttributeError(f"module 'egg_restrictions' has no attribute {name!r}")

--- a/shared/egg_restrictions/matchers.py
+++ b/shared/egg_restrictions/matchers.py
@@ -41,6 +41,13 @@ def match_pattern(file_path: str, pattern: str) -> bool:
     - Directory at any depth: "**/tests/" (matches any file under a
       ``tests/`` directory at any depth, including top-level)
 
+    Bare-prefix substring matching (e.g. ``"docs"`` matching
+    ``"src/docs/foo.py"``) is **not** supported — the pre-#2356
+    ``PhaseFileRestriction._matches_pattern`` had this fallback, but no
+    shipped config relied on it. Downstream configs that did should use
+    ``"**/docs/"`` (matches any file under a ``docs/`` directory at any
+    depth, identically across all four enforcement layers).
+
     Args:
         file_path: Path to check
         pattern: Pattern to match against

--- a/shared/egg_restrictions/matchers.py
+++ b/shared/egg_restrictions/matchers.py
@@ -1,0 +1,115 @@
+"""
+Canonical glob-pattern matcher for agent / phase / role file boundaries.
+
+This is the single ``match_pattern`` implementation shared by every layer
+that decides whether a path matches a configured pattern:
+
+- ``AgentFilePattern.can_write`` — per-role attribution (this package)
+- ``FileRestriction.is_file_blocked`` — gateway early-reject
+  (``gateway/phase_filter.py``)
+- ``PhaseFileRestriction.is_file_allowed`` — phase-level allow/block
+  (``gateway/phase_filter.py``)
+- ``FileAccessPattern.can_read`` / ``can_write`` — orchestrator
+  role-definition surface (``shared/egg_contracts/agent_roles.py``)
+
+#1903 unified the first two layers; #2356 collapses the remaining
+two onto this module so all four go through the same matcher and a
+``**/<dir>/`` pattern in any of those configurations means the same
+thing everywhere.
+
+The function lives in its own module so consumers in ``egg_contracts``
+can import it without re-introducing the ``egg_restrictions →
+egg_contracts → egg_restrictions`` import cycle that ``patterns.py``'s
+``AgentRole`` re-export established.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+
+__all__ = ["match_pattern"]
+
+
+def match_pattern(file_path: str, pattern: str) -> bool:
+    """Check if a file path matches a glob-like pattern.
+
+    Supports:
+    - Exact match: "foo/bar.py"
+    - Prefix match: "foo/" (matches any file under foo/)
+    - Wildcard: "*.py" (matches files ending in .py)
+    - Double wildcard: "**/*.py" (matches .py files at any depth)
+    - Directory at any depth: "**/tests/" (matches any file under a
+      ``tests/`` directory at any depth, including top-level)
+
+    Args:
+        file_path: Path to check
+        pattern: Pattern to match against
+
+    Returns:
+        True if the path matches the pattern
+    """
+    # Normalize both paths
+    file_path = file_path.lstrip("./")
+    pattern = pattern.lstrip("./")
+
+    # Directory patterns containing ** (e.g., "**/tests/", "**/test/")
+    # must be handled BEFORE the bare-prefix branch because the bare-prefix
+    # branch uses `file_path.startswith(pattern)` which would miss nested
+    # files like "gateway/tests/__init__.py" against "**/tests/".
+    # Fix for #1901 — previously the ** branch's fnmatch-on-basename logic
+    # returned False for nested directory files.
+    if pattern.endswith("/") and "**" in pattern:
+        # A pattern like "**/<dir>/" matches any file under a directory of
+        # that name at any depth, including top-level (zero segments before).
+        # We strip the leading "**/" and the trailing "/" to extract the
+        # directory segment(s) to look for.
+        inner = pattern
+        if inner.startswith("**/"):
+            inner = inner[3:]
+        # Strip a single leading "**" if someone wrote "**<dir>/" (unusual)
+        elif inner.startswith("**"):
+            inner = inner[2:]
+        # inner is now e.g. "tests/" — split it into a path prefix we
+        # look for as a complete segment inside file_path.
+        dir_segment = inner.rstrip("/")
+        if not dir_segment:
+            return False
+        # Match only if dir_segment appears as a complete path segment
+        # (i.e. surrounded by / or at path start) AND there is at least
+        # one more path segment after it (it must be a directory, not a
+        # leaf filename).
+        parts = file_path.split("/")
+        # dir_segment may itself contain slashes (e.g. "a/b"); handle both.
+        seg_parts = dir_segment.split("/")
+        seg_len = len(seg_parts)
+        if seg_len == 0:
+            return False
+        # Scan each possible starting index.
+        for i in range(0, len(parts) - seg_len):
+            if parts[i : i + seg_len] == seg_parts:
+                return True
+        return False
+
+    # Prefix match (directory pattern)
+    if pattern.endswith("/"):
+        return file_path.startswith(pattern) or file_path + "/" == pattern
+
+    # Handle ** patterns for recursive matching
+    if "**" in pattern:
+        # Convert ** to regex-style matching
+        # "**/*.py" should match "foo/bar/baz.py"
+        parts = pattern.split("**")
+        if len(parts) == 2:
+            prefix, suffix = parts
+            # Check if path starts with prefix (if any) and ends with suffix
+            prefix_match = not prefix or file_path.startswith(prefix.rstrip("/"))
+            suffix = suffix.lstrip("/")
+            suffix_match = not suffix or fnmatch.fnmatch(file_path.split("/")[-1], suffix)
+            if prefix_match and suffix_match:
+                # For patterns like "**/*.py", also check the full suffix matches
+                if suffix.startswith("*"):
+                    return fnmatch.fnmatch(file_path, "*" + suffix)
+                return True
+
+    # Standard fnmatch for simple wildcards
+    return fnmatch.fnmatch(file_path, pattern)

--- a/shared/egg_restrictions/patterns.py
+++ b/shared/egg_restrictions/patterns.py
@@ -8,7 +8,6 @@ that need to enforce agent file access boundaries.
 
 from __future__ import annotations
 
-import fnmatch
 import posixpath
 from dataclasses import dataclass, field
 
@@ -17,6 +16,8 @@ from dataclasses import dataclass, field
 # is now automatically visible here, removing the silent-drift failure
 # mode from #2066.
 from egg_contracts.agent_roles import AgentRole
+
+from .matchers import match_pattern
 
 __all__ = ["AGENT_PATTERNS", "AgentFilePattern", "AgentRole"]
 
@@ -65,15 +66,15 @@ class AgentFilePattern:
 
         # Check blocked patterns FIRST - security takes precedence
         # BUT skip the block if the path matches a block-exemption pattern.
-        if any(self.matches_pattern(normalized, p) for p in self.blocked_patterns):
-            if not any(self.matches_pattern(normalized, p) for p in self.block_exempt_patterns):
+        if any(match_pattern(normalized, p) for p in self.blocked_patterns):
+            if not any(match_pattern(normalized, p) for p in self.block_exempt_patterns):
                 return False
 
         # If no allowed patterns, nothing is allowed
         if not self.allowed_patterns:
             return False
 
-        return any(self.matches_pattern(normalized, p) for p in self.allowed_patterns)
+        return any(match_pattern(normalized, p) for p in self.allowed_patterns)
 
     @staticmethod
     def _normalize_path(file_path: str) -> str:
@@ -96,94 +97,6 @@ class AgentFilePattern:
         normalized = normalized.lstrip("/")
 
         return normalized
-
-    @staticmethod
-    def matches_pattern(file_path: str, pattern: str) -> bool:
-        """Check if a file path matches a glob-like pattern.
-
-        This is the canonical pattern-matcher used both inside this
-        module (for ``can_write`` decisions) and by external consumers
-        such as ``gateway/phase_filter.py``'s ``FileRestriction.is_file_blocked``
-        — keeping the two layers in sync (#1903).
-
-        Supports:
-        - Exact match: "foo/bar.py"
-        - Prefix match: "foo/" (matches any file under foo/)
-        - Wildcard: "*.py" (matches files ending in .py)
-        - Double wildcard: "**/*.py" (matches .py files at any depth)
-
-        Args:
-            file_path: Path to check
-            pattern: Pattern to match against
-
-        Returns:
-            True if the path matches the pattern
-        """
-        # Normalize both paths
-        file_path = file_path.lstrip("./")
-        pattern = pattern.lstrip("./")
-
-        # Directory patterns containing ** (e.g., "**/tests/", "**/test/")
-        # must be handled BEFORE the bare-prefix branch because the bare-prefix
-        # branch uses `file_path.startswith(pattern)` which would miss nested
-        # files like "gateway/tests/__init__.py" against "**/tests/".
-        # Fix for #1901 — previously the ** branch's fnmatch-on-basename logic
-        # returned False for nested directory files.
-        if pattern.endswith("/") and "**" in pattern:
-            # A pattern like "**/<dir>/" matches any file under a directory of
-            # that name at any depth, including top-level (zero segments before).
-            # We strip the leading "**/" and the trailing "/" to extract the
-            # directory segment(s) to look for.
-            inner = pattern
-            if inner.startswith("**/"):
-                inner = inner[3:]
-            # Strip a single leading "**" if someone wrote "**<dir>/" (unusual)
-            elif inner.startswith("**"):
-                inner = inner[2:]
-            # inner is now e.g. "tests/" — split it into a path prefix we
-            # look for as a complete segment inside file_path.
-            dir_segment = inner.rstrip("/")
-            if not dir_segment:
-                return False
-            # Match only if dir_segment appears as a complete path segment
-            # (i.e. surrounded by / or at path start) AND there is at least
-            # one more path segment after it (it must be a directory, not a
-            # leaf filename).
-            parts = file_path.split("/")
-            # dir_segment may itself contain slashes (e.g. "a/b"); handle both.
-            seg_parts = dir_segment.split("/")
-            seg_len = len(seg_parts)
-            if seg_len == 0:
-                return False
-            # Scan each possible starting index.
-            for i in range(0, len(parts) - seg_len):
-                if parts[i : i + seg_len] == seg_parts:
-                    return True
-            return False
-
-        # Prefix match (directory pattern)
-        if pattern.endswith("/"):
-            return file_path.startswith(pattern) or file_path + "/" == pattern
-
-        # Handle ** patterns for recursive matching
-        if "**" in pattern:
-            # Convert ** to regex-style matching
-            # "**/*.py" should match "foo/bar/baz.py"
-            parts = pattern.split("**")
-            if len(parts) == 2:
-                prefix, suffix = parts
-                # Check if path starts with prefix (if any) and ends with suffix
-                prefix_match = not prefix or file_path.startswith(prefix.rstrip("/"))
-                suffix = suffix.lstrip("/")
-                suffix_match = not suffix or fnmatch.fnmatch(file_path.split("/")[-1], suffix)
-                if prefix_match and suffix_match:
-                    # For patterns like "**/*.py", also check the full suffix matches
-                    if suffix.startswith("*"):
-                        return fnmatch.fnmatch(file_path, "*" + suffix)
-                    return True
-
-        # Standard fnmatch for simple wildcards
-        return fnmatch.fnmatch(file_path, pattern)
 
 
 # Default agent file patterns


### PR DESCRIPTION
## Summary

Closes #2356. Follow-up to #1903.

Lifts the canonical glob matcher out of `AgentFilePattern.matches_pattern` into a free function `egg_restrictions.matchers.match_pattern`, then collapses the two remaining ad-hoc matchers — `PhaseFileRestriction._matches_pattern` and `FileAccessPattern._matches_pattern` — onto it. After this, all four file-boundary layers go through one matcher:

| Layer | Where | Was |
| --- | --- | --- |
| Per-role attribution | `AgentFilePattern.can_write` | canonical (since #1903) |
| Gateway early-reject | `FileRestriction.is_file_blocked` | canonical (since #1903) |
| Phase-level allow/block | `PhaseFileRestriction.is_file_allowed` | private fnmatch + prefix |
| Role-definition surface | `FileAccessPattern.can_read` / `can_write` | private fnmatch + prefix |

The simpler matchers were a strict subset of the canonical one. For phase-level patterns this is **behavior-preserving** — the defaults in `_get_default_phase_file_restrictions` are all fnmatch-style globs (`.egg-state/contracts/*`, `*analysis*`, `*`) and never use `**`. For `FileAccessPattern` it's a **strict tightening**: patterns like `**/tests/`, `**/*.py`, `**/*.test.ts` were silently dead in role definitions before and now match nested paths, exactly the silent-drift failure mode #1903 cited.

## Notes

- `egg_restrictions/__init__.py` re-exports lazily via PEP 562 `__getattr__`. Without this, `egg_contracts.agent_roles → egg_restrictions.matchers` re-enters `egg_contracts` mid-import via `egg_restrictions.patterns`'s `AgentRole` re-export. Existing `from egg_restrictions import …` imports keep working unchanged.
- `PhaseFileRestriction.is_file_allowed` keeps its `"*" in allowed_patterns` short-circuit so the PR phase doesn't pay per-file fnmatch cost.
- Tests that called the now-removed `AgentFilePattern.matches_pattern` and `PhaseFileRestriction._matches_pattern` static methods were migrated to call `match_pattern` directly. Coverage is unchanged.

## Test plan

- [x] `make lint` clean on touched files
- [x] `pytest shared/tests/test_egg_restrictions.py shared/egg_contracts/tests/test_agent_roles.py tests/shared/egg_contracts/test_agent_roles.py gateway/tests/test_phase_filter*.py gateway/tests/test_agent_restrictions*.py tests/gateway/test_agent_restrictions.py` — 956 passed (1 pre-existing-skip, 1 pre-existing-fail unrelated: `TestRoleSyncWithOrchestratorModels::test_all_canonical_roles_in_orchestrator_models` fails on `main` too with `ModuleNotFoundError: No module named 'models'`)
- [x] `pytest gateway/ shared/ orchestrator/tests/test_overseer_role.py orchestrator/tests/test_concurrent_executor.py` — 4379 passed; 3 pre-existing failures in `test_phase_api.py::TestPathTraversalProtection` reproduce on `main`
- [ ] CI green

## Out of scope

- The static method `AgentFilePattern.matches_pattern` was the canonical implementation; consumers now use `match_pattern` directly. No backwards-compat alias was added — only test code referenced the old name and was migrated. If any out-of-tree consumer still imports it, the breaking signal is loud (`AttributeError`).