### PR TITLE
Fix #2584: frame refiner work-decomposition decisions on slice-DAG, not PR count

### DIFF
--- a/docs/templates/analysis.md
+++ b/docs/templates/analysis.md
@@ -51,7 +51,17 @@
 [Each open question is registered using `egg-contract add-decision` (multiple-choice)
 or `egg-contract add-feedback` (open-ended). Paste the markdown output of each
 registration command here. Questions written as plain text will not be seen by the
-human.]
+human.
+
+For **work-decomposition decisions** on multi-part tasks, frame the question on the
+slice-DAG shape, not on PR count. In egg, each slice has its own integration branch,
+agent team, BRC consensus, and PR, and sibling slices in the same wave run in parallel
+(see [Slice-DAG Implement Phase](../architecture/slice-dag.md)). Slice count = PR count
+by construction, so annotate the PR consequence in parentheses — e.g.
+`Two slices in parallel: [A] || [B+C] (2 PRs)`,
+`Two slices with dependency: [A] -> [B] (2 PRs)` — rather than registering an option
+list framed as "N PRs" or "N sequential PRs". The "sequential" wording is especially
+wrong because the slice scheduler does not require sibling slices to serialize.]
 
 ---
 

--- a/docs/templates/analysis.md
+++ b/docs/templates/analysis.md
@@ -58,8 +58,8 @@ slice-DAG shape, not on PR count. In egg, each slice has its own integration bra
 agent team, BRC consensus, and PR, and sibling slices in the same wave run in parallel
 (see [Slice-DAG Implement Phase](../architecture/slice-dag.md)). Slice count = PR count
 by construction, so annotate the PR consequence in parentheses — e.g.
