### PR TITLE
Fix #2421: validate slice_id against contract in restart endpoint

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2337,6 +2337,54 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
     except ValueError as e:
         return make_error_response(str(e), status_code=400)
 
+    # Slice-existence check (#2421): a well-formed but unknown
+    # ``slice_id`` would otherwise spawn an orphan Job + worktree
+    # the rest of the system has no record of. The shape regex in
+    # ``extract_slice_id`` only catches malformed values; only the
+    # contract knows which slices the pipeline actually has. Skip
+    # silently when the contract isn't loadable (e.g. worktree pruned
+    # for a CANCELLED pipeline) so we don't regress legitimate
+    # restarts on the existing pipeline-level path.
+    if slice_id is not None:
+        try:
+            from egg_contracts.loader import load_contract
+            from routes import resolve_worktree_path
+        except ImportError:
+            logger.warning(
+                "egg_contracts unavailable; skipping slice_id existence check",
+                pipeline_id=pipeline_id,
+                slice_id=slice_id,
+            )
+        else:
+            contract = None
+            try:
+                worktree_path = resolve_worktree_path(pipeline_id, Path(repo_path))
+                contract_id = _pipeline_identifier(pipeline.issue_number, pipeline_id)
+                contract = load_contract(contract_id, worktree_path)
+            except Exception as exc:  # noqa: BLE001 — best-effort gate
+                # Worktree pruned, contract not yet populated, or filesystem
+                # error: log and fall through. The reviewer's #2421 ask was
+                # to catch the easy "wrong slice_id" case, not to gate
+                # restarts on contract reachability.
+                logger.warning(
+                    "Could not load contract for slice_id existence check; allowing restart",
+                    pipeline_id=pipeline_id,
+                    slice_id=slice_id,
+                    error=str(exc),
+                )
+            if contract is not None:
+                known_slice_ids = {s.id for s in contract.slices}
+                if slice_id not in known_slice_ids:
+                    return make_error_response(
+                        f"slice_id {slice_id!r} does not match any slice in "
+                        f"pipeline {pipeline_id}'s contract",
+                        status_code=404,
+                        details={
+                            "slice_id": slice_id,
+                            "known_slices": sorted(known_slice_ids),
+                        },
+                    )
+
     # Restart the container via spawner
     spawner = _get_spawner()
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2382,8 +2382,9 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
                 try:
                     contract = load_contract(contract_id, worktree_path)
                 except ContractNotFoundError:
-                    # Contract not yet populated — fall through silently.
-                    contract = None
+                    # Contract not yet populated — fall through silently
+                    # (``contract`` already initialised to ``None`` above).
+                    pass
             except (OSError, ValueError, ContractValidationError) as exc:
                 # Worktree pruned, filesystem failure, or corrupt/invalid
                 # contract JSON: log and fall through. The reviewer's #2421

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2341,17 +2341,36 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
     # ``slice_id`` would otherwise spawn an orphan Job + worktree
     # the rest of the system has no record of. The shape regex in
     # ``extract_slice_id`` only catches malformed values; only the
-    # contract knows which slices the pipeline actually has. Skip
-    # silently when the contract isn't loadable (e.g. worktree pruned
-    # for a CANCELLED pipeline) so we don't regress legitimate
-    # restarts on the existing pipeline-level path.
+    # contract knows which slices the pipeline actually has.
+    #
+    # Pipelines without a contract (BABYSIT, CUSTOM+PR) are not
+    # slice-aware, so any non-``None`` ``slice_id`` targeting them is
+    # by definition unknown — reject outright. For contracted
+    # pipelines, load the contract and check membership; fall through
+    # silently if the contract can't be loaded (worktree pruned,
+    # contract not yet populated, filesystem error) so we don't
+    # regress legitimate restarts on the existing pipeline-level path.
     if slice_id is not None:
+        if not pipeline.has_contract:
+            return make_error_response(
+                f"slice_id {slice_id!r} is invalid for pipeline "
+                f"{pipeline_id} (pipeline has no contract; not slice-aware)",
+                status_code=404,
+                details={
+                    "slice_id": slice_id,
+                    "known_slices": [],
+                },
+            )
         try:
-            from egg_contracts.loader import load_contract
+            from egg_contracts.loader import (
+                ContractNotFoundError,
+                ContractValidationError,
+                load_contract,
+            )
             from routes import resolve_worktree_path
         except ImportError:
             logger.warning(
-                "egg_contracts unavailable; skipping slice_id existence check",
+                "Required modules unavailable; skipping slice_id existence check",
                 pipeline_id=pipeline_id,
                 slice_id=slice_id,
             )
