### PR TITLE
Fix #2422: scope phase_exec.agents walks by (role, slice_id)

### DIFF
--- a/orchestrator/concurrent_executor.py
+++ b/orchestrator/concurrent_executor.py
@@ -460,6 +460,7 @@ class ConcurrentPhaseExecutor:
                             role=role,
                             status=AgentExecutionStatus.FAILED,
                             error=str(e),
+                            slice_id=self._slice_id,
                         )
                     )
 
@@ -500,6 +501,7 @@ class ConcurrentPhaseExecutor:
             container_id=container_id,
             container_info=result.container_info,
             started_at=datetime.now(UTC),
+            slice_id=self._slice_id,
         )
 
     def handle_agent_failure(self, role: str, error: str) -> dict[str, Any]:

--- a/orchestrator/kubernetes_monitor.py
+++ b/orchestrator/kubernetes_monitor.py
@@ -814,7 +814,7 @@ class KubernetesMonitor:
                 # ``stall_slice_id`` is always ``None`` here, but the moment
                 # the upstream check becomes slice-aware this path will mark
                 # the whole phase COMPLETE while other slices are still
-                # RUNNING. Scope to \"no other slice still active\" or split
+                # RUNNING. Scope to "no other slice still active" or split
                 # ``phase_exec`` into per-slice status when #2441 lands.
                 phase_exec.status = PipelineStatus.COMPLETE
                 phase_exec.completed_at = now

--- a/orchestrator/kubernetes_monitor.py
+++ b/orchestrator/kubernetes_monitor.py
@@ -746,6 +746,14 @@ class KubernetesMonitor:
                 if phase_key is None:
                     return
 
+                # ``slice_id`` is optional in the health-check details dict
+                # (the consensus_stall check is currently pipeline-level
+                # only, but #2422's audit asks every walker of
+                # ``phase_exec.agents`` to scope by ``(role, slice_id)`` so
+                # the moment it becomes slice-aware this path doesn't flip
+                # other slices' agents to COMPLETE).
+                stall_slice_id = details.get("slice_id")
+
                 fresh_pipeline = store.load_pipeline(pipeline_id)
                 original_version = fresh_pipeline.version
 
@@ -764,6 +772,8 @@ class KubernetesMonitor:
                 now = datetime.now(UTC)
                 completed_container_ids: set[str] = set()
                 for agent in phase_exec.agents:
+                    if getattr(agent, "slice_id", None) != stall_slice_id:
+                        continue
                     if agent.status in (AgentExecutionStatus.RUNNING, AgentExecutionStatus.FAILED):
                         agent.status = AgentExecutionStatus.COMPLETE
                         agent.completed_at = now

--- a/orchestrator/kubernetes_monitor.py
+++ b/orchestrator/kubernetes_monitor.py
@@ -808,6 +808,14 @@ class KubernetesMonitor:
                 if phase_exec.cycle_timings and phase_exec.cycle_timings[-1].completed_at is None:
                     phase_exec.cycle_timings[-1].completed_at = now
 
+                # TODO(#2441): the phase-level mutations below are unconditional
+                # even though the agent walk above is now slice-scoped. Safe
+                # today because ``consensus_stall`` is pipeline-level only and
+                # ``stall_slice_id`` is always ``None`` here, but the moment
+                # the upstream check becomes slice-aware this path will mark
+                # the whole phase COMPLETE while other slices are still
+                # RUNNING. Scope to \"no other slice still active\" or split
+                # ``phase_exec`` into per-slice status when #2441 lands.
                 phase_exec.status = PipelineStatus.COMPLETE
                 phase_exec.completed_at = now
 

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -229,6 +229,17 @@ class AgentExecution(BaseModel):
             "Optional for backward compatibility with older state files."
         ),
     )
+    slice_id: str | None = Field(
+        default=None,
+        description=(
+            "Slice scope (e.g. ``slice-2``) when the agent runs as part of a "
+            "per-slice team in a multi-slice phase (#2137). ``None`` for "
+            "pipeline-level (non-sliced) agents. Distinguishes concurrent "
+            "same-role agents in the same ``phase_exec.agents`` list so "
+            "consumers that walk by role match on ``(role, slice_id)`` "
+            "rather than role alone (#2422)."
+        ),
+    )
     started_at: datetime | None = Field(default=None, description="When started")
     completed_at: datetime | None = Field(default=None, description="When completed")
     commit: str | None = Field(default=None, description="Commit SHA if changes made")

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -13,6 +13,7 @@ from typing import Any, Literal, NamedTuple
 
 from egg_contracts.models import PipelinePhase
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from slice_id_validation import SLICE_ID_PATTERN
 
 # Phase-aware fallback defaults for consensus timeout. Calibrated against
 # producer/reviewer fan-out and iteration profile per phase — see #2263.
@@ -240,6 +241,26 @@ class AgentExecution(BaseModel):
             "rather than role alone (#2422)."
         ),
     )
