### PR TITLE
Fix #2725: subscription filtering on egg-orch message wait-loop

### DIFF
--- a/docs/reference/agent-wait-patterns.md
+++ b/docs/reference/agent-wait-patterns.md
@@ -118,6 +118,43 @@ calls together into a "block forever server-side" behaviour so the agent
 can issue one command and **do nothing else** until the orchestrator
 SIGTERMs it or a terminal event arrives.
 
+### Auto-scoping by slice and producer-allowlist (#2725)
+
+`wait` and `wait-loop` auto-apply two filter axes from the agent
+container's environment when they are set — the canonical idiom shown
+above does **not** change, but a reviewer in `slice-1` only wakes on
+events scoped to its slice (or pipeline-level signals like
+OVERSEER_ALERT) and only when the sender is one of its graph neighbors
+or the system roles `overseer` / `orchestrator`.
+
+| Env var | Set by | Effect |
+|---------|--------|--------|
+| `EGG_SLICE_ID` | `kubernetes_spawner` for every slice-scoped agent | `--slice` defaults to this. The wait only matches messages whose `metadata.slice_id` equals this value OR is null (pipeline-level passthrough — OVERSEER_ALERT and global phase signals continue to wake every waiter). |
+| `EGG_WAIT_PRODUCER_ALLOWLIST` | `kubernetes_spawner` for slice + phase agents that participate in the BRC review graph | `--from-producer` defaults to the comma-separated values. The wait only matches messages whose `from_role` is in this set. The spawner derives the set from `review_graph.get_review_graph_for_phase(phase, repo)` — neighbors only — plus the always-included system senders `overseer` and `orchestrator`. |
+
+Explicit `--slice` / `--from-producer` CLI args override the env-derived
+defaults. Pipeline-level spawns (no `phase`) get no allowlist env var
+set and keep the pre-#2725 wake-on-anything behavior.
+
+Both axes apply **inside the server-side blocking branch** so a
+wrong-slice or wrong-sender message does not unblock the wait — it
+isn't filtered client-side after a wake, it never wakes the agent at
+all. That's where the LLM-round-trip savings come from.
+
+> **Filter safety.** A blocking filter that's too tight would sleep the
+> agent through a legitimate event. Three guarantees prevent this:
+>
+> 1. Null `metadata.slice_id` on the message always passes a slice
+>    filter (pipeline-level passthrough). OVERSEER_ALERT, phase
+>    boundary CONSENSUS_CONFIRMED emitted without slice scope, and
+>    the orchestrator's CONSENSUS_RE_REVIEW all reach scoped waiters.
+> 2. The spawner-built allowlist always includes `overseer` and
+>    `orchestrator` so the system senders are never filtered out.
+> 3. An explicit-but-empty `from_producer` list is rejected by the
+>    route with HTTP 400 — silent acceptance would sleep the caller
+>    through every event, which is worse than the wake-storm the
+>    filter exists to fix.
+
 ### Cursor threading is automatic across re-entered waits
 
 Reviewer `POLL` (waiting for proposals from each producer in turn) and
@@ -484,13 +521,17 @@ without callers having to opt in. The mechanism:
 1. **Path derivation.** When `EGG_AGENT_ROLE` is set, the CLI uses
    `${EGG_WAIT_CURSOR_DIR:-/tmp}/egg-wait-cursor-<pipeline_id>-<role>-<hash>`,
    where `<hash>` is an MD5 of the **sorted** `--for` types together
-   with the `--from` filter (if any). Same type set + same `--from` →
-   same file (regardless of `--for` arg order); different type sets,
-   different `--from` filters, or different pipelines → different
-   files. POLL (`--for CONSENSUS_PROPOSE`) and STAY ALIVE
+   with the `--from` filter, the **sorted** `--from-producer` set, and
+   the `--slice` value (if any — #2725). Same type set + same `--from`
+   + same `--from-producer` set + same `--slice` → same file
+   (regardless of arg order); any axis differs → distinct file.
+   POLL (`--for CONSENSUS_PROPOSE`) and STAY ALIVE
    (`--for ... 4 types ...`) hash to distinct files automatically;
    two pipelines sharing a `/tmp` mount (debug shells, integration
-   test reuse) cannot leak cursors into each other.
+   test reuse) cannot leak cursors into each other; and a scoped wait
+   never shares a cursor with an unscoped sibling — a wait that
+   advanced past a message its filter dropped would otherwise mask
+   that message for the sibling.
 2. **Read on entry.** If the file exists and is non-empty, its
    contents become the default for `--since`. An explicit `--since`
    still wins. A corrupt file (non-UTF-8, unreadable) is treated as
@@ -550,9 +591,10 @@ restarting from that cursor will not see the dropped `Y`. Mitigate
 by including all relevant types in the `--for` list — different
 type sets get different cursor files automatically, so a drifted
 POLL cursor can never affect a STAY ALIVE wait. The same isolation
-holds for `--from` filters: a wait scoped to one sender can drop
-messages its filter rejected, but a sibling wait with a different
-`--from` keeps its own cursor and sees them.
+holds for `--from`, `--from-producer`, and `--slice` filters: a
+wait scoped to one sender / producer set / slice can drop messages
+its filter rejected, but a sibling wait with a different filter
+keeps its own cursor and sees them.
 
 ## 4. `HEARTBEAT` Message Type
 

--- a/integration_tests/regression/test_message_bus_routing.py
+++ b/integration_tests/regression/test_message_bus_routing.py
@@ -1422,6 +1422,278 @@ class TestBlockingGetMessages:
 
 
 # ---------------------------------------------------------------------------
+# 9b. Subscription filtering — slice + producer-allowlist axes on
+#     /messages/wait (issue #2725). Cross-backend through the live
+#     Flask route to pin the end-to-end contract.
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _blocking_get_meta_signal(backend):
+    """``/messages/wait`` route variant of ``_blocking_get_signal``.
+
+    The status-wait route uses ``get_messages``; the messages-wait
+    route uses ``get_messages_with_meta`` (issue #2464 — returns the
+    cursor-staleness side-channel). Wrap *that* method so the producer
+    side of these filter tests knows the route is parked in the
+    blocking branch before injecting.
+    """
+    consumer_entered = threading.Event()
+    original = backend.get_messages_with_meta
+
+    def _instrumented(*args, **kwargs):
+        if kwargs.get("wait"):
+            consumer_entered.set()
+        return original(*args, **kwargs)
+
+    with patch.object(backend, "get_messages_with_meta", side_effect=_instrumented):
+        yield consumer_entered
+
+
+class TestSubscriptionFiltering:
+    """``/messages/wait`` accepts ``slice`` + repeatable ``from_producer``
+    filters (#2725). Tests run cross-backend (in-memory + fakeredis)
+    against the live Flask blueprint so a regression in the route
+    layer, either store's filter logic, or the route-store wiring
+    surfaces in the integration tier.
+
+    Load-bearing invariants pinned here:
+
+    * Wrong-slice messages do NOT unblock a slice-filtered wait —
+      otherwise the filter just delays the wake-storm by one LLM
+      round-trip instead of eliminating it.
+    * Null-on-message slice IS a passthrough — OVERSEER_ALERT,
+      phase-boundary CONSENSUS_CONFIRMED, and other pipeline-level
+      signals continue to wake every blocked waiter.
+    * Wrong-sender messages do NOT unblock a from_producer-filtered
+      wait.
+    * Negative conformance: an orchestrator-emitted CONSENSUS_RE_REVIEW
+      addressed to this reviewer wakes a tight slice + producer
+      allowlist. The spawner builds the allowlist to always include
+      ``orchestrator``; this test pins the end-to-end behavior so a
+      regression that drops the system sender (or shifts the null-
+      slice passthrough) surfaces here, not in production where it
+      would manifest as a silent reviewer stall.
+    """
+
+    def test_messages_wait_slice_filter_drops_other_slice(
+        self,
+        client,
+        resolve_pipeline_to,
+        message_backend,
+    ):
+        """A reviewer in ``slice-1`` does NOT wake on a ``slice-2``
+        CONSENSUS_PROPOSE — pinned through the live route on both
+        backends.
+        """
+        with _blocking_get_meta_signal(message_backend) as consumer_entered:
+
+            def _fire() -> None:
+                assert consumer_entered.wait(timeout=3), "consumer never entered blocking wait"
+                message_backend.add_message(
+                    Message(
+                        pipeline_id=_PIPELINE_ID,
+                        from_role="coder",
+                        to_role="all",
+                        message_type=MessageType.CONSENSUS_PROPOSE,
+                        subject="slice-2 propose",
+                        metadata={"slice_id": "slice-2"},
+                    )
+                )
+
+            threading.Thread(target=_fire, daemon=True).start()
+            resp = client.get(
+                f"/api/v1/pipelines/{_PIPELINE_ID}/messages/wait"
+                "?for=CONSENSUS_PROPOSE&slice=slice-1&timeout=1"
+            )
+        envelope = json.loads(resp.data)["data"]
+        assert resp.status_code == 200
+        assert envelope["matched"] is False, (
+            "slice-2 message unblocked a slice-1 wait — filter is leaking across slices"
+        )
+
+    def test_messages_wait_slice_filter_passthrough_null_slice(
+        self,
+        client,
+        resolve_pipeline_to,
+        message_backend,
+    ):
+        """An OVERSEER_ALERT with no ``metadata.slice_id`` wakes a
+        slice-filtered wait — the null-passthrough invariant. Pinned
+        end-to-end so a future change that adds strict slice equality
+        (and breaks this) is caught."""
+        with _blocking_get_meta_signal(message_backend) as consumer_entered:
+
+            def _fire() -> None:
+                assert consumer_entered.wait(timeout=3), "consumer never entered blocking wait"
+                message_backend.add_message(
+                    Message(
+                        pipeline_id=_PIPELINE_ID,
+                        from_role="overseer",
+                        to_role="all",
+                        message_type=MessageType.OVERSEER_ALERT,
+                        subject="alert",
+                    )
+                )
+
+            threading.Thread(target=_fire, daemon=True).start()
+            resp = client.get(
+                f"/api/v1/pipelines/{_PIPELINE_ID}/messages/wait"
+                "?for=OVERSEER_ALERT&slice=slice-1&timeout=3"
+            )
+        envelope = json.loads(resp.data)["data"]
+        assert resp.status_code == 200
+        assert envelope["matched"] is True, (
+            "null-slice OVERSEER_ALERT did not wake a slice-filtered wait "
+            "— pipeline-level passthrough invariant broken"
+        )
+        assert envelope["messages"][0]["message_type"] == "OVERSEER_ALERT"
+
+    def test_messages_wait_from_producer_filter_drops_other_sender(
+        self,
+        client,
+        resolve_pipeline_to,
+        message_backend,
+    ):
+        """A reviewer with ``--from-producer coder,tester`` does NOT
+        wake on a ``documenter`` CONSENSUS_PROPOSE — cross-backend
+        through the live route."""
+        with _blocking_get_meta_signal(message_backend) as consumer_entered:
+
+            def _fire() -> None:
+                assert consumer_entered.wait(timeout=3), "consumer never entered blocking wait"
+                message_backend.add_message(
+                    Message(
+                        pipeline_id=_PIPELINE_ID,
+                        from_role="documenter",
+                        to_role="all",
+                        message_type=MessageType.CONSENSUS_PROPOSE,
+                        subject="not-my-producer",
+                    )
+                )
+
+            threading.Thread(target=_fire, daemon=True).start()
+            resp = client.get(
+                f"/api/v1/pipelines/{_PIPELINE_ID}/messages/wait"
+                "?for=CONSENSUS_PROPOSE"
+                "&from_producer=coder&from_producer=tester&timeout=1"
+            )
+        envelope = json.loads(resp.data)["data"]
+        assert resp.status_code == 200
+        assert envelope["matched"] is False
+
+    def test_messages_wait_from_producer_filter_wakes_on_allowed_sender(
+        self,
+        client,
+        resolve_pipeline_to,
+        message_backend,
+    ):
+        """A reviewer with ``--from-producer coder,tester`` DOES wake
+        when ``coder`` proposes — pinned through the live route on
+        both backends."""
+        with _blocking_get_meta_signal(message_backend) as consumer_entered:
+
+            def _fire() -> None:
+                assert consumer_entered.wait(timeout=3), "consumer never entered blocking wait"
+                message_backend.add_message(
+                    Message(
+                        pipeline_id=_PIPELINE_ID,
+                        from_role="coder",
+                        to_role="all",
+                        message_type=MessageType.CONSENSUS_PROPOSE,
+                        subject="my producer",
+                    )
+                )
+
+            threading.Thread(target=_fire, daemon=True).start()
+            resp = client.get(
+                f"/api/v1/pipelines/{_PIPELINE_ID}/messages/wait"
+                "?for=CONSENSUS_PROPOSE"
+                "&from_producer=coder&from_producer=tester&timeout=3"
+            )
+        envelope = json.loads(resp.data)["data"]
+        assert resp.status_code == 200
+        assert envelope["matched"] is True
+        assert envelope["messages"][0]["from_role"] == "coder"
+
+    def test_messages_wait_negative_conformance_orchestrator_re_review(
+        self,
+        client,
+        resolve_pipeline_to,
+        message_backend,
+    ):
+        """Negative-conformance pin (#2725) at the integration tier.
+
+        An orchestrator-emitted ``CONSENSUS_RE_REVIEW`` addressed to a
+        reviewer in ``slice-1`` MUST wake even a tight filter:
+        ``slice=slice-1`` + ``from_producer=coder,tester,overseer,
+        orchestrator`` (the shape the spawner builds for
+        ``reviewer_code`` in the implement phase). The route layer +
+        message-store filter chain together must let this through
+        — silent sleep is the failure mode worse than the original
+        wake-storm, and the test exists so a future change that drops
+        the ``orchestrator`` system sender from the allowlist (or
+        breaks the null-slice passthrough that ``CONSENSUS_RE_REVIEW``
+        relies on when emitted without a slice scope) is caught
+        cross-backend rather than in production.
+
+        Constructed to mirror routes/signals.py:1373-1393 — the actual
+        re-review path: ``from_role="orchestrator"``,
+        ``to_role=<reviewer>``, ``metadata.slice_id`` set to the
+        reviewer's slice.
+        """
+        with _blocking_get_meta_signal(message_backend) as consumer_entered:
+
+            def _fire() -> None:
+                assert consumer_entered.wait(timeout=3), "consumer never entered blocking wait"
+                message_backend.add_message(
+                    Message(
+                        pipeline_id=_PIPELINE_ID,
+                        from_role="orchestrator",
+                        to_role="reviewer_code",
+                        message_type=MessageType.CONSENSUS_RE_REVIEW,
+                        subject="Re-review required: coder submitted new proposal v2",
+                        metadata={"slice_id": "slice-1", "producer_role": "coder"},
+                    )
+                )
+
+            threading.Thread(target=_fire, daemon=True).start()
+            resp = client.get(
+                f"/api/v1/pipelines/{_PIPELINE_ID}/messages/wait"
+                "?for=CONSENSUS_RE_REVIEW&role=reviewer_code&slice=slice-1"
+                "&from_producer=coder&from_producer=tester"
+                "&from_producer=overseer&from_producer=orchestrator&timeout=3"
+            )
+        envelope = json.loads(resp.data)["data"]
+        assert resp.status_code == 200
+        assert envelope["matched"] is True, (
+            "orchestrator-emitted CONSENSUS_RE_REVIEW did NOT wake a tight "
+            "reviewer wait — the filter is silently sleeping through a "
+            "cross-graph cascade, which is worse than the wake-storm"
+        )
+        msg = envelope["messages"][0]
+        assert msg["from_role"] == "orchestrator"
+        assert msg["message_type"] == "CONSENSUS_RE_REVIEW"
+
+    def test_messages_wait_empty_from_producer_rejected_at_route(
+        self,
+        client,
+        resolve_pipeline_to,
+        message_backend,
+    ):
+        """An explicit-but-empty ``from_producer`` is rejected with
+        HTTP 400 — silent acceptance would sleep the caller through
+        every event. Cross-backend through the live route."""
+        resp = client.get(
+            f"/api/v1/pipelines/{_PIPELINE_ID}/messages/wait"
+            "?for=CONSENSUS_PROPOSE&from_producer=&timeout=1"
+        )
+        assert resp.status_code == 400
+        body = json.loads(resp.data)
+        assert "from_producer" in body["message"]
+
+
+# ---------------------------------------------------------------------------
 # 10. Message store ordering matches event-bus ordering for a single
 #     agent's stream (issue #2640 starting point 3, exact wording)
 # ---------------------------------------------------------------------------

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -55,6 +55,62 @@ from kubernetes_client import (
     get_kubernetes_client,
 )
 from models import AgentRole, ContainerInfo
