### PR TITLE
fix: chain portmap CNI so Cilium honors hostPort mappings

### DIFF
--- a/scripts/install-cilium.sh
+++ b/scripts/install-cilium.sh
@@ -123,11 +123,20 @@ if [ "$SKIP_INSTALL" -eq 0 ]; then
   # can blackhole host connectivity entirely. The legacy/iptables datapath
   # keeps Cilium's eBPF on cilium_* interfaces and pod veths only, and still
   # provides full L3/L4 NetworkPolicy enforcement.
+  #
+  # cni.chainingMode=portmap chains the standard portmap CNI plugin after
+  # Cilium. With kubeProxyReplacement=false Cilium does not implement
+  # Kubernetes hostPort itself, and without portmap chaining hostPort
+  # mappings (e.g. orchestrator's 9849/9850 in the local overlay) are
+  # silently dropped — pods serve fine inside the cluster but the mapped
+  # ports never bind on the node, so Claude Code's MCP client at
+  # http://localhost:9850/mcp gets connection-refused.
   CILIUM_INSTALL_ARGS=(
     --version "$CILIUM_VERSION"
     --set kubeProxyReplacement=false
     --set bpf.masquerade=false
     --set bpf.hostLegacyRouting=true
+    --set cni.chainingMode=portmap
   )
   log "Running 'cilium install ${CILIUM_INSTALL_ARGS[*]}'..."
   "$CILIUM_BIN" install "${CILIUM_INSTALL_ARGS[@]}"
@@ -151,7 +160,8 @@ verify_failed=0
 for kv in \
     'kube-proxy-replacement:false' \
     'enable-bpf-masquerade:false' \
-    'enable-host-legacy-routing:true'; do
+    'enable-host-legacy-routing:true' \
+    'cni-chaining-mode:portmap'; do
   key="${kv%%:*}"
   want="${kv##*:}"
   # kubectl jsonpath returns the value directly (empty string if the key

--- a/scripts/install-cilium.sh
+++ b/scripts/install-cilium.sh
@@ -293,15 +293,52 @@ fi
 #
 # Install the equivalent rule directly in POSTROUTING (not
 # CILIUM_POST_nat, which the agent flushes on every config sync) so it
-# survives agent restarts. The match is what cilium-agent would install
-# in non-chained mode. Idempotent — re-running the script is a no-op
-# if the rule is already present.
+# survives agent restarts and config reloads. NOTE: this is a runtime
+# iptables rule — it is NOT persisted across host reboots. Re-run this
+# script (or `make k3s-setup`) after a reboot, or wire the rule into
+# `netfilter-persistent`/`iptables-restore` at the system level.
+#
+# Idempotent — re-running the script is a no-op if the rule is already
+# present.
+#
+# Footgun: Cilium's default cluster-pool is 10.0.0.0/8 (very broad
+# RFC1918) since we don't pass --set ipam.operator.clusterPoolIPv4PodCIDRList.
+# On hosts whose own primary IP is in 10.0.0.0/8 (corporate VPNs,
+# AWS/GCP VPCs with 10.x subnets), the rule "-s 10.0.0.0/8
+# ! -d 10.0.0.0/8 -j MASQUERADE" also matches host-originated traffic
+# from that IP; MASQUERADE rewrites source to the outbound iface IP
+# (usually the same address) so it's functionally a no-op, but a
+# narrower pool (e.g. 10.244.0.0/16) would scope the rule strictly to
+# pod traffic if exotic routing topologies become a concern.
+#
+# IPv6 / dual-stack TODO: only cluster-pool-ipv4-cidr is read. If
+# dual-stack is enabled in the future (cilium-config gets
+# cluster-pool-ipv6-cidr), an equivalent
+# `ip6tables -t nat -A POSTROUTING -s <v6-pool> ! -d <v6-pool> -j MASQUERADE`
+# is required or v6 pod egress will silently fail the same way v4 did.
+#
+# iptables backend skew: this rule lands in whichever backend
+# /usr/sbin/iptables points to. Modern Ubuntu and stock k3s both default
+# to iptables-nft, so this matches what cilium-agent (and k3s-agent's
+# embedded kube-proxy) use. Surface the active backend in the log so a
+# rare iptables-legacy host shows up at install time, not as silent
+# packet loss later.
 log "Installing pod-egress MASQUERADE rule (compensates for chained-CNI mode)..."
