### PR TITLE
fix: gate the gateway gh passthrough with a deny-by-default allowlist

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -272,7 +272,15 @@ POST /api/v1/gh/pr/close
 
 POST /api/v1/gh/execute
   Request: {args[], require_auth}
-  Policy: filtered passthrough for read operations
+  Policy: deny-by-default allowlist (parity with /api/v1/git/execute).
+          The full `gh auth` group is blocklisted — `gh auth token` and
+          `gh auth status --show-token` would print the gateway's GitHub
+          App token. The allowlist (see ALLOWED_GH_COMMANDS in
+          github_client.py) covers `pr`/`issue`/`repo`/`release` reads,
+          `pr checkout`, and the writes the sandbox wrapper / orchestrator
+          route through here (`issue create/comment/edit/close`,
+          `pr review`, `pr ready`). `gh api` is allowed at this layer and
+          gated further by GH_API_ALLOWED_PATHS. Anything else returns 403.
   Note: For 'gh pr review' commands, automatically switches to reviewer
         token if available (separate GitHub App identity for posting
         approve/request-changes on bot-authored PRs)

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -137,13 +137,13 @@ try:
         ALLOWED_GH_COMMANDS,
         BLOCKED_GH_COMMANDS,
         GH_COMMANDS_BLOCKED_IN_PRIVATE_MODE,
-        READONLY_GH_COMMANDS,
         GitHubClient,
         extract_comment_edit_info,
         extract_issue_label_info,
         extract_pr_review_info,
         extract_pr_reviewer_info,
         extract_repo_from_gh_command,
+        find_gh_command_index,
         get_github_client,
         is_gh_command_allowed,
         parse_gh_api_args,
@@ -241,13 +241,13 @@ except ImportError:
         ALLOWED_GH_COMMANDS,
         BLOCKED_GH_COMMANDS,
         GH_COMMANDS_BLOCKED_IN_PRIVATE_MODE,
-        READONLY_GH_COMMANDS,
         GitHubClient,
         extract_comment_edit_info,
         extract_issue_label_info,
         extract_pr_review_info,
         extract_pr_reviewer_info,
         extract_repo_from_gh_command,
+        find_gh_command_index,
         get_github_client,
         is_gh_command_allowed,
         parse_gh_api_args,
@@ -4265,7 +4265,7 @@ def gh_execute() -> tuple[Response, int] | Response:
             )
             return make_error(
                 f"Command '{blocked}' is not allowed through the gateway. "
-                f"Allowed read-only commands: {', '.join(sorted(READONLY_GH_COMMANDS))}",
+                f"Allowed: {', '.join(sorted(ALLOWED_GH_COMMANDS))}, api.",
                 status_code=403,
                 details={"blocked_command": blocked, "command_args": args},
             )
@@ -4283,8 +4283,9 @@ def gh_execute() -> tuple[Response, int] | Response:
             success=False,
             details={"command_args": args, "command_key": gh_cmd_key},
         )
+        _display_key = gh_cmd_key or "(no subcommand)"
         return make_error(
-            f"Command 'gh {gh_cmd_key}' is not permitted through the gateway. "
+            f"Command 'gh {_display_key}' is not permitted through the gateway. "
             f"Allowed: {', '.join(sorted(ALLOWED_GH_COMMANDS))}, api.",
             status_code=403,
             details={"command_key": gh_cmd_key, "command_args": args},
@@ -4517,12 +4518,17 @@ def gh_execute() -> tuple[Response, int] | Response:
                 },
             )
 
-    # For 'gh api' commands, validate the path against allowlist
+    # For 'gh api' commands, validate the path against allowlist.
+    # Look past any leading -R/--repo selector so `gh -R owner/repo api /path`
+    # is still subjected to GH_API_ALLOWED_PATHS — otherwise the leading
+    # selector would shift args[0] off "api" and the path check would be
+    # silently skipped.
     api_path: str | None = None
     method: str = "GET"
-    if args and args[0] == "api" and len(args) > 1:
+    _gh_cmd_idx = find_gh_command_index(args)
+    if _gh_cmd_idx < len(args) and args[_gh_cmd_idx] == "api" and len(args) > _gh_cmd_idx + 1:
         # Parse arguments to find the actual API path (skip flags like -X, --method, etc.)
-        api_path, method = parse_gh_api_args(args[1:])
+        api_path, method = parse_gh_api_args(args[_gh_cmd_idx + 1 :])
         if api_path is None:
             audit_log(
                 "api_path_missing",

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -4294,7 +4294,19 @@ def gh_execute() -> tuple[Response, int] | Response:
     # --- Phase and role-based operation filtering ---
     # Block operations like "issue comment" / "issue edit" when phase or role restricts them.
     # Build a command string from the first 3 non-flag args for matching.
-    non_flag_args = [a for a in args if not a.startswith("-")]
+    #
+    # Normalize past any leading -R/--repo selector before constructing the
+    # command string used by the phase and role filters — parity with the
+    # overseer block below (line 4379) and the api-path guard further down
+    # (line 4541). Without this, an argv like `["-R", "owner/repo", "issue",
+    # "comment", "1032", "--body", "..."]` keys as `"owner/repo issue
+    # comment"`, which doesn't fnmatch `"issue comment *"` (phase filter)
+    # and doesn't `startswith("issue comment")` (_BLOCKED_GH_OPS), letting
+    # the role/phase enforcement be bypassed entirely. The allowlist check
+    # above already normalizes via `find_gh_command_index`, so doing the
+    # same here keeps the three positional-key call sites consistent.
+    _filter_cmd_idx = find_gh_command_index(args)
+    non_flag_args = [a for a in args[_filter_cmd_idx:] if not a.startswith("-")]
     gh_command_str = " ".join(non_flag_args[:3])
 
     session_phase = getattr(g, "session_phase", None)
@@ -4373,9 +4385,10 @@ def gh_execute() -> tuple[Response, int] | Response:
     # `find_gh_command_index` so an argv like
     # `[-R owner/repo issue create --title ... --body <secret>]`
     # still runs the secret-pattern scan; otherwise the leading
-    # selector would shift args[0] off "issue" and the entire
-    # overseer block would be silently skipped (parity fix with
-    # the api-path guard below).
+    # selector would put the `"issue"` token at args[2] instead of
+    # args[0], so an `args[0] == "issue"` check would miss it and
+    # the entire overseer block would be silently skipped (parity
+    # fix with the api-path guard below).
     _overseer_cmd_idx = find_gh_command_index(args)
     if (
         session_role

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -4368,12 +4368,21 @@ def gh_execute() -> tuple[Response, int] | Response:
     # repo enforcement against EGG_PIPELINE_REPO, label injection,
     # title/body size limits, and a defense-in-depth secret-pattern
     # scan on the body. Failure is a structured 403.
+    #
+    # The guard looks past any leading `-R`/`--repo` selector via
+    # `find_gh_command_index` so an argv like
+    # `[-R owner/repo issue create --title ... --body <secret>]`
+    # still runs the secret-pattern scan; otherwise the leading
+    # selector would shift args[0] off "issue" and the entire
+    # overseer block would be silently skipped (parity fix with
+    # the api-path guard below).
+    _overseer_cmd_idx = find_gh_command_index(args)
     if (
         session_role
         and session_role.lower() == "overseer"
-        and len(args) >= 2
-        and args[0] == "issue"
-        and args[1] == "create"
+        and _overseer_cmd_idx + 1 < len(args)
+        and args[_overseer_cmd_idx] == "issue"
+        and args[_overseer_cmd_idx + 1] == "create"
     ):
         from .agent_restrictions import check_overseer_gh_issue_create
 
@@ -4415,7 +4424,11 @@ def gh_execute() -> tuple[Response, int] | Response:
                 )
             return val, None
 
-        i = 2
+        # Start past the `issue create` tokens; `_overseer_cmd_idx` is the
+        # index of `"issue"`, so the flag walk begins at `_overseer_cmd_idx
+        # + 2`. With no leading selector this collapses to the original
+        # `i = 2`.
+        i = _overseer_cmd_idx + 2
         while i < len(args):
             tok = args[i]
             if tok in _OVERSEER_VALUE_FLAGS:

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -134,6 +134,7 @@ try:
         validate_repo_path,
     )
     from .github_client import (
+        ALLOWED_GH_COMMANDS,
         BLOCKED_GH_COMMANDS,
         GH_COMMANDS_BLOCKED_IN_PRIVATE_MODE,
         READONLY_GH_COMMANDS,
@@ -144,6 +145,7 @@ try:
         extract_pr_reviewer_info,
         extract_repo_from_gh_command,
         get_github_client,
+        is_gh_command_allowed,
         parse_gh_api_args,
         resolve_gh_api_template_variables,
         validate_gh_api_path,
@@ -236,6 +238,7 @@ except ImportError:
         validate_repo_path,
     )
     from github_client import (  # type: ignore[no-redef, import-untyped]
+        ALLOWED_GH_COMMANDS,
         BLOCKED_GH_COMMANDS,
         GH_COMMANDS_BLOCKED_IN_PRIVATE_MODE,
         READONLY_GH_COMMANDS,
@@ -246,6 +249,7 @@ except ImportError:
         extract_pr_reviewer_info,
         extract_repo_from_gh_command,
         get_github_client,
+        is_gh_command_allowed,
         parse_gh_api_args,
         resolve_gh_api_template_variables,
         validate_gh_api_path,
@@ -4265,6 +4269,26 @@ def gh_execute() -> tuple[Response, int] | Response:
                 status_code=403,
                 details={"blocked_command": blocked, "command_args": args},
             )
