### PR TITLE
Fix #2535: stop slice-N from inheriting slice-(N-1) consensus, drop gateway import

### DIFF
--- a/orchestrator/concurrent_executor.py
+++ b/orchestrator/concurrent_executor.py
@@ -636,27 +636,31 @@ class ConcurrentPhaseExecutor:
                 pipeline_id=self.pipeline.id,
                 slice_id=self._slice_id,
             )
-            # Attempt lazy reconstruction from message store
-            # Reconstruction does NOT yet support slice scoping — for
-            # slice-scoped trackers we fall back to fetching the bare
-            # pipeline-id tracker (legacy behaviour). This is acceptable
-            # because reconstruction is a backstop for orchestrator
-            # restarts, not the steady-state path; per-slice trackers
-            # are stateless event consumers and are recreated by the
-            # slice scheduler on the next iteration.
-            try:
-                from peer_consensus import reconstruct_tracker_from_messages
+            # Attempt lazy reconstruction from message store — pipeline-
+            # scoped only. Slice-scoped reconstruction is unsafe today:
+            # CONSENSUS_* messages are persisted under the bare
+            # pipeline_id, so a per-slice replay would mingle siblings'
+            # messages and reach false consensus the moment a fresh
+            # slice spawns roles whose names match an already-confirmed
+            # prior slice. Per-slice trackers are stateless event
+            # consumers and are recreated by the slice scheduler on the
+            # next iteration; the pipeline run loop's empty-tracker
+            # iteration will simply observe is_complete=False, which is
+            # the correct answer for a brand-new slice (#2535).
+            if self._slice_id is None:
+                try:
+                    from peer_consensus import reconstruct_tracker_from_messages
 
-                graph = self._get_review_graph()
-                tracker = reconstruct_tracker_from_messages(self.pipeline.id, graph)
-            except ImportError:
-                pass
-            except Exception as e:
-                logger.warning(
-                    "Tracker reconstruction failed",
-                    error=str(e),
-                    pipeline_id=self.pipeline.id,
-                )
+                    graph = self._get_review_graph()
+                    tracker = reconstruct_tracker_from_messages(self.pipeline.id, graph)
+                except ImportError:
+                    pass
+                except Exception as e:
+                    logger.warning(
+                        "Tracker reconstruction failed",
+                        error=str(e),
+                        pipeline_id=self.pipeline.id,
+                    )
         if tracker:
             result = tracker.evaluate()
             # Message-bus fallback: if reconstruction produced a tracker but
@@ -678,7 +682,9 @@ class ConcurrentPhaseExecutor:
                 # Safety net (#1671): if the tracker has all roles in
                 # confirmed_roles but evaluate() returned False due to stale
                 # NACK edges in the approval matrix (common after NACK →
-                # re-propose cycles), trust the confirmed set.
+                # re-propose cycles), trust the confirmed set. This path is
+                # safe for slice-scoped trackers because ``confirmed_roles``
+                # is the per-slice tracker's own state.
                 tracker_confirmed = tracker.confirmed_roles
                 if all_roles and all_roles.issubset(tracker_confirmed):
                     logger.warning(
@@ -691,6 +697,23 @@ class ConcurrentPhaseExecutor:
                     )
                     result["is_complete"] = True
                     result["fallback"] = "tracker_confirmed"
+                elif self._slice_id is not None:
+                    # Slice-scoped: the message-bus fallback below scans
+                    # ``store.get_messages(pipeline_id)`` pipeline-wide and
+                    # cannot distinguish slice-1's CONFIRMs from slice-2's,
+                    # so it would falsely declare consensus the moment a
+                    # fresh slice spawns roles whose names match an already-
+                    # confirmed prior slice (#2535). The in-memory per-slice
+                    # tracker is the authoritative source for slice work;
+                    # an empty fresh tracker correctly returns
+                    # is_complete=False here so the pipeline run loop keeps
+                    # polling.
+                    logger.info(
+                        "Skipping pipeline-wide message-bus fallback for slice-scoped tracker",
+                        pipeline_id=self.pipeline.id,
+                        slice_id=self._slice_id,
+                        blocking_agents=result.get("blocking_agents", []),
+                    )
                 else:
                     # Message-bus fallback: scan message store for
                     # CONSENSUS_CONFIRMED messages (#1471/#1615).

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -10,6 +10,7 @@ Provides coordination between the orchestrator and gateway sidecar for:
 
 import json
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -46,6 +47,49 @@ except ImportError:
     GATEWAY_PORT = 9848  # noqa: EGG002
 
 logger = get_logger("orchestrator.gateway_client")
