### PR TITLE
docs: instruct SDLC skill to TaskStop prior Monitor before HITL re-arm

### DIFF
--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -3,7 +3,7 @@ name: sdlc
 description: "Run an egg SDLC pipeline: full lifecycle (default) or lightweight coder+reviewer with --short."
 disable-model-invocation: true
 argument-hint: "[--short] [--qualifier <name>] [JIRA-1234 or issue# or description] [--repo owner/name]"
-allowed-tools: Monitor Bash(skills/sdlc/bin/wait-status:*) Bash(gh issue view:*) Bash(gh issue list:*) Bash(gh pr list:*) Bash(gh pr view:*) Bash(git remote:*) Bash(git -C * remote:*) AskUserQuestion mcp__egg__submit_task mcp__egg__get_status mcp__egg__provide_input mcp__egg__list_tasks mcp__egg__cancel_task mcp__egg__check_health mcp__egg__list_containers mcp__egg__get_container_logs mcp__egg__send_message mcp__egg__get_consensus_status mcp__egg__get_phase mcp__egg__get_pipeline_snapshot mcp__egg__get_contract mcp__egg__list_checkpoints mcp__egg__search_checkpoints
+allowed-tools: Monitor TaskStop Bash(skills/sdlc/bin/wait-status:*) Bash(gh issue view:*) Bash(gh issue list:*) Bash(gh pr list:*) Bash(gh pr view:*) Bash(git remote:*) Bash(git -C * remote:*) AskUserQuestion mcp__egg__submit_task mcp__egg__get_status mcp__egg__provide_input mcp__egg__list_tasks mcp__egg__cancel_task mcp__egg__check_health mcp__egg__list_containers mcp__egg__get_container_logs mcp__egg__send_message mcp__egg__get_consensus_status mcp__egg__get_phase mcp__egg__get_pipeline_snapshot mcp__egg__get_contract mcp__egg__list_checkpoints mcp__egg__search_checkpoints
 ---
 
 # SDLC Pipeline
@@ -330,6 +330,8 @@ Drive the pipeline through one Monitor invocation per quiet stretch. On entry:
 
    Keep the escaped quotes around `<last_cursor>` — the cursor is shaped `msg:<id>|evt:<seq>` and the literal `|` is shell-significant; without quoting the shell would treat it as a pipe.
 
+   **Cache the Monitor's task_id as `monitor_task_id` in conversation context.** You'll need it to call `TaskStop` before re-arming a new Monitor after HITL (see [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first) below) — `wait-status` does not exit on `decision.created`, so without an explicit stop the prior CLI keeps polling in parallel and double-emits the next event.
+
    The launcher wraps `sandbox/bin/egg-orch pipeline wait-status`, setting `PYTHONPATH` and `EGG_ORCHESTRATOR_URL` so no host-side configuration is required beyond `make deps`. It loops the orchestrator's `/status/wait` route server-side, threading the cursor between calls. Stdout is **JSON-lines** — one line per pipeline-relevant event, surfaced to the LLM as one notification per line. The CLI is silent on `no_change`, so the LLM only wakes when something happened. Exit codes (Monitor reports them as the watch's exit code):
 
    | Exit code | Meaning | Skill action |