+
+    # --- Deny-by-default allowlist (parity with git_execute) ---
+    # A generic gh command must be on ALLOWED_GH_COMMANDS, or be `gh api`
+    # (further constrained below by GH_API_ALLOWED_PATHS). Anything else fails
+    # closed — this is what keeps credential-adjacent and otherwise
+    # unanticipated subcommands from executing by default.
+    gh_allowed, gh_cmd_key = is_gh_command_allowed(args)
+    if not gh_allowed:
+        audit_log(
+            "gh_command_not_allowed",
+            "gh_execute",
+            success=False,
+            details={"command_args": args, "command_key": gh_cmd_key},
+        )
+        return make_error(
+            f"Command 'gh {gh_cmd_key}' is not permitted through the gateway. "
+            f"Allowed: {', '.join(sorted(ALLOWED_GH_COMMANDS))}, api.",
+            status_code=403,
+            details={"command_key": gh_cmd_key, "command_args": args},
+        )
 
     # --- Phase and role-based operation filtering ---
     # Block operations like "issue comment" / "issue edit" when phase or role restricts them.

--- a/gateway/github_client.py
+++ b/gateway/github_client.py
@@ -113,6 +113,14 @@ ALLOWED_GH_COMMANDS = frozenset(
         "repo list",
         "release view",
         "release list",
+        # Read-only Actions runs surface. The self-improvement log collector
+        # (sandbox/egg_lib/self_improvement/collectors/gha.py) uses
+        # `gh run view <id> --log` to pull workflow run logs; the JSON-only
+        # listing path `repos/.../actions/runs` is already on
+        # GH_API_ALLOWED_PATHS, so this just keeps the convenience wrapper
+        # working in-sandbox.
+        "run view",
+        "run list",
         "config get",
         # --- writes the sandbox wrapper / orchestrator route through here ---
         "issue create",
@@ -124,19 +132,50 @@ ALLOWED_GH_COMMANDS = frozenset(
     }
 )
 
-# Leading gh flags that select a repo/host and consume the next token as a
-# value. They may precede the command (`gh -R owner/repo pr view 1`), so the
-# command-key extractor must skip both the flag and the token it consumes.
-_GH_LEADING_VALUE_FLAGS = frozenset({"-R", "--repo", "-H", "--hostname"})
+# Leading gh flag that selects a repo and consumes the next token as a value.
+# `-R`/`--repo` is the only global gh flag that may precede the command and
+# takes a separate-token value, so the command-key extractor must skip both
+# the flag and the token it consumes. `--hostname` is a per-command flag on
+# the auth-group commands (already blocklisted), and `-H` is not a global gh
+# flag at all — it means `--header` for `gh api` and `--head` for `gh pr
+# create`, both of which are subcommand-positional.
+_GH_LEADING_VALUE_FLAGS = frozenset({"-R", "--repo"})
+
+
+def find_gh_command_index(args: list[str]) -> int:
+    """Return the index of the first non-flag (command) token in gh argv.
+
+    Skips a leading ``-R``/``--repo``/``--repo=…`` selector and any other
+    leading flags. ``gh -R owner/repo api /path`` returns ``2`` (the index
+    of ``"api"``). Returns ``len(args)`` if no command token is present.
+
+    Callers that need to slice past the command (e.g. ``args[idx+1:]`` to
+    pass the api path through ``parse_gh_api_args``) must use this rather
+    than hardcoding ``args[1:]``, otherwise a leading repo selector
+    silently shifts the slice and the validator gets the wrong tokens.
+    """
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in _GH_LEADING_VALUE_FLAGS:
+            i += 2  # skip the flag and the token it consumes
+            continue
+        if arg.startswith("--repo="):
+            i += 1
+            continue
+        if arg.startswith("-"):
+            i += 1
+            continue
+        return i
+    return len(args)
 
 
 def extract_gh_command_key(args: list[str]) -> str:
     """Return the ``"<command> [subcommand]"`` key used for allowlist matching.
 
-    Skips a leading repo/host selector flag and its value so that
+    Skips a leading ``-R``/``--repo`` selector and its value so that
     ``gh -R owner/repo pr view 1`` keys as ``"pr view"``. Other leading flags
-    are skipped without consuming a value — no global gh flag that precedes
-    the command takes a separate-token value except the repo/host selectors.
+    are skipped without consuming a value.
 
     Args:
         args: gh argv with the ``gh`` prefix already stripped.
@@ -147,15 +186,9 @@ def extract_gh_command_key(args: list[str]) -> str:
         the argv carries no command token.
     """
     tokens: list[str] = []
-    i = 0
+    i = find_gh_command_index(args)
     while i < len(args) and len(tokens) < 2:
         arg = args[i]
-        if arg in _GH_LEADING_VALUE_FLAGS:
-            i += 2  # skip the flag and the token it consumes
-            continue
-        if arg.startswith(("--repo=", "--hostname=")):
-            i += 1
-            continue
         if arg.startswith("-"):
             i += 1
             continue