+
+
+_REBASE_REF_RE = re.compile(r"^[A-Za-z0-9._/+-][A-Za-z0-9._/+-]*$")
+
+
+def _build_rebase_onto_args(
+    branch: str, new_base: str, old_base: str
+) -> tuple[list[str], bool, str]:
+    """Construct the canonical ``rebase --onto`` argv for the reconciler.
+
+    Mirrors :func:`gateway.git_client.build_rebase_onto_args`, but lives in
+    the orchestrator package so the deployed orchestrator image (which does
+    not ship ``gateway/``) can build the argv without an import-time
+    dependency on the gateway code. The gateway server's ``/git`` endpoint
+    is the authoritative allowlist boundary — it re-validates this argv on
+    every request, so this helper is purely client-side argv construction
+    plus a ref-shape sanity check that fails fast on caller mistakes.
+    """
+    if not isinstance(branch, str) or not branch.strip():
+        return [], False, "branch must be a non-empty string"
+    if not isinstance(new_base, str) or not new_base.strip():
+        return [], False, "new_base must be a non-empty string"
+    if not isinstance(old_base, str) or not old_base.strip():
+        return [], False, "old_base must be a non-empty string"
+
+    for label, value in (("branch", branch), ("new_base", new_base), ("old_base", old_base)):
+        v = value.strip()
+        if v.startswith("-"):
+            return [], False, f"{label} must not start with '-' (rejected flag-shaped ref: {v!r})"
+        if any(ch.isspace() or ch == "\x00" for ch in v):
+            return (
+                [],
+                False,
+                f"{label} must not contain whitespace or NUL (rejected: {v!r})",
+            )
+        if not _REBASE_REF_RE.fullmatch(v):
+            return (
+                [],
+                False,
+                f"{label} must look like a git ref (alnum + . _ / + -); got {v!r}",
+            )
+
+    return ["--onto", new_base.strip(), old_base.strip(), branch.strip()], True, ""
 
 
 @dataclass
@@ -1390,8 +1434,11 @@ class GatewayClient:
 
         1. ``git rebase --onto <new_base> <old_base> <branch>``
            (via the existing per-agent ``/api/v1/git/execute``
-           endpoint and the canonical argv from
-           :func:`gateway.git_client.build_rebase_onto_args`).
+           endpoint and the canonical argv from the local
+           :func:`_build_rebase_onto_args` helper — which mirrors
+           ``gateway.git_client.build_rebase_onto_args`` so the
+           orchestrator image does not need ``gateway/`` on its
+           Python path).
         2. ``git push --force-with-lease origin <branch>``
            (via the existing per-agent ``/api/v1/git/push``
            endpoint) — propagates the rewritten history to origin
@@ -1420,16 +1467,7 @@ class GatewayClient:
         reconciler counts both ``False`` and exceptions as
         ``rebases_failed``.
         """
-        try:
-            from gateway.git_client import build_rebase_onto_args
-        except ImportError:
-            logger.error(
-                "rebase_onto: gateway/git_client module unavailable",
-                pipeline_id=pipeline_id,
-            )
-            return False
-
-        args, ok, err = build_rebase_onto_args(branch, new_base, old_base)
+        args, ok, err = _build_rebase_onto_args(branch, new_base, old_base)
         if not ok:
             logger.warning(
                 "rebase_onto: argv rejected by allowlist validator",

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -57,13 +57,22 @@ def _build_rebase_onto_args(
 ) -> tuple[list[str], bool, str]:
     """Construct the canonical ``rebase --onto`` argv for the reconciler.
 
-    Mirrors :func:`gateway.git_client.build_rebase_onto_args`, but lives in
-    the orchestrator package so the deployed orchestrator image (which does
-    not ship ``gateway/``) can build the argv without an import-time
-    dependency on the gateway code. The gateway server's ``/git`` endpoint
-    is the authoritative allowlist boundary — it re-validates this argv on
-    every request, so this helper is purely client-side argv construction
-    plus a ref-shape sanity check that fails fast on caller mistakes.
+    Performs the same ref-shape sanity checks as
+    :func:`gateway.git_client.build_rebase_onto_args` (reject empty,
+    flag-shaped, whitespace-bearing, or non-git-ref-shaped inputs) but
+    lives in the orchestrator package so the deployed orchestrator image
+    (which does not ship ``gateway/``) can build the argv without an
+    import-time dependency on the gateway code. Two intentional
+    differences from the gateway helper:
+
+    - The argv is emitted with each ref *stripped*, so leading/trailing
+      whitespace that the regex would otherwise reject as the input is
+      normalised before the gateway round-trip.
+    - This helper does NOT call ``gateway.git_client.validate_git_args``
+      — pulling that import in would defeat the point of inlining. The
+      gateway server's ``/git`` endpoint runs the same allowlist
+      validator on every submission, so the security floor is unchanged
+      (audit boundary is the server, not the client-side helper).
     """
     if not isinstance(branch, str) or not branch.strip():
         return [], False, "branch must be a non-empty string"

--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -1465,6 +1465,7 @@ def _existing_confirmed_for_role(
     pipeline_id: str,
     agent_role: str,
     phase: str | None,
+    slice_id: str | None = None,
 ) -> tuple[bool, bool]:
     """Return (has_final, has_pending_acks) for prior CONFIRMED messages.
 
