### PR TITLE
Fix #2531: add `--for STATUS` to producer pre-confirm wait-loop

### DIFF
--- a/docs/reference/agent-wait-patterns.md
+++ b/docs/reference/agent-wait-patterns.md
@@ -47,6 +47,7 @@ and issues [#2064](https://github.com/jwbron/egg/issues/2064), [#2482](https://g
 | `CONSENSUS_ACK` | A reviewer ACKed — check if all required reviewers have ACKed, then confirm | Print and exit 0; act on the message |
 | `CONSENSUS_NACK` | A reviewer NACKed — start fixing immediately | Print and exit 0; act on the message |
 | `CONSENSUS_RE_REVIEW` | Re-review requested (peer re-proposed) | Print and exit 0; act on the message |
+| `STATUS` | Directed *Ready to confirm — all confirm preconditions satisfied* nudge fires once every blocking review clears and global guards pass — the only signal once every reviewer has already ACKed (#2531) | Print and exit 0; if `metadata.ready_to_confirm == true` go to step 5 CONFIRM, otherwise re-enter the wait |
 | `OVERSEER_ALERT` | Overseer escalation | Print and exit 0; act on the message |
 
 ```bash
@@ -55,8 +56,20 @@ egg-orch message wait-loop \
   --for CONSENSUS_ACK \
   --for CONSENSUS_NACK \
   --for CONSENSUS_RE_REVIEW \
+  --for STATUS \
   --for OVERSEER_ALERT
 ```
+
+> **Why `STATUS` is in the pre-confirm allowlist (#2531):** when every
+> reviewer ACKs the current version, no further `CONSENSUS_ACK` /
+> `CONSENSUS_NACK` arrive on the bus. The orchestrator's directed
+> *Ready to confirm* nudge (`MessageType.STATUS`,
+> `metadata.ready_to_confirm == True`) is the only signal that the
+> global preconditions cleared. Without `STATUS` in the filter, the
+> producer sleeps through the nudge and only wakes via the
+> health-monitor `OVERSEER_ALERT` backstop — minutes later. See the
+> "Disambiguator" note in [Anti-pattern 5](#anti-pattern-5--producer-waits-on-consensus_confirmed-before-its-own-confirm-has-succeeded-2064)
+> for handling unrelated `STATUS` wakeups (e.g. *Producer X excused*).
 
 ### Producer STAY ALIVE (post-confirm, step 6)
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -585,18 +585,22 @@ def _send_brc_confirmation_nudge(
     it directly to the stuck producer rather than relying on the
     overseer agent's discretion.
 
-    Uses ``OVERSEER_ALERT`` (not ``STATUS`` or ``NUDGE``) because it is
-    the only message type that appears in **both** the producer's
-    pre-confirm wait_loop filter
-    (``CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,OVERSEER_ALERT``)
-    and post-confirm wait_loop filter
-    (``CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT``), so it
-    wakes the producer regardless of which wait they are blocked on.
-    A wedged producer is in the ``fully_acked but not confirmed`` set,
-    which means they are most likely blocked on the pre-confirm wait.
-    The subject calls out that the alert originated from the
-    orchestrator's deterministic detector rather than the overseer
-    agent.
+    Uses ``OVERSEER_ALERT`` (not ``STATUS`` or ``NUDGE``) because it
+    appears in **both** the producer's pre-confirm wait_loop filter
+    (``CONSENSUS_ACK,CONSENSUS_NACK,CONSENSUS_RE_REVIEW,STATUS,OVERSEER_ALERT``,
+    post-#2531) and post-confirm wait_loop filter
+    (``CONSENSUS_CONFIRMED,CONSENSUS_RE_REVIEW,OVERSEER_ALERT``) and has
+    no protocol-specific semantics that would conflict with a producer
+    nudge — ``CONSENSUS_RE_REVIEW`` is also in both filters but means
+    "a peer re-proposed; re-review their artifact," not "you are
+    wedged; confirm." ``STATUS`` is in the pre-confirm filter (it
+    carries the orchestrator's *Ready to confirm* nudge) but not the
+    post-confirm filter, so it wouldn't reach a producer wedged after
+    a successful confirm. A wedged producer is in the
+    ``fully_acked but not confirmed`` set, which means they are most
+    likely blocked on the pre-confirm wait. The subject calls out
+    that the alert originated from the orchestrator's deterministic
+    detector rather than the overseer agent.
 
     Returns True when a message was posted, False otherwise (wrong
     alert type, missing fields, message store unavailable, send error).
@@ -9540,12 +9544,23 @@ def _build_brc_preamble(
                 "4. **RESPOND TO REVIEWS**: Poll for ACK/NACK from reviewers with "
                 "`egg-orch message wait-loop --for CONSENSUS_ACK "
                 "--for CONSENSUS_NACK --for CONSENSUS_RE_REVIEW "
-                "--for OVERSEER_ALERT`. Do **not** include "
+                "--for STATUS --for OVERSEER_ALERT`. Do **not** include "
                 "`CONSENSUS_CONFIRMED` in this pre-confirm wait — your own "
                 "confirm is part of what generates that signal, so the "
                 "orchestrator rejects the wait with HTTP 400 "
                 "(#2064, #2482); the confirmed event belongs only in step "
                 "6 STAY ALIVE, after your confirm has succeeded. "
+                "`STATUS` is required so the orchestrator's directed "
+                "**Ready to confirm — all confirm preconditions satisfied** "
+                "nudge wakes you (#2531): when every reviewer has already "
+                "ACKed the current version, no further `CONSENSUS_ACK` / "
+                "`CONSENSUS_NACK` will arrive, and the directed `STATUS` "
+                "(metadata `ready_to_confirm: true`) is the only signal "
+                "that the global confirm preconditions cleared. On wake, "
+                "if the message is the directed *Ready to confirm* nudge, "
+                "go straight to step 5 **CONFIRM**; other `STATUS` wakeups "
+                "(e.g. *Producer X excused from consensus*) are "
+                "informational — re-enter the wait. "
                 "On the first NACK, start fixing "
                 "immediately — don't wait. **Aggregation is enforced by the "
                 "orchestrator, not by you (#2142):** when **two or more distinct "

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -3884,13 +3884,44 @@ class TestProducerRespondToReviewsWaitLoop:
             "--for CONSENSUS_ACK",
             "--for CONSENSUS_NACK",
             "--for CONSENSUS_RE_REVIEW",
+            "--for STATUS",
             "--for OVERSEER_ALERT",
         ):
             assert required in respond_block, (
                 f"RESPOND TO REVIEWS step must include `{required}` in the "
                 f"pre-confirm wait-loop incantation for role={role} "
-                f"phase={phase} (issue #2482)."
+                f"phase={phase} (issues #2482, #2531)."
             )
+
+    @pytest.mark.parametrize(("role", "phase"), _PRODUCER_ROLES_BY_PHASE)
+    def test_step4_explains_status_ready_to_confirm_nudge(self, role, phase):
+        """`--for STATUS` must come with guidance on the directed
+        ``Ready to confirm`` nudge (issue #2531).
+
+        Background: when every reviewer has already ACKed the current
+        version, no further ``CONSENSUS_ACK`` / ``CONSENSUS_NACK`` arrive
+        and the producer would deadlock until its wait timed out. The
+        orchestrator emits a directed ``STATUS`` (subject ``Ready to
+        confirm — all confirm preconditions satisfied``,
+        ``metadata.ready_to_confirm == True``) once the global
+        preconditions clear. The prompt has to tell the producer to act
+        on that wake (go to step 5 CONFIRM), or the agent will read the
+        message, treat it as informational, and re-enter the wait.
+        """
+        preamble = _build_brc_preamble(role, phase, branch="egg/issue-123")
+        respond_start = preamble.index("**RESPOND TO REVIEWS**")
+        respond_end = preamble.index("**CONFIRM**", respond_start)
+        respond_block = preamble[respond_start:respond_end]
+        assert "Ready to confirm" in respond_block, (
+            f"RESPOND TO REVIEWS step must mention the orchestrator's "
+            f"`Ready to confirm` STATUS nudge so role={role} phase={phase} "
+            "knows what to do on a STATUS wake (issue #2531)."
+        )
+        assert "#2531" in respond_block, (
+            "RESPOND TO REVIEWS step must cite #2531 next to the STATUS "
+            "guidance so future readers have the context for why STATUS "
+            "is in the allowlist."
+        )
 
     @pytest.mark.parametrize(("role", "phase"), _PRODUCER_ROLES_BY_PHASE)
     def test_step4_excludes_consensus_confirmed(self, role, phase):


### PR DESCRIPTION
## Summary

- Fixes the BRC producer wait-loop deadlock from #2531: producers waited on `CONSENSUS_ACK` / `CONSENSUS_NACK` only and slept through the orchestrator's directed `STATUS` "Ready to confirm" nudge once every reviewer had already ACKed.
- Adds `--for STATUS` to the producer's pre-confirm wait-loop in the BRC preamble (`orchestrator/routes/pipelines.py`) and explains how to disambiguate the directed `Ready to confirm` nudge (act → step 5 CONFIRM) from unrelated `STATUS` wakeups (re-enter the wait).
- Pins the new filter + on-wake guidance with a regression test parametrized across every producer role × phase, and updates `agent-wait-patterns.md` to match.

## Background

Pipeline `issue-2474-v2` slice-1 stalled at 6/8 CONFIRMs in implement phase. Coder + documenter were `PROPOSED v3` with all 5 reviewer ACKs in but never confirmed: their `wait-loop --for CONSENSUS_ACK --for CONSENSUS_NACK ...` filter didn't include `STATUS`, so the orchestrator's two `Ready to confirm — all confirm preconditions satisfied` broadcasts (at 03:48:46 and 03:49:51 UTC) flew past them. Net effect: the producer's wait timed out empty, re-entered the same wait, and only woke via the `OVERSEER_ALERT` health-monitor backstop minutes later.

The reference doc already prescribed waiting on `STATUS` for the pending-acks recovery path (`agent-wait-patterns.md` Anti-pattern 5, lines 282–302) — the prompt template just hadn't caught up. This is suggestion (1) from the issue: the smallest change that addresses the immediate deadlock.

## Test plan

- [x] `make test` (changeset-aware): 16799 passed, 41 skipped, 75 deselected
- [x] `pytest orchestrator/tests/test_pipeline_prompts.py::TestProducerRespondToReviewsWaitLoop`: 21/21 pass (was 14/14 — added 7 new parametrized cases for the `Ready to confirm` guidance)
- [x] `pytest orchestrator/tests/test_brc_confirmation_nudge.py`: 11/11 pass after the docstring update on `_send_brc_confirmation_nudge`
- [x] `make lint` clean
- [x] No callers grep for the literal old filter string outside frozen `.egg-state/brc-history/` logs

## Notes

- The `_send_brc_confirmation_nudge` docstring is updated: `OVERSEER_ALERT` is still the right type for the health-monitor backstop (it appears in *both* pre- and post-confirm filters and has no protocol-specific semantics that would conflict with a producer nudge), even though `STATUS` is now in the pre-confirm filter. The backstop remains useful when the directed nudge is missed for any reason.
- Suggestions (2)–(4) from the issue (poll `mcp__brc__get_state` between waits, orchestrator-mediated CONFIRMED, etc.) are deliberately out of scope for this PR.

Closes #2531.