### PR TITLE
Fix #2721: materialize tracked .egg-state files after cross-worktree advance

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7553,6 +7553,102 @@ def _read_tree_head(git_base: list[str]) -> None:
     )
 
 
+def _restore_missing_state_files_from_head(
+    git_base: list[str],
+    worktree_path: Path,
+    pipeline_id: str | None = None,
+) -> None:
+    """Materialize tracked ``.egg-state/`` files that HEAD has but disk doesn't.
+
+    Companion to :func:`_read_tree_head`: the same cross-worktree
+    ``update-ref`` advance behind #2626 leaves the working tree stale
+    relative to the just-advanced HEAD.  The #2626 fix protected the
+    *commit* (no delete-commit lands), but downstream readers go through
+    the working tree — :func:`_populate_contract_from_plan` reads the
+    plan draft via ``Path(...).read_text()``, which fails with the
+    natural ``PlanDraftMissingOnLocalError`` even though HEAD itself
+    carries the agent-pushed draft (the #2721 symptom; recovery in the
+    field was ``git checkout HEAD -- .egg-state/drafts/
+    .egg-state/agent-outputs/``).
+
+    ``git ls-files --deleted -- .egg-state/`` lists tracked files that
+    are missing on disk.  Must be called AFTER :func:`_read_tree_head`
+    so the index reflects HEAD; otherwise a stale index can leave the
+    delete-list incomplete.  ``git checkout HEAD -- <paths>`` then
+    restores each missing path in both the index and the working tree
+    (the index reset is a no-op because read-tree HEAD already aligned
+    it).  Confined to ``.egg-state/`` so the restoration cannot
+    resurrect a sibling-pipeline file the orchestrator deliberately
+    removed elsewhere in the tree.
+
+    Fail-open: any subprocess error logs and returns silently — the
+    downstream populator still has its own missing-draft guard, so a
+    failure here cannot silently hide a true draft-missing case.
+    """
+    try:
+        deleted = subprocess.run(
+            [*git_base, "ls-files", "--deleted", "--", ".egg-state/"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError) as ls_err:
+        logger.warning(
+            "_restore_missing_state_files_from_head: ls-files probe failed",
+            worktree_path=str(worktree_path),
+            pipeline_id=pipeline_id,
+            error=str(ls_err),
+        )
+        return
+    if deleted.returncode != 0:
+        logger.warning(
+            "_restore_missing_state_files_from_head: ls-files probe failed",
+            worktree_path=str(worktree_path),
+            pipeline_id=pipeline_id,
+            returncode=deleted.returncode,
+            stderr=deleted.stderr.strip()[:200],
+        )
+        return
+    missing_paths = [line for line in deleted.stdout.splitlines() if line.strip()]
+    if not missing_paths:
+        return
+    try:
+        restore = subprocess.run(
+            [*git_base, "checkout", "HEAD", "--", *missing_paths],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError) as checkout_err:
+        logger.warning(
+            "_restore_missing_state_files_from_head: checkout failed",
+            worktree_path=str(worktree_path),
+            pipeline_id=pipeline_id,
+            missing_count=len(missing_paths),
+            error=str(checkout_err),
+        )
+        return
+    if restore.returncode != 0:
+        logger.warning(
+            "_restore_missing_state_files_from_head: checkout failed",
+            worktree_path=str(worktree_path),
+            pipeline_id=pipeline_id,
+            missing_count=len(missing_paths),
+            returncode=restore.returncode,
+            stderr=restore.stderr.strip()[:200],
+        )
+        return
+    logger.info(
+        "_restore_missing_state_files_from_head: restored tracked-but-missing files",
+        worktree_path=str(worktree_path),
+        pipeline_id=pipeline_id,
+        restored_count=len(missing_paths),
+        restored_sample=missing_paths[:5],
+    )
+
+
 def _commit_statefiles_to_worktree(
     worktree_path: Path,
     message: str,
@@ -7660,6 +7756,7 @@ def _commit_statefiles_to_worktree(
 
         rel_paths = [str(Path(f).relative_to(worktree_path)) for f in matched]
         _read_tree_head(git_base)
+        _restore_missing_state_files_from_head(git_base, worktree_path, pipeline_id)
         subprocess.run(
             [*git_base, "add", "--force", "--"] + rel_paths,
             capture_output=True,
@@ -7669,6 +7766,7 @@ def _commit_statefiles_to_worktree(
         )
     else:
         _read_tree_head(git_base)
+        _restore_missing_state_files_from_head(git_base, worktree_path, pipeline_id)
         subprocess.run(
             [*git_base, "add", "--force", ".egg-state/"],
             capture_output=True,

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7571,15 +7571,22 @@ def _restore_missing_state_files_from_head(
     field was ``git checkout HEAD -- .egg-state/drafts/
     .egg-state/agent-outputs/``).
 
-    ``git ls-files --deleted -- .egg-state/`` lists tracked files that
-    are missing on disk.  Must be called AFTER :func:`_read_tree_head`
-    so the index reflects HEAD; otherwise a stale index can leave the
-    delete-list incomplete.  ``git checkout HEAD -- <paths>`` then
-    restores each missing path in both the index and the working tree
-    (the index reset is a no-op because read-tree HEAD already aligned
-    it).  Confined to ``.egg-state/`` so the restoration cannot
-    resurrect a sibling-pipeline file the orchestrator deliberately
-    removed elsewhere in the tree.
+    ``git ls-files -z --deleted -- .egg-state/`` lists tracked files
+    that are missing on disk.  ``-z`` switches the output to
+    NUL-separated raw bytes so paths with non-ASCII chars, newlines, or
+    quote chars survive parsing intact (with the default
+    ``core.quotePath=true`` the non-``-z`` form C-quote-encodes those
+    paths and ``splitlines()`` would misparse them).  Must be called
+    AFTER :func:`_read_tree_head` so the index reflects HEAD; otherwise
+    a stale index can leave the delete-list incomplete.  ``git checkout
+    HEAD --pathspec-from-file=- --pathspec-file-nul`` then restores each
+    missing path in both the index and the working tree (the index
+    reset is a no-op because read-tree HEAD already aligned it); piping
+    the NUL-separated list via stdin sidesteps any ARG_MAX limit on the
+    argv path even for pathological ``.egg-state/`` populations.
+    Confined to ``.egg-state/`` so the restoration cannot resurrect a
+    sibling-pipeline file the orchestrator deliberately removed
+    elsewhere in the tree.
 
     Fail-open: any subprocess error logs and returns silently — the
     downstream populator still has its own missing-draft guard, so a
@@ -7587,9 +7594,8 @@ def _restore_missing_state_files_from_head(
     """
     try:
         deleted = subprocess.run(
-            [*git_base, "ls-files", "--deleted", "--", ".egg-state/"],
+            [*git_base, "ls-files", "-z", "--deleted", "--", ".egg-state/"],
             capture_output=True,
-            text=True,
             check=False,
             timeout=30,
         )
@@ -7607,17 +7613,24 @@ def _restore_missing_state_files_from_head(
             worktree_path=str(worktree_path),
             pipeline_id=pipeline_id,
             returncode=deleted.returncode,
-            stderr=deleted.stderr.strip()[:200],
+            stderr=deleted.stderr.decode("utf-8", errors="replace").strip()[:200],
         )
         return
-    missing_paths = [line for line in deleted.stdout.splitlines() if line.strip()]
+    missing_paths = [p for p in deleted.stdout.split(b"\0") if p]
     if not missing_paths:
         return
+    pathspec_stdin = b"\0".join(missing_paths) + b"\0"
     try:
         restore = subprocess.run(
-            [*git_base, "checkout", "HEAD", "--", *missing_paths],
+            [
+                *git_base,
+                "checkout",
+                "HEAD",
+                "--pathspec-from-file=-",
+                "--pathspec-file-nul",
+            ],
+            input=pathspec_stdin,
             capture_output=True,
-            text=True,
             check=False,
             timeout=30,
         )
@@ -7637,7 +7650,7 @@ def _restore_missing_state_files_from_head(
             pipeline_id=pipeline_id,
             missing_count=len(missing_paths),
             returncode=restore.returncode,
-            stderr=restore.stderr.strip()[:200],
+            stderr=restore.stderr.decode("utf-8", errors="replace").strip()[:200],
         )
         return
     logger.info(
@@ -7645,7 +7658,7 @@ def _restore_missing_state_files_from_head(
         worktree_path=str(worktree_path),
         pipeline_id=pipeline_id,
         restored_count=len(missing_paths),
-        restored_sample=missing_paths[:5],
+        restored_sample=[p.decode("utf-8", errors="replace") for p in missing_paths[:5]],
     )
 
 
@@ -7756,6 +7769,11 @@ def _commit_statefiles_to_worktree(
 
         rel_paths = [str(Path(f).relative_to(worktree_path)) for f in matched]
         _read_tree_head(git_base)
+        # Restore scope is intentionally broader than the staging glob:
+        # the helper operates over all of ``.egg-state/`` to maintain
+        # HEAD↔disk parity (so other readers — e.g. peer-artifact loads —
+        # see what HEAD says).  Each pipeline has its own worktree, so
+        # broader scope cannot resurrect a sibling-pipeline file.
         _restore_missing_state_files_from_head(git_base, worktree_path, pipeline_id)
         subprocess.run(
             [*git_base, "add", "--force", "--"] + rel_paths,
@@ -7766,6 +7784,8 @@ def _commit_statefiles_to_worktree(
         )
     else:
         _read_tree_head(git_base)
+        # Restore scope matches the staging scope here — both span all of
+        # ``.egg-state/`` — so the broader restore is trivially safe.
         _restore_missing_state_files_from_head(git_base, worktree_path, pipeline_id)
         subprocess.run(
             [*git_base, "add", "--force", ".egg-state/"],

--- a/orchestrator/tests/test_commit_statefiles_cross_worktree_ref_advance.py
+++ b/orchestrator/tests/test_commit_statefiles_cross_worktree_ref_advance.py
@@ -324,3 +324,57 @@ def test_pre_sync_commit_idempotent_when_no_orch_writes_after_cross_worktree_adv
     assert head_after == head_before, (
         f"no commit expected, but HEAD moved from {head_before} to {head_after}"
     )
+
+
+def test_pre_sync_commit_materializes_agent_pushed_files_after_cross_worktree_advance(
+    tmp_path: Path,
+) -> None:
+    """Regression for #2721: helper must restore agent-pushed files to disk.
+
+    The #2626 fix protected the *commit* (no delete-commit lands), but the
+    same cross-worktree ``update-ref`` advance leaves the working tree
+    stale relative to the just-advanced HEAD.  Downstream readers go
+    through the working tree — ``_populate_contract_from_plan`` reads the
+    plan draft via ``Path(...).read_text()``, which fails with the
+    natural ``PlanDraftMissingOnLocalError`` even though HEAD itself
+    carries the agent-pushed draft.  Field recovery was ``git checkout
+    HEAD -- .egg-state/drafts/ .egg-state/agent-outputs/``; the helper
+    now does that automatically so the populator can read the draft.
+    """
+    orch_wt, agent_wt, branch, identifier = _setup_shared_worktrees(tmp_path)
+    _agent_pushes_draft_and_runs_update_ref(agent_wt, branch, identifier)
+
+    plan_draft = orch_wt / ".egg-state" / "drafts" / f"{identifier}-plan.md"
+    architect_output = (
+        orch_wt / ".egg-state" / "agent-outputs" / f"{identifier}-architect-output.json"
+    )
+    assert not plan_draft.exists(), (
+        "precondition: orch worktree should NOT have the agent's plan draft on "
+        "disk after a cross-worktree update-ref advance"
+    )
+    assert not architect_output.exists(), (
+        "precondition: orch worktree should NOT have the agent's architect-output "
+        "on disk after a cross-worktree update-ref advance"
+    )
+
+    _commit_statefiles_to_worktree(
+        orch_wt,
+        "Persist agent statefile writes before plan sync",
+        pipeline_identifier=identifier,
+        pipeline_id=identifier,
+    )
+
+    assert plan_draft.exists(), (
+        "regression #2721: agent's plan draft should be materialized on disk "
+        "after _commit_statefiles_to_worktree runs against a stale worktree"
+    )
+    assert plan_draft.read_text() == "# yaml-tasks\n\nagent-produced plan body\n", (
+        "restored draft content should match what the agent pushed to HEAD"
+    )
+    assert architect_output.exists(), (
+        "regression #2721: agent's architect-output should be materialized on "
+        "disk after _commit_statefiles_to_worktree runs against a stale worktree"
+    )
+    assert architect_output.read_text() == '{"role":"architect"}\n', (
+        "restored architect-output content should match what the agent pushed to HEAD"
+    )

--- a/orchestrator/tests/test_commit_statefiles_cross_worktree_ref_advance.py
+++ b/orchestrator/tests/test_commit_statefiles_cross_worktree_ref_advance.py
@@ -51,7 +51,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 _orchestrator_path = Path(__file__).parent.parent
 if str(_orchestrator_path) not in sys.path:
@@ -357,7 +357,9 @@ def test_pre_sync_commit_materializes_agent_pushed_files_after_cross_worktree_ad
         "on disk after a cross-worktree update-ref advance"
     )
 
-    _commit_statefiles_to_worktree(
+    head_before = _git("rev-parse", "HEAD", cwd=orch_wt).stdout.strip()
+
+    committed = _commit_statefiles_to_worktree(
         orch_wt,
         "Persist agent statefile writes before plan sync",
         pipeline_identifier=identifier,
@@ -377,4 +379,70 @@ def test_pre_sync_commit_materializes_agent_pushed_files_after_cross_worktree_ad
     )
     assert architect_output.read_text() == '{"role":"architect"}\n', (
         "restored architect-output content should match what the agent pushed to HEAD"
+    )
+    # Restoration writes files that match HEAD byte-for-byte, so the
+    # subsequent ``git diff --cached --quiet`` exits zero and no commit
+    # lands — restore must not silently dirty the index.
+    assert committed is False, (
+        "restore should match HEAD exactly — no commit expected, but the helper "
+        "reported it created one"
+    )
+    head_after = _git("rev-parse", "HEAD", cwd=orch_wt).stdout.strip()
+    assert head_after == head_before, (
+        f"restore must not move HEAD — moved from {head_before} to {head_after}"
+    )
+
+
+def test_pre_sync_commit_fail_open_when_restore_probe_times_out(
+    tmp_path: Path,
+) -> None:
+    """Restore-helper fail-open contract: timeouts must not raise.
+
+    The docstring on :func:`_restore_missing_state_files_from_head`
+    promises that any subprocess error logs and returns silently — the
+    downstream populator still has its own missing-draft guard, so a
+    flaky probe cannot silently hide a true missing-draft case.  This
+    test locks the contract in by monkeypatching the ``ls-files`` probe
+    to raise :class:`subprocess.TimeoutExpired`, then asserting:
+
+    1. ``_commit_statefiles_to_worktree`` does not propagate the
+       exception (the helper has to swallow it).
+    2. The stale-worktree state is left as-is — no restore happened,
+       so the agent's plan draft is still missing from disk.  This is
+       exactly the state where the downstream populator's own missing-
+       draft guard becomes the source of truth.
+    """
+    orch_wt, agent_wt, branch, identifier = _setup_shared_worktrees(tmp_path)
+    _agent_pushes_draft_and_runs_update_ref(agent_wt, branch, identifier)
+
+    plan_draft = orch_wt / ".egg-state" / "drafts" / f"{identifier}-plan.md"
+    assert not plan_draft.exists(), "precondition: draft is missing from disk"
+
+    real_run = subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+        # The restore helper's ls-files probe is the only
+        # ``ls-files -z --deleted`` invocation in this code path; match
+        # on its hallmark token sequence and pass everything else
+        # through to the real subprocess.run.
+        if isinstance(cmd, list) and "ls-files" in cmd and "--deleted" in cmd and "-z" in cmd:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=30)
+        return real_run(cmd, *args, **kwargs)
+
+    with patch("routes.pipelines.subprocess.run", side_effect=fake_run):
+        # Must not raise — the helper swallows the timeout and returns.
+        _commit_statefiles_to_worktree(
+            orch_wt,
+            "Persist agent statefile writes before plan sync",
+            pipeline_identifier=identifier,
+            pipeline_id=identifier,
+        )
+
+    # Restore was suppressed — the draft is still missing on disk.  The
+    # downstream populator's own guard is now the source of truth, which
+    # is the whole point of the fail-open contract.
+    assert not plan_draft.exists(), (
+        "fail-open: restore probe failed, so the draft must still be missing "
+        "from disk — the downstream populator is responsible for surfacing the "
+        "missing-draft error from here"
     )

--- a/orchestrator/tests/test_commit_statefiles_scoping.py
+++ b/orchestrator/tests/test_commit_statefiles_scoping.py
@@ -40,8 +40,20 @@ def _make_run_side_effect(*, diff_has_changes: bool = True):
             result.returncode = 1 if diff_has_changes else 0
         else:
             result.returncode = 0
-        result.stdout = ""
-        result.stderr = ""
+        # ``_restore_missing_state_files_from_head`` invokes
+        # ``ls-files -z --deleted`` in binary mode (no ``text=True``) so
+        # NUL-separated output survives ``core.quotePath`` re-encoding;
+        # the probe is therefore the one call whose stdout the helper
+        # ``.split(b"\0")`` parses.  Return bytes for that single call
+        # shape so the mock matches the helper's binary contract; every
+        # other call still uses string stdout/stderr to keep the
+        # existing assertions valid.
+        if isinstance(cmd, list) and "ls-files" in cmd and "-z" in cmd and "--deleted" in cmd:
+            result.stdout = b""
+            result.stderr = b""
+        else:
+            result.stdout = ""
+            result.stderr = ""
         return result
 
     return _side_effect

--- a/orchestrator/tests/test_diagnostic_logging_1633.py
+++ b/orchestrator/tests/test_diagnostic_logging_1633.py
@@ -517,8 +517,15 @@ class TestIntegrationBrcHistory:
                 result.returncode = 1
             else:
                 result.returncode = 0
-            result.stdout = ""
-            result.stderr = ""
+            # subprocess.run returns bytes unless text=True is passed; the
+            # ls-files probe in _restore_missing_state_files_from_head omits
+            # text= and splits stdout on b"\0", so the mock must match.
+            if kwargs.get("text"):
+                result.stdout = ""
+                result.stderr = ""
+            else:
+                result.stdout = b""
+                result.stderr = b""
             return result
 
         monkeypatch.setattr(mod.subprocess, "run", fake_run)


### PR DESCRIPTION
## Summary

- Same operator-visible halt as #2714 (`plan_complete` blocked with `reason=plan_draft_missing_on_local`), different root cause: the #2626 cross-worktree `git update-ref` advance leaves the orchestrator's working tree stale relative to HEAD. The #2626 fix protected the *commit* from landing a delete, but the populator reads the plan draft from the *working tree* and still fails because the agent-pushed files were never materialized into the orchestrator's checkout.
- `_commit_statefiles_to_worktree` now restores tracked-but-missing-on-disk `.egg-state/` files from HEAD after `read-tree HEAD`. This mirrors the field recovery procedure (`git checkout HEAD -- .egg-state/drafts/ .egg-state/agent-outputs/`).
- Fail-open: a restore failure logs and continues — the populator's own missing-draft guard still catches genuine missing-draft cases, so a flaky probe can't silently hide a real failure.

## Root cause walkthrough

1. Agent commits drafts + agent-outputs in its sibling worktree, pushes to `origin/<pipeline-branch>`, runs `git update-ref refs/heads/<pipeline-branch> <sha>` per `sandbox/agent-config/rules/branch-recovery.md`.
2. `update-ref` is plumbing and does NOT respect per-worktree locks — the orchestrator worktree (which has the same branch checked out) has its HEAD symref silently advance to the agent's commit; the working tree and index stay at the prior state. (Same hazard as #2626.)
3. `_commit_statefiles_to_worktree` runs at the phase boundary: `read-tree HEAD` aligns the index with HEAD (#2626 protection — no delete commit lands), the orchestrator's writes (if any) get committed. **Files in HEAD but missing on disk stay missing on disk.**
4. `_sync_worktree_with_remote` sees local == origin (both have the agent's commit) and short-circuits via `already_in_sync`.
5. `_populate_contract_from_plan_safe` checks `local_path.exists()` → False → raises `PlanDraftMissingOnLocalError`. Pipeline halts at `plan_complete`.

## Why this didn't trip the existing #2626 tests

The existing tests assert "the commit didn't delete the agent's files from HEAD" — they passed because `read-tree HEAD` + dropping the `--` pathspec stopped the delete-commit from landing. They never asserted the agent files were present on disk after the helper ran, so the working-tree gap survived.

## Test plan

- [x] New regression test `test_pre_sync_commit_materializes_agent_pushed_files_after_cross_worktree_advance` in `test_commit_statefiles_cross_worktree_ref_advance.py` reproduces the production shape end-to-end with real `git worktree` plumbing (no subprocess mocks) and verifies the agent-pushed files are on disk after the helper returns. Verified to fail without the new helper.
- [x] All 3 tests in `test_commit_statefiles_cross_worktree_ref_advance.py` pass with the fix.
- [x] All 15 tests across `test_commit_statefiles_*` pass.
- [x] 170 tests in the touched-area set (`commit_statefiles`, `populate_contract`, `sync_worktree`, `reconcile_and_push`) pass.
- [x] Full `make test` green (3022 passed).
- [x] `make lint` clean for changed files.

Closes #2721.