### PR TITLE
Fix #2593: wire context-PR hook into all plan→implement transition paths

### DIFF
--- a/orchestrator/routes/phases.py
+++ b/orchestrator/routes/phases.py
@@ -455,6 +455,45 @@ def advance_phase(pipeline_id: str) -> tuple[Response, int]:
                     error=str(exit_err),
                 )
 
+            # #2593 — open the doc-only base/context PR on the
+            # advance_phase REST/MCP path too.  Before this, the hook
+            # was wired into only the inline ``_run_pipeline``
+            # auto-advance path, so operators who cleared the plan
+            # gate via this endpoint silently left the slice stack
+            # rooted on ``/work`` with no PR to ``main``.  The helper
+            # is idempotent on its inner ``contract.pr.context_pr_number``
+            # short-circuit so multiple call sites are safe.  Only
+            # fire on plan→implement; other ``previous_phase`` values
+            # never need a context PR.
+            if target_phase == PipelinePhase.IMPLEMENT:
+                try:
+                    from routes import resolve_worktree_path
+                    from routes.pipelines import (
+                        _compute_gateway_mode,
+                        _get_spawner,
+                        _maybe_open_base_pr_for_plan_to_implement,
+                    )
+
+                    _gw_mode, _ = _compute_gateway_mode(pipeline)
+                    _worktree_path = resolve_worktree_path(pipeline_id, store.repo_path)
+                    _maybe_open_base_pr_for_plan_to_implement(
+                        pipeline,
+                        _get_spawner(),
+                        _worktree_path,
+                        gateway_mode=_gw_mode,
+                        source="advance_phase_rest",
+                    )
+                except Exception as ctx_outer_err:  # noqa: BLE001
+                    # Defence in depth: the helper already swallows
+                    # everything internally, but a failure resolving
+                    # the worktree path or importing helpers must not
+                    # strand the advance.
+                    logger.warning(
+                        "Context PR hook outer wrapper raised on advance_phase (continuing) (#2593)",
+                        pipeline_id=pipeline_id,
+                        error=str(ctx_outer_err),
+                    )
+
         # Launch a new _run_pipeline thread to process the target phase.
         # Without this, the pipeline stays in RUNNING state with no thread
         # driving agent spawning or consensus detection.  See #1672.

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9589,6 +9589,7 @@ def _open_context_pr_for_pipeline(
     worktree_repo_path: Path,
     *,
     gateway_mode: Literal["public", "private"] = "public",
+    source: str = "unknown",
 ) -> str | None:
     """Open the dedicated doc-only context PR (#2548).
 
@@ -9653,6 +9654,21 @@ def _open_context_pr_for_pipeline(
     (#2548 review note from reviewer_concurrency).
     """
     pipeline_id = pipeline.id
+
+    # Single "hook entered" log line emitted before any short-circuit so
+    # operators can confirm the hook was reached without grepping for the
+    # specific short-circuit string.  Surfaces the gap reported in #2593
+    # where the hook was wired into only one of the plan→implement
+    # transition paths and no log line appeared at all when the operator
+    # advanced via a different path.
+    _pipeline_mode = getattr(pipeline, "mode", None)
+    logger.info(
+        "Context PR hook entered (#2548)",
+        pipeline_id=pipeline_id,
+        source=source,
+        current_phase=getattr(pipeline.current_phase, "value", str(pipeline.current_phase)),
+        mode=getattr(_pipeline_mode, "value", str(_pipeline_mode)),
+    )
 
     # --- Step 1: load contract + sanity-check inputs ---
     if not pipeline.repo:
