### PR TITLE
Fix #2489: stop duplicate naive role-restriction check from trapping role-restricted producers

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -176,7 +176,6 @@ try:
         PipelinePhase,
         check_agent_restrictions,  # noqa: F401 — re-exported for test patching
         check_anchor_write_permission,
-        check_file_restrictions,  # noqa: F401 — re-exported for test patching
         check_phase_file_restrictions,
         filter_operation,
     )
@@ -324,7 +323,6 @@ except ImportError:
         PipelinePhase,
         check_agent_restrictions,  # noqa: F401 — re-exported for test patching
         check_anchor_write_permission,
-        check_file_restrictions,  # noqa: F401 — re-exported for test patching
         check_phase_file_restrictions,
         filter_operation,
     )
@@ -1727,6 +1725,25 @@ def git_push() -> tuple[Response, int] | Response:
                 "human reviewer (see issue #1998 for the conditional-ACK "
                 "pattern)."
             )
+            details: dict[str, Any] = {
+                "error": "restricted_path_modified",
+                "role": session_role,
+                "blocked_paths": sorted_blocked,
+                "recommended_action": recommended_action,
+                "doc_ref": "#1998",
+                "pulled_commits": pulled_commits_summary,
+                "attribution_fallback": attribution_fallback,
+            }
+            # #2355 hint catalogue: surface category-specific guidance
+            # (e.g. "Use egg-contract CLI commands…" for contract paths,
+            # "Documentation changes belong to the documenter role." for
+            # docs/) alongside the generic conditional-ACK pointer.  The
+            # legacy whole-push-diff check used to do this; restoring it
+            # here keeps the response shape consistent with the anchor-
+            # write 403 below.
+            hint = _derive_push_denied_hint(sorted_blocked)
+            if hint is not None:
+                details["hint"] = hint
             return make_error(
                 (
                     f"Push denied: role '{session_role}' cannot modify restricted "
@@ -1734,15 +1751,7 @@ def git_push() -> tuple[Response, int] | Response:
                     f"{recommended_action}"
                 ),
                 status_code=403,
-                details={
-                    "error": "restricted_path_modified",
-                    "role": session_role,
-                    "blocked_paths": sorted_blocked,
-                    "recommended_action": recommended_action,
-                    "doc_ref": "#1998",
-                    "pulled_commits": pulled_commits_summary,
-                    "attribution_fallback": attribution_fallback,
-                },
+                details=details,
             )
         elif blocked_own and not enforce:
             # Warn-only mode: log but let the plain push proceed.
@@ -2454,7 +2463,11 @@ def git_execute() -> tuple[Response, int] | Response:
                     f"the contamination shape from #2222. If you need to "
                     f"bring in new commits from the base, ask the operator "
                     f"to resume the pipeline so the orchestrator-side "
-                    f"rebase runs."
+                    f"rebase runs. If you were trying to drop pulled upstream "
+                    f"commits to recover from a 'restricted_path_modified' "
+                    f"push 403, that is no longer necessary (#2489) — pulled "
+                    f"commits authored by other roles are exempt from your "
+                    f"role allowlist; retry the push as-is."
                 )
                 audit_log(
                     "git_execute_blocked",

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -1815,9 +1815,9 @@ def git_push() -> tuple[Response, int] | Response:
                     "blocked_files": anchor_result.blocked_files,
                     "blocked_reason": anchor_result.blocked_reason,
                 }
-                # Anchor-write violations bypass check_file_restrictions (the
-                # role-level coder blocklist exempts .egg-state/agent-anchors/),
-                # so they need their own derive_hint call to deliver the
+                # Anchor-write violations bypass the role-level partition (the
+                # coder blocklist exempts .egg-state/agent-anchors/), so they
+                # need their own derive_hint call to deliver the
                 # orchestrator-API guidance from BLOCKED_HINTS. See #2355.
                 anchor_hint = _derive_push_denied_hint(anchor_result.blocked_files)
                 if anchor_hint is not None:

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -176,7 +176,7 @@ try:
         PipelinePhase,
         check_agent_restrictions,  # noqa: F401 — re-exported for test patching
         check_anchor_write_permission,
-        check_file_restrictions,
+        check_file_restrictions,  # noqa: F401 — re-exported for test patching
         check_phase_file_restrictions,
         filter_operation,
     )
@@ -324,7 +324,7 @@ except ImportError:
         PipelinePhase,
         check_agent_restrictions,  # noqa: F401 — re-exported for test patching
         check_anchor_write_permission,
-        check_file_restrictions,
+        check_file_restrictions,  # noqa: F401 — re-exported for test patching
         check_phase_file_restrictions,
         filter_operation,
     )
@@ -1500,14 +1500,11 @@ def git_push() -> tuple[Response, int] | Response:
             details=policy_result.details,
         )
 
-    # SECURITY: Check for protected file modifications based on agent role.
-    # File restrictions are configured in phase-permissions.json and enforced
-    # by the PhaseFilter module. This prevents certain roles from modifying
-    # specific files via git push (e.g., implementers cannot modify contract files).
-    #
-    # Note: Only configured roles are checked. The SYSTEM role is typically NOT
-    # blocked because SYSTEM never makes git pushes - it only initializes contracts
-    # via the contract API. The gateway itself runs without a role context.
+    # SECURITY: Resolve the changed-file set + fail closed if we can't.
+    # The agent-role and phase-based restriction checks below both consume
+    # ``changed_files``; computing it once here keeps the security gates
+    # consistent and lets the fail-closed branch run even if neither
+    # session has a role (the phase check still runs in that case).
     #
     # Infrastructure pushes (checkpoint branches, pipeline-state, and synthetic-
     # session slice integration-branch creation pushes; see is_infrastructure_push
@@ -1523,12 +1520,14 @@ def git_push() -> tuple[Response, int] | Response:
     # The downstream anchor/phase/agent-restriction checks already gate on
     # `not is_infrastructure_push`; this gate makes the role check symmetric.
     session_role = None
-    changed_files = None  # May be populated by role check, reused by phase check
+    changed_files = None  # populated below; reused by attribution + phase checks
     if hasattr(g, "session") and g.session:
         session_role = getattr(g.session, "agent_role", None)
 
     if session_role and not is_infrastructure_push:
-        # Get the list of files being pushed
+        # Get the list of files being pushed for downstream attribution-aware
+        # role enforcement (the canonical agent-role check below) and the
+        # phase-restriction check further down.
         changed_files, check_error = get_changed_files_in_push(exec_path, remote, branch)
 
         # SECURITY: Fail closed - if we can't determine changed files, block the push.