@@ -2360,12 +2379,18 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
             try:
                 worktree_path = resolve_worktree_path(pipeline_id, Path(repo_path))
                 contract_id = _pipeline_identifier(pipeline.issue_number, pipeline_id)
-                contract = load_contract(contract_id, worktree_path)
-            except Exception as exc:  # noqa: BLE001 — best-effort gate
-                # Worktree pruned, contract not yet populated, or filesystem
-                # error: log and fall through. The reviewer's #2421 ask was
-                # to catch the easy "wrong slice_id" case, not to gate
-                # restarts on contract reachability.
+                try:
+                    contract = load_contract(contract_id, worktree_path)
+                except ContractNotFoundError:
+                    # Contract not yet populated — fall through silently.
+                    contract = None
+            except (OSError, ValueError, ContractValidationError) as exc:
+                # Worktree pruned, filesystem failure, or corrupt/invalid
+                # contract JSON: log and fall through. The reviewer's #2421
+                # ask was to catch the easy "wrong slice_id" case, not to
+                # gate restarts on contract reachability. Programmer errors
+                # (AttributeError, TypeError, NameError) are left to
+                # propagate so they surface during development.
                 logger.warning(
                     "Could not load contract for slice_id existence check; allowing restart",
                     pipeline_id=pipeline_id,

--- a/orchestrator/tests/test_restart_agent.py
+++ b/orchestrator/tests/test_restart_agent.py
@@ -924,6 +924,110 @@ class TestRestartAgentEndpointSliceScope:
         get_count_call = mock_spawner.get_restart_count.call_args
         assert get_count_call.kwargs.get("slice_id") is None
 
+    @patch("egg_contracts.loader.load_contract")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_unknown_slice_id_returns_404(
+        self,
+        mock_repo,
+        mock_resolve,
+        mock_spawner_fn,
+        mock_load_contract,
+        client,
+    ):
+        """``slice_id`` not present in the pipeline's contract is rejected (#2421).
+
+        Without this gate a well-formed but unknown ``slice-<N>`` would
+        spawn an orphan Job + worktree the rest of the system has no
+        record of.
+        """
+        from egg_contracts.models import Contract, Slice
+
+        mock_repo.return_value = "/repo"
+        pipeline = _make_pipeline_with_running_agent()
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_load_contract.return_value = Contract(
+            pipeline_id="issue-100",
+            slices=[Slice(id="slice-1", name="Only known slice")],
+        )
+
+        mock_spawner = MagicMock()
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart?slice_id=slice-99",
+            json={},
+        )
+
+        assert response.status_code == 404
+        body = response.get_json()
+        assert body["success"] is False
+        assert "slice-99" in body["message"]
+        assert body["details"]["slice_id"] == "slice-99"
+        assert body["details"]["known_slices"] == ["slice-1"]
+        mock_spawner.restart_agent_container.assert_not_called()
+
+    @patch("egg_contracts.loader.load_contract")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_known_slice_id_passes_validation(
+        self,
+        mock_repo,
+        mock_resolve,
+        mock_spawner_fn,
+        mock_lock_fn,
+        mock_load_contract,
+        client,
+    ):
+        """A ``slice_id`` matching the contract still reaches the spawner (#2421)."""
+        from egg_contracts.models import Contract, Slice
+
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        pipeline = _make_pipeline_with_running_agent()
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_load_contract.return_value = Contract(
+            pipeline_id="issue-100",
+            slices=[
+                Slice(id="slice-1", name="First"),
+                Slice(id="slice-2", name="Second"),
+            ],
+        )
+
+        mock_spawner = MagicMock()
+        new_container = SpawnedContainer(
+            container_info=ContainerInfo(
+                container_id="new-container-xyz",
+                container_name="egg-issue-100-slice-2-coder",
+                status=ContainerStatus.RUNNING,
+            ),
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-100",
+            environment={},
+        )
+        mock_spawner.restart_agent_container.return_value = new_container
+        mock_spawner.get_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart?slice_id=slice-2",
+            json={},
+        )
+
+        assert response.status_code == 200
+        restart_call = mock_spawner.restart_agent_container.call_args
+        assert restart_call.kwargs["slice_id"] == "slice-2"
+
 
 # ---------------------------------------------------------------------------
 # Issue #1695: mode=None raises ValueError (issue 7)

