### PR TITLE
Fix #2464: surface stale-cursor signal and stop /status/wait re-emission

### DIFF
--- a/orchestrator/message_store.py
+++ b/orchestrator/message_store.py
@@ -323,6 +323,7 @@ class MessageStore:
         wait_for_types: Sequence[str] | None = None,
         from_role: str | None = None,
         from_tip: bool = False,
+        _suppress_stale_warning: bool = False,
     ) -> tuple[list[Message], GetMessagesMeta]:
         """Same as :meth:`get_messages` but also returns staleness metadata.
 
@@ -334,6 +335,14 @@ class MessageStore:
         :meth:`get_messages` would return — but consumers now have a
         structured signal they can use to clear cached cursors instead
         of re-passing the same dead value forever (issue #2464).
+
+        ``_suppress_stale_warning`` is internal: ``True`` suppresses the
+        ``since_id not found in store`` log line on a stale cursor while
+        still populating ``meta.since_id_stale``. Used by ``/status/wait``
+        to avoid double-logging when its synchronous probe and its
+        long-poll daemon both reach for the same cursor on a single
+        request (the probe call sets it; the daemon's later call still
+        logs once if reached, matching pre-PR cadence).
         """
         # Snapshot the tip / since_id index at call entry under the lock
         # below so from_tip semantics are race-free against concurrent
@@ -383,13 +392,14 @@ class MessageStore:
                     start_idx = found_idx + 1
                 else:
                     since_id_stale = True
-                    logger.warning(
-                        "since_id not found in store; returning full history",
-                        extra={
-                            "pipeline_id": pipeline_id,
-                            "since_id": since_id,
-                        },
-                    )
+                    if not _suppress_stale_warning:
+                        logger.warning(
+                            "since_id not found in store; returning full history",
+                            extra={
+                                "pipeline_id": pipeline_id,
+                                "since_id": since_id,
+                            },
+                        )
 
             meta = GetMessagesMeta(since_id_stale=since_id_stale)
             matches = _filter(initial_msgs)

--- a/orchestrator/message_store.py
+++ b/orchestrator/message_store.py
@@ -11,11 +11,31 @@ import time
 import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, NamedTuple
 
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger("orchestrator.message_store")
+
+
+class GetMessagesMeta(NamedTuple):
+    """Side-channel metadata returned alongside ``get_messages_with_meta``.
+
+    Issue #2464. The store advertises "fall back to full history" when a
+    caller passes a ``since_id`` it doesn't recognize, but consumers had
+    no structured way to *know* this happened — they just saw whatever
+    messages came back and kept threading the same cursor forward, which
+    produced the chronic ``since_id not found in store`` warning cadence
+    described in #2454.
+
+    ``since_id_stale`` is the explicit signal: ``True`` iff the caller
+    passed a non-None ``since_id`` that did not resolve to any message
+    in the store. Consumers (the route layer, the sandbox CLI cursor
+    file) treat ``True`` as "your cursor is dead — drop it and re-snap
+    to tip".
+    """
+
+    since_id_stale: bool
 
 
 class MessageType:
@@ -244,6 +264,10 @@ class MessageStore:
     ) -> list[Message]:
         """Get messages for a pipeline, optionally filtered.
 
+        Thin wrapper around :meth:`get_messages_with_meta` that drops the
+        meta tuple. Existing callers that don't care about cursor staleness
+        continue to use this signature unchanged.
+
         Args:
             pipeline_id: Pipeline ID to query.
             role: If set, return messages where to_role is this role or 'all'.
@@ -276,6 +300,41 @@ class MessageStore:
         Returns:
             List of matching messages, oldest first. Empty list on timeout.
         """
+        messages, _meta = self.get_messages_with_meta(
+            pipeline_id,
+            role=role,
+            since_id=since_id,
+            limit=limit,
+            wait=wait,
+            wait_for_types=wait_for_types,
+            from_role=from_role,
+            from_tip=from_tip,
+        )
+        return messages
+
+    def get_messages_with_meta(
+        self,
+        pipeline_id: str,
+        *,
+        role: str | None = None,
+        since_id: str | None = None,
+        limit: int = 100,
+        wait: int = 0,
+        wait_for_types: Sequence[str] | None = None,
+        from_role: str | None = None,
+        from_tip: bool = False,
+    ) -> tuple[list[Message], GetMessagesMeta]:
+        """Same as :meth:`get_messages` but also returns staleness metadata.
+
+        The second return value is a :class:`GetMessagesMeta` whose
+        ``since_id_stale`` field is ``True`` iff the caller supplied a
+        non-None ``since_id`` that did not resolve to any message in the
+        store at call entry. The full-history fallback contract is
+        preserved — the messages returned are exactly what
+        :meth:`get_messages` would return — but consumers now have a
+        structured signal they can use to clear cached cursors instead
+        of re-passing the same dead value forever (issue #2464).
+        """
         # Snapshot the tip / since_id index at call entry under the lock
         # below so from_tip semantics are race-free against concurrent
         # add_message calls. Resolving the cursor ONCE (issue #2454) — not
@@ -286,6 +345,7 @@ class MessageStore:
         # heartbeat fan-in could fan the same warning out 10+ times).
         use_tip = from_tip and not since_id and wait > 0
         start_idx = 0
+        since_id_stale = False
 
         def _filter(all_msgs: list[Message]) -> list[Message]:
             # Slice forward from the resolved start_idx (set under the
@@ -322,6 +382,7 @@ class MessageStore:
                 if found_idx is not None:
                     start_idx = found_idx + 1
                 else:
+                    since_id_stale = True
                     logger.warning(
                         "since_id not found in store; returning full history",
                         extra={
@@ -329,22 +390,27 @@ class MessageStore:
                             "since_id": since_id,
                         },
                     )
+
+            meta = GetMessagesMeta(since_id_stale=since_id_stale)
             matches = _filter(initial_msgs)
             if wait_for_types:
                 typed = [m for m in matches if m.message_type in set(wait_for_types)]
                 if typed:
-                    return typed[-limit:] if len(typed) > limit else typed
+                    out = typed[-limit:] if len(typed) > limit else typed
+                    return out, meta
                 # fall through to blocking branch only if wait > 0
             else:
                 if matches:
-                    return matches[-limit:] if len(matches) > limit else matches
+                    out = matches[-limit:] if len(matches) > limit else matches
+                    return out, meta
                 # fall through to blocking branch only if wait > 0
 
             if wait <= 0:
                 # Non-blocking: return whatever we have (empty or filtered).
                 if wait_for_types:
-                    return []
-                return matches[-limit:] if len(matches) > limit else matches
+                    return [], meta
+                out = matches[-limit:] if len(matches) > limit else matches
+                return out, meta
 
             # Blocking branch: wait on the per-pipeline condition variable.
             # We already hold the lock via `with self._lock:`; the cv shares
@@ -374,25 +440,27 @@ class MessageStore:
                 # cleanly instead of sleeping out the budget.
                 current_cv = self._cond.get(pipeline_id)
                 if current_cv is not cv:
-                    return []
+                    return [], meta
 
                 if pipeline_id in self._messages:
                     observed = True
                 elif observed:
                     # Pipeline existed and was cleared while we were waiting.
-                    return []
+                    return [], meta
 
                 matches = _filter(self._messages.get(pipeline_id, []))
                 if want_types is not None:
                     typed = [m for m in matches if m.message_type in want_types]
                     if typed:
-                        return typed[-limit:] if len(typed) > limit else typed
+                        out = typed[-limit:] if len(typed) > limit else typed
+                        return out, meta
                 elif matches:
-                    return matches[-limit:] if len(matches) > limit else matches
+                    out = matches[-limit:] if len(matches) > limit else matches
+                    return out, meta
 
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
-                    return []
+                    return [], meta
 
                 # wait() releases the lock, waits for notify, re-acquires it.
                 cv.wait(timeout=remaining)

--- a/orchestrator/redis_message_store.py
+++ b/orchestrator/redis_message_store.py
@@ -29,7 +29,7 @@ except ImportError:
 
 
 import redis
-from message_store import Message, coerce_deprecated_message_type
+from message_store import GetMessagesMeta, Message, coerce_deprecated_message_type
 
 logger = get_logger("orchestrator.redis_message_store")
 
@@ -169,6 +169,10 @@ class RedisMessageStore:
     ) -> list[Message]:
         """Get messages from the Redis Stream.
 
+        Thin wrapper around :meth:`get_messages_with_meta` that drops the
+        meta tuple. Existing callers that don't care about cursor staleness
+        continue to use this signature unchanged (issue #2464).
+
         Args:
             pipeline_id: Pipeline ID to query.
             role: If set, return messages where to_role is this role or 'all'.
@@ -196,10 +200,44 @@ class RedisMessageStore:
                 contract (issue #1925) — without it, a repeated wait-loop
                 call returns the same already-seen event on every invocation.
         """