@@ -1555,38 +1554,17 @@ def git_push() -> tuple[Response, int] | Response:
                 },
             )
 
-        # Check file restrictions using the PhaseFilter configuration
-        restriction_result = check_file_restrictions(session_role, changed_files)
-        if not restriction_result.allowed:
-            audit_log(
-                "push_denied_protected_files",
-                "git_push",
-                success=False,
-                details={
-                    "repo": repo,
-                    "branch": branch,
-                    "role": session_role,
-                    "blocked_files": restriction_result.blocked_files,
-                    "blocked_reason": restriction_result.blocked_reason,
-                },
-            )
-            details: dict[str, Any] = {
-                "role": session_role,
-                "blocked_files": restriction_result.blocked_files,
-                "blocked_reason": restriction_result.blocked_reason,
-            }
-            # Derive the hint from the blocked path's category so non-contract
-            # violations (CI workflows, anchors, role-scope mismatches) get
-            # actionable guidance instead of the legacy contract-only hint.
-            # See #2355.
-            hint = _derive_push_denied_hint(restriction_result.blocked_files)
-            if hint is not None:
-                details["hint"] = hint
-            return make_error(
-                f"Push denied: {restriction_result.message}. {restriction_result.blocked_reason}",
-                status_code=403,
-                details=details,
-            )
+        # Note: the legacy whole-push-diff role check that used to live here
+        # (``check_file_restrictions(session_role, changed_files)``) was
+        # removed in #2489.  It treated every file in the diff range as the
+        # pushing role's responsibility, even files modified only by pulled
+        # commits authored by other roles, which trapped role-restricted
+        # producers whose branches inherited unrelated upstream commits
+        # (the role had no sanctioned recovery path).  The attribution-
+        # aware block below partitions own-authored vs pulled files via the
+        # commit-authorship registry and is now the canonical agent-role
+        # restriction enforcer; it preserves fail-closed semantics when
+        # attribution is unavailable.
 
     # Agent-role file restrictions (#2039 restricted-path rejection).
     # The gateway partitions the push range into own-authored vs
@@ -2277,7 +2255,12 @@ def git_execute() -> tuple[Response, int] | Response:
             if positional[0] != expected_ref:
                 denial_reason = (
                     f"git update-ref target '{positional[0]}' is not allowed. "
-                    f"Only '{expected_ref}' (your assigned branch) may be updated."
+                    f"Only '{expected_ref}' (your assigned branch) may be updated. "
+                    f"If you are trying to manually retarget your branch to drop "
+                    f"pulled upstream commits and recover from a "
+                    f"'restricted_path_modified' push 403, that is no longer "
+                    f"necessary (#2489) — pulled commits authored by other roles "
+                    f"are exempt from your role allowlist; retry the push as-is."
                 )
         if denial_reason is not None:
             audit_log(
@@ -2510,7 +2493,13 @@ def git_execute() -> tuple[Response, int] | Response:
                 f"Branch switching is not allowed in pipeline sessions. "
                 f"You are locked to branch '{assigned}'. "
                 f"Use 'git checkout [<commit-ish>] -- <file>' to restore files instead "
-                f"(e.g. 'git checkout HEAD -- <file>' or 'git checkout <sha> -- <file>').",
+                f"(e.g. 'git checkout HEAD -- <file>' or 'git checkout <sha> -- <file>'). "
+                f"If you are recovering from a 'restricted_path_modified' push 403, "
+                f"note that pulled commits authored by other roles are exempt from "
+                f"your role allowlist (#2489) — only your own commits' paths trigger "
+                f"the rejection, so retry the push first; if it still rejects, drop "
+                f"the disallowed paths from your own commits and re-propose with "
+                f"--pre-merge-condition (#1998 conditional ACK).",
                 status_code=403,
             )
 
@@ -2569,7 +2558,11 @@ def git_execute() -> tuple[Response, int] | Response:
                         f"Off-lineage 'git reset' is not allowed in pipeline sessions. "
                         f"Target ref '{target_ref}' is not an ancestor of HEAD on your "
                         f"assigned branch '{assigned}'. To incorporate new commits from the "
-                        f"remote, use 'git rebase origin/{assigned}' instead.",
+                        f"remote, use 'git rebase origin/{assigned}' instead. "
+                        f"If you are trying to drop pulled upstream commits to recover "
+                        f"from a 'restricted_path_modified' push 403, that is no longer "
+                        f"necessary (#2489) — pulled commits authored by other roles are "
+                        f"exempt from your role allowlist; retry the push as-is.",
                         status_code=403,
                     )
 
@@ -2599,7 +2592,12 @@ def git_execute() -> tuple[Response, int] | Response:
         return make_error(
             "Branch switching is not allowed in pipeline worktree sessions. "
             "You are locked to your assigned branch. "
-            "Use 'git restore' for file operations instead of 'git checkout'.",
+            "Use 'git restore' for file operations instead of 'git checkout'. "
+            "If you are recovering from a 'restricted_path_modified' push 403, "
+            "note that pulled commits authored by other roles are exempt from "
+            "your role allowlist (#2489) — retry the push as-is; if it still "
+            "rejects, drop the disallowed paths from your own commits and "
+            "re-propose with --pre-merge-condition (#1998 conditional ACK).",
             status_code=403,
         )
 

--- a/gateway/tests/test_agent_restrictions_enforce.py
+++ b/gateway/tests/test_agent_restrictions_enforce.py
@@ -27,7 +27,6 @@ import git_client
 import pytest
 import session_manager
 from git_client import AttributedFile, AttributedPushRange
-from phase_filter import FileRestrictionResult
 from policy import PolicyResult
 from private_repo_policy import PrivateRepoPolicyResult
 from session_manager import SessionValidationResult
@@ -150,9 +149,9 @@ def _push_context(mock_session, agent_blocked=True):
         ),
         patch.object(gateway, "get_token_for_repo", return_value=("test-token", "bot", "")),
         patch.object(gateway, "get_changed_files_in_push", return_value=(changed_files, None)),
-        patch.object(
-            gateway, "check_file_restrictions", return_value=FileRestrictionResult.allow()
-        ),
+        # Legacy ``gateway.check_file_restrictions`` patch removed in
+        # #2489 — the gateway no longer calls that function from
+        # ``git_push`` (see ``test_filtered_push_blocked_modify``).
         patch.object(
             git_client,
             "get_attributed_changed_files_in_push",
@@ -210,7 +209,6 @@ class TestAgentRestrictionsWarnOnly:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "false"}):
                 response = _do_push(client)
