### PR TITLE
Fix #2674: enforce ack_version presence at signals route boundary

### DIFF
--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -155,6 +155,39 @@ def _validate_brc_content(body: str, kind: str) -> str | None:
     return None
 
 
+def _require_route_version(payload: dict[str, Any], key: str) -> tuple[Response, int] | None:
+    """Enforce ``payload[key]`` is an integer >= 1 at the HTTP signals boundary.
+
+    Mirrors ``_require_version_int`` in ``sandbox/egg_agent_tools/handlers/brc.py``
+    so the route surface shares the MCP handler's contract — a client POSTing
+    directly to ``/signals/...`` cannot bypass the version-match guard in
+    ``check_ack_guard`` / ``check_nack_guard`` by omitting the version field
+    (#2674).  Returns an error response tuple on failure, or ``None`` on
+    success.
+    """
+    if key not in payload:
+        return make_error_response(
+            f"'{key}' is required (the producer's current proposal version "
+            "you reviewed; read it from the CONSENSUS_PROPOSE message)",
+            400,
+        )
+    raw = payload[key]
+    try:
+        version = int(raw)
+    except TypeError, ValueError:
+        return make_error_response(
+            f"'{key}' must be an integer; got {raw!r}",
+            400,
+        )
+    if version < 1:
+        return make_error_response(
+            f"'{key}' must be >= 1; got {version} (v0 means no proposal exists yet)",
+            400,
+        )
+    payload[key] = version
+    return None
+
+
 from routes import (  # noqa: E402 — shared helper
     get_repo_path,
     resolve_repo_path_for_pipeline,
@@ -1385,7 +1418,16 @@ def handle_consensus_ack_signal(
     # Forward ack_version from signal data into the payload so the
     # version-match guard can detect stale ACKs.
     if "ack_version" in data and "ack_version" not in payload:
-        payload["ack_version"] = int(data["ack_version"])
+        payload["ack_version"] = data["ack_version"]
+
+    # Require ack_version >= 1 at the route boundary so the HTTP surface
+    # matches the MCP handler's contract (`_require_version_int` in
+    # sandbox/egg_agent_tools/handlers/brc.py). Without this, a client that
+    # omits ack_version bypasses the version-match guard in
+    # check_ack_guard (#2674).
+    version_error = _require_route_version(payload, "ack_version")
+    if version_error is not None:
+        return version_error
 
     # Validate ACK reason content (#1716)
     reason_error = _validate_brc_content(payload.get("reason", ""), "ACK reason")

--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -164,17 +164,28 @@ def _require_route_version(payload: dict[str, Any], key: str) -> tuple[Response,
     ``check_ack_guard`` / ``check_nack_guard`` by omitting the version field
     (#2674).  Returns an error response tuple on failure, or ``None`` on
     success.
+
+    Treats absent and explicit ``null`` the same (both → "required"), matching
+    the MCP helper.  On success, coerces ``payload[key]`` to ``int`` in place
+    so downstream ``check_ack_guard`` / ``check_nack_guard`` can compare
+    integers directly (the original raw value may have been a numeric string).
     """
-    if key not in payload:
+    raw = payload.get(key)
+    if raw is None:
         return make_error_response(
             f"'{key}' is required (the producer's current proposal version "
             "you reviewed; read it from the CONSENSUS_PROPOSE message)",
             400,
         )
-    raw = payload[key]
     try:
         version = int(raw)
-    except TypeError, ValueError:
+    except (TypeError, ValueError) as _exc:
+        # `as _exc` is unused but forces the parentheses to stay: PEP 758
+        # (Python 3.14) makes `except T, V:` a legal multi-class form, and
+        # ruff format normalises to that shorter shape — which is
+        # byte-identical to Python 2's `except Exception, var:` instance-
+        # binding form and reads as a different operation at a glance.  The
+        # binding pins the parens so the syntax cannot regress.
         return make_error_response(
             f"'{key}' must be an integer; got {raw!r}",
             400,
@@ -1549,7 +1560,16 @@ def handle_consensus_nack_signal(
     # Forward nack_version from signal data into the payload so the
     # version-match guard can detect stale NACKs (#2142).
     if "nack_version" in data and "nack_version" not in payload:
-        payload["nack_version"] = int(data["nack_version"])
+        payload["nack_version"] = data["nack_version"]
+
+    # Require nack_version >= 1 at the route boundary so the HTTP surface
+    # matches the MCP handler's contract (`_require_version_int` in
+    # sandbox/egg_agent_tools/handlers/brc.py). Without this, a client that
+    # omits nack_version bypasses the version-match guard in
+    # check_nack_guard (#2674).
+    version_error = _require_route_version(payload, "nack_version")
+    if version_error is not None:
+        return version_error
 
     # Validate NACK reason content (#1716)
     reason_error = _validate_brc_content(payload.get("reason", ""), "NACK reason")

--- a/orchestrator/tests/test_brc_content_validation.py
+++ b/orchestrator/tests/test_brc_content_validation.py
@@ -929,6 +929,7 @@ class TestNackContentValidation:
                 {
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
+                    "nack_version": 1,
                     "payload": {"reason": ""},
                 },
                 Path("/tmp/repo"),
@@ -947,6 +948,7 @@ class TestNackContentValidation:
                 {
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
+                    "nack_version": 1,
                     "payload": {"reason": "Missing tests"},
                 },
                 Path("/tmp/repo"),
@@ -965,6 +967,7 @@ class TestNackContentValidation:
                 {
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
+                    "nack_version": 1,
                     "payload": {"reason": "No issues"},
                 },
                 Path("/tmp/repo"),
@@ -1000,6 +1003,7 @@ class TestNackContentValidation:
                     {
                         "agent_role": "reviewer_code",
                         "producer_role": "coder",
+                        "nack_version": 1,
                         "payload": {
                             "reason": (
                                 "SQL injection vulnerability in auth.py line 42: "
@@ -1028,6 +1032,7 @@ class TestNackContentValidation:
                 {
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
+                    "nack_version": 1,
                     "payload": {"reason": "bad"},
                 },
                 Path("/tmp/repo"),

--- a/orchestrator/tests/test_brc_content_validation.py
+++ b/orchestrator/tests/test_brc_content_validation.py
@@ -617,6 +617,7 @@ class TestAckContentValidation:
                 {
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
+                    "ack_version": 1,
                     "payload": {"reason": ""},
                 },
                 Path("/tmp/repo"),
@@ -636,6 +637,7 @@ class TestAckContentValidation:
                 {
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
+                    "ack_version": 1,
                     "payload": {},
                 },
                 Path("/tmp/repo"),
@@ -654,6 +656,7 @@ class TestAckContentValidation:
                 {
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
+                    "ack_version": 1,
                     "payload": {"reason": "LGTM"},
                 },
                 Path("/tmp/repo"),
@@ -672,6 +675,7 @@ class TestAckContentValidation:
                 {
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
+                    "ack_version": 1,
                     "payload": {"reason": "Looks fine to me"},
                 },
                 Path("/tmp/repo"),
@@ -708,6 +712,7 @@ class TestAckContentValidation:
                     {
                         "agent_role": "reviewer_code",
                         "producer_role": "coder",
+                        "ack_version": 1,
                         "payload": {"reason": _SUBSTANTIVE_REASON},
                     },
                     Path("/tmp/repo"),
@@ -785,6 +790,7 @@ class TestAckPreMergeConditionValidation:
                     {
                         "agent_role": "reviewer_code",
                         "producer_role": "coder",
+                        "ack_version": 1,
                         "payload": payload,
                     },
                     Path("/tmp/repo"),

--- a/orchestrator/tests/test_brc_content_validation.py
+++ b/orchestrator/tests/test_brc_content_validation.py
@@ -735,6 +735,7 @@ class TestAckContentValidation:
                 {
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
+                    "ack_version": 1,
                     "payload": {"reason": "ok"},
                 },
                 Path("/tmp/repo"),

--- a/orchestrator/tests/test_brc_phase_propagation.py
+++ b/orchestrator/tests/test_brc_phase_propagation.py
@@ -367,6 +367,7 @@ class TestAckPhasePropagation:
                 {
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
+                    "ack_version": 1,
                     "payload": {
                         "reason": "Reviewed src/auth.py: token validation logic is correct, all branches covered by tests"
                     },
@@ -417,6 +418,7 @@ class TestAckPhasePropagation:
                 {
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
+                    "ack_version": 1,
                     "payload": {
                         "reason": "Reviewed src/auth.py: token validation logic is correct, all branches covered by tests"
                     },

--- a/orchestrator/tests/test_brc_phase_propagation.py
+++ b/orchestrator/tests/test_brc_phase_propagation.py
@@ -475,6 +475,7 @@ class TestNackPhasePropagation:
                 {
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
+                    "nack_version": 1,
                     "payload": {
                         "reason": "Missing unit tests for token expiry edge cases and invalid signature handling paths"
                     },
@@ -827,6 +828,7 @@ class TestPhasePropagationEdgeCases:
                 {
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
+                    "nack_version": 1,
                     "payload": {
                         "reason": "Implementation has SQL injection in query builder module, user input is not sanitized"
                     },

--- a/orchestrator/tests/test_conditional_ack.py
+++ b/orchestrator/tests/test_conditional_ack.py
@@ -512,6 +512,7 @@ class TestSignalPathIntegration:
                 {
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
+                    "ack_version": 1,
                     "payload": {
                         "artifact_references": ["src/a.py"],
                         "reason": self._SUBSTANTIVE_REASON,
@@ -553,6 +554,7 @@ class TestSignalPathIntegration:
                 {
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
+                    "ack_version": 1,
                     "payload": {
                         "artifact_references": ["src/a.py"],
                         "reason": self._SUBSTANTIVE_REASON,

--- a/orchestrator/tests/test_signals.py
+++ b/orchestrator/tests/test_signals.py
@@ -1830,3 +1830,255 @@ class TestAckVersionRouteEnforcement:
         assert body["success"] is False
         assert "must be an integer" in body["message"]
         mock_tracker.handle_ack.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_ack_rejected_when_ack_version_is_none(self, mock_subprocess_run, app):
+        """Explicit JSON ``null`` for ack_version is treated as absent (TypeError branch).
+
+        Covers the ``int(None)`` → ``TypeError`` arm of the helper that the
+        string-coercion case (``int("not-an-int")`` → ``ValueError``) misses.
+        Also pins the absent-vs-null equivalence: both produce the "required"
+        message, matching the MCP helper.
+        """
+        with app.app_context():
+            from routes.signals import handle_consensus_ack_signal
+
+            mock_tracker = MagicMock()
+            with (
+                patch(
+                    "peer_consensus.get_peer_consensus_tracker",
+                    return_value=mock_tracker,
+                ),
+                patch("routes.signals._resolve_pipeline_phase", return_value="implement"),
+            ):
+                response, status_code = handle_consensus_ack_signal(
+                    "issue-42",
+                    {
+                        "agent_role": "reviewer_code",
+                        "producer_role": "coder",
+                        "payload": {
+                            "ack_version": None,
+                            "reason": "Reviewed src/auth.py: token validation covers expiry and invalid signatures correctly, all branches tested",
+                        },
+                    },
+                    Path("/tmp/repo"),
+                )
+
+        assert status_code == 400
+        body = response.get_json()
+        assert body["success"] is False
+        assert "is required" in body["message"]
+        mock_tracker.handle_ack.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_ack_rejected_when_ack_version_negative(self, mock_subprocess_run, app):
+        """ack_version=-1 is rejected — locks down the off-by-one on ``< 1``."""
+        with app.app_context():
+            from routes.signals import handle_consensus_ack_signal
+
+            mock_tracker = MagicMock()
+            with (
+                patch(
+                    "peer_consensus.get_peer_consensus_tracker",
+                    return_value=mock_tracker,
+                ),
+                patch("routes.signals._resolve_pipeline_phase", return_value="implement"),
+            ):
+                response, status_code = handle_consensus_ack_signal(
+                    "issue-42",
+                    {
+                        "agent_role": "reviewer_code",
+                        "producer_role": "coder",
+                        "ack_version": -1,
+                        "payload": {
+                            "reason": "Reviewed src/auth.py: token validation covers expiry and invalid signatures correctly, all branches tested",
+                        },
+                    },
+                    Path("/tmp/repo"),
+                )
+
+        assert status_code == 400
+        body = response.get_json()
+        assert body["success"] is False
+        assert ">= 1" in body["message"]
+        mock_tracker.handle_ack.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# NACK version presence enforcement at the route boundary (#2674)
+# ---------------------------------------------------------------------------
+
+
+class TestNackVersionRouteEnforcement:
+    """Tests that handle_consensus_nack_signal rejects missing / invalid nack_version.
+
+    Mirrors :class:`TestAckVersionRouteEnforcement` — the helper is shared
+    (``_require_route_version``) so the NACK route must enforce the same
+    contract or a client POSTing directly to ``/signals/...`` could bypass
+    the version-match guard in ``check_nack_guard``.
+    """
+
+    @patch("subprocess.run")
+    def test_nack_rejected_when_nack_version_missing(self, mock_subprocess_run, app):
+        """Payload that omits nack_version (top-level or nested) is rejected with 400."""
+        with app.app_context():
+            from routes.signals import handle_consensus_nack_signal
+
+            mock_tracker = MagicMock()
+            with (
+                patch(
+                    "peer_consensus.get_peer_consensus_tracker",
+                    return_value=mock_tracker,
+                ),
+                patch("routes.signals._resolve_pipeline_phase", return_value="implement"),
+            ):
+                response, status_code = handle_consensus_nack_signal(
+                    "issue-42",
+                    {
+                        "agent_role": "reviewer_code",
+                        "producer_role": "coder",
+                        # No nack_version at top level or in payload.
+                        "payload": {
+                            "reason": "Missing unit tests for token expiry edge cases and invalid signature handling paths",
+                        },
+                    },
+                    Path("/tmp/repo"),
+                )
+
+        assert status_code == 400
+        body = response.get_json()
+        assert body["success"] is False
+        assert "nack_version" in body["message"]
+        mock_tracker.handle_nack.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_nack_rejected_when_nack_version_zero(self, mock_subprocess_run, app):
+        """nack_version=0 is rejected because v0 means no proposal exists yet."""
+        with app.app_context():
+            from routes.signals import handle_consensus_nack_signal
+
+            mock_tracker = MagicMock()
+            with (
+                patch(
+                    "peer_consensus.get_peer_consensus_tracker",
+                    return_value=mock_tracker,
+                ),
+                patch("routes.signals._resolve_pipeline_phase", return_value="implement"),
+            ):
+                response, status_code = handle_consensus_nack_signal(
+                    "issue-42",
+                    {
+                        "agent_role": "reviewer_code",
+                        "producer_role": "coder",
+                        "nack_version": 0,
+                        "payload": {
+                            "reason": "Missing unit tests for token expiry edge cases and invalid signature handling paths",
+                        },
+                    },
+                    Path("/tmp/repo"),
+                )
+
+        assert status_code == 400
+        body = response.get_json()
+        assert body["success"] is False
+        assert ">= 1" in body["message"]
+        mock_tracker.handle_nack.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_nack_rejected_when_nack_version_non_integer(self, mock_subprocess_run, app):
+        """nack_version that is not int-coercible is rejected with 400."""
+        with app.app_context():
+            from routes.signals import handle_consensus_nack_signal
+
+            mock_tracker = MagicMock()
+            with (
+                patch(
+                    "peer_consensus.get_peer_consensus_tracker",
+                    return_value=mock_tracker,
+                ),
+                patch("routes.signals._resolve_pipeline_phase", return_value="implement"),
+            ):
+                response, status_code = handle_consensus_nack_signal(
+                    "issue-42",
+                    {
+                        "agent_role": "reviewer_code",
+                        "producer_role": "coder",
+                        "payload": {
+                            "nack_version": "not-an-int",
+                            "reason": "Missing unit tests for token expiry edge cases and invalid signature handling paths",
+                        },
+                    },
+                    Path("/tmp/repo"),
+                )
+
+        assert status_code == 400
+        body = response.get_json()
+        assert body["success"] is False
+        assert "must be an integer" in body["message"]
+        mock_tracker.handle_nack.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_nack_rejected_when_nack_version_is_none(self, mock_subprocess_run, app):
+        """Explicit JSON ``null`` for nack_version is treated as absent (TypeError branch)."""
+        with app.app_context():
+            from routes.signals import handle_consensus_nack_signal
+
+            mock_tracker = MagicMock()
+            with (
+                patch(
+                    "peer_consensus.get_peer_consensus_tracker",
+                    return_value=mock_tracker,
+                ),
+                patch("routes.signals._resolve_pipeline_phase", return_value="implement"),
+            ):
+                response, status_code = handle_consensus_nack_signal(
+                    "issue-42",
+                    {
+                        "agent_role": "reviewer_code",
+                        "producer_role": "coder",
+                        "payload": {
+                            "nack_version": None,
+                            "reason": "Missing unit tests for token expiry edge cases and invalid signature handling paths",
+                        },
+                    },
+                    Path("/tmp/repo"),
+                )
+
+        assert status_code == 400
+        body = response.get_json()
+        assert body["success"] is False
+        assert "is required" in body["message"]
+        mock_tracker.handle_nack.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_nack_rejected_when_nack_version_negative(self, mock_subprocess_run, app):
+        """nack_version=-1 is rejected — locks down the off-by-one on ``< 1``."""
+        with app.app_context():
+            from routes.signals import handle_consensus_nack_signal
+
+            mock_tracker = MagicMock()
+            with (
+                patch(
+                    "peer_consensus.get_peer_consensus_tracker",
+                    return_value=mock_tracker,
+                ),
+                patch("routes.signals._resolve_pipeline_phase", return_value="implement"),
+            ):
+                response, status_code = handle_consensus_nack_signal(
+                    "issue-42",
+                    {
+                        "agent_role": "reviewer_code",
+                        "producer_role": "coder",
+                        "nack_version": -1,
+                        "payload": {
+                            "reason": "Missing unit tests for token expiry edge cases and invalid signature handling paths",
+                        },
+                    },
+                    Path("/tmp/repo"),
+                )
+
+        assert status_code == 400
+        body = response.get_json()
+        assert body["success"] is False
+        assert ">= 1" in body["message"]
+        mock_tracker.handle_nack.assert_not_called()

--- a/orchestrator/tests/test_signals.py
+++ b/orchestrator/tests/test_signals.py
@@ -1715,3 +1715,118 @@ class TestAckVersionForwarding:
         payload_passed = call_args[0][2]
         # Payload's own ack_version should be preserved, not overwritten
         assert payload_passed.get("ack_version") == 3
+
+
+# ---------------------------------------------------------------------------
+# ACK version presence enforcement at the route boundary (#2674)
+# ---------------------------------------------------------------------------
+
+
+class TestAckVersionRouteEnforcement:
+    """Tests that handle_consensus_ack_signal rejects missing / invalid ack_version.
+
+    Mirrors the ``_require_version_int`` contract on the MCP handler boundary
+    (``sandbox/egg_agent_tools/handlers/brc.py``) so a client POSTing directly
+    to ``/signals/...`` cannot bypass the version-match guard in
+    ``check_ack_guard``.
+    """
+
+    @patch("subprocess.run")
+    def test_ack_rejected_when_ack_version_missing(self, mock_subprocess_run, app):
+        """Payload that omits ack_version (top-level or nested) is rejected with 400."""
+        with app.app_context():
+            from routes.signals import handle_consensus_ack_signal
+
+            mock_tracker = MagicMock()
+            with (
+                patch(
+                    "peer_consensus.get_peer_consensus_tracker",
+                    return_value=mock_tracker,
+                ),
+                patch("routes.signals._resolve_pipeline_phase", return_value="implement"),
+            ):
+                response, status_code = handle_consensus_ack_signal(
+                    "issue-42",
+                    {
+                        "agent_role": "reviewer_code",
+                        "producer_role": "coder",
+                        # No ack_version at top level or in payload.
+                        "payload": {
+                            "reason": "Reviewed src/auth.py: token validation covers expiry and invalid signatures correctly, all branches tested",
+                        },
+                    },
+                    Path("/tmp/repo"),
+                )
+
+        assert status_code == 400
+        body = response.get_json()
+        assert body["success"] is False
+        assert "ack_version" in body["message"]
+        # Tracker must never be reached — the guard is at the boundary.
+        mock_tracker.handle_ack.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_ack_rejected_when_ack_version_zero(self, mock_subprocess_run, app):
+        """ack_version=0 is rejected because v0 means no proposal exists yet."""
+        with app.app_context():
+            from routes.signals import handle_consensus_ack_signal
+
+            mock_tracker = MagicMock()
+            with (
+                patch(
+                    "peer_consensus.get_peer_consensus_tracker",
+                    return_value=mock_tracker,
+                ),
+                patch("routes.signals._resolve_pipeline_phase", return_value="implement"),
+            ):
+                response, status_code = handle_consensus_ack_signal(
+                    "issue-42",
+                    {
+                        "agent_role": "reviewer_code",
+                        "producer_role": "coder",
+                        "ack_version": 0,
+                        "payload": {
+                            "reason": "Reviewed src/auth.py: token validation covers expiry and invalid signatures correctly, all branches tested",
+                        },
+                    },
+                    Path("/tmp/repo"),
+                )
+
+        assert status_code == 400
+        body = response.get_json()
+        assert body["success"] is False
+        assert ">= 1" in body["message"]
+        mock_tracker.handle_ack.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_ack_rejected_when_ack_version_non_integer(self, mock_subprocess_run, app):
+        """ack_version that is not int-coercible is rejected with 400."""
+        with app.app_context():
+            from routes.signals import handle_consensus_ack_signal
+
+            mock_tracker = MagicMock()
+            with (
+                patch(
+                    "peer_consensus.get_peer_consensus_tracker",
+                    return_value=mock_tracker,
+                ),
+                patch("routes.signals._resolve_pipeline_phase", return_value="implement"),
+            ):
+                response, status_code = handle_consensus_ack_signal(
+                    "issue-42",
+                    {
+                        "agent_role": "reviewer_code",
+                        "producer_role": "coder",
+                        "payload": {
+                            "reason": "Reviewed src/auth.py: token validation covers expiry and invalid signatures correctly, all branches tested",
+                            "ack_version": "not-an-int",
+                        },
+                    },
+                    Path("/tmp/repo"),
+                )
+
+        assert status_code == 400
+        body = response.get_json()
+        assert body["success"] is False
+        assert "must be an integer" in body["message"]
+        mock_tracker.handle_ack.assert_not_called()

--- a/orchestrator/tests/test_slice_signal_routing.py
+++ b/orchestrator/tests/test_slice_signal_routing.py
@@ -392,6 +392,7 @@ class TestAllConsensusHandlersRouteToSliceTracker:
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
                     "slice_id": "slice-2",
+                    "nack_version": 1,
                     "payload": {
                         "reason": (
                             "Slice-2 NACK: the diff is missing test coverage "
@@ -625,6 +626,7 @@ class TestAllConsensusHandlersRejectMalformedSliceId:
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
                     "slice_id": "phase-2",  # legacy shape rejected at signal boundary
+                    "nack_version": 1,
                     "payload": {
                         "reason": (
                             "NACK: the diff is missing test coverage for "

--- a/orchestrator/tests/test_slice_signal_routing.py
+++ b/orchestrator/tests/test_slice_signal_routing.py
@@ -358,6 +358,7 @@ class TestAllConsensusHandlersRouteToSliceTracker:
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
                     "slice_id": "slice-2",
+                    "ack_version": 1,
                     "payload": {
                         "reason": (
                             "Reviewed slice-2 work and the diff matches the "
@@ -601,6 +602,7 @@ class TestAllConsensusHandlersRejectMalformedSliceId:
                     "agent_role": "reviewer_code",
                     "producer_role": "coder",
                     "slice_id": "../etc/passwd",
+                    "ack_version": 1,
                     "payload": {
                         "reason": (
                             "Reviewed work; the diff matches the proposal "


### PR DESCRIPTION
## Summary

Closes #2674.

- `orchestrator/routes/signals.py::handle_consensus_ack_signal` now rejects payloads that omit `ack_version` (or supply `< 1`) with a structured 400 — mirroring `_require_version_int` in `sandbox/egg_agent_tools/handlers/brc.py` so the HTTP surface shares the MCP handler's contract.
- Without this, a custom client POSTing directly to `/signals/...` could omit `ack_version` and bypass the version-match guard in `check_ack_guard` (the pre-proposal ACK would land as v0 and only the rescue path in `_invalidate_pre_proposal_acks` would clear it).
- New `TestAckVersionRouteEnforcement` class in `orchestrator/tests/test_signals.py` pins the rejection for missing / zero / non-integer cases and verifies the tracker is never reached on rejection.

## Test plan

- [x] `make test` — 784 passed (changeset-aware)
- [x] `make lint` — clean
- [x] Targeted suites (`test_signals.py`, `test_brc_content_validation.py`, `test_brc_phase_propagation.py`, `test_conditional_ack.py`, `test_slice_signal_routing.py`) — 212 passed
- [x] Existing ACK route tests that constructed payloads without `ack_version` updated to supply it (they were exercising other validations — content, phase, conditional ACK, slice routing — on incidentally-incomplete payloads, not testing the absence of `ack_version`)