### PR TITLE
Fix #2445: emit TRANSITION audit action for current_phase mutations

### DIFF
--- a/shared/egg_contracts/validator.py
+++ b/shared/egg_contracts/validator.py
@@ -8,8 +8,8 @@ only authorized roles can modify specific fields.
 from dataclasses import dataclass
 from typing import Any
 
-from .audit import create_update_entry
-from .models import AuditEntry, AuditRole, Contract
+from .audit import create_transition_entry, create_update_entry
+from .models import AuditEntry, AuditRole, Contract, PipelinePhase
 from .roles import Role, can_modify, get_field_owner, normalize_path
 
 
@@ -119,16 +119,28 @@ def apply_mutation(
             message=f"Failed to apply mutation: {e}",
         )
 
-    # Create audit entry
+    # Create audit entry. ``current_phase`` mutations get the dedicated
+    # TRANSITION action so the audit log shape is uniform across all
+    # phase-transition code paths (gateway phase API, direct contract
+    # PATCH, orchestrator-side populator). See #2445.
     audit_role = AuditRole(role.value)
-    audit_entry = create_update_entry(
-        actor=actor,
-        role=audit_role,
-        field_path=field_path,
-        old_value=old_value,
-        new_value=new_value,
-        reason=reason,
-    )
+    if field_path == "current_phase":
+        audit_entry = create_transition_entry(
+            actor=actor,
+            role=audit_role,
+            from_phase=old_value.value if isinstance(old_value, PipelinePhase) else old_value,
+            to_phase=new_value.value if isinstance(new_value, PipelinePhase) else new_value,
+            reason=reason,
+        )
+    else:
+        audit_entry = create_update_entry(
+            actor=actor,
+            role=audit_role,
+            field_path=field_path,
+            old_value=old_value,
+            new_value=new_value,
+            reason=reason,
+        )
     contract.audit_log.append(audit_entry)
 
     return MutationResult(

--- a/tests/shared/egg_contracts/test_validator.py
+++ b/tests/shared/egg_contracts/test_validator.py
@@ -241,6 +241,13 @@ class TestApplyMutation:
 
         assert result.success is True
         assert result.audit_entry.action == AuditAction.TRANSITION
+        # The normalisation in validator.py converts PipelinePhase -> str so
+        # downstream consumers see a plain string. Asserting type() (rather than
+        # equality) is required because PipelinePhase is a StrEnum and would
+        # compare equal to "implement" even without normalisation.
+        assert type(result.audit_entry.old_value) is str
+        assert type(result.audit_entry.new_value) is str
+        assert not isinstance(result.audit_entry.new_value, PipelinePhase)
         assert result.audit_entry.old_value == "plan"
         assert result.audit_entry.new_value == "implement"
 

--- a/tests/shared/egg_contracts/test_validator.py
+++ b/tests/shared/egg_contracts/test_validator.py
@@ -247,7 +247,6 @@ class TestApplyMutation:
         # compare equal to "implement" even without normalisation.
         assert type(result.audit_entry.old_value) is str
         assert type(result.audit_entry.new_value) is str
-        assert not isinstance(result.audit_entry.new_value, PipelinePhase)
         assert result.audit_entry.old_value == "plan"
         assert result.audit_entry.new_value == "implement"
 

--- a/tests/shared/egg_contracts/test_validator.py
+++ b/tests/shared/egg_contracts/test_validator.py
@@ -2,9 +2,11 @@
 
 import pytest
 from egg_contracts.models import (
+    AuditAction,
     Contract,
     IssueInfo,
     Phase,
+    PipelinePhase,
     Task,
     TaskStatus,
 )
@@ -200,6 +202,61 @@ class TestApplyMutation:
         assert result.success is True
         assert result.audit_entry.old_value == "Original notes"
         assert result.audit_entry.new_value == "Updated notes"
+
+    def test_current_phase_emits_transition_action(self, sample_contract):
+        """current_phase mutations emit AuditAction.TRANSITION (not UPDATE)."""
+        sample_contract.current_phase = PipelinePhase.REFINE
+
+        result = apply_mutation(
+            contract=sample_contract,
+            role=Role.HUMAN,
+            actor="human-reviewer",
+            field_path="current_phase",
+            new_value=PipelinePhase.PLAN.value,
+            reason="Analysis approved",
+        )
+
+        assert result.success is True
+        assert result.audit_entry is not None
+        assert result.audit_entry.action == AuditAction.TRANSITION
+        assert result.audit_entry.field_path == "current_phase"
+        # Old/new values are normalised to the enum string form regardless
+        # of whether the caller passed a string or a PipelinePhase instance.
+        assert result.audit_entry.old_value == "refine"
+        assert result.audit_entry.new_value == "plan"
+        assert result.audit_entry.reason == "Analysis approved"
+
+    def test_current_phase_normalises_enum_new_value(self, sample_contract):
+        """Passing a PipelinePhase enum as new_value still produces a string-valued audit entry."""
+        sample_contract.current_phase = PipelinePhase.PLAN
+
+        result = apply_mutation(
+            contract=sample_contract,
+            role=Role.HUMAN,
+            actor="human-reviewer",
+            field_path="current_phase",
+            new_value=PipelinePhase.IMPLEMENT,
+            reason="Plan approved",
+        )
+
+        assert result.success is True
+        assert result.audit_entry.action == AuditAction.TRANSITION
+        assert result.audit_entry.old_value == "plan"
+        assert result.audit_entry.new_value == "implement"
+
+    def test_non_current_phase_field_still_emits_update_action(self, sample_contract):
+        """Non-current_phase fields continue to emit AuditAction.UPDATE."""
+        result = apply_mutation(
+            contract=sample_contract,
+            role=Role.IMPLEMENTER,
+            actor="james-in-a-box",
+            field_path="phases.0.tasks.0.commit",
+            new_value="abc1234",
+        )
+
+        assert result.success is True
+        assert result.audit_entry is not None
+        assert result.audit_entry.action == AuditAction.UPDATE
 
 
 class TestValidateTaskMutation:


### PR DESCRIPTION
## Summary
- Route `current_phase` mutations in `apply_mutation` through `create_transition_entry` so they emit `AuditAction.TRANSITION` instead of the generic `UPDATE`.
- Converges the audit-log shape across all three phase-transition code paths: gateway phase API (`gateway/phase_api.py`), direct contract PATCH (`orchestrator/routes/contracts.py`), and the orchestrator-side populator added in #2437. Operators inspecting the audit log to debug a phase mismatch (the situation that surfaced in #2427) now see one action shape for the same semantic field transition.
- Old/new phase values are normalised to their string form whether the caller passed a `PipelinePhase` enum or a raw string, matching the populator path.

No behavior change for any other field — only `current_phase` is affected.

Fixes #2445.

## Test plan
- [x] New unit tests in `tests/shared/egg_contracts/test_validator.py`:
  - `test_current_phase_emits_transition_action` — passing a string `new_value` produces `AuditAction.TRANSITION` with normalised old/new values.
  - `test_current_phase_normalises_enum_new_value` — passing a `PipelinePhase` enum as `new_value` also normalises to a plain string.
  - `test_non_current_phase_field_still_emits_update_action` — non-`current_phase` fields keep emitting `AuditAction.UPDATE`.
- [x] `tests/shared/egg_contracts/test_validator.py`, `tests/shared/egg_contracts/test_audit.py`, `integration_tests/sdlc/test_happy_path.py`, `integration_tests/sdlc/test_role_enforcement.py`, and `gateway/tests/test_phase_api.py::TestReviewerPhaseTransitionIntegration` — all 90 tests pass.
- [x] `make test` is otherwise green; the three pre-existing `TestPathTraversalProtection` failures in `gateway/tests/test_phase_api.py` reproduce on `main` and are unrelated to this change.
- [x] `ruff check` clean on the changed files.