-POD_POOL_CIDR=$(kubectl -n kube-system get cm cilium-config -o "jsonpath={.data.cluster-pool-ipv4-cidr}" 2>/dev/null \
-  | grep -oE '[0-9]{1,3}(\.[0-9]{1,3}){3}/[0-9]{1,2}' | head -1)
+update-alternatives --display iptables 2>/dev/null | head -3 | sed 's/^/  iptables-alt: /' || true
+# Bracket-notation jsonpath for the hyphenated key — older kubectl
+# parsed dotted hyphens as subtraction. `|| true` keeps the assignment
+# alive when the key is absent (renamed by a future Cilium release, or
+# operator on a non-cluster-pool IPAM mode like ipam.mode=kubernetes/eni);
+# without it, `set -euo pipefail` + grep's exit 1 would short-circuit
+# the script and the explicit empty-check below would never fire.
+POD_POOL_CIDR=$(kubectl -n kube-system get cm cilium-config -o "jsonpath={.data['cluster-pool-ipv4-cidr']}" 2>/dev/null \
+  | grep -oE '[0-9]{1,3}(\.[0-9]{1,3}){3}/[0-9]{1,2}' | head -1 || true)
 if [ -z "$POD_POOL_CIDR" ]; then
   error "Could not read cluster-pool-ipv4-cidr from cilium-config — cannot install pod-egress MASQUERADE rule."
-  error "Pod-to-external traffic (gateway -> GitHub, sandbox agents -> APIs) will fail without it."
+  error "Likely causes: non-cluster-pool IPAM mode (ipam.mode=kubernetes/eni), or the key was"
+  error "renamed in a newer Cilium release. Inspect with:"
+  error "  kubectl -n kube-system get cm cilium-config -o yaml | grep -i cidr"
+  error "Pod-to-external traffic (gateway -> GitHub, sandbox agents -> APIs) will fail without the rule."
   exit 1
 fi
 MASQ_COMMENT="egg: cilium pod egress (chained-mode masquerade compensation)"

--- a/scripts/install-cilium.sh
+++ b/scripts/install-cilium.sh
@@ -180,6 +180,36 @@ if [ "$verify_failed" -ne 0 ]; then
 fi
 log "cilium-config matches expected datapath."
 
+# Post-install verification: cni.chainingMode=portmap writes a CNI
+# conflist that references the upstream portmap plugin binary, but
+# Cilium only installs cilium-cni — not portmap — into its binPath
+# (default /opt/cni/bin). When kubelet sets up a pod sandbox it walks
+# the chain and exec's each plugin from CNI_PATH; if portmap is missing
+# it fails with "failed to find plugin 'portmap' in path [/opt/cni/bin]"
+# and every pod with a hostPort: (orchestrator's 9849/9850 in the local
+# overlay) sits in ContainerCreating forever. k3s ships portmap in its
+# own bundled CNI bin dir; copy it into Cilium's binPath when missing so
+# the fix works on fresh CI runners and fresh local installs alike,
+# without adding a network dependency to this script.
+log "Verifying portmap CNI plugin binary is available..."
+CNI_BIN_DIR="/opt/cni/bin"
+if [ ! -x "$CNI_BIN_DIR/portmap" ]; then
+  K3S_CNI_BIN_DIR="/var/lib/rancher/k3s/data/current/bin"
+  if [ -x "$K3S_CNI_BIN_DIR/portmap" ]; then
+    log "  portmap missing from ${CNI_BIN_DIR}; copying from ${K3S_CNI_BIN_DIR}..."
+    sudo mkdir -p "$CNI_BIN_DIR"
+    sudo cp "$K3S_CNI_BIN_DIR/portmap" "$CNI_BIN_DIR/portmap"
+  else
+    error "portmap CNI plugin binary not found at ${CNI_BIN_DIR}/portmap or ${K3S_CNI_BIN_DIR}/portmap."
+    error "cni.chainingMode=portmap needs portmap at ${CNI_BIN_DIR}/ to handle hostPort —"
+    error "without it, pods with hostPort: stay in ContainerCreating indefinitely."
+    error "Install the standard CNI plugins (e.g. 'apt-get install -y containernetworking-plugins'"
+    error "and copy /usr/lib/cni/portmap to ${CNI_BIN_DIR}/portmap)."
+    exit 1
+  fi
+fi
+log "portmap CNI plugin binary OK at ${CNI_BIN_DIR}/portmap."
+
 # Post-install verification: the host CNI config directory should now
 # contain Cilium's conflist and nothing from a previous CNI. This catches
 # the silent-failure mode where kubelet keeps using a leftover Calico