@@ -10209,6 +10225,114 @@ def _derive_producer_roles_with_tasks(
         return None
 
     return {(t.role or "coder") for t in _slice_obj.tasks}
+
+
+def _maybe_open_base_pr_for_plan_to_implement(
+    pipeline,
+    spawner: "ContainerSpawner",  # noqa: UP037
+    worktree_repo_path: Path,
+    *,
+    gateway_mode: Literal["public", "private"] = "public",
+    source: str,
+) -> None:
+    """Open the doc-only base/context PR for the plan→implement transition (#2548, #2593).
+
+    Single call site for every plan→implement code path:
+
+    * the inline auto-advance in :func:`_run_pipeline` (the path #2548
+      originally wired up);
+    * the ``advance_phase`` REST/MCP handler (force or normal advance
+      out of the plan phase);
+    * the HITL-approval recovery path in :func:`start_pipeline`
+      (re-spawning ``_run_pipeline`` after the human resolved the
+      plan_gate while the pipeline was AWAITING_HUMAN);
+    * the IMPLEMENT phase entry backstop (catches any future
+      transition path added without ceremony — the inner short-circuit
+      makes re-entry a no-op).
+
+    CUSTOM-mode pipelines run a single phase and terminate (#1762) —
+    they never advance to implement, so opening a context PR for them
+    would orphan a PR on GitHub that has no slice PRs to stack on top
+    of (#2548 review issue 3).  Skip them up front.
+
+    Failures are logged and swallowed: a transient infra problem in
+    this hook must not strand the plan→implement transition (decision-3
+    / D3 of #2548).  The inner short-circuits and the swallowed
+    exception path also emit a STATUS message on the pipeline event
+    bus so operators using ``wait-status`` / ``get_status`` see the
+    skipped/failed signal without having to grep orchestrator logs
+    (#2593).
+    """
+    pipeline_id = pipeline.id
+    _is_custom_mode = getattr(pipeline, "mode", None) == PipelineMode.CUSTOM
+    if _is_custom_mode:
+        return
+    raised: Exception | None = None
+    try:
+        _open_context_pr_for_pipeline(
+            pipeline,
+            spawner,
+            worktree_repo_path,
+            gateway_mode=gateway_mode,
+            source=source,
+        )
+    except Exception as ctx_err:  # noqa: BLE001
+        raised = ctx_err
+        logger.warning(
+            "Context PR hook raised at plan→implement transition (continuing) (#2548)",
+            pipeline_id=pipeline_id,
+            source=source,
+            error=str(ctx_err),
+        )
+
+    # #2593 — surface "context PR not opened" on the pipeline message
+    # bus so operators using ``wait-status`` / ``get_status`` see the
+    # skip without having to grep orchestrator logs.  Only emit when
+    # the pipeline *should* have a context PR (has a remote and a
+    # base_branch) but doesn't, so we don't spam the bus for local
+    # mode pipelines that legitimately skip the hook.  Re-load the
+    # contract from disk to read the post-hook ``context_pr_number``
+    # rather than trusting the in-memory ``pipeline`` (the hook may
+    # have written through to disk under the per-pipeline state lock
+    # without mutating the caller's reference).
+    if pipeline.repo and pipeline.base_branch:
+        _ctx_pr_number: int | None = None
+        try:
+            from egg_contracts.loader import (
+                ContractNotFoundError as _CtxCNF,
+            )
+            from egg_contracts.loader import (
+                load_contract as _ctx_load,
+            )
+
+            _ctx_contract = _ctx_load(pipeline_id, worktree_repo_path)
+            if _ctx_contract.pr is not None:
+                _ctx_pr_number = _ctx_contract.pr.context_pr_number
+        except _CtxCNF:
+            pass
+        except Exception:  # noqa: BLE001
+            pass
+
+        if _ctx_pr_number is None:
+            try:
+                _reason = "raised" if raised is not None else "skipped"
+                _detail = f": {str(raised)[:200]}" if raised is not None else ""
+                report_pipeline_status(
+                    pipeline,
+                    event_type=(
+                        "context_pr.failed" if raised is not None else "context_pr.skipped"
+                    ),
+                    message=(
+                        f"Context PR not opened (source={source}, "
+                        f"reason={_reason}){_detail}. "
+                        "Slice stack will not have a path to the base "
+                        "branch until an operator opens one manually."
+                    ),
+                )
+            except Exception:  # noqa: BLE001
+                # Status reporting is best-effort — must not raise out
+                # of the swallow-all wrapper.
+                pass
 
 
 def _resolve_slice_1_context_branch_from_contract(
@@ -18541,6 +18665,27 @@ def _run_pipeline(
                 )
                 _emit_pipeline_event(pipeline, "phase.started")
 
+                # #2593 — implement-phase entry backstop.  Fires once
+                # on the PENDING→RUNNING transition into the IMPLEMENT
+                # phase, regardless of which transition path (inline
+                # auto-advance, ``advance_phase`` REST, HITL recovery,
+                # or any future path) got us here.  The inner
+                # ``context_pr_number`` short-circuit makes this a
+                # no-op when the PR was already opened on the
+                # plan-exit side, so the backstop only does real work
+                # when every other path missed it.  Belt-and-suspenders:
+                # makes "context PR exists when slice-1 spawns" a
+                # property of the IMPLEMENT phase rather than of one
+                # specific exit path from PLAN.
+                if current_phase == PipelinePhase.IMPLEMENT:
+                    _maybe_open_base_pr_for_plan_to_implement(
+                        pipeline,
+                        spawner,
+                        worktree_repo_path,
+                        gateway_mode=gateway_mode,
+                        source="implement_entry_backstop",
+                    )
+
             # Spawn overseer container for this phase's health monitoring.
             # The overseer is phase-scoped: spawned at phase start and torn
             # down at phase completion/advance/failure.  Each phase gets a
@@ -19791,33 +19936,21 @@ def _run_pipeline(
 
             # ----------------------------------------------------------
             # #2548 — open the doc-only context PR after plan_gate
-            # approval and BEFORE slice-1 provisioning.  The hook is
-            # idempotent on retry (re-entering this block is a no-op
-            # if ``contract.pr.context_pr_number`` is already set), so
-            # respawned _run_pipeline threads do not double-open.  Any
-            # failure inside the hook is logged and swallowed so a
-            # transient infra problem cannot strand the plan→implement
-            # transition (decision-3 / D3 of #2548).
+            # approval and BEFORE slice-1 provisioning.  Routed through
+            # the shared :func:`_maybe_open_base_pr_for_plan_to_implement`
+            # helper so this and the other three transition paths
+            # (advance_phase REST, HITL-approval recovery, implement-entry
+            # backstop) all share the same CUSTOM-mode guard, swallow-all
+            # semantics, and "hook entered" log line (#2593).
             # ----------------------------------------------------------
-            # CUSTOM-mode pipelines run a single phase and terminate
-            # (#1762) — they never advance to implement, so opening a
-            # context PR for them would orphan a PR on GitHub that has
-            # no slice PRs to stack on top of (#2548 review issue 3).
-            _ctx_is_custom_mode = getattr(pipeline, "mode", None) == PipelineMode.CUSTOM
-            if current_phase.value == "plan" and not _ctx_is_custom_mode:
-                try:
-                    _open_context_pr_for_pipeline(
-                        pipeline,
-                        spawner,
-                        worktree_repo_path,
-                        gateway_mode=gateway_mode,
-                    )
-                except Exception as ctx_err:  # noqa: BLE001
-                    logger.warning(
-                        "Context PR hook raised at plan→implement transition (continuing) (#2548)",
-                        pipeline_id=pipeline_id,
-                        error=str(ctx_err),
-                    )
+            if current_phase.value == "plan":
+                _maybe_open_base_pr_for_plan_to_implement(
+                    pipeline,
+                    spawner,
+                    worktree_repo_path,
+                    gateway_mode=gateway_mode,
+                    source="run_pipeline_autoadvance",
+                )
 
             # Tear down the phase-scoped overseer before advancing.
             # Each phase gets a fresh overseer instance — no state carries
@@ -20484,6 +20617,70 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                     # CUSTOM-mode pipelines complete after their single
                     # phase — no auto-advance (#1762 TASK-2-9).
                     _is_custom_mode = getattr(pipeline, "mode", None) == PipelineMode.CUSTOM
+
+                    # #2593 — populate contract from the plan draft and
+                    # open the doc-only base/context PR when the HITL
+                    # recovery is advancing the pipeline out of the
+                    # plan phase.  Without this, contract.pr is empty
+                    # (so the PR phase falls back to placeholder
+                    # title/body and the context PR hook short-circuits
+                    # on "contract has no pr block"), and the slice
+                    # stack ends up rooted on ``/work`` with no PR to
+                    # ``main`` — exactly the symptom reported on the
+                    # in-flight #2474 pipeline.  Mirrors the
+                    # plan-exit logic in ``advance_phase``
+                    # (routes/phases.py) and the auto-advance path in
+                    # ``_run_pipeline``.  Best-effort: failures warn
+                    # and continue so a transient infra problem cannot
+                    # strand the HITL recovery.
+                    _next_phase_peek = next_phases[0] if next_phases else None
+                    if (
+                        current_phase == PipelinePhase.PLAN
+                        and _next_phase_peek == PipelinePhase.IMPLEMENT
+                        and not _is_custom_mode
+                    ):
+                        _hitl_worktree_path = _resolve_pipeline_worktree_path(pipeline, repo_path)
+                        try:
+                            _pipeline_mode = pipeline.mode.value if pipeline.mode else "issue"
+                            _populate_contract_from_plan_safe(
+                                _hitl_worktree_path,
+                                pipeline_id,
+                                _pipeline_mode,
+                                pipeline.issue_number,
+                                source="advance_phase_force",
+                            )
+                            try:
+                                _commit_statefiles_to_worktree(
+                                    _hitl_worktree_path,
+                                    "Populate contract from plan on HITL plan-gate approval",
+                                    pipeline_identifier=_pipeline_identifier(
+                                        pipeline.issue_number, pipeline_id
+                                    ),
+                                    pipeline_id=pipeline_id,
+                                )
+                            except Exception as _hitl_commit_err:  # noqa: BLE001
+                                logger.warning(
+                                    "Failed to commit populated contract on HITL plan-gate approval (continuing) (#2593)",
+                                    pipeline_id=pipeline_id,
+                                    error=str(_hitl_commit_err),
+                                )
+                        except Exception as _hitl_pop_err:  # noqa: BLE001
+                            logger.warning(
+                                "Failed to run plan-exit populate on HITL recovery (continuing) (#2593)",
+                                pipeline_id=pipeline_id,
+                                error=str(_hitl_pop_err),
+                            )
+
+                        # Open the base/context PR now that the contract
+                        # is populated.  Idempotent on retry via the
+                        # inner ``context_pr_number`` short-circuit.
+                        _maybe_open_base_pr_for_plan_to_implement(
+                            pipeline,
+                            _get_spawner(),
+                            _hitl_worktree_path,
+                            gateway_mode=_gw_mode,
+                            source="hitl_resume",
+                        )
 
                     if not next_phases or _is_custom_mode:
                         # Terminal phase — pipeline complete.

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2073,6 +2073,25 @@ def _clear_pipeline_runtime_state(pipeline_id: str, *, reason: str) -> None:
             error=str(e),
         )
 
+    # #2599 review 2 item 1 — the context_pr.skipped / context_pr.failed
+    # dedupe set is also keyed by ``pipeline_id`` alone. Without this
+    # clear, a fresh pipeline that reuses an id from a prior terminal
+    # run (allowed — see branch-reuse logic for terminal-state pipelines)
+    # would inherit the prior run's emitted-event set; if the new run
+    # also fails to open its context PR, operators using ``wait-status``
+    # would see no event for the new failure. Same shape as #2053 (the
+    # other per-pipeline-id leak this function exists to plug).
+    try:
+        with _context_pr_events_emitted_lock:
+            _context_pr_events_emitted.pop(pipeline_id, None)
+    except Exception as e:
+        logger.warning(
+            "Failed to clear context PR event dedupe state",
+            pipeline_id=pipeline_id,
+            reason=reason,
+            error=str(e),
+        )
+
 
 def _mark_pipeline_records_terminated(
     store: StateStore,

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -10227,6 +10227,20 @@ def _derive_producer_roles_with_tasks(
     return {(t.role or "coder") for t in _slice_obj.tasks}
 
 
+# #2593 — dedupe of context_pr.skipped / context_pr.failed bus events.
+# The wrapper can run multiple times for the same pipeline (auto-advance
+# + implement-entry backstop, HITL recovery + backstop) and the inner
+# hook's idempotency makes those re-runs cheap — but the post-hook bus
+# emission is *not* idempotent on its own: on a real failure it sees
+# ``context_pr_number is None`` every time and would emit a duplicate
+# ``context_pr.failed`` / ``context_pr.skipped`` message.  Keyed on
+# ``(pipeline_id, event_type)`` so the first emission wins per event
+# kind; entries are not removed because once ``context_pr_number`` is
+# set we never reach the emit branch again.
+_context_pr_events_emitted: dict[str, set[str]] = {}
+_context_pr_events_emitted_lock = threading.Lock()
+
+
 def _maybe_open_base_pr_for_plan_to_implement(
     pipeline,
     spawner: "ContainerSpawner",  # noqa: UP037
@@ -10246,9 +10260,14 @@ def _maybe_open_base_pr_for_plan_to_implement(
     * the HITL-approval recovery path in :func:`start_pipeline`
       (re-spawning ``_run_pipeline`` after the human resolved the
       plan_gate while the pipeline was AWAITING_HUMAN);
-    * the IMPLEMENT phase entry backstop (catches any future
-      transition path added without ceremony — the inner short-circuit
-      makes re-entry a no-op).
+    * the IMPLEMENT phase entry backstop (fires once on the
+      PENDING→RUNNING transition into IMPLEMENT — paths that set
+      ``phase_execution.status = RUNNING`` before spawning the runner
+      thread (e.g. the ``advance_phase`` REST handler at
+      ``routes/phases.py:379``) bypass the backstop and so must call
+      the wrapper directly; the inner short-circuit on
+      ``context_pr_number`` makes any path that DOES re-enter the
+      backstop a no-op).
 
     CUSTOM-mode pipelines run a single phase and terminate (#1762) —
     they never advance to implement, so opening a context PR for them
@@ -10262,10 +10281,32 @@ def _maybe_open_base_pr_for_plan_to_implement(
     bus so operators using ``wait-status`` / ``get_status`` see the
     skipped/failed signal without having to grep orchestrator logs
     (#2593).
+
+    Bus emission semantics: the ``context_pr.skipped`` /
+    ``context_pr.failed`` event reflects *contract state* (does the
+    contract record a ``context_pr_number``?), NOT *PR state on
+    GitHub*.  The inner hook has late short-circuit paths that swallow
+    ``save_contract`` failures after the gateway has already opened
+    the PR on GitHub; in those rare cases the wrapper will see
+    ``context_pr_number is None`` and emit ``context_pr.skipped`` even
+    though a context PR exists on the remote.  Operators chasing a
+    skipped/failed event must therefore verify both ``contract.pr``
+    and the remote PR list before concluding the PR is genuinely
+    missing.
     """
     pipeline_id = pipeline.id
     _is_custom_mode = getattr(pipeline, "mode", None) == PipelineMode.CUSTOM
     if _is_custom_mode:
+        # #2593 review issue 10 — keep the "hook ran" observability
+        # promise on CUSTOM-mode pipelines too.  Operators tracing
+        # transition paths via the ``Context PR hook entered`` line
+        # would otherwise see no log emission for CUSTOM mode and
+        # have to infer the skip from the pipeline config.
+        logger.info(
+            "Context PR hook skipped (CUSTOM mode) (#2548)",
+            pipeline_id=pipeline_id,
+            source=source,
+        )
         return
     raised: Exception | None = None
     try:
@@ -10294,34 +10335,46 @@ def _maybe_open_base_pr_for_plan_to_implement(
     # contract from disk to read the post-hook ``context_pr_number``
     # rather than trusting the in-memory ``pipeline`` (the hook may
     # have written through to disk under the per-pipeline state lock
-    # without mutating the caller's reference).
+    # without mutating the caller's reference).  Use
+    # ``_pipeline_identifier`` so the contract path matches the one the
+    # inner hook used (#2593 review issue 7) — both currently resolve
+    # to the same on-disk file, but pinning the resolution keeps the
+    # wrapper from drifting if the ISSUE-mode key logic ever changes.
     if pipeline.repo and pipeline.base_branch:
         _ctx_pr_number: int | None = None
+        _ctx_identifier = _pipeline_identifier(
+            pipeline.issue_number,
+            pipeline_id,
+            mode=getattr(pipeline, "mode", None),
+        )
         try:
-            from egg_contracts.loader import (
-                ContractNotFoundError as _CtxCNF,
-            )
-            from egg_contracts.loader import (
-                load_contract as _ctx_load,
-            )
+            from egg_contracts.loader import load_contract as _ctx_load
 
-            _ctx_contract = _ctx_load(pipeline_id, worktree_repo_path)
+            _ctx_contract = _ctx_load(_ctx_identifier, worktree_repo_path)
             if _ctx_contract.pr is not None:
                 _ctx_pr_number = _ctx_contract.pr.context_pr_number
-        except _CtxCNF:
-            pass
         except Exception:  # noqa: BLE001
+            # ContractNotFoundError and any other failure both converge
+            # on "we cannot read the post-hook state"; either way we
+            # fall through to the emit branch with _ctx_pr_number=None.
             pass
 
         if _ctx_pr_number is None:
+            event_type = "context_pr.failed" if raised is not None else "context_pr.skipped"
+            # Dedupe: a single failure on a pipeline should produce one
+            # event per kind, not one per transition path that re-ran
+            # the hook.  See ``_context_pr_events_emitted`` docstring.
+            with _context_pr_events_emitted_lock:
+                already = _context_pr_events_emitted.setdefault(pipeline_id, set())
+                if event_type in already:
+                    return
+                already.add(event_type)
             try:
                 _reason = "raised" if raised is not None else "skipped"
                 _detail = f": {str(raised)[:200]}" if raised is not None else ""
                 report_pipeline_status(
                     pipeline,
-                    event_type=(
-                        "context_pr.failed" if raised is not None else "context_pr.skipped"
-                    ),
+                    event_type=event_type,
                     message=(
                         f"Context PR not opened (source={source}, "
                         f"reason={_reason}){_detail}. "
@@ -17021,20 +17074,28 @@ def _populate_contract_from_plan_safe(
     pipeline_mode: str = "issue",
     issue_number: int | None = None,
     *,
-    source: Literal["plan_complete", "advance_phase_force"] = "advance_phase_force",
+    source: Literal[
+        "plan_complete",
+        "advance_phase_force",
+        "hitl_plan_gate_approval",
+    ] = "advance_phase_force",
     branch: str | None = None,
     current_phase: PipelinePhase | None = None,
 ) -> None:
     """Run :func:`_populate_contract_from_plan` without propagating failures.
 
-    Shared call path for the two code sites that run the populate step when a
-    pipeline leaves the ``plan`` phase: ``_run_pipeline``'s post-complete
-    block (``source="plan_complete"``) and ``advance_phase`` (used by the
-    MCP ``advance_phase`` tool, especially with ``force=true`` —
-    ``source="advance_phase_force"``).  Blocking the phase transition on
-    a populate failure would defeat the purpose of the advance hammer — see
-    #1941 — so the force-advance call site keeps the swallow-everything
-    behaviour.
+    Shared call path for the three code sites that run the populate step
+    when a pipeline leaves the ``plan`` phase: ``_run_pipeline``'s
+    post-complete block (``source="plan_complete"``), ``advance_phase``
+    (used by the MCP ``advance_phase`` tool, especially with
+    ``force=true`` — ``source="advance_phase_force"``), and the HITL
+    plan-gate approval path in :func:`start_pipeline`
+    (``source="hitl_plan_gate_approval"`` — operator approved the
+    plan_gate while the pipeline was AWAITING_HUMAN, recovery
+    re-spawns ``_run_pipeline``).  Blocking the phase transition on a
+    populate failure would defeat the purpose of the advance hammer
+    or recovery path — see #1941 — so all non-natural call sites
+    keep the swallow-everything behaviour.
 
     The natural plan-completion call site (``source="plan_complete"``)
     additionally raises :class:`PlanDraftMissingOnLocalError` when the
@@ -18667,16 +18728,18 @@ def _run_pipeline(
 
                 # #2593 — implement-phase entry backstop.  Fires once
                 # on the PENDING→RUNNING transition into the IMPLEMENT
-                # phase, regardless of which transition path (inline
-                # auto-advance, ``advance_phase`` REST, HITL recovery,
-                # or any future path) got us here.  The inner
-                # ``context_pr_number`` short-circuit makes this a
-                # no-op when the PR was already opened on the
-                # plan-exit side, so the backstop only does real work
-                # when every other path missed it.  Belt-and-suspenders:
-                # makes "context PR exists when slice-1 spawns" a
-                # property of the IMPLEMENT phase rather than of one
-                # specific exit path from PLAN.
+                # phase when the runner thread itself drives the
+                # transition: inline ``_run_pipeline`` auto-advance and
+                # the HITL-approval recovery in ``start_pipeline`` both
+                # leave ``phase_execution.status`` as ``PENDING`` and
+                # spawn the runner, so the backstop covers them.
+                # ``advance_phase`` (routes/phases.py:379) sets
+                # ``RUNNING`` before spawning, so the backstop does
+                # NOT fire from that path — that REST handler must
+                # therefore call the wrapper directly (and does, at
+                # ``routes/phases.py``).  The inner ``context_pr_number``
+                # short-circuit makes this a no-op when the PR was
+                # already opened on the plan-exit side.
                 if current_phase == PipelinePhase.IMPLEMENT:
                     _maybe_open_base_pr_for_plan_to_implement(
                         pipeline,
@@ -20485,6 +20548,13 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
             # No pending decisions — the polling thread died (e.g. restart)
             # but the human already resolved everything.  Recover based on
             # the latest phase_gate decision's resolution.
+            #
+            # #2593 review issue 1 — initialised before the lock so the
+            # post-lock deferred ``_maybe_open_base_pr_for_plan_to_implement``
+            # invocation has a stable name to read regardless of which
+            # branch inside the lock executes.
+            _hitl_open_context_pr_after_lock: bool = False
+            _hitl_pr_worktree_path: Path | None = None
             with get_pipeline_state_lock(pipeline_id):
                 pipeline = store.load_pipeline(pipeline_id)
 
@@ -20618,21 +20688,24 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                     # phase — no auto-advance (#1762 TASK-2-9).
                     _is_custom_mode = getattr(pipeline, "mode", None) == PipelineMode.CUSTOM
 
-                    # #2593 — populate contract from the plan draft and
-                    # open the doc-only base/context PR when the HITL
-                    # recovery is advancing the pipeline out of the
-                    # plan phase.  Without this, contract.pr is empty
-                    # (so the PR phase falls back to placeholder
+                    # #2593 — populate contract from the plan draft when
+                    # the HITL recovery is advancing the pipeline out
+                    # of the plan phase.  Without this, contract.pr is
+                    # empty (so the PR phase falls back to placeholder
                     # title/body and the context PR hook short-circuits
                     # on "contract has no pr block"), and the slice
                     # stack ends up rooted on ``/work`` with no PR to
                     # ``main`` — exactly the symptom reported on the
-                    # in-flight #2474 pipeline.  Mirrors the
-                    # plan-exit logic in ``advance_phase``
-                    # (routes/phases.py) and the auto-advance path in
-                    # ``_run_pipeline``.  Best-effort: failures warn
-                    # and continue so a transient infra problem cannot
-                    # strand the HITL recovery.
+                    # in-flight #2474 pipeline.  Mirrors the plan-exit
+                    # logic in ``advance_phase`` (routes/phases.py)
+                    # and the auto-advance path in ``_run_pipeline``.
+                    # Best-effort: failures warn and continue so a
+                    # transient infra problem cannot strand the HITL
+                    # recovery.  The actual context-PR open is
+                    # deferred until after the lock is released
+                    # (#2593 review issue 1) so the multi-second
+                    # gateway sequence does not extend the
+                    # per-pipeline state lock's hold time.
                     _next_phase_peek = next_phases[0] if next_phases else None
                     if (
                         current_phase == PipelinePhase.PLAN
@@ -20647,7 +20720,7 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                                 pipeline_id,
                                 _pipeline_mode,
                                 pipeline.issue_number,
-                                source="advance_phase_force",
+                                source="hitl_plan_gate_approval",
                             )
                             try:
                                 _commit_statefiles_to_worktree(
@@ -20664,6 +20737,34 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                                     pipeline_id=pipeline_id,
                                     error=str(_hitl_commit_err),
                                 )
+
+                            # #2593 review issue 5 — the earlier
+                            # ``push_worktree_branch`` at line ~20598
+                            # ran *before* this populate commit, so
+                            # the populated ``contract.pr`` only
+                            # exists locally until the IMPLEMENT
+                            # phase's next phase-boundary sync.  Push
+                            # again now so any slice-agent container
+                            # that materialises a fresh worktree from
+                            # origin before that sync still sees
+                            # ``contract.pr``.  Mirrors the
+                            # auto-advance flow's pre-context-PR push
+                            # in ``_run_pipeline``.
+                            if pipeline.branch and _hitl_worktree_path != repo_path:
+                                try:
+                                    _get_spawner().gateway.push_worktree_branch(
+                                        pipeline_id=pipeline_id,
+                                        repo_path=str(_hitl_worktree_path),
+                                        branch=pipeline.branch,
+                                        mode=_gw_mode,
+                                        base_branch=pipeline.base_branch,
+                                    )
+                                except Exception as _hitl_push_err:  # noqa: BLE001
+                                    logger.warning(
+                                        "Failed to push populated contract on HITL plan-gate approval (continuing) (#2593)",
+                                        pipeline_id=pipeline_id,
+                                        error=str(_hitl_push_err),
+                                    )
                         except Exception as _hitl_pop_err:  # noqa: BLE001
                             logger.warning(
                                 "Failed to run plan-exit populate on HITL recovery (continuing) (#2593)",
@@ -20671,16 +20772,14 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                                 error=str(_hitl_pop_err),
                             )
 
-                        # Open the base/context PR now that the contract
-                        # is populated.  Idempotent on retry via the
-                        # inner ``context_pr_number`` short-circuit.
-                        _maybe_open_base_pr_for_plan_to_implement(
-                            pipeline,
-                            _get_spawner(),
-                            _hitl_worktree_path,
-                            gateway_mode=_gw_mode,
-                            source="hitl_resume",
-                        )
+                        # Defer the context-PR open until after the
+                        # per-pipeline state lock is released — see
+                        # ``_open_context_pr_for_pipeline``'s
+                        # idempotency docstring on why this multi-
+                        # second network sequence must not run under
+                        # the lock (#2593 review issue 1).
+                        _hitl_open_context_pr_after_lock = True
+                        _hitl_pr_worktree_path = _hitl_worktree_path
 
                     if not next_phases or _is_custom_mode:
                         # Terminal phase — pipeline complete.
@@ -20770,6 +20869,23 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                 from routes.phases import _clear_concurrent_state
 
                 _clear_concurrent_state(pipeline_id)
+
+            # #2593 review issue 1 — context-PR open moved out of the
+            # per-pipeline state lock so the multi-second gateway
+            # sequence (create_context_branch → file copy → commit →
+            # push → ``gh pr create``) no longer holds the lock and
+            # block concurrent ``advance_phase`` / status reads.  The
+            # helper is idempotent on its inner ``context_pr_number``
+            # short-circuit so a racing call from the runner thread's
+            # implement-entry backstop converges safely.
+            if _hitl_open_context_pr_after_lock and _hitl_pr_worktree_path is not None:
+                _maybe_open_base_pr_for_plan_to_implement(
+                    pipeline,
+                    _get_spawner(),
+                    _hitl_pr_worktree_path,
+                    gateway_mode=_gw_mode,
+                    source="hitl_resume",
+                )
 
             # Launch runner thread
             thread = threading.Thread(

--- a/orchestrator/tests/test_context_pr.py
+++ b/orchestrator/tests/test_context_pr.py
@@ -1246,10 +1246,14 @@ class TestOpenContextPRCallSiteWiring:
         src = Path(__file__).parent.parent / "routes" / "pipelines.py"
         text = src.read_text()
         # Look inside the wrapper for the CUSTOM-mode early return.
+        # The body between ``if _is_custom_mode:`` and the ``return``
+        # may contain a log line (#2593 review issue 10) — match
+        # non-greedy across comments/logging so the regression check
+        # still catches a missing return.
         m = re.search(
             r"def\s+_maybe_open_base_pr_for_plan_to_implement\b.+?"
             r"_is_custom_mode\s*=\s*getattr\(pipeline,\s*['\"]mode['\"],\s*None\)"
-            r"\s*==\s*PipelineMode\.CUSTOM.+?if\s+_is_custom_mode\s*:\s*\n\s*return",
+            r"\s*==\s*PipelineMode\.CUSTOM.+?if\s+_is_custom_mode\s*:.+?return\b",
             text,
             flags=re.DOTALL,
         )

--- a/orchestrator/tests/test_context_pr.py
+++ b/orchestrator/tests/test_context_pr.py
@@ -1214,71 +1214,73 @@ class TestOpenContextPRCallSiteWiring:
 
     def test_call_site_is_gated_on_plan_phase(self):
         """The hook only fires after the plan phase — re-entering the
-        same code on a different phase MUST NOT re-open the context PR."""
+        same code on a different phase MUST NOT re-open the context PR.
+
+        After #2593 the call site routes through the shared
+        ``_maybe_open_base_pr_for_plan_to_implement`` wrapper, so the
+        regression check is against the wrapper invocation rather than
+        the inner ``_open_context_pr_for_pipeline`` call (the wrapper
+        owns the CUSTOM-mode guard and exception swallow now)."""
         src = Path(__file__).parent.parent / "routes" / "pipelines.py"
         text = src.read_text()
-        # The call site must be inside an ``if current_phase.value == "plan"``
-        # block.  Allow optional extra ``and ...`` conjuncts between
-        # ``"plan"`` and ``:`` so the post-#2548 CUSTOM-mode gate (#2548
-        # review issue 3 — ``and not _ctx_is_custom_mode``) does not
-        # break this regression check.
         m = re.search(
-            r'if\s+current_phase\.value\s*==\s*"plan"[^\n:]*:\s*\n\s*try:\s*\n\s*'
-            r"_open_context_pr_for_pipeline\(",
+            r'if\s+current_phase\.value\s*==\s*"plan"[^\n:]*:\s*\n\s*'
+            r"_maybe_open_base_pr_for_plan_to_implement\(",
             text,
         )
         assert m is not None, (
-            "_open_context_pr_for_pipeline call site must be gated on "
-            "current_phase.value == 'plan' AND wrapped in try/except (D3)"
+            "plan→implement call site must be gated on "
+            "current_phase.value == 'plan' and route through "
+            "_maybe_open_base_pr_for_plan_to_implement (D3, #2593)"
         )
 
     def test_call_site_is_gated_on_non_custom_mode(self):
         """CUSTOM-mode pipelines (#1762) terminate after a single phase
         and never advance to implement — opening a context PR for them
         would orphan a PR on GitHub with no slice PRs to stack on
-        (#2548 review issue 3).  Pin the gate so a refactor that drops
-        it is caught immediately."""
+        (#2548 review issue 3).  Under #2593 the CUSTOM-mode skip moved
+        from the call site into the
+        ``_maybe_open_base_pr_for_plan_to_implement`` wrapper so every
+        transition path inherits the same guard.  Pin the guard in the
+        wrapper body."""
         src = Path(__file__).parent.parent / "routes" / "pipelines.py"
         text = src.read_text()
+        # Look inside the wrapper for the CUSTOM-mode early return.
         m = re.search(
-            r'if\s+current_phase\.value\s*==\s*"plan"\s+and\s+not\s+'
-            r"_ctx_is_custom_mode\s*:\s*\n\s*try:\s*\n\s*"
-            r"_open_context_pr_for_pipeline\(",
-            text,
-        )
-        assert m is not None, (
-            "_open_context_pr_for_pipeline call site must skip CUSTOM-mode "
-            "pipelines: they terminate after one phase and would orphan "
-            "the context PR (#2548 review issue 3)"
-        )
-
-    def test_call_site_swallows_any_exception(self):
-        """The call site catches a broad ``except`` so the hook can never
-        block the plan→implement transition, even if the helper raises
-        on top of its own internal swallows.
-
-        Regex brittleness (#2548 review issue 9): the pattern requires
-        the call's closing ``)`` to be followed (modulo whitespace) by
-        ``except``.  This is deliberate — it catches any refactor that
-        inserts logging, metric emission, or another helper call
-        between the helper invocation and its except clause, which
-        would silently widen the failure window.  If a future change
-        legitimately needs to do work between the call and the except
-        (e.g. debounce a respawn), update both this test AND the call
-        site comment in pipelines.py to spell out the new contract.
-        """
-        src = Path(__file__).parent.parent / "routes" / "pipelines.py"
-        text = src.read_text()
-        # Locate the call and verify the surrounding ``except`` clause
-        # logs-and-continues.
-        # Allow flexible whitespace + trailing kwargs between the call and
-        # the closing paren before the matching except.
-        m = re.search(
-            r"_open_context_pr_for_pipeline\(.+?\)\s*\n\s*except\s+Exception",
+            r"def\s+_maybe_open_base_pr_for_plan_to_implement\b.+?"
+            r"_is_custom_mode\s*=\s*getattr\(pipeline,\s*['\"]mode['\"],\s*None\)"
+            r"\s*==\s*PipelineMode\.CUSTOM.+?if\s+_is_custom_mode\s*:\s*\n\s*return",
             text,
             flags=re.DOTALL,
         )
         assert m is not None, (
-            "call site must be inside ``try: ...; except Exception``: a hook "
-            "failure must never escape into _run_pipeline (D3)"
+            "_maybe_open_base_pr_for_plan_to_implement must skip CUSTOM-mode "
+            "pipelines: they terminate after one phase and would orphan "
+            "the context PR (#2548 review issue 3, #2593)"
+        )
+
+    def test_call_site_swallows_any_exception(self):
+        """The hook can never block the plan→implement transition, even
+        if the inner helper raises on top of its own internal swallows
+        (D3 of #2548).  Under #2593 the swallow moved from the call
+        site into the
+        ``_maybe_open_base_pr_for_plan_to_implement`` wrapper so every
+        transition path inherits the same protection.  Pin the
+        try/except around the inner call inside the wrapper.
+        """
+        src = Path(__file__).parent.parent / "routes" / "pipelines.py"
+        text = src.read_text()
+        # The wrapper must wrap the inner _open_context_pr_for_pipeline
+        # call in a try/except Exception so any raise becomes a log line.
+        m = re.search(
+            r"def\s+_maybe_open_base_pr_for_plan_to_implement\b.+?"
+            r"try:\s*\n\s*_open_context_pr_for_pipeline\(.+?\)"
+            r"\s*\n\s*except\s+Exception",
+            text,
+            flags=re.DOTALL,
+        )
+        assert m is not None, (
+            "_maybe_open_base_pr_for_plan_to_implement must wrap "
+            "_open_context_pr_for_pipeline in try/except Exception so a "
+            "hook failure can never escape into the transition path (D3)"
         )

--- a/orchestrator/tests/test_context_pr_transition_paths.py
+++ b/orchestrator/tests/test_context_pr_transition_paths.py
@@ -105,6 +105,18 @@ def propagate_orchestrator_logs():
         pl_logger.propagate = prior
 
 
+@pytest.fixture(autouse=True)
+def reset_context_pr_dedupe():
+    """The wrapper dedupes ``context_pr.skipped`` / ``context_pr.failed``
+    via a module-level set keyed on ``pipeline_id`` (#2593 review issue
+    2).  Clear the set per test so tests that re-use the same pipeline
+    fixture do not see the dedupe from a sibling test's first call.
+    """
+    _pipelines_mod._context_pr_events_emitted.clear()
+    yield
+    _pipelines_mod._context_pr_events_emitted.clear()
+
+
 # ---------------------------------------------------------------------------
 # CUSTOM-mode guard
 # ---------------------------------------------------------------------------
@@ -123,6 +135,33 @@ class TestCustomModeGuard:
                 source="run_pipeline_autoadvance",
             )
         inner.assert_not_called()
+
+    def test_emits_skip_log_line_for_custom_mode(
+        self,
+        tmp_path,
+        custom_pipeline,
+        spawner,
+        caplog,
+        propagate_orchestrator_logs,
+    ):
+        """#2593 review issue 10 — CUSTOM-mode pipelines short-circuit
+        before the inner hook is invoked, but the wrapper still emits
+        a "hook skipped (CUSTOM mode)" log line so operators tracing
+        transition paths via log greps see one record per call site
+        (not silence)."""
+        with caplog.at_level(logging.INFO):
+            _maybe_open_base_pr_for_plan_to_implement(
+                custom_pipeline,
+                spawner,
+                tmp_path,
+                source="run_pipeline_autoadvance",
+            )
+        skipped = [
+            rec
+            for rec in caplog.records
+            if "Context PR hook skipped (CUSTOM mode)" in rec.getMessage()
+        ]
+        assert skipped, "expected a 'Context PR hook skipped (CUSTOM mode)' log line"
 
 
 # ---------------------------------------------------------------------------
@@ -366,56 +405,142 @@ class TestMessageBusEmission:
             )
         assert reports == [], "must not emit context_pr.* on local-mode pipelines (no remote)"
 
+    def test_repeated_invocations_dedupe_emitted_event(self, tmp_path, issue_pipeline, spawner):
+        """#2593 review issue 2 — the wrapper can run multiple times
+        for the same pipeline (auto-advance + implement-entry backstop,
+        HITL recovery + backstop).  The inner hook's idempotency
+        short-circuits the PR-creation work, but the bus emission
+        would otherwise fire on each invocation.  The wrapper must
+        dedupe so a single failure produces one ``context_pr.failed``
+        event, not one per call site."""
+        reports: list[tuple[str | None, str | None]] = []
+
+        def _fake_report(pipeline, event_type=None, message=None):
+            reports.append((event_type, message))
+
+        from egg_contracts.models import (
+            Contract,
+            IssueInfo,
+            PRMetadata,
+        )
+        from egg_contracts.models import (
+            PipelinePhase as ContractPhase,
+        )
+
+        contract = Contract(
+            issue=IssueInfo(number=2593, title="t", url=""),
+            pipeline_id="issue-2593",
+            current_phase=ContractPhase.PLAN,
+            pr=PRMetadata(title="t"),
+        )
+
+        def _fake_load(identifier, repo_root):
+            return contract
+
+        with (
+            patch.object(_pipelines_mod, "_open_context_pr_for_pipeline") as inner,
+            patch.object(_pipelines_mod, "report_pipeline_status", _fake_report),
+            patch("egg_contracts.loader.load_contract", _fake_load),
+        ):
+            inner.side_effect = RuntimeError("gateway down")
+            # Simulate auto-advance then implement-entry backstop.
+            _maybe_open_base_pr_for_plan_to_implement(
+                issue_pipeline,
+                spawner,
+                tmp_path,
+                source="run_pipeline_autoadvance",
+            )
+            _maybe_open_base_pr_for_plan_to_implement(
+                issue_pipeline,
+                spawner,
+                tmp_path,
+                source="implement_entry_backstop",
+            )
+
+        failed_events = [r for r in reports if r[0] == "context_pr.failed"]
+        assert len(failed_events) == 1, (
+            f"expected exactly one context_pr.failed event across two "
+            f"wrapper invocations for the same pipeline; got {reports!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Call-site wiring: the four transition paths route through the helper
 # ---------------------------------------------------------------------------
 
 
+def _collect_helper_call_sources(file_path: Path) -> list[str | None]:
+    """AST-walk ``file_path`` and return the ``source=`` kwarg literal
+    of every call to ``_maybe_open_base_pr_for_plan_to_implement``.
+
+    Returns one entry per call site (function definitions are NOT
+    counted — only ``ast.Call`` nodes).  A ``None`` entry means the
+    call site was found but its ``source`` kwarg was not a plain
+    string literal (a future refactor might dispatch on a variable —
+    flag for human review).
+    """
+    import ast
+
+    tree = ast.parse(file_path.read_text())
+    sources: list[str | None] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "_maybe_open_base_pr_for_plan_to_implement":
+            literal: str | None = None
+            for kw in node.keywords:
+                if kw.arg == "source" and isinstance(kw.value, ast.Constant):
+                    if isinstance(kw.value.value, str):
+                        literal = kw.value.value
+            sources.append(literal)
+    return sources
+
+
 class TestCallSiteWiring:
-    """Static / textual assertions that each known transition path
-    routes through ``_maybe_open_base_pr_for_plan_to_implement`` and
-    passes a recognised ``source`` value.  These guard against future
+    """AST-based assertions that each known transition path routes
+    through ``_maybe_open_base_pr_for_plan_to_implement`` and passes
+    a recognised ``source`` value.  These guard against future
     refactors silently breaking the wiring (regression class for
-    #2593)."""
+    #2593).
 
-    def test_run_pipeline_autoadvance_source_present(self):
-        src = (_orchestrator_path / "routes" / "pipelines.py").read_text()
-        assert 'source="run_pipeline_autoadvance"' in src
+    AST-based (#2593 review issue 8) so the count is not perturbed by
+    docstring examples that mention the helper name, by import-line
+    splits, or by string-literal occurrences in error messages.  The
+    function definition itself is an ``ast.FunctionDef`` and is not
+    counted.
+    """
 
-    def test_implement_entry_backstop_source_present(self):
-        src = (_orchestrator_path / "routes" / "pipelines.py").read_text()
-        assert 'source="implement_entry_backstop"' in src
-
-    def test_hitl_resume_source_present(self):
-        src = (_orchestrator_path / "routes" / "pipelines.py").read_text()
-        assert 'source="hitl_resume"' in src
-
-    def test_advance_phase_rest_source_present(self):
-        src = (_orchestrator_path / "routes" / "phases.py").read_text()
-        assert 'source="advance_phase_rest"' in src
-
-    def test_helper_called_from_all_four_sites(self):
-        """Belt-and-suspenders: count call sites of the helper across
-        both files.  Exactly four expected (run_pipeline auto-advance,
-        implement-entry backstop, HITL resume in pipelines.py, plus
-        advance_phase in phases.py).  An accidental refactor that
-        drops one will trip this."""
-        pl_src = (_orchestrator_path / "routes" / "pipelines.py").read_text()
-        ph_src = (_orchestrator_path / "routes" / "phases.py").read_text()
-        # Count call-site invocations, not the definition line.
-        pl_calls = pl_src.count("_maybe_open_base_pr_for_plan_to_implement(")
-        ph_calls = ph_src.count("_maybe_open_base_pr_for_plan_to_implement(")
-        # pipelines.py has 1 (definition) + 3 (autoadvance, backstop,
-        # HITL) = 4 occurrences of the bare name.
-        # phases.py has 1 (advance_phase REST handler).
-        assert pl_calls == 4, (
-            f"expected 4 occurrences of "
-            f"_maybe_open_base_pr_for_plan_to_implement( in pipelines.py "
-            f"(1 def + 3 call sites), got {pl_calls}"
+    def test_pipelines_py_has_expected_call_sites(self):
+        """``pipelines.py`` calls the helper from auto-advance,
+        implement-entry backstop, and HITL resume — three call sites
+        with three distinct, recognised source values.  The wrapper
+        definition itself is an ``ast.FunctionDef`` and is excluded
+        by the AST filter."""
+        pl_path = _orchestrator_path / "routes" / "pipelines.py"
+        sources = _collect_helper_call_sources(pl_path)
+        assert len(sources) == 3, (
+            f"expected 3 call sites in pipelines.py (auto-advance, "
+            f"implement-entry backstop, HITL resume), got {len(sources)} "
+            f"with sources {sources!r}"
         )
-        assert ph_calls == 1, (
-            f"expected 1 occurrence of "
-            f"_maybe_open_base_pr_for_plan_to_implement( in phases.py "
-            f"(advance_phase REST call site), got {ph_calls}"
+        # No call site should pass a non-literal ``source`` — that
+        # would defeat the per-path log tagging.
+        assert all(s is not None for s in sources), (
+            f"every helper call must pass source= as a string literal; got {sources!r}"
+        )
+        assert set(sources) == {
+            "run_pipeline_autoadvance",
+            "implement_entry_backstop",
+            "hitl_resume",
+        }, f"unexpected source values in pipelines.py: {sources!r}"
+
+    def test_phases_py_has_expected_call_site(self):
+        """``phases.py`` calls the helper exactly once, from the
+        plan→implement branch of the ``advance_phase`` REST/MCP
+        handler, with ``source="advance_phase_rest"``."""
+        ph_path = _orchestrator_path / "routes" / "phases.py"
+        sources = _collect_helper_call_sources(ph_path)
+        assert sources == ["advance_phase_rest"], (
+            f"expected 1 call site in phases.py with source='advance_phase_rest'; got {sources!r}"
         )

--- a/orchestrator/tests/test_context_pr_transition_paths.py
+++ b/orchestrator/tests/test_context_pr_transition_paths.py
@@ -1,0 +1,421 @@
+"""Tests for the plan→implement context-PR transition wiring (#2593).
+
+#2548 added ``_open_context_pr_for_pipeline`` and wired it into the
+inline ``_run_pipeline`` auto-advance path.  #2593 found that the
+hook was missing from the other plan→implement transition paths
+(``advance_phase`` REST/MCP and the HITL-approval recovery in
+``start_pipeline``), so operators clearing the plan gate via those
+paths got a slice stack rooted on ``/work`` with no PR to ``main``.
+
+This file pins:
+
+* ``_maybe_open_base_pr_for_plan_to_implement`` wraps the inner hook
+  with the CUSTOM-mode guard, the swallow-all-exceptions semantics,
+  and the post-hook message-bus emission;
+* The wrapper passes ``source`` through to the inner hook so logs
+  identify the call site that fired;
+* The "hook entered" log line is emitted on every call, even on
+  idempotent short-circuit, so operators can confirm the hook ran
+  without grepping for per-short-circuit strings;
+* A ``context_pr.skipped`` / ``context_pr.failed`` message is appended
+  to the pipeline message bus when the hook returned without opening
+  a PR on a pipeline that should have one;
+* The four call sites (autoadvance, advance_phase REST, HITL resume,
+  implement-entry backstop) all route through the same helper.
+"""
+
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mock heavy dependencies before importing routes.pipelines.
+_docker_mock = MagicMock()
+sys.modules.setdefault("docker", _docker_mock)
+sys.modules.setdefault("docker.errors", _docker_mock.errors)
+sys.modules.setdefault("docker.types", _docker_mock.types)
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+_shared_path = _orchestrator_path.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+
+from models import Pipeline, PipelineMode, PipelinePhase, PipelineStatus  # noqa: E402
+from routes import pipelines as _pipelines_mod  # noqa: E402
+from routes.pipelines import (  # noqa: E402
+    _maybe_open_base_pr_for_plan_to_implement,
+)
+
+
+@pytest.fixture
+def issue_pipeline():
+    return Pipeline(
+        id="issue-2593",
+        issue_number=2593,
+        repo="owner/repo",
+        branch="egg/issue-2593/work",
+        base_branch="main",
+        mode=PipelineMode.ISSUE,
+        status=PipelineStatus.RUNNING,
+        current_phase=PipelinePhase.PLAN,
+    )
+
+
+@pytest.fixture
+def custom_pipeline():
+    return Pipeline(
+        id="issue-2593-custom",
+        issue_number=2593,
+        repo="owner/repo",
+        branch="egg/issue-2593-custom/work",
+        base_branch="main",
+        mode=PipelineMode.CUSTOM,
+        status=PipelineStatus.RUNNING,
+        current_phase=PipelinePhase.PLAN,
+    )
+
+
+@pytest.fixture
+def spawner():
+    s = MagicMock(name="spawner")
+    s.gateway = MagicMock(name="gateway")
+    return s
+
+
+@pytest.fixture
+def propagate_orchestrator_logs():
+    """``egg_logging`` configures ``orchestrator.pipelines`` with
+    ``propagate=False`` so structured records don't bubble up to the
+    root logger.  pytest's ``caplog`` attaches to the root logger, so
+    without re-enabling propagation the test would never see the
+    records we're asserting on.  Restore the original setting on
+    teardown.
+    """
+    pl_logger = logging.getLogger("orchestrator.pipelines")
+    prior = pl_logger.propagate
+    pl_logger.propagate = True
+    try:
+        yield
+    finally:
+        pl_logger.propagate = prior
+
+
+# ---------------------------------------------------------------------------
+# CUSTOM-mode guard
+# ---------------------------------------------------------------------------
+
+
+class TestCustomModeGuard:
+    def test_skips_custom_mode_pipelines(self, tmp_path, custom_pipeline, spawner):
+        """CUSTOM-mode pipelines run a single phase and terminate (#1762).
+        Opening a context PR for them would orphan a PR with no slices.
+        The wrapper must short-circuit before invoking the inner hook."""
+        with patch.object(_pipelines_mod, "_open_context_pr_for_pipeline") as inner:
+            _maybe_open_base_pr_for_plan_to_implement(
+                custom_pipeline,
+                spawner,
+                tmp_path,
+                source="run_pipeline_autoadvance",
+            )
+        inner.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Source propagation + exception swallow
+# ---------------------------------------------------------------------------
+
+
+class TestSourcePropagation:
+    def test_passes_source_through_to_inner_hook(self, tmp_path, issue_pipeline, spawner):
+        with patch.object(_pipelines_mod, "_open_context_pr_for_pipeline") as inner:
+            _maybe_open_base_pr_for_plan_to_implement(
+                issue_pipeline,
+                spawner,
+                tmp_path,
+                gateway_mode="public",
+                source="advance_phase_rest",
+            )
+        inner.assert_called_once()
+        kwargs = inner.call_args.kwargs
+        assert kwargs["source"] == "advance_phase_rest"
+        assert kwargs["gateway_mode"] == "public"
+
+
+class TestSwallowExceptions:
+    def test_inner_exception_is_logged_and_swallowed(
+        self,
+        tmp_path,
+        issue_pipeline,
+        spawner,
+        caplog,
+        propagate_orchestrator_logs,
+    ):
+        """A transient infra problem inside the hook must not strand the
+        plan→implement transition.  The wrapper logs the error and
+        returns normally."""
+        with (
+            patch.object(_pipelines_mod, "_open_context_pr_for_pipeline") as inner,
+            caplog.at_level(logging.WARNING),
+        ):
+            inner.side_effect = RuntimeError("gateway down")
+            # Must not raise.
+            _maybe_open_base_pr_for_plan_to_implement(
+                issue_pipeline,
+                spawner,
+                tmp_path,
+                source="implement_entry_backstop",
+            )
+        # The structured log message survives the swallow.
+        assert any(
+            "Context PR hook raised at plan→implement transition" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# "Hook entered" log line on every invocation
+# ---------------------------------------------------------------------------
+
+
+class TestHookEnteredLog:
+    def test_log_line_emitted_on_idempotent_skip(
+        self,
+        tmp_path,
+        issue_pipeline,
+        spawner,
+        caplog,
+        propagate_orchestrator_logs,
+    ):
+        """The "hook entered" line must be emitted even when the inner
+        function short-circuits — that's the whole point of the gap
+        detector added in #2593.  Use a contract whose
+        ``context_pr_number`` is already set so the inner short-circuits
+        cleanly without touching the gateway."""
+        from egg_contracts.models import (
+            Contract,
+            IssueInfo,
+            PRMetadata,
+        )
+        from egg_contracts.models import (
+            PipelinePhase as ContractPhase,
+        )
+
+        contract = Contract(
+            issue=IssueInfo(number=2593, title="t", url=""),
+            pipeline_id="issue-2593",
+            current_phase=ContractPhase.PLAN,
+            pr=PRMetadata(
+                title="t",
+                context_branch="egg/issue-2593/context",
+                context_pr_number=42,
+            ),
+        )
+
+        def _fake_load(identifier, repo_root):
+            return contract
+
+        with (
+            patch("egg_contracts.loader.load_contract", _fake_load),
+            caplog.at_level(logging.INFO),
+        ):
+            _maybe_open_base_pr_for_plan_to_implement(
+                issue_pipeline,
+                spawner,
+                tmp_path,
+                source="run_pipeline_autoadvance",
+            )
+
+        # Look for the structured "Context PR hook entered" log message.
+        # egg_logging emits structured records; either the message or a
+        # source key on the record will carry the marker.
+        entered = [rec for rec in caplog.records if "Context PR hook entered" in rec.getMessage()]
+        assert entered, "expected a 'Context PR hook entered' log line"
+
+
+# ---------------------------------------------------------------------------
+# Message-bus emission when hook fails to open a PR
+# ---------------------------------------------------------------------------
+
+
+class TestMessageBusEmission:
+    def test_emits_context_pr_failed_on_inner_exception(self, tmp_path, issue_pipeline, spawner):
+        """When the hook raises (gateway down etc.), and the pipeline
+        still has no ``context_pr_number`` afterwards, surface that on
+        the message bus so operators using ``wait-status`` see it."""
+        reports: list[tuple[str | None, str | None]] = []
+
+        def _fake_report(pipeline, event_type=None, message=None):
+            reports.append((event_type, message))
+
+        # Simulate "post-hook contract still has no context PR number".
+        from egg_contracts.models import (
+            Contract,
+            IssueInfo,
+            PRMetadata,
+        )
+        from egg_contracts.models import (
+            PipelinePhase as ContractPhase,
+        )
+
+        contract = Contract(
+            issue=IssueInfo(number=2593, title="t", url=""),
+            pipeline_id="issue-2593",
+            current_phase=ContractPhase.PLAN,
+            pr=PRMetadata(title="t"),  # context_pr_number left as None
+        )
+
+        def _fake_load(identifier, repo_root):
+            return contract
+
+        with (
+            patch.object(_pipelines_mod, "_open_context_pr_for_pipeline") as inner,
+            patch.object(_pipelines_mod, "report_pipeline_status", _fake_report),
+            patch("egg_contracts.loader.load_contract", _fake_load),
+        ):
+            inner.side_effect = RuntimeError("gateway down")
+            _maybe_open_base_pr_for_plan_to_implement(
+                issue_pipeline,
+                spawner,
+                tmp_path,
+                source="advance_phase_rest",
+            )
+
+        failed_events = [r for r in reports if r[0] == "context_pr.failed"]
+        assert failed_events, (
+            f"expected a context_pr.failed status message on inner exception; got {reports!r}"
+        )
+        # The status message should include the source so the operator
+        # can tell which transition path missed it.
+        assert "advance_phase_rest" in (failed_events[0][1] or "")
+
+    def test_emits_context_pr_skipped_on_silent_short_circuit(
+        self, tmp_path, issue_pipeline, spawner
+    ):
+        """When the inner hook short-circuits silently (e.g. contract.pr
+        missing) and the contract still has no context_pr_number, emit
+        ``context_pr.skipped`` so the operator knows nothing was
+        opened."""
+        reports: list[tuple[str | None, str | None]] = []
+
+        def _fake_report(pipeline, event_type=None, message=None):
+            reports.append((event_type, message))
+
+        from egg_contracts.models import Contract, IssueInfo
+        from egg_contracts.models import (
+            PipelinePhase as ContractPhase,
+        )
+
+        contract = Contract(
+            issue=IssueInfo(number=2593, title="t", url=""),
+            pipeline_id="issue-2593",
+            current_phase=ContractPhase.PLAN,
+            pr=None,
+        )
+
+        def _fake_load(identifier, repo_root):
+            return contract
+
+        with (
+            patch.object(_pipelines_mod, "_open_context_pr_for_pipeline") as inner,
+            patch.object(_pipelines_mod, "report_pipeline_status", _fake_report),
+            patch("egg_contracts.loader.load_contract", _fake_load),
+        ):
+            # Inner returns None silently (no exception).
+            inner.return_value = None
+            _maybe_open_base_pr_for_plan_to_implement(
+                issue_pipeline,
+                spawner,
+                tmp_path,
+                source="hitl_resume",
+            )
+
+        skipped_events = [r for r in reports if r[0] == "context_pr.skipped"]
+        assert skipped_events, (
+            "expected a context_pr.skipped status message when inner "
+            "returned without opening a PR; "
+            f"got {reports!r}"
+        )
+        assert "hitl_resume" in (skipped_events[0][1] or "")
+
+    def test_does_not_emit_for_local_mode_pipeline(self, tmp_path, issue_pipeline, spawner):
+        """A pipeline without a remote (``pipeline.repo is None``) is
+        local-mode by configuration — it can't have a PR and should not
+        appear on the bus as a failure.  The wrapper must skip the
+        emission entirely for these."""
+        reports: list = []
+
+        def _fake_report(pipeline, event_type=None, message=None):
+            reports.append((event_type, message))
+
+        issue_pipeline.repo = None
+        with (
+            patch.object(_pipelines_mod, "_open_context_pr_for_pipeline") as inner,
+            patch.object(_pipelines_mod, "report_pipeline_status", _fake_report),
+        ):
+            inner.return_value = None
+            _maybe_open_base_pr_for_plan_to_implement(
+                issue_pipeline,
+                spawner,
+                tmp_path,
+                source="run_pipeline_autoadvance",
+            )
+        assert reports == [], "must not emit context_pr.* on local-mode pipelines (no remote)"
+
+
+# ---------------------------------------------------------------------------
+# Call-site wiring: the four transition paths route through the helper
+# ---------------------------------------------------------------------------
+
+
+class TestCallSiteWiring:
+    """Static / textual assertions that each known transition path
+    routes through ``_maybe_open_base_pr_for_plan_to_implement`` and
+    passes a recognised ``source`` value.  These guard against future
+    refactors silently breaking the wiring (regression class for
+    #2593)."""
+
+    def test_run_pipeline_autoadvance_source_present(self):
+        src = (_orchestrator_path / "routes" / "pipelines.py").read_text()
+        assert 'source="run_pipeline_autoadvance"' in src
+
+    def test_implement_entry_backstop_source_present(self):
+        src = (_orchestrator_path / "routes" / "pipelines.py").read_text()
+        assert 'source="implement_entry_backstop"' in src
+
+    def test_hitl_resume_source_present(self):
+        src = (_orchestrator_path / "routes" / "pipelines.py").read_text()
+        assert 'source="hitl_resume"' in src
+
+    def test_advance_phase_rest_source_present(self):
+        src = (_orchestrator_path / "routes" / "phases.py").read_text()
+        assert 'source="advance_phase_rest"' in src
+
+    def test_helper_called_from_all_four_sites(self):
+        """Belt-and-suspenders: count call sites of the helper across
+        both files.  Exactly four expected (run_pipeline auto-advance,
+        implement-entry backstop, HITL resume in pipelines.py, plus
+        advance_phase in phases.py).  An accidental refactor that
+        drops one will trip this."""
+        pl_src = (_orchestrator_path / "routes" / "pipelines.py").read_text()
+        ph_src = (_orchestrator_path / "routes" / "phases.py").read_text()
+        # Count call-site invocations, not the definition line.
+        pl_calls = pl_src.count("_maybe_open_base_pr_for_plan_to_implement(")
+        ph_calls = ph_src.count("_maybe_open_base_pr_for_plan_to_implement(")
+        # pipelines.py has 1 (definition) + 3 (autoadvance, backstop,
+        # HITL) = 4 occurrences of the bare name.
+        # phases.py has 1 (advance_phase REST handler).
+        assert pl_calls == 4, (
+            f"expected 4 occurrences of "
+            f"_maybe_open_base_pr_for_plan_to_implement( in pipelines.py "
+            f"(1 def + 3 call sites), got {pl_calls}"
+        )
+        assert ph_calls == 1, (
+            f"expected 1 occurrence of "
+            f"_maybe_open_base_pr_for_plan_to_implement( in phases.py "
+            f"(advance_phase REST call site), got {ph_calls}"
+        )

--- a/orchestrator/tests/test_pipelines_api.py
+++ b/orchestrator/tests/test_pipelines_api.py
@@ -1260,3 +1260,32 @@ class TestRuntimeStateLeakageOnBranchReuse:
         assert get_peer_consensus_tracker(pipeline_id) is None
         assert evaluator.get_state(pipeline_id)["agents"] == {}
         assert store.get_status(pipeline_id)["total"] == 0
+
+    def test_clear_runtime_state_evicts_context_pr_dedupe(self):
+        """#2599 review 2 item 1 — dedupe set keyed on pipeline_id alone
+        is per-lifecycle, not per-id.  Without eviction at the same
+        terminal-state hook the other backends use, a pipeline id reused
+        across runs inherits the prior run's emitted-event set and the
+        new run's failure goes unreported on the message bus.
+        """
+        from routes.pipelines import (
+            _clear_pipeline_runtime_state,
+            _context_pr_events_emitted,
+            _context_pr_events_emitted_lock,
+        )
+
+        pipeline_id = "issue-2599-test"
+        # Defensive: clear any leftover state from a prior test run
+        with _context_pr_events_emitted_lock:
+            _context_pr_events_emitted.pop(pipeline_id, None)
+
+        # Seed dedupe state — simulate a prior failed context-PR open
+        with _context_pr_events_emitted_lock:
+            _context_pr_events_emitted[pipeline_id] = {"context_pr.failed"}
+        assert pipeline_id in _context_pr_events_emitted
+
+        _clear_pipeline_runtime_state(pipeline_id, reason="test")
+
+        # Stale set would otherwise silently suppress a fresh pipeline's
+        # ``context_pr.failed`` emission.
+        assert pipeline_id not in _context_pr_events_emitted


### PR DESCRIPTION
## Summary

The context PR (#2548) is the structural base PR for the slice stack — slice-1 stacks on `egg/<pipeline>/context`, every later slice on its parent, and only the context PR merges into main/deploy. When the hook fails to open it, the slice stack has no path to the base branch.

#2548 wired `_open_context_pr_for_pipeline` into only the inline `_run_pipeline` auto-advance path. Operators clearing the plan gate via the `advance_phase` REST/MCP handler or the HITL-approval recovery in `start_pipeline` silently bypassed the hook — pipeline `issue-2474` hit exactly this: `contract.pr.context_branch` was null, slice-1's base resolver fell back to `pipeline_branch` (`/work`), and slice PRs landed on `/work` with no PR to `main`.

This PR routes every plan→implement transition through a shared helper and adds an implement-entry backstop so future transition paths inherit the hook automatically.

- Extract `_maybe_open_base_pr_for_plan_to_implement` wrapper that owns the CUSTOM-mode guard, swallow-all-exceptions semantics, and a `source` kwarg for logging.
- Wire the wrapper into `advance_phase` REST (`routes/phases.py`), the HITL-approval recovery in `start_pipeline` (also adds the missing `_populate_contract_from_plan_safe` call on that path so `contract.pr` is populated before the hook fires), and an implement-entry backstop at the top of the IMPLEMENT phase handler. The inner `context_pr_number` short-circuit keeps multiple invocations safe.
- Emit a single `Context PR hook entered` log line at the top of `_open_context_pr_for_pipeline`, before any short-circuit, so the gap is detectable in logs without grepping per-short-circuit strings.
- When the hook returns without opening a PR on a pipeline that should have one (has a remote + `base_branch` but no `context_pr_number` afterwards), emit a `context_pr.skipped` or `context_pr.failed` message on the pipeline message bus so operators using `wait-status` / `get_status` see it without grepping orchestrator logs.

## Test plan

- [x] `make lint` (clean — only pre-existing soft-cap warnings)
- [x] `make test` — 17,236 passed, 41 skipped
- [x] New `orchestrator/tests/test_context_pr_transition_paths.py` (12 tests) covers: CUSTOM-mode skip, source-kwarg propagation, exception swallow, "hook entered" log line on idempotent skip, message-bus `context_pr.skipped` / `context_pr.failed` emission, no emission for local-mode pipelines, and textual checks that the helper is called from all four expected sites (auto-advance, `advance_phase` REST, HITL resume, implement-entry backstop).
- [x] Existing `test_context_pr.py` regression checks updated to assert the wrapper-level shape since the per-call-site guard moved into the wrapper. All 45 prior tests still pass.

## Notes

- The in-flight `issue-2474` pipeline is **not** unstuck by this change — the operator should manually `gh pr create --base main --head egg/issue-2474/work` (or `/context` once one exists) to give the existing slice stack a path to main.
- Adjacent observations on the same pipeline filed as #2584 and #2585 are out of scope here.

Closes #2593.