### PR TITLE
test+fix: harden probe-flake in validate-network-isolation

### DIFF
--- a/integration_tests/test_deployment_validation_logic.py
+++ b/integration_tests/test_deployment_validation_logic.py
@@ -440,6 +440,11 @@ class TestValidateNetworkIsolationLogic:
         data = resp.json()["data"]
         # Probe-launched shape, not the short-circuit shape.
         assert "probe_id" in data, f"expected probe-launched shape with probe_id; got {data!r}"
+        # Probe-timeout shape (``probe_id`` + ``error: probe_timeout``, no
+        # ``result``) is environmental — surface a useful message instead
+        # of letting ``data["result"]`` raise ``KeyError``.
+        if "result" not in data:
+            pytest.fail(f"probe pod did not complete before route timeout: {data!r}")
         result = data["result"]
         assert result.get("gateway_reachable") is True
         assert result.get("internet_blocked") is True

--- a/orchestrator/routes/deployment.py
+++ b/orchestrator/routes/deployment.py
@@ -1267,7 +1267,10 @@ def validate_network_isolation() -> tuple[Response, int]:
         return jsonify({"success": False, "message": f"probe submit failed: {exc}"}), 500
 
     try:
-        pod = _wait_for_probe_pod(k8s, namespace, probe_id, timeout=30.0)
+        # 30s was too tight: probe-pod scheduling on the k3s integration
+        # cluster intermittently exceeded the deadline. 75s sits under the
+        # require_lifecycle_secret route's 90s HTTP-timeout ceiling.
+        pod = _wait_for_probe_pod(k8s, namespace, probe_id, timeout=75.0)
         if pod is None:
             return (
                 jsonify(


### PR DESCRIPTION
## Summary
- Bump `_wait_for_probe_pod` timeout from 30s → 75s in `orchestrator/routes/deployment.py`. The k3s integration cluster intermittently took longer than 30s to schedule the probe pod, so the route returned the `probe_timeout` shape (`probe_id` present, no `result`). 75s leaves headroom under the test's 90s HTTP timeout.
- In `integration_tests/test_deployment_validation_logic.py::test_probe_runs_and_returns_expected_shape`, handle the probe-timeout shape explicitly with `pytest.fail(...)` instead of letting `data["result"]` raise a bare `KeyError: 'result'`. Future flakes now name the probe, not look like a generic test bug.

Surfaced by [#2688 comment](https://github.com/jwbron/egg/pull/2688#issuecomment-4437896684). The same `KeyError: 'result'` was hitting unrelated branches today (e.g. `egg/doc-update-populate-contract-errors`).

## Test plan
- [ ] Integration Tests job passes (was previously flaking on this exact test).
- [ ] Confirm `test_probe_runs_and_returns_expected_shape` still asserts the four `gateway_reachable / internet_blocked / agent_pods_unreachable / orchestrator_api_reachable` invariants on the happy path.