### PR TITLE
Fix #2681: verify sha256 on kustomize tarball install

### DIFF
--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -10,10 +10,15 @@ RUN apt-get update && apt-get install -y \
 # it `_run_kustomize` falls through both kustomize and `kubectl
 # kustomize` invocations and the route returns 500
 # `kustomize_unavailable` for every call (#2647). Pinned to a known-
-# good release; bump deliberately.
+# good release; bump deliberately. SHA256 is the published checksum
+# for the linux_amd64 tarball (see checksums.txt alongside the
+# release); bumping KUSTOMIZE_VERSION requires updating
+# KUSTOMIZE_SHA256 in lockstep (#2681).
 ARG KUSTOMIZE_VERSION=5.6.0
+ARG KUSTOMIZE_SHA256=54e4031ddc4e7fc59e408da29e7c646e8e57b8088c51b84b3df0864f47b5148f
 RUN curl -fsSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" \
         -o /tmp/kustomize.tar.gz \
+    && echo "${KUSTOMIZE_SHA256}  /tmp/kustomize.tar.gz" | sha256sum -c - \
     && tar -xzf /tmp/kustomize.tar.gz -C /usr/local/bin kustomize \
     && rm /tmp/kustomize.tar.gz \
     && chmod +x /usr/local/bin/kustomize


### PR DESCRIPTION
## Summary
- Pins `KUSTOMIZE_SHA256` to the published linux_amd64 checksum for v5.6.0 (`54e4031d…12a03`, from kustomize's `checksums.txt`).
- Adds `sha256sum -c` before extracting the tarball so a compromised release mirror or in-flight tampering on the build node fails the build instead of silently shipping a swapped binary.
- Comment above the ARGs notes that bumping `KUSTOMIZE_VERSION` requires updating `KUSTOMIZE_SHA256` in lockstep.

Closes #2681.

## Stacked on #2658
The kustomize install line this PR hardens is introduced by PR #2658 and isn't on `main` yet, so the base for this PR is `egg/2641-deployment-validation-integration-tests`. The actual diff (visible after #2658 merges) is the comment update + `ARG KUSTOMIZE_SHA256=…` + `sha256sum -c -` line in `orchestrator/Dockerfile`. After #2658 merges, please retarget this PR to `main`.

## Test plan
- [ ] Docker build of the orchestrator image succeeds (Docker CI job will exercise this).
- [ ] Confirm `sha256sum -c -` fails the build if the published checksum is wrong (manually verifiable by flipping a hex digit and rebuilding locally).