### PR TITLE
Fix #2490: extend validate_assignment to sibling Contract models

### DIFF
--- a/shared/egg_contracts/models.py
+++ b/shared/egg_contracts/models.py
@@ -12,6 +12,22 @@ from typing import Any, cast
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
 
 
+class EggContractBaseModel(BaseModel):
+    """Shared base for every model in the contract object graph.
+
+    ``validate_assignment=True`` makes ``setattr`` re-run field
+    validation, so ``contract.current_phase = "plan"`` coerces to
+    ``PipelinePhase.PLAN`` (and ``task.status = "garbage"`` raises
+    ``pydantic.ValidationError``) instead of silently storing the raw
+    string. Originally added to ``Contract`` only in #2484; lifted to a
+    shared base in #2490 so the strictness applies uniformly to sibling
+    models (``Task``, ``Slice``, ``Decision``, ``AgentExecutionModel``,
+    …) — without per-model duplication of the config.
+    """
+
+    model_config = ConfigDict(validate_assignment=True)
+
+
 class TaskStatus(StrEnum):
     """Status values for tasks."""
 
@@ -92,7 +108,7 @@ class AuditRole(StrEnum):
     SYSTEM = "system"
 
 
-class IssueInfo(BaseModel):
+class IssueInfo(EggContractBaseModel):
     """Issue metadata."""
 
     number: int = Field(..., ge=1, description="GitHub issue number")
@@ -100,7 +116,7 @@ class IssueInfo(BaseModel):
     url: str = Field(..., description="Issue URL")
 
 
-class AcceptanceCriterion(BaseModel):
+class AcceptanceCriterion(EggContractBaseModel):
     """Top-level acceptance criterion."""
 
     id: str = Field(..., pattern=r"^ac-[0-9]+$", description="Unique identifier")
@@ -108,7 +124,7 @@ class AcceptanceCriterion(BaseModel):
     verified: bool = Field(default=False, description="Whether verified by reviewer")
 
 
-class ReviewFeedback(BaseModel):
+class ReviewFeedback(EggContractBaseModel):
     """Feedback from reviewer on a task."""
 
     timestamp: datetime = Field(..., description="When feedback was given")
@@ -137,7 +153,7 @@ def _normalise_slice_id(value: str) -> str:
     return value
 
 
-class TaskGap(BaseModel):
+class TaskGap(EggContractBaseModel):
     """Tester→coder coverage-gap handoff record.
 
     Added in iteration 2 of the agent-facing MCP tools (#1917) so the
@@ -163,7 +179,7 @@ class TaskGap(BaseModel):
     resolved: bool = Field(default=False, description="Set True when the gap is addressed")
 
 
-class Task(BaseModel):
+class Task(EggContractBaseModel):
     """A task within a phase."""
 
     id: str = Field(
@@ -211,7 +227,7 @@ class Task(BaseModel):
         return _normalize_commit(v)
 
 
-class Slice(BaseModel):
+class Slice(EggContractBaseModel):
     """An implementation slice containing tasks.
 
     Renamed from ``Phase`` in #2137 to support the slice-DAG implement
@@ -291,7 +307,7 @@ class Slice(BaseModel):
 Phase = Slice
 
 
-class DecisionOption(BaseModel):
+class DecisionOption(EggContractBaseModel):
     """An option for a decision."""
 
     id: str = Field(..., description="Option identifier")
@@ -299,7 +315,7 @@ class DecisionOption(BaseModel):
     description: str | None = Field(default=None, description="Option description")
 
 
-class Decision(BaseModel):
+class Decision(EggContractBaseModel):
     """A HITL decision point."""
 
     id: str = Field(..., pattern=r"^decision-[0-9]+$", description="Unique decision identifier")
@@ -318,7 +334,7 @@ class Decision(BaseModel):
     debounce_until: datetime | None = Field(default=None, description="Debounce expiration")
 
 