+        messages, _meta = self.get_messages_with_meta(
+            pipeline_id,
+            role=role,
+            since_id=since_id,
+            limit=limit,
+            wait=wait,
+            wait_for_types=wait_for_types,
+            from_role=from_role,
+            from_tip=from_tip,
+        )
+        return messages
+
+    def get_messages_with_meta(
+        self,
+        pipeline_id: str,
+        *,
+        role: str | None = None,
+        since_id: str | None = None,
+        limit: int = 100,
+        wait: int = 0,
+        wait_for_types: Sequence[str] | None = None,
+        from_role: str | None = None,
+        from_tip: bool = False,
+    ) -> tuple[list[Message], GetMessagesMeta]:
+        """Same as :meth:`get_messages` but also returns staleness metadata.
+
+        ``meta.since_id_stale`` is ``True`` iff the caller supplied a
+        non-None ``since_id`` that did not resolve to any stream entry
+        (cache miss + paginated scan miss). The full-history fallback
+        contract is preserved (returns from ``0-0``); the meta lets
+        consumers clear cached cursors instead of re-passing the dead
+        value forever (issue #2464).
+        """
         key = _stream_key(pipeline_id)
 
         # Resolve since_id (message UUID) to Redis stream ID
         start_id = "0-0"
+        since_id_stale = False
         if from_tip and not since_id and wait > 0:
             # Redis XREAD treats ``$`` as "only entries with an ID greater
             # than the greatest ID in the stream at call time" — i.e., a
@@ -213,9 +251,17 @@ class RedisMessageStore:
             if stream_id:
                 start_id = stream_id
             else:
-                # Fallback: scan the stream to find this message ID
-                start_id = self._find_stream_id_by_message_id(pipeline_id, since_id) or "0-0"
+                # Fallback: scan the stream to find this message ID. If
+                # the scan also misses, the cursor is genuinely unknown —
+                # signal staleness so the consumer can clear it (#2464).
+                resolved = self._find_stream_id_by_message_id(pipeline_id, since_id)
+                if resolved:
+                    start_id = resolved
+                else:
+                    since_id_stale = True
+                    start_id = "0-0"
 
+        meta = GetMessagesMeta(since_id_stale=since_id_stale)
         want_types = set(wait_for_types) if wait_for_types else None
 
         def _read_once(
@@ -279,7 +325,8 @@ class RedisMessageStore:
                 messages = [m for m in messages if m.to_role == role or m.to_role == "all"]
             if from_role:
                 messages = [m for m in messages if m.from_role == from_role]
-            return messages[-limit:] if len(messages) > limit else messages
+            out_msgs = messages[-limit:] if len(messages) > limit else messages
+            return out_msgs, meta
 
         # wait_for_types: re-block on remaining time budget until we find a
         # matching row or the deadline elapses. Cap the inner loop so a
@@ -290,7 +337,7 @@ class RedisMessageStore:
         while True:
             remaining = deadline - time.monotonic() if wait > 0 else 0.0
             if wait > 0 and remaining <= 0:
-                return []
+                return [], meta
 
             block_ms: int | None
             if wait > 0:
@@ -306,12 +353,13 @@ class RedisMessageStore:
 
             matching = [m for m in messages if m.message_type in want_types]
             if matching:
-                return matching[-limit:] if len(matching) > limit else matching
+                out_msgs = matching[-limit:] if len(matching) > limit else matching
+                return out_msgs, meta
 
             # No match. If wait=0, bail out. Otherwise advance the cursor
             # past what we just read and keep blocking.
             if wait <= 0:
-                return []
+                return [], meta
 
             if last_sid is not None:
                 # Advance exclusively past the last sid so we don't re-read
@@ -326,7 +374,7 @@ class RedisMessageStore:
                     cap=self._WAIT_FOR_TYPES_MAX_INNER_LOOPS,
                     type_filter=list(want_types),
                 )
-                return []
+                return [], meta
 
     def get_latest_id(self, pipeline_id: str) -> str | None:
         """Return the ID of the most recent message for *pipeline_id*, or ``None``.

--- a/orchestrator/redis_message_store.py
+++ b/orchestrator/redis_message_store.py
@@ -223,6 +223,7 @@ class RedisMessageStore:
         wait_for_types: Sequence[str] | None = None,
         from_role: str | None = None,
         from_tip: bool = False,
+        _suppress_stale_warning: bool = False,
     ) -> tuple[list[Message], GetMessagesMeta]:
         """Same as :meth:`get_messages` but also returns staleness metadata.
 
@@ -231,7 +232,17 @@ class RedisMessageStore:
         (cache miss + paginated scan miss). The full-history fallback
         contract is preserved (returns from ``0-0``); the meta lets
         consumers clear cached cursors instead of re-passing the dead
