### PR TITLE
Fix #2502: clear consensus tracker on _run_pipeline auto-advance

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -17911,6 +17911,22 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                 pipeline.status = PipelineStatus.RUNNING
                 store.save_pipeline(pipeline)
 
+            # TEST_MARKER: recover_advance_clear (load-bearing: brackets
+            # the post-lock clear for TestRecoverPipelineClearsConcurrentState;
+            # do not remove without updating that test class).
+            # Drop the previous phase's in-memory consensus tracker on
+            # cross-phase advance (#2502).  The request_changes /
+            # change_approach branch above already cleared inside the
+            # lock for same-phase re-runs (#1296); the advance branch
+            # needs its own post-lock clear so persisted state lands
+            # before the tracker is wiped, matching the persist-then-
+            # clear-then-spawn order used by ``advance_phase`` and the
+            # auto-advance block.
+            if is_approved:
+                from routes.phases import _clear_concurrent_state
+
+                _clear_concurrent_state(pipeline_id)
+
             # Launch runner thread
             thread = threading.Thread(
                 target=_run_pipeline,

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -17235,6 +17235,22 @@ def _run_pipeline(
                 # ``updated_at`` is unconditionally set by ``StateStore.save_pipeline``.
                 store.save_pipeline(pipeline, force_commit=(pipeline.issue_number is None))
 
+            # Drop the previous phase's in-memory consensus tracker and
+            # message-store entries (#2502).  The other phase-transition
+            # paths -- ``advance_phase`` REST handler, HITL-revision
+            # re-run, and the ``recover_pipeline`` resume path -- all
+            # call this; the auto-advance path used to skip it, leaving
+            # a stale plan-phase tracker keyed under the bare
+            # ``pipeline_id`` for ``_get_concurrent_status`` to find and
+            # report as ``is_complete: True`` long after the implement
+            # phase had started.  ``_write_brc_history`` already ran
+            # earlier in this iteration (line ~16753) so the BRC
+            # transcript is already on disk by the time we wipe the
+            # message store here.
+            from routes.phases import _clear_concurrent_state
+
+            _clear_concurrent_state(pipeline_id)
+
             logger.info(
                 "Phase advanced (auto), respawning driver thread",
                 pipeline_id=pipeline_id,

--- a/orchestrator/tests/test_advance_phase_thread.py
+++ b/orchestrator/tests/test_advance_phase_thread.py
@@ -314,6 +314,31 @@ class TestAutoAdvanceRespawnsThread:
             "health monitor — the new thread builds its own."
         )
 
+    def test_auto_advance_clears_concurrent_state(self):
+        """Regression for #2502.
+
+        The auto-advance block must drop the previous phase's in-memory
+        consensus tracker (and message-store entries) before spawning the
+        next phase's driver thread.  Otherwise ``_get_concurrent_status``
+        keeps finding the prior phase's tracker keyed under the bare
+        ``pipeline_id`` and reports its ``is_complete: True`` indefinitely
+        — which is exactly what masked an in-progress implement-phase
+        BRC stall in pipeline ``issue-2474`` (see issue #2502).
+
+        Source-inspection in the same style as the sibling assertions: a
+        behavioural test would need to drive the full phase loop through
+        a mock harness.  Pairs with the explicit ``_clear_concurrent_state``
+        calls already present in the ``advance_phase`` REST handler, the
+        HITL-revision re-run path, and the ``recover_pipeline`` resume
+        path.
+        """
+        block = self._auto_advance_block()
+        assert "_clear_concurrent_state(pipeline_id)" in block, (
+            "Auto-advance must call _clear_concurrent_state(pipeline_id) so "
+            "the next phase's get_pipeline_snapshot / get_consensus_status "
+            "calls don't surface the previous phase's tracker (#2502)."
+        )
+
 
 # ---------------------------------------------------------------------------
 # Tests for #2219: post-BRC band must not strand the pipeline on

--- a/orchestrator/tests/test_advance_phase_thread.py
+++ b/orchestrator/tests/test_advance_phase_thread.py
@@ -278,7 +278,7 @@ class TestAutoAdvanceRespawnsThread:
         )
         idx = source.index(self._BLOCK_MARKER)
         # Take a generous window so the block including the return is included.
-        return source[idx : idx + 2000]
+        return source[idx : idx + 3000]
 
     def test_auto_advance_bumps_run_epoch(self):
         block = self._auto_advance_block()

--- a/orchestrator/tests/test_advance_phase_thread.py
+++ b/orchestrator/tests/test_advance_phase_thread.py
@@ -341,11 +341,72 @@ class TestAutoAdvanceRespawnsThread:
 
 
 # ---------------------------------------------------------------------------
-# Tests for #2219: post-BRC band must not strand the pipeline on
-# best-effort sub-call failures.  The implement→PR auto-advance silently
-# wedged when an exception escaped one of the post-phase helpers and the
-# outer FAILED-marking handler then failed silently.
+# Tests for #2502 (recover_pipeline advance branch): the AWAITING_HUMAN
+# resume path must also drop the previous phase's tracker when the HITL
+# decision approves a phase advance (cross-phase), mirroring the auto-
+# advance block in ``_run_pipeline``.  The same-phase re-run branch
+# (request_changes / change_approach) already clears under the lock for
+# #1296.
 # ---------------------------------------------------------------------------
+
+
+class TestRecoverPipelineClearsConcurrentState:
+    """Verify ``start_pipeline``'s AWAITING_HUMAN advance branch wipes the
+    previous phase's consensus tracker before launching the runner thread.
+
+    Source-inspection in the same style as
+    ``TestAutoAdvanceRespawnsThread`` — a behavioural test would need a
+    full Flask + state-store harness exercising the HITL resolution
+    flow.  Pairs with the explicit ``_clear_concurrent_state`` calls in
+    ``advance_phase``, the HITL-revision re-run branch, and the
+    auto-advance block.
+    """
+
+    _BLOCK_MARKER = "TEST_MARKER: recover_advance_clear"
+
+    def _recover_advance_block(self) -> str:
+        """Extract the recover-advance clear block from start_pipeline."""
+        from routes import pipelines
+
+        source = inspect.getsource(pipelines.start_pipeline)
+        assert self._BLOCK_MARKER in source, (
+            f"Could not find {self._BLOCK_MARKER!r} in start_pipeline source. "
+            "Tests rely on this token bracketing the recover_pipeline advance "
+            "branch's clear call; if the block was moved or removed, update "
+            "both source and tests."
+        )
+        idx = source.index(self._BLOCK_MARKER)
+        # Window large enough to cover the comment + the conditional clear.
+        return source[idx : idx + 1200]
+
+    def test_recover_advance_calls_clear_concurrent_state(self):
+        """Regression for #2502 (advance branch).
+
+        Without this, an HITL-approved advance from plan→implement would
+        leave the plan-phase tracker keyed under the bare ``pipeline_id``
+        for ``_get_concurrent_status`` to find and report ``is_complete:
+        True`` indefinitely — the same shape as the auto-advance bug.
+        """
+        block = self._recover_advance_block()
+        assert "_clear_concurrent_state(pipeline_id)" in block, (
+            "recover_pipeline's advance branch must call "
+            "_clear_concurrent_state(pipeline_id) so the next phase's "
+            "snapshot doesn't surface the previous phase's tracker (#2502)."
+        )
+
+    def test_recover_advance_clear_is_conditional_on_is_approved(self):
+        """The clear must only fire on the advance branch, not the
+        request_changes/change_approach branch (which already clears
+        inside the lock for #1296)."""
+        block = self._recover_advance_block()
+        assert re.search(
+            r"if is_approved:\s*\n(?:\s*(?:from|#).*\n)*\s*_clear_concurrent_state\(pipeline_id\)",
+            block,
+        ), (
+            "The recover_pipeline clear must be guarded by `if is_approved:` "
+            "so the request_changes branch's existing in-lock clear (#1296) "
+            "is not duplicated."
+        )
 
 
 class TestPostBrcBandSwallowsErrors:


### PR DESCRIPTION
## Summary

- The in-process auto-advance block in `_run_pipeline` (`orchestrator/routes/pipelines.py:17220-17246`) advanced `pipeline.current_phase`, bumped `run_epoch`, and respawned the driver thread, but never called `_clear_concurrent_state(pipeline_id)`. Every other phase-transition path -- `advance_phase` REST handler, HITL-revision re-run, and `recover_pipeline` resume path -- already calls it.
- Without the clear, the previous phase's `PeerConsensusTracker` (keyed under the bare `pipeline_id` in `peer_consensus._trackers`) lingered in memory with `is_complete: True`. `_get_concurrent_status` happily found that stale tracker for every later `get_pipeline_snapshot` / `get_consensus_status` call, so the snapshot's top-level `concurrent.consensus.agents` reported the **previous** phase's roster (e.g. plan-phase `architect / reviewer_plan / risk_analyst / task_planner`) marked complete, while `pipeline.current_phase` and `pipeline.phases.<phase>.agents` correctly reflected the new phase.
- In pipeline `issue-2474` (the live repro cited in #2502) this masked an in-progress implement-phase BRC stall: operators and the dashboard logic in `skills/sdlc/SKILL.md` saw `concurrent.consensus.is_complete: true` for the plan-phase agents and missed real stalls in implement.

The fix adds the missing `_clear_concurrent_state(pipeline_id)` call right after the auto-advance's `store.save_pipeline` and before `_spawn_pipeline_run_thread`, matching the persist-then-clear order used by `advance_phase`. The phase's BRC history was already written by `_write_brc_history` earlier in the same iteration (line ~16753), so wiping the message store here doesn't drop the transcript.

A source-inspection regression test sits alongside the existing `TestAutoAdvanceRespawnsThread` assertions.

Closes #2502.

## Test plan

- [ ] `make test` passes
- [ ] `test_auto_advance_clears_concurrent_state` fires the source-inspection assertion if the call is removed
- [ ] Manual: after a plan→implement auto-advance on a fresh pipeline, `mcp__egg__get_pipeline_snapshot` returns either no `concurrent.consensus` or the implement-phase roster (not the plan-phase one)