### PR TITLE
Fix #2565: reject producer-only slices at plan-propose time

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9408,6 +9408,15 @@ def _build_phase_prompt(
                 "should list any pre-merge or post-merge actions required by the reviewer "
                 "or deployer; use an empty string if none.",
                 "",
+                "**No producer-only slices (HARD, #2565)**: every slice must contain "
+                "at least one ``coder`` task (a task with ``role`` omitted defaults to "
+                "``coder``). Do NOT emit a ``Documentation`` or ``Write the tests`` "
+                "slice whose tasks are exclusively ``tester`` and/or ``documenter`` — "
+                "every implement-phase BRC already runs those agents alongside the "
+                "coder. Distribute documentation and test work across the slices that "
+                "introduce the behaviour they describe; producer-only slices are "
+                "rejected at propose time.",
+                "",
                 f"Write your plan to `{plan_path}`.",
                 "Commit and push the draft when done.",
                 "",
@@ -11247,6 +11256,22 @@ def _build_agent_prompt(
                 "slice as a stacked PR with exactly one base branch. "
                 "Multi-parent slices break the stacking invariant and are "
                 "rejected at plan ingestion.",
+                "",
+                "**No producer-only slices (HARD, #2565)**: every slice must "
+                "contain at least one ``coder`` task (a task with ``role`` "
+                "omitted defaults to ``coder`` and counts). Do NOT emit a "
+                "slice whose tasks are exclusively ``tester`` and/or "
+                "``documenter`` — every implement-phase BRC already spawns a "
+                "documenter and tester agent alongside the coder, so a "
+                "follow-up ``Documentation`` or ``Write the tests`` slice "
+                "burns the full BRC roster on work the in-slice peers of the "
+                "code-bearing slice should have done concurrently. "
+                "Documentation and test work belong in the slice that "
+                "introduces the behaviour they describe; reviewers can flag "
+                "missing doc/test coverage at the moment it is reviewable. "
+                "Producer-only slices are rejected at propose time (HTTP "
+                "400, before the tracker is mutated and before any reviewer "
+                "sees the proposal).",
                 "",
                 "**Auto-serialization rule for would-be multi-parent slices**: "
                 "when you identify a slice that would naturally have >1 "

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9415,7 +9415,11 @@ def _build_phase_prompt(
                 "every implement-phase BRC already runs those agents alongside the "
                 "coder. Distribute documentation and test work across the slices that "
                 "introduce the behaviour they describe; producer-only slices are "
-                "rejected at propose time.",
+                "rejected at propose time. **Escape hatch**: if a slice genuinely "
+                "needs to be only docs or tests (e.g. backfilling test coverage for "
+                "already-merged code, or a docs-only update with no code change), "
+                "omit the ``role`` field on those tasks — they default to ``coder`` "
+                "and the slice passes.",
                 "",
                 f"Write your plan to `{plan_path}`.",
                 "Commit and push the draft when done.",
@@ -11271,7 +11275,11 @@ def _build_agent_prompt(
                 "missing doc/test coverage at the moment it is reviewable. "
                 "Producer-only slices are rejected at propose time (HTTP "
                 "400, before the tracker is mutated and before any reviewer "
-                "sees the proposal).",
+                "sees the proposal). **Escape hatch**: if a slice genuinely "
+                "needs to be only docs or tests (e.g. backfilling test "
+                "coverage for already-merged code, or a docs-only update "
+                "with no code change), omit the ``role`` field on those "
+                "tasks — they default to ``coder`` and the slice passes.",
                 "",
                 "**Auto-serialization rule for would-be multi-parent slices**: "
                 "when you identify a slice that would naturally have >1 "

--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -925,27 +925,41 @@ def _validate_planner_role_alignment(
     pipeline_state: Any | None = None,
     worktree_path: Path | None = None,
 ) -> None:
-    """Validate task role↔files alignment for a planner proposal (#2527).
+    """Validate plan structure for a planner proposal (#2527, #2565).
 
     Reads the plan draft at the proposed commit via ``git show`` against
-    the orchestrator's pipeline worktree and runs
-    ``validate_task_role_alignment``. Raises ``ValueError`` if any task
-    is assigned to a role that cannot push its files — the caller's
-    ``handle_consensus_propose_signal`` ``except`` block then returns 400
-    to the planner before the proposal is recorded on the tracker, so no
-    reviewer cycle is wasted on a structurally-broken plan.
+    the orchestrator's pipeline worktree and runs both:
 
-    The check mirrors the gateway's push-time blocked-pattern logic
-    (``gateway/phase_filter.py::FileRestriction.is_file_blocked``), so a
-    rejection here predicts a push-time ``403 restricted_path_modified``
-    in the implement phase. Caught here it costs the planner one
-    re-propose; caught at push time it costs a full producer cycle.
+    * ``validate_task_role_alignment`` (#2527) — rejects tasks whose
+      ``role`` cannot push their ``files_affected`` (would 403 at the
+      gateway's push-time blocked-pattern check).
+    * ``validate_producer_only_slices`` (#2565) — rejects slices whose
+      tasks are exclusively ``tester`` / ``documenter``, since every
+      implement-phase BRC already runs those agents alongside the coder
+      and a producer-only follow-up slice burns the full BRC roster.
+
+    Raises ``ValueError`` if either check returns errors — the caller's
+    ``handle_consensus_propose_signal`` ``except`` block then returns
+    400 to the planner before the proposal is recorded on the tracker,
+    so no reviewer cycle is wasted on a structurally-broken plan. Both
+    checks are bundled into a single rejection so a planner whose plan
+    trips both rules sees them at once rather than re-propose twice.
+
+    The role↔files check mirrors the gateway's push-time blocked-pattern
+    logic (``gateway/phase_filter.py::FileRestriction.is_file_blocked``),
+    so a rejection here predicts a push-time ``403
+    restricted_path_modified`` in the implement phase. Caught here it
+    costs the planner one re-propose; caught at push time it costs a
+    full producer cycle. The slice-composition check has no push-time
+    equivalent — the gateway can't see slice shape — so propose-time
+    rejection is the only enforcement seam (the planner-prompt rule is
+    defense-in-depth on the generation side).
 
     Graceful degradation: when the plan file doesn't exist at the
-    proposed commit, ``git show`` fails, parsing fails, or the validator
+    proposed commit, ``git show`` fails, parsing fails, or a validator
     raises, this function returns silently. The push-time gateway check
-    remains the backstop, and the existing forest-validation pass at
-    plan-ingestion time still runs.
+    remains the backstop for #2527, and the existing forest-validation
+    pass at plan-ingestion time still runs.
 
     ``pipeline_state`` and ``worktree_path`` should be passed in by
     ``handle_consensus_propose_signal`` so the state-store + worktree
@@ -1015,6 +1029,7 @@ def _validate_planner_role_alignment(
     try:
         from egg_contracts.plan_parser import (
             parse_plan,
+            validate_producer_only_slices,
             validate_task_role_alignment,
         )
     except ImportError:
@@ -1025,7 +1040,12 @@ def _validate_planner_role_alignment(
         if not parsed.success:
             return
         slices = parsed.to_contract_slices()
-        errors = validate_task_role_alignment(slices)
+        alignment_errors = validate_task_role_alignment(slices)
+        # #2565 — reject slices with no coder task. Bundled into the
+        # same propose-time hook so a planner whose plan trips both
+        # rules sees them in one rejection rather than re-propose
+        # twice.
+        composition_errors = validate_producer_only_slices(slices)
     except Exception as exc:
         logger.warning(
             "plan role-alignment validation: validator raised (non-blocking)",
@@ -1035,17 +1055,28 @@ def _validate_planner_role_alignment(
         )
         return
 
-    if not errors:
+    if not alignment_errors and not composition_errors:
         return
 
-    bullet_list = "\n".join(f"  - {e}" for e in errors)
-    raise ValueError(
-        "Plan proposal rejected: task role↔files alignment violations.\n"
-        "The following tasks are assigned to roles whose blocklist "
-        "forbids their files (would 403 at push time per "
-        "shared/egg_restrictions/patterns.py). Update the affected "
-        "tasks' 'role' field and re-propose:\n" + bullet_list
-    )
+    sections: list[str] = []
+    if alignment_errors:
+        bullets = "\n".join(f"  - {e}" for e in alignment_errors)
+        sections.append(
+            "Task role↔files alignment violations — the following "
+            "tasks are assigned to roles whose blocklist forbids their "
+            "files (would 403 at push time per "
+            "shared/egg_restrictions/patterns.py). Update the affected "
+            "tasks' 'role' field and re-propose:\n" + bullets
+        )
+    if composition_errors:
+        bullets = "\n".join(f"  - {e}" for e in composition_errors)
+        sections.append(
+            "Slice composition violations (#2565) — the following "
+            "slices have no coder task. Distribute the documentation "
+            "and test work across the slice(s) that introduce the "
+            "behaviour they describe and re-propose:\n" + bullets
+        )
+    raise ValueError("Plan proposal rejected:\n" + "\n\n".join(sections))
 
 
 def _resolve_pipeline_phase(pipeline_id: str, repo_path: Path) -> str:

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -2427,6 +2427,293 @@ class TestPlannerRoleAlignmentValidation:
             mock_tracker.handle_propose.assert_not_called()
 
 
+class TestPlannerProducerOnlySliceValidation:
+    """Tests for the #2565 slice-composition check bundled into
+    ``_validate_planner_role_alignment``.
+
+    The check rejects plans whose tasks for a given slice are
+    exclusively ``tester`` and/or ``documenter`` — every implement-phase
+    BRC already runs those agents alongside the coder, so a follow-up
+    producer-only slice burns ~8 agents on work the in-slice peers of
+    the code-bearing slice should have done concurrently.
+
+    Bundled into the same ``_validate_planner_role_alignment`` hook as
+    #2527's role↔files check so a planner whose plan trips both rules
+    sees them in one rejection rather than re-propose twice.
+    """
+
+    _PLAN_WITH_DOCUMENTER_ONLY_SLICE = (
+        "# Plan\n"
+        "\n"
+        "```yaml\n"
+        "# yaml-tasks\n"
+        "slices:\n"
+        "  - id: 1\n"
+        "    name: Foundations\n"
+        "    goal: scaffolding\n"
+        "    tasks:\n"
+        "      - id: TASK-1-1\n"
+        "        description: Add module\n"
+        "        acceptance: builds\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - src/foo.py\n"
+        "  - id: 5\n"
+        "    name: Documentation\n"
+        "    goal: Update docs after the code lands\n"
+        "    dependencies: [slice-1]\n"
+        "    tasks:\n"
+        "      - id: TASK-5-1\n"
+        "        description: Update guide\n"
+        "        acceptance: doc reads correctly\n"
+        "        role: documenter\n"
+        "        files:\n"
+        "          - docs/guide.md\n"
+        "```\n"
+    )
+
+    _PLAN_WITH_TESTER_ONLY_SLICE = (
+        "# Plan\n"
+        "\n"
+        "```yaml\n"
+        "# yaml-tasks\n"
+        "slices:\n"
+        "  - id: 1\n"
+        "    name: Implementation\n"
+        "    goal: code\n"
+        "    tasks:\n"
+        "      - id: TASK-1-1\n"
+        "        description: Add module\n"
+        "        acceptance: builds\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - src/foo.py\n"
+        "  - id: 2\n"
+        "    name: Write the tests\n"
+        "    goal: Land coverage for slice-1\n"
+        "    dependencies: [slice-1]\n"
+        "    tasks:\n"
+        "      - id: TASK-2-1\n"
+        "        description: Add tests for foo\n"
+        "        acceptance: pytest green\n"
+        "        role: tester\n"
+        "        files:\n"
+        "          - tests/test_foo.py\n"
+        "```\n"
+    )
+
+    _PLAN_WITH_BOTH_VIOLATIONS = (
+        # Slice-1 has a coder task assigned to a `.github/workflows/`
+        # file (blocked for coder per AGENT_PATTERNS) — trips the #2527
+        # role↔files check. Slice-2 is documenter-only — trips the
+        # #2565 slice-composition check. A single rejection should
+        # surface both.
+        "# Plan\n"
+        "\n"
+        "```yaml\n"
+        "# yaml-tasks\n"
+        "slices:\n"
+        "  - id: 1\n"
+        "    name: Workflow\n"
+        "    goal: tweak CI\n"
+        "    tasks:\n"
+        "      - id: TASK-1-1\n"
+        "        description: Edit workflow\n"
+        "        acceptance: green CI\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - .github/workflows/ci.yml\n"
+        "  - id: 2\n"
+        "    name: Documentation\n"
+        "    goal: Update docs\n"
+        "    dependencies: [slice-1]\n"
+        "    tasks:\n"
+        "      - id: TASK-2-1\n"
+        "        description: Update guide\n"
+        "        acceptance: doc reads correctly\n"
+        "        role: documenter\n"
+        "        files:\n"
+        "          - docs/guide.md\n"
+        "```\n"
+    )
+
+    @staticmethod
+    def _patched_store(issue_number: int = 2565, branch: str = "egg/issue-2565"):
+        mock_pipeline = MagicMock()
+        mock_pipeline.issue_number = issue_number
+        mock_pipeline.branch = branch
+        mock_pipeline.mode = None
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = mock_pipeline
+        return patch("routes.signals.get_state_store", return_value=mock_store)
+
+    @staticmethod
+    def _patched_subprocess(plan_text: str, returncode: int = 0):
+        result = subprocess.CompletedProcess(
+            args=[], returncode=returncode, stdout=plan_text, stderr=""
+        )
+        return patch("routes.signals.subprocess.run", return_value=result)
+
+    @staticmethod
+    def _patched_worktree():
+        return patch("routes.signals.resolve_worktree_path", return_value=Path("/tmp/wt"))
+
+    def test_rejects_documenter_only_slice(self):
+        """Plan with a terminal Documentation slice is rejected at
+        propose time — the issue's exact reproduction shape."""
+        from routes.signals import _validate_planner_role_alignment
+
+        with (
+            self._patched_store(),
+            self._patched_worktree(),
+            self._patched_subprocess(self._PLAN_WITH_DOCUMENTER_ONLY_SLICE),
+        ):
+            payload = {"commit_sha": "abc1234"}
+            with pytest.raises(ValueError) as excinfo:
+                _validate_planner_role_alignment("issue-2565", payload, Path("/tmp/repo"))
+
+        msg = str(excinfo.value)
+        assert "Slice composition violations (#2565)" in msg
+        assert "slice-2" in msg or "slice-5" in msg
+        assert "documenter" in msg
+        assert "no coder task" in msg
+
+    def test_rejects_tester_only_slice(self):
+        """Plan with a 'Write the tests' follow-up slice is rejected."""
+        from routes.signals import _validate_planner_role_alignment
+
+        with (
+            self._patched_store(),
+            self._patched_worktree(),
+            self._patched_subprocess(self._PLAN_WITH_TESTER_ONLY_SLICE),
+        ):
+            payload = {"commit_sha": "abc1234"}
+            with pytest.raises(ValueError) as excinfo:
+                _validate_planner_role_alignment("issue-2565", payload, Path("/tmp/repo"))
+
+        msg = str(excinfo.value)
+        assert "Slice composition violations (#2565)" in msg
+        assert "tester" in msg
+
+    def test_bundles_both_violations_into_one_rejection(self):
+        """A plan that trips both #2527 and #2565 is rejected once,
+        with both error sections surfaced. This is the bundling
+        guarantee — a planner shouldn't have to re-propose twice
+        when both classes of violation are caught at the same hook.
+        """
+        from routes.signals import _validate_planner_role_alignment
+
+        with (
+            self._patched_store(),
+            self._patched_worktree(),
+            self._patched_subprocess(self._PLAN_WITH_BOTH_VIOLATIONS),
+        ):
+            payload = {"commit_sha": "abc1234"}
+            with pytest.raises(ValueError) as excinfo:
+                _validate_planner_role_alignment("issue-2565", payload, Path("/tmp/repo"))
+
+        msg = str(excinfo.value)
+        # Both section headers must appear.
+        assert "role↔files alignment violations" in msg
+        assert "Slice composition violations (#2565)" in msg
+        # Single rejection — the message starts with a unified header.
+        assert msg.startswith("Plan proposal rejected:")
+
+    def test_rejected_proposal_does_not_mutate_tracker(self):
+        """End-to-end: producer-only-slice plan rejected at
+        ``handle_consensus_propose_signal`` BEFORE the tracker is
+        mutated — same guarantee as the #2527 / tester-coverage
+        regression tests."""
+        from flask import Flask
+        from routes.signals import handle_consensus_propose_signal
+
+        mock_tracker = MagicMock()
+        mock_tracker.handle_propose = MagicMock(return_value={"version": 1})
+
+        # Three subprocess calls (matches the role-alignment test):
+        #   1. _verify_commit_on_branch's git fetch
+        #   2. _verify_commit_on_branch's git branch --contains
+        #   3. _validate_planner_role_alignment's git show
+        side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="  origin/egg/issue-2565\n",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=self._PLAN_WITH_DOCUMENTER_ONLY_SLICE,
+                stderr="",
+            ),
+        ]
+
+        app = Flask(__name__)
+        with (
+            app.app_context(),
+            self._patched_store(),
+            self._patched_worktree(),
+            patch("routes.signals.subprocess.run", side_effect=side_effect),
+            patch("peer_consensus.get_peer_consensus_tracker", return_value=mock_tracker),
+        ):
+            data = {
+                "agent_role": "task_planner",
+                "payload": {
+                    "summary": "Plan v1: code slice + terminal documenter-only slice",
+                    "artifacts": [".egg-state/drafts/2565-plan.md"],
+                    "commit_sha": "abc1234",
+                },
+            }
+            response, status_code = handle_consensus_propose_signal(
+                "issue-2565", data, Path("/tmp/repo")
+            )
+            assert status_code == 400
+            data_out = response.get_json()
+            assert "Slice composition violations (#2565)" in data_out.get("message", "")
+            mock_tracker.handle_propose.assert_not_called()
+
+
+class TestPlannerPromptProducerOnlySliceRule:
+    """Regression tests asserting the #2565 rule text appears in both
+    planner-facing prompt blocks. The validator catches the case the
+    prompt missed; the prompt prevents the case from being generated.
+    Both layers must stay in sync.
+    """
+
+    def test_task_planner_role_prompt_includes_rule(self):
+        """The concurrent-BRC ``task_planner`` prompt mentions the
+        no-producer-only-slice rule and #2565."""
+        result = _build_agent_prompt(
+            role_value="task_planner",
+            phase="plan",
+            pipeline_id="pid-1",
+            pipeline_mode="issue",
+            issue_number=10,
+        )
+        assert "No producer-only slices" in result
+        assert "#2565" in result
+        # A producer-only slice is the targeted anti-pattern; the
+        # rule's remediation must name the in-slice peers.
+        assert "documenter" in result
+        assert "tester" in result
+
+    def test_phase_plan_prompt_includes_rule(self):
+        """The legacy single-agent plan prompt
+        (``_build_phase_prompt(phase='plan')``) also mentions the
+        rule — kept in sync with the canonical task_planner prompt."""
+        result = _build_phase_prompt(
+            phase="plan",
+            pipeline_id="pid-1",
+            pipeline_mode="issue",
+            prompt="Build feature X",
+            issue_number=10,
+        )
+        assert "No producer-only slices" in result
+        assert "#2565" in result
+
+
 class TestReadTesterGapsNamespacedEdgeCases:
     """Additional edge-case tests for _read_tester_gaps with identifier."""
 

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -2237,6 +2237,8 @@ class TestPlannerRoleAlignmentValidation:
     )
 
     _PLAN_WITH_CLEAN_ASSIGNMENTS = (
+        # Slice has both a coder task (satisfies #2565 slice-composition)
+        # and a tester task on a test file (satisfies #2527 role↔files).
         "# Plan\n"
         "\n"
         "```yaml\n"
@@ -2247,6 +2249,12 @@ class TestPlannerRoleAlignmentValidation:
         "    goal: scaffolding\n"
         "    tasks:\n"
         "      - id: TASK-1-1\n"
+        "        description: Add module\n"
+        "        acceptance: builds\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - src/foo.py\n"
+        "      - id: TASK-1-2\n"
         "        description: Add pytest fixtures\n"
         "        acceptance: fixtures load\n"
         "        role: tester\n"

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -2582,7 +2582,7 @@ class TestPlannerProducerOnlySliceValidation:
 
         msg = str(excinfo.value)
         assert "Slice composition violations (#2565)" in msg
-        assert "slice-2" in msg or "slice-5" in msg
+        assert "slice-5" in msg
         assert "documenter" in msg
         assert "no coder task" in msg
 
@@ -2601,6 +2601,7 @@ class TestPlannerProducerOnlySliceValidation:
 
         msg = str(excinfo.value)
         assert "Slice composition violations (#2565)" in msg
+        assert "slice-2" in msg
         assert "tester" in msg
 
     def test_bundles_both_violations_into_one_rejection(self):

--- a/shared/egg_contracts/__init__.py
+++ b/shared/egg_contracts/__init__.py
@@ -202,6 +202,7 @@ from .plan_parser import (
     parse_plan,
     parse_plan_file,
     validate_forest,
+    validate_producer_only_slices,
     validate_task_role_alignment,
 )
 from .resilience import (
@@ -306,6 +307,7 @@ __all__ = [
     "parse_plan",
     "parse_plan_file",
     "validate_forest",
+    "validate_producer_only_slices",
     "validate_task_role_alignment",
     # Phase Defaults
     "get_default_phase_config",

--- a/shared/egg_contracts/plan_parser.py
+++ b/shared/egg_contracts/plan_parser.py
@@ -1458,7 +1458,7 @@ def validate_producer_only_slices(slices: list[Slice]) -> list[str]:
     """
     errors: list[str] = []
     for slice_ in slices:
-        tasks = list(slice_.tasks or [])
+        tasks = list(slice_.tasks)
         if not tasks:
             # Empty-task slices are handled elsewhere — the parser
             # injects a placeholder coder task for any phase it can't

--- a/shared/egg_contracts/plan_parser.py
+++ b/shared/egg_contracts/plan_parser.py
@@ -1413,6 +1413,79 @@ def validate_task_role_alignment(slices: list[Slice]) -> list[str]:
     return errors
 
 
+# ---------------------------------------------------------------------------
+# #2565 — reject slices with no coder task (producer-only slices)
+# ---------------------------------------------------------------------------
+
+# Producer roles other than ``coder``. A slice whose tasks are
+# exclusively assigned to these roles has no coder work and is the
+# anti-pattern #2565 rejects.
+_PRODUCER_ONLY_ROLES: frozenset[str] = frozenset({"tester", "documenter"})
+
+
+def validate_producer_only_slices(slices: list[Slice]) -> list[str]:
+    """Reject slices whose tasks are all assigned to ``tester`` and/or
+    ``documenter`` roles.
+
+    Added in #2565. Every implement-phase BRC already spawns a
+    ``documenter`` and ``tester`` agent alongside the ``coder``, so a
+    follow-up slice whose only tasks are documentation or test work
+    burns the full BRC roster (~8 agents) on work the in-slice peers
+    of the code-bearing slice should have done concurrently. The plan's
+    role distribution should match the agent roster's role
+    distribution: documentation and test work belong in the slice that
+    introduces the behaviour they describe.
+
+    A task with ``role=None`` defaults to ``coder`` at execution time
+    (see the role filter in ``_run_concurrent_phase``), so a slice
+    where every task omits ``role`` passes — the rule fires only when
+    the planner *explicitly* assigned every task in a slice to
+    ``tester`` or ``documenter``.
+
+    Out of scope (per the issue): re-shaping the role taxonomy and
+    validating that every coder task has matching tester/documenter
+    coverage (#2527's territory). This validator only rejects the
+    structural anti-pattern of a slice with no coder task.
+
+    Args:
+        slices: The slice list extracted from the contract / plan.
+
+    Returns:
+        A list of structured-error strings — one entry per offending
+        slice — naming the slice ID, slice name, the role distribution
+        that triggered the rejection, and the remediation. An empty
+        list means every slice has at least one (effective) coder task.
+    """
+    errors: list[str] = []
+    for slice_ in slices:
+        tasks = list(slice_.tasks or [])
+        if not tasks:
+            # Empty-task slices are handled elsewhere — the parser
+            # injects a placeholder coder task for any phase it can't
+            # populate (see ``parse_plan``). Nothing to validate here.
+            continue
+        # Treat ``role=None`` as effective ``coder`` — that's the
+        # execution-time default applied by the role-filtering pass
+        # in ``_run_concurrent_phase``. A slice where every task
+        # omits ``role`` therefore has implicit coder work and passes.
+        effective_roles = {(task.role or "coder") for task in tasks}
+        if effective_roles.issubset(_PRODUCER_ONLY_ROLES):
+            roles_list = sorted(effective_roles)
+            errors.append(
+                f"Slice '{slice_.id}' '{slice_.name}' has no coder task "
+                f"(task roles: {roles_list}). Every implement-phase BRC "
+                "already runs a documenter and tester agent alongside the "
+                "coder, so a slice with no coder task burns the full BRC "
+                "roster on follow-up work the in-slice peers of the "
+                "code-bearing slice should have done concurrently. Move "
+                "these tasks into the slice(s) that introduce the "
+                "behaviour they describe — documentation and test work "
+                "belong with the code that introduces it, not in a "
+                "terminal producer-only slice."
+            )
+    return errors
+
+
 __all__ = (
     "ParsedPhase",
     "ParsedTask",
@@ -1422,5 +1495,6 @@ __all__ = (
     "parse_plan",
     "parse_plan_file",
     "validate_forest",
+    "validate_producer_only_slices",
     "validate_task_role_alignment",
 )

--- a/shared/egg_contracts/tests/test_validate_producer_only_slices.py
+++ b/shared/egg_contracts/tests/test_validate_producer_only_slices.py
@@ -1,0 +1,222 @@
+"""Tests for ``plan_parser.validate_producer_only_slices`` (#2565).
+
+The plan-phase ``task_planner`` can decompose work into slices that
+include a terminal documentation- or test-only slice (e.g. a final
+``Documentation`` slice whose only task is a ``documenter``). Such
+slices burn the full implement-phase BRC roster (~8 agents) on work
+the in-slice ``documenter`` / ``tester`` agents already produce in
+every other slice. The validator runs at plan-time so the
+``handle_consensus_propose_signal`` hook can NACK a planner before any
+producer cycle is wasted.
+
+These tests cover:
+
+* Slices with at least one ``coder`` task pass.
+* Slices where every task omits ``role`` pass — the execution-time
+  default treats ``role=None`` as ``coder``.
+* Slices with mixed ``coder`` + ``tester`` / ``documenter`` tasks pass.
+* ``documenter``-only slices are rejected with the slice ID and name
+  in the structured error.
+* ``tester``-only slices are rejected.
+* Mixed ``tester`` + ``documenter`` (no coder) slices are rejected.
+* Empty-task slices are skipped (the parser injects a placeholder
+  coder task for any unparseable phase, so an empty list at this
+  point is benign).
+* Multi-slice inputs report one error per offending slice and leave
+  clean slices alone.
+"""
+
+from __future__ import annotations
+
+from egg_contracts.models import Slice, Task
+from egg_contracts.plan_parser import validate_producer_only_slices
+
+
+def _slice(slice_id: str, name: str, tasks: list[Task]) -> Slice:
+    return Slice(id=slice_id, name=name, tasks=tasks)
+
+
+def _task(task_id: str, role: str | None) -> Task:
+    return Task(
+        id=task_id,
+        description="task",
+        acceptance_criteria="acc",
+        files_affected=["src/foo.py"],
+        role=role,
+    )
+
+
+class TestSlicesThatPass:
+    """Slices that contain (effective) coder work — the validator
+    must leave them alone."""
+
+    def test_empty_input(self) -> None:
+        assert validate_producer_only_slices([]) == []
+
+    def test_explicit_coder_only(self) -> None:
+        slices = [_slice("slice-1", "Setup", [_task("task-1-1", "coder")])]
+        assert validate_producer_only_slices(slices) == []
+
+    def test_role_none_counts_as_coder(self) -> None:
+        # Tasks without an explicit role default to coder at execution
+        # time. The rule fires only when the planner *explicitly*
+        # assigned every task in the slice to a non-coder producer
+        # role — a slice where every task omits ``role`` has implicit
+        # coder work and passes.
+        slices = [_slice("slice-1", "Setup", [_task("task-1-1", None)])]
+        assert validate_producer_only_slices(slices) == []
+
+    def test_mixed_coder_and_tester(self) -> None:
+        slices = [
+            _slice(
+                "slice-1",
+                "Setup with tests",
+                [_task("task-1-1", "coder"), _task("task-1-2", "tester")],
+            )
+        ]
+        assert validate_producer_only_slices(slices) == []
+
+    def test_mixed_coder_and_documenter(self) -> None:
+        slices = [
+            _slice(
+                "slice-1",
+                "Setup with docs",
+                [
+                    _task("task-1-1", "coder"),
+                    _task("task-1-2", "documenter"),
+                ],
+            )
+        ]
+        assert validate_producer_only_slices(slices) == []
+
+    def test_coder_alongside_tester_and_documenter(self) -> None:
+        slices = [
+            _slice(
+                "slice-1",
+                "Full slice",
+                [
+                    _task("task-1-1", "coder"),
+                    _task("task-1-2", "tester"),
+                    _task("task-1-3", "documenter"),
+                ],
+            )
+        ]
+        assert validate_producer_only_slices(slices) == []
+
+    def test_one_coder_one_role_none_passes(self) -> None:
+        slices = [
+            _slice(
+                "slice-1",
+                "Mixed",
+                [_task("task-1-1", "coder"), _task("task-1-2", None)],
+            )
+        ]
+        assert validate_producer_only_slices(slices) == []
+
+
+class TestEmptyTaskSlice:
+    """Slices with no tasks are skipped — the parser handles those
+    by injecting a placeholder coder task elsewhere."""
+
+    def test_empty_tasks_skipped(self) -> None:
+        slices = [_slice("slice-1", "Empty", [])]
+        assert validate_producer_only_slices(slices) == []
+
+
+class TestProducerOnlySlicesRejected:
+    """The structural anti-pattern #2565 targets — slices whose
+    tasks are exclusively ``tester`` / ``documenter``."""
+
+    def test_documenter_only_slice_rejected(self) -> None:
+        slices = [
+            _slice(
+                "slice-5",
+                "Documentation",
+                [_task("task-5-1", "documenter")],
+            )
+        ]
+        errors = validate_producer_only_slices(slices)
+        assert len(errors) == 1
+        assert "slice-5" in errors[0]
+        assert "Documentation" in errors[0]
+        assert "documenter" in errors[0]
+        assert "no coder task" in errors[0]
+
+    def test_tester_only_slice_rejected(self) -> None:
+        slices = [
+            _slice(
+                "slice-3",
+                "Write the tests",
+                [_task("task-3-1", "tester")],
+            )
+        ]
+        errors = validate_producer_only_slices(slices)
+        assert len(errors) == 1
+        assert "slice-3" in errors[0]
+        assert "tester" in errors[0]
+
+    def test_mixed_tester_documenter_no_coder_rejected(self) -> None:
+        slices = [
+            _slice(
+                "slice-4",
+                "Tests and docs",
+                [
+                    _task("task-4-1", "tester"),
+                    _task("task-4-2", "documenter"),
+                ],
+            )
+        ]
+        errors = validate_producer_only_slices(slices)
+        assert len(errors) == 1
+        assert "slice-4" in errors[0]
+        # Both roles surface in the role-distribution hint so the
+        # planner sees what they actually emitted.
+        assert "tester" in errors[0]
+        assert "documenter" in errors[0]
+
+    def test_multiple_documenter_tasks_in_one_slice(self) -> None:
+        # Several docs tasks but still no coder — same rejection.
+        slices = [
+            _slice(
+                "slice-5",
+                "Documentation",
+                [
+                    _task("task-5-1", "documenter"),
+                    _task("task-5-2", "documenter"),
+                ],
+            )
+        ]
+        errors = validate_producer_only_slices(slices)
+        assert len(errors) == 1
+        assert "slice-5" in errors[0]
+
+
+class TestMultipleSlices:
+    """Multi-slice inputs: one error per offending slice; clean slices
+    are unaffected."""
+
+    def test_one_offender_among_clean_slices(self) -> None:
+        slices = [
+            _slice("slice-1", "Setup", [_task("task-1-1", "coder")]),
+            _slice("slice-2", "Wire up", [_task("task-2-1", "coder")]),
+            _slice("slice-3", "Documentation", [_task("task-3-1", "documenter")]),
+        ]
+        errors = validate_producer_only_slices(slices)
+        assert len(errors) == 1
+        assert "slice-3" in errors[0]
+        # Clean slices must NOT appear.
+        assert "slice-1" not in errors[0]
+        assert "slice-2" not in errors[0]
+
+    def test_multiple_offenders_each_reported(self) -> None:
+        slices = [
+            _slice("slice-1", "Setup", [_task("task-1-1", "coder")]),
+            _slice("slice-2", "Tests", [_task("task-2-1", "tester")]),
+            _slice("slice-3", "Docs", [_task("task-3-1", "documenter")]),
+        ]
+        errors = validate_producer_only_slices(slices)
+        assert len(errors) == 2
+        joined = "\n".join(errors)
+        assert "slice-2" in joined
+        assert "slice-3" in joined
+        assert "slice-1" not in joined


### PR DESCRIPTION
## Summary

- Adds `validate_producer_only_slices` in `shared/egg_contracts/plan_parser.py` that rejects any slice whose tasks are exclusively `tester` and/or `documenter`. Treats `role=None` as effective `coder` (the execution-time default), so a slice where every task omits `role` passes — the rule fires only when the planner *explicitly* assigned every task to a non-coder producer role.
- Bundles the new check into `_validate_planner_role_alignment` in `orchestrator/routes/signals.py`. A planner whose plan trips both the #2527 role↔files rule and this new #2565 rule sees one rejection rather than re-propose twice. Rejection raises `ValueError` → HTTP 400 before the tracker is mutated and before any reviewer sees the proposal — same production-sequence guarantee as #2551.
- Updates the `task_planner` prompt (slice-DAG guidance section, alongside the forest constraint) and the legacy `phase == \"plan\"` prompt block to document the rule explicitly. Validator catches the case the prompt missed; prompt prevents the case from being generated.

## Why

The pipeline `issue-2548` planner decomposed #2548 into 5 slices, the last being a documenter-only `Documentation` slice. That slice spawns the full BRC roster (8 agents) for what is purely a docs change every other slice's documenter agent already produces. Same anti-pattern can show up as a tester-only `Write the tests` follow-up. The structural fix: require at least one coder task per slice — doc and test work belong with the code that introduces it.

## Test plan

- [x] `make lint` clean on all touched files (one pre-existing failure in `orchestrator/tests/test_cli.py` is on main, unrelated)
- [ ] New unit tests in `shared/egg_contracts/tests/test_validate_producer_only_slices.py`: documenter-only / tester-only / mixed-non-coder rejected; coder-only / mixed-with-coder / all-`role=None` / empty-task slices pass; multi-slice inputs report one error per offender
- [ ] New `TestPlannerProducerOnlySliceValidation` in `orchestrator/tests/test_pipeline_prompts.py`: propose-time rejection for documenter-only and tester-only plans; combined-violation plan surfaces both #2527 and #2565 sections in one rejection (bundling guarantee); end-to-end test asserts tracker is not mutated on rejection
- [ ] New `TestPlannerPromptProducerOnlySliceRule` regression: rule text appears in both planner-facing prompts
- [ ] Verify on a future plan-phase pipeline that a planner emitting a producer-only slice gets HTTP 400 at propose time

## Out of scope (per the issue)

- No retroactive change to in-flight pipelines — the validator only affects future plans.
- No re-shape of the role taxonomy.
- No coder→tester/documenter coverage validation — that's #2527's territory.

Closes #2565.