### PR TITLE
test(brc): add k3s-tier regression coverage for BRC consensus (#2635)

### DIFF
--- a/integration_tests/regression/_helpers.py
+++ b/integration_tests/regression/_helpers.py
@@ -1,0 +1,110 @@
+"""Module-level helpers for BRC regression tests (issue #2635).
+
+Lives next to ``conftest.py`` because pytest's conftest discovery does
+NOT make conftest's module-level symbols importable from sibling test
+modules — only fixtures (declared with ``@pytest.fixture``) are.
+Splitting plain helpers into their own module keeps both available
+without contorting them into fixtures.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+# Mirror conftest.py's path setup so this module can be imported
+# stand-alone (pytest collects conftest before test modules, but
+# IDEs / type-checkers don't).
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+for _p in (
+    _PROJECT_ROOT / "orchestrator",
+    _PROJECT_ROOT / "shared",
+    _PROJECT_ROOT,
+):
+    if _p.exists() and str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from events import Event, EventType  # noqa: E402
+from peer_consensus import (  # noqa: E402
+    PeerConsensusTracker,
+    create_peer_consensus_tracker,
+    remove_peer_consensus_tracker,
+)
+from review_graph import ReviewGraph  # noqa: E402
+
+
+def make_tracker(
+    pipeline_id: str,
+    graph: ReviewGraph,
+    *,
+    cooldown_seconds: int = 0,
+) -> PeerConsensusTracker:
+    """Build a tracker with all agents registered (cooldown=0 for tests).
+
+    Registers the tracker in the module-level registry via
+    ``create_peer_consensus_tracker`` so ``get_peer_consensus_tracker``
+    — the API consumed by ``_handle_brc_consensus_timeout`` and the
+    SSE bridge — finds it.  A direct ``PeerConsensusTracker(...)``
+    constructor call would be a registry-bypass and break the
+    timeout-handler test scenarios silently (the handler's
+    ``_brc_tracker = get_peer_consensus_tracker(...)`` returns
+    ``None`` and the alert paths short-circuit).
+    """
+    # Reset any tracker the previous test left under the same id —
+    # ``create_peer_consensus_tracker`` overwrites silently, but
+    # explicit removal also clears any per-agent state that survives
+    # across re-creation.
+    remove_peer_consensus_tracker(pipeline_id)
+    tracker = create_peer_consensus_tracker(pipeline_id, graph, cooldown_seconds=cooldown_seconds)
+    for role in graph.all_roles():
+        tracker.register_agent(role)
+    return tracker
+
+
+def propose_payload(
+    *,
+    artifacts: list[str] | None = None,
+    commit_sha: str = "abc1234",
+    summary: str = "test proposal",
+) -> dict[str, Any]:
+    """Minimal valid ``ProposalPayload`` dict (no attestation)."""
+    return {
+        "summary": summary,
+        "artifacts": list(artifacts or ["a.py"]),
+        "commit_sha": commit_sha,
+    }
+
+
+def ack_payload(*, artifacts: list[str] | None = None) -> dict[str, Any]:
+    """Minimal valid ``ReviewPayload`` ACK dict."""
+    return {"artifact_references": list(artifacts or ["a.py"])}
+
+
+def nack_payload(
+    *,
+    artifacts: list[str] | None = None,
+    reason: str = "regression in a.py:42",
+) -> dict[str, Any]:
+    """Minimal valid ``ReviewPayload`` NACK dict (reason is required)."""
+    return {
+        "artifact_references": list(artifacts or ["a.py"]),
+        "reason": reason,
+    }
+
+
+def filter_events(
+    events: list[Event],
+    *,
+    pipeline_id: str,
+    event_type: EventType | None = None,
+) -> list[Event]:
+    """Return events for ``pipeline_id`` (and optional ``event_type``)."""
+    out = [e for e in events if e.pipeline_id == pipeline_id]
+    if event_type is not None:
+        out = [e for e in out if e.event_type == event_type]
+    return out
+
+
+EventFilter = Callable[..., list[Event]]

--- a/integration_tests/regression/conftest.py
+++ b/integration_tests/regression/conftest.py
@@ -81,6 +81,13 @@ def event_capture() -> Generator[Callable[[], list[Event]]]:
     and returns a callable that yields only events appended since,
     isolating the test from events emitted by unrelated tests in the
     same session.
+
+    Note: ``get_history()`` is bounded by ``EventBus._max_history``
+    (default 100 — see ``orchestrator/events.py:154``).  All tests in
+    this folder stay well under that bound between fixture entry and
+    snapshot, but a future test that emits >100 events would lose its
+    earliest ones to history eviction; widen ``max_history`` on the
+    bus or capture more granularly if you anticipate larger volumes.
     """
     bus = get_event_bus()
     seq_before = bus.current_sequence()

--- a/integration_tests/regression/conftest.py
+++ b/integration_tests/regression/conftest.py
@@ -41,7 +41,30 @@ for _p in (
 import pytest  # noqa: E402
 from _helpers import EventFilter, filter_events  # noqa: E402
 from events import Event, get_event_bus  # noqa: E402
+from peer_consensus import _trackers as _global_trackers  # noqa: E402
+from peer_consensus import _trackers_lock as _global_trackers_lock  # noqa: E402
 from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_tracker_registry() -> Generator[None]:
+    """Snapshot + restore the global ``_trackers`` registry around each test.
+
+    ``create_peer_consensus_tracker`` stores trackers in a module-level
+    dict keyed by pipeline_id.  Without cleanup these survive across
+    tests and a later test's ``get_peer_consensus_tracker(same_id)``
+    can find leftover state from a previous test (the surfaced gap
+    in #2635 PR review).  Snapshot+restore is safer than ``clear()``
+    in case a parent test suite seeded trackers we shouldn't remove.
+    """
+    with _global_trackers_lock:
+        snapshot = dict(_global_trackers)
+    try:
+        yield
+    finally:
+        with _global_trackers_lock:
+            _global_trackers.clear()
+            _global_trackers.update(snapshot)
 
 
 @pytest.fixture

--- a/integration_tests/regression/conftest.py
+++ b/integration_tests/regression/conftest.py
@@ -1,0 +1,110 @@
+"""Shared fixtures for BRC consensus regression tests (issue #2635).
+
+The regression tier covers behaviours that have been hand-rolled into
+postmortems — BRC single-cycle, phase-aware timeouts, NACK round-trip,
+reviewer disagreement, etc.  Tests live here (not under
+``orchestrator/tests/``) because they exercise the orchestrator's
+Python API at the integration boundary — the same shape #2474
+recommends after the ScriptedProvider pod-injection avenue was ruled
+out (the constraint write-up referenced from issue #2635).
+
+Tests in this folder are marked ``integration`` so they run under
+``make test-integration`` alongside the k3s tier, but they do NOT
+require k3s and never call into the ``egg_stack`` fixture — they
+drive ``PeerConsensusTracker`` and the timeout-handler entry points
+in-process against real implementations.
+
+Plain helper functions (``make_tracker``, ``propose_payload``,
+``filter_events``) live in ``_helpers.py``; pytest's conftest
+discovery only surfaces fixtures cross-module.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Generator
+from pathlib import Path
+
+# Make sibling ``_helpers.py`` and the orchestrator/shared trees
+# importable before any conftest-level imports below land.
+_REGRESSION_DIR = Path(__file__).resolve().parent
+_PROJECT_ROOT = _REGRESSION_DIR.parent.parent
+for _p in (
+    _REGRESSION_DIR,
+    _PROJECT_ROOT / "orchestrator",
+    _PROJECT_ROOT / "shared",
+    _PROJECT_ROOT,
+):
+    if _p.exists() and str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import pytest  # noqa: E402
+from _helpers import EventFilter, filter_events  # noqa: E402
+from events import Event, get_event_bus  # noqa: E402
+from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph  # noqa: E402
+
+
+@pytest.fixture
+def event_capture() -> Generator[Callable[[], list[Event]]]:
+    """Snapshot events published after the fixture is acquired.
+
+    The orchestrator's event bus runs with ``async_delivery=True``,
+    so handlers are dispatched on a worker thread — subscribing and
+    immediately reading the buffer races the delivery loop and is
+    flaky.  ``get_history()`` is updated **synchronously** inside the
+    publish path's lock, so reading it gives a deterministic snapshot.
+
+    The fixture captures the bus's sequence-tip before the test runs
+    and returns a callable that yields only events appended since,
+    isolating the test from events emitted by unrelated tests in the
+    same session.
+    """
+    bus = get_event_bus()
+    seq_before = bus.current_sequence()
+
+    def snapshot() -> list[Event]:
+        history = bus.get_history()  # newest first per the bus contract
+        # Restore publish order and filter to events emitted during this test.
+        return [e for e in reversed(history) if e.sequence > seq_before]
+
+    yield snapshot
+
+
+@pytest.fixture(name="filter_events")
+def filter_events_fixture() -> EventFilter:
+    """``filter_events`` as a fixture so tests can take it via injection.
+
+    Exposed under the bare name ``filter_events`` so tests read naturally
+    (``def test_x(self, event_capture, filter_events): ...``).  The
+    underlying helper is also importable from ``_helpers`` for sites
+    that don't want fixture injection.
+    """
+    return filter_events
+
+
+@pytest.fixture
+def single_reviewer_graph() -> ReviewGraph:
+    """1 producer, 1 critical reviewer — the minimal BRC topology."""
+    return ReviewGraph([ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL)])
+
+
+@pytest.fixture
+def two_reviewer_graph() -> ReviewGraph:
+    """1 producer, 2 critical reviewers — exercises disagreement paths."""
+    return ReviewGraph(
+        [
+            ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL),
+            ReviewEdge("reviewer_contract", "coder", ReviewCriticality.CRITICAL),
+        ]
+    )
+
+
+@pytest.fixture
+def advisory_blocker_graph() -> ReviewGraph:
+    """1 producer, 1 critical + 1 advisory reviewer — timeout-handler triage path."""
+    return ReviewGraph(
+        [
+            ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL),
+            ReviewEdge("reviewer_contract", "coder", ReviewCriticality.ADVISORY),
+        ]
+    )

--- a/integration_tests/regression/test_brc_concurrency.py
+++ b/integration_tests/regression/test_brc_concurrency.py
@@ -263,9 +263,9 @@ class TestWithdrawCooldownAndLockout:
         r1 = tracker.handle_withdraw("coder", reason="bug found")
         assert r1["status"] == "withdrawn"
 
-        # Cycle 2: propose → withdraw → counter=2, allowed (still < max=2 at peek time).
-        # Note: the peek is ``current + 1 >= max`` so with max=2 the second
-        # withdraw is the one that gets locked out.
+        # Cycle 2: propose → withdraw → peek=2, 2 >= max=2, locked out.
+        # The guard's peek is ``current + 1 >= max`` so with max=2 the
+        # second withdraw is the one that gets locked out.
         tracker.handle_propose("coder", propose_payload(commit_sha="def"))
         r2 = tracker.handle_withdraw("coder", reason="another bug")
         assert r2["status"] == "locked_out"

--- a/integration_tests/regression/test_brc_concurrency.py
+++ b/integration_tests/regression/test_brc_concurrency.py
@@ -1,0 +1,272 @@
+"""BRC concurrency invariants — issue #2635 follow-up coverage.
+
+The ``PeerConsensusTracker`` is designed for concurrent use — every
+mutating method holds ``self._lock`` (RLock) so producers and reviewers
+can call into the same tracker from different threads.  None of that
+serialisation was exercised before; the unit tier under
+``orchestrator/tests/`` is single-threaded.
+
+These tests drive the tracker from multiple Python threads to make
+sure:
+
+1. The lock genuinely serialises mutations — no torn state, no
+   duplicate ACK entries, every event reaches the bus.
+2. The open-NACK barrier (#2142) actually fires when two reviewers
+   race a NACK against the same proposal version.
+3. The withdraw cooldown + flip-flop lockout guards hold under
+   rapid re-tries.
+
+ScriptedProvider can't drive deployed agent pods (see #2474), so
+the tests exercise the BRC Python API directly.
+
+Threading note: BRC's lock is an ``RLock`` so a deadlock between
+``handle_propose`` and ``handle_ack`` is structurally impossible.
+The tests still use a ``threading.Barrier`` to give the threads
+roughly-simultaneous entry — that maximises the chance of catching
+a non-serialised mutation if one is ever introduced.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import pytest
+from _helpers import ack_payload, make_tracker, nack_payload, propose_payload
+from events import EventType
+
+pytestmark = pytest.mark.integration
+
+
+class TestConcurrentAcks:
+    """Multiple reviewers ACKing the same proposal in parallel are serialised."""
+
+    PIPELINE_ID = "issue-2635-concurrent-acks"
+
+    def _wide_graph(self, n_reviewers: int):
+        from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph
+
+        # All distinct critical reviewers reviewing a single producer.
+        edges = [
+            ReviewEdge(f"reviewer_{i}", "coder", ReviewCriticality.CRITICAL)
+            for i in range(n_reviewers)
+        ]
+        return ReviewGraph(edges)
+
+    def test_six_reviewers_acking_in_parallel_all_recorded(
+        self, event_capture, filter_events
+    ) -> None:
+        """Six threaded ACKs land six matrix entries — no torn writes.
+
+        If the RLock ever became a no-op, we'd expect either fewer
+        than six recorded ACKs (lost write) or duplicate
+        ``CONSENSUS_ACK_RECEIVED`` events (double-emit).
+        """
+        n = 6
+        graph = self._wide_graph(n)
+        tracker = make_tracker(self.PIPELINE_ID, graph)
+        tracker.handle_propose("coder", propose_payload(commit_sha="abc"))
+
+        barrier = threading.Barrier(n)
+
+        def ack(reviewer: str) -> dict:
+            barrier.wait(timeout=5)
+            return tracker.handle_ack(reviewer, "coder", {"ack_version": 1, **ack_payload()})
+
+        with ThreadPoolExecutor(max_workers=n) as ex:
+            futures = [ex.submit(ack, f"reviewer_{i}") for i in range(n)]
+            results = [f.result(timeout=10) for f in as_completed(futures)]
+
+        # Every ACK reported success and the producer is fully ACKed.
+        assert all(r["status"] == "acked" for r in results)
+        assert tracker.matrix.is_fully_acked("coder") is True
+
+        # Exactly N ACK events on the bus — no doubles, no drops.
+        ack_events = filter_events(
+            event_capture(),
+            pipeline_id=self.PIPELINE_ID,
+            event_type=EventType.CONSENSUS_ACK_RECEIVED,
+        )
+        assert len(ack_events) == n
+        # And every reviewer reported in the events is distinct.
+        assert {e.data["reviewer"] for e in ack_events} == {f"reviewer_{i}" for i in range(n)}
+
+    def test_propose_and_ack_interleaved_does_not_corrupt_state(self, two_reviewer_graph) -> None:
+        """Re-propose racing an ACK on the previous version: matrix stays consistent.
+
+        Without proper serialisation, the ACK could land at the
+        wrong version or the version counter could double-increment.
+        We don't assert a specific timing outcome — only that the
+        post-race state is self-consistent (is_fully_acked agrees
+        with the recorded ACK versions).
+        """
+        tracker = make_tracker(self.PIPELINE_ID + "-interleave", two_reviewer_graph)
+        tracker.handle_propose("coder", propose_payload(commit_sha="v1"))
+
+        # reviewer_code ACKs v1.
+        tracker.handle_ack("reviewer_code", "coder", {"ack_version": 1, **ack_payload()})
+
+        barrier = threading.Barrier(2)
+
+        def repropose() -> dict:
+            barrier.wait(timeout=5)
+            return tracker.handle_re_propose(
+                "coder",
+                propose_payload(commit_sha="v2"),
+                changed_artifacts=["a.py"],
+            )
+
+        def ack_v1() -> dict:
+            barrier.wait(timeout=5)
+            # Reviewer trying to ACK the old version — guard should
+            # reject either via version-match or this lands before
+            # re_propose. Either way the matrix must end up consistent.
+            try:
+                return tracker.handle_ack(
+                    "reviewer_contract", "coder", {"ack_version": 1, **ack_payload()}
+                )
+            except ValueError as e:
+                return {"status": "rejected", "reason": str(e)}
+
+        with ThreadPoolExecutor(max_workers=2) as ex:
+            f_re = ex.submit(repropose)
+            f_ack = ex.submit(ack_v1)
+            re_result = f_re.result(timeout=10)
+            ack_result = f_ack.result(timeout=10)
+
+        # Final state self-consistent: either the v1 ACK lost the race
+        # (post-repropose ACKs land at v2, never v1) or it landed first
+        # and is_fully_acked is False because re_propose invalidated it.
+        # In both cases, the recorded version cannot exceed the current
+        # proposal version.
+        current_version = tracker.matrix.get_proposal_version("coder")
+        assert current_version == 2  # repropose always bumps
+        # ACK result is either acked@1 (raced) or rejected.
+        assert ack_result["status"] in {"acked", "rejected"}
+        assert re_result["version"] == 2
+
+
+class TestOpenNackBarrier:
+    """Two reviewers NACKing the same version trigger the #2142 aggregation barrier."""
+
+    PIPELINE_ID = "issue-2635-open-nack-barrier"
+
+    def test_two_concurrent_nacks_block_repropose_until_acknowledged(
+        self, two_reviewer_graph
+    ) -> None:
+        """A producer cannot re_propose past 2+ NACKs against the same version.
+
+        The barrier exists to prevent the multi-reviewer aggregation
+        hazard — without it a producer could re-propose addressing
+        only the *first* NACK they saw via wait-loop, hiding the
+        second reviewer's NACK from the cycle.
+
+        The first re_propose attempt is rejected with
+        ``open_nacks_blocked``; the second (after the producer has
+        been informed) is accepted.
+        """
+        tracker = make_tracker(self.PIPELINE_ID, two_reviewer_graph)
+        tracker.handle_propose("coder", propose_payload(commit_sha="abc"))
+
+        barrier = threading.Barrier(2)
+
+        def nack(reviewer: str) -> dict:
+            barrier.wait(timeout=5)
+            return tracker.handle_nack(
+                reviewer,
+                "coder",
+                {"nack_version": 1, **nack_payload(reason=f"{reviewer} concern")},
+            )
+
+        with ThreadPoolExecutor(max_workers=2) as ex:
+            futures = [
+                ex.submit(nack, "reviewer_code"),
+                ex.submit(nack, "reviewer_contract"),
+            ]
+            results = [f.result(timeout=10) for f in as_completed(futures)]
+
+        assert all(r["status"] == "nacked" for r in results)
+
+        # First re_propose hits the barrier — both reviewers' NACKs are
+        # surfaced before the producer can advance.
+        first = tracker.handle_re_propose(
+            "coder",
+            propose_payload(commit_sha="def"),
+            changed_artifacts=["a.py"],
+        )
+        assert first["status"] == "open_nacks_blocked"
+        assert set(first["nacking_reviewers"]) == {"reviewer_code", "reviewer_contract"}
+        assert len(first["nacks"]) == 2
+
+        # Producer has now been informed — retry proceeds.
+        second = tracker.handle_re_propose(
+            "coder",
+            propose_payload(commit_sha="def"),
+            changed_artifacts=["a.py"],
+        )
+        assert second["version"] == 2
+
+
+class TestWithdrawCooldownAndLockout:
+    """Withdraw cooldown and flip-flop lockout under rapid retries."""
+
+    PIPELINE_ID = "issue-2635-withdraw-cooldown"
+
+    def test_withdraw_within_cooldown_is_rejected(self) -> None:
+        """A producer can't withdraw within ``cooldown_seconds`` of proposing.
+
+        Defends against rapid propose/withdraw cycles that would
+        thrash reviewers' review queues.  Using a non-zero cooldown
+        for this test (the make_tracker default is 0 for speed).
+        """
+        from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph
+
+        graph = ReviewGraph([ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL)])
+        tracker = make_tracker(self.PIPELINE_ID, graph, cooldown_seconds=60)
+        tracker.handle_propose("coder", propose_payload(commit_sha="abc"))
+
+        # Immediate withdraw — well within the 60s cooldown.
+        with pytest.raises(ValueError, match="[Cc]ooldown"):
+            tracker.handle_withdraw("coder", reason="changed my mind")
+
+    def test_flip_flop_lockout_after_repeated_withdrawals(self) -> None:
+        """Producer is locked out after ``max_flip_flops`` propose/withdraw cycles.
+
+        Uses cooldown=0 + max_flip_flops=2 so the test runs without
+        wallclock waits.  After 2 successful withdraws, the third
+        triggers the lockout — the tracker returns ``locked_out``
+        instead of raising.
+        """
+        from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph
+
+        graph = ReviewGraph([ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL)])
+        # Override defaults: cooldown=0 (no waits), max_flip_flops=2 (small).
+        # ``make_tracker`` doesn't expose max_flip_flops; build directly via
+        # the registered creator with kwargs.
+        from peer_consensus import (
+            create_peer_consensus_tracker,
+            remove_peer_consensus_tracker,
+        )
+
+        remove_peer_consensus_tracker(self.PIPELINE_ID + "-flipflop")
+        tracker = create_peer_consensus_tracker(
+            self.PIPELINE_ID + "-flipflop",
+            graph,
+            cooldown_seconds=0,
+            max_flip_flops=2,
+        )
+        tracker.register_agent("coder")
+        tracker.register_agent("reviewer_code")
+
+        # Cycle 1: propose → withdraw → counter=1, allowed.
+        tracker.handle_propose("coder", propose_payload(commit_sha="abc"))
+        r1 = tracker.handle_withdraw("coder", reason="bug found")
+        assert r1["status"] == "withdrawn"
+
+        # Cycle 2: propose → withdraw → counter=2, allowed (still < max=2 at peek time).
+        # Note: the peek is ``current + 1 >= max`` so with max=2 the second
+        # withdraw is the one that gets locked out.
+        tracker.handle_propose("coder", propose_payload(commit_sha="def"))
+        r2 = tracker.handle_withdraw("coder", reason="another bug")
+        assert r2["status"] == "locked_out"
+        assert r2["needs_escalation"] is True

--- a/integration_tests/regression/test_brc_edge_cases.py
+++ b/integration_tests/regression/test_brc_edge_cases.py
@@ -1,0 +1,245 @@
+"""BRC edge-case coverage — issue #2635 follow-up.
+
+Covers BRC paths that the unit tier has touched in isolation but
+that weren't pinned at the integration boundary:
+
+* Dual-role agents (tester is producer + reviewer) — both state
+  machines must confirm before the agent is in the ``confirmed``
+  set.
+* Slice-aware tracker keys — per-slice trackers under
+  ``{pipeline_id}/{slice_id}`` don't bleed into each other or
+  into the bare ``pipeline_id`` tracker.
+* Conditional ACK with ``pre_merge_condition`` + in-cycle
+  resolution via ``handle_resolve_obligation`` (#2338).
+* Stale-version ACK rejection — when a reviewer claims an ACK
+  version that doesn't match the producer's current proposal,
+  the guard rejects.
+
+ScriptedProvider can't drive deployed agent pods (see #2474), so
+the tests exercise the BRC Python API directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+from _helpers import ack_payload, make_tracker, propose_payload
+from events import EventType
+from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph
+
+pytestmark = pytest.mark.integration
+
+
+class TestDualRoleAgent:
+    """Tester is producer (writes tests) AND reviewer (runs tests on coder)."""
+
+    PIPELINE_ID = "issue-2635-dual-role"
+
+    def _graph(self) -> ReviewGraph:
+        # coder produces; reviewer_code reviews coder.
+        # tester produces (tests) AND reviews coder.
+        return ReviewGraph(
+            [
+                ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL),
+                ReviewEdge("tester", "coder", ReviewCriticality.CRITICAL),
+                ReviewEdge("reviewer_code", "tester", ReviewCriticality.CRITICAL),
+            ]
+        )
+
+    def test_tester_confirms_only_when_both_state_machines_confirm(self) -> None:
+        """Dual-role tester needs producer-side AND reviewer-side confirmation."""
+        graph = self._graph()
+        assert graph.is_dual_role("tester") is True
+
+        tracker = make_tracker(self.PIPELINE_ID, graph)
+
+        # Both producers propose.
+        tracker.handle_propose("coder", propose_payload(commit_sha="abc"))
+        tracker.handle_propose("tester", propose_payload(commit_sha="def", artifacts=["test_x.py"]))
+
+        # All cross-ACKs.
+        tracker.handle_ack("reviewer_code", "coder", {"ack_version": 1, **ack_payload()})
+        tracker.handle_ack("tester", "coder", {"ack_version": 1, **ack_payload()})
+        tracker.handle_ack(
+            "reviewer_code",
+            "tester",
+            {"ack_version": 1, **ack_payload(artifacts=["test_x.py"])},
+        )
+
+        # All three roles confirm — only after tester confirms BOTH
+        # state machines (which happens in one ``handle_confirmed``
+        # call since the same method walks both) does the global
+        # consensus tip.
+        tracker.handle_confirmed("reviewer_code")
+        tracker.handle_confirmed("coder")
+        result = tracker.handle_confirmed("tester")
+        assert result["status"] == "confirmed"
+        assert result["consensus_reached"] is True
+
+        state = tracker.evaluate()
+        assert state["is_complete"] is True
+        # Tester appears in both producer and reviewer phase reports.
+        tester_state = state["agents"]["tester"]
+        # ``ConsensusPhase.CONFIRMED.value`` (the enum's serialised form)
+        # is upper-cased — assert against the enum to insulate the test
+        # from a future rename.
+        from egg_orchestrator.types import ConsensusPhase
+
+        assert tester_state["producer_phase"] == ConsensusPhase.CONFIRMED.value
+        assert tester_state["reviewer_phase"] == ConsensusPhase.CONFIRMED.value
+        assert tester_state["confirmed"] is True
+
+
+class TestSliceAwareTrackerIsolation:
+    """Per-slice trackers are keyed by ``{pipeline_id}/{slice_id}``."""
+
+    PIPELINE_ID = "issue-2635-slice-aware"
+
+    def test_two_slices_have_independent_trackers(self) -> None:
+        """A NACK in slice-1 does not pollute slice-2's tracker state."""
+        from peer_consensus import (
+            create_peer_consensus_tracker,
+            get_peer_consensus_tracker,
+            remove_peer_consensus_tracker,
+        )
+
+        graph_1 = ReviewGraph([ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL)])
+        graph_2 = ReviewGraph([ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL)])
+
+        # Two slice trackers under the same pipeline id.
+        remove_peer_consensus_tracker(self.PIPELINE_ID, slice_id="slice-1")
+        remove_peer_consensus_tracker(self.PIPELINE_ID, slice_id="slice-2")
+        tracker_1 = create_peer_consensus_tracker(
+            self.PIPELINE_ID, graph_1, slice_id="slice-1", cooldown_seconds=0
+        )
+        tracker_2 = create_peer_consensus_tracker(
+            self.PIPELINE_ID, graph_2, slice_id="slice-2", cooldown_seconds=0
+        )
+        for role in graph_1.all_roles():
+            tracker_1.register_agent(role)
+            tracker_2.register_agent(role)
+
+        # slice-1: PROPOSE → NACK (consensus blocked).
+        tracker_1.handle_propose("coder", propose_payload(commit_sha="aaa"))
+        tracker_1.handle_nack(
+            "reviewer_code",
+            "coder",
+            {"nack_version": 1, "artifact_references": ["a.py"], "reason": "bug"},
+        )
+
+        # slice-2: PROPOSE → ACK → CONFIRMED (consensus reached).
+        tracker_2.handle_propose("coder", propose_payload(commit_sha="bbb"))
+        tracker_2.handle_ack("reviewer_code", "coder", {"ack_version": 1, **ack_payload()})
+        tracker_2.handle_confirmed("coder")
+        tracker_2.handle_confirmed("reviewer_code")
+
+        # slice-1 still blocked; slice-2 done. The registry lookup
+        # is what production routes use (signals, timeout handler).
+        assert get_peer_consensus_tracker(self.PIPELINE_ID, "slice-1") is tracker_1
+        assert get_peer_consensus_tracker(self.PIPELINE_ID, "slice-2") is tracker_2
+        # The bare pipeline-level lookup is None — slice-aware trackers
+        # don't pollute the umbrella key.
+        assert get_peer_consensus_tracker(self.PIPELINE_ID) is None
+
+        assert tracker_1.evaluate()["is_complete"] is False
+        assert tracker_2.evaluate()["is_complete"] is True
+
+
+class TestConditionalAckObligationResolution:
+    """``pre_merge_condition`` lifecycle: conditional-ACK → resolve in-cycle (#2338)."""
+
+    PIPELINE_ID = "issue-2635-conditional-ack"
+
+    def test_conditional_ack_then_obligation_resolved_clears_merge_block(
+        self, event_capture, filter_events
+    ) -> None:
+        """Conditional ACK creates a pre-merge obligation; resolution clears it.
+
+        Before resolution: ``get_pre_merge_conditions`` returns the
+        condition (PR-body builder surfaces it as a "do not merge until X"
+        marker).  After ``handle_resolve_obligation``, the same query
+        returns empty — the operator is no longer prompted to perform
+        the obligation manually.
+
+        The resolution emits ``CONSENSUS_OBLIGATION_RESOLVED`` so the
+        SDLC skill's HITL gate can re-evaluate without polling the
+        matrix.
+        """
+        graph = ReviewGraph(
+            [
+                ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL),
+                ReviewEdge("tester", "coder", ReviewCriticality.CRITICAL),
+            ]
+        )
+        tracker = make_tracker(self.PIPELINE_ID, graph)
+        tracker.handle_propose("coder", propose_payload(commit_sha="abc"))
+
+        # Conditional ACK — reviewer says "I'd merge if you ran git mv X Y first".
+        tracker.handle_ack(
+            "reviewer_code",
+            "coder",
+            {
+                "ack_version": 1,
+                "artifact_references": ["a.py"],
+                "pre_merge_condition": "git mv old.py new.py before merge",
+            },
+        )
+        # Plain ACK from the other reviewer (no condition).
+        tracker.handle_ack("tester", "coder", {"ack_version": 1, **ack_payload()})
+
+        # Condition is visible until resolved.
+        before = tracker.get_pre_merge_conditions()
+        assert len(before) == 1
+        assert before[0]["reviewer"] == "reviewer_code"
+        assert "git mv" in before[0]["condition"]
+
+        # Tester resolves the obligation in-cycle (#2338 — the agent
+        # that landed the conditioning commit reports it).
+        result = tracker.handle_resolve_obligation(
+            resolver_role="tester",
+            reviewer_role="reviewer_code",
+            producer_role="coder",
+            commit_sha="resolved-by-tester-sha",
+            note="git mv landed in this branch",
+        )
+        assert result["status"] == "resolved"
+        assert result["remaining_pre_merge_conditions"] == []
+        assert tracker.get_pre_merge_conditions() == []
+
+        # Event emitted so the SDLC HITL gate can react without polling.
+        resolved_events = filter_events(
+            event_capture(),
+            pipeline_id=self.PIPELINE_ID,
+            event_type=EventType.CONSENSUS_OBLIGATION_RESOLVED,
+        )
+        assert len(resolved_events) == 1
+        assert resolved_events[0].data["resolver"] == "tester"
+
+
+class TestStaleVersionAckRejection:
+    """``check_ack_guard`` rejects ACKs whose ``ack_version`` doesn't match current."""
+
+    PIPELINE_ID = "issue-2635-stale-version"
+
+    def test_acking_old_version_after_repropose_is_rejected(self, single_reviewer_graph) -> None:
+        """A reviewer can't ACK v1 after the producer has re-proposed to v2."""
+        tracker = make_tracker(self.PIPELINE_ID, single_reviewer_graph)
+        tracker.handle_propose("coder", propose_payload(commit_sha="v1"))
+        # Reviewer NACKs v1.
+        tracker.handle_nack(
+            "reviewer_code",
+            "coder",
+            {"nack_version": 1, "artifact_references": ["a.py"], "reason": "bug"},
+        )
+        # Producer re-proposes (v2).
+        tracker.handle_re_propose(
+            "coder",
+            propose_payload(commit_sha="v2"),
+            changed_artifacts=["a.py"],
+        )
+        # Reviewer mistakenly tries to ACK the old v1 — guard rejects.
+        with pytest.raises(ValueError, match="version"):
+            tracker.handle_ack(
+                "reviewer_code",
+                "coder",
+                {"ack_version": 1, **ack_payload()},
+            )

