### PR TITLE
Fix #2378: short-circuit /status/wait for already-terminal pipelines

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -3019,6 +3019,34 @@ def wait_pipeline_status(pipeline_id: str) -> tuple[Response, int]:
 
     event_bus = get_event_bus()
 
+    # Late-subscriber short-circuit (issue #2378): if the pipeline is
+    # already terminal at subscription time, the relevant ``pipeline.*``
+    # event was emitted before this call could subscribe — and the
+    # snap-to-tip below would cement that miss.  Synthesize a Path-A
+    # envelope so callers don't loop until the 1-hour cap.  This covers
+    # the common path where ``mark FAILED`` succeeds; the synthetic
+    # emit at ``_run_pipeline``'s mark-FAILED-failed branch covers the
+    # rarer case where the FAILED-mark itself raises.
+    _TERMINAL_EVENT_TYPES = {
+        PipelineStatus.COMPLETE: "pipeline.completed",
+        PipelineStatus.FAILED: "pipeline.failed",
+        PipelineStatus.CANCELLED: "pipeline.cancelled",
+    }
+    if pipeline.status in _TERMINAL_EVENT_TYPES:
+        terminal_cursor = _build_status_wait_cursor(
+            _message_store_tip_id(pipeline_id) or msg_since_id,
+            event_bus.current_sequence(),
+        )
+        terminal_envelope = _build_minimal_status_envelope(pipeline, terminal_cursor)
+        terminal_envelope.update(
+            {
+                "changed": True,
+                "trigger": "event",
+                "event_type": _TERMINAL_EVENT_TYPES[pipeline.status],
+            }
+        )
+        return make_success_response("Pipeline already terminal", data=terminal_envelope)
+
     # Snap event_since_seq to the current tip on first call.  This
     # preserves the "events before the call are already seen"
     # semantic and matches the message-bus ``from_tip`` behaviour

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -3020,7 +3020,7 @@ def wait_pipeline_status(pipeline_id: str) -> tuple[Response, int]:
     event_bus = get_event_bus()
 
     # Late-subscriber short-circuit (issue #2378): if the pipeline is
-    # already terminal at subscription time, the relevant ``pipeline.*``
+    # already terminal at request time, the relevant ``pipeline.*``
     # event was emitted before this call could subscribe — and the
     # snap-to-tip below would cement that miss.  Synthesize a Path-A
     # envelope so callers don't loop until the 1-hour cap.  This covers

--- a/orchestrator/tests/test_pipelines_status_wait_route.py
+++ b/orchestrator/tests/test_pipelines_status_wait_route.py
@@ -443,3 +443,79 @@ class TestQueueFull:
         assert resp.status_code == 200
         assert envelope["changed"] is True
         assert envelope["trigger"] == "event"
