### PR TITLE
Fix #2532: align .github/ block in agent_roles.py for plan and reviewer roles

### DIFF
--- a/shared/egg_contracts/agent_roles.py
+++ b/shared/egg_contracts/agent_roles.py
@@ -364,6 +364,8 @@ ARCHITECT_ROLE = AgentRoleDefinition(
             "**/*.go",
             "**/*.java",
             ".egg-state/contracts/",
+            # Issue #2532: parity with ARCHITECT_PATTERNS — see #2508 / #2521.
+            ".github/",
         ],
     ),
     produces_outputs=["architecture_analysis", "technical_decisions"],
@@ -397,6 +399,8 @@ TASK_PLANNER_ROLE = AgentRoleDefinition(
             "**/*.go",
             "**/*.java",
             ".egg-state/contracts/",
+            # Issue #2532: parity with TASK_PLANNER_PATTERNS — see #2508 / #2521.
+            ".github/",
         ],
     ),
     produces_outputs=["task_breakdown", "acceptance_criteria"],
@@ -430,6 +434,8 @@ RISK_ANALYST_ROLE = AgentRoleDefinition(
             "**/*.go",
             "**/*.java",
             ".egg-state/contracts/",
+            # Issue #2532: parity with RISK_ANALYST_PATTERNS — see #2508 / #2521.
+            ".github/",
         ],
     ),
     can_run_in_parallel=True,  # Can run in parallel with task_planner
@@ -488,6 +494,8 @@ _REVIEWER_BLOCKED_WRITE = [
     "test/",
     ".egg-state/contracts/",
     ".egg-state/drafts/",
+    # Issue #2532: parity with _REVIEWER_BLOCKED in patterns.py — see #2508 / #2521.
+    ".github/",
 ]
 
 REVIEWER_CODE_ROLE = AgentRoleDefinition(
@@ -551,6 +559,8 @@ _REVIEWER_CONTRACT_BLOCKED_WRITE = [
     "tests/",
     "test/",
     ".egg-state/drafts/",
+    # Issue #2532: parity with _REVIEWER_CONTRACT_BLOCKED in patterns.py — see #2508 / #2521.
+    ".github/",
 ]
 
 REVIEWER_CONTRACT_ROLE = AgentRoleDefinition(

--- a/shared/egg_contracts/agent_roles.py
+++ b/shared/egg_contracts/agent_roles.py
@@ -336,6 +336,23 @@ DOCUMENTER_ROLE = AgentRoleDefinition(
 )
 
 # Plan-phase agent role definitions
+# Plan-phase agents (architect, task_planner, risk_analyst) share a
+# blocked_write list mirroring ``_PLAN_AGENT_BLOCKED`` in
+# ``shared/egg_restrictions/patterns.py``. Keeping the two views in
+# lockstep is the invariant issue #2532 closed; using a shared constant
+# eliminates one future drift surface within ``agent_roles.py`` itself.
+_PLAN_AGENT_BLOCKED_WRITE = [
+    "**/*.py",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.go",
+    "**/*.java",
+    ".egg-state/contracts/",
+    # Issue #2532: parity with _PLAN_AGENT_BLOCKED in patterns.py — see #2508 / #2521.
+    ".github/",
+]
 
 ARCHITECT_ROLE = AgentRoleDefinition(
     role=AgentRole.ARCHITECT,
@@ -355,18 +372,7 @@ ARCHITECT_ROLE = AgentRoleDefinition(
             ".egg-state/drafts/",
             ".egg-state/agent-outputs/",
         ],
-        blocked_write=[
-            "**/*.py",
-            "**/*.ts",
-            "**/*.tsx",
-            "**/*.js",
-            "**/*.jsx",
-            "**/*.go",
-            "**/*.java",
-            ".egg-state/contracts/",
-            # Issue #2532: parity with ARCHITECT_PATTERNS — see #2508 / #2521.
-            ".github/",
-        ],
+        blocked_write=_PLAN_AGENT_BLOCKED_WRITE,
     ),
     produces_outputs=["architecture_analysis", "technical_decisions"],
     requires_inputs=[],
@@ -390,18 +396,7 @@ TASK_PLANNER_ROLE = AgentRoleDefinition(
             ".egg-state/drafts/",
             ".egg-state/agent-outputs/",
         ],
-        blocked_write=[
-            "**/*.py",
-            "**/*.ts",
-            "**/*.tsx",
-            "**/*.js",
-            "**/*.jsx",
-            "**/*.go",
-            "**/*.java",
-            ".egg-state/contracts/",
-            # Issue #2532: parity with TASK_PLANNER_PATTERNS — see #2508 / #2521.
-            ".github/",
-        ],
+        blocked_write=_PLAN_AGENT_BLOCKED_WRITE,
     ),
     produces_outputs=["task_breakdown", "acceptance_criteria"],
     requires_inputs=["architecture_analysis"],
@@ -425,18 +420,7 @@ RISK_ANALYST_ROLE = AgentRoleDefinition(
             ".egg-state/drafts/",
             ".egg-state/agent-outputs/",
         ],
-        blocked_write=[
-            "**/*.py",
-            "**/*.ts",
-            "**/*.tsx",
-            "**/*.js",
-            "**/*.jsx",
-            "**/*.go",
-            "**/*.java",
-            ".egg-state/contracts/",
-            # Issue #2532: parity with RISK_ANALYST_PATTERNS — see #2508 / #2521.
-            ".github/",
-        ],
+        blocked_write=_PLAN_AGENT_BLOCKED_WRITE,
     ),
     can_run_in_parallel=True,  # Can run in parallel with task_planner
     produces_outputs=["risk_assessment", "mitigation_plan"],

