### PR TITLE
Fix #2441: scope phase-status flip to last-slice-active

### DIFF
--- a/orchestrator/kubernetes_monitor.py
+++ b/orchestrator/kubernetes_monitor.py
@@ -808,16 +808,26 @@ class KubernetesMonitor:
                 if phase_exec.cycle_timings and phase_exec.cycle_timings[-1].completed_at is None:
                     phase_exec.cycle_timings[-1].completed_at = now
 
-                # TODO(#2441): the phase-level mutations below are unconditional
-                # even though the agent walk above is now slice-scoped. Safe
-                # today because ``consensus_stall`` is pipeline-level only and
-                # ``stall_slice_id`` is always ``None`` here, but the moment
-                # the upstream check becomes slice-aware this path will mark
+                # Phase-level mutations are scoped to "no other slice
+                # still active": only flip phase status when every other
+                # slice's agents in this phase are already terminal
+                # (COMPLETE / FAILED). This is a no-op today because
+                # ``consensus_stall`` is pipeline-level only and
+                # ``stall_slice_id`` is always ``None`` (so any sibling
+                # slice with a non-terminal agent would correctly hold
+                # the phase open), but it prevents the path from marking
                 # the whole phase COMPLETE while other slices are still
-                # RUNNING. Scope to "no other slice still active" or split
-                # ``phase_exec`` into per-slice status when #2441 lands.
-                phase_exec.status = PipelineStatus.COMPLETE
-                phase_exec.completed_at = now
+                # RUNNING the moment the upstream check becomes
+                # slice-aware (#2441).
+                other_slice_active = any(
+                    getattr(agent, "slice_id", None) != stall_slice_id
+                    and agent.status
+                    not in (AgentExecutionStatus.COMPLETE, AgentExecutionStatus.FAILED)
+                    for agent in phase_exec.agents
+                )
+                if not other_slice_active:
+                    phase_exec.status = PipelineStatus.COMPLETE
+                    phase_exec.completed_at = now
 
                 store.save_pipeline(fresh_pipeline, expected_version=original_version)
                 logger.info(

--- a/orchestrator/startup_reconciliation.py
+++ b/orchestrator/startup_reconciliation.py
@@ -345,15 +345,28 @@ def reconcile_stale_containers(store: object, docker_client: object) -> int:
                                 if agent.status == AgentExecutionStatus.RUNNING:
                                     agent.status = AgentExecutionStatus.COMPLETE
                                     agent.completed_at = datetime.now(UTC)
-                            # TODO(#2441): phase-level mutations are
-                            # unconditional even though the agent walk above
-                            # is slice-scoped (only pipeline-level agents
-                            # flipped). Marks the whole phase COMPLETE even
-                            # if per-slice trackers are still RUNNING; safe
-                            # today because per-slice tracker reconstruction
-                            # isn't wired in here yet.
-                            phase_exec.status = PipelineStatus.COMPLETE
-                            phase_exec.completed_at = datetime.now(UTC)
+                            # Phase-level mutations are scoped to "no
+                            # other slice still active": the
+                            # reconstructed tracker is the pipeline-level
+                            # one, so only ``slice_id is None`` agents
+                            # were flipped above. If sibling slice-scoped
+                            # agents are still non-terminal, their
+                            # per-slice trackers haven't been
+                            # reconstructed here yet — leave the phase
+                            # RUNNING so they aren't prematurely marked
+                            # COMPLETE (#2441).
+                            other_slice_active = any(
+                                getattr(agent, "slice_id", None) is not None
+                                and agent.status
+                                not in (
+                                    AgentExecutionStatus.COMPLETE,
+                                    AgentExecutionStatus.FAILED,
+                                )
+                                for agent in phase_exec.agents
+                            )
+                            if not other_slice_active:
+                                phase_exec.status = PipelineStatus.COMPLETE
+                                phase_exec.completed_at = datetime.now(UTC)
                             store.save_pipeline(pipeline)
                 except Exception as eval_err:
                     logger.warning(

--- a/orchestrator/tests/test_consensus_stall_check.py
+++ b/orchestrator/tests/test_consensus_stall_check.py
@@ -776,3 +776,128 @@ class TestHandleConsensusStallRecovery:
         # Both containers should be stopped
         stopped_ids = {call.args[0] for call in f.monitor.k8s_client.stop_container.call_args_list}
         assert stopped_ids == {"container-coder", "container-tester"}
+
+
+def _make_multi_slice_pipeline() -> Pipeline:
+    """Return a RUNNING pipeline whose implement phase has two active slices."""
+    pipeline = _make_pipeline()
+    phase_exec = pipeline.get_phase_execution(PipelinePhase.IMPLEMENT)
+    phase_exec.status = PipelineStatus.RUNNING
+    phase_exec.started_at = datetime.now(UTC) - timedelta(seconds=120)
+
+    for slice_id in ("slice-2", "slice-3"):
+        for role in (AgentRole.CODER, AgentRole.TESTER):
+            container_id = f"container-{slice_id}-{role.value}"
+            phase_exec.containers.append(
+                ContainerInfo(
+                    container_id=container_id,
+                    container_name=f"egg-{role.value}-{slice_id}-issue-1014",
+                    status=ContainerStatus.RUNNING,
+                    started_at=datetime.now(UTC),
+                )
+            )
+            phase_exec.agents.append(
+                AgentExecution(
+                    role=role,
+                    status=AgentExecutionStatus.RUNNING,
+                    container_id=container_id,
+                    started_at=datetime.now(UTC),
+                    slice_id=slice_id,
+                )
+            )
+    return pipeline
+
+
+class TestSliceScopedAggressiveRecovery:
+    """Regression coverage for #2441: phase-level mutations must be scoped
+    to "no other slice still active" so that a slice-aware ``stall_slice_id``
+    in the future doesn't mark the whole phase COMPLETE while sibling slices
+    are still RUNNING."""
+
+    def test_slice_3_recovery_with_slice_2_running_does_not_flip_phase(self):
+        monitor = _make_monitor()
+        result = _make_degraded_result()
+        result.details["slice_id"] = "slice-3"
+
+        fresh_pipeline = _make_multi_slice_pipeline()
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = fresh_pipeline
+
+        mock_pc = MagicMock()
+        mock_pc.get_peer_consensus_tracker.return_value = None
+        mock_pc.reconstruct_tracker_from_messages.return_value = None
+        mock_graph_mod = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "peer_consensus": mock_pc,
+                "review_graph": mock_graph_mod,
+            },
+        ):
+            monitor._handle_consensus_stall_recovery(
+                [result], _make_multi_slice_pipeline(), mock_store
+            )
+
+        phase_exec = fresh_pipeline.phases.get("implement")
+        assert phase_exec is not None
+
+        # Phase must remain RUNNING — slice-2 has not finished yet.
+        assert phase_exec.status == PipelineStatus.RUNNING
+        assert phase_exec.completed_at is None
+
+        # slice-3 agents flipped to COMPLETE.
+        slice_3 = [a for a in phase_exec.agents if a.slice_id == "slice-3"]
+        assert slice_3
+        for agent in slice_3:
+            assert agent.status == AgentExecutionStatus.COMPLETE
+            assert agent.completed_at is not None
+
+        # slice-2 agents must be untouched.
+        slice_2 = [a for a in phase_exec.agents if a.slice_id == "slice-2"]
+        assert slice_2
+        for agent in slice_2:
+            assert agent.status == AgentExecutionStatus.RUNNING
+            assert agent.completed_at is None
+
+        # Only slice-3 pods should be stopped — slice-2 keeps running.
+        stopped_ids = {call.args[0] for call in monitor.k8s_client.stop_container.call_args_list}
+        assert stopped_ids == {"container-slice-3-coder", "container-slice-3-tester"}
+
+    def test_slice_3_recovery_with_slice_2_terminal_flips_phase(self):
+        """When the only sibling slice is already terminal, the phase
+        flip still fires — preserves today's pipeline-level behavior."""
+        monitor = _make_monitor()
+        result = _make_degraded_result()
+        result.details["slice_id"] = "slice-3"
+
+        fresh_pipeline = _make_multi_slice_pipeline()
+        # Mark slice-2 agents already terminal (consensus completed earlier).
+        for agent in fresh_pipeline.phases["implement"].agents:
+            if agent.slice_id == "slice-2":
+                agent.status = AgentExecutionStatus.COMPLETE
+                agent.completed_at = datetime.now(UTC)
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = fresh_pipeline
+
+        mock_pc = MagicMock()
+        mock_pc.get_peer_consensus_tracker.return_value = None
+        mock_pc.reconstruct_tracker_from_messages.return_value = None
+        mock_graph_mod = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "peer_consensus": mock_pc,
+                "review_graph": mock_graph_mod,
+            },
+        ):
+            monitor._handle_consensus_stall_recovery(
+                [result], _make_multi_slice_pipeline(), mock_store
+            )
+
+        phase_exec = fresh_pipeline.phases.get("implement")
+        assert phase_exec is not None
+        assert phase_exec.status == PipelineStatus.COMPLETE
+        assert phase_exec.completed_at is not None

