### PR TITLE
Fix #2454: resolve since_id once per call to bound warning spam

### DIFF
--- a/orchestrator/message_store.py
+++ b/orchestrator/message_store.py
@@ -273,33 +273,22 @@ class MessageStore:
         Returns:
             List of matching messages, oldest first. Empty list on timeout.
         """
-        # Snapshot the tip index at call entry under the lock below so
-        # from_tip semantics are race-free against concurrent add_message
-        # calls.
-        tip_index: int | None = None
+        # Snapshot the tip / since_id index at call entry under the lock
+        # below so from_tip semantics are race-free against concurrent
+        # add_message calls. Resolving the cursor ONCE (issue #2454) — not
+        # on every notify in the blocking branch — keeps the per-iteration
+        # cost O(n_new_messages) instead of O(n_total_history) and ensures
+        # the "since_id not found" warning fires at most once per call
+        # rather than once per notify (which during a 25 s long-poll under
+        # heartbeat fan-in could fan the same warning out 10+ times).
         use_tip = from_tip and not since_id and wait > 0
+        start_idx = 0
 
         def _filter(all_msgs: list[Message]) -> list[Message]:
-            msgs = list(all_msgs)
-            # from_tip branch: since_id is guaranteed unset here (guard
-            # above ensures mutual exclusion).
-            if use_tip and tip_index is not None:
-                msgs = msgs[tip_index:]
-            # Filter by since_id. If the cursor is unknown, degrade to
-            # "return all" instead of returning empty, so a stale cursor
-            # doesn't silently hide new messages from a polling agent.
-            elif since_id:
-                found_idx = next((i for i, m in enumerate(msgs) if m.id == since_id), None)
-                if found_idx is not None:
-                    msgs = msgs[found_idx + 1 :]
-                else:
-                    logger.warning(
-                        "since_id not found in store; returning full history",
-                        extra={
-                            "pipeline_id": pipeline_id,
-                            "since_id": since_id,
-                        },
-                    )
+            # Slice forward from the resolved start_idx (set under the
+            # lock below). Cheap: O(n_total - start_idx) plus the filter
+            # passes, regardless of how many notifies fire during a wait.
+            msgs = all_msgs[start_idx:]
 
             # from_role filter — applied here so it participates in the
             # wait-for-match decision (wrong sender does not unblock).
@@ -314,9 +303,30 @@ class MessageStore:
 
         # Fast path: check once under the lock.
         with self._lock:
+            initial_msgs = self._messages.get(pipeline_id, [])
             if use_tip:
-                tip_index = len(self._messages.get(pipeline_id, []))
-            matches = _filter(self._messages.get(pipeline_id, []))
+                start_idx = len(initial_msgs)
+            elif since_id:
+                # Resolve since_id to an index ONCE. If the cursor is
+                # unknown, log a single warning and degrade to "return
+                # all" (start_idx stays 0) instead of returning empty,
+                # so a stale cursor doesn't silently hide new messages
+                # from a polling agent.
+                found_idx = next(
+                    (i for i, m in enumerate(initial_msgs) if m.id == since_id),
+                    None,
+                )
+                if found_idx is not None:
+                    start_idx = found_idx + 1
+                else:
+                    logger.warning(
+                        "since_id not found in store; returning full history",
+                        extra={
+                            "pipeline_id": pipeline_id,
+                            "since_id": since_id,
+                        },
+                    )
+            matches = _filter(initial_msgs)
             if wait_for_types:
                 typed = [m for m in matches if m.message_type in set(wait_for_types)]
                 if typed:

--- a/orchestrator/message_store.py
+++ b/orchestrator/message_store.py
@@ -252,7 +252,10 @@ class MessageStore:
                 clear or a post-compaction anchor recovery), fall back to
                 returning all messages rather than silently dropping to empty.
                 This matches the Redis backend's behavior and avoids a silent
-                delivery failure that can stall agents.
+                delivery failure that can stall agents. Cursor resolution happens
+                exactly once per call (under the fast-path lock); the blocking
+                branch slices forward from the resolved index rather than
+                re-resolving on every notify (issue #2454).
             limit: Maximum messages to return.
             wait: If > 0, block up to this many seconds waiting for matching
                 messages to arrive.  Issue #1897.

--- a/orchestrator/tests/test_message_store.py
+++ b/orchestrator/tests/test_message_store.py
@@ -562,6 +562,13 @@ class TestStaleSinceIdInBlockingWait:
         assert len(warnings) == 1, (
             f"expected exactly one stale-cursor warning across the wait, got {len(warnings)}"
         )
+        # Pin the wait-for-types contract too: none of the eight intervening
+        # adds were CONSENSUS_CONFIRMED, so the wait must time out empty.
+        # Catches a future regression where wait_for_types filtering breaks
+        # while the warning suppression still works.
+        assert got == [[]], (
+            f"expected empty result on timeout (no CONSENSUS_CONFIRMED arrived), got {got}"
+        )
 
     def test_stale_cursor_still_returns_full_history(self, store: MessageStore) -> None:
         """The contract from

--- a/orchestrator/tests/test_message_store.py
+++ b/orchestrator/tests/test_message_store.py
@@ -497,6 +497,88 @@ class TestFromTipSemantics:
         assert msgs[0].message_type == MessageType.CONSENSUS_CONFIRMED
 
 
