### PR TITLE
Fix #2528: per-repo role-pattern overrides for non-Python conventions

### DIFF
--- a/config/repo_config.py
+++ b/config/repo_config.py
@@ -31,12 +31,15 @@ Usage:
     reviewer = get_default_reviewer()
 """
 
+import logging
 import os
 import time
 from pathlib import Path
 from typing import Any, cast
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 
 def _get_config_path() -> Path:
@@ -399,28 +402,67 @@ def get_repo_role_patterns(repo: str) -> dict[str, list[str]] | None:
         of ``tests_globs`` / ``code_globs`` / ``docs_globs`` whose value
         is a non-empty list of strings). Returns ``None`` when no
         ``role_patterns`` block is set, or when every configured key is
-        invalid. Unknown keys (e.g. attempts to override
-        ``contracts_blocklist``) are silently dropped — the security
-        boundary is enforced in
-        ``shared/egg_restrictions/patterns.py`` builders, but rejecting
-        the unknown key here gives operators a clean signal in the
-        logs.
+        invalid.
+
+        Dropped input emits a WARNING log so operators can correlate a
+        repo's stale globs with the offending key/value:
+
+        - Unknown keys (e.g. an attempt to invent a
+          ``contracts_blocklist`` knob, or a typo such as
+          ``tests_glob`` missing the trailing ``s``).
+        - Non-list values (``tests_globs: 42``).
+        - Non-string list entries (``tests_globs: [null]``).
+
+        Defense-in-depth: dropping unknown keys at the parser layer
+        keeps a misconfigured repo from widening security boundaries.
+        The pattern builders also ignore anything outside the three
+        knobs, but the parser is the single place that produces a
+        diagnostic signal.
     """
     raw = get_repo_setting(repo, "role_patterns", None)
+    if raw is None:
+        return None
     if not isinstance(raw, dict):
+        logger.warning(
+            "repositories.yaml: role_patterns for %r must be a mapping, got %s; "
+            "ignoring entire block",
+            repo,
+            type(raw).__name__,
+        )
         return None
 
     out: dict[str, list[str]] = {}
     for key, value in raw.items():
         if key not in _VALID_ROLE_PATTERN_KEYS:
-            # Defense-in-depth: a misconfigured repo cannot widen
-            # security boundaries by inventing keys. The pattern
-            # builders already ignore anything outside the three knobs,
-            # so dropping here is purely diagnostic.
+            logger.warning(
+                "repositories.yaml: role_patterns key %r is not recognised for "
+                "repo %r (valid keys: %s); dropping",
+                key,
+                repo,
+                sorted(_VALID_ROLE_PATTERN_KEYS),
+            )
             continue
         if not isinstance(value, list):
+            logger.warning(
+                "repositories.yaml: role_patterns.%s for repo %r must be a list, got %s; dropping",
+                key,
+                repo,
+                type(value).__name__,
+            )
             continue
-        cleaned = [str(item) for item in value if isinstance(item, str) and item]
+        cleaned: list[str] = []
+        for item in value:
+            if isinstance(item, str) and item:
+                cleaned.append(item)
+            else:
+                logger.warning(
+                    "repositories.yaml: role_patterns.%s for repo %r contains "
+                    "invalid entry %r (expected non-empty string); dropping that "
+                    "entry",
+                    key,
+                    repo,
+                    item,
+                )
         if cleaned:
             out[key] = cleaned
 

