### PR TITLE
Fix #2481: refiner skips questions resolved in pre-refine `## Additional Context`

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -8797,6 +8797,15 @@ def _build_phase_prompt(
                 "decision or feedback item using `egg-contract`.** Do not just write "
                 "questions as prose — they will not be seen by the human unless "
                 "registered.\n",
+                "**Skip already-resolved questions.** If the Task Description above "
+                "includes an `## Additional Context` section, treat anything addressed "
+                "there as already decided by the operator (those came from a pre-refine "
+                "HITL round). Do NOT call `egg-contract add-decision` or "
+                "`egg-contract add-feedback` for questions whose answers are already "
+                "captured in `## Additional Context` — re-registering them wastes turns "
+                "and produces no-op decisions. Read that section first, list the "
+                "decisions it already settles, and only register questions that go "
+                "beyond it.\n",
                 "Surface **all** uncertainties, ambiguities, and assumptions that need "
                 "human input. Do not limit yourself to a small number — every genuine "
                 "ambiguity, missing requirement, unstated assumption, or design choice "

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -8803,9 +8803,11 @@ def _build_phase_prompt(
                 "HITL round). Do NOT call `egg-contract add-decision` or "
                 "`egg-contract add-feedback` for questions whose answers are already "
                 "captured in `## Additional Context` — re-registering them wastes turns "
-                "and produces no-op decisions. Read that section first, list the "
-                "decisions it already settles, and only register questions that go "
-                "beyond it.\n",
+                "and produces no-op decisions. Read that section first; if it settles "
+                "anything, list those items in a `### Resolved in Pre-Refine` "
+                "subsection at the top of `## Open Questions` (one bullet per resolved "
+                "item, citing the answer). Only register questions that go beyond what "
+                "`## Additional Context` covers.\n",
                 "Surface **all** uncertainties, ambiguities, and assumptions that need "
                 "human input. Do not limit yourself to a small number — every genuine "
                 "ambiguity, missing requirement, unstated assumption, or design choice "

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -2842,6 +2842,7 @@ class TestRefinePromptHonorsAdditionalContext:
         assert "already decided" in prompt or "already-resolved" in prompt.lower()
         assert "pre-refine" in prompt
         assert "Skip already-resolved questions" in prompt
+        assert "### Resolved in Pre-Refine" in prompt
 
 
 class TestReviewerBrcPreamble:

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -2820,6 +2820,30 @@ class TestExternalResearchInstructions:
         assert "WebFetch" in prompt
 
 
+class TestRefinePromptHonorsAdditionalContext:
+    """Refine prompt must instruct refiner to skip already-resolved questions.
+
+    Regression for #2481: when the SDLC skill's pre-refine HITL captures
+    answers and embeds them under `## Additional Context` in the task
+    description, the refiner used to re-register those answered questions
+    as `register_open_question` decisions, wasting turns and producing
+    no-op decisions that the skill auto-resolves.
+    """
+
+    def test_refine_prompt_warns_against_re_registering_resolved_questions(self):
+        prompt = _build_phase_prompt(
+            phase="refine",
+            pipeline_id="test-pipe",
+            pipeline_mode="issue",
+            prompt="Analyze this issue.\n\n## Additional Context\n\nAlready answered.",
+            issue_number=100,
+        )
+        assert "Additional Context" in prompt
+        assert "already decided" in prompt or "already-resolved" in prompt.lower()
+        assert "pre-refine" in prompt
+        assert "Skip already-resolved questions" in prompt
+
+
 class TestReviewerBrcPreamble:
     """Tests that reviewer agents receive BRC preamble in concurrent mode."""
 


### PR DESCRIPTION
## Summary
- Add an explicit instruction in the refine-phase prompt's *Open Questions* block telling the refiner to read the task description's `## Additional Context` section first and skip any question whose answer is already captured there.
- The SDLC skill's Phase 1.5 Step 6 documents `## Additional Context` as the durable contract for pre-refine answers (`skills/sdlc/SKILL.md`), so the refiner can reliably detect the section.
- Adds a regression test (`TestRefinePromptHonorsAdditionalContext`) verifying the new instruction is present in the refine-phase prompt.

Fixes #2481.

### Why
In pipeline `issue-2474`, the operator answered the issue's two open questions during pre-refine; those answers were embedded in `## Additional Context` and shipped to `submit_task`. The refiner still called `register_open_question` for both, generating no-op decisions that the skill's `resolved_questions_map` had to silently auto-resolve. That defeats one of the main purposes of the pre-refine phase — and burns refiner turns producing decisions that go nowhere.

### Approach
Per option 2 of the issue's *Suggested investigation*: a targeted prompt-template change rather than a structural reformat of the description. The refiner is now told (a) what `## Additional Context` means, (b) that items there are already decided, and (c) to register only questions that go beyond what's captured there.

## Test plan
- [x] `.venv/bin/pytest orchestrator/tests/test_pipeline_prompts.py -k "TestRefinePromptHonorsAdditionalContext or test_refine_prompt_includes_external_research" -v` — passes
- [x] `make test` — 2313 passed (1 unrelated port-in-use error in `test_cli.py::TestHealthCommand::test_health_success`)
- [x] `.venv/bin/ruff check orchestrator/routes/pipelines.py orchestrator/tests/test_pipeline_prompts.py` — clean
- [ ] Live verification on the next pipeline whose submitted description carries an `## Additional Context` block: refiner should *not* register open questions duplicating items already in that section.