### PR TITLE
Fix #2439: align slice restart base_branch with parent edge

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2520,6 +2520,17 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
     # edge (#2439) so the spawner's ``base_branch`` matches the
     # parent slice's integration branch on a worktree-absent restart.
     parent_slice_id: str | None = None
+    # ``parent_branch_recorded`` captures ``Slice.parent_branch_at_creation``
+    # — the literal branch the parent slice's integration branch was forked
+    # off of when its worktree was provisioned (#2137 TASK-4-2). Preferring
+    # the recorded value over reconstructing
+    # ``f"{_issue_branch}/{parent_slice_id}"`` is more robust: if a future
+    # qualifier-suffix or namespacing change lands in
+    # ``_run_one_slice_inner`` but not here, the reconstruction would
+    # silently drift while the recorded value would not (#2460 review).
+    # ``None`` for slices whose worktree has not been provisioned yet, in
+    # which case we fall through to reconstruction.
+    parent_branch_recorded: str | None = None
     if slice_id is not None:
         if not pipeline.has_contract:
             return make_error_response(
@@ -2569,15 +2580,18 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
                     error=str(exc),
                 )
             if contract is not None:
-                known_slice_ids = {s.id for s in contract.slices}
-                if slice_id not in known_slice_ids:
+                # Single-pass slice lookup: the existence check and the
+                # parent-edge read both need the same record, so do them
+                # together (#2460 review observation 4).
+                slice_obj = next((s for s in contract.slices if s.id == slice_id), None)
+                if slice_obj is None:
                     return make_error_response(
                         f"slice_id {slice_id!r} does not match any slice in "
                         f"pipeline {pipeline_id}'s contract",
                         status_code=404,
                         details={
                             "slice_id": slice_id,
-                            "known_slices": sorted(known_slice_ids),
+                            "known_slices": sorted(s.id for s in contract.slices),
                         },
                     )
                 # Resolve the slice's parent edge (#2439). The forest
@@ -2585,9 +2599,9 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
                 # at most one DAG parent per slice, so taking the first
                 # dependency is sufficient. Root slices (no parent)
                 # leave ``parent_slice_id`` as ``None``.
-                slice_obj = next((s for s in contract.slices if s.id == slice_id), None)
-                if slice_obj is not None and slice_obj.dependencies:
+                if slice_obj.dependencies:
                     parent_slice_id = slice_obj.dependencies[0]
+                    parent_branch_recorded = slice_obj.parent_branch_at_creation
 
     # Restart the container via spawner
     spawner = _get_spawner()
@@ -2639,6 +2653,16 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
     #     in :func:`_run_one_slice_inner`.
     #   - Root-slice restart, or slice restart when the contract
     #     can't be loaded: ``pipeline.base_branch`` (fallback).
+    #
+    # Note: this intentionally diverges from the initial-spawn path at
+    # :func:`_run_concurrent_phase` (line ~12398), which always passes
+    # ``base_branch=pipeline.base_branch`` regardless of slice forest
+    # position. #2439 specifically asks for the parent-slice fork on
+    # the *restart* path so a worktree-absent restart of a child slice
+    # rebuilds atop its parent slice rather than re-forking from
+    # ``pipeline.base_branch`` and losing the parent's commits. Don't
+    # "fix" this asymmetry by aligning the two paths without first
+    # re-reading #2439.
     if slice_id is not None:
         _pipeline_branch = pipeline.branch or (
             f"egg/issue-{pipeline.issue_number}/work"
@@ -2661,19 +2685,36 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
             )
         agent_branch = f"{_issue_branch}/{slice_id}"
         if parent_slice_id is not None:
-            # Defense-in-depth: ``parent_slice_id`` came from the
-            # contract loader (whose ``Slice.id`` regex permits both
-            # canonical ``slice-<N>`` and legacy ``phase-<N>``), so
-            # accept either shape before embedding into a git ref.
-            # Anything outside that envelope is a corrupt-contract
-            # smell — fail loudly rather than synthesising a malformed
-            # ref the gateway would reject anyway.
-            if not _SLICE_OR_PHASE_ID_PATTERN.fullmatch(parent_slice_id):
-                raise ValueError(
-                    f"parent_slice_id={parent_slice_id!r} does not match "
-                    f"the canonical shape ``slice-<N>`` (or legacy ``phase-<N>``)"
-                )
-            base_branch_for_restart = f"{_issue_branch}/{parent_slice_id}"
+            if parent_branch_recorded:
+                # Prefer the literal branch the parent slice was
+                # provisioned against (#2460 review observation 2).
+                # Set by ``_run_one_slice_inner`` at slice creation
+                # time; per the docstring on
+                # ``Slice.parent_branch_at_creation``, it is *the*
+                # recorded fact about how the slice was provisioned.
+                # We trust our own writer here — no extra ref-shape
+                # validation, just the gateway's per-repo ``git
+                # fetch`` will surface a malformed value.
+                base_branch_for_restart = parent_branch_recorded
+            else:
+                # Fallback: contract has the dependency edge but no
+                # provisioning record. Reconstruct from the slice
+                # namespace root and the parent's id.
+                #
+                # Defense-in-depth: ``parent_slice_id`` came from the
+                # contract loader (whose ``Slice.id`` regex permits
+                # both canonical ``slice-<N>`` and legacy
+                # ``phase-<N>``), so accept either shape before
+                # embedding into a git ref. Anything outside that
+                # envelope is a corrupt-contract smell — fail loudly
+                # rather than synthesising a malformed ref the
+                # gateway would reject anyway.
+                if not _SLICE_OR_PHASE_ID_PATTERN.fullmatch(parent_slice_id):
+                    raise ValueError(
+                        f"parent_slice_id={parent_slice_id!r} does not match "
+                        f"the canonical shape ``slice-<N>`` (or legacy ``phase-<N>``)"
+                    )
+                base_branch_for_restart = f"{_issue_branch}/{parent_slice_id}"
         else:
             base_branch_for_restart = pipeline.base_branch
     else:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -245,6 +245,16 @@ def _track_host_wait_end() -> None:
 # -----------------------------------------------------------------
 _STATUS_WAIT_CURSOR_RE = re.compile(r"^msg:([^|]*)\|evt:(-?\d*)$")
 
+# Slice-or-phase id shape used when reading the parent edge from the
+# contract for the restart route's ``base_branch`` derivation (#2439).
+# ``Slice.id`` permits either ``slice-<N>`` (canonical) or ``phase-<N>``
+# (legacy, pre-#2137) and the contract migration shim only normalises
+# the typical case where the input has a top-level ``phases`` key. A
+# directly-loaded ``slices`` field with legacy ids is rare but allowed
+# by the model — accept either shape here so the gate doesn't false-
+# reject a legitimate restart on a long-lived contract.
+_SLICE_OR_PHASE_ID_PATTERN = re.compile(r"^(?:slice|phase)-[0-9]+$")
+
 # Event allowlist for ``/status/wait`` (issue #1932 locked in
 # refine HITL decision 2).  The route returns early when an event
 # matching any of these types is published.  ``DECISION_RESOLVED``
@@ -2505,6 +2515,11 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
     # silently if the contract can't be loaded (worktree pruned,
     # contract not yet populated, filesystem error) so we don't
     # regress legitimate restarts on the existing pipeline-level path.
+    #
+    # The contract is also consulted to resolve the slice's parent
+    # edge (#2439) so the spawner's ``base_branch`` matches the
+    # parent slice's integration branch on a worktree-absent restart.
+    parent_slice_id: str | None = None
     if slice_id is not None:
         if not pipeline.has_contract:
             return make_error_response(
@@ -2565,6 +2580,14 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
                             "known_slices": sorted(known_slice_ids),
                         },
                     )
+                # Resolve the slice's parent edge (#2439). The forest
+                # constraint enforced by contract ingestion guarantees
+                # at most one DAG parent per slice, so taking the first
+                # dependency is sufficient. Root slices (no parent)
+                # leave ``parent_slice_id`` as ``None``.
+                slice_obj = next((s for s in contract.slices if s.id == slice_id), None)
+                if slice_obj is not None and slice_obj.dependencies:
+                    parent_slice_id = slice_obj.dependencies[0]
 
     # Restart the container via spawner
     spawner = _get_spawner()
@@ -2600,6 +2623,22 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
     # derivation in :func:`_run_implement_phase_slices` so a restarted
     # slice agent lands on the same integration branch its peers are
     # using.
