### PR TITLE
Tighten feedback-addresser deferral contract: bias hard toward in-PR fixes

### DIFF
--- a/action/build-feedback-prompt.sh
+++ b/action/build-feedback-prompt.sh
@@ -133,13 +133,30 @@ top-level response comment must list every item with its disposition tag:
   posting your response, and \`#<NNNN>\` must be the resulting issue number.
 - \`disagree (<reasoning>)\` — you disagree the change is needed. Explain why.
 
-**Default to in-PR fixes.** Deferral is the exception, not a coequal option.
-You may only defer when one of the following is true, and you must state which:
+**Default to in-PR fixes — strongly.** Open a follow-up issue ONLY when one
+of the following is true, and you must state which in your response:
 
-  (i) the fix is large and risky enough that landing it here would balloon
-      this PR's scope past what reviewers can sensibly approve;
-  (ii) the fix needs design alignment that cannot be reached in this PR;
-  (iii) the reviewer explicitly asked for a follow-up.
+  (i)  the fix requires a human-in-the-loop decision you cannot make on your
+       own — design, product, or architecture input the reviewer's feedback
+       didn't supply, with no defensible default you could pick, ship, and
+       let the reviewer push back on in another round;
+  (ii) the reviewer EXPLICITLY asked for a follow-up issue (e.g. \"track as
+       follow-up #NNNN\", \"let's do this in a separate PR\"). A
+       \"non-blocking\" label, a soft observation (\"worth one more case\",
+       \"minor\", \"nit\"), or your own judgment that something is \"out of
+       scope\" or \"would balloon the PR\" do NOT count as explicit
+       defer requests.
+
+Apparent scope, apparent risk, \"this PR is already big\", or \"this is
+adjacent\" are NOT grounds for deferral. Reviewers who flag a problem in a
+PR review want it fixed in that PR; if they wanted a separate issue they
+would have filed one themselves. Bias toward in-PR in every ambiguous case
+— a small fix bundled into the PR is far cheaper than opening,
+prioritizing, and shepherding an issue, and an ever-growing follow-up
+backlog is its own form of debt. Prefer \`disagree (out of scope; <reason>)\`
+over a deferral when you genuinely think the reviewer is wrong about
+needing the change at all — that puts the burden back on them rather than
+expanding the issue tracker.
 
 **No phantom follow-ups.** The following are forbidden in your response:
 

--- a/action/build-feedback-prompt.sh
+++ b/action/build-feedback-prompt.sh
@@ -140,8 +140,8 @@ of the following is true, and you must state which in your response:
        own — design, product, or architecture input the reviewer's feedback
        didn't supply, with no defensible default you could pick, ship, and
        let the reviewer push back on in another round;
-  (ii) the reviewer EXPLICITLY asked for a follow-up issue (e.g. \"track as
-       follow-up #NNNN\", \"let's do this in a separate PR\"). A
+  (ii) the reviewer EXPLICITLY asked for a follow-up issue (e.g. \"please
+       file a follow-up for this\", \"let's do this in a separate PR\"). A
        \"non-blocking\" label, a soft observation (\"worth one more case\",
        \"minor\", \"nit\"), or your own judgment that something is \"out of
        scope\" or \"would balloon the PR\" do NOT count as explicit
@@ -153,10 +153,12 @@ PR review want it fixed in that PR; if they wanted a separate issue they
 would have filed one themselves. Bias toward in-PR in every ambiguous case
 — a small fix bundled into the PR is far cheaper than opening,
 prioritizing, and shepherding an issue, and an ever-growing follow-up
-backlog is its own form of debt. Prefer \`disagree (out of scope; <reason>)\`
-over a deferral when you genuinely think the reviewer is wrong about
-needing the change at all — that puts the burden back on them rather than
-expanding the issue tracker.
+backlog is its own form of debt. Prefer \`disagree (<why this isn't a real
+problem>)\` over a deferral when you genuinely think the reviewer is wrong
+about needing the change at all — that puts the burden back on them rather
+than expanding the issue tracker. Reserve \`disagree\` for \"this isn't a
+real problem,\" not for \"valid concern, wrong PR\" (the latter is either
+fix-in-PR or, if the reviewer explicitly asked, deferral).
 
 **No phantom follow-ups.** The following are forbidden in your response:
 

--- a/docs/guides/github-automation.md
+++ b/docs/guides/github-automation.md
@@ -228,9 +228,11 @@ defensible default to pick and ship), or (b) the reviewer EXPLICITLY asked for a
 follow-up issue. A "non-blocking" label, a soft observation ("nit", "worth one more
 case", "minor"), or the agent's own judgment that something is "out of scope" or
 "would balloon the PR" are NOT grounds for deferral — reviewers who flag a problem
-in a PR review want it fixed in that PR. The agent should prefer `disagree (out of
-scope; <reason>)` over a deferral when it genuinely thinks the change isn't warranted.
-Phantom follow-ups — promises to file an issue after posting the response, or
+in a PR review want it fixed in that PR. The agent should prefer `disagree (<why
+this isn't a real problem>)` over a deferral when it genuinely thinks the change
+isn't warranted; `disagree` is reserved for "this isn't a real problem," not for
+"valid concern, wrong PR." Phantom follow-ups — promises to file an issue after
+posting the response, or
 `deferred-to` references to non-existent or pre-existing issues — are forbidden and
 detected by a post-run guard that fails the workflow.
 

--- a/docs/guides/github-automation.md
+++ b/docs/guides/github-automation.md
@@ -221,9 +221,16 @@ top-level response comment:
 | `deferred-to #<NNNN>` | Not fixing in this PR. Agent must file the issue with `gh issue create` *before* posting the response; `#NNNN` must be the resulting issue number created during this run. |
 | `disagree (<reasoning>)` | Agent disagrees the change is needed. Must explain why. |
 
-**Default to in-PR fixes.** Deferral is allowed only when the fix would balloon PR scope,
-requires design alignment that can't be reached here, or the reviewer explicitly asked for
-a follow-up. Phantom follow-ups — promises to file an issue after posting the response, or
+**Default to in-PR fixes — strongly.** A follow-up issue is allowed only when (a) the
+fix requires a human-in-the-loop decision the agent cannot make on its own (design,
+product, or architecture input the reviewer's feedback didn't supply, with no
+defensible default to pick and ship), or (b) the reviewer EXPLICITLY asked for a
+follow-up issue. A "non-blocking" label, a soft observation ("nit", "worth one more
+case", "minor"), or the agent's own judgment that something is "out of scope" or
+"would balloon the PR" are NOT grounds for deferral — reviewers who flag a problem
+in a PR review want it fixed in that PR. The agent should prefer `disagree (out of
+scope; <reason>)` over a deferral when it genuinely thinks the change isn't warranted.
+Phantom follow-ups — promises to file an issue after posting the response, or
 `deferred-to` references to non-existent or pre-existing issues — are forbidden and
 detected by a post-run guard that fails the workflow.
 


### PR DESCRIPTION
## Summary

The review-feedback-addresser agent has been too aggressive about opening follow-up issues instead of rolling fixes into the open PR. Today alone, ~6 of the new issues filed were "spun out from PR #XXXX review" entries the addresser created in response to small, non-blocking reviewer observations on already-approved PRs (#2486, #2473, #2471, #2469, #2465, #2443, etc.). The follow-up backlog grows without bound and small-fix work is harder to land than it should be.

The previous contract in `action/build-feedback-prompt.sh` listed three deferral lanes:

```
(i)  the fix is large and risky enough that landing it here would balloon scope
(ii) the fix needs design alignment that cannot be reached in this PR
(iii) the reviewer explicitly asked for a follow-up
```

Lane (i) is the abused one — "balloons scope" is a judgment call the agent always finds in its own favor.

This PR:

- Drops lane (i) entirely.
- Reframes (ii) explicitly as "needs a HITL decision the agent cannot make on its own — design, product, or architecture input the reviewer didn't supply, with no defensible default to pick and ship."
- Keeps (iii), but calls out that "non-blocking" labels, soft observations ("nit", "minor", "worth one more case"), and the agent's own assessment that something is "out of scope" or "would balloon the PR" are NOT explicit defer requests.
- Adds guidance to prefer `disagree (out of scope; <reason>)` over a deferral when the agent thinks the reviewer is wrong — puts the burden back on the reviewer instead of growing the tracker.
- Updates the matching docs section in `docs/guides/github-automation.md`.

The post-run guard (`action/verify-feedback-contract.sh`) is unchanged — it still enforces "deferred-to issues exist + no phantom follow-ups." Mechanical enforcement of the new policy (e.g. requiring each `deferred-to` line to carry a `(HITL: …)` or `(reviewer requested)` marker) is a possible follow-up if the prompt change alone doesn't curb the behavior, but starting with the prompt-only change since that is the lever the agent reads each run.

## Test plan

- [ ] On the next PR-review cycle, observe whether the addresser switches to `fixed-in-PR` for items it would previously have deferred.
- [ ] Spot-check that legitimate HITL deferrals (e.g. design questions surfaced by the reviewer) still flow to issues with the rationale stated.
- [ ] Confirm `verify-feedback-contract.sh` still passes on a normal addresser run (no behavior change there, but the prompt is its sibling).