### PR TITLE
Fix #2463: protect slice-scoped worktrees from gateway startup cleanup

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -7810,6 +7810,15 @@ def worktree_list() -> tuple[Response, int] | Response:
 _worktree_prune_lock = threading.Lock()
 
 
+# Slice-scoped per-agent worktree dir suffix:
+# ``{pipeline_id}-slice-{N}-{role}``.  The role part follows AgentRole
+# values (``[a-z_]+``).  Used by ``_derive_worktree_anchor_ids`` to
+# recognise slice-scoped worktrees of a live pipeline that the session
+# metadata alone can't express (sessions carry pipeline_id + agent_role
+# but not slice_id).
+_SLICE_WORKTREE_SUFFIX_RE = re.compile(r"^-slice-[0-9]+-[a-z_]+$")
+
+
 def _derive_worktree_anchor_ids(sessions: list[dict[str, Any]]) -> set[str]:
     """Return the set of worktree directory names implied by active sessions.
 
@@ -7821,15 +7830,45 @@ def _derive_worktree_anchor_ids(sessions: list[dict[str, Any]]) -> set[str]:
     derivation, ``cleanup_orphaned_worktrees`` treats every per-agent
     worktree as an orphan, which wiped live pipelines' worktrees during
     gateway startup cleanup (#1874).
+
+    Slice-scoped per-agent worktrees (``{pipeline_id}-slice-{N}-{role}``,
+    introduced in #2403) carry no slice context on the session, so for
+    each live pipeline we additionally scan the worktree base for
+    matching directories and add them to the anchor set.  Without this
+    scan, slice-scoped agent worktrees with unpushed local commits are
+    wiped during gateway startup cleanup — silently destroying the work
+    that ``salvage_agent_commits`` was designed to recover (#2463).
     """
     anchors: set[str] = set()
+    pipeline_ids: set[str] = set()
     for session_info in sessions:
         pipeline_id = session_info.get("pipeline_id")
         agent_role = session_info.get("agent_role")
         if pipeline_id:
             anchors.add(pipeline_id)
+            pipeline_ids.add(pipeline_id)
             if agent_role:
                 anchors.add(f"{pipeline_id}-{agent_role}")
+
+    if pipeline_ids:
+        try:
+            entries = list(WORKTREE_BASE_DIR.iterdir())
+        except OSError:
+            entries = []
+        for entry in entries:
+            try:
+                if not entry.is_dir():
+                    continue
+            except OSError:
+                continue
+            name = entry.name
+            for pid in pipeline_ids:
+                if not name.startswith(pid):
+                    continue
+                suffix = name[len(pid) :]
+                if _SLICE_WORKTREE_SUFFIX_RE.match(suffix):
+                    anchors.add(name)
+                    break
     return anchors
 
 
@@ -7837,9 +7876,10 @@ def _container_ids_from_sessions(sessions: list[dict[str, Any]]) -> set[str]:
     """Return container IDs and worktree anchor IDs from session dicts.
 
     Each session contributes its own ``container_id`` plus the derived
-    per-agent (``{pipeline_id}-{agent_role}``) and pipeline-level
-    (``{pipeline_id}``) worktree anchor IDs so that cleanup never wipes
-    a live pipeline's worktrees (#1874).
+    per-agent (``{pipeline_id}-{agent_role}``), pipeline-level
+    (``{pipeline_id}``), and slice-scoped
+    (``{pipeline_id}-slice-{N}-{role}``) worktree anchor IDs so that
+    cleanup never wipes a live pipeline's worktrees (#1874, #2463).
     """
     ids: set[str] = set()
     for session_info in sessions:

--- a/gateway/tests/test_worktree_prune_route.py
+++ b/gateway/tests/test_worktree_prune_route.py
@@ -576,6 +576,77 @@ class TestDeriveWorktreeAnchorIds:
         anchors = gateway._derive_worktree_anchor_ids([{"container_id": "adhoc"}])
         assert anchors == set()
 