+
+
+class TestWaitRouteAlreadyTerminal:
+    """Late-subscriber short-circuit (issue #2378).
+
+    When ``/status/wait`` is called against a pipeline whose status is
+    already ``complete``/``failed``/``cancelled``, the relevant
+    ``pipeline.*`` event was emitted before this call could subscribe.
+    Without the short-circuit the route snaps the cursor to tip and
+    returns Path-B no_change indefinitely; the host then loops until
+    the 1-hour cap. The route must instead return Path-A immediately
+    so callers exit cleanly.
+    """
+
+    @pytest.mark.parametrize(
+        ("status", "expected_event_type"),
+        [
+            (PipelineStatus.FAILED, "pipeline.failed"),
+            (PipelineStatus.COMPLETE, "pipeline.completed"),
+            (PipelineStatus.CANCELLED, "pipeline.cancelled"),
+        ],
+    )
+    @patch("routes.pipelines.get_repo_path", return_value="/tmp/test")
+    @patch("routes.pipelines._resolve_pipeline")
+    def test_terminal_pipeline_returns_path_a_immediately(
+        self,
+        mock_resolve: MagicMock,
+        mock_repo: MagicMock,
+        status: PipelineStatus,
+        expected_event_type: str,
+        client,
+        isolated_event_bus: EventBus,
+    ) -> None:
+        pipeline = _make_pipeline()
+        pipeline.status = status
+        mock_resolve.return_value = (MagicMock(), pipeline)
+
+        start = time.monotonic()
+        resp = client.get("/api/v1/pipelines/issue-1932-test/status/wait?wait=25")
+        elapsed = time.monotonic() - start
+
+        assert resp.status_code == 200
+        envelope = json.loads(resp.data)["data"]
+        assert envelope["changed"] is True
+        assert envelope["trigger"] == "event"
+        assert envelope["event_type"] == expected_event_type
+        assert envelope["status"] == status.value
+        assert "cursor" in envelope
+        assert elapsed < 1.0, (
+            f"terminal short-circuit took {elapsed:.2f}s — did it block on the wake queue?"
+        )
+
+    @patch("routes.pipelines.get_repo_path", return_value="/tmp/test")
+    @patch("routes.pipelines._resolve_pipeline")
+    def test_running_pipeline_still_blocks(
+        self,
+        mock_resolve: MagicMock,
+        mock_repo: MagicMock,
+        client,
+        isolated_event_bus: EventBus,
+    ) -> None:
+        """Regression guard: the short-circuit must not fire on RUNNING."""
+        pipeline = _make_pipeline()
+        assert pipeline.status == PipelineStatus.RUNNING
+
+        mock_resolve.return_value = (MagicMock(), pipeline)
+
+        start = time.monotonic()
+        resp = client.get("/api/v1/pipelines/issue-1932-test/status/wait?wait=1")
+        elapsed = time.monotonic() - start
+
+        assert resp.status_code == 200
+        envelope = json.loads(resp.data)["data"]
+        assert envelope["changed"] is False
+        assert envelope["no_change"] is True
+        assert elapsed >= 0.5, "RUNNING pipeline must still block until timeout"

--- a/orchestrator/tests/test_pipelines_status_wait_route.py
+++ b/orchestrator/tests/test_pipelines_status_wait_route.py
@@ -491,7 +491,10 @@ class TestWaitRouteAlreadyTerminal:
         assert envelope["event_type"] == expected_event_type
         assert envelope["status"] == status.value
         assert "cursor" in envelope
-        assert elapsed < 1.0, (
+        # The actual short-circuit returns within microseconds; budget
+        # 5s rather than 1s to absorb slow-runner noise without losing
+        # the "did it block on the wake queue?" signal.
+        assert elapsed < 5.0, (
             f"terminal short-circuit took {elapsed:.2f}s — did it block on the wake queue?"
         )
 

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -639,7 +639,23 @@ def cmd_pipeline_wait_status(args: argparse.Namespace) -> int:
                 isinstance(status_str, str) and status_str in _WAIT_STATUS_TERMINAL_STATUSES
             ) or event_type in _WAIT_STATUS_TERMINAL_EVENTS:
                 return 0
-        # Path B (no_change): silent, loop again.
+        else:
+            # Path B (no_change): defense-in-depth for issue #2378. The
+            # server short-circuits already-terminal pipelines on Path A,
+            # but if any other code path leaves us subscribed past a
+            # terminal state, the envelope's ``status`` field still
+            # carries the truth — emit a synthetic terminal line and
+            # exit 0 instead of looping silently.
+            status_str = envelope.get("status")
+            if isinstance(status_str, str) and status_str in _WAIT_STATUS_TERMINAL_STATUSES:
+                line = {
+                    "trigger": "synthetic-terminal",
+                    "cursor": envelope.get("cursor"),
+                    "current_phase": envelope.get("current_phase"),
+                    "status": status_str,
+                }
+                print(json.dumps(line), flush=True)
+                return 0
 
     return 1
 

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -543,6 +543,16 @@ _WAIT_STATUS_TERMINAL_STATUSES = frozenset({"complete", "failed", "cancelled"})
 _WAIT_STATUS_TERMINAL_EVENTS = frozenset(
     {"pipeline.completed", "pipeline.failed", "pipeline.cancelled"}
 )