--- a/orchestrator/tests/test_startup_reconciliation.py
+++ b/orchestrator/tests/test_startup_reconciliation.py
@@ -987,3 +987,94 @@ class TestStartupConsensusReconstruction:
         assert phase.agents[0].completed_at is not None
         # save_pipeline should have been called
         store.save_pipeline.assert_called()
+
+    def test_phase_stays_running_when_slice_scoped_agents_still_active(self):
+        """Regression for #2441: the reconstructed tracker is pipeline-level,
+        so only ``slice_id is None`` agents are flipped. If sibling
+        slice-scoped agents are still RUNNING (their per-slice trackers
+        haven't been reconstructed here yet), the whole phase must NOT be
+        marked COMPLETE — that would prematurely terminate active slices."""
+
+        pipeline = Pipeline(
+            id="issue-concurrent",
+            issue_number=42,
+            repo="owner/repo",
+            branch="egg/issue-42",
+            mode="issue",
+            status=PipelineStatus.RUNNING,
+            current_phase=PipelinePhase.IMPLEMENT,
+        )
+        pipeline.config.concurrent_execution = True
+
+        phase = pipeline.get_phase_execution(PipelinePhase.IMPLEMENT)
+        phase.status = PipelineStatus.RUNNING
+        phase.started_at = datetime.now(UTC)
+
+        # Pipeline-level (slice_id=None) agent — eligible for the flip.
+        phase.containers.append(
+            ContainerInfo(
+                container_id="pipeline-coder",
+                container_name="egg-coder",
+                status=ContainerStatus.RUNNING,
+                started_at=datetime.now(UTC),
+            )
+        )
+        phase.agents.append(
+            AgentExecution(
+                role=AgentRole.CODER,
+                status=AgentExecutionStatus.RUNNING,
+                container_id="pipeline-coder",
+                started_at=datetime.now(UTC),
+            )
+        )
+
+        # Slice-scoped agent — must remain RUNNING.
+        phase.containers.append(
+            ContainerInfo(
+                container_id="slice-1-coder",
+                container_name="egg-coder-slice-1",
+                status=ContainerStatus.RUNNING,
+                started_at=datetime.now(UTC),
+            )
+        )
+        phase.agents.append(
+            AgentExecution(
+                role=AgentRole.CODER,
+                status=AgentExecutionStatus.RUNNING,
+                container_id="slice-1-coder",
+                started_at=datetime.now(UTC),
+                slice_id="slice-1",
+            )
+        )
+
+        store = _make_store(pipeline)
+        docker_client = _make_docker_client(
+            live_ids=["pipeline-coder", "slice-1-coder"],
+            pipeline_live_map={pipeline.id: ["pipeline-coder", "slice-1-coder"]},
+        )
+
+        mock_tracker = MagicMock()
+        mock_tracker.evaluate.return_value = {"is_complete": True}
+
+        with (
+            patch("peer_consensus.reconstruct_tracker_from_messages") as mock_reconstruct,
+            patch("concurrent_executor.is_concurrent_execution", return_value=True),
+            patch("peer_consensus.get_peer_consensus_tracker", return_value=None),
+        ):
+            mock_reconstruct.return_value = mock_tracker
+
+            reconcile_stale_containers(store, docker_client)
+
+        # Phase must NOT be marked COMPLETE — the slice-1 agent is still active.
+        assert phase.status == PipelineStatus.RUNNING
+        assert phase.completed_at is None
+
+        # Pipeline-level agent flipped to COMPLETE.
+        pipeline_level = next(a for a in phase.agents if a.slice_id is None)
+        assert pipeline_level.status == AgentExecutionStatus.COMPLETE
+        assert pipeline_level.completed_at is not None
+
+        # Slice-1 agent untouched.
+        sliced = next(a for a in phase.agents if a.slice_id == "slice-1")
+        assert sliced.status == AgentExecutionStatus.RUNNING
+        assert sliced.completed_at is None


