### PR TITLE
Fix `make build`: invoke prepare-sandbox-build-context.py via venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -458,9 +458,9 @@ lint-yaml-fix: sync-venv-if-uv
 # Build
 # ============================================================================
 
-build:
+build: sync-venv-if-uv
 	@echo "==> Preparing sandbox build context from repositories.yaml..."
-	@scripts/prepare-sandbox-build-context.py repo-deps
+	@$(PYTHON) scripts/prepare-sandbox-build-context.py repo-deps
 	@echo "==> Building images with tag $(EGG_IMAGE_TAG)..."
 	@echo "==> Building gateway container..."
 	docker build -t egg-gateway:latest -t egg-gateway:$(EGG_IMAGE_TAG) -f gateway/Dockerfile .


### PR DESCRIPTION
## Summary

`make build` was failing in the integration-tests CI job with:

```
==> Preparing sandbox build context from repositories.yaml...
Error: PyYAML is required. Install with: pip install pyyaml
make: *** [Makefile:463: build] Error 1
```

Observed on PR #2642 ([run 25752177721](https://github.com/jwbron/egg/actions/runs/25752177721/job/75631107879)).

## Root cause

`scripts/prepare-sandbox-build-context.py` has a `#!/usr/bin/env python3` shebang. The `build` recipe invoked it directly:

```make
@scripts/prepare-sandbox-build-context.py repo-deps
```

That resolves to system `python3`, which has no PyYAML — so `_load_repos_config()` aborts before any `docker build` runs. The `.github/workflows/test-integration.yml` job does `uv sync --extra dev` first, which populates `.venv/` with the project's pinned PyYAML, but `make build` bypassed it.

This is the same pattern other targets (`test`, `lint`, `security`) avoid by routing through `$(PYTHON)` (Makefile:21), which resolves to `.venv/bin/python` when the venv exists and falls back to `python3` otherwise.

## Fix

- Route the script through `$(PYTHON)` so the venv's interpreter (and pinned PyYAML) is used.
- Gate `build` on `sync-venv-if-uv` so a fresh worktree provisions `.venv` before the script runs — same prereq pattern as `test`/`lint`/`security`.

## Test plan

- [x] CI on this PR runs `make build` in the integration-tests job — it must reach the `docker build` steps (the failure mode was the script aborting before any image build).
- [ ] Manual: re-run failing job on #2642 once this lands (or rebase #2642 on top of this).