@@ -229,7 +227,6 @@ class TestAgentRestrictionsWarnOnly:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "0"}):
                 response = _do_push(client)
@@ -248,7 +245,6 @@ class TestAgentRestrictionsWarnOnly:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "no"}):
                 response = _do_push(client)
@@ -267,7 +263,6 @@ class TestAgentRestrictionsWarnOnly:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             # Remove the env var entirely — default should enforce
             with patch.dict(os.environ, {}, clear=False):
@@ -292,7 +287,6 @@ class TestAgentRestrictionsEnforceMode:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -311,7 +305,6 @@ class TestAgentRestrictionsEnforceMode:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -330,7 +323,6 @@ class TestAgentRestrictionsEnforceMode:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "yes"}):
                 response = _do_push(client)
@@ -349,7 +341,6 @@ class TestAgentRestrictionsEnforceMode:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "1"}):
                 response = _do_push(client)
@@ -379,7 +370,6 @@ class TestAgentRestrictionsUnknownRole:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -403,7 +393,6 @@ class TestAgentRestrictionsNoRole:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -475,9 +464,9 @@ def _push_context_real_check(mock_session, changed_files):
         ),
         patch.object(gateway, "get_token_for_repo", return_value=("test-token", "bot", "")),
         patch.object(gateway, "get_changed_files_in_push", return_value=(changed_files, None)),
-        patch.object(
-            gateway, "check_file_restrictions", return_value=FileRestrictionResult.allow()
-        ),
+        # Legacy ``gateway.check_file_restrictions`` patch removed in
+        # #2489 — the gateway no longer calls that function from
+        # ``git_push`` (see ``test_filtered_push_blocked_modify``).
         patch.object(
             git_client,
             "get_attributed_changed_files_in_push",
@@ -529,7 +518,6 @@ class TestCoderEndToEndPushRejection1901:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -547,7 +535,6 @@ class TestCoderEndToEndPushRejection1901:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -565,7 +552,6 @@ class TestCoderEndToEndPushRejection1901:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -583,7 +569,6 @@ class TestCoderEndToEndPushRejection1901:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -607,7 +592,6 @@ class TestTesterEndToEndPushRejection1901:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -625,7 +609,6 @@ class TestTesterEndToEndPushRejection1901:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -645,7 +628,6 @@ class TestTesterEndToEndPushRejection1901:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -667,7 +649,6 @@ class TestDocumenterEndToEndPushRejection1901:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -685,7 +666,6 @@ class TestDocumenterEndToEndPushRejection1901:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -703,7 +683,6 @@ class TestDocumenterEndToEndPushRejection1901:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)

--- a/gateway/tests/test_filtered_push_blocked_modify.py
+++ b/gateway/tests/test_filtered_push_blocked_modify.py
@@ -22,7 +22,6 @@ import git_client
 import pytest
 import session_manager
 from git_client import AttributedFile, AttributedPushRange
-from phase_filter import FileRestrictionResult
 from policy import PolicyResult
 from private_repo_policy import PrivateRepoPolicyResult
 from session_manager import SessionValidationResult
@@ -62,7 +61,17 @@ def _attributed(files_per_sha: list[tuple[str, list[str], str]]) -> AttributedPu
 
 def _push_patches(session, attributed: AttributedPushRange, changed_files: list[str]):
     """Patch the surrounding gateway machinery so the push reaches the
-    auto-filter branch with the supplied attribution."""
+    auto-filter branch with the supplied attribution.
+
+    Note: after #2489 the gateway no longer calls
+    ``check_file_restrictions`` from ``git_push`` — the attribution-
+    aware path is the sole agent-role enforcer.  We therefore do NOT
+    patch ``gateway.check_file_restrictions`` here; if a regression
+    re-introduced the legacy whole-push-diff call, the
+    ``TestPulledCommitsDoNotTrigger403`` regression test would catch
+    it (architect-authored ``docs/`` and ``gateway/`` paths in the
+    diff range would block the risk_analyst push).
+    """
     import auth
 
     auth._session_manager = None
@@ -117,9 +126,6 @@ def _push_patches(session, attributed: AttributedPushRange, changed_files: list[
         ),
         patch.object(gateway, "get_token_for_repo", return_value=("test-token", "bot", "")),
         patch.object(gateway, "get_changed_files_in_push", return_value=(changed_files, None)),
-        patch.object(
-            gateway, "check_file_restrictions", return_value=FileRestrictionResult.allow()
-        ),
         patch.object(
             git_client,
             "get_attributed_changed_files_in_push",

--- a/gateway/tests/test_filtered_push_blocked_modify.py
+++ b/gateway/tests/test_filtered_push_blocked_modify.py
@@ -315,3 +315,67 @@ class TestNoRoleSkipsCheck:
             stack.enter_context(patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}))
             response = _do_push(client)
         assert response.status_code == 200, response.data
+
+
+class TestPulledCommitsDoNotTrigger403:
+    """Regression for #2489: when the diff range contains commits authored
+    by *other* roles (e.g. an agent's per-role branch picked up upstream
+    work from the shared work branch), those commits' file paths must NOT
+    count against the pushing role's allowlist.  Only the role's own
+    commits' paths can trigger the rejection.
+
+    Before #2489 a duplicate naive ``check_file_restrictions`` call ran
+    before the attribution-aware path and rejected any restricted path
+    in the whole-push diff, which trapped role-restricted producers
+    (e.g. risk_analyst) whose branches inherited unrelated upstream
+    commits — the role had no sanctioned recovery path.
+    """
+
+    def test_pulled_blocked_paths_do_not_block_push(self, client):
+        """risk_analyst pushes its own clean commit; the diff range also
+        contains an upstream commit (authored by ``architect``) that
+        touches ``docs/`` and ``gateway/``.  The push must succeed —
+        pulled commits are exempt from the pushing role's allowlist."""
+        session = _make_session("risk_analyst")
+        attributed = _attributed(
+            [
+                # Inherited upstream commit authored by another role —
+                # touches paths that risk_analyst cannot write.
+                (
+                    _FAKE_SHA,
+                    [
+                        "docs/architecture/orchestrator.md",
+                        "gateway/checkpoint_handler.py",
+                    ],
+                    "architect",
+                ),
+                # The risk_analyst's own commit — only touches its
+                # allowlist (``.egg-state/agent-outputs/``).
+                (
+                    _FAKE_SHA_2,
+                    [".egg-state/agent-outputs/2474-risk_analyst-output.json"],
+                    "risk_analyst",
+                ),
+            ]
+        )
+        patches = _push_patches(
+            session,
+            attributed,
+            [
+                "docs/architecture/orchestrator.md",
+                "gateway/checkpoint_handler.py",
+                ".egg-state/agent-outputs/2474-risk_analyst-output.json",
+            ],
+        )
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            stack.enter_context(patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}))
+            response = _do_push(client)
+        assert response.status_code == 200, response.data
+        body = json.loads(response.data)
+        assert body["success"] is True, body
+        # Pulled cross-role commits are surfaced for observability.
+        data = body.get("data") or {}
+        pulled = data.get("pulled_commits") or []
+        assert any(p.get("author_role") == "architect" for p in pulled), body

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -600,6 +600,14 @@ class TestGitPush:
 
         current_session_manager = sys.modules.get("session_manager", session_manager)
 
