### PR TITLE
Fix #2465: coerce Contract field assignments via validate_assignment

### DIFF
--- a/shared/egg_contracts/models.py
+++ b/shared/egg_contracts/models.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any, cast
 
-from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
 
 
 class TaskStatus(StrEnum):
@@ -595,6 +595,15 @@ class AgentExecutionModel(BaseModel):
 
 class Contract(BaseModel):
     """The complete SDLC contract."""
+
+    # ``validate_assignment=True`` ensures that ``setattr`` on Contract
+    # fields coerces the value back to the declared type — most
+    # importantly, that ``contract.current_phase = "plan"`` produces a
+    # ``PipelinePhase`` enum rather than a plain ``str``. See #2465 for
+    # the bug this guards against (apply_mutation leaving
+    # ``current_phase`` as a string until the next save/load round-trip,
+    # which broke ``.value`` reads and emitted serializer warnings).
+    model_config = ConfigDict(validate_assignment=True)
 
     schemaVersion: str = Field(  # noqa: N815
         default="1.0", pattern=r"^[0-9]+\.[0-9]+$", description="Schema version"

--- a/shared/egg_contracts/validator.py
+++ b/shared/egg_contracts/validator.py
@@ -8,6 +8,8 @@ only authorized roles can modify specific fields.
 from dataclasses import dataclass
 from typing import Any
 
+from pydantic import ValidationError
+
 from .audit import create_transition_entry, create_update_entry
 from .models import AuditEntry, AuditRole, Contract, PipelinePhase
 from .roles import Role, can_modify, get_field_owner, normalize_path
@@ -117,6 +119,17 @@ def apply_mutation(
         return MutationResult(
             success=False,
             message=f"Failed to apply mutation: {e}",
+        )
+    except ValidationError as e:
+        # ``Contract.model_config = ConfigDict(validate_assignment=True)``
+        # (added for #2465) makes ``setattr`` raise pydantic
+        # ``ValidationError`` for out-of-domain values (e.g. an
+        # arbitrary string for an enum field). Surface that through the
+        # existing ``MutationResult`` channel so the contract /mutate
+        # route returns a structured 4xx instead of an opaque 500.
+        return MutationResult(
+            success=False,
+            message=f"Invalid value for {field_path}: {e}",
         )
 
     # Create audit entry. ``current_phase`` mutations get the dedicated

--- a/tests/shared/egg_contracts/test_validator.py
+++ b/tests/shared/egg_contracts/test_validator.py
@@ -283,6 +283,33 @@ class TestApplyMutation:
             warnings.simplefilter("error", PydanticSerializationUnexpectedValue)
             result.contract.model_dump(mode="json")
 
+    def test_invalid_enum_value_returns_failed_mutation(self, sample_contract):
+        """Out-of-domain enum strings return ``success=False`` instead of raising.
+
+        With ``validate_assignment=True`` on ``Contract`` (added for
+        #2465), ``setattr(contract, "current_phase", "garbage")`` raises
+        ``pydantic.ValidationError`` from inside the assignment.
+        ``apply_mutation`` must catch that and surface it through the
+        existing ``MutationResult(success=False, ...)`` channel so the
+        contract /mutate route returns a structured 4xx instead of an
+        opaque 500.
+        """
+        sample_contract.current_phase = PipelinePhase.REFINE
+
+        result = apply_mutation(
+            contract=sample_contract,
+            role=Role.HUMAN,
+            actor="human-reviewer",
+            field_path="current_phase",
+            new_value="invalid_phase_value",
+        )
+
+        assert result.success is False
+        assert result.message is not None
+        assert "current_phase" in result.message
+        # The original value is unchanged.
+        assert sample_contract.current_phase is PipelinePhase.REFINE
+
     def test_non_current_phase_field_still_emits_update_action(self, sample_contract):
         """Non-current_phase fields continue to emit AuditAction.UPDATE."""
         result = apply_mutation(

--- a/tests/shared/egg_contracts/test_validator.py
+++ b/tests/shared/egg_contracts/test_validator.py
@@ -1,5 +1,7 @@
 """Tests for egg_contracts.validator module."""
 
+import warnings
+
 import pytest
 from egg_contracts.models import (
     AuditAction,
@@ -17,6 +19,7 @@ from egg_contracts.validator import (
     validate_phase_mutation,
     validate_task_mutation,
 )
+from pydantic_core import PydanticSerializationUnexpectedValue
 
 
 class TestValidateMutation:
@@ -249,6 +252,36 @@ class TestApplyMutation:
         assert type(result.audit_entry.new_value) is str
         assert result.audit_entry.old_value == "plan"
         assert result.audit_entry.new_value == "implement"
+
+    def test_current_phase_string_assignment_coerces_to_enum(self, sample_contract):
+        """``apply_mutation`` with a raw string leaves ``current_phase`` as ``PipelinePhase``.
+
+        Regression for #2465: before ``validate_assignment=True`` was set
+        on ``Contract``, ``setattr(contract, "current_phase", "plan")``
+        left the field as a plain ``str``, breaking ``.value`` reads and
+        triggering ``PydanticSerializationUnexpectedValue`` on the next
+        ``model_dump``.
+        """
+        sample_contract.current_phase = PipelinePhase.REFINE
+
+        result = apply_mutation(
+            contract=sample_contract,
+            role=Role.HUMAN,
+            actor="human-reviewer",
+            field_path="current_phase",
+            new_value="plan",
+        )
+
+        assert result.success is True
+        assert type(result.contract.current_phase) is PipelinePhase
+        assert result.contract.current_phase is PipelinePhase.PLAN
+
+        # Re-serialising the contract must not emit
+        # PydanticSerializationUnexpectedValue (the warning that #2465
+        # called out as the second symptom of the bug).
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", PydanticSerializationUnexpectedValue)
+            result.contract.model_dump(mode="json")
 
     def test_non_current_phase_field_still_emits_update_action(self, sample_contract):
         """Non-current_phase fields continue to emit AuditAction.UPDATE."""


### PR DESCRIPTION
## Summary

- Add `model_config = ConfigDict(validate_assignment=True)` to `Contract` so `setattr` (the path `apply_mutation` / `_set_value` ultimately takes) coerces values back to their declared type.
- Closes #2465.

Before this change, `apply_mutation(field_path="current_phase", new_value="plan")` left `current_phase` as a plain `str` until the next save/load round-trip — breaking `.value` reads and emitting `PydanticSerializationUnexpectedValue` warnings on the next `save_contract`.

This is **Option A** from the issue (the principled fix). Option B would have only normalised `current_phase`; `validate_assignment=True` covers every enum/typed field on the contract uniformly. Blast radius is small: the wrap-mode `_migrate_phases_to_slices` validator already short-circuits on non-dict input, and the only `mode="after"` validator (`_require_issue_or_pipeline_id`) is a cheap assertion.

## Test plan

- [x] New regression test `TestApplyMutation::test_current_phase_string_assignment_coerces_to_enum` covers both acceptance criteria — type is `PipelinePhase` after the mutation, and `model_dump(mode="json")` emits no `PydanticSerializationUnexpectedValue` warning.
- [x] `pytest tests/shared/egg_contracts/test_validator.py` — 25/25 pass.
- [x] `pytest tests/shared/egg_contracts/test_models.py tests/shared/egg_contracts/test_models_gaps.py orchestrator/tests/test_contracts_routes.py` — 208/208 pass.
- [x] `make test` — only pre-existing failures (3× `TestPathTraversalProtection` in `gateway/tests/test_phase_api.py`, reproduce on `main`).

— Authored by James Wiesebron with help from Claude Code