### PR TITLE
fix: race between probe-pod TTL GC and _wait_for_probe_pod poll

### DIFF
--- a/integration_tests/test_deployment_validation_logic.py
+++ b/integration_tests/test_deployment_validation_logic.py
@@ -73,7 +73,7 @@ def _post(
     *,
     secret: str,
     body: dict,
-    timeout: int = 60,
+    timeout: int = 90,
 ) -> requests.Response:
     return requests.post(
         f"{orchestrator_url}{path}",

--- a/integration_tests/test_deployment_validation_logic.py
+++ b/integration_tests/test_deployment_validation_logic.py
@@ -682,10 +682,11 @@ class TestProbeJobCleanup:
     """Belt-and-braces: no orphan probe Jobs after the route returns.
 
     The route uses a ``try/finally`` to call ``_delete_probe_job`` and
-    sets ``ttlSecondsAfterFinished: 0`` on the Job. With #2646 fixed
-    the probe actually launches, so this assertion catches a cleanup
-    regression where the finally path failed to delete the Job (or the
-    ttl-after-finished GC failed to fire).
+    sets ``ttlSecondsAfterFinished: 30`` on the Job as a backstop. With
+    #2646 fixed the probe actually launches, so this assertion catches
+    a cleanup regression where the finally path failed to delete the
+    Job (or the ttl-after-finished GC failed to fire within the 30s +
+    grace window).
     """
 
     def test_no_orphan_probe_jobs_after_call(
@@ -710,9 +711,12 @@ class TestProbeJobCleanup:
             timeout=90,
         )
 
-        # Allow up to a few seconds for ttlSecondsAfterFinished=0 to
-        # reap any Job that did launch — the API call returned, but
-        # the controller may not have run the GC pass yet.
+        # The route's try/finally _delete_probe_job is the primary
+        # cleanup path, so the Job should be gone within milliseconds
+        # of the route returning. The 15s headroom is for the
+        # ttlSecondsAfterFinished=30 backstop in the case where the
+        # route crashed before reaching finally — 15s + the ~10s probe
+        # runtime still sits well under ttl + GC sync.
         deadline = time.time() + 15
         leftover: list[str] = []
         while time.time() < deadline:
@@ -742,5 +746,5 @@ class TestProbeJobCleanup:
             time.sleep(1)
         pytest.fail(
             f"probe Jobs still present after route returned (route should "
-            f"clean up via finally + ttlSecondsAfterFinished=0): {leftover}"
+            f"clean up via finally + ttlSecondsAfterFinished=30): {leftover}"
         )

--- a/integration_tests/test_deployment_validation_logic.py
+++ b/integration_tests/test_deployment_validation_logic.py
@@ -713,10 +713,10 @@ class TestProbeJobCleanup:
 
         # The route's try/finally _delete_probe_job is the primary
         # cleanup path, so the Job should be gone within milliseconds
-        # of the route returning. The 15s headroom is for the
-        # ttlSecondsAfterFinished=30 backstop in the case where the
-        # route crashed before reaching finally — 15s + the ~10s probe
-        # runtime still sits well under ttl + GC sync.
+        # of the route returning. The 15s deadline is deliberately
+        # below ttlSecondsAfterFinished=30: a finally-path regression
+        # must surface as a test failure here, not get masked by the
+        # TTL controller sweeping the orphan inside the poll window.
         deadline = time.time() + 15
         leftover: list[str] = []
         while time.time() < deadline:

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -1111,9 +1111,10 @@ PIPELINE_TOOLS = [
             "Spawn a throwaway probe Job in the egg-agents namespace to verify "
             "Calico NetworkPolicy enforcement. Returns a structured "
             "{gateway_reachable, internet_blocked, agent_pods_unreachable, "
-            "orchestrator_api_reachable} result. The Job self-deletes on exit "
-            "(ttlSecondsAfterFinished=0). Only available on the Kubernetes "
-            "runtime and on CNIs that enforce NetworkPolicies."
+            "orchestrator_api_reachable} result. The route deletes the Job "
+            "in a try/finally; ttlSecondsAfterFinished=30 is the backstop. "
+            "Only available on the Kubernetes runtime and on CNIs that "
+            "enforce NetworkPolicies."
         ),
         "inputSchema": {
             "type": "object",

--- a/orchestrator/routes/deployment.py
+++ b/orchestrator/routes/deployment.py
@@ -1020,7 +1020,18 @@ def _build_probe_job_manifest(
             },
         },
         "spec": {
-            "ttlSecondsAfterFinished": 0,
+            # 0 raced with _wait_for_probe_pod's 1s poll: the Job could
+            # complete and be GC'd by the TTL-after-finished controller
+            # before the next poll observed the pod's terminal phase,
+            # leaving the wait loop scanning an empty list until its 75s
+            # ceiling (seen as the bimodal ~10s-or-75s distribution in
+            # https://github.com/jwbron/egg/actions/runs/25817353877).
+            # 30s guarantees the wait loop sees Succeeded/Failed and
+            # _read_probe_log still has a pod to read from; the route's
+            # try/finally _delete_probe_job remains the primary cleanup
+            # path, so this only extends lifetime when the route crashed
+            # before reaching finally.
+            "ttlSecondsAfterFinished": 30,
             "activeDeadlineSeconds": 30,
             "backoffLimit": 0,
             "template": {

--- a/orchestrator/tests/test_deployment_routes.py
+++ b/orchestrator/tests/test_deployment_routes.py
@@ -961,7 +961,12 @@ class TestProbeManifestAndEnv:
         assert labels["egg.agent.role"] == "coder"
 
         spec = manifest["spec"]
-        assert spec["ttlSecondsAfterFinished"] == 0
+        # 30s (not 0): _wait_for_probe_pod polls at 1Hz, and ttl=0
+        # raced the poll cadence — Job/pod could be GC'd before the
+        # terminal-phase observation. 30s keeps the pod observable for
+        # the wait loop and the subsequent _read_probe_log. The route's
+        # try/finally is still the primary cleanup path.
+        assert spec["ttlSecondsAfterFinished"] == 30
         assert spec["activeDeadlineSeconds"] == 30
         assert spec["backoffLimit"] == 0
 


### PR DESCRIPTION
## Summary

Two flake fixes for `validate-network-isolation` integration tests:

### 1. Probe-pod TTL race (root cause of #2700's first red CI)

`test_probe_runs_and_returns_expected_shape` intermittently saw the route return the `probe_timeout` shape instead of the happy-path result. The probe Job set `ttlSecondsAfterFinished=0`, which races `_wait_for_probe_pod`'s 1Hz poll:

1. Probe pod completes → `phase=Succeeded` (or `Failed` via `activeDeadlineSeconds`)
2. Job marked Complete → `ttlSecondsAfterFinished=0` → TTL controller cascade-deletes the Job/pod within milliseconds
3. Wait loop's next 1s poll finds **no pods matching the selector** (not "Failed")
4. Loop never observes a terminal phase → keeps polling until 75s ceiling → returns `probe_timeout`

**Evidence from [Actions run 25817353877](https://github.com/jwbron/egg/actions/runs/25817353877):**

- Orchestrator log durations were **bimodal**: 9-12s (happy path) or 75-76s (full ceiling), no middle ground.
- The route's `finally _delete_probe_job` got **404** on the hung calls: `"(404) Reason: Not Found"` — the Job was already gone, GC'd by `ttl=0`.
- The pod's k8s events stop at `Started`; no `DeadlineExceeded`, no `Killing` — the pod completed normally and was reaped before the poll observed it.

**Fix:** bump `ttlSecondsAfterFinished` from `0` to `30`. The route's `try/finally` remains the primary cleanup path; 30s is the backstop that guarantees both:
- `_wait_for_probe_pod` sees the terminal phase before GC
- `_read_probe_log` can still read the pod's stdout after `_wait_for_probe_pod` returns

### 2. `_post()` helper default timeout (`60s` → `90s`)

PR #2699 raised the route's `_wait_for_probe_pod` from 30s → 75s. The integration helper `_post()` still defaulted to `timeout=60`, leaving any test that proceeds past the CNI gate (valid labels → probe launches) structurally underweight against the route's 75s ceiling.

Surfaced by [#2689 comment 4443847011](https://github.com/jwbron/egg/pull/2689#issuecomment-4443847011). `test_pipeline_id_regex_valid_at_boundaries_pass` had the same latent bug across 4 parametrize cases. 90s matches the explicit `timeout=90` already used in `test_probe_runs_and_returns_expected_shape`, the concurrency test, and the JSON-validity test.

## Files

- `orchestrator/routes/deployment.py` — `ttlSecondsAfterFinished` 0 → 30 with explanatory comment
- `orchestrator/tests/test_deployment_routes.py` — matching unit-test assertion
- `orchestrator/mcp_tools.py` — tool description text
- `integration_tests/test_deployment_validation_logic.py` — `_post()` default timeout 60 → 90; `TestProbeJobCleanup` docstring + failure message updated to reference `ttl=30`

## Test plan

- [ ] Integration Tests / Integration Tests job passes (the run that revealed #2 still passing on the rerun).
- [ ] `test_probe_runs_and_returns_expected_shape` consistently observes the terminal phase (no more bimodal hangs).
- [ ] `test_no_orphan_probe_jobs_after_call` still passes — the route's explicit `finally` cleanup runs before the test polls, so `ttl=30` is invisible to it on the happy path.
- [ ] `test_default_pipeline_id_and_role_pass_label_validation` and `test_pipeline_id_regex_valid_at_boundaries_pass` (4 parametrize cases) pass with the bumped default `_post()` timeout.

## Closes

This PR root-causes the probe hang that was opened as #2701; that issue can be closed when this lands.