+        # After #2489 the gateway no longer calls
+        # ``gateway.check_file_restrictions`` from ``git_push`` — the
+        # attribution-aware path is the sole agent-role enforcer.  Drive
+        # the new behavior by letting the attribution lookup fall back
+        # (no commits in range → fail-closed → every file treated as
+        # own-authored, real ``partition_files_by_role`` consulted
+        # against AGENT_PATTERNS), which still produces the canonical
+        # ``restricted_path_modified`` 403 for coder + contracts.
         with (
             patch.object(
                 current_session_manager, "validate_session_for_request", return_value=mock_result
@@ -608,7 +616,6 @@ class TestGitPush:
             patch("subprocess.run") as mock_run,
             patch.object(gateway, "get_policy_engine") as mock_policy,
             patch.object(gateway, "get_changed_files_in_push") as mock_get_changed_files,
-            patch.object(gateway, "check_file_restrictions") as mock_check_restrictions,
         ):
             # Mock git remote get-url
             mock_run.return_value = MagicMock(
@@ -632,16 +639,6 @@ class TestGitPush:
                 None,
             )
 
-            # Mock check_file_restrictions - contract file is blocked
-            from phase_filter import FileRestrictionResult
-
-            mock_check_restrictions.return_value = FileRestrictionResult.block(
-                message="Role 'implementer' cannot modify: .egg-state/contracts/123.json",
-                role="coder",
-                blocked_files=[".egg-state/contracts/123.json"],
-                blocked_reason="Contract files can only be modified through the contract API",
-            )
-
             response = client.post(
                 "/api/v1/git/push",
                 headers={"Authorization": "Bearer test-session-token"},
@@ -658,11 +655,9 @@ class TestGitPush:
             assert response.status_code == 403
             data = json.loads(response.data)
             assert "cannot modify" in data["message"].lower()
-            # The legacy ``blocked_files`` shape from the duplicate naive
-            # check that ran before the attribution-aware path was removed
-            # in #2489.  The canonical attribution-aware rejection (#2039)
-            # surfaces the same data under ``blocked_paths`` along with the
-            # ``error: restricted_path_modified`` discriminator.
+            # Canonical attribution-aware rejection shape (#2039) — the
+            # legacy ``blocked_files`` shape from the duplicate naive
+            # check was removed in #2489.
             assert data["data"]["error"] == "restricted_path_modified"
             assert ".egg-state/contracts/123.json" in data["data"]["blocked_paths"]
             assert data["data"]["role"] == "coder"
@@ -701,6 +696,11 @@ class TestGitPush:
 
         current_session_manager = sys.modules.get("session_manager", session_manager)
 
+        # After #2489 the gateway no longer calls
+        # ``gateway.check_file_restrictions`` from ``git_push``.  The
+        # attribution-aware path is the sole agent-role enforcer, and
+        # ``reviewer_contract``'s allowlist permits ``.egg-state/contracts/``,
+        # so the push proceeds without any explicit role-check mock.
         with (
             patch.object(
                 current_session_manager, "validate_session_for_request", return_value=mock_result
@@ -710,7 +710,6 @@ class TestGitPush:
             patch.object(gateway, "get_policy_engine") as mock_policy,
             patch.object(gateway, "get_token_for_repo") as mock_get_token,
             patch.object(gateway, "get_changed_files_in_push") as mock_get_changed_files,
-            patch.object(gateway, "check_file_restrictions") as mock_check_restrictions,
         ):
 
             def run_side_effect(*args, **kwargs):
@@ -745,13 +744,6 @@ class TestGitPush:
 
             # Mock get_changed_files_in_push
             mock_get_changed_files.return_value = ([".egg-state/contracts/123.json"], None)
-
-            # Mock check_file_restrictions - reviewer is allowed (no restrictions for reviewer)
-            from phase_filter import FileRestrictionResult
-
-            mock_check_restrictions.return_value = FileRestrictionResult.allow(
-                "No file restrictions for role: reviewer"
-            )
 
             response = client.post(
                 "/api/v1/git/push",
@@ -810,9 +802,13 @@ class TestGitPush:
             patch("subprocess.run") as mock_run,
             patch.object(gateway, "get_policy_engine") as mock_policy,
             patch.object(gateway, "get_changed_files_in_push") as mock_get_changed_files,
-            patch.object(gateway, "check_file_restrictions") as mock_check_restrictions,
             patch.object(gateway, "get_token_for_repo") as mock_get_token,
         ):
+            # The legacy ``gateway.check_file_restrictions`` patch lived
+            # here before #2489.  The gateway no longer calls that
+            # function from ``git_push`` (the attribution-aware path is
+            # the sole agent-role enforcer); coder may write to
+            # ``src/`` and root config files, so the push proceeds.
 
             def run_side_effect(*args, **kwargs):
                 cmd = args[0] if args else kwargs.get("args", [])
@@ -844,11 +840,6 @@ class TestGitPush:
             # Mock get_changed_files_in_push - NO contract files being modified
             # Use coder-allowed files (README.md is blocked for coders)
             mock_get_changed_files.return_value = (["src/main.py", "config.yml"], None)
-
-            # Mock check_file_restrictions - all files allowed
-            from phase_filter import FileRestrictionResult
-
-            mock_check_restrictions.return_value = FileRestrictionResult.allow("All files allowed")
 
             # Mock get_token_for_repo to return valid token
             mock_get_token.return_value = ("test-token", "bot", "")
@@ -988,9 +979,14 @@ class TestGitPush:
             patch("subprocess.run") as mock_run,
             patch.object(gateway, "get_policy_engine") as mock_policy,
             patch.object(gateway, "get_changed_files_in_push") as mock_get_changed_files,
-            patch.object(gateway, "check_file_restrictions") as mock_check_restrictions,
         ):
-            # Mock git remote get-url
+            # The legacy ``gateway.check_file_restrictions`` patch lived
+            # here before #2489.  The gateway no longer calls that
+            # function from ``git_push`` (the attribution-aware path is
+            # the sole agent-role enforcer); ``coder`` cannot write
+            # ``.egg-state/contracts/`` so the push is rejected with
+            # the canonical ``restricted_path_modified`` shape — even
+            # with ``force=true``.
             mock_run.return_value = MagicMock(
                 returncode=0,
                 stdout="https://github.com/owner/repo.git\n",
@@ -1008,16 +1004,6 @@ class TestGitPush:
 
             # Mock get_changed_files_in_push - contract file is being modified
             mock_get_changed_files.return_value = ([".egg-state/contracts/123.json"], None)
-
-            # Mock check_file_restrictions - contract file is blocked
-            from phase_filter import FileRestrictionResult
-
-            mock_check_restrictions.return_value = FileRestrictionResult.block(
-                message="Role 'implementer' cannot modify: .egg-state/contracts/123.json",
-                role="coder",
-                blocked_files=[".egg-state/contracts/123.json"],
-                blocked_reason="Contract files can only be modified through the contract API",
-            )
 
             # Request with force=true
             response = client.post(
@@ -1086,7 +1072,6 @@ class TestGitPush:
             patch.object(gateway, "get_policy_engine") as mock_policy,
             patch.object(gateway, "get_token_for_repo") as mock_get_token,
             patch.object(gateway, "get_changed_files_in_push") as mock_get_changed_files,
-            patch.object(gateway, "check_file_restrictions") as mock_check_restrictions,
         ):
 
             def run_side_effect(*args, **kwargs):
@@ -1141,10 +1126,11 @@ class TestGitPush:
             data = json.loads(response.data)
             assert data["success"] is True
 
-            # Verify file restriction check was NOT invoked
-            mock_check_restrictions.assert_not_called()
-
-            # Verify get_changed_files_in_push was NOT invoked (check skipped entirely)
+            # The agent-role check (now the attribution-aware path,
+            # post-#2489) is gated on ``session_role`` being set.  When
+            # ``agent_role=None`` the gate is skipped and the gateway
+            # never even computes the changed-file list — assert the
+            # observable side: ``get_changed_files_in_push`` is silent.
             mock_get_changed_files.assert_not_called()
 
     def test_push_phase_hint_with_non_state_files(self, client):

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -658,7 +658,13 @@ class TestGitPush:
             assert response.status_code == 403
             data = json.loads(response.data)
             assert "cannot modify" in data["message"].lower()
-            assert ".egg-state/contracts/123.json" in data["data"]["blocked_files"]
+            # The legacy ``blocked_files`` shape from the duplicate naive
+            # check that ran before the attribution-aware path was removed
+            # in #2489.  The canonical attribution-aware rejection (#2039)
+            # surfaces the same data under ``blocked_paths`` along with the
+            # ``error: restricted_path_modified`` discriminator.
+            assert data["data"]["error"] == "restricted_path_modified"
+            assert ".egg-state/contracts/123.json" in data["data"]["blocked_paths"]
             assert data["data"]["role"] == "coder"
 
     def test_push_allowed_for_reviewer_modifying_contract_files(self, client):

--- a/gateway/tests/test_pipeline_push_block.py
+++ b/gateway/tests/test_pipeline_push_block.py
@@ -123,11 +123,12 @@ def _push_context(mock_session):
         ),
         patch.object(gateway, "get_token_for_repo", return_value=("test-token", "bot", "")),
         patch.object(gateway, "get_changed_files_in_push", return_value=([], None)),
-        patch.object(
-            gateway,
-            "check_file_restrictions",
-            return_value=MagicMock(allowed=True, blocked=False),
-        ),
+        # Slot 6 of the returned tuple is reserved for the agent-role
+        # restriction patch.  After #2489 the gateway no longer calls
+        # the legacy whole-push-diff ``check_file_restrictions`` from
+        # ``git_push`` (the attribution-aware ``check_agent_restrictions``
+        # path is the sole agent-role enforcer), so we no longer patch
+        # the dead symbol here.
         patch.object(
             gateway,
             "check_agent_restrictions",
@@ -169,7 +170,6 @@ class TestPipelinePushBlock:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _do_push(client)
             assert response.status_code == 403
@@ -191,7 +191,6 @@ class TestPipelinePushBlock:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _do_push(client, consensus_push=True)
             assert response.status_code == 200, (
@@ -216,7 +215,6 @@ class TestPipelinePushBlock:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, env):
                 response = _do_push(client)
@@ -237,7 +235,6 @@ class TestPipelinePushBlock:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _do_push(client)
             assert response.status_code == 200, (
@@ -261,7 +258,6 @@ class TestPipelinePushBlock:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, env):
                 response = _do_push(client)
@@ -286,7 +282,6 @@ class TestPipelinePushBlock:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, env):
                 response = _do_push(client)
@@ -309,7 +304,6 @@ class TestPipelinePushBlock:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             # Push to infrastructure branch — should not be blocked by
             # pipeline-push enforcement (infrastructure is exempt).
@@ -339,7 +333,6 @@ class TestPipelinePushBlockEdgeCases:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _do_push(client, consensus_push=False)
             assert response.status_code == 403
@@ -359,7 +352,6 @@ class TestPipelinePushBlockEdgeCases:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _do_push(client)
             assert response.status_code == 403
@@ -383,7 +375,6 @@ class TestPipelinePushBlockEdgeCases:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _do_push(client)
             assert response.status_code == 403
@@ -410,7 +401,6 @@ class TestPipelinePushBlockEdgeCases:
                 patches[4],
                 patches[5],
                 patches[6],
-                patches[7],
             ):
                 with patch.dict(os.environ, env):
                     response = _do_push(client)
@@ -432,7 +422,6 @@ class TestPipelinePushBlockEdgeCases:
                 patches[4],
                 patches[5],
                 patches[6],
-                patches[7],
             ):
                 response = _do_push(client)
                 assert response.status_code == 403, (
@@ -452,7 +441,6 @@ class TestPipelinePushBlockEdgeCases:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.object(gateway, "audit_log") as mock_audit:
                 response = _do_push(client)
@@ -605,7 +593,6 @@ class TestOrchestratorLauncherAuthPush:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _do_push(client)
             assert response.status_code == 403, (
@@ -717,7 +704,6 @@ class TestSliceIntegrationBranchExemption:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _do_push(
                 client,
@@ -740,7 +726,6 @@ class TestSliceIntegrationBranchExemption:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _do_push(
                 client,
@@ -760,7 +745,6 @@ class TestSliceIntegrationBranchExemption:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _do_push(
                 client,
@@ -781,7 +765,6 @@ class TestSliceIntegrationBranchExemption:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _do_push(
                 client,
@@ -808,7 +791,6 @@ class TestSliceIntegrationBranchExemption:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _do_push(
                 client,
@@ -838,7 +820,6 @@ class TestSliceIntegrationBranchExemption:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _do_push(client, refspec="egg/issue-2261")
             assert response.status_code == 403
@@ -861,7 +842,6 @@ class TestSliceIntegrationBranchExemption:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _do_push(
                 client,
@@ -882,7 +862,6 @@ class TestSliceIntegrationBranchExemption:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.object(gateway, "audit_log") as mock_audit:
                 response = _do_push(
@@ -921,10 +900,14 @@ class TestSliceIntegrationBranchExemption:
         the same way the anchor/phase/agent-restriction checks already
         do, otherwise a logical no-op push gets falsely blocked.
 
-        Mock ``check_file_restrictions`` to return ``allowed=False`` so
-        the test fails loudly if the gate ever regresses, and assert
-        that ``get_changed_files_in_push`` is never even called for an
-        infrastructure push.
+        After #2489 the role check lives in the attribution-aware block
+        and is gated on ``not is_infrastructure_push`` —
+        ``get_changed_files_in_push`` is the single observable that
+        proves the gate fired.  Asserting it was never called pins the
+        infrastructure-bypass behavior end-to-end (the assertion would
+        also have caught the legacy duplicate ``check_file_restrictions``
+        if it had remained, since that path also consumed
+        ``changed_files``).
         """
         session = _make_session(synthetic=True, assigned_branch="egg/issue-2261-v3/slice-2")
         patches = _push_context(session)
@@ -939,26 +922,14 @@ class TestSliceIntegrationBranchExemption:
             patches[2],
             patches[3],
             patches[4],
-            # Override patches[5] (get_changed_files_in_push) and patches[6]
-            # (check_file_restrictions) so the role check would 403 if it ran.
+            # Override patches[5] (get_changed_files_in_push) so the
+            # attribution-aware role check would 403 if it ran.
             patch.object(
                 gateway,
                 "get_changed_files_in_push",
                 MagicMock(return_value=(forbidden_files, None)),
             ) as mock_changed_files,
-            patch.object(
-                gateway,
-                "check_file_restrictions",
-                MagicMock(
-                    return_value=MagicMock(
-                        allowed=False,
-                        blocked_files=forbidden_files,
-                        blocked_reason="Role 'coder' cannot modify .egg-state/brc-history/...",
-                        message="Path allowlist violation",
-                    )
-                ),
-            ) as mock_check_restrictions,
-            patches[7],
+            patches[6],
         ):
             response = _do_push(
                 client,
@@ -969,7 +940,6 @@ class TestSliceIntegrationBranchExemption:
                 f"path allowlist (#2372). Got {response.status_code}: {response.data!r}"
             )
             mock_changed_files.assert_not_called()
-            mock_check_restrictions.assert_not_called()
 
     def test_role_path_allowlist_still_enforced_for_non_infrastructure_pushes(self, client):
         """Regression guard: the gate added in #2372 must NOT weaken the role
@@ -1004,7 +974,6 @@ class TestSliceIntegrationBranchExemption:
                 MagicMock(return_value=(forbidden_files, None)),
             ),
             patches[6],
-            patches[7],
         ):
             response = _do_push(client, refspec="egg/some-branch")
             assert response.status_code == 403, (

--- a/gateway/tests/test_pipeline_push_block.py
+++ b/gateway/tests/test_pipeline_push_block.py
@@ -976,9 +976,13 @@ class TestSliceIntegrationBranchExemption:
         check for ordinary (non-infrastructure) pushes.
 
         Use a non-pipeline session so the pipeline-session and push-target
-        enforcers don't fire first; the role check should still 403 with
-        ``push_denied_protected_files`` when ``check_file_restrictions``
-        rejects the diff.
+        enforcers don't fire first; the role check should still 403 with the
+        canonical attribution-aware ``restricted_path_modified`` rejection
+        (#2039) — replaces the legacy ``push_denied_protected_files`` event,
+        which fired from a duplicate naive check the gateway no longer runs
+        (#2489).  When attribution lookup returns no commits the handler
+        fails closed and treats every file in the diff as own-authored, so
+        the 403 still fires for restricted paths.
         """
         session = _make_session(
             role="coder",
@@ -999,18 +1003,7 @@ class TestSliceIntegrationBranchExemption:
                 "get_changed_files_in_push",
                 MagicMock(return_value=(forbidden_files, None)),
             ),
-            patch.object(
-                gateway,
-                "check_file_restrictions",
-                MagicMock(
-                    return_value=MagicMock(
-                        allowed=False,
-                        blocked_files=forbidden_files,
-                        blocked_reason="Role 'coder' cannot modify .egg-state/contracts/...",
-                        message="Path allowlist violation",
-                    )
-                ),
-            ),
+            patches[6],
             patches[7],
         ):
             response = _do_push(client, refspec="egg/some-branch")
@@ -1018,5 +1011,8 @@ class TestSliceIntegrationBranchExemption:
                 f"Non-infrastructure pushes must still hit the role path-allowlist "
                 f"check. Got {response.status_code}: {response.data!r}"
             )
-            data = json.loads(response.data)
-            assert "Path allowlist violation" in data["message"]
+            body = json.loads(response.data)
+            data = body.get("data") or {}
+            assert data.get("error") == "restricted_path_modified", body
+            assert data.get("role") == "coder", body
+            assert ".egg-state/contracts/some.json" in (data.get("blocked_paths") or []), body

--- a/gateway/tests/test_push_author_attribution.py
+++ b/gateway/tests/test_push_author_attribution.py
@@ -37,7 +37,6 @@ import git_client
 import pytest
 import session_manager
 from git_client import AttributedFile, AttributedPushRange
-from phase_filter import FileRestrictionResult
 from policy import PolicyResult
 from private_repo_policy import PrivateRepoPolicyResult
 from session_manager import SessionValidationResult
@@ -122,9 +121,9 @@ def _patches_for(
         ),
         patch.object(gateway, "get_token_for_repo", return_value=("test-token", "bot", "")),
         patch.object(gateway, "get_changed_files_in_push", return_value=(file_paths, None)),
-        patch.object(
-            gateway, "check_file_restrictions", return_value=FileRestrictionResult.allow()
-        ),
+        # Legacy ``gateway.check_file_restrictions`` patch removed in
+        # #2489 — the gateway no longer calls that function from
+        # ``git_push`` (see ``test_filtered_push_blocked_modify``).
         patch.object(
             git_client,
             "get_attributed_changed_files_in_push",

--- a/gateway/tests/test_push_by_sha.py
+++ b/gateway/tests/test_push_by_sha.py
@@ -112,11 +112,9 @@ def _push_context(mock_session: MagicMock, captured_cmd: list[list[str]]):
         ),
         patch.object(gateway, "get_token_for_repo", return_value=("test-token", "bot", "")),
         patch.object(gateway, "get_changed_files_in_push", return_value=([], None)),
-        patch.object(
-            gateway,
-            "check_file_restrictions",
-            return_value=MagicMock(allowed=True, blocked=False),
-        ),
+        # Legacy ``gateway.check_file_restrictions`` patch removed in
+        # #2489 — the gateway no longer calls that function from
+        # ``git_push`` (see ``test_filtered_push_blocked_modify``).
         patch.object(
             gateway,
             "check_agent_restrictions",
@@ -148,7 +146,6 @@ class TestCommitShaPush:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _post(
                 client,
@@ -175,7 +172,6 @@ class TestCommitShaPush:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _post(
                 client,
@@ -203,7 +199,6 @@ class TestCommitShaPush:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _post(
                 client,
@@ -232,7 +227,6 @@ class TestCommitShaPush:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _post(
                 client,
@@ -265,7 +259,6 @@ class TestCommitShaPush:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _post(
                 client,
@@ -302,7 +295,6 @@ class TestCommitShaPush:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _post(
                 client,
@@ -341,7 +333,6 @@ class TestCommitShaPush:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _post(
                 client,
@@ -374,7 +365,6 @@ class TestCommitShaPush:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _post(
                 client,
@@ -410,7 +400,6 @@ class TestCommitShaPush:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _post(
                 client,

--- a/gateway/tests/test_push_error_enrichment.py
+++ b/gateway/tests/test_push_error_enrichment.py
@@ -124,9 +124,10 @@ def _push_context(mock_session, file_paths: list[str]):
         ),
         patch.object(gateway, "get_token_for_repo", return_value=("test-token", "bot", "")),
         patch.object(gateway, "get_changed_files_in_push", return_value=(file_paths, None)),
-        patch.object(
-            gateway, "check_file_restrictions", return_value=FileRestrictionResult.allow()
-        ),
+        # Legacy ``gateway.check_file_restrictions`` patch removed in
+        # #2489 — the gateway no longer calls that function from
+        # ``git_push`` (the attribution-aware path is the sole agent-
+        # role enforcer).  See ``test_filtered_push_blocked_modify``.
         patch.object(
             git_client,
             "get_attributed_changed_files_in_push",
@@ -177,7 +178,6 @@ class TestRestrictedPathRejection:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -197,7 +197,6 @@ class TestRestrictedPathRejection:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -215,7 +214,6 @@ class TestRestrictedPathRejection:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -244,7 +242,6 @@ class TestAllAllowedResponse:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -264,7 +261,6 @@ class TestAllAllowedResponse:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -282,7 +278,6 @@ class TestAllAllowedResponse:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)
@@ -309,7 +304,6 @@ class TestWarnOnlyPassthrough:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "false"}):
                 response = _do_push(client)
@@ -390,9 +384,9 @@ class TestPulledCommitsField:
                 "get_changed_files_in_push",
                 return_value=(["src/main.py", "tests/test_main.py"], None),
             ),
-            patch.object(
-                gateway, "check_file_restrictions", return_value=FileRestrictionResult.allow()
-            ),
+            # Legacy ``gateway.check_file_restrictions`` patch removed in
+            # #2489 — the gateway no longer calls that function from
+            # ``git_push`` (see ``test_filtered_push_blocked_modify``).
             patch.object(
                 git_client,
                 "get_attributed_changed_files_in_push",
@@ -429,7 +423,6 @@ class TestNoAgentRole:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             with patch.dict(os.environ, {"EGG_AGENT_RESTRICTIONS_ENFORCE": "true"}):
                 response = _do_push(client)

--- a/gateway/tests/test_push_error_enrichment.py
+++ b/gateway/tests/test_push_error_enrichment.py
@@ -446,17 +446,26 @@ class TestFileRestrictionsThreeRoleEnrichment1901:
     (coder/tester/documenter) in .egg/phase-permissions.json must produce
     the correct enriched error response when violated.
 
-    These tests drive the real ``check_file_restrictions`` path (NOT the
-    agent_restrictions path) because the file_restrictions array is
-    enforced by gateway.gateway → phase_filter.check_file_restrictions
-    BEFORE agent_restrictions runs.
+    Originally these tests drove the legacy ``check_file_restrictions``
+    path that ran before the attribution-aware enforcement.  That naive
+    whole-push-diff check was removed in #2489 because it falsely
+    rejected role-restricted producers whose branches inherited
+    upstream commits authored by other roles.  The attribution-aware
+    path (#2039) is now the canonical agent-role enforcer; when
+    attribution lookup returns no commits the handler fails closed and
+    treats every file in the diff as own-authored, so these three
+    role/path combinations still produce a 403 — under the
+    ``restricted_path_modified`` shape rather than the old
+    ``Path allowlist violation`` shape.
     """
 
     def _push_context_real_file_restrictions(self, mock_session, blocked_files):
         """Push context that does NOT mock check_file_restrictions — the
-        real phase-permissions.json file_restrictions array drives the
-        decision.  check_agent_restrictions is mocked to allow so we can
-        exercise the file_restrictions branch in isolation.
+        attribution-aware path's fail-closed branch (empty commit list →
+        every file treated as own-authored, partition_files_by_role
+        consulted directly against AGENT_PATTERNS) drives the decision.
+        check_agent_restrictions is mocked to allow so we can exercise
+        the agent-role branch in isolation.
         """
         import auth
 
@@ -538,13 +547,14 @@ class TestFileRestrictionsThreeRoleEnrichment1901:
                 response = _do_push(client)
                 assert response.status_code == 403
                 data = json.loads(response.data)
-                # Top-level message uses gateway phase_filter's
-                # "Role '<role>' cannot modify: <files>" format.
+                # Top-level message uses the canonical
+                # restricted_path_modified format (#2039).
                 assert "coder" in data["message"]
                 assert ".egg-state/contracts/foo.json" in data["message"]
                 resp_data = data.get("data", {})
+                assert resp_data.get("error") == "restricted_path_modified"
                 assert resp_data["role"] == "coder"
-                assert ".egg-state/contracts/foo.json" in resp_data["blocked_files"]
+                assert ".egg-state/contracts/foo.json" in resp_data.get("blocked_paths", [])
 
     def test_tester_role_blocked_from_contracts(self, client):
         """The tester file_restrictions entry blocks .egg-state/contracts/."""
@@ -568,8 +578,9 @@ class TestFileRestrictionsThreeRoleEnrichment1901:
                 assert "tester" in data["message"]
                 assert ".egg-state/contracts/spec.json" in data["message"]
                 resp_data = data.get("data", {})
+                assert resp_data.get("error") == "restricted_path_modified"
                 assert resp_data["role"] == "tester"
-                assert ".egg-state/contracts/spec.json" in resp_data["blocked_files"]
+                assert ".egg-state/contracts/spec.json" in resp_data.get("blocked_paths", [])
 
     def test_documenter_role_blocked_from_contracts(self, client):
         """The documenter file_restrictions entry blocks .egg-state/contracts/."""
@@ -593,5 +604,6 @@ class TestFileRestrictionsThreeRoleEnrichment1901:
                 assert "documenter" in data["message"]
                 assert ".egg-state/contracts/x.json" in data["message"]
                 resp_data = data.get("data", {})
+                assert resp_data.get("error") == "restricted_path_modified"
                 assert resp_data["role"] == "documenter"
-                assert ".egg-state/contracts/x.json" in resp_data["blocked_files"]
+                assert ".egg-state/contracts/x.json" in resp_data.get("blocked_paths", [])

--- a/gateway/tests/test_push_nack_fix_regressions.py
+++ b/gateway/tests/test_push_nack_fix_regressions.py
@@ -45,7 +45,6 @@ import git_client
 import pytest
 import session_manager
 from git_client import AttributedFile, AttributedPushRange
-from phase_filter import FileRestrictionResult
 from policy import PolicyResult
 from private_repo_policy import PrivateRepoPolicyResult
 from session_manager import SessionValidationResult
@@ -128,9 +127,9 @@ def _patches_for(mock_session, file_paths, attributed_range):
         ),
         patch.object(gateway, "get_token_for_repo", return_value=("test-token", "bot", "")),
         patch.object(gateway, "get_changed_files_in_push", return_value=(file_paths, None)),
-        patch.object(
-            gateway, "check_file_restrictions", return_value=FileRestrictionResult.allow()
-        ),
+        # Legacy ``gateway.check_file_restrictions`` patch removed in
+        # #2489 — the gateway no longer calls that function from
+        # ``git_push`` (see ``test_filtered_push_blocked_modify``).
         patch.object(
             git_client,
             "get_attributed_changed_files_in_push",

--- a/gateway/tests/test_reconciler_push_wiring.py
+++ b/gateway/tests/test_reconciler_push_wiring.py
@@ -128,11 +128,11 @@ def _push_context(mock_session, captured_cmds: list[list[str]]):
         ),
         patch.object(gateway, "get_token_for_repo", return_value=("test-token", "bot", "")),
         patch.object(gateway, "get_changed_files_in_push", return_value=([], None)),
-        patch.object(
-            gateway,
-            "check_file_restrictions",
-            return_value=MagicMock(allowed=True, blocked=False),
-        ),
+        # The legacy whole-push-diff ``check_file_restrictions`` patch
+        # used to live here.  After #2489 the gateway no longer calls
+        # that function from ``git_push`` (the attribution-aware
+        # ``check_agent_restrictions`` path is the sole agent-role
+        # enforcer), so the patch is dead and has been dropped.
         patch.object(
             gateway,
             "check_agent_restrictions",
@@ -173,7 +173,6 @@ class TestForceWithLeaseWiring:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _post_push(
                 client,
@@ -214,7 +213,6 @@ class TestForceWithLeaseWiring:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _post_push(
                 client,
@@ -250,7 +248,6 @@ class TestForceWithLeaseWiring:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _post_push(
                 client,
@@ -292,7 +289,6 @@ class TestReconcilerConsensusPushPlumbing:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _post_push(
                 client,
@@ -323,7 +319,6 @@ class TestReconcilerConsensusPushPlumbing:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
         ):
             response = _post_push(
                 client,


### PR DESCRIPTION
## Summary

- Drops the duplicate naive ``check_file_restrictions`` call in ``gateway/gateway.py``.  It examined the whole-push diff without commit attribution and rejected the push for any restricted-path file in the range — including paths modified only by **pulled** upstream commits authored by other roles.  That trapped role-restricted producers (e.g. risk_analyst on a per-role branch that picked up architect's pushes to the shared work branch); every standard git recovery primitive is correctly blocked by the gateway, so the agent had no sanctioned exit.
- The attribution-aware enforcement (#2039 / #1882 commit-authorship registry) becomes the sole agent-role gate.  It already partitions the push range into own-authored vs pulled files and only checks the pushing role's allowlist against the own-authored set — pulled commits pass through verbatim.  Fail-closed semantics are preserved: when attribution is unavailable the handler treats every file as own-authored, so unknown-role / registry-outage cases stay at least as strict as before.
- Extends the blocked-command 403 reasons (branch switch, off-lineage reset, update-ref, worktree branch switch) with a hint pointing at the attribution-aware behavior and #1998 conditional ACK, so an agent searching for a manual recovery sees the supported pattern instead of bouncing between gateway-blocked git ops.

## Test plan

- [x] ``make lint`` clean (only pre-existing soft-cap file-size warnings).
- [x] Targeted pytest sweep across the affected gateway test files all green:
  - ``gateway/tests/test_filtered_push_blocked_modify.py``
  - ``gateway/tests/test_pipeline_push_block.py``
  - ``gateway/tests/test_gateway.py``
  - ``gateway/tests/test_push_error_enrichment.py``
  - ``gateway/tests/test_push_nack_fix_regressions.py``
  - ``gateway/tests/test_agent_restrictions_enforce.py``
  - ``gateway/tests/test_push_author_attribution.py``
  - ``gateway/tests/test_push_by_sha.py``
- [x] New regression test ``TestPulledCommitsDoNotTrigger403::test_pulled_blocked_paths_do_not_block_push`` pins the trap fix end-to-end: risk_analyst's own clean commit to ``.egg-state/agent-outputs/`` succeeds even when the diff range also contains an architect-authored upstream commit touching ``docs/`` and ``gateway/``.
- [x] Updated existing tests that asserted on the legacy ``push_denied_protected_files`` / ``blocked_files`` shape to assert on the canonical ``push_denied_restricted_path_modified`` / ``blocked_paths`` shape from #2039 — same 403, same blocked-paths semantics, just the now-canonical event name.

Closes #2489.