--- a/orchestrator/tests/test_restart_agent.py
+++ b/orchestrator/tests/test_restart_agent.py
@@ -12,6 +12,7 @@ Covers:
 
 import threading
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1025,8 +1026,59 @@ class TestRestartAgentEndpointSliceScope:
         )
 
         assert response.status_code == 200
+        # Lock in the "gate ran AND accepted" intent: without this assertion
+        # the test would pass identically whether the gate executed or fell
+        # through silently on a fast-path skip. ``load_contract`` may also
+        # be invoked downstream by the spawner flow, so we verify the gate's
+        # specific call rather than the total count.
+        mock_load_contract.assert_any_call(100, Path("/repo"))
         restart_call = mock_spawner.restart_agent_container.call_args
         assert restart_call.kwargs["slice_id"] == "slice-2"
+
+    @patch("egg_contracts.loader.load_contract")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_slice_id_rejected_for_pipeline_without_contract(
+        self,
+        mock_repo,
+        mock_resolve,
+        mock_spawner_fn,
+        mock_load_contract,
+        client,
+    ):
+        """``slice_id`` is rejected for pipelines with ``has_contract=False`` (#2421).
+
+        BABYSIT and CUSTOM+PR pipelines are not slice-aware (no
+        contract = no slices), so any non-``None`` ``slice_id`` against
+        them is by definition unknown. Rejecting outright also avoids a
+        wasted ``resolve_worktree_path`` + ``load_contract`` call that
+        would always raise ``ContractNotFoundError``.
+        """
+        mock_repo.return_value = "/repo"
+        pipeline = _make_pipeline_with_running_agent()
+        pipeline.has_contract = False
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart?slice_id=slice-1",
+            json={},
+        )
+
+        assert response.status_code == 404
+        body = response.get_json()
+        assert body["success"] is False
+        assert "slice-1" in body["message"]
+        assert body["details"]["slice_id"] == "slice-1"
+        assert body["details"]["known_slices"] == []
+        # Fast-path: no contract load attempted, no spawner call.
+        mock_load_contract.assert_not_called()
+        mock_spawner.restart_agent_container.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2421. Filed as v1 BRC review item #4 follow-up to PR #2419 —
the reviewer flagged that ``POST /pipelines/.../agents/<role>/restart``
forwards any well-formed ``slice-<N>`` to the spawner even when the
pipeline's contract has no such slice, spawning an orphan Job +
worktree the rest of the system can't track.

## Why

``extract_slice_id`` (added in #2419) validates the canonical
``slice-<N>`` shape but cannot tell whether that slice actually
exists for the pipeline being restarted. Only the contract knows.
Without a slice-existence gate, an operator typo (``?slice_id=slice-99``
on a pipeline that only has ``slice-1``) silently spawns a Kubernetes
Job nothing else in the system tracks — no consensus tracker, no
worktree, no per-slice restart budget bucket.

## Change

In ``orchestrator/routes/pipelines.py:restart_agent``:

1. After ``extract_slice_id`` returns a non-``None`` value, load the
   pipeline's contract from its worktree path (mirroring the existing
   pattern in ``orchestrator/routes/phases.py:_unresolved_decisions``).
2. If the contract loads, reject ``slice_id`` values not in
   ``{s.id for s in contract.slices}`` with **404** plus a structured
   ``details: {slice_id, known_slices}`` payload.
3. If the contract doesn't load (worktree pruned, contract not yet
   populated, filesystem error), log a warning and fall through. The
   reviewer's ask was to catch the easy "wrong slice_id" case, not to
   gate restarts on contract reachability.

Pipeline-level (``slice_id=None``) restarts skip the new path entirely.

## Tests

New cases in ``TestRestartAgentEndpointSliceScope``:

- ``test_unknown_slice_id_returns_404`` — well-formed slice not in
  contract is rejected; ``restart_agent_container`` is not called.
- ``test_known_slice_id_passes_validation`` — slice present in
  contract still reaches the spawner with ``slice_id`` forwarded.

Existing #2410 tests (query/body forwarding, malformed-slice
rejection, ``slice_id=None`` path) continue to pass — the new gate
only fires when ``slice_id`` is a non-``None`` canonical value.

## Test plan

- [x] ``.venv/bin/pytest -q orchestrator/tests/test_restart_agent.py`` — 50 passed
- [x] ``make test`` (changeset-aware) — 2252 passed
- [x] ``make lint`` — clean