### PR TITLE
Fix #2410: plumb slice_id through restart and uncommitted-change paths

### DIFF
--- a/orchestrator/concurrent_executor.py
+++ b/orchestrator/concurrent_executor.py
@@ -41,6 +41,7 @@ from peer_consensus import (
     get_peer_consensus_tracker,
 )
 from review_graph import ReviewGraph, get_review_graph_for_phase
+from slice_id_validation import SLICE_ID_PATTERN
 
 logger = get_logger("orchestrator.concurrent_executor")
 
@@ -293,10 +294,10 @@ class ConcurrentPhaseExecutor:
             # validation must not be able to smuggle path separators
             # or shell metacharacters in via this seam (per the
             # security reviewer's defense-in-depth suggestion on the
-            # v1 BRC review).
-            import re
-
-            if not re.fullmatch(r"slice-[0-9]+", normalised_slice):
+            # v1 BRC review). The pattern is the canonical one shared
+            # with the signal handlers (#2403) and the operator restart
+            # route (#2410) — see ``slice_id_validation``.
+            if not SLICE_ID_PATTERN.fullmatch(normalised_slice):
                 raise ValueError(
                     f"slice_id={slice_id!r} does not match the canonical shape ``slice-<N>``"
                 )
@@ -331,9 +332,7 @@ class ConcurrentPhaseExecutor:
         if issue_branch.count("/") >= 2 and issue_branch.rsplit("/", 1)[1] == "work":
             issue_branch = issue_branch.rsplit("/", 1)[0]
         normalised_slice = slice_id if slice_id.startswith("slice-") else f"slice-{slice_id}"
-        import re
-
-        if not re.fullmatch(r"slice-[0-9]+", normalised_slice):
+        if not SLICE_ID_PATTERN.fullmatch(normalised_slice):
             raise ValueError(
                 f"slice_id={slice_id!r} does not match the canonical shape ``slice-<N>``"
             )

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -323,11 +323,15 @@ class KubernetesSpawner:
         self._k8s = k8s_client
         self._gateway = gateway_client
         self._namespace = namespace
-        # Track restart counts per (pipeline_id, agent_role) pair
-        self._restart_counts: dict[tuple[str, str], int] = {}
-        # Per-(pipeline_id, agent_role) locks for serialising concurrent restarts.
-        # Protected by _restart_locks_lock (same pattern as state_store.py).
-        self._restart_locks: dict[tuple[str, str], threading.Lock] = {}
+        # Track restart counts per (pipeline_id, agent_role, slice_id) tuple.
+        # ``slice_id`` is ``None`` for pipeline-level agents and
+        # ``"slice-<N>"`` for slice-scoped agents (#2410), so concurrent
+        # slices each get an independent budget.
+        self._restart_counts: dict[tuple[str, str, str | None], int] = {}
+        # Per-(pipeline_id, agent_role, slice_id) locks for serialising
+        # concurrent restarts. Protected by _restart_locks_lock (same
+        # pattern as state_store.py).
+        self._restart_locks: dict[tuple[str, str, str | None], threading.Lock] = {}
         self._restart_locks_lock = threading.Lock()
 
     @property
@@ -356,8 +360,8 @@ class KubernetesSpawner:
             self._gateway = get_gateway_client()
         return self._gateway
 
-    def _get_restart_lock(self, key: tuple[str, str]) -> threading.Lock:
-        """Get or create a per-(pipeline_id, agent_role) restart lock."""
+    def _get_restart_lock(self, key: tuple[str, str, str | None]) -> threading.Lock:
+        """Get or create a per-(pipeline_id, agent_role, slice_id) restart lock."""
         with self._restart_locks_lock:
             if key not in self._restart_locks:
                 self._restart_locks[key] = threading.Lock()
@@ -1044,6 +1048,7 @@ class KubernetesSpawner:
         reason: str = "",
         spawn_max_retries: int = DEFAULT_SPAWN_MAX_RETRIES,
         spawn_retry_initial_backoff_seconds: float = (DEFAULT_SPAWN_RETRY_INITIAL_BACKOFF_SECONDS),
+        slice_id: str | None = None,
     ) -> SpawnedContainer:
         """Restart an agent Job: delete and respawn preserving worktree.
 
@@ -1067,6 +1072,13 @@ class KubernetesSpawner:
                 during worktree creation (forwarded to ``spawn_agent_job``).
             spawn_retry_initial_backoff_seconds: Initial backoff for spawn
                 retries (forwarded to ``spawn_agent_job``).
+            slice_id: Optional slice scope (#2410). When supplied, the
+                slice-scoped Job name (``egg-agent-{pid}-{slice_id}-{role}``)
+                is the one deleted and respawned, the slice-scoped worktree
+                id is preserved, and ``EGG_SLICE_ID`` is propagated so the
+                restarted agent re-enters the per-slice consensus tracker.
+                The restart-budget key includes the slice scope so each
+                slice gets an independent budget.
 
         Returns:
             SpawnedContainer with new Job info.
@@ -1078,7 +1090,11 @@ class KubernetesSpawner:
         if mode is None:
             raise ValueError("mode must be explicitly provided ('public' or 'private')")
 
-        restart_key = (pipeline_id, agent_role.value)
+        # Slice scope is part of the restart key so concurrent slice-N
+        # and slice-M agents of the same role each get an independent
+        # restart budget and lock. ``reset_restart_counts(pipeline_id)``
+        # still clears all of them because it filters on ``k[0]``.
+        restart_key = (pipeline_id, agent_role.value, slice_id)
         lock = self._get_restart_lock(restart_key)
 
         # Timeout prevents indefinite blocking if a concurrent restart of the
@@ -1106,7 +1122,12 @@ class KubernetesSpawner:
             # spawn time (hyphenated, no JOB_PREFIX); ``actual_k8s_job_name``
             # is the real k8s Job name. Using the wrong form for either side
             # broke restart for every role with an underscore — see #2070.
-            job_name, actual_k8s_job_name = self._build_k8s_job_names(pipeline_id, agent_role)
+            # Slice scope (#2410) must be threaded through here so the
+            # delete + respawn target the slice-scoped Job name, not the
+            # pipeline-level one.
+            job_name, actual_k8s_job_name = self._build_k8s_job_names(
+                pipeline_id, agent_role, slice_id=slice_id
+            )
 
             logger.info(
                 "Restarting agent Job",
@@ -1148,7 +1169,10 @@ class KubernetesSpawner:
                     error=str(e),
                 )
 
-            # Respawn — gateway's create_worktrees() is idempotent
+            # Respawn — gateway's create_worktrees() is idempotent.
+            # ``slice_id`` is forwarded so spawn_agent_job builds the
+            # slice-scoped Job + worktree id and sets ``EGG_SLICE_ID``
+            # on the new Job (#2410).
             spawned = self.spawn_agent_job(
                 pipeline_id=pipeline_id,
                 agent_role=agent_role,
@@ -1167,6 +1191,7 @@ class KubernetesSpawner:
                 preserve_worktree_on_failure=True,
                 spawn_max_retries=spawn_max_retries,
                 spawn_retry_initial_backoff_seconds=spawn_retry_initial_backoff_seconds,
+                slice_id=slice_id,
             )
 
             logger.info(
@@ -1181,17 +1206,26 @@ class KubernetesSpawner:
         finally:
             lock.release()
 
-    def get_restart_count(self, pipeline_id: str, agent_role: str) -> int:
+    def get_restart_count(
+        self,
+        pipeline_id: str,
+        agent_role: str,
+        slice_id: str | None = None,
+    ) -> int:
         """Get the current restart count for an agent.
 
         Args:
             pipeline_id: Pipeline ID.
             agent_role: Agent role value string.
