### PR TITLE
Fix #2539: drop duplicate `slice ` prefix in non-terminal slice PR titles

### DIFF
--- a/docs/architecture/slice-dag.md
+++ b/docs/architecture/slice-dag.md
@@ -445,7 +445,7 @@ terminal_slice_id=None, ...)` opens one PR per slice with two body
 shapes:
 
 - **Non-terminal slices** (no `program_title`) — title is
-  `"slice {slice_id}: {slice_name}"` truncated to 70 chars; body lists
+  `"{slice_id}: {slice_name}"` truncated to 70 chars; body lists
   the slice's tasks (each truncated to 300 chars), optionally followed
   by a one-line pointer to `terminal_slice_id` so reviewers can jump
   to the umbrella PR; footer names the slice ID, pipeline, and base.

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1246,7 +1246,7 @@ class GatewayClient:
           fallback so this path stays at parity with the legacy
           single-PR renderer.
         * **Non-terminal slice** (no ``program_title``): deterministic
-          ``slice {slice_id}: {slice_name}`` title, bulleted task list
+          ``{slice_id}: {slice_name}`` title, bulleted task list
           body. When ``terminal_slice_id`` is supplied, the body also
           carries a pointer to the terminal slice so reviewers can
           jump to the umbrella PR. ``program_deferred_actions`` MUST
@@ -1264,7 +1264,7 @@ class GatewayClient:
             assert program_title is not None  # implied by has_program_block
             title = program_title.strip()
         else:
-            title = f"slice {slice_id}: {slice_name}".strip()
+            title = f"{slice_id}: {slice_name}".strip()
         if len(title) > 70:
             title = title[:67] + "..."
 

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -1357,7 +1357,7 @@ class TestCreateSlicePR:
 
     def test_non_terminal_slice_uses_auto_generated_title_and_body(self, gateway_client):
         """Without program_title the helper still emits the deterministic
-        ``slice <id>: <name>`` title and the bulleted task body."""
+        ``<slice_id>: <name>`` title and the bulleted task body."""
         captured, ctx = self._capture(gateway_client)
         with ctx:
             gateway_client.create_slice_pr(
@@ -1369,7 +1369,7 @@ class TestCreateSlicePR:
                 head="egg/issue-42/slice-1",
                 base="egg/issue-42",
             )
-        assert captured["title"] == "slice slice-1: Pattern adoption"
+        assert captured["title"] == "slice-1: Pattern adoption"
         assert "Pattern adoption" in captured["body"]
         assert "Tasks in this slice:" in captured["body"]
         assert "- task-1-1: Add the barrel re-export" in captured["body"]
@@ -1394,7 +1394,7 @@ class TestCreateSlicePR:
                 base="egg/issue-42",
                 terminal_slice_id="slice-3",
             )
-        assert captured["title"] == "slice slice-1: Pattern adoption"
+        assert captured["title"] == "slice-1: Pattern adoption"
         assert "`slice-3`" in captured["body"]
         assert "program-level narrative" in captured["body"]
         assert "Program-level umbrella PR" not in captured["body"]


### PR DESCRIPTION
## Summary

- `create_slice_pr` rendered non-terminal slice PR titles as `slice slice-1: …` because `slice_id` already starts with `slice-` (observed on #2533: *slice slice-1: Cleanup — k3s only, drop dead test tiers*).
- Drop the literal `slice ` prefix so the title is just `{slice_id}: {slice_name}` (e.g. `slice-1: Cleanup — k3s only, drop dead test tiers`).
- Update the two test assertions in `test_gateway_client.py` and the docstring + `docs/architecture/slice-dag.md` reference that pinned the buggy form.

Side benefit: 6 more chars of headroom against the 70-char truncation.

Fixes #2539.

## Test plan

- [ ] `make test` (or targeted `.venv/bin/pytest orchestrator/tests/test_gateway_client.py::TestCreateSlicePR`) passes.
- [ ] Manual: next slice PR opened by the orchestrator has title `slice-1: …`, not `slice slice-1: …`.