+    #
+    # The spawner's ``base_branch`` is the ref the per-agent worktree
+    # is forked off of when the worktree must be (re)created (#2439).
+    # ``pipeline.branch`` (the integration tip) is the wrong target —
+    # if the worktree is absent at restart time, forking from the
+    # pipeline tip pulls sibling slices' commits into the rebuilt
+    # worktree. The right base depends on context:
+    #   - Pipeline-level restart: ``pipeline.base_branch`` (matches
+    #     the rest of the codebase: every other call site uses
+    #     ``pipeline.base_branch`` for spawner ``base_branch``).
+    #   - Slice restart with a parent in the contract's slice forest:
+    #     the parent slice's integration branch
+    #     (``<root>/<parent_slice_id>``), mirroring ``parent_branch``
+    #     in :func:`_run_one_slice_inner`.
+    #   - Root-slice restart, or slice restart when the contract
+    #     can't be loaded: ``pipeline.base_branch`` (fallback).
     if slice_id is not None:
         _pipeline_branch = pipeline.branch or (
             f"egg/issue-{pipeline.issue_number}/work"
@@ -2621,8 +2660,25 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
                 f"slice_id={slice_id!r} does not match the canonical shape ``slice-<N>``"
             )
         agent_branch = f"{_issue_branch}/{slice_id}"
+        if parent_slice_id is not None:
+            # Defense-in-depth: ``parent_slice_id`` came from the
+            # contract loader (whose ``Slice.id`` regex permits both
+            # canonical ``slice-<N>`` and legacy ``phase-<N>``), so
+            # accept either shape before embedding into a git ref.
+            # Anything outside that envelope is a corrupt-contract
+            # smell — fail loudly rather than synthesising a malformed
+            # ref the gateway would reject anyway.
+            if not _SLICE_OR_PHASE_ID_PATTERN.fullmatch(parent_slice_id):
+                raise ValueError(
+                    f"parent_slice_id={parent_slice_id!r} does not match "
+                    f"the canonical shape ``slice-<N>`` (or legacy ``phase-<N>``)"
+                )
+            base_branch_for_restart = f"{_issue_branch}/{parent_slice_id}"
+        else:
+            base_branch_for_restart = pipeline.base_branch
     else:
         agent_branch = pipeline.branch
+        base_branch_for_restart = pipeline.base_branch
 
     # Reconstruct command and extra_env for concurrent agents.
     # In concurrent mode, agents need a consensus-wrapped prompt command
@@ -2701,7 +2757,7 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
             phase=current_phase,
             command=command,
             branch=agent_branch,
-            base_branch=pipeline.branch,
+            base_branch=base_branch_for_restart,
             reason=reason,
             spawn_max_retries=pipeline.config.spawn_max_retries,
             spawn_retry_initial_backoff_seconds=pipeline.config.spawn_retry_initial_backoff_seconds,

--- a/orchestrator/tests/test_restart_agent.py
+++ b/orchestrator/tests/test_restart_agent.py
@@ -1176,6 +1176,272 @@ class TestRestartAgentEndpointSliceScope:
 
 
 # ---------------------------------------------------------------------------
