### PR TITLE
Fix #2412: wrap socket / HTTP-protocol errors as ApiError in api_request

### DIFF
--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -236,11 +236,11 @@ def api_request(
         # peer closes the connection mid-flight (e.g. orch pod restart during
         # a long-poll). Not wrapped by urllib, so without this branch they
         # propagate raw past every caller's ``except ApiError`` (issue #2412).
-        raise ApiError(f"HTTP protocol error: {e}") from e
+        raise ApiError(f"HTTP protocol error: {url}: {e}") from e
     except OSError as e:
         # ``ConnectionResetError``, ``ConnectionRefusedError``, and other
         # socket-level errors that bypass the ``URLError`` wrapper.
-        raise ApiError(f"Network error: {e}") from e
+        raise ApiError(f"Network error: {url}: {e}") from e
 
 
 def api_request_or_exit(

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -51,6 +51,7 @@ import json
 import os
 import re
 import sys
+from http.client import HTTPException
 from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode
@@ -230,6 +231,16 @@ def api_request(
         raise ApiError(f"Connection error: {e.reason}") from e
     except TimeoutError as e:
         raise ApiError(f"Request timed out: {url}") from e
+    except HTTPException as e:
+        # ``http.client.RemoteDisconnected`` and friends — raised when the
+        # peer closes the connection mid-flight (e.g. orch pod restart during
+        # a long-poll). Not wrapped by urllib, so without this branch they
+        # propagate raw past every caller's ``except ApiError`` (issue #2412).
+        raise ApiError(f"HTTP protocol error: {e}") from e
+    except OSError as e:
+        # ``ConnectionResetError``, ``ConnectionRefusedError``, and other
+        # socket-level errors that bypass the ``URLError`` wrapper.
+        raise ApiError(f"Network error: {e}") from e
 
 
 def api_request_or_exit(

--- a/sandbox/tests/test_pipeline_wait_status_cli.py
+++ b/sandbox/tests/test_pipeline_wait_status_cli.py
@@ -11,6 +11,7 @@ emission, cursor threading, and exit codes per the §3 contract in
 from __future__ import annotations
 
 import argparse
+import http.client
 import json
 import sys
 from pathlib import Path
@@ -23,8 +24,10 @@ _sandbox_path = str(Path(__file__).parent.parent)
 if _sandbox_path not in sys.path:
     sys.path.insert(0, _sandbox_path)
 
+from egg_lib import orch_cli  # noqa: E402
 from egg_lib.orch_cli import (  # noqa: E402
     ApiError,
+    api_request,
     cmd_pipeline_wait_status,
     create_parser,
 )
@@ -374,6 +377,73 @@ class TestPathBTerminalShortCircuit:
 
         assert rc == 0
         assert mock.call_count == 3
+
+
+class TestApiRequestWrapsSocketErrors:
+    """Issue #2412: ``api_request`` must wrap raw socket / HTTP-protocol
+    errors as ``ApiError`` so callers' ``except ApiError`` branches catch
+    them. Previously ``http.client.RemoteDisconnected`` (raised when the
+    peer closes a long-poll connection mid-flight) propagated past
+    ``cmd_pipeline_wait_status``'s except chain and exited the CLI with
+    code 1 — outside the §3 contract.
+    """
+
+    def test_remote_disconnected_wrapped_as_api_error(self):
+        err = http.client.RemoteDisconnected("Remote end closed connection without response")
+        with patch.object(orch_cli._opener, "open", side_effect=err):
+            with pytest.raises(ApiError) as exc_info:
+                api_request("http://test-orchestrator:9849", "/api/v1/health")
+        # No HTTP status code → wait-status classifies as transient, not 4xx.
+        assert exc_info.value.status_code is None
+
+    def test_connection_reset_wrapped_as_api_error(self):
+        with patch.object(orch_cli._opener, "open", side_effect=ConnectionResetError("reset")):
+            with pytest.raises(ApiError) as exc_info:
+                api_request("http://test-orchestrator:9849", "/api/v1/health")
+        assert exc_info.value.status_code is None
+
+    def test_timeout_error_wrapped_as_api_error(self):
+        # ``socket.timeout`` is an alias for ``TimeoutError`` in 3.10+; the
+        # existing ``except TimeoutError`` branch handles it. Pinning the
+        # behavior so a future refactor of the except chain can't drop it.
+        with patch.object(orch_cli._opener, "open", side_effect=TimeoutError("timed out")):
+            with pytest.raises(ApiError) as exc_info:
+                api_request("http://test-orchestrator:9849", "/api/v1/health")
+        assert exc_info.value.status_code is None
+
+
+class TestWaitStatusSurvivesSocketErrors:
+    """End-to-end: with the ``api_request`` fix, transient socket errors
+    flow into wait-status's existing transient-retry branch and the loop
+    recovers cleanly to the next terminal event.
+    """
+
+    def test_remote_disconnected_then_terminal_returns_zero(self):
+        err = ApiError("HTTP protocol error: Remote end closed connection without response")
+        with (
+            patch(_API_MOCK_PATH, side_effect=[err, _terminal_event("msg:|evt:1")]),
+            patch("time.sleep"),
+        ):
+            rc = cmd_pipeline_wait_status(_ns(max_iterations=5))
+        assert rc == 0
+
+    def test_connection_reset_then_terminal_returns_zero(self):
+        err = ApiError("Network error: [Errno 104] Connection reset by peer")
+        with (
+            patch(_API_MOCK_PATH, side_effect=[err, _terminal_event("msg:|evt:1")]),
+            patch("time.sleep"),
+        ):
+            rc = cmd_pipeline_wait_status(_ns(max_iterations=5))
+        assert rc == 0
+
+    def test_repeated_socket_errors_exhaust_budget_returns_two(self):
+        err = ApiError("HTTP protocol error: Remote end closed connection without response")
+        with (
+            patch(_API_MOCK_PATH, side_effect=err),
+            patch("time.sleep"),
+        ):
+            rc = cmd_pipeline_wait_status(_ns(max_iterations=200))
+        assert rc == 2
 
 
 @pytest.fixture(autouse=True)

--- a/sandbox/tests/test_pipeline_wait_status_cli.py
+++ b/sandbox/tests/test_pipeline_wait_status_cli.py
@@ -396,6 +396,18 @@ class TestApiRequestWrapsSocketErrors:
         # No HTTP status code → wait-status classifies as transient, not 4xx.
         assert exc_info.value.status_code is None
 
+    def test_incomplete_read_wrapped_as_api_error(self):
+        # ``IncompleteRead`` is a pure ``HTTPException`` (not also ``OSError``),
+        # so it pins the ``except HTTPException`` branch specifically — the
+        # ``RemoteDisconnected`` test alone would still pass if that branch
+        # were deleted (it's also a ``ConnectionResetError`` → ``OSError``).
+        err = http.client.IncompleteRead(partial=b"", expected=10)
+        with patch.object(orch_cli._opener, "open", side_effect=err):
+            with pytest.raises(ApiError) as exc_info:
+                api_request("http://test-orchestrator:9849", "/api/v1/health")
+        assert exc_info.value.status_code is None
+        assert exc_info.value.message.startswith("HTTP protocol error:")
+
     def test_connection_reset_wrapped_as_api_error(self):
         with patch.object(orch_cli._opener, "open", side_effect=ConnectionResetError("reset")):
             with pytest.raises(ApiError) as exc_info:
@@ -406,17 +418,62 @@ class TestApiRequestWrapsSocketErrors:
         # ``socket.timeout`` is an alias for ``TimeoutError`` in 3.10+; the
         # existing ``except TimeoutError`` branch handles it. Pinning the
         # behavior so a future refactor of the except chain can't drop it.
+        # Asserting the message prefix is what genuinely pins the dedicated
+        # ``except TimeoutError`` clause: without that assertion the test
+        # passes identically against the fallback ``except OSError`` branch
+        # (since ``TimeoutError`` is an ``OSError`` subclass).
         with patch.object(orch_cli._opener, "open", side_effect=TimeoutError("timed out")):
             with pytest.raises(ApiError) as exc_info:
                 api_request("http://test-orchestrator:9849", "/api/v1/health")
         assert exc_info.value.status_code is None
+        assert exc_info.value.message.startswith("Request timed out:")
+
+
+class _FakeOpenerResponse:
+    """Minimal context-manager mimic of ``urllib`` response — yields itself
+    from ``__enter__`` and exposes ``.read()``."""
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __enter__(self) -> _FakeOpenerResponse:
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
 
 
 class TestWaitStatusSurvivesSocketErrors:
-    """End-to-end: with the ``api_request`` fix, transient socket errors
-    flow into wait-status's existing transient-retry branch and the loop
-    recovers cleanly to the next terminal event.
+    """The ``api_request`` fix lets transient socket errors flow into
+    wait-status's existing transient-retry branch and the loop recovers
+    cleanly to the next terminal event.
+
+    The first test exercises the full path end-to-end (mocks
+    ``_opener.open`` so production wrapping logic runs); the rest mock
+    ``api_request`` directly to keep the wait-status decision matrix
+    focused and fast.
     """
+
+    def test_remote_disconnected_then_terminal_e2e_returns_zero(self):
+        """True end-to-end: ``_opener.open`` raises ``RemoteDisconnected``
+        on the first call, returns a terminal envelope on the second.
+        Production ``api_request`` wrapping and wait-status retry must
+        compose correctly without any layer being mocked out."""
+        err = http.client.RemoteDisconnected("Remote end closed connection without response")
+        success_body = json.dumps(_terminal_event("msg:|evt:1")).encode()
+        with (
+            patch.object(
+                orch_cli._opener,
+                "open",
+                side_effect=[err, _FakeOpenerResponse(success_body)],
+            ),
+            patch("time.sleep"),
+        ):
+            rc = cmd_pipeline_wait_status(_ns(max_iterations=5))
+        assert rc == 0
 
     def test_remote_disconnected_then_terminal_returns_zero(self):
         err = ApiError("HTTP protocol error: Remote end closed connection without response")


### PR DESCRIPTION
## Summary

Fixes #2412. `api_request` in `sandbox/egg_lib/orch_cli.py` promised "Raises: ApiError: On request failure" but only translated `HTTPError`, `URLError`, and `TimeoutError`. `http.client.RemoteDisconnected` — raised by `_opener.open()` when the orch closes a long-poll connection mid-flight (e.g. pod restart) — inherits from `(ConnectionResetError, BadStatusLine)`. Neither matches the existing except chain, so it propagated raw past `cmd_pipeline_wait_status`'s `except ApiError`, killed the loop, and exited the CLI with code 1 — outside the documented `0/2/3` contract for the SDLC skill's host monitor.

Fixed at the source rather than at the call site: catch `HTTPException` and `OSError` in `api_request` and re-raise as `ApiError`. The wait-status retry branch already handles `ApiError` with no status_code as transient (sleep + backoff + retry until budget), so no changes needed there. Same fix protects every other `api_request` caller from the same bug class.

## Why fix `api_request` instead of `cmd_pipeline_wait_status`

The issue suggested catching the new exception types in `cmd_pipeline_wait_status`. Fixing `api_request` is smaller (one place, not every caller) and makes the function actually live up to its docstring contract.

## Changes

- **`sandbox/egg_lib/orch_cli.py`** — add `HTTPException` and `OSError` branches to `api_request`; import `http.client.HTTPException`. The new branches go after `URLError`/`TimeoutError` (more-specific first) so existing classifications are preserved.
- **`sandbox/tests/test_pipeline_wait_status_cli.py`** — two new test classes:
  - `TestApiRequestWrapsSocketErrors`: pin that `RemoteDisconnected`, `ConnectionResetError`, and `TimeoutError` from `_opener.open()` get wrapped as `ApiError` with no `status_code`.
  - `TestWaitStatusSurvivesSocketErrors`: end-to-end — wrapped errors flow into the existing transient-retry branch and the loop recovers cleanly to terminal exit 0; repeated errors exhaust the budget and return 2.

## Test plan

- [x] `make test` (16317 passed, 41 skipped)
- [x] `make lint` — clean
- [x] Targeted `sandbox/tests/test_pipeline_wait_status_cli.py` — 27 passed
- [ ] End-to-end: kill the orch pod during a wait-status long-poll and confirm the CLI retries instead of crashing

## Refs

- #2412 — host-side wait-status crash on `RemoteDisconnected`
- #2378 — wait-status terminal-state visibility (sibling fix already landed)
- #2211 — original wait-status CLI introduction