--- a/gateway/github_client.py
+++ b/gateway/github_client.py
@@ -47,26 +47,6 @@ USER_TOKEN_VAR = "GITHUB_USER_TOKEN"
 # gh Command Validation
 # =============================================================================
 
-# Read-only gh commands that don't require ownership checks
-READONLY_GH_COMMANDS = frozenset(
-    {
-        "pr view",
-        "pr list",
-        "pr checks",
-        "pr diff",
-        "pr status",
-        "issue view",
-        "issue list",
-        "issue status",
-        "repo view",
-        "repo list",
-        "release view",
-        "release list",
-        "api",  # Read-only API calls (GET)
-        "config get",
-    }
-)
-
 # Blocked gh commands (dangerous operations)
 BLOCKED_GH_COMMANDS = frozenset(
     {
@@ -76,9 +56,22 @@ BLOCKED_GH_COMMANDS = frozenset(
         "release delete",
         # Entire `gh auth` group. Agents are credential-less by design;
         # `gh auth token` and `gh auth status --show-token` would print the
-        # gateway's GitHub App token. Blocklist entries match by prefix, so
-        # this rejects `auth login`, `auth logout`, `auth token`,
-        # `auth status`, `auth refresh`, `auth setup-git`, etc.
+        # gateway's GitHub App token. Blocklist entries match by prefix on
+        # `" ".join(args[:2])`, so this rejects `auth login`, `auth logout`,
+        # `auth token`, `auth status`, `auth refresh`, `auth setup-git`,
+        # etc. when `auth` is the first positional token.
+        #
+        # The prefix match has argv-shape limitations: an argv with a
+        # leading global flag (e.g. `["-R", "owner/repo", "auth", "token"]`)
+        # keys as `"-R owner/repo"` and slips past this branch. The
+        # `ALLOWED_GH_COMMANDS` allowlist below is the load-bearing second
+        # layer that catches those smuggle attempts — it normalizes the
+        # argv via `find_gh_command_index` before keying, so
+        # `["-R", "owner/repo", "auth", "token"]` resolves to `"auth token"`
+        # and fails the allowlist check. See
+        # `test_denies_auth_token_with_leading_repo_selector` and
+        # `test_execute_blocks_auth_token_with_leading_repo_selector` for
+        # the in-tree evidence of this layering.
         "auth",
         "config set",
     }

--- a/gateway/github_client.py
+++ b/gateway/github_client.py
@@ -63,7 +63,6 @@ READONLY_GH_COMMANDS = frozenset(
         "release view",
         "release list",
         "api",  # Read-only API calls (GET)
-        "auth status",
         "config get",
     }
 )
@@ -75,11 +74,117 @@ BLOCKED_GH_COMMANDS = frozenset(
         "repo delete",
         "repo archive",
         "release delete",
-        "auth logout",
-        "auth login",
+        # Entire `gh auth` group. Agents are credential-less by design;
+        # `gh auth token` and `gh auth status --show-token` would print the
+        # gateway's GitHub App token. Blocklist entries match by prefix, so
+        # this rejects `auth login`, `auth logout`, `auth token`,
+        # `auth status`, `auth refresh`, `auth setup-git`, etc.
+        "auth",
         "config set",
     }
 )
+
+# Generic gh commands permitted through POST /api/v1/gh/execute.
+#
+# This is a deny-by-default allowlist: any "<command> <subcommand>" pair not
+# listed here — and not `gh api`, which is gated separately by
+# GH_API_ALLOWED_PATHS — is rejected with 403. It brings the gh passthrough
+# to parity with the git passthrough (GIT_ALLOWED_COMMANDS in git_client.py),
+# so unanticipated credential-adjacent subcommands (`gh auth token`,
+# `gh alias set --shell`, `gh extension`, ...) fail closed instead of open.
+#
+# Writes are included only where the sandbox `gh` wrapper or the orchestrator
+# legitimately POST them to this endpoint; per-phase (phase_filter.py) and
+# per-role (agent_restrictions.py) filters apply additional restrictions on
+# top of this allowlist.
+ALLOWED_GH_COMMANDS = frozenset(
+    {
+        # --- read-only ---
+        "pr view",
+        "pr list",
+        "pr checks",
+        "pr diff",
+        "pr status",
+        "pr checkout",
+        "issue view",
+        "issue list",
+        "issue status",
+        "repo view",
+        "repo list",
+        "release view",
+        "release list",
+        "config get",
+        # --- writes the sandbox wrapper / orchestrator route through here ---
+        "issue create",
+        "issue comment",
+        "issue edit",
+        "issue close",
+        "pr review",
+        "pr ready",
+    }
+)
+
+# Leading gh flags that select a repo/host and consume the next token as a
+# value. They may precede the command (`gh -R owner/repo pr view 1`), so the
+# command-key extractor must skip both the flag and the token it consumes.
+_GH_LEADING_VALUE_FLAGS = frozenset({"-R", "--repo", "-H", "--hostname"})
+
+
+def extract_gh_command_key(args: list[str]) -> str:
+    """Return the ``"<command> [subcommand]"`` key used for allowlist matching.
+
+    Skips a leading repo/host selector flag and its value so that
+    ``gh -R owner/repo pr view 1`` keys as ``"pr view"``. Other leading flags
+    are skipped without consuming a value — no global gh flag that precedes
+    the command takes a separate-token value except the repo/host selectors.
+
+    Args:
+        args: gh argv with the ``gh`` prefix already stripped.
+
+    Returns:
+        The first one or two non-flag tokens joined by a space (e.g.
+        ``"pr view"``, ``"issue create"``, ``"api"``), or an empty string if
+        the argv carries no command token.
+    """
+    tokens: list[str] = []
+    i = 0
+    while i < len(args) and len(tokens) < 2:
+        arg = args[i]
+        if arg in _GH_LEADING_VALUE_FLAGS:
+            i += 2  # skip the flag and the token it consumes
+            continue
+        if arg.startswith(("--repo=", "--hostname=")):
+            i += 1
+            continue
+        if arg.startswith("-"):
+            i += 1
+            continue
+        tokens.append(arg)
+        i += 1
+    return " ".join(tokens)
+
+
+def is_gh_command_allowed(args: list[str]) -> tuple[bool, str]:
+    """Check a generic gh command against the deny-by-default allowlist.
+
+    ``gh api`` is allowed here and further constrained by
+    ``GH_API_ALLOWED_PATHS`` / ``validate_gh_api_path`` in the caller.
+
+    Args:
+        args: gh argv with the ``gh`` prefix already stripped.
+
+    Returns:
+        ``(allowed, command_key)`` — ``command_key`` is the value matched
+        against ``ALLOWED_GH_COMMANDS`` (``"api"`` for gh api commands),
+        suitable for an audit-log entry or error message.
+    """
+    key = extract_gh_command_key(args)
+    if not key:
+        return False, key
+    if key.split(" ", 1)[0] == "api":
+        return True, "api"
+    return key in ALLOWED_GH_COMMANDS, key
+
 
 # Allowlist of gh api paths that are permitted
 # These patterns match GitHub API endpoints that are safe for read/write operations

--- a/gateway/tests/README-integration.md
+++ b/gateway/tests/README-integration.md
@@ -52,7 +52,7 @@ Options:
 | Connectivity | Health endpoint, token validity |
 | Authentication | 401 for missing/invalid tokens, 200 for valid |
 | Git Operations | remote, status, fetch, push (with policy) |