--- a/scripts/install-cilium.sh
+++ b/scripts/install-cilium.sh
@@ -79,6 +79,54 @@ if kubectl get daemonset -n kube-system cilium &>/dev/null; then
   fi
 fi
 
+# Ensure the portmap CNI plugin binary is available BEFORE running
+# 'cilium install'. cni.chainingMode=portmap makes cilium-agent drop a
+# conflist that references portmap as soon as the agent pod is up; if
+# portmap is missing from /opt/cni/bin at that moment, kubelet retries
+# every pending pod (coredns, traefik, local-path-provisioner — none
+# use hostPort but all traverse the CNI chain on every ADD) against
+# the missing plugin and they fall into sandbox-creation backoff
+# (capped at 5 min). Cilium only installs cilium-cni into its binPath
+# (default /opt/cni/bin) — not portmap — so we copy it from k3s's
+# bundled CNI bin dir, which is already populated by the time this
+# script runs. No new network dependency.
+#
+# sudo test -x (not [ -x ... ]) so a hardened parent-dir mode that
+# blocks the invoking user's traverse surfaces as a real permissions
+# error instead of a misleading "not found".
+log "Verifying portmap CNI plugin binary is available..."
+CNI_BIN_DIR="/opt/cni/bin"
+if ! sudo test -x "$CNI_BIN_DIR/portmap"; then
+  K3S_CNI_BIN_DIR="/var/lib/rancher/k3s/data/current/bin"
+  if sudo test -x "$K3S_CNI_BIN_DIR/portmap"; then
+    log "  portmap missing from ${CNI_BIN_DIR}; copying from ${K3S_CNI_BIN_DIR}..."
+    sudo mkdir -p "$CNI_BIN_DIR"
+    sudo cp "$K3S_CNI_BIN_DIR/portmap" "$CNI_BIN_DIR/portmap"
+  elif sudo test -e "$K3S_CNI_BIN_DIR/portmap"; then
+    error "portmap exists at ${K3S_CNI_BIN_DIR}/portmap but is not executable."
+    error "Check filesystem and SELinux permissions on the k3s data dir."
+    exit 1
+  else
+    error "portmap CNI plugin binary not found at ${CNI_BIN_DIR}/portmap or ${K3S_CNI_BIN_DIR}/portmap."
+    error "cni.chainingMode=portmap needs portmap at ${CNI_BIN_DIR}/ to handle hostPort —"
+    error "without it, pods with hostPort: stay in ContainerCreating indefinitely."
+    error "Install the standard CNI plugins (e.g. 'apt-get install -y containernetworking-plugins'"
+    error "and copy /usr/lib/cni/portmap to ${CNI_BIN_DIR}/portmap)."
+    exit 1
+  fi
+fi
+# Smoke-test the binary so wrong-arch or truncated copies fail here
+# instead of as cryptic CNI ADD errors at first pod schedule. portmap
+# with no CNI_* env vars writes a CNI-spec error to stderr (e.g.
+# "CNI ... missing"); a broken binary fails with ENOEXEC/segfault and
+# produces no "CNI" token.
+if ! sudo "$CNI_BIN_DIR/portmap" </dev/null 2>&1 | grep -q CNI; then
+  error "portmap binary at ${CNI_BIN_DIR}/portmap failed smoke test."
+  error "Likely wrong architecture or a corrupted copy — remove it and re-run."
+  exit 1
+fi
+log "portmap CNI plugin binary OK at ${CNI_BIN_DIR}/portmap."
+
 if [ "$SKIP_INSTALL" -eq 0 ]; then
   # Detect arch
   ARCH=$(uname -m)
@@ -175,40 +223,14 @@ for kv in \
 done
 if [ "$verify_failed" -ne 0 ]; then
   error "The cilium-cli may have silently overridden a --set flag during install."
-  error "Run 'kubectl -n kube-system get cm cilium-config -o yaml' to inspect."
+  error "If this is a Cilium install from before #2713 (no cni-chaining-mode key),"
+  error "the supported remediation is 'make k3s-teardown && make k3s-setup' — the"
+  error "chainingMode value cannot be changed by editing cilium-config on a live"
+  error "cluster, as the agent only reads it at startup."
+  error "Otherwise, run 'kubectl -n kube-system get cm cilium-config -o yaml' to inspect."
   exit 1
 fi
 log "cilium-config matches expected datapath."