-        value forever (issue #2464).
+        value forever (issue #2464). A transient ``RedisError`` raised
+        from the scan fallback (e.g., a connection blip during
+        ``XRANGE``) is caught here and treated as "preserve cursor,
+        degrade to full history" — ``meta.since_id_stale`` stays
+        ``False`` in that case so a polling consumer doesn't drop a
+        live cursor on a momentary connectivity hiccup.
+
+        ``_suppress_stale_warning`` mirrors the in-memory backend's
+        kwarg for API symmetry. The Redis path does not log on stale
+        resolution today, so the flag is a no-op here; it is accepted
+        so callers can pass the same kwargs through both backends.
         """
         key = _stream_key(pipeline_id)
 
@@ -254,12 +265,27 @@ class RedisMessageStore:
                 # Fallback: scan the stream to find this message ID. If
                 # the scan also misses, the cursor is genuinely unknown —
                 # signal staleness so the consumer can clear it (#2464).
-                resolved = self._find_stream_id_by_message_id(pipeline_id, since_id)
-                if resolved:
-                    start_id = resolved
-                else:
-                    since_id_stale = True
+                # A RedisError during the scan is *transient* (connection
+                # blip mid-XRANGE), not a "scan miss" — preserving the
+                # consumer's cursor through the blip is preferable to
+                # telling them to drop it. Degrade to the pre-PR
+                # full-history fallback without flagging staleness.
+                try:
+                    resolved = self._find_stream_id_by_message_id(pipeline_id, since_id)
+                except redis.RedisError as exc:
+                    logger.warning(
+                        "since_id scan failed transiently; degrading to full history",
+                        pipeline_id=pipeline_id,
+                        error=str(exc),
+                    )
+                    resolved = None
                     start_id = "0-0"
+                else:
+                    if resolved:
+                        start_id = resolved
+                    else:
+                        since_id_stale = True
+                        start_id = "0-0"
 
         meta = GetMessagesMeta(since_id_stale=since_id_stale)
         want_types = set(wait_for_types) if wait_for_types else None
@@ -452,37 +478,42 @@ class RedisMessageStore:
         """Scan the stream to find a message by its UUID. Fallback for cache miss.
 
         Uses paginated XRANGE with count=500 to avoid unbounded scans on large streams.
+
+        Returns ``None`` for a *genuine* miss (the scan completed and no
+        entry matched). Re-raises :class:`redis.RedisError` so the
+        caller can distinguish a transient connection failure from a
+        completed-but-empty scan and act accordingly (the staleness
+        signal in :meth:`get_messages_with_meta` is suppressed on the
+        transient path so a momentary blip does not tell the consumer
+        to drop a still-live cursor — issue #2464 reviewer note #3).
         """
         key = _stream_key(pipeline_id)
         batch_size = 500
         cursor = "-"
-        try:
-            while True:
-                entries = self._redis.xrange(key, min=cursor, count=batch_size)
-                if not entries:
-                    break
-                for stream_id, fields in entries:
-                    if isinstance(stream_id, bytes):
-                        stream_id = stream_id.decode("utf-8")
-                    msg_id = fields.get(b"id", fields.get("id", b""))
-                    if isinstance(msg_id, bytes):
-                        msg_id = msg_id.decode("utf-8")
-                    if msg_id == message_id:
-                        # Cache it for next time
-                        with self._lock:
-                            if pipeline_id not in self._id_to_stream_id:
-                                self._id_to_stream_id[pipeline_id] = {}
-                            self._id_to_stream_id[pipeline_id][message_id] = stream_id
-                        return stream_id
-                # Advance cursor past the last entry in this batch
-                last_id = entries[-1][0]
-                if isinstance(last_id, bytes):
-                    last_id = last_id.decode("utf-8")
-                cursor = self._increment_stream_id(last_id)
-                if len(entries) < batch_size:
-                    break
-        except redis.RedisError:
-            pass
+        while True:
+            entries = self._redis.xrange(key, min=cursor, count=batch_size)
+            if not entries:
+                break
+            for stream_id, fields in entries:
+                if isinstance(stream_id, bytes):
+                    stream_id = stream_id.decode("utf-8")
+                msg_id = fields.get(b"id", fields.get("id", b""))
+                if isinstance(msg_id, bytes):
+                    msg_id = msg_id.decode("utf-8")
+                if msg_id == message_id:
+                    # Cache it for next time
+                    with self._lock:
+                        if pipeline_id not in self._id_to_stream_id:
+                            self._id_to_stream_id[pipeline_id] = {}
+                        self._id_to_stream_id[pipeline_id][message_id] = stream_id
+                    return stream_id
+            # Advance cursor past the last entry in this batch
+            last_id = entries[-1][0]
+            if isinstance(last_id, bytes):
+                last_id = last_id.decode("utf-8")
+            cursor = self._increment_stream_id(last_id)
+            if len(entries) < batch_size:
+                break
         return None
 
     @staticmethod

--- a/orchestrator/routes/messages.py
+++ b/orchestrator/routes/messages.py
@@ -299,20 +299,24 @@ def poll_messages(pipeline_id: str) -> tuple[Response, int]:
     if wait > 0:
         _track_long_poll_start()
     try:
-        messages = message_store.get_messages(pipeline_id, **kwargs)
+        messages, meta = message_store.get_messages_with_meta(pipeline_id, **kwargs)
     finally:
         if wait > 0:
             _track_long_poll_end()
 
     messages = _apply_delphi_filter(pipeline_id, role, messages)
 
-    return _make_success(
-        "Messages retrieved",
-        data={
-            "messages": [m.to_dict() for m in messages],
-            "count": len(messages),
-        },
-    )
+    data: dict[str, Any] = {
+        "messages": [m.to_dict() for m in messages],
+        "count": len(messages),
+    }
+    # Structured staleness signal (issue #2464). Only emitted when True so
+    # responses stay byte-identical for the common case; consumers that
+    # care (the sandbox CLI cursor file, agent wait_loop) clear their
+    # cached cursor when they see this and re-snap to tip.
+    if meta.since_id_stale:
+        data["since_id_stale"] = True
+    return _make_success("Messages retrieved", data=data)
 
 
 def _apply_delphi_filter(
@@ -497,7 +501,7 @@ def wait_messages(pipeline_id: str) -> tuple[Response, int]:
         # "0-0" (issue #1925). Callers that want cursor-passing
         # semantics pass ``since_id`` explicitly, which disables
         # from_tip below.
-        messages = message_store.get_messages(
+        messages, meta = message_store.get_messages_with_meta(
             pipeline_id,
             role=role,
             since_id=since_id,
@@ -522,15 +526,16 @@ def wait_messages(pipeline_id: str) -> tuple[Response, int]:
     else:
         cursor = message_store.get_latest_id(pipeline_id)
 
-    return _make_success(
-        "Wait completed",
-        data={
-            "messages": [m.to_dict() for m in messages],
-            "count": len(messages),
-            "matched": bool(messages),
-            "cursor": cursor,
-        },
-    )
+    data: dict[str, Any] = {
+        "messages": [m.to_dict() for m in messages],
+        "count": len(messages),
+        "matched": bool(messages),
+        "cursor": cursor,
+    }
+    # Structured staleness signal (issue #2464). See poll_messages above.
+    if meta.since_id_stale:
+        data["since_id_stale"] = True
+    return _make_success("Wait completed", data=data)
 
 
 @messages_bp.route("/<pipeline_id>/heartbeat", methods=["POST"])

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -3738,6 +3738,34 @@ def wait_pipeline_status(pipeline_id: str) -> tuple[Response, int]:
 
     event_bus = get_event_bus()
 
+    # Synchronous up-front cursor-staleness probe (issue #2464). The route
+    # used to silently keep re-emitting ``msg_since_id`` whenever the store
+    # tip was empty (post-phase-clear), so a polling client kept feeding
+    # the dead cursor back forever. Probe once at entry with ``wait=0`` so
+    # we can both stop re-emitting it and surface ``since_id_stale: True``
+    # in the envelope, letting consumers (sandbox CLI cursor file, agent
+    # wait_loop) drop the stale cursor and re-snap to tip. Done before
+    # the terminal short-circuit below so a request that arrives after
+    # both a phase clear and pipeline completion still sees the flag.
+    since_id_stale = False
+    if msg_since_id is not None:
+        try:
+            store_fn = _get_message_store()
+            store = store_fn()
+            _msgs, meta = store.get_messages_with_meta(
+                pipeline_id,
+                since_id=msg_since_id,
+                limit=1,
+                wait=0,
+            )
+            since_id_stale = meta.since_id_stale
+        except Exception as exc:  # pragma: no cover
+            logger.debug(
+                "status_wait staleness probe error",
+                pipeline_id=pipeline_id,
+                error=str(exc),
+            )
+
     # Late-subscriber short-circuit (issue #2378): if the pipeline is
     # already terminal at request time, the relevant ``pipeline.*``
     # event was emitted before this call could subscribe — and the
@@ -3752,8 +3780,11 @@ def wait_pipeline_status(pipeline_id: str) -> tuple[Response, int]:
         PipelineStatus.CANCELLED: "pipeline.cancelled",
     }
     if pipeline.status in _TERMINAL_EVENT_TYPES:
+        # Issue #2464: don't fall back to ``msg_since_id`` when the tip
+        # is empty — that's exactly the post-clear state that perpetuates
+        # the dead cursor.
         terminal_cursor = _build_status_wait_cursor(
-            _message_store_tip_id(pipeline_id) or msg_since_id,
+            _message_store_tip_id(pipeline_id),
             event_bus.current_sequence(),
         )
         terminal_envelope = _build_minimal_status_envelope(pipeline, terminal_cursor)
@@ -3764,6 +3795,8 @@ def wait_pipeline_status(pipeline_id: str) -> tuple[Response, int]:
                 "event_type": _TERMINAL_EVENT_TYPES[pipeline.status],
             }
         )
+        if since_id_stale:
+            terminal_envelope["since_id_stale"] = True
         return make_success_response("Pipeline already terminal", data=terminal_envelope)
 
     # Snap event_since_seq to the current tip on first call.  This
@@ -3846,7 +3879,13 @@ def wait_pipeline_status(pipeline_id: str) -> tuple[Response, int]:
 
         if source == "event":
             event = payload
-            tip_msg_id = _message_store_tip_id(pipeline_id) or msg_since_id
+            # Issue #2464: never fall back to ``msg_since_id`` when the
+            # tip is empty. After a phase-boundary clear the caller's
+            # cursor is dead; re-emitting it here is what kept the
+            # ``since_id not found in store`` warning firing on every
+            # subsequent poll. ``since_id_stale: True`` in the envelope
+            # tells the consumer to drop its cached cursor.
+            tip_msg_id = _message_store_tip_id(pipeline_id)
             cursor = _build_status_wait_cursor(tip_msg_id, event.sequence)
             envelope = _build_minimal_status_envelope(fresh_pipeline, cursor)
             envelope.update(
@@ -3856,11 +3895,16 @@ def wait_pipeline_status(pipeline_id: str) -> tuple[Response, int]:
                     "event_type": event.event_type.value,
                 }
             )
+            if since_id_stale:
+                envelope["since_id_stale"] = True
             return make_success_response("Event wake", data=envelope)
 
         if source == "message":
             messages = payload
-            last_id = messages[-1].id if messages else msg_since_id
+            # Issue #2464: same as the event path — fall back to None
+            # when the message half is unavailable rather than re-emitting
+            # the stale ``msg_since_id``.
+            last_id = messages[-1].id if messages else None
             # Delphi filter pass — currently a no-op for the host caller
             # (role=None returns messages unchanged) but plumbed here so a
             # future role parameter can enable reviewer-redaction (R13).
@@ -3879,14 +3923,18 @@ def wait_pipeline_status(pipeline_id: str) -> tuple[Response, int]:
                     "messages": [m.to_dict() for m in messages],
                 }
             )
+            if since_id_stale:
+                envelope["since_id_stale"] = True
             return make_success_response("Message wake", data=envelope)
 
         # Timeout path — minimal envelope only.
-        tip_msg_id = _message_store_tip_id(pipeline_id) or msg_since_id
+        tip_msg_id = _message_store_tip_id(pipeline_id)
         tip_evt_seq = event_bus.current_sequence()
         cursor = _build_status_wait_cursor(tip_msg_id, tip_evt_seq)
         envelope = _build_minimal_status_envelope(fresh_pipeline, cursor)
         envelope.update({"changed": False, "no_change": True})
+        if since_id_stale:
+            envelope["since_id_stale"] = True
         return make_success_response("No change within wait window", data=envelope)
     finally:
         try:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -333,6 +333,28 @@ def _message_store_tip_id(pipeline_id: str) -> str | None:
     returns without matching a message.  Returns ``None`` when the
     store has no messages yet — the caller formats this as the
     empty ``msg:`` half of the compound cursor.
+
+    Three distinct conditions all collapse to ``None`` here and
+    callers cannot distinguish between them:
+
+    1. **Store import failure** — the message-store module is not
+       loadable in this process (test harness without Redis,
+       packaging skew). Pre-PR / post-#2464: same behavior.
+    2. **Transient ``get_latest_id`` failure** — e.g.,
+       :class:`redis.RedisError` from ``XREVRANGE`` on a connection
+       blip. ``RedisMessageStore.get_latest_id`` already catches
+       this and returns ``None``, so we see "no tip". This conflates
+       a transient error with a genuinely empty store; #2464's fix
+       at the call site (``_message_store_tip_id() or msg_since_id``
+       removal) drops the consumer's cursor on this transient as
+       well, which is a small behavioral regression vs. pre-PR
+       graceful-degradation behavior. Acceptable in practice
+       because transient Redis errors degrade many other paths
+       simultaneously, but worth knowing.
+    3. **Empty store** — the ``/status/wait`` post-clear case the
+       PR is fixing. Returning ``None`` lets the route emit an
+       empty ``msg:`` half so the consumer doesn't re-feed the
+       dead cursor.
     """
     try:
         store = _get_message_store()()
@@ -3757,6 +3779,13 @@ def wait_pipeline_status(pipeline_id: str) -> tuple[Response, int]:
                 since_id=msg_since_id,
                 limit=1,
                 wait=0,
+                # Suppress the "since_id not found in store" warning on
+                # this probe so a single ``/status/wait`` request that
+                # hits a stale cursor doesn't double-log: the long-poll
+                # daemon below makes its own ``get_messages`` call with
+                # the same cursor and emits the warning once. Pre-PR
+                # cadence was one warning per request; we preserve that.
+                _suppress_stale_warning=True,
             )
             since_id_stale = meta.since_id_stale
         except Exception as exc:  # pragma: no cover

--- a/orchestrator/tests/test_host_wait_integration.py
+++ b/orchestrator/tests/test_host_wait_integration.py
@@ -322,3 +322,76 @@ class TestStatusWaitRoute:
             assert ok is True
             assert got_msg == msg_id
             assert got_seq == evt_seq
+
+
+class TestStaleSinceIdSignal:
+    """Issue #2464 — ``/status/wait`` no longer re-emits a stale
+    ``msg_since_id`` when the message store is empty (post-phase-clear),
+    and surfaces ``since_id_stale: true`` so consumers can drop cached
+    cursors instead of feeding the dead value back forever.
+    """
+
+    def test_timeout_after_clear_drops_stale_msg_half(
+        self,
+        client,
+        mock_pipeline_resolver,
+        isolated_event_bus,
+    ) -> None:
+        """A request whose ``since`` cursor refers to a wiped message
+        must return a cursor with an EMPTY ``msg:`` half AND
+        ``since_id_stale: true``. Pre-fix the route would happily
+        re-emit the dead msg id forever as long as the store stayed
+        empty."""
+        store = MessageStore()
+        anchor = Message(
+            pipeline_id="issue-1932-e2e",
+            from_role="coder",
+            to_role="all",
+            message_type=MessageType.PROGRESS,
+            subject="pre-clear",
+        )
+        store.add_message(anchor)
+        # Phase-boundary clear wipes the cursor.
+        store.clear("issue-1932-e2e")
+        stale_cursor = _build_status_wait_cursor(anchor.id, 0)
+
+        with patch("routes.pipelines._get_message_store", return_value=lambda: store):
+            envelope = _wait(client, wait=1, since=stale_cursor)
+
+        assert envelope["no_change"] is True
+        assert envelope.get("since_id_stale") is True
+        # Critical regression guard: the response cursor must NOT carry
+        # the dead msg id forward — otherwise the consumer just feeds
+        # it back next call and the warning fires forever.
+        ok, got_msg, _got_seq = _parse_status_wait_cursor(envelope["cursor"])
+        assert ok is True
+        assert got_msg is None, (
+            f"expected empty msg half after clear, got {got_msg!r} — "
+            "this is the #2464 re-emission bug"
+        )
+
+    def test_fresh_cursor_does_not_set_flag(
+        self,
+        client,
+        mock_pipeline_resolver,
+        isolated_event_bus,
+    ) -> None:
+        """A request with a still-resolvable ``since`` does NOT carry
+        the staleness flag — pins the byte-shape contract so legacy
+        consumers see no extra fields in the common case."""
+        store = MessageStore()
+        anchor = Message(
+            pipeline_id="issue-1932-e2e",
+            from_role="coder",
+            to_role="all",
+            message_type=MessageType.PROGRESS,
+            subject="anchor",
+        )
+        store.add_message(anchor)
+        cursor = _build_status_wait_cursor(anchor.id, 0)
+
+        with patch("routes.pipelines._get_message_store", return_value=lambda: store):
+            envelope = _wait(client, wait=1, since=cursor)
+
+        # Cursor was resolvable; flag must be absent.
+        assert "since_id_stale" not in envelope

--- a/orchestrator/tests/test_message_store.py
+++ b/orchestrator/tests/test_message_store.py
@@ -655,6 +655,49 @@ class TestGetMessagesWithMeta:
         assert isinstance(result, list)
         assert len(result) == 1
 
+    def test_suppress_stale_warning_silences_log_but_keeps_meta(
+        self, store: MessageStore, caplog
+    ) -> None:
+        """``_suppress_stale_warning=True`` (used by ``/status/wait``'s
+        synchronous probe) silences the ``since_id not found in store``
+        log line on a stale cursor but still populates the structured
+        ``meta.since_id_stale`` flag — reviewer note #2 on PR #2485."""
+        import logging
+
+        store.add_message(_make_message(message_type=MessageType.PROGRESS))
+
+        # Probe-shape call: limit=1, wait=0, with the suppression flag.
+        with caplog.at_level(logging.WARNING, logger="orchestrator.message_store"):
+            _msgs, meta = store.get_messages_with_meta(
+                "test-pipeline",
+                since_id="cursor-the-store-never-saw",
+                limit=1,
+                wait=0,
+                _suppress_stale_warning=True,
+            )
+
+        # Structured signal still set — consumers can still detect.
+        assert meta.since_id_stale is True
+        # Warning log line is silenced.
+        assert not any("since_id not found in store" in rec.getMessage() for rec in caplog.records)
+
+    def test_default_emits_stale_warning(self, store: MessageStore, caplog) -> None:
+        """Pin the regression boundary: without the suppression flag
+        the warning still fires (the daemon's later call relies on this
+        to preserve pre-PR cadence of one warning per request)."""
+        import logging
+
+        store.add_message(_make_message(message_type=MessageType.PROGRESS))
+
+        with caplog.at_level(logging.WARNING, logger="orchestrator.message_store"):
+            _msgs, meta = store.get_messages_with_meta(
+                "test-pipeline",
+                since_id="cursor-the-store-never-saw",
+            )
+
+        assert meta.since_id_stale is True
+        assert any("since_id not found in store" in rec.getMessage() for rec in caplog.records)
+
 
 class TestGetLatestId:
     """Tests for ``MessageStore.get_latest_id``."""

--- a/orchestrator/tests/test_message_store.py
+++ b/orchestrator/tests/test_message_store.py
@@ -29,6 +29,7 @@ if str(_orchestrator_path) not in sys.path:
 
 from message_store import (  # noqa: E402
     HEARTBEAT_STATES,
+    GetMessagesMeta,
     Message,
     MessageStore,
     MessageType,
@@ -584,6 +585,75 @@ class TestStaleSinceIdInBlockingWait:
             since_id="nonexistent-cursor-xyz",
         )
         assert len(msgs) == 2
+
+
+class TestGetMessagesWithMeta:
+    """``get_messages_with_meta`` (issue #2464) returns a structured
+    staleness signal alongside the message list so consumers can drop
+    cached cursors instead of re-passing dead values forever.
+    """
+
+    def test_meta_signals_stale_cursor(self, store: MessageStore) -> None:
+        """An unknown ``since_id`` produces ``since_id_stale=True`` and
+        the message list still falls back to full history (existing
+        contract)."""
+        store.add_message(_make_message(message_type=MessageType.PROGRESS))
+
+        msgs, meta = store.get_messages_with_meta(
+            "test-pipeline",
+            since_id="cursor-the-store-never-saw",
+        )
+        assert isinstance(meta, GetMessagesMeta)
+        assert meta.since_id_stale is True
+        # Full-history fallback still in effect — the bug-fix preserves
+        # delivery, only changes whether we *advertise* the staleness.
+        assert len(msgs) == 1
+
+    def test_meta_clean_when_cursor_known(self, store: MessageStore) -> None:
+        """A resolvable ``since_id`` produces ``since_id_stale=False``
+        and only newer messages come back."""
+        anchor = store.add_message(_make_message(message_type=MessageType.PROGRESS))
+        store.add_message(_make_message(message_type=MessageType.CONSENSUS_CONFIRMED))
+
+        msgs, meta = store.get_messages_with_meta(
+            "test-pipeline",
+            since_id=anchor.id,
+        )
+        assert meta.since_id_stale is False
+        assert len(msgs) == 1
+        assert msgs[0].message_type == MessageType.CONSENSUS_CONFIRMED
+
+    def test_meta_clean_when_no_since_id(self, store: MessageStore) -> None:
+        """No ``since_id`` passed → never stale (there is no cursor to
+        resolve)."""
+        store.add_message(_make_message(message_type=MessageType.PROGRESS))
+
+        _msgs, meta = store.get_messages_with_meta("test-pipeline")
+        assert meta.since_id_stale is False
+
+    def test_meta_signals_stale_after_phase_clear(self, store: MessageStore) -> None:
+        """Pin the original-bug shape: a cursor that resolved fine
+        before a ``clear()`` is reported stale on the next call. This
+        is the exact post-phase-boundary path #2464 unblocks."""
+        anchor = store.add_message(_make_message(message_type=MessageType.PROGRESS))
+        # Cursor is currently fine.
+        _, meta_before = store.get_messages_with_meta("test-pipeline", since_id=anchor.id)
+        assert meta_before.since_id_stale is False
+
+        store.clear("test-pipeline")
+        store.add_message(_make_message(message_type=MessageType.PROGRESS))
+
+        _, meta_after = store.get_messages_with_meta("test-pipeline", since_id=anchor.id)
+        assert meta_after.since_id_stale is True
+
+    def test_get_messages_drops_meta_for_legacy_callers(self, store: MessageStore) -> None:
+        """``get_messages`` is now a thin wrapper around the meta variant
+        so existing callers see no signature change."""
+        store.add_message(_make_message(message_type=MessageType.PROGRESS))
+        result = store.get_messages("test-pipeline", since_id="bogus")
+        # Just a list of messages, no tuple.
+        assert isinstance(result, list)
+        assert len(result) == 1
 
 
 class TestGetLatestId:

--- a/orchestrator/tests/test_messages.py
+++ b/orchestrator/tests/test_messages.py
@@ -956,6 +956,104 @@ class TestSinceIdStaleSignal:
                 assert resp.status_code == 200
                 assert data["data"].get("since_id_stale") is True
 
+    def test_messages_wait_omits_flag_for_fresh_cursor(self, client, app):
+        """Pin the byte-shape contract for ``/messages/wait`` on the
+        fresh-cursor path: when the supplied ``since_id`` resolves
+        cleanly the response must omit ``since_id_stale`` entirely
+        (instead of carrying ``false``). A future divergence between
+        ``/messages`` and ``/messages/wait`` field handling would
+        otherwise slip through — see reviewer note #6 on PR #2485."""
+        store = MessageStore()
+        first = Message(
+            pipeline_id="test-pipeline",
+            from_role="coder",
+            to_role="all",
+            message_type=MessageType.PROGRESS,
+            subject="first",
+        )
+        store.add_message(first)
+        # Add a matching second message so the wait returns immediately
+        # via the fast-path filter rather than blocking on the timeout.
+        store.add_message(
+            Message(
+                pipeline_id="test-pipeline",
+                from_role="coder",
+                to_role="all",
+                message_type=MessageType.CONSENSUS_CONFIRMED,
+                subject="match",
+            )
+        )
+
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+
+                resp = client.get(
+                    "/api/v1/pipelines/test-pipeline/messages/wait"
+                    f"?for=CONSENSUS_CONFIRMED&timeout=2&since_id={first.id}"
+                )
+                data = json.loads(resp.data)
+
+                assert resp.status_code == 200
+                assert data["data"]["matched"] is True
+                assert "since_id_stale" not in data["data"]
+
+    def test_messages_wait_omits_flag_when_no_since_id(self, client, app):
+        """No ``since_id`` parameter → ``from_tip=True`` semantics,
+        ``meta.since_id_stale`` is irrelevant by construction, and the
+        field must be absent from the response (mirrors the
+        ``/messages`` no-cursor case)."""
+        import threading
+        import time as _t
+
+        store = MessageStore()
+
+        def _add_after_delay() -> None:
+            _t.sleep(0.15)
+            store.add_message(
+                Message(
+                    pipeline_id="test-pipeline",
+                    from_role="coder",
+                    to_role="all",
+                    message_type=MessageType.CONSENSUS_CONFIRMED,
+                    subject="match",
+                )
+            )
+
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                t = threading.Thread(target=_add_after_delay)
+                t.start()
+                try:
+                    resp = client.get(
+                        "/api/v1/pipelines/test-pipeline/messages/wait"
+                        "?for=CONSENSUS_CONFIRMED&timeout=3"
+                    )
+                finally:
+                    t.join(timeout=2)
+                data = json.loads(resp.data)
+
+                assert resp.status_code == 200
+                assert data["data"]["matched"] is True
+                assert "since_id_stale" not in data["data"]
+
 
 class TestMessageStatus:
     """Test message status endpoint."""

--- a/orchestrator/tests/test_messages.py
+++ b/orchestrator/tests/test_messages.py
@@ -806,6 +806,157 @@ class TestSinceIdRecovery:
                 assert data["data"]["messages"][0]["subject"] == "second"
 
 
+class TestSinceIdStaleSignal:
+    """Issue #2464 — ``/messages`` and ``/messages/wait`` advertise a
+    structured ``since_id_stale: true`` flag when the cursor was unknown,
+    so consumers (sandbox CLI cursor file, agent ``wait_loop``) can drop
+    cached cursors instead of feeding the dead value back forever.
+    """
+
+    def test_messages_carries_flag_on_stale_cursor(self, client, app):
+        store = MessageStore()
+        store.add_message(
+            Message(
+                pipeline_id="test-pipeline",
+                from_role="coder",
+                to_role="all",
+                message_type=MessageType.PROGRESS,
+                subject="test",
+            )
+        )
+
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+
+                resp = client.get(
+                    "/api/v1/pipelines/test-pipeline/messages?since_id=cursor-the-store-never-saw"
+                )
+                data = json.loads(resp.data)
+
+                assert resp.status_code == 200
+                assert data["data"].get("since_id_stale") is True
+                # Full-history fallback still in effect.
+                assert data["data"]["count"] == 1
+
+    def test_messages_omits_flag_for_fresh_cursor(self, client, app):
+        """Pin the byte-shape contract: responses with no staleness DO
+        NOT carry a ``since_id_stale`` field at all (instead of
+        ``false``), so legacy consumers see byte-identical output."""
+        store = MessageStore()
+        first = Message(
+            pipeline_id="test-pipeline",
+            from_role="coder",
+            to_role="all",
+            message_type=MessageType.PROGRESS,
+            subject="first",
+        )
+        store.add_message(first)
+        store.add_message(
+            Message(
+                pipeline_id="test-pipeline",
+                from_role="coder",
+                to_role="all",
+                message_type=MessageType.PROGRESS,
+                subject="second",
+            )
+        )
+
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+
+                resp = client.get(f"/api/v1/pipelines/test-pipeline/messages?since_id={first.id}")
+                data = json.loads(resp.data)
+
+                assert resp.status_code == 200
+                assert "since_id_stale" not in data["data"]
+
+    def test_messages_omits_flag_when_no_since_id(self, client, app):
+        """No cursor passed → the flag is irrelevant and must be absent."""
+        store = MessageStore()
+        store.add_message(
+            Message(
+                pipeline_id="test-pipeline",
+                from_role="coder",
+                to_role="all",
+                message_type=MessageType.PROGRESS,
+                subject="x",
+            )
+        )
+
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+
+                resp = client.get("/api/v1/pipelines/test-pipeline/messages")
+                data = json.loads(resp.data)
+
+                assert resp.status_code == 200
+                assert "since_id_stale" not in data["data"]
+
+    def test_messages_wait_carries_flag_on_stale_cursor(self, client, app):
+        """``/messages/wait`` mirrors the same flag — agent ``wait_loop``
+        relies on it to drop ``inner["since"]`` mid-loop after a phase
+        clear."""
+        store = MessageStore()
+        store.add_message(
+            Message(
+                pipeline_id="test-pipeline",
+                from_role="coder",
+                to_role="all",
+                message_type=MessageType.OVERSEER_ALERT,
+                subject="alert",
+            )
+        )
+
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+
+                resp = client.get(
+                    "/api/v1/pipelines/test-pipeline/messages/wait"
+                    "?for=OVERSEER_ALERT&timeout=1"
+                    "&since_id=cursor-the-store-never-saw"
+                )
+                data = json.loads(resp.data)
+
+                assert resp.status_code == 200
+                assert data["data"].get("since_id_stale") is True
+
+
 class TestMessageStatus:
     """Test message status endpoint."""
 

--- a/orchestrator/tests/test_redis_message_store.py
+++ b/orchestrator/tests/test_redis_message_store.py
@@ -176,6 +176,45 @@ class TestGetMessages:
         msgs = store.get_messages("test-pipeline", since_id="nonexistent-cursor-xyz")
         assert len(msgs) == 3
 
+    def test_get_messages_with_meta_signals_stale_cursor(self, store):
+        """Issue #2464 — Redis backend mirrors the in-memory staleness
+        signal: an unknown ``since_id`` produces ``since_id_stale=True``
+        on the meta sibling, while ``get_messages`` keeps its full-history
+        fallback."""
+        self._add_messages(store, 3)
+        msgs, meta = store.get_messages_with_meta(
+            "test-pipeline", since_id="nonexistent-cursor-xyz"
+        )
+        assert meta.since_id_stale is True
+        assert len(msgs) == 3
+
+    def test_get_messages_with_meta_clean_when_cursor_known(self, store):
+        """A resolvable ``since_id`` reports ``since_id_stale=False``."""
+        msgs = self._add_messages(store, 3)
+        _result, meta = store.get_messages_with_meta("test-pipeline", since_id=msgs[0].id)
+        assert meta.since_id_stale is False
+
+    def test_get_messages_with_meta_clean_when_no_since_id(self, store):
+        """No ``since_id`` → never stale (no cursor to resolve)."""
+        self._add_messages(store, 3)
+        _msgs, meta = store.get_messages_with_meta("test-pipeline")
+        assert meta.since_id_stale is False
+
+    def test_get_messages_with_meta_signals_stale_after_clear(self, store):
+        """After ``clear()`` the previously-valid cursor is stale —
+        exactly the post-phase-boundary case #2464 surfaces."""
+        msgs = self._add_messages(store, 3)
+        anchor = msgs[0].id
+        # Pre-clear, anchor is fresh.
+        _, meta_before = store.get_messages_with_meta("test-pipeline", since_id=anchor)
+        assert meta_before.since_id_stale is False
+
+        store.clear("test-pipeline")
+        self._add_messages(store, 1)
+
+        _, meta_after = store.get_messages_with_meta("test-pipeline", since_id=anchor)
+        assert meta_after.since_id_stale is True
+
     def test_limit(self, store):
         self._add_messages(store, 10)
         messages = store.get_messages("test-pipeline", limit=3)

--- a/orchestrator/tests/test_redis_message_store.py
+++ b/orchestrator/tests/test_redis_message_store.py
@@ -215,6 +215,68 @@ class TestGetMessages:
         _, meta_after = store.get_messages_with_meta("test-pipeline", since_id=anchor)
         assert meta_after.since_id_stale is True
 
+    def test_get_messages_with_meta_transient_redis_error_is_not_stale(self, store):
+        """Issue #2464 reviewer note #3 — a transient ``RedisError``
+        raised from the scan fallback (e.g., a connection blip during
+        ``XRANGE``) must NOT be reported as cursor staleness. Pre-fix
+        this path swallowed the exception inside
+        ``_find_stream_id_by_message_id`` and returned ``None``, which
+        the caller treated as "scan miss → since_id_stale=True". A
+        well-behaved consumer would then drop a still-live cursor on a
+        momentary blip.
+
+        Post-fix the scan helper re-raises ``RedisError`` so the caller
+        can distinguish "scan completed empty" from "scan errored out"
+        — the route preserves the cursor on the latter."""
+        from unittest.mock import patch
+
+        import redis
+
+        # Pre-populate the stream so the cache resolve fails (cache cleared
+        # below) and the scan fallback path is taken.
+        msgs = self._add_messages(store, 3)
+        target_id = msgs[1].id
+        with store._lock:
+            store._id_to_stream_id.clear()
+
+        # Force *only* the scan helper to raise — leaves the downstream
+        # XRANGE / XREAD calls in ``_read_once`` (which serve the
+        # full-history fallback) backed by real fakeredis, so we
+        # exercise the route's branch without breaking the rest of
+        # the call. Pre-fix the swallow turned this into
+        # ``since_id_stale=True``; post-fix the caller catches the
+        # raise and reports ``False`` so consumers keep the cursor
+        # through the blip.
+        with patch.object(
+            store,
+            "_find_stream_id_by_message_id",
+            side_effect=redis.RedisError("connection blip"),
+        ):
+            _msgs, meta = store.get_messages_with_meta("test-pipeline", since_id=target_id)
+
+        assert meta.since_id_stale is False, (
+            "transient RedisError during scan must not be reported as "
+            "cursor staleness — would tell consumers to drop a live cursor"
+        )
+
+    def test_find_stream_id_by_message_id_propagates_redis_error(self, store):
+        """Pin the contract change at the helper level: ``_find_stream_id_by_message_id``
+        used to swallow ``RedisError`` and return ``None`` (indistinguishable
+        from a genuine scan miss). It must now propagate the exception so
+        :meth:`get_messages_with_meta` can branch on it."""
+        from unittest.mock import patch
+
+        import redis
+
+        self._add_messages(store, 1)
+        with patch.object(
+            store._redis,
+            "xrange",
+            side_effect=redis.RedisError("connection blip"),
+        ):
+            with pytest.raises(redis.RedisError):
+                store._find_stream_id_by_message_id("test-pipeline", "any-id")
+
     def test_limit(self, store):
         self._add_messages(store, 10)
         messages = store.get_messages("test-pipeline", limit=3)

--- a/sandbox/egg_agent_tools/handlers/message.py
+++ b/sandbox/egg_agent_tools/handlers/message.py
@@ -319,6 +319,19 @@ def message_wait_loop(req: dict[str, Any]) -> dict[str, Any]:
         }
     }
     last_resp: dict[str, Any] = {}
