### PR TITLE
fix: rebase with --autostash so divergence reconcile survives dirty worktree (#2714)

### DIFF
--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -2789,6 +2789,13 @@ def _rebase_with_agent_output_autoresolve(
     continued; conflicts anywhere else cause the rebase to be aborted
     and a failure ``PushResult`` returned.
 
+    The rebase runs with ``--autostash`` so it can proceed against a
+    dirty worktree (#2714).  The orchestrator continuously writes
+    statefile / agent-output deltas without committing them eagerly, so
+    every divergence-reconcile attempt hits a working tree with unstaged
+    changes; without autostash, ``git rebase`` aborts immediately and the
+    sync helper returns without bringing origin's commits into local.
+
     The auto-resolve loop is bounded by ``max_autoresolve_iterations``
     to defend against pathological cases where every replayed commit
     re-introduces an agent-outputs conflict — three iterations is
@@ -3026,9 +3033,18 @@ def _build_rebase_cmd(
       upstream main commits that landed since the stale snapshot) on top
       of the stale tip, producing a PR full of duplicate-by-content
       commits with rewritten SHAs.
+
+    ``--autostash`` is set on every returned form (#2714): the orchestrator
+    writes statefile / agent-output deltas continuously and does not commit
+    them eagerly, so the worktree is routinely dirty at sync time.  Without
+    autostash, ``git rebase`` refuses with ``cannot rebase: You have
+    unstaged changes`` and the divergence-reconcile path that #2352 added
+    fails 100% of the time on the plan-complete sync.  With autostash, git
+    stashes the unstaged delta before the rebase and pops it on success;
+    on abort the stash entry is preserved in the stash list for recovery.
     """
     if base_branch is None:
-        return [*git_base, "rebase", f"origin/{branch}"]
+        return [*git_base, "rebase", "--autostash", f"origin/{branch}"]
 
     base_ref = f"origin/{base_branch}"
     try:
@@ -3042,7 +3058,7 @@ def _build_rebase_cmd(
     except subprocess.TimeoutExpired:
         verify = None
     if verify and verify.returncode == 0:
-        return [*git_base, "rebase", "--onto", f"origin/{branch}", base_ref]
+        return [*git_base, "rebase", "--autostash", "--onto", f"origin/{branch}", base_ref]
     return None
 
 

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -2795,6 +2795,13 @@ def _rebase_with_agent_output_autoresolve(
     every divergence-reconcile attempt hits a working tree with unstaged
     changes; without autostash, ``git rebase`` aborts immediately and the
     sync helper returns without bringing origin's commits into local.
+    ``git rebase --autostash`` can also exit 0 with a half-applied
+    autostash pop (rebase succeeded, but the pop hit a conflict because
+    the rebased HEAD touches the same paths as the stashed delta) — that
+    leaves ``UU`` entries in the worktree and the autostash sitting in
+    ``git stash list``.  We detect this post-rebase via
+    ``_list_unmerged_paths`` and surface ``reconcile_autostash_pop_conflict``
+    so callers do not treat a half-merged worktree as a successful sync.
 
     The auto-resolve loop is bounded by ``max_autoresolve_iterations``
     to defend against pathological cases where every replayed commit
@@ -2852,6 +2859,9 @@ def _rebase_with_agent_output_autoresolve(
         )
 
     if rebase_result.returncode == 0:
+        pop_conflict = _autostash_pop_conflict_result(git_base, pipeline_id, branch)
+        if pop_conflict is not None:
+            return pop_conflict
         return PushResult(ok=True)
 
     for iteration in range(max_autoresolve_iterations):
@@ -2968,6 +2978,9 @@ def _rebase_with_agent_output_autoresolve(
             )
 
         if rebase_result.returncode == 0:
+            pop_conflict = _autostash_pop_conflict_result(git_base, pipeline_id, branch)
+            if pop_conflict is not None:
+                return pop_conflict
             return PushResult(ok=True)
 
     logger.error(
@@ -2981,6 +2994,43 @@ def _rebase_with_agent_output_autoresolve(
         ok=False,
         category="reconcile_rebase_failed",
         detail=(f"agent-outputs auto-resolve exceeded {max_autoresolve_iterations} iterations"),
+    )
+
+
+def _autostash_pop_conflict_result(
+    git_base: list[str],
+    pipeline_id: str,
+    branch: str,
+) -> PushResult | None:
+    """Detect a successful-rebase-with-conflicted-autostash-pop and
+    return a failure ``PushResult`` for it; return ``None`` if the
+    worktree is clean.
+
+    ``git rebase --autostash`` exits 0 even when its final ``git stash
+    pop`` of the autostash hits a conflict: the rebase itself succeeded,
+    but the pop leaves ``UU`` entries in the worktree and the original
+    autostash entry stays in ``git stash list``.  Without this check a
+    half-merged worktree would be consumed as a successful sync by
+    downstream code (#2714 review fallout).
+    """
+    unmerged = _list_unmerged_paths(git_base)
+    if not unmerged:
+        return None
+    logger.error(
+        "Push reconcile: rebase succeeded but autostash pop produced conflicts",
+        pipeline_id=pipeline_id,
+        branch=branch,
+        conflicting_paths=unmerged,
+    )
+    return PushResult(
+        ok=False,
+        category="reconcile_autostash_pop_conflict",
+        detail=(
+            "git rebase --autostash succeeded but the autostash pop "
+            f"left unmerged paths in the worktree: {', '.join(unmerged)}; "
+            "the autostash entry is preserved in `git stash list` for "
+            "manual recovery"
+        ),
     )
 
 
@@ -3040,8 +3090,16 @@ def _build_rebase_cmd(
     autostash, ``git rebase`` refuses with ``cannot rebase: You have
     unstaged changes`` and the divergence-reconcile path that #2352 added
     fails 100% of the time on the plan-complete sync.  With autostash, git
-    stashes the unstaged delta before the rebase and pops it on success;
-    on abort the stash entry is preserved in the stash list for recovery.
+    stashes the unstaged delta before the rebase and pops it on success
+    (or on abort: ``git rebase --abort`` automatically reapplies the
+    autostash to the working tree, and only preserves the stash entry in
+    ``git stash list`` as a fallback if that reapply itself conflicts).
+    The successful-pop path is itself not conflict-free — when the pop
+    collides with the rebased state, git rebase still exits 0 but leaves
+    ``UU`` entries in the worktree.  The caller
+    (``_rebase_with_agent_output_autoresolve``) detects that case and
+    surfaces ``reconcile_autostash_pop_conflict`` so a half-merged
+    worktree is never consumed as a successful sync.
     """
     if base_branch is None:
         return [*git_base, "rebase", "--autostash", f"origin/{branch}"]

--- a/orchestrator/tests/test_reconcile_and_push_pr_branch.py
+++ b/orchestrator/tests/test_reconcile_and_push_pr_branch.py
@@ -767,21 +767,22 @@ class TestPushWorktreeBranchReconcile:
             statefile_path.write_text('{"v": 2}\n')
 
             # Sanity: the precondition that broke the pre-fix rebase is
-            # an unstaged modification to a *tracked* path (porcelain
-            # code starting with ``M`` or `` M``), not an untracked one
-            # (``??``).  A ``??``-only worktree would not reproduce the
-            # bug.
+            # specifically an *unstaged* modification to a tracked path
+            # (porcelain code `` M``).  Staged-only (``M ``) would trip
+            # a different error (``Your index contains uncommitted
+            # changes``) and would not exercise the ``--autostash`` code
+            # path; untracked (``??``) would not refuse the rebase at
+            # all.  Pin to `` M`` so a future setup drift cannot silently
+            # regress this test back to not exercising the bug.
             status = subprocess.run(
                 ["git", "-C", str(work), "status", "--porcelain"],
                 capture_output=True,
                 text=True,
                 check=True,
             )
-            assert any(
-                line.startswith(("M ", " M", "MM")) for line in status.stdout.splitlines()
-            ), (
-                f"[{case_label}] precondition failed: worktree should have a "
-                f"modified tracked file, got: {status.stdout!r}"
+            assert any(line.startswith(" M") for line in status.stdout.splitlines()), (
+                f"[{case_label}] precondition failed: worktree should have an "
+                f"unstaged modification to a tracked file, got: {status.stdout!r}"
             )
 
             git_base = [

--- a/orchestrator/tests/test_reconcile_and_push_pr_branch.py
+++ b/orchestrator/tests/test_reconcile_and_push_pr_branch.py
@@ -123,7 +123,11 @@ class TestPushWorktreeBranchReconcile:
         client = _make_client([False, True])
         with patch(
             "gateway_client.subprocess.run",
-            side_effect=[_run_result(), _run_result()],
+            side_effect=[
+                _run_result(),  # fetch
+                _run_result(),  # rebase (returncode 0)
+                _run_result(),  # diff --diff-filter=U (autostash pop conflict check)
+            ],
         ) as mock_run:
             ok = client.push_worktree_branch(
                 pipeline_id="issue-42",
@@ -133,7 +137,7 @@ class TestPushWorktreeBranchReconcile:
 
         assert ok.ok is True
         assert client._do_push.call_count == 2
-        assert mock_run.call_count == 2
+        assert mock_run.call_count == 3
         fetch_cmd = mock_run.call_args_list[0].args[0]
         rebase_cmd = mock_run.call_args_list[1].args[0]
         assert "fetch" in fetch_cmd and "origin" in fetch_cmd and "egg/feature" in fetch_cmd
@@ -198,6 +202,7 @@ class TestPushWorktreeBranchReconcile:
                 _run_result(),  # add
                 _run_result(returncode=1),  # diff --cached --quiet → has staged changes
                 _run_result(),  # rebase --continue (success)
+                _run_result(),  # diff --diff-filter=U (autostash pop conflict check)
             ],
         ) as mock_run:
             ok = client.push_worktree_branch(
@@ -228,6 +233,7 @@ class TestPushWorktreeBranchReconcile:
                 _run_result(),  # add
                 _run_result(returncode=0),  # diff --cached --quiet → empty index
                 _run_result(),  # rebase --skip (success)
+                _run_result(),  # diff --diff-filter=U (autostash pop conflict check)
             ],
         ) as mock_run:
             ok = client.push_worktree_branch(
@@ -299,7 +305,11 @@ class TestPushWorktreeBranchReconcile:
         client = _make_client([False, False])
         with patch(
             "gateway_client.subprocess.run",
-            side_effect=[_run_result(), _run_result()],  # fetch, rebase
+            side_effect=[
+                _run_result(),  # fetch
+                _run_result(),  # rebase
+                _run_result(),  # diff --diff-filter=U (autostash pop conflict check)
+            ],
         ):
             ok = client.push_worktree_branch(
                 pipeline_id="issue-42",
@@ -339,7 +349,11 @@ class TestPushWorktreeBranchReconcile:
         client = _make_client([False, True])
         with patch(
             "gateway_client.subprocess.run",
-            side_effect=[_run_result(), _run_result()],
+            side_effect=[
+                _run_result(),  # fetch
+                _run_result(),  # rebase
+                _run_result(),  # diff --diff-filter=U (autostash pop conflict check)
+            ],
         ) as mock_run:
             ok = client.push_worktree_branch(
                 pipeline_id="issue-42",
@@ -348,8 +362,9 @@ class TestPushWorktreeBranchReconcile:
             )
 
         assert ok.ok is True
-        # Order: fetch, rebase (no --onto, no base-branch fetch/verify).
-        assert mock_run.call_count == 2
+        # Order: fetch, rebase (no --onto, no base-branch fetch/verify),
+        # autostash pop-conflict check.
+        assert mock_run.call_count == 3
         rebase_cmd = mock_run.call_args_list[1].args[0]
         assert "rebase" in rebase_cmd
         assert "--onto" not in rebase_cmd
@@ -372,6 +387,7 @@ class TestPushWorktreeBranchReconcile:
                 _run_result(),  # fetch origin {base_branch}
                 _run_result(),  # rev-parse --verify origin/{base_branch}
                 _run_result(),  # rebase --onto ...
+                _run_result(),  # diff --diff-filter=U (autostash pop conflict check)
             ],
         ) as mock_run:
             ok = client.push_worktree_branch(
@@ -382,7 +398,7 @@ class TestPushWorktreeBranchReconcile:
             )
 
         assert ok.ok is True
-        assert mock_run.call_count == 4
+        assert mock_run.call_count == 5
         base_fetch_cmd = mock_run.call_args_list[1].args[0]
         assert "fetch" in base_fetch_cmd and "main" in base_fetch_cmd
         rebase_cmd = mock_run.call_args_list[3].args[0]
@@ -677,12 +693,18 @@ class TestPushWorktreeBranchReconcile:
         """End-to-end regression for #2714.
 
         Reproduces the production shape: divergent remote, local worktree
-        with uncommitted statefile / agent-output writes.  Before
-        ``--autostash`` was added to ``_build_rebase_cmd`` the rebase
-        refused with ``cannot rebase: You have unstaged changes`` and the
-        sync helper returned without bringing origin's commits into local
-        — the populator then tripped ``PlanDraftMissingOnLocalError`` and
-        the pipeline halted at ``plan_complete``.
+        with a *modified tracked* statefile.  Before ``--autostash`` was
+        added to ``_build_rebase_cmd`` the rebase refused with ``cannot
+        rebase: You have unstaged changes`` and the sync helper returned
+        without bringing origin's commits into local — the populator then
+        tripped ``PlanDraftMissingOnLocalError`` and the pipeline halted
+        at ``plan_complete``.
+
+        Why a modified tracked file (not an untracked one): ``git rebase``
+        only refuses for unstaged changes to *tracked* paths.  Untracked
+        files under ``.egg-state/`` do not block a rebase, so a test that
+        only creates untracked junk does not exercise the bug at all — it
+        passes whether or not ``--autostash`` is present.
 
         Exercises both forms returned by ``_build_rebase_cmd``: the plain
         ``git rebase origin/{branch}`` form (no ``base_branch``) and the
@@ -703,7 +725,13 @@ class TestPushWorktreeBranchReconcile:
             seed.mkdir()
             _git_init(seed, str(origin))
             (seed / "README.md").write_text("initial\n")
-            _git(seed, "add", "README.md")
+            # Seed a tracked statefile under .egg-state/ so the work tree
+            # can *modify* it (not just add a new untracked file) and
+            # actually reproduce the rebase-refuses-dirty-tracked-file
+            # precondition.
+            (seed / ".egg-state").mkdir()
+            (seed / ".egg-state" / "contract.json").write_text('{"v": 1}\n')
+            _git(seed, "add", "README.md", ".egg-state/contract.json")
             _git(seed, "commit", "-m", "initial main commit")
             _git(seed, "push", "origin", "main")
 
@@ -716,9 +744,9 @@ class TestPushWorktreeBranchReconcile:
             _git(seed, "push", "origin", "egg/issue-2714")
 
             # Local worktree: cut from origin/{branch}, then add a local
-            # commit (the "local ahead" half) and leave an *uncommitted*
-            # statefile write in the working tree — the precondition that
-            # used to abort the rebase.
+            # commit (the "local ahead" half) and leave an *uncommitted
+            # modification of the tracked statefile* in the working tree
+            # — the precondition that used to abort the rebase.
             work = case_root / "work"
             work.mkdir()
             _git_init(work, str(origin))
@@ -731,23 +759,29 @@ class TestPushWorktreeBranchReconcile:
 
             # Fetch the divergent remote tip so origin/{branch} has a
             # commit the local branch doesn't, then dirty the worktree
-            # with an unstaged statefile write — exactly the shape the
-            # orchestrator continuously produces.
+            # with an *unstaged modification of a tracked statefile* —
+            # exactly the shape the orchestrator continuously produces,
+            # and exactly the shape that makes git rebase refuse.
             _git(work, "fetch", "origin", "egg/issue-2714")
-            statefile_dir = work / ".egg-state"
-            statefile_dir.mkdir()
-            statefile_path = statefile_dir / "junk.txt"
-            statefile_path.write_text("uncommitted statefile write\n")
+            statefile_path = work / ".egg-state" / "contract.json"
+            statefile_path.write_text('{"v": 2}\n')
 
-            # Sanity: the precondition that broke the pre-fix rebase.
+            # Sanity: the precondition that broke the pre-fix rebase is
+            # an unstaged modification to a *tracked* path (porcelain
+            # code starting with ``M`` or `` M``), not an untracked one
+            # (``??``).  A ``??``-only worktree would not reproduce the
+            # bug.
             status = subprocess.run(
                 ["git", "-C", str(work), "status", "--porcelain"],
                 capture_output=True,
                 text=True,
                 check=True,
             )
-            assert status.stdout.strip(), (
-                f"[{case_label}] precondition failed: worktree should be dirty"
+            assert any(
+                line.startswith(("M ", " M", "MM")) for line in status.stdout.splitlines()
+            ), (
+                f"[{case_label}] precondition failed: worktree should have a "
+                f"modified tracked file, got: {status.stdout!r}"
             )
 
             git_base = [
@@ -782,12 +816,90 @@ class TestPushWorktreeBranchReconcile:
                 f"[{case_label}] local commit should have been rewritten by rebase"
             )
 
-            # The uncommitted statefile write must be restored to the
-            # working tree by the autostash pop — without it, the orchestrator
-            # would lose pending state on every sync.
-            assert statefile_path.exists(), (
-                f"[{case_label}] autostash did not restore unstaged statefile write"
+            # The uncommitted statefile modification must be restored to
+            # the working tree by the autostash pop — without it, the
+            # orchestrator would lose pending state on every sync.
+            assert statefile_path.read_text() == '{"v": 2}\n', (
+                f"[{case_label}] autostash did not restore the modified "
+                "tracked statefile (or restored contents were corrupted)"
             )
-            assert statefile_path.read_text() == "uncommitted statefile write\n", (
-                f"[{case_label}] restored statefile contents were corrupted"
-            )
+
+    def test_rebase_autostash_pop_conflict_is_surfaced(self, tmp_path):
+        """Regression for the autostash-pop-conflict gap (#2714 review).
+
+        ``git rebase --autostash`` exits 0 even when the final stash pop
+        conflicts: the rebase itself succeeded, but the pop leaves
+        ``UU`` entries in the worktree and the original autostash entry
+        stays in ``git stash list``.  Before this guard a half-merged
+        worktree would be consumed as a successful sync; the helper now
+        surfaces ``reconcile_autostash_pop_conflict``.
+        """
+        case_root = tmp_path
+        origin = case_root / "origin.git"
+        subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)], check=True)
+
+        # Seed: tracked ``shared.txt`` that both the remote-only commit
+        # and the uncommitted worktree change will touch with conflicting
+        # content, so the autostash pop hits a merge conflict.
+        seed = case_root / "seed"
+        seed.mkdir()
+        _git_init(seed, str(origin))
+        (seed / "README.md").write_text("initial\n")
+        (seed / "shared.txt").write_text("A\n")
+        _git(seed, "add", "README.md", "shared.txt")
+        _git(seed, "commit", "-m", "initial main commit")
+        _git(seed, "push", "origin", "main")
+
+        # Remote tip rewrites ``shared.txt`` to "C\n" — diverges from the
+        # uncommitted "D\n" the worktree will hold.
+        _git(seed, "checkout", "-b", "egg/issue-2714")
+        (seed / "shared.txt").write_text("C\n")
+        _git(seed, "add", "shared.txt")
+        _git(seed, "commit", "-m", "remote: shared.txt -> C")
+        _git(seed, "push", "origin", "egg/issue-2714")
+
+        # Local worktree cut from origin/egg/issue-2714~1.  Adds a local
+        # commit on an *unrelated* path so the rebase replay itself does
+        # not conflict, then modifies ``shared.txt`` to "D\n" without
+        # committing — the autostash will capture that delta.
+        work = case_root / "work"
+        work.mkdir()
+        _git_init(work, str(origin))
+        _git(work, "fetch", "origin")
+        _git(work, "checkout", "-b", "egg/issue-2714-work", "origin/egg/issue-2714~1")
+        (work / "local_only.md").write_text("orchestrator bookkeeping\n")
+        _git(work, "add", "local_only.md")
+        _git(work, "commit", "-m", "state: orchestrator commit (local-only)")
+        _git(work, "fetch", "origin", "egg/issue-2714")
+        (work / "shared.txt").write_text("D\n")
+
+        git_base = [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            f"safe.directory={work}",
+            "-C",
+            str(work),
+        ]
+        result = _rebase_with_agent_output_autoresolve(
+            git_base=git_base,
+            pipeline_id="issue-2714",
+            branch="egg/issue-2714",
+            base_branch=None,
+        )
+        assert not result.ok, "expected reconcile_autostash_pop_conflict failure, got success"
+        assert result.category == "reconcile_autostash_pop_conflict", (
+            f"unexpected failure category: {result.category} ({result.detail})"
+        )
+        # Detail should call out the conflicting path so the operator
+        # has a starting point for recovery.
+        assert "shared.txt" in (result.detail or ""), (
+            f"failure detail should name the conflicting path, got: {result.detail!r}"
+        )
+
+        # The autostash entry must still be in `git stash list` for
+        # manual recovery — losing it would mean losing the uncommitted
+        # statefile delta the orchestrator was holding.
+        stash_list = _git(work, "stash", "list").stdout
+        assert "autostash" in stash_list, f"autostash entry missing from stash list: {stash_list!r}"

--- a/orchestrator/tests/test_reconcile_and_push_pr_branch.py
+++ b/orchestrator/tests/test_reconcile_and_push_pr_branch.py
@@ -354,6 +354,9 @@ class TestPushWorktreeBranchReconcile:
         assert "rebase" in rebase_cmd
         assert "--onto" not in rebase_cmd
         assert "origin/egg/feature" in rebase_cmd
+        # ``--autostash`` is set on the plain form too (#2714) so the
+        # rebase tolerates the orchestrator's continuously-dirty worktree.
+        assert "--autostash" in rebase_cmd
 
     def test_rebase_with_base_branch_uses_onto_form(self, tmp_path):
         """With ``base_branch`` and ``origin/{base_branch}`` resolvable,
@@ -383,8 +386,12 @@ class TestPushWorktreeBranchReconcile:
         base_fetch_cmd = mock_run.call_args_list[1].args[0]
         assert "fetch" in base_fetch_cmd and "main" in base_fetch_cmd
         rebase_cmd = mock_run.call_args_list[3].args[0]
-        assert rebase_cmd[-4:] == [
+        # ``--autostash`` (#2714) precedes ``--onto`` so the rebase can run
+        # against a dirty worktree; statefile / agent-output writes are
+        # routinely uncommitted at sync time.
+        assert rebase_cmd[-5:] == [
             "rebase",
+            "--autostash",
             "--onto",
             "origin/egg/issue-42",
             "origin/main",
@@ -665,3 +672,122 @@ class TestPushWorktreeBranchReconcile:
         )
         # And the retry push was never attempted.
         assert client._do_push.call_count == 1
+
+    def test_rebase_succeeds_against_dirty_worktree(self, tmp_path):
+        """End-to-end regression for #2714.
+
+        Reproduces the production shape: divergent remote, local worktree
+        with uncommitted statefile / agent-output writes.  Before
+        ``--autostash`` was added to ``_build_rebase_cmd`` the rebase
+        refused with ``cannot rebase: You have unstaged changes`` and the
+        sync helper returned without bringing origin's commits into local
+        — the populator then tripped ``PlanDraftMissingOnLocalError`` and
+        the pipeline halted at ``plan_complete``.
+
+        Exercises both forms returned by ``_build_rebase_cmd``: the plain
+        ``git rebase origin/{branch}`` form (no ``base_branch``) and the
+        ``--onto`` form used when the pipeline's base branch is threaded
+        through.  Both must succeed against a dirty worktree.
+        """
+        for case_label, base_branch_arg in [
+            ("plain_form", None),
+            ("onto_form", "main"),
+        ]:
+            case_root = tmp_path / case_label
+            case_root.mkdir()
+
+            origin = case_root / "origin.git"
+            subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)], check=True)
+
+            seed = case_root / "seed"
+            seed.mkdir()
+            _git_init(seed, str(origin))
+            (seed / "README.md").write_text("initial\n")
+            _git(seed, "add", "README.md")
+            _git(seed, "commit", "-m", "initial main commit")
+            _git(seed, "push", "origin", "main")
+
+            # Pipeline branch with a remote commit the local worktree
+            # doesn't have yet — the "remote ahead" half of divergence.
+            _git(seed, "checkout", "-b", "egg/issue-2714")
+            (seed / "remote_draft.md").write_text("plan draft from agent\n")
+            _git(seed, "add", "remote_draft.md")
+            _git(seed, "commit", "-m", "plan: agent wrote draft (remote-only)")
+            _git(seed, "push", "origin", "egg/issue-2714")
+
+            # Local worktree: cut from origin/{branch}, then add a local
+            # commit (the "local ahead" half) and leave an *uncommitted*
+            # statefile write in the working tree — the precondition that
+            # used to abort the rebase.
+            work = case_root / "work"
+            work.mkdir()
+            _git_init(work, str(origin))
+            _git(work, "fetch", "origin")
+            _git(work, "checkout", "-b", "egg/issue-2714-work", "origin/egg/issue-2714~1")
+            (work / "local_commit.md").write_text("orchestrator bookkeeping commit\n")
+            _git(work, "add", "local_commit.md")
+            _git(work, "commit", "-m", "state: orchestrator commit (local-only)")
+            head_local_only = _git(work, "rev-parse", "HEAD").stdout.strip()
+
+            # Fetch the divergent remote tip so origin/{branch} has a
+            # commit the local branch doesn't, then dirty the worktree
+            # with an unstaged statefile write — exactly the shape the
+            # orchestrator continuously produces.
+            _git(work, "fetch", "origin", "egg/issue-2714")
+            statefile_dir = work / ".egg-state"
+            statefile_dir.mkdir()
+            statefile_path = statefile_dir / "junk.txt"
+            statefile_path.write_text("uncommitted statefile write\n")
+
+            # Sanity: the precondition that broke the pre-fix rebase.
+            status = subprocess.run(
+                ["git", "-C", str(work), "status", "--porcelain"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            assert status.stdout.strip(), (
+                f"[{case_label}] precondition failed: worktree should be dirty"
+            )
+
+            git_base = [
+                "git",
+                "-c",
+                "core.hooksPath=/dev/null",
+                "-c",
+                f"safe.directory={work}",
+                "-C",
+                str(work),
+            ]
+            result = _rebase_with_agent_output_autoresolve(
+                git_base=git_base,
+                pipeline_id="issue-2714",
+                branch="egg/issue-2714",
+                base_branch=base_branch_arg,
+            )
+            assert result.ok, (
+                f"[{case_label}] rebase failed against dirty worktree: "
+                f"{result.category} {result.detail}"
+            )
+
+            # The remote-only commit must now be reachable from HEAD (the
+            # whole point of the sync) and the local-only commit must
+            # still be present on top of it.
+            log_shas = _git(work, "log", "--format=%H", "HEAD").stdout.strip().splitlines()
+            remote_sha = _git(work, "rev-parse", "origin/egg/issue-2714").stdout.strip()
+            assert remote_sha in log_shas, (
+                f"[{case_label}] remote commit missing from local after rebase"
+            )
+            assert head_local_only not in log_shas, (
+                f"[{case_label}] local commit should have been rewritten by rebase"
+            )
+
+            # The uncommitted statefile write must be restored to the
+            # working tree by the autostash pop — without it, the orchestrator
+            # would lose pending state on every sync.
+            assert statefile_path.exists(), (
+                f"[{case_label}] autostash did not restore unstaged statefile write"
+            )
+            assert statefile_path.read_text() == "uncommitted statefile write\n", (
+                f"[{case_label}] restored statefile contents were corrupted"
+            )


### PR DESCRIPTION
## Summary

- `_sync_worktree_with_remote`'s divergence-rebase fallback (added by #2352 to fix #2337) aborted whenever the worktree had unstaged changes. The orchestrator's worktree is always dirty at sync time because statefile / agent-output writes are not committed eagerly, so this fired 100% of the time on plan-complete sync — the populator then tripped `PlanDraftMissingOnLocalError` and the pipeline halted at `plan_complete`.
- Set `--autostash` on both forms returned by `_build_rebase_cmd` (plain `git rebase origin/{branch}` and `--onto origin/{branch} origin/{base_branch}`). Git stashes unstaged changes before the rebase and pops them on success; on abort the stash entry is preserved in the stash list for recovery.
- Adds an end-to-end regression test against a real git repo that reproduces the production shape (divergent remote + dirty worktree, both rebase forms) and verifies the unstaged statefile delta is restored after the rebase.

This is fix option (1) from the issue — the author flagged it as lowest risk and one-line at heart.

## Test plan

- [x] `orchestrator/tests/test_reconcile_and_push_pr_branch.py` — all 16 pass, including the new `test_rebase_succeeds_against_dirty_worktree` that exercises both rebase forms against a dirty worktree with real git.
- [x] Existing assertions on the rebase argv updated to include `--autostash` so the flag is locked in for both forms.
- [ ] Full `make test-all` in CI.

Closes #2714.