### PR TITLE
sandbox: retry deadsnakes apt install on transient PPA failures

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -28,14 +28,28 @@ ENV GOMODCACHE=/usr/local/pkg/mod
 # pyproject.toml. Without it, uv downloads a managed Python into /root/ which
 # creates broken symlinks when the .venv is persisted and restored for the
 # non-root runtime user.
-RUN apt-get update && apt-get install -y \
-    python3 python3-pip \
-    git curl wget make build-essential pkg-config \
-    # Common build deps needed by repo build_commands
-    jq unzip software-properties-common \
+RUN set -eux \
+    && apt-get update && apt-get install -y \
+        python3 python3-pip \
+        git curl wget make build-essential pkg-config \
+        jq unzip software-properties-common \
     && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt-get update \
-    && apt-get install -y python3.14 python3.14-venv python3.14-dev \
+    # deadsnakes PPA occasionally returns 5xx during apt-get update, leaving
+    # python3.14* packages unlocatable on install (see PR #2694 CI failure).
+    # Retry the post-PPA update+install with backoff; Acquire::Retries handles
+    # short blips inside a single apt invocation, the outer loop handles
+    # longer outages.
+    && for i in 1 2 3 4 5; do \
+        if apt-get update -o Acquire::Retries=3 \
+            && apt-get install -y python3.14 python3.14-venv python3.14-dev; then \
+            break; \
+        fi; \
+        if [ "$i" = 5 ]; then \
+            echo "deadsnakes install failed after 5 attempts" >&2; exit 1; \
+        fi; \
+        echo "deadsnakes install attempt $i failed, sleeping $((i*15))s..." >&2; \
+        sleep $((i*15)); \
+    done \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.14 1 \
     && update-alternatives --set python3 /usr/bin/python3.14 \
     && python3.14 -m ensurepip --upgrade \
@@ -121,17 +135,30 @@ RUN curl -fsSL https://repo.charm.sh/apt/gpg.key | gpg --dearmor -o /usr/share/k
 # to pick up deadsnakes packages.
 # python3-pip from apt targets the system Python (3.10), not 3.14 — so we
 # omit it and bootstrap pip via ensurepip after setting update-alternatives.
-RUN apt-get update && \
-    add-apt-repository -y ppa:deadsnakes/ppa && \
-    apt-get update && \
-    apt-get install -y python3.14 python3.14-venv python3.14-dev && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.14 1 && \
-    update-alternatives --set python3 /usr/bin/python3.14 && \
-    # Ensure 'python' command maps to python3 (many tools expect this)
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.14 1 && \
-    # Bootstrap pip for Python 3.14 (ensurepip installs pip3 to /usr/local/bin)
-    python3.14 -m ensurepip --upgrade && \
-    python3.14 -m pip install --no-cache-dir --upgrade pip
+RUN set -eux \
+    && apt-get update \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    # deadsnakes PPA occasionally returns 5xx during apt-get update, leaving
+    # python3.14* packages unlocatable on install (see PR #2694 CI failure).
+    # Retry the post-PPA update+install with backoff; Acquire::Retries handles
+    # short blips inside a single apt invocation, the outer loop handles
+    # longer outages.
+    && for i in 1 2 3 4 5; do \
+        if apt-get update -o Acquire::Retries=3 \
+            && apt-get install -y python3.14 python3.14-venv python3.14-dev; then \
+            break; \
+        fi; \
+        if [ "$i" = 5 ]; then \
+            echo "deadsnakes install failed after 5 attempts" >&2; exit 1; \
+        fi; \
+        echo "deadsnakes install attempt $i failed, sleeping $((i*15))s..." >&2; \
+        sleep $((i*15)); \
+    done \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.14 1 \
+    && update-alternatives --set python3 /usr/bin/python3.14 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.14 1 \
+    && python3.14 -m ensurepip --upgrade \
+    && python3.14 -m pip install --no-cache-dir --upgrade pip
 
 # Install pyyaml early - required by docker-setup.py for reading config
 RUN pip3 install --no-cache-dir pyyaml

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -38,9 +38,11 @@ RUN set -eux \
     # python3.14* packages unlocatable on install (see PR #2694 CI failure).
     # Retry the post-PPA update+install with backoff; Acquire::Retries handles
     # short blips inside a single apt invocation, the outer loop handles
-    # longer outages.
+    # longer outages. APT::Update::Error-Mode=any promotes per-source index
+    # errors to a non-zero exit, so a deadsnakes 5xx trips the retry directly
+    # instead of leaking through as an unlocatable-package install failure.
     && for i in 1 2 3 4 5; do \
-        if apt-get update -o Acquire::Retries=3 \
+        if apt-get update -o Acquire::Retries=3 -o APT::Update::Error-Mode=any \
             && apt-get install -y python3.14 python3.14-venv python3.14-dev; then \
             break; \
         fi; \
@@ -142,9 +144,11 @@ RUN set -eux \
     # python3.14* packages unlocatable on install (see PR #2694 CI failure).
     # Retry the post-PPA update+install with backoff; Acquire::Retries handles
     # short blips inside a single apt invocation, the outer loop handles
-    # longer outages.
+    # longer outages. APT::Update::Error-Mode=any promotes per-source index
+    # errors to a non-zero exit, so a deadsnakes 5xx trips the retry directly
+    # instead of leaking through as an unlocatable-package install failure.
     && for i in 1 2 3 4 5; do \
-        if apt-get update -o Acquire::Retries=3 \
+        if apt-get update -o Acquire::Retries=3 -o APT::Update::Error-Mode=any \
             && apt-get install -y python3.14 python3.14-venv python3.14-dev; then \
             break; \
         fi; \


### PR DESCRIPTION
## Summary

- The deadsnakes PPA occasionally returns HTTP 5xx during `apt-get update`, which silently leaves the deadsnakes package index unpopulated. The subsequent `apt-get install python3.14-venv python3.14-dev` then exits 100 with "Unable to locate package", killing `make build` in CI (see #2694 Integration Tests failure, comment [#4435427457](https://github.com/jwbron/egg/pull/2694#issuecomment-4435427457)).
- Both `repo-deps` (Stage 1) and `base` (Stage 2) of `sandbox/Dockerfile` independently install python3.14 from deadsnakes, so both stages can fail this way.
- Wrap the post-PPA `apt-get update + apt-get install` in each stage with a 5-attempt retry loop using 15s/30s/45s/60s backoff, and pass `-o Acquire::Retries=3` for in-call resilience to short blips. Outer loop survives multi-minute outages, inner option survives sub-second flakes.
- No other apt invocations are touched — the install of base Ubuntu packages doesn't go through deadsnakes and hasn't shown flakiness.

## Test plan

- [ ] CI Integration Tests / Integration Tests passes on this branch — confirms the hardened build still produces a working sandbox image.
- [ ] Visually inspect that the retry loop appears in both Stage 1 and Stage 2 RUN blocks of `sandbox/Dockerfile`.
- [ ] Local smoke: `make build` on a clean machine succeeds (recovery path can't be exercised without a flake injector, but the always-fail path was verified offline to exit non-zero after 5 attempts).