+# Map terminal ``status`` strings to the Path-A ``event_type`` they
+# correspond to.  Used by the Path-B defense-in-depth path (issue #2378)
+# so synthetic-terminal JSON lines carry the same ``event_type`` field
+# Path-A consumers already key off (``failed``/``completed``/
+# ``cancelled``).
+_WAIT_STATUS_TO_EVENT_TYPE = {
+    "complete": "pipeline.completed",
+    "failed": "pipeline.failed",
+    "cancelled": "pipeline.cancelled",
+}
 
 
 def cmd_pipeline_wait_status(args: argparse.Namespace) -> int:
@@ -653,6 +663,7 @@ def cmd_pipeline_wait_status(args: argparse.Namespace) -> int:
                     "cursor": envelope.get("cursor"),
                     "current_phase": envelope.get("current_phase"),
                     "status": status_str,
+                    "event_type": _WAIT_STATUS_TO_EVENT_TYPE[status_str],
                 }
                 print(json.dumps(line), flush=True)
                 return 0

--- a/sandbox/tests/test_pipeline_wait_status_cli.py
+++ b/sandbox/tests/test_pipeline_wait_status_cli.py
@@ -306,6 +306,66 @@ class TestCursorThreading:
         assert "since=msg%3Aabc%7Cevt%3A5" in second_endpoint
 
 
+def _no_change_terminal(
+    cursor: str = "msg:|evt:0",
+    status: str = "failed",
+    current_phase: str = "implement",
+) -> dict[str, Any]:
+    """Path-B (no_change) envelope carrying a terminal ``status`` field.
+
+    Mirrors the shape that ``_build_minimal_status_envelope`` would
+    produce on a hypothetical late-subscriber path that wasn't caught
+    by the server-side short-circuit (issue #2378). Used to exercise
+    the CLI's defense-in-depth check.
+    """
+    return {
+        "success": True,
+        "data": {
+            "changed": False,
+            "no_change": True,
+            "cursor": cursor,
+            "current_phase": current_phase,
+            "status": status,
+        },
+    }
+
+
+class TestPathBTerminalShortCircuit:
+    """Issue #2378 defense-in-depth: a Path-B no_change envelope whose
+    ``status`` field carries a terminal value (``failed``/``complete``/
+    ``cancelled``) must end the loop with exit 0 and one synthetic
+    JSON line, instead of looping silently.
+    """
+
+    @pytest.mark.parametrize("status", ["failed", "complete", "cancelled"])
+    def test_no_change_with_terminal_status_returns_zero(self, capsys, status: str):
+        with patch(_API_MOCK_PATH, side_effect=[_no_change_terminal(status=status)]) as mock:
+            rc = cmd_pipeline_wait_status(_ns(max_iterations=5))
+
+        assert rc == 0
+        # Loop exited after one call — no second iteration.
+        assert mock.call_count == 1
+        out = capsys.readouterr().out.strip().splitlines()
+        assert len(out) == 1
+        line = json.loads(out[0])
+        assert line["trigger"] == "synthetic-terminal"
+        assert line["status"] == status
+        assert line["current_phase"] == "implement"
+        assert line["cursor"] == "msg:|evt:0"
+
+    def test_no_change_running_still_loops(self):
+        """Regression guard: only terminal statuses short-circuit Path-B."""
+        running = _no_change_terminal(status="running")
+        with patch(
+            _API_MOCK_PATH,
+            side_effect=[running, running, _terminal_event("msg:|evt:9")],
+        ) as mock:
+            rc = cmd_pipeline_wait_status(_ns(max_iterations=5))
+
+        assert rc == 0
+        assert mock.call_count == 3
+
+
 @pytest.fixture(autouse=True)
 def _set_env(monkeypatch):
     """Ensure the CLI hits a deterministic URL during tests."""

--- a/sandbox/tests/test_pipeline_wait_status_cli.py
+++ b/sandbox/tests/test_pipeline_wait_status_cli.py
@@ -354,6 +354,14 @@ class TestPathBTerminalShortCircuit:
         assert line["status"] == status
         assert line["current_phase"] == "implement"
         assert line["cursor"] == "msg:|evt:0"