+
+    @field_validator("slice_id")
+    @classmethod
+    def _validate_slice_id(cls, v: str | None) -> str | None:
+        """Defense-in-depth: reject non-canonical ``slice_id`` values.
+
+        Production write paths populate this field from validated values
+        produced by ``extract_slice_id`` / ``concurrent_executor._slice_id``,
+        which already enforce ``SLICE_ID_PATTERN``. This validator closes
+        the gap for hand-built fixtures, migration tools, or any future
+        caller that constructs ``AgentExecution`` directly — a non-canonical
+        value would silently break the ``(role, slice_id)`` walks that
+        consumers rely on.
+        """
+        if v is None:
+            return None
+        if not SLICE_ID_PATTERN.fullmatch(v):
+            raise ValueError(f"Invalid slice_id {v!r}: must match 'slice-<N>'")
+        return v
+
     started_at: datetime | None = Field(default=None, description="When started")
     completed_at: datetime | None = Field(default=None, description="When completed")
     commit: str | None = Field(default=None, description="Commit SHA if changes made")

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2555,17 +2555,27 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
                 # ``agent-heartbeat-stall`` trigger is structurally dead on
                 # the ``restart_agent`` path (issue #2084).
                 respawn_started_at = datetime.now(UTC)
+                # Match on ``(role, slice_id)`` — without the slice tiebreaker
+                # the first matching role wins, which on a multi-slice phase
+                # mutates the wrong slice's record (#2422). ``slice_id`` is
+                # the route-level scope already plumbed into the spawner and
+                # consensus tracker above.
                 found = False
                 for agent in fresh_phase_exec.agents:
-                    if hasattr(agent, "role") and (
-                        agent.role == role
-                        or (hasattr(agent.role, "value") and agent.role.value == role.value)
-                    ):
-                        agent.container_id = spawned.container_info.container_id
-                        agent.status = AgentExecutionStatus.RUNNING
-                        agent.started_at = respawn_started_at
-                        found = True
-                        break
+                    if not hasattr(agent, "role"):
+                        continue
+                    role_match = agent.role == role or (
+                        hasattr(agent.role, "value") and agent.role.value == role.value
+                    )
+                    if not role_match:
+                        continue
+                    if getattr(agent, "slice_id", None) != slice_id:
+                        continue
+                    agent.container_id = spawned.container_info.container_id
+                    agent.status = AgentExecutionStatus.RUNNING
+                    agent.started_at = respawn_started_at
+                    found = True
+                    break
                 if not found:
                     fresh_phase_exec.agents.append(
                         AgentExecution(
@@ -2573,6 +2583,7 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
                             container_id=spawned.container_info.container_id,
                             status=AgentExecutionStatus.RUNNING,
                             started_at=respawn_started_at,
+                            slice_id=slice_id,
                         )
                     )
 
@@ -11903,6 +11914,7 @@ def _run_concurrent_phase(
                         ),
                         container_id=exec_info.container_id,
                         started_at=datetime.now(UTC),
+                        slice_id=slice_id,
                     )
                     phase_execution.agents.append(agent_state)
                 store.save_pipeline(pip)
