### PR TITLE
Fix #2470: fall back to pipeline.base_branch when parent slice is complete

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2531,6 +2531,16 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
     # ``None`` for slices whose worktree has not been provisioned yet, in
     # which case we fall through to reconstruction.
     parent_branch_recorded: str | None = None
+    # ``parent_slice_complete`` is set when the parent slice has reached
+    # ``SliceStatus.COMPLETE`` per the contract — i.e. its PR has plausibly
+    # been merged. GitHub's standard branch-auto-cleanup deletes the head
+    # branch on merge, so the gateway's per-repo ``git fetch origin
+    # <parent_branch>`` would wedge the restart on a missing-branch fetch
+    # error. When ``True``, we fall back to ``pipeline.base_branch`` rather
+    # than depend on a (likely deleted) parent ref — matching the
+    # contract-unloadable fall-through policy: prefer letting the restart
+    # proceed over over-strict gating (#2470).
+    parent_slice_complete: bool = False
     if slice_id is not None:
         if not pipeline.has_contract:
             return make_error_response(
@@ -2602,6 +2612,20 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
                 if slice_obj.dependencies:
                     parent_slice_id = slice_obj.dependencies[0]
                     parent_branch_recorded = slice_obj.parent_branch_at_creation
+                    # #2470: if the parent slice is complete, its PR has
+                    # plausibly been merged and its branch deleted by
+                    # GitHub auto-cleanup. Detect that here so the
+                    # base-branch selection below can fall back to
+                    # ``pipeline.base_branch`` rather than wedge the
+                    # restart on a missing-branch fetch.
+                    from egg_contracts.models import SliceStatus
+
+                    parent_obj = next(
+                        (s for s in contract.slices if s.id == parent_slice_id),
+                        None,
+                    )
+                    if parent_obj is not None and parent_obj.status == SliceStatus.COMPLETE:
+                        parent_slice_complete = True
 
     # Restart the container via spawner
     spawner = _get_spawner()
@@ -2684,7 +2708,15 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
                 f"slice_id={slice_id!r} does not match the canonical shape ``slice-<N>``"
             )
         agent_branch = f"{_issue_branch}/{slice_id}"
-        if parent_slice_id is not None:
+        if parent_slice_id is not None and parent_slice_complete:
+            # #2470: parent slice's PR has plausibly been merged and its
+            # branch deleted by GitHub auto-cleanup. Falling back to
+            # ``pipeline.base_branch`` is safe: ``complete`` means the
+            # parent's commits have been integrated upstream (either via
+            # PR merge or via the cascade), and prefer letting the
+            # restart proceed over wedging on a missing-branch fetch.
+            base_branch_for_restart = pipeline.base_branch
+        elif parent_slice_id is not None:
             if parent_branch_recorded:
                 # Prefer the literal branch the parent slice was
                 # provisioned against (#2460 review observation 2).

--- a/orchestrator/tests/test_restart_agent.py
+++ b/orchestrator/tests/test_restart_agent.py
@@ -1522,6 +1522,95 @@ class TestRestartAgentEndpointBaseBranch:
         # ``egg/issue-100/slice-1``.
         assert restart_call.kwargs["base_branch"] == recorded_parent_branch
 
+    @patch("egg_contracts.loader.load_contract")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_child_slice_restart_falls_back_when_parent_complete(
+        self,
+        mock_repo,
+        mock_resolve,
+        mock_spawner_fn,
+        mock_lock_fn,
+        mock_load_contract,
+        client,
+    ):
+        """Restart falls back to ``pipeline.base_branch`` when the parent slice is complete (#2470).
+
+        When the parent slice has reached ``SliceStatus.COMPLETE``,
+        its PR has plausibly been merged and the head branch deleted
+        by GitHub's standard auto-cleanup. The gateway's per-repo
+        ``git fetch origin <parent_branch>`` would then wedge the
+        restart on a missing-branch fetch error. The route detects
+        this via the contract's slice status and falls back to
+        ``pipeline.base_branch`` — equivalent to the
+        contract-unloadable fall-through (#2421/#2439): prefer
+        letting the restart proceed over over-strict gating.
+
+        The recorded ``parent_branch_at_creation`` is set on the
+        child slice here to confirm the fallback wins even when the
+        recorded value is available (the issue here is the *branch's*
+        existence, not the route's knowledge of its name).
+        """
+        from egg_contracts.models import Contract, Slice, SliceStatus
+
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        pipeline = _make_pipeline_with_running_agent()
+        pipeline.branch = "egg/issue-100/work"
+        pipeline.base_branch = "main"
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_load_contract.return_value = Contract(
+            pipeline_id="issue-100",
+            slices=[
+                Slice(
+                    id="slice-1",
+                    name="Parent slice (complete, branch likely deleted on origin)",
+                    status=SliceStatus.COMPLETE,
+                ),
+                Slice(
+                    id="slice-2",
+                    name="Child slice",
+                    dependencies=["slice-1"],
+                    parent_branch_at_creation="egg/issue-100/slice-1",
+                ),
+            ],
+        )
+
+        mock_spawner = MagicMock()
+        new_container = SpawnedContainer(
+            container_info=ContainerInfo(
+                container_id="new-container-xyz",
+                container_name="egg-issue-100-slice-2-coder",
+                status=ContainerStatus.RUNNING,
+            ),
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-100",
+            environment={},
+        )
+        mock_spawner.restart_agent_container.return_value = new_container
+        mock_spawner.get_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart?slice_id=slice-2",
+            json={"reason": "Child slice restart after parent merged"},
+        )
+
+        assert response.status_code == 200
+        restart_call = mock_spawner.restart_agent_container.call_args
+        # Fallback wins over both the recorded parent branch and
+        # reconstructed ``egg/issue-100/slice-1``.
+        assert restart_call.kwargs["base_branch"] == "main"
+        # Agent's assigned branch is unaffected — still its own
+        # integration branch.
+        assert restart_call.kwargs["branch"] == "egg/issue-100/slice-2"
+
 
 # ---------------------------------------------------------------------------
 # Issue #2422: in-place agent-state mutation matches on (role, slice_id)


### PR DESCRIPTION
## Summary

- Fixes #2470. The restart route at `orchestrator/routes/pipelines.py::restart_agent` now detects when a child slice's parent is `SliceStatus.COMPLETE` (its PR plausibly merged + branch deleted by GitHub auto-cleanup) and falls back to `pipeline.base_branch` rather than wedge on the gateway's per-repo `git fetch origin <parent_branch>` in `worktree_manager.create_worktree`.
- Mirrors the existing contract-unloadable fall-through policy (#2421/#2439) — prefer letting the restart proceed over over-strict gating.
- Existing behavior preserved when the parent slice is not yet complete: the route still uses `parent_branch_at_creation` (preferred) or the reconstructed `<root>/<parent_slice_id>`.

## Test plan

- [x] New regression test `test_child_slice_restart_falls_back_when_parent_complete` in `orchestrator/tests/test_restart_agent.py` confirming a `SliceStatus.COMPLETE` parent forwards `pipeline.base_branch` to the spawner (overriding both the recorded and reconstructed parent branches).
- [x] All 6 base-branch tests in `TestRestartAgentEndpointBaseBranch` pass.
- [x] All 61 tests in `orchestrator/tests/test_restart_agent.py` pass.