+from review_graph import get_review_graph_for_phase
+
+# #2725: senders we always include in EGG_WAIT_PRODUCER_ALLOWLIST so
+# system-emitted bus messages keep waking slice-scoped waiters. The
+# overseer emits OVERSEER_ALERT and the orchestrator emits
+# CONSENSUS_RE_REVIEW + the "ready to confirm" STATUS nudge; both
+# carry these literal ``from_role`` values, so excluding them would
+# turn the filter into a deadlock surface.
+_WAIT_ALLOWLIST_SYSTEM_SENDERS: tuple[str, ...] = ("overseer", "orchestrator")
+
+
+def _resolve_wait_producer_allowlist(phase: str | None, role: str, repo: str | None) -> str | None:
+    """Build the ``EGG_WAIT_PRODUCER_ALLOWLIST`` value for a spawn (#2725).
+
+    Looks the role up in the BRC review graph for the supplied phase and
+    returns a comma-separated allowlist of:
+
+    - the role's graph neighbors — reviewers get the producers they
+      review; producers get their reviewers so they wake on ACK/NACK
+      and (for dual-role) any producers they also review.
+    - the system senders ``overseer`` and ``orchestrator`` so
+      ``OVERSEER_ALERT`` and ``CONSENSUS_RE_REVIEW`` keep waking the
+      agent regardless of the producer set.
+
+    Returns ``None`` when the role has no graph neighbors in the
+    requested phase. This omits the env var entirely so the spawn
+    preserves legacy wake-on-anything behavior — the wake-storm fix
+    is opt-in via graph membership, not a default ratchet.
+    """
+    if not phase:
+        return None
+    try:
+        graph = get_review_graph_for_phase(phase, repo)
+    except Exception:
+        # Defensive: a missing / malformed graph must not block spawning.
+        # Falling through leaves EGG_WAIT_PRODUCER_ALLOWLIST unset and
+        # the agent keeps the pre-#2725 behavior.
+        logger.exception(
+            "Failed to load review graph for #2725 allowlist; skipping env var",
+            phase=phase,
+            role=role,
+        )
+        return None
+
+    neighbors: set[str] = set()
+    if graph.is_reviewer(role):
+        neighbors.update(graph.producers_for(role))
+    if graph.is_producer(role):
+        neighbors.update(graph.reviewers_for(role))
+    if not neighbors:
+        # Role not in the graph (pipeline-level helpers, ad-hoc roles)
+        # — no allowlist, no filter, no behavior change.
+        return None
+    allowlist = sorted(neighbors | set(_WAIT_ALLOWLIST_SYSTEM_SENDERS))
+    return ",".join(allowlist)
+
 
 if TYPE_CHECKING:
     from egg_container import MountSpec
