### PR TITLE
Fix #2429: salvage unpushed agent commits before cleanup

### DIFF
--- a/docs/reference/agent-recovery.md
+++ b/docs/reference/agent-recovery.md
@@ -239,6 +239,51 @@ Restarts are allowed when the pipeline is in `RUNNING`, `AWAITING_HUMAN`, `FAILE
 
 The optional `context` parameter injects additional guidance into the respawned agents (e.g., "Previous attempt stalled during BRC convergence — focus on completing reviews first").
 
+## Salvaging Unpushed Local Commits
+
+Source: `orchestrator/agent_salvage.py`
+
+When an agent's pushes to its assigned branch are wedged — gateway branch-allowlist rejection from a wrong-branch spawn-time env var ([#2428](https://github.com/jwbron/egg/issues/2428)), restart-reconciliation marking a still-running pipeline `failed` ([#2411](https://github.com/jwbron/egg/issues/2411)), or any other class of in-flight failure that leaves work committed locally but unreachable from origin — the orchestrator's per-agent worktree at `/home/egg/.egg-worktrees/{worktree_id}/{repo_short}` still holds the work on its local `egg/{worktree_id}/work` branch. Without recovery, `cleanup_pipeline` later deletes that worktree and the work is silently lost. Salvage closes that gap ([#2429](https://github.com/jwbron/egg/issues/2429)).
+
+### How It Works
+
+1. **Enumeration** scans `WORKTREE_BASE_DIR` for the pipeline's worktrees — pipeline-level (`{pipeline_id}`), per-role (`{pipeline_id}-{role}`), and slice-scoped (`{pipeline_id}-slice-{N}-{role}`). Same parsing rules as `cleanup_pipeline`, so salvage covers exactly the worktrees cleanup is about to delete.
+2. **Diff** runs `git log {local_branch} ^origin/{assigned_branch}` against the worktree, falling back to `^origin/{base_branch}` when the assigned-branch tracking ref is absent. No fetch — over-including already-pushed commits is harmless because the receiver dedupes when cherry-picking, but trimming a real commit would be silent loss.
+3. **Push to recovery ref** sends the worktree's HEAD to `egg/recovered/{pipeline_id}/{scope}/{short_sha}` via `gateway.push_worktree_branch(...)` with launcher auth. Launcher auth bypasses the agent-targeted branch-allowlist check, so this works to recover work even when the agent's own pushes were the thing that wedged.
+4. The recovery-ref name embeds the HEAD short SHA, so re-salvages produce immutable refs instead of force-overwriting earlier ones.
+
+### Triggering Salvage
+
+| Method | How |
+|--------|-----|
+| **API (read)** | `GET /api/v1/pipelines/{id}/local-commits[?agent_role=&slice_id=]` — list unpushed commits per worktree (read-only) |
+| **API (write)** | `POST /api/v1/pipelines/{id}/salvage[?agent_role=&slice_id=]` — push HEAD to `egg/recovered/...` |
+| **MCP tool** | `list_agent_local_commits(task_id, agent_role?, slice_id?)` and `salvage_agent_commits(task_id, agent_role?, slice_id?)` |
+| **Auto-salvage** | Best-effort, automatic — runs from `kubernetes_spawner.cleanup_pipeline` before worktree deletion. Skipped when `preserve_worktrees=True` (the worktree survives, no need to mirror it). Failures are logged and never block cleanup |
+
+### Recovery Workflow
+
+After salvage, the unpushed work is reachable from origin under the recovery namespace. To replay it onto an intended branch:
+
+```bash
+# Find every recovery ref for a pipeline
+git ls-remote origin 'refs/heads/egg/recovered/<pipeline-id>/*'
+
+# Fetch the recovered ref into a local branch
+git fetch origin egg/recovered/<pipeline-id>/<scope>/<short-sha>:recovered/<scope>
+
+# Cherry-pick onto the intended branch (de-dupes already-pushed commits)
+git switch <target-branch>
+git cherry-pick <recovered-base>..recovered/<scope>
+```
+
+The orchestrator never deletes `egg/recovered/*` refs — they outlive the pipeline they belong to. Operators clean up after replay (`git push origin --delete <ref>`).
+
+### What Salvage Does Not Do
+
+- **No exec into the container.** Agent commits land in the orchestrator-side worktree, not the container's filesystem, so no `kubectl exec` is needed. Containers may already be terminated when salvage runs.
+- **No re-targeting of pending pushes.** The original push is still rejected; salvage produces a separate, recoverable record. To stop new rejections, fix the upstream branch-resolution bug.
+
 ## When Recovery Is Triggered vs. HITL Escalation
 
 | Scenario | Behavior |

--- a/docs/reference/orchestrator-cli.md
+++ b/docs/reference/orchestrator-cli.md
@@ -322,6 +322,19 @@ curl -X POST http://egg-orchestrator:9849/api/v1/pipelines/<id>/phase/complete \
   -d '{"force": true, "force_reason": "Manual recovery: decision stale"}'
 ```
 
+## Salvage MCP Tools
+
+Two MCP tools recover unpushed agent commits before `cleanup_pipeline` deletes the worktree (see [#2429](https://github.com/jwbron/egg/issues/2429); architecture in [Agent Recovery: Salvaging Unpushed Local Commits](agent-recovery.md#salvaging-unpushed-local-commits)).
+
+| MCP Tool | REST Endpoint | Description |
+|----------|---------------|-------------|
+| `list_agent_local_commits` | `GET /pipelines/{id}/local-commits` | Read-only enumeration of commits on each per-agent worktree's local `egg/{worktree_id}/work` branch that are not reachable from `origin/<assigned_branch>` (with `origin/<base_branch>` fallback). No fetch, no push. Optional `agent_role` and `slice_id` filters narrow the scope to one worktree |
+| `salvage_agent_commits` | `POST /pipelines/{id}/salvage` | Push the worktree's HEAD to `egg/recovered/{pipeline_id}/{scope}/{short_sha}` via launcher auth. Launcher auth bypasses the agent-targeted branch-allowlist check, so this works to recover work even when the agent's own pushes were the thing that wedged. Returns per-worktree results — failure of one worktree never blocks others. The recovery-ref name embeds the HEAD short SHA so re-salvages produce immutable refs instead of force-overwriting earlier ones |
+
+`cleanup_pipeline` runs salvage automatically before deleting any worktree (best-effort; failures are logged and never block cleanup). The MCP tools are for explicit operator-driven recovery — typically before `cancel_task(cleanup=true)` on a pipeline whose pushes are wedged.
+
+After salvage, recover the work with `git ls-remote origin 'refs/heads/egg/recovered/<pipeline-id>/*'`, then `git fetch` + `git cherry-pick`.
+
 ## BRC Consensus Protocol
 
 The BRC (Broadcast-Review-Converge) protocol is used during concurrent execution for multi-agent consensus. All protocol actions are gated by formal **action guards** defined in `orchestrator/action_guards.py` — see [Concurrent Execution — Action Guards](../guides/concurrent-execution.md#action-guards) for the complete guard table.

--- a/orchestrator/agent_salvage.py
+++ b/orchestrator/agent_salvage.py
@@ -1,0 +1,725 @@
+"""Operator-facing salvage of unpushed agent commits (#2429).
+
+When an agent's pushes to its assigned branch are wedged (gateway
+rejection from a wrong-branch spawn-time env var, transient infra
+failure, restart-reconciliation marking a still-running pipeline
+``failed``, etc.), the orchestrator's per-agent worktree at
+
+    /home/egg/.egg-worktrees/{worktree_id}/{repo_short}
+
+still holds the work on its local ``egg/{worktree_id}/work`` branch.
+Without a recovery path, ``cleanup_pipeline`` later deletes that
+worktree and the work is silently lost.
+
+This module exposes:
+
+* :func:`enumerate_agent_worktrees` — list per-agent worktrees that
+  exist on disk for a pipeline (pipeline-level + per-role +
+  slice-scoped). Pure filesystem inspection — does not consult the
+  pipeline state file, so it works even when state has been
+  truncated mid-cleanup.
+* :func:`list_unpushed_commits` — for a single worktree, return the
+  commits on its local work branch that are not reachable from
+  ``origin/<assigned_branch>`` (or ``origin/<base_branch>`` as a
+  fallback when the assigned-branch tracking ref is absent).
+* :func:`salvage_worktree` — push the worktree's HEAD to a recovery
+  ref under ``egg/recovered/<pipeline>/<scope>/<short_sha>`` via
+  the gateway's launcher-auth path. The recovery ref name embeds
+  the HEAD SHA so re-salvages don't force-overwrite earlier ones.
+* :func:`auto_salvage_pipeline` — best-effort salvage of every
+  per-agent worktree for a pipeline. Called from
+  ``kubernetes_spawner.cleanup_pipeline`` before worktree deletion
+  so the default policy on cleanup-with-unpushed-work is no longer
+  silent loss.
+
+Recovery refs are the durable record. Operators can locate every
+salvaged commit for a pipeline with::
+
+    git ls-remote origin 'refs/heads/egg/recovered/<pipeline>/*'
+
+and replay them onto a recovery branch with ``git fetch`` plus
+``git cherry-pick``. The orchestrator never deletes ``egg/recovered/*``
+refs — they outlive the pipeline they belong to.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+try:
+    from egg_logging import get_logger
+except ImportError:
+    import logging
+
+    def get_logger(name: str, **_: object) -> logging.Logger:  # type: ignore[misc]
+        return logging.getLogger(name)
+
+
+if TYPE_CHECKING:
+    from gateway_client import GatewayClient
+
+
+logger = get_logger("orchestrator.agent_salvage")
+
+
+# Mirrors gateway / kubernetes_spawner.WORKTREE_BASE_DIR. Kept local so this
+# module has no import-time dependency on the spawner (which pulls in the
+# Kubernetes client at import time).
+WORKTREE_BASE_DIR = Path("/home/egg/.egg-worktrees")
+
+# Recovery refs land under egg/recovered/. The gateway's egg/-prefix
+# branch-ownership check accepts them without per-pipeline allowlisting,
+# and operators can locate every salvaged commit with
+# ``git ls-remote origin 'refs/heads/egg/recovered/*'``.
+RECOVERY_BRANCH_PREFIX = "egg/recovered"
+
+# Regex for slice-scoped per-agent worktree directory names:
+# ``{pipeline_id}-slice-{N}-{role}``. Matches the role suffix as a separate
+# group so the caller can validate it against the AgentRole allowlist.
+_SLICE_WORKTREE_RE = re.compile(r"^(slice-[0-9]+)-(.+)$")
+
+
+@dataclass(frozen=True)
+class AgentWorktree:
+    """A per-agent (or pipeline-level) worktree visible on disk."""
+
+    worktree_id: str
+    """Filesystem name under ``WORKTREE_BASE_DIR`` (e.g.
+    ``issue-2261-v9-slice-2-coder``).
+    """
+
+    pipeline_id: str
+    agent_role: str | None
+    """``None`` for the pipeline-level worktree, otherwise an
+    ``AgentRole`` value.
+    """
+
+    slice_id: str | None
+    """``slice-<N>`` for slice-scoped worktrees, ``None`` otherwise."""
+
+    repo_path: Path
+    """Path to the worktree's repo checkout
+    (``WORKTREE_BASE_DIR / worktree_id / repo_short``)."""
+
+    local_branch: str
+    """Local branch name the worktree is checked out to:
+    ``egg/{worktree_id}/work``."""
+
+    @property
+    def scope_label(self) -> str:
+        """Stable label used in recovery-ref paths."""
+        if self.agent_role is None:
+            return "pipeline"
+        if self.slice_id is None:
+            return self.agent_role
+        return f"{self.slice_id}-{self.agent_role}"
+
+
+@dataclass(frozen=True)
+class UnpushedCommit:
+    sha: str
+    summary: str
+    author: str
+    authored_at: str  # ISO-8601 with timezone (``%aI``)
+    files_changed: int
+
+
+@dataclass(frozen=True)
+class WorktreeCommitReport:
+    worktree: AgentWorktree
+    assigned_branch: str | None
+    """Remote branch the worktree was configured to push to (from
+    ``branch.<local>.merge``), or ``None`` when no upstream was
+    configured.
+    """
+
+    anchor_ref: str | None
+    """Remote-tracking ref used as the ``^anchor`` cut for ``git log`` —
+    typically ``origin/<assigned_branch>``, falling back to
+    ``origin/<base_branch>``. ``None`` when neither tracking ref
+    exists; in that case ``commits`` is the full HEAD history (capped
+    at 200) and the report is best-effort.
+    """
+
+    commits: list[UnpushedCommit]
+    error: str | None = None
+    """Set when worktree git inspection failed (corrupt worktree,
+    permission error, etc.). ``commits`` is empty in that case.
+    """
+
+
+@dataclass(frozen=True)
+class SalvageResult:
+    worktree_id: str
+    agent_role: str | None
+    slice_id: str | None
+    recovery_ref: str | None  # set on success
+    head_sha: str | None
+    n_commits: int
+    ok: bool
+    error: str | None = None
+
+
+# Lazy-resolved AgentRole values. Imported at call time to avoid hard-wiring
+# the orchestrator package layout into a module that may run standalone in
+# unit tests.
+_VALID_ROLE_VALUES: frozenset[str] | None = None
+
+
+def _role_values() -> frozenset[str]:
+    global _VALID_ROLE_VALUES
+    if _VALID_ROLE_VALUES is None:
+        try:
+            from egg_contracts.agent_roles import AgentRole  # type: ignore
+        except ImportError:
+            from shared.egg_contracts.agent_roles import AgentRole  # type: ignore
+        _VALID_ROLE_VALUES = frozenset(role.value for role in AgentRole)
+    return _VALID_ROLE_VALUES
+
+
+# Maximum number of commits to enumerate per worktree. Operators care about
+# "is there real work here?", not the full commit graph; capping keeps the
+# response bounded for huge histories.
+_MAX_COMMITS_PER_WORKTREE = 200
+
+
+def _run_git(
+    *args: str,
+    cwd: Path,
+    check: bool = True,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess[str]:
+    """Run a git command in ``cwd`` with hooks disabled.
+
+    ``core.hooksPath=/dev/null`` mirrors ``StateStore._run_git`` — the
+    orchestrator runs git on agent-controlled worktrees and must never
+    execute their hooks.
+    """
+    cmd = ["git", "-c", "core.hooksPath=/dev/null", "-C", str(cwd), *args]
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=check,
+        timeout=timeout,
+    )
+
+
+def _is_git_worktree(repo_path: Path) -> bool:
+    """Return True when ``repo_path`` looks like a git worktree.
+
+    Checked-out worktrees carry a ``.git`` *file* (not a directory) that
+    points at ``.git/worktrees/<name>`` in the parent repo. Bare clones
+    have a ``.git`` directory. Either form is acceptable for a worktree
+    that holds real commits — accept both.
+    """
+    git_marker = repo_path / ".git"
+    return git_marker.exists()
+
+
+def enumerate_agent_worktrees(pipeline_id: str) -> list[AgentWorktree]:
+    """List per-agent worktrees on disk for ``pipeline_id``.
+
+    Scans ``WORKTREE_BASE_DIR`` for directories that match the
+    pipeline-level (``{pipeline_id}``), per-role
+    (``{pipeline_id}-{role}``), or slice-scoped
+    (``{pipeline_id}-slice-{N}-{role}``) shapes. Same parsing rules as
+    :meth:`KubernetesSpawner.cleanup_pipeline` so the salvage hook
+    enumerates exactly the worktrees the cleanup loop is about to
+    delete.
+
+    Each returned ``AgentWorktree.repo_path`` points at the first
+    sub-directory inside the worktree that has a ``.git`` marker. Worktrees
+    with no usable repo checkout are skipped — they have nothing to
+    salvage.
+    """
+    if not WORKTREE_BASE_DIR.exists():
+        return []
+
+    valid_roles = _role_values()
+    valid_role_suffixes = {f"-{role}" for role in valid_roles}
+    found: list[AgentWorktree] = []
+
+    try:
+        entries = sorted(WORKTREE_BASE_DIR.iterdir())
+    except OSError as e:
+        logger.warning(
+            "Salvage enumeration failed: cannot iterate worktree base",
+            pipeline_id=pipeline_id,
+            error=str(e),
+        )
+        return []
+
+    for entry in entries:
+        if not entry.is_dir():
+            continue
+        name = entry.name
+
+        agent_role: str | None
+        slice_id: str | None
+
+        if name == pipeline_id:
+            agent_role = None
+            slice_id = None
+        elif name.startswith(pipeline_id):
+            suffix = name[len(pipeline_id) :]
+            if suffix in valid_role_suffixes:
+                agent_role = suffix.lstrip("-")
+                slice_id = None
+            else:
+                # Slice-scoped: suffix is "-slice-N-{role}". Strip the
+                # leading hyphen, then match.
+                if not suffix.startswith("-"):
+                    continue
+                m = _SLICE_WORKTREE_RE.match(suffix[1:])
+                if m is None:
+                    continue
+                role_value = m.group(2)
+                if role_value not in valid_roles:
+                    continue
+                slice_id = m.group(1)
+                agent_role = role_value
+        else:
+            continue
+
+        repo_path = _resolve_repo_path(entry)
+        if repo_path is None:
+            continue
+
+        worktree = AgentWorktree(
+            worktree_id=name,
+            pipeline_id=pipeline_id,
+            agent_role=agent_role,
+            slice_id=slice_id,
+            repo_path=repo_path,
+            local_branch=f"egg/{name}/work",
+        )
+        found.append(worktree)
+
+    return found
+
+
+def _resolve_repo_path(worktree_dir: Path) -> Path | None:
+    """Pick the repo subdirectory inside a worktree.
+
+    A worktree dir contains a per-repo subdirectory:
+    ``{worktree_dir}/{repo_short}/.git``. Return the first match. If the
+    worktree itself is the checkout (rare but seen in tests) accept it
+    too.
+    """
+    if _is_git_worktree(worktree_dir):
+        return worktree_dir
+    try:
+        for sub in sorted(worktree_dir.iterdir()):
+            if sub.is_dir() and _is_git_worktree(sub):
+                return sub
+    except OSError:
+        return None
+    return None
+
+
+def _read_assigned_branch(repo_path: Path, local_branch: str) -> str | None:
+    """Read the remote branch the worktree was configured to push to.
+
+    The gateway sets ``branch.<local>.merge`` at worktree-create time
+    (``GatewayClient.create_worktrees(... assigned_branch=...)``) so a
+    naive ``git push`` from the agent resolves to a refspec targeting
+    the assigned remote branch. Reading it back gives us the right
+    ``^origin/...`` cut without consulting the pipeline state file.
+    """
+    try:
+        result = _run_git(
+            "config",
+            "--get",
+            f"branch.{local_branch}.merge",
+            cwd=repo_path,
+            check=False,
+        )
+    except OSError, subprocess.SubprocessError:
+        return None
+    raw = (result.stdout or "").strip()
+    if result.returncode != 0 or not raw:
+        return None
+    if raw.startswith("refs/heads/"):
+        return raw[len("refs/heads/") :]
+    return raw
+
+
+def _ref_exists(repo_path: Path, ref: str) -> bool:
+    try:
+        result = _run_git(
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            ref,
+            cwd=repo_path,
+            check=False,
+        )
+    except OSError, subprocess.SubprocessError:
+        return False
+    return result.returncode == 0
+
+
+def _resolve_anchor(
+    repo_path: Path,
+    assigned_branch: str | None,
+    base_branch: str | None,
+) -> str | None:
+    """Pick the ``^anchor`` ref for the unpushed-commits diff.
+
+    Order: ``origin/<assigned_branch>`` → ``origin/<base_branch>`` →
+    ``None`` (HEAD-only fallback, capped). Skipping fetch is intentional:
+    accuracy in salvage means "don't trim too much" — over-including
+    already-pushed commits is harmless (the receiver dedupes when
+    cherry-picking) but trimming a real commit is silent loss.
+    """
+    if assigned_branch:
+        ref = f"refs/remotes/origin/{assigned_branch}"
+        if _ref_exists(repo_path, ref):
+            return ref
+    if base_branch:
+        ref = f"refs/remotes/origin/{base_branch}"
+        if _ref_exists(repo_path, ref):
+            return ref
+    return None
+
+
+def list_unpushed_commits(
+    worktree: AgentWorktree,
+    base_branch: str | None = None,
+) -> WorktreeCommitReport:
+    """Enumerate commits on the worktree's local branch not in the anchor.
+
+    Returns a ``WorktreeCommitReport`` whose ``commits`` is the
+    chronological-newest-first list of up to
+    ``_MAX_COMMITS_PER_WORKTREE`` commits. ``error`` is set when the
+    worktree is unreadable; in that case ``commits`` is empty and the
+    caller should skip salvage.
+    """
+    if not _is_git_worktree(worktree.repo_path):
+        return WorktreeCommitReport(
+            worktree=worktree,
+            assigned_branch=None,
+            anchor_ref=None,
+            commits=[],
+            error="worktree has no .git marker",
+        )
+
+    if not _ref_exists(worktree.repo_path, worktree.local_branch):
+        # The work branch was never created (agent never committed) — not
+        # an error, just nothing to salvage.
+        return WorktreeCommitReport(
+            worktree=worktree,
+            assigned_branch=None,
+            anchor_ref=None,
+            commits=[],
+        )
+
+    assigned_branch = _read_assigned_branch(worktree.repo_path, worktree.local_branch)
+    anchor_ref = _resolve_anchor(worktree.repo_path, assigned_branch, base_branch)
+
+    log_args: list[str] = [
+        "log",
+        f"--max-count={_MAX_COMMITS_PER_WORKTREE}",
+        # %x09 is a literal tab; chosen so we can str.split('\t', 4) without
+        # a fragile separator.
+        "--format=%H%x09%s%x09%an%x09%aI",
+        "--shortstat",
+        worktree.local_branch,
+    ]
+    if anchor_ref is not None:
+        log_args.append(f"^{anchor_ref}")
+
+    try:
+        result = _run_git(*log_args, cwd=worktree.repo_path, check=True)
+    except subprocess.CalledProcessError as e:
+        return WorktreeCommitReport(
+            worktree=worktree,
+            assigned_branch=assigned_branch,
+            anchor_ref=anchor_ref,
+            commits=[],
+            error=(e.stderr or str(e)).strip(),
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        return WorktreeCommitReport(
+            worktree=worktree,
+            assigned_branch=assigned_branch,
+            anchor_ref=anchor_ref,
+            commits=[],
+            error=str(e),
+        )
+
+    commits = _parse_git_log(result.stdout)
+    return WorktreeCommitReport(
+        worktree=worktree,
+        assigned_branch=assigned_branch,
+        anchor_ref=anchor_ref,
+        commits=commits,
+    )
+
+
+_SHORTSTAT_FILES_RE = re.compile(r"(\d+)\s+files?\s+changed")
+
+
+def _parse_git_log(output: str) -> list[UnpushedCommit]:
+    """Parse ``git log --format=... --shortstat`` output.
+
+    Each commit looks like::
+
+        <sha>\t<summary>\t<author>\t<authored_at>
+        <blank>
+         3 files changed, 12 insertions(+), 4 deletions(-)
+        <blank>
+
+    Empty lines separate commits. Shortstat may be absent (merge with no
+    diff, empty commit). We skip blank lines, parse the tab-separated
+    line as the commit header, and accumulate any following non-tab
+    line as the shortstat for that commit.
+    """
+    commits: list[UnpushedCommit] = []
+    pending: list[str] | None = None
+    files_changed = 0
+
+    def _flush() -> None:
+        nonlocal pending, files_changed
+        if pending is None:
+            return
+        sha, summary, author, authored_at = pending[0], pending[1], pending[2], pending[3]
+        commits.append(
+            UnpushedCommit(
+                sha=sha,
+                summary=summary,
+                author=author,
+                authored_at=authored_at,
+                files_changed=files_changed,
+            )
+        )
+        pending = None
+        files_changed = 0
+
+    for raw in output.splitlines():
+        line = raw.rstrip()
+        if not line:
+            continue
+        if "\t" in line:
+            _flush()
+            parts = line.split("\t", 3)
+            if len(parts) == 4:
+                pending = parts
+                files_changed = 0
+            continue
+        m = _SHORTSTAT_FILES_RE.search(line)
+        if m and pending is not None:
+            try:
+                files_changed = int(m.group(1))
+            except ValueError:
+                files_changed = 0
+
+    _flush()
+    return commits
+
+
+def _recovery_ref(
+    pipeline_id: str,
+    scope_label: str,
+    head_sha: str,
+) -> str:
+    """Compose the recovery ref name.
+
+    ``egg/recovered/<pipeline_id>/<scope>/<short_sha>``. The short SHA
+    makes each salvage immutable: re-salvaging the same HEAD is a no-op
+    fast-forward, and a re-run after new commits gets a fresh ref
+    instead of force-overwriting the prior one.
+    """
+    short = head_sha[:12]
+    return f"{RECOVERY_BRANCH_PREFIX}/{pipeline_id}/{scope_label}/{short}"
+
+
+def salvage_worktree(
+    gateway: GatewayClient,
+    worktree: AgentWorktree,
+    *,
+    base_branch: str | None = None,
+    mode: str = "public",
+) -> SalvageResult:
+    """Push ``worktree``'s HEAD to a recovery ref, if it has unpushed work.
+
+    Returns a ``SalvageResult`` with ``ok=True`` when a push succeeded or
+    when there was nothing to salvage (``n_commits=0``). ``ok=False``
+    only on push failure or worktree corruption.
+    """
+    report = list_unpushed_commits(worktree, base_branch=base_branch)
+    if report.error:
+        return SalvageResult(
+            worktree_id=worktree.worktree_id,
+            agent_role=worktree.agent_role,
+            slice_id=worktree.slice_id,
+            recovery_ref=None,
+            head_sha=None,
+            n_commits=0,
+            ok=False,
+            error=report.error,
+        )
+
+    if not report.commits:
+        # Nothing to salvage. ok=True so callers can short-circuit
+        # without surfacing a spurious failure.
+        return SalvageResult(
+            worktree_id=worktree.worktree_id,
+            agent_role=worktree.agent_role,
+            slice_id=worktree.slice_id,
+            recovery_ref=None,
+            head_sha=None,
+            n_commits=0,
+            ok=True,
+        )
+
+    head_sha = report.commits[0].sha
+    target_ref = _recovery_ref(worktree.pipeline_id, worktree.scope_label, head_sha)
+
+    # ``ref=local_branch`` would push that named ref; we want the
+    # worktree's HEAD (which equals the local branch tip), so
+    # ``ref=None`` is the right call. ``branch=target_ref`` becomes the
+    # remote ref name. Launcher auth bypasses the agent-targeted
+    # pipeline-push enforcement.
+    try:
+        push_result = gateway.push_worktree_branch(
+            pipeline_id=worktree.pipeline_id,
+            repo_path=str(worktree.repo_path),
+            branch=target_ref,
+            mode=mode,  # type: ignore[arg-type]
+            ref=None,
+            force=False,
+        )
+    except Exception as e:
+        # GatewayError or transport failure
+        return SalvageResult(
+            worktree_id=worktree.worktree_id,
+            agent_role=worktree.agent_role,
+            slice_id=worktree.slice_id,
+            recovery_ref=None,
+            head_sha=head_sha,
+            n_commits=len(report.commits),
+            ok=False,
+            error=str(e),
+        )
+
+    if not push_result.ok:
+        return SalvageResult(
+            worktree_id=worktree.worktree_id,
+            agent_role=worktree.agent_role,
+            slice_id=worktree.slice_id,
+            recovery_ref=None,
+            head_sha=head_sha,
+            n_commits=len(report.commits),
+            ok=False,
+            error=push_result.describe(),
+        )
+
+    logger.info(
+        "Salvaged unpushed commits to recovery ref",
+        pipeline_id=worktree.pipeline_id,
+        worktree_id=worktree.worktree_id,
+        agent_role=worktree.agent_role,
+        slice_id=worktree.slice_id,
+        recovery_ref=target_ref,
+        head_sha=head_sha,
+        n_commits=len(report.commits),
+    )
+    return SalvageResult(
+        worktree_id=worktree.worktree_id,
+        agent_role=worktree.agent_role,
+        slice_id=worktree.slice_id,
+        recovery_ref=target_ref,
+        head_sha=head_sha,
+        n_commits=len(report.commits),
+        ok=True,
+    )
+
+
+def auto_salvage_pipeline(
+    gateway: GatewayClient,
+    pipeline_id: str,
+    *,
+    base_branch: str | None = None,
+    mode: str = "public",
+    worktree_filter: set[str] | None = None,
+) -> list[SalvageResult]:
+    """Best-effort salvage of every per-agent worktree for a pipeline.
+
+    Called from ``cleanup_pipeline`` before worktree deletion so any
+    unpushed work lands on ``egg/recovered/...`` before the filesystem
+    state is gone. Always returns — never raises — so a salvage failure
+    cannot block the cleanup loop.
+
+    ``worktree_filter`` (when set) restricts salvage to worktree ids in
+    the given set, so the caller can pass exactly the ids it is about
+    to delete and skip stale on-disk worktrees from a prior pipeline
+    re-use.
+    """
+    results: list[SalvageResult] = []
+    try:
+        worktrees = enumerate_agent_worktrees(pipeline_id)
+    except Exception as e:
+        logger.warning(
+            "Salvage enumeration failed; cleanup proceeding without salvage",
+            pipeline_id=pipeline_id,
+            error=str(e),
+        )
+        return results
+
+    for wt in worktrees:
+        if worktree_filter is not None and wt.worktree_id not in worktree_filter:
+            continue
+        try:
+            result = salvage_worktree(
+                gateway,
+                wt,
+                base_branch=base_branch,
+                mode=mode,
+            )
+        except Exception as e:
+            # salvage_worktree is supposed to catch its own failures, but
+            # an unexpected exception here must not block cleanup.
+            logger.warning(
+                "Salvage raised unexpectedly; continuing cleanup",
+                pipeline_id=pipeline_id,
+                worktree_id=wt.worktree_id,
+                error=str(e),
+            )
+            results.append(
+                SalvageResult(
+                    worktree_id=wt.worktree_id,
+                    agent_role=wt.agent_role,
+                    slice_id=wt.slice_id,
+                    recovery_ref=None,
+                    head_sha=None,
+                    n_commits=0,
+                    ok=False,
+                    error=str(e),
+                )
+            )
+            continue
+        results.append(result)
+        if not result.ok:
+            logger.warning(
+                "Salvage failed for worktree",
+                pipeline_id=pipeline_id,
+                worktree_id=wt.worktree_id,
+                error=result.error,
+            )
+
+    salvaged = [r for r in results if r.ok and r.recovery_ref]
+    if salvaged:
+        logger.info(
+            "Auto-salvage complete",
+            pipeline_id=pipeline_id,
+            n_worktrees_inspected=len(results),
+            n_salvaged=len(salvaged),
+            recovery_refs=[r.recovery_ref for r in salvaged],
+        )
+    return results

--- a/orchestrator/agent_salvage.py
+++ b/orchestrator/agent_salvage.py
@@ -50,14 +50,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-try:
-    from egg_logging import get_logger
-except ImportError:
-    import logging
-
-    def get_logger(name: str, **_: object) -> logging.Logger:  # type: ignore[misc]
-        return logging.getLogger(name)
-
+from egg_logging import get_logger
 
 if TYPE_CHECKING:
     from gateway_client import GatewayClient
@@ -425,9 +418,11 @@ def list_unpushed_commits(
     log_args: list[str] = [
         "log",
         f"--max-count={_MAX_COMMITS_PER_WORKTREE}",
-        # %x09 is a literal tab; chosen so we can str.split('\t', 4) without
-        # a fragile separator.
-        "--format=%H%x09%s%x09%an%x09%aI",
+        # %x1f is the ASCII unit separator (U+001F). Using it instead of
+        # a tab keeps the parser correct when the commit subject itself
+        # contains a tab — git would otherwise pass the literal tab
+        # through and shift the trailing fields on str.split.
+        "--format=%H%x1f%s%x1f%an%x1f%aI",
         "--shortstat",
         worktree.local_branch,
     ]
@@ -465,20 +460,23 @@ def list_unpushed_commits(
 _SHORTSTAT_FILES_RE = re.compile(r"(\d+)\s+files?\s+changed")
 
 
+_UNIT_SEP = "\x1f"
+
+
 def _parse_git_log(output: str) -> list[UnpushedCommit]:
     """Parse ``git log --format=... --shortstat`` output.
 
     Each commit looks like::
 
-        <sha>\t<summary>\t<author>\t<authored_at>
+        <sha>\x1f<summary>\x1f<author>\x1f<authored_at>
         <blank>
          3 files changed, 12 insertions(+), 4 deletions(-)
         <blank>
 
     Empty lines separate commits. Shortstat may be absent (merge with no
-    diff, empty commit). We skip blank lines, parse the tab-separated
-    line as the commit header, and accumulate any following non-tab
-    line as the shortstat for that commit.
+    diff, empty commit). We skip blank lines, parse the unit-separated
+    line as the commit header, and accumulate any following line
+    without a unit separator as the shortstat for that commit.
     """
     commits: list[UnpushedCommit] = []
     pending: list[str] | None = None
@@ -505,9 +503,9 @@ def _parse_git_log(output: str) -> list[UnpushedCommit]:
         line = raw.rstrip()
         if not line:
             continue
-        if "\t" in line:
+        if _UNIT_SEP in line:
             _flush()
-            parts = line.split("\t", 3)
+            parts = line.split(_UNIT_SEP, 3)
             if len(parts) == 4:
                 pending = parts
                 files_changed = 0

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -33,6 +33,7 @@ except ImportError:
         return logging.getLogger(name)
 
 
+import agent_salvage
 from egg_config import GATEWAY_PORT, GATEWAY_PROXY_PORT
 from gateway_client import (
     GatewayClient,
@@ -932,6 +933,8 @@ class KubernetesSpawner:
         pipeline_id: str,
         force: bool = True,
         preserve_worktrees: bool = False,
+        salvage_mode: str | None = None,
+        salvage_base_branch: str | None = None,
     ) -> int:
         """Clean up all Jobs and sessions for a pipeline.
 
@@ -943,6 +946,20 @@ class KubernetesSpawner:
                 worktrees. Jobs and gateway sessions are still removed so the
                 retry spawns fresh pods. Default False preserves the prior
                 behavior of deleting every worktree.
+            salvage_mode: Gateway session mode (``"public"`` / ``"private"``)
+                used by the auto-salvage hook for the launcher-auth push to
+                ``egg/recovered/...``. Callers with a ``Pipeline`` in scope
+                should compute this via ``_compute_gateway_mode(pipeline)``
+                so private-repo / private-network pipelines salvage with
+                the policy they ran under. ``None`` (the default) falls
+                back to ``"public"`` and is only correct for callers that
+                cannot load the pipeline.
+            salvage_base_branch: Base branch (e.g. ``"main"``) used by the
+                salvage hook as the secondary ``^anchor`` cut when
+                ``origin/<assigned_branch>`` is missing. ``None`` is safe
+                — the hook falls back to the full HEAD history (capped at
+                200 commits) — but threading ``pipeline.base_branch``
+                produces tighter recovery refs.
 
         Returns:
             Number of Jobs removed
@@ -1038,17 +1055,17 @@ class KubernetesSpawner:
         # then delete" so salvageable work is always reachable from
         # origin before the worktree filesystem state is gone.
         try:
-            try:
-                from agent_salvage import auto_salvage_pipeline
-            except ImportError:
-                from orchestrator.agent_salvage import (  # type: ignore[no-redef]
-                    auto_salvage_pipeline,
-                )
-
-            auto_salvage_pipeline(
+            agent_salvage.auto_salvage_pipeline(
                 self.gateway,
                 pipeline_id,
                 worktree_filter=worktree_ids_to_clean,
+                # Mismatching the running-pipeline mode would re-create
+                # the silent-loss class this hook exists to prevent for
+                # private-mode pipelines. Callers without a Pipeline in
+                # scope keep the historical default ("public") via
+                # ``mode=None`` → omitted-kwarg below.
+                **({"mode": salvage_mode} if salvage_mode is not None else {}),
+                base_branch=salvage_base_branch,
             )
         except Exception as e:
             logger.warning(

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -1030,6 +1030,33 @@ class KubernetesSpawner:
                     error=str(e),
                 )
 
+        # Auto-salvage unpushed agent commits before deleting worktrees
+        # (#2429). Best-effort: any failure logs and continues so cleanup
+        # cannot be blocked by salvage. The default policy here used to
+        # be silent loss when an agent's pushes were wedged — this hook
+        # makes the default policy "push to egg/recovered/<pipeline>/...
+        # then delete" so salvageable work is always reachable from
+        # origin before the worktree filesystem state is gone.
+        try:
+            try:
+                from agent_salvage import auto_salvage_pipeline
+            except ImportError:
+                from orchestrator.agent_salvage import (  # type: ignore[no-redef]
+                    auto_salvage_pipeline,
+                )
+
+            auto_salvage_pipeline(
+                self.gateway,
+                pipeline_id,
+                worktree_filter=worktree_ids_to_clean,
+            )
+        except Exception as e:
+            logger.warning(
+                "Auto-salvage failed during cleanup; proceeding with worktree deletion",
+                pipeline_id=pipeline_id,
+                error=str(e),
+            )
+
         for wt_id in worktree_ids_to_clean:
             try:
                 self.gateway.delete_worktrees(container_id=wt_id, force=True)

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -704,6 +704,81 @@ PIPELINE_TOOLS = [
             "required": ["task_id", "phase"],
         },
     },
+    # --- Salvage tools (#2429) ---
+    {
+        "name": "list_agent_local_commits",
+        "description": (
+            "List unpushed commits sitting in this pipeline's per-agent worktrees. "
+            "Use to triage whether wedged agents have local work that would be "
+            "lost on cleanup — for example after a gateway branch-allowlist "
+            "rejection (#2428) or a restart-reconciliation false-failure (#2411). "
+            "Read-only: inspects each worktree's git log against "
+            "origin/<assigned_branch> (with origin/<base_branch> fallback) and "
+            "reports commits that are not yet on the remote. No fetch, no push. "
+            "Pair with `salvage_agent_commits` to push the work to a recovery ref."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "Pipeline/task ID",
+                },
+                "agent_role": {
+                    "type": "string",
+                    "description": (
+                        "Optional. Restrict to a single agent role (e.g. 'coder'). "
+                        "Omit to enumerate every per-agent worktree for the pipeline."
+                    ),
+                },
+                "slice_id": {
+                    "type": "string",
+                    "description": (
+                        "Optional. Restrict to a single slice scope "
+                        "(e.g. 'slice-2'). Omit to include all scopes."
+                    ),
+                },
+            },
+            "required": ["task_id"],
+        },
+    },
+    {
+        "name": "salvage_agent_commits",
+        "description": (
+            "Push unpushed agent commits to recovery refs under "
+            "egg/recovered/<pipeline>/<scope>/<short_sha>. Authenticates with the "
+            "orchestrator's launcher secret, which bypasses the agent-targeted "
+            "branch-allowlist check that rejected the original push — so this "
+            "works to recover work even when the agent's own pushes were the "
+            "thing that wedged. The recovery ref name embeds the HEAD SHA so "
+            "re-salvages produce immutable refs instead of force-overwriting "
+            "earlier ones. After salvage, fetch and cherry-pick onto the "
+            "intended branch. Always returns per-worktree results — failure of "
+            "one worktree never blocks others."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "Pipeline/task ID",
+                },
+                "agent_role": {
+                    "type": "string",
+                    "description": (
+                        "Optional. Salvage only this agent role's worktree "
+                        "(e.g. 'coder'). Omit to salvage every per-agent "
+                        "worktree for the pipeline."
+                    ),
+                },
+                "slice_id": {
+                    "type": "string",
+                    "description": ("Optional. Salvage only this slice scope (e.g. 'slice-2')."),
+                },
+            },
+            "required": ["task_id"],
+        },
+    },
     # --- Phase management tools ---
     {
         "name": "advance_phase",
@@ -1117,6 +1192,8 @@ class PipelineToolHandler:
             "validate_config": self._handle_validate_config,
             "restart_agent": self._handle_restart_agent,
             "restart_phase": self._handle_restart_phase,
+            "list_agent_local_commits": self._handle_list_agent_local_commits,
+            "salvage_agent_commits": self._handle_salvage_agent_commits,
             "advance_phase": self._handle_advance_phase,
             "start_pipeline": self._handle_start_pipeline,
             "start_phase": self._handle_start_phase,
@@ -2564,6 +2641,66 @@ class PipelineToolHandler:
             }
         except Exception as e:
             return {"error": f"Failed to restart phase: {e}"}
+
+    def _handle_list_agent_local_commits(self, args: dict[str, Any]) -> dict[str, Any]:
+        """List unpushed commits in this pipeline's per-agent worktrees (#2429)."""
+        task_id = quote(args["task_id"], safe="")
+        params: list[str] = []
+        if args.get("agent_role"):
+            params.append(f"agent_role={quote(args['agent_role'], safe='')}")
+        if args.get("slice_id"):
+            params.append(f"slice_id={quote(args['slice_id'], safe='')}")
+        suffix = f"?{'&'.join(params)}" if params else ""
+        try:
+            result = self._make_request(
+                f"/api/v1/pipelines/{task_id}/local-commits{suffix}",
+            )
+        except Exception as e:
+            return {"error": f"Failed to list local commits: {e}"}
+
+        data = result.get("data", {}) if isinstance(result, dict) else {}
+        worktrees = data.get("worktrees", [])
+        n_commits = sum(len(wt.get("commits") or []) for wt in worktrees)
+        return {
+            "pipeline_id": data.get("pipeline_id", args["task_id"]),
+            "n_worktrees": len(worktrees),
+            "n_commits": n_commits,
+            "worktrees": worktrees,
+        }
+
+    def _handle_salvage_agent_commits(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Push unpushed agent commits to recovery refs (#2429)."""
+        task_id = quote(args["task_id"], safe="")
+        params: list[str] = []
+        if args.get("agent_role"):
+            params.append(f"agent_role={quote(args['agent_role'], safe='')}")
+        if args.get("slice_id"):
+            params.append(f"slice_id={quote(args['slice_id'], safe='')}")
+        suffix = f"?{'&'.join(params)}" if params else ""
+        try:
+            result = self._make_request(
+                f"/api/v1/pipelines/{task_id}/salvage{suffix}",
+                method="POST",
+                data={},
+                # Push goes through the gateway with launcher auth and may
+                # block on git for a few seconds per worktree.
+                timeout=120,
+            )
+        except Exception as e:
+            return {"error": f"Failed to salvage commits: {e}"}
+
+        data = result.get("data", {}) if isinstance(result, dict) else {}
+        results = data.get("results", [])
+        salvaged = [r for r in results if r.get("ok") and r.get("recovery_ref")]
+        failed = [r for r in results if not r.get("ok")]
+        return {
+            "pipeline_id": data.get("pipeline_id", args["task_id"]),
+            "n_worktrees": len(results),
+            "n_salvaged": len(salvaged),
+            "n_failed": len(failed),
+            "recovery_refs": [r["recovery_ref"] for r in salvaged],
+            "results": results,
+        }
 
     def _handle_advance_phase(self, args: dict[str, Any]) -> dict[str, Any]:
         """Advance pipeline to a target phase.

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -82,6 +82,7 @@ except ImportError:
 
 # Import orchestrator modules - try relative import first
 try:
+    from .. import agent_salvage
     from ..container_spawner import ContainerSpawnError, SpawnFailureError, get_container_spawner
     from ..decision_queue import get_decision_queue
     from ..docker_client import ContainerNotFoundError, ContainerOperationError, DockerClientError
@@ -118,6 +119,7 @@ try:
         get_state_store,
     )
 except ImportError:
+    import agent_salvage  # type: ignore[no-redef]
     from container_spawner import (  # type: ignore
         ContainerSpawnError,
         SpawnFailureError,
@@ -2029,6 +2031,17 @@ def update_pipeline(pipeline_id: str) -> tuple[Response, int]:
             # so the PATCH response returns immediately.  The DELETE handler
             # already re-runs cleanup_pipeline() as a safety net, so it will
             # catch anything the background thread hasn't finished.
+            #
+            # Compute the salvage mode + base branch up front (in the
+            # request thread, where ``pipeline`` is still in scope) so the
+            # background thread can pass them to ``cleanup_pipeline``
+            # without re-loading state. Using the wrong mode here would
+            # mismatch the policy the rest of the pipeline ran under and
+            # the launcher-auth push could be rejected — see #2429
+            # review.
+            _bg_salvage_mode, _ = _compute_gateway_mode(pipeline)
+            _bg_salvage_base_branch = pipeline.base_branch
+
             def _background_cleanup(pid: str, status_value: str) -> None:
                 try:
                     spawner = _get_spawner()
@@ -2039,6 +2052,8 @@ def update_pipeline(pipeline_id: str) -> tuple[Response, int]:
                         pid,
                         force=True,
                         preserve_worktrees=(status_value == "cancelled"),
+                        salvage_mode=_bg_salvage_mode,
+                        salvage_base_branch=_bg_salvage_base_branch,
                     )
                     if removed > 0:
                         logger.info(
@@ -2205,7 +2220,16 @@ def delete_pipeline(pipeline_id: str) -> tuple[Response, int]:
         # Clean up any running containers for this pipeline
         try:
             spawner = _get_spawner()
-            removed = spawner.cleanup_pipeline(pipeline_id, force=True)
+            # Pass the running pipeline's gateway mode + base branch so the
+            # auto-salvage hook in cleanup_pipeline pushes recovery refs
+            # under the same policy the pipeline ran under (#2429 review).
+            _delete_salvage_mode, _ = _compute_gateway_mode(_pipeline)
+            removed = spawner.cleanup_pipeline(
+                pipeline_id,
+                force=True,
+                salvage_mode=_delete_salvage_mode,
+                salvage_base_branch=_pipeline.base_branch,
+            )
             if removed > 0:
                 logger.info(
                     "Cleaned up pipeline containers",
@@ -3002,20 +3026,15 @@ def list_pipeline_local_commits(pipeline_id: str) -> tuple[Response, int]:
     except ValueError as e:
         return make_error_response(str(e), status_code=400)
 
-    try:
-        from agent_salvage import enumerate_agent_worktrees, list_unpushed_commits
-    except ImportError:
-        from ..agent_salvage import (  # type: ignore[no-redef]
-            enumerate_agent_worktrees,
-            list_unpushed_commits,
-        )
-
     worktrees = _filter_salvage_worktrees(
-        enumerate_agent_worktrees(pipeline_id),
+        agent_salvage.enumerate_agent_worktrees(pipeline_id),
         agent_role=agent_role,
         slice_id=slice_id,
     )
-    reports = [list_unpushed_commits(wt, base_branch=pipeline.base_branch) for wt in worktrees]
+    reports = [
+        agent_salvage.list_unpushed_commits(wt, base_branch=pipeline.base_branch)
+        for wt in worktrees
+    ]
 
     return make_success_response(
         f"Listed local commits for pipeline {pipeline_id}",
@@ -3078,16 +3097,8 @@ def salvage_pipeline_local_commits(pipeline_id: str) -> tuple[Response, int]:
     except ValueError as e:
         return make_error_response(str(e), status_code=400)
 
-    try:
-        from agent_salvage import enumerate_agent_worktrees, salvage_worktree
-    except ImportError:
-        from ..agent_salvage import (  # type: ignore[no-redef]
-            enumerate_agent_worktrees,
-            salvage_worktree,
-        )
-
     worktrees = _filter_salvage_worktrees(
-        enumerate_agent_worktrees(pipeline_id),
+        agent_salvage.enumerate_agent_worktrees(pipeline_id),
         agent_role=agent_role,
         slice_id=slice_id,
     )
@@ -3098,7 +3109,7 @@ def salvage_pipeline_local_commits(pipeline_id: str) -> tuple[Response, int]:
     results = []
     for wt in worktrees:
         try:
-            result = salvage_worktree(
+            result = agent_salvage.salvage_worktree(
                 gateway,
                 wt,
                 base_branch=pipeline.base_branch,
@@ -3111,11 +3122,7 @@ def salvage_pipeline_local_commits(pipeline_id: str) -> tuple[Response, int]:
                 worktree_id=wt.worktree_id,
                 error=str(e),
             )
-            try:
-                from agent_salvage import SalvageResult
-            except ImportError:
-                from ..agent_salvage import SalvageResult  # type: ignore[no-redef]
-            result = SalvageResult(
+            result = agent_salvage.SalvageResult(
                 worktree_id=wt.worktree_id,
                 agent_role=wt.agent_role,
                 slice_id=wt.slice_id,
@@ -16863,10 +16870,15 @@ def _run_pipeline(
         # new thread's containers are not killed.  See #1386, #1638.
         if not pipeline_was_restarted:
             try:
+                # ``gateway_mode`` is the mode this pipeline ran under;
+                # the auto-salvage hook needs it to push recovery refs
+                # under the same policy (#2429 review).
                 removed = _spawner.cleanup_pipeline(
                     pipeline_id,
                     force=True,
                     preserve_worktrees=skip_cleanup,
+                    salvage_mode=gateway_mode,
+                    salvage_base_branch=pipeline.base_branch,
                 )
                 if removed > 0:
                     logger.info(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2881,6 +2881,262 @@ def restart_phase(pipeline_id: str, phase: str) -> tuple[Response, int]:
     )
 
 
+def _filter_salvage_worktrees(
+    worktrees: list[Any],
+    *,
+    agent_role: str | None,
+    slice_id: str | None,
+) -> list[Any]:
+    """Filter ``enumerate_agent_worktrees`` output by role / slice scope.
+
+    ``agent_role`` and ``slice_id`` may both be ``None`` (return all) or
+    set together to scope down to one specific worktree. ``agent_role``
+    set with ``slice_id=None`` matches non-slice per-agent worktrees.
+    The pipeline-level worktree (``agent_role=None`` on the worktree)
+    is included only when the caller did not specify ``agent_role``.
+    """
+    out = []
+    for wt in worktrees:
+        if agent_role is not None and wt.agent_role != agent_role:
+            continue
+        if slice_id is not None and wt.slice_id != slice_id:
+            continue
+        out.append(wt)
+    return out
+
+
+def _serialize_commit_report(report: Any) -> dict[str, Any]:
+    """Convert a ``WorktreeCommitReport`` to a JSON-safe dict."""
+    return {
+        "worktree_id": report.worktree.worktree_id,
+        "agent_role": report.worktree.agent_role,
+        "slice_id": report.worktree.slice_id,
+        "local_branch": report.worktree.local_branch,
+        "assigned_branch": report.assigned_branch,
+        "anchor_ref": report.anchor_ref,
+        "commits": [
+            {
+                "sha": c.sha,
+                "summary": c.summary,
+                "author": c.author,
+                "authored_at": c.authored_at,
+                "files_changed": c.files_changed,
+            }
+            for c in report.commits
+        ],
+        "error": report.error,
+    }
+
+
+def _serialize_salvage_result(result: Any) -> dict[str, Any]:
+    """Convert a ``SalvageResult`` to a JSON-safe dict."""
+    return {
+        "worktree_id": result.worktree_id,
+        "agent_role": result.agent_role,
+        "slice_id": result.slice_id,
+        "recovery_ref": result.recovery_ref,
+        "head_sha": result.head_sha,
+        "n_commits": result.n_commits,
+        "ok": result.ok,
+        "error": result.error,
+    }
+
+
+@pipelines_bp.route("/<pipeline_id>/local-commits", methods=["GET"])
+def list_pipeline_local_commits(pipeline_id: str) -> tuple[Response, int]:
+    """List unpushed commits across this pipeline's per-agent worktrees.
+
+    Inspects every per-agent worktree on disk
+    (``{pipeline_id}``, ``{pipeline_id}-{role}``,
+    ``{pipeline_id}-slice-{N}-{role}``) and reports the commits on its
+    local ``egg/{worktree_id}/work`` branch that are not reachable from
+    ``origin/<assigned_branch>`` (or ``origin/<base_branch>`` as a
+    fallback). Read-only — no fetch, no push.
+
+    Query string (optional):
+        agent_role: Filter to a single agent role (e.g. ``coder``).
+        slice_id: Filter to a single slice scope (e.g. ``slice-2``).
+
+    Response:
+        {
+            "success": true,
+            "data": {
+                "pipeline_id": "issue-2261-v9",
+                "worktrees": [
+                    {
+                        "worktree_id": "issue-2261-v9-slice-2-coder",
+                        "agent_role": "coder",
+                        "slice_id": "slice-2",
+                        "local_branch": "egg/issue-2261-v9-slice-2-coder/work",
+                        "assigned_branch": "egg/issue-2261-v9/slice-2",
+                        "anchor_ref": "refs/remotes/origin/egg/issue-2261-v9/slice-2",
+                        "commits": [
+                            {"sha": "...", "summary": "...", "author": "...",
+                             "authored_at": "...", "files_changed": 3}
+                        ],
+                        "error": null
+                    }
+                ]
+            }
+        }
+    """
+    repo_path = get_repo_path()
+
+    try:
+        _store, pipeline = _resolve_pipeline(pipeline_id, repo_path)
+    except InvalidPipelineIdError:
+        return make_error_response(f"Invalid pipeline ID format: {pipeline_id}", status_code=400)
+    except PipelineNotFoundError:
+        return make_error_response(f"Pipeline {pipeline_id} not found", status_code=404)
+
+    agent_role = request.args.get("agent_role") or None
+    if agent_role is not None:
+        try:
+            AgentRole(agent_role)
+        except ValueError:
+            return make_error_response(f"Invalid agent role: {agent_role}", status_code=400)
+
+    raw_slice_id = request.args.get("slice_id")
+    try:
+        slice_id = extract_slice_id({"slice_id": raw_slice_id} if raw_slice_id is not None else {})
+    except ValueError as e:
+        return make_error_response(str(e), status_code=400)
+
+    try:
+        from agent_salvage import enumerate_agent_worktrees, list_unpushed_commits
+    except ImportError:
+        from ..agent_salvage import (  # type: ignore[no-redef]
+            enumerate_agent_worktrees,
+            list_unpushed_commits,
+        )
+
+    worktrees = _filter_salvage_worktrees(
+        enumerate_agent_worktrees(pipeline_id),
+        agent_role=agent_role,
+        slice_id=slice_id,
+    )
+    reports = [list_unpushed_commits(wt, base_branch=pipeline.base_branch) for wt in worktrees]
+
+    return make_success_response(
+        f"Listed local commits for pipeline {pipeline_id}",
+        data={
+            "pipeline_id": pipeline_id,
+            "worktrees": [_serialize_commit_report(r) for r in reports],
+        },
+    )
+
+
+@pipelines_bp.route("/<pipeline_id>/salvage", methods=["POST"])
+@require_lifecycle_secret
+def salvage_pipeline_local_commits(pipeline_id: str) -> tuple[Response, int]:
+    """Push unpushed agent commits to recovery refs (#2429).
+
+    For every matching per-agent worktree, push its HEAD to
+    ``egg/recovered/<pipeline_id>/<scope>/<short_sha>`` via the gateway's
+    launcher-auth path. Launcher auth bypasses the agent-targeted
+    branch-allowlist check so this works even when the agent's own
+    pushes were rejected for the wrong-branch reason this verb exists
+    to recover from.
+
+    Query string (optional):
+        agent_role: Salvage only this role's worktree.
+        slice_id: Salvage only this slice scope.
+
+    Response (always ``success: true`` when the request was well-formed
+    — per-worktree failures are reported in ``data.results``):
+        {
+            "success": true,
+            "data": {
+                "pipeline_id": "issue-2261-v9",
+                "results": [
+                    {"worktree_id": "...", "agent_role": "coder", "slice_id": "slice-2",
+                     "recovery_ref": "egg/recovered/issue-2261-v9/slice-2-coder/9665f37a6...",
+                     "head_sha": "9665f37a6...", "n_commits": 14, "ok": true, "error": null}
+                ]
+            }
+        }
+    """
+    repo_path = get_repo_path()
+
+    try:
+        _store, pipeline = _resolve_pipeline(pipeline_id, repo_path)
+    except InvalidPipelineIdError:
+        return make_error_response(f"Invalid pipeline ID format: {pipeline_id}", status_code=400)
+    except PipelineNotFoundError:
+        return make_error_response(f"Pipeline {pipeline_id} not found", status_code=404)
+
+    agent_role = request.args.get("agent_role") or None
+    if agent_role is not None:
+        try:
+            AgentRole(agent_role)
+        except ValueError:
+            return make_error_response(f"Invalid agent role: {agent_role}", status_code=400)
+
+    raw_slice_id = request.args.get("slice_id")
+    try:
+        slice_id = extract_slice_id({"slice_id": raw_slice_id} if raw_slice_id is not None else {})
+    except ValueError as e:
+        return make_error_response(str(e), status_code=400)
+
+    try:
+        from agent_salvage import enumerate_agent_worktrees, salvage_worktree
+    except ImportError:
+        from ..agent_salvage import (  # type: ignore[no-redef]
+            enumerate_agent_worktrees,
+            salvage_worktree,
+        )
+
+    worktrees = _filter_salvage_worktrees(
+        enumerate_agent_worktrees(pipeline_id),
+        agent_role=agent_role,
+        slice_id=slice_id,
+    )
+
+    gateway_mode, _vis = _compute_gateway_mode(pipeline)
+    gateway = get_gateway_client()
+
+    results = []
+    for wt in worktrees:
+        try:
+            result = salvage_worktree(
+                gateway,
+                wt,
+                base_branch=pipeline.base_branch,
+                mode=gateway_mode,
+            )
+        except Exception as e:  # noqa: BLE001 — must always return a result row
+            logger.warning(
+                "Salvage raised unexpectedly",
+                pipeline_id=pipeline_id,
+                worktree_id=wt.worktree_id,
+                error=str(e),
+            )
+            try:
+                from agent_salvage import SalvageResult
+            except ImportError:
+                from ..agent_salvage import SalvageResult  # type: ignore[no-redef]
+            result = SalvageResult(
+                worktree_id=wt.worktree_id,
+                agent_role=wt.agent_role,
+                slice_id=wt.slice_id,
+                recovery_ref=None,
+                head_sha=None,
+                n_commits=0,
+                ok=False,
+                error=str(e),
+            )
+        results.append(result)
+
+    return make_success_response(
+        f"Salvaged {sum(1 for r in results if r.ok and r.recovery_ref)} of "
+        f"{len(results)} per-agent worktrees for pipeline {pipeline_id}",
+        data={
+            "pipeline_id": pipeline_id,
+            "results": [_serialize_salvage_result(r) for r in results],
+        },
+    )
+
+
 @pipelines_bp.route("/<pipeline_id>/status", methods=["GET"])
 def get_pipeline_status(pipeline_id: str) -> tuple[Response, int]:
     """

--- a/orchestrator/tests/test_agent_salvage.py
+++ b/orchestrator/tests/test_agent_salvage.py
@@ -1,0 +1,566 @@
+"""Unit tests for agent_salvage (#2429)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from agent_salvage import (
+    RECOVERY_BRANCH_PREFIX,
+    AgentWorktree,
+    SalvageResult,
+    UnpushedCommit,
+    WorktreeCommitReport,
+    auto_salvage_pipeline,
+    enumerate_agent_worktrees,
+    list_unpushed_commits,
+    salvage_worktree,
+)
+from gateway_client import PushResult
+
+# ---------------------------------------------------------------------------
+# Test helpers — build real git repos under tmp_path so the salvage helper
+# exercises real git plumbing rather than mocked subprocess output.
+# ---------------------------------------------------------------------------
+
+
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "user.email=t@t.com",
+            "-c",
+            "user.name=Tester",
+            "-C",
+            str(cwd),
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _make_repo(path: Path, branch_name: str) -> str:
+    """Initialise a repo at *path* on *branch_name* with one commit. Returns HEAD SHA."""
+    path.mkdir(parents=True, exist_ok=True)
+    _git("init", "-q", "--initial-branch", branch_name, cwd=path)
+    (path / "README.md").write_text("seed\n")
+    _git("add", "README.md", cwd=path)
+    _git("commit", "-q", "-m", "seed", cwd=path)
+    return _git("rev-parse", "HEAD", cwd=path).stdout.strip()
+
+
+def _commit(path: Path, filename: str, content: str, message: str) -> str:
+    (path / filename).write_text(content)
+    _git("add", filename, cwd=path)
+    _git("commit", "-q", "-m", message, cwd=path)
+    return _git("rev-parse", "HEAD", cwd=path).stdout.strip()
+
+
+def _set_assigned_branch(repo_path: Path, local_branch: str, assigned_branch: str) -> None:
+    """Mirror what gateway worktree_manager configures at create time."""
+    _git(
+        "config",
+        f"branch.{local_branch}.merge",
+        f"refs/heads/{assigned_branch}",
+        cwd=repo_path,
+    )
+
+
+def _create_remote_tracking(repo_path: Path, remote_branch: str, sha: str) -> None:
+    """Stand in for ``origin/<branch>`` after a fetch."""
+    _git("update-ref", f"refs/remotes/origin/{remote_branch}", sha, cwd=repo_path)
+
+
+def _make_worktree_layout(
+    base: Path,
+    pipeline_id: str,
+    *,
+    agent_role: str | None,
+    slice_id: str | None,
+) -> tuple[Path, str]:
+    """Create ``{base}/{worktree_id}/repo/`` with a real git repo on
+    ``egg/{worktree_id}/work``. Returns (repo_path, local_branch).
+    """
+    if agent_role is None:
+        worktree_id = pipeline_id
+    elif slice_id is None:
+        worktree_id = f"{pipeline_id}-{agent_role}"
+    else:
+        worktree_id = f"{pipeline_id}-{slice_id}-{agent_role}"
+    local_branch = f"egg/{worktree_id}/work"
+    repo_path = base / worktree_id / "repo"
+    _make_repo(repo_path, local_branch)
+    return repo_path, local_branch
+
+
+# ---------------------------------------------------------------------------
+# enumerate_agent_worktrees
+# ---------------------------------------------------------------------------
+
+
+class TestEnumerate:
+    def test_empty_base_dir(self, tmp_path: Path) -> None:
+        with patch("agent_salvage.WORKTREE_BASE_DIR", tmp_path):
+            assert enumerate_agent_worktrees("issue-99") == []
+
+    def test_pipeline_level_worktree(self, tmp_path: Path) -> None:
+        _make_worktree_layout(tmp_path, "issue-99", agent_role=None, slice_id=None)
+        with patch("agent_salvage.WORKTREE_BASE_DIR", tmp_path):
+            wts = enumerate_agent_worktrees("issue-99")
+        assert len(wts) == 1
+        wt = wts[0]
+        assert wt.worktree_id == "issue-99"
+        assert wt.agent_role is None
+        assert wt.slice_id is None
+        assert wt.local_branch == "egg/issue-99/work"
+        assert wt.repo_path == tmp_path / "issue-99" / "repo"
+
+    def test_per_role_worktree(self, tmp_path: Path) -> None:
+        _make_worktree_layout(tmp_path, "issue-99", agent_role="coder", slice_id=None)
+        with patch("agent_salvage.WORKTREE_BASE_DIR", tmp_path):
+            wts = enumerate_agent_worktrees("issue-99")
+        assert len(wts) == 1
+        wt = wts[0]
+        assert wt.agent_role == "coder"
+        assert wt.slice_id is None
+        assert wt.scope_label == "coder"
+
+    def test_slice_scoped_worktree(self, tmp_path: Path) -> None:
+        _make_worktree_layout(tmp_path, "issue-99", agent_role="coder", slice_id="slice-2")
+        with patch("agent_salvage.WORKTREE_BASE_DIR", tmp_path):
+            wts = enumerate_agent_worktrees("issue-99")
+        assert len(wts) == 1
+        wt = wts[0]
+        assert wt.agent_role == "coder"
+        assert wt.slice_id == "slice-2"
+        assert wt.worktree_id == "issue-99-slice-2-coder"
+        assert wt.scope_label == "slice-2-coder"
+
+    def test_mixed_worktrees(self, tmp_path: Path) -> None:
+        _make_worktree_layout(tmp_path, "issue-99", agent_role=None, slice_id=None)
+        _make_worktree_layout(tmp_path, "issue-99", agent_role="coder", slice_id=None)
+        _make_worktree_layout(tmp_path, "issue-99", agent_role="tester", slice_id="slice-1")
+        with patch("agent_salvage.WORKTREE_BASE_DIR", tmp_path):
+            wts = enumerate_agent_worktrees("issue-99")
+        scope_labels = sorted(wt.scope_label for wt in wts)
+        assert scope_labels == ["coder", "pipeline", "slice-1-tester"]
+
+    def test_skips_unrelated_pipeline_with_shared_prefix(self, tmp_path: Path) -> None:
+        """``issue-99-worktree-fix-tester`` must not be matched by ``issue-99``.
+
+        Mirrors the #1865 protection in ``cleanup_pipeline`` — a shared
+        prefix between two pipeline ids must not pull a sibling pipeline's
+        worktree into the salvage scope.
+        """
+        # Active worktree of the *other* pipeline. Suffix "-worktree-fix-tester"
+        # is not a valid AgentRole and not a slice shape, so the
+        # enumerator should skip it.
+        unrelated_id = "issue-99-worktree-fix-tester"
+        _make_repo(tmp_path / unrelated_id / "repo", f"egg/{unrelated_id}/work")
+        with patch("agent_salvage.WORKTREE_BASE_DIR", tmp_path):
+            wts = enumerate_agent_worktrees("issue-99")
+        assert wts == []
+
+    def test_skips_dir_without_git_marker(self, tmp_path: Path) -> None:
+        (tmp_path / "issue-99-coder" / "repo").mkdir(parents=True)
+        with patch("agent_salvage.WORKTREE_BASE_DIR", tmp_path):
+            wts = enumerate_agent_worktrees("issue-99")
+        assert wts == []
+
+    def test_returns_empty_when_base_dir_missing(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does-not-exist"
+        with patch("agent_salvage.WORKTREE_BASE_DIR", missing):
+            assert enumerate_agent_worktrees("issue-99") == []
+
+
+# ---------------------------------------------------------------------------
+# list_unpushed_commits
+# ---------------------------------------------------------------------------
+
+
+class TestListUnpushedCommits:
+    def test_no_local_branch(self, tmp_path: Path) -> None:
+        # repo on 'main', no egg/.../work branch — nothing to salvage.
+        repo = tmp_path / "issue-99-coder" / "repo"
+        _make_repo(repo, "main")
+        wt = AgentWorktree(
+            worktree_id="issue-99-coder",
+            pipeline_id="issue-99",
+            agent_role="coder",
+            slice_id=None,
+            repo_path=repo,
+            local_branch="egg/issue-99-coder/work",
+        )
+        report = list_unpushed_commits(wt)
+        assert report.error is None
+        assert report.commits == []
+        assert report.assigned_branch is None
+
+    def test_corrupt_worktree(self, tmp_path: Path) -> None:
+        # No .git anywhere
+        repo = tmp_path / "issue-99-coder" / "repo"
+        repo.mkdir(parents=True)
+        wt = AgentWorktree(
+            worktree_id="issue-99-coder",
+            pipeline_id="issue-99",
+            agent_role="coder",
+            slice_id=None,
+            repo_path=repo,
+            local_branch="egg/issue-99-coder/work",
+        )
+        report = list_unpushed_commits(wt)
+        assert report.error is not None
+        assert report.commits == []
+
+    def test_with_anchor_returns_only_unpushed(self, tmp_path: Path) -> None:
+        repo, local_branch = _make_worktree_layout(
+            tmp_path, "issue-99", agent_role="coder", slice_id=None
+        )
+        # Seed commit becomes the anchor (origin/<assigned>).
+        anchor_sha = _git("rev-parse", "HEAD", cwd=repo).stdout.strip()
+        _set_assigned_branch(repo, local_branch, "egg/issue-99/work")
+        _create_remote_tracking(repo, "egg/issue-99/work", anchor_sha)
+
+        # Two new local-only commits.
+        sha1 = _commit(repo, "a.txt", "a\n", "first salvage commit")
+        sha2 = _commit(repo, "b.txt", "b\n", "second salvage commit")
+
+        wt = AgentWorktree(
+            worktree_id="issue-99-coder",
+            pipeline_id="issue-99",
+            agent_role="coder",
+            slice_id=None,
+            repo_path=repo,
+            local_branch=local_branch,
+        )
+        report = list_unpushed_commits(wt)
+        assert report.error is None
+        assert report.assigned_branch == "egg/issue-99/work"
+        assert report.anchor_ref == "refs/remotes/origin/egg/issue-99/work"
+        # git log is newest-first.
+        shas = [c.sha for c in report.commits]
+        assert shas == [sha2, sha1]
+        for c in report.commits:
+            assert c.author == "Tester"
+            assert c.files_changed == 1
+
+    def test_falls_back_to_base_branch_anchor(self, tmp_path: Path) -> None:
+        repo, local_branch = _make_worktree_layout(
+            tmp_path, "issue-99", agent_role="coder", slice_id=None
+        )
+        anchor_sha = _git("rev-parse", "HEAD", cwd=repo).stdout.strip()
+        # No assigned-branch tracking ref. Base-branch tracking only.
+        _create_remote_tracking(repo, "main", anchor_sha)
+        _commit(repo, "a.txt", "a\n", "post-anchor")
+        wt = AgentWorktree(
+            worktree_id="issue-99-coder",
+            pipeline_id="issue-99",
+            agent_role="coder",
+            slice_id=None,
+            repo_path=repo,
+            local_branch=local_branch,
+        )
+        report = list_unpushed_commits(wt, base_branch="main")
+        assert report.anchor_ref == "refs/remotes/origin/main"
+        assert len(report.commits) == 1
+        assert report.commits[0].summary == "post-anchor"
+
+    def test_no_anchor_falls_back_to_full_history(self, tmp_path: Path) -> None:
+        repo, local_branch = _make_worktree_layout(
+            tmp_path, "issue-99", agent_role="coder", slice_id=None
+        )
+        _commit(repo, "a.txt", "a\n", "extra")
+        wt = AgentWorktree(
+            worktree_id="issue-99-coder",
+            pipeline_id="issue-99",
+            agent_role="coder",
+            slice_id=None,
+            repo_path=repo,
+            local_branch=local_branch,
+        )
+        report = list_unpushed_commits(wt)  # no base_branch given
+        assert report.anchor_ref is None
+        assert len(report.commits) == 2  # seed + extra
+
+
+# ---------------------------------------------------------------------------
+# salvage_worktree
+# ---------------------------------------------------------------------------
+
+
+class TestSalvageWorktree:
+    def _setup_worktree_with_unpushed(self, tmp_path: Path) -> tuple[AgentWorktree, str, str]:
+        """Build a worktree with one unpushed commit on top of an anchor."""
+        repo, local_branch = _make_worktree_layout(
+            tmp_path, "issue-99", agent_role="coder", slice_id="slice-2"
+        )
+        anchor_sha = _git("rev-parse", "HEAD", cwd=repo).stdout.strip()
+        _set_assigned_branch(repo, local_branch, "egg/issue-99/slice-2")
+        _create_remote_tracking(repo, "egg/issue-99/slice-2", anchor_sha)
+        head_sha = _commit(repo, "a.txt", "a\n", "salvage me")
+        wt = AgentWorktree(
+            worktree_id="issue-99-slice-2-coder",
+            pipeline_id="issue-99",
+            agent_role="coder",
+            slice_id="slice-2",
+            repo_path=repo,
+            local_branch=local_branch,
+        )
+        return wt, anchor_sha, head_sha
+
+    def test_no_unpushed_commits_short_circuits(self, tmp_path: Path) -> None:
+        repo, local_branch = _make_worktree_layout(
+            tmp_path, "issue-99", agent_role="coder", slice_id=None
+        )
+        anchor_sha = _git("rev-parse", "HEAD", cwd=repo).stdout.strip()
+        _set_assigned_branch(repo, local_branch, "egg/issue-99/work")
+        _create_remote_tracking(repo, "egg/issue-99/work", anchor_sha)
+        wt = AgentWorktree(
+            worktree_id="issue-99-coder",
+            pipeline_id="issue-99",
+            agent_role="coder",
+            slice_id=None,
+            repo_path=repo,
+            local_branch=local_branch,
+        )
+        gateway = MagicMock()
+        result = salvage_worktree(gateway, wt)
+        assert result.ok is True
+        assert result.n_commits == 0
+        assert result.recovery_ref is None
+        gateway.push_worktree_branch.assert_not_called()
+
+    def test_pushes_to_recovery_ref(self, tmp_path: Path) -> None:
+        wt, _, head_sha = self._setup_worktree_with_unpushed(tmp_path)
+        gateway = MagicMock()
+        gateway.push_worktree_branch.return_value = PushResult(ok=True)
+
+        result = salvage_worktree(gateway, wt, mode="public")
+
+        assert result.ok is True
+        assert result.head_sha == head_sha
+        assert result.n_commits == 1
+        expected_ref = f"{RECOVERY_BRANCH_PREFIX}/issue-99/slice-2-coder/{head_sha[:12]}"
+        assert result.recovery_ref == expected_ref
+
+        gateway.push_worktree_branch.assert_called_once()
+        kwargs = gateway.push_worktree_branch.call_args.kwargs
+        assert kwargs["pipeline_id"] == "issue-99"
+        assert kwargs["repo_path"] == str(wt.repo_path)
+        assert kwargs["branch"] == expected_ref
+        assert kwargs["mode"] == "public"
+        assert kwargs["ref"] is None
+        assert kwargs["force"] is False
+
+    def test_push_failure_returns_not_ok(self, tmp_path: Path) -> None:
+        wt, _, _ = self._setup_worktree_with_unpushed(tmp_path)
+        gateway = MagicMock()
+        gateway.push_worktree_branch.return_value = PushResult(
+            ok=False, category="non_fast_forward", detail="rejected"
+        )
+        result = salvage_worktree(gateway, wt)
+        assert result.ok is False
+        assert result.recovery_ref is None
+        assert result.error is not None
+        assert "non_fast_forward" in result.error
+
+    def test_gateway_exception_returns_not_ok(self, tmp_path: Path) -> None:
+        wt, _, _ = self._setup_worktree_with_unpushed(tmp_path)
+        gateway = MagicMock()
+        gateway.push_worktree_branch.side_effect = RuntimeError("boom")
+        result = salvage_worktree(gateway, wt)
+        assert result.ok is False
+        assert "boom" in (result.error or "")
+
+    def test_corrupt_worktree_returns_not_ok(self, tmp_path: Path) -> None:
+        repo = tmp_path / "issue-99-coder" / "repo"
+        repo.mkdir(parents=True)  # No .git
+        wt = AgentWorktree(
+            worktree_id="issue-99-coder",
+            pipeline_id="issue-99",
+            agent_role="coder",
+            slice_id=None,
+            repo_path=repo,
+            local_branch="egg/issue-99-coder/work",
+        )
+        gateway = MagicMock()
+        result = salvage_worktree(gateway, wt)
+        assert result.ok is False
+        gateway.push_worktree_branch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# auto_salvage_pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestAutoSalvagePipeline:
+    def test_filters_by_worktree_filter(self, tmp_path: Path) -> None:
+        # Two worktrees on disk; salvage only one via filter.
+        for role in ("coder", "tester"):
+            repo, local_branch = _make_worktree_layout(
+                tmp_path, "issue-99", agent_role=role, slice_id=None
+            )
+            anchor = _git("rev-parse", "HEAD", cwd=repo).stdout.strip()
+            _set_assigned_branch(repo, local_branch, "egg/issue-99/work")
+            _create_remote_tracking(repo, "egg/issue-99/work", anchor)
+            _commit(repo, "x.txt", role, f"unpushed by {role}")
+
+        gateway = MagicMock()
+        gateway.push_worktree_branch.return_value = PushResult(ok=True)
+        with patch("agent_salvage.WORKTREE_BASE_DIR", tmp_path):
+            results = auto_salvage_pipeline(
+                gateway,
+                "issue-99",
+                worktree_filter={"issue-99-coder"},
+            )
+        assert [r.worktree_id for r in results] == ["issue-99-coder"]
+        assert all(r.ok for r in results)
+
+    def test_continues_on_per_worktree_failure(self, tmp_path: Path) -> None:
+        for role in ("coder", "tester"):
+            repo, local_branch = _make_worktree_layout(
+                tmp_path, "issue-99", agent_role=role, slice_id=None
+            )
+            anchor = _git("rev-parse", "HEAD", cwd=repo).stdout.strip()
+            _set_assigned_branch(repo, local_branch, "egg/issue-99/work")
+            _create_remote_tracking(repo, "egg/issue-99/work", anchor)
+            _commit(repo, "x.txt", role, f"unpushed by {role}")
+
+        # First push raises, second succeeds — caller must see both rows.
+        gateway = MagicMock()
+        gateway.push_worktree_branch.side_effect = [
+            RuntimeError("first one explodes"),
+            PushResult(ok=True),
+        ]
+        with patch("agent_salvage.WORKTREE_BASE_DIR", tmp_path):
+            results = auto_salvage_pipeline(gateway, "issue-99")
+        assert len(results) == 2
+        ok_count = sum(1 for r in results if r.ok)
+        # One success, one failure.
+        assert ok_count == 1
+
+    def test_never_raises_on_enumeration_failure(self, tmp_path: Path) -> None:
+        gateway = MagicMock()
+        with patch(
+            "agent_salvage.enumerate_agent_worktrees",
+            side_effect=RuntimeError("disk failure"),
+        ):
+            results = auto_salvage_pipeline(gateway, "issue-99")
+        assert results == []
+
+    def test_empty_pipeline_no_worktrees(self, tmp_path: Path) -> None:
+        gateway = MagicMock()
+        with patch("agent_salvage.WORKTREE_BASE_DIR", tmp_path):
+            results = auto_salvage_pipeline(gateway, "issue-99")
+        assert results == []
+        gateway.push_worktree_branch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# git-log shortstat parser
+# ---------------------------------------------------------------------------
+
+
+class TestParseGitLog:
+    def test_parses_single_commit_with_shortstat(self) -> None:
+        from agent_salvage import _parse_git_log
+
+        out = (
+            "abc1234567890\tfix bug\tAlice\t2026-05-06T10:00:00+00:00\n"
+            "\n"
+            " 3 files changed, 12 insertions(+), 4 deletions(-)\n"
+        )
+        commits = _parse_git_log(out)
+        assert len(commits) == 1
+        c = commits[0]
+        assert c.sha == "abc1234567890"
+        assert c.summary == "fix bug"
+        assert c.author == "Alice"
+        assert c.files_changed == 3
+
+    def test_parses_multiple_commits(self) -> None:
+        from agent_salvage import _parse_git_log
+
+        out = (
+            "sha1\tone\tA\t2026-05-06T10:00:00+00:00\n"
+            "\n"
+            " 1 file changed, 1 insertion(+)\n"
+            "\n"
+            "sha2\ttwo\tB\t2026-05-06T11:00:00+00:00\n"
+            "\n"
+            " 2 files changed, 5 insertions(+)\n"
+        )
+        commits = _parse_git_log(out)
+        assert [c.sha for c in commits] == ["sha1", "sha2"]
+        assert [c.files_changed for c in commits] == [1, 2]
+
+    def test_parses_commit_without_shortstat(self) -> None:
+        from agent_salvage import _parse_git_log
+
+        # Empty/merge commits may have no shortstat line.
+        out = "abc\tempty merge\tBot\t2026-05-06T10:00:00+00:00\n"
+        commits = _parse_git_log(out)
+        assert len(commits) == 1
+        assert commits[0].files_changed == 0
+
+
+# ---------------------------------------------------------------------------
+# Static dataclass smoke tests — ensure public surface didn't drift
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_ref_namespace_constant() -> None:
+    assert RECOVERY_BRANCH_PREFIX == "egg/recovered"
+
+
+def test_salvage_result_ok_with_no_commits_is_short_circuit() -> None:
+    """``ok=True`` + ``recovery_ref=None`` is the canonical "nothing to do" shape."""
+    r = SalvageResult(
+        worktree_id="x",
+        agent_role="coder",
+        slice_id=None,
+        recovery_ref=None,
+        head_sha=None,
+        n_commits=0,
+        ok=True,
+    )
+    assert r.ok and r.recovery_ref is None and r.n_commits == 0
+
+
+def test_unpushed_commit_is_frozen() -> None:
+    c = UnpushedCommit(
+        sha="x",
+        summary="y",
+        author="z",
+        authored_at="2026-05-06",
+        files_changed=1,
+    )
+    with pytest.raises((AttributeError, TypeError)):
+        c.sha = "mutated"  # type: ignore[misc]
+
+
+def test_worktree_commit_report_is_dataclass() -> None:
+    wt = AgentWorktree(
+        worktree_id="w",
+        pipeline_id="p",
+        agent_role="coder",
+        slice_id=None,
+        repo_path=Path("/tmp"),
+        local_branch="egg/w/work",
+    )
+    report = WorktreeCommitReport(
+        worktree=wt,
+        assigned_branch="egg/p/work",
+        anchor_ref=None,
+        commits=[],
+    )
+    assert report.worktree is wt
+    assert report.error is None

--- a/orchestrator/tests/test_agent_salvage.py
+++ b/orchestrator/tests/test_agent_salvage.py
@@ -470,11 +470,17 @@ class TestAutoSalvagePipeline:
 
 
 class TestParseGitLog:
+    # ASCII unit separator (U+001F) — the field separator the production
+    # ``--format`` string uses (`%x1f`). Picked because it cannot appear
+    # in a commit subject, so the parser does not shift on a tab-bearing
+    # subject the way the original ``%x09`` separator did.
+    _US = "\x1f"
+
     def test_parses_single_commit_with_shortstat(self) -> None:
         from agent_salvage import _parse_git_log
 
         out = (
-            "abc1234567890\tfix bug\tAlice\t2026-05-06T10:00:00+00:00\n"
+            f"abc1234567890{self._US}fix bug{self._US}Alice{self._US}2026-05-06T10:00:00+00:00\n"
             "\n"
             " 3 files changed, 12 insertions(+), 4 deletions(-)\n"
         )
@@ -490,11 +496,11 @@ class TestParseGitLog:
         from agent_salvage import _parse_git_log
 
         out = (
-            "sha1\tone\tA\t2026-05-06T10:00:00+00:00\n"
+            f"sha1{self._US}one{self._US}A{self._US}2026-05-06T10:00:00+00:00\n"
             "\n"
             " 1 file changed, 1 insertion(+)\n"
             "\n"
-            "sha2\ttwo\tB\t2026-05-06T11:00:00+00:00\n"
+            f"sha2{self._US}two{self._US}B{self._US}2026-05-06T11:00:00+00:00\n"
             "\n"
             " 2 files changed, 5 insertions(+)\n"
         )
@@ -506,10 +512,34 @@ class TestParseGitLog:
         from agent_salvage import _parse_git_log
 
         # Empty/merge commits may have no shortstat line.
-        out = "abc\tempty merge\tBot\t2026-05-06T10:00:00+00:00\n"
+        out = f"abc{self._US}empty merge{self._US}Bot{self._US}2026-05-06T10:00:00+00:00\n"
         commits = _parse_git_log(out)
         assert len(commits) == 1
         assert commits[0].files_changed == 0
+
+    def test_tab_in_commit_subject_does_not_shift_fields(self) -> None:
+        """Subjects with literal tabs must not bleed into trailing fields.
+
+        Regression test for the original ``%x09`` (tab) separator: a commit
+        whose subject contained a tab caused ``str.split('\\t', 3)`` to
+        slice the subject in half and shift author / authored_at. The
+        unit separator (`%x1f`) cannot appear in a subject, so the parser
+        keeps every field intact.
+        """
+        from agent_salvage import _parse_git_log
+
+        subject_with_tab = "fix:\tindentation in helper"
+        out = (
+            f"deadbeef{self._US}{subject_with_tab}{self._US}Alice"
+            f"{self._US}2026-05-06T10:00:00+00:00\n"
+        )
+        commits = _parse_git_log(out)
+        assert len(commits) == 1
+        c = commits[0]
+        assert c.sha == "deadbeef"
+        assert c.summary == subject_with_tab
+        assert c.author == "Alice"
+        assert c.authored_at == "2026-05-06T10:00:00+00:00"
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_cancel_async_cleanup.py
+++ b/orchestrator/tests/test_cancel_async_cleanup.py
@@ -135,7 +135,7 @@ class TestAsyncCleanupOnCancel:
         cleanup_started = threading.Event()
         cleanup_can_finish = threading.Event()
 
-        def slow_cleanup(pipeline_id, force=False, preserve_worktrees=False):
+        def slow_cleanup(pipeline_id, force=False, preserve_worktrees=False, **kwargs):
             cleanup_started.set()
             # Block until we allow it to finish (simulates slow Docker cleanup)
             cleanup_can_finish.wait(timeout=10)
@@ -164,7 +164,11 @@ class TestAsyncCleanupOnCancel:
 
         # Verify cleanup was actually called (in the background)
         mock_spawner.cleanup_pipeline.assert_called_once_with(
-            "test-pipeline", force=True, preserve_worktrees=True
+            "test-pipeline",
+            force=True,
+            preserve_worktrees=True,
+            salvage_mode="public",
+            salvage_base_branch=None,
         )
 
     @patch("routes.pipelines.get_decision_queue")
@@ -222,7 +226,7 @@ class TestAsyncCleanupOnCancel:
 
         mock_spawner = MagicMock()
 
-        def cleanup_with_signal(pipeline_id, force=False, preserve_worktrees=False):
+        def cleanup_with_signal(pipeline_id, force=False, preserve_worktrees=False, **kwargs):
             cleanup_done.set()
             return 2
 
@@ -245,7 +249,11 @@ class TestAsyncCleanupOnCancel:
         # Verify FAILED pipelines do NOT preserve worktrees
         assert cleanup_done.wait(timeout=5), "Background cleanup was never called"
         mock_spawner.cleanup_pipeline.assert_called_once_with(
-            "test-pipeline", force=True, preserve_worktrees=False
+            "test-pipeline",
+            force=True,
+            preserve_worktrees=False,
+            salvage_mode="public",
+            salvage_base_branch=None,
         )
 
     @patch("routes.pipelines.get_decision_queue")
@@ -298,7 +306,7 @@ class TestAsyncCleanupOnCancel:
 
         cleanup_completed = threading.Event()
 
-        def cleanup_with_signal(pipeline_id, force=False, preserve_worktrees=False):
+        def cleanup_with_signal(pipeline_id, force=False, preserve_worktrees=False, **kwargs):
             time.sleep(0.1)  # Simulate some work
             cleanup_completed.set()
             return 4
@@ -320,7 +328,11 @@ class TestAsyncCleanupOnCancel:
         # Wait for background cleanup to complete
         assert cleanup_completed.wait(timeout=5), "Background cleanup did not run to completion"
         mock_spawner.cleanup_pipeline.assert_called_once_with(
-            "test-pipeline", force=True, preserve_worktrees=True
+            "test-pipeline",
+            force=True,
+            preserve_worktrees=True,
+            salvage_mode="public",
+            salvage_base_branch=None,
         )
 
     @patch("routes.pipelines.get_decision_queue")
@@ -387,7 +399,7 @@ class TestAsyncCleanupOnCancel:
 
         error_raised = threading.Event()
 
-        def cleanup_that_raises(pipeline_id, force=False, preserve_worktrees=False):
+        def cleanup_that_raises(pipeline_id, force=False, preserve_worktrees=False, **kwargs):
             error_raised.set()
             raise RuntimeError("Docker daemon unavailable")
 
@@ -523,7 +535,7 @@ class TestCleanupBackgroundThreadBehavior:
 
         cleanup_done = threading.Event()
 
-        def cleanup_with_signal(pipeline_id, force=False, preserve_worktrees=False):
+        def cleanup_with_signal(pipeline_id, force=False, preserve_worktrees=False, **kwargs):
             cleanup_done.set()
             return 2
 
@@ -546,7 +558,11 @@ class TestCleanupBackgroundThreadBehavior:
 
         # Verify the correct pipeline_id was passed
         mock_spawner.cleanup_pipeline.assert_called_once_with(
-            "specific-pipeline-123", force=True, preserve_worktrees=True
+            "specific-pipeline-123",
+            force=True,
+            preserve_worktrees=True,
+            salvage_mode="public",
+            salvage_base_branch=None,
         )
 
     @patch("routes.pipelines.get_decision_queue")
@@ -570,7 +586,7 @@ class TestCleanupBackgroundThreadBehavior:
 
         cleanup_called = threading.Event()
 
-        def cleanup_raises_docker_error(pipeline_id, force=False, preserve_worktrees=False):
+        def cleanup_raises_docker_error(pipeline_id, force=False, preserve_worktrees=False, **kwargs):
             cleanup_called.set()
             raise DockerException("Container not found")
 

--- a/orchestrator/tests/test_cancel_async_cleanup.py
+++ b/orchestrator/tests/test_cancel_async_cleanup.py
@@ -586,7 +586,9 @@ class TestCleanupBackgroundThreadBehavior:
 
         cleanup_called = threading.Event()
 
-        def cleanup_raises_docker_error(pipeline_id, force=False, preserve_worktrees=False, **kwargs):
+        def cleanup_raises_docker_error(
+            pipeline_id, force=False, preserve_worktrees=False, **kwargs
+        ):
             cleanup_called.set()
             raise DockerException("Container not found")
 

--- a/orchestrator/tests/test_kubernetes_spawner_salvage.py
+++ b/orchestrator/tests/test_kubernetes_spawner_salvage.py
@@ -1,0 +1,152 @@
+"""Verify cleanup_pipeline auto-salvages before deleting worktrees (#2429)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def mock_k8s_client():
+    from kubernetes_client import PodNotFoundError
+    from models import ContainerInfo, ContainerStatus
+
+    client = MagicMock()
+    client.delete_job.side_effect = PodNotFoundError("No existing job")
+    client.list_containers.return_value = []
+    client.remove_container.return_value = None
+    client.create_container.return_value = ContainerInfo(
+        container_id="uid-x",
+        container_name="egg-x",
+        job_name="egg-x",
+        status=ContainerStatus.PENDING,
+    )
+    return client
+
+
+class _FakeWorktreeResult:
+    def __init__(self, **kwargs):
+        self.worktrees = kwargs.get("worktrees", {})
+        self.errors = kwargs.get("errors", [])
+        self.success = kwargs.get("success", True)
+
+
+class _FakeGatewayHealth:
+    healthy = True
+    details = ""
+
+
+class _FakeSessionInfo:
+    container_id = "x"
+    session_token = "tok"
+    container_ip = "127.0.0.1"
+
+
+class _FakeGatewayError(Exception):
+    pass
+
+
+@pytest.fixture()
+def mock_gateway():
+    gw = MagicMock()
+    gw.check_health.return_value = _FakeGatewayHealth()
+    gw.register_session.return_value = _FakeSessionInfo()
+    gw.delete_session.return_value = True
+    gw.delete_session_by_container.return_value = True
+    gw.create_worktrees.return_value = _FakeWorktreeResult()
+    gw.delete_worktrees.return_value = _FakeWorktreeResult(worktrees={})
+    return gw
+
+
+@pytest.fixture()
+def spawner(mock_k8s_client, mock_gateway):
+    from kubernetes_spawner import KubernetesSpawner
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "gateway_client": MagicMock(
+                GatewayClient=MagicMock,
+                GatewayError=_FakeGatewayError,
+                SessionInfo=_FakeSessionInfo,
+                get_gateway_client=MagicMock(return_value=mock_gateway),
+            ),
+        },
+    ):
+        return KubernetesSpawner(k8s_client=mock_k8s_client, gateway_client=mock_gateway)
+
+
+class TestCleanupSalvageHook:
+    def test_salvage_runs_before_worktree_deletion(self, spawner, mock_gateway):
+        """auto_salvage_pipeline is invoked before any delete_worktrees call."""
+        call_order: list[str] = []
+
+        def fake_salvage(*_args, **_kwargs):
+            call_order.append("salvage")
+            return []
+
+        def fake_delete(*_args, **_kwargs):
+            call_order.append("delete")
+            return _FakeWorktreeResult(worktrees={})
+
+        mock_gateway.delete_worktrees.side_effect = fake_delete
+
+        with (
+            patch("agent_salvage.auto_salvage_pipeline", side_effect=fake_salvage),
+            patch(
+                "kubernetes_spawner.WORKTREE_BASE_DIR",
+                MagicMock(exists=MagicMock(return_value=False)),
+            ),
+        ):
+            spawner.cleanup_pipeline("pipe-1")
+
+        # Salvage must come before any deletion.
+        assert "salvage" in call_order
+        if "delete" in call_order:
+            assert call_order.index("salvage") < call_order.index("delete")
+
+    def test_salvage_failure_does_not_block_deletion(self, spawner, mock_gateway):
+        """A salvage exception logs and continues — worktrees are still deleted."""
+        with (
+            patch(
+                "agent_salvage.auto_salvage_pipeline",
+                side_effect=RuntimeError("salvage exploded"),
+            ),
+            patch(
+                "kubernetes_spawner.WORKTREE_BASE_DIR",
+                MagicMock(exists=MagicMock(return_value=False)),
+            ),
+        ):
+            # Must not raise.
+            spawner.cleanup_pipeline("pipe-1")
+        # delete_worktrees still called for the pipeline-level worktree id.
+        mock_gateway.delete_worktrees.assert_any_call(container_id="pipe-1", force=True)
+
+    def test_salvage_skipped_when_preserve_worktrees(self, spawner, mock_gateway):
+        """preserve_worktrees=True takes the early-return; no salvage attempted."""
+        with patch("agent_salvage.auto_salvage_pipeline") as mock_salvage:
+            spawner.cleanup_pipeline("pipe-1", preserve_worktrees=True)
+        mock_salvage.assert_not_called()
+        mock_gateway.delete_worktrees.assert_not_called()
+
+    def test_salvage_filter_includes_pipeline_level_id(self, spawner, mock_gateway):
+        """The salvage filter receives the same set used for deletion."""
+        captured: dict[str, object] = {}
+
+        def fake_salvage(_gateway, pipeline_id, *, worktree_filter=None, **_kw):
+            captured["pipeline_id"] = pipeline_id
+            captured["filter"] = worktree_filter
+            return []
+
+        with (
+            patch("agent_salvage.auto_salvage_pipeline", side_effect=fake_salvage),
+            patch(
+                "kubernetes_spawner.WORKTREE_BASE_DIR",
+                MagicMock(exists=MagicMock(return_value=False)),
+            ),
+        ):
+            spawner.cleanup_pipeline("pipe-1")
+        assert captured["pipeline_id"] == "pipe-1"
+        # At minimum, the pipeline-level worktree id is in scope for salvage.
+        assert "pipe-1" in (captured["filter"] or set())

--- a/orchestrator/tests/test_kubernetes_spawner_salvage.py
+++ b/orchestrator/tests/test_kubernetes_spawner_salvage.py
@@ -150,3 +150,59 @@ class TestCleanupSalvageHook:
         assert captured["pipeline_id"] == "pipe-1"
         # At minimum, the pipeline-level worktree id is in scope for salvage.
         assert "pipe-1" in (captured["filter"] or set())
+
+    def test_salvage_mode_and_base_branch_threaded_through(self, spawner, mock_gateway):
+        """``salvage_mode`` / ``salvage_base_branch`` reach the hook (#2429 review).
+
+        Regression test for the blocking review feedback: cleanup_pipeline
+        used to default to ``mode="public"`` for every pipeline, which
+        could silently lose private-mode work the hook is supposed to
+        save. The caller now passes the running-pipeline's mode + base
+        branch.
+        """
+        captured: dict[str, object] = {}
+
+        def fake_salvage(_gateway, _pipeline_id, *, mode=None, base_branch=None, **_kw):
+            captured["mode"] = mode
+            captured["base_branch"] = base_branch
+            return []
+
+        with (
+            patch("agent_salvage.auto_salvage_pipeline", side_effect=fake_salvage),
+            patch(
+                "kubernetes_spawner.WORKTREE_BASE_DIR",
+                MagicMock(exists=MagicMock(return_value=False)),
+            ),
+        ):
+            spawner.cleanup_pipeline(
+                "pipe-1",
+                salvage_mode="private",
+                salvage_base_branch="main",
+            )
+        assert captured["mode"] == "private"
+        assert captured["base_branch"] == "main"
+
+    def test_salvage_mode_omitted_falls_back_to_public(self, spawner, mock_gateway):
+        """``salvage_mode=None`` keeps the historical default (``"public"``).
+
+        Callers that cannot load the Pipeline (legacy in-flight callers)
+        are still safe — only public-repo work, which is the original
+        behavior — because the hook passes no ``mode`` kwarg and
+        ``auto_salvage_pipeline`` defaults to ``"public"``. The contract
+        here is "if ``salvage_mode is None``, ``mode=`` is not forwarded."
+        """
+        captured: dict[str, object] = {}
+
+        def fake_salvage(_gateway, _pipeline_id, *, mode="public", **_kw):
+            captured["mode"] = mode
+            return []
+
+        with (
+            patch("agent_salvage.auto_salvage_pipeline", side_effect=fake_salvage),
+            patch(
+                "kubernetes_spawner.WORKTREE_BASE_DIR",
+                MagicMock(exists=MagicMock(return_value=False)),
+            ),
+        ):
+            spawner.cleanup_pipeline("pipe-1")  # no salvage_mode kwarg
+        assert captured["mode"] == "public"

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -854,6 +854,9 @@ class TestToolRouting:
             "validate_network_isolation",
             "rebuild_and_rollout",
             "get_service_logs",
+            # Agent-salvage tools (#2429)
+            "list_agent_local_commits",
+            "salvage_agent_commits",
         }
         assert tool_names == expected
 

--- a/orchestrator/tests/test_mcp_tools_salvage.py
+++ b/orchestrator/tests/test_mcp_tools_salvage.py
@@ -1,0 +1,173 @@
+"""MCP tool handler tests for list_agent_local_commits / salvage_agent_commits (#2429)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from egg_config.constants import TEST_GATEWAY_PORT
+from mcp_tools import PIPELINE_TOOLS, PipelineToolHandler
+
+
+@pytest.fixture
+def handler():
+    return PipelineToolHandler(
+        orchestrator_url="http://localhost:9849",
+        gateway_url=f"http://test-gateway:{TEST_GATEWAY_PORT}",
+    )
+
+
+class TestSchemaRegistration:
+    def test_both_tools_are_registered(self):
+        names = {t["name"] for t in PIPELINE_TOOLS}
+        assert "list_agent_local_commits" in names
+        assert "salvage_agent_commits" in names
+
+    def test_required_field_is_task_id_only(self):
+        for name in ("list_agent_local_commits", "salvage_agent_commits"):
+            tool = next(t for t in PIPELINE_TOOLS if t["name"] == name)
+            assert tool["inputSchema"]["required"] == ["task_id"]
+
+
+class TestListAgentLocalCommits:
+    def test_no_filter(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {
+                "data": {
+                    "pipeline_id": "issue-99",
+                    "worktrees": [
+                        {
+                            "worktree_id": "issue-99-coder",
+                            "agent_role": "coder",
+                            "slice_id": None,
+                            "commits": [{"sha": "abc", "summary": "x", "files_changed": 1}],
+                            "assigned_branch": "egg/issue-99/work",
+                            "anchor_ref": "refs/remotes/origin/egg/issue-99/work",
+                            "error": None,
+                        }
+                    ],
+                }
+            }
+            result = handler.handle_tool_call(
+                "list_agent_local_commits",
+                {"task_id": "issue-99"},
+            )
+
+        mock_req.assert_called_once_with("/api/v1/pipelines/issue-99/local-commits")
+        assert result["pipeline_id"] == "issue-99"
+        assert result["n_worktrees"] == 1
+        assert result["n_commits"] == 1
+        assert result["worktrees"][0]["agent_role"] == "coder"
+
+    def test_with_role_and_slice_filters(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {"data": {"pipeline_id": "issue-99", "worktrees": []}}
+            handler.handle_tool_call(
+                "list_agent_local_commits",
+                {"task_id": "issue-99", "agent_role": "coder", "slice_id": "slice-2"},
+            )
+        # Query string must contain both filters.
+        url = mock_req.call_args.args[0]
+        assert url.startswith("/api/v1/pipelines/issue-99/local-commits?")
+        assert "agent_role=coder" in url
+        assert "slice_id=slice-2" in url
+
+    def test_url_quotes_task_id(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {"data": {"pipeline_id": "x", "worktrees": []}}
+            handler.handle_tool_call(
+                "list_agent_local_commits",
+                {"task_id": "name with spaces"},
+            )
+        url = mock_req.call_args.args[0]
+        assert "name%20with%20spaces" in url
+
+    def test_request_failure_returns_error(self, handler):
+        with patch.object(handler, "_make_request", side_effect=RuntimeError("down")):
+            result = handler.handle_tool_call(
+                "list_agent_local_commits",
+                {"task_id": "issue-99"},
+            )
+        assert "error" in result
+        assert "down" in result["error"]
+
+
+class TestSalvageAgentCommits:
+    def test_aggregates_response(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {
+                "data": {
+                    "pipeline_id": "issue-99",
+                    "results": [
+                        {
+                            "worktree_id": "issue-99-coder",
+                            "agent_role": "coder",
+                            "slice_id": None,
+                            "recovery_ref": "egg/recovered/issue-99/coder/abc123def456",
+                            "head_sha": "abc123def456",
+                            "n_commits": 3,
+                            "ok": True,
+                            "error": None,
+                        },
+                        {
+                            "worktree_id": "issue-99-tester",
+                            "agent_role": "tester",
+                            "slice_id": None,
+                            "recovery_ref": None,
+                            "head_sha": None,
+                            "n_commits": 0,
+                            "ok": True,
+                            "error": None,
+                        },
+                        {
+                            "worktree_id": "issue-99-documenter",
+                            "agent_role": "documenter",
+                            "slice_id": None,
+                            "recovery_ref": None,
+                            "head_sha": None,
+                            "n_commits": 0,
+                            "ok": False,
+                            "error": "non_fast_forward: rejected",
+                        },
+                    ],
+                }
+            }
+            result = handler.handle_tool_call(
+                "salvage_agent_commits",
+                {"task_id": "issue-99"},
+            )
+
+        # Posted to the salvage endpoint with launcher-auth on the
+        # orchestrator side; the MCP layer just proxies.
+        endpoint = mock_req.call_args.args[0]
+        assert endpoint == "/api/v1/pipelines/issue-99/salvage"
+        method = mock_req.call_args.kwargs.get("method")
+        assert method == "POST"
+
+        assert result["pipeline_id"] == "issue-99"
+        assert result["n_worktrees"] == 3
+        assert result["n_salvaged"] == 1
+        assert result["n_failed"] == 1
+        assert result["recovery_refs"] == [
+            "egg/recovered/issue-99/coder/abc123def456",
+        ]
+
+    def test_with_role_filter(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {"data": {"pipeline_id": "issue-99", "results": []}}
+            handler.handle_tool_call(
+                "salvage_agent_commits",
+                {"task_id": "issue-99", "agent_role": "coder"},
+            )
+        endpoint = mock_req.call_args.args[0]
+        assert endpoint.startswith("/api/v1/pipelines/issue-99/salvage?")
+        assert "agent_role=coder" in endpoint
+
+    def test_request_failure_returns_error(self, handler):
+        with patch.object(handler, "_make_request", side_effect=RuntimeError("boom")):
+            result = handler.handle_tool_call(
+                "salvage_agent_commits",
+                {"task_id": "issue-99"},
+            )
+        assert "error" in result
+        assert "boom" in result["error"]

--- a/orchestrator/tests/test_pipeline_failure_path.py
+++ b/orchestrator/tests/test_pipeline_failure_path.py
@@ -1802,10 +1802,16 @@ class TestSafetyNetContainerCleanup:
         # cleanup_pipeline should have been called as safety net.  When the
         # pipeline ended in FAILED, the caller also passes
         # preserve_worktrees=True so a retry can reuse the worktrees
-        # (#1878).
+        # (#1878).  Salvage kwargs (#2429) are threaded through so the
+        # auto-salvage hook pushes recovery refs under the same gateway
+        # mode the pipeline ran under.
         mock_spawner = mock_get_spawner.return_value
         mock_spawner.cleanup_pipeline.assert_called_with(
-            "issue-42", force=True, preserve_worktrees=True
+            "issue-42",
+            force=True,
+            preserve_worktrees=True,
+            salvage_mode="public",
+            salvage_base_branch=None,
         )
 
 

--- a/orchestrator/tests/test_routes_salvage.py
+++ b/orchestrator/tests/test_routes_salvage.py
@@ -1,0 +1,290 @@
+"""Route-level tests for /local-commits and /salvage (#2429)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+from models import Pipeline, PipelinePhase, PipelineStatus
+from routes.pipelines import pipelines_bp
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.register_blueprint(pipelines_bp)
+    app.config["TESTING"] = True
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _make_pipeline(pid: str = "issue-99") -> Pipeline:
+    return Pipeline(
+        id=pid,
+        issue_number=99,
+        repo="owner/repo",
+        branch=f"egg/{pid}/work",
+        base_branch="main",
+        status=PipelineStatus.RUNNING,
+        current_phase=PipelinePhase.IMPLEMENT,
+    )
+
+
+class TestListLocalCommits:
+    def test_returns_404_for_unknown_pipeline(self, client):
+        from state_store import PipelineNotFoundError
+
+        with patch(
+            "routes.pipelines._resolve_pipeline",
+            side_effect=PipelineNotFoundError("missing"),
+        ):
+            resp = client.get("/api/v1/pipelines/missing-pipeline/local-commits")
+        assert resp.status_code == 404
+
+    def test_returns_400_for_invalid_role(self, client):
+        pipeline = _make_pipeline()
+        with patch(
+            "routes.pipelines._resolve_pipeline",
+            return_value=(MagicMock(), pipeline),
+        ):
+            resp = client.get("/api/v1/pipelines/issue-99/local-commits?agent_role=not-a-role")
+        assert resp.status_code == 400
+
+    def test_returns_serialized_reports(self, client):
+        from agent_salvage import (
+            AgentWorktree,
+            UnpushedCommit,
+            WorktreeCommitReport,
+        )
+
+        pipeline = _make_pipeline()
+        wt = AgentWorktree(
+            worktree_id="issue-99-coder",
+            pipeline_id="issue-99",
+            agent_role="coder",
+            slice_id=None,
+            repo_path=Path("/tmp/issue-99-coder/repo"),
+            local_branch="egg/issue-99-coder/work",
+        )
+        report = WorktreeCommitReport(
+            worktree=wt,
+            assigned_branch="egg/issue-99/work",
+            anchor_ref="refs/remotes/origin/egg/issue-99/work",
+            commits=[
+                UnpushedCommit(
+                    sha="abc123def456",
+                    summary="salvageable change",
+                    author="Coder",
+                    authored_at="2026-05-06T10:00:00+00:00",
+                    files_changed=3,
+                )
+            ],
+        )
+
+        with (
+            patch(
+                "routes.pipelines._resolve_pipeline",
+                return_value=(MagicMock(), pipeline),
+            ),
+            patch(
+                "agent_salvage.enumerate_agent_worktrees",
+                return_value=[wt],
+            ),
+            patch(
+                "agent_salvage.list_unpushed_commits",
+                return_value=report,
+            ),
+        ):
+            resp = client.get("/api/v1/pipelines/issue-99/local-commits")
+        assert resp.status_code == 200, resp.data
+        body = resp.get_json()
+        assert body["success"] is True
+        data = body["data"]
+        assert data["pipeline_id"] == "issue-99"
+        assert len(data["worktrees"]) == 1
+        wt_data = data["worktrees"][0]
+        assert wt_data["agent_role"] == "coder"
+        assert wt_data["assigned_branch"] == "egg/issue-99/work"
+        assert wt_data["commits"][0]["sha"] == "abc123def456"
+        assert wt_data["commits"][0]["files_changed"] == 3
+
+    def test_filters_by_agent_role_and_slice(self, client):
+        from agent_salvage import AgentWorktree
+
+        pipeline = _make_pipeline()
+        wts = [
+            AgentWorktree(
+                worktree_id="issue-99-coder",
+                pipeline_id="issue-99",
+                agent_role="coder",
+                slice_id=None,
+                repo_path=Path("/tmp/c"),
+                local_branch="egg/issue-99-coder/work",
+            ),
+            AgentWorktree(
+                worktree_id="issue-99-slice-2-coder",
+                pipeline_id="issue-99",
+                agent_role="coder",
+                slice_id="slice-2",
+                repo_path=Path("/tmp/sc"),
+                local_branch="egg/issue-99-slice-2-coder/work",
+            ),
+            AgentWorktree(
+                worktree_id="issue-99-tester",
+                pipeline_id="issue-99",
+                agent_role="tester",
+                slice_id=None,
+                repo_path=Path("/tmp/t"),
+                local_branch="egg/issue-99-tester/work",
+            ),
+        ]
+        seen: list[str] = []
+
+        def fake_list(wt, base_branch=None):
+            from agent_salvage import WorktreeCommitReport
+
+            seen.append(wt.worktree_id)
+            return WorktreeCommitReport(
+                worktree=wt,
+                assigned_branch=None,
+                anchor_ref=None,
+                commits=[],
+            )
+
+        with (
+            patch(
+                "routes.pipelines._resolve_pipeline",
+                return_value=(MagicMock(), pipeline),
+            ),
+            patch("agent_salvage.enumerate_agent_worktrees", return_value=wts),
+            patch("agent_salvage.list_unpushed_commits", side_effect=fake_list),
+        ):
+            resp = client.get(
+                "/api/v1/pipelines/issue-99/local-commits?agent_role=coder&slice_id=slice-2"
+            )
+        assert resp.status_code == 200, resp.data
+        # Only the slice-2 coder worktree should have been inspected.
+        assert seen == ["issue-99-slice-2-coder"]
+
+
+class TestSalvagePipeline:
+    def test_returns_404_for_unknown_pipeline(self, client):
+        from state_store import PipelineNotFoundError
+
+        with patch(
+            "routes.pipelines._resolve_pipeline",
+            side_effect=PipelineNotFoundError("missing"),
+        ):
+            resp = client.post("/api/v1/pipelines/missing-pipeline/salvage")
+        assert resp.status_code == 404
+
+    def test_aggregates_per_worktree_results(self, client):
+        from agent_salvage import AgentWorktree, SalvageResult
+
+        pipeline = _make_pipeline()
+        wts = [
+            AgentWorktree(
+                worktree_id="issue-99-coder",
+                pipeline_id="issue-99",
+                agent_role="coder",
+                slice_id=None,
+                repo_path=Path("/tmp/c"),
+                local_branch="egg/issue-99-coder/work",
+            ),
+            AgentWorktree(
+                worktree_id="issue-99-tester",
+                pipeline_id="issue-99",
+                agent_role="tester",
+                slice_id=None,
+                repo_path=Path("/tmp/t"),
+                local_branch="egg/issue-99-tester/work",
+            ),
+        ]
+
+        def fake_salvage(_gw, wt, base_branch=None, mode="public"):
+            if wt.agent_role == "coder":
+                return SalvageResult(
+                    worktree_id=wt.worktree_id,
+                    agent_role=wt.agent_role,
+                    slice_id=wt.slice_id,
+                    recovery_ref=(f"egg/recovered/issue-99/{wt.scope_label}/abc123def456"),
+                    head_sha="abc123def456",
+                    n_commits=2,
+                    ok=True,
+                )
+            return SalvageResult(
+                worktree_id=wt.worktree_id,
+                agent_role=wt.agent_role,
+                slice_id=wt.slice_id,
+                recovery_ref=None,
+                head_sha=None,
+                n_commits=0,
+                ok=True,
+            )
+
+        with (
+            patch(
+                "routes.pipelines._resolve_pipeline",
+                return_value=(MagicMock(), pipeline),
+            ),
+            patch("routes.pipelines.get_gateway_client", return_value=MagicMock()),
+            patch("agent_salvage.enumerate_agent_worktrees", return_value=wts),
+            patch("agent_salvage.salvage_worktree", side_effect=fake_salvage),
+        ):
+            resp = client.post("/api/v1/pipelines/issue-99/salvage")
+
+        assert resp.status_code == 200, resp.data
+        data = resp.get_json()["data"]
+        assert data["pipeline_id"] == "issue-99"
+        assert len(data["results"]) == 2
+        coder_result = next(r for r in data["results"] if r["agent_role"] == "coder")
+        assert coder_result["recovery_ref"] == ("egg/recovered/issue-99/coder/abc123def456")
+        tester_result = next(r for r in data["results"] if r["agent_role"] == "tester")
+        assert tester_result["recovery_ref"] is None
+
+    def test_per_worktree_exception_is_captured_in_results(self, client):
+        from agent_salvage import AgentWorktree
+
+        pipeline = _make_pipeline()
+        wt = AgentWorktree(
+            worktree_id="issue-99-coder",
+            pipeline_id="issue-99",
+            agent_role="coder",
+            slice_id=None,
+            repo_path=Path("/tmp/c"),
+            local_branch="egg/issue-99-coder/work",
+        )
+        with (
+            patch(
+                "routes.pipelines._resolve_pipeline",
+                return_value=(MagicMock(), pipeline),
+            ),
+            patch("routes.pipelines.get_gateway_client", return_value=MagicMock()),
+            patch("agent_salvage.enumerate_agent_worktrees", return_value=[wt]),
+            patch(
+                "agent_salvage.salvage_worktree",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            resp = client.post("/api/v1/pipelines/issue-99/salvage")
+        assert resp.status_code == 200
+        data = resp.get_json()["data"]
+        assert len(data["results"]) == 1
+        result = data["results"][0]
+        assert result["ok"] is False
+        assert "boom" in (result["error"] or "")
+
+    def test_invalid_slice_id_returns_400(self, client):
+        pipeline = _make_pipeline()
+        with patch(
+            "routes.pipelines._resolve_pipeline",
+            return_value=(MagicMock(), pipeline),
+        ):
+            resp = client.post("/api/v1/pipelines/issue-99/salvage?slice_id=not-a-slice")
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary

Closes #2429.

When an agent's pushes are wedged (gateway branch-allowlist rejection per #2428, restart-reconciliation false-failures per #2411, etc.), the orchestrator's per-agent worktree still holds the work on `egg/{worktree_id}/work` — but `cleanup_pipeline` later deletes the worktree and the work is silently lost. This PR makes the default cleanup policy "push to a recovery ref, *then* delete" so salvageable work is always reachable from origin before filesystem state is gone.

- **`orchestrator/agent_salvage.py`** — pure-function helpers: enumerate per-agent worktrees, list unpushed commits via `git log {local_branch} ^origin/{assigned_branch}` (with `^origin/{base_branch}` fallback, no fetch), and push HEAD to `egg/recovered/{pipeline}/{scope}/{short_sha}` via the gateway's launcher-auth path. Launcher auth bypasses the agent-targeted branch-allowlist check that originally rejected the push, so this works even when the agent's own pushes were the thing that wedged.
- **REST**: `GET /api/v1/pipelines/<id>/local-commits` (read-only) and `POST /api/v1/pipelines/<id>/salvage` (write), both with optional `agent_role` / `slice_id` filters. Per-worktree result rows mean a failure on one worktree never blocks others.
- **MCP**: `list_agent_local_commits` and `salvage_agent_commits` verbs proxy through the orchestrator HTTP API.
- **Auto-salvage hook** in `kubernetes_spawner.cleanup_pipeline` runs before worktree deletion. Best-effort: failures log and continue; `preserve_worktrees=True` skips it (worktree survives, no need to mirror it).

Recovery refs embed the HEAD short SHA so re-salvages produce immutable refs instead of force-overwriting earlier ones. The orchestrator never deletes `egg/recovered/*` refs — operators clean up after replay.

### Reframe vs. the issue's strawman

The issue proposed cherry-picking commits *from inside the agent's running container* via a new exec primitive. Investigation showed that's misframed: agent commits land in the orchestrator-side worktree (`/home/egg/.egg-worktrees/{worktree_id}/{repo_short}`), not the container's filesystem. The orchestrator already owns those worktrees and can read / push them directly via `gateway.push_worktree_branch` with launcher auth — no `kubectl exec`, no new container access surface. This is materially simpler than the strawman and is what the PR implements.

The issue's `redirect_pending_push` (re-target a wedged push to a different branch) is intentionally deferred — that's a workaround for branch-resolution bugs (#2428 / #2403), better fixed at the source.

## Recovery workflow

```bash
# Find every recovery ref for a pipeline
git ls-remote origin 'refs/heads/egg/recovered/<pipeline-id>/*'

# Fetch and replay onto the intended branch (cherry-pick dedupes already-pushed commits)
git fetch origin egg/recovered/<pipeline-id>/<scope>/<short-sha>:recovered/<scope>
git switch <target-branch>
git cherry-pick <recovered-base>..recovered/<scope>
```

## Test plan

- [x] `make lint` clean
- [x] 50 new tests across four suites, covering:
  - Enumeration: pipeline-level, per-role, slice-scoped worktrees + the #1865 shared-prefix protection
  - Unpushed-commit listing: `origin/<assigned>` anchor, `origin/<base>` fallback, no-anchor full-HEAD fallback, missing local branch, corrupt worktree
  - Salvage: short-circuit on no-commits, push success, push failure, gateway exception, corrupt worktree
  - Auto-salvage: `worktree_filter`, exception isolation, never-raises invariant
  - Cleanup hook: salvage runs before any `delete_worktrees` call, salvage failure does not block deletion, `preserve_worktrees=True` skips it
  - MCP verbs: schema, dispatch, query-string filter wiring, request-failure path
  - Routes: 404 / 400 paths, JSON serialization, agent-role + slice-id filtering, per-worktree exception capture
- [ ] Full `make test-all` run (deferred — would benefit from cluster-aware sanity check; salvage code paths are well-covered by the unit suite, and auto-salvage is best-effort by design)
- [ ] Operator dry run on a wedged-push reproduction in a dev pipeline before relying on auto-salvage in production