--- a/integration_tests/regression/test_brc_gap_audit.py
+++ b/integration_tests/regression/test_brc_gap_audit.py
@@ -1,0 +1,295 @@
+"""BRC gap-audit invariants — issue #2635.
+
+Covers the failure modes flagged in the issue's gap-audit section
+that weren't already pinned at the integration boundary:
+
+* NACK → re-propose → ACK round-trip restores consensus.
+* Reviewer disagreement (one ACK + one NACK) blocks consensus and
+  unresolved-NACK signal surfaces on the bus.
+* Mid-cycle restart: ``reconstruct_tracker_from_messages`` replays
+  PROPOSE/ACK/CONFIRMED into a fresh tracker without re-emitting
+  message-bus events.  This is the orchestrator-restart recovery
+  contract — without it, the consensus state is lost on every
+  pod cycle.
+* Phase-specific config inheritance: per-phase overrides do not
+  bleed across phases (regression for the precedence order the
+  resolver implements).
+
+ScriptedProvider can't drive deployed agent pods (see #2474), so
+these tests exercise the orchestrator's BRC Python API directly.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from _helpers import ack_payload, make_tracker, nack_payload, propose_payload
+from events import EventType
+from message_store import Message, MessageStore, MessageType
+from models import (
+    PHASE_CONSENSUS_TIMEOUT_DEFAULTS_MIN,
+    PipelineConfig,
+    resolve_consensus_timeout_minutes,
+)
+from peer_consensus import reconstruct_tracker_from_messages
+from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph
+
+pytestmark = pytest.mark.integration
+
+
+class TestNackReproposeRoundTrip:
+    """Producer NACK → re-propose → fresh ACKs restores consensus."""
+
+    PIPELINE_ID = "issue-2635-nack-roundtrip"
+
+    def test_nack_then_repropose_then_ack_reaches_consensus(
+        self, single_reviewer_graph, event_capture, filter_events
+    ) -> None:
+        tracker = make_tracker(self.PIPELINE_ID, single_reviewer_graph)
+
+        # v1: PROPOSE → NACK
+        tracker.handle_propose("coder", propose_payload(commit_sha="aaa1111"))
+        nack = tracker.handle_nack(
+            "reviewer_code",
+            "coder",
+            {"nack_version": 1, **nack_payload(reason="SQLi on a.py:42")},
+        )
+        assert nack["status"] == "nacked"
+        assert nack["revision_count"] == 1
+        assert nack["needs_escalation"] is False
+        # Producer is back in WORKING, consensus blocked by unresolved NACK.
+        state = tracker.evaluate()
+        assert state["is_complete"] is False
+        assert state["has_unresolved_nacks"] is True
+
+        # v2: re-PROPOSE → ACK — fresh version invalidates the stale ACK/NACK.
+        repropose = tracker.handle_re_propose(
+            "coder",
+            propose_payload(commit_sha="bbb2222"),
+            changed_artifacts=["a.py"],
+        )
+        assert repropose["version"] == 2
+        tracker.handle_ack("reviewer_code", "coder", {"ack_version": 2, **ack_payload()})
+        tracker.handle_confirmed("coder")
+        result = tracker.handle_confirmed("reviewer_code")
+        assert result["consensus_reached"] is True
+
+        state = tracker.evaluate()
+        assert state["is_complete"] is True
+        assert state["has_unresolved_nacks"] is False
+
+        # Event-count contract for the round-trip path.
+        events = event_capture()
+        assert (
+            len(
+                filter_events(
+                    events,
+                    pipeline_id=self.PIPELINE_ID,
+                    event_type=EventType.CONSENSUS_PROPOSE_RECEIVED,
+                )
+            )
+            == 2
+        )
+        assert (
+            len(
+                filter_events(
+                    events,
+                    pipeline_id=self.PIPELINE_ID,
+                    event_type=EventType.CONSENSUS_NACK_RECEIVED,
+                )
+            )
+            == 1
+        )
+        assert (
+            len(
+                filter_events(
+                    events,
+                    pipeline_id=self.PIPELINE_ID,
+                    event_type=EventType.CONSENSUS_REACHED,
+                )
+            )
+            == 1
+        )
+
+
+class TestReviewerDisagreement:
+    """One ACK + one NACK from critical reviewers blocks consensus."""
+
+    PIPELINE_ID = "issue-2635-disagreement"
+
+    def test_split_critical_reviewers_block_consensus(
+        self, two_reviewer_graph, event_capture, filter_events
+    ) -> None:
+        tracker = make_tracker(self.PIPELINE_ID, two_reviewer_graph)
+        tracker.handle_propose("coder", propose_payload(commit_sha="ccc3333"))
+
+        tracker.handle_ack("reviewer_code", "coder", {"ack_version": 1, **ack_payload()})
+        tracker.handle_nack(
+            "reviewer_contract",
+            "coder",
+            {"nack_version": 1, **nack_payload(reason="contract drift in models.py")},
+        )
+
+        state = tracker.evaluate()
+        assert state["is_complete"] is False
+        assert state["has_unresolved_nacks"] is True
+        # The NACKing reviewer surfaces in the unresolved set.
+        nacking = [n["reviewer"] for n in state["unresolved_nacks"]]
+        assert "reviewer_contract" in nacking
+
+        # The producer cannot confirm — pending NACK from reviewer_contract.
+        result = tracker.handle_confirmed("coder")
+        assert result["status"] == "pending_acks"
+
+        # Event payload reflects the disagreement.
+        nack_events = filter_events(
+            event_capture(),
+            pipeline_id=self.PIPELINE_ID,
+            event_type=EventType.CONSENSUS_NACK_RECEIVED,
+        )
+        assert len(nack_events) == 1
+        assert nack_events[0].data["reviewer"] == "reviewer_contract"
+        assert nack_events[0].data["producer"] == "coder"
+
+
+class TestMidCycleRestartReplay:
+    """``reconstruct_tracker_from_messages`` rebuilds state from persisted msgs."""
+
+    PIPELINE_ID = "issue-2635-restart-replay"
+
+    def _record_message(
+        self,
+        store: MessageStore,
+        *,
+        from_role: str,
+        to_role: str,
+        message_type: str,
+        timestamp: datetime,
+        metadata: dict | None = None,
+        body: str = "",
+    ) -> Message:
+        msg = Message(
+            pipeline_id=self.PIPELINE_ID,
+            from_role=from_role,
+            to_role=to_role,
+            message_type=message_type,
+            subject=message_type,
+            body=body,
+            metadata=metadata or {},
+            timestamp=timestamp,
+        )
+        store.add_message(msg)
+        return msg
+
+    def test_replay_rebuilds_consensus_state(self) -> None:
+        """Persisted PROPOSE+ACK+CONFIRMED messages reconstruct a confirmed tracker.
+
+        Drops a real ``MessageStore`` and ``reconstruct_tracker_from_messages``
+        with it, then asserts the rebuilt tracker reports consensus reached.
+        This is the regression for a pod-cycle that loses the in-memory
+        tracker mid-cycle (#2429-style scenarios).
+        """
+        store = MessageStore()
+        now = datetime.now(UTC)
+
+        # Producer proposed at t-30s.
+        self._record_message(
+            store,
+            from_role="coder",
+            to_role="reviewer_code",
+            message_type=MessageType.CONSENSUS_PROPOSE,
+            timestamp=now - timedelta(seconds=30),
+            metadata={
+                "payload": {
+                    "summary": "v1",
+                    "artifacts": ["a.py"],
+                    "commit_sha": "abc1234",
+                }
+            },
+        )
+        # Reviewer ACKed at t-20s.
+        self._record_message(
+            store,
+            from_role="reviewer_code",
+            to_role="coder",
+            message_type=MessageType.CONSENSUS_ACK,
+            timestamp=now - timedelta(seconds=20),
+            metadata={
+                "payload": {
+                    "artifact_references": ["a.py"],
+                    "ack_version": 1,
+                }
+            },
+        )
+        # Both roles confirmed.
+        self._record_message(
+            store,
+            from_role="coder",
+            to_role="all",
+            message_type=MessageType.CONSENSUS_CONFIRMED,
+            timestamp=now - timedelta(seconds=10),
+        )
+        self._record_message(
+            store,
+            from_role="reviewer_code",
+            to_role="all",
+            message_type=MessageType.CONSENSUS_CONFIRMED,
+            timestamp=now - timedelta(seconds=5),
+        )
+
+        graph = ReviewGraph([ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL)])
+        tracker = reconstruct_tracker_from_messages(self.PIPELINE_ID, graph, message_store=store)
+        assert tracker is not None
+        state = tracker.evaluate()
+        # The rebuilt tracker reports the same consensus shape the live one
+        # would have — that's the contract that lets a restarted orchestrator
+        # resume without re-running the BRC cycle.
+        assert state["is_complete"] is True
+        assert state["blocking_agents"] == []
+        # ``coder``'s commit SHA must round-trip — the ``_update_agents_complete``
+        # path reads this back to populate ``agent.commit`` (#1691).
+        assert tracker.get_proposal_commit_sha("coder") == "abc1234"
+
+    def test_replay_with_no_messages_returns_none(self) -> None:
+        """An empty message store yields ``None`` rather than a phantom tracker."""
+        store = MessageStore()
+        graph = ReviewGraph([ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL)])
+        tracker = reconstruct_tracker_from_messages(
+            self.PIPELINE_ID + "-empty", graph, message_store=store
+        )
+        assert tracker is None
+
+
+class TestPhaseConfigInheritance:
+    """Per-phase timeout overrides don't bleed across phases.
+
+    Complements the unit-tier resolver tests by asserting the
+    precedence holds when multiple per-phase overrides are set
+    simultaneously — the production case where ``refine`` and
+    ``implement`` have explicit overrides but ``plan`` falls back
+    to the calibrated default.
+    """
+
+    def test_three_phase_overrides_isolate_correctly(self) -> None:
+        config = PipelineConfig(
+            consensus_timeout_minutes_refine=20,
+            consensus_timeout_minutes_implement=120,
+        )
+        assert resolve_consensus_timeout_minutes(config, "refine") == 20
+        # plan has no override and no legacy global → calibrated default.
+        assert (
+            resolve_consensus_timeout_minutes(config, "plan")
+            == PHASE_CONSENSUS_TIMEOUT_DEFAULTS_MIN["plan"]
+        )
+        assert resolve_consensus_timeout_minutes(config, "implement") == 120
+
+    def test_legacy_global_with_one_phase_override_yields_two_buckets(self) -> None:
+        """Legacy global wins where no per-phase override is set, override wins where one is."""
+        config = PipelineConfig(
+            consensus_timeout_minutes=45,
+            consensus_timeout_minutes_implement=120,
+        )
+        assert resolve_consensus_timeout_minutes(config, "refine") == 45
+        assert resolve_consensus_timeout_minutes(config, "plan") == 45
+        assert resolve_consensus_timeout_minutes(config, "implement") == 120

--- a/integration_tests/regression/test_brc_phase_timeout.py
+++ b/integration_tests/regression/test_brc_phase_timeout.py
@@ -21,11 +21,14 @@ handler in-process.
   The actual field is ``PipelineConfig.consensus_timeout_minutes_plan``
   (minutes, lives on ``PipelineConfig`` rather than the contract's
   ``phase_configs``).  Tests use the real field name.
-* ``handle_timeout`` only triages edges that have a recorded entry in
-  the approval matrix — a producer that proposed but received no
-  ACK/NACK yet does **not** appear in ``get_all_blocking_edges()``
-  and falls through to the "proceed" (no-alert) branch.  Tests
-  record a NACK to materialise an entry.
+* An idle reviewer with no ACK/NACK **does** appear in
+  ``get_all_blocking_edges()`` — the matrix constructor pre-populates
+  one PENDING entry per graph edge, so a producer waiting on a
+  no-show reviewer drives the timeout handler to the appropriate
+  branch (critical → escalate, advisory-only → notify).  The
+  ``test_idle_*`` cases below pin this end-to-end; #2653 was filed on
+  the misread that ``_entries`` is empty until ``record_ack`` /
+  ``record_nack`` populates it.
 * The **advisory-only** branch is intentionally silent at the
   OVERSEER_ALERT layer — see ``test_pipelines_routes.py::
   test_brc_handled_without_escalate_no_alert``.  Operator visibility
@@ -205,6 +208,90 @@ class TestPhaseAwareTimeoutPropagation:
         assert len(timeouts) == 1
         assert timeouts[0].data["type"] == "timeout_advisory_only"
         # Operator-facing alert layer stays silent on the advisory branch.
+        assert alerts == []
+
+    def test_idle_critical_reviewer_fires_overseer_alert(
+        self, event_capture, filter_events
+    ) -> None:
+        """A producer waiting on a no-show critical reviewer escalates at timeout.
+
+        Pins the operator-facing alert for the case operators most
+        care about: producer proposed, critical reviewer never showed
+        up.  The matrix constructor pre-populates one PENDING edge
+        per graph edge, so ``get_all_blocking_edges`` returns the
+        idle reviewer and the handler takes the escalate branch.
+        Issue #2653 was filed on the assumption that this branch was
+        silent; the test verifies it is not.
+        """
+        pipeline_id = "issue-2653-timeout-idle-critical"
+        config = PipelineConfig(consensus_timeout_minutes_plan=20)
+        pipeline = _make_pipeline(pipeline_id, config, PipelinePhase.PLAN)
+        graph = ReviewGraph([ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL)])
+        tracker = make_tracker(pipeline_id, graph)
+        # Producer proposes; reviewer never ACKs or NACKs.
+        tracker.handle_propose("coder", propose_payload(commit_sha="abc"))
+
+        capture, alerts = _capture_alerts()
+        with capture:
+            _handle_brc_consensus_timeout(
+                pipeline,
+                pipeline_id,
+                consensus_timeout=20 * 60,
+                blocking_agents=["reviewer_code"],
+                store=None,
+                slice_id=None,
+                active_role_names=["coder", "reviewer_code"],
+            )
+
+        failures = filter_events(
+            event_capture(),
+            pipeline_id=pipeline_id,
+            event_type=EventType.CONSENSUS_FAILURE,
+        )
+        assert any(e.data.get("type") == "timeout_critical" for e in failures)
+        assert len(alerts) == 1
+        alert = alerts[0]
+        assert alert.metadata["consensus_timeout_minutes"] == 20
+        assert alert.metadata["priority"] == "high"
+        assert "reviewer_code" in alert.metadata["blocking_agents"]
+
+    def test_idle_advisory_reviewer_fires_notification(self, event_capture, filter_events) -> None:
+        """Idle advisory reviewer routes to the advisory-only branch, not silence.
+
+        Pairs with the critical case to lock in that the
+        pre-populated PENDING edges respect the reviewer's
+        criticality — advisory-only stays silent at the alert layer
+        but still emits ``CONSENSUS_TIMEOUT``.
+        """
+        pipeline_id = "issue-2653-timeout-idle-advisory"
+        pipeline = _make_pipeline(
+            pipeline_id,
+            PipelineConfig(consensus_timeout_minutes_plan=15),
+            PipelinePhase.PLAN,
+        )
+        graph = ReviewGraph([ReviewEdge("reviewer_contract", "coder", ReviewCriticality.ADVISORY)])
+        tracker = make_tracker(pipeline_id, graph)
+        tracker.handle_propose("coder", propose_payload(commit_sha="abc"))
+
+        capture, alerts = _capture_alerts()
+        with capture:
+            _handle_brc_consensus_timeout(
+                pipeline,
+                pipeline_id,
+                consensus_timeout=15 * 60,
+                blocking_agents=["reviewer_contract"],
+                store=None,
+                slice_id=None,
+                active_role_names=["coder", "reviewer_contract"],
+            )
+
+        timeouts = filter_events(
+            event_capture(),
+            pipeline_id=pipeline_id,
+            event_type=EventType.CONSENSUS_TIMEOUT,
+        )
+        assert len(timeouts) == 1
+        assert timeouts[0].data["type"] == "timeout_advisory_only"
         assert alerts == []
 
     def test_consensus_reached_before_timeout_is_no_op(self, event_capture, filter_events) -> None:

--- a/integration_tests/regression/test_brc_phase_timeout.py
+++ b/integration_tests/regression/test_brc_phase_timeout.py
@@ -1,0 +1,304 @@
+"""Phase-aware consensus timeouts honored end-to-end — issue #2635 starting point 2.
+
+The unit tier covers ``resolve_consensus_timeout_minutes`` exhaustively
+(see ``orchestrator/tests/test_models.py::TestResolveConsensusTimeoutMinutes``)
+but no test verifies the *full* contract: config → resolver →
+``_handle_brc_consensus_timeout`` triage → CONSENSUS_TIMEOUT /
+CONSENSUS_FAILURE event + (on critical-blocker / fallback paths)
+``OVERSEER_ALERT`` message whose ``consensus_timeout_minutes``
+metadata reflects the configured value.
+
+Wallclock-bounded "fires within N±5s" assertions aren't feasible
+without standing up the real wait loop (which needs containers).
+The contract that actually matters to operators is **"the configured
+phase-specific value is the one that lands in the alert"** — that's
+what's verified here, by composing the resolver with the timeout
+handler in-process.
+
+## Gap notes (issue text vs. current code)
+
+* Issue text references ``phase_configs.plan.consensus_timeout_s = 30``.
+  The actual field is ``PipelineConfig.consensus_timeout_minutes_plan``
+  (minutes, lives on ``PipelineConfig`` rather than the contract's
+  ``phase_configs``).  Tests use the real field name.
+* ``handle_timeout`` only triages edges that have a recorded entry in
+  the approval matrix — a producer that proposed but received no
+  ACK/NACK yet does **not** appear in ``get_all_blocking_edges()``
+  and falls through to the "proceed" (no-alert) branch.  Tests
+  record a NACK to materialise an entry.
+* The **advisory-only** branch is intentionally silent at the
+  OVERSEER_ALERT layer — see ``test_pipelines_routes.py::
+  test_brc_handled_without_escalate_no_alert``.  Operator visibility
+  for advisory-only timeouts is the in-tracker CONSENSUS_TIMEOUT
+  event, not an alert message.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from _helpers import ack_payload, make_tracker, nack_payload, propose_payload
+from events import EventType
+from models import (
+    PHASE_CONSENSUS_TIMEOUT_DEFAULTS_MIN,
+    Pipeline,
+    PipelineConfig,
+    PipelinePhase,
+    PipelineStatus,
+    resolve_consensus_timeout_minutes,
+)
+from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph
+from routes.pipelines import _handle_brc_consensus_timeout
+
+pytestmark = pytest.mark.integration
+
+
+def _make_pipeline(pipeline_id: str, config: PipelineConfig, phase: PipelinePhase) -> Pipeline:
+    return Pipeline(
+        id=pipeline_id,
+        issue_number=2635,
+        repo="owner/repo",
+        branch=f"egg/{pipeline_id}",
+        status=PipelineStatus.RUNNING,
+        current_phase=phase,
+        config=config,
+    )
+
+
+def _capture_alerts() -> tuple[Any, list[Any]]:
+    """Return ``(patch_context, alerts_list)`` for capturing OVERSEER_ALERT writes.
+
+    Mirrors ``orchestrator/tests/test_pipelines_routes.py::_capture_alerts``
+    so the in-process integration tests use the same alert-capture
+    seam as the unit tier.  The handler reaches the alert store via
+    ``routes.pipelines._get_message_store``; we patch that to inject
+    a list-backed fake.
+    """
+    alerts: list[Any] = []
+    fake_store = MagicMock()
+    fake_store.add_message.side_effect = lambda msg: alerts.append(msg) or msg
+    factory = MagicMock(return_value=fake_store)
+    return (
+        patch("routes.pipelines._get_message_store", return_value=factory),
+        alerts,
+    )
+
+
+class TestPhaseAwareTimeoutPropagation:
+    """Triage branches honor the configured per-phase timeout.
+
+    Three branches of ``_handle_brc_consensus_timeout``:
+
+    1. No blocking edges → ``proceed`` (no event, no alert).
+    2. Advisory blockers only → ``CONSENSUS_TIMEOUT`` (from
+       ``handle_timeout``), no alert.
+    3. Critical blockers → ``CONSENSUS_FAILURE`` + high-priority
+       ``OVERSEER_ALERT`` whose ``consensus_timeout_minutes``
+       metadata is the operator-visible knob.
+    """
+
+    def test_critical_blocker_lands_phase_override_in_alert(
+        self, event_capture, filter_events
+    ) -> None:
+        """``consensus_timeout_minutes_plan=45`` flows to OVERSEER_ALERT metadata.
+
+        Critical-blocker path is the chosen probe because it
+        produces both the audit event AND the operator-facing
+        alert.  Together they pin the resolver→handler→alert chain.
+        """
+        pipeline_id = "issue-2635-timeout-critical-45"
+        config = PipelineConfig(consensus_timeout_minutes_plan=45)
+
+        # Resolver picks up the per-phase override.
+        assert resolve_consensus_timeout_minutes(config, "plan") == 45
+        assert (
+            resolve_consensus_timeout_minutes(config, "refine")
+            == PHASE_CONSENSUS_TIMEOUT_DEFAULTS_MIN["refine"]
+        )
+
+        pipeline = _make_pipeline(pipeline_id, config, PipelinePhase.PLAN)
+        graph = ReviewGraph([ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL)])
+        tracker = make_tracker(pipeline_id, graph)
+        tracker.handle_propose("coder", propose_payload(commit_sha="abc"))
+        tracker.handle_nack(
+            "reviewer_code",
+            "coder",
+            {"nack_version": 1, **nack_payload(reason="critical regress")},
+        )
+
+        capture, alerts = _capture_alerts()
+        with capture:
+            _handle_brc_consensus_timeout(
+                pipeline,
+                pipeline_id,
+                consensus_timeout=45 * 60,
+                blocking_agents=["reviewer_code"],
+                store=None,
+                slice_id=None,
+                active_role_names=["coder", "reviewer_code"],
+            )
+
+        # CONSENSUS_FAILURE with ``type=timeout_critical`` is the audit event.
+        failures = filter_events(
+            event_capture(),
+            pipeline_id=pipeline_id,
+            event_type=EventType.CONSENSUS_FAILURE,
+        )
+        assert any(e.data.get("type") == "timeout_critical" for e in failures)
+
+        # OVERSEER_ALERT carries the configured value in metadata.
+        assert len(alerts) == 1
+        alert = alerts[0]
+        assert alert.metadata["consensus_timeout_minutes"] == 45
+        assert alert.metadata["priority"] == "high"
+        assert alert.metadata["phase"] == "plan"
+        # Alert lists both endpoints of the blocking critical edge —
+        # operators see the reviewer that NACKed and the producer that
+        # couldn't get acked.
+        assert "reviewer_code" in alert.metadata["blocking_agents"]
+
+    def test_advisory_only_path_is_silent_at_alert_layer(
+        self, event_capture, filter_events
+    ) -> None:
+        """Advisory-only blockers fire CONSENSUS_TIMEOUT but no OVERSEER_ALERT.
+
+        Pins the design constraint documented in
+        ``test_pipelines_routes.py::test_brc_handled_without_escalate_no_alert``
+        at the integration boundary: a future refactor that adds an
+        alert here would change the operator-facing surface and
+        should be a deliberate decision.
+        """
+        pipeline_id = "issue-2635-timeout-advisory"
+        pipeline = _make_pipeline(
+            pipeline_id,
+            PipelineConfig(consensus_timeout_minutes_plan=10),
+            PipelinePhase.PLAN,
+        )
+        graph = ReviewGraph([ReviewEdge("reviewer_contract", "coder", ReviewCriticality.ADVISORY)])
+        tracker = make_tracker(pipeline_id, graph)
+        tracker.handle_propose("coder", propose_payload(commit_sha="abc"))
+        tracker.handle_nack(
+            "reviewer_contract",
+            "coder",
+            {"nack_version": 1, **nack_payload(reason="advisory NACK")},
+        )
+
+        capture, alerts = _capture_alerts()
+        with capture:
+            _handle_brc_consensus_timeout(
+                pipeline,
+                pipeline_id,
+                consensus_timeout=10 * 60,
+                blocking_agents=["reviewer_contract"],
+                store=None,
+                slice_id=None,
+                active_role_names=["coder", "reviewer_contract"],
+            )
+
+        timeouts = filter_events(
+            event_capture(),
+            pipeline_id=pipeline_id,
+            event_type=EventType.CONSENSUS_TIMEOUT,
+        )
+        assert len(timeouts) == 1
+        assert timeouts[0].data["type"] == "timeout_advisory_only"
+        # Operator-facing alert layer stays silent on the advisory branch.
+        assert alerts == []
+
+    def test_consensus_reached_before_timeout_is_no_op(self, event_capture, filter_events) -> None:
+        """If consensus reached before timeout fires, handler emits no alert."""
+        pipeline_id = "issue-2635-timeout-noop"
+        pipeline = _make_pipeline(pipeline_id, PipelineConfig(), PipelinePhase.PLAN)
+        graph = ReviewGraph([ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL)])
+        tracker = make_tracker(pipeline_id, graph)
+        tracker.handle_propose("coder", propose_payload(commit_sha="abc"))
+        tracker.handle_ack("reviewer_code", "coder", {"ack_version": 1, **ack_payload()})
+        tracker.handle_confirmed("coder")
+        tracker.handle_confirmed("reviewer_code")
+        assert tracker.evaluate()["is_complete"] is True
+
+        capture, alerts = _capture_alerts()
+        with capture:
+            _handle_brc_consensus_timeout(
+                pipeline,
+                pipeline_id,
+                consensus_timeout=60.0,
+                blocking_agents=[],
+                store=None,
+                slice_id=None,
+                active_role_names=["coder", "reviewer_code"],
+            )
+
+        events = event_capture()
+        assert (
+            filter_events(events, pipeline_id=pipeline_id, event_type=EventType.CONSENSUS_TIMEOUT)
+            == []
+        )
+        late_failures = [
+            e
+            for e in filter_events(
+                events, pipeline_id=pipeline_id, event_type=EventType.CONSENSUS_FAILURE
+            )
+            if e.data.get("type", "").startswith("timeout")
+        ]
+        assert late_failures == []
+        assert alerts == []
+
+
+class TestPhaseAwareTimeoutResolutionPrecedence:
+    """Resolver precedence integrates with the handler.
+
+    The unit-tier resolver tests cover the precedence math
+    (``test_models.py::TestResolveConsensusTimeoutMinutes``); this
+    suite asserts the **handler's alert metadata** matches across
+    the three precedence tiers — guards against a future refactor
+    where the resolver and the alert metadata fall out of sync.
+    """
+
+    @pytest.mark.parametrize(
+        ("config_kwargs", "phase", "expected_minutes"),
+        [
+            ({"consensus_timeout_minutes_plan": 15}, "plan", 15),
+            ({"consensus_timeout_minutes": 22}, "plan", 22),
+            ({}, "plan", PHASE_CONSENSUS_TIMEOUT_DEFAULTS_MIN["plan"]),
+            ({}, "refine", PHASE_CONSENSUS_TIMEOUT_DEFAULTS_MIN["refine"]),
+            ({}, "implement", PHASE_CONSENSUS_TIMEOUT_DEFAULTS_MIN["implement"]),
+        ],
+    )
+    def test_resolved_minutes_match_alert_metadata(
+        self, config_kwargs, phase, expected_minutes
+    ) -> None:
+        pipeline_id = f"issue-2635-precedence-{phase}-{expected_minutes}"
+        config = PipelineConfig(**config_kwargs)
+        assert resolve_consensus_timeout_minutes(config, phase) == expected_minutes
+
+        pipeline = _make_pipeline(pipeline_id, config, PipelinePhase(phase))
+        # Critical reviewer NACKs so the handler takes the escalate
+        # branch — that's the path that publishes an alert.
+        graph = ReviewGraph([ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL)])
+        tracker = make_tracker(pipeline_id, graph)
+        tracker.handle_propose("coder", propose_payload(commit_sha="abc"))
+        tracker.handle_nack(
+            "reviewer_code",
+            "coder",
+            {"nack_version": 1, **nack_payload(reason="regress")},
+        )
+
+        capture, alerts = _capture_alerts()
+        with capture:
+            _handle_brc_consensus_timeout(
+                pipeline,
+                pipeline_id,
+                consensus_timeout=expected_minutes * 60,
+                blocking_agents=["reviewer_code"],
+                store=None,
+                slice_id=None,
+                active_role_names=["coder", "reviewer_code"],
+            )
+
+        assert len(alerts) == 1
+        assert alerts[0].metadata["consensus_timeout_minutes"] == expected_minutes
+        assert alerts[0].metadata["priority"] == "high"
+        assert alerts[0].metadata["phase"] == phase

