### PR TITLE
Fix #2473: forward slice_id from heartbeat and validate CLI EGG_SLICE_ID

### DIFF
--- a/sandbox/egg_agent_tools/handlers/progress.py
+++ b/sandbox/egg_agent_tools/handlers/progress.py
@@ -138,7 +138,12 @@ def progress_heartbeat(req: dict[str, Any]) -> dict[str, Any]:
     pid = _require_pipeline_id(req)
     role = _require_role(req)
 
-    data = {"signal_type": "heartbeat", "agent_role": role}
+    data: dict[str, Any] = {"signal_type": "heartbeat", "agent_role": role}
+    # ``handle_heartbeat_signal`` is a no-op consumer today (#2473), but
+    # any future change that slice-scopes per-role liveness would otherwise
+    # silently treat this as pipeline-level. Forward for consistency with
+    # ``progress_signal_error``.
+    _maybe_attach_slice_id(req, data)
     result = orchestrator_request(f"/api/v1/pipelines/{pid}/signal", method="POST", data=data)
     if not result.get("success"):
         raise GatewayError(result.get("message", "heartbeat failed"))

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -69,6 +69,13 @@ except ImportError:
 # Validation pattern for IDs used in URL path segments
 _SAFE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_\-\.]+$")
 
+# Canonical ``slice-<N>`` shape — mirrors orchestrator's
+# ``slice_id_validation.SLICE_ID_PATTERN`` and the handler-side regex in
+# ``egg_agent_tools.handlers.{brc,progress}``. Kept inline rather than
+# importing from the orchestrator package because ``egg_lib`` ships in
+# the sandbox and must not depend on orchestrator code.
+_SLICE_ID_PATTERN = re.compile(r"^slice-[0-9]+$")
+
 
 class ApiError(Exception):
     """Error from an API request."""