+    # Issue #2464 follow-up: the staleness flag from the *server* only
+    # appears on iterations whose ``inner["since"]`` is non-None. Once
+    # iteration 1 sees ``since_id_stale: True`` we drop ``inner["since"]``,
+    # so iteration 2+ have nothing for the server to flag and the response
+    # comes back with no flag (or false). That left the CLI's
+    # ``if resp.get("since_id_stale"): _delete_cursor_file`` branch
+    # depending on the *last* iteration's flag — which would miss the
+    # safety-cap exit case where iteration 1 saw staleness but the loop
+    # exhausted ``--max-iterations`` before matching. Track "did the loop
+    # ever observe staleness" and propagate it on the final response so
+    # the CLI's unlink branch fires regardless of which iteration tripped
+    # it.
+    loop_saw_stale = False
     try:
         for i in range(1, max_iter + 1):
             try:
@@ -338,6 +351,7 @@ def message_wait_loop(req: dict[str, Any]) -> dict[str, Any]:
             # threading the new cursor — otherwise a server-side tip of
             # ``None`` would let the dead cursor live another iteration.
             if resp.get("since_id_stale"):
+                loop_saw_stale = True
                 inner.pop("since", None)
             # Thread the server cursor into the next wait's ``since`` so
             # events that arrive between this response and the next call