-
-# Post-install verification: cni.chainingMode=portmap writes a CNI
-# conflist that references the upstream portmap plugin binary, but
-# Cilium only installs cilium-cni — not portmap — into its binPath
-# (default /opt/cni/bin). When kubelet sets up a pod sandbox it walks
-# the chain and exec's each plugin from CNI_PATH; if portmap is missing
-# it fails with "failed to find plugin 'portmap' in path [/opt/cni/bin]"
-# and every pod with a hostPort: (orchestrator's 9849/9850 in the local
-# overlay) sits in ContainerCreating forever. k3s ships portmap in its
-# own bundled CNI bin dir; copy it into Cilium's binPath when missing so
-# the fix works on fresh CI runners and fresh local installs alike,
-# without adding a network dependency to this script.
-log "Verifying portmap CNI plugin binary is available..."
-CNI_BIN_DIR="/opt/cni/bin"
-if [ ! -x "$CNI_BIN_DIR/portmap" ]; then
-  K3S_CNI_BIN_DIR="/var/lib/rancher/k3s/data/current/bin"
-  if [ -x "$K3S_CNI_BIN_DIR/portmap" ]; then
-    log "  portmap missing from ${CNI_BIN_DIR}; copying from ${K3S_CNI_BIN_DIR}..."
-    sudo mkdir -p "$CNI_BIN_DIR"
-    sudo cp "$K3S_CNI_BIN_DIR/portmap" "$CNI_BIN_DIR/portmap"
-  else
-    error "portmap CNI plugin binary not found at ${CNI_BIN_DIR}/portmap or ${K3S_CNI_BIN_DIR}/portmap."
-    error "cni.chainingMode=portmap needs portmap at ${CNI_BIN_DIR}/ to handle hostPort —"
-    error "without it, pods with hostPort: stay in ContainerCreating indefinitely."
-    error "Install the standard CNI plugins (e.g. 'apt-get install -y containernetworking-plugins'"
-    error "and copy /usr/lib/cni/portmap to ${CNI_BIN_DIR}/portmap)."
-    exit 1
-  fi
-fi
-log "portmap CNI plugin binary OK at ${CNI_BIN_DIR}/portmap."
 
 # Post-install verification: the host CNI config directory should now
 # contain Cilium's conflist and nothing from a previous CNI. This catches

--- a/scripts/install-cilium.sh
+++ b/scripts/install-cilium.sh
@@ -106,6 +106,11 @@ if ! sudo test -x "$CNI_BIN_DIR/portmap"; then
     error "portmap exists at ${K3S_CNI_BIN_DIR}/portmap but is not executable."
     error "Check filesystem and SELinux permissions on the k3s data dir."
     exit 1
+  elif sudo test -e "$CNI_BIN_DIR/portmap"; then
+    error "portmap exists at ${CNI_BIN_DIR}/portmap but is not executable,"
+    error "and no fallback binary was found at ${K3S_CNI_BIN_DIR}/portmap."
+    error "Check file mode (expected 0755) on ${CNI_BIN_DIR}/portmap."
+    exit 1
   else
     error "portmap CNI plugin binary not found at ${CNI_BIN_DIR}/portmap or ${K3S_CNI_BIN_DIR}/portmap."
     error "cni.chainingMode=portmap needs portmap at ${CNI_BIN_DIR}/ to handle hostPort —"
@@ -116,10 +121,13 @@ if ! sudo test -x "$CNI_BIN_DIR/portmap"; then
   fi
 fi
 # Smoke-test the binary so wrong-arch or truncated copies fail here
-# instead of as cryptic CNI ADD errors at first pod schedule. portmap
-# with no CNI_* env vars writes a CNI-spec error to stderr (e.g.
-# "CNI ... missing"); a broken binary fails with ENOEXEC/segfault and
-# produces no "CNI" token.
+# instead of as cryptic CNI ADD errors at first pod schedule. Modern
+# portmap (e.g. v1.5.1 shipped by k3s and containernetworking-plugins)
+# exits 0 with a "CNI portmap plugin vX.Y.Z" banner on stdout when
+# invoked with no CNI_* env vars; older versions print a CNI-spec
+# error to stderr. The 2>&1 merge means either path matches. A broken
+# binary (wrong arch, truncated) fails with ENOEXEC/segfault and
+# produces no "CNI" token on either stream.
 if ! sudo "$CNI_BIN_DIR/portmap" </dev/null 2>&1 | grep -q CNI; then
   error "portmap binary at ${CNI_BIN_DIR}/portmap failed smoke test."
   error "Likely wrong architecture or a corrupted copy — remove it and re-run."