@@ -153,8 +160,34 @@ def get_slice_id_from_env() -> str | None:
     Set on agents spawned for a per-slice BRC team (#2403). When
     present, consensus signal commands forward it on the request body
     so the orchestrator routes ``CONSENSUS_*`` to the slice's tracker.
+
+    Prefer :func:`resolve_slice_id` for CLI commands that forward the
+    value — that helper validates against the canonical ``slice-<N>``
+    shape so a misconfigured env var fails fast locally instead of
+    round-tripping a 400 through the orchestrator.
     """
     return os.environ.get("EGG_SLICE_ID") or None
+
+
+def resolve_slice_id() -> str | None:
+    """Validated counterpart of :func:`get_slice_id_from_env` (#2473).
+
+    Returns the canonical ``slice-<N>`` value, or ``None`` when unset.
+    A non-empty value that fails the regex prints to stderr and exits
+    with status 1, so CLI commands surface a misconfigured
+    ``EGG_SLICE_ID`` locally rather than letting the orchestrator
+    reject the request via ``slice_id_validation.extract_slice_id``.
+    """
+    raw = os.environ.get("EGG_SLICE_ID") or None
+    if raw is None:
+        return None
+    if not _SLICE_ID_PATTERN.fullmatch(raw):
+        print(
+            f"Error: Invalid EGG_SLICE_ID {raw!r}: must match 'slice-<N>'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return raw
 
 
 def get_agent_role_from_env() -> str | None:
@@ -2581,7 +2614,7 @@ def cmd_consensus_withdraw(args: argparse.Namespace) -> int:
         "agent_role": role,
         "reason": args.reason,
     }
-    slice_id = get_slice_id_from_env()
+    slice_id = resolve_slice_id()
     if slice_id:
         data["slice_id"] = slice_id
 

--- a/tests/sandbox/egg_agent_tools/test_handlers_progress.py
+++ b/tests/sandbox/egg_agent_tools/test_handlers_progress.py
@@ -134,6 +134,35 @@ class TestProgressHeartbeat:
             with pytest.raises(GatewayError):
                 progress.progress_heartbeat({"pipeline_id": "p", "role": "r"})
 
+    def test_attaches_slice_id_from_env(self, monkeypatch):
+        # #2473: heartbeat must mirror progress_signal_error's slice_id
+        # forwarding so a future slice-scoped consumer can route correctly.
+        monkeypatch.setenv("EGG_SLICE_ID", "slice-3")
+        with patch(
+            "egg_agent_tools.handlers.progress.orchestrator_request",
+            return_value={"success": True, "data": {}},
+        ) as req:
+            progress.progress_heartbeat({"pipeline_id": "p", "role": "coder"})
+        assert req.call_args.kwargs["data"]["slice_id"] == "slice-3"
+
+    def test_omits_slice_id_when_unset(self, monkeypatch):
+        monkeypatch.delenv("EGG_SLICE_ID", raising=False)
+        with patch(
+            "egg_agent_tools.handlers.progress.orchestrator_request",
+            return_value={"success": True, "data": {}},
+        ) as req:
+            progress.progress_heartbeat({"pipeline_id": "p", "role": "coder"})
+        assert "slice_id" not in req.call_args.kwargs["data"]
+
+    def test_invalid_slice_id_rejected(self, monkeypatch):
+        monkeypatch.setenv("EGG_SLICE_ID", "slice-2/../etc")
+        with patch(
+            "egg_agent_tools.handlers.progress.orchestrator_request",
+            return_value={"success": True, "data": {}},
+        ):
+            with pytest.raises(HandlerError, match="slice_id"):
+                progress.progress_heartbeat({"pipeline_id": "p", "role": "coder"})
+
 
 # ---------------------------------------------------------------------------
 # Iter-2 (#1917): progress_overseer_alert + progress_query_status

--- a/tests/sandbox/test_orch_cli_slice_id.py
+++ b/tests/sandbox/test_orch_cli_slice_id.py
@@ -15,9 +15,11 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "sandbox"))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "sandbox"))
+sys.path.insert(0, str(ROOT / "shared"))
 
-from egg_lib import orch_cli
+from egg_lib import orch_cli  # noqa: E402
 
 
 class TestResolveSliceId:

--- a/tests/sandbox/test_orch_cli_slice_id.py
+++ b/tests/sandbox/test_orch_cli_slice_id.py
@@ -1,0 +1,96 @@
+"""Fail-fast EGG_SLICE_ID validation in egg_lib.orch_cli (#2473).
+
+CLI commands that forward ``slice_id`` should reject a misconfigured
+``EGG_SLICE_ID`` locally — surfacing a clear error to stderr — instead
+of round-tripping a 400 through the orchestrator's
+``slice_id_validation.extract_slice_id``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "sandbox"))
+
+from egg_lib import orch_cli
+
+
+class TestResolveSliceId:
+    def test_returns_none_when_unset(self, monkeypatch):
+        monkeypatch.delenv("EGG_SLICE_ID", raising=False)
+        assert orch_cli.resolve_slice_id() is None
+
+    def test_returns_none_when_empty(self, monkeypatch):
+        # Empty string is treated as unset — mirrors get_slice_id_from_env.
+        monkeypatch.setenv("EGG_SLICE_ID", "")
+        assert orch_cli.resolve_slice_id() is None
+
+    def test_returns_validated_value(self, monkeypatch):
+        monkeypatch.setenv("EGG_SLICE_ID", "slice-7")
+        assert orch_cli.resolve_slice_id() == "slice-7"
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "slice-2/../etc",
+            "phase-2",
+            "slice-",
+            "slice-2a",
+            "../slice-2",
+        ],
+    )
+    def test_invalid_value_exits(self, monkeypatch, capsys, bad):
+        monkeypatch.setenv("EGG_SLICE_ID", bad)
+        with pytest.raises(SystemExit) as exc:
+            orch_cli.resolve_slice_id()
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "EGG_SLICE_ID" in err
+        assert "slice-<N>" in err
+
+
+class TestConsensusWithdrawForwardsSliceId:
+    """``cmd_consensus_withdraw`` validates ``EGG_SLICE_ID`` before posting."""
+
+    def _args(self) -> argparse.Namespace:
+        return argparse.Namespace(
+            pipeline_id="issue-2473",
+            role="coder",
+            reason="superseded by v2",
+            json=False,
+        )
+
+    def test_attaches_slice_id_from_env(self, monkeypatch):
+        monkeypatch.setenv("EGG_SLICE_ID", "slice-3")
+        with patch(
+            "egg_lib.orch_cli.orch_request",
+            return_value={"success": True},
+        ) as req:
+            rc = orch_cli.cmd_consensus_withdraw(self._args())
+        assert rc == 0
+        assert req.call_args.kwargs["data"]["slice_id"] == "slice-3"
+
+    def test_omits_slice_id_when_unset(self, monkeypatch):
+        monkeypatch.delenv("EGG_SLICE_ID", raising=False)
+        with patch(
+            "egg_lib.orch_cli.orch_request",
+            return_value={"success": True},
+        ) as req:
+            rc = orch_cli.cmd_consensus_withdraw(self._args())
+        assert rc == 0
+        assert "slice_id" not in req.call_args.kwargs["data"]
+
+    def test_invalid_slice_id_fails_fast(self, monkeypatch, capsys):
+        # Misconfigured env var must exit before any orchestrator call.
+        monkeypatch.setenv("EGG_SLICE_ID", "slice-2/../etc")
+        with patch("egg_lib.orch_cli.orch_request") as req:
+            with pytest.raises(SystemExit) as exc:
+                orch_cli.cmd_consensus_withdraw(self._args())
+        assert exc.value.code == 1
+        assert not req.called, "fail-fast must short-circuit before the request"
+        assert "EGG_SLICE_ID" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Closes #2473 — two `slice_id`-related improvements deferred from #2459 review.

- **`progress_heartbeat` now forwards `slice_id`** via `_maybe_attach_slice_id`, mirroring `progress_signal_error`. The orchestrator-side consumer (`handle_heartbeat_signal`) is a no-op today, but the inconsistency would silently treat per-slice agents as pipeline-level if a future change ever slice-scopes per-role liveness.
- **New `egg_lib.orch_cli.resolve_slice_id` validator** (sibling of `get_slice_id_from_env`) checks `EGG_SLICE_ID` against the canonical `^slice-[0-9]+$` regex and prints a clear stderr error + exits 1 on a non-canonical value. `cmd_consensus_withdraw` now uses it — only CLI-side `slice_id` forwarder in `orch_cli.py` (the BRC consensus commands delegate to handlers, which already validate).

Net effect: a misconfigured `EGG_SLICE_ID` fails fast locally instead of round-tripping a 400 through `slice_id_validation.extract_slice_id`.

## Test plan
- [x] `tests/sandbox/egg_agent_tools/test_handlers_progress.py::TestProgressHeartbeat` — pins payload shape under `EGG_SLICE_ID` (set, unset, malformed)
- [x] `tests/sandbox/test_orch_cli_slice_id.py` — `resolve_slice_id` regex coverage + `cmd_consensus_withdraw` short-circuits before `orch_request` on a malformed env var
- [x] `make test` — 637 passed
- [x] `ruff check` + `ruff format --check` clean