### PR TITLE
Fix #2486: dedupe sandbox-side _SLICE_ID_PATTERN

### DIFF
--- a/sandbox/egg_agent_tools/handlers/brc.py
+++ b/sandbox/egg_agent_tools/handlers/brc.py
@@ -10,6 +10,8 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from egg_lib._slice_id import SLICE_ID_PATTERN as _SLICE_ID_PATTERN
+
 from egg_agent_tools.handlers._gateway import (
     get_agent_role,
     get_pipeline_id,
@@ -20,7 +22,6 @@ from egg_agent_tools.handlers.errors import GatewayError, HandlerError
 
 _COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{7,40}$")
 _PIPELINE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
-_SLICE_ID_PATTERN = re.compile(r"^slice-[0-9]+$")
 
 
 def _maybe_attach_slice_id(req: dict[str, Any], data: dict[str, Any]) -> None:

--- a/sandbox/egg_agent_tools/handlers/progress.py
+++ b/sandbox/egg_agent_tools/handlers/progress.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from egg_lib._slice_id import SLICE_ID_PATTERN as _SLICE_ID_PATTERN
+
 from egg_agent_tools.handlers._gateway import (
     get_agent_role,
     get_pipeline_id,
@@ -14,7 +16,6 @@ from egg_agent_tools.handlers._gateway import (
 from egg_agent_tools.handlers.errors import GatewayError, HandlerError
 
 _PIPELINE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
-_SLICE_ID_PATTERN = re.compile(r"^slice-[0-9]+$")
 
 
 def _maybe_attach_slice_id(req: dict[str, Any], data: dict[str, Any]) -> None:

--- a/sandbox/egg_lib/_slice_id.py
+++ b/sandbox/egg_lib/_slice_id.py
@@ -1,0 +1,17 @@
+"""Canonical sandbox-side ``slice-<N>`` regex.
+
+The sandbox imports the canonical ``slice_id`` shape from a single
+module so the handler-side validation in
+``egg_agent_tools.handlers.{brc,progress}`` and the CLI-side validation
+in ``egg_lib.orch_cli`` can't drift apart. The orchestrator-side
+canonical source is ``orchestrator.slice_id_validation.SLICE_ID_PATTERN``;
+sandbox code does not import from the orchestrator package, so this
+mirror is kept in step by the parity check in
+``tests/sandbox/test_slice_id_pattern_parity.py``.
+"""
+
+from __future__ import annotations
+
+import re
+
+SLICE_ID_PATTERN = re.compile(r"^slice-[0-9]+$")

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -66,15 +66,10 @@ except ImportError:
     ORCHESTRATOR_PORT = 9849  # noqa: EGG002
     GATEWAY_PORT = 9848  # noqa: EGG002
 
+from egg_lib._slice_id import SLICE_ID_PATTERN as _SLICE_ID_PATTERN
+
 # Validation pattern for IDs used in URL path segments
 _SAFE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_\-\.]+$")
-
-# Canonical ``slice-<N>`` shape — mirrors orchestrator's
-# ``slice_id_validation.SLICE_ID_PATTERN`` and the handler-side regex in
-# ``egg_agent_tools.handlers.{brc,progress}``. Kept inline rather than
-# importing from the orchestrator package because ``egg_lib`` ships in
-# the sandbox and must not depend on orchestrator code.
-_SLICE_ID_PATTERN = re.compile(r"^slice-[0-9]+$")
 
 
 class ApiError(Exception):

--- a/tests/sandbox/test_slice_id_pattern_parity.py
+++ b/tests/sandbox/test_slice_id_pattern_parity.py
@@ -1,0 +1,40 @@
+"""Parity check: sandbox-side ``SLICE_ID_PATTERN`` mirrors the orchestrator (#2486).
+
+The sandbox can't import from the orchestrator package at runtime
+(``egg_lib`` ships in the container with no orchestrator code), so the
+canonical ``slice-<N>`` regex is mirrored in ``egg_lib._slice_id``.
+This test pins the two definitions together so a future tweak on
+either side trips CI instead of silently letting them drift.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "sandbox"))
+sys.path.insert(0, str(ROOT / "shared"))
+
+
+def test_sandbox_pattern_matches_orchestrator():
+    from egg_lib._slice_id import SLICE_ID_PATTERN as sandbox_pattern
+
+    from orchestrator.slice_id_validation import SLICE_ID_PATTERN as orch_pattern
+
+    assert sandbox_pattern.pattern == orch_pattern.pattern
+
+
+def test_call_sites_share_the_same_object():
+    """All three sandbox call sites import the canonical regex (#2486).
+
+    Importing the *same* compiled object — not a re-defined equivalent —
+    means a tweak to ``egg_lib._slice_id.SLICE_ID_PATTERN`` propagates
+    to every call site without a follow-up edit.
+    """
+    from egg_agent_tools.handlers import brc, progress
+    from egg_lib import _slice_id, orch_cli
+
+    assert brc._SLICE_ID_PATTERN is _slice_id.SLICE_ID_PATTERN
+    assert progress._SLICE_ID_PATTERN is _slice_id.SLICE_ID_PATTERN
+    assert orch_cli._SLICE_ID_PATTERN is _slice_id.SLICE_ID_PATTERN

--- a/tests/sandbox/test_slice_id_pattern_parity.py
+++ b/tests/sandbox/test_slice_id_pattern_parity.py
@@ -5,16 +5,13 @@ The sandbox can't import from the orchestrator package at runtime
 canonical ``slice-<N>`` regex is mirrored in ``egg_lib._slice_id``.
 This test pins the two definitions together so a future tweak on
 either side trips CI instead of silently letting them drift.
+
+Imports rely on ``tests/conftest.py`` (which puts ``sandbox/`` and
+``shared/`` on ``sys.path``) and on pytest's rootdir discovery for the
+``orchestrator`` package.
 """
 
 from __future__ import annotations
-
-import sys
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT / "sandbox"))
-sys.path.insert(0, str(ROOT / "shared"))
 
 
 def test_sandbox_pattern_matches_orchestrator():


### PR DESCRIPTION
## Summary

Closes #2486. The canonical ``slice-<N>`` regex was duplicated in three sandbox modules — ``egg_lib.orch_cli`` (added in #2476), ``egg_agent_tools.handlers.brc``, and ``egg_agent_tools.handlers.progress``. Replace with a single shared constant in ``egg_lib._slice_id`` that all three import.

A new parity test (``tests/sandbox/test_slice_id_pattern_parity.py``) pins the sandbox-side pattern to the orchestrator's ``slice_id_validation.SLICE_ID_PATTERN`` and asserts the three call sites import the same compiled object — so a future tweak to the canonical regex propagates without a follow-up edit.

**Stacking note:** this PR is based on #2476 (where the third copy in ``orch_cli.py`` lands). Targeting #2476's branch as base; once #2476 merges, GitHub will retarget this onto ``main``. Net diff vs. main is the 5 files in this commit.

## Test plan
- [x] `make test` — 753 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] New parity test asserts sandbox / orchestrator regex strings match and all three call sites share the same compiled object