### PR TITLE
Fix #2500: split refine template literal from meta-instructions

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -8874,10 +8874,10 @@ def _build_phase_prompt(
                 "## Output Format\n",
                 "Create an analysis document following the template below. The "
                 "fenced block is the **template literal** — copy it as-is and fill "
-                "in the bracketed placeholders. The unfenced section that follows "
-                "(`## How to Populate Open Questions`) is **meta-guidance** about "
-                "how to populate the `## Open Questions` section — do **not** "
-                "transcribe it into your analysis document.\n",
+                "in the bracketed placeholders. The unfenced sections that follow "
+                "(`## How to Populate Open Questions`, `## Complexity Assessment`) "
+                "are **meta-guidance** — do **not** transcribe them into your "
+                "analysis document.\n",
                 "````markdown",
                 "# Analysis: [Issue Title]\n",
                 "> Issue: #[number] | Phase: refine\n",

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -8907,11 +8907,11 @@ def _build_phase_prompt(
                 "## Recommended Approach\n",
                 "[Which option is recommended and why. Reference the option above.]\n",
                 "## Open Questions\n",
-                "[Register every open question via `egg-contract add-decision` or "
-                "`egg-contract add-feedback` and paste the markdown output of each "
-                "command into this section. See `## How to Populate Open Questions` "
-                "below the template for the registration protocol — do **not** copy "
-                "those instructions into this document.]\n",
+                "[Register every open question by following the protocol in "
+                "`## How to Populate Open Questions` below the template, then paste "
+                "the markdown output of each registration command into this section. "
+                "Do **not** copy the protocol instructions themselves into this "
+                "document.]\n",
                 "---\n",
                 "*Authored-by: egg*",
                 "````\n",

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -8872,7 +8872,12 @@ def _build_phase_prompt(
                 "evaluating options, and surfacing decisions for the human.",
                 "",
                 "## Output Format\n",
-                "Create an analysis document following this template:\n",
+                "Create an analysis document following the template below. The "
+                "fenced block is the **template literal** — copy it as-is and fill "
+                "in the bracketed placeholders. The unfenced section that follows "
+                "(`## How to Populate Open Questions`) is **meta-guidance** about "
+                "how to populate the `## Open Questions` section — do **not** "
+                "transcribe it into your analysis document.\n",
                 "````markdown",
                 "# Analysis: [Issue Title]\n",
                 "> Issue: #[number] | Phase: refine\n",
@@ -8902,10 +8907,23 @@ def _build_phase_prompt(
                 "## Recommended Approach\n",
                 "[Which option is recommended and why. Reference the option above.]\n",
                 "## Open Questions\n",
-                "**IMPORTANT: Every open question MUST be registered as a contract "
-                "decision or feedback item using `egg-contract`.** Do not just write "
-                "questions as prose — they will not be seen by the human unless "
-                "registered.\n",
+                "[Register every open question via `egg-contract add-decision` or "
+                "`egg-contract add-feedback` and paste the markdown output of each "
+                "command into this section. See `## How to Populate Open Questions` "
+                "below the template for the registration protocol — do **not** copy "
+                "those instructions into this document.]\n",
+                "---\n",
+                "*Authored-by: egg*",
+                "````\n",
+                "",
+                "## How to Populate Open Questions\n",
+                "These instructions tell you how to handle the `## Open Questions` "
+                "section of the template above. They are **meta-guidance**, not "
+                "template content — do **not** transcribe this section into the "
+                "analysis document you write.\n",
+                "**Every open question MUST be registered as a contract decision or "
+                "feedback item using `egg-contract`.** Do not just write questions "
+                "as prose — they will not be seen by the human unless registered.\n",
                 "**Skip already-resolved questions.** If the Task Description above "
                 "includes an `## Additional Context` section, treat anything addressed "
                 "there as already decided by the operator (those came from a pre-refine "
@@ -8949,10 +8967,10 @@ def _build_phase_prompt(
                 "- Use custom HTML comment markers like "
                 "`<!-- DECISION: ... -->` instead of the contract CLI",
                 "- Skip registration because you think the questions are minor — "
-                "register every question\n",
-                "---\n",
-                "*Authored-by: egg*",
-                "````\n",
+                "register every question",
+                "- Transcribe this `## How to Populate Open Questions` section "
+                "into your analysis document — it is meta-guidance, not template "
+                "content\n",
                 "",
             ]
         )

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -2901,6 +2901,10 @@ class TestRefinePromptTemplateFenceSeparation:
             "egg-contract add-feedback",
             "**DO NOT:**",
             "Skip already-resolved questions",
+            "Surface **all** uncertainties",
+            "**Multiple-choice questions**",
+            "**Open-ended questions**",
+            "Transcribe this `## How to Populate Open Questions` section",
         ):
             assert needle not in body, (
                 f"meta-instruction {needle!r} leaked into template fence — "

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -2845,6 +2845,80 @@ class TestRefinePromptHonorsAdditionalContext:
         assert "### Resolved in Pre-Refine" in prompt
 
 
+class TestRefinePromptTemplateFenceSeparation:
+    """Refine prompt must keep template literal and meta-instructions separate.
+
+    Regression for #2500: the refiner used to see a single ```markdown fence
+    that mixed the analysis-document skeleton with meta-guidance about how to
+    register questions via `egg-contract`. The risk is the agent transcribes
+    the meta-paragraphs (e.g. the `egg-contract add-decision` bash example,
+    the **DO NOT:** list, the "Skip already-resolved questions" guidance)
+    verbatim into its analysis document. The fix splits the prompt: only the
+    template skeleton lives inside the fence; the registration protocol
+    lives in a clearly-labelled `## How to Populate Open Questions` section
+    after the fence closes.
+    """
+
+    @staticmethod
+    def _refine_prompt() -> str:
+        return _build_phase_prompt(
+            phase="refine",
+            pipeline_id="test-pipe",
+            pipeline_mode="issue",
+            prompt="Analyze this issue.",
+            issue_number=100,
+        )
+
+    @staticmethod
+    def _template_fence_body(prompt: str) -> str:
+        # The template uses a four-backtick fence so its inner code blocks
+        # (if any) don't terminate it. Find the body between the opening
+        # ````markdown line and the next standalone ```` line.
+        open_marker = "````markdown"
+        open_idx = prompt.find(open_marker)
+        assert open_idx != -1, "expected ````markdown opening fence in refine prompt"
+        body_start = open_idx + len(open_marker)
+        close_idx = prompt.find("\n````", body_start)
+        assert close_idx != -1, "expected ```` closing fence after template body"
+        return prompt[body_start:close_idx]
+
+    def test_template_fence_holds_only_skeleton(self):
+        body = self._template_fence_body(self._refine_prompt())
+        # Skeleton headings stay inside the fence.
+        assert "# Analysis: [Issue Title]" in body
+        assert "## Problem Statement" in body
+        assert "## Open Questions" in body
+        assert "*Authored-by: egg*" in body
+
+    def test_meta_instructions_live_outside_template_fence(self):
+        prompt = self._refine_prompt()
+        body = self._template_fence_body(prompt)
+        # Meta-paragraphs (and the bash examples) must NOT live inside the
+        # template fence — that is what tempts the refiner to transcribe
+        # them. They must still appear elsewhere in the prompt.
+        for needle in (
+            "egg-contract add-decision",
+            "egg-contract add-feedback",
+            "**DO NOT:**",
+            "Skip already-resolved questions",
+        ):
+            assert needle not in body, (
+                f"meta-instruction {needle!r} leaked into template fence — "
+                "the refiner may transcribe it into its analysis document"
+            )
+            assert needle in prompt, f"meta-instruction {needle!r} missing from prompt entirely"
+
+    def test_prompt_labels_meta_section_distinctly(self):
+        prompt = self._refine_prompt()
+        # A clearly-named section header for the meta-guidance lets the
+        # refiner tell template content from registration protocol.
+        assert "## How to Populate Open Questions" in prompt
+        # The Open Questions placeholder inside the template should point
+        # the refiner at that section instead of restating the protocol.
+        body = self._template_fence_body(prompt)
+        assert "How to Populate Open Questions" in body
+
+
 class TestReviewerBrcPreamble:
     """Tests that reviewer agents receive BRC preamble in concurrent mode."""
 


### PR DESCRIPTION
## Summary
- Refine-phase prompt opened a single ` ```markdown ` fence containing both the analysis-document skeleton and meta-paragraphs about registering questions via `egg-contract` (bash examples, **DO NOT:** list, the "Skip already-resolved questions" guidance from #2493). The fence ambiguity tempts the refiner to transcribe meta text into its analysis document.
- Move all meta-guidance out of the fence into a clearly-labelled `## How to Populate Open Questions` section that follows the template. The fenced template now holds only the skeleton; its `## Open Questions` placeholder points at the new section and warns the refiner not to copy it into the document.
- Add `TestRefinePromptTemplateFenceSeparation` (`orchestrator/tests/test_pipeline_prompts.py`) — extracts the body between the `` ```` ``-fenced markdown block and asserts the meta-paragraphs appear in the prompt but **not** inside that body.

Closes #2500.

## Test plan
- [ ] `make test` covers `orchestrator/tests/test_pipeline_prompts.py` — existing `TestRefinePromptHonorsAdditionalContext` and `test_refine_prompt_includes_external_research` still pass (preserved strings); new `TestRefinePromptTemplateFenceSeparation` cases pass.
- [ ] `make lint` passes (pre-commit ruff-format already applied locally).
- [ ] Spot-check a real refine run to confirm the analysis document no longer contains the `egg-contract add-decision` bash examples or the **DO NOT:** list.