@@ -104,6 +160,13 @@ _PROTECTED_ENV_KEYS: frozenset[str] = frozenset(
         # without this, the agent's signals could land on a different
         # slice than its Job/worktree, with no warning.
         "EGG_SLICE_ID",
+        # Wait-loop producer allowlist (#2725). Spawner derives this
+        # from the BRC review graph for the (phase, role) being spawned
+        # — protecting it prevents an upstream ``extra_env`` from
+        # silently substituting a stale or wrong allowlist, which would
+        # cause the agent to sleep through legitimate ACK/NACK/PROPOSE
+        # events without surfacing the misconfiguration.
+        "EGG_WAIT_PRODUCER_ALLOWLIST",
         # Same single-source-of-truth shape (#2428). The agent's
         # ``egg-orch push`` retargets the refspec to ``HEAD:$EGG_BRANCH``
         # (sandbox/egg_lib/cli_push.py); the gateway's session-scoped
@@ -803,6 +866,19 @@ class KubernetesSpawner:
             # are also derived from this same ``slice_id`` parameter.
             if slice_id is not None:
                 environment["EGG_SLICE_ID"] = slice_id
+
+            # #2725: pre-resolve the producer allowlist for this role +
+            # phase so the wait-loop CLI auto-applies it. The allowlist
+            # lives in env so the agent rubric stays graph-agnostic; a
+            # change to the BRC review graph propagates on the next
+            # spawn without prompt edits. Skipped for pipeline-level
+            # spawns (no phase or no graph neighbors) so legacy
+            # behavior is preserved unchanged.
+            wait_allowlist = _resolve_wait_producer_allowlist(
+                phase=phase, role=agent_role.value, repo=pipeline_repo
+            )
+            if wait_allowlist:
+                environment["EGG_WAIT_PRODUCER_ALLOWLIST"] = wait_allowlist
 
             # Caller's extra_env overrides defaults, except protected keys
             if extra_env:

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -74,7 +74,11 @@ def _resolve_wait_producer_allowlist(phase: str | None, role: str, repo: str | N
 
     - the role's graph neighbors — reviewers get the producers they
       review; producers get their reviewers so they wake on ACK/NACK
-      and (for dual-role) any producers they also review.
+      and (for dual-role) any producers they also review. For
+      dual-role agents (e.g. ``tester`` is both a producer reviewed by
+      ``reviewer_code`` and a reviewer of ``coder``) the union of both
+      neighbor sets is used so the agent wakes on both directions of
+      cross-graph traffic.
     - the system senders ``overseer`` and ``orchestrator`` so
       ``OVERSEER_ALERT`` and ``CONSENSUS_RE_REVIEW`` keep waking the
       agent regardless of the producer set.
@@ -83,21 +87,17 @@ def _resolve_wait_producer_allowlist(phase: str | None, role: str, repo: str | N
     requested phase. This omits the env var entirely so the spawn
     preserves legacy wake-on-anything behavior — the wake-storm fix
     is opt-in via graph membership, not a default ratchet.
+
+    ``get_review_graph_for_phase`` is documented to return an empty
+    :class:`ReviewGraph` for unknown phases rather than raising, so
+    this function intentionally does NOT wrap it in a ``try/except``:
+    a programmer-error exception from a future refactor should surface
+    loudly during spawn rather than degrade silently to "no allowlist,
+    wake on everything," which is the wake-storm we are fixing.
     """
     if not phase:
         return None
-    try:
-        graph = get_review_graph_for_phase(phase, repo)
-    except Exception:
-        # Defensive: a missing / malformed graph must not block spawning.
-        # Falling through leaves EGG_WAIT_PRODUCER_ALLOWLIST unset and
-        # the agent keeps the pre-#2725 behavior.
-        logger.exception(
-            "Failed to load review graph for #2725 allowlist; skipping env var",
-            phase=phase,
-            role=role,
-        )
-        return None
+    graph = get_review_graph_for_phase(phase, repo)
 
     neighbors: set[str] = set()
     if graph.is_reviewer(role):

--- a/orchestrator/message_store.py
+++ b/orchestrator/message_store.py
@@ -260,6 +260,8 @@ class MessageStore:
         wait: int = 0,
         wait_for_types: Sequence[str] | None = None,
         from_role: str | None = None,
+        from_roles: Sequence[str] | None = None,
+        slice_id: str | None = None,
         from_tip: bool = False,
     ) -> list[Message]:
         """Get messages for a pipeline, optionally filtered.
@@ -291,6 +293,20 @@ class MessageStore:
                 ``from_role`` equals this value.  Applied inside the blocking
                 loop so a message from the wrong sender does NOT unblock the
                 wait (prevents spinning — issue #1897 reviewer_code non-blocker).
+            from_roles: If set, the wait only matches messages whose
+                ``from_role`` is in this set. The set form of ``from_role``
+                (#2725) — agents pass their consensus-graph neighbors plus
+                system senders to avoid waking on unrelated producers' BRC
+                chatter. When both ``from_role`` and ``from_roles`` are
+                supplied, ``from_role`` wins (single-sender semantics
+                preserve back-compat).
+            slice_id: If set, only match messages whose ``metadata.slice_id``
+                equals this value OR is ``None`` (#2725). Null on the message
+                is a passthrough — pipeline-level signals (OVERSEER_ALERT,
+                phase-boundary CONSENSUS_CONFIRMED emitted without slice
+                scope) wake every blocked waiter regardless of the requested
+                slice. Applied inside the blocking branch so a wrong-slice
+                message does not unblock the wait.
             from_tip: If True AND ``since_id`` is not set AND ``wait > 0``, snap
                 the starting cursor to ``len(messages)`` at call entry so only
                 messages added *after* this call starts can unblock the wait.
@@ -308,6 +324,8 @@ class MessageStore:
             wait=wait,
             wait_for_types=wait_for_types,
             from_role=from_role,
+            from_roles=from_roles,
+            slice_id=slice_id,
             from_tip=from_tip,
         )
         return messages
@@ -322,6 +340,8 @@ class MessageStore:
         wait: int = 0,
         wait_for_types: Sequence[str] | None = None,
         from_role: str | None = None,
+        from_roles: Sequence[str] | None = None,
+        slice_id: str | None = None,
         from_tip: bool = False,
         _suppress_stale_warning: bool = False,
     ) -> tuple[list[Message], GetMessagesMeta]:
@@ -356,6 +376,18 @@ class MessageStore:
         start_idx = 0
         since_id_stale = False
 
+        # Pre-resolve the from_roles set once. ``from_role`` (singular) wins
+        # if both are set so single-sender back-compat is preserved.
+        from_roles_set: set[str] | None
+        if from_role:
+            from_roles_set = None  # singular path handled below
+        elif from_roles:
+            from_roles_set = {r for r in from_roles if r}
+            if not from_roles_set:
+                from_roles_set = None
+        else:
+            from_roles_set = None
+
         def _filter(all_msgs: list[Message]) -> list[Message]:
             # Slice forward from the resolved start_idx (set under the
             # lock below). Cheap: O(n_total - start_idx) plus the filter
@@ -366,6 +398,24 @@ class MessageStore:
             # wait-for-match decision (wrong sender does not unblock).
             if from_role:
                 msgs = [m for m in msgs if m.from_role == from_role]
+            elif from_roles_set is not None:
+                # Sender allowlist (#2725). Messages whose from_role is not in
+                # the set are dropped inside the blocking branch so wrong
+                # senders do NOT unblock a filtered wait.
+                msgs = [m for m in msgs if m.from_role in from_roles_set]
+
+            # Slice scope (#2725). A message whose metadata.slice_id is None
+            # is treated as a pipeline-level signal and passes through any
+            # slice filter — OVERSEER_ALERT and global phase-boundary signals
+            # continue to fan out. Strict equality otherwise.
+            if slice_id is not None:
+                msgs = [
+                    m
+                    for m in msgs
+                    if (
+                        m.metadata.get("slice_id") is None or m.metadata.get("slice_id") == slice_id
+                    )
+                ]
 
             # Filter by role (messages targeted to this role or broadcast)
             if role:

--- a/orchestrator/redis_message_store.py
+++ b/orchestrator/redis_message_store.py
@@ -165,6 +165,8 @@ class RedisMessageStore:
         wait: int = 0,
         wait_for_types: Sequence[str] | None = None,
         from_role: str | None = None,
+        from_roles: Sequence[str] | None = None,
+        slice_id: str | None = None,
         from_tip: bool = False,
     ) -> list[Message]:
         """Get messages from the Redis Stream.
@@ -208,6 +210,8 @@ class RedisMessageStore:
             wait=wait,
             wait_for_types=wait_for_types,
             from_role=from_role,
+            from_roles=from_roles,
+            slice_id=slice_id,
             from_tip=from_tip,
         )
         return messages
@@ -222,6 +226,8 @@ class RedisMessageStore:
         wait: int = 0,
         wait_for_types: Sequence[str] | None = None,
         from_role: str | None = None,
+        from_roles: Sequence[str] | None = None,
+        slice_id: str | None = None,
         from_tip: bool = False,
         _suppress_stale_warning: bool = False,
     ) -> tuple[list[Message], GetMessagesMeta]:
@@ -289,6 +295,33 @@ class RedisMessageStore:
 
         meta = GetMessagesMeta(since_id_stale=since_id_stale)
         want_types = set(wait_for_types) if wait_for_types else None
+        # Sender allowlist (#2725): set form of from_role. ``from_role``
+        # (singular) wins when both are provided so legacy callers see no
+        # behavior change.
+        from_roles_set: set[str] | None
+        if from_role:
+            from_roles_set = None
+        elif from_roles:
+            from_roles_set = {r for r in from_roles if r}
+            if not from_roles_set:
+                from_roles_set = None
+        else:
+            from_roles_set = None
+
+        def _passes_filters(m: Message) -> bool:
+            """Apply slice + sender-allowlist filters (#2725).
+
+            Null-on-message slice is a pipeline-level passthrough so
+            OVERSEER_ALERT and global phase signals continue to wake
+            slice-scoped waiters.
+            """
+            if slice_id is not None:
+                msg_slice = m.metadata.get("slice_id")
+                if msg_slice is not None and msg_slice != slice_id:
+                    return False
+            if from_roles_set is not None and m.from_role not in from_roles_set:
+                return False
+            return True
 
         def _read_once(
             read_start_id: str, block_ms: int | None
@@ -351,6 +384,7 @@ class RedisMessageStore:
                 messages = [m for m in messages if m.to_role == role or m.to_role == "all"]
             if from_role:
                 messages = [m for m in messages if m.from_role == from_role]
+            messages = [m for m in messages if _passes_filters(m)]
             out_msgs = messages[-limit:] if len(messages) > limit else messages
             return out_msgs, meta
 
@@ -376,6 +410,7 @@ class RedisMessageStore:
                 messages = [m for m in messages if m.to_role == role or m.to_role == "all"]
             if from_role:
                 messages = [m for m in messages if m.from_role == from_role]
+            messages = [m for m in messages if _passes_filters(m)]
 
             matching = [m for m in messages if m.message_type in want_types]
             if matching:

--- a/orchestrator/routes/messages.py
+++ b/orchestrator/routes/messages.py
@@ -41,6 +41,30 @@ from routes import get_state_store_for_pipeline
 from slice_id_validation import extract_slice_id as _extract_slice_id
 from state_store import InvalidPipelineIdError, PipelineNotFoundError
 
+# #2725: the system senders the spawner always injects into
+# ``EGG_WAIT_PRODUCER_ALLOWLIST`` (kubernetes_spawner
+# ``_WAIT_ALLOWLIST_SYSTEM_SENDERS``). They must stay accepted at the
+# route boundary so OVERSEER_ALERT / CONSENSUS_RE_REVIEW keep waking
+# scoped waiters. Kept separate from ``AgentRole`` because neither
+# ``overseer`` nor ``orchestrator`` is a spawnable agent role.
+_SYSTEM_FROM_PRODUCER_SENDERS: frozenset[str] = frozenset({"overseer", "orchestrator"})
+
+
+def _build_known_from_producer_values() -> frozenset[str]:
+    """Resolve the accepted ``from_producer`` value set (#2725).
+
+    The route validates every supplied value against this set so a
+    typo (``codr`` instead of ``coder``) fails fast with HTTP 400
+    rather than silently filtering every event and sleeping the
+    caller — the same rationale as the empty-allowlist rejection.
+    """
+    from models import AgentRole  # type: ignore[import-not-found]
+
+    return frozenset({role.value for role in AgentRole}) | _SYSTEM_FROM_PRODUCER_SENDERS
+
+
+_KNOWN_FROM_PRODUCER_VALUES: frozenset[str] = _build_known_from_producer_values()
+
 logger = get_logger("orchestrator.messages")
 
 # Delegate env-var reads to the central ``env_config`` module (issue
@@ -475,18 +499,39 @@ def wait_messages(pipeline_id: str) -> tuple[Response, int]:
     # see no behaviour change. An explicit-but-empty list (e.g.
     # ``?from_producer=&from_producer=``) is rejected here rather than
     # silently dropped — silent acceptance would sleep the caller
-    # through every event, which is worse than the wake-storm.
+    # through every event, which is worse than the wake-storm. The same
+    # rationale applies to unknown role values: a typo like
+    # ``?from_producer=codr`` would silently filter every event, so we
+    # reject anything outside ``_KNOWN_FROM_PRODUCER_VALUES`` (canonical
+    # AgentRole names plus the system senders the spawner always
+    # includes) at the route boundary.
     raw_from_producers = request.args.getlist("from_producer")
     from_producers = [r for r in raw_from_producers if r]
     if raw_from_producers and not from_producers:
         return _make_error(
             "Invalid 'from_producer' parameter: must list at least one non-empty role"
         )
+    if from_producers:
+        unknown = [r for r in from_producers if r not in _KNOWN_FROM_PRODUCER_VALUES]
+        if unknown:
+            return _make_error(
+                "Invalid 'from_producer' value(s): "
+                f"{', '.join(sorted(set(unknown)))} — must be a known AgentRole "
+                "or system sender (overseer / orchestrator)"
+            )
     # #2725: optional slice scope. Null-on-message is a passthrough so
     # OVERSEER_ALERT and global phase signals still wake slice-scoped
-    # waiters.
+    # waiters. An explicit-but-empty ``?slice=`` is rejected here rather
+    # than silently dropped — mirrors the ``from_producer`` rejection
+    # above so an asymmetric "empty is fine for slice, error for sender"
+    # surface doesn't paper over a misconfigured caller.
     slice_id_arg = request.args.get("slice")
     if slice_id_arg is not None:
+        if slice_id_arg == "":
+            return _make_error(
+                "Invalid 'slice' parameter: must be a non-empty 'slice-<N>' value "
+                "(omit the parameter entirely for pipeline-level scope)"
+            )
         try:
             slice_id_arg = _extract_slice_id({"slice_id": slice_id_arg})
         except ValueError as exc:

--- a/orchestrator/routes/messages.py
+++ b/orchestrator/routes/messages.py
@@ -470,6 +470,27 @@ def wait_messages(pipeline_id: str) -> tuple[Response, int]:
 
     role = request.args.get("role")
     from_role = request.args.get("from")
+    # #2725: ``from_producer`` is the repeatable set form of ``from``.
+    # ``from`` (singular) wins when both are provided so legacy callers
+    # see no behaviour change. An explicit-but-empty list (e.g.
+    # ``?from_producer=&from_producer=``) is rejected here rather than
+    # silently dropped — silent acceptance would sleep the caller
+    # through every event, which is worse than the wake-storm.
+    raw_from_producers = request.args.getlist("from_producer")
+    from_producers = [r for r in raw_from_producers if r]
+    if raw_from_producers and not from_producers:
+        return _make_error(
+            "Invalid 'from_producer' parameter: must list at least one non-empty role"
+        )
+    # #2725: optional slice scope. Null-on-message is a passthrough so
+    # OVERSEER_ALERT and global phase signals still wake slice-scoped
+    # waiters.
+    slice_id_arg = request.args.get("slice")
+    if slice_id_arg is not None:
+        try:
+            slice_id_arg = _extract_slice_id({"slice_id": slice_id_arg})
+        except ValueError as exc:
+            return _make_error(f"Invalid slice: {exc}")
     since_id = request.args.get("since_id")
     try:
         limit = int(request.args.get("limit", "100"))
@@ -513,6 +534,8 @@ def wait_messages(pipeline_id: str) -> tuple[Response, int]:
             wait=timeout,
             wait_for_types=wait_for_types,
             from_role=from_role,
+            from_roles=from_producers or None,
+            slice_id=slice_id_arg,
             from_tip=since_id is None,
         )
     finally:

--- a/orchestrator/routes/messages.py
+++ b/orchestrator/routes/messages.py
@@ -493,7 +493,25 @@ def wait_messages(pipeline_id: str) -> tuple[Response, int]:
         )
 
     role = request.args.get("role")
+    # #2725: ``from`` (singular) and ``from_producer`` (repeatable set)
+    # both flow into the same store-level sender filter. Validating
+    # only the plural form would leave a typo like ``?from=codr``
+    # silently filtering every event — the same silent-sleep failure
+    # mode the from_producer rejection exists to prevent. Reject empty
+    # explicit values and unknown roles at the route boundary on both
+    # forms so the surface is symmetric.
     from_role = request.args.get("from")
+    if from_role is not None:
+        if from_role == "":
+            return _make_error(
+                "Invalid 'from' parameter: must be a non-empty role name "
+                "(omit the parameter entirely for no sender filter)"
+            )
+        if from_role not in _KNOWN_FROM_PRODUCER_VALUES:
+            return _make_error(
+                f"Invalid 'from' value: {from_role} — must be a known AgentRole "
+                "or system sender (overseer / orchestrator)"
+            )
     # #2725: ``from_producer`` is the repeatable set form of ``from``.
     # ``from`` (singular) wins when both are provided so legacy callers
     # see no behaviour change. An explicit-but-empty list (e.g.

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -401,6 +401,97 @@ class TestSpawnAgentJob:
         create_kwargs = mock_k8s_client.create_container.call_args.kwargs
         assert "EGG_SLICE_ID" not in create_kwargs["environment"]
 
+    def test_spawn_sets_egg_wait_producer_allowlist_for_reviewer(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """#2725: spawner pre-resolves the producer allowlist from the
+        BRC review graph for a reviewer role.
+
+        ``reviewer_code`` reviews ``coder`` and ``tester`` in the implement
+        graph; the env var must list both producers plus the system
+        senders so the wait-loop CLI auto-scopes without rubric changes.
+        """
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.REVIEWER_CODE,
+            repos=["jwbron/egg"],
+            phase="implement",
+            slice_id="slice-1",
+        )
+        allowlist = result.environment.get("EGG_WAIT_PRODUCER_ALLOWLIST")
+        assert allowlist is not None
+        roles = set(allowlist.split(","))
+        # Graph neighbors: producers reviewer_code reviews.
+        assert "coder" in roles
+        assert "tester" in roles
+        # System senders always included so OVERSEER_ALERT /
+        # CONSENSUS_RE_REVIEW keep waking the reviewer.
+        assert "overseer" in roles
+        assert "orchestrator" in roles
+
+    def test_spawn_sets_egg_wait_producer_allowlist_for_producer(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """#2725: producers get their reviewers in the allowlist so they
+        wake on ACK/NACK from the right callers."""
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.CODER,
+            repos=["jwbron/egg"],
+            phase="implement",
+            slice_id="slice-1",
+        )
+        allowlist = result.environment.get("EGG_WAIT_PRODUCER_ALLOWLIST")
+        assert allowlist is not None
+        roles = set(allowlist.split(","))
+        # coder is reviewed by reviewer_code, reviewer_code_holistic,
+        # reviewer_contract, tester, reviewer_security,
+        # reviewer_concurrency — all must be present.
+        for r in (
+            "reviewer_code",
+            "reviewer_code_holistic",
+            "reviewer_contract",
+            "tester",
+            "reviewer_security",
+            "reviewer_concurrency",
+        ):
+            assert r in roles, f"expected {r} in coder's allowlist: {roles}"
+        assert {"overseer", "orchestrator"}.issubset(roles)
+
+    def test_spawn_skips_allowlist_without_phase(self, spawner, mock_k8s_client, mock_gateway):
+        """#2725: pipeline-level spawns (no phase) skip the env var so
+        legacy wake-on-anything behavior is preserved unchanged."""
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.CODER,
+            repos=["jwbron/egg"],
+        )
+        assert "EGG_WAIT_PRODUCER_ALLOWLIST" not in result.environment
+
+    def test_extra_env_cannot_override_egg_wait_producer_allowlist(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """#2725: spawner is the single source of truth for the
+        allowlist. ``extra_env`` cannot smuggle a stale or wrong list
+        in — silent acceptance would sleep the agent through
+        legitimate events its rubric expects to handle.
+        """
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.REVIEWER_CODE,
+            repos=["jwbron/egg"],
+            phase="implement",
+            slice_id="slice-1",
+            extra_env={"EGG_WAIT_PRODUCER_ALLOWLIST": "evil_role"},
+        )
+        allowlist = result.environment.get("EGG_WAIT_PRODUCER_ALLOWLIST")
+        assert allowlist is not None
+        # extra_env's "evil_role" did not win — the spawner-derived
+        # graph allowlist did.
+        assert "evil_role" not in allowlist
+        assert "coder" in allowlist
+        assert "tester" in allowlist
+
     def test_extra_env_cannot_override_egg_branch(self, spawner, mock_k8s_client, mock_gateway):
         """``extra_env`` cannot override ``EGG_BRANCH`` — protected key (#2428).
 

--- a/orchestrator/tests/test_message_store.py
+++ b/orchestrator/tests/test_message_store.py
@@ -751,3 +751,292 @@ class TestGetLatestId:
         # Every read must have returned a valid id (never None after the
         # initial message was added).
         assert all(i is not None for i in ids)
+
+
+def _make_message_with_slice(
+    pipeline_id: str = "p1",
+    message_type: str = MessageType.CONSENSUS_PROPOSE,
+    from_role: str = "coder",
+    to_role: str = "all",
+    slice_id: str | None = None,
+) -> Message:
+    """Build a CONSENSUS-shaped Message with optional slice metadata.
+
+    Used by the #2725 filter tests where ``metadata.slice_id`` drives the
+    new slice-scoped wait filter.
+    """
+    metadata: dict[str, object] = {}
+    if slice_id is not None:
+        metadata["slice_id"] = slice_id
+    return Message(
+        pipeline_id=pipeline_id,
+        from_role=from_role,
+        to_role=to_role,
+        message_type=message_type,
+        subject="test",
+        metadata=metadata,
+    )
+
+
+class TestSliceFilter:
+    """``slice_id`` filter: only match the requested slice OR null (#2725).
+
+    Null on the message is a pipeline-level passthrough so OVERSEER_ALERT
+    and global phase signals continue to wake slice-scoped waiters.
+    """
+
+    def test_fast_path_drops_wrong_slice(self, store: MessageStore) -> None:
+        store.add_message(_make_message_with_slice(slice_id="slice-2"))
+        msgs = store.get_messages("p1", slice_id="slice-1", wait=0)
+        assert msgs == []
+
+    def test_fast_path_keeps_matching_slice(self, store: MessageStore) -> None:
+        store.add_message(_make_message_with_slice(slice_id="slice-1"))
+        msgs = store.get_messages("p1", slice_id="slice-1", wait=0)
+        assert len(msgs) == 1
+
+    def test_fast_path_keeps_null_slice_message(self, store: MessageStore) -> None:
+        """A pipeline-level message (null slice_id) passes the slice filter.
+
+        OVERSEER_ALERT is the canonical example — it has no slice scope and
+        must wake every slice-filtered waiter.
+        """
+        store.add_message(
+            _make_message_with_slice(
+                message_type=MessageType.OVERSEER_ALERT,
+                from_role="overseer",
+                slice_id=None,
+            )
+        )
+        msgs = store.get_messages("p1", slice_id="slice-1", wait=0)
+        assert len(msgs) == 1
+        assert msgs[0].message_type == MessageType.OVERSEER_ALERT
+
+    def test_wrong_slice_does_not_unblock(self, store: MessageStore) -> None:
+        """Wrong-slice messages must not unblock a slice-filtered wait —
+        otherwise the filter would just delay the wake-storm by one round-trip."""
+        got: list[list[Message]] = []
+
+        def _block() -> None:
+            got.append(
+                store.get_messages(
+                    "p1",
+                    slice_id="slice-1",
+                    wait=1,
+                    wait_for_types=[MessageType.CONSENSUS_PROPOSE],
+                )
+            )
+
+        t = threading.Thread(target=_block)
+        t.start()
+        time.sleep(0.1)
+
+        # Flood with wrong-slice events. Each notifies the cv but must not
+        # be returned to the slice-1 waiter.
+        for _ in range(5):
+            store.add_message(_make_message_with_slice(slice_id="slice-2"))
+
+        t.join(timeout=3)
+        assert not t.is_alive()
+        assert got == [[]]
+
+    def test_null_slice_unblocks_filtered_wait(self, store: MessageStore) -> None:
+        """Null-slice (pipeline-level) message unblocks a slice-filtered wait."""
+        got: list[list[Message]] = []
+
+        def _block() -> None:
+            got.append(
+                store.get_messages(
+                    "p1",
+                    slice_id="slice-1",
+                    wait=2,
+                    wait_for_types=[MessageType.OVERSEER_ALERT],
+                )
+            )
+
+        t = threading.Thread(target=_block)
+        t.start()
+        time.sleep(0.1)
+
+        store.add_message(
+            _make_message_with_slice(
+                message_type=MessageType.OVERSEER_ALERT,
+                from_role="overseer",
+                slice_id=None,
+            )
+        )
+
+        t.join(timeout=3)
+        assert not t.is_alive()
+        assert len(got[0]) == 1
+
+
+class TestFromRolesFilter:
+    """``from_roles`` allowlist filter: only match named senders (#2725).
+
+    ``from_role`` (singular) wins when both are supplied so legacy callers
+    see no behavior change.
+    """
+
+    def test_fast_path_keeps_allowed_sender(self, store: MessageStore) -> None:
+        store.add_message(_make_message_with_slice(from_role="coder"))
+        msgs = store.get_messages("p1", from_roles=["coder", "tester"], wait=0)
+        assert len(msgs) == 1
+
+    def test_fast_path_drops_disallowed_sender(self, store: MessageStore) -> None:
+        store.add_message(_make_message_with_slice(from_role="documenter"))
+        msgs = store.get_messages("p1", from_roles=["coder", "tester"], wait=0)
+        assert msgs == []
+
+    def test_wrong_sender_does_not_unblock(self, store: MessageStore) -> None:
+        got: list[list[Message]] = []
+
+        def _block() -> None:
+            got.append(
+                store.get_messages(
+                    "p1",
+                    from_roles=["coder", "tester"],
+                    wait=1,
+                    wait_for_types=[MessageType.CONSENSUS_PROPOSE],
+                )
+            )
+
+        t = threading.Thread(target=_block)
+        t.start()
+        time.sleep(0.1)
+
+        for _ in range(5):
+            store.add_message(_make_message_with_slice(from_role="documenter"))
+
+        t.join(timeout=3)
+        assert not t.is_alive()
+        assert got == [[]]
+
+    def test_singular_from_role_wins_over_set(self, store: MessageStore) -> None:
+        """When both are supplied, ``from_role`` (singular) wins.
+
+        This preserves single-sender back-compat — a caller that already
+        passes ``from_role="X"`` and adds ``from_roles=["X","Y"]`` for some
+        reason gets exactly the X-only matches the singular form has
+        always returned.
+        """
+        store.add_message(_make_message_with_slice(from_role="coder"))
+        store.add_message(_make_message_with_slice(from_role="tester"))
+        msgs = store.get_messages(
+            "p1",
+            from_role="coder",
+            from_roles=["coder", "tester"],
+            wait=0,
+        )
+        assert [m.from_role for m in msgs] == ["coder"]
+
+    def test_empty_set_is_no_filter(self, store: MessageStore) -> None:
+        """An empty ``from_roles`` set is treated as no filter at the
+        store layer — the route layer rejects this at request time so an
+        empty list never reaches the store from network callers."""
+        store.add_message(_make_message_with_slice(from_role="documenter"))
+        msgs = store.get_messages("p1", from_roles=[], wait=0)
+        assert len(msgs) == 1
+
+
+class TestSliceAndFromRolesCombined:
+    """Filters compose — both must accept the message for it to match."""
+
+    def test_both_match(self, store: MessageStore) -> None:
+        store.add_message(_make_message_with_slice(from_role="coder", slice_id="slice-1"))
+        msgs = store.get_messages(
+            "p1",
+            slice_id="slice-1",
+            from_roles=["coder", "tester"],
+            wait=0,
+        )
+        assert len(msgs) == 1
+
+    def test_wrong_slice_right_sender_drops(self, store: MessageStore) -> None:
+        store.add_message(_make_message_with_slice(from_role="coder", slice_id="slice-2"))
+        msgs = store.get_messages(
+            "p1",
+            slice_id="slice-1",
+            from_roles=["coder", "tester"],
+            wait=0,
+        )
+        assert msgs == []
+
+    def test_right_slice_wrong_sender_drops(self, store: MessageStore) -> None:
+        store.add_message(_make_message_with_slice(from_role="documenter", slice_id="slice-1"))
+        msgs = store.get_messages(
+            "p1",
+            slice_id="slice-1",
+            from_roles=["coder", "tester"],
+            wait=0,
+        )
+        assert msgs == []
+
+    def test_overseer_alert_bypasses_slice_filter(self, store: MessageStore) -> None:
+        """Combined filter still respects the null-slice passthrough so
+        system senders included in the allowlist (overseer / orchestrator)
+        keep waking slice-filtered waiters."""
+        store.add_message(
+            _make_message_with_slice(
+                message_type=MessageType.OVERSEER_ALERT,
+                from_role="overseer",
+                slice_id=None,
+            )
+        )
+        msgs = store.get_messages(
+            "p1",
+            slice_id="slice-1",
+            from_roles=["coder", "tester", "overseer", "orchestrator"],
+            wait=0,
+        )
+        assert len(msgs) == 1
+
+    def test_orchestrator_re_review_wakes_tightly_filtered_reviewer(
+        self, store: MessageStore
+    ) -> None:
+        """Negative-conformance pin (#2725): an orchestrator-emitted
+        CONSENSUS_RE_REVIEW targeted at this reviewer must wake even a
+        tight slice + producer-allowlist filter — otherwise the filter
+        silently sleeps the reviewer through a legitimate cross-graph
+        cascade, which is the failure mode worse than the wake-storm.
+
+        Constructed to mirror the orchestrator's signal-handler shape
+        (routes/signals.py:1373-1393): from_role="orchestrator", to_role
+        targeted at the reviewer, metadata.slice_id matching the
+        reviewer's slice. The spawner-built allowlist always includes
+        ``orchestrator`` so this works without rubric edits.
+        """
+        got: list[list[Message]] = []
+
+        def _block() -> None:
+            got.append(
+                store.get_messages(
+                    "p1",
+                    role="reviewer_code",
+                    slice_id="slice-1",
+                    from_roles=["coder", "tester", "overseer", "orchestrator"],
+                    wait=2,
+                    wait_for_types=[MessageType.CONSENSUS_RE_REVIEW],
+                )
+            )
+
+        t = threading.Thread(target=_block)
+        t.start()
+        time.sleep(0.1)
+
+        store.add_message(
+            Message(
+                pipeline_id="p1",
+                from_role="orchestrator",
+                to_role="reviewer_code",
+                message_type=MessageType.CONSENSUS_RE_REVIEW,
+                subject="Re-review required: coder submitted new proposal v2",
+                metadata={"slice_id": "slice-1", "producer_role": "coder"},
+            )
+        )
+
+        t.join(timeout=3)
+        assert not t.is_alive()
+        assert len(got[0]) == 1
+        assert got[0][0].from_role == "orchestrator"
+        assert got[0][0].message_type == MessageType.CONSENSUS_RE_REVIEW

--- a/orchestrator/tests/test_messages.py
+++ b/orchestrator/tests/test_messages.py
@@ -2099,6 +2099,79 @@ class TestWaitEndpoint:
                 )
                 assert resp.status_code == 200
 
+    def test_wait_empty_from_returns_400(self, client, app):
+        """An explicit-but-empty ``?from=`` is rejected with 400 (#2725
+        review follow-up). Mirrors the empty ``?from_producer=`` and
+        ``?slice=`` rejections — silent acceptance would degrade the
+        filter to "any sender", which is fine here but hides a
+        misconfigured caller."""
+        with app.test_request_context():
+            with patch(
+                "routes.messages.get_state_store_for_pipeline"
+            ) as mock_get_store_for_pipeline:
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                resp = client.get(
+                    "/api/v1/pipelines/test-pipeline/messages/wait"
+                    "?for=CONSENSUS_PROPOSE&from=&timeout=1"
+                )
+                assert resp.status_code == 400
+                body = json.loads(resp.data)
+                assert "from" in body["message"]
+
+    def test_wait_unknown_from_value_returns_400(self, client, app):
+        """An unknown singular ``?from=`` value is rejected with 400
+        (#2725 review follow-up). A typo like ``?from=codr`` would
+        silently filter every event — same failure mode as the plural
+        ``?from_producer=`` rejection. Validating both keeps the route
+        surface symmetric so callers can't accidentally land in the
+        silent-sleep mode by using the legacy singular parameter."""
+        with app.test_request_context():
+            with patch(
+                "routes.messages.get_state_store_for_pipeline"
+            ) as mock_get_store_for_pipeline:
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                resp = client.get(
+                    "/api/v1/pipelines/test-pipeline/messages/wait"
+                    "?for=CONSENSUS_PROPOSE&from=codr&timeout=1"
+                )
+                assert resp.status_code == 400
+                body = json.loads(resp.data)
+                assert "codr" in body["message"]
+                assert "from" in body["message"]
+
+    def test_wait_known_from_value_accepted(self, client, app):
+        """``?from=`` accepts canonical ``AgentRole`` values and the
+        system senders (``overseer`` / ``orchestrator``). Pins the
+        symmetric acceptance contract between singular and plural forms
+        so a future change to ``_KNOWN_FROM_PRODUCER_VALUES`` covers
+        both surfaces at once."""
+        store = MessageStore()
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                # ``orchestrator`` exercises the system-sender branch;
+                # the existing test_wait_from_filter covers the
+                # AgentRole branch end-to-end.
+                resp = client.get(
+                    "/api/v1/pipelines/test-pipeline/messages/wait"
+                    "?for=CONSENSUS_PROPOSE&from=orchestrator&timeout=1"
+                )
+                assert resp.status_code == 200
+
 
 class TestProducerPendingConfirmGuard:
     """Reject ``wait --for CONSENSUS_CONFIRMED`` from producers in

--- a/orchestrator/tests/test_messages.py
+++ b/orchestrator/tests/test_messages.py
@@ -2022,6 +2022,83 @@ class TestWaitEndpoint:
                 )
                 assert resp.status_code == 400
 
+    def test_wait_empty_slice_returns_400(self, client, app):
+        """Explicit empty ``?slice=`` is rejected (#2725 review). The
+        empty-string value would be silently dropped by
+        ``extract_slice_id`` (returns ``None`` for ``""``), turning a
+        misconfigured caller's slice filter into "no scope" instead of
+        surfacing the bug. Mirrors the empty-``from_producer`` rejection
+        so the two filter axes have a consistent error surface."""
+        with app.test_request_context():
+            with patch(
+                "routes.messages.get_state_store_for_pipeline"
+            ) as mock_get_store_for_pipeline:
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                resp = client.get(
+                    "/api/v1/pipelines/test-pipeline/messages/wait"
+                    "?for=CONSENSUS_PROPOSE&slice=&timeout=1"
+                )
+                assert resp.status_code == 400
+                body = json.loads(resp.data)
+                assert "slice" in body["message"].lower()
+
+    def test_wait_unknown_from_producer_value_returns_400(self, client, app):
+        """An unknown ``from_producer`` role value is rejected with 400
+        (#2725 review). A typo like ``?from_producer=codr`` would
+        silently filter every event and sleep the caller — exactly the
+        failure mode the empty-list rejection exists to prevent. The
+        accepted set is canonical ``AgentRole`` names plus the system
+        senders the spawner always injects (``overseer``,
+        ``orchestrator``)."""
+        with app.test_request_context():
+            with patch(
+                "routes.messages.get_state_store_for_pipeline"
+            ) as mock_get_store_for_pipeline:
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                resp = client.get(
+                    "/api/v1/pipelines/test-pipeline/messages/wait"
+                    "?for=CONSENSUS_PROPOSE&from_producer=codr&timeout=1"
+                )
+                assert resp.status_code == 400
+                body = json.loads(resp.data)
+                assert "codr" in body["message"]
+                assert "from_producer" in body["message"]
+
+    def test_wait_known_from_producer_values_accepted(self, client, app):
+        """The accepted-value set includes every canonical AgentRole
+        plus the system senders ``overseer`` and ``orchestrator``.
+        This pins the route's acceptance contract so a future change
+        that narrows the set (and silently filters legitimate senders)
+        is caught — same direction as the negative-conformance
+        ``CONSENSUS_RE_REVIEW`` test."""
+        store = MessageStore()
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                # ``coder`` + ``orchestrator`` exercise both the
+                # AgentRole branch and the system-sender branch in
+                # _KNOWN_FROM_PRODUCER_VALUES.
+                resp = client.get(
+                    "/api/v1/pipelines/test-pipeline/messages/wait"
+                    "?for=CONSENSUS_PROPOSE"
+                    "&from_producer=coder&from_producer=orchestrator&timeout=1"
+                )
+                assert resp.status_code == 200
+
 
 class TestProducerPendingConfirmGuard:
     """Reject ``wait --for CONSENSUS_CONFIRMED`` from producers in

--- a/orchestrator/tests/test_messages.py
+++ b/orchestrator/tests/test_messages.py
@@ -1806,6 +1806,222 @@ class TestWaitEndpoint:
                 assert resp.status_code == 200
                 assert elapsed < 5  # would be 999s without clamp
 
+    def test_wait_slice_filter_drops_other_slice(self, client, app):
+        """``slice`` query param drops wrong-slice events (#2725).
+
+        A reviewer in slice-1 must not be woken by a slice-2 CONSENSUS_PROPOSE.
+        """
+        import threading
+        import time as _t
+
+        store = MessageStore()
+
+        def _add_after_delay() -> None:
+            _t.sleep(0.15)
+            # Wrong-slice event — must not match the slice-1 wait.
+            store.add_message(
+                Message(
+                    pipeline_id="test-pipeline",
+                    from_role="coder",
+                    to_role="all",
+                    message_type=MessageType.CONSENSUS_PROPOSE,
+                    subject="slice-2 propose",
+                    metadata={"slice_id": "slice-2"},
+                )
+            )
+
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                t = threading.Thread(target=_add_after_delay)
+                t.start()
+                try:
+                    resp = client.get(
+                        "/api/v1/pipelines/test-pipeline/messages/wait"
+                        "?for=CONSENSUS_PROPOSE&slice=slice-1&timeout=1"
+                    )
+                finally:
+                    t.join(timeout=2)
+                assert resp.status_code == 200
+                data = json.loads(resp.data)
+                assert data["data"]["matched"] is False
+
+    def test_wait_slice_filter_wakes_on_null_slice(self, client, app):
+        """Null-slice message (pipeline-level) wakes a slice-filtered wait.
+
+        Implements the passthrough invariant — OVERSEER_ALERT and global
+        phase signals carry no slice scope and must keep fanning out.
+        """
+        import threading
+        import time as _t
+
+        store = MessageStore()
+
+        def _add_after_delay() -> None:
+            _t.sleep(0.15)
+            store.add_message(
+                Message(
+                    pipeline_id="test-pipeline",
+                    from_role="overseer",
+                    to_role="all",
+                    message_type=MessageType.OVERSEER_ALERT,
+                    subject="alert",
+                    metadata={},
+                )
+            )
+
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                t = threading.Thread(target=_add_after_delay)
+                t.start()
+                try:
+                    resp = client.get(
+                        "/api/v1/pipelines/test-pipeline/messages/wait"
+                        "?for=OVERSEER_ALERT&slice=slice-1&timeout=3"
+                    )
+                finally:
+                    t.join(timeout=2)
+                assert resp.status_code == 200
+                data = json.loads(resp.data)
+                assert data["data"]["matched"] is True
+
+    def test_wait_invalid_slice_returns_400(self, client, app):
+        """Malformed slice ids are rejected with 400."""
+        with app.test_request_context():
+            with patch(
+                "routes.messages.get_state_store_for_pipeline"
+            ) as mock_get_store_for_pipeline:
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                resp = client.get(
+                    "/api/v1/pipelines/test-pipeline/messages/wait"
+                    "?for=CONSENSUS_PROPOSE&slice=not-canonical&timeout=1"
+                )
+                assert resp.status_code == 400
+
+    def test_wait_from_producer_filter_drops_other_sender(self, client, app):
+        """Repeatable ``from_producer`` drops wrong-sender events (#2725)."""
+        import threading
+        import time as _t
+
+        store = MessageStore()
+
+        def _add_after_delay() -> None:
+            _t.sleep(0.15)
+            store.add_message(
+                Message(
+                    pipeline_id="test-pipeline",
+                    from_role="documenter",
+                    to_role="all",
+                    message_type=MessageType.CONSENSUS_PROPOSE,
+                    subject="not-my-producer",
+                )
+            )
+
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                t = threading.Thread(target=_add_after_delay)
+                t.start()
+                try:
+                    resp = client.get(
+                        "/api/v1/pipelines/test-pipeline/messages/wait"
+                        "?for=CONSENSUS_PROPOSE&from_producer=coder&from_producer=tester&timeout=1"
+                    )
+                finally:
+                    t.join(timeout=2)
+                assert resp.status_code == 200
+                data = json.loads(resp.data)
+                assert data["data"]["matched"] is False
+
+    def test_wait_from_producer_filter_wakes_on_allowed_sender(self, client, app):
+        """Allowed sender in ``from_producer`` set unblocks the wait."""
+        import threading
+        import time as _t
+
+        store = MessageStore()
+
+        def _add_after_delay() -> None:
+            _t.sleep(0.15)
+            store.add_message(
+                Message(
+                    pipeline_id="test-pipeline",
+                    from_role="coder",
+                    to_role="all",
+                    message_type=MessageType.CONSENSUS_PROPOSE,
+                    subject="my producer",
+                )
+            )
+
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                t = threading.Thread(target=_add_after_delay)
+                t.start()
+                try:
+                    resp = client.get(
+                        "/api/v1/pipelines/test-pipeline/messages/wait"
+                        "?for=CONSENSUS_PROPOSE&from_producer=coder&from_producer=tester&timeout=3"
+                    )
+                finally:
+                    t.join(timeout=2)
+                assert resp.status_code == 200
+                data = json.loads(resp.data)
+                assert data["data"]["matched"] is True
+
+    def test_wait_empty_from_producer_returns_400(self, client, app):
+        """Explicit empty ``from_producer`` is rejected — silent acceptance
+        would sleep the caller through every event, which is worse than the
+        wake-storm we're trying to fix."""
+        with app.test_request_context():
+            with patch(
+                "routes.messages.get_state_store_for_pipeline"
+            ) as mock_get_store_for_pipeline:
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                resp = client.get(
+                    "/api/v1/pipelines/test-pipeline/messages/wait"
+                    "?for=CONSENSUS_PROPOSE&from_producer=&timeout=1"
+                )
+                assert resp.status_code == 400
+
 
 class TestProducerPendingConfirmGuard:
     """Reject ``wait --for CONSENSUS_CONFIRMED`` from producers in

--- a/orchestrator/tests/test_messages.py
+++ b/orchestrator/tests/test_messages.py
@@ -2119,7 +2119,7 @@ class TestWaitEndpoint:
                 )
                 assert resp.status_code == 400
                 body = json.loads(resp.data)
-                assert "from" in body["message"]
+                assert "'from' parameter" in body["message"]
 
     def test_wait_unknown_from_value_returns_400(self, client, app):
         """An unknown singular ``?from=`` value is rejected with 400

--- a/orchestrator/tests/test_redis_message_store.py
+++ b/orchestrator/tests/test_redis_message_store.py
@@ -910,3 +910,135 @@ class TestGetLatestId:
         store.add_message(m2)
         assert store.get_latest_id("pipeline-a") == m1.id
         assert store.get_latest_id("pipeline-b") == m2.id
+
+
+def _slice_message(
+    pipeline_id: str = "test-pipeline",
+    message_type: str = MessageType.PROGRESS,
+    from_role: str = "coder",
+    to_role: str = "all",
+    slice_id: str | None = None,
+) -> Message:
+    """Helper for #2725 redis-store filter tests."""
+    metadata: dict[str, object] = {}
+    if slice_id is not None:
+        metadata["slice_id"] = slice_id
+    return Message(
+        pipeline_id=pipeline_id,
+        from_role=from_role,
+        to_role=to_role,
+        message_type=message_type,
+        subject="filter-test",
+        metadata=metadata,
+    )
+
+
+class TestRedisSingularFromRoleAndSliceCombined:
+    """``from_role`` (singular) + ``slice_id`` compose on the Redis path (#2725).
+
+    The redis store applies ``from_role`` and the slice filter on
+    *different* code paths — singular ``from_role`` is filtered inline
+    in ``get_messages_with_meta`` (redis_message_store.py:385-386 / 411-412),
+    while ``slice_id`` is filtered inside ``_passes_filters``. The
+    cross-backend integration tests cover the plural ``from_roles=``
+    form; this class closes the matrix for singular + slice on the
+    redis path so a future reorder of the two filter blocks (or a
+    refactor that drops one branch) is caught before production.
+    """
+
+    def test_both_match_no_wait(self, store):
+        store.add_message(_slice_message(from_role="coder", slice_id="slice-1"))
+        msgs = store.get_messages(
+            "test-pipeline",
+            from_role="coder",
+            slice_id="slice-1",
+            wait=0,
+        )
+        assert len(msgs) == 1
+        assert msgs[0].from_role == "coder"
+
+    def test_wrong_slice_right_sender_drops(self, store):
+        store.add_message(_slice_message(from_role="coder", slice_id="slice-2"))
+        msgs = store.get_messages(
+            "test-pipeline",
+            from_role="coder",
+            slice_id="slice-1",
+            wait=0,
+        )
+        assert msgs == []
+
+    def test_right_slice_wrong_sender_drops(self, store):
+        store.add_message(_slice_message(from_role="documenter", slice_id="slice-1"))
+        msgs = store.get_messages(
+            "test-pipeline",
+            from_role="coder",
+            slice_id="slice-1",
+            wait=0,
+        )
+        assert msgs == []
+
+    def test_null_slice_passthrough_with_singular_from_role(self, store):
+        """A pipeline-level message (null ``slice_id``) from the same sender
+        still passes the combined filter — the null-passthrough invariant
+        composes with the singular sender filter the same way it composes
+        with the plural form."""
+        store.add_message(_slice_message(from_role="coder", slice_id=None))
+        msgs = store.get_messages(
+            "test-pipeline",
+            from_role="coder",
+            slice_id="slice-1",
+            wait=0,
+        )
+        assert len(msgs) == 1
+        assert msgs[0].from_role == "coder"
+
+    def test_combined_filter_inside_wait_for_types(self, store):
+        """Singular ``from_role`` + ``slice_id`` must compose inside the
+        ``wait_for_types`` inner loop (redis_message_store.py:409-413) —
+        a wrong-slice or wrong-sender message must NOT unblock the wait.
+        """
+        got: list[list[Message]] = []
+
+        def _block() -> None:
+            got.append(
+                store.get_messages(
+                    "test-pipeline",
+                    from_role="coder",
+                    slice_id="slice-1",
+                    wait=2,
+                    wait_for_types=[MessageType.CONSENSUS_PROPOSE],
+                    from_tip=True,
+                )
+            )
+
+        t = threading.Thread(target=_block)
+        t.start()
+        time.sleep(0.1)
+
+        store.add_message(
+            _slice_message(
+                message_type=MessageType.CONSENSUS_PROPOSE,
+                from_role="coder",
+                slice_id="slice-2",
+            )
+        )
+        store.add_message(
+            _slice_message(
+                message_type=MessageType.CONSENSUS_PROPOSE,
+                from_role="documenter",
+                slice_id="slice-1",
+            )
+        )
+        store.add_message(
+            _slice_message(
+                message_type=MessageType.CONSENSUS_PROPOSE,
+                from_role="coder",
+                slice_id="slice-1",
+            )
+        )
+
+        t.join(timeout=3)
+        assert not t.is_alive()
+        assert len(got[0]) == 1
+        assert got[0][0].from_role == "coder"
+        assert got[0][0].metadata.get("slice_id") == "slice-1"

--- a/sandbox/egg_agent_tools/handlers/message.py
+++ b/sandbox/egg_agent_tools/handlers/message.py
@@ -123,6 +123,19 @@ def message_wait(req: dict[str, Any]) -> dict[str, Any]:
     from_role = req.get("from_role") or req.get("from")
     if from_role:
         params.append(("from", str(from_role)))
+    # #2725: producer allowlist — repeatable set form of ``from`` so a
+    # reviewer can name every producer it reviews (and the system senders
+    # ``overseer`` / ``orchestrator``) in one call.
+    from_roles = req.get("from_roles")
+    if from_roles and not from_role:
+        for r in from_roles:
+            if r:
+                params.append(("from_producer", str(r)))
+    # #2725: slice scope — only match messages whose metadata.slice_id
+    # equals this OR is null (pipeline-level passthrough).
+    slice_id = req.get("slice_id")
+    if slice_id:
+        params.append(("slice", str(slice_id)))
     if req.get("since"):
         params.append(("since_id", str(req["since"])))
     if req.get("limit"):

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -1362,6 +1362,8 @@ def _wait_cursor_path(
     role: str | None,
     for_types: list[str],
     from_role: str | None = None,
+    from_roles: list[str] | None = None,
+    slice_id: str | None = None,
 ) -> str | None:
     """Derive the cursor file path for a wait call (issue #2323).
 
@@ -1409,7 +1411,16 @@ def _wait_cursor_path(
 
     base = os.environ.get("EGG_WAIT_CURSOR_DIR", "/tmp")
     types_key = ",".join(sorted(for_types))
-    hash_input = f"{types_key}|from={from_role or ''}"
+    # #2725: include the new filter axes in the hash so a scoped wait
+    # never shares a cursor with an unscoped sibling. Two waits whose
+    # filters could diverge on which messages they keep MUST have
+    # different cursor files — otherwise a wait that advanced its
+    # cursor past a message its filter dropped would cause the sibling
+    # to silently miss that message.
+    from_roles_key = ",".join(sorted(from_roles)) if from_roles else ""
+    hash_input = (
+        f"{types_key}|from={from_role or ''}|from_set={from_roles_key}|slice={slice_id or ''}"
+    )
     digest = hashlib.md5(hash_input.encode("utf-8"), usedforsecurity=False).hexdigest()[:12]
     pid_segment = pipeline_id or "no-pipeline"
     return os.path.join(base, f"egg-wait-cursor-{pid_segment}-{role}-{digest}")
@@ -1556,12 +1567,30 @@ def cmd_message_wait(args: argparse.Namespace) -> int:
     role = args.role or get_agent_role_from_env()
     for_types_list = list(args.for_ or [])
     from_role = getattr(args, "from_", None)
+    # #2725: slice scope + producer allowlist with env-var defaults.
+    # Spawner sets EGG_SLICE_ID + EGG_WAIT_PRODUCER_ALLOWLIST so the
+    # canonical wait idiom auto-scopes without rubric changes. Explicit
+    # CLI args take precedence over env defaults.
+    slice_id_arg = getattr(args, "slice_id", None) or os.environ.get("EGG_SLICE_ID") or None
+    from_producer_arg = list(getattr(args, "from_producer", None) or [])
+    if not from_producer_arg:
+        env_allowlist = os.environ.get("EGG_WAIT_PRODUCER_ALLOWLIST", "")
+        from_producer_arg = [r.strip() for r in env_allowlist.split(",") if r.strip()]
     # Cursor file is auto-derived per (pipeline_id, role, for_types,
-    # from_role) so every wait re-entry threads its cursor without
-    # callers having to opt in (issue #2323). Explicit --since still
-    # wins, for callers that want to resume from a specific anchor;
-    # ``role`` unset (debug shells) skips cursor handling entirely.
-    cursor_file = _wait_cursor_path(pid, role, for_types_list, from_role)
+    # from_role, from_roles, slice_id) so every wait re-entry threads
+    # its cursor without callers having to opt in (issue #2323). The
+    # extra axes (#2725) keep a scoped wait from sharing a cursor with
+    # an unscoped sibling. Explicit --since still wins, for callers
+    # that want to resume from a specific anchor; ``role`` unset
+    # (debug shells) skips cursor handling entirely.
+    cursor_file = _wait_cursor_path(
+        pid,
+        role,
+        for_types_list,
+        from_role,
+        from_roles=from_producer_arg or None,
+        slice_id=slice_id_arg,
+    )
     effective_since = args.since or _read_cursor_file(cursor_file)
     req: dict[str, Any] = {
         "pipeline_id": pid,
@@ -1571,6 +1600,10 @@ def cmd_message_wait(args: argparse.Namespace) -> int:
     }
     if from_role:
         req["from_role"] = from_role
+    elif from_producer_arg:
+        req["from_roles"] = from_producer_arg
+    if slice_id_arg:
+        req["slice_id"] = slice_id_arg
     if effective_since:
         req["since"] = effective_since
     if args.limit:
@@ -1677,10 +1710,25 @@ def cmd_message_wait_loop(args: argparse.Namespace) -> int:
     role = args.role or get_agent_role_from_env()
     for_types_list = list(args.for_ or [])
     from_role = getattr(args, "from_", None)
+    # #2725: slice scope + producer allowlist with env-var defaults —
+    # mirrors cmd_message_wait. The auto-apply makes the wake-storm fix
+    # transparent: spawner-set env vars suffice; rubrics don't change.
+    slice_id_arg = getattr(args, "slice_id", None) or os.environ.get("EGG_SLICE_ID") or None
+    from_producer_arg = list(getattr(args, "from_producer", None) or [])
+    if not from_producer_arg:
+        env_allowlist = os.environ.get("EGG_WAIT_PRODUCER_ALLOWLIST", "")
+        from_producer_arg = [r.strip() for r in env_allowlist.split(",") if r.strip()]
     # Cursor file is auto-derived per (pipeline_id, role, for_types,
-    # from_role) — see cmd_message_wait for the rationale (issue
-    # #2323).
-    cursor_file = _wait_cursor_path(pid, role, for_types_list, from_role)
+    # from_role, from_roles, slice_id) — see cmd_message_wait for the
+    # rationale (issues #2323 + #2725).
+    cursor_file = _wait_cursor_path(
+        pid,
+        role,
+        for_types_list,
+        from_role,
+        from_roles=from_producer_arg or None,
+        slice_id=slice_id_arg,
+    )
     effective_since = args.since or _read_cursor_file(cursor_file)
     req: dict[str, Any] = {
         "pipeline_id": pid,
@@ -1690,6 +1738,10 @@ def cmd_message_wait_loop(args: argparse.Namespace) -> int:
     }
     if from_role:
         req["from_role"] = from_role
+    elif from_producer_arg:
+        req["from_roles"] = from_producer_arg
+    if slice_id_arg:
+        req["slice_id"] = slice_id_arg
     if effective_since:
         req["since"] = effective_since
     if args.limit:
@@ -3232,6 +3284,29 @@ def create_parser() -> argparse.ArgumentParser:
     )
     msg_wait.add_argument("--role", help="Filter for role (default: EGG_AGENT_ROLE)")
     msg_wait.add_argument("--from", dest="from_", help="Filter by sender role")
+    msg_wait.add_argument(
+        "--from-producer",
+        dest="from_producer",
+        action="append",
+        help=(
+            "Sender allowlist (repeatable, #2725). Only messages whose "
+            "from_role is in this set wake the wait. Defaults to the "
+            "comma-separated list in $EGG_WAIT_PRODUCER_ALLOWLIST when set "
+            "by the spawner. Explicit --from-producer args replace the "
+            "env-derived list."
+        ),
+    )
+    msg_wait.add_argument(
+        "--slice",
+        dest="slice_id",
+        help=(
+            "Slice scope (#2725). Only match messages whose "
+            "metadata.slice_id equals this value OR is null "
+            "(pipeline-level passthrough — OVERSEER_ALERT and global "
+            "phase signals continue to wake every waiter). Defaults to "
+            "$EGG_SLICE_ID when set."
+        ),
+    )
     msg_wait.add_argument("--since", help="Return messages after this ID")
     msg_wait.add_argument("--limit", type=int, help="Max messages")
     msg_wait.add_argument(
@@ -3265,6 +3340,29 @@ def create_parser() -> argparse.ArgumentParser:
     )
     msg_wait_loop.add_argument("--role", help="Filter for role (default: EGG_AGENT_ROLE)")
     msg_wait_loop.add_argument("--from", dest="from_", help="Filter by sender role")
+    msg_wait_loop.add_argument(
+        "--from-producer",
+        dest="from_producer",
+        action="append",
+        help=(
+            "Sender allowlist (repeatable, #2725). Only messages whose "
+            "from_role is in this set wake the wait. Defaults to the "
+            "comma-separated list in $EGG_WAIT_PRODUCER_ALLOWLIST when set "
+            "by the spawner. Explicit --from-producer args replace the "
+            "env-derived list."
+        ),
+    )
+    msg_wait_loop.add_argument(
+        "--slice",
+        dest="slice_id",
+        help=(
+            "Slice scope (#2725). Only match messages whose "
+            "metadata.slice_id equals this value OR is null "
+            "(pipeline-level passthrough — OVERSEER_ALERT and global "
+            "phase signals continue to wake every waiter). Defaults to "
+            "$EGG_SLICE_ID when set."
+        ),
+    )
     msg_wait_loop.add_argument("--since", help="Return messages after this ID")
     msg_wait_loop.add_argument("--limit", type=int, help="Max messages")
     msg_wait_loop.add_argument(

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -1538,6 +1538,32 @@ def _write_cursor_file(path: str | None, cursor: str | None) -> None:
         print(f"Warning: could not write cursor file {path}: {err}", file=sys.stderr)
 
 
+def _resolve_from_producer_arg(cli_values: list[str] | None) -> list[str]:
+    """Resolve the producer allowlist from CLI args and the env var (#2725).
+
+    Explicit CLI ``--from-producer`` args (repeatable) replace the
+    env-derived default. Each CLI value is split on commas so
+    ``--from-producer coder,tester`` and ``--from-producer coder
+    --from-producer tester`` behave identically; without the split
+    the value would be treated as a single literal role
+    ``"coder,tester"`` that matches no real sender, silently
+    sleeping the wait through every event — exactly the failure
+    mode the wake-storm filter exists to avoid (see #2727 review).
+
+    Falls back to ``$EGG_WAIT_PRODUCER_ALLOWLIST`` (the spawner-set
+    env var) when no CLI value was supplied. Empty values are
+    skipped on both paths.
+    """
+    cli_list = list(cli_values or [])
+    if cli_list:
+        out: list[str] = []
+        for value in cli_list:
+            out.extend(r.strip() for r in value.split(",") if r.strip())
+        return out
+    env_allowlist = os.environ.get("EGG_WAIT_PRODUCER_ALLOWLIST", "")
+    return [r.strip() for r in env_allowlist.split(",") if r.strip()]
+
+
 def cmd_message_wait(args: argparse.Namespace) -> int:
     """Event-driven wait for a message of one or more types.
 
@@ -1571,11 +1597,12 @@ def cmd_message_wait(args: argparse.Namespace) -> int:
     # Spawner sets EGG_SLICE_ID + EGG_WAIT_PRODUCER_ALLOWLIST so the
     # canonical wait idiom auto-scopes without rubric changes. Explicit
     # CLI args take precedence over env defaults.
-    slice_id_arg = getattr(args, "slice_id", None) or os.environ.get("EGG_SLICE_ID") or None
-    from_producer_arg = list(getattr(args, "from_producer", None) or [])
-    if not from_producer_arg:
-        env_allowlist = os.environ.get("EGG_WAIT_PRODUCER_ALLOWLIST", "")
-        from_producer_arg = [r.strip() for r in env_allowlist.split(",") if r.strip()]
+    # ``resolve_slice_id`` validates ``$EGG_SLICE_ID`` against the
+    # canonical ``slice-<N>`` shape and exits 1 on a malformed value,
+    # so a misconfigured env var fails fast at the agent instead of
+    # producing a tight 400-error retry loop against the route.
+    slice_id_arg = getattr(args, "slice_id", None) or resolve_slice_id()
+    from_producer_arg = _resolve_from_producer_arg(getattr(args, "from_producer", None))
     # Cursor file is auto-derived per (pipeline_id, role, for_types,
     # from_role, from_roles, slice_id) so every wait re-entry threads
     # its cursor without callers having to opt in (issue #2323). The
@@ -1713,11 +1740,10 @@ def cmd_message_wait_loop(args: argparse.Namespace) -> int:
     # #2725: slice scope + producer allowlist with env-var defaults —
     # mirrors cmd_message_wait. The auto-apply makes the wake-storm fix
     # transparent: spawner-set env vars suffice; rubrics don't change.
-    slice_id_arg = getattr(args, "slice_id", None) or os.environ.get("EGG_SLICE_ID") or None
-    from_producer_arg = list(getattr(args, "from_producer", None) or [])
-    if not from_producer_arg:
-        env_allowlist = os.environ.get("EGG_WAIT_PRODUCER_ALLOWLIST", "")
-        from_producer_arg = [r.strip() for r in env_allowlist.split(",") if r.strip()]
+    # ``resolve_slice_id`` validates ``$EGG_SLICE_ID`` and exits 1 on
+    # a malformed value (see cmd_message_wait for rationale).
+    slice_id_arg = getattr(args, "slice_id", None) or resolve_slice_id()
+    from_producer_arg = _resolve_from_producer_arg(getattr(args, "from_producer", None))
     # Cursor file is auto-derived per (pipeline_id, role, for_types,
     # from_role, from_roles, slice_id) — see cmd_message_wait for the
     # rationale (issues #2323 + #2725).

--- a/sandbox/tests/test_message_wait_cli.py
+++ b/sandbox/tests/test_message_wait_cli.py
@@ -307,6 +307,64 @@ class TestWaitExitCodes:
             assert "slice=" not in endpoint
             assert "from_producer=" not in endpoint
 
+    def test_wait_from_producer_splits_comma_separated_cli_value(self, monkeypatch):
+        """A single ``--from-producer coder,tester`` (comma-separated)
+        is split into per-role URL params (#2725 review). Without this
+        split argparse stores the literal ``"coder,tester"`` as a single
+        sender that matches no real message — silently filtering every
+        event, the failure mode the wake-storm fix exists to avoid. The
+        env-var path always splits on commas, so doing the same on the
+        CLI keeps the two surfaces symmetric.
+        """
+        monkeypatch.delenv("EGG_SLICE_ID", raising=False)
+        monkeypatch.delenv("EGG_WAIT_PRODUCER_ALLOWLIST", raising=False)
+        args = _make_wait_args()
+        args.from_producer = ["coder,tester"]
+        with patch(_ORCH_MOCK_PATH) as mock_req:
+            mock_req.return_value = {
+                "success": True,
+                "data": {"messages": [], "matched": False, "count": 0},
+            }
+            cmd_message_wait(args)
+            endpoint = mock_req.call_args.args[0]
+            assert "from_producer=coder" in endpoint
+            assert "from_producer=tester" in endpoint
+            assert "from_producer=coder%2Ctester" not in endpoint
+            assert "from_producer=coder,tester" not in endpoint
+
+    def test_wait_from_producer_mixes_repeatable_and_comma(self, monkeypatch):
+        """``--from-producer coder,tester --from-producer documenter``
+        flattens to three roles. Mixing the two CLI shapes keeps
+        scripts ergonomic without sacrificing the comma-split safety
+        net for the most common single-arg case."""
+        monkeypatch.delenv("EGG_SLICE_ID", raising=False)
+        monkeypatch.delenv("EGG_WAIT_PRODUCER_ALLOWLIST", raising=False)
+        args = _make_wait_args()
+        args.from_producer = ["coder,tester", "documenter"]
+        with patch(_ORCH_MOCK_PATH) as mock_req:
+            mock_req.return_value = {
+                "success": True,
+                "data": {"messages": [], "matched": False, "count": 0},
+            }
+            cmd_message_wait(args)
+            endpoint = mock_req.call_args.args[0]
+            assert "from_producer=coder" in endpoint
+            assert "from_producer=tester" in endpoint
+            assert "from_producer=documenter" in endpoint
+
+    def test_wait_invalid_egg_slice_id_exits_with_error(self, monkeypatch):
+        """A malformed ``$EGG_SLICE_ID`` (e.g. ``phase-1`` or ``garbage``)
+        fails fast at the agent via ``resolve_slice_id`` — exiting 1
+        instead of round-tripping a 400 to the route on every wait-loop
+        iteration. Pin the behavior so the CLI keeps using the
+        validated env reader rather than bare ``os.environ.get``."""
+        monkeypatch.setenv("EGG_SLICE_ID", "phase-1")
+        monkeypatch.delenv("EGG_WAIT_PRODUCER_ALLOWLIST", raising=False)
+        with patch(_ORCH_MOCK_PATH):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_message_wait(_make_wait_args())
+            assert exc_info.value.code == 1
+
 
 # ---------------------------------------------------------------------------
 # cmd_message_wait_loop

--- a/sandbox/tests/test_message_wait_cli.py
+++ b/sandbox/tests/test_message_wait_cli.py
@@ -244,6 +244,69 @@ class TestWaitExitCodes:
             endpoint = mock_req.call_args.args[0]
             assert "timeout=15" in endpoint
 
+    def test_wait_auto_applies_egg_slice_id(self, monkeypatch):
+        """#2725: ``$EGG_SLICE_ID`` flows into the request URL with no
+        explicit --slice flag, so the wake-storm fix is transparent."""
+        monkeypatch.setenv("EGG_SLICE_ID", "slice-1")
+        monkeypatch.delenv("EGG_WAIT_PRODUCER_ALLOWLIST", raising=False)
+        with patch(_ORCH_MOCK_PATH) as mock_req:
+            mock_req.return_value = {
+                "success": True,
+                "data": {"messages": [], "matched": False, "count": 0},
+            }
+            cmd_message_wait(_make_wait_args())
+            endpoint = mock_req.call_args.args[0]
+            assert "slice=slice-1" in endpoint
+
+    def test_wait_auto_applies_egg_wait_producer_allowlist(self, monkeypatch):
+        """#2725: ``$EGG_WAIT_PRODUCER_ALLOWLIST`` (comma-separated)
+        flows into one ``from_producer`` URL param per role."""
+        monkeypatch.delenv("EGG_SLICE_ID", raising=False)
+        monkeypatch.setenv("EGG_WAIT_PRODUCER_ALLOWLIST", "coder,tester,overseer,orchestrator")
+        with patch(_ORCH_MOCK_PATH) as mock_req:
+            mock_req.return_value = {
+                "success": True,
+                "data": {"messages": [], "matched": False, "count": 0},
+            }
+            cmd_message_wait(_make_wait_args())
+            endpoint = mock_req.call_args.args[0]
+            assert "from_producer=coder" in endpoint
+            assert "from_producer=tester" in endpoint
+            assert "from_producer=overseer" in endpoint
+            assert "from_producer=orchestrator" in endpoint
+
+    def test_wait_explicit_slice_overrides_env(self, monkeypatch):
+        """An explicit --slice value beats $EGG_SLICE_ID (escape hatch
+        for debug shells / integration tests)."""
+        monkeypatch.setenv("EGG_SLICE_ID", "slice-1")
+        args = _make_wait_args()
+        args.slice_id = "slice-7"
+        with patch(_ORCH_MOCK_PATH) as mock_req:
+            mock_req.return_value = {
+                "success": True,
+                "data": {"messages": [], "matched": False, "count": 0},
+            }
+            cmd_message_wait(args)
+            endpoint = mock_req.call_args.args[0]
+            assert "slice=slice-7" in endpoint
+            assert "slice=slice-1" not in endpoint
+
+    def test_wait_no_env_no_filter_params(self, monkeypatch):
+        """Without env vars and without explicit args, no new filter
+        params are emitted — back-compat with the pre-#2725 wake-on-all
+        behavior for callers that haven't migrated."""
+        monkeypatch.delenv("EGG_SLICE_ID", raising=False)
+        monkeypatch.delenv("EGG_WAIT_PRODUCER_ALLOWLIST", raising=False)
+        with patch(_ORCH_MOCK_PATH) as mock_req:
+            mock_req.return_value = {
+                "success": True,
+                "data": {"messages": [], "matched": False, "count": 0},
+            }
+            cmd_message_wait(_make_wait_args())
+            endpoint = mock_req.call_args.args[0]
+            assert "slice=" not in endpoint
+            assert "from_producer=" not in endpoint
+
 
 # ---------------------------------------------------------------------------
 # cmd_message_wait_loop
@@ -606,6 +669,56 @@ class TestWaitCursorPath:
         assert a != b
         assert a != no_filter
         assert b != no_filter
+
+    def test_distinct_slice_ids_yield_distinct_paths(self, monkeypatch, tmp_path):
+        """#2725: two waits with the same ``--for`` set but different
+        ``--slice`` filters must NOT share a cursor — same rationale as
+        for ``--from`` above. Slice filter is similarly drop-bearing."""
+        monkeypatch.setenv("EGG_WAIT_CURSOR_DIR", str(tmp_path))
+        a = _wait_cursor_path("issue-42", "reviewer_plan", ["X"], slice_id="slice-1")
+        b = _wait_cursor_path("issue-42", "reviewer_plan", ["X"], slice_id="slice-2")
+        no_filter = _wait_cursor_path("issue-42", "reviewer_plan", ["X"])
+        assert a != b
+        assert a != no_filter
+        assert b != no_filter
+
+    def test_distinct_from_roles_sets_yield_distinct_paths(self, monkeypatch, tmp_path):
+        """#2725: producer-allowlist set membership changes drive
+        distinct cursors. A reviewer with ``--from-producer coder,tester``
+        and one with ``--from-producer coder`` MUST NOT share — the
+        first's cursor may have advanced past a tester message the
+        second's filter would drop, masking events."""
+        monkeypatch.setenv("EGG_WAIT_CURSOR_DIR", str(tmp_path))
+        a = _wait_cursor_path(
+            "issue-42",
+            "reviewer_plan",
+            ["X"],
+            from_roles=["coder", "tester"],
+        )
+        b = _wait_cursor_path("issue-42", "reviewer_plan", ["X"], from_roles=["coder"])
+        no_filter = _wait_cursor_path("issue-42", "reviewer_plan", ["X"])
+        assert a != b
+        assert a != no_filter
+        assert b != no_filter
+
+    def test_from_roles_set_order_independent(self, monkeypatch, tmp_path):
+        """The producer-allowlist set is order-insensitive — the
+        hash MUST be stable across permutations so a rubric that lists
+        producers in different orders does not fragment cursors."""
+        monkeypatch.setenv("EGG_WAIT_CURSOR_DIR", str(tmp_path))
+        a = _wait_cursor_path(
+            "issue-42",
+            "reviewer_plan",
+            ["X"],
+            from_roles=["coder", "tester"],
+        )
+        b = _wait_cursor_path(
+            "issue-42",
+            "reviewer_plan",
+            ["X"],
+            from_roles=["tester", "coder"],
+        )
+        assert a == b
 
     def test_path_lives_under_egg_wait_cursor_dir(self, monkeypatch, tmp_path):
         monkeypatch.setenv("EGG_WAIT_CURSOR_DIR", str(tmp_path))


### PR DESCRIPTION
## Summary

Eliminates the BRC wake-storm documented in #2725 by adding two filter axes to the agent-side wait endpoint, both auto-applied from container env vars set at agent spawn time. Agent rubrics do not change.

- **Slice scope**: `--slice` defaults from `$EGG_SLICE_ID`. Wait only matches messages whose `metadata.slice_id` equals the value OR is null (pipeline-level passthrough — OVERSEER_ALERT, global phase signals still fan out).
- **Producer allowlist**: `--from-producer` (repeatable) defaults from `$EGG_WAIT_PRODUCER_ALLOWLIST` (comma-separated). The spawner resolves the set from the BRC review graph for the (phase, role) being spawned and includes the system senders `overseer` + `orchestrator` so CONSENSUS_RE_REVIEW and OVERSEER_ALERT keep waking the agent.
- Both filters apply inside the blocking branch so wrong-slice / wrong-sender messages do not unblock the wait — the LLM-round-trip savings come from never waking the agent, not filtering after the wake.

The expected impact for the #2717 implement phase (5 slices × 8 agents × ~150 events/slice × 2 LLM round-trips ≈ 12k wake/re-arm round-trips) is a dramatic reduction in cross-graph wake amplification. Producers / reviewers in slice-1 stay asleep through slice-2's BRC chatter, and a confirmed reviewer stays asleep through unrelated producers' PROPOSE/ACK/NACK traffic in the same slice.

Closes #2725.

## Highlights

- Server: `routes/messages.py` + `message_store.py` + `redis_message_store.py` filter chain
- CLI: `orch_cli.py` flags + env-var auto-apply + cursor-file hash includes new axes
- Spawner: `kubernetes_spawner._resolve_wait_producer_allowlist` resolves graph neighbors + system senders; new env var is in `_PROTECTED_ENV_KEYS` so `extra_env` cannot smuggle a stale allowlist past the spawner
- Docs: `agent-wait-patterns.md` §1 (auto-scoping) and §3 (cursor-key hash)

## Test plan

- [x] Unit (message_store): 14 new filter tests pin null-slice passthrough, wrong-slice / wrong-sender drop-without-wake, combined-filter semantics, singular `from_role` wins over set, empty set is no-filter at store layer.
- [x] **Negative conformance**: `test_orchestrator_re_review_wakes_tightly_filtered_reviewer` — an orchestrator-emitted CONSENSUS_RE_REVIEW wakes a tight slice + producer-allowlist reviewer. Filter cannot silently sleep through a NACK.
- [x] Route: 6 new `/messages/wait` tests for `slice` + `from_producer` query params, slice id validator, and empty-allowlist 400 rejection.
- [x] Spawner: 4 new tests pin reviewer / producer allowlists, no-phase skips, and `extra_env`-cannot-override invariants.
- [x] CLI: 6 new tests pin env-var auto-apply (`$EGG_SLICE_ID`, `$EGG_WAIT_PRODUCER_ALLOWLIST`), explicit-arg override, no-env back-compat, and cursor-key isolation across slice + producer-set axes.
- [x] Full suite: `make test` — 18,028 passed, 44 skipped, 0 failures.
- [x] `make lint` clean.

## Migration / rollout

- Default off for pipeline-level spawns (no `phase` parameter) — preserves pre-#2725 wake-on-anything behavior unchanged.
- Slice + phase spawns get the env vars set automatically. The CLI applies them transparently; existing rubrics keep working with their current `--for` lists.
- A change to the BRC review graph (`review_graph.py`) propagates on the next spawn without prompt edits — the allowlist is graph-derived, not hand-maintained in prompts (Option B from the plan discussion in #2725).