### PR TITLE
Fix #2427: route get_contract MCP handler through string-identifier endpoint

### DIFF
--- a/docs/architecture/orchestrator.md
+++ b/docs/architecture/orchestrator.md
@@ -474,13 +474,13 @@ NetworkPolicies (enforced by Calico CNI):
 - `GET /health` - MCP server health check
 - `POST /mcp` - Streamable HTTP transport endpoint (MCP protocol via JSON-RPC)
 
-Available MCP tools (orchestrator-backed): `submit_task`, `get_status`, `provide_input`, `list_tasks`, `cancel_task`, `check_health`, `list_containers`, `get_container_logs`, `send_message`, `get_consensus_status`, `get_phase`, `get_pipeline_snapshot`, `validate_config`, `restart_agent`, `restart_phase`, `advance_phase`, `start_phase`, `complete_phase`, `populate_contract`
+Available MCP tools (orchestrator-backed): `submit_task`, `get_status`, `provide_input`, `list_tasks`, `cancel_task`, `check_health`, `list_containers`, `get_container_logs`, `send_message`, `get_consensus_status`, `get_phase`, `get_pipeline_snapshot`, `get_contract`, `validate_config`, `restart_agent`, `restart_phase`, `advance_phase`, `start_phase`, `complete_phase`, `populate_contract`
 
 Blocking host-side waits run via the `egg-orch pipeline wait-status` Bash CLI rather than an MCP tool (issue [#2211](https://github.com/jwbron/egg/issues/2211)). The CLI loops the orchestrator's `/api/v1/pipelines/<id>/status/wait` route server-side and emits one JSON-line per pipeline-relevant event. See [Host-Side Waits](../reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the envelope, exit-code contract, and cursor protocol. The route itself stays — the CLI is a wrapper.
 
-Available MCP tools (gateway-backed, requires `gateway_url`): `list_checkpoints`, `search_checkpoints`, `get_contract`
+Available MCP tools (gateway-backed, requires `gateway_url`): `list_checkpoints`, `search_checkpoints`
 
-The gateway-backed checkpoint tools (`list_checkpoints`, `search_checkpoints`) accept an optional `repo` parameter to specify the checkpoint repository in `owner/repo` format (e.g., `owner/repo-checkpoints`). When provided, this is forwarded as the `source_repo` query parameter to the gateway checkpoint endpoint. The `get_contract` tool also uses the gateway session but does not require the `repo` parameter.
+The gateway-backed checkpoint tools (`list_checkpoints`, `search_checkpoints`) accept an optional `repo` parameter to specify the checkpoint repository in `owner/repo` format (e.g., `owner/repo-checkpoints`). When provided, this is forwarded as the `source_repo` query parameter to the gateway checkpoint endpoint.
 
 **CLI Access:**
 The `egg-orch` CLI (`sandbox/bin/egg-orch`) provides command-line access to all orchestrator API endpoints. Available in sandbox containers for agent use, or can be run from the host with appropriate environment variables. See the [README CLI Reference](../../README.md#egg-orch-cli) for command details.

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -2472,6 +2472,7 @@ class PipelineToolHandler:
         # resolve the unqualified contract on disk even when a qualified one
         # exists.
         if not pipeline_id:
+            issue_int = int(issue_number)
             try:
                 pipelines_resp = self._make_request("/api/v1/pipelines?active_only=true")
                 # If multiple active pipelines exist for this issue (e.g. a retry
@@ -2480,7 +2481,7 @@ class PipelineToolHandler:
                 # so we scan all matching entries and keep the latest by created_at.
                 best: dict[str, Any] | None = None
                 for p in pipelines_resp.get("data", {}).get("pipelines", []):
-                    if p.get("issue_number") == int(issue_number):
+                    if p.get("issue_number") == issue_int:
                         if best is None or p.get("created_at", "") > best.get("created_at", ""):
                             best = p
                 if best is not None:
@@ -2489,7 +2490,7 @@ class PipelineToolHandler:
                 pass  # best-effort; fall back to canonical issue-<N>
 
             if not pipeline_id:
-                pipeline_id = f"issue-{int(issue_number)}"
+                pipeline_id = f"issue-{issue_int}"
 
         encoded = quote(pipeline_id, safe="")
         url = f"/api/v1/contracts/{encoded}?pipeline_id={encoded}"

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -2454,21 +2454,23 @@ class PipelineToolHandler:
         }
 
     def _handle_get_contract(self, args: dict[str, Any]) -> dict[str, Any]:
-        """Get SDLC contract state."""
+        """Get SDLC contract state.
+
+        Routes through the orchestrator's ``/api/v1/contracts/<identifier>``
+        endpoint with the pipeline_id as the path identifier so qualified
+        pipelines (e.g. ``issue-42-v9``) resolve to their own contract file
+        instead of the unqualified ``issue-42.json`` (#2427).
+        """
         issue_number = args.get("issue_number")
         pipeline_id: str | None = args.get("task_id")
 
-        if not issue_number and pipeline_id:
-            # Look up issue_number from pipeline data
-            task_id = quote(pipeline_id, safe="")
-            pipeline_result = self._make_request(f"/api/v1/pipelines/{task_id}")
-            issue_number = pipeline_result.get("data", {}).get("pipeline", {}).get("issue_number")
+        if not pipeline_id and issue_number is None:
+            return {"error": "Either issue_number or task_id is required"}
 
-        if not issue_number:
-            return {"error": "Either issue_number or task_id (with linked issue) is required"}
-
-        # When only issue_number was provided, try to find the active pipeline
-        # so we can pass its ID for worktree resolution.
+        # When only issue_number was provided, find the active pipeline so we
+        # use its qualified ID — the canonical issue-<N> key would always
+        # resolve the unqualified contract on disk even when a qualified one
+        # exists.
         if not pipeline_id:
             try:
                 pipelines_resp = self._make_request("/api/v1/pipelines?active_only=true")
@@ -2484,12 +2486,14 @@ class PipelineToolHandler:
                 if best is not None:
                     pipeline_id = best["id"]
             except Exception:
-                pass  # best-effort; proceed without pipeline_id
+                pass  # best-effort; fall back to canonical issue-<N>
 
-        url = f"/api/v1/contract/{int(issue_number)}"
-        if pipeline_id:
-            url += f"?pipeline_id={quote(pipeline_id, safe='')}"
-        return self._make_gateway_request(url)
+            if not pipeline_id:
+                pipeline_id = f"issue-{int(issue_number)}"
+
+        encoded = quote(pipeline_id, safe="")
+        url = f"/api/v1/contracts/{encoded}?pipeline_id={encoded}"
+        return self._make_request(url)
 
     def _handle_restart_agent(self, args: dict[str, Any]) -> dict[str, Any]:
         """Restart a single agent in a pipeline."""

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -2,8 +2,9 @@
 
 Tests cover the 10 new tools added for comprehensive platform interface:
 - check_health, list_containers, get_container_logs, send_message,
-  get_consensus_status, get_phase, get_pipeline_snapshot (orchestrator-backed)
-- list_checkpoints, search_checkpoints, get_contract (gateway-backed)
+  get_consensus_status, get_phase, get_pipeline_snapshot,
+  get_contract (orchestrator-backed)
+- list_checkpoints, search_checkpoints (gateway-backed)
 """
 
 import asyncio
@@ -718,6 +719,25 @@ class TestGetContract:
         assert mock_req.call_args_list[-1][0][0] == (
             "/api/v1/contracts/issue-42?pipeline_id=issue-42"
         )
+
+    def test_contract_fetch_http_error_surfaces_to_caller(self, handler):
+        """A 404 from the orchestrator's contracts route is surfaced to the
+        caller via handle_tool_call's outer catch, not swallowed silently."""
+        http_err = _make_http_error(404, {"error": "Contract not found"})
+        with patch.object(handler, "_make_request", side_effect=http_err):
+            result = handler.handle_tool_call("get_contract", {"task_id": "issue-42-v9"})
+
+        assert "error" in result
+        assert "404" in result["error"]
+
+    def test_contract_fetch_returns_orchestrator_envelope_unchanged(self, handler):
+        """When the orchestrator returns a JSON envelope (success or error
+        dict), the handler passes it through verbatim — no rewrapping."""
+        envelope = {"success": False, "error": "worktree gone", "code": "WORKTREE_MISSING"}
+        with patch.object(handler, "_make_request", return_value=envelope):
+            result = handler.handle_tool_call("get_contract", {"task_id": "issue-42-v9"})
+
+        assert result == envelope
 
 
 class TestGatewayAuth:

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -628,20 +628,21 @@ class TestSearchCheckpoints:
 class TestGetContract:
     def test_with_issue_number_and_active_pipeline(self, handler):
         """issue_number resolves pipeline_id from active pipelines list."""
-        with patch.object(handler, "_make_request") as mock_req:
-            mock_req.return_value = {
-                "data": {"pipelines": [{"id": "issue-42", "issue_number": 42}]}
-            }
-            with patch.object(handler, "_make_gateway_request") as mock_gw:
-                mock_gw.return_value = {"success": True, "data": {"contract": {}}}
-                handler.handle_tool_call("get_contract", {"issue_number": 42})
+        responses = [
+            {"data": {"pipelines": [{"id": "issue-42", "issue_number": 42}]}},
+            {"success": True, "data": {"contract": {}}},
+        ]
+        with patch.object(handler, "_make_request", side_effect=responses) as mock_req:
+            handler.handle_tool_call("get_contract", {"issue_number": 42})
 
-        mock_gw.assert_called_once_with("/api/v1/contract/42?pipeline_id=issue-42")
+        assert mock_req.call_args_list[-1][0][0] == (
+            "/api/v1/contracts/issue-42?pipeline_id=issue-42"
+        )
 
     def test_with_issue_number_picks_latest_pipeline(self, handler):
         """When multiple active pipelines match the issue, pick the latest by created_at."""
-        with patch.object(handler, "_make_request") as mock_req:
-            mock_req.return_value = {
+        responses = [
+            {
                 "data": {
                     "pipelines": [
                         {"id": "old-run", "issue_number": 42, "created_at": "2026-04-01T10:00:00Z"},
@@ -653,52 +654,70 @@ class TestGetContract:
                         {"id": "mid-run", "issue_number": 42, "created_at": "2026-04-02T10:00:00Z"},
                     ]
                 }
-            }
-            with patch.object(handler, "_make_gateway_request") as mock_gw:
-                mock_gw.return_value = {"success": True, "data": {"contract": {}}}
-                handler.handle_tool_call("get_contract", {"issue_number": 42})
+            },
+            {"success": True, "data": {"contract": {}}},
+        ]
+        with patch.object(handler, "_make_request", side_effect=responses) as mock_req:
+            handler.handle_tool_call("get_contract", {"issue_number": 42})
 
-        mock_gw.assert_called_once_with("/api/v1/contract/42?pipeline_id=newest-run")
+        assert mock_req.call_args_list[-1][0][0] == (
+            "/api/v1/contracts/newest-run?pipeline_id=newest-run"
+        )
 
     def test_with_issue_number_no_active_pipeline(self, handler):
-        """issue_number without matching active pipeline omits pipeline_id."""
+        """issue_number without matching active pipeline falls back to canonical issue-<N>."""
+        responses = [
+            {"data": {"pipelines": []}},
+            {"success": True, "data": {"contract": {}}},
+        ]
+        with patch.object(handler, "_make_request", side_effect=responses) as mock_req:
+            handler.handle_tool_call("get_contract", {"issue_number": 42})
+
+        assert mock_req.call_args_list[-1][0][0] == (
+            "/api/v1/contracts/issue-42?pipeline_id=issue-42"
+        )
+
+    def test_with_task_id_uses_qualified_path(self, handler):
+        """task_id is used directly as the path identifier — no issue lookup needed."""
         with patch.object(handler, "_make_request") as mock_req:
-            mock_req.return_value = {"data": {"pipelines": []}}
-            with patch.object(handler, "_make_gateway_request") as mock_gw:
-                mock_gw.return_value = {"success": True, "data": {"contract": {}}}
-                handler.handle_tool_call("get_contract", {"issue_number": 42})
+            mock_req.return_value = {"success": True, "data": {"contract": {}}}
+            handler.handle_tool_call("get_contract", {"task_id": "issue-42"})
 
-        mock_gw.assert_called_once_with("/api/v1/contract/42")
+        mock_req.assert_called_once_with("/api/v1/contracts/issue-42?pipeline_id=issue-42")
 
-    def test_with_task_id_lookup(self, handler):
+    def test_with_qualified_task_id_preserves_qualifier(self, handler):
+        """Regression for #2427: qualified pipeline IDs (e.g. issue-42-v9) must
+        load the qualified contract file, not the unqualified issue-42.json."""
         with patch.object(handler, "_make_request") as mock_req:
-            mock_req.return_value = {"data": {"pipeline": {"issue_number": 42}}}
-            with patch.object(handler, "_make_gateway_request") as mock_gw:
-                mock_gw.return_value = {"success": True, "data": {"contract": {}}}
-                handler.handle_tool_call("get_contract", {"task_id": "issue-42"})
+            mock_req.return_value = {"success": True, "data": {"contract": {}}}
+            handler.handle_tool_call("get_contract", {"task_id": "issue-42-v9"})
 
-        mock_gw.assert_called_once_with("/api/v1/contract/42?pipeline_id=issue-42")
+        mock_req.assert_called_once_with("/api/v1/contracts/issue-42-v9?pipeline_id=issue-42-v9")
+
+    def test_with_jira_task_id(self, handler):
+        """Non-issue pipeline IDs (e.g. JIRA tickets) work without an issue_number."""
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {"success": True, "data": {"contract": {}}}
+            handler.handle_tool_call("get_contract", {"task_id": "ABC-1234"})
+
+        mock_req.assert_called_once_with("/api/v1/contracts/ABC-1234?pipeline_id=ABC-1234")
 
     def test_missing_both_params(self, handler):
         result = handler.handle_tool_call("get_contract", {})
         assert "error" in result
 
-    def test_task_id_without_issue(self, handler):
-        with patch.object(handler, "_make_request") as mock_req:
-            mock_req.return_value = {"data": {"pipeline": {"issue_number": None}}}
-            result = handler.handle_tool_call("get_contract", {"task_id": "prompt-based"})
-
-        assert "error" in result
-
     def test_pipeline_lookup_failure_is_graceful(self, handler):
-        """If listing pipelines fails, the request proceeds without pipeline_id."""
-        with patch.object(handler, "_make_request") as mock_req:
-            mock_req.side_effect = Exception("connection refused")
-            with patch.object(handler, "_make_gateway_request") as mock_gw:
-                mock_gw.return_value = {"success": True, "data": {"contract": {}}}
-                handler.handle_tool_call("get_contract", {"issue_number": 42})
+        """If listing active pipelines fails, fall back to the canonical issue-<N> key."""
+        responses = [
+            Exception("connection refused"),
+            {"success": True, "data": {"contract": {}}},
+        ]
+        with patch.object(handler, "_make_request", side_effect=responses) as mock_req:
+            handler.handle_tool_call("get_contract", {"issue_number": 42})
 
-        mock_gw.assert_called_once_with("/api/v1/contract/42")
+        assert mock_req.call_args_list[-1][0][0] == (
+            "/api/v1/contracts/issue-42?pipeline_id=issue-42"
+        )
 
 
 class TestGatewayAuth:


### PR DESCRIPTION
## Summary

- `_handle_get_contract` (orchestrator/mcp_tools.py) was building its URL as `/api/v1/contract/{int(issue_number)}` — bare integer path — so qualified pipelines (e.g. `issue-2261-v9`) always loaded the unqualified `issue-<N>.json` even when a v9 contract existed on disk. The `pipeline_id` query param was attached but did not influence file resolution downstream.
- Switch the handler to the orchestrator's `/api/v1/contracts/<identifier>` endpoint, passing `pipeline_id` as both the path identifier (preserving the qualifier) and the worktree-resolution query hint. Falls back to `issue-<N>` when only `issue_number` is given and no active pipeline lookup matches.
- Side benefit: `task_id` callers no longer need the prerequisite issue-number lookup, so non-issue pipelines (JIRA tickets, prompt-driven IDs) now resolve cleanly.

Fixes #2427 (primary read-side bug). The sub-bug noted in the issue — `_populate_contract_from_plan` not advancing `current_phase` to the configured `start_phase` — is **not** addressed here; it's a separate write-side fix that warrants its own PR.

## Test plan

- [x] `make test` (full changeset-aware suite — 2,251 passed)
- [x] `orchestrator/tests/test_mcp_tools.py::TestGetContract` — updated existing 6 tests for the new URL pattern, added 2 regression tests:
  - `test_with_qualified_task_id_preserves_qualifier` — the #2427 repro, asserts `task_id="issue-42-v9"` calls `/api/v1/contracts/issue-42-v9?pipeline_id=issue-42-v9`
  - `test_with_jira_task_id` — non-issue pipeline IDs (e.g. `ABC-1234`) work without an `issue_number`
- [x] `make lint` (warnings are pre-existing soft-cap notices)