+class TestStaleSinceIdInBlockingWait:
+    """Regression coverage for issue #2454.
+
+    A stale ``since_id`` (e.g., a cursor that survived a phase-boundary
+    ``clear()``) used to log ``since_id not found in store`` from inside
+    ``_filter`` — which the blocking branch invokes once per ``notify``,
+    producing one log line per concurrent message arrival during a long
+    poll. With multiple consumers polling and heartbeats fanning in, the
+    same warning could be emitted dozens of times for a single 25 s
+    wait. Resolution moved into the fast-path lock, so the warning is
+    bound to one emission per call regardless of the number of notifies
+    that fire while the caller is blocked.
+    """
+
+    def test_stale_cursor_logs_warning_once_per_call(
+        self,
+        store: MessageStore,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A stale ``since_id`` that survives a flood of intervening
+        notifies must produce exactly one warning, not one per notify."""
+        # Seed and clear the store — anchor.id is now a "valid-looking"
+        # cursor that the store no longer indexes.
+        anchor = store.add_message(_make_message(message_type=MessageType.PROGRESS))
+        store.clear("test-pipeline")
+
+        # Re-seed so the blocking branch's ``observed`` flag stays True
+        # after the clear (otherwise the cv-detach branch returns early
+        # before any flood of notifies can run through ``_filter``).
+        store.add_message(_make_message(message_type=MessageType.PROGRESS))
+
+        got: list[list[Message]] = []
+
+        def _block() -> None:
+            with caplog.at_level("WARNING", logger="orchestrator.message_store"):
+                got.append(
+                    store.get_messages(
+                        "test-pipeline",
+                        wait=2,
+                        wait_for_types=[MessageType.CONSENSUS_CONFIRMED],
+                        since_id=anchor.id,
+                    )
+                )
+
+        t = threading.Thread(target=_block)
+        t.start()
+        time.sleep(0.1)  # let the thread enter the blocking wait
+
+        # Flood with non-matching adds — every add fires notify_all and
+        # the pre-fix code would log the warning on each wake-up.
+        for _ in range(8):
+            store.add_message(_make_message(message_type=MessageType.PROGRESS))
+            time.sleep(0.01)
+
+        t.join(timeout=4)
+        assert not t.is_alive()
+
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING" and "since_id not found" in r.message
+        ]
+        assert len(warnings) == 1, (
+            f"expected exactly one stale-cursor warning across the wait, got {len(warnings)}"
+        )
+
+    def test_stale_cursor_still_returns_full_history(self, store: MessageStore) -> None:
+        """The contract from
+        ``test_stale_since_id_returns_all_messages`` (HTTP layer) still
+        holds at the store level: an unknown ``since_id`` falls back to
+        full-history replay rather than empty, so a directed message
+        sent before the stale cursor is still delivered."""
+        store.add_message(_make_message(message_type=MessageType.PROGRESS))
+        store.add_message(_make_message(message_type=MessageType.CONSENSUS_CONFIRMED))
+
+        msgs = store.get_messages(
+            "test-pipeline",
+            since_id="nonexistent-cursor-xyz",
+        )
+        assert len(msgs) == 2
+
+
 class TestGetLatestId:
     """Tests for ``MessageStore.get_latest_id``."""
 


### PR DESCRIPTION
## Summary

- The in-memory `MessageStore`'s `get_messages()` resolved `since_id` inside `_filter()`, which the blocking branch invokes once per `cv.notify`. Under heartbeat fan-in during a 25 s long-poll, the same stale-cursor warning could be fanned out 10+ times for a single call — that's the chronic `since_id not found in store; returning full history` log noise the issue identified, and each notify also paid a redundant O(n_total) linear scan over the full history.
- Lift the cursor lookup out of `_filter` into the fast-path lock so the warning fires at most once per call and the inner loop just slices forward from a fixed `start_idx`.
- The full-history fallback contract is preserved: an unknown `since_id` still returns all messages (matching the existing HTTP-layer regression test `test_stale_since_id_returns_all_messages` and the route's docstring), it's just done without the per-notify rescan.

## Scope

- This addresses the warning-spam dimension of #2454 (Open Question 1: cursor mismatch). It does **not** touch the Redis backend (which uses `XREAD`-block semantics rather than a per-notify wake loop), and it does **not** change the steady-state cost of *legitimately* returning a full history when a cursor is genuinely stale (Open Question 3) — that's a larger contract change worth discussing separately.
- The 14–32 s end-to-end latencies the issue cites are mostly the natural long-poll timeout (`/status/wait` clamps to 25 s, `/messages` to 60 s); the warning fires *during* those waits, not because of them. The fix removes the misleading log signal so future incidents aren't masked by it.

## Test plan

- [ ] `make test` covering `orchestrator/tests/test_message_store.py` — new `TestStaleSinceIdInBlockingWait` class asserts (a) exactly one warning across a wait that absorbs eight intervening notifies and (b) the existing full-history fallback contract still holds at the store level.
- [ ] Existing `TestFromTipSemantics` and the HTTP-layer `test_stale_since_id_returns_all_messages` still pass (no behavior change for valid cursors or stale-cursor responses).