### PR TITLE
Fix #2452: accept worktree paths in bare_repo_lock

### DIFF
--- a/shared/egg_git/cross_process_lock.py
+++ b/shared/egg_git/cross_process_lock.py
@@ -54,6 +54,14 @@ def _resolve_main_repo(repo_path: Path) -> Path:
     (``.git`` is a directory) or if the ``.git`` file cannot be parsed.
     The latter is intentional — the subsequent ``mkdir`` will fail with
     a clear error rather than silently locking the wrong inode.
+
+    Assumes the standard ``git worktree add`` layout where ``gitdir:``
+    points at ``<main>/.git/worktrees/<name>``.  A repo created with
+    ``git init --separate-git-dir`` produces a ``.git`` file pointing
+    outside ``<main>/.git/``, so this helper falls through and returns
+    ``repo_path`` unchanged — fine for the egg gateway (which never uses
+    ``--separate-git-dir``), but a future caller in that context should
+    not expect resolution to succeed.
     """
     git = repo_path / ".git"
     if not git.is_file():

--- a/shared/egg_git/cross_process_lock.py
+++ b/shared/egg_git/cross_process_lock.py
@@ -8,9 +8,16 @@ orchestrator's state-store commit on ``.git/config.lock`` (#2311).
 
 This module wraps that file with an ``fcntl.flock`` so both processes
 serialise on the same inode.  The lock file lives at
-``<repo_path>/.git/.egg-cross-process.lock`` — inside the resource being
+``<main_repo>/.git/.egg-cross-process.lock`` — inside the resource being
 protected, on the shared mount, so any process that can run git against
 the repo can also see and acquire the lock.
+
+Worktree paths (where ``.git`` is a file pointing at
+``<main>/.git/worktrees/<name>``) are accepted and silently collapsed
+onto the underlying main repo, so all worktrees of the same repo share
+one lock — the racing resource is the main repo's
+``.git/config.lock``, regardless of which worktree triggered the git
+operation (#2452).
 
 Reentrancy: nested ``with bare_repo_lock(repo)`` blocks in the same
 process do not block — the inner acquisitions just bump a depth counter.
@@ -32,15 +39,50 @@ from typing import Final
 LOCK_FILENAME: Final = ".egg-cross-process.lock"
 
 
+def _resolve_main_repo(repo_path: Path) -> Path:
+    """Resolve a worktree path to its main repo path.
+
+    A worktree's ``.git`` is a *file* whose contents are
+    ``gitdir: <main>/.git/worktrees/<name>``.  The main repo is the
+    grand-grandparent of that admin dir.  This lets ``bare_repo_lock``
+    accept either a main-repo path or any of its worktrees and end up
+    flocking the same inode under the main repo's ``.git/`` — which is
+    exactly the cross-process serialisation we want, because all
+    worktrees share the same ``.git/config.lock`` (#2452).
+
+    Returns ``repo_path`` unchanged if it is already a main repo
+    (``.git`` is a directory) or if the ``.git`` file cannot be parsed.
+    The latter is intentional — the subsequent ``mkdir`` will fail with
+    a clear error rather than silently locking the wrong inode.
+    """
+    git = repo_path / ".git"
+    if not git.is_file():
+        return repo_path
+    try:
+        content = git.read_text().strip()
+    except OSError:
+        return repo_path
+    if not content.startswith("gitdir:"):
+        return repo_path
+    gitdir = Path(content.split("gitdir:", 1)[1].strip())
+    if not gitdir.is_absolute():
+        gitdir = (repo_path / gitdir).resolve()
+    # gitdir = <main>/.git/worktrees/<name>; main = gitdir.parent.parent.parent
+    if gitdir.parent.name == "worktrees" and gitdir.parent.parent.name == ".git":
+        return gitdir.parent.parent.parent
+    return repo_path
+
+
 def lock_path_for_repo(repo_path: Path | str) -> Path:
     """Return the cross-process lock path for ``repo_path``.
 
-    The path is ``<repo_path>/.git/<LOCK_FILENAME>``.  ``repo_path`` must
-    be the main repo (with ``.git`` as a directory).  Worktree paths
-    (where ``.git`` is a file) are not valid arguments — callers should
-    resolve to the main repo first.
+    The path is ``<main_repo>/.git/<LOCK_FILENAME>``.  Both main-repo
+    paths (with ``.git`` as a directory) and worktree paths (where
+    ``.git`` is a file) are accepted; worktrees are resolved to the
+    underlying main repo so all worktrees of the same repo lock against
+    the same inode.
     """
-    return Path(repo_path) / ".git" / LOCK_FILENAME
+    return _resolve_main_repo(Path(repo_path)) / ".git" / LOCK_FILENAME
 
 
 class _RepoLockState:
@@ -62,6 +104,14 @@ _per_repo_state: dict[str, _RepoLockState] = {}
 
 
 def _get_state(repo_path: Path) -> _RepoLockState:
+    # Worktree paths (.git is a file) collapse onto their main repo so
+    # every worktree of the same repo shares one lock — the kernel
+    # flock is inode-keyed, and the main repo's ``.git/config.lock`` is
+    # what we are actually racing.  Without this, ``mkdir`` below would
+    # fail with EEXIST because a worktree's ``.git`` is a regular file
+    # and ``mkdir(exist_ok=True)`` only ignores existing *directories*
+    # (#2452).
+    repo_path = _resolve_main_repo(repo_path)
     # Resolve so two equivalent path forms (abs vs rel, with/without
     # trailing slash, symlinks) hit the same cache entry.  flock keys
     # on the inode regardless, but a single fd avoids redundant state

--- a/shared/tests/test_cross_process_lock.py
+++ b/shared/tests/test_cross_process_lock.py
@@ -40,6 +40,78 @@ def test_lock_path_lives_inside_dot_git(tmp_path: Path) -> None:
     assert lock_path_for_repo(tmp_path) == tmp_path / ".git" / LOCK_FILENAME
 
 
+def _make_main_and_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """Build a main-repo / worktree pair laid out the way git would.
+
+    The worktree's ``.git`` is a regular file containing
+    ``gitdir: <main>/.git/worktrees/<name>`` — exactly the layout the
+    gateway encounters when an agent's worktree path is passed to the
+    cross-process lock (#2452).
+    """
+    main_repo = tmp_path / "main"
+    main_dot_git = main_repo / ".git"
+    main_dot_git.mkdir(parents=True)
+    worktree_admin = main_dot_git / "worktrees" / "wt"
+    worktree_admin.mkdir(parents=True)
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".git").write_text(f"gitdir: {worktree_admin}\n")
+    return main_repo, worktree
+
+
+def test_lock_path_for_worktree_resolves_to_main_repo(tmp_path: Path) -> None:
+    """A worktree path locks against the main repo's ``.git/`` (#2452).
+
+    Without this, ``bare_repo_lock(worktree)`` would try to ``mkdir``
+    inside the worktree's ``.git`` — but ``.git`` is a *file* in a
+    worktree, so that fails with ``FileExistsError [Errno 17]`` and
+    silently breaks every checkpoint store driven from a worktree path.
+    """
+    main_repo, worktree = _make_main_and_worktree(tmp_path)
+    assert lock_path_for_repo(worktree) == main_repo / ".git" / LOCK_FILENAME
+
+
+def test_acquiring_lock_via_worktree_path_succeeds(tmp_path: Path) -> None:
+    """``bare_repo_lock`` on a worktree path no longer raises EEXIST (#2452)."""
+    main_repo, worktree = _make_main_and_worktree(tmp_path)
+    expected = main_repo / ".git" / LOCK_FILENAME
+    assert not expected.exists()
+    with bare_repo_lock(worktree):
+        assert expected.exists()
+
+
+def test_main_and_worktree_share_one_lock(tmp_path: Path) -> None:
+    """Same-process callers via main-repo and worktree paths block each other.
+
+    The kernel flock keys on inode, and our state cache keys on the
+    resolved main-repo path — so worktree and main-repo callers must
+    share one ``_RepoLockState`` (RLock + fd), not two.
+    """
+    main_repo, worktree = _make_main_and_worktree(tmp_path)
+
+    in_section: list[str] = []
+    overlap = threading.Event()
+
+    def hold(path: Path, label: str, duration: float) -> None:
+        with bare_repo_lock(path):
+            if in_section:
+                overlap.set()
+            in_section.append(label)
+            try:
+                time.sleep(duration)
+            finally:
+                in_section.pop()
+
+    t1 = threading.Thread(target=hold, args=(main_repo, "main", 0.05))
+    t2 = threading.Thread(target=hold, args=(worktree, "wt", 0.05))
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert not overlap.is_set(), "main-repo and worktree callers were not serialised"
+
+
 def test_acquiring_creates_lock_file(repo: Path) -> None:
     expected = repo / ".git" / LOCK_FILENAME
     assert not expected.exists()

--- a/shared/tests/test_cross_process_lock.py
+++ b/shared/tests/test_cross_process_lock.py
@@ -86,30 +86,53 @@ def test_main_and_worktree_share_one_lock(tmp_path: Path) -> None:
     The kernel flock keys on inode, and our state cache keys on the
     resolved main-repo path — so worktree and main-repo callers must
     share one ``_RepoLockState`` (RLock + fd), not two.
+
+    The ``t1_holding`` event forces actual contention: t2 only attempts
+    acquisition after t1 is inside the critical section, so the test
+    asserts the worktree caller was *blocked* by the main-repo caller,
+    not just that the two threads happened to run sequentially.
     """
     main_repo, worktree = _make_main_and_worktree(tmp_path)
 
     in_section: list[str] = []
     overlap = threading.Event()
+    t1_holding = threading.Event()
+    t2_acquired = threading.Event()
 
-    def hold(path: Path, label: str, duration: float) -> None:
-        with bare_repo_lock(path):
-            if in_section:
-                overlap.set()
-            in_section.append(label)
+    def first_holder() -> None:
+        with bare_repo_lock(main_repo):
+            in_section.append("main")
+            t1_holding.set()
             try:
-                time.sleep(duration)
+                # Hold long enough that t2's acquisition would observe
+                # the overlap if the locks were independent.
+                time.sleep(0.1)
+                if t2_acquired.is_set():
+                    overlap.set()
             finally:
                 in_section.pop()
 
-    t1 = threading.Thread(target=hold, args=(main_repo, "main", 0.05))
-    t2 = threading.Thread(target=hold, args=(worktree, "wt", 0.05))
+    def second_holder() -> None:
+        assert t1_holding.wait(timeout=5), "t1 never reported holding the lock"
+        with bare_repo_lock(worktree):
+            t2_acquired.set()
+            if in_section:
+                overlap.set()
+            in_section.append("wt")
+            try:
+                pass
+            finally:
+                in_section.pop()
+
+    t1 = threading.Thread(target=first_holder)
+    t2 = threading.Thread(target=second_holder)
     t1.start()
     t2.start()
     t1.join(timeout=5)
     t2.join(timeout=5)
 
     assert not overlap.is_set(), "main-repo and worktree callers were not serialised"
+    assert t2_acquired.is_set(), "worktree caller never acquired — test did not run to completion"
 
 
 def test_acquiring_creates_lock_file(repo: Path) -> None:


### PR DESCRIPTION
## Summary

Resolves #2452.

The async checkpoint store thread invokes `bare_repo_lock(repo_path)` with the agent's *worktree* path (`capture_and_store_checkpoint(repo_path=exec_path, ...)` in `gateway/gateway.py:2070`). Inside the lock primitive, `_get_state` calls `lock_path.parent.mkdir(parents=True, exist_ok=True)` on `<repo_path>/.git/.egg-cross-process.lock`'s parent — but in a worktree `.git` is a regular *file* pointing at `<main>/.git/worktrees/<name>`, and `Path.mkdir(exist_ok=True)` only swallows EEXIST when the existing path is a directory. Result: every push-driven checkpoint store fails with the paired `[Errno 17] File exists: '/home/egg/.egg-worktrees/<container_id>/<repo>'` reported in the issue, and the checkpoint never reaches the checkpoint branch.

The fix resolves worktree paths to their underlying main repo inside `bare_repo_lock` itself, so the lock file lands under `<main>/.git/`. That is the correct serialisation target anyway — every worktree shares the main repo's `.git/config.lock`, so all worktree-driven git operations need the same flock. Two existing call sites (`worktree_manager._get_repo_lock` already passes the main repo; `checkpoint_handler.store_checkpoint_v2` was the broken one) collapse onto the same lock as before.

The proxy-buffer-missing warning paired with the EEXIST in the issue is intentionally left out of scope — its impact (\"what does losing transcript data cost us?\") is flagged as an open question in the issue and needs separate investigation.

## Test plan
- [ ] `make test` covers `shared/tests/test_cross_process_lock.py`, which gains:
  - `test_lock_path_for_worktree_resolves_to_main_repo`
  - `test_acquiring_lock_via_worktree_path_succeeds` — the regression test for the EEXIST symptom
  - `test_main_and_worktree_share_one_lock` — confirms same-process callers via worktree and main-repo paths serialise on one lock state
- [ ] In a smoke run, confirm `gateway-* | grep -E "checkpoint-handler.*File exists"` is empty after a documenter push, and that the corresponding checkpoint commit appears on `egg/checkpoints/v2`.