+            slice_id: Optional slice scope (#2410). Pipeline-level callers
+                pass ``None``; slice-aware callers pass the same
+                ``slice-<N>`` string they used at restart time so each
+                slice's budget is reported independently.
 
         Returns:
             Number of times the agent has been restarted.
         """
-        key = (pipeline_id, agent_role)
+        key = (pipeline_id, agent_role, slice_id)
         lock = self._get_restart_lock(key)
         with lock:
             return self._restart_counts.get(key, 0)
@@ -1218,19 +1252,33 @@ class KubernetesSpawner:
         self,
         pipeline_id: str,
         agent_role: str,
+        slice_id: str | None = None,
     ) -> dict | None:
         """Detect uncommitted changes in an agent's worktree after Job exit.
 
         Checks the agent's worktree directly on the filesystem for uncommitted
         changes. Per-agent worktrees are at:
-        /home/egg/.egg-worktrees/{pipeline_id}-{role}/{repo}/
+        /home/egg/.egg-worktrees/{pipeline_id}-{role}/{repo}/ (pipeline-level)
+        /home/egg/.egg-worktrees/{pipeline_id}-{slice_id}-{role}/{repo}/
+        (slice-scoped, #2410).
+
+        Args:
+            pipeline_id: Pipeline ID.
+            agent_role: Agent role value string.
+            slice_id: Optional slice scope. When supplied, the slice-scoped
+                worktree id is inspected; pipeline-level callers omit this.
 
         Returns:
             Dict with change info if uncommitted changes found, None otherwise.
         """
         import subprocess
 
-        agent_worktree_id = f"{pipeline_id}-{agent_role}"
+        # Mirrors ``_build_agent_worktree_id`` so a slice-scoped restart
+        # path can detect uncommitted work in the slice's worktree, not
+        # the (possibly absent) pipeline-level one.
+        agent_worktree_id = (
+            f"{pipeline_id}-{slice_id}-{agent_role}" if slice_id else f"{pipeline_id}-{agent_role}"
+        )
         worktree_base = WORKTREE_BASE_DIR / agent_worktree_id
 
         if not worktree_base.exists():
@@ -1269,6 +1317,7 @@ class KubernetesSpawner:
                         event_type="agent_uncommitted_changes",
                         pipeline_id=pipeline_id,
                         agent_role=agent_role,
+                        slice_id=slice_id,
                         worktree_path=str(repo_dir),
                         file_count=len(files),
                         changed_files=files[:20],
@@ -1276,6 +1325,7 @@ class KubernetesSpawner:
                     return {
                         "pipeline_id": pipeline_id,
                         "agent_role": agent_role,
+                        "slice_id": slice_id,
                         "worktree_id": agent_worktree_id,
                         "worktree_path": str(repo_dir),
                         "file_count": len(files),

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -94,6 +94,14 @@ _PROTECTED_ENV_KEYS: frozenset[str] = frozenset(
         # /resolve. Blocking the key here is defense in depth; the base
         # spawner env below never sets it to begin with.
         "EGG_LIFECYCLE_SECRET",
+        # Slice scope (#2410, v2 review follow-up). The spawner is the
+        # single source of truth: ``EGG_SLICE_ID`` is derived from the
+        # ``slice_id`` parameter that already drives Job naming and
+        # worktree id. Protecting the key prevents a future caller from
+        # silently shipping a mismatched value via ``extra_env`` —
+        # without this, the agent's signals could land on a different
+        # slice than its Job/worktree, with no warning.
+        "EGG_SLICE_ID",
     }
 )
 
@@ -742,10 +750,13 @@ class KubernetesSpawner:
             # ``slice_id`` parameter only drove naming + worktree id and the
             # restarted Job came up with no slice scope in its env — its
             # signals would land on the pipeline-level tracker, which has
-            # no record of the agent (failure mode #3 from #2410). The
-            # concurrent-spawn path also stuffs ``EGG_SLICE_ID`` into
-            # ``sandbox_env`` (routes/pipelines.py) so both signals agree;
-            # the override below is idempotent in that case.
+            # no record of the agent (failure mode #3 from #2410).
+            #
+            # Single source of truth (v2 review follow-up): the spawner is
+            # the only writer; ``EGG_SLICE_ID`` is in ``_PROTECTED_ENV_KEYS``
+            # so any ``extra_env`` value is logged and dropped, guaranteeing
+            # the env stays consistent with the Job name + worktree id that
+            # are also derived from this same ``slice_id`` parameter.
             if slice_id is not None:
                 environment["EGG_SLICE_ID"] = slice_id
 

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -735,6 +735,20 @@ class KubernetesSpawner:
             elif pipeline_id:
                 environment["EGG_BRANCH"] = f"egg/{pipeline_id}/work"
 
+            # Slice scope (#2403, #2410): when this spawn is for a per-slice
+            # agent, propagate ``EGG_SLICE_ID`` so the agent's BRC handlers
+            # tag CONSENSUS_* signals with the slice and the orchestrator
+            # routes them to the per-slice tracker. Without this, the
+            # ``slice_id`` parameter only drove naming + worktree id and the
+            # restarted Job came up with no slice scope in its env — its
+            # signals would land on the pipeline-level tracker, which has
+            # no record of the agent (failure mode #3 from #2410). The
+            # concurrent-spawn path also stuffs ``EGG_SLICE_ID`` into
+            # ``sandbox_env`` (routes/pipelines.py) so both signals agree;
+            # the override below is idempotent in that case.
+            if slice_id is not None:
+                environment["EGG_SLICE_ID"] = slice_id
+
             # Caller's extra_env overrides defaults, except protected keys
             if extra_env:
                 for key, value in extra_env.items():

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2579,7 +2579,13 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
         pipeline.updated_at = datetime.now(UTC)
         store.update_pipeline(pipeline_id, pipeline.model_dump(mode="json"))
 
-    restart_count = spawner.get_restart_count(pipeline_id, agent_role)
+    # Slice-scoped restarts (#2410) bumped the per-slice budget bucket
+    # ``(pipeline_id, agent_role, slice_id)``; the pipeline-level
+    # ``(pipeline_id, agent_role, None)`` bucket is untouched. Reading
+    # without ``slice_id`` here would return the pipeline-level count
+    # (typically zero) and the audit log + JSON response below would
+    # misreport the operator's "you've burned N of M restarts" telemetry.
+    restart_count = spawner.get_restart_count(pipeline_id, agent_role, slice_id=slice_id)
 
     logger.info(
         "Agent restarted",

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -107,6 +107,7 @@ try:
         PipelineStatus,
         ReviewVerdict,
     )
+    from ..slice_id_validation import extract_slice_id
     from ..state_store import (
         InvalidPipelineIdError,
         PipelineNotFoundError,
@@ -153,6 +154,7 @@ except ImportError:
         PipelineStatus,
         ReviewVerdict,
     )
+    from slice_id_validation import extract_slice_id  # type: ignore
     from state_store import (  # type: ignore
         InvalidPipelineIdError,
         PipelineNotFoundError,
@@ -2270,9 +2272,17 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
         pipeline_id: Pipeline ID
         agent_role: Agent role to restart (e.g. "coder", "tester")
 
+    Query string (optional):
+        slice_id: Slice scope (``slice-<N>``). When supplied, the
+            slice-scoped Job and worktree are restarted, ``EGG_SLICE_ID``
+            is propagated to the new Job, and consensus reset targets
+            the per-slice tracker. Pipeline-level agents omit it.
+            ``slice_id`` may also be supplied via the JSON body.
+
     Request body (optional):
         {
-            "reason": "Human-readable reason for the restart"
+            "reason": "Human-readable reason for the restart",
+            "slice_id": "slice-2"
         }
 
     Response:
@@ -2316,6 +2326,16 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
 
     body = request.get_json(silent=True) or {}
     reason = body.get("reason", "Manual restart via API")
+
+    # Slice scope (#2410): query param wins over body so the URL
+    # form is unambiguous; both forms validate against the canonical
+    # ``slice-<N>`` shape via ``extract_slice_id``.
+    raw_slice_id = request.args.get("slice_id")
+    slice_payload = {"slice_id": raw_slice_id} if raw_slice_id is not None else body
+    try:
+        slice_id = extract_slice_id(slice_payload)
+    except ValueError as e:
+        return make_error_response(str(e), status_code=400)
 
     # Restart the container via spawner
     spawner = _get_spawner()
@@ -2423,6 +2443,7 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
             reason=reason,
             spawn_max_retries=pipeline.config.spawn_max_retries,
             spawn_retry_initial_backoff_seconds=pipeline.config.spawn_retry_initial_backoff_seconds,
+            slice_id=slice_id,
         )
     except (ContainerSpawnError, KubernetesSpawnError) as e:
         # Revert early status update — the agent is not actually running.
@@ -2442,6 +2463,8 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
     # Spawn succeeded — now reset consensus state for this agent.
     # If consensus reset fails, log a warning but don't fail the restart:
     # the restarted agent will re-enter consensus on its own.
+    # Slice-scoped restarts (#2410) target the per-slice tracker; the
+    # pipeline-level tracker has no record of the slice agent.
     try:
         try:
             from peer_consensus import get_peer_consensus_tracker
@@ -2450,13 +2473,14 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
                 get_peer_consensus_tracker,  # type: ignore[import-not-found]
             )
 
-        tracker = get_peer_consensus_tracker(pipeline_id)
+        tracker = get_peer_consensus_tracker(pipeline_id, slice_id)
         if tracker:
             tracker.remove_agent(agent_role)
             logger.info(
                 "Reset consensus state for agent",
                 pipeline_id=pipeline_id,
                 agent_role=agent_role,
+                slice_id=slice_id,
             )
     except ImportError:
         pass
@@ -2465,6 +2489,7 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
             "Failed to reset consensus state (agent will re-enter consensus)",
             pipeline_id=pipeline_id,
             agent_role=agent_role,
+            slice_id=slice_id,
             error=str(e),
         )
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -11628,13 +11628,13 @@ def _run_concurrent_phase(
     pipeline_mode = "issue" if pipeline.issue_number is not None else "prompt"
 
     # Slice-aware sandbox env (#2137 TASK-4-3 / #2403): when running a
-    # per-slice team, expose the slice id via ``EGG_SLICE_ID`` and
-    # leave ``EGG_PIPELINE_ID`` as the bare pipeline id. An earlier
-    # shape encoded the slice into ``EGG_PIPELINE_ID`` itself
-    # (``{pipeline_id}/{slice_id}``) so the orchestrator's
-    # ``_tracker_key`` would route CONSENSUS_* to the slice tracker
-    # without an extra signal-level field. That broke every agent →
-    # orchestrator round-trip:
+    # per-slice team, the spawner exposes the slice id via
+    # ``EGG_SLICE_ID`` and leaves ``EGG_PIPELINE_ID`` as the bare
+    # pipeline id. An earlier shape encoded the slice into
+    # ``EGG_PIPELINE_ID`` itself (``{pipeline_id}/{slice_id}``) so the
+    # orchestrator's ``_tracker_key`` would route CONSENSUS_* to the
+    # slice tracker without an extra signal-level field. That broke
+    # every agent → orchestrator round-trip:
     #
     #   * the orchestrator-side ``PIPELINE_ID_PATTERN`` and the agent
     #     handler validator (``[a-zA-Z0-9_-]+``) both reject the slash,
@@ -11655,9 +11655,13 @@ def _run_concurrent_phase(
     # pipeline-level fan-out for OVERSEER_ALERT mentioned in earlier
     # comments here is tracked alongside the per-slice MCP control
     # verbs in #2199.
-    if slice_id is not None:
-        sandbox_env = dict(sandbox_env)
-        sandbox_env["EGG_SLICE_ID"] = slice_id
+    #
+    # Single source of truth (#2410 v2 review): ``EGG_SLICE_ID`` is
+    # injected by ``KubernetesSpawner.spawn_agent_job`` from the same
+    # ``slice_id`` parameter that drives Job naming and worktree id, so
+    # there is no need to also stuff it into ``sandbox_env`` here. The
+    # key is in ``_PROTECTED_ENV_KEYS`` so any future caller that does
+    # supply a value via ``extra_env`` is logged and overridden.
 
     # Build per-role prompts for concurrent phase execution.
     from egg_contracts.agent_roles import get_roles_for_phase as _get_roles_for_phase

--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -39,6 +39,19 @@ from egg_contracts.loader import ContractNotFoundError
 from egg_contracts.orchestrator import create_orchestrator
 from handoffs import AgentOutput, save_agent_output
 from models import AgentExecutionStatus, AgentRole, Pipeline, PipelineStatus
+
+# Slice-aware consensus routing (#2403): per-slice agents tag their
+# signals with a ``slice_id`` field on the request body so the
+# orchestrator routes each ``CONSENSUS_*`` to the per-slice tracker
+# (``peer_consensus._tracker_key`` composes ``{pipeline_id}/{slice_id}``).
+# The canonical extractor lives in ``slice_id_validation`` so the
+# operator-triggered restart route (#2410) and the gateway-bound branch
+# builders in ``concurrent_executor`` validate against the same shape.
+# The alias below preserves the existing private name for the many
+# handler call sites in this file.
+from slice_id_validation import (
+    extract_slice_id as _extract_slice_id,
+)
 from state_store import (
     InvalidPipelineIdError,
     PipelineNotFoundError,
@@ -64,45 +77,6 @@ _AGENT_ROLE_TO_CONTRACT_ROLE: dict[AgentRole, ContractAgentRole] = {
 }
 
 _SIGTERM_PATTERN = re.compile(r"\b143\b")
-
-# Slice-aware consensus routing (#2403): per-slice agents tag their
-# signals with a ``slice_id`` field on the request body so the
-# orchestrator routes each ``CONSENSUS_*`` to the per-slice tracker
-# (``peer_consensus._tracker_key`` composes ``{pipeline_id}/{slice_id}``).
-# Defense-in-depth: validate the shape here even though the spawn-side
-# is already canonical — a future caller that forgets the upstream
-# regex must not be able to smuggle path separators or shell
-# metacharacters into a tracker registry key.
-#
-# Note: the contract-side ``Slice.id`` field accepts the broader
-# pattern ``^(?:slice|phase)-[0-9]+$`` (egg_contracts.models.Slice) for
-# backward compatibility with pre-#2137 contracts. The signal-side
-# pattern below is intentionally narrower — only the canonical
-# ``slice-<N>`` shape — because the model loader's
-# ``_migrate_phases_to_slices`` validator rewrites legacy
-# ``phase-<N>`` ids to ``slice-<N>`` on contract load, so every
-# slice_id reaching the spawn / signal path is already canonical. If
-# a future migration tool ever constructs a ``Slice`` from raw legacy
-# JSON without going through the loader, the resulting ``phase-<N>``
-# id will be rejected here (as it should — the registry key MUST be
-# canonical so the per-slice tracker can be looked up).
-_SLICE_ID_PATTERN = re.compile(r"^slice-[0-9]+$")
-
-
-def _extract_slice_id(data: dict[str, Any]) -> str | None:
-    """Return the ``slice_id`` from the signal payload, validated.
-
-    Returns ``None`` when no slice scope was supplied (the agent is
-    pipeline-level, not slice-scoped). Raises ``ValueError`` when the
-    caller supplied a non-empty value that does not match the
-    canonical ``slice-<N>`` shape.
-    """
-    raw = data.get("slice_id")
-    if raw is None or raw == "":
-        return None
-    if not isinstance(raw, str) or not _SLICE_ID_PATTERN.fullmatch(raw):
-        raise ValueError(f"Invalid slice_id {raw!r}: must match 'slice-<N>'")
-    return raw
 
 
 def _is_sigterm_after_completion(pipeline: Pipeline, error_message: str) -> bool:

--- a/orchestrator/slice_id_validation.py
+++ b/orchestrator/slice_id_validation.py
@@ -1,0 +1,53 @@
+"""Canonical ``slice_id`` shape and request-payload extractor.
+
+The orchestrator pins slice ids to the canonical ``slice-<N>`` shape
+at every gateway-facing seam where an external caller could supply
+one — signal handlers (#2403), the operator-triggered restart route
+(#2410), and the gateway-bound branch builders in
+``concurrent_executor``. The pattern lives here, in a small shared
+module, so each seam validates against the same regex rather than
+re-deriving it inline.
+
+The contract-side ``Slice.id`` field accepts the broader pattern
+``^(?:slice|phase)-[0-9]+$`` (``egg_contracts.models.Slice``) for
+backward compatibility with pre-#2137 contracts. The pattern below
+is intentionally narrower — only the canonical ``slice-<N>`` shape —
+because the model loader's ``_migrate_phases_to_slices`` validator
+rewrites legacy ``phase-<N>`` ids to ``slice-<N>`` on contract load,
+so every slice_id reaching the spawn / signal / restart path is
+already canonical. If a future migration tool ever constructs a
+``Slice`` from raw legacy JSON without going through the loader, the
+resulting ``phase-<N>`` id will be rejected here (as it should — the
+registry key MUST be canonical so the per-slice tracker can be
+looked up, and Job names / worktree ids that embed it MUST be
+RFC-1123 safe).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+SLICE_ID_PATTERN = re.compile(r"^slice-[0-9]+$")
+
+
+def extract_slice_id(data: dict[str, Any]) -> str | None:
+    """Return ``slice_id`` from a request payload, validated.
+
+    Returns ``None`` when no slice scope was supplied (the agent is
+    pipeline-level, not slice-scoped). Raises ``ValueError`` when the
+    caller supplied a non-empty value that does not match the
+    canonical ``slice-<N>`` shape.
+
+    Defense-in-depth: validate at every gateway-facing seam even
+    though the spawn-side is already canonical — a future caller
+    that forgets the upstream regex must not be able to smuggle path
+    separators or shell metacharacters into a tracker registry key,
+    a Job name, or a worktree id.
+    """
+    raw = data.get("slice_id")
+    if raw is None or raw == "":
+        return None
+    if not isinstance(raw, str) or not SLICE_ID_PATTERN.fullmatch(raw):
+        raise ValueError(f"Invalid slice_id {raw!r}: must match 'slice-<N>'")
+    return raw

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -902,7 +902,7 @@ class TestRestartAgentJob:
         """Restart raises when limit is exceeded."""
         from kubernetes_spawner import KubernetesSpawnError
 
-        spawner._restart_counts[("pipe-1", "coder")] = 2
+        spawner._restart_counts[("pipe-1", "coder", None)] = 2
         with pytest.raises(KubernetesSpawnError, match="Restart limit.*exceeded"):
             spawner.restart_agent_job(
                 pipeline_id="pipe-1",
@@ -991,9 +991,9 @@ class TestRestartCounts:
 
     def test_reset_restart_counts(self, spawner):
         """reset_restart_counts clears all counts for a pipeline."""
-        spawner._restart_counts[("pipe-1", "coder")] = 3
-        spawner._restart_counts[("pipe-1", "tester")] = 1
-        spawner._restart_counts[("pipe-2", "coder")] = 2
+        spawner._restart_counts[("pipe-1", "coder", None)] = 3
+        spawner._restart_counts[("pipe-1", "tester", None)] = 1
+        spawner._restart_counts[("pipe-2", "coder", None)] = 2
 
         spawner.reset_restart_counts("pipe-1")
 
@@ -1281,6 +1281,156 @@ class TestSpawnAgentJobSliceScope:
         spawn_fn(role=AgentRole.CODER, branch="egg/issue-2261-v7/slice-2")
         cw_kwargs = mock_gateway.create_worktrees.call_args.kwargs
         assert cw_kwargs["container_id"] == "issue-2261-v7-slice-2-coder"
+
+
+class TestRestartAgentJobSliceScope:
+    """``restart_agent_job`` threads ``slice_id`` into delete + respawn (#2410)."""
+
+    def test_delete_targets_slice_scoped_job_name(self, spawner, mock_k8s_client, mock_gateway):
+        """A slice-scoped restart must delete the slice-scoped Job, not the pipeline-level one.
+
+        Without the fix, ``delete_job`` was called against ``egg-sandbox-egg-agent-{pid}-{role}``
+        — leaving the actual ``egg-agent-{pid}-slice-{N}-{role}`` Job running while a fresh
+        non-scoped Job was spawned alongside it.
+        """
+        spawner.restart_agent_job(
+            pipeline_id="issue-2261-v7",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+            slice_id="slice-2",
+        )
+        delete_call = mock_k8s_client.delete_job.call_args_list[-1]
+        assert delete_call.args[0] == "egg-sandbox-egg-agent-issue-2261-v7-slice-2-coder"
+
+    def test_gateway_session_cleanup_uses_slice_scoped_container_id(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """The gateway session is keyed by the slice-scoped unprefixed name."""
+        spawner.restart_agent_job(
+            pipeline_id="issue-2261-v7",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+            slice_id="slice-2",
+        )
+        gw_call = mock_gateway.delete_session_by_container.call_args_list[-1]
+        assert gw_call.args[0] == "egg-agent-issue-2261-v7-slice-2-coder"
+
+    def test_respawn_uses_slice_scoped_worktree_id(self, spawner, mock_k8s_client, mock_gateway):
+        """The respawned Job mounts the slice-scoped worktree.
+
+        Pre-spawn ``create_worktrees`` is keyed by the slice-scoped container_id
+        — failure mode #2 from the issue (worktree wrong / absent) is fixed by
+        threading slice_id into the spawn call.
+        """
+        spawner.restart_agent_job(
+            pipeline_id="issue-2261-v7",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+            slice_id="slice-2",
+        )
+        cw_kwargs = mock_gateway.create_worktrees.call_args.kwargs
+        assert cw_kwargs["container_id"] == "issue-2261-v7-slice-2-coder"
+
+    def test_restart_count_is_per_slice(self, spawner, mock_k8s_client, mock_gateway):
+        """Concurrent slices each get an independent restart budget."""
+        spawner.restart_agent_job(
+            pipeline_id="issue-2261-v7",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+            slice_id="slice-2",
+        )
+        spawner.restart_agent_job(
+            pipeline_id="issue-2261-v7",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+            slice_id="slice-3",
+        )
+        # Each slice's coder has burned exactly one budget slot.
+        assert spawner.get_restart_count("issue-2261-v7", "coder", slice_id="slice-2") == 1
+        assert spawner.get_restart_count("issue-2261-v7", "coder", slice_id="slice-3") == 1
+        # The pipeline-level bucket is untouched.
+        assert spawner.get_restart_count("issue-2261-v7", "coder") == 0
+
+    def test_reset_restart_counts_clears_slice_buckets(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """Per-pipeline reset must sweep every slice bucket too."""
+        spawner._restart_counts[("issue-2261-v7", "coder", "slice-2")] = 3
+        spawner._restart_counts[("issue-2261-v7", "coder", "slice-3")] = 2
+        spawner._restart_counts[("issue-2261-v7", "coder", None)] = 1
+        spawner._restart_counts[("issue-9999", "coder", "slice-2")] = 4
+
+        spawner.reset_restart_counts("issue-2261-v7")
+
+        assert spawner.get_restart_count("issue-2261-v7", "coder", slice_id="slice-2") == 0
+        assert spawner.get_restart_count("issue-2261-v7", "coder", slice_id="slice-3") == 0
+        assert spawner.get_restart_count("issue-2261-v7", "coder") == 0
+        # Sibling pipeline untouched.
+        assert spawner.get_restart_count("issue-9999", "coder", slice_id="slice-2") == 4
+
+
+class TestDetectUncommittedChangesSliceScope:
+    """``detect_uncommitted_changes`` inspects the slice-scoped worktree (#2410)."""
+
+    def test_detects_changes_in_slice_scoped_worktree(self, spawner, tmp_path):
+        worktree_dir = tmp_path / "issue-2261-v7-slice-2-coder" / "owner-repo"
+        worktree_dir.mkdir(parents=True)
+
+        with (
+            patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=" M file1.py\n?? file2.py\n",
+            )
+            result = spawner.detect_uncommitted_changes(
+                "issue-2261-v7", "coder", slice_id="slice-2"
+            )
+
+        assert result is not None
+        assert result["worktree_id"] == "issue-2261-v7-slice-2-coder"
+        assert result["slice_id"] == "slice-2"
+        assert result["file_count"] == 2
+
+    def test_pipeline_level_call_does_not_pick_up_slice_worktree(self, spawner, tmp_path):
+        """Without slice_id, only the pipeline-level worktree is inspected.
+
+        A slice agent's uncommitted work must not surface through a
+        pipeline-level call — they're separate worktrees with separate
+        ownership semantics.
+        """
+        # Only the slice-scoped worktree exists on disk.
+        slice_dir = tmp_path / "issue-2261-v7-slice-2-coder" / "owner-repo"
+        slice_dir.mkdir(parents=True)
+
+        with (
+            patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout=" M file1.py\n")
+            result = spawner.detect_uncommitted_changes("issue-2261-v7", "coder")
+
+        # No pipeline-level worktree → returns None even though the slice worktree
+        # has uncommitted changes.
+        assert result is None
+
+    def test_slice_call_does_not_pick_up_pipeline_worktree(self, spawner, tmp_path):
+        """Symmetric guard: a slice-scoped lookup must not surface pipeline-level work."""
+        # Only the pipeline-level worktree exists on disk.
+        pipeline_dir = tmp_path / "issue-2261-v7-coder" / "owner-repo"
+        pipeline_dir.mkdir(parents=True)
+
+        with (
+            patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout=" M file1.py\n")
+            result = spawner.detect_uncommitted_changes(
+                "issue-2261-v7", "coder", slice_id="slice-2"
+            )
+
+        assert result is None
 
 
 class TestCleanupPipelineSliceWorktrees:

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -328,6 +328,37 @@ class TestSpawnAgentJob:
         assert result.environment["EGG_AGENT_ROLE"] == "custom"
         assert result.environment["MY_KEY"] == "val"
 
+    def test_spawn_with_slice_id_sets_egg_slice_id_env(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """``slice_id=`` parameter propagates into ``EGG_SLICE_ID`` (#2410).
+
+        The spawner's ``slice_id`` parameter previously only drove the Job
+        name and worktree id; the agent container had no slice scope in
+        its environment, so its BRC handlers couldn't tag CONSENSUS_*
+        signals with the slice (failure mode #3 from #2410).
+        """
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+            slice_id="slice-2",
+        )
+        assert result.environment.get("EGG_SLICE_ID") == "slice-2"
+        create_kwargs = mock_k8s_client.create_container.call_args.kwargs
+        assert create_kwargs["environment"].get("EGG_SLICE_ID") == "slice-2"
+
+    def test_spawn_without_slice_id_does_not_set_egg_slice_id(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """Pipeline-level spawns leave ``EGG_SLICE_ID`` unset."""
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+        )
+        assert "EGG_SLICE_ID" not in result.environment
+
     def test_spawn_labels(self, spawner, mock_k8s_client):
         """Spawn sets the expected labels on the Job."""
         spawner.spawn_agent_job(
@@ -1367,6 +1398,43 @@ class TestRestartAgentJobSliceScope:
         assert spawner.get_restart_count("issue-2261-v7", "coder") == 0
         # Sibling pipeline untouched.
         assert spawner.get_restart_count("issue-9999", "coder", slice_id="slice-2") == 4
+
+    def test_restart_propagates_egg_slice_id_to_container_env(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """The respawned Job's environment carries ``EGG_SLICE_ID``.
+
+        Failure mode #3 from #2410: without the env var on the new Job,
+        the agent's BRC handlers can't tag CONSENSUS_* signals with the
+        slice and the orchestrator routes them to the pipeline-level
+        tracker. Naming + worktree id alone are insufficient — the env
+        is what the *agent* reads.
+        """
+        result = spawner.restart_agent_job(
+            pipeline_id="issue-2261-v7",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+            slice_id="slice-2",
+        )
+        # The env on the SpawnedContainer reflects what spawn_agent_job
+        # assembled — and what was forwarded to ``create_container``.
+        assert result.environment.get("EGG_SLICE_ID") == "slice-2"
+        # Belt-and-braces: the env actually reached the k8s create call.
+        create_kwargs = mock_k8s_client.create_container.call_args.kwargs
+        assert create_kwargs["environment"].get("EGG_SLICE_ID") == "slice-2"
+
+    def test_pipeline_level_restart_does_not_set_egg_slice_id(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """Without ``slice_id``, the restarted Job's env has no slice scope."""
+        result = spawner.restart_agent_job(
+            pipeline_id="issue-2261-v7",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+        )
+        assert "EGG_SLICE_ID" not in result.environment
+        create_kwargs = mock_k8s_client.create_container.call_args.kwargs
+        assert "EGG_SLICE_ID" not in create_kwargs["environment"]
 
 
 class TestDetectUncommittedChangesSliceScope:

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -359,6 +359,48 @@ class TestSpawnAgentJob:
         )
         assert "EGG_SLICE_ID" not in result.environment
 
+    def test_extra_env_cannot_override_egg_slice_id(self, spawner, mock_k8s_client, mock_gateway):
+        """``extra_env`` cannot override ``EGG_SLICE_ID`` — protected key (#2410 v2 review).
+
+        The spawner is the single source of truth: ``EGG_SLICE_ID`` is
+        derived from the ``slice_id`` parameter that already drives Job
+        naming and worktree id. A future caller that tried to ship a
+        different value via ``extra_env`` would silently end up with the
+        agent's signals tagged for one slice while its Job + worktree
+        belong to another. Protecting the key catches that.
+        """
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+            slice_id="slice-2",
+            extra_env={"EGG_SLICE_ID": "slice-99"},
+        )
+        # Spawner's value wins, not extra_env's.
+        assert result.environment.get("EGG_SLICE_ID") == "slice-2"
+        create_kwargs = mock_k8s_client.create_container.call_args.kwargs
+        assert create_kwargs["environment"].get("EGG_SLICE_ID") == "slice-2"
+
+    def test_extra_env_cannot_inject_egg_slice_id_when_pipeline_level(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """Without ``slice_id``, ``extra_env`` cannot smuggle ``EGG_SLICE_ID`` in.
+
+        Pipeline-level spawns must not be tagged with a slice scope —
+        protecting the key blocks a regression where a slice-aware
+        caller would forget the ``slice_id`` parameter and try to bolt
+        the env var on directly via ``extra_env``.
+        """
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+            extra_env={"EGG_SLICE_ID": "slice-2"},
+        )
+        assert "EGG_SLICE_ID" not in result.environment
+        create_kwargs = mock_k8s_client.create_container.call_args.kwargs
+        assert "EGG_SLICE_ID" not in create_kwargs["environment"]
+
     def test_spawn_labels(self, spawner, mock_k8s_client):
         """Spawn sets the expected labels on the Job."""
         spawner.spawn_agent_job(

--- a/orchestrator/tests/test_restart_agent.py
+++ b/orchestrator/tests/test_restart_agent.py
@@ -810,6 +810,13 @@ class TestRestartAgentEndpointSliceScope:
         assert response.status_code == 200
         restart_call = mock_spawner.restart_agent_container.call_args
         assert restart_call.kwargs["slice_id"] == "slice-2"
+        # Reading the restart count after a slice-scoped restart MUST
+        # query the per-slice budget bucket (#2410). Without this, the
+        # JSON response and audit log report the pipeline-level count
+        # (typically 0) and operators can't trust "you've burned N of M
+        # restarts" telemetry.
+        get_count_call = mock_spawner.get_restart_count.call_args
+        assert get_count_call.kwargs.get("slice_id") == "slice-2"
 
     @patch("routes.pipelines.get_pipeline_state_lock")
     @patch("routes.pipelines.get_container_spawner")
@@ -851,6 +858,8 @@ class TestRestartAgentEndpointSliceScope:
         assert response.status_code == 200
         restart_call = mock_spawner.restart_agent_container.call_args
         assert restart_call.kwargs["slice_id"] == "slice-2"
+        get_count_call = mock_spawner.get_restart_count.call_args
+        assert get_count_call.kwargs.get("slice_id") == "slice-2"
 
     @patch("routes.pipelines._resolve_pipeline")
     @patch("routes.pipelines.get_repo_path")
@@ -912,6 +921,8 @@ class TestRestartAgentEndpointSliceScope:
         assert response.status_code == 200
         restart_call = mock_spawner.restart_agent_container.call_args
         assert restart_call.kwargs["slice_id"] is None
+        get_count_call = mock_spawner.get_restart_count.call_args
+        assert get_count_call.kwargs.get("slice_id") is None
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_restart_agent.py
+++ b/orchestrator/tests/test_restart_agent.py
@@ -169,7 +169,7 @@ class TestRestartAgentContainer:
     def test_restart_limit_exceeded_raises(self, spawner, mock_docker_client, mock_gateway_client):
         """Restart should raise ContainerSpawnError when limit is exceeded."""
         # Pre-set restart count to the limit
-        spawner._restart_counts[("issue-100", "coder")] = 2
+        spawner._restart_counts[("issue-100", "coder", None)] = 2
 
         with pytest.raises(ContainerSpawnError, match="Restart limit"):
             spawner.restart_agent_container(
@@ -182,7 +182,7 @@ class TestRestartAgentContainer:
 
     def test_restart_custom_max_restarts(self, spawner, mock_docker_client, mock_gateway_client):
         """Custom max_restarts should be respected."""
-        spawner._restart_counts[("issue-100", "coder")] = 5
+        spawner._restart_counts[("issue-100", "coder", None)] = 5
 
         with pytest.raises(ContainerSpawnError, match="Restart limit"):
             spawner.restart_agent_container(
@@ -303,14 +303,14 @@ class TestRestartCountManagement:
 
     def test_get_restart_count_after_restart(self, spawner):
         """Count should increment after manual tracking."""
-        spawner._restart_counts[("issue-100", "coder")] = 3
+        spawner._restart_counts[("issue-100", "coder", None)] = 3
         assert spawner.get_restart_count("issue-100", "coder") == 3
 
     def test_reset_restart_counts_clears_pipeline(self, spawner):
         """reset_restart_counts should clear all counts for a pipeline."""
-        spawner._restart_counts[("issue-100", "coder")] = 2
-        spawner._restart_counts[("issue-100", "tester")] = 1
-        spawner._restart_counts[("issue-200", "coder")] = 3
+        spawner._restart_counts[("issue-100", "coder", None)] = 2
+        spawner._restart_counts[("issue-100", "tester", None)] = 1
+        spawner._restart_counts[("issue-200", "coder", None)] = 3
 
         spawner.reset_restart_counts("issue-100")
 
@@ -762,6 +762,159 @@ class TestRestartAgentEndpoint:
 
 
 # ---------------------------------------------------------------------------
+# Issue #2410: slice_id forwarding through the operator restart route
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _HAS_FLASK, reason="Flask not available")
+class TestRestartAgentEndpointSliceScope:
+    """``slice_id`` query / body parameter is validated and forwarded (#2410)."""
+
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_slice_id_query_param_forwarded_to_spawner(
+        self, mock_repo, mock_resolve, mock_spawner_fn, mock_lock_fn, client
+    ):
+        """``?slice_id=slice-2`` reaches ``restart_agent_container``."""
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        pipeline = _make_pipeline_with_running_agent()
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        new_container = SpawnedContainer(
+            container_info=ContainerInfo(
+                container_id="new-container-xyz",
+                container_name="egg-issue-100-slice-2-coder",
+                status=ContainerStatus.RUNNING,
+            ),
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-100",
+            environment={},
+        )
+        mock_spawner.restart_agent_container.return_value = new_container
+        mock_spawner.get_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart?slice_id=slice-2",
+            json={"reason": "Slice agent stalled"},
+        )
+
+        assert response.status_code == 200
+        restart_call = mock_spawner.restart_agent_container.call_args
+        assert restart_call.kwargs["slice_id"] == "slice-2"
+
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_slice_id_body_field_forwarded_to_spawner(
+        self, mock_repo, mock_resolve, mock_spawner_fn, mock_lock_fn, client
+    ):
+        """``{"slice_id": "slice-2"}`` in the body reaches the spawner."""
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        pipeline = _make_pipeline_with_running_agent()
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        new_container = SpawnedContainer(
+            container_info=ContainerInfo(
+                container_id="new-container-xyz",
+                container_name="egg-issue-100-slice-2-coder",
+                status=ContainerStatus.RUNNING,
+            ),
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-100",
+            environment={},
+        )
+        mock_spawner.restart_agent_container.return_value = new_container
+        mock_spawner.get_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart",
+            json={"reason": "Slice agent stalled", "slice_id": "slice-2"},
+        )
+
+        assert response.status_code == 200
+        restart_call = mock_spawner.restart_agent_container.call_args
+        assert restart_call.kwargs["slice_id"] == "slice-2"
+
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_invalid_slice_id_returns_400(self, mock_repo, mock_resolve, client):
+        """Non-canonical slice_id values are rejected with 400 before spawn."""
+        mock_repo.return_value = "/repo"
+        pipeline = _make_pipeline_with_running_agent()
+
+        mock_store = MagicMock()
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        # Path-separator and shell-metacharacter values must not reach
+        # the spawner — defense-in-depth against a future caller that
+        # forgets the upstream regex.
+        for bad in ("phase-2", "slice-2/etc", "../slice-2", "slice-"):
+            response = client.post(
+                f"/api/v1/pipelines/issue-100/agents/coder/restart?slice_id={bad}",
+                json={},
+            )
+            assert response.status_code == 400, f"slice_id={bad!r} should be rejected"
+
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_no_slice_id_forwards_none(
+        self, mock_repo, mock_resolve, mock_spawner_fn, mock_lock_fn, client
+    ):
+        """Pipeline-level callers (no slice_id) get ``slice_id=None`` forwarded."""
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        pipeline = _make_pipeline_with_running_agent()
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        new_container = SpawnedContainer(
+            container_info=ContainerInfo(
+                container_id="new-container-xyz",
+                container_name="egg-issue-100-coder",
+                status=ContainerStatus.RUNNING,
+            ),
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-100",
+            environment={},
+        )
+        mock_spawner.restart_agent_container.return_value = new_container
+        mock_spawner.get_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart",
+            json={"reason": "Pipeline-level restart"},
+        )
+
+        assert response.status_code == 200
+        restart_call = mock_spawner.restart_agent_container.call_args
+        assert restart_call.kwargs["slice_id"] is None
+
+
+# ---------------------------------------------------------------------------
 # Issue #1695: mode=None raises ValueError (issue 7)
 # ---------------------------------------------------------------------------
 
@@ -967,7 +1120,7 @@ class TestRestartConcurrencyGuard:
     ):
         """If one thread consumes the last restart, the other should get limit error."""
         # Pre-set count to 1 with max_restarts=2 — only one more slot
-        spawner._restart_counts[("issue-100", "coder")] = 1
+        spawner._restart_counts[("issue-100", "coder", None)] = 1
 
         results = []
         errors = []
@@ -1001,17 +1154,21 @@ class TestRestartConcurrencyGuard:
         assert "Restart limit" in str(errors[0])
 
     def test_restart_lock_created_per_key(self, spawner):
-        """Each (pipeline_id, agent_role) pair should get its own lock."""
-        key1 = ("issue-100", "coder")
-        key2 = ("issue-100", "tester")
-        key3 = ("issue-200", "coder")
+        """Each (pipeline_id, agent_role, slice_id) tuple should get its own lock."""
+        key1 = ("issue-100", "coder", None)
+        key2 = ("issue-100", "tester", None)
+        key3 = ("issue-200", "coder", None)
+        # Slice scope splits the key further (#2410).
+        key4 = ("issue-100", "coder", "slice-2")
 
         lock1 = spawner._get_restart_lock(key1)
         lock2 = spawner._get_restart_lock(key2)
         lock3 = spawner._get_restart_lock(key3)
+        lock4 = spawner._get_restart_lock(key4)
 
         assert lock1 is not lock2, "Different agents should have different locks"
         assert lock1 is not lock3, "Different pipelines should have different locks"
+        assert lock1 is not lock4, "Different slice scopes should have different locks"
 
         # Same key should return the same lock
         assert spawner._get_restart_lock(key1) is lock1
@@ -1034,28 +1191,28 @@ class TestRestartLockCleanup:
         lock for the same key — breaking mutual exclusion.
         """
         # Create some locks by accessing them
-        spawner._get_restart_lock(("issue-100", "coder"))
-        spawner._get_restart_lock(("issue-100", "tester"))
-        spawner._get_restart_lock(("issue-200", "coder"))
+        spawner._get_restart_lock(("issue-100", "coder", None))
+        spawner._get_restart_lock(("issue-100", "tester", None))
+        spawner._get_restart_lock(("issue-200", "coder", None))
 
         # Set some counts
-        spawner._restart_counts[("issue-100", "coder")] = 2
-        spawner._restart_counts[("issue-100", "tester")] = 1
-        spawner._restart_counts[("issue-200", "coder")] = 3
+        spawner._restart_counts[("issue-100", "coder", None)] = 2
+        spawner._restart_counts[("issue-100", "tester", None)] = 1
+        spawner._restart_counts[("issue-200", "coder", None)] = 3
 
         spawner.reset_restart_counts("issue-100")
 
         # Counts for issue-100 should be cleared
-        assert spawner._restart_counts.get(("issue-100", "coder"), 0) == 0
-        assert spawner._restart_counts.get(("issue-100", "tester"), 0) == 0
+        assert spawner._restart_counts.get(("issue-100", "coder", None), 0) == 0
+        assert spawner._restart_counts.get(("issue-100", "tester", None), 0) == 0
 
         # Locks for issue-100 should be retained (not deleted)
-        assert ("issue-100", "coder") in spawner._restart_locks
-        assert ("issue-100", "tester") in spawner._restart_locks
+        assert ("issue-100", "coder", None) in spawner._restart_locks
+        assert ("issue-100", "tester", None) in spawner._restart_locks
 
         # issue-200 should be untouched
-        assert spawner._restart_counts.get(("issue-200", "coder"), 0) == 3
-        assert ("issue-200", "coder") in spawner._restart_locks
+        assert spawner._restart_counts.get(("issue-200", "coder", None), 0) == 3
+        assert ("issue-200", "coder", None) in spawner._restart_locks
 
     def test_restart_lock_initialization(self):
         """Restart lock dicts should be initialised in constructor."""

--- a/orchestrator/tests/test_slice_run_loop_integration.py
+++ b/orchestrator/tests/test_slice_run_loop_integration.py
@@ -1183,7 +1183,10 @@ class TestRunConcurrentPhaseSliceIdPropagation:
             worktree_repo_path=Path("/tmp/x"),
             slice_id="slice-3",
         )
-        # Caller's dict is not mutated; the function takes a shallow copy.
+        # Caller's dict is not mutated — _run_concurrent_phase no longer
+        # touches sandbox_env (the EGG_SLICE_ID assignment was dropped in
+        # the v2 review fix; slice scope flows through the spawner via the
+        # slice_id kwarg instead).
         assert original_env == {"EGG_PIPELINE_ID": pipeline.id, "OTHER": "v"}
         # Executor receives slice_id="slice-3".
         assert MockExecutor.call_args.kwargs["slice_id"] == "slice-3"

--- a/orchestrator/tests/test_slice_signal_routing.py
+++ b/orchestrator/tests/test_slice_signal_routing.py
@@ -95,14 +95,25 @@ def _setup_spawn(executions: list[AgentExecution]):
 
 
 class TestSliceSpawnEnvShape:
-    """``EGG_PIPELINE_ID`` stays canonical; slice scope rides on ``EGG_SLICE_ID``."""
+    """``EGG_PIPELINE_ID`` stays canonical; slice scope rides on ``EGG_SLICE_ID``.
+
+    Single-source-of-truth (#2410 v2 review): ``EGG_SLICE_ID`` is injected
+    by ``KubernetesSpawner.spawn_agent_job`` from the ``slice_id`` parameter
+    that already drives Job naming and worktree id, and the key is in
+    ``_PROTECTED_ENV_KEYS`` so ``extra_env`` cannot smuggle a mismatched
+    value. These tests pin the wrapper-side contract: ``slice_id`` must
+    flow through ``create_concurrent_spawn_fn`` as a kwarg, and
+    ``sandbox_env`` must not carry ``EGG_SLICE_ID`` (a duplicate setter
+    here would just trip the protected-key warning every spawn).
+    ``test_kubernetes_spawner.py`` covers the spawner-side env injection.
+    """
 
     @patch("routes.pipelines.time.sleep")
     @patch("routes.pipelines.time.monotonic", return_value=0.0)
     @patch("routes.pipelines.get_pipeline_state_lock")
     @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
     @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
-    def test_slice_scope_sets_egg_slice_id_and_keeps_egg_pipeline_id_bare(
+    def test_slice_scope_forwards_slice_id_and_keeps_egg_pipeline_id_bare(
         self, MockExecutor, mock_prompt, mock_lock, _mono, _sleep
     ):
         executions = [_make_execution(AgentRole.CODER, "coder-1")]
@@ -130,20 +141,24 @@ class TestSliceSpawnEnvShape:
             **_CALL_ARGS,
         )
 
-        # ``create_concurrent_spawn_fn`` is the seam where the env is
-        # frozen for the spawn closure.
+        # ``create_concurrent_spawn_fn`` is the seam where the slice scope
+        # is frozen for the spawn closure.
         kwargs = mock_spawner.create_concurrent_spawn_fn.call_args.kwargs
         assert kwargs["pipeline_id"] == "issue-2403"
+        # Slice scope rides on the ``slice_id`` kwarg, not on
+        # ``sandbox_env``. The spawner sets ``EGG_SLICE_ID`` itself from
+        # this parameter (single source of truth).
+        assert kwargs["slice_id"] == "slice-2"
         env = kwargs["sandbox_env"]
-        # The bare pipeline id MUST pass the orchestrator's validator —
-        # otherwise every ``/api/v1/pipelines/{pid}/...`` round-trip 404s.
-        assert env.get("EGG_SLICE_ID") == "slice-2"
+        # ``sandbox_env`` must NOT carry ``EGG_SLICE_ID`` — the key is
+        # protected and a duplicate would log the override every spawn.
+        assert "EGG_SLICE_ID" not in env
         # Agent CLIs read EGG_PIPELINE_ID via ``get_pipeline_id`` — only
         # set if the caller seeded it. We assert here that the function
         # didn't smuggle a slashed value into it.
         if "EGG_PIPELINE_ID" in env:
             assert PIPELINE_ID_PATTERN.match(env["EGG_PIPELINE_ID"]) is not None
-        # Pre-existing keys must survive the slice-aware mutation.
+        # Pre-existing keys must survive the slice-aware path.
         assert env["PRESERVED"] == "yes"
 
     @patch("routes.pipelines.time.sleep")
@@ -179,7 +194,9 @@ class TestSliceSpawnEnvShape:
             **_CALL_ARGS,
         )
 
-        env = mock_spawner.create_concurrent_spawn_fn.call_args.kwargs["sandbox_env"]
+        kwargs = mock_spawner.create_concurrent_spawn_fn.call_args.kwargs
+        assert kwargs.get("slice_id") is None
+        env = kwargs["sandbox_env"]
         assert "EGG_SLICE_ID" not in env
 
 

--- a/scripts/file-size-allowlist.yaml
+++ b/scripts/file-size-allowlist.yaml
@@ -48,3 +48,5 @@ files:
     issue: "2248"
   orchestrator/routes/deployment.py:
     issue: "2248"
+  orchestrator/kubernetes_spawner.py:
+    issue: "2248"


### PR DESCRIPTION
Fixes #2410. Stacked on #2402 (`egg/issue-2399`) — that PR landed the
#2403 spawn-side slice plumbing and explicitly deferred the restart
side. This PR closes the deferred gap so the next operator-route
extension that wires slice scope can't silently regress.

## Why

`KubernetesSpawner.restart_agent_job` and
`KubernetesSpawner.detect_uncommitted_changes` did not yet take
`slice_id`. The gap is dormant today (no production caller drives
restart with slice scope), but the moment a slice-aware caller hit
the restart path, three failure modes would surface together:

1. `delete_job(name=...)` against the non-slice-scoped Job name —
   the slice agent's actual Job (`egg-agent-{pid}-slice-{N}-{role}`)
   left running while a fresh non-scoped Job is spawned alongside it.
2. The fresh Job's `agent_worktree_id` is `{pid}-{role}` rather than
   `{pid}-slice-{N}-{role}`, so it mounts the wrong worktree (or
   none, if no pipeline-level worktree exists).
3. Without `EGG_SLICE_ID`, the restarted agent's `CONSENSUS_*`
   signals route to the pipeline-level tracker, which has no record
   of this agent.

The v2 review of #2402 asked for the follow-up — this is it.

## Changes

- **`orchestrator/slice_id_validation.py`** (new) — canonical
  `SLICE_ID_PATTERN` + `extract_slice_id`. Lifted from
  `routes/signals.py` so the operator restart route validates
  against the same regex. `signals.py` re-exports under the existing
  private name to keep handler call sites unchanged.
- **`KubernetesSpawner.restart_agent_job`** — add `slice_id`
  parameter, thread to `_build_k8s_job_names(..., slice_id=...)` and
  forward to `spawn_agent_job(..., slice_id=...)`. Restart budget key
  becomes `(pipeline_id, agent_role, slice_id)` so concurrent slices
  each get an independent budget; `reset_restart_counts(pid)` still
  clears every slice's bucket via the `k[0] == pipeline_id` filter.
- **`KubernetesSpawner.detect_uncommitted_changes`** — add `slice_id`
  parameter, build the worktree id with the slice segment when
  supplied, surface `slice_id` in the result dict + log line.
- **`KubernetesSpawner.get_restart_count`** — optional `slice_id`
  parameter so slice-aware callers can read the per-slice budget.
- **`POST /pipelines/<id>/agents/<role>/restart`** — accept
  `slice_id` via query param (wins) or JSON body, validate against
  the canonical `slice-<N>` shape, forward to the spawner, and
  target the per-slice consensus tracker on reset.

## Tests

- `TestRestartAgentJobSliceScope` — slice-scoped delete, gateway
  cleanup, respawn worktree, per-slice restart budget,
  `reset_restart_counts` sweeps slice buckets.
- `TestDetectUncommittedChangesSliceScope` — slice-scoped lookup
  hits the right worktree; pipeline-level / slice-level lookups
  don't cross-contaminate.
- `TestRestartAgentEndpointSliceScope` — query/body forwarding,
  invalid-shape rejection (`phase-2`, `slice-2/etc`, `../slice-2`,
  `slice-`), pipeline-level restart still forwards `slice_id=None`.
- Existing 2-tuple restart-key fixtures updated for the new 3-tuple
  shape.

## Test plan

- [x] `make lint` (ruff check + format on changed files)
- [x] `pytest test_kubernetes_spawner.py test_restart_agent.py
      test_per_agent_worktree.py test_worktree_hitl.py
      test_slice_signal_routing.py test_brc_content_validation.py`
      — 261 tests pass
- [ ] Full `make test-all` deferred for CI
- [ ] End-to-end: trigger an operator-driven slice agent restart
      against a live slice-DAG pipeline and confirm the slice-scoped
      Job + worktree are recreated and `EGG_SLICE_ID` propagates

## Refs

- #2403 — original slice-scope spawn plumbing, deferred this gap.
- #2402 — base branch, contains the #2403 fix.
- `orchestrator/kubernetes_spawner.py` — the two helpers.
- `orchestrator/routes/pipelines.py:restart_agent` — operator route.