--- a/config/repo_config.py
+++ b/config/repo_config.py
@@ -356,6 +356,75 @@ def reload_config() -> None:
     """
     global _checkpoint_repos_cache
     _checkpoint_repos_cache = None
+    # Per-repo role patterns are cached inside egg_restrictions; clearing
+    # that cache here keeps the SIGHUP path single-entry. Imported lazily
+    # so this module doesn't pull egg_restrictions at every config load.
+    try:
+        from egg_restrictions.patterns import reset_pattern_cache
+
+        reset_pattern_cache()
+    except ImportError:
+        pass
+
+
+_VALID_ROLE_PATTERN_KEYS = frozenset({"tests_globs", "code_globs", "docs_globs"})
+
+
+def get_repo_role_patterns(repo: str) -> dict[str, list[str]] | None:
+    """Get the per-repo role-pattern overrides for a repository (#2528).
+
+    Repos can declare alternate test/code/docs file conventions in
+    ``repositories.yaml`` so non-Python repos (Go, JS/TS, …) get correct
+    coder/tester/documenter boundaries. Only the language-convention
+    glob lists are configurable; security-relevant blocklists
+    (``.egg-state/contracts/``, ``.github/``) stay fixed and cannot be
+    relaxed by the target repo.
+
+    Schema (all keys optional):
+
+    .. code-block:: yaml
+
+        repo_settings:
+          owner/example-go-repo:
+            role_patterns:
+              tests_globs: ["**/*_test.go", "**/testdata/**"]
+              code_globs:  ["**/*.go"]
+              docs_globs:  ["**/*.md", "docs/"]
+
+    Args:
+        repo: Repository in ``owner/repo`` format.
+
+    Returns:
+        A dict containing only the keys the repo configured (any subset
+        of ``tests_globs`` / ``code_globs`` / ``docs_globs`` whose value
+        is a non-empty list of strings). Returns ``None`` when no
+        ``role_patterns`` block is set, or when every configured key is
+        invalid. Unknown keys (e.g. attempts to override
+        ``contracts_blocklist``) are silently dropped — the security
+        boundary is enforced in
+        ``shared/egg_restrictions/patterns.py`` builders, but rejecting
+        the unknown key here gives operators a clean signal in the
+        logs.
+    """
+    raw = get_repo_setting(repo, "role_patterns", None)
+    if not isinstance(raw, dict):
+        return None
+
+    out: dict[str, list[str]] = {}
+    for key, value in raw.items():
+        if key not in _VALID_ROLE_PATTERN_KEYS:
+            # Defense-in-depth: a misconfigured repo cannot widen
+            # security boundaries by inventing keys. The pattern
+            # builders already ignore anything outside the three knobs,
+            # so dropping here is purely diagnostic.
+            continue
+        if not isinstance(value, list):
+            continue
+        cleaned = [str(item) for item in value if isinstance(item, str) and item]
+        if cleaned:
+            out[key] = cleaned
+
+    return out or None
 
 
 def get_all_checkpoint_repos() -> frozenset[str]:

--- a/config/repo_config.py
+++ b/config/repo_config.py
@@ -39,7 +39,8 @@ from typing import Any, cast
 
 import yaml
 
-logger = logging.getLogger(__name__)
+_LOGGER_NAME = "egg.repo_config"
+logger = logging.getLogger(_LOGGER_NAME)
 
 
 def _get_config_path() -> Path:

--- a/gateway/agent_restrictions.py
+++ b/gateway/agent_restrictions.py
@@ -38,10 +38,16 @@ from egg_restrictions.patterns import (
     AGENT_PATTERNS,
     AUTOFIXER_PATTERNS,
     CONFLICT_RESOLVER_PATTERNS,
+    DEFAULT_CODE_GLOBS,
+    DEFAULT_DOCS_GLOBS,
+    DEFAULT_TESTS_GLOBS,
     INSPECTOR_PATTERNS,
     OVERSEER_PATTERNS,
     AgentFilePattern,
     AgentRole,
+    build_agent_patterns,
+    get_agent_pattern_for_repo,
+    reset_pattern_cache,
 )
 
 logger = logging.getLogger("gateway.agent_restrictions")
@@ -50,12 +56,21 @@ logger = logging.getLogger("gateway.agent_restrictions")
 def partition_files_by_role(
     role: str,
     files: list[str],
+    repo: str | None = None,
 ) -> tuple[list[str], list[str]]:
     """Split ``files`` into ``(allowed, blocked)`` by what ``role`` may write.
 
     Used by the gateway's push handler to decide which files in a push
     diff would be rejected by the role's AgentFilePattern and therefore
     need to be auto-filtered out by the per-commit rewriter (#1882).
+
+    Args:
+        role: The agent role identifier.
+        files: Files in the push diff.
+        repo: Optional ``owner/repo`` for per-repo pattern overrides
+            (#2528). When set, the role's pattern reflects the
+            ``role_patterns:`` block in ``repositories.yaml`` for this
+            repo; when ``None``, falls back to global defaults.
 
     Behaviour:
 
@@ -71,7 +86,7 @@ def partition_files_by_role(
     if not files:
         return [], []
 
-    pattern = get_agent_pattern(role)
+    pattern = get_agent_pattern(role, repo=repo)
     if pattern is None:
         logger.warning(
             "partition_files_by_role_unknown_role",
@@ -96,12 +111,18 @@ __all__ = [
     "AgentRestrictionResult",
     "AgentRole",
     "CONFLICT_RESOLVER_PATTERNS",
+    "DEFAULT_CODE_GLOBS",
+    "DEFAULT_DOCS_GLOBS",
+    "DEFAULT_TESTS_GLOBS",
     "INSPECTOR_PATTERNS",
     "OVERSEER_PATTERNS",
+    "build_agent_patterns",
     "check_agent_file_access",
     "check_agent_gh_operation",
     "get_agent_pattern",
+    "get_agent_pattern_for_repo",
     "partition_files_by_role",
+    "reset_pattern_cache",
     "validate_agent_push",
 ]
 

--- a/gateway/agent_restrictions.py
+++ b/gateway/agent_restrictions.py
@@ -47,6 +47,8 @@ from egg_restrictions.patterns import (
     AgentRole,
     build_agent_patterns,
     get_agent_pattern_for_repo,
+    get_agent_patterns_for_repo,
+    load_repo_pattern_override,
     reset_pattern_cache,
 )
 
@@ -121,6 +123,8 @@ __all__ = [
     "check_agent_gh_operation",
     "get_agent_pattern",
     "get_agent_pattern_for_repo",
+    "get_agent_patterns_for_repo",
+    "load_repo_pattern_override",
     "partition_files_by_role",
     "reset_pattern_cache",
     "validate_agent_push",

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -1679,7 +1679,7 @@ def git_push() -> tuple[Response, int] | Response:
             if role_for_sha and role_for_sha != session_role:
                 pulled_commits_summary.append({"sha": sha, "author_role": role_for_sha})
 
-        allowed_own, blocked_own = _partition_fn(session_role, own_files)
+        allowed_own, blocked_own = _partition_fn(session_role, own_files, repo=repo)
 
         if unregistered_files and enforce:
             audit_log(

--- a/gateway/tests/test_per_repo_role_patterns.py
+++ b/gateway/tests/test_per_repo_role_patterns.py
@@ -1,0 +1,282 @@
+"""Tests for per-repo role-pattern overrides (#2528).
+
+Covers:
+- ``build_agent_patterns`` produces the same registry as ``AGENT_PATTERNS``
+  when called with no arguments (default-repo regression).
+- Per-repo overrides shift coder / tester / documenter boundaries
+  according to the language conventions a repo declares.
+- Security blocklists (``.egg-state/contracts/``, ``.github/``) cannot be
+  bypassed by an attempted override.
+- ``get_repo_role_patterns`` validates the YAML shape and silently drops
+  unknown keys / non-list values / non-string entries.
+- The cache invalidates on ``reset_pattern_cache``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+# Imports go through the gateway-side re-export barrel
+# (``gateway/agent_restrictions.py``) rather than directly through
+# ``egg_restrictions.patterns`` so the gateway test conftest's
+# import-replacement / sys.path setup resolves the worktree's shared/
+# package, not the editable install's main-repo copy. The legacy
+# pattern-matrix tests use the same convention; see
+# gateway/tests/test_agent_restrictions_patterns.py.
+from agent_restrictions import (
+    AGENT_PATTERNS,
+    DEFAULT_CODE_GLOBS,
+    DEFAULT_DOCS_GLOBS,
+    DEFAULT_TESTS_GLOBS,
+    build_agent_patterns,
+    get_agent_pattern_for_repo,
+    reset_pattern_cache,
+)
+
+
+class TestDefaultRegistryParity:
+    """``build_agent_patterns(None)`` must equal the legacy ``AGENT_PATTERNS``."""
+
+    def test_default_registry_has_same_roles(self):
+        assert set(build_agent_patterns(None).keys()) == set(AGENT_PATTERNS.keys())
+
+    def test_default_registry_has_same_allowed_patterns(self):
+        built = build_agent_patterns(None)
+        for role, pattern in AGENT_PATTERNS.items():
+            assert built[role].allowed_patterns == pattern.allowed_patterns, role
+
+    def test_default_registry_has_same_blocked_patterns(self):
+        built = build_agent_patterns(None)
+        for role, pattern in AGENT_PATTERNS.items():
+            assert built[role].blocked_patterns == pattern.blocked_patterns, role
+
+    def test_default_registry_has_same_block_exempt_patterns(self):
+        built = build_agent_patterns(None)
+        for role, pattern in AGENT_PATTERNS.items():
+            assert built[role].block_exempt_patterns == pattern.block_exempt_patterns, role
+
+
+class TestJsConventionRepo:
+    """A repo that declares JS conventions should have JS test paths route
+    to tester, not coder."""
+
+    def setup_method(self):
+        self.patterns = build_agent_patterns(
+            None,
+            tests_globs=[
+                "tests/",
+                "**/__tests__/",
+                "**/*.test.ts",
+                "**/*.test.tsx",
+                "**/*.spec.ts",
+            ],
+            code_globs=["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+            docs_globs=["docs/", "**/*.md"],
+        )
+
+    def test_coder_blocked_from_js_test_files(self):
+        assert not self.patterns["coder"].can_write("src/foo/__tests__/foo.test.ts")
+        assert not self.patterns["coder"].can_write("src/bar.spec.ts")
+
+    def test_coder_can_write_production_code(self):
+        assert self.patterns["coder"].can_write("src/foo.ts")
+        assert self.patterns["coder"].can_write("src/foo.tsx")
+
+    def test_tester_can_write_js_test_files(self):
+        assert self.patterns["tester"].can_write("src/foo/__tests__/foo.test.ts")
+        assert self.patterns["tester"].can_write("src/bar.spec.ts")
+
+    def test_documenter_blocked_from_js_test_files(self):
+        # Tester scope, not documenter — documenter's blocklist must
+        # include the repo's tests_globs.
+        assert not self.patterns["documenter"].can_write("src/foo/__tests__/foo.test.ts")
+
+
+class TestGoConventionRepo:
+    """A Go repo with same-directory test files (``*_test.go``)."""
+
+    def setup_method(self):
+        self.patterns = build_agent_patterns(
+            None,
+            tests_globs=["**/*_test.go", "**/testdata/**"],
+            code_globs=["**/*.go"],
+            docs_globs=["docs/", "**/*.md"],
+        )
+
+    def test_coder_blocked_from_go_tests_in_source_dirs(self):
+        # Go puts tests next to source — `internal/foo/bar_test.go` is
+        # a test file.
+        assert not self.patterns["coder"].can_write("internal/foo/bar_test.go")
+
+    def test_coder_can_write_go_source(self):
+        assert self.patterns["coder"].can_write("internal/foo/bar.go")
+        assert self.patterns["coder"].can_write("cmd/server/main.go")
+
+    def test_tester_can_write_go_tests(self):
+        assert self.patterns["tester"].can_write("internal/foo/bar_test.go")
+
+    def test_tester_can_write_testdata(self):
+        assert self.patterns["tester"].can_write("internal/foo/testdata/sample.json")
+
+
+class TestSecurityBlocklistsAreNotBypassable:
+    """Per-repo overrides MUST NOT relax the security blocklists.
+
+    A repo cannot, e.g., add ``.egg-state/contracts/`` to ``tests_globs``
+    in an attempt to grant tester write access there. The pattern
+    builders hard-code the security blocks independent of the per-repo
+    knobs.
+    """
+
+    def test_attempted_contract_bypass_via_tests_globs_fails(self):
+        sneaky = build_agent_patterns(None, tests_globs=[".egg-state/contracts/", "**/*_test.py"])
+        # Tester's blocked_patterns still forbid contracts.
+        assert not sneaky["tester"].can_write(".egg-state/contracts/foo.json")
+        # Coder's `.egg-state/` block still forbids contracts.
+        assert not sneaky["coder"].can_write(".egg-state/contracts/foo.json")
+
+    def test_attempted_github_bypass_via_code_globs_fails(self):
+        sneaky = build_agent_patterns(None, code_globs=["**/*.py", ".github/**"])
+        # Coder's `.github/` block holds.
+        assert not sneaky["coder"].can_write(".github/workflows/ci.yml")
+        # Tester's `.github/` block holds (added in #2521 for parity).
+        assert not sneaky["tester"].can_write(".github/workflows/ci.yml")
+        # Documenter's `.github/` block holds (#2508 branch-protection
+        # invariant).
+        assert not sneaky["documenter"].can_write(".github/PULL_REQUEST_TEMPLATE.md")
+
+    def test_attempted_pipeline_state_bypass_via_docs_globs_fails(self):
+        sneaky = build_agent_patterns(None, docs_globs=[".egg-state/drafts/", "**/*.md"])
+        # Documenter's `.egg-state/contracts/` block holds (it lives in
+        # blocked_patterns, not in the configurable docs_globs).
+        assert not sneaky["documenter"].can_write(".egg-state/contracts/foo.json")
+
+
+class TestGetRepoRolePatternsValidation:
+    """``config.repo_config.get_repo_role_patterns`` validation."""
+
+    def _patch_setting(self, value):
+        return patch("config.repo_config.get_repo_setting", return_value=value)
+
+    def test_missing_block_returns_none(self):
+        from config.repo_config import get_repo_role_patterns
+
+        with self._patch_setting(None):
+            assert get_repo_role_patterns("owner/repo") is None
+
+    def test_non_dict_returns_none(self):
+        from config.repo_config import get_repo_role_patterns
+
+        with self._patch_setting(["not", "a", "dict"]):
+            assert get_repo_role_patterns("owner/repo") is None
+
+    def test_valid_subset_returned(self):
+        from config.repo_config import get_repo_role_patterns
+
+        with self._patch_setting({"tests_globs": ["**/*_test.go"]}):
+            assert get_repo_role_patterns("owner/repo") == {"tests_globs": ["**/*_test.go"]}
+
+    def test_unknown_keys_dropped(self):
+        from config.repo_config import get_repo_role_patterns
+
+        # Contracts blocklist is NOT a configurable knob; it must be
+        # silently dropped so a misconfig cannot relax security.
+        with self._patch_setting(
+            {
+                "tests_globs": ["**/*_test.go"],
+                "contracts_blocklist": [],
+                "github_blocklist": [],
+            }
+        ):
+            assert get_repo_role_patterns("owner/repo") == {"tests_globs": ["**/*_test.go"]}
+
+    def test_non_list_values_dropped(self):
+        from config.repo_config import get_repo_role_patterns
+
+        with self._patch_setting({"tests_globs": "not-a-list"}):
+            assert get_repo_role_patterns("owner/repo") is None
+
+    def test_non_string_entries_filtered(self):
+        from config.repo_config import get_repo_role_patterns
+
+        with self._patch_setting({"tests_globs": ["**/*_test.go", 42, None, ""]}):
+            assert get_repo_role_patterns("owner/repo") == {"tests_globs": ["**/*_test.go"]}
+
+    def test_empty_dict_returns_none(self):
+        from config.repo_config import get_repo_role_patterns
+
+        with self._patch_setting({}):
+            assert get_repo_role_patterns("owner/repo") is None
+
+
+class TestPerRepoCacheInvalidation:
+    """``reset_pattern_cache`` must clear per-repo entries so a SIGHUP /
+    config reload picks up edited overrides."""
+
+    def setup_method(self):
+        reset_pattern_cache()
+
+    def teardown_method(self):
+        reset_pattern_cache()
+
+    def test_get_agent_pattern_for_repo_returns_default_when_no_override(self):
+        # Sanity: repo=None falls back to AGENT_PATTERNS.
+        coder = get_agent_pattern_for_repo("coder", repo=None)
+        assert coder is AGENT_PATTERNS["coder"]
+
+    def test_repo_overrides_picked_up_after_cache_reset(self):
+        from config import repo_config
+
+        # First call with mocked config returns A.
+        with patch.object(
+            repo_config,
+            "get_repo_role_patterns",
+            return_value={"tests_globs": ["**/__tests__/"]},
+        ):
+            first = get_agent_pattern_for_repo("coder", repo="owner/js-repo")
+        assert not first.can_write("src/__tests__/foo.test.ts")
+
+        # Without resetting, a second mock with different config still
+        # returns the cached pattern.
+        with patch.object(
+            repo_config,
+            "get_repo_role_patterns",
+            return_value={"tests_globs": ["**/*_test.go"]},
+        ):
+            cached = get_agent_pattern_for_repo("coder", repo="owner/js-repo")
+        assert cached is first
+
+        # After reset, the next call re-reads the config.
+        reset_pattern_cache()
+        with patch.object(
+            repo_config,
+            "get_repo_role_patterns",
+            return_value={"tests_globs": ["**/*_test.go"]},
+        ):
+            refreshed = get_agent_pattern_for_repo("coder", repo="owner/js-repo")
+        assert refreshed is not first
+        # Now the JS pattern is no longer blocked because tests_globs
+        # changed to Go conventions (no JS __tests__).
+        assert refreshed.can_write("src/__tests__/foo.test.ts")
+
+
+class TestDefaultGlobConstants:
+    """The exported default-glob constants must include the canonical
+    multi-language test/code/docs conventions so a repo *omitting* an
+    override gets coverage of all common shapes."""
+
+    def test_default_tests_globs_cover_python_go_js(self):
+        assert "**/test_*.py" in DEFAULT_TESTS_GLOBS
+        assert "**/conftest.py" in DEFAULT_TESTS_GLOBS
+        assert "**/*_test.go" in DEFAULT_TESTS_GLOBS
+        assert "**/*.test.ts" in DEFAULT_TESTS_GLOBS
+        assert "**/*.spec.tsx" in DEFAULT_TESTS_GLOBS
+
+    def test_default_code_globs_cover_common_languages(self):
+        assert "**/*.py" in DEFAULT_CODE_GLOBS
+        assert "**/*.go" in DEFAULT_CODE_GLOBS
+        assert "**/*.ts" in DEFAULT_CODE_GLOBS
+
+    def test_default_docs_globs_cover_markdown_and_docs_dir(self):
+        assert "docs/" in DEFAULT_DOCS_GLOBS
+        assert "**/*.md" in DEFAULT_DOCS_GLOBS

--- a/gateway/tests/test_per_repo_role_patterns.py
+++ b/gateway/tests/test_per_repo_role_patterns.py
@@ -469,6 +469,23 @@ class TestSandboxEnvVarInjection:
             result = load_repo_pattern_override("owner/repo")
         assert result is None
 
+    def test_env_var_lookup_is_case_insensitive(self, monkeypatch):
+        from agent_restrictions import load_repo_pattern_override
+
+        # Snapshot key is mixed-case; query is lower-case. Both should
+        # resolve, mirroring ``get_repo_setting``'s case-insensitive
+        # lookup and the ``_normalize_repo_key`` cache key.
+        monkeypatch.setenv(
+            "EGG_PIPELINE_REPO_PATTERNS_JSON",
+            json.dumps({"Owner/Go-Repo": {"tests_globs": ["**/*_test.go"]}}),
+        )
+        with patch(
+            "config.repo_config.get_repo_role_patterns",
+            side_effect=AssertionError("filesystem lookup should not run"),
+        ):
+            result = load_repo_pattern_override("owner/go-repo")
+        assert result == {"tests_globs": ["**/*_test.go"]}
+
     def test_pattern_lookup_uses_env_var_override(self, monkeypatch):
         # End-to-end: a sandbox-style env injection alters the registry
         # that ``get_agent_pattern_for_repo`` returns, without any
@@ -537,7 +554,7 @@ class TestConfigValidationLogging:
             "config.repo_config.get_repo_setting",
             return_value={"tests_glob": ["**/*_test.go"]},  # typo
         ):
-            with caplog.at_level("WARNING", logger="config.repo_config"):
+            with caplog.at_level("WARNING", logger="egg.repo_config"):
                 result = get_repo_role_patterns("owner/repo")
         assert result is None
         joined = " ".join(r.message for r in caplog.records)
@@ -551,7 +568,7 @@ class TestConfigValidationLogging:
             "config.repo_config.get_repo_setting",
             return_value={"tests_globs": 42},
         ):
-            with caplog.at_level("WARNING", logger="config.repo_config"):
+            with caplog.at_level("WARNING", logger="egg.repo_config"):
                 result = get_repo_role_patterns("owner/repo")
         assert result is None
         joined = " ".join(r.message for r in caplog.records)
@@ -564,7 +581,7 @@ class TestConfigValidationLogging:
             "config.repo_config.get_repo_setting",
             return_value={"tests_globs": ["**/*_test.go", None, ""]},
         ):
-            with caplog.at_level("WARNING", logger="config.repo_config"):
+            with caplog.at_level("WARNING", logger="egg.repo_config"):
                 result = get_repo_role_patterns("owner/repo")
         # The valid entry is kept; the None/"" entries are dropped with
         # warnings.

--- a/gateway/tests/test_per_repo_role_patterns.py
+++ b/gateway/tests/test_per_repo_role_patterns.py
@@ -10,10 +10,17 @@ Covers:
 - ``get_repo_role_patterns`` validates the YAML shape and silently drops
   unknown keys / non-list values / non-string entries.
 - The cache invalidates on ``reset_pattern_cache``.
+- Production-like import paths: when ``config.repo_config`` is not on
+  ``sys.path``, the fallback to top-level ``repo_config`` resolves
+  (mirrors the gateway / orchestrator container layout).
+- Sandbox env-var injection: when
+  ``EGG_PIPELINE_REPO_PATTERNS_JSON`` is set, the override is read
+  from the env without touching the filesystem.
 """
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 # Imports go through the gateway-side re-export barrel
@@ -54,6 +61,38 @@ class TestDefaultRegistryParity:
         built = build_agent_patterns(None)
         for role, pattern in AGENT_PATTERNS.items():
             assert built[role].block_exempt_patterns == pattern.block_exempt_patterns, role
+
+    def test_default_registry_preserves_canonical_partition(self):
+        """Pin ``can_write`` outcomes for paths whose role assignment
+        is load-bearing across every consumer (gateway push, sandbox
+        tool interceptor, plan-time validator). The structural-equality
+        tests above don't catch a regression where ``DEFAULT_*_GLOBS``
+        and the legacy hardcoded literals drift apart but happen to
+        produce dicts that look the same — these behavioral assertions
+        do.
+        """
+        built = build_agent_patterns(None)
+        # Python — coder owns source; tester owns tests; documenter
+        # owns markdown; everyone else is blocked from each other's
+        # scope.
+        assert built["coder"].can_write("orchestrator/routes/pipelines.py")
+        assert not built["coder"].can_write("tests/test_foo.py")
+        assert not built["coder"].can_write("docs/index.md")
+        assert built["tester"].can_write("tests/test_foo.py")
+        assert not built["tester"].can_write("orchestrator/routes/pipelines.py")
+        assert built["documenter"].can_write("docs/index.md")
+        assert not built["documenter"].can_write("orchestrator/routes/pipelines.py")
+        # Go — same-dir tests route to tester (default ``*_test.go``
+        # in tests_globs, even without a per-repo override).
+        assert not built["coder"].can_write("internal/foo/bar_test.go")
+        assert built["tester"].can_write("internal/foo/bar_test.go")
+        # JS / TS — test files route to tester.
+        assert not built["coder"].can_write("src/foo.spec.ts")
+        assert built["tester"].can_write("src/foo.spec.ts")
+        # Security — agents cannot bypass blocklists from any role.
+        for role in ("coder", "tester", "documenter"):
+            assert not built[role].can_write(".egg-state/contracts/foo.json")
+            assert not built[role].can_write(".github/workflows/ci.yml")
 
 
 class TestJsConventionRepo:
@@ -280,3 +319,255 @@ class TestDefaultGlobConstants:
     def test_default_docs_globs_cover_markdown_and_docs_dir(self):
         assert "docs/" in DEFAULT_DOCS_GLOBS
         assert "**/*.md" in DEFAULT_DOCS_GLOBS
+
+
+class TestProductionLikeImportPaths:
+    """The two-step ``config.repo_config`` → ``repo_config`` import is
+    load-bearing for every production runtime — gateway, orchestrator,
+    and sandbox each lay out the file differently. Tests that pass a
+    mock for ``config.repo_config.get_repo_role_patterns`` cover the
+    *function* but not the *import path*; the prior PR's tests passed
+    only because pytest runs with the repo root on ``sys.path``, where
+    ``config/`` happens to resolve as a Python namespace package — a
+    property that does not hold inside any container.
+
+    These tests simulate two production layouts:
+
+    1. ``config.repo_config`` import succeeds (gateway when ``/app/`` is
+       on ``PYTHONPATH`` *and* ``config/__init__.py`` exists alongside
+       — or when running from the worktree root in test).
+    2. ``config.repo_config`` raises ``ImportError`` and the fallback
+       ``from repo_config import …`` succeeds (gateway / orchestrator
+       containers, where ``repo_config.py`` lands at the top level).
+    """
+
+    def setup_method(self):
+        reset_pattern_cache()
+
+    def teardown_method(self):
+        reset_pattern_cache()
+
+    def test_falls_back_to_top_level_repo_config_when_config_package_missing(self, monkeypatch):
+        # Simulate the gateway's ``/app/repo_config.py`` (no ``config/``
+        # package on sys.path). We hide ``config.repo_config`` from
+        # ``sys.modules`` and stand up a fake top-level ``repo_config``.
+        import sys
+        import types
+
+        from agent_restrictions import load_repo_pattern_override
+
+        fake_top_level = types.ModuleType("repo_config")
+
+        def _override(repo: str):
+            if repo == "owner/go-repo":
+                return {"tests_globs": ["**/*_test.go", "**/testdata/**"]}
+            return None
+
+        fake_top_level.get_repo_role_patterns = _override
+        monkeypatch.setitem(sys.modules, "repo_config", fake_top_level)
+        # Make ``from config.repo_config import ...`` fail. A sentinel
+        # module without the symbol triggers ``ImportError`` for a
+        # ``from-import`` that asks for the missing name, which is what
+        # the production gateway sees when ``/config`` lacks
+        # ``__init__.py``.
+        broken_config = types.ModuleType("config")
+        monkeypatch.setitem(sys.modules, "config", broken_config)
+        monkeypatch.delitem(sys.modules, "config.repo_config", raising=False)
+
+        result = load_repo_pattern_override("owner/go-repo")
+        assert result == {"tests_globs": ["**/*_test.go", "**/testdata/**"]}
+
+    def test_returns_none_when_neither_module_importable(self, monkeypatch):
+        import sys
+        import types
+
+        from agent_restrictions import load_repo_pattern_override
+
+        # Hide both import paths.
+        broken_config = types.ModuleType("config")
+        monkeypatch.setitem(sys.modules, "config", broken_config)
+        monkeypatch.delitem(sys.modules, "config.repo_config", raising=False)
+        monkeypatch.delitem(sys.modules, "repo_config", raising=False)
+        # Block any subsequent import attempt for the top-level fallback.
+        original_meta_path = sys.meta_path
+
+        class _Blocker:
+            def find_spec(self, name, *_args, **_kwargs):
+                if name == "repo_config":
+                    raise ImportError("simulated: repo_config not on path")
+                return None
+
+        monkeypatch.setattr(sys, "meta_path", [_Blocker(), *original_meta_path])
+
+        # Should return None gracefully, not raise.
+        assert load_repo_pattern_override("owner/repo") is None
+
+
+class TestSandboxEnvVarInjection:
+    """The sandbox container has no ``repositories.yaml`` mounted, so
+    the orchestrator pre-resolves the override at spawn time and passes
+    it via ``EGG_PIPELINE_REPO_PATTERNS_JSON``. These tests pin the
+    env-var contract that the sandbox-side ``build_agent_patterns``
+    consumes."""
+
+    def setup_method(self):
+        reset_pattern_cache()
+
+    def teardown_method(self):
+        reset_pattern_cache()
+
+    def test_env_var_short_circuits_filesystem_lookup(self, monkeypatch):
+        from agent_restrictions import load_repo_pattern_override
+
+        # Even if the filesystem-side ``get_repo_role_patterns`` says
+        # something different, the env-var snapshot wins.
+        monkeypatch.setenv(
+            "EGG_PIPELINE_REPO_PATTERNS_JSON",
+            json.dumps(
+                {
+                    "owner/go-repo": {
+                        "tests_globs": ["**/*_test.go"],
+                        "code_globs": ["**/*.go"],
+                    }
+                }
+            ),
+        )
+
+        # If filesystem lookup were consulted it would raise; this
+        # confirms it isn't reached.
+        with patch(
+            "config.repo_config.get_repo_role_patterns",
+            side_effect=AssertionError("filesystem lookup should not run"),
+        ):
+            result = load_repo_pattern_override("owner/go-repo")
+        assert result == {
+            "tests_globs": ["**/*_test.go"],
+            "code_globs": ["**/*.go"],
+        }
+
+    def test_env_var_for_other_repos_is_ignored(self, monkeypatch):
+        from agent_restrictions import load_repo_pattern_override
+
+        # Snapshot only covers a different repo — the requested repo
+        # falls through to the filesystem path, which we mock.
+        monkeypatch.setenv(
+            "EGG_PIPELINE_REPO_PATTERNS_JSON",
+            json.dumps({"owner/other-repo": {"tests_globs": ["**/*_test.go"]}}),
+        )
+        with patch(
+            "config.repo_config.get_repo_role_patterns",
+            return_value={"tests_globs": ["**/__tests__/"]},
+        ):
+            result = load_repo_pattern_override("owner/js-repo")
+        assert result == {"tests_globs": ["**/__tests__/"]}
+
+    def test_malformed_env_var_does_not_raise(self, monkeypatch, caplog):
+        from agent_restrictions import load_repo_pattern_override
+
+        monkeypatch.setenv("EGG_PIPELINE_REPO_PATTERNS_JSON", "not-json{{")
+        with patch("config.repo_config.get_repo_role_patterns", return_value=None):
+            result = load_repo_pattern_override("owner/repo")
+        assert result is None
+
+    def test_pattern_lookup_uses_env_var_override(self, monkeypatch):
+        # End-to-end: a sandbox-style env injection alters the registry
+        # that ``get_agent_pattern_for_repo`` returns, without any
+        # filesystem access.
+        monkeypatch.setenv(
+            "EGG_PIPELINE_REPO_PATTERNS_JSON",
+            json.dumps({"owner/go-repo": {"tests_globs": ["**/*_test.go"]}}),
+        )
+        coder = get_agent_pattern_for_repo("coder", repo="owner/go-repo")
+        assert coder is not None
+        # Go same-dir tests are now blocked for coder.
+        assert not coder.can_write("internal/foo/bar_test.go")
+        # Python tests are no longer special — coder can write them
+        # because the override replaced the global tests_globs.
+        assert coder.can_write("internal/foo/test_bar.py")
+
+
+class TestCaseInsensitiveCacheKey:
+    """Repo lookups should not produce two cache entries for the same
+    repo spelled with different casings (``Owner/Repo`` vs
+    ``owner/repo``). Mirrors ``config.repo_config.get_repo_setting``'s
+    case-insensitive lookup."""
+
+    def setup_method(self):
+        reset_pattern_cache()
+
+    def teardown_method(self):
+        reset_pattern_cache()
+
+    def test_mixed_case_resolves_same_object(self, monkeypatch):
+        # Stub the override resolver so both casings would *otherwise*
+        # see the same data — what we're checking is the cache key.
+        monkeypatch.setattr(
+            "agent_restrictions.load_repo_pattern_override",
+            lambda repo: {"tests_globs": ["**/*_test.go"]},
+        )
+
+        a = get_agent_pattern_for_repo("coder", repo="Owner/Repo")
+        b = get_agent_pattern_for_repo("coder", repo="owner/repo")
+        assert a is b
+
+
+class TestAtomicCacheReset:
+    """``reset_pattern_cache`` must be atomic — a concurrent reader
+    must never see a half-empty cache. Atomic rebind of the module
+    global guarantees this under CPython's GIL."""
+
+    def test_reset_preserves_default_identity(self):
+        reset_pattern_cache()
+        # The default-repo entry must point at the module-level
+        # ``AGENT_PATTERNS`` (not a fresh registry of identical
+        # contents), so callers comparing with ``is`` keep working.
+        coder = get_agent_pattern_for_repo("coder", repo=None)
+        assert coder is AGENT_PATTERNS["coder"]
+
+
+class TestConfigValidationLogging:
+    """``get_repo_role_patterns`` must emit WARNING logs for every
+    dropped key/value so a misconfigured operator gets a signal in the
+    logs instead of silently shipping the global default."""
+
+    def test_unknown_key_logs_warning(self, caplog):
+        from config.repo_config import get_repo_role_patterns
+
+        with patch(
+            "config.repo_config.get_repo_setting",
+            return_value={"tests_glob": ["**/*_test.go"]},  # typo
+        ):
+            with caplog.at_level("WARNING", logger="config.repo_config"):
+                result = get_repo_role_patterns("owner/repo")
+        assert result is None
+        joined = " ".join(r.message for r in caplog.records)
+        assert "tests_glob" in joined
+        assert "not recognised" in joined or "valid keys" in joined
+
+    def test_non_list_value_logs_warning(self, caplog):
+        from config.repo_config import get_repo_role_patterns
+
+        with patch(
+            "config.repo_config.get_repo_setting",
+            return_value={"tests_globs": 42},
+        ):
+            with caplog.at_level("WARNING", logger="config.repo_config"):
+                result = get_repo_role_patterns("owner/repo")
+        assert result is None
+        joined = " ".join(r.message for r in caplog.records)
+        assert "tests_globs" in joined and "list" in joined
+
+    def test_non_string_entry_logs_warning(self, caplog):
+        from config.repo_config import get_repo_role_patterns
+
+        with patch(
+            "config.repo_config.get_repo_setting",
+            return_value={"tests_globs": ["**/*_test.go", None, ""]},
+        ):
+            with caplog.at_level("WARNING", logger="config.repo_config"):
+                result = get_repo_role_patterns("owner/repo")
+        # The valid entry is kept; the None/"" entries are dropped with
+        # warnings.
+        assert result == {"tests_globs": ["**/*_test.go"]}
+        joined = " ".join(r.message for r in caplog.records)
+        assert "invalid entry" in joined

--- a/k8s/base/orchestrator-deployment.yaml
+++ b/k8s/base/orchestrator-deployment.yaml
@@ -102,6 +102,18 @@ spec:
             # (`egg-sandbox:latest`), and nothing exists at docker.io/egg.
             - name: EGG_SANDBOX_IMAGE
               value: "egg-sandbox:latest"
+            # #2528: read per-repo role_patterns from the same
+            # repositories.yaml the gateway uses so plan-time validation
+            # and the planner-prompt boundaries match push-time
+            # enforcement. Mounted from the gateway-secrets Secret below;
+            # absence is non-fatal (the lookup degrades to defaults).
+            # The mount path is distinct from the gateway's ``/secrets``
+            # so the local-dev overlay's full ``/secrets`` projection
+            # (which exposes all credentials) does not collide with this
+            # production-default ``items``-projected mount that exposes
+            # only ``repositories.yaml``.
+            - name: EGG_REPO_CONFIG
+              value: "/etc/egg-config/repositories.yaml"
           # Probes target the standalone HTTP listener on the ``probe``
           # port (#2414). #2191 made the probe handlers cache-backed so
           # they did not run ``git`` on the request path, but they still
@@ -157,6 +169,14 @@ spec:
               mountPath: /home/egg/.egg-state
             - name: tmp
               mountPath: /tmp
+            # #2528: read-only mount of repositories.yaml so the
+            # orchestrator can resolve per-repo role_patterns (same
+            # source the gateway sidecar reads from). The Secret's
+            # other keys (PATs, launcher-secret, etc.) are not
+            # projected — only ``repositories.yaml`` is exposed.
+            - name: repo-config
+              mountPath: /etc/egg-config
+              readOnly: true
           resources:
             requests:
               cpu: 250m
@@ -171,3 +191,15 @@ spec:
           emptyDir: {}
         - name: tmp
           emptyDir: {}
+        # #2528: project the repositories.yaml key out of the shared
+        # gateway-secrets Secret. Optional so the deployment still
+        # rolls out cleanly in test fixtures that don't pre-create the
+        # Secret; the orchestrator's lookup degrades to defaults when
+        # the file is missing.
+        - name: repo-config
+          secret:
+            secretName: gateway-secrets
+            optional: true
+            items:
+              - key: repositories.yaml
+                path: repositories.yaml

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -28,6 +28,14 @@ COPY shared/egg_git/ ./egg_git/
 COPY shared/egg_anchor/ ./egg_anchor/
 COPY shared/egg_health/ ./egg_health/
 
+# Copy config module (#2528: orchestrator reads per-repo role_patterns
+# from repositories.yaml so plan-time validation and the planner prompt
+# match what the gateway will enforce at push time). The two-step
+# import in shared/egg_restrictions/patterns.py falls back from
+# ``config.repo_config`` to top-level ``repo_config``, mirroring the
+# gateway's existing pattern.
+COPY config/repo_config.py ./repo_config.py
+
 # Copy anchor schema files (required by egg_anchor.validator)
 COPY .egg/schemas/ ./.egg/schemas/
 

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -747,6 +747,31 @@ class KubernetesSpawner:
                 # owner/repo string used by the overseer auto-issue verb
                 # (issue #1962) and the gateway's overseer guardrails.
                 environment["EGG_PIPELINE_REPO"] = pipeline_repo
+                # #2528: sandbox containers don't have repositories.yaml
+                # mounted, so the orchestrator pre-resolves the per-repo
+                # role-pattern override here and passes it as a JSON
+                # env var. ``shared.egg_restrictions.patterns`` checks
+                # this env var first before attempting a filesystem
+                # lookup. Failures are non-fatal — the lookup degrades
+                # to the global defaults.
+                try:
+                    import json as _json
+
+                    from egg_restrictions.patterns import (
+                        load_repo_pattern_override,
+                    )
+
+                    snapshot = load_repo_pattern_override(pipeline_repo)
+                    if snapshot:
+                        environment["EGG_PIPELINE_REPO_PATTERNS_JSON"] = _json.dumps(
+                            {pipeline_repo: snapshot}
+                        )
+                except Exception:
+                    logger.exception(
+                        "Failed to pre-resolve role-pattern override for sandbox; "
+                        "falling back to defaults",
+                        repo=pipeline_repo,
+                    )
             if issue_number is not None:
                 environment["EGG_ISSUE_NUMBER"] = str(issue_number)
             if phase:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -10492,27 +10492,31 @@ def _build_producer_orientation(
     )
 
 
-def _build_file_boundary_section(role_value: str) -> str:
+def _build_file_boundary_section(role_value: str, repo: str | None = None) -> str:
     """Build a file boundary section for an agent prompt.
 
-    Reads the role's ``FileAccessPattern`` from ``egg_contracts.agent_roles``
-    and formats it as a prompt section so the agent knows which files it can
-    and cannot push *before* it starts writing files (#1431).
+    Sources the role's allowed/blocked patterns from
+    ``egg_restrictions.patterns.build_agent_patterns`` so the prompt
+    matches what the gateway will actually enforce on push — including
+    per-repo ``role_patterns:`` overrides from ``repositories.yaml``
+    (#2528). The legacy ``egg_contracts.agent_roles`` patterns were
+    Python-only and didn't honour the per-repo knobs, which created a
+    contradictory message for non-Python repos: the gateway would
+    enforce Go conventions while the prompt told the agent the boundary
+    was Python.
 
     Returns an empty string when no patterns are defined for the role.
     """
     try:
-        from egg_contracts.agent_roles import get_role_definition
-
-        role_def = get_role_definition(role_value)
-    except ValueError, KeyError, ImportError:
+        from egg_restrictions.patterns import get_agent_pattern_for_repo
+    except ImportError:
         return ""
 
-    if not role_def or not role_def.file_access:
+    pattern = get_agent_pattern_for_repo(role_value, repo=repo)
+    if pattern is None:
         return ""
 
-    fa = role_def.file_access
-    if not fa.allowed_write and not fa.blocked_write:
+    if not pattern.allowed_patterns and not pattern.blocked_patterns:
         return ""
 
     lines = [
@@ -10522,10 +10526,10 @@ def _build_file_boundary_section(role_value: str) -> str:
         "includes files outside your boundaries. Only create and modify files "
         "you are allowed to push.\n",
     ]
-    if fa.allowed_write:
-        lines.append("**Allowed:** " + ", ".join(f"`{p}`" for p in fa.allowed_write))
-    if fa.blocked_write:
-        lines.append("**Blocked:** " + ", ".join(f"`{p}`" for p in fa.blocked_write))
+    if pattern.allowed_patterns:
+        lines.append("**Allowed:** " + ", ".join(f"`{p}`" for p in pattern.allowed_patterns))
+    if pattern.blocked_patterns:
+        lines.append("**Blocked:** " + ", ".join(f"`{p}`" for p in pattern.blocked_patterns))
 
     # `.github/` staging-dir convention (issue #2508). Surfaced for the
     # coder role specifically because it's the producer that's expected
@@ -10627,7 +10631,9 @@ def _build_agent_prompt(
             repo_path=repo_path,
         )
         # Surface file boundaries so agent knows what it can push (#1431).
-        boundary_section = _build_file_boundary_section(role_value)
+        # Pass repo so the rendered patterns match per-repo overrides
+        # (#2528) the gateway will enforce on push.
+        boundary_section = _build_file_boundary_section(role_value, repo=repo)
         if boundary_section:
             base_prompt += "\n" + boundary_section
         # In concurrent mode, inject BRC consensus preamble so the coder/refiner
@@ -11323,7 +11329,9 @@ def _build_agent_prompt(
 
     # File boundaries (#1431) — surface allowed/blocked patterns so
     # the agent avoids creating files the gateway will reject on push.
-    boundary_section = _build_file_boundary_section(role_value)
+    # Pass repo so the rendered patterns match per-repo overrides
+    # (#2528) the gateway will enforce on push.
+    boundary_section = _build_file_boundary_section(role_value, repo=repo)
     if boundary_section:
         lines.append(boundary_section)
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5676,7 +5676,7 @@ def _build_role_restrictions_section(repo: str | None = None) -> str:
     Returns:
         Formatted markdown string describing role file boundaries.
     """
-    from egg_restrictions.patterns import build_agent_patterns
+    from egg_restrictions.patterns import get_agent_patterns_for_repo
 
     lines: list[str] = [
         "## Execution Role File Restrictions",
@@ -5687,7 +5687,7 @@ def _build_role_restrictions_section(repo: str | None = None) -> str:
         "",
     ]
 
-    patterns_by_role = build_agent_patterns(repo)
+    patterns_by_role = get_agent_patterns_for_repo(repo)
     for role_name in ("coder", "tester", "documenter"):
         pattern = patterns_by_role.get(role_name)
         if pattern is None:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5659,17 +5659,24 @@ def _build_role_context(
     return "\n".join(lines)
 
 
-def _build_role_restrictions_section() -> str:
+def _build_role_restrictions_section(repo: str | None = None) -> str:
     """Build a prompt section describing file access restrictions per execution role.
 
     This section is injected into the task_planner prompt so that it can
     assign each task to the correct execution role (coder, tester, documenter)
     based on which files the task will modify.
 
+    Args:
+        repo: Optional ``owner/repo`` for per-repo pattern overrides
+            (#2528). When set, the rendered patterns reflect
+            ``role_patterns:`` from ``repositories.yaml`` for the repo
+            so the planner sees the same boundaries the gateway will
+            enforce. When ``None``, falls back to global defaults.
+
     Returns:
         Formatted markdown string describing role file boundaries.
     """
-    from egg_contracts.agent_roles import get_file_patterns
+    from egg_restrictions.patterns import build_agent_patterns
 
     lines: list[str] = [
         "## Execution Role File Restrictions",
@@ -5680,15 +5687,16 @@ def _build_role_restrictions_section() -> str:
         "",
     ]
 
+    patterns_by_role = build_agent_patterns(repo)
     for role_name in ("coder", "tester", "documenter"):
-        patterns = get_file_patterns(role_name)
-        if patterns is None:
+        pattern = patterns_by_role.get(role_name)
+        if pattern is None:
             continue
         lines.append(f"### {role_name}")
-        if patterns.get("allowed"):
-            lines.append(f"- **Allowed**: {', '.join(f'`{p}`' for p in patterns['allowed'])}")
-        if patterns.get("blocked"):
-            lines.append(f"- **Blocked**: {', '.join(f'`{p}`' for p in patterns['blocked'])}")
+        if pattern.allowed_patterns:
+            lines.append(f"- **Allowed**: {', '.join(f'`{p}`' for p in pattern.allowed_patterns)}")
+        if pattern.blocked_patterns:
+            lines.append(f"- **Blocked**: {', '.join(f'`{p}`' for p in pattern.blocked_patterns)}")
         lines.append("")
 
     lines.append(
@@ -11199,8 +11207,11 @@ def _build_agent_prompt(
                 "",
             ]
         )
-        # Append role file restriction info so the planner assigns tasks correctly
-        lines.append(_build_role_restrictions_section())
+        # Append role file restriction info so the planner assigns tasks correctly.
+        # Pass the pipeline's repo so per-repo role_patterns from
+        # repositories.yaml are rendered (#2528) — keeps planner-prompt
+        # boundaries in sync with the gateway's push-time enforcement.
+        lines.append(_build_role_restrictions_section(repo=repo or None))
     elif role_value == "risk_analyst":
         lines.extend(
             [

--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -1025,7 +1025,13 @@ def _validate_planner_role_alignment(
         if not parsed.success:
             return
         slices = parsed.to_contract_slices()
-        errors = validate_task_role_alignment(slices)
+        # #2528: pass the pipeline's repo so per-repo role_patterns from
+        # repositories.yaml are honoured. Plan-time validation must
+        # mirror push-time enforcement, which now also reads the per-repo
+        # overrides (gateway/agent_restrictions.py).
+        errors = validate_task_role_alignment(
+            slices, repo=getattr(pipeline_state, "repo", None) or None
+        )
     except Exception as exc:
         logger.warning(
             "plan role-alignment validation: validator raised (non-blocking)",

--- a/shared/egg_agent/tool_interceptor.py
+++ b/shared/egg_agent/tool_interceptor.py
@@ -68,12 +68,18 @@ def check_file_write_permission(
         # If egg_restrictions not available, allow (fail-open for backward compat)
         return None
 
-    allowed, blocked_files, reason = check_agent_file_access(agent_role, [file_path])
+    # Per-repo overrides (#2528): the orchestrator injects EGG_PIPELINE_REPO
+    # into the sandbox so check_agent_file_access can read role_patterns
+    # from repositories.yaml. Falls back to global defaults outside a
+    # pipeline.
+    repo = os.environ.get("EGG_PIPELINE_REPO", "").strip() or None
+
+    allowed, blocked_files, reason = check_agent_file_access(agent_role, [file_path], repo=repo)
     if allowed:
         return None
 
     # Find which role owns this file for helpful error message
-    owner_role = _find_owning_role(file_path, agent_role)
+    owner_role = _find_owning_role(file_path, agent_role, repo=repo)
     owner_hint = f" -- this file belongs to the '{owner_role}' role" if owner_role else ""
 
     return (
@@ -97,28 +103,31 @@ def _normalize_to_repo_relative(file_path: str) -> str:
     return file_path.lstrip("/")
 
 
-def _find_owning_role(file_path: str, excluded_role: str) -> str | None:
+def _find_owning_role(file_path: str, excluded_role: str, repo: str | None = None) -> str | None:
     """Find which role is allowed to write to a file.
 
     Used for helpful error messages to tell agents which role
-    should handle the file.
+    should handle the file. Honours per-repo pattern overrides (#2528)
+    so the suggested role matches what the gateway will actually accept.
     """
     try:
-        from egg_restrictions import AGENT_PATTERNS
+        from egg_restrictions.patterns import build_agent_patterns
     except ImportError:
         return None
+
+    patterns = build_agent_patterns(repo)
 
     # Check common roles first (most likely targets for delegation)
     priority_roles = ["coder", "tester", "documenter"]
     for role_name in priority_roles:
         if role_name == excluded_role:
             continue
-        pattern = AGENT_PATTERNS.get(role_name)
+        pattern = patterns.get(role_name)
         if pattern and pattern.can_write(file_path):
             return role_name
 
     # Check remaining roles
-    for role_name, pattern in AGENT_PATTERNS.items():
+    for role_name, pattern in patterns.items():
         if role_name == excluded_role or role_name in priority_roles:
             continue
         if pattern.can_write(file_path):

--- a/shared/egg_agent/tool_interceptor.py
+++ b/shared/egg_agent/tool_interceptor.py
@@ -111,11 +111,13 @@ def _find_owning_role(file_path: str, excluded_role: str, repo: str | None = Non
     so the suggested role matches what the gateway will actually accept.
     """
     try:
-        from egg_restrictions.patterns import build_agent_patterns
+        from egg_restrictions.patterns import get_agent_patterns_for_repo
     except ImportError:
         return None
 
-    patterns = build_agent_patterns(repo)
+    # Use the cached lookup so we don't rebuild all 19 role patterns on
+    # every blocked write — write checks can be hot in noisy sessions.
+    patterns = get_agent_patterns_for_repo(repo)
 
     # Check common roles first (most likely targets for delegation)
     priority_roles = ["coder", "tester", "documenter"]

--- a/shared/egg_contracts/plan_parser.py
+++ b/shared/egg_contracts/plan_parser.py
@@ -1279,7 +1279,7 @@ def _detect_cycles(slices: list[Slice], known_ids: set[str]) -> list[list[str]]:
 # ---------------------------------------------------------------------------
 
 
-def _is_file_blocked_for_role(role: str, file_path: str) -> bool:
+def _is_file_blocked_for_role(role: str, file_path: str, repo: str | None = None) -> bool:
     """Return True if ``file_path`` is blocked for ``role`` per the role's
     ``AGENT_PATTERNS`` blocklist (with block-exempt carve-outs).
 
@@ -1287,6 +1287,11 @@ def _is_file_blocked_for_role(role: str, file_path: str) -> bool:
     so plan-time validation matches push-time enforcement 1:1. The
     gateway's check intentionally consults only blocked + block-exempt
     patterns (not allowed_patterns), and so does this function.
+
+    Per-repo overrides (#2528): when ``repo`` is supplied, the pattern
+    used reflects ``role_patterns:`` in ``repositories.yaml`` for that
+    repo, so plan-time validation predicts push-time enforcement for
+    non-Python repos too.
     """
     # AGENT_PATTERNS is imported lazily here to avoid a circular import:
     # egg_restrictions.patterns imports egg_contracts.agent_roles, which
@@ -1294,10 +1299,10 @@ def _is_file_blocked_for_role(role: str, file_path: str) -> bool:
     # module-scope import would deadlock that cycle and break the gateway
     # production boot path. egg_restrictions.matchers.match_pattern is
     # deliberately split out of patterns.py for safe module-scope use
-    # (see matchers.py docstring); only AGENT_PATTERNS needs to be lazy.
-    from egg_restrictions.patterns import AGENT_PATTERNS
+    # (see matchers.py docstring); only the registry lookup needs to be lazy.
+    from egg_restrictions.patterns import get_agent_pattern_for_repo
 
-    pattern = AGENT_PATTERNS.get(role)
+    pattern = get_agent_pattern_for_repo(role, repo=repo)
     if pattern is None:
         return False
 
@@ -1314,24 +1319,25 @@ def _is_file_blocked_for_role(role: str, file_path: str) -> bool:
     return True
 
 
-def _eligible_producer_roles(files: list[str]) -> list[str]:
+def _eligible_producer_roles(files: list[str], repo: str | None = None) -> list[str]:
     """Return the producer roles (coder/tester/documenter) for which
     every file in ``files`` passes the gateway's blocked-pattern check.
 
     The result preserves the canonical coder→tester→documenter ordering
-    so suggestions are deterministic across runs.
+    so suggestions are deterministic across runs. Honours per-repo
+    pattern overrides (#2528).
     """
     from .agent_roles import AgentRole
 
     ordered_roles = (AgentRole.CODER, AgentRole.TESTER, AgentRole.DOCUMENTER)
     eligible: list[str] = []
     for role in ordered_roles:
-        if all(not _is_file_blocked_for_role(role, f) for f in files):
+        if all(not _is_file_blocked_for_role(role, f, repo=repo) for f in files):
             eligible.append(role.value)
     return eligible
 
 
-def _check_role_files(task: Task, slice_id: str) -> str | None:
+def _check_role_files(task: Task, slice_id: str, repo: str | None = None) -> str | None:
     """Return a structured error string for a misaligned task, or
     ``None`` if the task's ``role`` can push every file in
     ``files_affected``.
@@ -1352,10 +1358,10 @@ def _check_role_files(task: Task, slice_id: str) -> str | None:
     files = list(task.files_affected or [])
     if not role or not files:
         return None
-    blocked = [f for f in files if _is_file_blocked_for_role(role, f)]
+    blocked = [f for f in files if _is_file_blocked_for_role(role, f, repo=repo)]
     if not blocked:
         return None
-    eligible = _eligible_producer_roles(files)
+    eligible = _eligible_producer_roles(files, repo=repo)
     if len(eligible) == 1:
         hint = f"Reassign to role '{eligible[0]}' — it can push every file in this task."
     elif len(eligible) > 1:
@@ -1378,7 +1384,7 @@ def _check_role_files(task: Task, slice_id: str) -> str | None:
     )
 
 
-def validate_task_role_alignment(slices: list[Slice]) -> list[str]:
+def validate_task_role_alignment(slices: list[Slice], repo: str | None = None) -> list[str]:
     """Walk the slice/task tree and reject tasks whose ``role`` cannot
     push their ``files_affected``.
 
@@ -1397,6 +1403,12 @@ def validate_task_role_alignment(slices: list[Slice]) -> list[str]:
 
     Args:
         slices: The slice list extracted from the contract / plan.
+        repo: Optional ``owner/repo`` for per-repo pattern overrides
+            (#2528). When set, the validator uses the repo's
+            ``role_patterns:`` block from ``repositories.yaml`` so
+            plan-time validation predicts push-time enforcement on
+            non-Python repos. When ``None``, falls back to the global
+            default patterns.
 
     Returns:
         A list of structured-error strings — one entry per offending
@@ -1407,7 +1419,7 @@ def validate_task_role_alignment(slices: list[Slice]) -> list[str]:
     errors: list[str] = []
     for slice_ in slices:
         for task in slice_.tasks:
-            err = _check_role_files(task, slice_.id)
+            err = _check_role_files(task, slice_.id, repo=repo)
             if err is not None:
                 errors.append(err)
     return errors

--- a/shared/egg_restrictions/checker.py
+++ b/shared/egg_restrictions/checker.py
@@ -10,35 +10,41 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from .patterns import AGENT_PATTERNS, AgentFilePattern
+from .patterns import AgentFilePattern, get_agent_pattern_for_repo
 
 
-def get_agent_pattern(role: str) -> AgentFilePattern | None:
+def get_agent_pattern(role: str, repo: str | None = None) -> AgentFilePattern | None:
     """Get the file pattern for an agent role.
 
     Args:
         role: The agent role identifier
+        repo: Optional repository in ``owner/repo`` format. When set, the
+            returned pattern reflects per-repo overrides from
+            ``repositories.yaml`` (#2528). When ``None``, returns the
+            global default pattern for the role.
 
     Returns:
         AgentFilePattern for the role, or None if not found
     """
-    return AGENT_PATTERNS.get(role.lower())
+    return get_agent_pattern_for_repo(role.lower(), repo)
 
 
 def check_agent_file_access(
     role: str,
     files: list[str],
+    repo: str | None = None,
 ) -> tuple[bool, list[str], str]:
     """Check if an agent can modify the given files.
 
     Args:
         role: The agent role identifier
         files: List of file paths being modified
+        repo: Optional repository for per-repo pattern overrides (#2528).
 
     Returns:
         Tuple of (allowed, blocked_files, reason)
     """
-    pattern = get_agent_pattern(role)
+    pattern = get_agent_pattern(role, repo=repo)
     if pattern is None:
         # Unknown role - deny all (deny-by-default)
         return False, files, f"Unknown agent role '{role}' \u2014 access denied (deny-by-default)"
@@ -92,6 +98,7 @@ class AgentRestrictionResult:
 def validate_agent_push(
     role: str,
     files: list[str],
+    repo: str | None = None,
 ) -> AgentRestrictionResult:
     """Validate that an agent can push changes to the given files.
 
@@ -100,6 +107,7 @@ def validate_agent_push(
     Args:
         role: The agent role identifier (e.g., "coder", "tester")
         files: List of file paths being modified in the push
+        repo: Optional repository for per-repo pattern overrides (#2528).
 
     Returns:
         AgentRestrictionResult indicating whether the push is allowed
@@ -110,7 +118,7 @@ def validate_agent_push(
     if not files:
         return AgentRestrictionResult.allow(role, "No files to validate")
 
-    allowed, blocked_files, reason = check_agent_file_access(role, files)
+    allowed, blocked_files, reason = check_agent_file_access(role, files, repo=repo)
 
     if allowed:
         return AgentRestrictionResult.allow(role, reason)

--- a/shared/egg_restrictions/patterns.py
+++ b/shared/egg_restrictions/patterns.py
@@ -879,7 +879,7 @@ def load_repo_pattern_override(repo: str) -> dict[str, list[str]] | None:
         from config.repo_config import get_repo_role_patterns as _loader
     except ImportError:
         try:
-            from repo_config import get_repo_role_patterns as _loader
+            from repo_config import get_repo_role_patterns as _loader  # type: ignore[no-redef]
         except ImportError:
             logger.debug(
                 "repo_config not importable; per-repo overrides disabled",

--- a/shared/egg_restrictions/patterns.py
+++ b/shared/egg_restrictions/patterns.py
@@ -19,7 +19,17 @@ from egg_contracts.agent_roles import AgentRole
 
 from .matchers import match_pattern
 
-__all__ = ["AGENT_PATTERNS", "AgentFilePattern", "AgentRole"]
+__all__ = [
+    "AGENT_PATTERNS",
+    "AgentFilePattern",
+    "AgentRole",
+    "DEFAULT_CODE_GLOBS",
+    "DEFAULT_DOCS_GLOBS",
+    "DEFAULT_TESTS_GLOBS",
+    "build_agent_patterns",
+    "get_agent_pattern_for_repo",
+    "reset_pattern_cache",
+]
 
 
 @dataclass
@@ -105,165 +115,224 @@ class AgentFilePattern:
 # This module is the single source of truth for per-role file boundaries
 # (#1903). The gateway's PhaseFilter and the sandbox container's readonly
 # mounts derive from here; do not duplicate these patterns elsewhere.
-CODER_PATTERNS = AgentFilePattern(
-    role=AgentRole.CODER,
-    description=(
-        "everything except tester's test scope, documenter's "
-        "docs/markdown scope, and the pipeline-state .egg-state/ "
-        "directory (agent-outputs/ carved back)"
-    ),
-    # Catch-all allow list — coder owns every file that is NOT carved out
-    # by the blocklist below. This replaces the legacy extension-based
-    # allowlist so extensionless scripts (bin/egg, sandbox/egg, LICENSE,
-    # .dockerignore, etc.) and future file types no longer need the
-    # allowlist to be edited.  See #1901.
-    allowed_patterns=["**"],
-    blocked_patterns=[
-        # Pipeline state (catch-all for every current and future subdir;
-        # .egg-state/agent-outputs/ is carved back via block_exempt_patterns)
-        ".egg-state/",
-        # Documenter scope
-        "docs/",
-        "**/*.md",
-        "**/README.md",
-        # Tester scope — directory patterns
-        "tests/",
-        "test/",
-        "**/tests/",
-        "**/test/",
-        # Tester scope — file-name patterns (fnmatch does NOT support
-        # brace expansion, so each language/suffix is spelled out)
-        "**/*_test.py",
-        "**/test_*.py",
-        "**/*_test.go",
-        "**/test_*.go",
-        "**/*.test.ts",
-        "**/*.test.tsx",
-        "**/*.test.js",
-        "**/*.test.jsx",
-        "**/*.spec.ts",
-        "**/*.spec.tsx",
-        "**/*.spec.js",
-        "**/*.spec.jsx",
-        "**/conftest.py",
-        # Defense-in-depth: CI workflows and CODEOWNERS — preserves the
-        # branch-protection invariant. Agents that need to propose
-        # `.github/` changes (CI workflow edits, CODEOWNERS rotation)
-        # write the proposed end-state to top-level `.github-staging/`
-        # mirroring the `.github/` structure; the prefix-match below
-        # leaves `.github-staging/` allowed via the `**` allowlist, and
-        # `_build_pr_body` auto-emits a manual step for the human
-        # reviewer to move the files into `.github/` before merge
-        # (issue #2508).
-        ".github/",
-    ],
-    block_exempt_patterns=[
-        # Coder's handoff directory — the only .egg-state/ subdir the coder
-        # owns.
-        ".egg-state/agent-outputs/",
-        # Per-agent anchor files. The gateway's `check_anchor_write_permission`
-        # (gateway/phase_filter.py::check_anchor_write_permission) enforces
-        # per-agent scoping — an agent may only write its own
-        # `.egg-state/agent-anchors/<AGENT_ANCHOR_ID>.json`. That downstream
-        # guard can only run if the role-level check lets the path through,
-        # so this exemption restores the pre-#1901 behavior where the legacy
-        # `**/*.json` allowlist matched anchor files. The contract task
-        # TASK-1-1 for #1901 did not enumerate this exemption — the gap was
-        # surfaced by tester's pre-existing test_push_*_anchor_write tests
-        # against the new blocklist-complement. See #1901 NACK discussion.
-        ".egg-state/agent-anchors/",
-        # Agent config .md files are functional code (rules, skills, commands),
-        # not documentation. See #1537. Paths are specific to avoid bypassing
-        # other blocked patterns (docs/, tests/, .egg-state/contracts/).
-        "sandbox/agent-config/rules/*.md",
-        "sandbox/agent-config/commands/*.md",
-        # Top-level skills directory (skill definitions are functional code)
-        "skills/",
-    ],
+#
+# Per-repo overrides (#2528): the three test/code/docs glob lists below
+# are the load-bearing language conventions. Repos can override them via
+# ``role_patterns:`` in ``repositories.yaml`` so non-Python conventions
+# (Go ``*_test.go``, JS ``__tests__/``, etc.) get correct role boundaries.
+# Security-relevant blocklists (``.egg-state/contracts/``, ``.github/``)
+# are NOT overridable — they enforce the policy boundary independent of
+# repo-specific conventions.
+
+# Default test-file conventions: directory patterns + file-name patterns.
+# fnmatch does NOT support brace expansion, so each suffix is spelled out.
+DEFAULT_TESTS_GLOBS: list[str] = [
+    # Test directories
+    "tests/",
+    "test/",
+    "**/tests/",
+    "**/test/",
+    # Python
+    "**/*_test.py",
+    "**/test_*.py",
+    "**/conftest.py",
+    # Go
+    "**/*_test.go",
+    "**/test_*.go",
+    # JS/TS
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.test.js",
+    "**/*.test.jsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+]
+
+# Default production-code conventions (used by tester's auto-fix allow
+# list and documenter's blocklist).
+DEFAULT_CODE_GLOBS: list[str] = [
+    "**/*.py",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.go",
+    "**/*.java",
+    "**/*.rb",
+    "**/*.rs",
+    "**/*.sh",
+]
+
+# Default documentation conventions.
+DEFAULT_DOCS_GLOBS: list[str] = [
+    "docs/",
+    "**/*.md",
+    "**/README.md",
+]
+
+
+def _build_coder_pattern(
+    *,
+    tests_globs: list[str],
+    docs_globs: list[str],
+) -> AgentFilePattern:
+    """Build the coder role's file pattern.
+
+    Coder owns every file that is NOT carved out by the blocklist (the
+    catch-all ``**`` allow). The per-repo knobs widen the test/docs
+    blocks so non-Python repos route those files to the appropriate
+    role.
+    """
+    return AgentFilePattern(
+        role=AgentRole.CODER,
+        description=(
+            "everything except tester's test scope, documenter's "
+            "docs/markdown scope, and the pipeline-state .egg-state/ "
+            "directory (agent-outputs/ carved back)"
+        ),
+        # Catch-all allow list — coder owns every file that is NOT carved out
+        # by the blocklist below. This replaces the legacy extension-based
+        # allowlist so extensionless scripts (bin/egg, sandbox/egg, LICENSE,
+        # .dockerignore, etc.) and future file types no longer need the
+        # allowlist to be edited.  See #1901.
+        allowed_patterns=["**"],
+        blocked_patterns=[
+            # Pipeline state (catch-all for every current and future subdir;
+            # .egg-state/agent-outputs/ is carved back via block_exempt_patterns)
+            ".egg-state/",
+            # Documenter scope
+            *docs_globs,
+            # Tester scope
+            *tests_globs,
+            # Defense-in-depth: CI workflows and CODEOWNERS — preserves the
+            # branch-protection invariant. Agents that need to propose
+            # `.github/` changes (CI workflow edits, CODEOWNERS rotation)
+            # write the proposed end-state to top-level `.github-staging/`
+            # mirroring the `.github/` structure; the prefix-match below
+            # leaves `.github-staging/` allowed via the `**` allowlist, and
+            # `_build_pr_body` auto-emits a manual step for the human
+            # reviewer to move the files into `.github/` before merge
+            # (issue #2508).
+            ".github/",
+        ],
+        block_exempt_patterns=[
+            # Coder's handoff directory — the only .egg-state/ subdir the coder
+            # owns.
+            ".egg-state/agent-outputs/",
+            # Per-agent anchor files. The gateway's `check_anchor_write_permission`
+            # (gateway/phase_filter.py::check_anchor_write_permission) enforces
+            # per-agent scoping — an agent may only write its own
+            # `.egg-state/agent-anchors/<AGENT_ANCHOR_ID>.json`. That downstream
+            # guard can only run if the role-level check lets the path through,
+            # so this exemption restores the pre-#1901 behavior where the legacy
+            # `**/*.json` allowlist matched anchor files. The contract task
+            # TASK-1-1 for #1901 did not enumerate this exemption — the gap was
+            # surfaced by tester's pre-existing test_push_*_anchor_write tests
+            # against the new blocklist-complement. See #1901 NACK discussion.
+            ".egg-state/agent-anchors/",
+            # Agent config .md files are functional code (rules, skills, commands),
+            # not documentation. See #1537. Paths are specific to avoid bypassing
+            # other blocked patterns (docs/, tests/, .egg-state/contracts/).
+            "sandbox/agent-config/rules/*.md",
+            "sandbox/agent-config/commands/*.md",
+            # Top-level skills directory (skill definitions are functional code)
+            "skills/",
+        ],
+    )
+
+
+def _build_tester_pattern(
+    *,
+    tests_globs: list[str],
+    code_globs: list[str],
+    docs_globs: list[str],
+) -> AgentFilePattern:
+    """Build the tester role's file pattern.
+
+    Tester writes test files plus auto-fix touches to source. Per-repo
+    knobs change the test-file allowlist + the docs blocklist.
+    """
+    # Production code is also in tester's allow list because tester
+    # applies lint/type-check auto-fixes; ``code_globs`` extends both.
+    return AgentFilePattern(
+        role=AgentRole.TESTER,
+        description="test files and pytest infrastructure only",
+        allowed_patterns=[
+            *tests_globs,
+            *code_globs,
+            # Config files needed for test environment setup
+            ".python-version",
+            # Dependency files (test dependency management)
+            "**/*.lock",
+            "**/requirements*.txt",
+            # Handoff output
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_patterns=[
+            # Documentation (Documenter handles)
+            *docs_globs,
+            # Contracts
+            ".egg-state/contracts/",
+            # Issue #2521: parity with TESTER_ROLE.blocked_write — see CODER_PATTERNS for rationale.
+            ".github/",
+        ],
+    )
+
+
+def _build_documenter_pattern(
+    *,
+    tests_globs: list[str],
+    code_globs: list[str],
+    docs_globs: list[str],
+) -> AgentFilePattern:
+    """Build the documenter role's file pattern.
+
+    Documenter writes only docs. Per-repo knobs change the docs allow
+    list + the test/code blocklist.
+    """
+    return AgentFilePattern(
+        role=AgentRole.DOCUMENTER,
+        description="documentation and markdown files",
+        allowed_patterns=[
+            *docs_globs,
+            # Handoff output
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_patterns=[
+            # Source code (Coder handles)
+            *code_globs,
+            # Test files (Tester handles)
+            *tests_globs,
+            # Contracts
+            ".egg-state/contracts/",
+            # Issue #2508: branch-protection invariant — even markdown
+            # files under `.github/` (PULL_REQUEST_TEMPLATE.md,
+            # ISSUE_TEMPLATE.md, etc.) must go through the
+            # `.github-staging/` convention so a human reviewer moves them
+            # in before merge. Without this block, `**/*.md` would let the
+            # documenter rewrite `.github/PULL_REQUEST_TEMPLATE.md`.
+            ".github/",
+        ],
+    )
+
+
+CODER_PATTERNS = _build_coder_pattern(
+    tests_globs=DEFAULT_TESTS_GLOBS,
+    docs_globs=DEFAULT_DOCS_GLOBS,
 )
 
-TESTER_PATTERNS = AgentFilePattern(
-    role=AgentRole.TESTER,
-    description="test files and pytest infrastructure only",
-    allowed_patterns=[
-        # Test directories
-        "tests/",
-        "test/",
-        "**/tests/",
-        "**/test/",
-        # Test file patterns
-        "**/*_test.py",
-        "**/test_*.py",
-        "**/*_test.go",
-        "**/test_*.go",
-        "**/*.test.ts",
-        "**/*.test.tsx",
-        "**/*.test.js",
-        "**/*.test.jsx",
-        "**/*.spec.ts",
-        "**/*.spec.tsx",
-        "**/*.spec.js",
-        "**/*.spec.jsx",
-        # Pytest infrastructure
-        "**/conftest.py",
-        # Config files needed for test environment setup
-        ".python-version",
-        # Dependency files (test dependency management)
-        "**/*.lock",
-        "**/requirements*.txt",
-        # Handoff output
-        ".egg-state/agent-outputs/",
-    ],
-    blocked_patterns=[
-        # Documentation (Documenter handles)
-        "docs/",
-        "**/README.md",
-        "**/*.md",
-        # Contracts
-        ".egg-state/contracts/",
-        # Issue #2521: parity with TESTER_ROLE.blocked_write — see CODER_PATTERNS for rationale.
-        ".github/",
-    ],
+TESTER_PATTERNS = _build_tester_pattern(
+    tests_globs=DEFAULT_TESTS_GLOBS,
+    code_globs=DEFAULT_CODE_GLOBS,
+    docs_globs=DEFAULT_DOCS_GLOBS,
 )
 
-DOCUMENTER_PATTERNS = AgentFilePattern(
-    role=AgentRole.DOCUMENTER,
-    description="documentation and markdown files",
-    allowed_patterns=[
-        # Documentation directories
-        "docs/",
-        # Markdown files anywhere
-        "**/*.md",
-        "**/README.md",
-        # Handoff output
-        ".egg-state/agent-outputs/",
-    ],
-    blocked_patterns=[
-        # Source code (Coder handles)
-        "**/*.py",
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.js",
-        "**/*.jsx",
-        "**/*.go",
-        "**/*.java",
-        "**/*.rb",
-        "**/*.rs",
-        # Test files (Tester handles)
-        "tests/",
-        "test/",
-        "**/tests/",
-        "**/test/",
-        # Contracts
-        ".egg-state/contracts/",
-        # Issue #2508: branch-protection invariant — even markdown
-        # files under `.github/` (PULL_REQUEST_TEMPLATE.md,
-        # ISSUE_TEMPLATE.md, etc.) must go through the
-        # `.github-staging/` convention so a human reviewer moves them
-        # in before merge. Without this block, `**/*.md` would let the
-        # documenter rewrite `.github/PULL_REQUEST_TEMPLATE.md`.
-        ".github/",
-    ],
+DOCUMENTER_PATTERNS = _build_documenter_pattern(
+    tests_globs=DEFAULT_TESTS_GLOBS,
+    code_globs=DEFAULT_CODE_GLOBS,
+    docs_globs=DEFAULT_DOCS_GLOBS,
 )
 
 # Plan-phase agent patterns
@@ -472,131 +541,131 @@ OVERSEER_PATTERNS = AgentFilePattern(
 # The autofixer applies automated lint/type-check/formatting fixes to source
 # and config files.  It cannot modify docs or contracts.
 
-AUTOFIXER_PATTERNS = AgentFilePattern(
-    role=AgentRole.AUTOFIXER,
-    description="source code and config files for automated fixes",
-    allowed_patterns=[
-        # Source code
-        "**/*.py",
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.js",
-        "**/*.jsx",
-        "**/*.go",
-        "**/*.java",
-        "**/*.rb",
-        "**/*.rs",
-        "**/*.sh",
-        # Configuration
-        "**/*.yml",
-        "**/*.yaml",
-        "**/*.json",
-        "**/*.toml",
-        # Build/config files (extensionless)
-        "Makefile",
-        "**/Makefile",
-        "Dockerfile",
-        "**/Dockerfile",
-        ".python-version",
-        ".node-version",
-        ".nvmrc",
-        ".gitignore",
-        ".gitattributes",
-        ".editorconfig",
-        # Lock files
-        "**/*.lock",
-        "**/requirements*.txt",
-        # Handoff output
-        ".egg-state/agent-outputs/",
-    ],
-    blocked_patterns=[
-        # Documentation
-        "docs/",
-        "**/*.md",
-        # Contracts
-        ".egg-state/contracts/",
-        # Issue #2508: branch-protection invariant — even an autofixer
-        # YAML lint fix to `.github/workflows/*.yml` must go through
-        # the `.github-staging/` convention so a human reviewer moves
-        # it in before merge. Without this block, `**/*.yml` would let
-        # the autofixer rewrite workflows directly.
-        ".github/",
-    ],
-)
+
+def _build_autofixer_pattern(
+    *,
+    code_globs: list[str],
+    docs_globs: list[str],
+) -> AgentFilePattern:
+    """Build the autofixer role's file pattern.
+
+    Autofixer writes source + config (lint/type-check fixes) and never
+    docs. Per-repo ``code_globs`` widens the allow list; ``docs_globs``
+    widens the docs block.
+    """
+    return AgentFilePattern(
+        role=AgentRole.AUTOFIXER,
+        description="source code and config files for automated fixes",
+        allowed_patterns=[
+            *code_globs,
+            # Configuration
+            "**/*.yml",
+            "**/*.yaml",
+            "**/*.json",
+            "**/*.toml",
+            # Build/config files (extensionless)
+            "Makefile",
+            "**/Makefile",
+            "Dockerfile",
+            "**/Dockerfile",
+            ".python-version",
+            ".node-version",
+            ".nvmrc",
+            ".gitignore",
+            ".gitattributes",
+            ".editorconfig",
+            # Lock files
+            "**/*.lock",
+            "**/requirements*.txt",
+            # Handoff output
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_patterns=[
+            # Documentation
+            *docs_globs,
+            # Contracts
+            ".egg-state/contracts/",
+            # Issue #2508: branch-protection invariant — even an autofixer
+            # YAML lint fix to `.github/workflows/*.yml` must go through
+            # the `.github-staging/` convention so a human reviewer moves
+            # it in before merge. Without this block, `**/*.yml` would let
+            # the autofixer rewrite workflows directly.
+            ".github/",
+        ],
+    )
+
 
 # Conflict resolver agent pattern
 # The conflict resolver can modify source, test, docs, and config files to
 # resolve merge conflicts.  It cannot modify pipeline state directories.
 
-CONFLICT_RESOLVER_PATTERNS = AgentFilePattern(
-    role=AgentRole.CONFLICT_RESOLVER,
-    description="source, test, docs, and config files",
-    allowed_patterns=[
-        # Source code
-        "**/*.py",
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.js",
-        "**/*.jsx",
-        "**/*.go",
-        "**/*.java",
-        "**/*.rb",
-        "**/*.rs",
-        "**/*.sh",
-        # Tests
-        "tests/",
-        "test/",
-        "**/tests/",
-        "**/test/",
-        "**/*_test.py",
-        "**/test_*.py",
-        "**/*.test.ts",
-        "**/*.test.tsx",
-        "**/*.test.js",
-        "**/*.test.jsx",
-        "**/*.spec.ts",
-        "**/*.spec.tsx",
-        "**/*.spec.js",
-        "**/*.spec.jsx",
-        # Documentation
-        "docs/",
-        "**/*.md",
-        # Configuration
-        "**/*.yml",
-        "**/*.yaml",
-        "**/*.json",
-        "**/*.toml",
-        # Build/config files (extensionless)
-        "Makefile",
-        "**/Makefile",
-        "Dockerfile",
-        "**/Dockerfile",
-        "Procfile",
-        ".python-version",
-        ".node-version",
-        ".nvmrc",
-        ".gitignore",
-        ".gitattributes",
-        ".editorconfig",
-        # Lock files
-        "**/*.lock",
-        "**/requirements*.txt",
-        # Handoff output
-        ".egg-state/agent-outputs/",
-    ],
-    blocked_patterns=[
-        # Pipeline state (specific subdirs, excluding agent-outputs)
-        ".egg-state/contracts/",
-        ".egg-state/drafts/",
-        ".egg-state/pipelines/",
-        ".egg-state/reviews/",
-        ".egg-state/oversight/",
-        # Issue #2508: branch-protection invariant — when resolving a
-        # merge conflict that touches a workflow / CODEOWNERS file,
-        # the resolution must go through the `.github-staging/`
-        # convention so a human reviewer moves it in before merge.
-        ".github/",
-    ],
+
+def _build_conflict_resolver_pattern(
+    *,
+    tests_globs: list[str],
+    code_globs: list[str],
+    docs_globs: list[str],
+) -> AgentFilePattern:
+    """Build the conflict-resolver role's file pattern.
+
+    Conflict resolver writes source, tests, and docs (any file may be in
+    a merge conflict). Per-repo knobs widen all three allow lists.
+    """
+    return AgentFilePattern(
+        role=AgentRole.CONFLICT_RESOLVER,
+        description="source, test, docs, and config files",
+        allowed_patterns=[
+            *code_globs,
+            *tests_globs,
+            *docs_globs,
+            # Configuration
+            "**/*.yml",
+            "**/*.yaml",
+            "**/*.json",
+            "**/*.toml",
+            # Build/config files (extensionless)
+            "Makefile",
+            "**/Makefile",
+            "Dockerfile",
+            "**/Dockerfile",
+            "Procfile",
+            ".python-version",
+            ".node-version",
+            ".nvmrc",
+            ".gitignore",
+            ".gitattributes",
+            ".editorconfig",
+            # Lock files
+            "**/*.lock",
+            "**/requirements*.txt",
+            # Handoff output
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_patterns=[
+            # Pipeline state (specific subdirs, excluding agent-outputs)
+            ".egg-state/contracts/",
+            ".egg-state/drafts/",
+            ".egg-state/pipelines/",
+            ".egg-state/reviews/",
+            ".egg-state/oversight/",
+            # Issue #2508: branch-protection invariant — when resolving a
+            # merge conflict that touches a workflow / CODEOWNERS file,
+            # the resolution must go through the `.github-staging/`
+            # convention so a human reviewer moves it in before merge.
+            ".github/",
+        ],
+    )
+
+
+AUTOFIXER_PATTERNS = _build_autofixer_pattern(
+    code_globs=DEFAULT_CODE_GLOBS,
+    docs_globs=DEFAULT_DOCS_GLOBS,
+)
+
+CONFLICT_RESOLVER_PATTERNS = _build_conflict_resolver_pattern(
+    tests_globs=DEFAULT_TESTS_GLOBS,
+    code_globs=DEFAULT_CODE_GLOBS,
+    docs_globs=DEFAULT_DOCS_GLOBS,
 )
 
 # Inspector agent pattern
@@ -649,3 +718,144 @@ AGENT_PATTERNS: dict[str, AgentFilePattern] = {
     AgentRole.CONFLICT_RESOLVER: CONFLICT_RESOLVER_PATTERNS,
     AgentRole.INSPECTOR: INSPECTOR_PATTERNS,
 }
+
+
+# ---------------------------------------------------------------------------
+# #2528 — per-repo role-pattern overrides
+# ---------------------------------------------------------------------------
+#
+# Repos can override the language conventions in ``repositories.yaml`` via
+# a ``role_patterns:`` block (parsed in ``config/repo_config.py``). Only
+# the three glob lists are configurable; security-relevant blocklists
+# (``.egg-state/contracts/``, ``.github/``, draft/review state dirs) are
+# fixed and cannot be relaxed by a target repo.
+#
+# Default callers don't need to change: ``AGENT_PATTERNS`` keeps its
+# legacy global-default shape (= ``build_agent_patterns(None)``).
+# Callers that have a repo identifier in scope (gateway push handler,
+# tool interceptor, plan-time validator, planner prompt) can opt into
+# per-repo patterns via ``get_agent_pattern_for_repo(role, repo)``.
+
+
+def build_agent_patterns(
+    repo: str | None = None,
+    *,
+    tests_globs: list[str] | None = None,
+    code_globs: list[str] | None = None,
+    docs_globs: list[str] | None = None,
+) -> dict[str, AgentFilePattern]:
+    """Build the per-role pattern registry for a repo.
+
+    When ``repo`` is provided and the optional glob arguments are not,
+    this function reads ``repositories.yaml`` via
+    ``config.repo_config.get_repo_role_patterns(repo)`` and substitutes
+    only the keys the repo configured. Unset keys fall back to the
+    ``DEFAULT_*_GLOBS`` constants. When all three glob arguments are
+    None (and the repo has no override), the result is identical to the
+    module-level ``AGENT_PATTERNS`` registry.
+
+    The explicit ``tests_globs`` / ``code_globs`` / ``docs_globs``
+    keyword arguments exist so unit tests can build a registry without
+    requiring a ``repositories.yaml`` lookup; production callers should
+    only pass ``repo``.
+
+    Args:
+        repo: Repository in ``owner/repo`` format. ``None`` means
+            global defaults.
+        tests_globs: Override for the test-file convention. Falls back
+            to repo config or ``DEFAULT_TESTS_GLOBS``.
+        code_globs: Override for the production-code convention.
+        docs_globs: Override for the documentation convention.
+
+    Returns:
+        A fresh dict mapping role name to ``AgentFilePattern``.
+
+    Security note:
+        Security-relevant blocklists (``.egg-state/contracts/``,
+        ``.github/``, etc.) are sourced from this module's hard-coded
+        builders and CANNOT be overridden by a repo's config. The
+        per-repo knobs only widen the language-convention lists.
+    """
+    if repo is not None and tests_globs is None and code_globs is None and docs_globs is None:
+        # Lazy import — config.repo_config pulls yaml + filesystem state
+        # that we don't want at module-import time.
+        try:
+            from config.repo_config import get_repo_role_patterns
+
+            override = get_repo_role_patterns(repo)
+        except Exception:
+            override = None
+        if override:
+            tests_globs = override.get("tests_globs")
+            code_globs = override.get("code_globs")
+            docs_globs = override.get("docs_globs")
+
+    final_tests = list(tests_globs) if tests_globs is not None else DEFAULT_TESTS_GLOBS
+    final_code = list(code_globs) if code_globs is not None else DEFAULT_CODE_GLOBS
+    final_docs = list(docs_globs) if docs_globs is not None else DEFAULT_DOCS_GLOBS
+
+    coder = _build_coder_pattern(tests_globs=final_tests, docs_globs=final_docs)
+    tester = _build_tester_pattern(
+        tests_globs=final_tests, code_globs=final_code, docs_globs=final_docs
+    )
+    documenter = _build_documenter_pattern(
+        tests_globs=final_tests, code_globs=final_code, docs_globs=final_docs
+    )
+    autofixer = _build_autofixer_pattern(code_globs=final_code, docs_globs=final_docs)
+    conflict_resolver = _build_conflict_resolver_pattern(
+        tests_globs=final_tests, code_globs=final_code, docs_globs=final_docs
+    )
+
+    return {
+        AgentRole.CODER: coder,
+        AgentRole.TESTER: tester,
+        AgentRole.DOCUMENTER: documenter,
+        AgentRole.ARCHITECT: ARCHITECT_PATTERNS,
+        AgentRole.TASK_PLANNER: TASK_PLANNER_PATTERNS,
+        AgentRole.RISK_ANALYST: RISK_ANALYST_PATTERNS,
+        AgentRole.REVIEWER_CODE: REVIEWER_CODE_PATTERNS,
+        AgentRole.REVIEWER_CODE_HOLISTIC: REVIEWER_CODE_HOLISTIC_PATTERNS,
+        AgentRole.REVIEWER_CONTRACT: REVIEWER_CONTRACT_PATTERNS,
+        AgentRole.REVIEWER_AGENT_DESIGN: REVIEWER_AGENT_DESIGN_PATTERNS,
+        AgentRole.REFINER: REFINER_PATTERNS,
+        AgentRole.REVIEWER_REFINE: REVIEWER_REFINE_PATTERNS,
+        AgentRole.REVIEWER_PLAN: REVIEWER_PLAN_PATTERNS,
+        AgentRole.REVIEWER_SECURITY: REVIEWER_SECURITY_PATTERNS,
+        AgentRole.REVIEWER_CONCURRENCY: REVIEWER_CONCURRENCY_PATTERNS,
+        AgentRole.OVERSEER: OVERSEER_PATTERNS,
+        AgentRole.AUTOFIXER: autofixer,
+        AgentRole.CONFLICT_RESOLVER: conflict_resolver,
+        AgentRole.INSPECTOR: INSPECTOR_PATTERNS,
+    }
+
+
+# Per-repo cache. The build is cheap but called on every push, plan-time
+# validation, and tool-interceptor write check; memoizing avoids redoing
+# the YAML read per-call. Reset via ``reset_pattern_cache`` (wired into
+# the gateway's existing config-reload path).
+_repo_pattern_cache: dict[str | None, dict[str, AgentFilePattern]] = {None: AGENT_PATTERNS}
+
+
+def get_agent_pattern_for_repo(role: str, repo: str | None = None) -> AgentFilePattern | None:
+    """Look up the role pattern for a given repo, or ``None`` if the
+    role is not defined.
+
+    Equivalent to ``AGENT_PATTERNS.get(role)`` when ``repo`` is None or
+    no override exists. Memoizes per repo.
+    """
+    cached = _repo_pattern_cache.get(repo)
+    if cached is None:
+        cached = build_agent_patterns(repo)
+        _repo_pattern_cache[repo] = cached
+    return cached.get(role)
+
+
+def reset_pattern_cache() -> None:
+    """Clear the per-repo pattern cache.
+
+    Called by ``config.repo_config.reload_config`` so a SIGHUP /
+    ``/api/v1/config/reload`` picks up edited ``role_patterns:``
+    overrides without restarting the gateway.
+    """
+    _repo_pattern_cache.clear()
+    _repo_pattern_cache[None] = AGENT_PATTERNS

--- a/shared/egg_restrictions/patterns.py
+++ b/shared/egg_restrictions/patterns.py
@@ -862,7 +862,18 @@ def load_repo_pattern_override(repo: str) -> dict[str, list[str]] | None:
             )
             decoded = None
         if isinstance(decoded, dict):
-            entry = decoded.get(repo)
+            # Match the case-insensitive lookup used by ``get_repo_setting``
+            # and the per-repo cache key, so a developer hand-setting the
+            # env var with one case and querying with another still hits.
+            normalized_repo = repo.lower()
+            entry = next(
+                (
+                    v
+                    for k, v in decoded.items()
+                    if isinstance(k, str) and k.lower() == normalized_repo
+                ),
+                None,
+            )
             if isinstance(entry, dict):
                 cleaned: dict[str, list[str]] = {}
                 for key in ("tests_globs", "code_globs", "docs_globs"):

--- a/shared/egg_restrictions/patterns.py
+++ b/shared/egg_restrictions/patterns.py
@@ -246,22 +246,20 @@ def _build_coder_pattern(
 def _build_tester_pattern(
     *,
     tests_globs: list[str],
-    code_globs: list[str],
+    code_globs: list[str],  # noqa: ARG001 — kept for signature parity with other builders
     docs_globs: list[str],
 ) -> AgentFilePattern:
     """Build the tester role's file pattern.
 
-    Tester writes test files plus auto-fix touches to source. Per-repo
-    knobs change the test-file allowlist + the docs blocklist.
+    Tester writes test files only — source-code edits are the coder's
+    or autofixer's job. Per-repo knobs change the test-file allowlist
+    + the docs blocklist.
     """
-    # Production code is also in tester's allow list because tester
-    # applies lint/type-check auto-fixes; ``code_globs`` extends both.
     return AgentFilePattern(
         role=AgentRole.TESTER,
         description="test files and pytest infrastructure only",
         allowed_patterns=[
             *tests_globs,
-            *code_globs,
             # Config files needed for test environment setup
             ".python-version",
             # Dependency files (test dependency management)

--- a/shared/egg_restrictions/patterns.py
+++ b/shared/egg_restrictions/patterns.py
@@ -8,6 +8,9 @@ that need to enforce agent file access boundaries.
 
 from __future__ import annotations
 
+import json
+import logging
+import os
 import posixpath
 from dataclasses import dataclass, field
 
@@ -19,6 +22,8 @@ from egg_contracts.agent_roles import AgentRole
 
 from .matchers import match_pattern
 
+logger = logging.getLogger(__name__)
+
 __all__ = [
     "AGENT_PATTERNS",
     "AgentFilePattern",
@@ -28,6 +33,8 @@ __all__ = [
     "DEFAULT_TESTS_GLOBS",
     "build_agent_patterns",
     "get_agent_pattern_for_repo",
+    "get_agent_patterns_for_repo",
+    "load_repo_pattern_override",
     "reset_pattern_cache",
 ]
 
@@ -775,14 +782,7 @@ def build_agent_patterns(
         per-repo knobs only widen the language-convention lists.
     """
     if repo is not None and tests_globs is None and code_globs is None and docs_globs is None:
-        # Lazy import — config.repo_config pulls yaml + filesystem state
-        # that we don't want at module-import time.
-        try:
-            from config.repo_config import get_repo_role_patterns
-
-            override = get_repo_role_patterns(repo)
-        except Exception:
-            override = None
+        override = load_repo_pattern_override(repo)
         if override:
             tests_globs = override.get("tests_globs")
             code_globs = override.get("code_globs")
@@ -827,6 +827,89 @@ def build_agent_patterns(
     }
 
 
+def load_repo_pattern_override(repo: str) -> dict[str, list[str]] | None:
+    """Resolve the per-repo role-pattern override for ``repo``.
+
+    Production runtimes have three different shapes for reading the
+    override:
+
+    1. **Sandbox** — has no access to ``repositories.yaml``. The
+       orchestrator pre-resolves the override at spawn time and passes
+       it via the ``EGG_PIPELINE_REPO_PATTERNS_JSON`` env var (a JSON
+       object whose top-level keys are repos). This is checked first.
+    2. **Gateway** — copies ``config/repo_config.py`` to ``/app/`` (top
+       level) and to ``/config/`` (no ``__init__.py``). Only the
+       top-level layout is on ``PYTHONPATH``, so the import has to fall
+       back from ``config.repo_config`` to ``repo_config``.
+    3. **Orchestrator** — copies ``config/repo_config.py`` to its
+       working directory as ``repo_config.py`` (top level). Same
+       fallback path as the gateway.
+
+    The two-step import mirrors the existing
+    ``gateway.gateway._reload_all_config`` pattern. Failures are
+    swallowed (the feature degrades to defaults) but logged at DEBUG so
+    operators can correlate a missing override with the import path.
+    """
+    env_blob = os.environ.get("EGG_PIPELINE_REPO_PATTERNS_JSON")
+    if env_blob:
+        try:
+            decoded = json.loads(env_blob)
+        except json.JSONDecodeError:
+            logger.warning(
+                "EGG_PIPELINE_REPO_PATTERNS_JSON is not valid JSON; ignoring",
+                extra={"repo": repo},
+            )
+            decoded = None
+        if isinstance(decoded, dict):
+            entry = decoded.get(repo)
+            if isinstance(entry, dict):
+                cleaned: dict[str, list[str]] = {}
+                for key in ("tests_globs", "code_globs", "docs_globs"):
+                    value = entry.get(key)
+                    if isinstance(value, list):
+                        only_strings = [v for v in value if isinstance(v, str) and v]
+                        if only_strings:
+                            cleaned[key] = only_strings
+                if cleaned:
+                    return cleaned
+
+    get_repo_role_patterns = None
+    try:
+        from config.repo_config import get_repo_role_patterns  # type: ignore[no-redef]
+    except ImportError:
+        try:
+            from repo_config import get_repo_role_patterns  # type: ignore[no-redef]
+        except ImportError:
+            logger.debug(
+                "repo_config not importable; per-repo overrides disabled",
+                extra={"repo": repo},
+            )
+            return None
+
+    try:
+        override = get_repo_role_patterns(repo)
+    except FileNotFoundError:
+        # No repositories.yaml mounted — expected outside the gateway.
+        return None
+    except Exception:
+        logger.exception(
+            "Failed to load per-repo role-pattern override; using defaults",
+            extra={"repo": repo},
+        )
+        return None
+    return override or None
+
+
+def _normalize_repo_key(repo: str | None) -> str | None:
+    """Normalize the repo cache key so ``Owner/Repo`` and ``owner/repo``
+    share one entry. Mirrors the case-insensitive lookup in
+    ``config.repo_config.get_repo_setting``.
+    """
+    if repo is None:
+        return None
+    return repo.lower()
+
+
 # Per-repo cache. The build is cheap but called on every push, plan-time
 # validation, and tool-interceptor write check; memoizing avoids redoing
 # the YAML read per-call. Reset via ``reset_pattern_cache`` (wired into
@@ -839,13 +922,30 @@ def get_agent_pattern_for_repo(role: str, repo: str | None = None) -> AgentFileP
     role is not defined.
 
     Equivalent to ``AGENT_PATTERNS.get(role)`` when ``repo`` is None or
-    no override exists. Memoizes per repo.
+    no override exists. Memoizes per repo (case-insensitive).
     """
-    cached = _repo_pattern_cache.get(repo)
+    key = _normalize_repo_key(repo)
+    cached = _repo_pattern_cache.get(key)
     if cached is None:
         cached = build_agent_patterns(repo)
-        _repo_pattern_cache[repo] = cached
+        _repo_pattern_cache[key] = cached
     return cached.get(role)
+
+
+def get_agent_patterns_for_repo(repo: str | None = None) -> dict[str, AgentFilePattern]:
+    """Return the full per-role pattern registry for ``repo`` (memoized).
+
+    Used by callers that need to scan every role (e.g. the tool
+    interceptor's ``_find_owning_role``); cheaper than calling
+    ``build_agent_patterns`` once per call site since the cache is
+    shared with ``get_agent_pattern_for_repo``.
+    """
+    key = _normalize_repo_key(repo)
+    cached = _repo_pattern_cache.get(key)
+    if cached is None:
+        cached = build_agent_patterns(repo)
+        _repo_pattern_cache[key] = cached
+    return cached
 
 
 def reset_pattern_cache() -> None:
@@ -854,6 +954,11 @@ def reset_pattern_cache() -> None:
     Called by ``config.repo_config.reload_config`` so a SIGHUP /
     ``/api/v1/config/reload`` picks up edited ``role_patterns:``
     overrides without restarting the gateway.
+
+    Atomic rebind avoids a race where a concurrent reader sees the
+    cache mid-clear and rebuilds the ``None`` entry as a fresh dict
+    (functionally identical but a different object than
+    ``AGENT_PATTERNS`` — which the parity tests assert against).
     """
-    _repo_pattern_cache.clear()
-    _repo_pattern_cache[None] = AGENT_PATTERNS
+    global _repo_pattern_cache
+    _repo_pattern_cache = {None: AGENT_PATTERNS}

--- a/shared/egg_restrictions/patterns.py
+++ b/shared/egg_restrictions/patterns.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import posixpath
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 # Re-export the canonical AgentRole StrEnum from egg_contracts so the
@@ -873,12 +874,12 @@ def load_repo_pattern_override(repo: str) -> dict[str, list[str]] | None:
                 if cleaned:
                     return cleaned
 
-    get_repo_role_patterns = None
+    _loader: Callable[[str], dict[str, list[str]] | None] | None = None
     try:
-        from config.repo_config import get_repo_role_patterns  # type: ignore[no-redef]
+        from config.repo_config import get_repo_role_patterns as _loader
     except ImportError:
         try:
-            from repo_config import get_repo_role_patterns  # type: ignore[no-redef]
+            from repo_config import get_repo_role_patterns as _loader
         except ImportError:
             logger.debug(
                 "repo_config not importable; per-repo overrides disabled",
@@ -886,8 +887,9 @@ def load_repo_pattern_override(repo: str) -> dict[str, list[str]] | None:
             )
             return None
 
+    assert _loader is not None
     try:
-        override = get_repo_role_patterns(repo)
+        override = _loader(repo)
     except FileNotFoundError:
         # No repositories.yaml mounted — expected outside the gateway.
         return None

--- a/tests/shared/egg_agent/test_tool_interceptor.py
+++ b/tests/shared/egg_agent/test_tool_interceptor.py
@@ -198,3 +198,71 @@ class TestGetRoleFromEnv:
     def test_strips_whitespace(self, monkeypatch):
         monkeypatch.setenv("EGG_AGENT_ROLE", "  tester  ")
         assert get_role_from_env() == "tester"
+
+
+class TestPipelineRepoOverride:
+    """``EGG_PIPELINE_REPO`` + ``EGG_PIPELINE_REPO_PATTERNS_JSON``
+    propagation through ``check_file_write_permission`` (#2528).
+
+    The orchestrator pre-resolves the per-repo override and injects
+    both env vars when spawning the sandbox. The interceptor reads
+    them and routes the write check to the correct (per-repo) pattern.
+    """
+
+    def setup_method(self):
+        # Clear any cached pattern dicts between tests so a stale
+        # override from another test doesn't leak through.
+        from egg_restrictions.patterns import reset_pattern_cache
+
+        reset_pattern_cache()
+
+    def teardown_method(self):
+        from egg_restrictions.patterns import reset_pattern_cache
+
+        reset_pattern_cache()
+
+    def test_go_repo_override_blocks_coder_from_test_files(self, monkeypatch):
+        """Go conventions: coder cannot write ``*_test.go`` next to
+        source under a repo that declares Go ``tests_globs``."""
+        import json
+
+        monkeypatch.setenv("EGG_PIPELINE_REPO", "owner/go-repo")
+        monkeypatch.setenv(
+            "EGG_PIPELINE_REPO_PATTERNS_JSON",
+            json.dumps(
+                {
+                    "owner/go-repo": {
+                        "tests_globs": ["**/*_test.go", "**/testdata/**"],
+                        "code_globs": ["**/*.go"],
+                    }
+                }
+            ),
+        )
+
+        # The default pattern would let coder write ``*_test.go`` (the
+        # legacy Python-only blocklist had no Go entries pre-PR).
+        # With the override, this file routes to tester.
+        result = check_file_write_permission(
+            "Write",
+            {"file_path": "internal/foo/bar_test.go", "content": "..."},
+            agent_role="coder",
+        )
+        assert result is not None
+        assert "BLOCKED" in result
+        assert "tester" in result  # owner-role hint plumbed through override
+
+    def test_no_pipeline_repo_uses_default_patterns(self, monkeypatch):
+        """Outside a pipeline (no ``EGG_PIPELINE_REPO``), the
+        interceptor falls back to global defaults."""
+        monkeypatch.delenv("EGG_PIPELINE_REPO", raising=False)
+        monkeypatch.delenv("EGG_PIPELINE_REPO_PATTERNS_JSON", raising=False)
+
+        # Default patterns block ``test_*.py`` from coder; verifies
+        # the no-override branch still works.
+        result = check_file_write_permission(
+            "Write",
+            {"file_path": "tests/test_foo.py", "content": "..."},
+            agent_role="coder",
+        )
+        assert result is not None
+        assert "BLOCKED" in result


### PR DESCRIPTION
## Summary

- Adds a ``role_patterns:`` block under ``repo_settings`` in ``repositories.yaml`` so target repos can declare their test/code/docs file conventions (Go, JS/TS, etc.) without editing core code.
- Refactors ``shared/egg_restrictions/patterns.py`` to extract default globs into ``DEFAULT_TESTS_GLOBS`` / ``DEFAULT_CODE_GLOBS`` / ``DEFAULT_DOCS_GLOBS`` and slot them into per-role builders. Threads ``repo`` through the four consumers that have it in scope: gateway push enforcement (``partition_files_by_role``), sandbox tool interceptor (``EGG_PIPELINE_REPO`` env var), plan-time validator (#2527's ``validate_task_role_alignment``), and the planner prompt renderer.
- Security blocklists (``.egg-state/contracts/``, ``.github/``, draft/review state dirs) are NOT configurable — sourced from the builders and cannot be relaxed by a target repo's config. Unknown keys are silently dropped at the validation layer; defense-in-depth in the builders.

Schema:

```yaml
repo_settings:
  owner/example-go-repo:
    role_patterns:
      tests_globs: ["**/*_test.go", "**/testdata/**"]
      code_globs:  ["**/*.go"]
      docs_globs:  ["**/*.md", "docs/"]
```

Default-repo behaviour is unchanged: ``AGENT_PATTERNS`` is identical to ``build_agent_patterns(None)``. Tests pin this parity.

## Scope

Per the #2530 audit (the conftest line + test/code split are correct as-is) and the #2528 issue comment, this ships only the narrow knobs. The per-task ``includes_tests`` opt-in and any future per-repo ``pair_rule`` are deliberately out of scope; the schema is additive so a future ``role_patterns.pair_rule`` key slots in without breaking the current shape.

## Test plan

- [x] New ``gateway/tests/test_per_repo_role_patterns.py`` (27 tests, all passing) covers:
  - Default-registry parity (``build_agent_patterns(None)`` == legacy ``AGENT_PATTERNS``).
  - JS-convention override (``__tests__/``, ``*.test.ts``) shifts coder/tester/documenter boundaries.
  - Go-convention override (``*_test.go`` same-dir, ``testdata/``) ditto.
  - Security guarantee: an attempted ``.egg-state/contracts/`` / ``.github/`` / ``.egg-state/drafts/`` bypass via knobs is denied.
  - ``get_repo_role_patterns`` validation: missing block, non-dict, unknown keys, non-list values, non-string entries, empty dict.
  - Cache invalidation via ``reset_pattern_cache`` (wired into the SIGHUP / ``reload_config`` path).
- [ ] Full ``make test`` suite — please run in CI.

Closes #2528.