--- a/shared/tests/test_github_block_alignment.py
+++ b/shared/tests/test_github_block_alignment.py
@@ -1,0 +1,82 @@
+"""Cross-view alignment of the ``.github/`` block (issue #2532).
+
+The planner prompt reads ``shared/egg_contracts/agent_roles.py`` via
+``get_file_patterns()``; the gateway reads ``shared/egg_restrictions/patterns.py``
+via ``AgentFilePattern.can_write()``. Earlier work (#2508, #2514, #2521,
+#2525) added an explicit ``.github/`` block to several roles in lockstep
+across both files. Issue #2532 closes the remaining drift for plan-side
+and reviewer roles.
+
+A "load-bearing" test in the style of #2525 (a path the role's allowlist
+matches that only the new ``.github/`` block stops) is not constructible
+here: every affected role's allowlist is confined to ``.egg-state/...``,
+which never collides with ``.github/``. The block is therefore benign
+today — but the same forward-compat argument from #2521 applies. These
+tests assert the two views agree, so any future allowlist widening
+cannot silently bypass the branch-protection invariant.
+"""
+
+from __future__ import annotations
+
+import pytest
+from egg_contracts.agent_roles import AgentRole, get_file_patterns
+from egg_restrictions import get_agent_pattern
+
+# Roles whose ``blocked_write`` / ``blocked_patterns`` must include
+# ``.github/`` per #2532. The list is intentionally hand-maintained:
+# adding a new role here is a deliberate decision, not an automatic
+# consequence of role registration.
+ROLES_WITH_GITHUB_BLOCK = [
+    # Plan-side (#2532).
+    AgentRole.ARCHITECT,
+    AgentRole.TASK_PLANNER,
+    AgentRole.RISK_ANALYST,
+    # Reviewers sharing _REVIEWER_BLOCKED_WRITE / _REVIEWER_BLOCKED (#2532).
+    AgentRole.REVIEWER_CODE,
+    AgentRole.REVIEWER_CODE_HOLISTIC,
+    AgentRole.REVIEWER_AGENT_DESIGN,
+    AgentRole.REVIEWER_REFINE,
+    AgentRole.REVIEWER_PLAN,
+    AgentRole.REVIEWER_SECURITY,
+    AgentRole.REVIEWER_CONCURRENCY,
+    # Reviewer with its own blocked list (#2532).
+    AgentRole.REVIEWER_CONTRACT,
+]
+
+
+@pytest.mark.parametrize("role", ROLES_WITH_GITHUB_BLOCK, ids=lambda r: r.value)
+def test_agent_roles_view_blocks_github(role: AgentRole) -> None:
+    """``agent_roles.py`` (planner-prompt view) blocks ``.github/``."""
+    patterns = get_file_patterns(role.value)
+    assert patterns is not None, f"{role.value} has no file_access patterns"
+    assert ".github/" in patterns["blocked"], (
+        f"{role.value} blocked_write is missing '.github/' — "
+        "see issue #2532 for the drift this test guards against."
+    )
+
+
+@pytest.mark.parametrize("role", ROLES_WITH_GITHUB_BLOCK, ids=lambda r: r.value)
+def test_patterns_view_blocks_github(role: AgentRole) -> None:
+    """``patterns.py`` (gateway view) blocks ``.github/``."""
+    pattern = get_agent_pattern(role.value)
+    assert pattern is not None, f"{role.value} not registered in AGENT_PATTERNS"
+    assert ".github/" in pattern.blocked_patterns, (
+        f"{role.value} blocked_patterns is missing '.github/' — "
+        "see issue #2532 for the drift this test guards against."
+    )
+
+
+@pytest.mark.parametrize("role", ROLES_WITH_GITHUB_BLOCK, ids=lambda r: r.value)
+def test_two_views_agree_on_github(role: AgentRole) -> None:
+    """The planner-prompt view and the gateway view must agree on ``.github/``."""
+    contracts_patterns = get_file_patterns(role.value)
+    restrictions_pattern = get_agent_pattern(role.value)
+    assert contracts_patterns is not None
+    assert restrictions_pattern is not None
+    contracts_blocks_github = ".github/" in contracts_patterns["blocked"]
+    restrictions_blocks_github = ".github/" in restrictions_pattern.blocked_patterns
+    assert contracts_blocks_github == restrictions_blocks_github, (
+        f"{role.value}: agent_roles.py and patterns.py disagree on '.github/' — "
+        f"agent_roles={contracts_blocks_github}, patterns={restrictions_blocks_github}. "
+        "See issue #2532."
+    )