-class DeferredAction(BaseModel):
+class DeferredAction(EggContractBaseModel):
     """A single pre-merge obligation persisted from a conditional ACK.
 
     Replaces the free-form ``list[str]`` shape used in #2004 so the renderer
@@ -352,7 +368,7 @@ class DeferredAction(BaseModel):
     )
 
 
-class PRMetadata(BaseModel):
+class PRMetadata(EggContractBaseModel):
     """Planner-generated PR metadata: title, description, test plan, and manual steps."""
 
     title: str = Field(..., min_length=1, description="PR title (recommended max 70 chars)")
@@ -410,7 +426,7 @@ class PRMetadata(BaseModel):
         return coerced
 
 
-class CheckDefinition(BaseModel):
+class CheckDefinition(EggContractBaseModel):
     """Definition of a check to run during a phase."""
 
     id: str = Field(
@@ -425,7 +441,7 @@ class CheckDefinition(BaseModel):
     max_retries: int = Field(default=0, ge=0, description="Maximum number of retries")
 
 
-class CheckResult(BaseModel):
+class CheckResult(EggContractBaseModel):
     """Result of running a check."""
 
     check_id: str = Field(
@@ -439,7 +455,7 @@ class CheckResult(BaseModel):
     fixable: bool = Field(default=False, description="Whether this failure can be auto-fixed")
 
 
-class PhaseConfig(BaseModel):
+class PhaseConfig(EggContractBaseModel):
     """Configuration for a pipeline phase."""
 
     checks: list[CheckDefinition] = Field(
@@ -454,7 +470,7 @@ class PhaseConfig(BaseModel):
     )
 
 
-class FeedbackQuestion(BaseModel):
+class FeedbackQuestion(EggContractBaseModel):
     """A question for human feedback."""
 
     id: str = Field(..., pattern=r"^Q[0-9]+$", description="Unique question identifier (e.g., Q1)")
@@ -462,7 +478,7 @@ class FeedbackQuestion(BaseModel):
     answer: str | None = Field(default=None, description="Human-provided answer (free-form text)")
 
 
-class Feedback(BaseModel):
+class Feedback(EggContractBaseModel):
     """Feedback request for collecting open-ended questions from humans."""
 
     id: str = Field(
@@ -506,7 +522,7 @@ class Feedback(BaseModel):
         return all(q.answer is not None for q in self.questions)
 
 
-class AuditEntry(BaseModel):
+class AuditEntry(EggContractBaseModel):
     """Audit log entry for contract modifications."""
 
     timestamp: datetime = Field(..., description="When the action occurred")
@@ -555,7 +571,7 @@ class AgentRoleType(StrEnum):
     REVIEWER_PLAN = "reviewer_plan"
 
 
-class AgentExecutionModel(BaseModel):
+class AgentExecutionModel(EggContractBaseModel):
     """Tracks the execution state of a single agent.
 
     Used by the orchestrator to track which agents have run,
@@ -593,17 +609,8 @@ class AgentExecutionModel(BaseModel):
     )
 
 
-class Contract(BaseModel):
+class Contract(EggContractBaseModel):
     """The complete SDLC contract."""