@@ -407,6 +409,12 @@ Drive the pipeline through one Monitor invocation per quiet stretch. On entry:
 8. **Track elapsed time** using each line's `phase_elapsed_seconds` (server-computed). Fall back to local wall-clock only when this field is absent (phase boundaries, pending phases). Used for [Long-Running Phase Detection](#long-running-phase-detection).
 
 **Important: `wait-status` blocks server-side and emits events as they arrive. Do NOT wrap the Monitor invocation in an outer `for`-loop or `sleep` — the CLI is already the loop, server-side, and Monitor surfaces each emitted line as its own notification. The skill's liveness guarantee comes from the CLI re-issuing the route call with the threaded cursor on every Path-B no-change return; intra-process loop, no LLM turn.** When Monitor's `timeout_ms` (or the Bash 10-min cap, if you're on the fallback path) forces the CLI to terminate, simply re-invoke with the latest `last_cursor` from your conversation context. The overseer is the primary deadlock detector and emits `OVERSEER_ALERT` on stalls, which is in the trigger allowlist. See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the full event allowlist, exit-code contract, and concurrency model.
+
+#### HITL-driven re-arms: stop the prior Monitor first
+
+The exit-code re-arms above (`timeout`, exit code `2`, auto-stopped) are safe to re-invoke without ceremony — the prior CLI has already terminated. **HITL-driven re-arms are different.** When `wait-status` emits `decision.created`, the CLI does not exit — it just yields the JSON line and keeps polling for the next allowed trigger (`decision.resolved` is deliberately off the allowlist, so submitting `provide_input` doesn't wake or terminate it either). If you re-invoke Monitor after HITL without first stopping the prior one, two `wait-status` processes will poll the same `task_id` concurrently, each advancing its own in-process cursor — and both will emit the next allowed event, producing duplicate notifications to the LLM.
+
+**Rule:** before re-arming Monitor after handling HITL, call `TaskStop(task_id=monitor_task_id)` on the cached id from step 2, then start the new Monitor and overwrite `monitor_task_id` with the new id.
 
 Path A keeps the dashboard concise via deltas — skip lines that didn't change from the previous emit. Path B always renders full state, including the optional NACK and silent-agent rows.
 
@@ -862,7 +870,7 @@ The full status snapshot from `get_status` enriches phase_gate decisions with `d
      {"action": "request_changes", "feedback": "<user's text>", "context": "<resolved questions from 7a, or omit>"}
      ```
 
-After resolving this decision, move to the next pending decision (if any) before resuming monitoring. **On `approve`**, resume monitoring — do not announce the next phase has started yet. If the phase had deferred choice/feedback decisions, the pipeline stays in `awaiting_human` and Wave 2 surfaces them (see [Two-wave surfacing](#two-wave-surfacing)); tell the user: "Approved. The phase's deferred decisions will surface next." If no deferred decisions exist, the pipeline transitions to the next phase normally — you will see the phase change on the next emitted `wait-status` JSON-line.
+After resolving this decision, move to the next pending decision (if any) before resuming monitoring. **On `approve`**, resume monitoring — do not announce the next phase has started yet. If the phase had deferred choice/feedback decisions, the pipeline stays in `awaiting_human` and Wave 2 surfaces them (see [Two-wave surfacing](#two-wave-surfacing)); tell the user: "Approved. The phase's deferred decisions will surface next." If no deferred decisions exist, the pipeline transitions to the next phase normally — you will see the phase change on the next emitted `wait-status` JSON-line. **Before invoking the next Monitor, call `TaskStop(task_id=monitor_task_id)` on the cached id from Phase 3 step 2** — see [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first).
 
 ### For `choice` type decisions:
 
@@ -956,7 +964,7 @@ Arguments:
 
 **Important**: The `response` parameter is a string. Serialize the JSON payload to a string before passing it (e.g., `response: '{"action": "select", "selected": "Option A"}'`).
 
-Confirm the input was submitted, then proceed to the next pending decision. Once all decisions are resolved, resume monitoring (Phase 3).
+Confirm the input was submitted, then proceed to the next pending decision. Once all decisions are resolved, resume monitoring (Phase 3). **Before invoking the next Monitor, call `TaskStop(task_id=monitor_task_id)` on the cached id from Phase 3 step 2** — see [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first).
 
 ## Phase 5 — Complete
 
@@ -1357,6 +1365,8 @@ Drive the pipeline through one Monitor invocation per quiet stretch. On entry:
 
    Keep the escaped quotes around `<last_cursor>` — the cursor is shaped `msg:<id>|evt:<seq>` and the literal `|` is shell-significant; without quoting the shell would treat it as a pipe.
 
+   **Cache the Monitor's task_id as `monitor_task_id` in conversation context** — needed for `TaskStop` before re-arming after handling a decision (see [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first) in Phase 3; the same rule applies to the unexpected-decisions path below).
+
    The launcher wraps `sandbox/bin/egg-orch pipeline wait-status` and loops `/status/wait` server-side, threading the cursor between calls. Stdout is **JSON-lines** — one line per pipeline-relevant event, silent on `no_change`, surfaced as one notification per line. Exit codes:
 
    | Exit code | Meaning | Skill action |
@@ -1403,7 +1413,7 @@ Drive the pipeline through one Monitor invocation per quiet stretch. On entry:
 
 Path A keeps the dashboard concise via deltas — skip lines that didn't change from the previous emit. Path B always renders full state, including the optional NACK and silent-agent rows.
 
-**Important: `wait-status` blocks server-side and emits events as they arrive. Do NOT wrap the Monitor invocation in an outer `for`-loop or `sleep` — the CLI is already the loop, server-side, and Monitor surfaces each emitted line as its own notification. The skill's liveness guarantee comes from the CLI re-issuing the route call with the threaded cursor on every Path-B no-change return; intra-process loop, no LLM turn.** When Monitor's `timeout_ms` (or the 10-min Bash cap, if you're on the fallback path) forces the CLI to terminate, simply re-invoke with the latest `last_cursor` from your conversation context. See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the event allowlist, exit-code contract, and concurrency model.
+**Important: `wait-status` blocks server-side and emits events as they arrive. Do NOT wrap the Monitor invocation in an outer `for`-loop or `sleep` — the CLI is already the loop, server-side, and Monitor surfaces each emitted line as its own notification. The skill's liveness guarantee comes from the CLI re-issuing the route call with the threaded cursor on every Path-B no-change return; intra-process loop, no LLM turn.** When Monitor's `timeout_ms` (or the 10-min Bash cap, if you're on the fallback path) forces the CLI to terminate, simply re-invoke with the latest `last_cursor` from your conversation context. HITL-driven re-arms are different — the prior CLI is still alive — so call `TaskStop(task_id=monitor_task_id)` first; see [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first) in Phase 3. See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the event allowlist, exit-code contract, and concurrency model.
 
 ### Failed Status Grace Period
 
@@ -1451,7 +1461,7 @@ With `hitl_gates: false`, decisions should not appear. But if they do, handle th
 - For `feedback` type: present the questions, collect answers, then call `provide_input` with `{"action": "submit_feedback", "answers": {"<id>": "<answer>"}}` serialized as a JSON string.
 - For `phase_gate` type: auto-approve by calling `provide_input` with `{"action": "approve"}` serialized as a JSON string. Log the phase and decision ID, and inform the user.
 
-After resolving any decisions, resume monitoring.
+After resolving any decisions, resume monitoring. **Before invoking the next Monitor, call `TaskStop(task_id=monitor_task_id)` on the cached id from Phase S5 step 2** — see [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first) in Phase 3.
 
 ## Phase S6 — Complete
 

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -416,8 +416,6 @@ The exit-code re-arms above (`timeout`, exit code `2`, auto-stopped) are safe to
 
 **Rule:** before re-arming Monitor after handling HITL, call `TaskStop(task_id=monitor_task_id)` on the cached id from step 2, then start the new Monitor and overwrite `monitor_task_id` with the new id.
 
-Path A keeps the dashboard concise via deltas — skip lines that didn't change from the previous emit. Path B always renders full state, including the optional NACK and silent-agent rows.
-
 ### Failed Status Grace Period
 
 During phase cycle transitions (e.g., plan phase review cycles), the orchestrator may briefly report `status: failed` while spawning new containers. Treating this as terminal prematurely ends monitoring.
@@ -1410,8 +1408,6 @@ Drive the pipeline through one Monitor invocation per quiet stretch. On entry:
    - On `event_type: "decision.created"` → re-fetch the full snapshot via `get_status(task_id)` (the JSON-line does not carry `pending_decisions`) and handle the decision inline (see below).
    - On `status: "complete"` or `event_type: "pipeline.completed"` → exit, move to Phase S6.
    - On `status: "failed"` or `event_type: "pipeline.failed"` → apply the **failed status grace period** (see below) before exiting.
-
-Path A keeps the dashboard concise via deltas — skip lines that didn't change from the previous emit. Path B always renders full state, including the optional NACK and silent-agent rows.
 
 **Important: `wait-status` blocks server-side and emits events as they arrive. Do NOT wrap the Monitor invocation in an outer `for`-loop or `sleep` — the CLI is already the loop, server-side, and Monitor surfaces each emitted line as its own notification. The skill's liveness guarantee comes from the CLI re-issuing the route call with the threaded cursor on every Path-B no-change return; intra-process loop, no LLM turn.** When Monitor's `timeout_ms` (or the 10-min Bash cap, if you're on the fallback path) forces the CLI to terminate, simply re-invoke with the latest `last_cursor` from your conversation context. HITL-driven re-arms are different — the prior CLI is still alive — so call `TaskStop(task_id=monitor_task_id)` first; see [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first) in Phase 3. See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the event allowlist, exit-code contract, and concurrency model.
 

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -330,7 +330,7 @@ Drive the pipeline through one Monitor invocation per quiet stretch. On entry:
 
    Keep the escaped quotes around `<last_cursor>` — the cursor is shaped `msg:<id>|evt:<seq>` and the literal `|` is shell-significant; without quoting the shell would treat it as a pipe.
 
-   **Cache the Monitor's task_id as `monitor_task_id` in conversation context.** You'll need it to call `TaskStop` before re-arming a new Monitor after HITL (see [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first) below) — `wait-status` does not exit on `decision.created`, so without an explicit stop the prior CLI keeps polling in parallel and double-emits the next event.
+   **Cache the Monitor's task_id as `monitor_task_id` in conversation context** (returned in the Monitor tool's invocation response). You'll need it to call `TaskStop` before re-arming a new Monitor after HITL (see [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first) below) — `wait-status` does not exit on `decision.created`, so without an explicit stop the prior CLI keeps polling in parallel and double-emits the next event.
 
    The launcher wraps `sandbox/bin/egg-orch pipeline wait-status`, setting `PYTHONPATH` and `EGG_ORCHESTRATOR_URL` so no host-side configuration is required beyond `make deps`. It loops the orchestrator's `/status/wait` route server-side, threading the cursor between calls. Stdout is **JSON-lines** — one line per pipeline-relevant event, surfaced to the LLM as one notification per line. The CLI is silent on `no_change`, so the LLM only wakes when something happened. Exit codes (Monitor reports them as the watch's exit code):
 
@@ -410,7 +410,7 @@ Drive the pipeline through one Monitor invocation per quiet stretch. On entry:
 
 **Important: `wait-status` blocks server-side and emits events as they arrive. Do NOT wrap the Monitor invocation in an outer `for`-loop or `sleep` — the CLI is already the loop, server-side, and Monitor surfaces each emitted line as its own notification. The skill's liveness guarantee comes from the CLI re-issuing the route call with the threaded cursor on every Path-B no-change return; intra-process loop, no LLM turn.** When Monitor's `timeout_ms` (or the Bash 10-min cap, if you're on the fallback path) forces the CLI to terminate, simply re-invoke with the latest `last_cursor` from your conversation context. The overseer is the primary deadlock detector and emits `OVERSEER_ALERT` on stalls, which is in the trigger allowlist. See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the full event allowlist, exit-code contract, and concurrency model.
 
-#### HITL-driven re-arms: stop the prior Monitor first
+### HITL-driven re-arms: stop the prior Monitor first
 
 The exit-code re-arms above (`timeout`, exit code `2`, auto-stopped) are safe to re-invoke without ceremony — the prior CLI has already terminated. **HITL-driven re-arms are different.** When `wait-status` emits `decision.created`, the CLI does not exit — it just yields the JSON line and keeps polling for the next allowed trigger (`decision.resolved` is deliberately off the allowlist, so submitting `provide_input` doesn't wake or terminate it either). If you re-invoke Monitor after HITL without first stopping the prior one, two `wait-status` processes will poll the same `task_id` concurrently, each advancing its own in-process cursor — and both will emit the next allowed event, producing duplicate notifications to the LLM.
 
@@ -870,7 +870,7 @@ The full status snapshot from `get_status` enriches phase_gate decisions with `d
      {"action": "request_changes", "feedback": "<user's text>", "context": "<resolved questions from 7a, or omit>"}
      ```
 
-After resolving this decision, move to the next pending decision (if any) before resuming monitoring. **On `approve`**, resume monitoring — do not announce the next phase has started yet. If the phase had deferred choice/feedback decisions, the pipeline stays in `awaiting_human` and Wave 2 surfaces them (see [Two-wave surfacing](#two-wave-surfacing)); tell the user: "Approved. The phase's deferred decisions will surface next." If no deferred decisions exist, the pipeline transitions to the next phase normally — you will see the phase change on the next emitted `wait-status` JSON-line. **Before invoking the next Monitor, call `TaskStop(task_id=monitor_task_id)` on the cached id from Phase 3 step 2** — see [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first).
+After resolving this decision, move to the next pending decision (if any) before resuming monitoring. **On `approve`**, resume monitoring — do not announce the next phase has started yet. If the phase had deferred choice/feedback decisions, the pipeline stays in `awaiting_human` and Wave 2 surfaces them (see [Two-wave surfacing](#two-wave-surfacing)); tell the user: "Approved. The phase's deferred decisions will surface next." If no deferred decisions exist, the pipeline transitions to the next phase normally — you will see the phase change on the next emitted `wait-status` JSON-line. **Once all pending decisions are resolved and you are about to invoke the next Monitor, call `TaskStop(task_id=monitor_task_id)` on the cached id from Phase 3 step 2** — see [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first). Do this once, before the re-arm — not after each intermediate approve in a multi-decision batch.
 
 ### For `choice` type decisions:
 
@@ -1365,7 +1365,7 @@ Drive the pipeline through one Monitor invocation per quiet stretch. On entry:
 
    Keep the escaped quotes around `<last_cursor>` — the cursor is shaped `msg:<id>|evt:<seq>` and the literal `|` is shell-significant; without quoting the shell would treat it as a pipe.
 
-   **Cache the Monitor's task_id as `monitor_task_id` in conversation context** — needed for `TaskStop` before re-arming after handling a decision (see [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first) in Phase 3; the same rule applies to the unexpected-decisions path below).
+   **Cache the Monitor's task_id as `monitor_task_id` in conversation context** (returned in the Monitor tool's invocation response) — needed for `TaskStop` before re-arming after handling a decision (see [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first) in Phase 3; the same rule applies to the unexpected-decisions path below).
 
    The launcher wraps `sandbox/bin/egg-orch pipeline wait-status` and loops `/status/wait` server-side, threading the cursor between calls. Stdout is **JSON-lines** — one line per pipeline-relevant event, silent on `no_change`, surfaced as one notification per line. Exit codes:
 


### PR DESCRIPTION
## Summary

- `wait-status` does not exit on `decision.created` — it yields the JSON line and keeps polling. `decision.resolved` is deliberately off the trigger allowlist, so submitting `provide_input` doesn't terminate it either. Re-arming Monitor after HITL leaves the prior CLI alive, both processes advance their own in-process cursors, and both emit the next allowed event — duplicate notification to the LLM (observed on #1557's pipeline; see #2613).
- Docs-only fix in `skills/sdlc/SKILL.md`:
  - Add `TaskStop` to `allowed-tools`.
  - Instruct the operator to cache the Monitor's `task_id` as `monitor_task_id` in Phase 3 step 2 (and Phase S5 step 2).
  - Add a new `HITL-driven re-arms: stop the prior Monitor first` subsection in Phase 3 with the rule and the reason.
  - Insert one-sentence reminders at the three "resume monitoring" sites (Phase 3 post-`approve`, Phase 3 post-decision-resolution, Phase S5 post-decision).
  - Clarify in both `Important: wait-status blocks...` paragraphs that timeout/auto-stop re-arms are safe (CLI is dead) but HITL re-arms need the explicit `TaskStop`.
- No code changes — wait-status, the orchestrator, and the Monitor tool are unchanged. Auto-stopping prior Monitors with the same description and server-side `wait-status` dedup are explicitly out of scope per the issue.

Closes #2613.

## Test plan

- [ ] Skim the rendered diff on GitHub: anchor `#hitl-driven-re-arms-stop-the-prior-monitor-first` resolves; no broken cross-references from Phase S5 or from the two in-line "see [HITL-driven re-arms]" mentions.
- [ ] Next live SDLC run that traverses a HITL gate: operator captures `monitor_task_id`, calls `TaskStop` before re-arming, no duplicate event lines observed for the post-HITL phase transition.