### PR TITLE
Fix #2427 sub-bug: advance contract.current_phase when start_phase=implement

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -13525,11 +13525,21 @@ def _populate_contract_from_plan(
     Extracts task structure from markdown headers in the plan draft
     and writes tasks + acceptance criteria to the contract.
 
-    When ``current_phase`` is provided, also advances the contract's
-    ``current_phase`` to that value. This is needed when the populator
-    runs outside the natural plan-completion hook (e.g.
-    ``start_phase=implement``, which skips plan and never fires the
-    plan-completion advance — #2427 sub-bug).
+    When ``current_phase`` is provided, the contract's
+    ``current_phase`` is advanced to that value **only if it would move
+    the phase forward** (REFINE → PLAN → IMPLEMENT → PR).  Backward
+    transitions are silently ignored so a respawn of the safety-net
+    populator (e.g. when a ``start_phase=implement`` pipeline progresses
+    to PR and re-enters ``_run_pipeline``) cannot demote the contract.
+    The advance also appends a ``create_transition_entry`` audit log
+    entry so operators inspecting the audit trail see the transition.
+
+    This parameter is needed because the natural plan-completion path
+    advances ``pipeline.current_phase`` (orchestrator-side) but leaves
+    ``contract.current_phase`` for the reviewer agent / gateway phase
+    API to advance via ``apply_mutation``.  When ``start_phase=implement``
+    no plan reviewer runs, so the populator nudges the contract itself
+    (#2427 sub-bug).
     """
     try:
         from egg_contracts.loader import load_contract, save_contract
@@ -13668,8 +13678,40 @@ def _populate_contract_from_plan(
             changed = True
 
         if current_phase is not None and contract.current_phase != current_phase:
-            contract.current_phase = current_phase
-            changed = True
+            # Forward-only: never demote.  Without this guard a respawn
+            # of _run_pipeline (e.g. when a start_phase=implement pipeline
+            # progresses to the PR phase and re-enters the safety-net
+            # call site) would silently roll contract.current_phase back
+            # from PR/IMPLEMENT to whatever the call site hardcoded.
+            _phase_order = (
+                PipelinePhase.REFINE,
+                PipelinePhase.PLAN,
+                PipelinePhase.IMPLEMENT,
+                PipelinePhase.PR,
+            )
+            if (
+                contract.current_phase in _phase_order
+                and current_phase in _phase_order
+                and _phase_order.index(current_phase) > _phase_order.index(contract.current_phase)
+            ):
+                from egg_contracts.audit import create_transition_entry
+                from egg_contracts.models import AuditRole
+
+                old_phase = contract.current_phase
+                contract.audit_log.append(
+                    create_transition_entry(
+                        actor="orchestrator",
+                        role=AuditRole.SYSTEM,
+                        from_phase=old_phase.value,
+                        to_phase=current_phase.value,
+                        reason=(
+                            "populator advanced contract.current_phase "
+                            "(start_phase bypassed plan; #2427)"
+                        ),
+                    )
+                )
+                contract.current_phase = current_phase
+                changed = True
 
         if changed:
             save_contract(contract, repo_path)
@@ -14789,16 +14831,22 @@ def _run_pipeline(
             )
             if plan_draft_rel and (worktree_repo_path / plan_draft_rel).exists():
                 # Advance contract.current_phase alongside slice/PR
-                # ingestion: the plan-completion hook that normally
-                # advances the contract is skipped when start_phase
-                # bypasses plan, so the contract would otherwise stay
-                # at REFINE forever (#2427 sub-bug).
+                # ingestion.  In the natural flow contract.current_phase
+                # is mutated by the plan reviewer agent (or the gateway
+                # phase API) via apply_mutation; with start_phase=implement
+                # no such reviewer ever runs, so the contract would stay
+                # at REFINE forever (#2427 sub-bug).  We pass
+                # pipeline.current_phase rather than a hardcoded literal
+                # so the right value follows automatically if start_phase
+                # ever supports values other than 'implement'.  The
+                # populator enforces forward-only advancement, so a
+                # respawn during the PR phase cannot demote the contract.
                 _populate_contract_from_plan(
                     worktree_repo_path,
                     pipeline_id,
                     pipeline_mode,
                     pipeline.issue_number,
-                    current_phase=PipelinePhase.IMPLEMENT,
+                    current_phase=pipeline.current_phase,
                 )
 
         # Check for feedback preserved by the recovery path in start_pipeline

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -13706,7 +13706,7 @@ def _populate_contract_from_plan(
                         to_phase=current_phase.value,
                         reason=(
                             "populator advanced contract.current_phase "
-                            "(start_phase bypassed plan; #2427)"
+                            "(no apply_mutation caller for this pipeline; #2427)"
                         ),
                     )
                 )
@@ -14841,6 +14841,10 @@ def _run_pipeline(
                 # ever supports values other than 'implement'.  The
                 # populator enforces forward-only advancement, so a
                 # respawn during the PR phase cannot demote the contract.
+                # Note: the *outer* guard above remains hardcoded to
+                # ``"implement"``; widening it to other start_phase values
+                # is a two-line change (this guard plus the matching
+                # ``initial_phase`` mapping in start_pipeline).
                 _populate_contract_from_plan(
                     worktree_repo_path,
                     pipeline_id,

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -13437,6 +13437,7 @@ def _populate_contract_from_plan_safe(
     *,
     source: Literal["plan_complete", "advance_phase_force"] = "advance_phase_force",
     branch: str | None = None,
+    current_phase: PipelinePhase | None = None,
 ) -> None:
     """Run :func:`_populate_contract_from_plan` without propagating failures.
 
@@ -13479,7 +13480,13 @@ def _populate_contract_from_plan_safe(
                 )
 
     try:
-        _populate_contract_from_plan(repo_path, pipeline_id, pipeline_mode, issue_number)
+        _populate_contract_from_plan(
+            repo_path,
+            pipeline_id,
+            pipeline_mode,
+            issue_number,
+            current_phase=current_phase,
+        )
     except ForestValidationError as forest_err:
         # Forest-validation rejection is the expected #2137 NACK
         # path — log structurally so the discriminator shows up in
@@ -13510,11 +13517,19 @@ def _populate_contract_from_plan(
     pipeline_id: str,
     pipeline_mode: str = "issue",
     issue_number: int | None = None,
+    *,
+    current_phase: PipelinePhase | None = None,
 ) -> None:
     """Read the plan draft and populate the contract with tasks.
 
     Extracts task structure from markdown headers in the plan draft
     and writes tasks + acceptance criteria to the contract.
+
+    When ``current_phase`` is provided, also advances the contract's
+    ``current_phase`` to that value. This is needed when the populator
+    runs outside the natural plan-completion hook (e.g.
+    ``start_phase=implement``, which skips plan and never fires the
+    plan-completion advance — #2427 sub-bug).
     """
     try:
         from egg_contracts.loader import load_contract, save_contract
@@ -13650,6 +13665,10 @@ def _populate_contract_from_plan(
                 test_plan=result.pr_test_plan or "",
                 manual_steps=result.pr_manual_steps or "",
             )
+            changed = True
+
+        if current_phase is not None and contract.current_phase != current_phase:
+            contract.current_phase = current_phase
             changed = True
 
         if changed:
@@ -14769,11 +14788,17 @@ def _run_pipeline(
                 pipeline_id=pipeline.id,
             )
             if plan_draft_rel and (worktree_repo_path / plan_draft_rel).exists():
+                # Advance contract.current_phase alongside slice/PR
+                # ingestion: the plan-completion hook that normally
+                # advances the contract is skipped when start_phase
+                # bypasses plan, so the contract would otherwise stay
+                # at REFINE forever (#2427 sub-bug).
                 _populate_contract_from_plan(
                     worktree_repo_path,
                     pipeline_id,
                     pipeline_mode,
                     pipeline.issue_number,
+                    current_phase=PipelinePhase.IMPLEMENT,
                 )
 
         # Check for feedback preserved by the recovery path in start_pipeline

--- a/orchestrator/tests/test_short_flow_contract_population.py
+++ b/orchestrator/tests/test_short_flow_contract_population.py
@@ -600,6 +600,63 @@ class TestStartPhaseImplementContractPopulation:
         assert len(contract.phases) == 1
         assert len(contract.phases[0].tasks) == 2
 
+    def test_current_phase_advanced_when_explicitly_provided(self, tmp_path: Path):
+        """Regression for #2427 sub-bug: when start_phase=implement, the
+        plan-completion hook never fires, so the safety-net populator must
+        advance ``contract.current_phase`` itself. Without this, the contract
+        sticks at ``refine`` while the pipeline is actually in implement,
+        triggering false "phase tracking mismatch" alerts.
+        """
+        from egg_contracts.loader import create_contract, load_contract
+        from egg_contracts.models import PipelinePhase
+        from routes.pipelines import _get_draft_path, _populate_contract_from_plan
+
+        pipeline_id = "pipeline-phase-advance"
+
+        # Default initial_phase is REFINE.
+        create_contract(pipeline_id=pipeline_id, title="Test", repo_root=tmp_path)
+
+        draft_rel = _get_draft_path("plan", pipeline_id=pipeline_id)
+        draft_path = tmp_path / draft_rel
+        draft_path.parent.mkdir(parents=True, exist_ok=True)
+        draft_path.write_text(SAMPLE_PLAN)
+
+        _populate_contract_from_plan(
+            tmp_path,
+            pipeline_id,
+            "local",
+            current_phase=PipelinePhase.IMPLEMENT,
+        )
+
+        contract = load_contract(pipeline_id, tmp_path)
+        assert contract.current_phase == PipelinePhase.IMPLEMENT
+        # And slices/tasks were still populated.
+        assert len(contract.phases) == 1
+
+    def test_current_phase_unchanged_when_not_provided(self, tmp_path: Path):
+        """Default behaviour is preserved: callers that don't pass
+        ``current_phase`` (e.g. the natural plan-completion hook, which has
+        already advanced the pipeline elsewhere) leave the contract's
+        current_phase alone.
+        """
+        from egg_contracts.loader import create_contract, load_contract
+        from egg_contracts.models import PipelinePhase
+        from routes.pipelines import _get_draft_path, _populate_contract_from_plan
+
+        pipeline_id = "pipeline-phase-untouched"
+
+        create_contract(pipeline_id=pipeline_id, title="Test", repo_root=tmp_path)
+
+        draft_rel = _get_draft_path("plan", pipeline_id=pipeline_id)
+        draft_path = tmp_path / draft_rel
+        draft_path.parent.mkdir(parents=True, exist_ok=True)
+        draft_path.write_text(SAMPLE_PLAN)
+
+        _populate_contract_from_plan(tmp_path, pipeline_id, "local")
+
+        contract = load_contract(pipeline_id, tmp_path)
+        assert contract.current_phase == PipelinePhase.REFINE
+
 
 class TestSourceBranchArtifactWriteToDisk:
     """Source-branch artifacts are written to disk after _read_source_branch_artifacts.

--- a/orchestrator/tests/test_short_flow_contract_population.py
+++ b/orchestrator/tests/test_short_flow_contract_population.py
@@ -657,6 +657,76 @@ class TestStartPhaseImplementContractPopulation:
         contract = load_contract(pipeline_id, tmp_path)
         assert contract.current_phase == PipelinePhase.REFINE
 
+    def test_current_phase_does_not_demote(self, tmp_path: Path):
+        """Forward-only guard: a respawn of _run_pipeline (e.g. when a
+        ``start_phase=implement`` pipeline progresses to the PR phase and
+        re-enters the safety-net) must not demote the contract.  If the
+        contract has already advanced to PR, passing IMPLEMENT must be a
+        no-op.
+        """
+        from egg_contracts.loader import create_contract, load_contract, save_contract
+        from egg_contracts.models import PipelinePhase
+        from routes.pipelines import _get_draft_path, _populate_contract_from_plan
+
+        pipeline_id = "pipeline-no-demote"
+
+        create_contract(pipeline_id=pipeline_id, title="Test", repo_root=tmp_path)
+        contract = load_contract(pipeline_id, tmp_path)
+        contract.current_phase = PipelinePhase.PR
+        save_contract(contract, tmp_path)
+
+        draft_rel = _get_draft_path("plan", pipeline_id=pipeline_id)
+        draft_path = tmp_path / draft_rel
+        draft_path.parent.mkdir(parents=True, exist_ok=True)
+        draft_path.write_text(SAMPLE_PLAN)
+
+        _populate_contract_from_plan(
+            tmp_path,
+            pipeline_id,
+            "local",
+            current_phase=PipelinePhase.IMPLEMENT,
+        )
+
+        contract = load_contract(pipeline_id, tmp_path)
+        # PR was preserved — IMPLEMENT did not silently demote it.
+        assert contract.current_phase == PipelinePhase.PR
+
+    def test_current_phase_advance_appends_audit_entry(self, tmp_path: Path):
+        """Operators inspecting the contract audit log to debug a phase
+        mismatch (which is exactly the situation #2427 surfaced) must see a
+        structured ``current_phase`` transition entry when the populator
+        advances the contract — without this, the transition is invisible.
+        """
+        from egg_contracts.loader import create_contract, load_contract
+        from egg_contracts.models import AuditAction, PipelinePhase
+        from routes.pipelines import _get_draft_path, _populate_contract_from_plan
+
+        pipeline_id = "pipeline-audit"
+
+        create_contract(pipeline_id=pipeline_id, title="Test", repo_root=tmp_path)
+
+        draft_rel = _get_draft_path("plan", pipeline_id=pipeline_id)
+        draft_path = tmp_path / draft_rel
+        draft_path.parent.mkdir(parents=True, exist_ok=True)
+        draft_path.write_text(SAMPLE_PLAN)
+
+        _populate_contract_from_plan(
+            tmp_path,
+            pipeline_id,
+            "local",
+            current_phase=PipelinePhase.IMPLEMENT,
+        )
+
+        contract = load_contract(pipeline_id, tmp_path)
+        transitions = [
+            entry
+            for entry in contract.audit_log
+            if entry.action == AuditAction.TRANSITION and entry.field_path == "current_phase"
+        ]
+        assert len(transitions) == 1
+        assert transitions[0].old_value == PipelinePhase.REFINE.value
+        assert transitions[0].new_value == PipelinePhase.IMPLEMENT.value
+
 
 class TestSourceBranchArtifactWriteToDisk:
     """Source-branch artifacts are written to disk after _read_source_branch_artifacts.


### PR DESCRIPTION
## Summary

Sub-bug from #2427: when a pipeline is configured with `start_phase=implement`, the plan phase is skipped entirely, so the plan-completion hook that normally advances `contract.current_phase` never fires. The contract sticks at `refine` even though the pipeline is actually in implement, which is what triggered the original `OVERSEER_ALERT: Contract phase reports 'refine' while pipeline execution phase is 'implement'` mismatch.

- Add an optional keyword-only `current_phase` parameter to `_populate_contract_from_plan` (and forward through `_populate_contract_from_plan_safe`). When provided and different from the contract's current phase, advance it.
- Pass `PipelinePhase.IMPLEMENT` from the `start_phase=implement` safety-net call site in `_run_pipeline` so the contract advances alongside slice/PR ingestion.
- Default behaviour is preserved when the parameter is omitted: the natural plan-completion path (which advances elsewhere) leaves `current_phase` alone.

Companion to #2432 (the read-side fix). Together they address both halves of the operator confusion described in #2427.

## Test plan

- [x] `orchestrator/tests/test_short_flow_contract_population.py::TestStartPhaseImplementContractPopulation` — all 6 cases pass, including 2 new regressions:
  - `test_current_phase_advanced_when_explicitly_provided` — passing `current_phase=IMPLEMENT` advances the contract
  - `test_current_phase_unchanged_when_not_provided` — default path leaves `current_phase` alone
- [x] `orchestrator/tests/test_advance_phase_populate_on_plan_exit.py`, `test_populate_contract_endpoint.py`, `test_populate_contract_audit_events.py` — 54 existing populator-related tests pass unchanged