@@ -205,6 +213,7 @@ fi
 # live cluster's config without re-installing.
 log "Verifying cilium-config matches expected conservative datapath..."
 verify_failed=0
+chaining_mode_failed=0
 for kv in \
     'kube-proxy-replacement:false' \
     'enable-bpf-masquerade:false' \
@@ -219,15 +228,20 @@ for kv in \
   if [ "$got" != "$want" ]; then
     error "cilium-config[$key] = '$got', expected '$want'"
     verify_failed=1
+    if [ "$key" = "cni-chaining-mode" ]; then
+      chaining_mode_failed=1
+    fi
   fi
 done
 if [ "$verify_failed" -ne 0 ]; then
   error "The cilium-cli may have silently overridden a --set flag during install."
-  error "If this is a Cilium install from before #2713 (no cni-chaining-mode key),"
-  error "the supported remediation is 'make k3s-teardown && make k3s-setup' — the"
-  error "chainingMode value cannot be changed by editing cilium-config on a live"
-  error "cluster, as the agent only reads it at startup."
-  error "Otherwise, run 'kubectl -n kube-system get cm cilium-config -o yaml' to inspect."
+  if [ "$chaining_mode_failed" -eq 1 ]; then
+    error "cni-chaining-mode mismatch suggests this is a Cilium install from before"
+    error "#2713. The supported remediation is 'make k3s-teardown && make k3s-setup'"
+    error "— the chainingMode value cannot be changed by editing cilium-config on a"
+    error "live cluster, as the agent only reads it at startup."
+  fi
+  error "Run 'kubectl -n kube-system get cm cilium-config -o yaml' to inspect."
   exit 1
 fi
 log "cilium-config matches expected datapath."

--- a/scripts/install-cilium.sh
+++ b/scripts/install-cilium.sh
@@ -276,6 +276,49 @@ if [ -d "$CNI_DIR" ]; then
   fi
 fi
 
+# Post-install: install the pod-egress MASQUERADE rule that cilium-agent
+# does NOT install when running in chained-CNI mode.
+#
+# cni.chainingMode=portmap (which we set above to give us hostPort under
+# kubeProxyReplacement=false) puts cilium-agent into a "chained" mode
+# where it treats itself as a secondary plugin behind a notional primary
+# CNI and defers iptables masquerade to that primary. But here Cilium IS
+# the primary (it owns IPAM and the datapath); there is no other primary
+# to install the rule. So agent's CILIUM_POST_nat chain stays empty even
+# though cilium-config has enable-ipv4-masquerade=true, pod traffic
+# leaves the host with its pod-CIDR source IP intact, the internet
+# routes responses to an unrouteable address, and any pod that needs
+# external egress (gateway -> api.github.com, sandbox agents -> the
+# Anthropic API, etc.) silently fails.
+#
+# Install the equivalent rule directly in POSTROUTING (not
+# CILIUM_POST_nat, which the agent flushes on every config sync) so it
+# survives agent restarts. The match is what cilium-agent would install
+# in non-chained mode. Idempotent — re-running the script is a no-op
+# if the rule is already present.
+log "Installing pod-egress MASQUERADE rule (compensates for chained-CNI mode)..."
+POD_POOL_CIDR=$(kubectl -n kube-system get cm cilium-config -o "jsonpath={.data.cluster-pool-ipv4-cidr}" 2>/dev/null \
+  | grep -oE '[0-9]{1,3}(\.[0-9]{1,3}){3}/[0-9]{1,2}' | head -1)
+if [ -z "$POD_POOL_CIDR" ]; then
+  error "Could not read cluster-pool-ipv4-cidr from cilium-config — cannot install pod-egress MASQUERADE rule."
+  error "Pod-to-external traffic (gateway -> GitHub, sandbox agents -> APIs) will fail without it."
+  exit 1
+fi
+MASQ_COMMENT="egg: cilium pod egress (chained-mode masquerade compensation)"
+if sudo iptables -t nat -C POSTROUTING -s "$POD_POOL_CIDR" ! -d "$POD_POOL_CIDR" -m comment --comment "$MASQ_COMMENT" -j MASQUERADE 2>/dev/null; then
+  log "  MASQUERADE rule already present for ${POD_POOL_CIDR}; nothing to do."
+else
+  sudo iptables -t nat -A POSTROUTING -s "$POD_POOL_CIDR" ! -d "$POD_POOL_CIDR" -m comment --comment "$MASQ_COMMENT" -j MASQUERADE
+  log "  Installed MASQUERADE rule for ${POD_POOL_CIDR}."
+fi
+# Verify — same -C check, just sanity, fail loud if iptables silently rejected the add.
+if ! sudo iptables -t nat -C POSTROUTING -s "$POD_POOL_CIDR" ! -d "$POD_POOL_CIDR" -m comment --comment "$MASQ_COMMENT" -j MASQUERADE 2>/dev/null; then
+  error "Pod-egress MASQUERADE rule failed to install in POSTROUTING."
+  error "Pod-to-external traffic (gateway -> GitHub, sandbox agents -> APIs) will fail."
+  exit 1
+fi
+log "Pod-egress MASQUERADE verified."
+
 if [ "$SKIP_INSTALL" -eq 1 ]; then
   log "Cilium verification passed (install skipped, cluster was already ready)."
 else


