### PR TITLE
Fix #2471: slice-scope HeartbeatCoordinator dedup + rate limit keys

### DIFF
--- a/orchestrator/heartbeat.py
+++ b/orchestrator/heartbeat.py
@@ -3,10 +3,21 @@
 Provides server-side HEARTBEAT handling primitives that are independent
 of routing/HTTP concerns:
 
-* Sliding-window rate limiter keyed by ``(pipeline_id, role)`` honouring
-  ``EGG_HEARTBEAT_RATE_LIMIT`` (default 20/min per role).
-* Per-role dedup: two consecutive identical ``(state, waiting_on)``
-  tuples from the same role produce only one bus message.
+* Sliding-window rate limiter keyed by ``(pipeline_id, slice_id, role)``
+  honouring ``EGG_HEARTBEAT_RATE_LIMIT`` (default 20/min per role per
+  slice).
+* Per-(pipeline, slice, role) dedup: two consecutive identical
+  ``(state, waiting_on)`` tuples from the same role inside the same
+  slice produce only one bus message. Pipeline-level agents pass
+  ``slice_id=None`` and share a single bucket.
+
+Why slice-scope the keys (#2471): two parallel slices that share a
+role (e.g. slice-2 and slice-3 ``reviewer_code`` in the same wave) are
+independent pods. Sharing a per-(pipeline, role) dedup map silently
+suppresses slice-N's bus message the moment slice-(N-1) reports the
+same state, and a shared per-role rate budget lets one popular role
+under wide fan-out hit the per-minute ceiling and drop a sibling's
+beat. The keys carry the slice scope so siblings stay independent.
 
 See plan TASK-3-2 / TASK-3-4 and
 docs/reference/agent-wait-patterns.md §5.
@@ -19,6 +30,9 @@ import time
 from collections import deque
 from dataclasses import dataclass
 
+# (pipeline_id, slice_id_or_none, role)
+_Key = tuple[str, str | None, str]
+
 
 @dataclass
 class RateLimitDecision:
@@ -29,7 +43,7 @@ class RateLimitDecision:
 
 
 class HeartbeatCoordinator:
-    """Per-pipeline/per-role HEARTBEAT rate limiter + dedup tracker.
+    """Per-(pipeline, slice, role) HEARTBEAT rate limiter + dedup tracker.
 
     Thread-safe.  One instance lives as an orchestrator-process-global
     singleton (``get_heartbeat_coordinator``).
@@ -38,16 +52,17 @@ class HeartbeatCoordinator:
     def __init__(self, window_seconds: int = 60) -> None:
         self._window = float(window_seconds)
         self._lock = threading.Lock()
-        # (pipeline_id, role) -> deque of epoch-seconds timestamps
-        self._windows: dict[tuple[str, str], deque[float]] = {}
-        # (pipeline_id, role) -> last-seen (state, waiting_on)
-        self._last_state: dict[tuple[str, str], tuple[str, str]] = {}
-        # (pipeline_id, role) -> last gateway-session fan-out epoch-seconds
-        self._last_fan_out: dict[tuple[str, str], float] = {}
+        # (pipeline_id, slice_id, role) -> deque of epoch-seconds timestamps
+        self._windows: dict[_Key, deque[float]] = {}
+        # (pipeline_id, slice_id, role) -> last-seen (state, waiting_on)
+        self._last_state: dict[_Key, tuple[str, str]] = {}
+        # (pipeline_id, slice_id, role) -> last gateway-session fan-out epoch-seconds
+        self._last_fan_out: dict[_Key, float] = {}
 
     def check_rate_limit(
         self,
         pipeline_id: str,
+        slice_id: str | None,
         role: str,
         limit_per_minute: int,
     ) -> RateLimitDecision:
@@ -57,8 +72,12 @@ class HeartbeatCoordinator:
         allowed, returns a decision carrying the seconds until the
         oldest timestamp in the window expires (a caller can surface
         this via the ``retry_after`` body field of an HTTP 429).
+
+        Pipeline-level callers (no slice scope) pass ``slice_id=None``
+        and share a single bucket per ``(pipeline_id, role)``; slice-
+        scoped callers each get their own bucket.
         """
-        key = (pipeline_id, role)
+        key: _Key = (pipeline_id, slice_id, role)
         now = time.time()
         cutoff = now - self._window
         with self._lock:
@@ -75,18 +94,19 @@ class HeartbeatCoordinator:
     def is_duplicate(
         self,
         pipeline_id: str,
+        slice_id: str | None,
         role: str,
         state: str,
         waiting_on: str | None,
     ) -> bool:
         """Check whether this ``(state, waiting_on)`` equals the last.
 
-        Returns True (duplicate) if the role's most-recent heartbeat
-        tuple is identical; False (fresh) otherwise.  Does NOT record
-        the new tuple — the caller should call ``record_state`` after
-        successfully delivering the heartbeat.
+        Returns True (duplicate) if the (pipeline, slice, role)'s most-
+        recent heartbeat tuple is identical; False (fresh) otherwise.
+        Does NOT record the new tuple — the caller should call
+        ``record_state`` after successfully delivering the heartbeat.
         """
-        key = (pipeline_id, role)
+        key: _Key = (pipeline_id, slice_id, role)
         with self._lock:
             prev = self._last_state.get(key)
         cur = (state, waiting_on or "")
@@ -95,18 +115,20 @@ class HeartbeatCoordinator:
     def record_state(
         self,
         pipeline_id: str,
+        slice_id: str | None,
         role: str,
         state: str,
         waiting_on: str | None,
     ) -> None:
-        """Store this role's most-recent ``(state, waiting_on)``."""
-        key = (pipeline_id, role)
+        """Store this (pipeline, slice, role)'s most-recent ``(state, waiting_on)``."""
+        key: _Key = (pipeline_id, slice_id, role)
         with self._lock:
             self._last_state[key] = (state, waiting_on or "")
 
     def should_fan_out_gateway_session(
         self,
         pipeline_id: str,
+        slice_id: str | None,
         role: str,
         min_interval_seconds: float,
     ) -> bool:
@@ -114,18 +136,20 @@ class HeartbeatCoordinator:
 
         The HEARTBEAT route fans out a gateway-session refresh both on
         the dedup early-return path and after the rate-limit gate.  The
-        dedup path bypasses the per-role rate limiter (by design — see
-        ``check_rate_limit``'s NB1 from #1897), so a misbehaving agent
-        hot-looping with identical state can amplify into the gateway
-        without burning rate budget.  This per-role cooldown caps that
-        amplification independently of the heartbeat-acceptance rate.
+        dedup path bypasses the per-(slice, role) rate limiter (by
+        design — see ``check_rate_limit``'s NB1 from #1897), so a
+        misbehaving agent hot-looping with identical state can amplify
+        into the gateway without burning rate budget.  This per-(slice,
+        role) cooldown caps that amplification independently of the
+        heartbeat-acceptance rate.
 
         Returns ``True`` and records the new timestamp if at least
         ``min_interval_seconds`` have passed since the previous fan-out
-        for this ``(pipeline_id, role)``; returns ``False`` (without
-        recording) if the caller should skip the fan-out this round.
-        Any non-positive ``min_interval_seconds`` (``<= 0``) disables
-        throttling — every call returns ``True`` without recording.
+        for this ``(pipeline_id, slice_id, role)``; returns ``False``
+        (without recording) if the caller should skip the fan-out this
+        round.  Any non-positive ``min_interval_seconds`` (``<= 0``)
+        disables throttling — every call returns ``True`` without
+        recording.
 
         Callers must pass a finite real number. ``float('nan')`` falls
         through both branches (``nan <= 0`` and ``now - last < nan`` are
@@ -137,7 +161,7 @@ class HeartbeatCoordinator:
         """
         if min_interval_seconds <= 0:
             return True
-        key = (pipeline_id, role)
+        key: _Key = (pipeline_id, slice_id, role)
         now = time.time()
         with self._lock:
             last = self._last_fan_out.get(key, 0.0)
@@ -147,7 +171,13 @@ class HeartbeatCoordinator:
         return True
 
     def clear(self, pipeline_id: str) -> None:
-        """Drop all state for a pipeline (on phase transition)."""
+        """Drop all state for a pipeline (on phase transition).
+
+        Sweeps every ``(pipeline_id, *, *)`` key across all three
+        per-(pipeline, slice, role) maps so a phase transition resets
+        rate budgets, dedup memory, and fan-out cooldowns for both
+        pipeline-level and slice-scoped agents in one shot.
+        """
         with self._lock:
             for key in list(self._windows):
                 if key[0] == pipeline_id:

--- a/orchestrator/routes/messages.py
+++ b/orchestrator/routes/messages.py
@@ -107,15 +107,16 @@ def _track_long_poll_end() -> None:
 # liveness keep-alive emitted by ``mcp__brc__wait_loop`` while it's
 # blocked — periodic identical beats are exactly the signal the
 # overseer's stall detector consumes, so dedup must not collapse them.
-# Rate-limit (20/min per role) still applies.
+# Rate-limit (20/min per slice+role; #2471) still applies.
 _DEDUP_EXEMPT_HEARTBEAT_STATES: frozenset[str] = frozenset({"WAITING_FOR_EVENT"})
 
 # Minimum seconds between gateway-session fan-outs per (pipeline_id,
-# role) (#2076 NB2).  The dedup early-return path bypasses the per-role
-# heartbeat rate limit by design (#1897 NB1: dedup'd heartbeats are
-# no-ops and must not consume rate budget), so without a separate cap a
-# misbehaving agent hot-looping with identical state could amplify into
-# the gateway at the agent's emission rate.  The gateway's idle window
+# slice_id, role) (#2076 NB2, slice-scoped per #2471).  The dedup
+# early-return path bypasses the per-(slice, role) heartbeat rate limit
+# by design (#1897 NB1: dedup'd heartbeats are no-ops and must not
+# consume rate budget), so without a separate cap a misbehaving agent
+# hot-looping with identical state could amplify into the gateway at
+# the agent's emission rate.  The gateway's idle window
 # is 60 minutes, so fanning out every 30 s is far more than enough to
 # keep the session alive; the cap exists purely to bound amplification.
 _GATEWAY_FANOUT_MIN_INTERVAL_SECONDS: float = 30.0
@@ -556,13 +557,14 @@ def post_heartbeat(pipeline_id: str) -> tuple[Response, int]:
               ``retry_after`` seconds.
 
     Implementation notes:
-        * ``(state, waiting_on)`` tuples that match the role's
-          most-recent heartbeat are **silently deduped** (no bus
-          message written) so re-entering the same state twice is
-          idempotent.  See plan TASK-3-2.
+        * ``(state, waiting_on)`` tuples that match the most-recent
+          heartbeat for this ``(pipeline_id, slice_id, role)`` are
+          **silently deduped** (no bus message written) so re-entering
+          the same state twice is idempotent.  See plan TASK-3-2.
         * Rate limit: ``EGG_HEARTBEAT_RATE_LIMIT`` per minute per
-          ``(pipeline_id, role)``, default 20/min.  See plan
-          TASK-3-4.
+          ``(pipeline_id, slice_id, role)``, default 20/min.  See plan
+          TASK-3-4.  Slice-scoping (#2471) keeps sibling slices that
+          share a role from sharing each other's rate budget.
     """
     body = request.get_json() or {}
 
@@ -615,7 +617,7 @@ def post_heartbeat(pipeline_id: str) -> tuple[Response, int]:
     # per-role cooldown (#2076 NB2) to bound dedup-path amplification
     # without consuming rate budget.
     if state not in _DEDUP_EXEMPT_HEARTBEAT_STATES and coordinator.is_duplicate(
-        pipeline_id, from_role, state, waiting_on
+        pipeline_id, slice_id, from_role, state, waiting_on
     ):
         _refresh_gateway_session(pipeline_id, from_role, slice_id)
         return _make_success(
@@ -632,7 +634,7 @@ def post_heartbeat(pipeline_id: str) -> tuple[Response, int]:
     # ``Retry-After`` response header MUST echo N so standards-compliant
     # HTTP clients can honour it without parsing the JSON.
     limit = get_heartbeat_rate_limit()
-    decision = coordinator.check_rate_limit(pipeline_id, from_role, limit)
+    decision = coordinator.check_rate_limit(pipeline_id, slice_id, from_role, limit)
     if not decision.allowed:
         retry_after = int(decision.retry_after_seconds)
         resp = jsonify(
@@ -641,7 +643,7 @@ def post_heartbeat(pipeline_id: str) -> tuple[Response, int]:
                 "error": "rate_limited",
                 "message": (
                     f"HEARTBEAT rate limit exceeded "
-                    f"({limit}/min per role); retry after {retry_after}s."
+                    f"({limit}/min per slice+role); retry after {retry_after}s."
                 ),
                 "retry_after": retry_after,
             }
@@ -677,7 +679,7 @@ def post_heartbeat(pipeline_id: str) -> tuple[Response, int]:
     )
     store = get_message_store()
     store.add_message(msg)
-    coordinator.record_state(pipeline_id, from_role, state, waiting_on)
+    coordinator.record_state(pipeline_id, slice_id, from_role, state, waiting_on)
 
     # Emit an event so SSE consumers and HealthMonitor see it.
     emit_event(
@@ -736,16 +738,13 @@ def _refresh_gateway_session(pipeline_id: str, from_role: str, slice_id: str | N
     expiry under any realistic heartbeat cadence.
     """
     coordinator = get_heartbeat_coordinator()
-    # Compose the throttle role with the slice scope so concurrent
-    # slices that share a role (e.g. two reviewer-code agents in
-    # different slices of the same wave) do not suppress each other's
-    # fan-outs. The coordinator key is opaque to the throttle, so
-    # scoping at the call site keeps the coordinator API unchanged.
-    # ``:`` (not ``/``) so the composite never reads as a path if it
-    # surfaces in a log line — current usage is purely internal.
-    throttle_role = f"{slice_id}:{from_role}" if slice_id else from_role
+    # The coordinator's throttle key is now ``(pipeline_id, slice_id,
+    # role)`` (#2471) so concurrent slices that share a role (e.g. two
+    # reviewer-code agents in different slices of the same wave) do not
+    # suppress each other's fan-outs. Pass ``slice_id`` directly — no
+    # synthetic role-string composition needed.
     if not coordinator.should_fan_out_gateway_session(
-        pipeline_id, throttle_role, _GATEWAY_FANOUT_MIN_INTERVAL_SECONDS
+        pipeline_id, slice_id, from_role, _GATEWAY_FANOUT_MIN_INTERVAL_SECONDS
     ):
         return
     try:

--- a/orchestrator/tests/conftest.py
+++ b/orchestrator/tests/conftest.py
@@ -226,7 +226,7 @@ def _skip_worktree_disk_check(monkeypatch):
 def _reset_heartbeat_coordinator():
     """Reset the heartbeat coordinator singleton between every orchestrator test.
 
-    The coordinator carries per-(pipeline, role) dedup, rate-limit, and
+    The coordinator carries per-(pipeline, slice, role) dedup, rate-limit, and
     gateway-fan-out throttle state. Without resetting it, tests that
     share role names can observe contaminated state across files. As
     new coordinator surfaces are added, this single fixture covers them

--- a/orchestrator/tests/test_heartbeat.py
+++ b/orchestrator/tests/test_heartbeat.py
@@ -1,11 +1,16 @@
 """Unit tests for ``HeartbeatCoordinator``.
 
-Focused on ``should_fan_out_gateway_session`` (issue #2076 NB4) — the
-route-level integration tests in ``test_messages.py`` exercise the
-throttle through the HEARTBEAT endpoint, but a refactor of the
-coordinator is hard to do safely without targeted unit coverage of the
-disable case, the cooldown elapsed/not-elapsed branches, the ``clear()``
-reset, and concurrent access.
+Covers:
+
+* ``should_fan_out_gateway_session`` (issue #2076 NB4) — the route-
+  level integration tests in ``test_messages.py`` exercise the
+  throttle through the HEARTBEAT endpoint, but a refactor of the
+  coordinator is hard to do safely without targeted unit coverage of
+  the disable case, the cooldown elapsed/not-elapsed branches, the
+  ``clear()`` reset, and concurrent access.
+* Per-slice independence of ``is_duplicate`` and ``check_rate_limit``
+  (issue #2471) — two slices that share a role must not share dedup
+  state or rate budgets.
 """
 
 from __future__ import annotations
@@ -31,47 +36,47 @@ from heartbeat import (  # noqa: E402
 
 
 class TestShouldFanOutGatewaySession:
-    """Unit tests for the per-(pipeline, role) gateway-fan-out throttle."""
+    """Unit tests for the per-(pipeline, slice, role) gateway-fan-out throttle."""
 
     def test_zero_interval_disables_throttle(self):
         """``min_interval_seconds == 0`` always returns True without recording."""
         coord = HeartbeatCoordinator()
 
         for _ in range(5):
-            assert coord.should_fan_out_gateway_session("p1", "coder", 0.0) is True
+            assert coord.should_fan_out_gateway_session("p1", None, "coder", 0.0) is True
 
         # Nothing was recorded, so a subsequent positive-interval call
         # sees no prior fan-out and fires.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
 
     def test_negative_interval_disables_throttle(self):
         """Any non-positive value disables (matches the docstring contract)."""
         coord = HeartbeatCoordinator()
 
         for _ in range(3):
-            assert coord.should_fan_out_gateway_session("p1", "coder", -1.0) is True
+            assert coord.should_fan_out_gateway_session("p1", None, "coder", -1.0) is True
 
         # Same as the zero case — no recording happened.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
 
     def test_first_call_fires_and_records(self):
         """First call fires AND records the new timestamp.
 
         The recording side-effect is verified directly: a second call
         inside the cooldown window can only return False if the first
-        call wrote ``_last_fan_out[(p1, coder)]``.
+        call wrote ``_last_fan_out[(p1, None, coder)]``.
         """
         coord = HeartbeatCoordinator()
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
         # Recording side-effect: second call within the window is suppressed.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is False
 
     def test_second_call_within_cooldown_suppressed(self):
         """A second call inside the cooldown window returns False."""
         coord = HeartbeatCoordinator()
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
         # Immediately again — well inside 30s.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is False
 
     def test_call_after_cooldown_fires(self):
         """Once the window elapses, the next call fires again."""
@@ -80,27 +85,49 @@ class TestShouldFanOutGatewaySession:
         # robust against GC pauses or noisy CI scheduling. ``time.sleep``
         # is a guaranteed lower bound, so the cooldown is always elapsed
         # by the time the third assertion runs.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 0.05) is True
-        assert coord.should_fan_out_gateway_session("p1", "coder", 0.05) is False
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 0.05) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 0.05) is False
         time.sleep(0.2)
-        assert coord.should_fan_out_gateway_session("p1", "coder", 0.05) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 0.05) is True
 
     def test_different_roles_throttled_independently(self):
         """Throttle key includes the role — different roles don't collide."""
         coord = HeartbeatCoordinator()
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
-        assert coord.should_fan_out_gateway_session("p1", "tester", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "tester", 30.0) is True
         # Both are now suppressed independently.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is False
-        assert coord.should_fan_out_gateway_session("p1", "tester", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", None, "tester", 30.0) is False
 
     def test_different_pipelines_throttled_independently(self):
         """Throttle key includes the pipeline — different pipelines don't collide."""
         coord = HeartbeatCoordinator()
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
-        assert coord.should_fan_out_gateway_session("p2", "coder", 30.0) is True
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is False
-        assert coord.should_fan_out_gateway_session("p2", "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p2", None, "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p2", None, "coder", 30.0) is False
+
+    def test_different_slices_throttled_independently(self):
+        """Throttle key includes the slice — sibling slices don't collide (#2471)."""
+        coord = HeartbeatCoordinator()
+        assert coord.should_fan_out_gateway_session("p1", "slice-2", "reviewer_code", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", "slice-3", "reviewer_code", 30.0) is True
+        # Each sibling is suppressed inside its own window — they did not
+        # share the throttle entry.
+        assert coord.should_fan_out_gateway_session("p1", "slice-2", "reviewer_code", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", "slice-3", "reviewer_code", 30.0) is False
+
+    def test_pipeline_level_and_sliced_dont_collide(self):
+        """``slice_id=None`` is a distinct bucket from any ``slice-<N>`` (#2471)."""
+        coord = HeartbeatCoordinator()
+        # Pipeline-level agent fires.
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
+        # Slice-scoped agent in the same pipeline + role still fires —
+        # it lives in a separate bucket.
+        assert coord.should_fan_out_gateway_session("p1", "slice-1", "coder", 30.0) is True
+        # Both are now suppressed inside their own windows.
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", "slice-1", "coder", 30.0) is False
 
     def test_suppressed_call_does_not_advance_recorded_timestamp(self):
         """Hot-looping must not push the cooldown forward indefinitely.
@@ -109,34 +136,46 @@ class TestShouldFanOutGatewaySession:
         ``time.time()`` reads robust against scheduling jitter on CI.
         """
         coord = HeartbeatCoordinator()
-        assert coord.should_fan_out_gateway_session("p1", "coder", 0.05) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 0.05) is True
         # Hammer the coordinator inside the window — every call returns
         # False, but the recorded timestamp stays at the initial fire.
         for _ in range(10):
-            assert coord.should_fan_out_gateway_session("p1", "coder", 0.05) is False
+            assert coord.should_fan_out_gateway_session("p1", None, "coder", 0.05) is False
         time.sleep(0.2)
         # Still fires once the original window elapses, which proves the
         # suppressed calls didn't reset the clock.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 0.05) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 0.05) is True
 
     def test_clear_drops_throttle_state_for_pipeline(self):
         """``clear(pipeline)`` lets the next call fire immediately."""
         coord = HeartbeatCoordinator()
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is False
         coord.clear("p1")
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
 
     def test_clear_only_affects_targeted_pipeline(self):
         """``clear(p1)`` must not drop p2's throttle entries."""
         coord = HeartbeatCoordinator()
-        coord.should_fan_out_gateway_session("p1", "coder", 30.0)
-        coord.should_fan_out_gateway_session("p2", "coder", 30.0)
+        coord.should_fan_out_gateway_session("p1", None, "coder", 30.0)
+        coord.should_fan_out_gateway_session("p2", None, "coder", 30.0)
         coord.clear("p1")
         # p1 reset, fires again.
-        assert coord.should_fan_out_gateway_session("p1", "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
         # p2 untouched, still suppressed.
-        assert coord.should_fan_out_gateway_session("p2", "coder", 30.0) is False
+        assert coord.should_fan_out_gateway_session("p2", None, "coder", 30.0) is False
+
+    def test_clear_drops_all_slice_scoped_entries_for_pipeline(self):
+        """``clear(p1)`` must sweep every slice's entry, not just ``slice_id=None`` (#2471)."""
+        coord = HeartbeatCoordinator()
+        coord.should_fan_out_gateway_session("p1", None, "coder", 30.0)
+        coord.should_fan_out_gateway_session("p1", "slice-1", "coder", 30.0)
+        coord.should_fan_out_gateway_session("p1", "slice-2", "coder", 30.0)
+        coord.clear("p1")
+        # All three buckets reset — first post-clear call in each fires.
+        assert coord.should_fan_out_gateway_session("p1", None, "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", "slice-1", "coder", 30.0) is True
+        assert coord.should_fan_out_gateway_session("p1", "slice-2", "coder", 30.0) is True
 
     def test_concurrent_callers_only_one_wins(self):
         """Under contention, exactly one thread should see True per window."""
@@ -147,7 +186,7 @@ class TestShouldFanOutGatewaySession:
 
         def worker():
             barrier.wait()
-            res = coord.should_fan_out_gateway_session("p1", "coder", 30.0)
+            res = coord.should_fan_out_gateway_session("p1", None, "coder", 30.0)
             with results_lock:
                 results.append(res)
 
@@ -160,6 +199,124 @@ class TestShouldFanOutGatewaySession:
         # Exactly one thread crossed the throttle boundary first.
         assert sum(results) == 1
         assert len(results) == 20
+
+
+class TestIsDuplicate:
+    """Per-(pipeline, slice, role) dedup memory (#2471)."""
+
+    def test_first_observation_is_not_duplicate(self):
+        coord = HeartbeatCoordinator()
+        assert coord.is_duplicate("p1", None, "coder", "WORKING", None) is False
+
+    def test_repeat_after_record_is_duplicate(self):
+        coord = HeartbeatCoordinator()
+        coord.record_state("p1", None, "coder", "WORKING", None)
+        assert coord.is_duplicate("p1", None, "coder", "WORKING", None) is True
+
+    def test_different_state_is_not_duplicate(self):
+        coord = HeartbeatCoordinator()
+        coord.record_state("p1", None, "coder", "WORKING", None)
+        assert coord.is_duplicate("p1", None, "coder", "IDLE", None) is False
+
+    def test_sibling_slices_have_independent_dedup(self):
+        """slice-2 recording WORKING must not dedup slice-3's first WORKING (#2471).
+
+        Without slice-scope, slice-2's record poisons slice-3's first
+        non-exempt heartbeat for the same role into a silent dedup —
+        downstream consumers (HealthMonitor, overseer, UI) see only one
+        of the N siblings' state transitions even though all N are
+        independent agents in independent pods.
+        """
+        coord = HeartbeatCoordinator()
+        coord.record_state("p1", "slice-2", "reviewer_code", "WORKING", None)
+        # Slice-3's first WORKING observation is fresh — different bucket.
+        assert coord.is_duplicate("p1", "slice-3", "reviewer_code", "WORKING", None) is False
+        # And after slice-3 records, it dedups in its own bucket only.
+        coord.record_state("p1", "slice-3", "reviewer_code", "WORKING", None)
+        assert coord.is_duplicate("p1", "slice-3", "reviewer_code", "WORKING", None) is True
+        # Slice-2's bucket is unaffected by slice-3's writes.
+        assert coord.is_duplicate("p1", "slice-2", "reviewer_code", "WORKING", None) is True
+
+    def test_pipeline_level_does_not_collide_with_slice(self):
+        """``slice_id=None`` and a real ``slice-<N>`` are different buckets."""
+        coord = HeartbeatCoordinator()
+        coord.record_state("p1", None, "coder", "WORKING", None)
+        assert coord.is_duplicate("p1", "slice-1", "coder", "WORKING", None) is False
+
+    def test_clear_resets_dedup_for_all_slices_in_pipeline(self):
+        """Phase transitions must reset every slice's dedup memory."""
+        coord = HeartbeatCoordinator()
+        coord.record_state("p1", "slice-1", "coder", "WORKING", None)
+        coord.record_state("p1", "slice-2", "coder", "WORKING", None)
+        coord.record_state("p1", None, "coder", "WORKING", None)
+        coord.clear("p1")
+        assert coord.is_duplicate("p1", "slice-1", "coder", "WORKING", None) is False
+        assert coord.is_duplicate("p1", "slice-2", "coder", "WORKING", None) is False
+        assert coord.is_duplicate("p1", None, "coder", "WORKING", None) is False
+
+
+class TestCheckRateLimit:
+    """Per-(pipeline, slice, role) rate budgets (#2471)."""
+
+    def test_allows_up_to_limit(self):
+        coord = HeartbeatCoordinator()
+        for _ in range(3):
+            assert coord.check_rate_limit("p1", None, "coder", limit_per_minute=3).allowed is True
+
+    def test_rejects_after_limit(self):
+        coord = HeartbeatCoordinator()
+        for _ in range(3):
+            coord.check_rate_limit("p1", None, "coder", limit_per_minute=3)
+        decision = coord.check_rate_limit("p1", None, "coder", limit_per_minute=3)
+        assert decision.allowed is False
+        assert decision.retry_after_seconds >= 1
+
+    def test_sibling_slices_have_independent_budgets(self):
+        """slice-2 saturating its budget must not drop slice-3's beats (#2471).
+
+        ``EGG_HEARTBEAT_RATE_LIMIT`` defaults to 20/min. Under wide
+        fan-out, a popular role (e.g. reviewer-code in 4 slices each
+        emitting wait-loop's 1/min plus other beats) can plausibly hit
+        the per-role ceiling under the old key shape, silently dropping
+        slice-X's beat because slice-Y filled the window. Slice-scoping
+        the key gives each sibling its own bucket.
+        """
+        coord = HeartbeatCoordinator()
+        # Saturate slice-2 at the limit.
+        for _ in range(3):
+            assert (
+                coord.check_rate_limit("p1", "slice-2", "reviewer_code", limit_per_minute=3).allowed
+                is True
+            )
+        # slice-2 is now over the line.
+        assert (
+            coord.check_rate_limit("p1", "slice-2", "reviewer_code", limit_per_minute=3).allowed
+            is False
+        )
+        # slice-3 is in a separate bucket — it can still get its full budget.
+        for _ in range(3):
+            assert (
+                coord.check_rate_limit("p1", "slice-3", "reviewer_code", limit_per_minute=3).allowed
+                is True
+            )
+
+    def test_pipeline_level_does_not_collide_with_slice(self):
+        coord = HeartbeatCoordinator()
+        for _ in range(3):
+            coord.check_rate_limit("p1", None, "coder", limit_per_minute=3)
+        # slice-scoped agent in the same pipeline + role still gets a
+        # fresh budget.
+        assert coord.check_rate_limit("p1", "slice-1", "coder", limit_per_minute=3).allowed is True
+
+    def test_clear_drops_rate_state_for_all_slices_in_pipeline(self):
+        coord = HeartbeatCoordinator()
+        for _ in range(3):
+            coord.check_rate_limit("p1", "slice-1", "coder", limit_per_minute=3)
+            coord.check_rate_limit("p1", "slice-2", "coder", limit_per_minute=3)
+        coord.clear("p1")
+        # Both slices' windows reset.
+        assert coord.check_rate_limit("p1", "slice-1", "coder", limit_per_minute=3).allowed is True
+        assert coord.check_rate_limit("p1", "slice-2", "coder", limit_per_minute=3).allowed is True
 
 
 class TestSingletonAccessor:


### PR DESCRIPTION
## Summary

Closes #2471. Re-keys ``HeartbeatCoordinator``'s dedup map, rate-limit
window, and gateway-fan-out throttle from ``(pipeline_id, role)`` to
``(pipeline_id, slice_id, role)`` so two parallel slices that share a
role (e.g. ``slice-2`` and ``slice-3`` ``reviewer_code`` in the same
wave) stay independent.

- `is_duplicate`, `check_rate_limit`, `record_state`,
  `should_fan_out_gateway_session` all take `slice_id: str | None` as
  a positional arg between `pipeline_id` and `role`. Pipeline-level
  callers pass `None`; the buckets are distinct from any `slice-<N>`.
- `clear(pipeline_id)` already swept by `key[0]`, so it picks up every
  slice's entry for free — pinned by a new test.
- `_refresh_gateway_session` now passes `slice_id` directly instead of
  synthesising a `slice_id:role` string (the workaround #2459 used
  when the coordinator was role-only).

## Why a separate PR

Per the issue: this is pre-existing (predates #2451) and is not the
"Session not found for container" symptom #2451 / #2459 fix. Stacked
on #2459 because that PR threads `slice_id` through the heartbeat
route — this PR re-keys the coordinator that consumes it. Re-target to
`main` once #2459 lands.

## Acceptance criteria

- [x] `HeartbeatCoordinator.is_duplicate` keyed per-slice
- [x] `HeartbeatCoordinator.check_rate_limit` keyed per-slice
- [x] `HeartbeatCoordinator.clear` participates in the new key
- [x] Tests covering: two slices with the same role have independent
      dedup state and independent rate budgets

## Test plan

- [x] `pytest orchestrator/tests/test_heartbeat.py` — 27 passing,
      including new `TestIsDuplicate` / `TestCheckRateLimit` classes
      pinning per-slice independence and `slice_id=None` vs.
      `slice-<N>` non-collision.
- [x] `pytest orchestrator/tests/test_messages.py` — 90 passing,
      including the existing `test_heartbeat_sibling_slices_do_not_share_throttle`
      and slice-scoped fan-out tests from #2459.
- [x] `pytest orchestrator/tests/test_health_monitor.py
      tests/sandbox/egg_agent_tools/test_handlers_message.py
      sandbox/tests/test_message_wait_cli.py` — 225 passing
      (heartbeat consumers unchanged).
- [x] `ruff check` + `ruff format --check` clean.

— Authored by james-in-a-box (with Claude Code)