### PR DESCRIPTION
## Summary

- Two consensus-stall recovery paths (``_handle_consensus_stall_recovery``
  in ``kubernetes_monitor.py`` and the pipeline-level tracker
  reconstruction in ``startup_reconciliation.py``) flipped
  ``phase_exec.status = COMPLETE`` unconditionally even though their
  agent walks were already slice-scoped per #2422. Safe today because
  ``consensus_stall`` is pipeline-level only and ``stall_slice_id`` is
  always ``None``, but the moment the upstream check becomes
  slice-aware this would mark the whole phase COMPLETE while sibling
  slices were still RUNNING.
- Surgical fix per option 1 in #2441: gate the phase-status flip on
  every other slice's agents in this phase already being terminal
  (``COMPLETE`` / ``FAILED``). Pipeline-level recovery still flips the
  phase when no slice-scoped agents are non-terminal — current
  behavior preserved.
- Replaces the TODO comments at both sites with the new scoped
  block.

Closes #2441.

## Test plan

- [x] ``pytest orchestrator/tests/test_consensus_stall_check.py
      orchestrator/tests/test_startup_reconciliation.py`` — new
      regression tests:
  - slice-3 stall recovery with slice-2 still RUNNING does NOT flip
    ``phase_exec.status`` to ``COMPLETE`` and only stops slice-3 pods.
  - slice-3 stall recovery with slice-2 already terminal still flips
    the phase, preserving the current pipeline-level path.
  - startup-reconciliation: pipeline-level tracker complete +
    slice-scoped agent still RUNNING leaves phase RUNNING and
    untouched ``completed_at``.
- [x] ``ruff check`` and ``ruff format --check`` clean on changed
      files.