-
-    # ``validate_assignment=True`` ensures that ``setattr`` on Contract
-    # fields coerces the value back to the declared type — most
-    # importantly, that ``contract.current_phase = "plan"`` produces a
-    # ``PipelinePhase`` enum rather than a plain ``str``. See #2465 for
-    # the bug this guards against (apply_mutation leaving
-    # ``current_phase`` as a string until the next save/load round-trip,
-    # which broke ``.value`` reads and emitted serializer warnings).
-    model_config = ConfigDict(validate_assignment=True)
 
     schemaVersion: str = Field(  # noqa: N815
         default="1.0", pattern=r"^[0-9]+\.[0-9]+$", description="Schema version"

--- a/shared/egg_contracts/validator.py
+++ b/shared/egg_contracts/validator.py
@@ -121,12 +121,16 @@ def apply_mutation(
             message=f"Failed to apply mutation: {e}",
         )
     except ValidationError as e:
-        # ``Contract.model_config = ConfigDict(validate_assignment=True)``
-        # (added for #2465) makes ``setattr`` raise pydantic
-        # ``ValidationError`` for out-of-domain values (e.g. an
-        # arbitrary string for an enum field). Surface that through the
-        # existing ``MutationResult`` channel so the contract /mutate
-        # route returns a structured 4xx instead of an opaque 500.
+        # ``EggContractBaseModel.model_config = ConfigDict(validate_assignment=True)``
+        # (added for #2465 on ``Contract``, lifted to the shared base in
+        # #2490) makes ``setattr`` raise pydantic ``ValidationError`` for
+        # out-of-domain values (e.g. an arbitrary string for an enum
+        # field) on ``Contract`` *and* on every sibling model in the
+        # contract object graph (``Task.status = "garbage"``,
+        # ``Slice.status = "garbage"``, ``Decision.type = "garbage"``,
+        # …). Surface that through the existing ``MutationResult``
+        # channel so the contract /mutate route returns a structured
+        # 4xx instead of an opaque 500.
         return MutationResult(
             success=False,
             message=f"Invalid value for {field_path}: {e}",

--- a/tests/shared/egg_contracts/test_models.py
+++ b/tests/shared/egg_contracts/test_models.py
@@ -912,13 +912,22 @@ class TestValidateAssignmentSiblingModels:
         assert feedback.phase is PipelinePhase.PLAN
 
     def test_pr_metadata_invalid_deferred_actions_raises(self):
-        """Field validation re-runs on assignment for nested-model fields too."""
+        """Field validation re-runs on assignment for nested-model fields too.
+
+        Assigning a raw dict — rather than a pre-constructed
+        ``DeferredAction(...)`` — is what actually exercises pydantic's
+        list-element coercion path on the parent ``PRMetadata.deferred_actions``
+        setattr. (A pre-constructed inner instance is not deeply
+        revalidated under pydantic's default ``revalidate_instances="never"``,
+        so wrapping the bad value in ``DeferredAction(...)`` would raise
+        from the inner constructor, not from the outer assignment.)
+        """
         pr = PRMetadata(title="t")
         pr.deferred_actions = [DeferredAction(reviewer="r", condition="cond")]
         with pytest.raises(ValidationError):
             # ``resolved_in_diff`` has a hex-only pattern; non-hex must be rejected.
             pr.deferred_actions = [
-                DeferredAction(reviewer="r", condition="cond", resolved_in_diff="not-hex!")
+                {"reviewer": "r", "condition": "cond", "resolved_in_diff": "not-hex!"}
             ]
 
     def test_no_unexpected_serialization_warnings_after_sibling_assignments(self):

--- a/tests/shared/egg_contracts/test_models.py
+++ b/tests/shared/egg_contracts/test_models.py
@@ -1,9 +1,13 @@
 """Tests for egg_contracts.models module."""
 
+import warnings
 from datetime import UTC, datetime
 
 import pytest
 from egg_contracts.models import (
+    AgentExecutionModel,
+    AgentExecutionStatus,
+    AgentRoleType,
     AuditAction,
     AuditEntry,
     AuditRole,
@@ -13,16 +17,25 @@ from egg_contracts.models import (
     Contract,
     Decision,
     DecisionType,
+    DeferredAction,
+    EggContractBaseModel,
+    Feedback,
+    FeedbackQuestion,
     HumanReviewMechanism,
     IssueInfo,
     Phase,
     PhaseConfig,
     PhaseStatus,
     PipelinePhase,
+    PRMetadata,
+    ReviewFeedback,
+    Slice,
+    SliceStatus,
     Task,
     TaskStatus,
 )
 from pydantic import ValidationError
+from pydantic_core import PydanticSerializationUnexpectedValue
 
 
 class TestIssueInfo:
@@ -764,3 +777,177 @@ class TestContractWithPhaseConfigs:
         }
         contract = Contract.model_validate(data)
         assert contract.phase_configs is None
+
+
+class TestValidateAssignmentSiblingModels:
+    """Regression tests for #2490 — ``validate_assignment=True`` extended
+    from ``Contract`` to every sibling model in the contract object graph
+    via the shared ``EggContractBaseModel``.
+
+    Each test asserts the two halves of the acceptance criterion: a
+    string-compatible enum value coerces to the declared type, and an
+    out-of-domain value raises ``pydantic.ValidationError`` (which
+    ``apply_mutation`` then surfaces as ``MutationResult(success=False)``
+    via the catch added in #2484).
+    """
+
+    def test_base_class_sets_validate_assignment(self):
+        """The shared base flips ``validate_assignment`` on for everyone."""
+        assert EggContractBaseModel.model_config.get("validate_assignment") is True
+        # And every concrete model inherits the config — spot-check a
+        # representative sample across enum / nested-model / scalar
+        # field shapes.
+        for cls in (
+            Task,
+            Slice,
+            Decision,
+            AgentExecutionModel,
+            PRMetadata,
+            Feedback,
+            Contract,
+        ):
+            assert issubclass(cls, EggContractBaseModel)
+            assert cls.model_config.get("validate_assignment") is True
+
+    def test_task_status_string_coerces_to_enum(self):
+        task = Task(id="task-1", description="x")
+        # ``setattr`` (not ``=``) — this is the path ``apply_mutation``
+        # / ``_set_value`` ultimately takes, and avoids tripping mypy on
+        # str-to-enum assignments that are only legal at runtime thanks
+        # to ``validate_assignment=True``.
+        setattr(task, "status", "in_progress")  # noqa: B010
+        assert type(task.status) is TaskStatus
+        assert task.status is TaskStatus.IN_PROGRESS
+
+    def test_task_invalid_status_raises(self):
+        task = Task(id="task-1", description="x")
+        with pytest.raises(ValidationError):
+            setattr(task, "status", "garbage")  # noqa: B010
+        # Original value unchanged.
+        assert task.status is TaskStatus.PENDING
+
+    def test_slice_status_string_coerces_to_enum(self):
+        slice_ = Slice(id="slice-1", name="one")
+        setattr(slice_, "status", "in_progress")  # noqa: B010
+        assert type(slice_.status) is SliceStatus
+        assert slice_.status is SliceStatus.IN_PROGRESS
+
+    def test_slice_invalid_status_raises(self):
+        slice_ = Slice(id="slice-1", name="one")
+        with pytest.raises(ValidationError):
+            setattr(slice_, "status", "garbage")  # noqa: B010
+        assert slice_.status is SliceStatus.PENDING
+
+    def test_decision_type_string_coerces_to_enum(self):
+        decision = Decision(id="decision-1", question="q?", type=DecisionType.HITL)
+        setattr(decision, "type", "auto")  # noqa: B010
+        assert type(decision.type) is DecisionType
+        assert decision.type is DecisionType.AUTO
+
+    def test_decision_invalid_type_raises(self):
+        decision = Decision(id="decision-1", question="q?", type=DecisionType.HITL)
+        with pytest.raises(ValidationError):
+            setattr(decision, "type", "garbage")  # noqa: B010
+        assert decision.type is DecisionType.HITL
+
+    def test_agent_execution_status_string_coerces_to_enum(self):
+        execution = AgentExecutionModel(role=AgentRoleType.CODER)
+        setattr(execution, "status", "running")  # noqa: B010
+        assert type(execution.status) is AgentExecutionStatus
+        assert execution.status is AgentExecutionStatus.RUNNING
+
+    def test_agent_execution_invalid_status_raises(self):
+        execution = AgentExecutionModel(role=AgentRoleType.CODER)
+        with pytest.raises(ValidationError):
+            setattr(execution, "status", "garbage")  # noqa: B010
+        assert execution.status is AgentExecutionStatus.PENDING
+
+    def test_agent_execution_invalid_role_raises(self):
+        execution = AgentExecutionModel(role=AgentRoleType.CODER)
+        with pytest.raises(ValidationError):
+            setattr(execution, "role", "not-a-real-role")  # noqa: B010
+        assert execution.role is AgentRoleType.CODER
+
+    def test_review_feedback_status_string_coerces_to_enum(self):
+        review = ReviewFeedback(
+            timestamp=datetime.now(UTC),
+            task_id="task-1",
+            feedback="needs work",
+        )
+        setattr(review, "status", "complete")  # noqa: B010
+        assert type(review.status) is TaskStatus
+        assert review.status is TaskStatus.COMPLETE
+
+    def test_phase_config_human_review_mechanism_coerces_to_enum(self):
+        config = PhaseConfig()
+        setattr(config, "human_review_mechanism", "PR_REVIEW")  # noqa: B010
+        assert type(config.human_review_mechanism) is HumanReviewMechanism
+        assert config.human_review_mechanism is HumanReviewMechanism.PR_REVIEW
+
+    def test_check_result_status_string_coerces_to_enum(self):
+        result = CheckResult(check_id="check-lint", status=CheckStatus.PASS)
+        setattr(result, "status", "fail")  # noqa: B010
+        assert type(result.status) is CheckStatus
+        assert result.status is CheckStatus.FAIL
+
+    def test_audit_entry_invalid_action_raises(self):
+        entry = AuditEntry(
+            timestamp=datetime.now(UTC),
+            actor="actor",
+            role=AuditRole.HUMAN,
+            action=AuditAction.UPDATE,
+            field_path="x",
+        )
+        with pytest.raises(ValidationError):
+            setattr(entry, "action", "garbage")  # noqa: B010
+        assert entry.action is AuditAction.UPDATE
+
+    def test_feedback_phase_string_coerces_to_enum(self):
+        feedback = Feedback(
+            id="feedback-1",
+            questions=[FeedbackQuestion(id="Q1", question="q?")],
+        )
+        setattr(feedback, "phase", "plan")  # noqa: B010
+        assert type(feedback.phase) is PipelinePhase
+        assert feedback.phase is PipelinePhase.PLAN
+
+    def test_pr_metadata_invalid_deferred_actions_raises(self):
+        """Field validation re-runs on assignment for nested-model fields too."""
+        pr = PRMetadata(title="t")
+        pr.deferred_actions = [DeferredAction(reviewer="r", condition="cond")]
+        with pytest.raises(ValidationError):
+            # ``resolved_in_diff`` has a hex-only pattern; non-hex must be rejected.
+            pr.deferred_actions = [
+                DeferredAction(reviewer="r", condition="cond", resolved_in_diff="not-hex!")
+            ]
+
+    def test_no_unexpected_serialization_warnings_after_sibling_assignments(self):
+        """Round-trip after sibling-model setattrs emits no PydanticSerializationUnexpectedValue.
+
+        Mirror of the second acceptance criterion: existing tests that
+        round-trip a contract must not start emitting
+        ``PydanticSerializationUnexpectedValue`` warnings after the
+        sibling models adopt ``validate_assignment=True``.
+        """
+        contract = Contract(
+            issue=IssueInfo(
+                number=1,
+                title="t",
+                url="https://github.com/o/r/issues/1",
+            ),
+            slices=[
+                Slice(
+                    id="slice-1",
+                    name="one",
+                    tasks=[Task(id="task-1", description="x")],
+                )
+            ],
+            decisions=[Decision(id="decision-1", question="q?", type=DecisionType.HITL)],
+        )
+        setattr(contract.slices[0].tasks[0], "status", "complete")  # noqa: B010
+        setattr(contract.slices[0], "status", "complete")  # noqa: B010
+        setattr(contract.decisions[0], "type", "auto")  # noqa: B010
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", PydanticSerializationUnexpectedValue)
+            contract.model_dump(mode="json")


### PR DESCRIPTION
## Summary

- Lift `validate_assignment=True` from `Contract` (added in #2484) onto a shared `EggContractBaseModel` so every model in `shared/egg_contracts/models.py` (`Task`, `Slice`, `Decision`, `AgentExecutionModel`, `PRMetadata`, `Feedback`, …) gets uniform `setattr` coercion / rejection.
- This is **Option B** from the issue — shared base class, no per-model duplication.
- Closes #2490.

Before this change, the post-#2484 validation surface was uneven: `contract.current_phase = "plan"` coerced to `PipelinePhase.PLAN`, but `task.status = "garbage"` silently stored a raw string. Now both go through the same path.

The audit of sibling-model mutation sites (`shared/egg_contracts/orchestration.py:196,212` `execution.status = …`, `:414` `contract.agent_executions = …`, `orchestrator/routes/decisions.py:291` `contract.pr = PRMetadata(…)`, etc.) confirms they all assign well-typed values — enum members or constructed model instances — so the new strictness doesn't break existing call sites.

## Test plan

- [x] New `TestValidateAssignmentSiblingModels` class (17 tests) — per-model coverage of both branches of the acceptance criterion (string-compatible value coerces to enum; out-of-domain value raises `ValidationError`).
- [x] Round-trip test asserts no `PydanticSerializationUnexpectedValue` warnings emitted after sibling-model setattrs (mirror of the second criterion).
- [x] `pytest tests/shared/egg_contracts/test_models.py tests/shared/egg_contracts/test_models_gaps.py tests/shared/egg_contracts/test_validator.py` — 223 passed.
- [x] `pytest tests/shared/egg_contracts/ orchestrator/tests/test_contracts_routes.py` — 1089 passed; 1 pre-existing failure (`test_agent_roles.py::test_gateway_agent_role_is_canonical` — `ModuleNotFoundError: agent_restrictions`, reproduces on `main`).
- [x] `ruff check` / `ruff format --check` — clean on touched files.