+# Issue #2439: spawner ``base_branch`` matches the slice forest's parent edge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _HAS_FLASK, reason="Flask not available")
+class TestRestartAgentEndpointBaseBranch:
+    """Restart route forwards the right ``base_branch`` to the spawner (#2439).
+
+    ``gateway.create_worktrees`` is idempotent and ``restart_agent_job``
+    passes ``preserve_worktree_on_failure=True``, so most restarts hit a
+    pre-existing worktree and the wrong ``base_branch`` is never
+    consulted — but a worktree-absent restart (cleanup race, manual
+    gateway prune, container hostpath wiped) reaches the worktree
+    creation path. Forking from ``pipeline.branch`` (the integration
+    tip) at that point pulls sibling slices' commits into the rebuilt
+    worktree.
+    """
+
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_pipeline_level_restart_uses_pipeline_base_branch(
+        self, mock_repo, mock_resolve, mock_spawner_fn, mock_lock_fn, client
+    ):
+        """Pipeline-level restart forwards ``pipeline.base_branch`` (not ``pipeline.branch``).
+
+        Every other call site in the codebase uses ``pipeline.base_branch``
+        for spawner ``base_branch``; the operator-triggered restart route
+        was the lone outlier (#2439).
+        """
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        pipeline = _make_pipeline_with_running_agent()
+        pipeline.base_branch = "main"
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        new_container = SpawnedContainer(
+            container_info=ContainerInfo(
+                container_id="new-container-xyz",
+                container_name="egg-issue-100-coder",
+                status=ContainerStatus.RUNNING,
+            ),
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-100",
+            environment={},
+        )
+        mock_spawner.restart_agent_container.return_value = new_container
+        mock_spawner.get_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart",
+            json={"reason": "Pipeline-level restart"},
+        )
+
+        assert response.status_code == 200
+        restart_call = mock_spawner.restart_agent_container.call_args
+        assert restart_call.kwargs["base_branch"] == "main"
+        # Defensive: the integration tip must NEVER be forwarded as
+        # ``base_branch``. If the worktree is rebuilt, forking from
+        # the tip leaks tip commits into the per-agent worktree.
+        assert restart_call.kwargs["base_branch"] != pipeline.branch
+
+    @patch("egg_contracts.loader.load_contract")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_root_slice_restart_uses_pipeline_base_branch(
+        self,
+        mock_repo,
+        mock_resolve,
+        mock_spawner_fn,
+        mock_lock_fn,
+        mock_load_contract,
+        client,
+    ):
+        """A root slice (no parent in the slice forest) falls back to ``pipeline.base_branch``."""
+        from egg_contracts.models import Contract, Slice
+
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        pipeline = _make_pipeline_with_running_agent()
+        pipeline.branch = "egg/issue-100/work"
+        pipeline.base_branch = "main"
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_load_contract.return_value = Contract(
+            pipeline_id="issue-100",
+            # slice-1 has no dependencies → root of the forest.
+            slices=[Slice(id="slice-1", name="Root slice")],
+        )
+
+        mock_spawner = MagicMock()
+        new_container = SpawnedContainer(
+            container_info=ContainerInfo(
+                container_id="new-container-xyz",
+                container_name="egg-issue-100-slice-1-coder",
+                status=ContainerStatus.RUNNING,
+            ),
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-100",
+            environment={},
+        )
+        mock_spawner.restart_agent_container.return_value = new_container
+        mock_spawner.get_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart?slice_id=slice-1",
+            json={"reason": "Root slice agent stalled"},
+        )
+
+        assert response.status_code == 200
+        restart_call = mock_spawner.restart_agent_container.call_args
+        assert restart_call.kwargs["base_branch"] == "main"
+
+    @patch("egg_contracts.loader.load_contract")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_child_slice_restart_uses_parent_slice_integration_branch(
+        self,
+        mock_repo,
+        mock_resolve,
+        mock_spawner_fn,
+        mock_lock_fn,
+        mock_load_contract,
+        client,
+    ):
+        """A child slice's restart forks from its parent slice's integration branch.
+
+        Mirrors :func:`_run_one_slice_inner`'s ``parent_branch``
+        derivation: when ``slice-2`` lists ``slice-1`` as its
+        dependency, the parent integration branch is
+        ``<namespace_root>/slice-1``. Without this, a worktree-absent
+        restart of ``slice-2`` would re-fork from the pipeline tip
+        and pull sibling-slice commits into ``slice-2``'s rebuilt
+        worktree (#2439).
+        """
+        from egg_contracts.models import Contract, Slice
+
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        pipeline = _make_pipeline_with_running_agent()
+        pipeline.branch = "egg/issue-100/work"
+        pipeline.base_branch = "main"
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_load_contract.return_value = Contract(
+            pipeline_id="issue-100",
+            slices=[
+                Slice(id="slice-1", name="Parent slice"),
+                Slice(
+                    id="slice-2",
+                    name="Child slice",
+                    dependencies=["slice-1"],
+                ),
+            ],
+        )
+
+        mock_spawner = MagicMock()
+        new_container = SpawnedContainer(
+            container_info=ContainerInfo(
+                container_id="new-container-xyz",
+                container_name="egg-issue-100-slice-2-coder",
+                status=ContainerStatus.RUNNING,
+            ),
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-100",
+            environment={},
+        )
+        mock_spawner.restart_agent_container.return_value = new_container
+        mock_spawner.get_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart?slice_id=slice-2",
+            json={"reason": "Child slice agent stalled"},
+        )
+
+        assert response.status_code == 200
+        restart_call = mock_spawner.restart_agent_container.call_args
+        # The agent's assigned branch is still its OWN integration
+        # branch (slice-2). It's the spawner's ``base_branch`` — the
+        # ref the per-agent worktree is forked off of when rebuilt —
+        # that should reference the parent slice's integration branch.
+        assert restart_call.kwargs["branch"] == "egg/issue-100/slice-2"
+        assert restart_call.kwargs["base_branch"] == "egg/issue-100/slice-1"
+
+    @patch("egg_contracts.loader.load_contract")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_slice_restart_with_unloadable_contract_falls_back_to_pipeline_base(
+        self,
+        mock_repo,
+        mock_resolve,
+        mock_spawner_fn,
+        mock_lock_fn,
+        mock_load_contract,
+        client,
+    ):
+        """When the contract can't be loaded, slice restart falls back to ``pipeline.base_branch``.
+
+        The slice-id existence check (#2421) intentionally falls
+        through silently when the contract can't be loaded so legitimate
+        restarts on a pruned worktree aren't gated. The base-branch
+        fix (#2439) inherits that policy: with no contract to consult
+        for the parent edge, the spawner gets ``pipeline.base_branch``
+        — the same fallback the other call sites use.
+        """
+        from egg_contracts.loader import ContractNotFoundError
+
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        pipeline = _make_pipeline_with_running_agent()
+        pipeline.branch = "egg/issue-100/work"
+        pipeline.base_branch = "main"
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_load_contract.side_effect = ContractNotFoundError("not populated yet")
+
+        mock_spawner = MagicMock()
+        new_container = SpawnedContainer(
+            container_info=ContainerInfo(
+                container_id="new-container-xyz",
+                container_name="egg-issue-100-slice-2-coder",
+                status=ContainerStatus.RUNNING,
+            ),
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-100",
+            environment={},
+        )
+        mock_spawner.restart_agent_container.return_value = new_container
+        mock_spawner.get_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart?slice_id=slice-2",
+            json={"reason": "Slice restart with no contract"},
+        )
+
+        assert response.status_code == 200
+        restart_call = mock_spawner.restart_agent_container.call_args
+        assert restart_call.kwargs["base_branch"] == "main"
+
+
+# ---------------------------------------------------------------------------
 # Issue #2422: in-place agent-state mutation matches on (role, slice_id)
 # ---------------------------------------------------------------------------
 

