### PR TITLE
Fix #2446: bound egg/recovered/* refs with periodic TTL cleanup

### DIFF
--- a/docs/reference/agent-recovery.md
+++ b/docs/reference/agent-recovery.md
@@ -304,9 +304,9 @@ The sweep is best-effort. Any per-ref failure (gateway error, unparseable git ou
 |---------|---------|--------|
 | `EGG_ORCH_RECOVERY_REF_CLEANUP_ENABLED` | `true` | Master kill switch. Set to `false`/`0`/`no`/`off` to disable the loop entirely. |
 | `EGG_ORCH_RECOVERY_REF_TTL_DAYS` | `90` | Committer-date age past which a recovery ref is eligible for deletion. |
-| `EGG_ORCH_RECOVERY_REF_CLEANUP_INTERVAL_SECONDS` | `86400` | Period between sweeps (default 24 h). **Also gates the first sweep:** the loop sleeps a full `interval_seconds` *before* its first run so multiple replicas restarted together don't pile onto the same minute. After an orchestrator restart, expect no recovery-ref cleanup for one full interval; trigger a one-shot sweep manually if you need immediate cleanup. The sweep is cheap when no refs need deletion, but the gateway round-trip adds up if set very low. |
+| `EGG_ORCH_RECOVERY_REF_CLEANUP_INTERVAL_SECONDS` | `86400` | Period between sweeps (default 24 h). **Also gates the first sweep:** the loop sleeps a full `interval_seconds` *before* its first run so multiple replicas restarted together don't pile onto the same minute. After an orchestrator restart, expect no recovery-ref cleanup for one full interval. There is no operator CLI to force an immediate sweep; the supported escape hatches are (a) restart the orchestrator with a temporarily lowered interval, or (b) call `RecoveryRefCleaner.run_once()` directly on the cleaner stashed in `app.config["RECOVERY_REF_CLEANERS"]`. The sweep is cheap when no refs need deletion, but the gateway round-trip adds up if set very low. |
 
-The cleanup loop runs once per repo path discovered under `EGG_REPO_PATH`. Each loop is a daemon thread that sleeps `interval_seconds` before its first sweep so multiple replicas restarted together don't pile onto the same minute.
+The cleanup loop runs once per repo path discovered under `EGG_REPO_PATH`. Each loop is a daemon thread; see the `EGG_ORCH_RECOVERY_REF_CLEANUP_INTERVAL_SECONDS` row above for the first-sweep timing.
 
 **Metrics in logs**
 

--- a/docs/reference/agent-recovery.md
+++ b/docs/reference/agent-recovery.md
@@ -304,7 +304,7 @@ The sweep is best-effort. Any per-ref failure (gateway error, unparseable git ou
 |---------|---------|--------|
 | `EGG_ORCH_RECOVERY_REF_CLEANUP_ENABLED` | `true` | Master kill switch. Set to `false`/`0`/`no`/`off` to disable the loop entirely. |
 | `EGG_ORCH_RECOVERY_REF_TTL_DAYS` | `90` | Committer-date age past which a recovery ref is eligible for deletion. |
-| `EGG_ORCH_RECOVERY_REF_CLEANUP_INTERVAL_SECONDS` | `86400` | Period between sweeps (default 24 h). The sweep is cheap when no refs need deletion, but the gateway round-trip adds up if set very low. |
+| `EGG_ORCH_RECOVERY_REF_CLEANUP_INTERVAL_SECONDS` | `86400` | Period between sweeps (default 24 h). **Also gates the first sweep:** the loop sleeps a full `interval_seconds` *before* its first run so multiple replicas restarted together don't pile onto the same minute. After an orchestrator restart, expect no recovery-ref cleanup for one full interval; trigger a one-shot sweep manually if you need immediate cleanup. The sweep is cheap when no refs need deletion, but the gateway round-trip adds up if set very low. |
 
 The cleanup loop runs once per repo path discovered under `EGG_REPO_PATH`. Each loop is a daemon thread that sleeps `interval_seconds` before its first sweep so multiple replicas restarted together don't pile onto the same minute.
 

--- a/docs/reference/agent-recovery.md
+++ b/docs/reference/agent-recovery.md
@@ -277,7 +277,53 @@ git switch <target-branch>
 git cherry-pick <recovered-base>..recovered/<scope>
 ```
 
-The orchestrator never deletes `egg/recovered/*` refs — they outlive the pipeline they belong to. Operators clean up after replay (`git push origin --delete <ref>`).
+Operators may delete `egg/recovered/*` refs manually after replay (`git push origin --delete <ref>`). For automatic cleanup of refs left behind by replays that never came, see [Recovery Ref Cleanup](#recovery-ref-cleanup) below.
+
+### Recovery Ref Cleanup
+
+Source: `orchestrator/agent_salvage_cleanup.py`
+
+A periodic background sweep prunes `egg/recovered/*` refs older than a configurable TTL so the salvage namespace stays bounded on a busy cluster ([#2446](https://github.com/jwbron/egg/issues/2446)).
+
+**How it works**
+
+1. **List** every `egg/recovered/*` ref on origin via `git ls-remote --heads`. The same round-trip captures the SHA at each ref tip.
+2. **Refresh** local tracking refs (`refs/remotes/origin/egg/recovered/*`) via a scoped `git fetch --prune` so the staleness and reachability checks run against current state.
+3. **Classify** each ref by reading the committer date of the tip commit (`git log -1 --format=%cI`):
+   - **Recent**: committer date within the TTL window — leave alone.
+   - **Reachable**: committer date past the TTL but the SHA is reachable from any non-`egg/recovered/*` remote-tracking branch — leave alone (defensive against a pending or in-flight replay).
+   - **Unknown age**: tip commit not present locally and fetch couldn't recover it — leave alone (we never delete a ref whose age we can't determine).
+   - **Stale**: committer date past the TTL and not reachable elsewhere — delete via `gateway.delete_remote_branch`.
+4. **Delete** is idempotent: `already_deleted` from origin is treated as success, so concurrent operator deletes don't surface as errors.
+
+The sweep is best-effort. Any per-ref failure (gateway error, unparseable git output, etc.) is logged and counted against `refs_skipped_error`; the loop continues to the next ref.
+
+**Configuration**
+
+| Env var | Default | Effect |
+|---------|---------|--------|
+| `EGG_ORCH_RECOVERY_REF_CLEANUP_ENABLED` | `true` | Master kill switch. Set to `false`/`0`/`no`/`off` to disable the loop entirely. |
+| `EGG_ORCH_RECOVERY_REF_TTL_DAYS` | `90` | Committer-date age past which a recovery ref is eligible for deletion. |
+| `EGG_ORCH_RECOVERY_REF_CLEANUP_INTERVAL_SECONDS` | `86400` | Period between sweeps (default 24 h). The sweep is cheap when no refs need deletion, but the gateway round-trip adds up if set very low. |
+
+The cleanup loop runs once per repo path discovered under `EGG_REPO_PATH`. Each loop is a daemon thread that sleeps `interval_seconds` before its first sweep so multiple replicas restarted together don't pile onto the same minute.
+
+**Metrics in logs**
+
+Each sweep emits a single structured log line at INFO level:
+
+```
+Recovery-ref cleanup sweep complete  repo_path=/repos/foo  ttl_days=90
+  refs_inspected=42  refs_deleted=3  refs_skipped_recent=35
+  refs_skipped_reachable=2  refs_skipped_unknown_age=1  refs_skipped_error=1
+  oldest_remaining_age_days=78.4
+```
+
+`oldest_remaining_age_days` is the age of the oldest ref still on origin after the sweep. Drift in this metric (e.g. climbing past `ttl_days`) indicates refs are being skipped — usually by the reachability guard — so look for replay branches that are pinning recovery commits.
+
+**Recovery workflow interaction**
+
+Operators replaying a recovery ref should fetch and cherry-pick promptly: a recovered branch left at HEAD on origin (e.g. `recovered/<scope>` pushed back) keeps the salvage ref alive past the TTL via the reachability guard. After cherry-picking, deleting the replay branch lets the next sweep clean the original `egg/recovered/...` ref on schedule.
 
 ### What Salvage Does Not Do
 

--- a/orchestrator/agent_salvage.py
+++ b/orchestrator/agent_salvage.py
@@ -38,8 +38,11 @@ salvaged commit for a pipeline with::
     git ls-remote origin 'refs/heads/egg/recovered/<pipeline>/*'
 
 and replay them onto a recovery branch with ``git fetch`` plus
-``git cherry-pick``. The orchestrator never deletes ``egg/recovered/*``
-refs — they outlive the pipeline they belong to.
+``git cherry-pick``. A separate periodic sweep
+(:mod:`agent_salvage_cleanup`, #2446) deletes recovery refs older
+than the configured TTL (default 90 days) so the namespace stays
+bounded; see ``docs/reference/agent-recovery.md`` for the operator-
+visible knobs.
 """
 
 from __future__ import annotations

--- a/orchestrator/agent_salvage_cleanup.py
+++ b/orchestrator/agent_salvage_cleanup.py
@@ -1,0 +1,451 @@
+"""Periodic cleanup of recovery refs created by :mod:`agent_salvage` (#2446).
+
+The salvage hook (#2429) writes recovery refs to
+``egg/recovered/<pipeline_id>/<scope>/<short_sha>`` whenever a per-agent
+worktree is about to be deleted with unpushed work. By design those
+refs outlive the pipeline they belong to so operators can replay the
+work later — but on a busy cluster they accumulate without bound.
+
+This module runs a periodic sweep that:
+
+1. Lists every ``egg/recovered/*`` ref on origin via ``git ls-remote``.
+2. Reads each ref tip's committer date to decide staleness.
+3. Skips deletion for refs reachable from any non-recovered remote
+   branch — defensive against a pending replay that's been pushed back
+   to origin.
+4. Deletes refs older than the configured TTL via the gateway's
+   launcher-auth ``delete_remote_branch`` path.
+
+Cadence and TTL are configurable via :mod:`env_config`. The sweep is
+best-effort: any per-ref failure is logged and never aborts the loop.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import subprocess
+import threading
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agent_salvage import RECOVERY_BRANCH_PREFIX
+from egg_logging import get_logger
+
+if TYPE_CHECKING:
+    from gateway_client import GatewayClient
+
+logger = get_logger("orchestrator.agent_salvage_cleanup")
+
+
+# Pseudo-pipeline-id used for the synthetic gateway session that backs
+# the cleanup sweep. The salvage hook never sees this name — it only
+# shows up in audit logs and session tables.
+CLEANUP_PIPELINE_ID = "salvage-cleanup"
+
+
+@dataclass(frozen=True)
+class RecoveryRef:
+    """A single ``egg/recovered/...`` ref observed on origin."""
+
+    name: str
+    """Full branch name, e.g. ``egg/recovered/issue-99/coder/abc123def456``."""
+
+    sha: str
+    """Commit SHA at the ref tip (from ``git ls-remote``)."""
+
+    committed_at: datetime | None
+    """Committer date of the tip commit. ``None`` when the commit isn't
+    available locally (fetch failed) — such refs are skipped from
+    deletion so we never delete a ref whose age we can't determine.
+    """
+
+    @property
+    def short_sha(self) -> str:
+        return self.sha[:12]
+
+
+@dataclass
+class CleanupReport:
+    """Per-sweep metrics surfaced to logs and tests."""
+
+    refs_inspected: int = 0
+    refs_deleted: int = 0
+    refs_skipped_recent: int = 0
+    refs_skipped_reachable: int = 0
+    refs_skipped_unknown_age: int = 0
+    refs_skipped_error: int = 0
+    deleted_refs: list[str] = field(default_factory=list)
+    oldest_remaining_age_days: float | None = None
+    error: str | None = None
+
+
+def _run_git(
+    *args: str,
+    cwd: Path,
+    check: bool = True,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess[str]:
+    """Run a git command with hooks disabled. Mirrors agent_salvage._run_git."""
+    cmd = ["git", "-c", "core.hooksPath=/dev/null", "-C", str(cwd), *args]
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=check,
+        timeout=timeout,
+    )
+
+
+def list_recovery_refs(
+    gateway: GatewayClient,
+    repo_path: str,
+    *,
+    mode: str = "public",
+) -> dict[str, str]:
+    """Return ``{ref_name: sha}`` for every ``egg/recovered/*`` ref on origin.
+
+    Uses :meth:`GatewayClient.list_remote_branches_with_shas` so the
+    SHA is captured in the same round-trip as enumeration. Returns
+    ``{}`` on gateway error.
+    """
+    branches = gateway.list_remote_branches_with_shas(
+        CLEANUP_PIPELINE_ID,
+        repo_path,
+        mode=mode,  # type: ignore[arg-type]
+    )
+    prefix = f"{RECOVERY_BRANCH_PREFIX}/"
+    return {name: sha for name, sha in branches.items() if name.startswith(prefix)}
+
+
+def _fetch_recovery_refs(
+    gateway: GatewayClient,
+    repo_path: str,
+    *,
+    mode: str = "public",
+) -> bool:
+    """Refresh ``refs/remotes/origin/egg/recovered/*`` in the local repo.
+
+    Best-effort: on failure we still attempt to inspect already-cached
+    refs but the reachability and committer-date checks may rely on
+    stale local state.
+    """
+    refspec = (
+        f"+refs/heads/{RECOVERY_BRANCH_PREFIX}/*:refs/remotes/origin/{RECOVERY_BRANCH_PREFIX}/*"
+    )
+    return gateway.fetch_branch(
+        pipeline_id=CLEANUP_PIPELINE_ID,
+        repo_path=repo_path,
+        args=["--prune", refspec],
+        mode=mode,  # type: ignore[arg-type]
+    )
+
+
+def _committer_date(repo_path: Path, sha: str) -> datetime | None:
+    """Read the committer date (``%cI``) of *sha*. Returns ``None`` when
+    the commit isn't present locally or git rejects the SHA."""
+    try:
+        result = _run_git(
+            "log",
+            "-1",
+            "--format=%cI",
+            sha,
+            cwd=repo_path,
+            check=False,
+        )
+    except OSError, subprocess.SubprocessError:
+        return None
+    if result.returncode != 0:
+        return None
+    raw = (result.stdout or "").strip()
+    if not raw:
+        return None
+    try:
+        # ``%cI`` is strict ISO-8601 with timezone (``2026-01-01T12:00:00+00:00``).
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def _is_reachable_from_non_recovery(repo_path: Path, sha: str) -> bool:
+    """Return True iff any non-``egg/recovered/*`` remote-tracking branch
+    contains *sha*.
+
+    Uses ``git for-each-ref --contains=<sha>`` which is the cheapest way
+    to ask "what branches contain this commit?" and is bounded by the
+    number of remote-tracking refs. False (no other ref contains it) is
+    the default when the SHA isn't present locally — we can't prove
+    reachability without the commit.
+    """
+    try:
+        result = _run_git(
+            "for-each-ref",
+            f"--contains={sha}",
+            "--format=%(refname)",
+            "refs/remotes/origin/",
+            cwd=repo_path,
+            check=False,
+        )
+    except OSError, subprocess.SubprocessError:
+        return False
+    if result.returncode != 0:
+        return False
+    excluded_prefix = f"refs/remotes/origin/{RECOVERY_BRANCH_PREFIX}/"
+    for line in result.stdout.splitlines():
+        ref = line.strip()
+        if not ref:
+            continue
+        if ref.startswith(excluded_prefix):
+            continue
+        return True
+    return False
+
+
+def _classify(
+    name: str,
+    sha: str,
+    repo_path: Path,
+    cutoff: datetime,
+) -> tuple[RecoveryRef, str]:
+    """Return ``(ref, action)`` where action is one of:
+
+    - ``"delete"``    — older than cutoff and not reachable elsewhere.
+    - ``"recent"``    — newer than cutoff, leave alone.
+    - ``"reachable"`` — old enough but reachable from a non-recovered branch.
+    - ``"unknown"``   — couldn't determine committer date.
+    """
+    committed_at = _committer_date(repo_path, sha)
+    ref = RecoveryRef(name=name, sha=sha, committed_at=committed_at)
+    if committed_at is None:
+        return ref, "unknown"
+    if committed_at >= cutoff:
+        return ref, "recent"
+    if _is_reachable_from_non_recovery(repo_path, sha):
+        return ref, "reachable"
+    return ref, "delete"
+
+
+def sweep_recovery_refs(
+    gateway: GatewayClient,
+    repo_path: Path | str,
+    *,
+    ttl_days: int = 90,
+    mode: str = "public",
+    dry_run: bool = False,
+    now: datetime | None = None,
+) -> CleanupReport:
+    """One sweep across every ``egg/recovered/*`` ref on origin.
+
+    Idempotent — re-running is safe. Errors are logged and surfaced via
+    :class:`CleanupReport` rather than raised so the periodic driver
+    can keep running on transient failure.
+
+    ``dry_run`` skips the actual delete call but still classifies and
+    populates ``CleanupReport.deleted_refs`` with the names that
+    *would* have been deleted.
+    """
+    repo_path = Path(repo_path)
+    report = CleanupReport()
+    now = now or datetime.now(UTC)
+    cutoff = now - timedelta(days=ttl_days)
+
+    repo_path_str = str(repo_path)
+
+    # Step 1 — bring local recovery-ref state up to date so committer
+    # dates and reachability lookups see the truth on origin. Failure is
+    # non-fatal: we proceed with whatever local state exists.
+    fetched = _fetch_recovery_refs(gateway, repo_path_str, mode=mode)
+    if not fetched:
+        logger.debug(
+            "Recovery-ref fetch failed; sweep will use stale local state",
+            repo_path=repo_path_str,
+        )
+
+    # Step 2 — list candidate refs on origin.
+    try:
+        candidates = list_recovery_refs(gateway, repo_path_str, mode=mode)
+    except Exception as exc:  # noqa: BLE001
+        report.error = f"list_recovery_refs failed: {exc}"
+        logger.warning(
+            "Recovery-ref cleanup sweep aborted at list step",
+            repo_path=repo_path_str,
+            error=str(exc),
+        )
+        return report
+
+    report.refs_inspected = len(candidates)
+
+    # Track the youngest committer date among kept refs so operators can
+    # eyeball "what's the oldest thing still hanging around".
+    oldest_remaining: datetime | None = None
+
+    for name, sha in sorted(candidates.items()):
+        try:
+            ref, action = _classify(name, sha, repo_path, cutoff)
+        except Exception as exc:  # noqa: BLE001
+            report.refs_skipped_error += 1
+            logger.warning(
+                "Recovery-ref classification failed",
+                ref=name,
+                error=str(exc),
+            )
+            continue
+
+        if action == "delete":
+            if dry_run:
+                report.refs_deleted += 1
+                report.deleted_refs.append(name)
+                continue
+            try:
+                push_result = gateway.delete_remote_branch(
+                    pipeline_id=CLEANUP_PIPELINE_ID,
+                    repo_path=repo_path_str,
+                    branch=name,
+                    mode=mode,  # type: ignore[arg-type]
+                )
+            except Exception as exc:  # noqa: BLE001
+                report.refs_skipped_error += 1
+                logger.warning(
+                    "Recovery-ref delete raised",
+                    ref=name,
+                    error=str(exc),
+                )
+                continue
+            if push_result.ok or push_result.category == "already_deleted":
+                report.refs_deleted += 1
+                report.deleted_refs.append(name)
+                logger.info(
+                    "Deleted stale recovery ref",
+                    ref=name,
+                    head_sha=ref.sha,
+                    committed_at=(ref.committed_at.isoformat() if ref.committed_at else None),
+                )
+            else:
+                report.refs_skipped_error += 1
+                logger.warning(
+                    "Recovery-ref delete failed",
+                    ref=name,
+                    detail=push_result.describe(),
+                )
+            continue
+
+        if action == "recent":
+            report.refs_skipped_recent += 1
+        elif action == "reachable":
+            report.refs_skipped_reachable += 1
+        elif action == "unknown":
+            report.refs_skipped_unknown_age += 1
+
+        if ref.committed_at is not None:
+            if oldest_remaining is None or ref.committed_at < oldest_remaining:
+                oldest_remaining = ref.committed_at
+
+    if oldest_remaining is not None:
+        age_days = (now - oldest_remaining).total_seconds() / 86400.0
+        report.oldest_remaining_age_days = round(age_days, 2)
+
+    logger.info(
+        "Recovery-ref cleanup sweep complete",
+        repo_path=repo_path_str,
+        ttl_days=ttl_days,
+        dry_run=dry_run,
+        refs_inspected=report.refs_inspected,
+        refs_deleted=report.refs_deleted,
+        refs_skipped_recent=report.refs_skipped_recent,
+        refs_skipped_reachable=report.refs_skipped_reachable,
+        refs_skipped_unknown_age=report.refs_skipped_unknown_age,
+        refs_skipped_error=report.refs_skipped_error,
+        oldest_remaining_age_days=report.oldest_remaining_age_days,
+    )
+    return report
+
+
+class RecoveryRefCleaner:
+    """Background driver that runs :func:`sweep_recovery_refs` on a cadence.
+
+    One instance per repo path the orchestrator manages. Sweeps run in
+    a daemon thread so process shutdown is clean. Stop is cooperative
+    (the loop checks a flag between sleeps); a pending sweep finishes
+    before the thread exits.
+    """
+
+    def __init__(
+        self,
+        gateway: GatewayClient,
+        repo_path: Path,
+        *,
+        ttl_days: int = 90,
+        interval_seconds: float = 24 * 3600,
+        mode: str = "public",
+    ):
+        self._gateway = gateway
+        self._repo_path = repo_path
+        self._ttl_days = ttl_days
+        self._interval_seconds = interval_seconds
+        self._mode = mode
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    @property
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def start(self) -> None:
+        if self.is_running:
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._loop,
+            name=f"recovery-ref-cleaner:{self._repo_path.name}",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info(
+            "Recovery-ref cleanup loop started",
+            repo_path=str(self._repo_path),
+            ttl_days=self._ttl_days,
+            interval_seconds=self._interval_seconds,
+        )
+
+    def stop(self, timeout: float | None = None) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+
+    def run_once(self, *, dry_run: bool = False) -> CleanupReport:
+        """Synchronous one-shot — exposed for tests and operator CLIs."""
+        return sweep_recovery_refs(
+            self._gateway,
+            self._repo_path,
+            ttl_days=self._ttl_days,
+            mode=self._mode,
+            dry_run=dry_run,
+        )
+
+    def _loop(self) -> None:
+        # Sleep before the first sweep so multiple replicas don't pile
+        # up on the same minute after a coordinated restart.
+        if self._stop.wait(self._interval_seconds):
+            return
+        while not self._stop.is_set():
+            try:
+                sweep_recovery_refs(
+                    self._gateway,
+                    self._repo_path,
+                    ttl_days=self._ttl_days,
+                    mode=self._mode,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Recovery-ref cleanup sweep raised; loop continues",
+                    repo_path=str(self._repo_path),
+                    error=str(exc),
+                )
+            if self._stop.wait(self._interval_seconds):
+                return
+
+
+def is_recovery_ref(name: str) -> bool:
+    """Public predicate exposed for tests / operator scripts."""
+    return fnmatch.fnmatch(name, f"{RECOVERY_BRANCH_PREFIX}/*")

--- a/orchestrator/agent_salvage_cleanup.py
+++ b/orchestrator/agent_salvage_cleanup.py
@@ -22,7 +22,6 @@ best-effort: any per-ref failure is logged and never aborts the loop.
 
 from __future__ import annotations
 
-import fnmatch
 import subprocess
 import threading
 from dataclasses import dataclass, field
@@ -294,7 +293,9 @@ def sweep_recovery_refs(
 
         if action == "delete":
             if dry_run:
-                report.refs_deleted += 1
+                # No real delete happened — only `deleted_refs` records
+                # what *would* be removed. `refs_deleted` stays a count of
+                # actual deletes so operators can trust the metric.
                 report.deleted_refs.append(name)
                 continue
             try:
@@ -311,6 +312,12 @@ def sweep_recovery_refs(
                     ref=name,
                     error=str(exc),
                 )
+                # Ref is still on origin — fold its age into oldest_remaining
+                # so the metric reflects what is actually present, not what
+                # we hoped to remove.
+                if ref.committed_at is not None:
+                    if oldest_remaining is None or ref.committed_at < oldest_remaining:
+                        oldest_remaining = ref.committed_at
                 continue
             if push_result.ok or push_result.category == "already_deleted":
                 report.refs_deleted += 1
@@ -328,6 +335,11 @@ def sweep_recovery_refs(
                     ref=name,
                     detail=push_result.describe(),
                 )
+                # Same fold-in: the delete was rejected, so the ref still
+                # exists on origin and its age belongs in the metric.
+                if ref.committed_at is not None:
+                    if oldest_remaining is None or ref.committed_at < oldest_remaining:
+                        oldest_remaining = ref.committed_at
             continue
 
         if action == "recent":
@@ -447,5 +459,10 @@ class RecoveryRefCleaner:
 
 
 def is_recovery_ref(name: str) -> bool:
-    """Public predicate exposed for tests / operator scripts."""
-    return fnmatch.fnmatch(name, f"{RECOVERY_BRANCH_PREFIX}/*")
+    """Public predicate exposed for tests / operator scripts.
+
+    Uses ``startswith`` to match the same membership rule that
+    :func:`list_recovery_refs` applies, so a future change to the
+    prefix can't quietly diverge between the two paths.
+    """
+    return name.startswith(f"{RECOVERY_BRANCH_PREFIX}/")

--- a/orchestrator/cli.py
+++ b/orchestrator/cli.py
@@ -226,6 +226,53 @@ def cmd_serve(args: argparse.Namespace) -> int:
                 error=str(monitor_err),
             )
 
+        # --- Recovery-ref cleanup loop (#2446) ---
+        # Periodically deletes ``egg/recovered/*`` refs older than the
+        # configured TTL so the salvage namespace doesn't grow unbounded
+        # on a busy cluster. One cleaner per repo path; default-on but
+        # gated by ``EGG_ORCH_RECOVERY_REF_CLEANUP_ENABLED``.
+        try:
+            from agent_salvage_cleanup import RecoveryRefCleaner
+            from env_config import (
+                get_recovery_ref_cleanup_enabled,
+                get_recovery_ref_cleanup_interval_seconds,
+                get_recovery_ref_ttl_days,
+            )
+            from gateway_client import get_gateway_client
+
+            if get_recovery_ref_cleanup_enabled():
+                gateway = get_gateway_client()
+                ttl_days = get_recovery_ref_ttl_days()
+                interval = get_recovery_ref_cleanup_interval_seconds()
+                cleaners: list[RecoveryRefCleaner] = []
+                for rp in repo_paths:
+                    cleaner = RecoveryRefCleaner(
+                        gateway=gateway,
+                        repo_path=rp,
+                        ttl_days=ttl_days,
+                        interval_seconds=interval,
+                    )
+                    cleaner.start()
+                    cleaners.append(cleaner)
+                # Stash on app.config so a future shutdown hook (or
+                # operator-facing route) can reach the cleaner instances.
+                app.config["RECOVERY_REF_CLEANERS"] = cleaners
+                logger.info(
+                    "Recovery-ref cleanup loop started",
+                    repo_count=len(cleaners),
+                    ttl_days=ttl_days,
+                    interval_seconds=interval,
+                )
+            else:
+                logger.info(
+                    "Recovery-ref cleanup disabled by EGG_ORCH_RECOVERY_REF_CLEANUP_ENABLED"
+                )
+        except Exception as cleanup_err:
+            logger.warning(
+                "Recovery-ref cleanup loop startup failed",
+                error=str(cleanup_err),
+            )
+
         # --- Health check framework initialization ---
         # Register all Tier 1 (programmatic) health checks and run the
         # STARTUP trigger against every RUNNING pipeline.  The runner is

--- a/orchestrator/env_config.py
+++ b/orchestrator/env_config.py
@@ -412,3 +412,54 @@ def get_state_store_probe_interval() -> float:
     if val <= 0:
         return DEFAULT_STATE_STORE_PROBE_INTERVAL_SECONDS
     return val
+
+
+# -----------------------------------------------------------------
+# EGG_ORCH_RECOVERY_REF_CLEANUP_ENABLED — opt-out kill switch for the
+#   periodic ``egg/recovered/*`` cleanup sweep (#2446). Default: enabled.
+# EGG_ORCH_RECOVERY_REF_TTL_DAYS — committer-date age (days) past which
+#   a recovery ref is eligible for deletion. Default 90.
+# EGG_ORCH_RECOVERY_REF_CLEANUP_INTERVAL_SECONDS — period of the cleanup
+#   loop. Default 86400 (24h). Lower for tests; the sweep is cheap when
+#   no refs need deletion.
+# -----------------------------------------------------------------
+
+DEFAULT_RECOVERY_REF_TTL_DAYS = 90
+DEFAULT_RECOVERY_REF_CLEANUP_INTERVAL_SECONDS = 86400.0
+
+
+def get_recovery_ref_cleanup_enabled() -> bool:
+    """Return True iff the recovery-ref cleanup loop should run.
+
+    Reads ``EGG_ORCH_RECOVERY_REF_CLEANUP_ENABLED`` (default ``true``).
+    Accepts ``0/1``, ``true/false``, ``yes/no`` (case-insensitive). Any
+    other value falls back to the default (enabled) and logs a warning.
+    """
+    raw = os.environ.get("EGG_ORCH_RECOVERY_REF_CLEANUP_ENABLED", "").strip().lower()
+    if not raw:
+        return True
+    if raw in ("1", "true", "yes", "y", "on"):
+        return True
+    if raw in ("0", "false", "no", "n", "off"):
+        return False
+    logger.warning(
+        "EGG_ORCH_RECOVERY_REF_CLEANUP_ENABLED=%r is not a recognised boolean; treating as enabled",
+        raw,
+    )
+    return True
+
+
+def get_recovery_ref_ttl_days() -> int:
+    """Return the recovery-ref staleness TTL in days (default 90)."""
+    return _coerce_positive_int(
+        "EGG_ORCH_RECOVERY_REF_TTL_DAYS",
+        DEFAULT_RECOVERY_REF_TTL_DAYS,
+    )
+
+
+def get_recovery_ref_cleanup_interval_seconds() -> float:
+    """Return the recovery-ref cleanup cadence in seconds (default 86400)."""
+    return _coerce_positive_float(
+        "EGG_ORCH_RECOVERY_REF_CLEANUP_INTERVAL_SECONDS",
+        DEFAULT_RECOVERY_REF_CLEANUP_INTERVAL_SECONDS,
+    )

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1861,13 +1861,26 @@ class GatewayClient:
         in audit/session logs. Callers should pick a tag that matches
         the operation they are performing so existing log-filter rules
         keep working — e.g. the stacked-PR reconciler passes
-        ``"stacked-pr-ls-remote"``.
+        ``"stacked-pr-ls-remote"``. Empty / non-alphanumeric values are
+        rejected to keep the audit-log identifier well-formed: an empty
+        tag would produce a trailing-dash id, and a tag containing
+        whitespace or ``/`` would silently break the log-filter rules
+        the kwarg was added to preserve.
 
         Same error-handling contract as :meth:`list_remote_branches`:
         on any gateway failure returns an empty mapping.
         """
         if not repo_path:
             return {}
+        # Validation is intentionally strict: callers are all internal,
+        # so a bad tag is a programming error, not user input. Hyphens
+        # are allowed because the canonical tag format is hyphen-
+        # separated (e.g. "stacked-pr-ls-remote").
+        if not operation_tag or not operation_tag.replace("-", "").isalnum():
+            raise ValueError(
+                f"operation_tag must be non-empty and alphanumeric (hyphens allowed); "
+                f"got {operation_tag!r}"
+            )
         temp_container_id = f"{pipeline_id}-{operation_tag}"
         session_token: str | None = None
         try:

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1833,6 +1833,11 @@ class GatewayClient:
                 repo_path,
                 agent_role=agent_role,
                 mode=mode,
+                # Preserve the audit-log identifier the stacked-PR
+                # reconciler used before this method was unified with
+                # the SHA-returning variant — runbooks and dashboards
+                # filter by this string.
+                operation_tag="stacked-pr-ls-remote",
             ).keys()
         )
 
@@ -1843,6 +1848,7 @@ class GatewayClient:
         *,
         agent_role: str = "coder",
         mode: Literal["public", "private"] = "public",
+        operation_tag: str = "ls-remote",
     ) -> dict[str, str]:
         """Like :meth:`list_remote_branches` but returns ``{branch: sha}``.
 
@@ -1850,12 +1856,19 @@ class GatewayClient:
         SHA at each ref tip to read its committer date for staleness
         detection without an extra fetch round-trip.
 
+        ``operation_tag`` is appended to the synthetic gateway session's
+        container id (``f"{pipeline_id}-{operation_tag}"``) and shows up
+        in audit/session logs. Callers should pick a tag that matches
+        the operation they are performing so existing log-filter rules
+        keep working — e.g. the stacked-PR reconciler passes
+        ``"stacked-pr-ls-remote"``.
+
         Same error-handling contract as :meth:`list_remote_branches`:
         on any gateway failure returns an empty mapping.
         """
         if not repo_path:
             return {}
-        temp_container_id = f"{pipeline_id}-ls-remote"
+        temp_container_id = f"{pipeline_id}-{operation_tag}"
         session_token: str | None = None
         try:
             session = self.register_session(

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1827,9 +1827,35 @@ class GatewayClient:
         :func:`list_open_prs` is the join key, the empty set is
         safe — no PRs means no orphans.
         """
+        return set(
+            self.list_remote_branches_with_shas(
+                pipeline_id,
+                repo_path,
+                agent_role=agent_role,
+                mode=mode,
+            ).keys()
+        )
+
+    def list_remote_branches_with_shas(
+        self,
+        pipeline_id: str,
+        repo_path: str,
+        *,
+        agent_role: str = "coder",
+        mode: Literal["public", "private"] = "public",
+    ) -> dict[str, str]:
+        """Like :meth:`list_remote_branches` but returns ``{branch: sha}``.
+
+        Used by the recovery-ref cleanup sweep (#2446), which needs the
+        SHA at each ref tip to read its committer date for staleness
+        detection without an extra fetch round-trip.
+
+        Same error-handling contract as :meth:`list_remote_branches`:
+        on any gateway failure returns an empty mapping.
+        """
         if not repo_path:
-            return set()
-        temp_container_id = f"{pipeline_id}-stacked-pr-ls-remote"
+            return {}
+        temp_container_id = f"{pipeline_id}-ls-remote"
         session_token: str | None = None
         try:
             session = self.register_session(
@@ -1854,21 +1880,21 @@ class GatewayClient:
                 bearer_token=session_token,
             )
             stdout = (result.get("data", {}) or {}).get("stdout", "") or ""
-            branches: set[str] = set()
+            branches: dict[str, str] = {}
             for line in stdout.splitlines():
                 # Lines look like "<sha>\trefs/heads/<name>".
                 parts = line.strip().split("\t")
                 if len(parts) >= 2 and parts[1].startswith("refs/heads/"):
-                    branches.add(parts[1][len("refs/heads/") :])
+                    branches[parts[1][len("refs/heads/") :]] = parts[0]
             return branches
         except Exception as exc:  # noqa: BLE001
             logger.warning(
-                "list_remote_branches: gateway request failed",
+                "list_remote_branches_with_shas: gateway request failed",
                 pipeline_id=pipeline_id,
                 repo_path=repo_path,
                 error=str(exc),
             )
-            return set()
+            return {}
         finally:
             if session_token:
                 try:

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1875,10 +1875,17 @@ class GatewayClient:
         # Validation is intentionally strict: callers are all internal,
         # so a bad tag is a programming error, not user input. Hyphens
         # are allowed because the canonical tag format is hyphen-
-        # separated (e.g. "stacked-pr-ls-remote").
-        if not operation_tag or not operation_tag.replace("-", "").isalnum():
+        # separated (e.g. "stacked-pr-ls-remote"). The isascii() check
+        # rejects unicode alphanumerics (e.g. "café") that would
+        # otherwise pass isalnum() and produce mixed-encoding audit-log
+        # identifiers.
+        if (
+            not operation_tag
+            or not operation_tag.isascii()
+            or not operation_tag.replace("-", "").isalnum()
+        ):
             raise ValueError(
-                f"operation_tag must be non-empty and alphanumeric (hyphens allowed); "
+                f"operation_tag must be non-empty ASCII alphanumeric (hyphens allowed); "
                 f"got {operation_tag!r}"
             )
         temp_container_id = f"{pipeline_id}-{operation_tag}"

--- a/orchestrator/tests/test_agent_salvage_cleanup.py
+++ b/orchestrator/tests/test_agent_salvage_cleanup.py
@@ -1,0 +1,394 @@
+"""Unit tests for agent_salvage_cleanup (#2446)."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from agent_salvage_cleanup import (
+    CLEANUP_PIPELINE_ID,
+    CleanupReport,
+    RecoveryRefCleaner,
+    is_recovery_ref,
+    list_recovery_refs,
+    sweep_recovery_refs,
+)
+from gateway_client import PushResult
+
+# ---------------------------------------------------------------------------
+# Real-git helpers — building a tiny clone-with-tracking-refs lets the
+# committer-date and reachability paths exercise actual plumbing instead
+# of mock side-effects.
+# ---------------------------------------------------------------------------
+
+
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "user.email=t@t.com",
+            "-c",
+            "user.name=Tester",
+            "-C",
+            str(cwd),
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _make_repo(path: Path) -> str:
+    path.mkdir(parents=True, exist_ok=True)
+    _git("init", "-q", "--initial-branch", "main", cwd=path)
+    (path / "README.md").write_text("seed\n")
+    _git("add", "README.md", cwd=path)
+    _git("commit", "-q", "-m", "seed", cwd=path)
+    return _git("rev-parse", "HEAD", cwd=path).stdout.strip()
+
+
+def _commit_at(
+    path: Path,
+    filename: str,
+    content: str,
+    message: str,
+    *,
+    when: datetime | None = None,
+) -> str:
+    """Commit a file. ``when`` overrides committer/author date so age tests
+    can place a commit arbitrarily far in the past."""
+    (path / filename).write_text(content)
+    _git("add", filename, cwd=path)
+    if when is None:
+        _git("commit", "-q", "-m", message, cwd=path)
+    else:
+        iso = when.isoformat()
+        cmd = [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "user.email=t@t.com",
+            "-c",
+            "user.name=Tester",
+            "-C",
+            str(path),
+            "commit",
+            "-q",
+            "-m",
+            message,
+        ]
+        import os
+
+        env = os.environ.copy()
+        env["GIT_COMMITTER_DATE"] = iso
+        env["GIT_AUTHOR_DATE"] = iso
+        subprocess.run(cmd, cwd=path, capture_output=True, text=True, check=True, env=env)
+    return _git("rev-parse", "HEAD", cwd=path).stdout.strip()
+
+
+def _set_remote_tracking(repo: Path, ref: str, sha: str) -> None:
+    """Stand in for a fetched ``refs/remotes/origin/<ref>``."""
+    _git("update-ref", f"refs/remotes/origin/{ref}", sha, cwd=repo)
+
+
+# ---------------------------------------------------------------------------
+# Predicate
+# ---------------------------------------------------------------------------
+
+
+class TestIsRecoveryRef:
+    def test_matches_full_recovery_path(self) -> None:
+        assert is_recovery_ref("egg/recovered/issue-99/coder/abc123def456")
+
+    def test_rejects_other_egg_branches(self) -> None:
+        assert not is_recovery_ref("egg/issue-99/work")
+
+    def test_rejects_empty(self) -> None:
+        assert not is_recovery_ref("")
+
+
+# ---------------------------------------------------------------------------
+# list_recovery_refs filters output of list_remote_branches_with_shas
+# ---------------------------------------------------------------------------
+
+
+class TestListRecoveryRefs:
+    def test_filters_to_recovery_namespace(self) -> None:
+        gateway = MagicMock()
+        gateway.list_remote_branches_with_shas.return_value = {
+            "main": "0" * 40,
+            "egg/issue-99/work": "1" * 40,
+            "egg/recovered/issue-99/coder/abc123": "a" * 40,
+            "egg/recovered/issue-99/slice-1-tester/def456": "b" * 40,
+        }
+        out = list_recovery_refs(gateway, "/repo")
+        assert out == {
+            "egg/recovered/issue-99/coder/abc123": "a" * 40,
+            "egg/recovered/issue-99/slice-1-tester/def456": "b" * 40,
+        }
+
+    def test_returns_empty_on_empty(self) -> None:
+        gateway = MagicMock()
+        gateway.list_remote_branches_with_shas.return_value = {}
+        assert list_recovery_refs(gateway, "/repo") == {}
+
+
+# ---------------------------------------------------------------------------
+# sweep_recovery_refs
+# ---------------------------------------------------------------------------
+
+
+class TestSweepRecoveryRefs:
+    def _make_gateway(
+        self,
+        *,
+        refs: dict[str, str] | None = None,
+        delete_result: PushResult | None = None,
+    ) -> MagicMock:
+        gateway = MagicMock()
+        gateway.list_remote_branches_with_shas.return_value = refs or {}
+        gateway.fetch_branch.return_value = True
+        gateway.delete_remote_branch.return_value = (
+            delete_result if delete_result is not None else PushResult(ok=True)
+        )
+        return gateway
+
+    def test_no_refs_no_actions(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_repo(repo)
+        gateway = self._make_gateway(refs={})
+        report = sweep_recovery_refs(gateway, repo, ttl_days=90)
+        assert report.refs_inspected == 0
+        assert report.refs_deleted == 0
+        gateway.delete_remote_branch.assert_not_called()
+
+    def test_deletes_old_unreachable_ref(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_repo(repo)
+        # Commit dated 200 days ago, well past the 90-day cutoff.
+        old = datetime.now(UTC) - timedelta(days=200)
+        sha = _commit_at(repo, "old.txt", "stale", "old work", when=old)
+        # Mirror the recovery ref into refs/remotes/origin/...
+        ref_name = "egg/recovered/issue-99/coder/abc123def456"
+        _set_remote_tracking(repo, ref_name, sha)
+
+        gateway = self._make_gateway(refs={ref_name: sha})
+        report = sweep_recovery_refs(gateway, repo, ttl_days=90)
+
+        assert report.refs_inspected == 1
+        assert report.refs_deleted == 1
+        assert report.deleted_refs == [ref_name]
+        gateway.delete_remote_branch.assert_called_once()
+        kwargs = gateway.delete_remote_branch.call_args.kwargs
+        assert kwargs["branch"] == ref_name
+        assert kwargs["pipeline_id"] == CLEANUP_PIPELINE_ID
+
+    def test_skips_recent_ref(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_repo(repo)
+        recent = datetime.now(UTC) - timedelta(days=5)
+        sha = _commit_at(repo, "fresh.txt", "fresh", "recent work", when=recent)
+        ref_name = "egg/recovered/issue-99/coder/abc123def456"
+        _set_remote_tracking(repo, ref_name, sha)
+
+        gateway = self._make_gateway(refs={ref_name: sha})
+        report = sweep_recovery_refs(gateway, repo, ttl_days=90)
+
+        assert report.refs_skipped_recent == 1
+        assert report.refs_deleted == 0
+        gateway.delete_remote_branch.assert_not_called()
+        # Oldest-remaining metric tracks kept refs.
+        assert report.oldest_remaining_age_days is not None
+        assert 4.0 < report.oldest_remaining_age_days < 6.5
+
+    def test_skips_reachable_from_non_recovery_branch(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_repo(repo)
+        old = datetime.now(UTC) - timedelta(days=200)
+        sha = _commit_at(repo, "old.txt", "old", "stale work", when=old)
+        ref_name = "egg/recovered/issue-99/coder/abc123def456"
+        _set_remote_tracking(repo, ref_name, sha)
+        # Operator already replayed: this commit also lives at refs/remotes/origin/recovered/issue-99
+        _set_remote_tracking(repo, "recovered/issue-99", sha)
+
+        gateway = self._make_gateway(refs={ref_name: sha})
+        report = sweep_recovery_refs(gateway, repo, ttl_days=90)
+
+        assert report.refs_skipped_reachable == 1
+        assert report.refs_deleted == 0
+        gateway.delete_remote_branch.assert_not_called()
+
+    def test_skips_unknown_age_when_sha_missing_locally(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_repo(repo)
+        # SHA deliberately not present in the local repo.
+        ref_name = "egg/recovered/issue-99/coder/abc123def456"
+        gateway = self._make_gateway(refs={ref_name: "0" * 40})
+        report = sweep_recovery_refs(gateway, repo, ttl_days=90)
+
+        assert report.refs_skipped_unknown_age == 1
+        assert report.refs_deleted == 0
+        gateway.delete_remote_branch.assert_not_called()
+
+    def test_dry_run_does_not_call_delete(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_repo(repo)
+        old = datetime.now(UTC) - timedelta(days=200)
+        sha = _commit_at(repo, "old.txt", "old", "stale", when=old)
+        ref_name = "egg/recovered/issue-99/coder/abc123def456"
+        _set_remote_tracking(repo, ref_name, sha)
+
+        gateway = self._make_gateway(refs={ref_name: sha})
+        report = sweep_recovery_refs(gateway, repo, ttl_days=90, dry_run=True)
+
+        assert report.refs_deleted == 1
+        assert report.deleted_refs == [ref_name]
+        gateway.delete_remote_branch.assert_not_called()
+
+    def test_already_deleted_treated_as_success(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_repo(repo)
+        old = datetime.now(UTC) - timedelta(days=200)
+        sha = _commit_at(repo, "old.txt", "old", "stale", when=old)
+        ref_name = "egg/recovered/issue-99/coder/abc123def456"
+        _set_remote_tracking(repo, ref_name, sha)
+
+        gateway = self._make_gateway(
+            refs={ref_name: sha},
+            delete_result=PushResult(ok=False, category="already_deleted"),
+        )
+        report = sweep_recovery_refs(gateway, repo, ttl_days=90)
+        assert report.refs_deleted == 1
+        assert report.refs_skipped_error == 0
+
+    def test_real_delete_failure_counted_as_error(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_repo(repo)
+        old = datetime.now(UTC) - timedelta(days=200)
+        sha = _commit_at(repo, "old.txt", "old", "stale", when=old)
+        ref_name = "egg/recovered/issue-99/coder/abc123def456"
+        _set_remote_tracking(repo, ref_name, sha)
+
+        gateway = self._make_gateway(
+            refs={ref_name: sha},
+            delete_result=PushResult(ok=False, category="auth_failed", detail="403"),
+        )
+        report = sweep_recovery_refs(gateway, repo, ttl_days=90)
+        assert report.refs_skipped_error == 1
+        assert report.refs_deleted == 0
+
+    def test_list_failure_aborts_cleanly(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_repo(repo)
+        gateway = MagicMock()
+        gateway.fetch_branch.return_value = True
+        gateway.list_remote_branches_with_shas.side_effect = RuntimeError("gateway down")
+
+        report = sweep_recovery_refs(gateway, repo, ttl_days=90)
+        assert report.error is not None
+        assert "gateway down" in report.error
+        gateway.delete_remote_branch.assert_not_called()
+
+    def test_per_ref_classify_failure_does_not_abort_loop(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_repo(repo)
+        old = datetime.now(UTC) - timedelta(days=200)
+        sha_b = _commit_at(repo, "b.txt", "b", "b commit", when=old)
+        ref_a = "egg/recovered/issue-99/coder/aaa111"
+        ref_b = "egg/recovered/issue-99/tester/bbb222"
+        # Only B is locally available; A's SHA is unknown.
+        _set_remote_tracking(repo, ref_b, sha_b)
+
+        gateway = self._make_gateway(refs={ref_a: "0" * 40, ref_b: sha_b})
+        report = sweep_recovery_refs(gateway, repo, ttl_days=90)
+        # A → unknown_age (no local commit), B → deleted.
+        assert report.refs_inspected == 2
+        assert report.refs_deleted == 1
+        assert report.refs_skipped_unknown_age == 1
+
+
+# ---------------------------------------------------------------------------
+# RecoveryRefCleaner background driver
+# ---------------------------------------------------------------------------
+
+
+class TestRecoveryRefCleanerLifecycle:
+    def test_start_stop_is_idempotent(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_repo(repo)
+        gateway = MagicMock()
+        gateway.list_remote_branches_with_shas.return_value = {}
+        gateway.fetch_branch.return_value = True
+
+        # Long interval → loop sleeps and never sweeps within the test.
+        cleaner = RecoveryRefCleaner(gateway, repo, ttl_days=90, interval_seconds=3600)
+        cleaner.start()
+        # Second start is a no-op.
+        cleaner.start()
+        assert cleaner.is_running
+        cleaner.stop(timeout=2)
+        assert not cleaner.is_running
+
+    def test_run_once_returns_report(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_repo(repo)
+        gateway = MagicMock()
+        gateway.list_remote_branches_with_shas.return_value = {}
+        gateway.fetch_branch.return_value = True
+
+        cleaner = RecoveryRefCleaner(gateway, repo, ttl_days=90, interval_seconds=3600)
+        report = cleaner.run_once()
+        assert isinstance(report, CleanupReport)
+        assert report.refs_inspected == 0
+
+
+# ---------------------------------------------------------------------------
+# env_config knobs
+# ---------------------------------------------------------------------------
+
+
+class TestEnvConfig:
+    def test_enabled_default_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from env_config import get_recovery_ref_cleanup_enabled
+
+        monkeypatch.delenv("EGG_ORCH_RECOVERY_REF_CLEANUP_ENABLED", raising=False)
+        assert get_recovery_ref_cleanup_enabled() is True
+
+    @pytest.mark.parametrize("raw", ["0", "false", "False", "no", "off"])
+    def test_enabled_false(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        from env_config import get_recovery_ref_cleanup_enabled
+
+        monkeypatch.setenv("EGG_ORCH_RECOVERY_REF_CLEANUP_ENABLED", raw)
+        assert get_recovery_ref_cleanup_enabled() is False
+
+    def test_enabled_unrecognised_falls_back_to_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from env_config import get_recovery_ref_cleanup_enabled
+
+        monkeypatch.setenv("EGG_ORCH_RECOVERY_REF_CLEANUP_ENABLED", "maybe")
+        assert get_recovery_ref_cleanup_enabled() is True
+
+    def test_ttl_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from env_config import get_recovery_ref_ttl_days
+
+        monkeypatch.delenv("EGG_ORCH_RECOVERY_REF_TTL_DAYS", raising=False)
+        assert get_recovery_ref_ttl_days() == 90
+
+    def test_ttl_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from env_config import get_recovery_ref_ttl_days
+
+        monkeypatch.setenv("EGG_ORCH_RECOVERY_REF_TTL_DAYS", "30")
+        assert get_recovery_ref_ttl_days() == 30
+
+    def test_interval_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from env_config import get_recovery_ref_cleanup_interval_seconds
+
+        monkeypatch.delenv("EGG_ORCH_RECOVERY_REF_CLEANUP_INTERVAL_SECONDS", raising=False)
+        assert get_recovery_ref_cleanup_interval_seconds() == 86400.0

--- a/orchestrator/tests/test_agent_salvage_cleanup.py
+++ b/orchestrator/tests/test_agent_salvage_cleanup.py
@@ -249,7 +249,10 @@ class TestSweepRecoveryRefs:
         gateway = self._make_gateway(refs={ref_name: sha})
         report = sweep_recovery_refs(gateway, repo, ttl_days=90, dry_run=True)
 
-        assert report.refs_deleted == 1
+        # In dry-run nothing is removed from origin, so `refs_deleted`
+        # stays a count of *actual* deletes. `deleted_refs` lists what
+        # would be deleted in a real run.
+        assert report.refs_deleted == 0
         assert report.deleted_refs == [ref_name]
         gateway.delete_remote_branch.assert_not_called()
 
@@ -297,7 +300,10 @@ class TestSweepRecoveryRefs:
         assert "gateway down" in report.error
         gateway.delete_remote_branch.assert_not_called()
 
-    def test_per_ref_classify_failure_does_not_abort_loop(self, tmp_path: Path) -> None:
+    def test_unknown_age_does_not_abort_loop(self, tmp_path: Path) -> None:
+        """Unknown-age (SHA missing locally) is a normal classification
+        path that must not stop the sweep. Mixes A (unknown) with B
+        (deletable) and asserts both are processed."""
         repo = tmp_path / "repo"
         _make_repo(repo)
         old = datetime.now(UTC) - timedelta(days=200)
@@ -313,6 +319,48 @@ class TestSweepRecoveryRefs:
         assert report.refs_inspected == 2
         assert report.refs_deleted == 1
         assert report.refs_skipped_unknown_age == 1
+        # Symmetric assertion: the unknown-age path must NOT increment
+        # refs_skipped_error. A regression that swaps the two counters
+        # would be invisible without this.
+        assert report.refs_skipped_error == 0
+
+    def test_per_ref_classify_failure_does_not_abort_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A real raise inside ``_classify`` must hit the
+        ``refs_skipped_error`` counter and let the loop continue
+        processing the remaining refs."""
+        import agent_salvage_cleanup as cleanup
+
+        repo = tmp_path / "repo"
+        _make_repo(repo)
+        old = datetime.now(UTC) - timedelta(days=200)
+        sha_b = _commit_at(repo, "b.txt", "b", "b commit", when=old)
+        ref_a = "egg/recovered/issue-99/coder/aaa111"
+        ref_b = "egg/recovered/issue-99/tester/bbb222"
+        _set_remote_tracking(repo, ref_b, sha_b)
+
+        real_classify = cleanup._classify
+
+        def flaky_classify(name: str, sha: str, repo_path: Path, cutoff):
+            if name == ref_a:
+                raise RuntimeError("boom in classify")
+            return real_classify(name, sha, repo_path, cutoff)
+
+        monkeypatch.setattr(cleanup, "_classify", flaky_classify)
+
+        gateway = self._make_gateway(refs={ref_a: "0" * 40, ref_b: sha_b})
+        report = sweep_recovery_refs(gateway, repo, ttl_days=90)
+
+        # A → classify raised → refs_skipped_error. B → still deleted.
+        assert report.refs_inspected == 2
+        assert report.refs_deleted == 1
+        assert report.refs_skipped_error == 1
+        # Symmetric assertion: the exception path is *not* the
+        # unknown-age path. A regression that swaps the counters fails
+        # here and on `test_unknown_age_does_not_abort_loop` together.
+        assert report.refs_skipped_unknown_age == 0
+        assert report.deleted_refs == [ref_b]
 
 
 # ---------------------------------------------------------------------------
@@ -392,3 +440,9 @@ class TestEnvConfig:
 
         monkeypatch.delenv("EGG_ORCH_RECOVERY_REF_CLEANUP_INTERVAL_SECONDS", raising=False)
         assert get_recovery_ref_cleanup_interval_seconds() == 86400.0
+
+    def test_interval_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from env_config import get_recovery_ref_cleanup_interval_seconds
+
+        monkeypatch.setenv("EGG_ORCH_RECOVERY_REF_CLEANUP_INTERVAL_SECONDS", "600")
+        assert get_recovery_ref_cleanup_interval_seconds() == 600.0

--- a/orchestrator/tests/test_agent_salvage_cleanup.py
+++ b/orchestrator/tests/test_agent_salvage_cleanup.py
@@ -287,6 +287,36 @@ class TestSweepRecoveryRefs:
         report = sweep_recovery_refs(gateway, repo, ttl_days=90)
         assert report.refs_skipped_error == 1
         assert report.refs_deleted == 0
+        # Regression guard for the gateway-rejected fold-in: when the
+        # gateway refuses the delete, the ref is still on origin so its
+        # age must surface in oldest_remaining_age_days. Without the
+        # fold-in, this metric would be None and operators would see a
+        # misleadingly young (or absent) "oldest" exactly when they need
+        # the truth.
+        assert report.oldest_remaining_age_days is not None
+        assert report.oldest_remaining_age_days > 90
+
+    def test_delete_exception_folds_into_oldest_remaining(self, tmp_path: Path) -> None:
+        """Regression guard for the exception-path fold-in. When
+        ``gateway.delete_remote_branch`` raises, the ref is still on
+        origin and its age must show up in ``oldest_remaining_age_days``
+        — otherwise a future change that drops the fold-in would slide
+        through silently."""
+        repo = tmp_path / "repo"
+        _make_repo(repo)
+        old = datetime.now(UTC) - timedelta(days=200)
+        sha = _commit_at(repo, "old.txt", "old", "stale", when=old)
+        ref_name = "egg/recovered/issue-99/coder/abc123def456"
+        _set_remote_tracking(repo, ref_name, sha)
+
+        gateway = self._make_gateway(refs={ref_name: sha})
+        gateway.delete_remote_branch.side_effect = RuntimeError("network down")
+
+        report = sweep_recovery_refs(gateway, repo, ttl_days=90)
+        assert report.refs_skipped_error == 1
+        assert report.refs_deleted == 0
+        assert report.oldest_remaining_age_days is not None
+        assert report.oldest_remaining_age_days > 90
 
     def test_list_failure_aborts_cleanly(self, tmp_path: Path) -> None:
         repo = tmp_path / "repo"

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -1714,6 +1714,50 @@ class TestGetRepoVisibility:
             assert result is None
 
 
+class TestListRemoteBranchesWithShasOperationTag:
+    """Tests for the operation_tag kwarg on list_remote_branches_with_shas.
+
+    The kwarg controls the audit-log identifier the synthetic gateway
+    session registers under (``f"{pipeline_id}-{operation_tag}"``).
+    Empty / non-alphanumeric values would silently break the log-filter
+    rules the kwarg was added to preserve, so callers that pass garbage
+    must fail loudly rather than register a malformed session.
+    """
+
+    def test_empty_operation_tag_raises(self, gateway_client):
+        with pytest.raises(ValueError, match="operation_tag"):
+            gateway_client.list_remote_branches_with_shas(
+                "pipeline-1",
+                "/repo",
+                operation_tag="",
+            )
+
+    def test_operation_tag_with_slash_raises(self, gateway_client):
+        with pytest.raises(ValueError, match="operation_tag"):
+            gateway_client.list_remote_branches_with_shas(
+                "pipeline-1",
+                "/repo",
+                operation_tag="ls/remote",
+            )
+
+    def test_operation_tag_with_whitespace_raises(self, gateway_client):
+        with pytest.raises(ValueError, match="operation_tag"):
+            gateway_client.list_remote_branches_with_shas(
+                "pipeline-1",
+                "/repo",
+                operation_tag="ls remote",
+            )
+
+    def test_hyphenated_operation_tag_accepted(self, gateway_client, mock_gateway_server):
+        # The canonical caller passes a hyphen-separated tag — must pass.
+        result = gateway_client.list_remote_branches_with_shas(
+            "pipeline-1",
+            "/repo",
+            operation_tag="stacked-pr-ls-remote",
+        )
+        assert isinstance(result, dict)
+
+
 class TestSingletonClient:
     """Tests for singleton client."""
 

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -1748,14 +1748,39 @@ class TestListRemoteBranchesWithShasOperationTag:
                 operation_tag="ls remote",
             )
 
+    def test_unicode_operation_tag_raises(self, gateway_client):
+        # ``str.isalnum()`` accepts non-ASCII letters (e.g. "café"),
+        # which would silently produce a mixed-encoding audit-log
+        # identifier and break the log-filter rules the kwarg was
+        # added to preserve. The validator must reject these.
+        with pytest.raises(ValueError, match="operation_tag"):
+            gateway_client.list_remote_branches_with_shas(
+                "pipeline-1",
+                "/repo",
+                operation_tag="café",
+            )
+
     def test_hyphenated_operation_tag_accepted(self, gateway_client, mock_gateway_server):
-        # The canonical caller passes a hyphen-separated tag — must pass.
-        result = gateway_client.list_remote_branches_with_shas(
-            "pipeline-1",
-            "/repo",
-            operation_tag="stacked-pr-ls-remote",
-        )
+        # The canonical caller passes a hyphen-separated tag — must pass
+        # validation AND propagate to the synthetic-session container_id
+        # as ``f"{pipeline_id}-{operation_tag}"``. Pinning the container_id
+        # is the actual contract the kwarg was added to preserve, so we
+        # capture the ``register_session`` call-site rather than relying
+        # on the bare return-type assertion.
+        with patch.object(
+            gateway_client, "register_session", wraps=gateway_client.register_session
+        ) as mock_reg:
+            result = gateway_client.list_remote_branches_with_shas(
+                "pipeline-1",
+                "/repo",
+                operation_tag="stacked-pr-ls-remote",
+            )
         assert isinstance(result, dict)
+        mock_reg.assert_called_once()
+        registered_id = mock_reg.call_args.kwargs.get("container_id") or mock_reg.call_args[1].get(
+            "container_id"
+        )
+        assert registered_id == "pipeline-1-stacked-pr-ls-remote"
 
 
 class TestSingletonClient:


### PR DESCRIPTION
## Summary

- Adds `orchestrator/agent_salvage_cleanup.py` — a periodic sweep that deletes `egg/recovered/<pipeline>/<scope>/<short_sha>` refs older than the configured TTL (default 90 days), with a defensive reachability guard so refs that have been replayed back to origin under a non-recovered name are left alone.
- Wires the loop into `cli.py` startup as a daemon thread alongside the existing periodic-reconciliation loop. One cleaner per repo path. Default-on, gated by `EGG_ORCH_RECOVERY_REF_CLEANUP_ENABLED`.
- New `env_config` knobs: `EGG_ORCH_RECOVERY_REF_CLEANUP_ENABLED` (default `true`), `EGG_ORCH_RECOVERY_REF_TTL_DAYS` (default 90), `EGG_ORCH_RECOVERY_REF_CLEANUP_INTERVAL_SECONDS` (default 86400 / 24 h).
- `gateway_client.list_remote_branches_with_shas` returns `{name -> sha}`; the existing `list_remote_branches` projects from it so the SHA at each ref tip rides along with enumeration (no extra round-trip).
- Doc updates in `docs/reference/agent-recovery.md` covering how the sweep works, the env knobs, log metrics, and the operator workflow interaction.

## Acceptance criteria from #2446

- [x] Periodic job that lists `refs/heads/egg/recovered/*` on origin and deletes refs older than the configured TTL.
- [x] Configurable TTL (default 90 days) via env var.
- [x] Skip deletion when the ref is reachable from any non-recovered remote-tracking branch.
- [x] Metrics in logs: `refs_inspected`, `refs_deleted`, `refs_skipped_*`, `oldest_remaining_age_days`.
- [x] Documented in `docs/reference/agent-recovery.md`.

## Design notes

- **Staleness signal** = committer date (`%cI`) of the ref tip. Plausible alternatives (reflog, separate manifest) require new write-side work; committer date is "close enough" because re-salvaging always produces a fresh SHA anyway.
- **Reachability guard**: we run `git for-each-ref --contains=<sha> refs/remotes/origin/` and exclude `refs/remotes/origin/egg/recovered/*` from the result. Any other tracking ref containing the SHA is treated as "operator may be replaying" and skips deletion. False-negatives (replay branch not yet fetched locally) are tolerable — worst case the operator deletes one ref by hand.
- **No fetch on the rest of origin**: only `refs/heads/egg/recovered/*` is fetched per sweep. Reachability runs on whatever the local clone already has — adequate because the dominant case (no replay branch on origin yet) is handled correctly.
- **Idempotent**: re-running is safe. `already_deleted` from origin is treated as success.

## Test plan

- [x] Unit tests in `test_agent_salvage_cleanup.py` build real git repos with backdated commits and stand in tracking refs to exercise: deletion of stale unreachable refs, recent-ref skip, reachability skip, unknown-age skip (SHA missing locally), dry-run mode, `already_deleted` success path, real delete-failure error path, list-failure abort, per-ref classify failure non-aborting, cleaner lifecycle, and env-var knob parsing.
- [ ] Validate the sweep doesn't trip unexpected pre-commit / ruff issues — local pre-commit runs cleanly on this branch.
- [ ] Manual smoke against staging with `EGG_ORCH_RECOVERY_REF_TTL_DAYS=0` to force deletion of everything in the recovery namespace, then revert to default.

Closes #2446.