--- a/integration_tests/regression/test_brc_single_cycle.py
+++ b/integration_tests/regression/test_brc_single_cycle.py
@@ -1,0 +1,196 @@
+"""BRC happy-path consensus — issue #2635 starting point 1.
+
+Verifies the single-cycle PROPOSE → ACK → CONFIRMED protocol drives
+to consensus with exact message counts on the event bus.
+
+Why this lives in ``integration_tests/regression/``:
+
+The unit tier under ``orchestrator/tests/`` covers the
+``PeerConsensusTracker`` internals exhaustively (``test_brc_*.py``),
+but no test asserts the end-to-end event-counts contract that
+external consumers — the SSE bridge, the SDLC skill, the
+``babysit_pr`` BRC bridge — depend on.  When a future refactor
+re-routes one event type through a wrapper or skips emission on a
+fast path, the unit tier won't catch it; this regression will.
+
+ScriptedProvider can't drive deployed agent pods (see #2474), so
+the test exercises the orchestrator's BRC Python API directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+from _helpers import ack_payload, make_tracker, propose_payload
+from events import EventType
+
+pytestmark = pytest.mark.integration
+
+
+class TestBRCSingleCycleHappyPath:
+    """Producer PROPOSE → reviewer ACK → both CONFIRMED, no NACKs, no retries."""
+
+    PIPELINE_ID = "issue-2635-single-cycle"
+
+    def test_minimal_topology_reaches_consensus(
+        self, single_reviewer_graph, event_capture, filter_events
+    ) -> None:
+        """1 producer + 1 critical reviewer is the smallest valid BRC graph."""
+        tracker = make_tracker(self.PIPELINE_ID, single_reviewer_graph)
+
+        # ---- PROPOSE ----
+        result = tracker.handle_propose("coder", propose_payload(commit_sha="abc1234"))
+        assert result["status"] == "proposed"
+        assert result["version"] == 1
+        assert result["reviewers"] == ["reviewer_code"]
+
+        # ---- ACK ----
+        result = tracker.handle_ack("reviewer_code", "coder", {"ack_version": 1, **ack_payload()})
+        assert result["status"] == "acked"
+        assert result["fully_acked"] is True
+
+        # ---- CONFIRMED (producer) ----
+        result = tracker.handle_confirmed("coder")
+        assert result["status"] == "confirmed"
+        # coder has confirmed but reviewer hasn't yet → no global consensus
+        assert result["consensus_reached"] is False
+
+        # ---- CONFIRMED (reviewer) ----
+        result = tracker.handle_confirmed("reviewer_code")
+        assert result["status"] == "confirmed"
+        assert result["consensus_reached"] is True
+
+        # Tracker-level state is consistent with the event stream.
+        state = tracker.evaluate()
+        assert state["is_complete"] is True
+        assert state["blocking_agents"] == []
+        assert state["has_unresolved_nacks"] is False
+
+        # Exact event counts — the regression invariant.
+        events = event_capture()
+        assert (
+            len(
+                filter_events(
+                    events,
+                    pipeline_id=self.PIPELINE_ID,
+                    event_type=EventType.CONSENSUS_PROPOSE_RECEIVED,
+                )
+            )
+            == 1
+        )
+        assert (
+            len(
+                filter_events(
+                    events,
+                    pipeline_id=self.PIPELINE_ID,
+                    event_type=EventType.CONSENSUS_ACK_RECEIVED,
+                )
+            )
+            == 1
+        )
+        assert (
+            len(
+                filter_events(
+                    events,
+                    pipeline_id=self.PIPELINE_ID,
+                    event_type=EventType.CONSENSUS_NACK_RECEIVED,
+                )
+            )
+            == 0
+        )
+        assert (
+            len(
+                filter_events(
+                    events,
+                    pipeline_id=self.PIPELINE_ID,
+                    event_type=EventType.CONSENSUS_CONFIRMED_RECEIVED,
+                )
+            )
+            == 2
+        )
+        reached = filter_events(
+            events, pipeline_id=self.PIPELINE_ID, event_type=EventType.CONSENSUS_REACHED
+        )
+        assert len(reached) == 1
+        assert reached[0].data["protocol"] == "brc"
+        assert sorted(reached[0].data["confirmed_roles"]) == ["coder", "reviewer_code"]
+
+    def test_two_reviewer_topology_reaches_consensus(
+        self, two_reviewer_graph, event_capture, filter_events
+    ) -> None:
+        """Single PROPOSE drives 2 ACK + 3 CONFIRMED events.
+
+        Two critical reviewers each ACK the single producer's proposal at
+        the same version.  Then all three roles confirm — the producer
+        last because it cannot confirm until both reviewers have ACKed
+        (``check_confirm_guard.producer_not_fully_acked``).
+        """
+        pipeline_id = self.PIPELINE_ID + "-two-rev"
+        tracker = make_tracker(pipeline_id, two_reviewer_graph)
+
+        tracker.handle_propose("coder", propose_payload(commit_sha="def5678"))
+        tracker.handle_ack("reviewer_code", "coder", {"ack_version": 1, **ack_payload()})
+        tracker.handle_ack("reviewer_contract", "coder", {"ack_version": 1, **ack_payload()})
+        # Reviewers confirm first, then producer (matches production order).
+        tracker.handle_confirmed("reviewer_code")
+        tracker.handle_confirmed("reviewer_contract")
+        result = tracker.handle_confirmed("coder")
+        assert result["consensus_reached"] is True
+
+        events = event_capture()
+        counts = {
+            EventType.CONSENSUS_PROPOSE_RECEIVED: 1,
+            EventType.CONSENSUS_ACK_RECEIVED: 2,
+            EventType.CONSENSUS_NACK_RECEIVED: 0,
+            EventType.CONSENSUS_CONFIRMED_RECEIVED: 3,
+            EventType.CONSENSUS_REACHED: 1,
+        }
+        for event_type, expected in counts.items():
+            actual = filter_events(events, pipeline_id=pipeline_id, event_type=event_type)
+            assert len(actual) == expected, f"{event_type}: expected {expected}, got {len(actual)}"
+
+
+class TestBRCSingleCycleGuardsHonored:
+    """Out-of-order calls fail rather than silently advancing state."""
+
+    PIPELINE_ID = "issue-2635-single-cycle-guards"
+
+    def test_pre_proposal_ack_is_recorded_then_invalidated(self, single_reviewer_graph) -> None:
+        """A pre-proposal ACK is *recorded at version 0* and invalidated on PROPOSE.
+
+        ``check_ack_guard``'s version-match clause only fires when the
+        producer's current proposal version is ``> 0`` — a reviewer
+        racing the producer with ``ack_version=1`` therefore lands a
+        version-0 ACK in the matrix.  The producer's first PROPOSE
+        bumps the version and ``_invalidate_pre_proposal_acks`` clears
+        the stale entry, surfacing the invalidated reviewer in
+        ``stale_reviewers`` so the wait-loop knows to re-review.
+
+        This test pins the *actual* behavior so a future refactor of
+        the guard ordering doesn't silently regress the invalidation
+        rescue (see #2635 gap-audit note in the PR body).
+        """
+        tracker = make_tracker(self.PIPELINE_ID + "-ack", single_reviewer_graph)
+        # Reviewer ACKs before producer proposes — guard accepts because
+        # current proposal version is 0.  Omitting ``ack_version`` so the
+        # version-match clause skips (test-path comment in handle_ack).
+        result = tracker.handle_ack("reviewer_code", "coder", ack_payload())
+        assert result["status"] == "acked"
+        assert result["version"] == 0
+        # Now the producer proposes — invalidation kicks in.
+        result = tracker.handle_propose("coder", propose_payload(commit_sha="abc"))
+        assert "reviewer_code" in result["stale_reviewers"]
+
+    def test_producer_confirm_before_full_acks_is_pending(self, two_reviewer_graph) -> None:
+        """A producer must wait for every critical reviewer to ACK.
+
+        The guard returns ``pending_acks`` (not a raise) so the
+        producer's wait-loop is informed to keep polling.
+        """
+        pipeline_id = self.PIPELINE_ID + "-prod"
+        tracker = make_tracker(pipeline_id, two_reviewer_graph)
+        tracker.handle_propose("coder", propose_payload(commit_sha="abc"))
+        tracker.handle_ack("reviewer_code", "coder", {"ack_version": 1, **ack_payload()})
+        # Only reviewer_code has ACKed; reviewer_contract has not.
+        result = tracker.handle_confirmed("coder")
+        assert result["status"] == "pending_acks"
+        assert tracker.evaluate()["is_complete"] is False

--- a/integration_tests/regression/test_brc_single_cycle.py
+++ b/integration_tests/regression/test_brc_single_cycle.py
@@ -154,31 +154,53 @@ class TestBRCSingleCycleGuardsHonored:
 
     PIPELINE_ID = "issue-2635-single-cycle-guards"
 
-    def test_pre_proposal_ack_is_recorded_then_invalidated(self, single_reviewer_graph) -> None:
-        """A pre-proposal ACK is *recorded at version 0* and invalidated on PROPOSE.
+    def test_pre_proposal_ack_without_version_is_recorded_then_invalidated(
+        self, single_reviewer_graph
+    ) -> None:
+        """A pre-proposal ACK *with no version claim* lands at v0 and is invalidated.
 
-        ``check_ack_guard``'s version-match clause only fires when the
-        producer's current proposal version is ``> 0`` — a reviewer
-        racing the producer with ``ack_version=1`` therefore lands a
-        version-0 ACK in the matrix.  The producer's first PROPOSE
+        When the reviewer omits ``ack_version``, ``check_ack_guard``'s
+        version-match clause is skipped (the in-process test path
+        documented on ``handle_ack``) and the ACK is recorded at the
+        producer's current version (0).  The producer's first PROPOSE
         bumps the version and ``_invalidate_pre_proposal_acks`` clears
         the stale entry, surfacing the invalidated reviewer in
         ``stale_reviewers`` so the wait-loop knows to re-review.
 
-        This test pins the *actual* behavior so a future refactor of
-        the guard ordering doesn't silently regress the invalidation
-        rescue (see #2635 gap-audit note in the PR body).
+        Pins the rescue path so a future refactor of the guard ordering
+        doesn't silently regress the invalidation safety net.
         """
         tracker = make_tracker(self.PIPELINE_ID + "-ack", single_reviewer_graph)
-        # Reviewer ACKs before producer proposes — guard accepts because
-        # current proposal version is 0.  Omitting ``ack_version`` so the
-        # version-match clause skips (test-path comment in handle_ack).
+        # Reviewer ACKs before producer proposes — guard skips the
+        # version-match clause because ``ack_version`` is omitted.
         result = tracker.handle_ack("reviewer_code", "coder", ack_payload())
         assert result["status"] == "acked"
         assert result["version"] == 0
         # Now the producer proposes — invalidation kicks in.
         result = tracker.handle_propose("coder", propose_payload(commit_sha="abc"))
         assert "reviewer_code" in result["stale_reviewers"]
+
+    def test_pre_proposal_ack_with_explicit_version_is_rejected(
+        self, single_reviewer_graph
+    ) -> None:
+        """An explicit ``ack_version > 0`` against a v0 producer is rejected (#2654).
+
+        The previous version-match clause only fired when the
+        producer's current version was ``> 0``, so a predictive
+        ``ack_version=1`` claim against a never-proposed producer
+        slipped through and was recorded at v1.  Since
+        ``_invalidate_pre_proposal_acks`` only clears v0 entries, that
+        recorded v1 entry could have bypassed the rescue.  The guard
+        now rejects the claim outright — the reviewer must wait for
+        the producer to propose before naming a version.
+        """
+        tracker = make_tracker(self.PIPELINE_ID + "-ack-explicit", single_reviewer_graph)
+        with pytest.raises(ValueError, match="version mismatch"):
+            tracker.handle_ack(
+                "reviewer_code",
+                "coder",
+                {"ack_version": 1, **ack_payload()},
+            )
 
     def test_producer_confirm_before_full_acks_is_pending(self, two_reviewer_graph) -> None:
         """A producer must wait for every critical reviewer to ACK.

--- a/orchestrator/action_guards.py
+++ b/orchestrator/action_guards.py
@@ -201,10 +201,14 @@ def check_ack_guard(
         )
 
     # Version-match guard: ACK version must match the producer's current
-    # proposal version to prevent stale ACKs.
+    # proposal version to prevent stale ACKs. The previous form skipped
+    # the check when ``current_version == 0`` (no proposal yet), which
+    # let a predictive ``ack_version=N`` claim land in the matrix at
+    # version N — and ``_invalidate_pre_proposal_acks`` only clears
+    # version-0 entries, so the rescue could be bypassed (#2654).
     if matrix is not None and ack_version is not None:
         current_version = matrix.get_proposal_version(producer_role)
-        if current_version > 0 and ack_version != current_version:
+        if ack_version != current_version:
             return GuardResult(
                 allowed=False,
                 reason=(

--- a/orchestrator/tests/test_action_guards.py
+++ b/orchestrator/tests/test_action_guards.py
@@ -211,6 +211,21 @@ class TestCheckAckGuard:
         assert result.details["ack_version"] == 1
         assert result.details["current_version"] == 2
 
+    def test_pre_proposal_version_claim_rejected(self, graph, matrix):
+        """ACK with explicit version against v0 producer -> rejected (#2654).
+
+        Matrix has no recorded proposal — ``current_version`` is 0.
+        Predictive ``ack_version > 0`` claims used to slip past the
+        version-match guard (which only fired for ``current_version > 0``)
+        and survive ``_invalidate_pre_proposal_acks`` (which only clears
+        version-0 entries).  The guard now rejects them outright.
+        """
+        result = check_ack_guard("reviewer_code", "coder", graph, matrix=matrix, ack_version=1)
+        assert result.allowed is False
+        assert result.details["guard"] == "version_mismatch"
+        assert result.details["current_version"] == 0
+        assert result.details["ack_version"] == 1
+
 
 # ---------------------------------------------------------------------------
 # check_nack_guard


### PR DESCRIPTION
Closes #2635.
Closes #2654.
Closes #2653 — not a bug (see "Follow-up triage" below); pinned by new idle-reviewer regression tests.

## Summary

Adds `integration_tests/regression/` with in-process tests against the orchestrator's BRC Python API. Tests run under `make test-integration` (marked `integration`); they don't require k3s because per #2474 the constraint is "ScriptedProvider can't drive deployed agent pods," so the regression tier exercises the orchestrator's Python surface directly.

Post-review the PR also bundles the fix for the one real bug surfaced during the test write (#2654) plus regression coverage that closes #2653 as not-a-bug.

**30 tests, all passing**, ~0.4s local; full `make test-integration` is green.

## What's covered

**Issue #2635 starting points**
- `test_brc_single_cycle.py` — PROPOSE → ACK → CONFIRMED with exact `CONSENSUS_*` event counts (1-reviewer and 2-reviewer topologies); guard rejections for pre-proposal ACK + producer confirm before full ACKs.
- `test_brc_phase_timeout.py` — composes `resolve_consensus_timeout_minutes` with `_handle_brc_consensus_timeout` and asserts the configured value lands in the `OVERSEER_ALERT` metadata. Parametrized across the precedence tiers (per-phase override > legacy global > calibrated default).

**Gap-audit additions (issue text suggested these)**
- NACK → re-propose → ACK round-trip restores consensus.
- Reviewer disagreement (one ACK + one NACK from criticals) blocks consensus.
- `reconstruct_tracker_from_messages` rebuilds state from persisted messages (orchestrator-restart recovery).
- Three-phase config inheritance isolates per-phase overrides.

**Concurrency (`test_brc_concurrency.py` — added post-review)**
- Six reviewers ACKing in parallel land six distinct matrix entries and emit exactly six `CONSENSUS_ACK_RECEIVED` events (RLock serialisation check).
- Re-propose racing an ACK on the previous version leaves matrix state self-consistent.
- Two concurrent NACKs trigger the open-NACK aggregation barrier (#2142) — re_propose is blocked until the producer has been informed.
- Withdraw cooldown + flip-flop lockout under rapid retries.

**Edge cases (`test_brc_edge_cases.py` — added post-review)**
- Dual-role tester (producer + reviewer) needs both state machines to confirm.
- Slice-aware tracker keys `{pipeline_id}/{slice_id}` isolate per-slice state.
- Conditional ACK with `pre_merge_condition` + in-cycle `handle_resolve_obligation` (#2338) emits `CONSENSUS_OBLIGATION_RESOLVED` and clears the merge block.
- Stale-version ACK rejection — claiming v1 after producer re-proposed to v2 is blocked by `check_ack_guard`.

**Idle-reviewer timeout coverage (added during #2653 triage)**
- `test_idle_critical_reviewer_fires_overseer_alert` — producer proposed, critical reviewer never wrote a verdict → `_handle_brc_consensus_timeout` takes the escalate branch and publishes a high-priority `OVERSEER_ALERT`.
- `test_idle_advisory_reviewer_fires_notification` — same shape with an advisory reviewer → `CONSENSUS_TIMEOUT` event, no alert (per the design constraint pinned next to it).

**Pre-proposal ACK rejection (added for the #2654 fix)**
- `test_pre_proposal_ack_with_explicit_version_is_rejected` — pins the tightened `check_ack_guard` (predictive `ack_version > 0` against a v0 producer is now rejected outright).
- `test_pre_proposal_ack_without_version_is_recorded_then_invalidated` — preserved as the rescue-path pin (omitted `ack_version` still lands at v0 and is cleared by `_invalidate_pre_proposal_acks` on first propose).

**Test hygiene**
- Autouse `_reset_tracker_registry` fixture in `conftest.py` snapshots/restores the global `_trackers` dict around each test so cross-test leaks don't mask gaps.
- `event_capture` uses sequence-tip filtering on `get_history()` (bus history is updated synchronously inside the publish lock) rather than racing the async-delivery worker thread.

## Fix bundled in this PR

**#2654 — `check_ack_guard` pre-proposal ACK bypass.** The version-match clause only fired when `current_version > 0`, so a reviewer's predictive `ack_version=N` claim against a never-proposed producer was recorded at version N. Since `_invalidate_pre_proposal_acks` only clears version-0 entries, the rescue could be bypassed — as soon as the producer proposed at v1, the matrix already had a "clean" v1 ACK and `is_fully_acked` returned True without the reviewer actually reviewing anything substantive. Reproduced end-to-end on this branch before the fix.

Dropped the `current_version > 0` gate from `check_ack_guard` (`orchestrator/action_guards.py:207`). The omitted-version test path is unaffected — `handle_ack` only invokes the version-match clause when `ack_version` is supplied.

## Follow-up triage

- **#2653** (closed as not-a-bug). The issue body claimed `get_all_blocking_edges` only counts edges with a recorded matrix entry. Verified on this branch that's wrong: `ApprovalMatrix.__init__` pre-populates one PENDING entry per graph edge (`orchestrator/approval_matrix.py:101-108`), so an idle critical reviewer already appears in the blocking-edges set and `handle_timeout` correctly returns `{"action": "escalate", ...}`. The two `test_idle_*` cases above pin the verified behavior so a future refactor of the constructor pre-pop is caught.
- **#2635 comment** — Issue text references `phase_configs.plan.consensus_timeout_s = 30`; the actual field is `PipelineConfig.consensus_timeout_minutes_plan` (minutes, on `PipelineConfig` not the contract's `phase_configs`). Tests use the real name.

## Honest scope notes

* Wallclock timeout assertions ("within 30±5s") aren't feasible without standing up the real BRC wait loop (containers, network, the works). The contract operators consume is the value reflected in the alert payload; tests pin that end-to-end instead.
* Advisory-only timeout branch is intentionally silent at the alert layer (pinned by `test_advisory_only_path_is_silent_at_alert_layer`, mirrored against the existing unit test `test_pipelines_routes.py::test_brc_handled_without_escalate_no_alert`).

## Test plan

- [x] `make lint` clean
- [x] Affected orchestrator unit suites (action_guards, peer_consensus, conditional_ack, pre_proposal_ack_deadlock, auto_ack_pure_producers) — 289 passed
- [x] `integration_tests/regression/` — 30 pass in ~0.4s
- [x] Concurrency tests stress-looped 5× consecutively — no flake
- [ ] CI `Test / aggregate` green on this PR