--- a/orchestrator/tests/test_restart_agent.py
+++ b/orchestrator/tests/test_restart_agent.py
@@ -1442,6 +1442,86 @@ class TestRestartAgentEndpointBaseBranch:
         restart_call = mock_spawner.restart_agent_container.call_args
         assert restart_call.kwargs["base_branch"] == "main"
 
+    @patch("egg_contracts.loader.load_contract")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_child_slice_restart_prefers_parent_branch_at_creation(
+        self,
+        mock_repo,
+        mock_resolve,
+        mock_spawner_fn,
+        mock_lock_fn,
+        mock_load_contract,
+        client,
+    ):
+        """Restart prefers the recorded ``parent_branch_at_creation`` over reconstruction.
+
+        Set by ``_run_one_slice_inner`` when the slice was provisioned
+        (#2137 TASK-4-2); per the docstring on
+        ``Slice.parent_branch_at_creation`` it's *the* recorded fact
+        about how the slice was forked. Reconstructing
+        ``f"{_issue_branch}/{parent_slice_id}"`` would silently drift
+        if a future qualifier-suffix or namespacing change lands in
+        ``_run_one_slice_inner`` but not in the restart route — the
+        recorded value would not (#2460 review observation 2).
+        """
+        from egg_contracts.models import Contract, Slice
+
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        pipeline = _make_pipeline_with_running_agent()
+        pipeline.branch = "egg/issue-100/work"
+        pipeline.base_branch = "main"
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        # The recorded value differs from what reconstruction would
+        # produce (a hypothetical future qualifier suffix). The route
+        # must prefer the recorded value over reconstruction.
+        recorded_parent_branch = "egg/issue-100/slice-1-future-qualifier"
+        mock_load_contract.return_value = Contract(
+            pipeline_id="issue-100",
+            slices=[
+                Slice(id="slice-1", name="Parent slice"),
+                Slice(
+                    id="slice-2",
+                    name="Child slice",
+                    dependencies=["slice-1"],
+                    parent_branch_at_creation=recorded_parent_branch,
+                ),
+            ],
+        )
+
+        mock_spawner = MagicMock()
+        new_container = SpawnedContainer(
+            container_info=ContainerInfo(
+                container_id="new-container-xyz",
+                container_name="egg-issue-100-slice-2-coder",
+                status=ContainerStatus.RUNNING,
+            ),
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-100",
+            environment={},
+        )
+        mock_spawner.restart_agent_container.return_value = new_container
+        mock_spawner.get_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart?slice_id=slice-2",
+            json={"reason": "Child slice agent stalled"},
+        )
+
+        assert response.status_code == 200
+        restart_call = mock_spawner.restart_agent_container.call_args
+        # The recorded parent branch wins over reconstructed
+        # ``egg/issue-100/slice-1``.
+        assert restart_call.kwargs["base_branch"] == recorded_parent_branch
+
 
 # ---------------------------------------------------------------------------
 # Issue #2422: in-place agent-state mutation matches on (role, slice_id)

