### PR TITLE
fix: strip PIP_IGNORE_INSTALLED from build-command environment

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -15,6 +15,12 @@ FROM ubuntu:22.04 AS repo-deps
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
+# PIP_IGNORE_INSTALLED is for this stage's own system-Python `pip3 install`
+# below. It's an ARG so it doesn't persist into the final image, but Docker
+# still exposes ARGs as env vars to RUN subprocesses in this stage — including
+# `python3 /tmp/docker-setup.py` below, which then leaks it into each repo's
+# build commands. docker-setup.py's run_build_commands strips it from the env
+# it passes to those subprocesses; keep both halves of the contract in sync.
 ARG PIP_IGNORE_INSTALLED=1
 # Point GOMODCACHE at the module cache populated during `docker build`
 # (via build_commands in repositories.yaml). Without this, Go defaults to
@@ -67,8 +73,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 # PIP_IGNORE_INSTALLED bypasses the distutils uninstall error (e.g. blinker 1.4
 # installed by apt can't be removed by pip, but we can install a newer version
-# into Python 3.14's site-packages). ARG so it only applies during build — at
-# runtime it would cause pip to wastefully reinstall already-present packages.
+# into Python 3.14's site-packages). ARG so it doesn't persist into the final
+# image — at runtime it would cause pip to wastefully reinstall already-present
+# packages, and (more critically) leak into agent-launched venv pip installs
+# where it reinstalls pip itself, breaking version-pinned tooling. The Stage 1
+# `repo-deps` ARG is stripped by docker-setup.py for the same reason.
 ARG PIP_IGNORE_INSTALLED=1
 # Point GOMODCACHE at the module cache populated during `docker build`
 # (via build_commands in repositories.yaml). Without this, Go defaults to

--- a/sandbox/docker-setup.py
+++ b/sandbox/docker-setup.py
@@ -316,6 +316,15 @@ def run_build_commands(
 
     print("\n=== Running build commands ===")
 
+    # Build commands install each repo's deps into isolated virtualenvs. The
+    # sandbox image sets PIP_IGNORE_INSTALLED=1 for its own system-Python pip
+    # installs, but inheriting it here makes a fresh venv's `pip install`
+    # re-resolve and reinstall pip/setuptools/wheel themselves — pulling the
+    # newest pip, which can break version-pinned tooling (e.g. pip-tools 7.4.1's
+    # pip-compile against pip >= 25.1). Strip it so venv installs behave normally.
+    build_env = os.environ.copy()
+    build_env.pop("PIP_IGNORE_INSTALLED", None)
+
     for entry in build_commands:
         repo = entry["repo"]
         commands = entry["commands"]
@@ -342,6 +351,7 @@ def run_build_commands(
                     cwd=str(work_dir),
                     check=False,
                     capture_output=False,
+                    env=build_env,
                 )
             except Exception as e:
                 raise RuntimeError(

--- a/tests/sandbox/test_docker_setup.py
+++ b/tests/sandbox/test_docker_setup.py
@@ -418,9 +418,12 @@ class TestRunBuildCommands:
 
         The sandbox image sets it for system-Python installs; inherited by a
         repo's `pip install` it reinstalls pip itself, breaking pinned tooling.
+        Also asserts an unrelated sentinel var passes through, so a future
+        overzealous cleanup that wipes more than intended is caught here.
         """
         mock_run.return_value = MagicMock(returncode=0)
         monkeypatch.setenv("PIP_IGNORE_INSTALLED", "1")
+        monkeypatch.setenv("PATH", "/sentinel-path:/usr/bin")
 
         repo_deps = tmp_path / "repo-deps"
         (repo_deps / "org--app").mkdir(parents=True)
@@ -437,6 +440,7 @@ class TestRunBuildCommands:
 
         env = mock_run.call_args.kwargs["env"]
         assert "PIP_IGNORE_INSTALLED" not in env
+        assert env["PATH"] == "/sentinel-path:/usr/bin"
 
     @patch("subprocess.run")
     def test_command_failure_aborts_build(self, mock_run, tmp_path, capsys):

--- a/tests/sandbox/test_docker_setup.py
+++ b/tests/sandbox/test_docker_setup.py
@@ -413,6 +413,32 @@ class TestRunBuildCommands:
         assert captured.out == ""
 
     @patch("subprocess.run")
+    def test_strips_pip_ignore_installed_from_env(self, mock_run, tmp_path, monkeypatch):
+        """PIP_IGNORE_INSTALLED must not leak into build commands.
+
+        The sandbox image sets it for system-Python installs; inherited by a
+        repo's `pip install` it reinstalls pip itself, breaking pinned tooling.
+        """
+        mock_run.return_value = MagicMock(returncode=0)
+        monkeypatch.setenv("PIP_IGNORE_INSTALLED", "1")
+
+        repo_deps = tmp_path / "repo-deps"
+        (repo_deps / "org--app").mkdir(parents=True)
+
+        build_commands = [
+            {
+                "repo": "org/app",
+                "watch_files": [],
+                "commands": ["pip install -r requirements.txt"],
+            }
+        ]
+
+        run_build_commands(build_commands, repo_deps_base=repo_deps)
+
+        env = mock_run.call_args.kwargs["env"]
+        assert "PIP_IGNORE_INSTALLED" not in env
+
+    @patch("subprocess.run")
     def test_command_failure_aborts_build(self, mock_run, tmp_path, capsys):
         """A failed build command aborts the image build (was warn-only). See #2087."""
         mock_run.return_value = MagicMock(returncode=1)


### PR DESCRIPTION
## Summary

The `egg-sandbox` Docker build was failing in Stage 1, where `docker-setup.py` runs each repo's `build_commands`.

**Root cause:** `sandbox/Dockerfile` declares `ARG PIP_IGNORE_INSTALLED=1` for the image's own system-Python `pip3 install` lines. Docker exposes build `ARG`s as environment variables to `RUN` commands, so the variable leaked into the `build_commands` subprocesses spawned by `docker-setup.py`.

In a freshly-created virtualenv, `PIP_IGNORE_INSTALLED` makes `pip install <tool>` re-resolve and reinstall `pip` itself, pulling the newest pip. That broke an onboarded repo's pinned `pip-tools==7.4.1`: its `pip-compile` crashes against pip >= 25.1 with `AttributeError: 'PackageFinder' object has no attribute 'allow_all_prereleases'`, failing the whole image build.

**Fix:** `run_build_commands` now strips `PIP_IGNORE_INSTALLED` from the environment it passes to build commands. That variable is intended only for the Dockerfile's system-Python installs; build commands install repo deps into isolated venvs where ignore-installed is both wrong and harmful.

## Test plan

- [x] `make test` — 109160 passed, 44 skipped
- [x] Added regression test `test_strips_pip_ignore_installed_from_env`
- [x] Reproduced the failure: `make -C github-actions-runner deps` fails with the `allow_all_prereleases` error when `PIP_IGNORE_INSTALLED=1` is set, passes when it is not
- [x] Rebuilt Dockerfile Stage 1 (`docker build --target repo-deps -f sandbox/Dockerfile`) end-to-end with the fix — `pip` is no longer reinstalled by the `pip-tools` install, both `pip-compile` runs succeed, and that repo's build commands complete