@@ -350,6 +364,8 @@ def message_wait_loop(req: dict[str, Any]) -> dict[str, Any]:
             if resp.get("matched"):
                 resp_out = dict(resp)
                 resp_out["iterations"] = i
+                if loop_saw_stale:
+                    resp_out["since_id_stale"] = True
                 return resp_out
             # Timeout with no match — reset backoff and loop.
             backoff = 1.0
@@ -358,6 +374,8 @@ def message_wait_loop(req: dict[str, Any]) -> dict[str, Any]:
         capped.setdefault("ok", True)
         capped["matched"] = False
         capped["iterations"] = max_iter
+        if loop_saw_stale:
+            capped["since_id_stale"] = True
         return capped
     finally:
         stop_hb()

--- a/sandbox/egg_agent_tools/handlers/message.py
+++ b/sandbox/egg_agent_tools/handlers/message.py
@@ -138,11 +138,18 @@ def message_wait(req: dict[str, Any]) -> dict[str, Any]:
     messages = list(data.get("messages", []) or [])
     matched = bool(data.get("matched")) or bool(messages)
     cursor = data.get("cursor")
+    # Issue #2464: server signals when ``since_id`` resolved to no
+    # known message in the store (typically because a phase-boundary
+    # ``clear`` wiped the cursor). The CLI uses this to drop its on-disk
+    # cursor file so the next wait re-snaps to tip instead of feeding
+    # the dead cursor back forever.
+    since_id_stale = bool(data.get("since_id_stale"))
     return {
         "ok": True,
         "matched": matched,
         "messages": messages,
         "cursor": cursor,
+        "since_id_stale": since_id_stale,
         "role": role,
         "for_types": for_types,
         "raw": result,
@@ -326,6 +333,12 @@ def message_wait_loop(req: dict[str, Any]) -> dict[str, Any]:
                 backoff = min(backoff * 2, 5.0)
                 continue
             last_resp = resp
+            # Issue #2464: if the server flagged the previous ``since``
+            # as unresolvable (post-phase-clear cursor) drop it before
+            # threading the new cursor — otherwise a server-side tip of
+            # ``None`` would let the dead cursor live another iteration.
+            if resp.get("since_id_stale"):
+                inner.pop("since", None)
             # Thread the server cursor into the next wait's ``since`` so
             # events that arrive between this response and the next call
             # can't slip through the gap (issue #1995). A cursor of ``None``

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -1411,6 +1411,30 @@ def _read_cursor_file(path: str | None) -> str | None:
     return value or None
 
 
+def _delete_cursor_file(path: str | None) -> None:
+    """Remove a stale cursor file (issue #2464).
+
+    Called when the server signals ``since_id_stale: true`` — i.e. the
+    cached cursor pointed at a message the store no longer indexes
+    (typically because a phase-boundary ``clear`` wiped it). Dropping
+    the file causes the next wait to re-snap to tip instead of feeding
+    the dead cursor back forever.
+
+    Best-effort: a missing file is the desired post-state and any other
+    OSError just leaves the file in place — the next call will redo the
+    full-history fallback once and write a fresh cursor on success,
+    which clears the staleness on its own.
+    """
+    if not path:
+        return
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        return
+    except OSError as err:  # pragma: no cover - filesystem-dependent
+        print(f"Warning: could not unlink stale cursor file {path}: {err}", file=sys.stderr)
+
+
 def _write_cursor_file(path: str | None, cursor: str | None) -> None:
     """Atomically persist *cursor* under *path*.
 
@@ -1538,6 +1562,15 @@ def cmd_message_wait(args: argparse.Namespace) -> int:
     messages = list(resp.get("messages") or [])
     matched = bool(resp.get("matched"))
 
+    # Issue #2464: when the server flagged the request's ``since`` as
+    # stale, drop the cached cursor file before deciding whether to
+    # write a new one. The fresh cursor below replaces it on the
+    # common path (server returns the new tip on every response); the
+    # explicit unlink covers the rare case where the server returns a
+    # null cursor on the same response (empty stream after clear) so
+    # the dead value doesn't survive into the next wait.
+    if resp.get("since_id_stale"):
+        _delete_cursor_file(cursor_file)
     # Persist the response cursor on every successful round-trip
     # (match OR timeout). The server returns the latest stream tip on
     # timeout so the next call resumes strictly after what this one
@@ -1647,6 +1680,14 @@ def cmd_message_wait_loop(args: argparse.Namespace) -> int:
         print(f"Error: {err.message}", file=sys.stderr)
         return 1
 
+    # Issue #2464: drop the cached cursor before re-writing if the
+    # final inner iteration's response flagged staleness. The handler
+    # already drops ``inner["since"]`` mid-loop when it sees the flag,
+    # but we still need to make sure a later call doesn't re-read the
+    # dead cursor off disk if the server happened to return a null
+    # tip on the staleness response.
+    if resp.get("since_id_stale"):
+        _delete_cursor_file(cursor_file)
     # Persist the response cursor whenever we have one (match OR
     # safety-cap exit). The handler threads cursors internally between
     # inner iterations, so ``resp["cursor"]`` is the latest tip the

--- a/sandbox/tests/test_message_wait_cli.py
+++ b/sandbox/tests/test_message_wait_cli.py
@@ -943,6 +943,96 @@ class TestAutoCursorWaitLoop:
             cmd_message_wait_loop(self._make_loop_args(since="01-explicit"))
         assert captured.get("since") == "01-explicit"
 
+    def test_stale_response_with_fresh_tip_replaces_cursor_file(self, monkeypatch, tmp_path):
+        """Issue #2464 — mirror of ``test_stale_cursor_file_replaced_with_fresh_tip``
+        for the wait-loop wrapper: when the handler returns
+        ``since_id_stale: true`` plus a fresh tip cursor, the file ends
+        up holding the fresh tip (not the pre-clear value)."""
+        self._setenv(monkeypatch, tmp_path)
+        cursor_path = _wait_cursor_path("issue-42", "reviewer_plan", ["CONSENSUS_PROPOSE"])
+        assert cursor_path is not None
+        with open(cursor_path, "w") as fh:
+            fh.write("01-pre-clear")
+        with patch(
+            "egg_agent_tools.handlers.message.message_wait_loop",
+            return_value={
+                "ok": True,
+                "matched": False,
+                "messages": [],
+                "cursor": "01-fresh-tip",
+                "since_id_stale": True,
+                "iterations": 1,
+            },
+        ):
+            rc = cmd_message_wait_loop(self._make_loop_args())
+        assert rc == 1
+        with open(cursor_path) as fh:
+            assert fh.read().strip() == "01-fresh-tip"
+
+    def test_stale_response_with_null_cursor_unlinks_file(self, monkeypatch, tmp_path):
+        """Issue #2464 — mirror of
+        ``test_stale_response_with_null_cursor_unlinks_file`` for the
+        wait-loop wrapper: when the handler signals staleness AND the
+        loop ended without a fresh cursor (``cursor: None``), the file
+        must be unlinked. Without this the dead value would survive on
+        disk and be re-read on the next invocation. Direct coverage of
+        the ``_delete_cursor_file`` branch at
+        ``cmd_message_wait_loop`` (sandbox/egg_lib/orch_cli.py:1689)."""
+        self._setenv(monkeypatch, tmp_path)
+        cursor_path = _wait_cursor_path("issue-42", "reviewer_plan", ["CONSENSUS_PROPOSE"])
+        assert cursor_path is not None
+        with open(cursor_path, "w") as fh:
+            fh.write("01-dead-cursor")
+        with patch(
+            "egg_agent_tools.handlers.message.message_wait_loop",
+            return_value={
+                "ok": True,
+                "matched": False,
+                "messages": [],
+                "cursor": None,
+                "since_id_stale": True,
+                "iterations": 1,
+            },
+        ):
+            cmd_message_wait_loop(self._make_loop_args())
+        assert not Path(cursor_path).exists(), (
+            "stale cursor file should have been unlinked when the "
+            "wait-loop response carried since_id_stale + null cursor"
+        )
+
+    def test_stale_response_on_safety_cap_unlinks_file(self, monkeypatch, tmp_path):
+        """Issue #2464 follow-up — even when the handler hits its
+        ``--max-iterations`` safety cap (so ``matched=False``), the
+        propagated ``since_id_stale: true`` on the cap-exit response
+        must still trigger the unlink. Pre-fix the loop dropped
+        ``inner["since"]`` after iteration 1 saw staleness, so iteration
+        N+ saw no cursor and the server's response carried no flag —
+        leaving the stale file on disk for the next invocation. The
+        handler now tracks ``loop_saw_stale`` and re-attaches the flag
+        to the cap-exit response."""
+        self._setenv(monkeypatch, tmp_path)
+        cursor_path = _wait_cursor_path("issue-42", "reviewer_plan", ["CONSENSUS_PROPOSE"])
+        assert cursor_path is not None
+        with open(cursor_path, "w") as fh:
+            fh.write("01-pre-clear")
+        with patch(
+            "egg_agent_tools.handlers.message.message_wait_loop",
+            return_value={
+                "ok": True,
+                "matched": False,
+                "messages": [],
+                "cursor": None,
+                "since_id_stale": True,
+                "iterations": 5,
+            },
+        ):
+            rc = cmd_message_wait_loop(self._make_loop_args())
+        assert rc == 1
+        assert not Path(cursor_path).exists(), (
+            "stale cursor file should have been unlinked on cap-exit "
+            "when handler propagated since_id_stale=True"
+        )
+
 
 class TestCursorNullResponsePreservesPriorCursor:
     """A ``cursor=None`` response (empty stream, pathological safety
@@ -1261,6 +1351,106 @@ class TestWaitLoopStalenessHandling:
         assert observed_sinces[1] is None, (
             f"expected iteration 2 to start from-tip after staleness, "
             f"got since={observed_sinces[1]!r}"
+        )
+
+    def test_cap_exit_after_stale_seen_propagates_flag(self):
+        """Issue #2464 follow-up: iteration 1 sees ``since_id_stale``,
+        iteration 2+ start from-tip (no ``since``) so the server's
+        response on those iterations carries no flag. Pre-fix that meant
+        the cap-exit response (``last_resp`` from iteration N) had no
+        ``since_id_stale`` field and the CLI's unlink branch would not
+        fire. Post-fix the handler tracks ``loop_saw_stale`` and
+        re-attaches the flag on cap-exit."""
+        from egg_agent_tools.handlers import message as _handlers
+
+        observed_sinces: list[str | None] = []
+
+        def _fake_message_wait(req: dict[str, Any]) -> dict[str, Any]:
+            observed_sinces.append(req.get("since"))
+            if len(observed_sinces) == 1:
+                return {
+                    "ok": True,
+                    "matched": False,
+                    "messages": [],
+                    "cursor": None,
+                    "since_id_stale": True,
+                }
+            # Iterations 2+: no ``since``, so server returns no flag.
+            return {
+                "ok": True,
+                "matched": False,
+                "messages": [],
+                "cursor": None,
+                "since_id_stale": False,
+            }
+
+        with patch.object(_handlers, "message_wait", side_effect=_fake_message_wait):
+            resp = _handlers.message_wait_loop(
+                {
+                    "pipeline_id": "issue-42",
+                    "role": "coder",
+                    "for_types": ["CONSENSUS_CONFIRMED"],
+                    "since": "01-pre-clear",
+                    "timeout": 1,
+                    "max_iterations": 3,
+                    "_heartbeat_interval": 0,
+                }
+            )
+
+        assert resp["matched"] is False
+        assert resp["iterations"] == 3
+        # Critical: the cap-exit response carries the propagated flag,
+        # even though the *last* iteration's server response did not.
+        assert resp.get("since_id_stale") is True, (
+            "cap-exit response must surface since_id_stale when any "
+            "iteration in the loop observed it"
+        )
+
+    def test_match_after_stale_seen_propagates_flag(self):
+        """Mirror of the cap-exit test for the matched-exit path: if
+        iteration 1 saw staleness and iteration 2 matched (cursor
+        replaced via tip after the clear), the matched response also
+        carries the propagated ``since_id_stale`` flag so the CLI
+        unlinks the dead cursor file even on a successful match."""
+        from egg_agent_tools.handlers import message as _handlers
+
+        observed_sinces: list[str | None] = []
+
+        def _fake_message_wait(req: dict[str, Any]) -> dict[str, Any]:
+            observed_sinces.append(req.get("since"))
+            if len(observed_sinces) == 1:
+                return {
+                    "ok": True,
+                    "matched": False,
+                    "messages": [],
+                    "cursor": None,
+                    "since_id_stale": True,
+                }
+            return {
+                "ok": True,
+                "matched": True,
+                "messages": [{"id": "01-fresh", "subject": "go"}],
+                "cursor": "01-fresh",
+                "since_id_stale": False,
+            }
+
+        with patch.object(_handlers, "message_wait", side_effect=_fake_message_wait):
+            resp = _handlers.message_wait_loop(
+                {
+                    "pipeline_id": "issue-42",
+                    "role": "coder",
+                    "for_types": ["CONSENSUS_CONFIRMED"],
+                    "since": "01-pre-clear",
+                    "timeout": 1,
+                    "max_iterations": 3,
+                    "_heartbeat_interval": 0,
+                }
+            )
+
+        assert resp["matched"] is True
+        assert resp.get("since_id_stale") is True, (
+            "matched response must surface propagated since_id_stale "
+            "when an earlier iteration in the loop observed it"
         )
 
     def test_fresh_cursor_is_threaded_normally(self):

--- a/sandbox/tests/test_message_wait_cli.py
+++ b/sandbox/tests/test_message_wait_cli.py
@@ -744,6 +744,61 @@ class TestAutoCursorWait:
         assert "since_id=01-explicit" in endpoint
         assert "since_id=01-stale" not in endpoint
 
+    def test_stale_cursor_file_replaced_with_fresh_tip(self, monkeypatch, tmp_path):
+        """Issue #2464 — when the server signals ``since_id_stale: true``
+        the CLI drops the cached cursor before writing the new tip. End
+        state on disk is the fresh tip, NOT the stale value, so the
+        next call doesn't re-feed the dead cursor."""
+        self._setenv(monkeypatch, tmp_path)
+        for_types = ["CONSENSUS_PROPOSE"]
+        cursor_path = self._expected_path(tmp_path, for_types)
+        # Pre-seed a cursor that the server will flag as stale.
+        with open(cursor_path, "w") as fh:
+            fh.write("01-pre-clear")
+        with patch(_ORCH_MOCK_PATH) as mock_req:
+            mock_req.return_value = {
+                "success": True,
+                "data": {
+                    "messages": [],
+                    "matched": False,
+                    "count": 0,
+                    "cursor": "01-fresh-tip",
+                    "since_id_stale": True,
+                },
+            }
+            cmd_message_wait(_make_wait_args(for_=for_types))
+        # New cursor written; old "01-pre-clear" is not re-read on the
+        # next call.
+        with open(cursor_path) as fh:
+            assert fh.read().strip() == "01-fresh-tip"
+
+    def test_stale_response_with_null_cursor_unlinks_file(self, monkeypatch, tmp_path):
+        """Issue #2464 — if the server flags staleness AND happens to
+        return a null cursor (empty stream after a clear), the cursor
+        file must be removed. Pre-fix the file would survive with the
+        dead value and be threaded back into the next call."""
+        self._setenv(monkeypatch, tmp_path)
+        for_types = ["CONSENSUS_PROPOSE"]
+        cursor_path = self._expected_path(tmp_path, for_types)
+        with open(cursor_path, "w") as fh:
+            fh.write("01-dead-cursor")
+        with patch(_ORCH_MOCK_PATH) as mock_req:
+            mock_req.return_value = {
+                "success": True,
+                "data": {
+                    "messages": [],
+                    "matched": False,
+                    "count": 0,
+                    "cursor": None,
+                    "since_id_stale": True,
+                },
+            }
+            cmd_message_wait(_make_wait_args(for_=for_types))
+        assert not Path(cursor_path).exists(), (
+            "stale cursor file should have been unlinked when response "
+            "carried since_id_stale + null cursor"
+        )
+
 
 class TestAutoCursorWaitLoop:
     """``cmd_message_wait_loop`` mirrors the auto-cursor semantics."""
@@ -1143,3 +1198,110 @@ class TestCursorWriteDefenses:
         # clobber it (write was skipped at the isinstance guard).
         with open(cursor_path) as fh:
             assert fh.read().strip() == "01-prior-tip"
+
+
+class TestWaitLoopStalenessHandling:
+    """``message_wait_loop`` handler drops ``inner["since"]`` when the
+    server flags the cursor as stale (#2464), so the *next* iteration
+    starts from-tip instead of re-feeding the dead value. This covers
+    the case where wait_loop is left running across a phase clear: the
+    first iteration sees ``since_id_stale: True``, the second iteration
+    omits ``since`` entirely, and a real match in the new phase is
+    delivered without spinning on the dead cursor."""
+
+    def test_stale_response_drops_since_for_next_iteration(self):
+        """The handler must remove ``since`` from its inner request
+        dict the moment the server flags staleness — otherwise a
+        server-side ``cursor: None`` (empty stream after clear) would
+        leave the dead cursor active for another iteration."""
+        from egg_agent_tools.handlers import message as _handlers
+
+        observed_sinces: list[str | None] = []
+
+        def _fake_message_wait(req: dict[str, Any]) -> dict[str, Any]:
+            observed_sinces.append(req.get("since"))
+            if len(observed_sinces) == 1:
+                # First iteration: server flags the (post-clear) cursor
+                # as stale and returns null cursor (empty store).
+                return {
+                    "ok": True,
+                    "matched": False,
+                    "messages": [],
+                    "cursor": None,
+                    "since_id_stale": True,
+                }
+            # Second iteration: a real message arrives.
+            return {
+                "ok": True,
+                "matched": True,
+                "messages": [{"id": "01-fresh", "subject": "go"}],
+                "cursor": "01-fresh",
+                "since_id_stale": False,
+            }
+
+        with patch.object(_handlers, "message_wait", side_effect=_fake_message_wait):
+            resp = _handlers.message_wait_loop(
+                {
+                    "pipeline_id": "issue-42",
+                    "role": "coder",
+                    "for_types": ["CONSENSUS_CONFIRMED"],
+                    "since": "01-pre-clear-cursor",
+                    "timeout": 1,
+                    "max_iterations": 3,
+                    "_heartbeat_interval": 0,
+                }
+            )
+
+        assert resp["matched"] is True
+        assert resp["iterations"] == 2
+        # Iteration 1 saw the original (about-to-be-flagged-stale)
+        # cursor; iteration 2 must NOT see it — the handler dropped
+        # ``inner["since"]`` after the staleness flag.
+        assert observed_sinces[0] == "01-pre-clear-cursor"
+        assert observed_sinces[1] is None, (
+            f"expected iteration 2 to start from-tip after staleness, "
+            f"got since={observed_sinces[1]!r}"
+        )
+
+    def test_fresh_cursor_is_threaded_normally(self):
+        """Pin the regression boundary: a non-stale response still
+        threads ``cursor`` into the next iteration's ``since`` exactly
+        as before. Issue #1995's race-closing behavior is unchanged."""
+        from egg_agent_tools.handlers import message as _handlers
+
+        observed_sinces: list[str | None] = []
+
+        def _fake_message_wait(req: dict[str, Any]) -> dict[str, Any]:
+            observed_sinces.append(req.get("since"))
+            if len(observed_sinces) == 1:
+                return {
+                    "ok": True,
+                    "matched": False,
+                    "messages": [],
+                    "cursor": "01-tip-after-call-1",
+                    "since_id_stale": False,
+                }
+            return {
+                "ok": True,
+                "matched": True,
+                "messages": [{"id": "01-real", "subject": "go"}],
+                "cursor": "01-real",
+                "since_id_stale": False,
+            }
+
+        with patch.object(_handlers, "message_wait", side_effect=_fake_message_wait):
+            resp = _handlers.message_wait_loop(
+                {
+                    "pipeline_id": "issue-42",
+                    "role": "coder",
+                    "for_types": ["CONSENSUS_CONFIRMED"],
+                    "timeout": 1,
+                    "max_iterations": 3,
+                    "_heartbeat_interval": 0,
+                }
+            )
+
+        assert resp["matched"] is True
+        assert observed_sinces[0] is None  # first call from-tip
+        # Second call threads the cursor returned by call 1.
+        assert observed_sinces[1] == "01-tip-after-call-1"


### PR DESCRIPTION
## Summary

- Adds a structured ``since_id_stale`` signal to ``/messages``, ``/messages/wait``, and ``/status/wait`` so consumers can detect when their cursor was wiped by a phase-boundary ``clear()`` instead of feeding the dead value back forever.
- Fixes ``/status/wait``'s self-perpetuating loop where it re-emitted ``msg_since_id`` whenever the store tip was empty (lines 3756, 3849, 3885 of ``routes/pipelines.py``) — that fallback is what kept the chronic ``since_id not found in store`` warnings firing on every poll in #2454.
- Wires the signal through the sandbox CLI cursor file (#2323) and the ``message_wait_loop`` handler so a wait_loop running across a phase clear drops its dead cursor mid-loop and re-snaps to tip.

## Approach

**Store layer:** ``MessageStore`` / ``RedisMessageStore`` gain ``get_messages_with_meta`` returning ``(messages, GetMessagesMeta)`` where ``meta.since_id_stale`` is ``True`` iff the caller's ``since_id`` didn't resolve. ``get_messages`` becomes a thin wrapper that drops the meta — every existing caller signature is preserved. The "fall back to full history on stale cursor" contract from #2454 is unchanged at the store level; the meta is purely additive.

**Route layer:** ``/messages`` and ``/messages/wait`` surface ``since_id_stale: true`` in response data when stale; the field is omitted entirely on the fresh-cursor path so legacy consumers see byte-identical output. ``/status/wait`` does an up-front synchronous probe with ``wait=0``, surfaces the flag in every envelope (terminal / event / message / timeout), and no longer falls back to ``msg_since_id`` when ``_message_store_tip_id`` returns ``None``.

**Client layer:** The sandbox CLI's ``cmd_message_wait`` / ``cmd_message_wait_loop`` unlink the cursor file when the response carries the flag, and the ``message_wait_loop`` handler drops ``inner[\"since\"]`` mid-loop so iteration N+1 starts from-tip after iteration N saw staleness.

## Why a single PR

The three layers are co-load-bearing for the bug: fixing only the store contract leaves the CLI cursor file feeding stale values back across phases; fixing only the CLI leaves ``/status/wait``'s self-feeding loop intact. Splitting would land a half-fix that demos clean in tests but doesn't actually quiet the warning storm in production.

## Test plan

- [x] ``orchestrator/tests/test_message_store.py`` — new ``TestGetMessagesWithMeta`` class: meta signals stale cursor, clean cursor, no-since case, and the post-clear pattern from #2464. Plus a regression guard that ``get_messages`` is still a list (no signature change for legacy callers). 35 passed.
- [x] ``orchestrator/tests/test_redis_message_store.py`` — same matrix mirrored for the Redis backend (cache-miss + paginated-scan-miss → ``since_id_stale=True``). 49 passed.
- [x] ``orchestrator/tests/test_messages.py`` — new ``TestSinceIdStaleSignal`` class: ``/messages`` and ``/messages/wait`` carry the flag on stale cursors; the flag is **absent** (not ``false``) on the fresh-cursor and no-cursor paths so the byte-shape contract is pinned. 81 passed.
- [x] ``orchestrator/tests/test_host_wait_integration.py`` — new ``TestStaleSinceIdSignal`` class: timeout after a phase clear no longer re-emits the dead msg id (the critical regression guard for the #2464 closed loop) and surfaces ``since_id_stale: true``. Fresh cursors stay flag-free. 8 passed.
- [x] ``sandbox/tests/test_message_wait_cli.py`` — new tests for cursor-file unlink on stale + null-cursor response, plus ``TestWaitLoopStalenessHandling`` covering the handler's mid-loop ``inner[\"since\"]`` drop. 64 passed.
- [x] Lint clean across all 11 touched files.