@@ -1475,6 +1476,17 @@ def _existing_confirmed_for_role(
 
     - ``has_final``: a non-pending_acks CONFIRMED message already exists.
     - ``has_pending_acks``: a pending_acks CONFIRMED message exists.
+
+    ``slice_id`` scopes the check to a single slice. The message store
+    keys messages by bare ``pipeline_id``, so without scoping a fresh
+    slice-N coder would falsely appear "already confirmed" because
+    slice-(N-1)'s coder wrote a CONFIRMED message under the same
+    pipeline_id (#2535). Filtering on ``metadata["slice_id"]`` (written
+    by the per-slice tracker path below) confines the lookup to the
+    same slice. Pipeline-scoped (``slice_id is None``) callers continue
+    to see only messages with no ``slice_id`` in metadata, preserving
+    the legacy non-slice behaviour. Tracked under #2409 as part of
+    end-to-end slice-scoped message routing.
     """
     try:
         from message_store import get_message_store
@@ -1510,6 +1522,12 @@ def _existing_confirmed_for_role(
         if phase is not None and msg_phase is not None and msg_phase != phase:
             continue
         metadata = getattr(m, "metadata", None) or {}
+        # Scope idempotency check to the same slice. A None slice_id on
+        # either side (caller or message) only matches the same; this
+        # cleanly separates slice-N from slice-M and from pipeline-level
+        # confirms.
+        if metadata.get("slice_id") != slice_id:
+            continue
         if metadata.get("pending_acks"):
             has_pending = True
         else:
@@ -1669,9 +1687,16 @@ def handle_consensus_confirmed_signal(
         # check_consensus() can detect when all agents have *attempted*
         # confirmation even if the tracker rejected some (#1615).
         current_phase = _resolve_pipeline_phase(pipeline_id, repo_path)
+        # Pass slice_id so the idempotency probe doesn't see sibling-slice
+        # CONFIRMs as "already confirmed for this role" (#2535).
         has_final, has_pending = _existing_confirmed_for_role(
-            pipeline_id, agent_role, current_phase
+            pipeline_id, agent_role, current_phase, slice_id=slice_id
         )
+
+        # Common metadata tag so future _existing_confirmed_for_role probes
+        # can scope by slice (None for pipeline-level callers, matching the
+        # legacy behaviour exactly).
+        _slice_meta = {"slice_id": slice_id} if slice_id is not None else {}
 
         if result.get("status") == "pending_acks":
             # Dedupe pending_acks writes once an agent has already emitted one
@@ -1690,7 +1715,7 @@ def handle_consensus_confirmed_signal(
                         subject=f"Confirmed by {agent_role} (pending_acks)",
                         body=result.get("message", ""),
                         phase=current_phase,
-                        metadata={"pending_acks": True},
+                        metadata={"pending_acks": True, **_slice_meta},
                     )
                 )
             return make_success_response(result["message"], data=result, status_code=202)
@@ -1711,7 +1736,10 @@ def handle_consensus_confirmed_signal(
                     subject=f"Confirmed by {agent_role}",
                     body="",
                     phase=current_phase,
-                    metadata={"consensus_reached": result.get("consensus_reached", False)},
+                    metadata={
+                        "consensus_reached": result.get("consensus_reached", False),
+                        **_slice_meta,
+                    },
                 )
             )
 

--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -1581,6 +1581,16 @@ def handle_consensus_confirmed_signal(
                 error=str(recon_err),
             )
 
+        if not tracker and slice_id is not None:
+            # Slice-scoped: pipeline-wide message-bus fallback would mingle
+            # other slices' CONFIRMs and reach false consensus the moment a
+            # fresh slice spawns roles matching an already-confirmed prior
+            # slice (#2535). Per-slice trackers are recreated by the slice
+            # scheduler on the next iteration; surface the missing tracker
+            # rather than guessing from sibling-slice state.
+            scope = f"{pipeline_id}/{slice_id}"
+            return make_error_response(f"No consensus tracker for pipeline {scope}", 404)
+
         if not tracker:
             # Message-bus authoritative fallback: if all expected roles have
             # CONSENSUS_CONFIRMED messages, accept the confirmation directly.

--- a/orchestrator/stacked_pr_reconciler.py
+++ b/orchestrator/stacked_pr_reconciler.py
@@ -23,12 +23,18 @@ The reconciler runs on a fixed cadence (default 30 s, env var
 3. Calls ``GatewayClient.rebase_onto`` (orchestrator-side bridge
    in :mod:`orchestrator.gateway_client`) which forwards the
    request through the gateway's existing per-agent allowlist
-   plumbing — internally constructed via
-   :func:`gateway.git_client.build_rebase_onto_args` and submitted
-   through the same ``/api/v1/git/execute`` endpoint that
-   authorised agents use today. No new privileged
-   orchestrator-role endpoint is introduced (refine-phase
-   decision-15).
+   plumbing — argv is built client-side by
+   :func:`orchestrator.gateway_client._build_rebase_onto_args`
+   (an inlined copy of
+   :func:`gateway.git_client.build_rebase_onto_args` so the
+   orchestrator image, which does not ship ``gateway/``, has no
+   import-time dependency on the gateway package — see #2535)
+   and submitted through the same ``/api/v1/git/execute``
+   endpoint that authorised agents use today. The gateway server
+   re-validates the argv via the same allowlist, so dropping the
+   client-side ``validate_git_args`` call doesn't reduce the
+   security floor. No new privileged orchestrator-role endpoint
+   is introduced (refine-phase decision-15).
 
 This module is pure-Python and side-effect-free at import time —
 the orchestrator's pipeline run loop wires up an async timer that

--- a/orchestrator/tests/test_check_consensus_slice_isolation.py
+++ b/orchestrator/tests/test_check_consensus_slice_isolation.py
@@ -1,0 +1,158 @@
+"""Regression for #2535 Bug B — slice-2 false consensus at elapsed=0s.
+
+When a fresh slice-N tracker exists but is empty (the steady-state
+right after the slice-N spawn, before any agent has proposed), the
+``check_consensus`` fallbacks must NOT scan the pipeline-wide message
+bus. Doing so picks up CONSENSUS_CONFIRMED messages from a prior slice
+whose roster matches slice-N's (coder/tester/documenter + reviewers
+re-spawn per slice), aggregates them into ``confirmed_roles`` without
+slice scope, and falsely declares ``is_complete=True`` at the very
+first poll iteration.
+
+The fix gates both the reconstruction fallback and the message-bus
+fallback inside :meth:`ConcurrentPhaseExecutor.check_consensus` on
+``self._slice_id is None``. The in-memory per-slice tracker is the
+authoritative source for slice work; an empty fresh tracker correctly
+returns ``is_complete=False`` and the polling loop keeps going.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# sys.path setup — orchestrator + shared.
+_orchestrator_path = Path(__file__).parent.parent
+_shared_path = _orchestrator_path.parent / "shared"
+for _p in (_orchestrator_path, _shared_path):
+    if _p.exists() and str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from concurrent_executor import ConcurrentPhaseExecutor  # noqa: E402
+from message_store import Message, MessageType  # noqa: E402
+from models import (  # noqa: E402
+    Pipeline,
+    PipelineConfig,
+    PipelinePhase,
+    PipelineStatus,
+)
+from peer_consensus import (  # noqa: E402
+    create_peer_consensus_tracker,
+    remove_peer_consensus_tracker,
+)
+from review_graph import get_review_graph_for_phase  # noqa: E402
+
+
+def _make_pipeline(pipeline_id: str = "issue-2535-test") -> Pipeline:
+    config = PipelineConfig()
+    try:
+        config.concurrent_execution = True  # type: ignore[attr-defined]
+    except AttributeError, ValueError:
+        config.__dict__["concurrent_execution"] = True
+    return Pipeline(
+        id=pipeline_id,
+        repo="test/repo",
+        issue_number=2535,
+        status=PipelineStatus.RUNNING,
+        current_phase=PipelinePhase.IMPLEMENT,
+        config=config,
+    )
+
+
+def _slice_one_confirmed_messages(pipeline_id: str) -> list[Message]:
+    """Mimic the message-bus state after slice-1 reaches consensus.
+
+    All implement-phase roles emit CONSENSUS_CONFIRMED. The persisted
+    Message records key by bare ``pipeline_id`` (the message store does
+    not yet carry ``slice_id``), which is the contamination surface the
+    fix has to cordon off.
+    """
+    graph = get_review_graph_for_phase("implement", repo="test/repo")
+    msgs: list[Message] = []
+    for role in graph.all_roles():
+        msgs.append(
+            Message(
+                pipeline_id=pipeline_id,
+                from_role=role,
+                to_role="all",
+                message_type=MessageType.CONSENSUS_CONFIRMED,
+                subject=f"Confirmed by {role}",
+                body="",
+                phase="implement",
+                metadata={"consensus_reached": True},
+            )
+        )
+    return msgs
+
+
+class TestSliceTwoFreshTrackerDoesNotInheritSliceOneConsensus:
+    """A freshly-spawned slice-2 must not borrow slice-1's CONFIRMs."""
+
+    def test_check_consensus_returns_incomplete_for_empty_slice_tracker(self) -> None:
+        pipeline_id = "issue-2535-fresh-slice"
+        pipeline = _make_pipeline(pipeline_id)
+        graph = get_review_graph_for_phase("implement", repo="test/repo")
+
+        # Fresh slice-2 tracker — registered, empty, no proposals yet.
+        # Mirrors the state right after ``spawn_all`` registers the
+        # tracker but before any agent has reached the message bus.
+        create_peer_consensus_tracker(pipeline_id, graph, slice_id="slice-2")
+
+        # Mimic the bug-A state: slice-1's CONFIRMED messages are
+        # still in the bus under the bare pipeline_id.
+        fake_store = MagicMock()
+        fake_store.get_messages.return_value = _slice_one_confirmed_messages(pipeline_id)
+
+        try:
+            executor = ConcurrentPhaseExecutor(
+                pipeline,
+                spawn_fn=MagicMock(),
+                review_graph=graph,
+                slice_id="slice-2",
+            )
+            with patch("message_store.get_message_store", return_value=fake_store):
+                result = executor.check_consensus()
+        finally:
+            remove_peer_consensus_tracker(pipeline_id, "slice-2")
+
+        assert result["is_complete"] is False, (
+            "slice-2 with empty tracker must NOT inherit slice-1 CONFIRMs "
+            "via the pipeline-wide message-bus fallback (#2535)"
+        )
+        # blocking_agents must still surface the slice-2 roster so the
+        # caller can see the work is in flight.
+        assert set(result.get("blocking_agents", [])) == graph.all_roles()
+
+    def test_pipeline_scoped_executor_still_uses_message_bus_fallback(self) -> None:
+        """The fix must not break the legacy pipeline-scoped behaviour.
+
+        For executors with ``slice_id=None`` the message-bus fallback is
+        the long-standing recovery path for tracker loss after restart
+        (#1471/#1615). It MUST keep firing when all roles have CONFIRMED
+        messages — only slice-scoped executors are gated.
+        """
+        pipeline_id = "issue-2535-legacy-scope"
+        pipeline = _make_pipeline(pipeline_id)
+        graph = get_review_graph_for_phase("implement", repo="test/repo")
+
+        # Pipeline-scoped tracker, empty.
+        create_peer_consensus_tracker(pipeline_id, graph)
+
+        fake_store = MagicMock()
+        fake_store.get_messages.return_value = _slice_one_confirmed_messages(pipeline_id)
+
+        try:
+            executor = ConcurrentPhaseExecutor(
+                pipeline,
+                spawn_fn=MagicMock(),
+                review_graph=graph,
+                slice_id=None,
+            )
+            with patch("message_store.get_message_store", return_value=fake_store):
+                result = executor.check_consensus()
+        finally:
+            remove_peer_consensus_tracker(pipeline_id)
+
+        assert result["is_complete"] is True
+        assert result.get("fallback") == "message_bus"