### PR DESCRIPTION
## Summary

- Adds `.github/` to `blocked_write` in `shared/egg_contracts/agent_roles.py` for `ARCHITECT_ROLE`, `TASK_PLANNER_ROLE`, `RISK_ANALYST_ROLE`, the shared `_REVIEWER_BLOCKED_WRITE` list (8 roles share it), and `_REVIEWER_CONTRACT_BLOCKED_WRITE`. Their `patterns.py` counterparts already block `.github/`; this brings the two views into lockstep.
- Adds `shared/tests/test_github_block_alignment.py` with three parametrized regression tests across the affected roles: the planner-prompt view blocks `.github/`, the gateway view blocks `.github/`, and the two views agree.

The planner prompt reads `agent_roles.py` via `get_file_patterns()`; the gateway reads `patterns.py` via `AgentFilePattern.can_write()`. PR #2525 closed the same drift for the tester (#2521); this closes the remaining plan-side and reviewer cases. The disagreement is benign today — every affected role's `allowed_write` is confined to `.egg-state/...` paths that never collide with `.github/` — but aligning the two views means the next allowlist widening cannot silently bypass the branch-protection invariant from #2508.

A "load-bearing" test in #2525's style (a path the allowlist matches that only the new block stops) is not constructible here — the allowlists never intersect `.github/` — so the regression test asserts cross-view consistency instead.

Fixes #2532.

## Notes vs. the issue inventory

- **REFINER is not in scope.** #2532 lists `REFINER_ROLE` as drifting, but `REFINER_PATTERNS` in `patterns.py` uses its own custom blocked list (not `_PLAN_AGENT_BLOCKED`), and that list also omits `.github/`. The two views already agree for refiner — there's no drift to fix here. Whether refiner *should* block `.github/` is a separate change.
- **Reviewer count expanded.** #2532 names 3 reviewer roles; in fact every reviewer role sharing `_REVIEWER_BLOCKED_WRITE` (reviewer_code, reviewer_code_holistic, reviewer_agent_design, reviewer_refine, reviewer_plan, reviewer_security, reviewer_concurrency) drifts. Editing the shared list fixes all 7 in one shot.

## Test plan

- [x] `.venv/bin/pytest shared/tests/test_github_block_alignment.py shared/tests/test_egg_restrictions.py shared/egg_contracts/tests/test_agent_roles.py gateway/tests/test_agent_restrictions_patterns.py` — 440 passed
- [x] `make test` — 16878 passed, 41 skipped (pre-existing warnings unrelated to this change)
- [x] `make lint` — clean
- [ ] CI: full `make test-all` via the workflow