+        # event_type mirrors the Path-A line shape so downstream
+        # consumers can key off it uniformly (issue #2378 review).
+        expected_event = {
+            "failed": "pipeline.failed",
+            "complete": "pipeline.completed",
+            "cancelled": "pipeline.cancelled",
+        }[status]
+        assert line["event_type"] == expected_event
 
     def test_no_change_running_still_loops(self):
         """Regression guard: only terminal statuses short-circuit Path-B."""

--- a/sandbox/tests/test_pipeline_wait_status_cli.py
+++ b/sandbox/tests/test_pipeline_wait_status_cli.py
@@ -338,7 +338,9 @@ class TestPathBTerminalShortCircuit:
     """
 
     @pytest.mark.parametrize("status", ["failed", "complete", "cancelled"])
-    def test_no_change_with_terminal_status_returns_zero(self, capsys: pytest.CaptureFixture[str], status: str) -> None:
+    def test_no_change_with_terminal_status_returns_zero(
+        self, capsys: pytest.CaptureFixture[str], status: str
+    ) -> None:
         with patch(_API_MOCK_PATH, side_effect=[_no_change_terminal(status=status)]) as mock:
             rc = cmd_pipeline_wait_status(_ns(max_iterations=5))
 

--- a/sandbox/tests/test_pipeline_wait_status_cli.py
+++ b/sandbox/tests/test_pipeline_wait_status_cli.py
@@ -338,7 +338,7 @@ class TestPathBTerminalShortCircuit:
     """
 
     @pytest.mark.parametrize("status", ["failed", "complete", "cancelled"])
-    def test_no_change_with_terminal_status_returns_zero(self, capsys, status: str):
+    def test_no_change_with_terminal_status_returns_zero(self, capsys: pytest.CaptureFixture[str], status: str) -> None:
         with patch(_API_MOCK_PATH, side_effect=[_no_change_terminal(status=status)]) as mock:
             rc = cmd_pipeline_wait_status(_ns(max_iterations=5))
 


### PR DESCRIPTION
## Summary

Fixes #2378 — when a pipeline transitions to `complete`/`failed`/`cancelled` before the host's first `/status/wait` call subscribes, the route snaps its event-bus cursor to tip (past the terminal event) and returns Path-B `no_change` indefinitely. The `wait-status` CLI then loops silently for up to an hour while the pipeline is visibly terminal via `mcp__egg__get_status`. Today's incident was `issue-2261-v4` failing inside ~2s of `submit_task` due to #2372 — the host Monitor would have run for the full 1-hour `timeout_ms` cap.

This PR closes the gap on both sides:

- **Server (`orchestrator/routes/pipelines.py`)**: in `wait_pipeline_status`, immediately after `event_bus = get_event_bus()`, detect `PipelineStatus.{COMPLETE,FAILED,CANCELLED}` and synthesize a Path-A envelope with `event_type=pipeline.{completed,failed,cancelled}`. Generalizes the existing synthetic-failure block at `~:16284` (which only fires when the mark-FAILED block itself raises) to the common path where the FAILED-mark succeeds.
- **Client (`sandbox/egg_lib/orch_cli.py`)**: in `cmd_pipeline_wait_status`, on Path-B `no_change` also inspect `envelope["status"]`; if terminal, emit a `trigger=synthetic-terminal` JSON line and exit 0. Defense-in-depth — protects against any other code path that lets a host subscribe past a terminal state.

Either fix alone closes the symptom; both ship together as belt-and-suspenders per the issue's recommendation.

## Test plan

- [x] `ruff check` clean on all four touched files
- [ ] New route tests pass: `TestWaitRouteAlreadyTerminal` parametrized over FAILED/COMPLETE/CANCELLED, asserting Path-A within <1 s; regression guard that RUNNING still blocks until timeout
- [ ] New CLI tests pass: `TestPathBTerminalShortCircuit` parametrized over `failed`/`complete`/`cancelled`, asserting `rc == 0` after exactly one API call with one synthetic-terminal JSON line; regression guard that `running` still loops
- [ ] `make test-all` green in CI

## Related

- #2234 — original "zombie wait" symptom; partial fix at `routes/pipelines.py:~16284` covered only the mark-FAILED-raised case
- #2372 — the underlying failure that exposed this today
- #2211 — introduced the `wait-status` CLI