### PR TITLE
tester: emphasize adversarial bug-hunting alongside regression coverage

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9872,20 +9872,11 @@ def _build_producer_orientation(
                 "being implemented. Check the existing test infrastructure — "
                 "test frameworks, fixtures, conftest files, and naming conventions. "
                 "Identify edge cases from the requirements before writing tests. "
-                "**Your mandate is two-fold**: (a) write comprehensive tests "
-                "that prevent regressions and cover realistic paths, and "
-                "(b) actively hunt for bugs and edge cases the coder missed. "
-                "Treat the coder's implementation as suspect until you have "
-                "tried to break it — write tests that target weak spots, "
-                "boundary conditions, error paths, and contract violations. "
-                "When a test fails because of a coder-side bug, **the "
-                "committed failing test is evidence — the NACK is the bug "
-                "report**. Pair every failing test with an explicit NACK on "
-                "the coder's proposal that names the failing test in its "
-                "rationale; otherwise the bug is easy for the coder to miss. "
-                "Also list the bug in `gaps_found` and HANDOFF to coder with "
-                "the failure output. The coder owns the fix; you own "
-                "surfacing the bug. "
+                "**Your mandate is two-fold**: comprehensive regression "
+                "coverage AND adversarial probing for bugs the coder missed "
+                "— see the *Your Task* → mandate block for the full "
+                "instruction (including the failing-test → NACK → HANDOFF "
+                "workflow when you catch a coder-side bug). "
                 "**Scaffold-first while the coder is producing**: draft test "
                 "scaffolding from the plan alone — test file paths from "
                 "`tasks[].files`, function signatures from each task's acceptance "
@@ -10167,7 +10158,7 @@ def _build_agent_prompt(
                 "paths through every changed area. New behavior gets new tests; "
                 "modified behavior gets updated tests; nothing the coder changed "
                 "should silently lose coverage.",
-                "2. **Adversarial bug-hunting** — actively probe the coder's "
+                "2. **Adversarial probing** — actively probe the coder's "
                 "implementation for bugs and edge cases they missed. Treat the "
                 "implementation as suspect until you have tried to break it. "
                 "Write tests that target suspected weaknesses. When a test "
@@ -10226,7 +10217,11 @@ def _build_agent_prompt(
                 "explicitly naming the failing test in the NACK rationale**. "
                 "The committed test alone is not sufficient — the NACK is "
                 "what surfaces the bug to the coder. Also list the bug in "
-                "`gaps_found` and HANDOFF to the coder with the failure output",
+                "`gaps_found` and HANDOFF to the coder with the failure "
+                "output. Your `test` configured check will fail until the "
+                "coder pushes a fix — that is expected; do NOT propose "
+                "consensus until every configured check passes per the "
+                "*Configured Checks* section below",
                 "6. Commit all test files with descriptive messages",
                 "",
                 "Adversarial probing — actively try to break the implementation:",

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9468,8 +9468,11 @@ _ROLE_DESCRIPTIONS: dict[str, tuple[str, str]] = {
         "commits with source files, tests may be included",
     ),
     "tester": (
-        "Writes and runs tests (dual role: also reviews coder)",
-        "test files, coverage reports, test pass/fail results",
+        "Writes comprehensive regression tests AND adversarially probes the "
+        "coder's implementation for bugs and edge cases (dual role: also "
+        "reviews coder)",
+        "test files (including failing tests that demonstrate bugs), check "
+        "results, gap reports back to the coder",
     ),
     "documenter": (
         "Updates documentation for changes",
@@ -9869,6 +9872,17 @@ def _build_producer_orientation(
                 "being implemented. Check the existing test infrastructure — "
                 "test frameworks, fixtures, conftest files, and naming conventions. "
                 "Identify edge cases from the requirements before writing tests. "
+                "**Your mandate is two-fold**: (a) write comprehensive tests "
+                "that prevent regressions and cover realistic paths, and "
+                "(b) actively hunt for bugs and edge cases the coder missed. "
+                "Treat the coder's implementation as suspect until you have "
+                "tried to break it — write tests that target weak spots, "
+                "boundary conditions, error paths, and contract violations. "
+                "**A failing test IS a bug report**: when you find a bug, "
+                "commit the failing test, list it in `gaps_found`, NACK the "
+                "coder's proposal citing the test, and HANDOFF to coder with "
+                "the failure details. The coder owns the fix; you own "
+                "surfacing the bug. "
                 "**Scaffold-first while the coder is producing**: draft test "
                 "scaffolding from the plan alone — test file paths from "
                 "`tasks[].files`, function signatures from each task's acceptance "
@@ -10143,8 +10157,23 @@ def _build_agent_prompt(
                 "implementation, run checks, and report gaps. If the coder hasn't committed yet, "
                 "wait — do not implement the solution yourself.",
                 "",
-                "Validate the changes and find gaps in the CODER agent's implementation. "
-                "You are responsible for both **testing** and **lint/type-check validation**.",
+                "**Your mandate is two-fold**:",
+                "",
+                "1. **Comprehensive coverage** — write tests that prevent "
+                "regressions, covering the happy path and realistic alternative "
+                "paths through every changed area. New behavior gets new tests; "
+                "modified behavior gets updated tests; nothing the coder changed "
+                "should silently lose coverage.",
+                "2. **Adversarial bug-hunting** — actively probe the coder's "
+                "implementation for bugs and edge cases they missed. Treat the "
+                "implementation as suspect until you have tried to break it. "
+                "Write tests that target suspected weaknesses; **a failing test "
+                "IS a bug report**. Commit the failing test, list it in "
+                "`gaps_found`, NACK the coder's proposal citing the test, and "
+                "HANDOFF to coder with the failure output. The coder owns the "
+                "fix; you own surfacing the bug.",
+                "",
+                "You are also responsible for **lint/type-check validation**.",
                 "",
                 "### When the slice warrants no new tests (#2431)",
                 "",
@@ -10179,17 +10208,33 @@ def _build_agent_prompt(
                 "### Testing",
                 "",
                 "1. Review the changed files (available in handoff data or via git diff)",
-                "2. Identify gaps: missing error handling, boundary conditions, uncovered branches",
-                "3. Write or update tests targeting identified gaps and new/changed code",
-                "4. Run all tests and record which pass and which fail",
-                "5. Document gaps found in your handoff output (`gaps_found` field)",
-                "6. Commit test files with descriptive messages",
+                "2. Build coverage tests for the happy path and realistic "
+                "alternative paths in every changed area",
+                "3. **Adversarially probe** the implementation: identify "
+                "suspected bugs and untested edge cases, then write tests that "
+                "target them",
+                "4. Run all tests. Tests that pass demonstrate coverage; "
+                "**tests that fail demonstrate bugs you have found** — keep them",
+                "5. For every failing test caused by a coder-side bug: commit "
+                "the failing test, list the bug in `gaps_found`, NACK the "
+                "coder's proposal citing the test, and HANDOFF to the coder "
+                "with the failure output",
+                "6. Commit all test files with descriptive messages",
                 "",
-                "Gap-finding focus:",
+                "Adversarial probing — actively try to break the implementation:",
                 "- Missing error handling and input validation",
-                "- Boundary conditions and edge cases",
-                "- Uncovered code paths and branches",
-                "- Integration gaps between components",
+                "- Boundary conditions, off-by-one, empty/null/oversized inputs",
+                "- Uncovered code paths and branches (especially error paths)",
+                "- Concurrency: races, partial failures, retry behavior, ordering assumptions",
+                "- Contract violations: does the code actually match the "
+                "acceptance criteria, or just the happy path of them?",
+                "- Integration gaps between components and unstated interface assumptions",
+                "",
+                "Gap-finding focus (still report these in `gaps_found` even "
+                "when you cannot write a test for them):",
+                "- Logic errors that would require design changes to fix",
+                "- Inconsistencies between the implementation and the plan/contract",
+                "- Missing test infrastructure that prevents adequate coverage",
                 "",
                 "### Configured Checks (MANDATORY)",
                 "",

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9878,10 +9878,13 @@ def _build_producer_orientation(
                 "Treat the coder's implementation as suspect until you have "
                 "tried to break it — write tests that target weak spots, "
                 "boundary conditions, error paths, and contract violations. "
-                "**A failing test IS a bug report**: when you find a bug, "
-                "commit the failing test, list it in `gaps_found`, NACK the "
-                "coder's proposal citing the test, and HANDOFF to coder with "
-                "the failure details. The coder owns the fix; you own "
+                "When a test fails because of a coder-side bug, **the "
+                "committed failing test is evidence — the NACK is the bug "
+                "report**. Pair every failing test with an explicit NACK on "
+                "the coder's proposal that names the failing test in its "
+                "rationale; otherwise the bug is easy for the coder to miss. "
+                "Also list the bug in `gaps_found` and HANDOFF to coder with "
+                "the failure output. The coder owns the fix; you own "
                 "surfacing the bug. "
                 "**Scaffold-first while the coder is producing**: draft test "
                 "scaffolding from the plan alone — test file paths from "
@@ -10167,11 +10170,14 @@ def _build_agent_prompt(
                 "2. **Adversarial bug-hunting** — actively probe the coder's "
                 "implementation for bugs and edge cases they missed. Treat the "
                 "implementation as suspect until you have tried to break it. "
-                "Write tests that target suspected weaknesses; **a failing test "
-                "IS a bug report**. Commit the failing test, list it in "
-                "`gaps_found`, NACK the coder's proposal citing the test, and "
-                "HANDOFF to coder with the failure output. The coder owns the "
-                "fix; you own surfacing the bug.",
+                "Write tests that target suspected weaknesses. When a test "
+                "fails because of a coder-side bug, **the committed failing "
+                "test is evidence — the NACK is the bug report**. Pair every "
+                "failing test with an explicit NACK on the coder's proposal "
+                "that names the failing test in its rationale; otherwise the "
+                "bug is easy for the coder to miss. Also list the bug in "
+                "`gaps_found` and HANDOFF to coder with the failure output. "
+                "The coder owns the fix; you own surfacing the bug.",
                 "",
                 "You are also responsible for **lint/type-check validation**.",
                 "",
@@ -10215,10 +10221,12 @@ def _build_agent_prompt(
                 "target them",
                 "4. Run all tests. Tests that pass demonstrate coverage; "
                 "**tests that fail demonstrate bugs you have found** — keep them",
-                "5. For every failing test caused by a coder-side bug: commit "
-                "the failing test, list the bug in `gaps_found`, NACK the "
-                "coder's proposal citing the test, and HANDOFF to the coder "
-                "with the failure output",
+                "5. For every failing test caused by a coder-side bug: "
+                "commit the failing test AND **NACK the coder's proposal, "
+                "explicitly naming the failing test in the NACK rationale**. "
+                "The committed test alone is not sufficient — the NACK is "
+                "what surfaces the bug to the coder. Also list the bug in "
+                "`gaps_found` and HANDOFF to the coder with the failure output",
                 "6. Commit all test files with descriptive messages",
                 "",
                 "Adversarial probing — actively try to break the implementation:",

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -1600,12 +1600,17 @@ class TestTesterGapFindingPrompts:
     """Tests for tester gap-finding language in prompts."""
 
     def test_tester_prompt_contains_gap_finding_language(self):
-        """Tester prompt includes the dual-mandate framing and adversarial
-        probing focus items.
+        """Tester role-task block includes the dual-mandate framing and
+        adversarial probing focus items.
 
         The mandate has two parts: comprehensive regression coverage AND
-        adversarial bug-hunting that produces failing tests as bug reports
-        back to the coder. Both must surface in the prompt.
+        adversarial probing that produces failing tests as bug reports
+        back to the coder. Both must surface in the role-task block —
+        this test guards the implement-phase tester block in
+        `_build_agent_prompt`. The companion guard
+        `test_tester_orientation_contains_dual_mandate_pointer` covers
+        the orientation-side text; together they detect partial removal
+        across the two locations (review feedback on PR #2450).
         """
         result = _build_agent_prompt(
             role_value="tester",
@@ -1618,18 +1623,24 @@ class TestTesterGapFindingPrompts:
         # Dual mandate framing
         assert "mandate is two-fold" in result
         assert "Comprehensive coverage" in result
-        assert "Adversarial bug-hunting" in result
+        assert "Adversarial probing" in result
         # Failing test must be paired with an explicit NACK that names it —
         # the committed failing test alone is not the bug report.
         assert "the NACK is the bug report" in result
         assert "naming the failing test" in result.lower()
-        # Adversarial probing list
-        assert "Adversarial probing" in result
+        # The role-task probing list AND the testing-step header both use
+        # the "Adversarial probing" wording — count >= 2 protects against
+        # silent drift back to "Adversarial bug-hunting".
+        assert result.count("Adversarial probing") >= 2
         assert "Missing error handling" in result
         assert "Boundary conditions" in result
         assert "Uncovered code paths" in result
         # Untested-but-still-reported gap categories
         assert "Gap-finding focus" in result
+        # Bridge to Configured Checks: the failing-test workflow must
+        # connect to the propose-gate so testers don't propose with a
+        # red `test` check.
+        assert "Configured Checks" in result
 
     def test_phase_prompt_revision_reviewer_only_no_tester_language(self):
         """Phase prompt with reviewer-only feedback uses reviewer-only language."""
@@ -2941,6 +2952,29 @@ class TestAgentRoster:
         assert "unknown_agent" in roster
         assert "Executes assigned role" in roster
 
+    def test_tester_roster_description_signals_adversarial_mandate(self):
+        """The tester's roster description (visible to *every other* agent
+        in the BRC preamble) names the adversarial-probing half of the
+        mandate, not just the dual-role-also-reviews-coder framing.
+
+        Review feedback on PR #2450 noted that the roster description
+        changed from `"Writes and runs tests (dual role: also reviews
+        coder)"` to a longer adversarial-probing description, but no test
+        guarded the new text. Without this assertion, a future
+        well-meaning edit could shorten the description back to the old
+        defensive framing and the cross-agent visibility of the new
+        mandate would silently regress — the coder/reviewer/etc. would
+        stop seeing the adversarial signal in their preamble roster.
+        """
+        roster = _build_agent_roster(["coder", "reviewer_code", "tester"], "coder", "implement")
+        assert "tester" in roster
+        # The roster description names adversarial probing — the key
+        # cross-agent signal that the tester is not just a coverage role.
+        assert "adversarially probes" in roster
+        # And keeps the dual-role disclosure so reviewers/coder still see
+        # that the tester is wearing both hats.
+        assert "dual role" in roster.lower()
+
 
 class TestReviewerPreparation:
     """Tests for _build_reviewer_preparation — proactive prep instructions."""
@@ -3035,6 +3069,37 @@ class TestProducerOrientation:
         # agent has a concrete starting point, not just a mandate.
         assert "tasks[].files" in orient
         assert "acceptance criteria" in orient.lower()
+
+    def test_tester_orientation_contains_dual_mandate_pointer(self):
+        """Tester orientation carries a brief dual-mandate pointer, NOT the
+        full failing-test → NACK → HANDOFF instruction.
+
+        Review feedback on PR #2450 flagged that the dual-mandate paragraph
+        was duplicated nearly verbatim in `_build_producer_orientation` and
+        the implement-phase tester role-task block, so a single-callsite
+        edit could silently drift one copy. The fix keeps the full mandate
+        in the role-task block and trims the orientation copy to a one-line
+        pointer.
+
+        This test guards the trim from creeping back: orientation must
+        carry the brief two-fold signal but must NOT inline the full
+        failing-test → NACK paragraph (which lives in the role-task block,
+        guarded by `test_tester_prompt_contains_gap_finding_language`).
+        """
+        orient = _build_producer_orientation("tester", "implement", [])
+        # Brief two-fold pointer survives in the orientation block.
+        assert "mandate is two-fold" in orient
+        assert "adversarial probing" in orient.lower()
+        # Pointer must direct readers to the role-task block for the full
+        # mandate — preserves the single-source-of-truth for the workflow
+        # detail.
+        assert "Your Task" in orient
+        # The full failing-test → NACK paragraph must NOT be re-inlined in
+        # orientation. If a future edit copies it back, this assertion
+        # catches the drift before the prompt grows duplicated prose.
+        assert "the NACK is the bug report" not in orient
+        assert "naming the failing test" not in orient.lower()
+        assert "HANDOFF to coder" not in orient
 
     def test_tester_orientation_directs_no_op_propose_for_refactor(self):
         """Tester orientation tells tester to use the no-op propose path on

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -1619,8 +1619,10 @@ class TestTesterGapFindingPrompts:
         assert "mandate is two-fold" in result
         assert "Comprehensive coverage" in result
         assert "Adversarial bug-hunting" in result
-        # Failing-test-as-bug-report language
-        assert "a failing test is a bug report" in result.lower()
+        # Failing test must be paired with an explicit NACK that names it —
+        # the committed failing test alone is not the bug report.
+        assert "the NACK is the bug report" in result
+        assert "naming the failing test" in result.lower()
         # Adversarial probing list
         assert "Adversarial probing" in result
         assert "Missing error handling" in result

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -1600,7 +1600,13 @@ class TestTesterGapFindingPrompts:
     """Tests for tester gap-finding language in prompts."""
 
     def test_tester_prompt_contains_gap_finding_language(self):
-        """Tester prompt includes gap-finding focus items."""
+        """Tester prompt includes the dual-mandate framing and adversarial
+        probing focus items.
+
+        The mandate has two parts: comprehensive regression coverage AND
+        adversarial bug-hunting that produces failing tests as bug reports
+        back to the coder. Both must surface in the prompt.
+        """
         result = _build_agent_prompt(
             role_value="tester",
             phase="implement",
@@ -1609,11 +1615,19 @@ class TestTesterGapFindingPrompts:
             prompt="# Feature\n\nDetail.",
             issue_number=1,
         )
-        assert "Validate the changes and find gaps" in result
-        assert "Gap-finding focus" in result
+        # Dual mandate framing
+        assert "mandate is two-fold" in result
+        assert "Comprehensive coverage" in result
+        assert "Adversarial bug-hunting" in result
+        # Failing-test-as-bug-report language
+        assert "a failing test is a bug report" in result.lower()
+        # Adversarial probing list
+        assert "Adversarial probing" in result
         assert "Missing error handling" in result
         assert "Boundary conditions" in result
         assert "Uncovered code paths" in result
+        # Untested-but-still-reported gap categories
+        assert "Gap-finding focus" in result
 
     def test_phase_prompt_revision_reviewer_only_no_tester_language(self):
         """Phase prompt with reviewer-only feedback uses reviewer-only language."""


### PR DESCRIPTION
## Summary

- Reframe the tester agent's mandate from defensive gap-finding to a **two-part mandate**: comprehensive regression coverage AND adversarial probing of the coder's implementation.
- Establish that **a failing test IS a bug report** — when the tester finds a bug, the workflow is: commit the failing test, list it in `gaps_found`, NACK the coder's proposal, HANDOFF with the failure output. The coder owns the fix; the tester owns surfacing the bug.
- Updates land in three places that share the tester role surface: `_ROLE_DESCRIPTIONS["tester"]` (the roster shown to other agents), `_build_producer_orientation` (orientation read while scaffolding), and the implement-phase tester role-task block in `_build_agent_prompt`. Adversarial-probing list is widened (off-by-one, concurrency, contract violations) and an "untested-but-still-reportable" bullet list is added.

## Test plan
- [x] `pytest orchestrator/tests/test_pipeline_prompts.py` — 317 passed
- [x] `test_tester_prompt_contains_gap_finding_language` updated to assert on the new dual-mandate, adversarial-probing, and "a failing test is a bug report" language
- [ ] Watch first real pipeline run to confirm tester behavior shift (committing failing tests, HANDOFF on coder bugs) is showing up in BRC traffic