### PR TITLE
Fix #2453: defer authorship state-branch git commit out of request path

### DIFF
--- a/orchestrator/commit_authorship_store.py
+++ b/orchestrator/commit_authorship_store.py
@@ -177,19 +177,23 @@ _FLUSHER_POLL_SECONDS = 0.5
 # Time budget the atexit hook gives any in-flight flusher to drain.
 _FLUSHER_ATEXIT_TIMEOUT_SECONDS = 5.0
 
+# Upper bound on the flusher's pending queue.  Each item is a small
+# tuple, so the memory ceiling is well under 10 MiB even at full
+# capacity.  When the worker falls this far behind (e.g. the gateway is
+# holding the bare-repo flock for an extended push), ``enqueue`` falls
+# back to inline replication rather than letting the queue grow without
+# bound.
+_FLUSHER_QUEUE_MAX = 10_000
+
 
 def _commit_one_shard_inline(
     state_store: Any,
     path: Path,
-    entries: list[tuple[str, str, str]],
+    sha: str,
+    role: str,
+    pipeline_id: str,
 ) -> None:
-    """Stage ``path`` and commit the result through ``state_store``.
-
-    ``entries`` is a list of ``(sha, role, pipeline_id)`` triples that
-    contributed to this shard's current contents — used to compose a
-    descriptive commit message.  An empty list is treated as
-    "no message context", which only happens in defensive code paths.
-    """
+    """Stage ``path`` and commit the result through ``state_store``."""
     wt = state_store.worktree
     try:
         rel = str(path.relative_to(wt))
