### PR TITLE
Fix #2451: thread slice_id through heartbeat fan-out

### DIFF
--- a/orchestrator/heartbeat.py
+++ b/orchestrator/heartbeat.py
@@ -3,10 +3,21 @@
 Provides server-side HEARTBEAT handling primitives that are independent
 of routing/HTTP concerns:
 
-* Sliding-window rate limiter keyed by ``(pipeline_id, role)`` honouring
-  ``EGG_HEARTBEAT_RATE_LIMIT`` (default 20/min per role).
-* Per-role dedup: two consecutive identical ``(state, waiting_on)``
-  tuples from the same role produce only one bus message.
+* Sliding-window rate limiter keyed by ``(pipeline_id, slice_id, role)``
+  honouring ``EGG_HEARTBEAT_RATE_LIMIT`` (default 20/min per role per
+  slice).
+* Per-(pipeline, slice, role) dedup: two consecutive identical
+  ``(state, waiting_on)`` tuples from the same role inside the same
+  slice produce only one bus message. Pipeline-level agents pass
+  ``slice_id=None`` and share a single bucket.
+
+Why slice-scope the keys (#2471): two parallel slices that share a
+role (e.g. slice-2 and slice-3 ``reviewer_code`` in the same wave) are
+independent pods. Sharing a per-(pipeline, role) dedup map silently
+suppresses slice-N's bus message the moment slice-(N-1) reports the
+same state, and a shared per-role rate budget lets one popular role
+under wide fan-out hit the per-minute ceiling and drop a sibling's
+beat. The keys carry the slice scope so siblings stay independent.
 
 See plan TASK-3-2 / TASK-3-4 and
 docs/reference/agent-wait-patterns.md §5.
@@ -19,6 +30,9 @@ import time
 from collections import deque
 from dataclasses import dataclass
 
+# (pipeline_id, slice_id_or_none, role)
+_Key = tuple[str, str | None, str]
+
 
 @dataclass
 class RateLimitDecision:
@@ -29,7 +43,7 @@ class RateLimitDecision:
 
 
 class HeartbeatCoordinator:
-    """Per-pipeline/per-role HEARTBEAT rate limiter + dedup tracker.
+    """Per-(pipeline, slice, role) HEARTBEAT rate limiter + dedup tracker.
 
     Thread-safe.  One instance lives as an orchestrator-process-global
     singleton (``get_heartbeat_coordinator``).
@@ -38,16 +52,17 @@ class HeartbeatCoordinator:
     def __init__(self, window_seconds: int = 60) -> None:
         self._window = float(window_seconds)
         self._lock = threading.Lock()
-        # (pipeline_id, role) -> deque of epoch-seconds timestamps
-        self._windows: dict[tuple[str, str], deque[float]] = {}
-        # (pipeline_id, role) -> last-seen (state, waiting_on)
-        self._last_state: dict[tuple[str, str], tuple[str, str]] = {}
-        # (pipeline_id, role) -> last gateway-session fan-out epoch-seconds
-        self._last_fan_out: dict[tuple[str, str], float] = {}
+        # (pipeline_id, slice_id, role) -> deque of epoch-seconds timestamps
+        self._windows: dict[_Key, deque[float]] = {}
+        # (pipeline_id, slice_id, role) -> last-seen (state, waiting_on)
+        self._last_state: dict[_Key, tuple[str, str]] = {}
+        # (pipeline_id, slice_id, role) -> last gateway-session fan-out epoch-seconds
+        self._last_fan_out: dict[_Key, float] = {}
 
     def check_rate_limit(
         self,
         pipeline_id: str,
+        slice_id: str | None,
         role: str,
         limit_per_minute: int,
     ) -> RateLimitDecision:
@@ -57,8 +72,12 @@ class HeartbeatCoordinator:
         allowed, returns a decision carrying the seconds until the
         oldest timestamp in the window expires (a caller can surface
         this via the ``retry_after`` body field of an HTTP 429).
+
+        Pipeline-level callers (no slice scope) pass ``slice_id=None``
+        and share a single bucket per ``(pipeline_id, role)``; slice-
+        scoped callers each get their own bucket.
         """
-        key = (pipeline_id, role)
+        key: _Key = (pipeline_id, slice_id, role)
         now = time.time()
         cutoff = now - self._window
         with self._lock:
@@ -75,18 +94,19 @@ class HeartbeatCoordinator:
     def is_duplicate(
         self,
         pipeline_id: str,
+        slice_id: str | None,
         role: str,
         state: str,
         waiting_on: str | None,
     ) -> bool:
         """Check whether this ``(state, waiting_on)`` equals the last.
 
-        Returns True (duplicate) if the role's most-recent heartbeat
-        tuple is identical; False (fresh) otherwise.  Does NOT record
-        the new tuple — the caller should call ``record_state`` after
-        successfully delivering the heartbeat.
+        Returns True (duplicate) if the (pipeline, slice, role)'s most-
+        recent heartbeat tuple is identical; False (fresh) otherwise.
+        Does NOT record the new tuple — the caller should call
+        ``record_state`` after successfully delivering the heartbeat.
         """
-        key = (pipeline_id, role)
+        key: _Key = (pipeline_id, slice_id, role)
         with self._lock:
             prev = self._last_state.get(key)
         cur = (state, waiting_on or "")
@@ -95,18 +115,20 @@ class HeartbeatCoordinator:
     def record_state(
         self,
         pipeline_id: str,
+        slice_id: str | None,
         role: str,
         state: str,
         waiting_on: str | None,
     ) -> None:
-        """Store this role's most-recent ``(state, waiting_on)``."""
-        key = (pipeline_id, role)
+        """Store this (pipeline, slice, role)'s most-recent ``(state, waiting_on)``."""
+        key: _Key = (pipeline_id, slice_id, role)
         with self._lock:
             self._last_state[key] = (state, waiting_on or "")
 
     def should_fan_out_gateway_session(
         self,
         pipeline_id: str,
+        slice_id: str | None,
         role: str,
         min_interval_seconds: float,
     ) -> bool:
@@ -114,18 +136,20 @@ class HeartbeatCoordinator:
 
         The HEARTBEAT route fans out a gateway-session refresh both on
         the dedup early-return path and after the rate-limit gate.  The
-        dedup path bypasses the per-role rate limiter (by design — see
-        ``check_rate_limit``'s NB1 from #1897), so a misbehaving agent
-        hot-looping with identical state can amplify into the gateway
-        without burning rate budget.  This per-role cooldown caps that
-        amplification independently of the heartbeat-acceptance rate.
+        dedup path bypasses the per-(slice, role) rate limiter (by
+        design — see ``check_rate_limit``'s NB1 from #1897), so a
+        misbehaving agent hot-looping with identical state can amplify
+        into the gateway without burning rate budget.  This per-(slice,
+        role) cooldown caps that amplification independently of the
+        heartbeat-acceptance rate.
 
         Returns ``True`` and records the new timestamp if at least
         ``min_interval_seconds`` have passed since the previous fan-out
-        for this ``(pipeline_id, role)``; returns ``False`` (without
-        recording) if the caller should skip the fan-out this round.
-        Any non-positive ``min_interval_seconds`` (``<= 0``) disables
-        throttling — every call returns ``True`` without recording.
+        for this ``(pipeline_id, slice_id, role)``; returns ``False``
+        (without recording) if the caller should skip the fan-out this
+        round.  Any non-positive ``min_interval_seconds`` (``<= 0``)
+        disables throttling — every call returns ``True`` without
+        recording.
 
         Callers must pass a finite real number. ``float('nan')`` falls
         through both branches (``nan <= 0`` and ``now - last < nan`` are
@@ -137,7 +161,7 @@ class HeartbeatCoordinator:
         """
         if min_interval_seconds <= 0:
             return True
-        key = (pipeline_id, role)
+        key: _Key = (pipeline_id, slice_id, role)
         now = time.time()
         with self._lock:
             last = self._last_fan_out.get(key, 0.0)
@@ -147,7 +171,13 @@ class HeartbeatCoordinator:
         return True
 
     def clear(self, pipeline_id: str) -> None:
-        """Drop all state for a pipeline (on phase transition)."""
+        """Drop all state for a pipeline (on phase transition).
+
+        Sweeps every ``(pipeline_id, *, *)`` key across all three
+        per-(pipeline, slice, role) maps so a phase transition resets
+        rate budgets, dedup memory, and fan-out cooldowns for both
+        pipeline-level and slice-scoped agents in one shot.
+        """
         with self._lock:
             for key in list(self._windows):
                 if key[0] == pipeline_id:

--- a/orchestrator/routes/messages.py
+++ b/orchestrator/routes/messages.py
@@ -741,7 +741,9 @@ def _refresh_gateway_session(pipeline_id: str, from_role: str, slice_id: str | N
     # different slices of the same wave) do not suppress each other's
     # fan-outs. The coordinator key is opaque to the throttle, so
     # scoping at the call site keeps the coordinator API unchanged.
-    throttle_role = f"{slice_id}/{from_role}" if slice_id else from_role
+    # ``:`` (not ``/``) so the composite never reads as a path if it
+    # surfaces in a log line — current usage is purely internal.
+    throttle_role = f"{slice_id}:{from_role}" if slice_id else from_role
     if not coordinator.should_fan_out_gateway_session(
         pipeline_id, throttle_role, _GATEWAY_FANOUT_MIN_INTERVAL_SECONDS
     ):

--- a/orchestrator/routes/messages.py
+++ b/orchestrator/routes/messages.py
@@ -107,15 +107,16 @@ def _track_long_poll_end() -> None:
 # liveness keep-alive emitted by ``mcp__brc__wait_loop`` while it's
 # blocked — periodic identical beats are exactly the signal the
 # overseer's stall detector consumes, so dedup must not collapse them.
-# Rate-limit (20/min per role) still applies.
+# Rate-limit (20/min per slice+role; #2471) still applies.
 _DEDUP_EXEMPT_HEARTBEAT_STATES: frozenset[str] = frozenset({"WAITING_FOR_EVENT"})
 
 # Minimum seconds between gateway-session fan-outs per (pipeline_id,
-# role) (#2076 NB2).  The dedup early-return path bypasses the per-role
-# heartbeat rate limit by design (#1897 NB1: dedup'd heartbeats are
-# no-ops and must not consume rate budget), so without a separate cap a
-# misbehaving agent hot-looping with identical state could amplify into
-# the gateway at the agent's emission rate.  The gateway's idle window
+# slice_id, role) (#2076 NB2, slice-scoped per #2471).  The dedup
+# early-return path bypasses the per-(slice, role) heartbeat rate limit
+# by design (#1897 NB1: dedup'd heartbeats are no-ops and must not
+# consume rate budget), so without a separate cap a misbehaving agent
+# hot-looping with identical state could amplify into the gateway at
+# the agent's emission rate.  The gateway's idle window
 # is 60 minutes, so fanning out every 30 s is far more than enough to
 # keep the session alive; the cap exists purely to bound amplification.
 _GATEWAY_FANOUT_MIN_INTERVAL_SECONDS: float = 30.0
@@ -556,13 +557,14 @@ def post_heartbeat(pipeline_id: str) -> tuple[Response, int]:
               ``retry_after`` seconds.
 
     Implementation notes:
-        * ``(state, waiting_on)`` tuples that match the role's
-          most-recent heartbeat are **silently deduped** (no bus
-          message written) so re-entering the same state twice is
-          idempotent.  See plan TASK-3-2.
+        * ``(state, waiting_on)`` tuples that match the most-recent
+          heartbeat for this ``(pipeline_id, slice_id, role)`` are
+          **silently deduped** (no bus message written) so re-entering
+          the same state twice is idempotent.  See plan TASK-3-2.
         * Rate limit: ``EGG_HEARTBEAT_RATE_LIMIT`` per minute per
-          ``(pipeline_id, role)``, default 20/min.  See plan
-          TASK-3-4.
+          ``(pipeline_id, slice_id, role)``, default 20/min.  See plan
+          TASK-3-4.  Slice-scoping (#2471) keeps sibling slices that
+          share a role from sharing each other's rate budget.
     """
     body = request.get_json() or {}
 
@@ -615,7 +617,7 @@ def post_heartbeat(pipeline_id: str) -> tuple[Response, int]:
     # per-role cooldown (#2076 NB2) to bound dedup-path amplification
     # without consuming rate budget.
     if state not in _DEDUP_EXEMPT_HEARTBEAT_STATES and coordinator.is_duplicate(
-        pipeline_id, from_role, state, waiting_on
+        pipeline_id, slice_id, from_role, state, waiting_on
     ):
         _refresh_gateway_session(pipeline_id, from_role, slice_id)
         return _make_success(
@@ -632,7 +634,7 @@ def post_heartbeat(pipeline_id: str) -> tuple[Response, int]:
     # ``Retry-After`` response header MUST echo N so standards-compliant
     # HTTP clients can honour it without parsing the JSON.
     limit = get_heartbeat_rate_limit()
-    decision = coordinator.check_rate_limit(pipeline_id, from_role, limit)
+    decision = coordinator.check_rate_limit(pipeline_id, slice_id, from_role, limit)
     if not decision.allowed:
         retry_after = int(decision.retry_after_seconds)
         resp = jsonify(
@@ -641,7 +643,7 @@ def post_heartbeat(pipeline_id: str) -> tuple[Response, int]:
                 "error": "rate_limited",
                 "message": (
                     f"HEARTBEAT rate limit exceeded "
-                    f"({limit}/min per role); retry after {retry_after}s."
+                    f"({limit}/min per slice+role); retry after {retry_after}s."
                 ),
                 "retry_after": retry_after,
             }
@@ -677,7 +679,7 @@ def post_heartbeat(pipeline_id: str) -> tuple[Response, int]:
     )
     store = get_message_store()
     store.add_message(msg)
-    coordinator.record_state(pipeline_id, from_role, state, waiting_on)
+    coordinator.record_state(pipeline_id, slice_id, from_role, state, waiting_on)
 
     # Emit an event so SSE consumers and HealthMonitor see it.
     emit_event(
@@ -736,16 +738,13 @@ def _refresh_gateway_session(pipeline_id: str, from_role: str, slice_id: str | N
     expiry under any realistic heartbeat cadence.
     """
     coordinator = get_heartbeat_coordinator()
-    # Compose the throttle role with the slice scope so concurrent
-    # slices that share a role (e.g. two reviewer-code agents in
-    # different slices of the same wave) do not suppress each other's
-    # fan-outs. The coordinator key is opaque to the throttle, so
-    # scoping at the call site keeps the coordinator API unchanged.
-    # ``:`` (not ``/``) so the composite never reads as a path if it
-    # surfaces in a log line — current usage is purely internal.
-    throttle_role = f"{slice_id}:{from_role}" if slice_id else from_role
+    # The coordinator's throttle key is now ``(pipeline_id, slice_id,
+    # role)`` (#2471) so concurrent slices that share a role (e.g. two
+    # reviewer-code agents in different slices of the same wave) do not
+    # suppress each other's fan-outs. Pass ``slice_id`` directly — no
+    # synthetic role-string composition needed.
     if not coordinator.should_fan_out_gateway_session(
-        pipeline_id, throttle_role, _GATEWAY_FANOUT_MIN_INTERVAL_SECONDS
+        pipeline_id, slice_id, from_role, _GATEWAY_FANOUT_MIN_INTERVAL_SECONDS
     ):
         return
     try:

--- a/orchestrator/routes/messages.py
+++ b/orchestrator/routes/messages.py
@@ -38,6 +38,7 @@ from message_store import (
     get_message_store,
 )
 from routes import get_state_store_for_pipeline
+from slice_id_validation import extract_slice_id as _extract_slice_id
 from state_store import InvalidPipelineIdError, PipelineNotFoundError
 
 logger = get_logger("orchestrator.messages")
@@ -578,6 +579,16 @@ def post_heartbeat(pipeline_id: str) -> tuple[Response, int]:
             "state=WAITING_ON_ROLE requires waiting_on (the role this agent is waiting on)."
         )
 
+    # Optional slice scope (#2451): slice-scoped agents forward
+    # ``EGG_SLICE_ID`` so the gateway-session fan-out can reconstruct
+    # the slice-scoped container_id that ``kubernetes_spawner``
+    # registered. Pipeline-level agents send no ``slice_id`` and this
+    # resolves to ``None``.
+    try:
+        slice_id = _extract_slice_id(body)
+    except ValueError as exc:
+        return _make_error(f"Invalid slice_id: {exc}")
+
     # Validate pipeline.
     try:
         _store, pipeline = get_state_store_for_pipeline(pipeline_id)
@@ -606,7 +617,7 @@ def post_heartbeat(pipeline_id: str) -> tuple[Response, int]:
     if state not in _DEDUP_EXEMPT_HEARTBEAT_STATES and coordinator.is_duplicate(
         pipeline_id, from_role, state, waiting_on
     ):
-        _refresh_gateway_session(pipeline_id, from_role)
+        _refresh_gateway_session(pipeline_id, from_role, slice_id)
         return _make_success(
             "HEARTBEAT deduped (unchanged state)",
             data={"deduped": True},
@@ -644,7 +655,7 @@ def post_heartbeat(pipeline_id: str) -> tuple[Response, int]:
     # Best-effort: the gateway may be unreachable (tests, dev runs
     # without a gateway) and a missing session is a 404; never fail the
     # heartbeat on this path.
-    _refresh_gateway_session(pipeline_id, from_role)
+    _refresh_gateway_session(pipeline_id, from_role, slice_id)
 
     # Emit as a normal HEARTBEAT message on the bus so downstream
     # consumers (HealthMonitor, overseer, UI) see it.
@@ -686,7 +697,7 @@ def post_heartbeat(pipeline_id: str) -> tuple[Response, int]:
     )
 
 
-def _refresh_gateway_session(pipeline_id: str, from_role: str) -> None:
+def _refresh_gateway_session(pipeline_id: str, from_role: str, slice_id: str | None = None) -> None:
     """Best-effort POST to the gateway so the BRC heartbeat counts as session liveness.
 
     Container-id normalization: k8s names are RFC-1123 labels (no
@@ -698,6 +709,15 @@ def _refresh_gateway_session(pipeline_id: str, from_role: str) -> None:
     registered session and the gateway returns 404.  See
     ``orchestrator/kubernetes_spawner.py:370-375`` for the reference
     pattern.
+
+    Slice scope (#2451): slice-scoped agents register sessions under
+    ``egg-agent-{pid}-{slice_id}-{role}`` (``JOB_NAME_FORMAT_SLICE``);
+    pipeline-level agents register under ``egg-agent-{pid}-{role}``.
+    When ``slice_id`` is supplied (forwarded from the heartbeat body
+    via ``EGG_SLICE_ID``) the slice segment is embedded so the lookup
+    matches; without it every slice-scoped agent's heartbeat fan-out
+    would silently 404. The throttle key is also slice-aware so a
+    sibling slice's fan-out does not suppress this slice's refresh.
 
     Trust model: ``from_role`` is taken at face value from the request
     body and is **not** correlated against the calling container's
@@ -716,8 +736,14 @@ def _refresh_gateway_session(pipeline_id: str, from_role: str) -> None:
     expiry under any realistic heartbeat cadence.
     """
     coordinator = get_heartbeat_coordinator()
+    # Compose the throttle role with the slice scope so concurrent
+    # slices that share a role (e.g. two reviewer-code agents in
+    # different slices of the same wave) do not suppress each other's
+    # fan-outs. The coordinator key is opaque to the throttle, so
+    # scoping at the call site keeps the coordinator API unchanged.
+    throttle_role = f"{slice_id}/{from_role}" if slice_id else from_role
     if not coordinator.should_fan_out_gateway_session(
-        pipeline_id, from_role, _GATEWAY_FANOUT_MIN_INTERVAL_SECONDS
+        pipeline_id, throttle_role, _GATEWAY_FANOUT_MIN_INTERVAL_SECONDS
     ):
         return
     try:
@@ -732,13 +758,17 @@ def _refresh_gateway_session(pipeline_id: str, from_role: str) -> None:
         # — k8s labels disallow underscores, so the registered
         # container_id uses hyphens.
         normalized_role = from_role.replace("_", "-")
-        container_id = f"egg-agent-{pipeline_id}-{normalized_role}"
+        if slice_id:
+            container_id = f"egg-agent-{pipeline_id}-{slice_id}-{normalized_role}"
+        else:
+            container_id = f"egg-agent-{pipeline_id}-{normalized_role}"
         get_gateway_client().heartbeat_session_by_container(container_id)
     except Exception as exc:  # pragma: no cover - logging only
         logger.warning(
             "Gateway session heartbeat fan-out failed",
             pipeline_id=pipeline_id,
             from_role=from_role,
+            slice_id=slice_id,
             error=str(exc),
         )
 

--- a/orchestrator/tests/conftest.py
+++ b/orchestrator/tests/conftest.py
@@ -226,7 +226,7 @@ def _skip_worktree_disk_check(monkeypatch):
 def _reset_heartbeat_coordinator():
     """Reset the heartbeat coordinator singleton between every orchestrator test.
 
-    The coordinator carries per-(pipeline, role) dedup, rate-limit, and
+    The coordinator carries per-(pipeline, slice, role) dedup, rate-limit, and
     gateway-fan-out throttle state. Without resetting it, tests that
     share role names can observe contaminated state across files. As
     new coordinator surfaces are added, this single fixture covers them

--- a/orchestrator/tests/test_heartbeat.py
+++ b/orchestrator/tests/test_heartbeat.py
@@ -1,11 +1,16 @@
 """Unit tests for ``HeartbeatCoordinator``.
 
-Focused on ``should_fan_out_gateway_session`` (issue #2076 NB4) — the
-route-level integration tests in ``test_messages.py`` exercise the
-throttle through the HEARTBEAT endpoint, but a refactor of the
-coordinator is hard to do safely without targeted unit coverage of the
-disable case, the cooldown elapsed/not-elapsed branches, the ``clear()``
-reset, and concurrent access.
+Covers:
+
+* ``should_fan_out_gateway_session`` (issue #2076 NB4) — the route-
+  level integration tests in ``test_messages.py`` exercise the
+  throttle through the HEARTBEAT endpoint, but a refactor of the
+  coordinator is hard to do safely without targeted unit coverage of
+  the disable case, the cooldown elapsed/not-elapsed branches, the
+  ``clear()`` reset, and concurrent access.
+* Per-slice independence of ``is_duplicate`` and ``check_rate_limit``
+  (issue #2471) — two slices that share a role must not share dedup
+  state or rate budgets.
 """
 
 from __future__ import annotations
@@ -31,47 +36,47 @@ from heartbeat import (  # noqa: E402
 
 
 class TestShouldFanOutGatewaySession:
-    """Unit tests for the per-(pipeline, role) gateway-fan-out throttle."""
+    """Unit tests for the per-(pipeline, slice, role) gateway-fan-out throttle."""
 
     def test_zero_interval_disables_throttle(self):
         """``min_interval_seconds == 0`` always returns True without recording."""
         coord = HeartbeatCoordinator()
 
         for _ in range(5):
-            assert coord.should_fan_out_gateway_session("p1", "coder", 0.0) is True
+            assert coord.should_fan_out_gateway_session("p1", None, "coder", 0.0) is True
 
         # Nothing was recorded, so a subsequent positive-interval call
         # sees no prior fan-out and fires.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
 
     def test_negative_interval_disables_throttle(self):
         """Any non-positive value disables (matches the docstring contract)."""
         coord = HeartbeatCoordinator()
 
         for _ in range(3):
-            assert coord.should_fan_out_gateway_session("p1", "coder", -1.0) is True
+            assert coord.should_fan_out_gateway_session("p1", None, "coder", -1.0) is True
 
         # Same as the zero case — no recording happened.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
 
     def test_first_call_fires_and_records(self):
         """First call fires AND records the new timestamp.
 
         The recording side-effect is verified directly: a second call
         inside the cooldown window can only return False if the first
-        call wrote ``_last_fan_out[(p1, coder)]``.
+        call wrote ``_last_fan_out[(p1, None, coder)]``.
         """
         coord = HeartbeatCoordinator()
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
         # Recording side-effect: second call within the window is suppressed.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is False
 
     def test_second_call_within_cooldown_suppressed(self):
         """A second call inside the cooldown window returns False."""
         coord = HeartbeatCoordinator()
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
         # Immediately again — well inside 30s.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is False
 
     def test_call_after_cooldown_fires(self):
         """Once the window elapses, the next call fires again."""
@@ -80,27 +85,49 @@ class TestShouldFanOutGatewaySession:
         # robust against GC pauses or noisy CI scheduling. ``time.sleep``
         # is a guaranteed lower bound, so the cooldown is always elapsed
         # by the time the third assertion runs.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 0.05) is True
-        assert coord.should_fan_out_gateway_session("p1", "coder", 0.05) is False
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 0.05) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 0.05) is False
         time.sleep(0.2)
-        assert coord.should_fan_out_gateway_session("p1", "coder", 0.05) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 0.05) is True
 
     def test_different_roles_throttled_independently(self):
         """Throttle key includes the role — different roles don't collide."""
         coord = HeartbeatCoordinator()
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
-        assert coord.should_fan_out_gateway_session("p1", "tester", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "tester", 30.0) is True
         # Both are now suppressed independently.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is False
-        assert coord.should_fan_out_gateway_session("p1", "tester", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", None, "tester", 30.0) is False
 
     def test_different_pipelines_throttled_independently(self):
         """Throttle key includes the pipeline — different pipelines don't collide."""
         coord = HeartbeatCoordinator()
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
-        assert coord.should_fan_out_gateway_session("p2", "coder", 30.0) is True
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is False
-        assert coord.should_fan_out_gateway_session("p2", "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p2", None, "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p2", None, "coder", 30.0) is False
+
+    def test_different_slices_throttled_independently(self):
+        """Throttle key includes the slice — sibling slices don't collide (#2471)."""
+        coord = HeartbeatCoordinator()
+        assert coord.should_fan_out_gateway_session("p1", "slice-2", "reviewer_code", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", "slice-3", "reviewer_code", 30.0) is True
+        # Each sibling is suppressed inside its own window — they did not
+        # share the throttle entry.
+        assert coord.should_fan_out_gateway_session("p1", "slice-2", "reviewer_code", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", "slice-3", "reviewer_code", 30.0) is False
+
+    def test_pipeline_level_and_sliced_dont_collide(self):
+        """``slice_id=None`` is a distinct bucket from any ``slice-<N>`` (#2471)."""
+        coord = HeartbeatCoordinator()
+        # Pipeline-level agent fires.
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
+        # Slice-scoped agent in the same pipeline + role still fires —
+        # it lives in a separate bucket.
+        assert coord.should_fan_out_gateway_session("p1", "slice-1", "coder", 30.0) is True
+        # Both are now suppressed inside their own windows.
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", "slice-1", "coder", 30.0) is False
 
     def test_suppressed_call_does_not_advance_recorded_timestamp(self):
         """Hot-looping must not push the cooldown forward indefinitely.
@@ -109,34 +136,46 @@ class TestShouldFanOutGatewaySession:
         ``time.time()`` reads robust against scheduling jitter on CI.
         """
         coord = HeartbeatCoordinator()
-        assert coord.should_fan_out_gateway_session("p1", "coder", 0.05) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 0.05) is True
         # Hammer the coordinator inside the window — every call returns
         # False, but the recorded timestamp stays at the initial fire.
         for _ in range(10):
-            assert coord.should_fan_out_gateway_session("p1", "coder", 0.05) is False
+            assert coord.should_fan_out_gateway_session("p1", None, "coder", 0.05) is False
         time.sleep(0.2)
         # Still fires once the original window elapses, which proves the
         # suppressed calls didn't reset the clock.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 0.05) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 0.05) is True
 
     def test_clear_drops_throttle_state_for_pipeline(self):
         """``clear(pipeline)`` lets the next call fire immediately."""
         coord = HeartbeatCoordinator()
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is False
         coord.clear("p1")
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
 
     def test_clear_only_affects_targeted_pipeline(self):
         """``clear(p1)`` must not drop p2's throttle entries."""
         coord = HeartbeatCoordinator()
-        coord.should_fan_out_gateway_session("p1", "coder", 30.0)
-        coord.should_fan_out_gateway_session("p2", "coder", 30.0)
+        coord.should_fan_out_gateway_session("p1", None, "coder", 30.0)
+        coord.should_fan_out_gateway_session("p2", None, "coder", 30.0)
         coord.clear("p1")
         # p1 reset, fires again.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
         # p2 untouched, still suppressed.
-        assert coord.should_fan_out_gateway_session("p2", "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p2", None, "coder", 30.0) is False
+
+    def test_clear_drops_all_slice_scoped_entries_for_pipeline(self):
+        """``clear(p1)`` must sweep every slice's entry, not just ``slice_id=None`` (#2471)."""
+        coord = HeartbeatCoordinator()
+        coord.should_fan_out_gateway_session("p1", None, "coder", 30.0)
+        coord.should_fan_out_gateway_session("p1", "slice-1", "coder", 30.0)
+        coord.should_fan_out_gateway_session("p1", "slice-2", "coder", 30.0)
+        coord.clear("p1")
+        # All three buckets reset — first post-clear call in each fires.
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", "slice-1", "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", "slice-2", "coder", 30.0) is True
 
     def test_concurrent_callers_only_one_wins(self):
         """Under contention, exactly one thread should see True per window."""
@@ -147,7 +186,7 @@ class TestShouldFanOutGatewaySession:
 
         def worker():
             barrier.wait()
-            res = coord.should_fan_out_gateway_session("p1", "coder", 30.0)
+            res = coord.should_fan_out_gateway_session("p1", None, "coder", 30.0)
             with results_lock:
                 results.append(res)
 
@@ -160,6 +199,124 @@ class TestShouldFanOutGatewaySession:
         # Exactly one thread crossed the throttle boundary first.
         assert sum(results) == 1
         assert len(results) == 20
+
+
+class TestIsDuplicate:
+    """Per-(pipeline, slice, role) dedup memory (#2471)."""
+
+    def test_first_observation_is_not_duplicate(self):
+        coord = HeartbeatCoordinator()
+        assert coord.is_duplicate("p1", None, "coder", "WORKING", None) is False
+
+    def test_repeat_after_record_is_duplicate(self):
+        coord = HeartbeatCoordinator()
+        coord.record_state("p1", None, "coder", "WORKING", None)
+        assert coord.is_duplicate("p1", None, "coder", "WORKING", None) is True
+
+    def test_different_state_is_not_duplicate(self):
+        coord = HeartbeatCoordinator()
+        coord.record_state("p1", None, "coder", "WORKING", None)
+        assert coord.is_duplicate("p1", None, "coder", "IDLE", None) is False
+
+    def test_sibling_slices_have_independent_dedup(self):
+        """slice-2 recording WORKING must not dedup slice-3's first WORKING (#2471).
+
+        Without slice-scope, slice-2's record poisons slice-3's first
+        non-exempt heartbeat for the same role into a silent dedup —
+        downstream consumers (HealthMonitor, overseer, UI) see only one
+        of the N siblings' state transitions even though all N are
+        independent agents in independent pods.
+        """
+        coord = HeartbeatCoordinator()
+        coord.record_state("p1", "slice-2", "reviewer_code", "WORKING", None)
+        # Slice-3's first WORKING observation is fresh — different bucket.
+        assert coord.is_duplicate("p1", "slice-3", "reviewer_code", "WORKING", None) is False
+        # And after slice-3 records, it dedups in its own bucket only.
+        coord.record_state("p1", "slice-3", "reviewer_code", "WORKING", None)
+        assert coord.is_duplicate("p1", "slice-3", "reviewer_code", "WORKING", None) is True
+        # Slice-2's bucket is unaffected by slice-3's writes.
+        assert coord.is_duplicate("p1", "slice-2", "reviewer_code", "WORKING", None) is True
+
+    def test_pipeline_level_does_not_collide_with_slice(self):
+        """``slice_id=None`` and a real ``slice-<N>`` are different buckets."""
+        coord = HeartbeatCoordinator()
+        coord.record_state("p1", None, "coder", "WORKING", None)
+        assert coord.is_duplicate("p1", "slice-1", "coder", "WORKING", None) is False
+
+    def test_clear_resets_dedup_for_all_slices_in_pipeline(self):
+        """Phase transitions must reset every slice's dedup memory."""
+        coord = HeartbeatCoordinator()
+        coord.record_state("p1", "slice-1", "coder", "WORKING", None)
+        coord.record_state("p1", "slice-2", "coder", "WORKING", None)
+        coord.record_state("p1", None, "coder", "WORKING", None)
+        coord.clear("p1")
+        assert coord.is_duplicate("p1", "slice-1", "coder", "WORKING", None) is False
+        assert coord.is_duplicate("p1", "slice-2", "coder", "WORKING", None) is False
+        assert coord.is_duplicate("p1", None, "coder", "WORKING", None) is False
+
+
+class TestCheckRateLimit:
+    """Per-(pipeline, slice, role) rate budgets (#2471)."""
+
+    def test_allows_up_to_limit(self):
+        coord = HeartbeatCoordinator()
+        for _ in range(3):
+            assert coord.check_rate_limit("p1", None, "coder", limit_per_minute=3).allowed is True
+
+    def test_rejects_after_limit(self):
+        coord = HeartbeatCoordinator()
+        for _ in range(3):
+            coord.check_rate_limit("p1", None, "coder", limit_per_minute=3)
+        decision = coord.check_rate_limit("p1", None, "coder", limit_per_minute=3)
+        assert decision.allowed is False
+        assert decision.retry_after_seconds >= 1
+
+    def test_sibling_slices_have_independent_budgets(self):
+        """slice-2 saturating its budget must not drop slice-3's beats (#2471).
+
+        ``EGG_HEARTBEAT_RATE_LIMIT`` defaults to 20/min. Under wide
+        fan-out, a popular role (e.g. reviewer-code in 4 slices each
+        emitting wait-loop's 1/min plus other beats) can plausibly hit
+        the per-role ceiling under the old key shape, silently dropping
+        slice-X's beat because slice-Y filled the window. Slice-scoping
+        the key gives each sibling its own bucket.
+        """
+        coord = HeartbeatCoordinator()
+        # Saturate slice-2 at the limit.
+        for _ in range(3):
+            assert (
+                coord.check_rate_limit("p1", "slice-2", "reviewer_code", limit_per_minute=3).allowed
+                is True
+            )
+        # slice-2 is now over the line.
+        assert (
+            coord.check_rate_limit("p1", "slice-2", "reviewer_code", limit_per_minute=3).allowed
+            is False
+        )
+        # slice-3 is in a separate bucket — it can still get its full budget.
+        for _ in range(3):
+            assert (
+                coord.check_rate_limit("p1", "slice-3", "reviewer_code", limit_per_minute=3).allowed
+                is True
+            )
+
+    def test_pipeline_level_does_not_collide_with_slice(self):
+        coord = HeartbeatCoordinator()
+        for _ in range(3):
+            coord.check_rate_limit("p1", None, "coder", limit_per_minute=3)
+        # slice-scoped agent in the same pipeline + role still gets a
+        # fresh budget.
+        assert coord.check_rate_limit("p1", "slice-1", "coder", limit_per_minute=3).allowed is True
+
+    def test_clear_drops_rate_state_for_all_slices_in_pipeline(self):
+        coord = HeartbeatCoordinator()
+        for _ in range(3):
+            coord.check_rate_limit("p1", "slice-1", "coder", limit_per_minute=3)
+            coord.check_rate_limit("p1", "slice-2", "coder", limit_per_minute=3)
+        coord.clear("p1")
+        # Both slices' windows reset.
+        assert coord.check_rate_limit("p1", "slice-1", "coder", limit_per_minute=3).allowed is True
+        assert coord.check_rate_limit("p1", "slice-2", "coder", limit_per_minute=3).allowed is True
 
 
 class TestSingletonAccessor:

--- a/orchestrator/tests/test_messages.py
+++ b/orchestrator/tests/test_messages.py
@@ -2301,6 +2301,148 @@ class TestHeartbeatRoute:
                     expected_container_id
                 )
 
+    @pytest.mark.parametrize(
+        "from_role,slice_id,expected_container_id",
+        [
+            (
+                "reviewer_contract",
+                "slice-2",
+                "egg-agent-test-pipeline-slice-2-reviewer-contract",
+            ),
+            (
+                "reviewer_code_holistic",
+                "slice-12",
+                "egg-agent-test-pipeline-slice-12-reviewer-code-holistic",
+            ),
+            ("tester", "slice-5", "egg-agent-test-pipeline-slice-5-tester"),
+            ("coder", "slice-1", "egg-agent-test-pipeline-slice-1-coder"),
+        ],
+    )
+    def test_heartbeat_fan_out_includes_slice_id(
+        self, client, app, from_role, slice_id, expected_container_id
+    ):
+        """Slice-scoped heartbeats fan out to the slice-scoped container_id (#2451).
+
+        Slice-DAG agents register gateway sessions under
+        ``egg-agent-{pid}-{slice_id}-{role}`` per
+        ``kubernetes_spawner.JOB_NAME_FORMAT_SLICE``. The orchestrator
+        must thread the agent's ``slice_id`` (forwarded via the
+        heartbeat body from ``EGG_SLICE_ID``) into the fan-out's
+        container_id, otherwise every slice-scoped reviewer/tester
+        emits warnings ("Session not found for container") and the
+        gateway session never has its idle timer refreshed.
+        """
+        with app.test_request_context():
+            mock_gw_client = MagicMock()
+            with (
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+                patch(
+                    "gateway_client.get_gateway_client",
+                    return_value=mock_gw_client,
+                ),
+            ):
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                resp = client.post(
+                    "/api/v1/pipelines/test-pipeline/heartbeat",
+                    json={
+                        "from_role": from_role,
+                        "state": "WAITING_FOR_EVENT",
+                        "slice_id": slice_id,
+                    },
+                )
+                assert resp.status_code == 200
+                mock_gw_client.heartbeat_session_by_container.assert_called_once_with(
+                    expected_container_id
+                )
+
+    def test_heartbeat_rejects_invalid_slice_id(self, client, app):
+        """Malformed ``slice_id`` is rejected with 400 rather than smuggled into the fan-out.
+
+        Mirrors the canonical ``slice-<N>`` regex enforced at every
+        gateway-facing seam (#2403, ``slice_id_validation``). A path
+        separator or shell metacharacter must not reach the
+        container_id construction below.
+        """
+        with app.test_request_context():
+            mock_gw_client = MagicMock()
+            with (
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+                patch(
+                    "gateway_client.get_gateway_client",
+                    return_value=mock_gw_client,
+                ),
+            ):
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                resp = client.post(
+                    "/api/v1/pipelines/test-pipeline/heartbeat",
+                    json={
+                        "from_role": "tester",
+                        "state": "WORKING",
+                        "slice_id": "phase-2",  # legacy shape not allowed at this seam
+                    },
+                )
+                assert resp.status_code == 400
+                mock_gw_client.heartbeat_session_by_container.assert_not_called()
+
+    def test_heartbeat_sibling_slices_do_not_share_throttle(self, client, app):
+        """Sibling slices with the same role each fan out independently (#2451).
+
+        The dedup-amplification cap (#2076 NB2) is keyed per role to
+        bound a single hot-looping agent. Without slice-scoping the
+        throttle key, slice-2 reviewer-code's fan-out would suppress
+        slice-3 reviewer-code's fan-out for 30 s, leaving slice-3's
+        gateway session unrefreshed even though they are independent
+        agents in independent pods.
+        """
+        with app.test_request_context():
+            mock_gw_client = MagicMock()
+            with (
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+                patch(
+                    "gateway_client.get_gateway_client",
+                    return_value=mock_gw_client,
+                ),
+                patch(
+                    "routes.messages._GATEWAY_FANOUT_MIN_INTERVAL_SECONDS",
+                    300.0,
+                ),
+            ):
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                for slice_id in ("slice-2", "slice-3"):
+                    resp = client.post(
+                        "/api/v1/pipelines/test-pipeline/heartbeat",
+                        json={
+                            "from_role": "reviewer_code",
+                            "state": "WORKING",
+                            "slice_id": slice_id,
+                        },
+                    )
+                    assert resp.status_code == 200
+                assert mock_gw_client.heartbeat_session_by_container.call_count == 2
+                fan_out_calls = [
+                    call.args[0]
+                    for call in mock_gw_client.heartbeat_session_by_container.call_args_list
+                ]
+                assert fan_out_calls == [
+                    "egg-agent-test-pipeline-slice-2-reviewer-code",
+                    "egg-agent-test-pipeline-slice-3-reviewer-code",
+                ]
+
     def test_heartbeat_fan_out_throttle_caps_dedup_amplification(self, client, app):
         """#2076 NB2: dedup'd hot-loops cannot amplify into the gateway.
 

--- a/orchestrator/tests/test_messages.py
+++ b/orchestrator/tests/test_messages.py
@@ -2360,13 +2360,29 @@ class TestHeartbeatRoute:
                     expected_container_id
                 )
 
-    def test_heartbeat_rejects_invalid_slice_id(self, client, app):
+    @pytest.mark.parametrize(
+        "bad_slice_id",
+        [
+            "phase-2",  # legacy contract migration shape
+            "../escape",  # path traversal
+            "; rm -rf /",  # shell metacharacters
+            "slice-2/extra",  # path separator after a valid prefix
+            "slice-",  # missing index
+            "Slice-2",  # case mismatch
+            "",  # empty string disguised as set
+            "slice-2 ",  # trailing whitespace
+        ],
+    )
+    def test_heartbeat_rejects_invalid_slice_id(self, client, app, bad_slice_id):
         """Malformed ``slice_id`` is rejected with 400 rather than smuggled into the fan-out.
 
         Mirrors the canonical ``slice-<N>`` regex enforced at every
         gateway-facing seam (#2403, ``slice_id_validation``). A path
-        separator or shell metacharacter must not reach the
-        container_id construction below.
+        separator, shell metacharacter, or other contract-foreign value
+        must not reach the container_id construction below — covering
+        both real-world legacy payloads (``phase-2``) and obviously
+        malicious values (``../escape``, ``; rm -rf /``) so the
+        security intent of the regex is explicit in the test corpus.
         """
         with app.test_request_context():
             mock_gw_client = MagicMock()
@@ -2388,10 +2404,19 @@ class TestHeartbeatRoute:
                     json={
                         "from_role": "tester",
                         "state": "WORKING",
-                        "slice_id": "phase-2",  # legacy shape not allowed at this seam
+                        "slice_id": bad_slice_id,
                     },
                 )
-                assert resp.status_code == 400
+                # Empty-string ``slice_id`` is treated as "no slice" by
+                # the orchestrator's ``extract_slice_id`` (matches the
+                # agent-side ``or`` fallback) — the request still
+                # succeeds but pipeline-level fan-out semantics apply.
+                if bad_slice_id == "":
+                    assert resp.status_code == 200
+                    return
+                assert resp.status_code == 400, (
+                    f"slice_id={bad_slice_id!r} must reject with 400; got {resp.status_code}"
+                )
                 mock_gw_client.heartbeat_session_by_container.assert_not_called()
 
     def test_heartbeat_sibling_slices_do_not_share_throttle(self, client, app):

--- a/sandbox/egg_agent_tools/handlers/_gateway.py
+++ b/sandbox/egg_agent_tools/handlers/_gateway.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
@@ -27,7 +28,9 @@ except ImportError:  # pragma: no cover - env without egg_config
     GATEWAY_PORT = 9848  # noqa: EGG002
     ORCHESTRATOR_PORT = 9849  # noqa: EGG002
 
-from egg_agent_tools.handlers.errors import GatewayError
+from egg_agent_tools.handlers.errors import GatewayError, HandlerError
+
+_SLICE_ID_PATTERN = re.compile(r"^slice-[0-9]+$")
 
 # Bypass any HTTP(S)_PROXY for internal egg-network requests.
 _opener = build_opener(ProxyHandler({}))
@@ -95,6 +98,43 @@ def get_slice_id() -> str | None:
     agents leave it unset and route to the bare pipeline tracker.
     """
     return os.environ.get("EGG_SLICE_ID") or None
+
+
+def maybe_attach_slice_id(req: dict[str, Any], data: dict[str, Any]) -> None:
+    """Forward ``slice_id`` from the request or env onto a signal body.
+
+    Single source of truth for the BRC / progress / heartbeat handlers
+    (#2451 follow-up). Per-slice agents set ``EGG_SLICE_ID`` so the
+    orchestrator can route their ``CONSENSUS_*`` to the slice tracker
+    (#2403) and refresh the slice-scoped gateway session container_id
+    (#2451). Callers can also pass ``slice_id`` on ``req`` to override
+    (e.g. tests, or operator tooling acting on a specific slice).
+    Validation matches the canonical ``slice-<N>`` regex enforced at
+    the orchestrator seam so a malformed value cannot smuggle path
+    separators into a tracker key or container_id.
+    """
+    slice_id = req.get("slice_id") or get_slice_id()
+    if not slice_id:
+        return
+    if not isinstance(slice_id, str) or not _SLICE_ID_PATTERN.fullmatch(slice_id):
+        raise HandlerError(f"Invalid slice_id {slice_id!r}: must match 'slice-<N>'")
+    data["slice_id"] = slice_id
+
+
+def resolve_slice_id(req: dict[str, Any]) -> str | None:
+    """Return a validated ``slice_id`` (from ``req`` or env), or ``None``.
+
+    Same validation as :func:`maybe_attach_slice_id` but returns the
+    value instead of mutating a payload dict. Used by callers that
+    thread ``slice_id`` through their own data structures (e.g. the
+    wait-loop heartbeat emitter, which builds the payload itself).
+    """
+    slice_id = req.get("slice_id") or get_slice_id()
+    if not slice_id:
+        return None
+    if not isinstance(slice_id, str) or not _SLICE_ID_PATTERN.fullmatch(slice_id):
+        raise HandlerError(f"Invalid slice_id {slice_id!r}: must match 'slice-<N>'")
+    return slice_id
 
 
 def get_issue_number() -> int | None:

--- a/sandbox/egg_agent_tools/handlers/_gateway.py
+++ b/sandbox/egg_agent_tools/handlers/_gateway.py
@@ -177,7 +177,7 @@ def _parse_http_error(exc: HTTPError) -> GatewayError:
         body = json.loads(exc.read().decode())
         message = body.get("message", str(exc))
         details = body.get("details") or body.get("data") or {}
-    except json.JSONDecodeError, Exception:
+    except Exception:
         message = str(exc)
         details = {}
     return GatewayError(

--- a/sandbox/egg_agent_tools/handlers/brc.py
+++ b/sandbox/egg_agent_tools/handlers/brc.py
@@ -13,32 +13,13 @@ from typing import Any
 from egg_agent_tools.handlers._gateway import (
     get_agent_role,
     get_pipeline_id,
-    get_slice_id,
     orchestrator_request,
 )
+from egg_agent_tools.handlers._gateway import maybe_attach_slice_id as _maybe_attach_slice_id
 from egg_agent_tools.handlers.errors import GatewayError, HandlerError
 
 _COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{7,40}$")
 _PIPELINE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
-_SLICE_ID_PATTERN = re.compile(r"^slice-[0-9]+$")
-
-
-def _maybe_attach_slice_id(req: dict[str, Any], data: dict[str, Any]) -> None:
-    """Forward ``slice_id`` from the request or env onto the signal body.
-
-    Per-slice agents set ``EGG_SLICE_ID`` so the orchestrator can route
-    their ``CONSENSUS_*`` to the slice tracker instead of the bare
-    pipeline tracker (#2403). Callers can also pass ``slice_id`` on
-    ``req`` to override (e.g. tests, or operator tooling acting on a
-    specific slice). Validation mirrors the orchestrator side so a
-    malformed value can't smuggle path separators into a tracker key.
-    """
-    slice_id = req.get("slice_id") or get_slice_id()
-    if not slice_id:
-        return
-    if not isinstance(slice_id, str) or not _SLICE_ID_PATTERN.fullmatch(slice_id):
-        raise HandlerError(f"Invalid slice_id {slice_id!r}: must match 'slice-<N>'")
-    data["slice_id"] = slice_id
 
 
 def _validate_commit_sha(sha: str) -> str:

--- a/sandbox/egg_agent_tools/handlers/message.py
+++ b/sandbox/egg_agent_tools/handlers/message.py
@@ -16,6 +16,7 @@ structured dict directly and classify ``matched``/``ok`` themselves.
 from __future__ import annotations
 
 import datetime as _datetime
+import re
 import threading
 import time as _time
 from collections.abc import Callable
@@ -24,6 +25,7 @@ from typing import Any
 from egg_agent_tools.handlers._gateway import (
     get_agent_role,
     get_pipeline_id,
+    get_slice_id,
     orchestrator_request,
 )
 from egg_agent_tools.handlers.errors import GatewayError, HandlerError
@@ -35,6 +37,28 @@ _HEARTBEAT_STATES = {
     "PROPOSED",
     "IDLE",
 }
+
+_SLICE_ID_PATTERN = re.compile(r"^slice-[0-9]+$")
+
+
+def _maybe_attach_slice_id(req: dict[str, Any], data: dict[str, Any]) -> None:
+    """Forward ``slice_id`` from the request or env onto the heartbeat body.
+
+    Mirrors ``brc._maybe_attach_slice_id`` and ``progress._maybe_attach_slice_id``
+    so the orchestrator's gateway-session fan-out (#2068) can reconstruct
+    the slice-scoped container_id (``egg-agent-{pid}-{slice}-{role}``)
+    that ``kubernetes_spawner.JOB_NAME_FORMAT_SLICE`` registered. Without
+    this, slice-scoped agents emit heartbeats whose fan-out always 404s
+    against the gateway because the orchestrator falls back to the
+    pipeline-level shape ``egg-agent-{pid}-{role}``. See #2451.
+    """
+    slice_id = req.get("slice_id") or get_slice_id()
+    if not slice_id:
+        return
+    if not isinstance(slice_id, str) or not _SLICE_ID_PATTERN.fullmatch(slice_id):
+        raise HandlerError(f"Invalid slice_id {slice_id!r}: must match 'slice-<N>'")
+    data["slice_id"] = slice_id
+
 
 # Interval between ``WAITING_FOR_EVENT`` keep-alive heartbeats emitted by
 # ``message_wait_loop`` while blocked. Needs to be well under the
@@ -401,6 +425,7 @@ def message_heartbeat(req: dict[str, Any]) -> dict[str, Any]:
         body["since"] = req["since"]
     if req.get("body"):
         body["body"] = req["body"]
+    _maybe_attach_slice_id(req, body)
 
     result = orchestrator_request(
         f"/api/v1/pipelines/{pid}/heartbeat",

--- a/sandbox/egg_agent_tools/handlers/message.py
+++ b/sandbox/egg_agent_tools/handlers/message.py
@@ -16,7 +16,6 @@ structured dict directly and classify ``matched``/``ok`` themselves.
 from __future__ import annotations
 
 import datetime as _datetime
-import re
 import threading
 import time as _time
 from collections.abc import Callable
@@ -25,9 +24,10 @@ from typing import Any
 from egg_agent_tools.handlers._gateway import (
     get_agent_role,
     get_pipeline_id,
-    get_slice_id,
     orchestrator_request,
+    resolve_slice_id,
 )
+from egg_agent_tools.handlers._gateway import maybe_attach_slice_id as _maybe_attach_slice_id
 from egg_agent_tools.handlers.errors import GatewayError, HandlerError
 
 _HEARTBEAT_STATES = {
@@ -37,27 +37,6 @@ _HEARTBEAT_STATES = {
     "PROPOSED",
     "IDLE",
 }
-
-_SLICE_ID_PATTERN = re.compile(r"^slice-[0-9]+$")
-
-
-def _maybe_attach_slice_id(req: dict[str, Any], data: dict[str, Any]) -> None:
-    """Forward ``slice_id`` from the request or env onto the heartbeat body.
-
-    Mirrors ``brc._maybe_attach_slice_id`` and ``progress._maybe_attach_slice_id``
-    so the orchestrator's gateway-session fan-out (#2068) can reconstruct
-    the slice-scoped container_id (``egg-agent-{pid}-{slice}-{role}``)
-    that ``kubernetes_spawner.JOB_NAME_FORMAT_SLICE`` registered. Without
-    this, slice-scoped agents emit heartbeats whose fan-out always 404s
-    against the gateway because the orchestrator falls back to the
-    pipeline-level shape ``egg-agent-{pid}-{role}``. See #2451.
-    """
-    slice_id = req.get("slice_id") or get_slice_id()
-    if not slice_id:
-        return
-    if not isinstance(slice_id, str) or not _SLICE_ID_PATTERN.fullmatch(slice_id):
-        raise HandlerError(f"Invalid slice_id {slice_id!r}: must match 'slice-<N>'")
-    data["slice_id"] = slice_id
 
 
 # Interval between ``WAITING_FOR_EVENT`` keep-alive heartbeats emitted by
@@ -179,6 +158,7 @@ def _default_emit_wait_loop_heartbeat(
     state: str,
     body: str,
     since: str | None = None,
+    slice_id: str | None = None,
 ) -> None:
     """Emit a single liveness heartbeat from ``message_wait_loop``.
 
@@ -197,6 +177,16 @@ def _default_emit_wait_loop_heartbeat(
     entry so every periodic ``WAITING_FOR_EVENT`` beat carries the same
     value, letting the overseer read it as a monotonically aging
     "waiting since" rather than a clock that resets each tick.
+
+    ``slice_id`` (optional) is forwarded so the orchestrator's gateway
+    -session fan-out can reconstruct the slice-scoped container_id
+    (``egg-agent-{pid}-{slice}-{role}``) that
+    ``kubernetes_spawner.JOB_NAME_FORMAT_SLICE`` registered. Without it,
+    every ``wait_loop`` tick from a slice-scoped reviewer/tester would
+    log "Session not found for container" and leave the gateway
+    session's idle timer unrefreshed (#2451). Pipeline-level agents
+    (no slice) leave it ``None`` and fall through to the
+    ``egg-agent-{pid}-{role}`` shape.
     """
     if not pipeline_id or not role:
         return
@@ -207,6 +197,8 @@ def _default_emit_wait_loop_heartbeat(
     }
     if since:
         payload["since"] = since
+    if slice_id:
+        payload["slice_id"] = slice_id
     try:
         orchestrator_request(
             f"/api/v1/pipelines/{pipeline_id}/heartbeat",
@@ -302,6 +294,11 @@ def message_wait_loop(req: dict[str, Any]) -> dict[str, Any]:
     role_hb = _role_or_env(req)
     for_types_hb = _coerce_for_types(req)
     from_role_hb = req.get("from_role") or req.get("from")
+    # Capture (and validate) once at wait entry so every periodic tick
+    # forwards the same value. Slice-scoped reviewers/testers spend the
+    # bulk of their lifetimes blocked here, so this is the dominant
+    # heartbeat path #2451 was trying to fix.
+    slice_id_hb = resolve_slice_id(req)
     emit_hb: Callable[..., None] = req.get("_emit_heartbeat", _default_emit_wait_loop_heartbeat)
     hb_interval = float(req.get("_heartbeat_interval", _WAIT_LOOP_HEARTBEAT_INTERVAL_SECS))
     start_hb: Callable[[Callable[[], None], float], Callable[[], None]] = req.get(
@@ -318,7 +315,14 @@ def message_wait_loop(req: dict[str, Any]) -> dict[str, Any]:
     wait_since = _datetime.datetime.now(_datetime.UTC).isoformat()
 
     def _tick() -> None:
-        emit_hb(pipeline_id_hb, role_hb, "WAITING_FOR_EVENT", waiting_body, wait_since)
+        emit_hb(
+            pipeline_id_hb,
+            role_hb,
+            "WAITING_FOR_EVENT",
+            waiting_body,
+            wait_since,
+            slice_id=slice_id_hb,
+        )
 
     stop_hb = start_hb(_tick, hb_interval)
 
@@ -375,7 +379,13 @@ def message_wait_loop(req: dict[str, Any]) -> dict[str, Any]:
         # Final transition back to WORKING so the overseer sees the
         # agent leave the wait cleanly. Best-effort; dedup will still
         # collapse a follow-on manual WORKING beat from the caller.
-        emit_hb(pipeline_id_hb, role_hb, "WORKING", "wait_loop exited")
+        emit_hb(
+            pipeline_id_hb,
+            role_hb,
+            "WORKING",
+            "wait_loop exited",
+            slice_id=slice_id_hb,
+        )
 
 
 def message_heartbeat(req: dict[str, Any]) -> dict[str, Any]:

--- a/sandbox/egg_agent_tools/handlers/progress.py
+++ b/sandbox/egg_agent_tools/handlers/progress.py
@@ -8,30 +8,12 @@ from typing import Any
 from egg_agent_tools.handlers._gateway import (
     get_agent_role,
     get_pipeline_id,
-    get_slice_id,
     orchestrator_request,
 )
+from egg_agent_tools.handlers._gateway import maybe_attach_slice_id as _maybe_attach_slice_id
 from egg_agent_tools.handlers.errors import GatewayError, HandlerError
 
 _PIPELINE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
-_SLICE_ID_PATTERN = re.compile(r"^slice-[0-9]+$")
-
-
-def _maybe_attach_slice_id(req: dict[str, Any], data: dict[str, Any]) -> None:
-    """Forward ``slice_id`` from the request or env onto the signal body.
-
-    Mirrors ``brc._maybe_attach_slice_id`` so the orchestrator-side
-    ``handle_error_signal`` can scope its "agent already COMPLETE,
-    suppress error" check by ``(role, slice_id)`` rather than role
-    alone — without this, slice-2 coder finishing would silently
-    swallow slice-3 coder's error (#2422).
-    """
-    slice_id = req.get("slice_id") or get_slice_id()
-    if not slice_id:
-        return
-    if not isinstance(slice_id, str) or not _SLICE_ID_PATTERN.fullmatch(slice_id):
-        raise HandlerError(f"Invalid slice_id {slice_id!r}: must match 'slice-<N>'")
-    data["slice_id"] = slice_id
 
 
 def _require_pipeline_id(req: dict[str, Any]) -> str:

--- a/sandbox/tests/test_message_wait_cli.py
+++ b/sandbox/tests/test_message_wait_cli.py
@@ -475,6 +475,57 @@ class TestHeartbeat:
             rc = cmd_message_heartbeat(_make_hb_args(state="WORKING"))
         assert rc == 3
 
+    def test_heartbeat_forwards_slice_id_from_env(self):
+        """Issue #2451: slice-scoped agents forward ``EGG_SLICE_ID`` so
+        the orchestrator's gateway-session fan-out can build the
+        slice-scoped container_id (``egg-agent-{pid}-{slice}-{role}``)
+        that ``kubernetes_spawner.JOB_NAME_FORMAT_SLICE`` registered.
+        """
+        with (
+            patch(
+                "egg_agent_tools.handlers.message.get_slice_id",
+                return_value="slice-2",
+            ),
+            patch(_ORCH_MOCK_PATH) as mock_req,
+        ):
+            mock_req.return_value = {"success": True, "data": {"deduped": False}}
+            rc = cmd_message_heartbeat(_make_hb_args(state="WORKING"))
+        assert rc == 0
+        posted = mock_req.call_args.kwargs["data"]
+        assert posted["slice_id"] == "slice-2"
+
+    def test_heartbeat_omits_slice_id_for_pipeline_level_agents(self):
+        """Pipeline-level agents (no ``EGG_SLICE_ID``) MUST NOT include
+        a ``slice_id`` field — the orchestrator's fan-out then falls
+        back to the pipeline-level container_id shape, which is what
+        ``JOB_NAME_FORMAT`` (no slice) registered.
+        """
+        with (
+            patch(
+                "egg_agent_tools.handlers.message.get_slice_id",
+                return_value=None,
+            ),
+            patch(_ORCH_MOCK_PATH) as mock_req,
+        ):
+            mock_req.return_value = {"success": True, "data": {"deduped": False}}
+            rc = cmd_message_heartbeat(_make_hb_args(state="WORKING"))
+        assert rc == 0
+        posted = mock_req.call_args.kwargs["data"]
+        assert "slice_id" not in posted
+
+    def test_heartbeat_rejects_invalid_slice_id(self):
+        """Defense-in-depth: a malformed ``EGG_SLICE_ID`` is rejected at
+        handler-construction time (``HandlerError`` → CLI exit 3) so a
+        path separator or shell metacharacter cannot be smuggled to
+        the orchestrator's container_id construction.
+        """
+        with patch(
+            "egg_agent_tools.handlers.message.get_slice_id",
+            return_value="../escape",
+        ):
+            rc = cmd_message_heartbeat(_make_hb_args(state="WORKING"))
+        assert rc == 3
+
 
 # ---------------------------------------------------------------------------
 # Auto cursor file (issue #2323): close the wait→process→wait race that

--- a/sandbox/tests/test_message_wait_cli.py
+++ b/sandbox/tests/test_message_wait_cli.py
@@ -483,7 +483,7 @@ class TestHeartbeat:
         """
         with (
             patch(
-                "egg_agent_tools.handlers.message.get_slice_id",
+                "egg_agent_tools.handlers._gateway.get_slice_id",
                 return_value="slice-2",
             ),
             patch(_ORCH_MOCK_PATH) as mock_req,
@@ -502,7 +502,7 @@ class TestHeartbeat:
         """
         with (
             patch(
-                "egg_agent_tools.handlers.message.get_slice_id",
+                "egg_agent_tools.handlers._gateway.get_slice_id",
                 return_value=None,
             ),
             patch(_ORCH_MOCK_PATH) as mock_req,
@@ -520,7 +520,7 @@ class TestHeartbeat:
         the orchestrator's container_id construction.
         """
         with patch(
-            "egg_agent_tools.handlers.message.get_slice_id",
+            "egg_agent_tools.handlers._gateway.get_slice_id",
             return_value="../escape",
         ):
             rc = cmd_message_heartbeat(_make_hb_args(state="WORKING"))

--- a/tests/sandbox/egg_agent_tools/test_handlers_message.py
+++ b/tests/sandbox/egg_agent_tools/test_handlers_message.py
@@ -334,7 +334,7 @@ class TestMessageWaitLoopHeartbeat:
         """Return (emitted_list, fake_emit) for use in tests."""
         emitted: list[dict] = []
 
-        def fake_emit(pipeline_id, role, state, body, since=None):
+        def fake_emit(pipeline_id, role, state, body, since=None, slice_id=None):
             emitted.append(
                 {
                     "pipeline_id": pipeline_id,
@@ -342,6 +342,7 @@ class TestMessageWaitLoopHeartbeat:
                     "state": state,
                     "body": body,
                     "since": since,
+                    "slice_id": slice_id,
                 }
             )
 
@@ -442,7 +443,7 @@ class TestMessageWaitLoopHeartbeat:
                     "role": "coder",
                     "for_types": ["X"],
                     "_emit_heartbeat": (
-                        lambda pid, role, state, body, since=None: None
+                        lambda pid, role, state, body, since=None, slice_id=None: None
                     ),  # no-op (production default swallows errors)
                     "_heartbeat_interval": 0,
                     "_sleep": sleeps.append,
@@ -490,6 +491,118 @@ class TestMessageWaitLoopHeartbeat:
             message._default_emit_wait_loop_heartbeat("p", "coder", "WORKING", "exited")
         assert req.call_count == 1
         assert "since" not in req.call_args.kwargs["data"]
+
+    def test_default_emitter_forwards_slice_id_in_payload(self):
+        """Issue #2451: slice-scoped agents' wait-loop heartbeats must
+        forward ``slice_id`` so the orchestrator's gateway-session
+        fan-out can reconstruct ``egg-agent-{pid}-{slice}-{role}``
+        instead of falling back to the pipeline-level shape and 404'ing
+        the gateway lookup. This is the dominant heartbeat path — wait
+        -loop ticks at 60 s for every blocked agent — so a missing
+        forward here is what produced the steady stream of
+        "Session not found for container" warnings in #2451.
+        """
+        with patch("egg_agent_tools.handlers.message.orchestrator_request") as req:
+            message._default_emit_wait_loop_heartbeat(
+                "p", "reviewer_code", "WAITING_FOR_EVENT", "blocked", slice_id="slice-2"
+            )
+        assert req.call_count == 1
+        sent_body = req.call_args.kwargs["data"]
+        assert sent_body["slice_id"] == "slice-2"
+        assert sent_body["state"] == "WAITING_FOR_EVENT"
+        assert sent_body["from_role"] == "reviewer_code"
+
+    def test_default_emitter_omits_slice_id_for_pipeline_level_agents(self):
+        """Pipeline-level agents (no slice) must NOT include a
+        ``slice_id`` field — the orchestrator's fan-out then falls back
+        to the pipeline-level container_id shape, which is what
+        ``JOB_NAME_FORMAT`` (no slice) registered.
+        """
+        with patch("egg_agent_tools.handlers.message.orchestrator_request") as req:
+            message._default_emit_wait_loop_heartbeat(
+                "p", "planner", "WAITING_FOR_EVENT", "blocked"
+            )
+        assert req.call_count == 1
+        assert "slice_id" not in req.call_args.kwargs["data"]
+
+    def test_wait_loop_threads_slice_id_into_periodic_ticks(self):
+        """Regression for #2451: ``message_wait_loop`` must capture
+        ``slice_id`` once at entry and pass it on every emitted tick
+        (entry, periodic ``WAITING_FOR_EVENT``, and the final ``WORKING``
+        beat in the finally). Without this, slice-scoped reviewers /
+        testers spend their entire lifetime emitting fan-out 404s.
+        """
+        emitted, fake_emit = self._capture_emit()
+        with patch(
+            "egg_agent_tools.handlers.message.message_wait",
+            return_value={"ok": True, "matched": True, "messages": [{"id": "m"}]},
+        ):
+            message.message_wait_loop(
+                {
+                    "pipeline_id": "p",
+                    "role": "reviewer_code",
+                    "slice_id": "slice-3",
+                    "for_types": ["CONSENSUS_ACK"],
+                    "_emit_heartbeat": fake_emit,
+                    "_heartbeat_interval": 0,
+                }
+            )
+        assert emitted, "wait_loop must emit at least one heartbeat"
+        # Every emitted beat (entry + exit) must carry the captured slice_id.
+        slice_ids = {e["slice_id"] for e in emitted}
+        assert slice_ids == {"slice-3"}, (
+            f"every wait_loop tick must forward slice_id; got {slice_ids}"
+        )
+
+    def test_wait_loop_omits_slice_id_for_pipeline_level_agents(self):
+        """Pipeline-level agents (no env var, no override) must not
+        smuggle a ``slice_id`` onto the heartbeat — the orchestrator's
+        fan-out would otherwise build a slice-shaped container_id that
+        the pipeline-level pod never registered.
+        """
+        emitted, fake_emit = self._capture_emit()
+        with (
+            patch(
+                "egg_agent_tools.handlers.message.message_wait",
+                return_value={"ok": True, "matched": True, "messages": [{"id": "m"}]},
+            ),
+            patch(
+                "egg_agent_tools.handlers._gateway.get_slice_id",
+                return_value=None,
+            ),
+        ):
+            message.message_wait_loop(
+                {
+                    "pipeline_id": "p",
+                    "role": "planner",
+                    "for_types": ["CONSENSUS_ACK"],
+                    "_emit_heartbeat": fake_emit,
+                    "_heartbeat_interval": 0,
+                }
+            )
+        slice_ids = {e["slice_id"] for e in emitted}
+        assert slice_ids == {None}, (
+            f"pipeline-level wait_loop ticks must not carry slice_id; got {slice_ids}"
+        )
+
+    def test_wait_loop_rejects_invalid_slice_id_at_entry(self):
+        """Defense-in-depth: a malformed ``slice_id`` is rejected
+        before the wait begins so a path separator or shell metachar
+        cannot be smuggled into the heartbeat fan-out's container_id.
+        """
+        emitted, fake_emit = self._capture_emit()
+        with pytest.raises(HandlerError):
+            message.message_wait_loop(
+                {
+                    "pipeline_id": "p",
+                    "role": "reviewer_code",
+                    "slice_id": "../escape",
+                    "for_types": ["CONSENSUS_ACK"],
+                    "_emit_heartbeat": fake_emit,
+                    "_heartbeat_interval": 0,
+                }
+            )
+        assert emitted == [], "malformed slice_id must reject before any tick fires"
 
     def test_since_is_captured_once_and_shared_across_ticks(self):
         """``since`` is the wait *entry* time, captured once before the


### PR DESCRIPTION
## Summary

- Slice-scoped agents register gateway sessions under `egg-agent-{pid}-{slice_id}-{role}` (per `kubernetes_spawner.JOB_NAME_FORMAT_SLICE`), but the heartbeat fan-out always rebuilt the pipeline-level shape `egg-agent-{pid}-{role}` — so every slice-DAG reviewer/tester emitted a steady stream of `Session not found for container` warnings and the gateway's idle timer for those sessions never refreshed.
- The agent now forwards `EGG_SLICE_ID` on the heartbeat body (mirroring `brc._maybe_attach_slice_id` / `progress._maybe_attach_slice_id`); the orchestrator extracts it via the canonical `slice_id_validation.extract_slice_id` and threads it into `_refresh_gateway_session`'s container_id.
- Throttle key for `should_fan_out_gateway_session` is also slice-scoped so a sibling slice's refresh does not suppress this slice's (otherwise slice-2 reviewer-code would mute slice-3 reviewer-code's fan-out for 30 s).

Closes #2451.

## Test plan

- [ ] `make test` — unit tests for slice-scoped fan-out, sibling-slice throttle, and invalid-slice rejection on the orchestrator side; agent-side tests pinning slice_id forwarding from `EGG_SLICE_ID` and the malformed-slice rejection path
- [ ] Tail orchestrator logs on the next slice-DAG run (e.g. `kubectl logs -n egg-system <orch> -f | grep "Failed to heartbeat session"`) and confirm the warnings are gone for non-coder roles within the active wave
- [ ] Sanity-check pipeline-level (non-slice) heartbeats still fan out to the unchanged `egg-agent-{pid}-{role}` container_id