--- a/orchestrator/tests/test_restart_agent.py
+++ b/orchestrator/tests/test_restart_agent.py
@@ -1413,7 +1413,9 @@ class TestRestartAgentEndpointBaseBranch:
         mock_store.load_pipeline.return_value = pipeline
         mock_resolve.return_value = (mock_store, pipeline)
 
-        mock_load_contract.side_effect = ContractNotFoundError("not populated yet")
+        mock_load_contract.side_effect = ContractNotFoundError(
+            "issue-100", Path("/repo/.egg-state/contracts/issue-100.json")
+        )
 
         mock_spawner = MagicMock()
         new_container = SpawnedContainer(

--- a/orchestrator/tests/test_spawn_worktree_guard.py
+++ b/orchestrator/tests/test_spawn_worktree_guard.py
@@ -471,9 +471,11 @@ class TestRestartWorktreeIntegration:
     ):
         """restart_agent_container should forward base_branch to spawn_agent_container.
 
-        The restart path uses pipeline.branch as base_branch so the gateway
-        bases the worktree on the existing working branch rather than the
-        remote default.
+        Whatever ``base_branch`` the route chooses (``pipeline.base_branch``
+        for pipeline-level / root-slice restarts, the parent slice's
+        integration branch for child-slice restarts; see #2439) must
+        propagate through to the gateway worktree-create call, otherwise
+        the worktree-absent restart path forks from the wrong ref.
         """
         mock_docker_client.get_container_info.side_effect = ContainerNotFoundError(
             "already removed"


### PR DESCRIPTION
## Summary

- Fix #2439. The operator-triggered restart route in `orchestrator/routes/pipelines.py` passed `base_branch=pipeline.branch` (the integration tip) to the spawner; every other call site uses `pipeline.base_branch`. Now bypasses the tip:
  - **Pipeline-level restart** → `pipeline.base_branch` (matches the rest of the codebase).
  - **Slice restart with a parent in the contract's slice forest** → parent slice's integration branch (`<root>/<parent_slice_id>`), mirroring `parent_branch` in `_run_one_slice_inner`.
  - **Root-slice restart, or slice restart when the contract can't be loaded** → `pipeline.base_branch` fallback.
- The slice-id existence check from #2421 already loads the contract; this PR also extracts the slice's first DAG dependency (forest constraint guarantees ≤1 parent) under the same load.

## Why it was masked

`gateway.create_worktrees` is idempotent and `restart_agent_job` calls `spawn_agent_job` with `preserve_worktree_on_failure=True`, so most restarts hit a pre-existing worktree and the wrong `base_branch` is never consulted. A worktree-absent restart (cleanup race, manual gateway prune, container hostpath wipe) reaches the worktree-creation path and forks from the wrong ref — pulling sibling slices' commits into the rebuilt slice and masking BRC artifact-divergence the reviewer would flag.

## Test plan

- [ ] `make test` (changeset-aware narrowing).
- [ ] New regression tests in `orchestrator/tests/test_restart_agent.py::TestRestartAgentEndpointBaseBranch`:
  - `test_pipeline_level_restart_uses_pipeline_base_branch` — covers AC #2.
  - `test_root_slice_restart_uses_pipeline_base_branch` — root slice (no parent) falls back.
  - `test_child_slice_restart_uses_parent_slice_integration_branch` — covers AC #1 with a `slice-2 → slice-1` forest.
  - `test_slice_restart_with_unloadable_contract_falls_back_to_pipeline_base` — preserves the #2421 fall-through-silently policy.
- [ ] Existing slice-id forwarding tests (#2410, #2421, #2428) unchanged.