### PR DESCRIPTION
## Summary

- Add `--set cni.chainingMode=portmap` to the Cilium install args in `scripts/install-cilium.sh` so Kubernetes `hostPort:` mappings actually bind on the node.
- Add a matching `cni-chaining-mode: portmap` assertion to the post-install verification loop so the regression can't land silently again.

## The bug

#2705 installs Cilium with `kubeProxyReplacement=false` — deliberate, because KPR attaches eBPF programs to physical interfaces and blackholes connectivity on hosts with unusual primary NICs (the install script's own comment names wireless as the canonical case). With KPR off, **Cilium does not implement Kubernetes `hostPort` itself**. The install didn't chain a CNI plugin that does, so every `hostPort:` mapping in the local overlay was silently a no-op.

Concretely on this host, after `make k3s-teardown && make k3s-setup && make deploy`:

- `kubectl get pods -n egg-system` shows orchestrator + gateway `Running`/`Ready`.
- Orchestrator logs show `mcp_server` started on `0.0.0.0:9850` inside the pod, `Uvicorn running on http://0.0.0.0:9850`.
- `k8s/overlays/local/patches/orchestrator-volumes.yaml` declares `hostPort: 9850` (and `9849`).
- But `curl http://localhost:9850/mcp` returns `Connection refused`. Same for `9849`.
- `cilium-config` ConfigMap has only `kube-proxy-replacement: "false"` — no `cni-chaining-mode`, no `enable-host-port`.

That breaks Claude Code's `egg` MCP client (configured to talk to `http://localhost:9850/mcp`) and the SDLC skill's `wait-status` launcher (defaults `EGG_ORCHESTRATOR_URL=http://localhost:9849`).

## The fix

`cni.chainingMode=portmap` tells Cilium's CNI installer to drop its conflist with the standard `portmap` CNI plugin chained after it. `portmap` implements `hostPort` via iptables — compatible with `kubeProxyReplacement=false` and the rest of the wireless-NIC-safe datapath (`bpf.masquerade=false`, `bpf.hostLegacyRouting=true`). It produces the `cni-chaining-mode: portmap` key in the deployed `cilium-config` ConfigMap, which the verification loop now asserts.

## Why #2705 missed this

#2705's verification block checks datapath flags (`kube-proxy-replacement`, `enable-bpf-masquerade`, `enable-host-legacy-routing`) and CNI conflist presence, but doesn't end-to-end probe a `hostPort`. The integration tests touched (`integration_tests/test_deployment_validation_logic.py`) don't cover the hostPort path either. The new assertion in the verify loop closes the config-side gap; an end-to-end hostPort probe would be a useful follow-up but isn't included here (out of scope for the hotfix).

## Test plan

- [ ] `make k3s-teardown && make k3s-setup` succeeds on a clean host. Post-install verify loop passes with the new `cni-chaining-mode:portmap` line.
- [ ] After `make deploy`, `curl -sf http://localhost:9849/api/v1/live` returns OK and `curl -sf http://localhost:9850/mcp` reaches the MCP server (no `Connection refused`).
- [ ] `kubectl -n kube-system get cm cilium-config -o "jsonpath={.data.cni-chaining-mode}"` prints `portmap`.
- [ ] `kubectl -n kube-system get cm cilium-config -o "jsonpath={.data.kube-proxy-replacement}"` still prints `false` (regression check against the prior wireless-NIC fix).
- [ ] Claude Code's `egg` MCP client reconnects to `http://localhost:9850/mcp` after deploy.