-`Two slices in parallel: [A] || [B+C] (2 PRs)`,
-`Two slices with dependency: [A] -> [B] (2 PRs)` — rather than registering an option
+`Two slices in parallel: A || B+C (2 PRs)`,
+`Two slices with dependency: A -> B (2 PRs)` — rather than registering an option
 list framed as "N PRs" or "N sequential PRs". The "sequential" wording is especially
 wrong because the slice scheduler does not require sibling slices to serialize.]
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -10810,6 +10810,34 @@ def _build_phase_prompt(
                 'They edit the comment to add their responses and check "Submit '
                 'feedback" when done. The pipeline will resume with the feedback '
                 "available in the contract.\n",
+                "**Work-decomposition decisions** — when the task spans multiple "
+                "independently-implementable parts, the question to register is "
+                "**how to decompose the work into slices**, not how to package PRs. "
+                "In egg, slices are the decomposition primitive: each slice has its "
+                "own integration branch, agent team, BRC consensus, and PR, and "
+                "sibling slices in the same wave run in **parallel** "
+                "(see `docs/architecture/slice-dag.md`). Slice count = PR count by "
+                "construction, so frame the decision on the slice-DAG shape and "
+                "annotate the PR consequence in parentheses — do not frame it on "
+                "the PR count. Never offer "
+                '"N sequential PRs"-style options: that wording forces serialization '
+                "that the slice scheduler does not require and teaches the operator "
+                "the wrong mental model. Example:",
+                "```bash",
+                "egg-contract add-decision \\",
+                '  --question "How should this work be decomposed into slices?" \\',
+                "  --options \\",
+                '    "Single slice: all parts ship together (1 PR)" \\',
+                '    "Two slices in parallel: [A] || [B+C] (2 PRs)" \\',
+                '    "Two slices with dependency: [A] -> [B] (2 PRs)" \\',
+                '    "Three slices fully parallel: [A], [B], [C] (3 PRs)" \\',
+                "  --format markdown",
+                "```",
+                "Name the parts inside the brackets so the operator can see which "
+                "concrete work each slice owns. If a would-be slice has more than "
+                "one DAG parent, note it — the plan phase rejects multi-parent "
+                "slices and the planner will need to serialise the upstream cluster "
+                "into a chain.\n",
                 "**DO NOT:**",
                 "- Write questions as plain markdown text without running "
                 "`egg-contract add-decision` or `egg-contract add-feedback`",

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -3218,6 +3218,77 @@ class TestRefinePromptTemplateFenceSeparation:
         assert "How to Populate Open Questions" in body
 
 
+class TestRefinePromptSliceDagFraming:
+    """Refine prompt must frame work-decomposition decisions in slice-DAG terms.
+
+    Regression for #2584: refiner used to register multi-part work-decomposition
+    decisions with options framed as PR count ("Two PRs: E first, then A+F",
+    "Three sequential PRs: E -> A -> F"). In egg, slices are the
+    work-decomposition primitive — each slice has its own branch + BRC consensus
+    + PR, and sibling slices in a wave run in parallel under the slice scheduler.
+    Slice count = PR count by construction, so the decision should name the
+    slice-DAG shape and annotate the PR consequence in parentheses; "N sequential
+    PRs" is doubly wrong because it forces serialization the scheduler does not
+    require.
+    """
+
+    @staticmethod
+    def _refine_prompt() -> str:
+        return _build_phase_prompt(
+            phase="refine",
+            pipeline_id="test-pipe",
+            pipeline_mode="issue",
+            prompt="Analyze this issue.",
+            issue_number=100,
+        )
+
+    def test_prompt_introduces_work_decomposition_section(self):
+        prompt = self._refine_prompt()
+        assert "Work-decomposition decisions" in prompt
+
+    def test_prompt_frames_decomposition_on_slices_not_pr_count(self):
+        prompt = self._refine_prompt()
+        # Slice-DAG vocabulary must appear in the work-decomposition guidance.
+        for needle in (
+            "decomposition primitive",
+            "decomposed into slices",
+            "slice-dag.md",
+            "in parallel",
+        ):
+            assert needle in prompt, f"slice-DAG framing token {needle!r} missing"
+
+    def test_prompt_provides_slice_shaped_example_options(self):
+        prompt = self._refine_prompt()
+        # The worked egg-contract add-decision example should show options
+        # framed on slice-DAG shape with the PR count as an annotation.
+        assert "Single slice: all parts ship together (1 PR)" in prompt
+        assert "Two slices in parallel: [A] || [B+C] (2 PRs)" in prompt
+        assert "Two slices with dependency: [A] -> [B] (2 PRs)" in prompt
+        assert "Three slices fully parallel: [A], [B], [C] (3 PRs)" in prompt
+
+    def test_prompt_warns_against_sequential_pr_framing(self):
+        prompt = self._refine_prompt()
+        # "N sequential PRs" framing must be explicitly called out as wrong.
+        assert '"N sequential PRs"' in prompt
+        assert "the slice scheduler does not require" in prompt
+
+    def test_decomposition_guidance_lives_outside_template_fence(self):
+        prompt = self._refine_prompt()
+        body = TestRefinePromptTemplateFenceSeparation._template_fence_body(prompt)
+        # The decomposition guidance is meta-protocol — it must not leak
+        # into the analysis-document template body that the refiner copies.
+        for needle in (
+            "Work-decomposition decisions",
+            "decomposition primitive",
+            "Single slice: all parts ship together (1 PR)",
+            "the slice scheduler does not require",
+        ):
+            assert needle not in body, (
+                f"decomposition guidance {needle!r} leaked into template "
+                "fence — refiner may transcribe it into the analysis document"
+            )
+
+
 class TestReviewerBrcPreamble:
     """Tests that reviewer agents receive BRC preamble in concurrent mode."""
 


### PR DESCRIPTION
## Summary

- Adds a `**Work-decomposition decisions**` subsection to the refine-phase prompt's `## How to Populate Open Questions` meta-guidance. The new block defines slices as egg's decomposition primitive (cites `docs/architecture/slice-dag.md`), states slice count = PR count by construction, and gives a worked `egg-contract add-decision` example with options framed on slice-DAG shape (`[A] || [B+C]` / `[A] -> [B]`) and the PR count annotated in parentheses. Explicitly bans `"N sequential PRs"`-style options.
- Mirrors the same guidance under `## Open Questions` in `docs/templates/analysis.md` so the human-facing template doc stays in sync with what the prompt teaches the agent.
- Adds `TestRefinePromptSliceDagFraming` in `orchestrator/tests/test_pipeline_prompts.py` (5 cases). Verifies the new framing tokens appear, the worked example is present, the sequential-PR warning is explicit, and the guidance lives outside the template fence — preserving the #2500 invariant that meta-guidance cannot leak into the analysis document.

Closes #2584.

## Test plan

- [x] `make lint` (ruff + format + mypy) — clean
- [x] `.venv/bin/pytest orchestrator/tests/test_pipeline_prompts.py` — 367 passed, including the 5 new `TestRefinePromptSliceDagFraming` cases
- [x] `make test` (full suite this changeset pulls in) — 17226 passed, 41 skipped, exit 0
- [ ] Manual: next refine phase with a multi-part task should register `decision-1` with slice-shaped options rather than "Two PRs / Three sequential PRs"