### PR TITLE
Fix orchestrator CrashLoopBackOff: ship egg_restrictions in image

### DIFF
--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -16,10 +16,11 @@ COPY orchestrator/*.py ./
 COPY orchestrator/routes/ ./routes/
 COPY orchestrator/health_checks/ ./health_checks/
 
-# Copy shared modules (egg_logging, egg_config, egg_contracts, egg_container, egg_agent, egg_git, egg_anchor, egg_health)
+# Copy shared modules (egg_logging, egg_config, egg_contracts, egg_restrictions, egg_container, egg_agent, egg_git, egg_anchor, egg_health)
 COPY shared/egg_logging/ ./egg_logging/
 COPY shared/egg_config/ ./egg_config/
 COPY shared/egg_contracts/ ./egg_contracts/
+COPY shared/egg_restrictions/ ./egg_restrictions/
 COPY shared/egg_container/ ./egg_container/
 COPY shared/egg_agent/ ./egg_agent/
 COPY shared/egg_orchestrator/ ./egg_orchestrator/


### PR DESCRIPTION
## Summary
- The orchestrator container was crashing at startup with `ModuleNotFoundError: No module named 'egg_restrictions'`, causing `make redeploy` to fail with `timed out waiting for the condition on deployments/orchestrator`.
- Root cause: PR #2383 added a top-level `from egg_restrictions.matchers import match_pattern` to `shared/egg_contracts/agent_roles.py`, but `orchestrator/Dockerfile` was not updated to copy `shared/egg_restrictions/` into the image.
- The gateway Dockerfile already copies `egg_restrictions`; this brings the orchestrator in line.

## Test plan
- [ ] `make redeploy` succeeds and the orchestrator pod becomes Ready (no CrashLoopBackOff).
- [ ] `kubectl logs -n egg-system deploy/orchestrator` no longer shows the `ModuleNotFoundError: No module named 'egg_restrictions'` traceback.