### PR TITLE
Fix #2512: preserve prior slice work on restart_phase recovery

### DIFF
--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1742,7 +1742,14 @@ class GatewayClient:
                 # Fetch the integration branch so its tip object is
                 # in the local odb for the merge-base check below
                 # (parent_sha was made local by the earlier
-                # fetch_branch on parent_branch).
+                # fetch_branch on parent_branch).  Best-effort: if
+                # this fetch fails (gateway down, transient network,
+                # expired session), the existing tip won't be in the
+                # local odb and ``_sha_is_ancestor`` will return
+                # False, so we'll degrade to the original push-and-
+                # hope behaviour rather than mistakenly preserving
+                # prior work on an unverifiable check.  See the
+                # softened fall-through warning below.
                 self.fetch_branch(
                     pipeline_id,
                     repo_path,
@@ -1770,15 +1777,23 @@ class GatewayClient:
                         existing_sha=existing_sha,
                     )
                     return True
-                # Diverged: parent_sha is not reachable from the
-                # existing tip.  Fall through to the push so the
-                # rejection surfaces (and the operator gets a clear
-                # signal that the slice branch must be cleaned up
-                # rather than silently overwriting prior work).
+                # Could not verify ancestry: parent_sha is either not
+                # reachable from the existing tip (genuinely diverged
+                # history) or the merge-base call itself failed
+                # (gateway down, missing object after a failed
+                # integration-branch fetch, expired session).  The
+                # inner warning emitted by ``_sha_is_ancestor`` for
+                # the second case captures the true cause; the outer
+                # message stays deliberately neutral so an operator
+                # triaging "why was my slice rejected?" doesn't latch
+                # onto "diverged history" when the real failure was
+                # an unverifiable check.  Either way: fall through
+                # to the push so the rejection surfaces rather than
+                # silently overwriting unknown work.
                 logger.warning(
-                    "Slice integration branch exists with diverged "
-                    "history (parent_sha not ancestor of existing "
-                    "tip); push will be rejected",
+                    "Could not verify that parent is an ancestor of "
+                    "the existing slice integration tip; push may be "
+                    "rejected as non-fast-forward",
                     pipeline_id=pipeline_id,
                     integration_branch=integration_branch,
                     parent_sha=parent_sha,

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1570,6 +1570,55 @@ class GatewayClient:
     # #2137 — slice integration-branch creation (TASK-4-2)
     # ------------------------------------------------------------
 
+    def _sha_is_ancestor(
+        self,
+        pipeline_id: str,
+        repo_path: str,
+        ancestor_sha: str,
+        descendant_sha: str,
+        *,
+        bearer_token: str | None = None,
+    ) -> bool:
+        """Return True iff ``ancestor_sha`` is an ancestor of ``descendant_sha``.
+
+        Runs ``git merge-base --is-ancestor <ancestor> <descendant>``
+        through ``/api/v1/git/execute``.  Both SHAs must already be
+        reachable in the local odb — the caller is responsible for
+        any prior fetches.
+
+        ``git merge-base --is-ancestor`` exits 0 when the relation
+        holds and 1 when it does not.  The gateway surfaces a non-zero
+        exit as a 500 with ``returncode`` in the error details, which
+        we map back to ``False``; any other failure (network, missing
+        object) is also treated as ``False`` so callers can fall
+        through to a conservative path.
+        """
+        try:
+            self._make_request(
+                "/api/v1/git/execute",
+                method="POST",
+                data={
+                    "repo_path": repo_path,
+                    "operation": "merge-base",
+                    "args": ["--is-ancestor", ancestor_sha, descendant_sha],
+                },
+                bearer_token=bearer_token,
+            )
+            return True
+        except GatewayError as exc:
+            details = exc.details or {}
+            returncode = details.get("returncode")
+            if returncode != 1:
+                logger.warning(
+                    "merge-base --is-ancestor failed unexpectedly",
+                    pipeline_id=pipeline_id,
+                    ancestor=ancestor_sha,
+                    descendant=descendant_sha,
+                    returncode=returncode,
+                    error=str(exc),
+                )
+            return False
+
     def create_slice_integration_branch(
         self,
         pipeline_id: str,
@@ -1667,6 +1716,74 @@ class GatewayClient:
                     parent_branch=parent_branch,
                 )
                 return False
+
+            # #2512 — restart_phase recovery: if the slice integration
+            # branch already exists on origin with commits descended
+            # from the current parent tip, preserve them and short-
+            # circuit success.  This happens when a pipeline is
+            # cancelled mid-implement-phase (cleanup=false) and then
+            # restarted: the prior run's per-role commits live on
+            # the slice integration branch.  Naively pushing
+            # ``parent_sha:refs/heads/<integration_branch>`` against
+            # that tip is non-fast-forward and gets rejected by
+            # origin, which previously killed the slice (and cascaded
+            # to the whole phase) before any agent was spawned.
+            # decision-3's "Committed work is preserved on retry"
+            # wording is honored only if we treat that case as
+            # success rather than silent failure.
+            existing_sha = self.get_remote_branch_sha(
+                pipeline_id,
+                repo_path,
+                f"refs/heads/{integration_branch}",
+                mode=mode,
+                bearer_token=session_token,
+            )
+            if existing_sha and existing_sha != parent_sha:
+                # Fetch the integration branch so its tip object is
+                # in the local odb for the merge-base check below
+                # (parent_sha was made local by the earlier
+                # fetch_branch on parent_branch).
+                self.fetch_branch(
+                    pipeline_id,
+                    repo_path,
+                    args=[
+                        f"+refs/heads/{integration_branch}:refs/remotes/origin/{integration_branch}"
+                    ],
+                    mode=mode,
+                    bearer_token=session_token,
+                )
+                if self._sha_is_ancestor(
+                    pipeline_id,
+                    repo_path,
+                    parent_sha,
+                    existing_sha,
+                    bearer_token=session_token,
+                ):
+                    logger.info(
+                        "Slice integration branch already exists "
+                        "with commits descended from parent — "
+                        "preserving prior work (#2512 restart recovery)",
+                        pipeline_id=pipeline_id,
+                        integration_branch=integration_branch,
+                        parent_branch=parent_branch,
+                        parent_sha=parent_sha,
+                        existing_sha=existing_sha,
+                    )
+                    return True
+                # Diverged: parent_sha is not reachable from the
+                # existing tip.  Fall through to the push so the
+                # rejection surfaces (and the operator gets a clear
+                # signal that the slice branch must be cleaned up
+                # rather than silently overwriting prior work).
+                logger.warning(
+                    "Slice integration branch exists with diverged "
+                    "history (parent_sha not ancestor of existing "
+                    "tip); push will be rejected",
+                    pipeline_id=pipeline_id,
+                    integration_branch=integration_branch,
+                    parent_sha=parent_sha,
+                    existing_sha=existing_sha,
+                )
 
             refspec = f"{parent_sha}:refs/heads/{integration_branch}"
             self._make_request(

--- a/orchestrator/tests/test_create_slice_integration_branch.py
+++ b/orchestrator/tests/test_create_slice_integration_branch.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock, call, patch
 
 import pytest
-from gateway_client import GatewayClient, SessionInfo
+from gateway_client import GatewayClient, GatewayError, SessionInfo
 
 
 @pytest.fixture
@@ -107,7 +107,14 @@ class TestCreateSliceIntegrationBranchSuccess:
     def test_fetch_runs_before_sha_lookup_runs_before_push(self, gateway_client):
         """Defensive fetch must run before ``ls-remote`` so the parent's
         commit object is reachable in the local odb before we issue the
-        SHA-based push (``git push <sha>:...`` requires it locally)."""
+        SHA-based push (``git push <sha>:...`` requires it locally).
+
+        Also pins the #2512 ordering: the existence-check ls-remote on
+        the integration branch happens AFTER the parent ls-remote and
+        BEFORE the push.  When integration branch is absent (or its
+        tip equals parent_sha), no extra fetch is needed and the push
+        proceeds as a fast-forward.
+        """
         order: list[str] = []
         parent_sha = "abc12345" * 5
 
@@ -119,7 +126,8 @@ class TestCreateSliceIntegrationBranchSuccess:
             return True
 
         def fake_get_remote_branch_sha(*args, **kwargs):
-            order.append("ls-remote")
+            ref = args[2] if len(args) >= 3 else kwargs.get("ref")
+            order.append(f"ls-remote:{ref}")
             return parent_sha
 
         def fake_make_request(endpoint, method=None, data=None, **kwargs):
@@ -146,7 +154,12 @@ class TestCreateSliceIntegrationBranchSuccess:
             )
 
         assert ok is True
-        assert order == ["fetch", "ls-remote", "push"]
+        assert order == [
+            "fetch",
+            "ls-remote:refs/heads/egg/issue-2393",
+            "ls-remote:refs/heads/egg/issue-2393/slice-1",
+            "push",
+        ]
 
 
 class TestCreateSliceIntegrationBranchFailures:
@@ -417,3 +430,213 @@ class TestCreateSliceIntegrationBranchSession:
         assert ok is False
         assert register_spy.call_count == 1
         assert delete_spy.call_args_list == [call("orphan-tok")]
+
+
+class TestCreateSliceIntegrationBranchRestartRecovery:
+    """#2512 — restart_phase recovery when slice integration branch
+    already exists on origin with prior-run commits.
+
+    The pre-#2512 implementation issued ``parent_sha:refs/heads/<int>``
+    unconditionally, which is rejected as non-fast-forward when the
+    branch already carries commits descended from parent.  decision-3
+    advertises "Committed work is preserved on the per-role branch —
+    'Retry phase' restarts with artifacts intact"; that promise was
+    only honored on the first slice spawn.  These tests pin the
+    restart-recovery path: detect the existing branch, verify its
+    tip descends from the current parent, and short-circuit success
+    instead of pushing.
+    """
+
+    def test_existing_branch_descended_from_parent_is_preserved(self, gateway_client):
+        """Issue #2512 reproduction: slice-1 branch on origin contains
+        coder/tester commits descended from parent (cancel_task with
+        cleanup=false followed by restart_phase).  ``create_slice_
+        integration_branch`` must detect this and return True without
+        pushing — the prior commits are exactly what restart_phase
+        promises to preserve."""
+        parent_sha = "8a76c30d" * 5  # parent-branch tip
+        existing_sha = "0c5c6697" * 5  # slice-1 tip from prior run
+
+        push_invoked: list[bool] = []
+        merge_base_calls: list[dict] = []
+
+        def fake_get_remote_branch_sha(pipeline_id, repo_path, ref, **kwargs):
+            if ref == "refs/heads/egg/issue-2474":
+                return parent_sha
+            if ref == "refs/heads/egg/issue-2474/slice-1":
+                return existing_sha
+            return None
+
+        def fake_make_request(endpoint, method=None, data=None, **kwargs):
+            if endpoint == "/api/v1/git/push":
+                push_invoked.append(True)
+            elif endpoint == "/api/v1/git/execute":
+                merge_base_calls.append(dict(data or {}))
+                # operation=merge-base --is-ancestor parent existing
+                # parent IS an ancestor → returncode 0 / success
+                return {"success": True, "data": {"returncode": 0}}
+            return {"success": True, "data": {}}
+
+        with (
+            patch.object(gateway_client, "register_session", return_value=_session_info()),
+            patch.object(gateway_client, "delete_session", return_value=True),
+            patch.object(gateway_client, "fetch_branch", return_value=True),
+            patch.object(
+                gateway_client,
+                "get_remote_branch_sha",
+                side_effect=fake_get_remote_branch_sha,
+            ),
+            patch.object(gateway_client, "_make_request", side_effect=fake_make_request),
+        ):
+            ok = gateway_client.create_slice_integration_branch(
+                "issue-2474",
+                "/repo",
+                integration_branch="egg/issue-2474/slice-1",
+                parent_branch="egg/issue-2474",
+            )
+
+        assert ok is True, "must short-circuit success when prior work descends from parent"
+        assert push_invoked == [], (
+            "must NOT push when integration branch already descends from "
+            "parent — that push would be rejected as non-fast-forward"
+        )
+        assert len(merge_base_calls) == 1
+        mb = merge_base_calls[0]
+        assert mb["operation"] == "merge-base"
+        assert mb["args"] == ["--is-ancestor", parent_sha, existing_sha], (
+            "ancestry direction matters: parent must be ancestor of existing tip"
+        )
+
+    def test_existing_branch_diverged_falls_through_to_push(self, gateway_client):
+        """If parent_sha is NOT an ancestor of the existing slice tip
+        (genuinely diverged history), fall through to the push so
+        origin's rejection surfaces as a clear signal.  Better than
+        silently overwriting unknown work."""
+        parent_sha = "deadbeef" * 5
+        existing_sha = "feedface" * 5  # diverged
+
+        push_invoked: list[dict] = []
+
+        def fake_get_remote_branch_sha(pipeline_id, repo_path, ref, **kwargs):
+            if ref.endswith("/slice-1"):
+                return existing_sha
+            return parent_sha
+
+        def fake_make_request(endpoint, method=None, data=None, **kwargs):
+            if endpoint == "/api/v1/git/push":
+                push_invoked.append(dict(data or {}))
+            elif endpoint == "/api/v1/git/execute":
+                # not-ancestor → gateway returns 500 with returncode=1
+                raise GatewayError(
+                    "git merge-base failed",
+                    status_code=500,
+                    details={"returncode": 1, "stdout": "", "stderr": ""},
+                )
+            return {"success": True, "data": {}}
+
+        with (
+            patch.object(gateway_client, "register_session", return_value=_session_info()),
+            patch.object(gateway_client, "delete_session", return_value=True),
+            patch.object(gateway_client, "fetch_branch", return_value=True),
+            patch.object(
+                gateway_client,
+                "get_remote_branch_sha",
+                side_effect=fake_get_remote_branch_sha,
+            ),
+            patch.object(gateway_client, "_make_request", side_effect=fake_make_request),
+        ):
+            ok = gateway_client.create_slice_integration_branch(
+                "pipe-div",
+                "/repo",
+                integration_branch="egg/issue-1/slice-1",
+                parent_branch="egg/issue-1",
+            )
+
+        assert ok is True, "diverged history → push proceeds and (here) succeeds"
+        assert len(push_invoked) == 1, "must attempt the push when histories diverge"
+        assert push_invoked[0]["refspec"] == (f"{parent_sha}:refs/heads/egg/issue-1/slice-1")
+
+    def test_existing_branch_equal_to_parent_skips_recovery_path(self, gateway_client):
+        """When the integration branch already exists at exactly
+        parent_sha (e.g., the slice was created in a prior run but
+        no agent commits landed), the recovery path is unnecessary —
+        the push is a no-op fast-forward and we don't run merge-base."""
+        sha = "cafebabe" * 5
+        merge_base_calls: list[dict] = []
+        push_invoked: list[bool] = []
+
+        def fake_make_request(endpoint, method=None, data=None, **kwargs):
+            if endpoint == "/api/v1/git/push":
+                push_invoked.append(True)
+            elif endpoint == "/api/v1/git/execute":
+                merge_base_calls.append(dict(data or {}))
+            return {"success": True, "data": {}}
+
+        with (
+            patch.object(gateway_client, "register_session", return_value=_session_info()),
+            patch.object(gateway_client, "delete_session", return_value=True),
+            patch.object(gateway_client, "fetch_branch", return_value=True),
+            patch.object(gateway_client, "get_remote_branch_sha", return_value=sha),
+            patch.object(gateway_client, "_make_request", side_effect=fake_make_request),
+        ):
+            ok = gateway_client.create_slice_integration_branch(
+                "pipe-eq",
+                "/repo",
+                integration_branch="egg/issue-1/slice-1",
+                parent_branch="egg/issue-1",
+            )
+
+        assert ok is True
+        assert push_invoked == [True], "push still runs (it's a fast-forward no-op)"
+        assert merge_base_calls == [], (
+            "must not run merge-base when existing tip is already at parent_sha"
+        )
+
+
+class TestShaIsAncestor:
+    """Unit tests for the ``_sha_is_ancestor`` helper that backs the
+    #2512 restart-recovery detection."""
+
+    def test_returns_true_on_success_response(self, gateway_client):
+        with patch.object(
+            gateway_client,
+            "_make_request",
+            return_value={"success": True, "data": {"returncode": 0}},
+        ) as mock_req:
+            ok = gateway_client._sha_is_ancestor(
+                "pipe-1", "/repo", "aaaa", "bbbb", bearer_token="tok"
+            )
+        assert ok is True
+        call_data = mock_req.call_args.kwargs["data"]
+        assert call_data["operation"] == "merge-base"
+        assert call_data["args"] == ["--is-ancestor", "aaaa", "bbbb"]
+        assert mock_req.call_args.kwargs["bearer_token"] == "tok"
+
+    def test_returns_false_on_returncode_1(self, gateway_client):
+        """``merge-base --is-ancestor`` exits 1 when the relation does
+        not hold — surfaces as 500 from the gateway with
+        ``returncode: 1`` in the error details."""
+
+        def fake(*args, **kwargs):
+            raise GatewayError(
+                "git merge-base failed",
+                status_code=500,
+                details={"returncode": 1, "stderr": ""},
+            )
+
+        with patch.object(gateway_client, "_make_request", side_effect=fake):
+            ok = gateway_client._sha_is_ancestor("p", "/r", "a", "b")
+        assert ok is False
+
+    def test_returns_false_on_unexpected_error(self, gateway_client):
+        """Any failure that isn't ``returncode: 1`` (network, missing
+        object, gateway down) is treated as non-ancestor so callers
+        fall through to the conservative path rather than incorrectly
+        preserving prior work on a broken check."""
+
+        def fake(*args, **kwargs):
+            raise GatewayError("connection refused")
+
+        with patch.object(gateway_client, "_make_request", side_effect=fake):
+            ok = gateway_client._sha_is_ancestor("p", "/r", "a", "b")
+        assert ok is False

--- a/orchestrator/tests/test_create_slice_integration_branch.py
+++ b/orchestrator/tests/test_create_slice_integration_branch.py
@@ -719,7 +719,13 @@ class TestCreateSliceIntegrationBranchRestartRecovery:
             "branch-absent path must skip the integration-branch fetch — "
             "no need to fetch a branch that doesn't exist"
         )
-        assert "egg/issue-1" in fetch_calls[0][0]
+        # Tight assertion on the exact parent refspec — guards against a
+        # hypothetical "fetched the integration branch instead of the
+        # parent" regression that a substring check on ``"egg/issue-1"``
+        # (a prefix of ``"egg/issue-1/slice-1"``) wouldn't catch.
+        assert fetch_calls[0][0] == (
+            "+refs/heads/egg/issue-1:refs/remotes/origin/egg/issue-1"
+        )
 
 
 class TestShaIsAncestor:

--- a/orchestrator/tests/test_create_slice_integration_branch.py
+++ b/orchestrator/tests/test_create_slice_integration_branch.py
@@ -723,9 +723,7 @@ class TestCreateSliceIntegrationBranchRestartRecovery:
         # hypothetical "fetched the integration branch instead of the
         # parent" regression that a substring check on ``"egg/issue-1"``
         # (a prefix of ``"egg/issue-1/slice-1"``) wouldn't catch.
-        assert fetch_calls[0][0] == (
-            "+refs/heads/egg/issue-1:refs/remotes/origin/egg/issue-1"
-        )
+        assert fetch_calls[0][0] == ("+refs/heads/egg/issue-1:refs/remotes/origin/egg/issue-1")
 
 
 class TestShaIsAncestor:

--- a/orchestrator/tests/test_create_slice_integration_branch.py
+++ b/orchestrator/tests/test_create_slice_integration_branch.py
@@ -556,6 +556,70 @@ class TestCreateSliceIntegrationBranchRestartRecovery:
         assert len(push_invoked) == 1, "must attempt the push when histories diverge"
         assert push_invoked[0]["refspec"] == (f"{parent_sha}:refs/heads/egg/issue-1/slice-1")
 
+    def test_diverged_history_push_rejection_surfaces_as_failure(self, gateway_client):
+        """The whole point of falling through to the push on diverged
+        history is that origin's non-fast-forward rejection surfaces
+        as a clear ``ok is False`` signal (rather than silently
+        overwriting unknown work).  Pin that the rejection actually
+        propagates and that the synthetic session is still cleaned up
+        in the failure path."""
+        parent_sha = "deadbeef" * 5
+        existing_sha = "feedface" * 5  # diverged
+
+        register_spy = MagicMock(return_value=_session_info("diverged-tok"))
+        delete_spy = MagicMock(return_value=True)
+
+        def fake_get_remote_branch_sha(pipeline_id, repo_path, ref, **kwargs):
+            if ref.endswith("/slice-1"):
+                return existing_sha
+            return parent_sha
+
+        def fake_make_request(endpoint, method=None, data=None, **kwargs):
+            if endpoint == "/api/v1/git/push":
+                # Origin rejects the non-fast-forward push.
+                raise GatewayError(
+                    "git push failed",
+                    status_code=500,
+                    details={
+                        "returncode": 1,
+                        "stderr": "! [rejected] (non-fast-forward)",
+                    },
+                )
+            if endpoint == "/api/v1/git/execute":
+                # not-ancestor → returncode=1
+                raise GatewayError(
+                    "git merge-base failed",
+                    status_code=500,
+                    details={"returncode": 1, "stdout": "", "stderr": ""},
+                )
+            return {"success": True, "data": {}}
+
+        with (
+            patch.object(gateway_client, "register_session", side_effect=register_spy),
+            patch.object(gateway_client, "delete_session", side_effect=delete_spy),
+            patch.object(gateway_client, "fetch_branch", return_value=True),
+            patch.object(
+                gateway_client,
+                "get_remote_branch_sha",
+                side_effect=fake_get_remote_branch_sha,
+            ),
+            patch.object(gateway_client, "_make_request", side_effect=fake_make_request),
+        ):
+            ok = gateway_client.create_slice_integration_branch(
+                "pipe-div-rej",
+                "/repo",
+                integration_branch="egg/issue-1/slice-1",
+                parent_branch="egg/issue-1",
+            )
+
+        assert ok is False, (
+            "non-fast-forward rejection on diverged history must surface as "
+            "ok=False — that's the user-visible signal the operator needs"
+        )
+        assert delete_spy.call_args_list == [call("diverged-tok")], (
+            "synthetic session must still be cleaned up in the rejection path"
+        )
+
     def test_existing_branch_equal_to_parent_skips_recovery_path(self, gateway_client):
         """When the integration branch already exists at exactly
         parent_sha (e.g., the slice was created in a prior run but
@@ -591,6 +655,71 @@ class TestCreateSliceIntegrationBranchRestartRecovery:
         assert merge_base_calls == [], (
             "must not run merge-base when existing tip is already at parent_sha"
         )
+
+    def test_existing_branch_absent_skips_recovery_path(self, gateway_client):
+        """First-run / branch-absent path: ``get_remote_branch_sha``
+        returns None for the integration ref because the branch
+        doesn't exist on origin yet.  The recovery path is unnecessary
+        — no extra fetch, no merge-base, just the regular push.
+
+        This pins that the new ``if existing_sha and …`` guard
+        short-circuits correctly on the first conjunct and doesn't
+        accidentally start dereferencing a None ``existing_sha``.
+        """
+        parent_sha = "abc12345" * 5
+
+        merge_base_calls: list[dict] = []
+        push_invoked: list[bool] = []
+        fetch_calls: list[tuple] = []
+
+        def fake_fetch_branch(pipeline_id, repo_path, *, args=None, **kwargs):
+            fetch_calls.append(tuple(args or ()))
+            return True
+
+        def fake_get_remote_branch_sha(pipeline_id, repo_path, ref, **kwargs):
+            if ref == "refs/heads/egg/issue-1":
+                return parent_sha  # parent exists
+            if ref == "refs/heads/egg/issue-1/slice-1":
+                return None  # integration branch absent (first run)
+            return None
+
+        def fake_make_request(endpoint, method=None, data=None, **kwargs):
+            if endpoint == "/api/v1/git/push":
+                push_invoked.append(True)
+            elif endpoint == "/api/v1/git/execute":
+                merge_base_calls.append(dict(data or {}))
+            return {"success": True, "data": {}}
+
+        with (
+            patch.object(gateway_client, "register_session", return_value=_session_info()),
+            patch.object(gateway_client, "delete_session", return_value=True),
+            patch.object(gateway_client, "fetch_branch", side_effect=fake_fetch_branch),
+            patch.object(
+                gateway_client,
+                "get_remote_branch_sha",
+                side_effect=fake_get_remote_branch_sha,
+            ),
+            patch.object(gateway_client, "_make_request", side_effect=fake_make_request),
+        ):
+            ok = gateway_client.create_slice_integration_branch(
+                "pipe-firstrun",
+                "/repo",
+                integration_branch="egg/issue-1/slice-1",
+                parent_branch="egg/issue-1",
+            )
+
+        assert ok is True
+        assert push_invoked == [True], "push must run on the first-run / branch-absent path"
+        assert merge_base_calls == [], (
+            "must not run merge-base when integration branch doesn't exist on origin"
+        )
+        # Only the parent-branch fetch should run; the integration-
+        # branch fetch is gated on ``existing_sha`` being truthy.
+        assert len(fetch_calls) == 1, (
+            "branch-absent path must skip the integration-branch fetch — "
+            "no need to fetch a branch that doesn't exist"
+        )
+        assert "egg/issue-1" in fetch_calls[0][0]
 
 
 class TestShaIsAncestor:


### PR DESCRIPTION
## Summary

- Fixes #2512: `restart_phase` was killing the slice (and cascading the whole phase) before any agent was spawned when the slice integration branch on origin already carried commits from a prior cancelled run.
- `create_slice_integration_branch` now detects that case via `get_remote_branch_sha` + `git merge-base --is-ancestor`. When the existing slice tip descends from the current parent, we short-circuit success and let agents pick up where they left off — honoring decision-3's "Committed work is preserved on retry" promise.
- Genuinely diverged histories (parent_sha not reachable from existing tip) still fall through to the push so the rejection surfaces as a clear signal rather than silently overwriting unknown work.

## Why this fix and not the alternatives

The issue laid out three options:

1. **Inherit existing slice branch state** ← this PR. Non-destructive, matches what decision-3 already promises operators.
2. **Force-push with audit.** Loses the prior in-flight work.
3. **Detect-and-fail-loud HITL.** Adds operator burden for the common case (cancelled mid-phase, restart from where it stopped is what was wanted).

(1) is what the user-facing wording already implies, so the mechanism is now lined up with the wording — no doc update needed.

## Implementation notes

- New private helper `GatewayClient._sha_is_ancestor` wraps `git merge-base --is-ancestor` through `/api/v1/git/execute`. `merge-base` is already on the gateway's allowlist (`gateway/git_client.py:853`), so no new gateway surface is introduced. Returns `False` on any unexpected failure so callers can fall through conservatively.
- The recovery check reuses the synthetic launcher-authenticated session that the function already registers — no extra session round-trip.
- The integration-branch fetch only runs when `existing_sha != parent_sha`, so the common (first-run) path adds exactly one extra `ls-remote` over the prior implementation.

## Test plan

- [x] New `TestCreateSliceIntegrationBranchRestartRecovery`:
  - existing branch descended from parent → no push, returns True (the #2512 reproduction)
  - existing branch diverged from parent → falls through to push
  - existing branch equal to parent → no merge-base check, push runs as no-op fast-forward
- [x] New `TestShaIsAncestor` unit tests: success returns True; `returncode: 1` from gateway returns False; unexpected GatewayError returns False.
- [x] Updated existing `test_fetch_runs_before_sha_lookup_runs_before_push` to reflect the new ordering (parent ls-remote → integration ls-remote → push).
- [ ] CI runs full suite (local `.venv` not present in this worktree).
- [ ] Manual reproduction: re-run a cancelled (`cleanup=false`) implement-phase pipeline and confirm restart_phase recovers without the non-fast-forward rejection.