### PR TITLE
Fix #2430: bypass alive-signal gate for overseer silence

### DIFF
--- a/docs/guides/pipeline-health-monitoring.md
+++ b/docs/guides/pipeline-health-monitoring.md
@@ -242,6 +242,8 @@ If a peer signal is found within the window, the alert is deferred. The deferral
 
 **Setting `orchestrator_alert_progress_gate_seconds = 0` disables the peer-progress gate.** (#2242)
 
+**Caveat — overseer carve-out:** Both gates are skipped when the focal agent is the overseer (`agent_id == "overseer"`). The overseer is the platform's watchdog, so its silence is the signal that most needs to surface — without the carve-out, a healthy BRC roster's peer heartbeats would defer overseer escalations indefinitely. Repro from `issue-2261-v9`: overseer silent for 27+ minutes past threshold while every poll deferred with `reason="peer heartbeat 18s ago"`. Symmetrically, escalations *about* the overseer are routed to HITL rather than to the overseer itself — you cannot escalate a silent watchdog to itself. (#2430)
+
 ### Branch-Divergence Detection
 
 When a pipeline's branch absorbs merged-main commits (the contamination shape investigated in #2222), the resulting PR shows a diff against main that includes unrelated merged work. The branch-divergence detector catches this at phase-boundary granularity — strictly better than detecting at PR open, but complementary to the primary gate in #2282.

--- a/orchestrator/health_monitor.py
+++ b/orchestrator/health_monitor.py
@@ -72,6 +72,12 @@ ThrottleCallback = Callable[[dict[str, Any]], None]
 # float counts as never-seen. See `_has_recent_activity` (#2190).
 _NEVER_SEEN_ACTIVITY: float = 0.0
 
+# Canonical agent_id for the overseer. The watchdog's silence is the signal
+# we most need to surface, so the alive-signal gates and the escalation
+# router both special-case it. Matches AgentRole.OVERSEER.value but kept
+# literal here to avoid pulling shared/egg_contracts into health_monitor.
+_OVERSEER_AGENT_ID: str = "overseer"
+
 
 @dataclass
 class AgentState:
@@ -701,18 +707,23 @@ class HealthMonitor:
             # catches the case where the broader pipeline is clearly alive
             # via BRC bus signals or peer heartbeats. Don't set
             # heartbeat_escalated on defer — the next poll re-checks.
-            defer, gate_reason = self._has_recent_activity(agent_id, now)
-            if not defer:
-                defer, gate_reason = self._has_recent_peer_progress(agent_id, now)
-            if defer:
-                logger.info(
-                    "Heartbeat alert deferred by alive-signal gate",
-                    pipeline_id=self._pipeline_id,
-                    agent_id=agent_id,
-                    elapsed_seconds=int(elapsed),
-                    reason=gate_reason,
-                )
-                continue
+            #
+            # Overseer exemption (#2430): the watchdog's silence is the
+            # signal regardless of peer activity. Without this, a healthy
+            # BRC roster defers overseer escalations indefinitely.
+            if agent_id != _OVERSEER_AGENT_ID:
+                defer, gate_reason = self._has_recent_activity(agent_id, now)
+                if not defer:
+                    defer, gate_reason = self._has_recent_peer_progress(agent_id, now)
+                if defer:
+                    logger.info(
+                        "Heartbeat alert deferred by alive-signal gate",
+                        pipeline_id=self._pipeline_id,
+                        agent_id=agent_id,
+                        elapsed_seconds=int(elapsed),
+                        reason=gate_reason,
+                    )
+                    continue
 
             action = {
                 "action": "escalate",
@@ -722,7 +733,7 @@ class HealthMonitor:
             }
             actions.append(action)
 
-            escalation_type = "overseer" if self._config.overseer_enabled else "hitl"
+            escalation_type = self._resolve_escalation_target(agent_id)
             escalation = {
                 "type": escalation_type,
                 "agent_id": agent_id,
@@ -800,18 +811,22 @@ class HealthMonitor:
             # Focal-agent activity gate (#2190) OR alive-signal peer-progress
             # gate (#2242): same OR pattern as check_heartbeats — defer when
             # either fires.
-            defer, gate_reason = self._has_recent_activity(agent_id, now)
-            if not defer:
-                defer, gate_reason = self._has_recent_peer_progress(agent_id, now)
-            if defer:
-                logger.info(
-                    "Progress alert deferred by alive-signal gate",
-                    pipeline_id=self._pipeline_id,
-                    agent_id=agent_id,
-                    elapsed_seconds=int(elapsed),
-                    reason=gate_reason,
-                )
-                continue
+            #
+            # Overseer exemption (#2430): see check_heartbeats — the
+            # watchdog's silence must surface even when peers are alive.
+            if agent_id != _OVERSEER_AGENT_ID:
+                defer, gate_reason = self._has_recent_activity(agent_id, now)
+                if not defer:
+                    defer, gate_reason = self._has_recent_peer_progress(agent_id, now)
+                if defer:
+                    logger.info(
+                        "Progress alert deferred by alive-signal gate",
+                        pipeline_id=self._pipeline_id,
+                        agent_id=agent_id,
+                        elapsed_seconds=int(elapsed),
+                        reason=gate_reason,
+                    )
+                    continue
 
             action = {
                 "action": "escalate",
@@ -821,7 +836,7 @@ class HealthMonitor:
             }
             actions.append(action)
 
-            escalation_type = "overseer" if self._config.overseer_enabled else "hitl"
+            escalation_type = self._resolve_escalation_target(agent_id)
             escalation = {
                 "type": escalation_type,
                 "agent_id": agent_id,
@@ -857,9 +872,21 @@ class HealthMonitor:
     # Escalation helpers
     # -----------------------------------------------------------------
 
+    def _resolve_escalation_target(self, agent_id: str) -> str:
+        """Return the escalation route for an alert about ``agent_id``.
+
+        The overseer's own escalations always go to HITL — routing them to
+        the agent that is itself the problem would silently swallow them
+        (#2430). All other agents go to the overseer when enabled, HITL
+        otherwise.
+        """
+        if agent_id == _OVERSEER_AGENT_ID:
+            return "hitl"
+        return "overseer" if self._config.overseer_enabled else "hitl"
+
     def _escalate_error(self, agent_id: str, error_msg: str, count: int) -> None:
         """Escalate repeated identical errors."""
-        escalation_type = "overseer" if self._config.overseer_enabled else "hitl"
+        escalation_type = self._resolve_escalation_target(agent_id)
         escalation = {
             "type": escalation_type,
             "agent_id": agent_id,
@@ -1120,7 +1147,7 @@ class HealthMonitor:
                     timeout_seconds=timeout,
                 )
 
-                escalation_type = "overseer" if self._config.overseer_enabled else "hitl"
+                escalation_type = self._resolve_escalation_target(producer)
                 escalation = {
                     "type": escalation_type,
                     "agent_id": producer,

--- a/orchestrator/tests/test_health_monitor.py
+++ b/orchestrator/tests/test_health_monitor.py
@@ -3258,6 +3258,154 @@ class TestAlertProgressGate:
 
 
 # ---------------------------------------------------------------------------
+# Tests: overseer silence is exempt from the alive-signal gate (issue #2430)
+# ---------------------------------------------------------------------------
+
+
+class TestOverseerSilenceExemption:
+    """Issue #2430: the overseer is the watchdog, so its silence must
+    surface regardless of peer activity. The alive-signal peer-progress
+    gate (#2242) is correct for ordinary BRC agents but inverts the
+    contract for the overseer — a healthy BRC roster would otherwise
+    defer overseer escalations indefinitely. Repro from ``issue-2261-v9``:
+    overseer silent for 27+ minutes past threshold while every poll
+    deferred with ``reason="peer heartbeat 18s ago"``.
+    """
+
+    def test_overseer_heartbeat_alert_fires_despite_peer_heartbeats(self):
+        """Peer heartbeats must NOT defer the overseer's silence alert."""
+        bus = _make_event_bus()
+        config = _make_config(
+            orchestrator_heartbeat_timeout_seconds=60,
+            orchestrator_alert_progress_gate_seconds=300,
+        )
+        monitor = _make_monitor(bus, config)
+
+        base = time.time()
+
+        # Overseer registered at t=base, then silent.
+        _emit_heartbeat(bus, agent_id="overseer")
+
+        # Peer heartbeats steadily — broader pipeline alive.
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 200
+            _emit_heartbeat(bus, agent_id=AGENT_ID)
+            _emit_heartbeat(bus, agent_id=AGENT_ID_2)
+
+        # At t=base+250: overseer silent 250s (>60s threshold). Peer
+        # heartbeats are 50s old — well within the 300s gate. For an
+        # ordinary agent this would defer; the overseer must escalate.
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 250
+            actions = monitor.check_heartbeats()
+
+        overseer_actions = [a for a in actions if a["agent_id"] == "overseer"]
+        assert len(overseer_actions) == 1, (
+            "Overseer silence past threshold must escalate even when peers are heartbeating"
+        )
+
+    def test_overseer_progress_alert_fires_despite_peer_heartbeats(self):
+        """Same exemption applies to the progress-stall path."""
+        bus = _make_event_bus()
+        config = _make_config(
+            orchestrator_heartbeat_timeout_seconds=60,
+            orchestrator_alert_progress_gate_seconds=300,
+        )
+        monitor = _make_monitor(bus, config)
+
+        base = time.time()
+        _emit_progress(bus, agent_id="overseer")
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 200
+            _emit_heartbeat(bus, agent_id=AGENT_ID)
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 250
+            actions = monitor.check_progress()
+
+        overseer_actions = [a for a in actions if a["agent_id"] == "overseer"]
+        assert len(overseer_actions) == 1, (
+            "Overseer progress stall must escalate despite peer heartbeats"
+        )
+
+    def test_overseer_silence_routed_to_hitl_not_self(self):
+        """Escalations about the overseer's own silence must go to HITL —
+        you cannot escalate a silent watchdog to itself.
+        """
+        bus = _make_event_bus()
+        escalations: list[dict] = []
+        config = _make_config(
+            orchestrator_heartbeat_timeout_seconds=60,
+            orchestrator_alert_progress_gate_seconds=300,
+            overseer_enabled=True,
+        )
+        monitor = _make_monitor(bus, config)
+        monitor.on_escalation(escalations.append)
+
+        base = time.time()
+        _emit_heartbeat(bus, agent_id="overseer")
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 250
+            monitor.check_heartbeats()
+
+        overseer_escalations = [e for e in escalations if e["agent_id"] == "overseer"]
+        assert len(overseer_escalations) == 1
+        assert overseer_escalations[0]["type"] == "hitl", (
+            "Overseer self-escalation would be silently dropped — must route to HITL"
+        )
+
+    def test_non_overseer_silence_still_deferred_by_peers(self):
+        """Regression: ordinary agents keep the existing peer-progress gate."""
+        bus = _make_event_bus()
+        config = _make_config(
+            orchestrator_heartbeat_timeout_seconds=60,
+            orchestrator_alert_progress_gate_seconds=300,
+        )
+        monitor = _make_monitor(bus, config)
+
+        base = time.time()
+        _emit_heartbeat(bus, agent_id=AGENT_ID)
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 200
+            _emit_heartbeat(bus, agent_id=AGENT_ID_2)
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 250
+            actions = monitor.check_heartbeats()
+
+        assert actions == [], (
+            "Ordinary agents must still defer when peer heartbeats are within the gate"
+        )
+
+    def test_non_overseer_escalation_still_routes_to_overseer(self):
+        """Regression: non-overseer alerts continue to escalate to the overseer
+        when ``overseer_enabled=True``."""
+        bus = _make_event_bus()
+        escalations: list[dict] = []
+        config = _make_config(
+            orchestrator_heartbeat_timeout_seconds=60,
+            orchestrator_alert_progress_gate_seconds=0,  # disable gate so we isolate routing
+            overseer_enabled=True,
+        )
+        monitor = _make_monitor(bus, config)
+        monitor.on_escalation(escalations.append)
+
+        base = time.time()
+        _emit_heartbeat(bus, agent_id=AGENT_ID)
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 250
+            monitor.check_heartbeats()
+
+        agent_escalations = [e for e in escalations if e["agent_id"] == AGENT_ID]
+        assert len(agent_escalations) == 1
+        assert agent_escalations[0]["type"] == "overseer"
+
+
+# ---------------------------------------------------------------------------
 # Tests: phase-aware post-ACK confirmation timeout (issue #2242)
 # ---------------------------------------------------------------------------
 

--- a/orchestrator/tests/test_health_monitor.py
+++ b/orchestrator/tests/test_health_monitor.py
@@ -3404,6 +3404,67 @@ class TestOverseerSilenceExemption:
         assert len(agent_escalations) == 1
         assert agent_escalations[0]["type"] == "overseer"
 
+    def test_overseer_agent_id_constant_matches_role_enum(self):
+        """Pin the literal in `health_monitor` to `AgentRole.OVERSEER.value`.
+
+        `_OVERSEER_AGENT_ID` is duplicated as a literal to avoid pulling
+        ``shared/egg_contracts`` into the production module. A future rename
+        of ``AgentRole.OVERSEER`` would silently re-introduce #2430 without
+        this guard.
+        """
+        from egg_contracts import AgentRole
+        from health_monitor import _OVERSEER_AGENT_ID
+
+        assert _OVERSEER_AGENT_ID == AgentRole.OVERSEER.value, (
+            "If AgentRole.OVERSEER was renamed, update _OVERSEER_AGENT_ID "
+            "in orchestrator/health_monitor.py to match."
+        )
+
+    def test_escalate_error_routes_overseer_to_hitl(self):
+        """Direct test: `_escalate_error` with ``agent_id='overseer'`` routes
+        to HITL even when ``overseer_enabled=True``.
+
+        Repeated-error alerts reach the same `_resolve_escalation_target`
+        helper as heartbeat/progress alerts; this guards against a future
+        revert that re-introduces the ``overseer_enabled ? overseer : hitl``
+        ternary at the `_escalate_error` call site.
+        """
+        bus = _make_event_bus()
+        escalations: list[dict] = []
+        config = _make_config(
+            overseer_enabled=True,
+            orchestrator_error_repeat_threshold=2,
+        )
+        monitor = _make_monitor(bus, config)
+        monitor.on_escalation(escalations.append)
+
+        monitor._escalate_error("overseer", "watchdog hit an internal error", count=3)
+
+        assert len(escalations) == 1
+        assert escalations[0]["agent_id"] == "overseer"
+        assert escalations[0]["type"] == "hitl", (
+            "Repeated-error alerts about the overseer must route to HITL — "
+            "routing them to the overseer would silently swallow them"
+        )
+
+    def test_escalate_error_routes_non_overseer_to_overseer(self):
+        """Regression companion to the test above: non-overseer
+        ``_escalate_error`` calls still route to the overseer when enabled."""
+        bus = _make_event_bus()
+        escalations: list[dict] = []
+        config = _make_config(
+            overseer_enabled=True,
+            orchestrator_error_repeat_threshold=2,
+        )
+        monitor = _make_monitor(bus, config)
+        monitor.on_escalation(escalations.append)
+
+        monitor._escalate_error(AGENT_ID, "transient db error", count=3)
+
+        assert len(escalations) == 1
+        assert escalations[0]["agent_id"] == AGENT_ID
+        assert escalations[0]["type"] == "overseer"
+
 
 # ---------------------------------------------------------------------------
 # Tests: phase-aware post-ACK confirmation timeout (issue #2242)

--- a/orchestrator/tests/test_health_monitor.py
+++ b/orchestrator/tests/test_health_monitor.py
@@ -3431,10 +3431,7 @@ class TestOverseerSilenceExemption:
         """
         bus = _make_event_bus()
         escalations: list[dict] = []
-        config = _make_config(
-            overseer_enabled=True,
-            orchestrator_error_repeat_threshold=2,
-        )
+        config = _make_config(overseer_enabled=True)
         monitor = _make_monitor(bus, config)
         monitor.on_escalation(escalations.append)
 
@@ -3452,10 +3449,7 @@ class TestOverseerSilenceExemption:
         ``_escalate_error`` calls still route to the overseer when enabled."""
         bus = _make_event_bus()
         escalations: list[dict] = []
-        config = _make_config(
-            overseer_enabled=True,
-            orchestrator_error_repeat_threshold=2,
-        )
+        config = _make_config(overseer_enabled=True)
         monitor = _make_monitor(bus, config)
         monitor.on_escalation(escalations.append)
 


### PR DESCRIPTION
## Summary

The overseer is the platform's watchdog, but the alive-signal peer-progress gate (#2242) silently inverts that contract: as long as any peer is heartbeating, the overseer can be silent indefinitely without escalation. In `issue-2261-v9`, the orchestrator deferred the overseer's heartbeat alert on every poll for ~17 minutes (`elapsed_seconds=1648 reason="peer heartbeat 18s ago"`) before its container actually exited.

This change exempts `agent_id == "overseer"` from both alive-signal gates in `check_heartbeats` and `check_progress`, and routes overseer self-escalations to HITL — they can't be delivered to the silent watchdog.

- `orchestrator/health_monitor.py` — skip the `_has_recent_activity` / `_has_recent_peer_progress` gates for the overseer; new `_resolve_escalation_target` helper centralizes the HITL-fallback so heartbeat / progress / repeated-error / BRC-confirmation timeout sites all behave consistently.
- `orchestrator/tests/test_health_monitor.py` — `TestOverseerSilenceExemption` covers: heartbeat alert fires despite peer heartbeats, progress-stall alert same, escalation routes to HITL, regression for non-overseer deferral, and regression for non-overseer routing to overseer.

Out of scope: the `"You've hit your limit · resets …"` cascade that triggered the v9 container exits. That's a separate concern.

## Test plan

- [ ] `make test orchestrator/tests/test_health_monitor.py::TestOverseerSilenceExemption` passes locally
- [ ] Existing `TestAlertProgressGate` tests still pass (regression for non-overseer deferral)
- [ ] CI green