--- a/orchestrator/tests/test_check_consensus_slice_isolation.py
+++ b/orchestrator/tests/test_check_consensus_slice_isolation.py
@@ -45,11 +45,7 @@ from review_graph import get_review_graph_for_phase  # noqa: E402
 
 
 def _make_pipeline(pipeline_id: str = "issue-2535-test") -> Pipeline:
-    config = PipelineConfig()
-    try:
-        config.concurrent_execution = True  # type: ignore[attr-defined]
-    except AttributeError, ValueError:
-        config.__dict__["concurrent_execution"] = True
+    config = PipelineConfig(concurrent_execution=True)
     return Pipeline(
         id=pipeline_id,
         repo="test/repo",

--- a/orchestrator/tests/test_consensus_confirmed_idempotent.py
+++ b/orchestrator/tests/test_consensus_confirmed_idempotent.py
@@ -35,12 +35,21 @@ def mock_pipeline():
     return pip
 
 
-def _fake_message(from_role: str, phase: str, *, pending_acks: bool = False) -> MagicMock:
+def _fake_message(
+    from_role: str,
+    phase: str,
+    *,
+    pending_acks: bool = False,
+    slice_id: str | None = None,
+) -> MagicMock:
     m = MagicMock()
     m.from_role = from_role
     m.phase = phase
     m.message_type = str(MessageType.CONSENSUS_CONFIRMED)
-    m.metadata = {"pending_acks": True} if pending_acks else {"consensus_reached": True}
+    base = {"pending_acks": True} if pending_acks else {"consensus_reached": True}
+    if slice_id is not None:
+        base["slice_id"] = slice_id
+    m.metadata = base
     return m
 
 
@@ -110,6 +119,152 @@ def test_tracker_path_writes_first_confirmed(app, mock_pipeline):
 
     assert status_code == 200
     msg_store.add_message.assert_called_once()
+
+
+def test_slice_two_first_confirmed_not_idempotent_when_slice_one_already_confirmed(
+    app, mock_pipeline
+):
+    """Regression for #2535 follow-up: slice-2's first CONFIRMED must not
+    be marked ``idempotent`` by slice-1's CONFIRMED in the bus.
+
+    Before the fix, ``_existing_confirmed_for_role`` scanned the bus
+    without slice scope; any slice-1 ``coder`` CONFIRMED message would
+    trip ``has_final=True`` for the slice-2 coder, suppressing both the
+    new CONFIRMED message write and the consensus-confirmed marker
+    (#1473). The slice-2 coder's auto-commit would then push unreviewed
+    WIP. The new ``slice_id``-scoped check confines the lookup.
+    """
+    mock_store = MagicMock()
+    mock_store.load_pipeline.return_value = mock_pipeline
+
+    tracker = MagicMock()
+    tracker.handle_confirmed.return_value = {
+        "status": "confirmed",
+        "consensus_reached": True,
+    }
+
+    msg_store = MagicMock()
+    # Bus state: slice-1's coder already CONFIRMED. The slice-2 coder
+    # call must NOT see this as a same-role prior CONFIRMED.
+    msg_store.get_messages.return_value = [
+        _fake_message("coder", "implement", slice_id="slice-1"),
+    ]
+
+    with (
+        app.app_context(),
+        patch("routes.signals._resolve_pipeline_phase", return_value="implement"),
+        patch("routes.signals._write_consensus_confirmed_marker") as marker_mock,
+        patch("routes.signals.get_state_store", return_value=mock_store),
+        patch("peer_consensus.get_peer_consensus_tracker", return_value=tracker),
+        patch("message_store.get_message_store", return_value=msg_store),
+    ):
+        from routes.signals import handle_consensus_confirmed_signal
+
+        response, status_code = handle_consensus_confirmed_signal(
+            "issue-2535",
+            {"agent_role": "coder", "slice_id": "slice-2"},
+            Path("/tmp/repo"),
+        )
+
+    assert status_code == 200
+    data = json.loads(response.data)
+    # Must NOT report idempotent — this is slice-2's first CONFIRMED.
+    assert data["data"].get("idempotent") is not True
+    # New CONFIRMED message MUST be written, with slice_id metadata so the
+    # next slice-2 call can dedupe correctly.
+    msg_store.add_message.assert_called_once()
+    written = msg_store.add_message.call_args[0][0]
+    assert written.metadata.get("slice_id") == "slice-2"
+    # The consensus-confirmed marker MUST be written so auto-commit
+    # doesn't push unreviewed WIP from slice-2 (#1473).
+    marker_mock.assert_called_once()
+
+
+def test_slice_idempotency_within_same_slice(app, mock_pipeline):
+    """Within a single slice, the second CONFIRMED is still deduped."""
+    mock_store = MagicMock()
+    mock_store.load_pipeline.return_value = mock_pipeline
+
+    tracker = MagicMock()
+    tracker.handle_confirmed.return_value = {
+        "status": "confirmed",
+        "consensus_reached": True,
+    }
+
+    msg_store = MagicMock()
+    # Bus state: slice-2's coder already CONFIRMED.
+    msg_store.get_messages.return_value = [
+        _fake_message("coder", "implement", slice_id="slice-2"),
+    ]
+
+    with (
+        app.app_context(),
+        patch("routes.signals._resolve_pipeline_phase", return_value="implement"),
+        patch("routes.signals._write_consensus_confirmed_marker"),
+        patch("routes.signals.get_state_store", return_value=mock_store),
+        patch("peer_consensus.get_peer_consensus_tracker", return_value=tracker),
+        patch("message_store.get_message_store", return_value=msg_store),
+    ):
+        from routes.signals import handle_consensus_confirmed_signal
+
+        response, status_code = handle_consensus_confirmed_signal(
+            "issue-2535",
+            {"agent_role": "coder", "slice_id": "slice-2"},
+            Path("/tmp/repo"),
+        )
+
+    assert status_code == 200
+    data = json.loads(response.data)
+    assert data["data"].get("idempotent") is True
+    msg_store.add_message.assert_not_called()
+
+
+def test_pipeline_scoped_call_ignores_slice_scoped_prior_confirms(app, mock_pipeline):
+    """Pipeline-scoped (no slice_id) callers must not be deduped by
+    slice-scoped CONFIRMED messages.
+
+    A pipeline-scoped CONFIRMED and a slice-scoped CONFIRMED are
+    semantically separate. The legacy non-slice fallback path must keep
+    matching only its own kind so an old non-slice pipeline isn't
+    accidentally short-circuited by a slice-mode CONFIRMED that landed
+    in the bus from a sibling concern.
+    """
+    mock_store = MagicMock()
+    mock_store.load_pipeline.return_value = mock_pipeline
+
+    tracker = MagicMock()
+    tracker.handle_confirmed.return_value = {
+        "status": "confirmed",
+        "consensus_reached": True,
+    }
+
+    msg_store = MagicMock()
+    msg_store.get_messages.return_value = [
+        _fake_message("coder", "implement", slice_id="slice-1"),
+    ]
+
+    with (
+        app.app_context(),
+        patch("routes.signals._resolve_pipeline_phase", return_value="implement"),
+        patch("routes.signals._write_consensus_confirmed_marker"),
+        patch("routes.signals.get_state_store", return_value=mock_store),
+        patch("peer_consensus.get_peer_consensus_tracker", return_value=tracker),
+        patch("message_store.get_message_store", return_value=msg_store),
+    ):
+        from routes.signals import handle_consensus_confirmed_signal
+
+        response, status_code = handle_consensus_confirmed_signal(
+            "issue-2535", {"agent_role": "coder"}, Path("/tmp/repo")
+        )
+
+    assert status_code == 200
+    data = json.loads(response.data)
+    # Pipeline-scoped first CONFIRMED — not idempotent against slice-1.
+    assert data["data"].get("idempotent") is not True
+    msg_store.add_message.assert_called_once()
+    written = msg_store.add_message.call_args[0][0]
+    # Pipeline-scoped writes MUST NOT carry a slice_id tag.
+    assert "slice_id" not in (written.metadata or {})
 
 
 def test_pending_acks_path_is_idempotent(app, mock_pipeline):

--- a/orchestrator/tests/test_gateway_client_rebase_onto.py
+++ b/orchestrator/tests/test_gateway_client_rebase_onto.py
@@ -485,3 +485,51 @@ class TestEndToEndOrphanHeal:
         assert ok is False
         register.assert_not_called()
         make_request.assert_not_called()
+
+
+class TestNoGatewayPackageDependency:
+    """Regression for #2535 Bug A.
+
+    The deployed orchestrator image does not ship the ``gateway/`` source
+    tree, so importing :mod:`gateway.git_client` raises ``ImportError`` at
+    runtime. ``rebase_onto`` must build its argv from a helper that lives
+    in the orchestrator package itself; a successful rebase MUST NOT
+    require ``gateway.git_client`` to be importable.
+    """
+
+    def test_rebase_onto_succeeds_when_gateway_package_unavailable(
+        self, client: GatewayClient
+    ) -> None:
+        # Simulate the deployed image: ``gateway`` is not on sys.modules
+        # and any attempt to import it raises ImportError.  The local
+        # ``_build_rebase_onto_args`` helper must absorb the load.
+        original_import = __import__
+
+        def fail_gateway_import(name: str, *args, **kwargs):
+            if name == "gateway" or name.startswith("gateway."):
+                raise ImportError(f"No module named {name!r}")
+            return original_import(name, *args, **kwargs)
+
+        with (
+            patch("builtins.__import__", side_effect=fail_gateway_import),
+            patch.object(client, "register_session", return_value=_fake_session()),
+            patch.object(client, "_make_request", return_value={"success": True}) as make_request,
+            patch.object(client, "delete_session", return_value=True),
+            patch.object(GatewayClient, "self_ip", new="127.0.0.1"),
+        ):
+            ok = client.rebase_onto(
+                "issue-2535",
+                "/repo",
+                branch="egg/issue-2535/slice-2",
+                new_base="egg/issue-2535",
+                old_base="egg/issue-2535/slice-1",
+            )
+
+        assert ok is True
+        # Canonical argv was built by the local helper.
+        assert make_request.call_args.kwargs["data"]["args"] == [
+            "--onto",
+            "egg/issue-2535",
+            "egg/issue-2535/slice-1",
+            "egg/issue-2535/slice-2",
+        ]


### PR DESCRIPTION
## Summary

Closes #2535. Two bugs that together caused issue-2474-v2 slice-2 to spawn-and-fail in four seconds:

- **Bug A — `gateway/git_client module unavailable`** — `orchestrator/Dockerfile` does not COPY `gateway/`, so `from gateway.git_client import build_rebase_onto_args` (added by #2512 at `orchestrator/gateway_client.py:1424`) always raises `ImportError` in the deployed image. Slice integration branch reconciliation silently fails. Inlined the canonical argv builder as `_build_rebase_onto_args` in the orchestrator package; the gateway server's `/git` endpoint remains the authoritative allowlist boundary.

- **Bug B — slice-2 false consensus at `elapsed_seconds=0.0`** — `ConcurrentPhaseExecutor.check_consensus()` had two slice-unaware fallback paths (tracker reconstruction and the message-bus subset check). The per-slice tracker registry is already keyed by `{pipeline_id}/{slice_id}` and `spawn_all` registers a fresh empty tracker per slice, but when that tracker is empty both fallbacks scanned messages under the bare `pipeline_id` — picking up slice-1's CONSENSUS_CONFIRMED messages whose `from_role` set matches slice-2's roster (coder/tester/documenter + 5 reviewers re-spawn per slice) and declaring consensus instantly. Gated both fallbacks (plus the matching path in `handle_consensus_confirmed_signal`) on `slice_id is None`. The in-memory per-slice tracker is now the authoritative source for slice work; an empty fresh tracker correctly returns `is_complete=False`.

The same root cause — message-bus probes scoped only to the bare `pipeline_id` — also showed up in `_existing_confirmed_for_role` (the idempotency probe in the same handler). That made slice-N's first per-role CONFIRMED look "already confirmed" because slice-(N-1)'s same-role CONFIRMED was still in the bus, suppressing the new bus write and the #1473 consensus-confirmed marker. Fixed in the review-feedback follow-up commit by tagging CONSENSUS_CONFIRMED messages with `metadata["slice_id"]` and filtering the probe by it. Pipeline-scoped (no `slice_id`) callers see only pipeline-scoped messages, preserving the legacy non-slice path exactly.

### Out of scope (tracked separately)

The same slice-unaware `get_peer_consensus_tracker(pipeline_id)` / `reconstruct_tracker_from_messages(pipeline_id, ...)` pattern still exists in `orchestrator/kubernetes_monitor.py:915,934`, `startup_reconciliation.py:308,312`, `routes/pipelines.py:4166,4183` (status display), and the tier-1 `incomplete_consensus_stall.py` / `consensus_stall.py` health checks. None of those are consensus-determining (they observe rather than decide), so the worst case is bogus observability. Tracked under #2409, which already scopes the slice-aware reconstruction work and the `slice_id` field on `Message`.

## Test plan

- [x] `make lint` clean
- [x] `pytest orchestrator/tests/test_check_consensus_slice_isolation.py orchestrator/tests/test_gateway_client_rebase_onto.py orchestrator/tests/test_concurrent_executor.py orchestrator/tests/test_consensus.py orchestrator/tests/test_consensus_polling.py orchestrator/tests/test_consensus_confirmed_idempotent.py orchestrator/tests/test_slice_signal_routing.py` — 117 passed (95 from the original PR + 3 new slice-idempotency regressions + 19 from the slice signal routing suite that exercises the new `slice_id` kwarg)
- [x] New regression `test_check_consensus_slice_isolation.py` covers both directions: a fresh slice-2 tracker with stale slice-1 CONFIRMs in the bus must NOT report `is_complete`; a pipeline-scoped (`slice_id=None`) executor still uses the legacy message-bus fallback for #1471/#1615 tracker-loss recovery.
- [x] New regression `TestNoGatewayPackageDependency::test_rebase_onto_succeeds_when_gateway_package_unavailable` patches `__import__` to refuse `gateway*` imports and confirms `rebase_onto` still produces the canonical argv.
- [x] New idempotency regressions in `test_consensus_confirmed_idempotent.py`:
  - `test_slice_two_first_confirmed_not_idempotent_when_slice_one_already_confirmed` — slice-2's first CONFIRMED is NOT short-circuited by slice-1's CONFIRMED in the bus; bus message + #1473 marker are written.
  - `test_slice_idempotency_within_same_slice` — within slice-2, the second CONFIRMED IS deduped.
  - `test_pipeline_scoped_call_ignores_slice_scoped_prior_confirms` — legacy non-slice callers ignore slice-scoped CONFIRMs and don't tag their own writes with a `slice_id`.