### PR TITLE
Fix #2467: refresh _get_store_lock docstring for post-worktree reality

### DIFF
--- a/gateway/checkpoint_handler.py
+++ b/gateway/checkpoint_handler.py
@@ -1413,9 +1413,14 @@ _handler_lock = threading.Lock()
 # shared ``egg/checkpoints/v2`` branch (e.g. multiple agents from
 # different repos all targeting ``jwbron/egg-checkpoints``) serialize
 # their fetch + commit + push sequence. When ``checkpoint_repo`` is
-# unset, fall back to the source ``repo_path`` so same-source-repo
-# writers still serialize on local ``.git/worktrees`` state.
-# See #2069 (per-source-repo origin) and #2316 (target-keyed).
+# unset, the key is the caller's ``repo_path``; after the worktree-
+# per-agent rollout that is a worktree path, so this fallback only
+# serializes in-process callers that share the *same* worktree.
+# Cross-worktree serialization on local ``.git/worktrees`` state lives
+# in ``bare_repo_lock``, which resolves any worktree path onto the
+# underlying main repo (#2452 / PR #2456).
+# See #2069 (per-source-repo origin), #2316 (target-keyed), #2452
+# (bare_repo_lock worktree resolution).
 _store_locks: dict[str, threading.Lock] = {}
 _store_locks_guard = threading.Lock()
 
@@ -1428,9 +1433,16 @@ def _get_store_lock(key: str) -> Generator[None]:
     serialization.  When ``checkpoint_repo`` is set, callers pass it as
     ``key`` so cross-source-repo writers contending on the same shared
     ``egg/checkpoints/v2`` branch serialize their fetch + commit + push
-    sequence (#2316).  When unset, callers fall back to ``repo_path``
-    so same-source-repo writers still serialize on local
-    ``.git/worktrees`` state (#2069).  The destination key only
+    sequence (#2316).  When unset, callers fall back to ``repo_path``;
+    after the worktree-per-agent rollout that is a worktree path, so
+    two agents on the same main repo pass *different* keys and acquire
+    *different* locks here.  This fallback now only serializes in-
+    process callers that share the *same* worktree path (e.g. multiple
+    async tasks on a single agent); cross-worktree serialization on
+    local ``.git/worktrees`` state — what #2069 originally relied on —
+    lives in ``bare_repo_lock``, which resolves any worktree path to
+    its underlying main repo so all worktrees of the same repo flock
+    the same inode (#2452 / PR #2456).  The destination key also only
     synchronizes within a *single gateway process* — multiple gateway
     pods writing to the same ``checkpoint_repo`` race past this lock,
     and the regenerate-on-non-FF retry in ``store_checkpoint_v2`` is


### PR DESCRIPTION
## Summary

- Updates the docstring and lead-in comment block on ``_get_store_lock`` (`gateway/checkpoint_handler.py:1410-1456`) so they describe the lock's actual current behavior. Docstring-only change; no behavior change.
- The previous docstring claimed the per-``repo_path`` fallback serializes "same-source-repo writers" via local ``.git/worktrees`` state (citing #2069). After the worktree-per-agent rollout that's no longer true at this layer: two agents on the same main repo pass *different* worktree paths to ``_get_store_lock`` and end up with *different* in-process lock entries.
- Clarifies that cross-worktree, cross-process serialization is provided by ``bare_repo_lock`` (#2452 / PR #2456), which resolves any worktree path to its underlying main repo so all worktrees flock the same inode.

Spotted by ``egg-reviewer`` on PR #2456 ("Pre-existing docstring drift … flagging for follow-up"). Closes #2467.

## Test plan

- [x] `make lint` clean (only pre-existing soft-cap warnings unrelated to this file)
- [x] `pytest gateway/tests/test_checkpoint_handler.py` — 86/86 pass
- [x] Visual review of the diff — only the docstring and the per-destination-locks comment block change; ``_store_locks`` / ``_get_store_lock`` code is untouched