### PR TITLE
Fix #2469: split attestation table into structured claims vs reflection prompts

### DIFF
--- a/docs/guides/agent-teams.md
+++ b/docs/guides/agent-teams.md
@@ -140,17 +140,20 @@ This is a conditional redaction on one message type to one role category — a c
 
 ### Reasoning: Evidence-Backed Deliberation
 
-The reasoning layer ensures agents don't just signal states — they make **structured claims** that peers evaluate. This draws on Habermasian discourse theory, signaling theory, and sycophancy mitigation research.
+The reasoning layer combines two complementary mechanisms with different purposes:
+
+1. **Structured claims** — concrete artifact references (commit SHAs, file paths, test counts, `checks_passed` lists, sections updated) whose value is downstream: peers cross-verify them against the repo. The orchestrator enforces shape checks on the load-bearing ones at the message boundary (`orchestrator/attestation_schemas.py`); reviewers cover the rest by inspection. These are costly signals — hard to fabricate without doing the work — and draw on Habermasian discourse theory, signaling theory, and sycophancy mitigation research.
+2. **Reflection prompts** — open-ended fields (`risk_considered`, `concern_considered`) whose value is upstream: they exist to make the producing agent slow down and articulate at least one concern during composition. The orchestrator does **not** enforce non-emptiness, and reviewers treat them as advisory rather than audit-grade claims. They are metacognitive scaffolding for the producer, not a structured claim peers grade.
 
 #### Per-Role Attestations
 
 **Producer proposals (`CONSENSUS_PROPOSE`):**
 
-| Role | Required attestation |
-|------|---------------------|
-| Coder | Commit SHAs, files changed, test pass/fail summary, one risk considered |
-| Tester | Tests written/run count, coverage delta, edge cases covered, one concern considered, `checks_passed` list of all configured checks that passed (see notes below; refactor / doc-only slices use the no-op propose path — see "Tester no-op propose" callout) |
-| Documenter | Sections updated, links verified, one concern considered (refactor / test-only / no-doc-surface slices use the no-op propose path — see "Documenter no-op propose" callout) |
+| Role | Structured claims (peer-verifiable) | Reflection prompt (advisory) |
+|------|---------------------|------|
+| Coder | Commit SHAs, files changed, test pass/fail summary | One risk considered |
+| Tester | Tests written/run count, coverage delta, edge cases covered, `checks_passed` list of all configured checks that passed (see notes below; refactor / doc-only slices use the no-op propose path — see "Tester no-op propose" callout) | One concern considered |
+| Documenter | Sections updated, links verified (refactor / test-only / no-doc-surface slices use the no-op propose path — see "Documenter no-op propose" callout) | One concern considered |
 
 > **Tester blocked-execution attestation:** If tests could not execute (e.g., private network mode blocks dependency downloads), the Tester must set `tests_execution_blocked: true` with a `tests_execution_blocked_reason` explaining why. The orchestrator accepts this in place of a passing test count.
 
@@ -164,10 +167,10 @@ The reasoning layer ensures agents don't just signal states — they make **stru
 
 **Reviewer evaluations (`CONSENSUS_ACK/NACK`):**
 
-| Role | Required attestation |
-|------|---------------------|
-| Reviewer (code) | Files reviewed (specific paths), issues found + resolved count, one risk considered |
-| Reviewer (contract) | Tasks verified (specific IDs), acceptance criteria checked, gaps identified |
+| Role | Structured claims (peer-verifiable) | Reflection prompt (advisory) |
+|------|---------------------|------|
+| Reviewer (code) | Files reviewed (specific paths), issues found + resolved count | One risk considered |
+| Reviewer (contract) | Tasks verified (specific IDs), acceptance criteria checked, gaps identified | — |
 
 #### Cheap Talk vs Costly Signals
 

--- a/docs/guides/agent-teams.md
+++ b/docs/guides/agent-teams.md
@@ -197,7 +197,7 @@ Research (CONSENSAGENT, ACL 2025) shows LLM agents exhibit strong sycophancy in 
 
 2. **Delphi ordering.** Reviewers form independent judgments from git artifacts before seeing the producer's self-assessment.
 
-3. **Critical thinking prompt.** Every proposal/review must include "one risk I considered." This is a secondary measure — easy to satisfy with generic output and should not be weighted equally.
+3. **Critical thinking prompt.** Every proposal/review should articulate "one risk I considered." This is a secondary measure — advisory rather than enforced, easy to satisfy with generic output and not weighted equally with structured claims.
 
 4. **Dynamic prompt refinement.** Evolve prompts based on observed rubber-stamping patterns rather than relying solely on procedural rules.
 


### PR DESCRIPTION
## Summary

Resolves the doc/code inconsistency in #2469 by updating `docs/guides/agent-teams.md` to match what the orchestrator actually enforces. Picks **option 2** (soften the doc) over option 1 (tighten the validator) — see the decision rationale below.

The producer/reviewer attestation tables previously listed `risk_considered` / `concern_considered` as required attestation. The orchestrator's strict-mode validator never checked them, and a quick look at `.egg-state/brc-history/` confirms the field commonly ships as `''` without anyone NACKing on it. The doc was overclaiming.

## Decision: option 2, and *why* option 1 is worse than it looks

The issue framed option 1 (add a strict check for non-empty `concern_considered` / `risk_considered`) as "the more rigorous fix." On reflection, it isn't:

- **Validator enforcement of a free-text field is theater.** A non-emptiness check is satisfied trivially by `"None"` — and existing tests already use that exact placeholder (see `orchestrator/tests/test_peer_consensus_integration.py:86`). Tightening the rule just teaches agents to type `"None"` and move on; the doc claim about costly-signal evaluation is no truer afterward.
- **The fields are a reflection scaffold, not a structured claim.** Their value is upstream — making the producer slow down and articulate one concern during composition — not downstream peer verification. That's a different mechanism from the costly-signal layer the agent-teams preamble was citing (Habermasian discourse, signaling theory). Conflating them in one "Required attestation" column overclaims for the reflection fields and underclaims for the structured ones.
- **Reviewers don't actually NACK on empty values.** BRC history shows them shipping with `risk_considered: ''` regularly; reviewer judgment is the wrong layer for a metacognitive prompt directed at the producer.

The honest fix is to name the two mechanisms separately so the doc matches reality. If we later want producers to actually populate these fields, the right intervention is a richer prompt or a structured sub-schema, not a non-emptiness gate on free text.

## Changes

- Rewrote the "Reasoning: Evidence-Backed Deliberation" preamble (`docs/guides/agent-teams.md:141-145`) to distinguish *structured claims* (downstream, peer-verifiable, partially orchestrator-validated) from *reflection prompts* (upstream, advisory, not enforced).
- Split the producer attestation table (`agent-teams.md:147-153`) into two columns: structured claims vs reflection prompt.
- Same split applied to the reviewer evaluations table (`agent-teams.md:165-170`).
- No code changes — `attestation_schemas.py` remains as is.
- No new tests — option 2 has no validator behavior change to assert. The issue's "tests in `test_peer_consensus_integration.py`" criterion only applied to option 1.

## Test plan

- [x] Diff renders cleanly (verified with `git diff`).
- [x] No code paths touched, so no regressions possible from this PR.
- [x] Existing `concern_considered: ""` / `risk_considered: ""` proposals continue to be accepted by the validator (unchanged behavior).
- [ ] Reviewer sanity-check: does the two-column split correctly classify every existing field, or is anything ambiguous (e.g. should `coverage_delta` be in "structured claims" given the validator doesn't enforce it)?