-| gh Operations | auth status, repo view, pr list, issue list |
+| gh Operations | repo view, pr list, issue list (auth status now blocked — see security note) |
 | Blocked Operations | pr merge, repo delete, repo create |
 | Rate Limiting | Rate limit info, normal volume handling |
 | Fail-Closed | Operations fail when gateway unavailable |
@@ -66,7 +66,7 @@ For a working gateway sidecar setup:
 - **Connectivity**: Must pass
 - **Authentication**: Must pass
 - **Git Operations**: Most pass; push to main may be blocked by policy (expected)
-- **gh Operations**: All pass
+- **gh Operations**: All pass — except `gh auth status`, which must show "blocked" (the whole `gh auth` group is now denied to prevent token extraction via `gh auth token` / `gh auth status --show-token`)
 - **Blocked Operations**: All must show "blocked" (security-critical)
 - **Rate Limiting**: Pass or skip
 - **Fail-Closed**: Must pass (security-critical)

--- a/gateway/tests/conftest.py
+++ b/gateway/tests/conftest.py
@@ -355,6 +355,7 @@ gateway = _load_module_with_replaced_imports(
     GATEWAY_DIR / "gateway.py",
     import_replacements={
         "from ._module_loader import": "from _module_loader import",
+        "from .agent_restrictions import": "from agent_restrictions import",
         "from .anthropic_credentials import": "from anthropic_credentials import",
         "from .auth import": "from auth import",
         "from .checkpoint_handler import": "from checkpoint_handler import",

--- a/gateway/tests/integration_test.sh
+++ b/gateway/tests/integration_test.sh
@@ -261,16 +261,19 @@ test_authentication() {
     return
   fi
 
+  # `gh api user` is on the allowlist (commands without args, like
+  # `gh --version`, now 403 against the deny-by-default allowlist). We only
+  # care that auth succeeded, not what the upstream API returned.
   RESP=$(curl -s -w "\nHTTP_CODE:%{http_code}" -X POST "${GATEWAY_URL}/api/v1/gh/execute" \
     -H "Content-Type: application/json" \
     -H "Authorization: $AUTH" \
-    -d '{"args": ["--version"]}')
+    -d '{"args": ["api", "user"]}')
   HTTP_CODE=$(echo "$RESP" | grep "HTTP_CODE:" | cut -d: -f2)
   BODY=$(echo "$RESP" | grep -v "HTTP_CODE:")
 
-  if [[ "$HTTP_CODE" == "200" ]]; then
-    log_pass "Valid token accepted (200)"
-    record_result "auth_valid_token" "pass" "200 returned" "$BODY"
+  if [[ "$HTTP_CODE" != "401" ]] && [[ "$HTTP_CODE" != "403" ]]; then
+    log_pass "Valid token accepted ($HTTP_CODE)"
+    record_result "auth_valid_token" "pass" "$HTTP_CODE returned" "$BODY"
   else
     log_fail "Valid token rejected with $HTTP_CODE"
     record_result "auth_valid_token" "fail" "Wrong status: $HTTP_CODE" "$BODY"
@@ -390,15 +393,18 @@ test_gh_operations() {
 
   cd "$REPO_PATH" || return 1
 
-  log_test "gh auth status"
+  log_test "gh auth status is blocked (no token leak via --show-token)"
+  # `gh auth` is on BLOCKED_GH_COMMANDS — the whole auth group must 403 so
+  # the gateway's GitHub App token cannot be extracted by an agent.
   RESP=$(gh auth status 2>&1)
-  if [[ $? -eq 0 ]] || echo "$RESP" | grep -qi "logged in"; then
-    log_pass "gh auth status works"
-    record_result "gh_auth_status" "pass" "Works" "$RESP"
+  EXIT_CODE=$?
+  if [[ $EXIT_CODE -ne 0 ]] && echo "$RESP" | grep -qi "not allowed\|not permitted\|forbidden\|blocked"; then
+    log_pass "gh auth status correctly blocked"
+    record_result "gh_auth_status_blocked" "pass" "Blocked" "$RESP"
   else
-    log_fail "gh auth status failed"
+    log_fail "gh auth status was NOT blocked (exit $EXIT_CODE)"
     log_info "$RESP"
-    record_result "gh_auth_status" "fail" "Failed" "$RESP"
+    record_result "gh_auth_status_blocked" "fail" "Not blocked" "$RESP"
   fi
 
   log_test "gh repo view (read operation)"
@@ -525,7 +531,7 @@ test_rate_limiting() {
   RESP=$(curl -s -X POST "${GATEWAY_URL}/api/v1/gh/execute" \
     -H "Content-Type: application/json" \
     -H "Authorization: $AUTH" \
-    -d '{"args": ["--version"]}')
+    -d '{"args": ["api", "user"]}')
 
   if echo "$RESP" | grep -qi "rate\|limit\|remaining"; then
     log_pass "Rate limit info present in response"
@@ -542,8 +548,8 @@ test_rate_limiting() {
     RESP=$(curl -s -X POST "${GATEWAY_URL}/api/v1/gh/execute" \
       -H "Content-Type: application/json" \
       -H "Authorization: $AUTH" \
-      -d '{"args": ["--version"]}')
-    if ! echo "$RESP" | grep -q "success\|gh version"; then
+      -d '{"args": ["api", "user"]}')
+    if ! echo "$RESP" | grep -q "success\|login"; then
       if echo "$RESP" | grep -qi "rate.*limit\|too many"; then
         log_info "Rate limited at request $i (expected for high volume)"
         break

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -25,6 +25,7 @@ import pytest
 TEST_LAUNCHER_SECRET = os.environ.get("EGG_LAUNCHER_SECRET", "test-launcher-secret-12345")
 
 import session_manager
+from github_client import extract_gh_command_key, is_gh_command_allowed
 from policy import PolicyResult
 from session_manager import SessionValidationResult
 
@@ -2507,6 +2508,57 @@ class TestGhPrClose:
             assert response.status_code == 403
 
 
+class TestGhCommandAllowlist:
+    """Unit tests for the deny-by-default gh command allowlist helpers."""
+
+    def test_extract_key_basic(self):
+        """The command key is the first one or two non-flag tokens."""
+        assert extract_gh_command_key(["pr", "view", "123"]) == "pr view"
+        assert extract_gh_command_key(["issue", "create", "--title", "x"]) == "issue create"
+        assert extract_gh_command_key(["api", "repos/o/r/pulls"]) == "api repos/o/r/pulls"
+
+    def test_extract_key_skips_leading_repo_selector(self):
+        """A leading -R/--repo/-H/--hostname selector is skipped with its value."""
+        assert extract_gh_command_key(["-R", "owner/repo", "pr", "view"]) == "pr view"
+        assert extract_gh_command_key(["--repo", "o/r", "issue", "list"]) == "issue list"
+        assert extract_gh_command_key(["--repo=o/r", "pr", "diff"]) == "pr diff"
+
+    def test_extract_key_empty_without_command(self):
+        """Argv with no command token yields an empty key."""
+        assert extract_gh_command_key([]) == ""
+        assert extract_gh_command_key(["--version"]) == ""
+
+    def test_allowed_reads_and_writes(self):
+        """Allowlisted reads and the writes routed through gh/execute pass."""
+        for args in (
+            ["pr", "view", "1"],
+            ["pr", "checkout", "1"],
+            ["issue", "list"],
+            ["issue", "create", "--title", "x"],
+            ["pr", "review", "1", "--approve"],
+        ):
+            assert is_gh_command_allowed(args)[0] is True, args
+
+    def test_api_command_allowed(self):
+        """gh api is allowed at this layer; the path allowlist gates it later."""
+        allowed, key = is_gh_command_allowed(["api", "repos/o/r/pulls"])
+        assert allowed is True
+        assert key == "api"
+
+    def test_denies_credential_and_unlisted_commands(self):
+        """Credential-adjacent and otherwise unlisted commands fail closed."""
+        for args in (
+            ["auth", "token"],
+            ["auth", "status", "--show-token"],
+            ["secret", "list"],
+            ["alias", "set", "x", "!echo hi"],
+            ["extension", "exec", "x"],
+            ["repo", "create", "r"],
+            ["--version"],
+        ):
+            assert is_gh_command_allowed(args)[0] is False, args
+
+
 class TestGhExecute:
     """Tests for /api/v1/gh/execute endpoint."""
 
@@ -2547,6 +2599,72 @@ class TestGhExecute:
         )
 
         assert response.status_code == 403
+
+    def test_execute_blocks_auth_token(self, client, auth_headers):
+        """gh auth token is blocked -- it would print the gateway's GitHub token."""
+        response = client.post(
+            "/api/v1/gh/execute",
+            headers=auth_headers,
+            data=json.dumps({"args": ["auth", "token"]}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+        assert json.loads(response.data)["success"] is False
+
+    def test_execute_blocks_auth_status(self, client, auth_headers):
+        """gh auth status is blocked (auth status --show-token leaks the token)."""
+        for args in (["auth", "status"], ["auth", "status", "--show-token"]):
+            response = client.post(
+                "/api/v1/gh/execute",
+                headers=auth_headers,
+                data=json.dumps({"args": args}),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 403, args
+            assert json.loads(response.data)["success"] is False
+
+    def test_execute_denies_commands_not_on_allowlist(self, client, auth_headers):
+        """Commands absent from the allowlist fail closed (deny-by-default)."""
+        for args in (
+            ["secret", "list"],
+            ["alias", "set", "x", "!echo hi"],
+            ["extension", "list"],
+            ["repo", "create", "newrepo"],
+        ):
+            response = client.post(
+                "/api/v1/gh/execute",
+                headers=auth_headers,
+                data=json.dumps({"args": args}),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 403, args
+            assert json.loads(response.data)["success"] is False
+
+    def test_execute_allows_pr_checkout(self, client, auth_headers):
+        """pr checkout is allowlisted -- agents check out PRs to review them."""
+        with patch.object(gateway, "get_github_client") as mock_gh:
+            mock_result = MagicMock()
+            mock_result.success = True
+            mock_result.stdout = "Switched to branch"
+            mock_result.stderr = ""
+            mock_result.to_dict.return_value = {
+                "success": True,
+                "stdout": "Switched to branch",
+                "stderr": "",
+            }
+            mock_gh.return_value.execute.return_value = mock_result
+
+            response = client.post(
+                "/api/v1/gh/execute",
+                headers=auth_headers,
+                data=json.dumps({"args": ["pr", "checkout", "123"]}),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 200
 
     def test_execute_allows_read_operations(self, client, auth_headers):
         """Execute allows read-only operations."""
@@ -2836,7 +2954,7 @@ class TestGhExecuteReviewerToken:
             mock_gh.assert_called_with(mode="bot")
 
     def test_non_review_pr_commands_dont_switch_to_reviewer_mode(self, client, auth_headers):
-        """Non-review PR commands (like pr create) don't switch to reviewer mode."""
+        """Non-review PR commands (like pr view) don't switch to reviewer mode."""
         with (
             patch.object(gateway, "get_github_client") as mock_gh,
             patch.object(gateway, "get_auth_mode", return_value="bot"),
@@ -2858,7 +2976,7 @@ class TestGhExecuteReviewerToken:
                 headers=auth_headers,
                 data=json.dumps(
                     {
-                        "args": ["pr", "create", "--title", "Test"],
+                        "args": ["pr", "view", "123"],
                         "repo": "owner/repo",
                     }
                 ),
@@ -3425,29 +3543,24 @@ class TestGhExecutePrivateMode:
         assert data["success"] is False
         assert "private mode" in data["message"].lower()
 
-    def test_search_allowed_in_public_mode(self, client, auth_headers):
-        """gh search is allowed in public mode."""
-        with patch.object(gateway, "get_github_client") as mock_gh:
-            mock_result = MagicMock()
-            mock_result.success = True
-            mock_result.stdout = "search results"
-            mock_result.stderr = ""
-            mock_result.to_dict.return_value = {
-                "success": True,
-                "stdout": "search results",
-                "stderr": "",
-            }
-            mock_gh.return_value.execute.return_value = mock_result
+    def test_search_denied_by_allowlist_in_public_mode(self, client, auth_headers):
+        """gh search is not on the allowlist, so it is denied in public mode too.
 
-            response = client.post(
-                "/api/v1/gh/execute",
-                headers=auth_headers,
-                data=json.dumps({"args": ["search", "repos", "query"]}),
-                content_type="application/json",
-            )
+        Private mode already blocks `search` as "too broad"; the
+        deny-by-default allowlist makes it 403 in every mode, since `search`
+        is not a command the gateway mediates for agents.
+        """
+        response = client.post(
+            "/api/v1/gh/execute",
+            headers=auth_headers,
+            data=json.dumps({"args": ["search", "repos", "query"]}),
+            content_type="application/json",
+        )
 
-            # Should succeed (not blocked)
-            assert response.status_code == 200
+        assert response.status_code == 403
+        data = json.loads(response.data)
+        assert data["success"] is False
+        assert "not permitted" in data["message"].lower()
 
     def test_gh_repo_view_public_blocked_in_private_mode(self, client, private_mode_auth_headers):
         """gh repo view of public repo blocked in private mode (full integration)."""

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -7398,3 +7398,170 @@ class TestGhExecuteIssueCommentBlocking:
                     content_type="application/json",
                 )
                 assert response.status_code == 200
+
+
+class TestGhExecuteOverseerLeadingSelector:
+    """Regression: leading `-R`/`--repo` selector must not bypass the
+    overseer ``gh issue create`` guardrail.
+
+    The overseer block in ``gh_execute`` is the only enforcement layer
+    that runs ``check_overseer_gh_issue_create`` — repo enforcement,
+    label injection, title/body size limits, and the defense-in-depth
+    secret-pattern scan on the body. Before the fix it was guarded by
+    ``args[0] == "issue"``, so an argv like
+    ``["-R", "owner/repo", "issue", "create", ...]`` shifted ``args[0]``
+    off ``"issue"`` and the entire block was skipped — letting the
+    request fall through to the gh subprocess with no secret scan.
+    The fix normalizes the argv via ``find_gh_command_index`` (parity
+    with the api-path guard below it in the same handler).
+    """
+
+    _GH_PAT = "ghp_" + "A" * 36
+
+    def _make_overseer_session(self):
+        """Create a mock session with agent_role='overseer'."""
+        import sys
+
+        import auth
+
+        mock_session = MagicMock()
+        mock_session.mode = "public"
+        mock_session.container_id = "test-container"
+        mock_session.expires_at = None
+        mock_session.agent_role = "overseer"
+        mock_session.phase = None
+        mock_session.pipeline_id = "test-pipeline"
+
+        mock_result = SessionValidationResult(valid=True, session=mock_session)
+
+        from private_repo_policy import PrivateRepoPolicyResult
+
+        mock_policy_result = PrivateRepoPolicyResult(
+            allowed=True,
+            reason="Test mode",
+            visibility="public",
+        )
+
+        auth._session_manager = None
+        auth._rate_limiter = None
+        if "gateway.auth" in sys.modules:
+            sys.modules["gateway.auth"]._session_manager = None
+            sys.modules["gateway.auth"]._rate_limiter = None
+
+        current_session_manager = sys.modules.get("session_manager", session_manager)
+
+        return (
+            patch.object(
+                current_session_manager,
+                "validate_session_for_request",
+                return_value=mock_result,
+            ),
+            patch.object(gateway, "check_private_repo_access", return_value=mock_policy_result),
+        )
+
+    def test_overseer_issue_create_secret_scan_fires_without_leading_selector(self, client):
+        """Control: the overseer secret-scan fires for plain `issue create` argv.
+
+        Establishes the baseline behavior the leading-selector cases below
+        must also exhibit. If this case ever passes 200, the test
+        infrastructure (session mock / env var) is misconfigured.
+        """
+        ctx1, ctx2 = self._make_overseer_session()
+        with ctx1, ctx2, patch.dict(os.environ, {"EGG_PIPELINE_REPO": "owner/repo"}):
+            response = client.post(
+                "/api/v1/gh/execute",
+                headers={"Authorization": "Bearer test-session-token"},
+                data=json.dumps(
+                    {
+                        "args": [
+                            "issue",
+                            "create",
+                            "--repo",
+                            "owner/repo",
+                            "--title",
+                            "x",
+                            "--body",
+                            f"Token leaked: {self._GH_PAT}",
+                            "--label",
+                            "agent:overseer",
+                            "--label",
+                            "p1",
+                        ],
+                    }
+                ),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 403
+            data = json.loads(response.data)
+            assert data["success"] is False
+            assert "secret" in data["message"].lower()
+            assert "gh-pat" in data["data"].get("secret_kinds", [])
+
+    def test_overseer_issue_create_with_leading_repo_selector_still_runs_secret_scan(self, client):
+        """The fix: leading `-R`/`--repo` selector must NOT bypass the overseer block.
+
+        Each argv variant places a global repo selector before the
+        ``issue create`` tokens. The handler must normalize past the
+        selector via ``find_gh_command_index`` and still run
+        ``check_overseer_gh_issue_create``, including the secret-pattern
+        scan on ``--body``.
+        """
+        variants = (
+            [
+                "-R",
+                "owner/repo",
+                "issue",
+                "create",
+                "--title",
+                "x",
+                "--body",
+                f"Token leaked: {self._GH_PAT}",
+                "--label",
+                "agent:overseer",
+                "--label",
+                "p1",
+            ],
+            [
+                "--repo",
+                "owner/repo",
+                "issue",
+                "create",
+                "--title",
+                "x",
+                "--body",
+                f"Token leaked: {self._GH_PAT}",
+                "--label",
+                "agent:overseer",
+                "--label",
+                "p1",
+            ],
+            [
+                "--repo=owner/repo",
+                "issue",
+                "create",
+                "--title",
+                "x",
+                "--body",
+                f"Token leaked: {self._GH_PAT}",
+                "--label",
+                "agent:overseer",
+                "--label",
+                "p1",
+            ],
+        )
+        for args in variants:
+            ctx1, ctx2 = self._make_overseer_session()
+            with ctx1, ctx2, patch.dict(os.environ, {"EGG_PIPELINE_REPO": "owner/repo"}):
+                response = client.post(
+                    "/api/v1/gh/execute",
+                    headers={"Authorization": "Bearer test-session-token"},
+                    data=json.dumps({"args": args}),
+                    content_type="application/json",
+                )
+
+                assert response.status_code == 403, args
+                data = json.loads(response.data)
+                assert data["success"] is False, args
+                assert "secret" in data["message"].lower(), args
+                assert "gh-pat" in data["data"].get("secret_kinds", []), args

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -7399,6 +7399,58 @@ class TestGhExecuteIssueCommentBlocking:
                 )
                 assert response.status_code == 200
 
+    def test_issue_comment_with_leading_repo_selector_still_blocked_by_role(self, client):
+        """Regression: a leading `-R`/`--repo` selector must not bypass
+        the role-based `issue comment` block.
+
+        The phase + role filters build `gh_command_str` from non-flag
+        args. Before the fix, `["-R", "owner/repo", "issue", "comment",
+        "1032", "--body", "..."]` keyed as `"owner/repo issue comment"`,
+        which neither `fnmatch("issue comment *")` (phase filter) nor
+        `startswith("issue comment")` (`_BLOCKED_GH_OPS`) would catch —
+        letting role/phase enforcement be bypassed entirely. The fix
+        normalizes past the selector via `find_gh_command_index`
+        (parity with the overseer block and the api-path guard).
+        """
+        ctx1, ctx2 = self._make_session(phase=None, agent_role="coder")
+        with ctx1, ctx2:
+            for args in (
+                ["-R", "owner/repo", "issue", "comment", "1032", "--body", "t"],
+                ["--repo", "owner/repo", "issue", "comment", "1032", "--body", "t"],
+                ["--repo=owner/repo", "issue", "comment", "1032", "--body", "t"],
+            ):
+                response = client.post(
+                    "/api/v1/gh/execute",
+                    headers={"Authorization": "Bearer test-session-token"},
+                    data=json.dumps({"args": args}),
+                    content_type="application/json",
+                )
+                assert response.status_code == 403, args
+                data = json.loads(response.data)
+                assert "not allowed" in data["message"].lower(), args
+
+    def test_issue_comment_with_leading_repo_selector_still_blocked_by_phase(self, client):
+        """Regression: leading selector must not bypass the phase filter.
+
+        Companion to the role-filter regression above — same argv shape,
+        but exercises the phase-filter path (refine phase blocks
+        `issue comment *`).
+        """
+        ctx1, ctx2 = self._make_session(phase="refine", agent_role=None)
+        with ctx1, ctx2:
+            for args in (
+                ["-R", "owner/repo", "issue", "comment", "1032", "--body", "t"],
+                ["--repo", "owner/repo", "issue", "comment", "1032", "--body", "t"],
+                ["--repo=owner/repo", "issue", "comment", "1032", "--body", "t"],
+            ):
+                response = client.post(
+                    "/api/v1/gh/execute",
+                    headers={"Authorization": "Bearer test-session-token"},
+                    data=json.dumps({"args": args}),
+                    content_type="application/json",
+                )
+                assert response.status_code == 403, args
+
 
 class TestGhExecuteOverseerLeadingSelector:
     """Regression: leading `-R`/`--repo` selector must not bypass the

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -25,7 +25,11 @@ import pytest
 TEST_LAUNCHER_SECRET = os.environ.get("EGG_LAUNCHER_SECRET", "test-launcher-secret-12345")
 
 import session_manager
-from github_client import extract_gh_command_key, is_gh_command_allowed
+from github_client import (
+    extract_gh_command_key,
+    find_gh_command_index,
+    is_gh_command_allowed,
+)
 from policy import PolicyResult
 from session_manager import SessionValidationResult
 
@@ -2518,7 +2522,7 @@ class TestGhCommandAllowlist:
         assert extract_gh_command_key(["api", "repos/o/r/pulls"]) == "api repos/o/r/pulls"
 
     def test_extract_key_skips_leading_repo_selector(self):
-        """A leading -R/--repo/-H/--hostname selector is skipped with its value."""
+        """A leading -R/--repo selector is skipped with its value."""
         assert extract_gh_command_key(["-R", "owner/repo", "pr", "view"]) == "pr view"
         assert extract_gh_command_key(["--repo", "o/r", "issue", "list"]) == "issue list"
         assert extract_gh_command_key(["--repo=o/r", "pr", "diff"]) == "pr diff"
@@ -2557,6 +2561,35 @@ class TestGhCommandAllowlist:
             ["--version"],
         ):
             assert is_gh_command_allowed(args)[0] is False, args
+
+    def test_find_command_index_skips_leading_repo_selector(self):
+        """`find_gh_command_index` returns the index of the real command token."""
+        assert find_gh_command_index(["pr", "view"]) == 0
+        assert find_gh_command_index(["-R", "owner/repo", "pr", "view"]) == 2
+        assert find_gh_command_index(["--repo", "o/r", "api", "/path"]) == 2
+        assert find_gh_command_index(["--repo=o/r", "api", "/path"]) == 1
+        assert find_gh_command_index([]) == 0
+        # All flags, no command token → past-the-end.
+        assert find_gh_command_index(["--version"]) == 1
+
+    def test_denies_auth_token_with_leading_repo_selector(self):
+        """Layered defense: a leading -R/--repo can't smuggle past the allowlist.
+
+        The blocklist branch in gh_execute uses a prefix match on
+        ``" ".join(args[:2])`` and would NOT match ``["-R", "owner/repo",
+        "auth", "token"]``. The deny-by-default allowlist is the second
+        layer: ``extract_gh_command_key`` skips the ``-R`` value pair and
+        returns ``"auth token"``, which is not on ``ALLOWED_GH_COMMANDS``,
+        so the call still 403s.
+        """
+        for args in (
+            ["-R", "owner/repo", "auth", "token"],
+            ["--repo", "owner/repo", "auth", "status", "--show-token"],
+            ["--repo=owner/repo", "auth", "login"],
+        ):
+            allowed, key = is_gh_command_allowed(args)
+            assert allowed is False, args
+            assert key.startswith("auth"), (args, key)
 
 
 class TestGhExecute:
@@ -2615,6 +2648,30 @@ class TestGhExecute:
     def test_execute_blocks_auth_status(self, client, auth_headers):
         """gh auth status is blocked (auth status --show-token leaks the token)."""
         for args in (["auth", "status"], ["auth", "status", "--show-token"]):
+            response = client.post(
+                "/api/v1/gh/execute",
+                headers=auth_headers,
+                data=json.dumps({"args": args}),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 403, args
+            assert json.loads(response.data)["success"] is False
+
+    def test_execute_blocks_auth_token_with_leading_repo_selector(self, client, auth_headers):
+        """Layered defense: a leading -R selector can't smuggle `auth token` past the gateway.
+
+        The blocklist branch keys on ``" ".join(args[:2])`` and won't match
+        when the first two args are ``-R owner/repo``. The deny-by-default
+        allowlist behind it still fires because ``extract_gh_command_key``
+        looks past the leading repo selector and resolves the real command
+        key to ``"auth token"``, which is not on ``ALLOWED_GH_COMMANDS``.
+        """
+        for args in (
+            ["-R", "owner/repo", "auth", "token"],
+            ["--repo", "owner/repo", "auth", "status", "--show-token"],
+            ["--repo=owner/repo", "auth", "login"],
+        ):
             response = client.post(
                 "/api/v1/gh/execute",
                 headers=auth_headers,
@@ -2767,6 +2824,33 @@ class TestGhExecute:
             assert executed_args[0] == "--repo"  # --repo should be first
             assert executed_args[1] == "owner/repo"
             assert executed_args[2] == "pr"
+
+    def test_execute_api_with_leading_repo_selector_still_validates_path(
+        self, client, auth_headers
+    ):
+        """`gh -R owner/repo api /denied-path` is still gated by GH_API_ALLOWED_PATHS.
+
+        Pre-#2740 (and before this PR's allowlist landed) the api-path
+        validation was guarded by ``args[0] == "api"``, which a leading
+        ``-R``/``--repo`` selector would bypass — falling through to the
+        gh subprocess unchecked. The guard now looks past the leading
+        selector via ``find_gh_command_index``, so the allowlist applies
+        and a denied path returns 403.
+        """
+        for args in (
+            ["-R", "owner/repo", "api", "/admin/orgs/owner"],
+            ["--repo", "owner/repo", "api", "/admin/orgs/owner"],
+            ["--repo=owner/repo", "api", "/admin/orgs/owner"],
+        ):
+            response = client.post(
+                "/api/v1/gh/execute",
+                headers=auth_headers,
+                data=json.dumps({"args": args}),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 403, args
+            assert json.loads(response.data)["success"] is False
 
     def test_execute_api_with_template_variables_resolved(self, client, auth_headers):
         """Execute resolves {owner}/{repo} template variables from cwd.
@@ -2962,11 +3046,11 @@ class TestGhExecuteReviewerToken:
         ):
             mock_result = MagicMock()
             mock_result.success = True
-            mock_result.stdout = "PR created"
+            mock_result.stdout = "PR #123: ..."
             mock_result.stderr = ""
             mock_result.to_dict.return_value = {
                 "success": True,
-                "stdout": "PR created",
+                "stdout": "PR #123: ...",
                 "stderr": "",
             }
             mock_gh.return_value.execute.return_value = mock_result

--- a/integration_tests/test_credential_security.py
+++ b/integration_tests/test_credential_security.py
@@ -52,6 +52,38 @@ class TestCredentialIsolation:
             "SECURITY VIOLATION: BOT_GITHUB_TOKEN found in container environment"
         )
 
+    def test_agent_cannot_obtain_github_token_via_gh(self, egg_stack, gateway_session):
+        """`gh auth token` / `gh auth status --show-token` cannot extract the token.
+
+        The gateway holds the GitHub App token and runs `gh` with it in the
+        subprocess environment. `gh auth token` and `gh auth status
+        --show-token` exist only to print that credential, so the gateway
+        must reject the whole `gh auth` group instead of running it and
+        returning its output (gateway/github_client.py BLOCKED_GH_COMMANDS).
+        """
+        token = gateway_session.get("session_token")
+        # Prefixes for GitHub App installation / user / OAuth / PAT tokens.
+        token_prefixes = ("gho_", "ghs_", "ghp_", "ghu_", "github_pat_")
+        for args in (["auth", "token"], ["auth", "status", "--show-token"]):
+            label = "gh " + " ".join(args)
+            resp = egg_stack.api_request(
+                "POST",
+                "/api/v1/gh/execute",
+                token=token,
+                json_data={"args": args},
+            )
+            assert resp.status_code == 403, f"SECURITY VIOLATION: `{label}` was not blocked"
+            body = resp.json()
+            assert body.get("success") is not True, f"SECURITY VIOLATION: `{label}` succeeded"
+            # Belt-and-suspenders: even an error envelope must not carry a
+            # value that looks like a GitHub token.
+            blob = str(body)
+            for prefix in token_prefixes:
+                assert prefix not in blob, (
+                    f"SECURITY VIOLATION: response to `{label}` contains a "
+                    f"value with GitHub token prefix {prefix!r}"
+                )
+
     def test_container_cannot_reach_github_directly(self, egg_stack, isolated_container):
         """Container on the isolated network cannot reach github.com directly.
 

--- a/integration_tests/test_credential_security.py
+++ b/integration_tests/test_credential_security.py
@@ -60,11 +60,33 @@ class TestCredentialIsolation:
         --show-token` exist only to print that credential, so the gateway
         must reject the whole `gh auth` group instead of running it and
         returning its output (gateway/github_client.py BLOCKED_GH_COMMANDS).
+
+        Also covers the leading `-R`/`--repo` selector variants. The
+        blocklist branch keys on `" ".join(args[:2])`, so an argv like
+        `["-R", "owner/repo", "auth", "token"]` slips past it; the
+        deny-by-default `ALLOWED_GH_COMMANDS` allowlist is the
+        load-bearing second layer that normalizes via
+        `find_gh_command_index` and catches the smuggle. This test
+        drives that layered defense end-to-end through the real Flask
+        app + session manager, not just the route-level test client.
         """
         token = gateway_session.get("session_token")
         # Prefixes for GitHub App installation / user / OAuth / PAT tokens.
         token_prefixes = ("gho_", "ghs_", "ghp_", "ghu_", "github_pat_")
-        for args in (["auth", "token"], ["auth", "status", "--show-token"]):
+        variants = (
+            ["auth", "token"],
+            ["auth", "status", "--show-token"],
+            # Leading-selector smuggle variants — the blocklist's
+            # `" ".join(args[:2])` keying misses these; the allowlist
+            # is what catches them.
+            ["-R", "owner/repo", "auth", "token"],
+            ["--repo", "owner/repo", "auth", "token"],
+            ["--repo=owner/repo", "auth", "token"],
+            ["-R", "owner/repo", "auth", "status", "--show-token"],
+            ["--repo", "owner/repo", "auth", "status", "--show-token"],
+            ["--repo=owner/repo", "auth", "status", "--show-token"],
+        )
+        for args in variants:
             label = "gh " + " ".join(args)
             resp = egg_stack.api_request(
                 "POST",

--- a/integration_tests/test_gateway_operations.py
+++ b/integration_tests/test_gateway_operations.py
@@ -70,8 +70,13 @@ class TestGitExecuteEndpoint:
 class TestGhExecuteEndpoint:
     """Tests for POST /api/v1/gh/execute."""
 
-    def test_gh_version_works(self, egg_stack, gateway_session):
-        """gh --version executes successfully."""
+    def test_gh_bare_version_flag_denied(self, egg_stack, gateway_session):
+        """`gh --version` has no command token, so the allowlist denies it.
+
+        gh_execute is deny-by-default: an argv carrying no
+        `<command> <subcommand>` (only flags) is rejected. This also confirms
+        the endpoint is reachable and session auth works (not a 401).
+        """
         token = gateway_session.get("session_token")
         resp = egg_stack.api_request(
             "POST",
@@ -81,13 +86,10 @@ class TestGhExecuteEndpoint:
                 "args": ["--version"],
             },
         )
-        # Should succeed or at least not be an auth failure
+        # Endpoint reachable + authed (not a 401), but the command is denied.
         assert resp.status_code != 401
         body = resp.json()
-        # If successful, output should contain "gh version"
-        if body.get("success"):
-            output = body.get("data", {}).get("output", body.get("output", ""))
-            assert "gh" in output.lower() or body.get("success")
+        assert body.get("success") is not True
 
     def test_response_format_is_json(self, egg_stack, gateway_session):
         """gh/execute returns JSON, not HTML error pages."""

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -2248,8 +2248,9 @@ class GatewayClient:
         :func:`stacked_pr_reconciler.find_orphaned_child_prs`'s
         contract. The transport is the standard
         ``/api/v1/gh/execute`` route — ``pr list`` is on the
-        ``READONLY_GH_COMMANDS`` allowlist (gateway/github_client.py:54)
-        so no privileged endpoint is introduced (decision-15).
+        ``ALLOWED_GH_COMMANDS`` deny-by-default allowlist
+        (gateway/github_client.py) so no privileged endpoint is introduced
+        (decision-15).
 
         On any error (gateway 4xx/5xx, JSON parse failure) the
         function logs and returns an empty list — the reconciler


### PR DESCRIPTION
## Summary

The gateway's `gh` passthrough (`POST /api/v1/gh/execute`) was blocklist-based — allow-by-default. The gateway runs the real `gh` CLI with the GitHub App token in the subprocess environment, so `gh auth token` and `gh auth status --show-token` — commands whose sole function is to print that credential — would execute and return the token to the calling agent. The `git` passthrough (`/api/v1/git/execute`) is already allowlist-based (deny-by-default) and blocks the equivalent `git credential`; this brings `gh` to parity.

- **Block the `gh auth` group** — `"auth"` added to `BLOCKED_GH_COMMANDS`; the prefix match covers `auth token`, `auth status`, `auth login/logout`, `auth refresh`, `auth setup-git`.
- **Deny-by-default allowlist** — new `ALLOWED_GH_COMMANDS` plus `is_gh_command_allowed` / `extract_gh_command_key` helpers; `gh_execute` now returns 403 for any command not on the allowlist. `gh api` stays allowed, still constrained by `GH_API_ALLOWED_PATHS`. Unanticipated credential-adjacent subcommands (`gh alias set --shell`, `gh extension`, …) now fail closed.
- **`auth status` dropped** from `READONLY_GH_COMMANDS` — it leaks the token via `--show-token`.

Agents are credential-less by design; no legitimate flow needs `gh auth`.

### Behavior change

This is a hard switchover (no log-only phase). Commands off the allowlist now 403 — including `gh search`, `gh --version`, `gh run`, `gh label`. The allowlist covers `pr`/`issue`/`repo`/`release` reads, `pr checkout`, the writes the sandbox wrapper / orchestrator route through this endpoint (`issue create/comment/edit/close`, `pr review`, `pr ready`), and `gh api`.

Defense-in-depth token redaction on `gh`/gateway output is intentionally **not** in this PR; it is tracked as follow-up #2740.

## Test plan

- [x] `make test` — 18149 passed, 44 skipped
- [x] `make lint` — clean
- [x] New unit tests — `TestGhCommandAllowlist` (allowlist helpers, incl. leading `-R` selector handling); `TestGhExecute` cases: `auth token` / `auth status` / `auth status --show-token` → 403, non-allowlisted commands (`secret`, `alias`, `extension`, `repo create`) → 403, `pr checkout` → 200
- [x] New integration test — `test_agent_cannot_obtain_github_token_via_gh` drives the live gateway and asserts no GitHub-token-shaped value is returned
- [x] Updated tests for the behavior change — `gh search` now denied, `gh --version` now denied, non-review `pr` command example