@@ -12124,7 +12136,14 @@ def _run_concurrent_phase(
                     except Exception:
                         pass
 
+                # Filter to this slice's agents — without the filter, slice-2
+                # BRC completing flips slice-3's still-running agents to
+                # COMPLETE because they share ``pe.agents`` (#2422). For
+                # pipeline-level (non-sliced) phases ``slice_id`` is ``None``
+                # and we still match all agents whose ``slice_id`` is ``None``.
                 for agent in pe.agents:
+                    if getattr(agent, "slice_id", None) != slice_id:
+                        continue
                     if agent.status in (StateAgentStatus.RUNNING, StateAgentStatus.FAILED):
                         agent.status = StateAgentStatus.COMPLETE
                         agent.completed_at = datetime.now(UTC)

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -13065,11 +13065,20 @@ def _spawn_and_wait(
                 )
                 phase_execution.containers.append(container_info)
 
-                # Track agent execution
+                # Track agent execution.
+                #
+                # ``slice_id`` is explicitly ``None`` because this helper has
+                # no production callers today and is reachable only from
+                # tests that mock-patch it. If a future change resurrects
+                # this path for a sliced spawn, the caller MUST plumb a
+                # ``slice_id`` through here — otherwise the new
+                # ``(role, slice_id)`` walks added in #2422 will not see
+                # the record. See PR #2435 review thread.
                 agent_execution = AgentExecution(
                     role=agent_role,
                     status=AgentExecutionStatus.RUNNING,
                     container_id=spawned.container_info.container_id,
+                    slice_id=None,
                     started_at=datetime.now(UTC),
                 )
                 phase_execution.agents.append(agent_execution)

--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -573,6 +573,19 @@ def handle_error_signal(
     error_message = data.get("error", "Unknown error")
     recoverable = data.get("recoverable", False)
 
+    # Slice-scope the "already COMPLETE" suppression check below — without
+    # this, a slice-2 coder finishing would silently swallow a slice-3
+    # coder's error because both records share ``phase_execution.agents``
+    # (#2422). The sandbox attaches ``slice_id`` on per-slice agents via
+    # ``progress._maybe_attach_slice_id``; pipeline-level agents send no
+    # ``slice_id`` and this resolves to ``None`` (matches non-sliced
+    # records). ``_extract_slice_id`` rejects malformed values the same
+    # way the BRC handlers do.
+    try:
+        signal_slice_id = _extract_slice_id(data)
+    except Exception as exc:
+        return make_error_response(f"Invalid slice_id: {exc}")
+
     try:
         store = get_state_store(repo_path)
         pipeline = store.load_pipeline(pipeline_id)
@@ -602,11 +615,16 @@ def handle_error_signal(
         phase_execution = pipeline.phases.get(phase_key)
         if phase_execution is not None:
             for agent in phase_execution.agents:
-                if agent.role == agent_role and agent.status == AgentExecutionStatus.COMPLETE:
+                if (
+                    agent.role == agent_role
+                    and getattr(agent, "slice_id", None) == signal_slice_id
+                    and agent.status == AgentExecutionStatus.COMPLETE
+                ):
                     logger.info(
                         "Agent already COMPLETE, suppressing error signal (consensus path)",
                         pipeline_id=pipeline_id,
                         role=agent_role.value,
+                        slice_id=signal_slice_id,
                     )
                     return make_success_response(
                         "Error suppressed (agent already complete)",

--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -583,7 +583,7 @@ def handle_error_signal(
     # way the BRC handlers do.
     try:
         signal_slice_id = _extract_slice_id(data)
-    except Exception as exc:
+    except ValueError as exc:
         return make_error_response(f"Invalid slice_id: {exc}")
 
     try:

--- a/orchestrator/startup_reconciliation.py
+++ b/orchestrator/startup_reconciliation.py
@@ -316,7 +316,18 @@ def reconcile_stale_containers(store: object, docker_client: object) -> int:
 
                         phase_exec = pipeline.phases.get(pipeline.current_phase.value)
                         if phase_exec is not None:
+                            # The reconstructed tracker is the pipeline-level
+                            # one (``get_peer_consensus_tracker(pipeline_id)``
+                            # — no slice arg), so only mark pipeline-level
+                            # agents COMPLETE. Per-slice tracker
+                            # reconstruction would have to evaluate each
+                            # slice's tracker separately; flipping every
+                            # agent regardless of slice would prematurely
+                            # complete agents whose slice-scoped consensus
+                            # hadn't actually reached terminal state (#2422).
                             for agent in phase_exec.agents:
+                                if getattr(agent, "slice_id", None) is not None:
+                                    continue
                                 if agent.status == AgentExecutionStatus.RUNNING:
                                     agent.status = AgentExecutionStatus.COMPLETE
                                     agent.completed_at = datetime.now(UTC)

--- a/orchestrator/startup_reconciliation.py
+++ b/orchestrator/startup_reconciliation.py
@@ -331,6 +331,13 @@ def reconcile_stale_containers(store: object, docker_client: object) -> int:
                                 if agent.status == AgentExecutionStatus.RUNNING:
                                     agent.status = AgentExecutionStatus.COMPLETE
                                     agent.completed_at = datetime.now(UTC)
+                            # TODO(#2441): phase-level mutations are
+                            # unconditional even though the agent walk above
+                            # is slice-scoped (only pipeline-level agents
+                            # flipped). Marks the whole phase COMPLETE even
+                            # if per-slice trackers are still RUNNING; safe
+                            # today because per-slice tracker reconstruction
+                            # isn't wired in here yet.
                             phase_exec.status = PipelineStatus.COMPLETE
                             phase_exec.completed_at = datetime.now(UTC)
                             store.save_pipeline(pipeline)

--- a/orchestrator/tests/test_models.py
+++ b/orchestrator/tests/test_models.py
@@ -4,6 +4,7 @@ Tests for orchestrator models.
 
 from datetime import UTC, datetime
 
+import pytest
 from models import (
     PHASE_CONSENSUS_TIMEOUT_DEFAULTS_MIN,
     AgentExecution,
@@ -74,6 +75,32 @@ class TestAgentExecution:
         )
         assert agent.commit == "abc1234"
         assert agent.outputs["files_changed"] == ["src/main.py"]
+
+    def test_slice_id_none_allowed(self):
+        """``slice_id=None`` (the default) is the pipeline-level scope."""
+        agent = AgentExecution(role=AgentRole.CODER)
+        assert agent.slice_id is None
+
+    def test_slice_id_canonical_accepted(self):
+        """Canonical ``slice-<N>`` ids pass the validator."""
+        agent = AgentExecution(role=AgentRole.CODER, slice_id="slice-2")
+        assert agent.slice_id == "slice-2"
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        ["phase-2", "slice-", "slice-2a", "Slice-2", " slice-2", "slice-2 ", ""],
+    )
+    def test_slice_id_non_canonical_rejected(self, bad_value):
+        """Non-canonical ``slice_id`` values are rejected at construction.
+
+        Defense-in-depth (#2422 review): production write paths use
+        ``extract_slice_id`` / ``concurrent_executor._slice_id`` which
+        already enforce ``SLICE_ID_PATTERN``, but a hand-built fixture
+        or migration tool must not be able to smuggle a non-canonical
+        value through ``AgentExecution(...)``.
+        """
+        with pytest.raises(ValueError, match="Invalid slice_id"):
+            AgentExecution(role=AgentRole.CODER, slice_id=bad_value)
 
 
 class TestHITLDecision:

--- a/orchestrator/tests/test_restart_agent.py
+++ b/orchestrator/tests/test_restart_agent.py
@@ -1033,18 +1033,23 @@ class TestRestartAgentSliceMatching:
 
         assert response.status_code == 200, response.get_json()
 
-        # The store under update_pipeline serialized the mutated pipeline.
-        # Inspect the in-memory pipeline directly — the route mutates the
-        # same object that ``_resolve_pipeline`` returned.
-        agents = pipeline.phases["implement"].agents
-        slice2_after = next(a for a in agents if a.slice_id == "slice-2")
-        slice3_after = next(a for a in agents if a.slice_id == "slice-3")
+        # Assert on the *persisted* state, not just the in-memory pipeline.
+        # The route serialises the mutated pipeline via
+        # ``store.update_pipeline(pipeline_id, pipeline.model_dump(mode="json"))``;
+        # inspecting the call_args guards against a future refactor where
+        # ``_resolve_pipeline`` returns a copy and the route forgets to
+        # save the mutation back.
+        mock_store.update_pipeline.assert_called()
+        persisted = mock_store.update_pipeline.call_args[0][1]
+        persisted_agents = persisted["phases"]["implement"]["agents"]
+        slice2_persisted = next(a for a in persisted_agents if a["slice_id"] == "slice-2")
+        slice3_persisted = next(a for a in persisted_agents if a["slice_id"] == "slice-3")
 
-        assert slice2_after.container_id == slice2_container_before, (
+        assert slice2_persisted["container_id"] == slice2_container_before, (
             "slice-2 container_id must not change when slice-3 is restarted"
         )
-        assert slice3_after.container_id == "container-slice-3-RESTARTED"
-        assert slice3_after.status == AgentExecutionStatus.RUNNING
+        assert slice3_persisted["container_id"] == "container-slice-3-RESTARTED"
+        assert slice3_persisted["status"] == AgentExecutionStatus.RUNNING.value
 
     @patch("routes.pipelines.get_pipeline_state_lock")
     @patch("routes.pipelines.get_container_spawner")
@@ -1116,14 +1121,19 @@ class TestRestartAgentSliceMatching:
         )
 
         assert response.status_code == 200
-        agents = pipeline.phases["implement"].agents
+        # Assert on the *persisted* state — same robustness rationale as
+        # the slice-3-does-not-mutate-slice-2 test above.
+        mock_store.update_pipeline.assert_called()
+        persisted = mock_store.update_pipeline.call_args[0][1]
+        persisted_agents = persisted["phases"]["implement"]["agents"]
         # slice-2 untouched, slice-3 appended
         assert any(
-            a.slice_id == "slice-2" and a.container_id == "container-slice-2" for a in agents
+            a["slice_id"] == "slice-2" and a["container_id"] == "container-slice-2"
+            for a in persisted_agents
         )
-        slice3_rows = [a for a in agents if a.slice_id == "slice-3"]
+        slice3_rows = [a for a in persisted_agents if a["slice_id"] == "slice-3"]
         assert len(slice3_rows) == 1
-        assert slice3_rows[0].container_id == "container-slice-3-NEW"
+        assert slice3_rows[0]["container_id"] == "container-slice-3-NEW"
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_restart_agent.py
+++ b/orchestrator/tests/test_restart_agent.py
@@ -926,6 +926,207 @@ class TestRestartAgentEndpointSliceScope:
 
 
 # ---------------------------------------------------------------------------
+# Issue #2422: in-place agent-state mutation matches on (role, slice_id)
+# ---------------------------------------------------------------------------
+
+
+def _make_pipeline_with_two_slice_coders():
+    """Pipeline with concurrent slice-2 + slice-3 coder records.
+
+    The two ``AgentExecution`` records share ``role=CODER`` and only
+    differ on ``slice_id``. Pre-#2422 the restart route walked
+    ``phase_exec.agents`` looking for ``agent.role == role`` and mutated
+    the first match — so a slice-3 restart would clobber slice-2's
+    record. This fixture lets the test assert the new ``(role,
+    slice_id)`` predicate keeps the unrelated slice's row untouched.
+    """
+    pipeline = Pipeline(
+        id="issue-100",
+        issue_number=100,
+        repo="owner/repo",
+        branch="egg/issue-100",
+        status=PipelineStatus.RUNNING,
+        current_phase=PipelinePhase.IMPLEMENT,
+    )
+    pipeline.phases = {
+        "implement": PhaseExecution(
+            phase=PipelinePhase.IMPLEMENT,
+            status=PipelineStatus.RUNNING,
+            containers=[
+                ContainerInfo(
+                    container_id="container-slice-2",
+                    container_name="egg-issue-100-slice-2-coder",
+                    agent_role=AgentRole.CODER,
+                    status=ContainerStatus.RUNNING,
+                ),
+                ContainerInfo(
+                    container_id="container-slice-3",
+                    container_name="egg-issue-100-slice-3-coder",
+                    agent_role=AgentRole.CODER,
+                    status=ContainerStatus.RUNNING,
+                ),
+            ],
+            agents=[
+                AgentExecution(
+                    role=AgentRole.CODER,
+                    status=AgentExecutionStatus.RUNNING,
+                    container_id="container-slice-2",
+                    slice_id="slice-2",
+                ),
+                AgentExecution(
+                    role=AgentRole.CODER,
+                    status=AgentExecutionStatus.RUNNING,
+                    container_id="container-slice-3",
+                    slice_id="slice-3",
+                ),
+            ],
+        ),
+    }
+    return pipeline
+
+
+@pytest.mark.skipif(not _HAS_FLASK, reason="Flask not available")
+class TestRestartAgentSliceMatching:
+    """``restart_agent`` mutation predicate matches on ``(role, slice_id)`` (#2422)."""
+
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_slice_3_restart_does_not_mutate_slice_2_record(
+        self, mock_repo, mock_resolve, mock_spawner_fn, mock_lock_fn, client
+    ):
+        """Restarting slice-3 coder leaves slice-2 coder's AgentExecution intact."""
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        pipeline = _make_pipeline_with_two_slice_coders()
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        new_container = SpawnedContainer(
+            container_info=ContainerInfo(
+                container_id="container-slice-3-RESTARTED",
+                container_name="egg-issue-100-slice-3-coder",
+                status=ContainerStatus.RUNNING,
+            ),
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-100",
+            environment={},
+        )
+        mock_spawner.restart_agent_container.return_value = new_container
+        mock_spawner.get_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        slice2_before = next(
+            a for a in pipeline.phases["implement"].agents if a.slice_id == "slice-2"
+        )
+        slice2_container_before = slice2_before.container_id
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart?slice_id=slice-3",
+            json={"reason": "slice-3 stall"},
+        )
+
+        assert response.status_code == 200, response.get_json()
+
+        # The store under update_pipeline serialized the mutated pipeline.
+        # Inspect the in-memory pipeline directly — the route mutates the
+        # same object that ``_resolve_pipeline`` returned.
+        agents = pipeline.phases["implement"].agents
+        slice2_after = next(a for a in agents if a.slice_id == "slice-2")
+        slice3_after = next(a for a in agents if a.slice_id == "slice-3")
+
+        assert slice2_after.container_id == slice2_container_before, (
+            "slice-2 container_id must not change when slice-3 is restarted"
+        )
+        assert slice3_after.container_id == "container-slice-3-RESTARTED"
+        assert slice3_after.status == AgentExecutionStatus.RUNNING
+
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_slice_3_restart_with_no_existing_record_appends_with_slice_id(
+        self, mock_repo, mock_resolve, mock_spawner_fn, mock_lock_fn, client
+    ):
+        """Fall-through ``AgentExecution`` append carries the route's slice_id."""
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+
+        # Pipeline has only slice-2 coder; slice-3 restart should append
+        # a new slice-3 row rather than mutating slice-2's record.
+        pipeline = Pipeline(
+            id="issue-100",
+            issue_number=100,
+            repo="owner/repo",
+            branch="egg/issue-100",
+            status=PipelineStatus.RUNNING,
+            current_phase=PipelinePhase.IMPLEMENT,
+        )
+        pipeline.phases = {
+            "implement": PhaseExecution(
+                phase=PipelinePhase.IMPLEMENT,
+                status=PipelineStatus.RUNNING,
+                containers=[
+                    ContainerInfo(
+                        container_id="container-slice-2",
+                        container_name="egg-issue-100-slice-2-coder",
+                        agent_role=AgentRole.CODER,
+                        status=ContainerStatus.RUNNING,
+                    ),
+                ],
+                agents=[
+                    AgentExecution(
+                        role=AgentRole.CODER,
+                        status=AgentExecutionStatus.RUNNING,
+                        container_id="container-slice-2",
+                        slice_id="slice-2",
+                    ),
+                ],
+            ),
+        }
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        new_container = SpawnedContainer(
+            container_info=ContainerInfo(
+                container_id="container-slice-3-NEW",
+                container_name="egg-issue-100-slice-3-coder",
+                status=ContainerStatus.RUNNING,
+            ),
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-100",
+            environment={},
+        )
+        mock_spawner.restart_agent_container.return_value = new_container
+        mock_spawner.get_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart?slice_id=slice-3",
+            json={"reason": "slice-3 first restart"},
+        )
+
+        assert response.status_code == 200
+        agents = pipeline.phases["implement"].agents
+        # slice-2 untouched, slice-3 appended
+        assert any(
+            a.slice_id == "slice-2" and a.container_id == "container-slice-2" for a in agents
+        )
+        slice3_rows = [a for a in agents if a.slice_id == "slice-3"]
+        assert len(slice3_rows) == 1
+        assert slice3_rows[0].container_id == "container-slice-3-NEW"
+
+
+# ---------------------------------------------------------------------------
 # Issue #1695: mode=None raises ValueError (issue 7)
 # ---------------------------------------------------------------------------
 

--- a/orchestrator/tests/test_signals.py
+++ b/orchestrator/tests/test_signals.py
@@ -504,6 +504,169 @@ class TestAgentAlreadyCompleteSuppression:
         # Contract should have been updated with the error
         mock_orch.fail_agent.assert_called_once()
 
+    @patch("routes.signals.save_contract")
+    @patch("routes.signals.resolve_worktree_path")
+    @patch("routes.signals.get_state_store")
+    @patch("routes.signals.load_contract")
+    def test_slice_3_error_not_suppressed_by_slice_2_complete(
+        self,
+        mock_load_contract,
+        mock_get_store,
+        mock_resolve_wt,
+        mock_save_contract,
+        app,
+    ):
+        """slice-3 coder error must not be silently swallowed by a slice-2 coder
+        already-COMPLETE record (#2422). Pre-fix the role-only predicate matched
+        the slice-2 row first and returned ``already_complete``."""
+        from models import (
+            AgentExecution,
+            AgentExecutionStatus,
+            AgentRole,
+            PhaseExecution,
+            Pipeline,
+            PipelinePhase,
+            PipelineStatus,
+        )
+
+        pipeline = Pipeline(
+            id="issue-42",
+            issue_number=42,
+            repo="owner/repo",
+            branch="egg/issue-42",
+            status=PipelineStatus.RUNNING,
+            current_phase=PipelinePhase.IMPLEMENT,
+        )
+        phase_exec = PhaseExecution(
+            phase=PipelinePhase.IMPLEMENT,
+            agents=[
+                AgentExecution(
+                    role=AgentRole.CODER,
+                    status=AgentExecutionStatus.COMPLETE,
+                    slice_id="slice-2",
+                ),
+                AgentExecution(
+                    role=AgentRole.CODER,
+                    status=AgentExecutionStatus.RUNNING,
+                    slice_id="slice-3",
+                ),
+            ],
+        )
+        pipeline.phases["implement"] = phase_exec
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_get_store.return_value = mock_store
+        mock_resolve_wt.return_value = Path("/tmp/worktree")
+        mock_load_contract.return_value = MagicMock()
+
+        mock_orch = MagicMock()
+        mock_orch.apply_to_contract.return_value = MagicMock()
+
+        with patch("routes.signals.create_orchestrator", return_value=mock_orch):
+            with app.app_context():
+                from routes.signals import handle_error_signal
+
+                response, status_code = handle_error_signal(
+                    "issue-42",
+                    {
+                        "agent_role": "coder",
+                        "error": "Build failed in slice-3",
+                        "recoverable": False,
+                        "slice_id": "slice-3",
+                    },
+                    Path("/tmp/repo"),
+                )
+
+        assert status_code == 200
+        data = json.loads(response.data)
+        # slice-3 is RUNNING, so it must NOT be suppressed
+        assert "already_complete" not in data.get("data", {}), (
+            "slice-3 error was suppressed by slice-2's COMPLETE record"
+        )
+        mock_orch.fail_agent.assert_called_once()
+
+    @patch("routes.signals.get_state_store")
+    def test_slice_3_error_suppressed_when_slice_3_complete(
+        self,
+        mock_get_store,
+        app,
+    ):
+        """slice-3 coder COMPLETE → slice-3 coder error is suppressed (positive case)."""
+        from models import (
+            AgentExecution,
+            AgentExecutionStatus,
+            AgentRole,
+            PhaseExecution,
+            Pipeline,
+            PipelinePhase,
+            PipelineStatus,
+        )
+
+        pipeline = Pipeline(
+            id="issue-42",
+            issue_number=42,
+            repo="owner/repo",
+            branch="egg/issue-42",
+            status=PipelineStatus.RUNNING,
+            current_phase=PipelinePhase.IMPLEMENT,
+        )
+        phase_exec = PhaseExecution(
+            phase=PipelinePhase.IMPLEMENT,
+            agents=[
+                AgentExecution(
+                    role=AgentRole.CODER,
+                    status=AgentExecutionStatus.RUNNING,
+                    slice_id="slice-2",
+                ),
+                AgentExecution(
+                    role=AgentRole.CODER,
+                    status=AgentExecutionStatus.COMPLETE,
+                    slice_id="slice-3",
+                ),
+            ],
+        )
+        pipeline.phases["implement"] = phase_exec
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_get_store.return_value = mock_store
+
+        with app.app_context():
+            from routes.signals import handle_error_signal
+
+            response, status_code = handle_error_signal(
+                "issue-42",
+                {
+                    "agent_role": "coder",
+                    "error": "post-consensus SIGTERM",
+                    "recoverable": False,
+                    "slice_id": "slice-3",
+                },
+                Path("/tmp/repo"),
+            )
+
+        assert status_code == 200
+        data = json.loads(response.data)
+        assert data["data"]["already_complete"] is True
+
+    def test_invalid_slice_id_returns_400(self, app):
+        """Malformed slice_id is rejected before touching pipeline state."""
+        with app.app_context():
+            from routes.signals import handle_error_signal
+
+            response, status_code = handle_error_signal(
+                "issue-42",
+                {
+                    "agent_role": "coder",
+                    "error": "x",
+                    "slice_id": "../etc",
+                },
+                Path("/tmp/repo"),
+            )
+
+        assert status_code == 400
+
 
 # ---------------------------------------------------------------------------
 # Completion signal branch verification tests (TASK-5-3)

--- a/sandbox/egg_agent_tools/handlers/progress.py
+++ b/sandbox/egg_agent_tools/handlers/progress.py
@@ -8,11 +8,30 @@ from typing import Any
 from egg_agent_tools.handlers._gateway import (
     get_agent_role,
     get_pipeline_id,
+    get_slice_id,
     orchestrator_request,
 )
 from egg_agent_tools.handlers.errors import GatewayError, HandlerError
 
 _PIPELINE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+_SLICE_ID_PATTERN = re.compile(r"^slice-[0-9]+$")
+
+
+def _maybe_attach_slice_id(req: dict[str, Any], data: dict[str, Any]) -> None:
+    """Forward ``slice_id`` from the request or env onto the signal body.
+
+    Mirrors ``brc._maybe_attach_slice_id`` so the orchestrator-side
+    ``handle_error_signal`` can scope its "agent already COMPLETE,
+    suppress error" check by ``(role, slice_id)`` rather than role
+    alone — without this, slice-2 coder finishing would silently
+    swallow slice-3 coder's error (#2422).
+    """
+    slice_id = req.get("slice_id") or get_slice_id()
+    if not slice_id:
+        return
+    if not isinstance(slice_id, str) or not _SLICE_ID_PATTERN.fullmatch(slice_id):
+        raise HandlerError(f"Invalid slice_id {slice_id!r}: must match 'slice-<N>'")
+    data["slice_id"] = slice_id
 
 
 def _require_pipeline_id(req: dict[str, Any]) -> str:
@@ -97,12 +116,13 @@ def progress_signal_error(req: dict[str, Any]) -> dict[str, Any]:
         raise HandlerError("'error' is required")
     recoverable = bool(req.get("recoverable", False))
 
-    data = {
+    data: dict[str, Any] = {
         "signal_type": "error",
         "agent_role": role,
         "error": error,
         "recoverable": recoverable,
     }
+    _maybe_attach_slice_id(req, data)
     result = orchestrator_request(f"/api/v1/pipelines/{pid}/signal", method="POST", data=data)
     if not result.get("success"):
         raise GatewayError(result.get("message", "error signal failed"))

--- a/sandbox/tests/test_progress_slice_routing.py
+++ b/sandbox/tests/test_progress_slice_routing.py
@@ -1,0 +1,90 @@
+"""Progress error-signal handler threads ``slice_id`` from ``EGG_SLICE_ID`` (#2422).
+
+Per-slice agents must tag the error signal with their ``slice_id`` so the
+orchestrator's "agent already COMPLETE" suppression check can scope by
+``(role, slice_id)`` instead of role alone — without it, a slice-2 coder
+finishing first would silently swallow a slice-3 coder's error because
+both ``AgentExecution`` records share ``phase_exec.agents``.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+_sandbox_path = str(Path(__file__).parent.parent)
+if _sandbox_path not in sys.path:
+    sys.path.insert(0, _sandbox_path)
+
+
+_ERROR_REQ = {
+    "pipeline_id": "issue-2422",
+    "role": "coder",
+    "error": "Build failed",
+    "recoverable": False,
+}
+
+
+def _captured_data(mock_request: Any) -> dict[str, Any]:
+    assert mock_request.called, "orchestrator_request was not invoked"
+    return dict(mock_request.call_args.kwargs["data"])
+
+
+class TestErrorSignalSliceId:
+    """``EGG_SLICE_ID`` flows onto the error signal body (#2422)."""
+
+    def test_error_signal_attaches_slice_id_from_env(self, monkeypatch):
+        from egg_agent_tools.handlers import progress as handlers
+
+        monkeypatch.setenv("EGG_SLICE_ID", "slice-3")
+
+        with patch(
+            "egg_agent_tools.handlers.progress.orchestrator_request",
+            return_value={"success": True, "data": {}},
+        ) as mock_request:
+            handlers.progress_signal_error(dict(_ERROR_REQ))
+
+        assert _captured_data(mock_request)["slice_id"] == "slice-3"
+
+    def test_request_slice_id_overrides_env(self, monkeypatch):
+        from egg_agent_tools.handlers import progress as handlers
+
+        monkeypatch.setenv("EGG_SLICE_ID", "slice-9")
+
+        with patch(
+            "egg_agent_tools.handlers.progress.orchestrator_request",
+            return_value={"success": True, "data": {}},
+        ) as mock_request:
+            handlers.progress_signal_error({**_ERROR_REQ, "slice_id": "slice-3"})
+
+        assert _captured_data(mock_request)["slice_id"] == "slice-3"
+
+    def test_no_slice_id_omits_field(self, monkeypatch):
+        from egg_agent_tools.handlers import progress as handlers
+
+        monkeypatch.delenv("EGG_SLICE_ID", raising=False)
+
+        with patch(
+            "egg_agent_tools.handlers.progress.orchestrator_request",
+            return_value={"success": True, "data": {}},
+        ) as mock_request:
+            handlers.progress_signal_error(dict(_ERROR_REQ))
+
+        assert "slice_id" not in _captured_data(mock_request)
+
+    def test_invalid_slice_id_rejected(self, monkeypatch):
+        from egg_agent_tools.handlers import progress as handlers
+        from egg_agent_tools.handlers.errors import HandlerError
+
+        # Path-separator values must not reach the wire — defense in depth
+        # against a malformed env var.
+        monkeypatch.setenv("EGG_SLICE_ID", "slice-2/../etc")
+
+        with patch(
+            "egg_agent_tools.handlers.progress.orchestrator_request",
+            return_value={"success": True, "data": {}},
+        ):
+            with pytest.raises(HandlerError, match="slice_id"):
+                handlers.progress_signal_error(dict(_ERROR_REQ))


### PR DESCRIPTION
Fixes #2422. Follow-up to PR #2419 (v1 BRC review item #5).

## Why

`AgentExecution` had no slice scope, so every consumer that walked
`phase_exec.agents` looking for `agent.role == X` matched the first row
— which on a multi-slice phase (concurrent slice-2 + slice-3 same-role
agents in the same list) may be the wrong slice. PR #2419 made the
operator restart route the first slice-aware caller in production,
but the audit asked for in this issue surfaced the same role-uniqueness
assumption in four other consumers.

## What changed

**Schema**

`AgentExecution.slice_id: str | None`. Old persisted state files load
fine (defaults to `None`).

**Producers populate `slice_id`**

- `concurrent_executor._spawn_agent` (success + failure path) — pulls
  from `self._slice_id`
- `_concurrent_phase_run` — the per-execution `agent_state` record
  carries the route-level `slice_id`
- `restart_agent` fall-through `AgentExecution` append carries the
  route's `slice_id`

**Consumers rescoped**

| Site | Change |
|------|--------|
| `routes/pipelines.py:2559` (headline) | match on `(role, slice_id)` instead of role alone |
| `routes/pipelines.py:_update_agents_complete` | filter by `slice_id` so slice-2 BRC completion doesn't flip slice-3's still-running agents to COMPLETE |
| `kubernetes_monitor._handle_consensus_stall_recovery` | defensive `details["slice_id"]` scope so the path is safe the moment `consensus_stall` becomes slice-aware |
| `startup_reconciliation` | pipeline-level tracker reconstruction only marks pipeline-level agents COMPLETE |
| `routes/signals.handle_error_signal` | extract `slice_id` from payload (validated via `_extract_slice_id`); the "agent already COMPLETE, suppress" check now matches `(role, slice_id)` so slice-2 finishing doesn't silently swallow slice-3's error |

**Sandbox-side propagation**

`progress.progress_signal_error` now forwards `EGG_SLICE_ID` on the
error signal body, mirroring `brc._maybe_attach_slice_id`. Without
this the orchestrator-side fix has no scope key to match on for
agent-emitted errors.

**Consumers left untouched**

Sites that already match by `container_id` (unique across slices) are
slice-safe — `routes/pipelines.py:1935,3469,11939,12023`,
`kubernetes_monitor.py:450,1072`, `startup_reconciliation.py:239`, and
the `health_checks/tier1` walks. No change needed.

## Tests

- `test_restart_agent.TestRestartAgentSliceMatching` — the headline
  acceptance: slice-3 coder restart leaves slice-2 coder's
  `AgentExecution` untouched; fall-through append carries `slice_id`
- `test_signals.TestAgentAlreadyCompleteSuppression` — slice-2
  COMPLETE doesn't suppress slice-3 RUNNING error; positive case
  (slice-3 COMPLETE → slice-3 error suppressed); malformed `slice_id`
  → 400
- `sandbox/tests/test_progress_slice_routing.py` (new) — error
  signal forwards `EGG_SLICE_ID`, request `slice_id` overrides env,
  omitted when unset, malformed value rejected before the wire

## Test plan

- [x] `make lint`
- [x] Targeted test files pass: `test_restart_agent.py` (50 incl.
      2 new), `test_signals.py` (slice cases), `test_progress_slice_routing.py`
      (4 new), `test_brc_slice_routing.py`, `test_consensus_*`,
      `test_kubernetes_monitor.py`, `test_startup_reconciliation.py`
- [ ] CI green