+    def test_slice_scoped_worktrees_protected_via_disk_scan(self, tmp_path):
+        """Slice-scoped per-agent worktrees ({pipeline_id}-slice-N-{role})
+        carry no slice context on the session, so the helper discovers
+        them by scanning the worktree base for matching directories.
+        Without this, the gateway's startup cleanup would wipe slice-
+        scoped agent worktrees with unpushed commits — exactly the
+        scenario salvage_agent_commits exists to recover from (#2463).
+        """
+        # Realistic slice-DAG layout: pipeline-state, overseer (per-role),
+        # plus three slice-scoped agent worktrees.  A sibling worktree
+        # whose suffix doesn't match the slice pattern must not leak in.
+        (tmp_path / "issue-2261-v10").mkdir()
+        (tmp_path / "issue-2261-v10-overseer").mkdir()
+        (tmp_path / "issue-2261-v10-slice-2-coder").mkdir()
+        (tmp_path / "issue-2261-v10-slice-2-tester").mkdir()
+        (tmp_path / "issue-2261-v10-slice-5-coder").mkdir()
+        (tmp_path / "issue-2261-v10-not-a-slice").mkdir()
+        # Unrelated pipeline that must not be touched.
+        (tmp_path / "issue-9999-slice-1-coder").mkdir()
+
+        with patch.object(gateway, "WORKTREE_BASE_DIR", tmp_path):
+            anchors = gateway._derive_worktree_anchor_ids(
+                [
+                    # Only the overseer session is alive — the slice
+                    # agents may have died with the orch crash, but their
+                    # worktrees on disk still hold unpushed commits.
+                    {"pipeline_id": "issue-2261-v10", "agent_role": "overseer"},
+                ]
+            )
+
+        assert anchors == {
+            "issue-2261-v10",
+            "issue-2261-v10-overseer",
+            "issue-2261-v10-slice-2-coder",
+            "issue-2261-v10-slice-2-tester",
+            "issue-2261-v10-slice-5-coder",
+        }
+
+    def test_slice_scan_handles_missing_worktree_base(self, tmp_path):
+        """Helper must not raise when ``WORKTREE_BASE_DIR`` is absent."""
+        missing = tmp_path / "does-not-exist"
+        with patch.object(gateway, "WORKTREE_BASE_DIR", missing):
+            anchors = gateway._derive_worktree_anchor_ids(
+                [{"pipeline_id": "p1", "agent_role": "coder"}]
+            )
+        assert anchors == {"p1", "p1-coder"}
+
+    def test_slice_scan_skipped_when_no_live_pipelines(self, tmp_path):
+        """No live pipeline_ids means no scan — sessions with only
+        ``container_id`` fall through to the empty set.
+        """
+        (tmp_path / "issue-99-slice-1-coder").mkdir()
+        with patch.object(gateway, "WORKTREE_BASE_DIR", tmp_path):
+            anchors = gateway._derive_worktree_anchor_ids([{"container_id": "adhoc"}])
+        assert anchors == set()
+
+    def test_slice_scan_does_not_match_pipeline_id_prefix_collision(self, tmp_path):
+        """Pipeline ID ``p1`` must not absorb slice worktrees of an
+        unrelated pipeline ``p1-extra`` — the suffix regex anchors on
+        ``-slice-N-{role}`` immediately after the pipeline id.
+        """
+        (tmp_path / "p1-extra-slice-2-coder").mkdir()
+        with patch.object(gateway, "WORKTREE_BASE_DIR", tmp_path):
+            anchors = gateway._derive_worktree_anchor_ids(
+                [{"pipeline_id": "p1", "agent_role": "coder"}]
+            )
+        # p1's anchors are present, but p1-extra-slice-2-coder is not
+        # because ``-extra-slice-2-coder`` does not match the slice
+        # suffix regex anchored at the pipeline id boundary.
+        assert "p1-extra-slice-2-coder" not in anchors
+
 
 class TestContainerIdsFromSessions:
     """Unit tests for ``_container_ids_from_sessions`` — the shared helper


### PR DESCRIPTION
## Summary

- The gateway's startup cleanup wiped slice-scoped per-agent worktrees (`{pipeline_id}-slice-{N}-{role}`) on restart because `_derive_worktree_anchor_ids` only knew about the `{pipeline_id}` and `{pipeline_id}-{role}` shapes that #1874 established.
- After a crash+restart, this destroyed unpushed local commits before `salvage_agent_commits` (#2429) could recover them — exactly the moment the salvage tools were meant to save you.
- Fix: extend the anchor derivation to scan the worktree base for any directory of a live pipeline that matches the slice suffix pattern. No session-schema plumbing needed; sessions only assert the pipeline is alive, and the slice/role pairs are discovered from disk.

Closes #2463.

## Why filesystem scan rather than persisting `slice_id` on the session

Plumbing `slice_id` end-to-end (Session field → `register_session` → orch `gateway_client` → `kubernetes_spawner`) would be more invasive and only protects worktrees of a session that's still alive. The disk scan also covers the case where a slice agent's pod has died but its sibling overseer/pipeline session is alive — the typical orch-crash scenario the issue describes.

## Test plan

- [x] `gateway/tests/test_worktree_prune_route.py::TestDeriveWorktreeAnchorIds` — new cases for slice-scoped discovery, missing `WORKTREE_BASE_DIR`, no-live-pipelines, and pipeline-id prefix collisions
- [x] All 34 prune-route tests pass
- [x] `make lint` clean
- [ ] In-cluster verification: crash a slice-DAG pipeline mid-run, confirm `list_agent_local_commits` still surfaces all per-agent worktrees post-restart and `salvage_agent_commits` produces recovery refs

## Note on RCA

The original issue body hypothesised in-memory worktree-map loss. That's not the actual mechanism — `enumerate_agent_worktrees` reads from disk, not from the orch's pipeline-record cache. The on-disk worktrees were the thing being deleted, by the gateway's startup-cleanup with an incomplete anchor set. This PR closes that gap.