### PR TITLE
Autofix integration test failures via check-fixer

### DIFF
--- a/shared/check-fixers.yml
+++ b/shared/check-fixers.yml
@@ -48,3 +48,11 @@ workflows:
       max_retries: 2
     "Security Scan":
       max_retries: 2
+    # On PR CI, integration tests run as a nested job of the `Test` workflow
+    # via `uses: ./.github/workflows/test-integration.yml`. The GH jobs API
+    # reports the failure under the composite name `<caller-job>/<inner-job>`,
+    # so the key here must match that exact shape — not just "Integration Tests".
+    "Integration Tests / Integration Tests":
+      model: "opus"
+      timeout: "30"
+      max_retries: 2


### PR DESCRIPTION
## Summary

- Adds an `Integration Tests / Integration Tests` entry under the `Test:` workflow in `shared/check-fixers.yml` so the autofixer picks up the right model/retry budget when integration tests fail on PR CI.
- The GH jobs API reports the failure under the composite name `<caller-job>/<inner-job>` (because `test.yml` calls `test-integration.yml` via `uses:`), so the config key has to match that exact shape — not just `Integration Tests`. Verified against [run 25755160356](https://github.com/jwbron/egg/actions/runs/25755160356).
- Tunings: `model: opus` (k3s/networking failures need stronger reasoning), `timeout: 30` (matches the workflow's own 30-min budget), `max_retries: 2` (each retry rebuilds containers + spins up k3s, so cap below the default of 3). No `non_llm_fix` — there's no mechanical equivalent of `ruff format` for integration tests.

## Test plan

- [ ] Confirm yaml lint and parser-load are clean (done locally).
- [ ] Land and verify on the next PR whose `Integration Tests / Integration Tests` job fails — the autofixer should now invoke opus with a 2-retry cap rather than the sonnet default.