@@ -198,9 +202,6 @@ def _commit_one_shard_inline(
         # happen in production, but can in tests that point
         # ``worktree_dir`` elsewhere), skip the commit silently.
         return
-    sha = entries[0][0] if entries else "?"
-    role = entries[0][1] if entries else "?"
-    pipeline_id = entries[0][2] if entries else "?"
     try:
         state_store._run_git("add", rel, cwd=wt)
         diff = state_store._run_git("diff", "--cached", "--quiet", cwd=wt, check=False)
@@ -240,7 +241,7 @@ def _commit_batch_inline(
     ``git add`` + ``git commit`` cycles per flusher tick from N to 1,
     which is the whole point of the async path (#2453).
     """
-    if not state_store or not batch:
+    if not batch:
         return
     wt = state_store.worktree
     rel_to_entries: dict[str, list[tuple[str, str, str]]] = {}
@@ -262,7 +263,7 @@ def _commit_batch_inline(
         rel = rel_order[0]
         sha, role, pipeline_id = rel_to_entries[rel][0]
         path = wt / rel
-        _commit_one_shard_inline(state_store, path, [(sha, role, pipeline_id)])
+        _commit_one_shard_inline(state_store, path, sha, role, pipeline_id)
         return
     try:
         for rel in rel_order:
@@ -305,48 +306,87 @@ class _AuthorshipFlusher:
     ``_commit_batch_inline``).
     """
 
+    # Sentinel pushed onto the queue to wake the worker out of its
+    # blocking ``queue.get`` during shutdown.  ``None`` is unambiguous
+    # because every real item is a 4-tuple.
+    _SHUTDOWN_SENTINEL: Any = None
+
     def __init__(self, state_store: Any) -> None:
         self._state_store = state_store
-        self._queue: queue.Queue[tuple[Path, str, str, str]] = queue.Queue()
+        self._queue: queue.Queue[Any] = queue.Queue(maxsize=_FLUSHER_QUEUE_MAX)
         self._stop = threading.Event()
-        # ``_idle`` is set when the worker is between ticks (queue empty
-        # and no tick in progress).  ``flush()`` waits for both
-        # ``queue.empty()`` and ``_idle.is_set()`` to be true to avoid a
-        # race where the worker has dequeued an item but not yet
-        # processed it.
-        self._idle = threading.Event()
-        self._idle.set()
         self._thread = threading.Thread(
             target=self._run,
             name="authorship-flusher",
             daemon=True,
         )
         self._thread.start()
-        atexit.register(self._atexit_drain)
+        # Bind the atexit hook once so ``atexit.unregister`` can match
+        # the same callable in ``shutdown()`` — bound-method objects
+        # compare by identity in atexit's registry, and re-binding via
+        # ``self._atexit_drain`` would create a fresh object that
+        # ``unregister`` can't find.
+        self._atexit_hook = self._atexit_drain
+        atexit.register(self._atexit_hook)
 
     def enqueue(self, path: Path, sha: str, role: str, pipeline_id: str) -> None:
         if self._stop.is_set():
             # The flusher has been shut down; fall back to inline so the
             # caller still gets state-branch replication for this commit.
-            _commit_one_shard_inline(self._state_store, path, [(sha, role, pipeline_id)])
+            _commit_one_shard_inline(self._state_store, path, sha, role, pipeline_id)
             return
-        self._queue.put((path, sha, role, pipeline_id))
+        try:
+            self._queue.put_nowait((path, sha, role, pipeline_id))
+        except queue.Full:
+            # Worker has fallen far enough behind that the bounded queue
+            # is full.  Degrade gracefully by running this commit inline
+            # rather than blocking the caller or growing memory without
+            # bound.
+            logger.warning(
+                "authorship_flusher_queue_full sha=%s pipeline_id=%s "
+                "(falling back to inline commit)",
+                sha,
+                pipeline_id,
+            )
+            _commit_one_shard_inline(self._state_store, path, sha, role, pipeline_id)
 
     def flush(self, timeout: float | None = None) -> bool:
+        """Block until every enqueued item has been processed.
+
+        Implemented by polling ``Queue.unfinished_tasks`` rather than
+        rolling our own idle flag — the counter is incremented inside
+        ``Queue.put`` and decremented in ``Queue.task_done``, so the
+        "item dequeued but not yet processed" state is observable
+        race-free.
+        """
         deadline = time.monotonic() + timeout if timeout is not None else None
-        while True:
-            if self._queue.empty() and self._idle.is_set():
-                return True
+        while self._queue.unfinished_tasks > 0:
             if deadline is not None and time.monotonic() >= deadline:
                 return False
             time.sleep(0.01)
+        return True
 
     def shutdown(self, *, timeout: float = 5.0) -> None:
         self._stop.set()
         self.flush(timeout=timeout)
-        # Wake the worker out of its blocking ``queue.get`` if needed so
-        # it observes ``_stop`` promptly.
+        # Wake the worker out of its blocking ``queue.get`` so it
+        # observes ``_stop`` immediately rather than waiting up to
+        # ``_FLUSHER_POLL_SECONDS`` on the next poll.
+        try:
+            self._queue.put_nowait(self._SHUTDOWN_SENTINEL)
+        except queue.Full:  # pragma: no cover - defensive
+            # If the queue is somehow still full, the poll-timeout
+            # fallback in ``_run`` will catch ``_stop`` shortly.
+            pass
         self._thread.join(timeout=timeout)
+        # Drop the atexit registration so the hook (and the bound
+        # ``self`` it pins) can be garbage-collected.  Without this,
+        # every ``reset_singleton`` cycle would accumulate a hook for
+        # the lifetime of the process.
+        try:
+            atexit.unregister(self._atexit_hook)
+        except Exception:  # pragma: no cover - defensive
+            logger.debug("authorship_flusher_atexit_unregister_failed", exc_info=True)
 
     def _atexit_drain(self) -> None:
         # Best-effort: give in-flight registrations a short window to
@@ -362,19 +402,32 @@ class _AuthorshipFlusher:
                 first = self._queue.get(timeout=_FLUSHER_POLL_SECONDS)
             except queue.Empty:
                 continue
-            self._idle.clear()
+            if first is self._SHUTDOWN_SENTINEL:
+                # Shutdown wake-up.  Ack the sentinel so the
+                # unfinished-task counter stays in sync, then exit.
+                self._queue.task_done()
+                return
+            batch: list[tuple[Path, str, str, str]] = [first]
             try:
-                batch: list[tuple[Path, str, str, str]] = [first]
                 while True:
                     try:
-                        batch.append(self._queue.get_nowait())
+                        item = self._queue.get_nowait()
                     except queue.Empty:
                         break
+                    if item is self._SHUTDOWN_SENTINEL:
+                        # Don't fold the sentinel into the work batch;
+                        # ack it separately so unfinished_tasks balances.
+                        self._queue.task_done()
+                        continue
+                    batch.append(item)
                 _commit_batch_inline(self._state_store, batch)
             except Exception:  # pragma: no cover - defensive
                 logger.warning("authorship_flusher_tick_failed", exc_info=True)
             finally:
-                self._idle.set()
+                # Mark every real item we dequeued as done so
+                # ``unfinished_tasks`` returns to zero.
+                for _ in batch:
+                    self._queue.task_done()
 
 
 class CommitAuthorshipStore:
@@ -680,7 +733,7 @@ class CommitAuthorshipStore:
         """
         assert self._state_store is not None
         if self._synchronous:
-            _commit_one_shard_inline(self._state_store, path, [(sha, role, pipeline_id)])
+            _commit_one_shard_inline(self._state_store, path, sha, role, pipeline_id)
             return
         flusher = self._get_or_start_flusher()
         flusher.enqueue(path, sha, role, pipeline_id)

--- a/orchestrator/commit_authorship_store.py
+++ b/orchestrator/commit_authorship_store.py
@@ -47,13 +47,16 @@ Semantics:
 
 from __future__ import annotations
 
+import atexit
 import json
 import logging
 import os
+import queue
 import re
 import subprocess
 import tempfile
 import threading
+import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -162,6 +165,218 @@ def _validate_pipeline_id(pipeline_id: str) -> str:
     return pid
 
 
+# ---------------------------------------------------------------------------
+# State-branch git commit (inline + async background flusher)
+# ---------------------------------------------------------------------------
+
+# Polling interval for the background flusher's ``queue.get`` call.  The
+# value only bounds shutdown latency — items are picked up immediately on
+# arrival because ``queue.get`` returns as soon as a producer puts.
+_FLUSHER_POLL_SECONDS = 0.5
+
+# Time budget the atexit hook gives any in-flight flusher to drain.
+_FLUSHER_ATEXIT_TIMEOUT_SECONDS = 5.0
+
+
+def _commit_one_shard_inline(
+    state_store: Any,
+    path: Path,
+    entries: list[tuple[str, str, str]],
+) -> None:
+    """Stage ``path`` and commit the result through ``state_store``.
+
+    ``entries`` is a list of ``(sha, role, pipeline_id)`` triples that
+    contributed to this shard's current contents — used to compose a
+    descriptive commit message.  An empty list is treated as
+    "no message context", which only happens in defensive code paths.
+    """
+    wt = state_store.worktree
+    try:
+        rel = str(path.relative_to(wt))
+    except ValueError:
+        # If the shard lives outside the state worktree (shouldn't
+        # happen in production, but can in tests that point
+        # ``worktree_dir`` elsewhere), skip the commit silently.
+        return
+    sha = entries[0][0] if entries else "?"
+    role = entries[0][1] if entries else "?"
+    pipeline_id = entries[0][2] if entries else "?"
+    try:
+        state_store._run_git("add", rel, cwd=wt)
+        diff = state_store._run_git("diff", "--cached", "--quiet", cwd=wt, check=False)
+        if diff.returncode == 0:
+            return
+        msg = f"commit-authorship: register {sha[:12]} as {role} (pipeline={pipeline_id})"
+        state_store._run_git("commit", "--no-verify", "-m", msg, cwd=wt)
+        try:
+            state_store._sync_to_remote_async()
+        except Exception:
+            logger.debug("authorship_state_branch_push_deferred", exc_info=True)
+    except subprocess.CalledProcessError:
+        logger.warning(
+            "authorship_state_branch_commit_failed sha=%s pipeline_id=%s",
+            sha,
+            pipeline_id,
+            exc_info=True,
+        )
+    except Exception:
+        # Store-level errors (GitOperationError, etc.) must not
+        # poison the registration — the shard is already on disk.
+        logger.warning(
+            "authorship_state_branch_commit_failed sha=%s pipeline_id=%s",
+            sha,
+            pipeline_id,
+            exc_info=True,
+        )
+
+
+def _commit_batch_inline(
+    state_store: Any,
+    batch: list[tuple[Path, str, str, str]],
+) -> None:
+    """Stage every distinct shard path in ``batch`` and create one commit.
+
+    Coalescing N registers into one commit cuts the number of
+    ``git add`` + ``git commit`` cycles per flusher tick from N to 1,
+    which is the whole point of the async path (#2453).
+    """
+    if not state_store or not batch:
+        return
+    wt = state_store.worktree
+    rel_to_entries: dict[str, list[tuple[str, str, str]]] = {}
+    rel_order: list[str] = []
+    for path, sha, role, pipeline_id in batch:
+        try:
+            rel = str(path.relative_to(wt))
+        except ValueError:
+            continue
+        if rel not in rel_to_entries:
+            rel_to_entries[rel] = []
+            rel_order.append(rel)
+        rel_to_entries[rel].append((sha, role, pipeline_id))
+    if not rel_order:
+        return
+    if len(rel_order) == 1 and len(rel_to_entries[rel_order[0]]) == 1:
+        # Singleton path keeps the original per-sha commit message so log
+        # consumers and audit tools see the familiar format.
+        rel = rel_order[0]
+        sha, role, pipeline_id = rel_to_entries[rel][0]
+        path = wt / rel
+        _commit_one_shard_inline(state_store, path, [(sha, role, pipeline_id)])
+        return
+    try:
+        for rel in rel_order:
+            state_store._run_git("add", rel, cwd=wt)
+        diff = state_store._run_git("diff", "--cached", "--quiet", cwd=wt, check=False)
+        if diff.returncode == 0:
+            return
+        total_entries = sum(len(v) for v in rel_to_entries.values())
+        msg = (
+            f"commit-authorship: batch register "
+            f"({total_entries} entries across {len(rel_order)} shard(s))"
+        )
+        state_store._run_git("commit", "--no-verify", "-m", msg, cwd=wt)
+        try:
+            state_store._sync_to_remote_async()
+        except Exception:
+            logger.debug("authorship_state_branch_push_deferred", exc_info=True)
+    except subprocess.CalledProcessError:
+        logger.warning(
+            "authorship_state_branch_commit_failed batch_size=%d",
+            len(batch),
+            exc_info=True,
+        )
+    except Exception:
+        logger.warning(
+            "authorship_state_branch_commit_failed batch_size=%d",
+            len(batch),
+            exc_info=True,
+        )
+
+
+class _AuthorshipFlusher:
+    """Background worker that absorbs state-branch git commits.
+
+    The single worker design matches the cross-process ``flock`` the
+    state-store already holds on the bare repo — concurrent commits
+    serialise on that lock anyway, so an in-process pool would only add
+    contention.  Each tick drains the queue completely and folds every
+    pending shard into one ``git add`` + ``git commit`` (see
+    ``_commit_batch_inline``).
+    """
+
+    def __init__(self, state_store: Any) -> None:
+        self._state_store = state_store
+        self._queue: queue.Queue[tuple[Path, str, str, str]] = queue.Queue()
+        self._stop = threading.Event()
+        # ``_idle`` is set when the worker is between ticks (queue empty
+        # and no tick in progress).  ``flush()`` waits for both
+        # ``queue.empty()`` and ``_idle.is_set()`` to be true to avoid a
+        # race where the worker has dequeued an item but not yet
+        # processed it.
+        self._idle = threading.Event()
+        self._idle.set()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="authorship-flusher",
+            daemon=True,
+        )
+        self._thread.start()
+        atexit.register(self._atexit_drain)
+
+    def enqueue(self, path: Path, sha: str, role: str, pipeline_id: str) -> None:
+        if self._stop.is_set():
+            # The flusher has been shut down; fall back to inline so the
+            # caller still gets state-branch replication for this commit.
+            _commit_one_shard_inline(self._state_store, path, [(sha, role, pipeline_id)])
+            return
+        self._queue.put((path, sha, role, pipeline_id))
+
+    def flush(self, timeout: float | None = None) -> bool:
+        deadline = time.monotonic() + timeout if timeout is not None else None
+        while True:
+            if self._queue.empty() and self._idle.is_set():
+                return True
+            if deadline is not None and time.monotonic() >= deadline:
+                return False
+            time.sleep(0.01)
+
+    def shutdown(self, *, timeout: float = 5.0) -> None:
+        self._stop.set()
+        self.flush(timeout=timeout)
+        # Wake the worker out of its blocking ``queue.get`` if needed so
+        # it observes ``_stop`` promptly.
+        self._thread.join(timeout=timeout)
+
+    def _atexit_drain(self) -> None:
+        # Best-effort: give in-flight registrations a short window to
+        # land on the state branch before the process exits.
+        try:
+            self.flush(timeout=_FLUSHER_ATEXIT_TIMEOUT_SECONDS)
+        except Exception:  # pragma: no cover - defensive
+            logger.debug("authorship_flusher_atexit_failed", exc_info=True)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                first = self._queue.get(timeout=_FLUSHER_POLL_SECONDS)
+            except queue.Empty:
+                continue
+            self._idle.clear()
+            try:
+                batch: list[tuple[Path, str, str, str]] = [first]
+                while True:
+                    try:
+                        batch.append(self._queue.get_nowait())
+                    except queue.Empty:
+                        break
+                _commit_batch_inline(self._state_store, batch)
+            except Exception:  # pragma: no cover - defensive
+                logger.warning("authorship_flusher_tick_failed", exc_info=True)
+            finally:
+                self._idle.set()
+
+
 class CommitAuthorshipStore:
     """Git-backed, pipeline-sharded commit-authorship store.
 
@@ -170,6 +385,12 @@ class CommitAuthorshipStore:
     remote-sync daemon.  The state-store reference is optional so this
     module can be exercised in unit tests without standing up a full
     ``StateStore`` (the tests pass an explicit ``worktree_dir``).
+
+    Git replication of new shard contents to the ``egg/pipeline-state``
+    branch is dispatched to a background ``_AuthorshipFlusher`` thread so
+    ``register()`` returns as soon as the disk write completes.  Lookups
+    only ever read disk, so they remain correct even before the git
+    commit lands.  See issue #2453.
     """
 
     # Process-wide lock to serialize in-memory read-modify-write of the
@@ -182,6 +403,7 @@ class CommitAuthorshipStore:
         *,
         state_store: StateStore | None = None,
         worktree_dir: Path | None = None,
+        synchronous: bool = False,
     ) -> None:
         """Initialize the store.
 
@@ -194,11 +416,19 @@ class CommitAuthorshipStore:
             worktree_dir: Explicit worktree path.  Required when
                 ``state_store`` is None.  Ignored otherwise (the state
                 store's worktree wins).
+            synchronous: When True, run state-branch git work inline in
+                ``register()`` instead of dispatching to the background
+                flusher.  Intended for unit tests that want to assert on
+                git activity without driving a worker thread.  Defaults
+                to False (the production async path).
         """
         if state_store is None and worktree_dir is None:
             raise ValueError("Provide either state_store or worktree_dir")
         self._state_store = state_store
         self._worktree_dir = worktree_dir
+        self._synchronous = synchronous
+        self._flusher: _AuthorshipFlusher | None = None
+        self._flusher_lock = threading.Lock()
 
     # -- worktree resolution ----------------------------------------------
 
@@ -441,49 +671,59 @@ class CommitAuthorshipStore:
     def _commit_shard_to_state_branch(
         self, path: Path, sha: str, role: str, pipeline_id: str
     ) -> None:
-        """Commit the shard change through the state store's worktree."""
+        """Replicate the shard change to the state branch.
+
+        In the default (async) mode the work is enqueued onto the
+        process-wide flusher so ``register()`` returns within
+        microseconds.  In synchronous mode (tests) the git commit runs
+        inline.
+        """
         assert self._state_store is not None
-        wt = self._state_store.worktree
-        try:
-            rel = str(path.relative_to(wt))
-        except ValueError:
-            # If the shard lives outside the state worktree (shouldn't
-            # happen in production, but can in tests that point
-            # ``worktree_dir`` elsewhere), skip the commit silently.
+        if self._synchronous:
+            _commit_one_shard_inline(self._state_store, path, [(sha, role, pipeline_id)])
             return
-        try:
-            self._state_store._run_git("add", rel, cwd=wt)
-            # Skip commit if no changes staged (e.g., concurrent writer
-            # already flushed the same content).
-            diff = self._state_store._run_git("diff", "--cached", "--quiet", cwd=wt, check=False)
-            if diff.returncode == 0:
-                return
-            msg = f"commit-authorship: register {sha[:12]} as {role} (pipeline={pipeline_id})"
-            self._state_store._run_git("commit", "--no-verify", "-m", msg, cwd=wt)
-            # Best-effort async push; never block the caller on network.
-            try:
-                self._state_store._sync_to_remote_async()
-            except Exception:
-                logger.debug(
-                    "authorship_state_branch_push_deferred",
-                    exc_info=True,
-                )
-        except subprocess.CalledProcessError:
-            logger.warning(
-                "authorship_state_branch_commit_failed sha=%s pipeline_id=%s",
-                sha,
-                pipeline_id,
-                exc_info=True,
-            )
-        except Exception:
-            # Store-level errors (GitOperationError, etc.) must not
-            # poison the registration — the shard is already on disk.
-            logger.warning(
-                "authorship_state_branch_commit_failed sha=%s pipeline_id=%s",
-                sha,
-                pipeline_id,
-                exc_info=True,
-            )
+        flusher = self._get_or_start_flusher()
+        flusher.enqueue(path, sha, role, pipeline_id)
+
+    def _get_or_start_flusher(self) -> _AuthorshipFlusher:
+        """Lazily instantiate the flusher on first registration.
+
+        Lazy construction means tests that only exercise the
+        pure-filesystem mode never spin up a worker thread, and the
+        process-wide singleton starts the flusher exactly once.
+        """
+        with self._flusher_lock:
+            if self._flusher is None:
+                assert self._state_store is not None
+                self._flusher = _AuthorshipFlusher(self._state_store)
+            return self._flusher
+
+    def flush(self, timeout: float | None = None) -> bool:
+        """Block until any pending state-branch commits have landed.
+
+        Returns True when the queue drained within ``timeout`` seconds
+        (or unconditionally when no flusher has been started).  Tests
+        that need to observe state-branch state after ``register()`` use
+        this to avoid races; production callers usually do not need it.
+        """
+        with self._flusher_lock:
+            flusher = self._flusher
+        if flusher is None:
+            return True
+        return flusher.flush(timeout=timeout)
+
+    def _shutdown_flusher(self, *, timeout: float = 5.0) -> None:
+        """Stop the background flusher after one final drain attempt.
+
+        Exposed for tests / ``reset_singleton``; callers should not need
+        it during normal operation (the daemon thread exits with the
+        process and ``atexit`` flushes pending work).
+        """
+        with self._flusher_lock:
+            flusher = self._flusher
+            self._flusher = None
+        if flusher is not None:
+            flusher.shutdown(timeout=timeout)
 
 
 _singleton: CommitAuthorshipStore | None = None
@@ -582,4 +822,10 @@ def reset_singleton() -> None:
     """Drop the process-wide singleton.  Intended for tests only."""
     global _singleton
     with _singleton_lock:
+        existing = _singleton
         _singleton = None
+    if existing is not None:
+        try:
+            existing._shutdown_flusher(timeout=2.0)
+        except Exception:  # pragma: no cover - defensive
+            logger.debug("authorship_flusher_reset_shutdown_failed", exc_info=True)

--- a/orchestrator/tests/test_commit_authorship_store.py
+++ b/orchestrator/tests/test_commit_authorship_store.py
@@ -527,8 +527,18 @@ class TestAsyncFlusher:
         store = CommitAuthorshipStore(worktree_dir=worktree)
         assert store.flush(timeout=0) is True
 
-    def test_burst_coalesces_into_one_commit(self, worktree: Path):
-        """Multiple registers queued before the worker drains share one commit."""
+    def test_burst_coalesces_into_at_most_two_commits(self, worktree: Path):
+        """A burst of N registers fans out to a small constant number of commits.
+
+        The worker dequeues item 1 and immediately enters its first git
+        tick (gated below); items 2-5 land while the gate is held, so
+        they batch into a single follow-up tick.  Result: 1 singleton
+        commit + 1 batch commit = 2 total, which is the upper bound this
+        test pins.  The "1 commit for all 5" outcome would require
+        gating ``queue.get`` itself rather than the per-tick git call,
+        and is exercised separately by the unit-level tests on
+        ``_commit_batch_inline``.
+        """
         stub = _StubStateStore(worktree)
         # Block the worker until we've enqueued the whole batch so they
         # land in a single tick.
@@ -553,15 +563,37 @@ class TestAsyncFlusher:
             assert store.flush(timeout=5) is True
             cmds = [args[0] for args, _kwargs in stub.run_git_calls]
             # All 5 disk writes target the same shard (issue-1882.json), so
-            # the worker should issue exactly one commit covering the lot.
-            # Worst case (the worker briefly woke before all 5 enqueued)
-            # we still expect well below 5 commits.
+            # the worker should issue at most 2 commits (singleton + batch)
+            # rather than one per register.  The point of the async path is
+            # N → constant, not necessarily N → 1.
             assert cmds.count("commit") <= 2, (
                 f"expected coalesced commit(s) for a 5-write burst, got {cmds.count('commit')}"
             )
         finally:
             gate.set()
             store._shutdown_flusher(timeout=2.0)
+
+    def test_batch_inline_collapses_n_to_one_commit(self, worktree: Path):
+        """``_commit_batch_inline`` itself folds N entries into one commit."""
+        from commit_authorship_store import (  # type: ignore[import-not-found]
+            _commit_batch_inline,
+        )
+
+        stub = _StubStateStore(worktree)
+        shard_dir = worktree / SUBSTORE_DIR
+        shard_dir.mkdir(parents=True, exist_ok=True)
+        shard = shard_dir / "issue-1882.json"
+        shard.write_text("{}")
+        # 5 entries against the same shard should produce exactly one
+        # commit when the inline batcher is exercised directly.
+        batch = [(shard, f"{i:x}".rjust(40, "0"), "coder", "issue-1882") for i in range(5)]
+        _commit_batch_inline(stub, batch)  # type: ignore[arg-type]
+        cmds = [args[0] for args, _kwargs in stub.run_git_calls]
+        assert cmds.count("commit") == 1
+        # And the commit message reflects the batch shape rather than a
+        # single sha (the singleton path is not taken for N>1).
+        commit_calls = [args for args, _kwargs in stub.run_git_calls if args[0] == "commit"]
+        assert "batch register" in " ".join(str(arg) for arg in commit_calls[0])
 
     def test_flusher_swallows_git_errors_and_keeps_running(self, worktree: Path):
         """A failing tick must not poison subsequent registrations."""

--- a/orchestrator/tests/test_commit_authorship_store.py
+++ b/orchestrator/tests/test_commit_authorship_store.py
@@ -419,7 +419,7 @@ class TestStateBranchCommitOnWrite:
     def test_register_triggers_git_add_and_commit(self, worktree: Path):
         """A successful register triggers ``git add`` + ``git commit`` through the StateStore."""
         stub = _StubStateStore(worktree)
-        store = CommitAuthorshipStore(state_store=stub)  # type: ignore[arg-type]
+        store = CommitAuthorshipStore(state_store=stub, synchronous=True)  # type: ignore[arg-type]
         store.register(_VALID_SHA, "coder", "issue-1882")
         cmds = [args[0] for args, _kwargs in stub.run_git_calls]
         assert "add" in cmds
@@ -431,7 +431,7 @@ class TestStateBranchCommitOnWrite:
     def test_idempotent_reregister_skips_commit(self, worktree: Path):
         """When the diff probe reports no changes, no commit is made."""
         stub = _StubStateStore(worktree)
-        store = CommitAuthorshipStore(state_store=stub)  # type: ignore[arg-type]
+        store = CommitAuthorshipStore(state_store=stub, synchronous=True)  # type: ignore[arg-type]
         store.register(_VALID_SHA, "coder", "issue-1882")
         stub.run_git_calls.clear()
         stub.sync_called = False
@@ -444,7 +444,7 @@ class TestStateBranchCommitOnWrite:
     def test_commit_false_skips_git(self, worktree: Path):
         """Passing ``commit=False`` suppresses the state-branch writeback."""
         stub = _StubStateStore(worktree)
-        store = CommitAuthorshipStore(state_store=stub)  # type: ignore[arg-type]
+        store = CommitAuthorshipStore(state_store=stub, synchronous=True)  # type: ignore[arg-type]
         store.register(_VALID_SHA, "coder", "issue-1882", commit=False)
         assert stub.run_git_calls == []
         assert stub.sync_called is False
@@ -459,10 +459,171 @@ class TestStateBranchCommitOnWrite:
             raise _sp.CalledProcessError(1, ["git", "commit"])
 
         stub._run_git = boom  # type: ignore[assignment]
-        store = CommitAuthorshipStore(state_store=stub)  # type: ignore[arg-type]
+        store = CommitAuthorshipStore(state_store=stub, synchronous=True)  # type: ignore[arg-type]
         # Must not raise — the registration still succeeded on disk.
         store.register(_VALID_SHA, "coder", "issue-1882")
         assert store.lookup(_VALID_SHA) == "coder"
+
+
+# ---------------------------------------------------------------------------
+# Async flusher (issue #2453)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncFlusher:
+    """The default (non-synchronous) path defers state-branch git work to a
+    background ``_AuthorshipFlusher`` thread so ``register()`` is no longer
+    gated on the state-store flock + 3 git subprocess calls.
+
+    Each test drains via ``store.flush()`` to avoid sleep-based races; the
+    autouse ``_reset_store_singleton`` fixture tears down any leftover
+    flusher thread between tests.
+    """
+
+    def test_register_returns_before_git_commit_runs(self, worktree: Path):
+        """``register()`` must not block on git work in the default mode."""
+        slow_release = threading.Event()
+        in_git = threading.Event()
+        stub = _StubStateStore(worktree)
+        original_run_git = stub._run_git
+
+        def slow_git(*args, **kwargs):
+            in_git.set()
+            slow_release.wait(timeout=5)
+            return original_run_git(*args, **kwargs)
+
+        stub._run_git = slow_git  # type: ignore[assignment]
+        store = CommitAuthorshipStore(state_store=stub)  # type: ignore[arg-type]
+        try:
+            # register returns immediately, even though git will take seconds
+            store.register(_VALID_SHA, "coder", "issue-1882")
+            assert store.lookup(_VALID_SHA) == "coder"
+            # The worker has either entered the slow git call or is about to;
+            # wait briefly to confirm the work is dispatched out-of-band.
+            assert in_git.wait(timeout=2), "flusher never picked up the job"
+            slow_release.set()
+            assert store.flush(timeout=5) is True
+            cmds = [args[0] for args, _kwargs in stub.run_git_calls]
+            assert "commit" in cmds
+        finally:
+            slow_release.set()
+            store._shutdown_flusher(timeout=2.0)
+
+    def test_flush_drains_pending_writes(self, worktree: Path):
+        """A successful ``flush()`` guarantees the git commit has run."""
+        stub = _StubStateStore(worktree)
+        store = CommitAuthorshipStore(state_store=stub)  # type: ignore[arg-type]
+        try:
+            store.register(_VALID_SHA, "coder", "issue-1882")
+            assert store.flush(timeout=5) is True
+            cmds = [args[0] for args, _kwargs in stub.run_git_calls]
+            assert cmds.count("commit") == 1
+            assert stub.sync_called is True
+        finally:
+            store._shutdown_flusher(timeout=2.0)
+
+    def test_flush_with_no_flusher_returns_true(self, worktree: Path):
+        """Stores in pure-filesystem mode never start a flusher; flush is a no-op."""
+        store = CommitAuthorshipStore(worktree_dir=worktree)
+        assert store.flush(timeout=0) is True
+
+    def test_burst_coalesces_into_one_commit(self, worktree: Path):
+        """Multiple registers queued before the worker drains share one commit."""
+        stub = _StubStateStore(worktree)
+        # Block the worker until we've enqueued the whole batch so they
+        # land in a single tick.
+        gate = threading.Event()
+        original_run_git = stub._run_git
+        first_call = threading.Event()
+
+        def gated_git(*args, **kwargs):
+            if not first_call.is_set():
+                first_call.set()
+                gate.wait(timeout=5)
+            return original_run_git(*args, **kwargs)
+
+        stub._run_git = gated_git  # type: ignore[assignment]
+        store = CommitAuthorshipStore(state_store=stub)  # type: ignore[arg-type]
+        try:
+            shas = [f"{i:x}".rjust(40, "0") for i in range(5)]
+            for sha in shas:
+                store.register(sha, "coder", "issue-1882")
+            # Let the worker finish the first tick (which should batch all 5).
+            gate.set()
+            assert store.flush(timeout=5) is True
+            cmds = [args[0] for args, _kwargs in stub.run_git_calls]
+            # All 5 disk writes target the same shard (issue-1882.json), so
+            # the worker should issue exactly one commit covering the lot.
+            # Worst case (the worker briefly woke before all 5 enqueued)
+            # we still expect well below 5 commits.
+            assert cmds.count("commit") <= 2, (
+                f"expected coalesced commit(s) for a 5-write burst, got {cmds.count('commit')}"
+            )
+        finally:
+            gate.set()
+            store._shutdown_flusher(timeout=2.0)
+
+    def test_flusher_swallows_git_errors_and_keeps_running(self, worktree: Path):
+        """A failing tick must not poison subsequent registrations."""
+        import subprocess as _sp
+
+        stub = _StubStateStore(worktree)
+        fail_first_tick = {"armed": True}
+        original_run_git = stub._run_git
+
+        def flaky_git(*args, **kwargs):
+            # Fail the first ``git add`` we see, then disarm so every
+            # later call (this same tick's commit included if reached, and
+            # all subsequent ticks) succeeds.  This models a transient
+            # state-store failure rather than a permanent break.
+            if fail_first_tick["armed"] and args[:1] == ("add",):
+                fail_first_tick["armed"] = False
+                raise _sp.CalledProcessError(1, ["git", *list(args)])
+            return original_run_git(*args, **kwargs)
+
+        stub._run_git = flaky_git  # type: ignore[assignment]
+        store = CommitAuthorshipStore(state_store=stub)  # type: ignore[arg-type]
+        try:
+            store.register(_VALID_SHA, "coder", "issue-1882")
+            assert store.flush(timeout=5) is True
+            # First tick aborted on the add; no commit yet.
+            cmds_after_first = [args[0] for args, _kwargs in stub.run_git_calls]
+            assert "commit" not in cmds_after_first
+
+            store.register(_OTHER_SHA, "tester", "issue-1882")
+            assert store.flush(timeout=5) is True
+            cmds = [args[0] for args, _kwargs in stub.run_git_calls]
+            # The second register's commit must have landed — that's the
+            # "keeps running" check.
+            assert "commit" in cmds
+            # Both registrations are visible on disk regardless of git.
+            assert store.lookup(_VALID_SHA) == "coder"
+            assert store.lookup(_OTHER_SHA) == "tester"
+        finally:
+            store._shutdown_flusher(timeout=2.0)
+
+    def test_enqueue_after_shutdown_falls_back_to_inline(self, worktree: Path):
+        """Once the flusher has shut down, late registrations still replicate."""
+        stub = _StubStateStore(worktree)
+        store = CommitAuthorshipStore(state_store=stub)  # type: ignore[arg-type]
+        # Force the flusher to start, drain it, then shut it down.
+        store.register(_VALID_SHA, "coder", "issue-1882")
+        assert store.flush(timeout=5) is True
+        flusher = store._flusher
+        assert flusher is not None
+        flusher.shutdown(timeout=2.0)
+        stub.run_git_calls.clear()
+        stub.sync_called = False
+        # A second registration after shutdown should still cause a commit
+        # by falling back to the inline path.
+        flusher.enqueue(
+            store._shard_path("issue-1882"),
+            _OTHER_SHA,
+            "tester",
+            "issue-1882",
+        )
+        cmds = [args[0] for args, _kwargs in stub.run_git_calls]
+        assert "commit" in cmds
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #2453.

- Moves the state-branch `git add`/`commit` out of `CommitAuthorshipStore.register`'s critical section into a background `_AuthorshipFlusher` thread, so `/api/v1/commit-authorship/register` no longer blocks for the duration of three serialised git subprocess calls.
- The flusher drains its queue per tick and coalesces N pending shard writes into a single `git add` + `git commit`, killing the per-burst commit storm.
- Lookup correctness is unchanged — `lookup_bulk` only reads disk, and the in-memory shard write still completes synchronously inside `_lock` before `register()` returns.
- Adds a `synchronous=True` constructor flag so existing unit tests can keep asserting on inline git activity, plus an `atexit` hook that gives in-flight work a 5s drain window on shutdown.

## Why this fixes the timeouts

Per the issue, gateway clients see `commit_registry_client` time out at ~1/min during normal pipeline traffic. Root cause is that `register` synchronously holds a process-wide `RLock` across 3 git subprocess calls that contend with the gateway's own `git push` on the same bare-repo flock. With 16 waitress threads, this serialises every concurrent register past the 5s client timeout and starves the lookup endpoint as a side effect (its workers are blocked on register's lock chain).

Deferring the git work removes both the `_lock` and the flock from the request path. The disk-write durability boundary is preserved; the git commit is purely state-branch replication and now batches.

## Test plan
- [x] `make test` (changeset-aware) — 160 passed
- [x] `make lint` — passes; existing soft-cap warnings only
- [x] New `TestAsyncFlusher` covers: register-returns-before-git, flush drains, no-flusher no-op, burst coalescing into ≤2 commits, transient git failure recovery, post-shutdown enqueue falls back to inline.
- [ ] Production validation: tail `gateway.commit_registry_client` after deploy and confirm the per-1–2-min timeout cadence stops, and `register` p95 drops to sub-100ms.