### PR TITLE
Fix #2745: slice PR titles + bodies surface per-slice scope

### DIFF
--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -209,8 +209,16 @@ def _derive_program_slug(pipeline_id: str, max_len: int = 18) -> str:
     so reviewers see a stable identifier across pipeline re-runs).
     ``pipeline-<hash>`` keeps the prefix and truncates the hash to fit.
     Any other shape is truncated as-is.
+
+    ``max_len`` keeps the slug short so the slice-PR title still has room
+    for the position marker (``[slice-N/M]``) and the slice subject inside
+    the 70-char title cap. Worst-case budget: a hash-id pipeline at slice
+    99/100 leaves roughly 30 chars for the subject after the slug
+    (``[pipeline-f4c7d780ab][slice-99/100] ``) — tight, so the subject is
+    what gets truncated first. ``issue-<N>`` pipelines are unaffected
+    because the slug collapses to ``issue-<N>`` regardless of ``max_len``.
     """
-    if not pipeline_id:
+    if not pipeline_id or not pipeline_id.strip():
         return "pipeline"
     pid = pipeline_id.strip()
     issue_match = re.match(r"^(issue-\d+)(?:-v\d+)?", pid)
@@ -247,17 +255,29 @@ def _format_slice_title(program_slug: str, position_marker: str, subject: str) -
     return f"[{program_slug}][{position_marker}] {subject}".strip()
 
 
-def _first_sentence(text: str, max_len: int = 240) -> str:
+def _first_sentence(text: str, max_len: int = 120) -> str:
     """Return the first sentence of ``text``, capped at ``max_len`` chars.
 
-    Used as the slice-PR program blurb. Conservative on what counts as
-    a sentence boundary: first ``.``/``!``/``?`` followed by whitespace
-    or end-of-string. Falls back to the first ``max_len`` chars if no
-    sentence boundary is found.
+    Used as the slice-PR program blurb — meant to be a 1-line hook, not
+    a paragraph. The blurb ends at whichever boundary comes first:
+
+    * the first ``.``/``!``/``?`` followed by whitespace or end-of-string;
+    * the first newline (so a description that opens with a markdown
+      bullet list or a header doesn't bleed into the blurb);
+    * ``max_len`` chars (truncated with a trailing ``...``).
+
+    Returns ``""`` when ``text`` is empty / whitespace-only.
     """
     if not text:
         return ""
-    collapsed = " ".join(text.strip().split())
+    stripped = text.strip()
+    if not stripped:
+        return ""
+    # Take everything up to the first newline (in the original string,
+    # before collapsing whitespace) so a list / header on the second
+    # line is excluded from the blurb.
+    first_line = stripped.split("\n", 1)[0]
+    collapsed = " ".join(first_line.split())
     if not collapsed:
         return ""
     match = re.search(r"[.!?](?:\s|$)", collapsed)
@@ -323,23 +343,20 @@ def _append_this_slice_section(
     slice_files_affected: list[str] | None,
     slice_tasks: list[dict[str, Any]] | None,
 ) -> None:
-    """Render the ``## This slice`` block: subject + files + tasks."""
+    """Render the ``## This slice`` block: subject + files + tasks.
+
+    ``slice_files_affected`` is treated as already deduplicated /
+    empty-filtered by the caller (``_run_one_slice_inner`` is the only
+    production caller and does this work under the contract-state lock).
+    """
     body_lines.append("## This slice")
     body_lines.append("")
     body_lines.append(slice_name)
     if slice_files_affected:
-        seen: set[str] = set()
-        unique = []
+        body_lines.append("")
+        body_lines.append("Files affected:")
         for path in slice_files_affected:
-            if not path or path in seen:
-                continue
-            seen.add(path)
-            unique.append(path)
-        if unique:
-            body_lines.append("")
-            body_lines.append("Files affected:")
-            for path in unique:
-                body_lines.append(f"- `{path}`")
+            body_lines.append(f"- `{path}`")
     if slice_tasks:
         body_lines.append("")
         body_lines.append("Tasks:")
@@ -354,15 +371,18 @@ def _format_stack_block(
     slice_index: int | None,
     slice_count: int | None,
     base_branch: str,
-    parent_pr_number: int | None,
     context_pr_number: int | None,
     is_terminal_slice: bool,
 ) -> list[str]:
-    r"""Render the ``## Stack`` footer with parent + base PR pointers.
+    r"""Render the ``## Stack`` footer with base PR + position pointers.
 
     Replaces the pre-#2745 trailing ``"Slice X of pipeline Y. Stacked
     on top of \`base\`."`` line with a structured block so reviewers
     can navigate the stack without leaving the PR.
+
+    A ``Parent PR:`` line would also be useful here, but slice PR numbers
+    aren't persisted on the contract yet, so the parent PR # isn't
+    available at slice-PR-creation time. Tracked separately.
     """
     lines: list[str] = ["## Stack", ""]
     if slice_index is not None and slice_count is not None and slice_count >= 1:
@@ -374,8 +394,6 @@ def _format_stack_block(
     else:
         position = "merge-gate" if is_terminal_slice else slice_id
     lines.append(f"- Position: {position} in pipeline `{pipeline_id}`")
-    if parent_pr_number is not None and parent_pr_number >= 1:
-        lines.append(f"- Parent PR: #{parent_pr_number}")
     if context_pr_number is not None and context_pr_number >= 1:
         lines.append(f"- Base PR: #{context_pr_number}")
     lines.append(f"- Stacked on top of `{base_branch}`")
@@ -1468,7 +1486,6 @@ class GatewayClient:
         slice_count: int | None = None,
         slice_files_affected: list[str] | None = None,
         context_pr_number: int | None = None,
-        parent_pr_number: int | None = None,
     ) -> str | None:
         """Open a PR for one slice in a stacked-PR chain (#2745).
 
@@ -1492,7 +1509,7 @@ class GatewayClient:
         * **Body (non-terminal).** Optional 1-line program blurb →
           ``**Base PR:** #<context_pr_number>`` → ``## This slice``
           (subject, files affected, full task descriptions + acceptance
-          criteria) → ``## Stack`` (parent PR, base PR, position).
+          criteria) → ``## Stack`` (base PR, position).
         * **Body (terminal — umbrella).** Umbrella banner → program
           description → pre-merge obligations → ``## This slice`` →
           ``## Test Plan`` → ``## Manual Steps`` → ``## Stack``. The
@@ -1503,9 +1520,14 @@ class GatewayClient:
           merge gate.
 
         ``program_deferred_actions`` is terminal-only by convention
-        (the merge gate is the last-to-merge PR in the stack); the
-        assertion below fails fast if a caller wires obligations
-        through to a non-terminal slice (#2354 review nit).
+        (the merge gate is the last-to-merge PR in the stack); each
+        non-terminal body branch (``program_title is None`` umbrella
+        fallback, lean, inline-fallback) asserts ``program_deferred_actions
+        is None`` so a mis-routed obligations payload fails fast instead
+        of being silently dropped (#2354 review nit, #2746 review
+        item 1). The whitespace-only ``program_title`` case is
+        intentionally not covered — that's a ``PRMetadata`` data bug,
+        not a slice-routing error.
 
         When ``context_pr_number is None`` (covers the #2744 regression
         where the base/context PR is silently not opened) the
@@ -1524,6 +1546,16 @@ class GatewayClient:
         # single-slice pipeline, which is also terminal).
         is_terminal_slice = has_program_title and terminal_slice_id is None
         has_base_pr = context_pr_number is not None and context_pr_number >= 1
+
+        # Pre-merge obligations belong only on the merge-gate (terminal
+        # slice). The assertions live inside each non-terminal body
+        # branch below — not at the top — because a whitespace-only
+        # ``program_title`` (which ``PRMetadata.title`` allows under its
+        # ``min_length=1`` validator) flows into the deterministic
+        # else-branch and is a different bug (PRMetadata data
+        # validation), not a slice-routing error (#2354 review
+        # observation B). The branch-local assertions cover the lean /
+        # inline non-terminal paths that #2746 review item 1 flagged.
 
         program_slug = _derive_program_slug(pipeline_id)
         position_marker = _format_position_marker(
@@ -1603,6 +1635,14 @@ class GatewayClient:
         elif has_program_title and not is_terminal_slice and has_base_pr:
             # Non-terminal slice with a base/context PR opened: lean
             # body. Defer the strategic narrative to the base PR.
+            #
+            # Pre-merge obligations belong on the merge-gate only — fail
+            # fast here so the lean branch doesn't silently drop them
+            # (#2746 review item 1).
+            assert program_deferred_actions is None, (
+                "program_deferred_actions must be None on non-terminal slices; "
+                "obligations belong on the umbrella PR only"
+            )
             blurb = _first_sentence(program_description) if program_description else ""
             if blurb:
                 body_lines.append(blurb)
@@ -1617,6 +1657,14 @@ class GatewayClient:
             # the stack is still unmergeable in this state — fixing the
             # body here does not fix the missing-base-PR structural
             # break.
+            #
+            # Pre-merge obligations belong on the merge-gate only — fail
+            # fast here so the inline-fallback branch doesn't silently
+            # drop them (#2746 review item 1).
+            assert program_deferred_actions is None, (
+                "program_deferred_actions must be None on non-terminal slices; "
+                "obligations belong on the umbrella PR only"
+            )
             if program_description and program_description.strip():
                 body_lines.append(program_description.strip())
                 body_lines.append("")
@@ -1648,7 +1696,6 @@ class GatewayClient:
             slice_index=slice_index,
             slice_count=slice_count,
             base_branch=base,
-            parent_pr_number=parent_pr_number,
             context_pr_number=context_pr_number,
             is_terminal_slice=is_terminal_slice,
         )

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -197,6 +197,196 @@ def _classify_push_stderr(stderr: str) -> str:
     return "push_rejected"
 
 
+# ----------------------------------------------------------------------
+# Slice PR body / title helpers (#2745).
+# ----------------------------------------------------------------------
+
+
+def _derive_program_slug(pipeline_id: str, max_len: int = 18) -> str:
+    """Derive a short program slug from ``pipeline_id`` for slice PR titles.
+
+    ``issue-<N>[-v<K>]`` collapses to ``issue-<N>`` (drops version suffix
+    so reviewers see a stable identifier across pipeline re-runs).
+    ``pipeline-<hash>`` keeps the prefix and truncates the hash to fit.
+    Any other shape is truncated as-is.
+    """
+    if not pipeline_id:
+        return "pipeline"
+    pid = pipeline_id.strip()
+    issue_match = re.match(r"^(issue-\d+)(?:-v\d+)?", pid)
+    if issue_match:
+        return issue_match.group(1)
+    if len(pid) <= max_len:
+        return pid
+    return pid[:max_len]
+
+
+def _format_position_marker(
+    slice_id: str,
+    slice_index: int | None,
+    slice_count: int | None,
+    is_terminal_slice: bool,
+) -> str:
+    """Return ``slice-N/M`` (or ``merge-gate`` for the terminal slice).
+
+    Falls back to ``slice_id`` when index / count aren't supplied (older
+    callers / tests). Terminal gets the ``merge-gate`` marker so its
+    title is still distinguishable from a hypothetical sibling program
+    PR (the original #2745 complaint about the terminal title being
+    indistinguishable from any program-level PR).
+    """
+    if is_terminal_slice:
+        return "merge-gate"
+    if slice_index is not None and slice_count is not None and slice_count >= 1:
+        return f"slice-{slice_index}/{slice_count}"
+    return slice_id
+
+
+def _format_slice_title(program_slug: str, position_marker: str, subject: str) -> str:
+    """Compose ``[<slug>][<position>] <subject>``."""
+    return f"[{program_slug}][{position_marker}] {subject}".strip()
+
+
+def _first_sentence(text: str, max_len: int = 240) -> str:
+    """Return the first sentence of ``text``, capped at ``max_len`` chars.
+
+    Used as the slice-PR program blurb. Conservative on what counts as
+    a sentence boundary: first ``.``/``!``/``?`` followed by whitespace
+    or end-of-string. Falls back to the first ``max_len`` chars if no
+    sentence boundary is found.
+    """
+    if not text:
+        return ""
+    collapsed = " ".join(text.strip().split())
+    if not collapsed:
+        return ""
+    match = re.search(r"[.!?](?:\s|$)", collapsed)
+    if match:
+        end = match.start() + 1
+        sentence = collapsed[:end]
+    else:
+        sentence = collapsed
+    if len(sentence) > max_len:
+        sentence = sentence[: max_len - 3].rstrip() + "..."
+    return sentence
+
+
+def _render_pre_merge_obligations(
+    program_deferred_actions: list[dict[str, str]],
+) -> str:
+    """Thin wrapper around ``pr_obligations.render_obligations_section_from_normalized``.
+
+    Kept here so the import is resolved lazily once and the umbrella
+    rendering path stays at parity with the legacy
+    ``_auto_create_pr`` path."""
+    try:
+        from pr_obligations import render_obligations_section_from_normalized
+    except ImportError:
+        from orchestrator.pr_obligations import (  # type: ignore[no-redef]
+            render_obligations_section_from_normalized,
+        )
+    return render_obligations_section_from_normalized(program_deferred_actions)
+
+
+def _append_task_bullets(
+    body_lines: list[str],
+    slice_tasks: list[dict[str, Any]] | None,
+    *,
+    header: str | None = None,
+) -> None:
+    """Append task bullets — full descriptions + acceptance criteria.
+
+    Drops the pre-#2745 300-char truncation. Acceptance criteria render
+    as a nested bullet when present. Whitespace is collapsed to a single
+    line so list rendering on GitHub stays stable.
+    """
+    if not slice_tasks:
+        return
+    if header:
+        body_lines.append("")
+        body_lines.append(header)
+    for task in slice_tasks:
+        desc = task.get("description") or task.get("id") or ""
+        desc = " ".join(str(desc).split())
+        task_id = task.get("id") or ""
+        bullet_prefix = f"- {task_id}: " if task_id else "- "
+        body_lines.append(f"{bullet_prefix}{desc}")
+        ac = task.get("acceptance_criteria") or ""
+        ac = " ".join(str(ac).split())
+        if ac:
+            body_lines.append(f"  - Acceptance criteria: {ac}")
+
+
+def _append_this_slice_section(
+    body_lines: list[str],
+    slice_name: str,
+    slice_files_affected: list[str] | None,
+    slice_tasks: list[dict[str, Any]] | None,
+) -> None:
+    """Render the ``## This slice`` block: subject + files + tasks."""
+    body_lines.append("## This slice")
+    body_lines.append("")
+    body_lines.append(slice_name)
+    if slice_files_affected:
+        seen: set[str] = set()
+        unique = []
+        for path in slice_files_affected:
+            if not path or path in seen:
+                continue
+            seen.add(path)
+            unique.append(path)
+        if unique:
+            body_lines.append("")
+            body_lines.append("Files affected:")
+            for path in unique:
+                body_lines.append(f"- `{path}`")
+    if slice_tasks:
+        body_lines.append("")
+        body_lines.append("Tasks:")
+        _append_task_bullets(body_lines, slice_tasks, header=None)
+    body_lines.append("")
+
+
+def _format_stack_block(
+    *,
+    pipeline_id: str,
+    slice_id: str,
+    slice_index: int | None,
+    slice_count: int | None,
+    base_branch: str,
+    parent_pr_number: int | None,
+    context_pr_number: int | None,
+    is_terminal_slice: bool,
+) -> list[str]:
+    r"""Render the ``## Stack`` footer with parent + base PR pointers.
+
+    Replaces the pre-#2745 trailing ``"Slice X of pipeline Y. Stacked
+    on top of \`base\`."`` line with a structured block so reviewers
+    can navigate the stack without leaving the PR.
+    """
+    lines: list[str] = ["## Stack", ""]
+    if slice_index is not None and slice_count is not None and slice_count >= 1:
+        position = (
+            f"merge-gate (slice {slice_index} of {slice_count})"
+            if is_terminal_slice
+            else f"slice {slice_index} of {slice_count}"
+        )
+    else:
+        position = "merge-gate" if is_terminal_slice else slice_id
+    lines.append(f"- Position: {position} in pipeline `{pipeline_id}`")
+    if parent_pr_number is not None and parent_pr_number >= 1:
+        lines.append(f"- Parent PR: #{parent_pr_number}")
+    if context_pr_number is not None and context_pr_number >= 1:
+        lines.append(f"- Base PR: #{context_pr_number}")
+    lines.append(f"- Stacked on top of `{base_branch}`")
+    lines.append("")
+    # Keep the legacy footer string so existing tooling / scrapers that
+    # look for "Slice <id> of pipeline <pipeline>" keep working. The
+    # structured ``## Stack`` block above is the human-facing surface.
+    lines.append(f"Slice {slice_id} of pipeline {pipeline_id}. Stacked on top of `{base_branch}`.")
+    return lines
+
+
 class GatewayClient:
     """Client for interacting with the gateway sidecar.
 
@@ -1261,7 +1451,7 @@ class GatewayClient:
         *,
         slice_id: str,
         slice_name: str,
-        slice_tasks: list[dict[str, str]] | None,
+        slice_tasks: list[dict[str, Any]] | None,
         head: str,
         base: str,
         issue_number: int | None = None,
@@ -1274,44 +1464,57 @@ class GatewayClient:
         program_manual_steps: str | None = None,
         program_deferred_actions: list[dict[str, str]] | None = None,
         terminal_slice_id: str | None = None,
+        slice_index: int | None = None,
+        slice_count: int | None = None,
+        slice_files_affected: list[str] | None = None,
+        context_pr_number: int | None = None,
+        parent_pr_number: int | None = None,
     ) -> str | None:
-        """Open a PR for one slice in a stacked-PR chain.
+        """Open a PR for one slice in a stacked-PR chain (#2745).
 
-        Every slice — terminal or not — carries the planner-authored
-        program narrative (title, description, test plan, manual steps)
-        when ``contract.pr`` is populated, so reviewers see the program
-        rationale on whichever slice PR they open first (#2538).
+        Slice PRs are scoped to their own slice: subject + files
+        affected + full task descriptions with acceptance criteria.
+        Strategic context (analysis doc, plan doc, refine/plan BRC
+        history) lives on the base/context PR opened by #2548, which
+        slice PRs link to via ``context_pr_number``. The terminal
+        slice keeps the umbrella treatment (program-level test plan /
+        manual steps + pre-merge obligations) because it is the merge
+        gate — those are execution-time concerns, not strategic-direction
+        artifacts.
 
-        * **Title.** The terminal slice gets the bare ``program_title``;
-          non-terminal slices get a ``[<slice-id>] `` prefix so the
-          GitHub PR list stays scannable when several stacked PRs are
-          open at once. When ``program_title`` is empty (older contracts
-          / planner skipped the field), every slice falls back to the
-          deterministic ``{slice_id}: {slice_name}`` form (#2539).
-        * **Body.** Program description → ``## This slice`` (slice name
-          and task bullets) → ``## Test Plan`` → ``## Manual Steps`` →
-          stack footer. The terminal slice prepends a "merge gate /
-          umbrella" banner and (when ``program_deferred_actions`` is
-          non-empty) injects the ``## ⚠️ Pre-merge Obligations`` /
-          ``## ✅ Resolved within this PR`` section before
-          ``## Test Plan`` — same placement as the legacy
-          ``_auto_create_pr`` path. ``program_deferred_actions`` is
-          terminal-only by convention (the merge gate is the
-          last-to-merge PR in the stack); the assertion below fails
-          fast if a caller wires obligations through to a non-terminal
-          slice (#2354 review nit).
+        * **Title.** ``[<program-slug>][slice-N/M] <slice subject>`` for
+          non-terminal slices; ``[<program-slug>][merge-gate] <program_title>``
+          for the terminal slice. ``<program-slug>`` is derived from
+          ``pipeline_id`` (``issue-<N>`` collapsed to ``issue-<N>``;
+          ``pipeline-<hash>`` truncated). When ``program_title`` is empty
+          (older contracts / planner skipped the field), titles fall back
+          to the deterministic ``{slice_id}: {slice_name}`` form (#2539).
+        * **Body (non-terminal).** Optional 1-line program blurb →
+          ``**Base PR:** #<context_pr_number>`` → ``## This slice``
+          (subject, files affected, full task descriptions + acceptance
+          criteria) → ``## Stack`` (parent PR, base PR, position).
+        * **Body (terminal — umbrella).** Umbrella banner → program
+          description → pre-merge obligations → ``## This slice`` →
+          ``## Test Plan`` → ``## Manual Steps`` → ``## Stack``. The
+          umbrella rollup stays here because the base/context PR is a
+          *strategic-direction* surface (analysis + plan + BRC history,
+          per #2548), not a merge-the-whole-stack rollup. Execution-time
+          concerns (test plan, manual steps, obligations) live on the
+          merge gate.
 
-        The caller passes the *normalized* obligation shape produced
-        by ``routes.pipelines._collect_pre_merge_obligations`` (a list
-        of ``{reviewer, condition, resolved_in_diff}`` dicts) so this
-        path stays at parity with the legacy single-PR renderer.
+        ``program_deferred_actions`` is terminal-only by convention
+        (the merge gate is the last-to-merge PR in the stack); the
+        assertion below fails fast if a caller wires obligations
+        through to a non-terminal slice (#2354 review nit).
 
-        ``terminal_slice_id`` is the caller's signal for "this is a
-        non-terminal slice; the terminal slice's id is X." It's no
-        longer rendered into the body (every slice carries its own
-        narrative now), but it still selects the title shape: the
-        terminal slice gets the bare ``program_title``, non-terminal
-        slices get the ``[<slice-id>] `` prefix.
+        When ``context_pr_number is None`` (covers the #2744 regression
+        where the base/context PR is silently not opened) the
+        non-terminal body falls back to the pre-#2745 shape — inline
+        program description + test plan + manual steps — so slice PRs
+        stay reviewable as standalone diffs against ``/work``. This is a
+        **UX backstop**, not a structural fix: the stack is still
+        unmergeable in that state because no PR exists for
+        ``/work → main``.
         """
         has_program_title = bool(program_title and program_title.strip())
         # ``pipelines.py`` sets ``terminal_slice_id`` only for
@@ -1320,14 +1523,21 @@ class GatewayClient:
         # ``program_title`` identifies the terminal slice (or a
         # single-slice pipeline, which is also terminal).
         is_terminal_slice = has_program_title and terminal_slice_id is None
+        has_base_pr = context_pr_number is not None and context_pr_number >= 1
+
+        program_slug = _derive_program_slug(pipeline_id)
+        position_marker = _format_position_marker(
+            slice_id, slice_index, slice_count, is_terminal_slice
+        )
 
         if has_program_title:
             assert program_title is not None  # implied by has_program_title
             program_title_clean = program_title.strip()
             if is_terminal_slice:
-                title = program_title_clean
+                subject = program_title_clean
             else:
-                title = f"[{slice_id}] {program_title_clean}"
+                subject = (slice_name or slice_id).strip() or slice_id
+            title = _format_slice_title(program_slug, position_marker, subject)
         else:
             # Defensive: obligations belong only on the umbrella. Failing
             # fast here catches a caller wiring ``program_deferred_actions``
@@ -1352,16 +1562,19 @@ class GatewayClient:
 
         body_lines: list[str] = []
 
-        if has_program_title:
-            if is_terminal_slice:
-                body_lines.append(
-                    f"> **Program-level umbrella PR — terminal slice of pipeline `{pipeline_id}`.**"
-                )
-                body_lines.append(
-                    "> Roll-up of the slice-PR chain; this PR is the merge gate "
-                    "for the program. Pre-merge obligations (when present) live here."
-                )
-                body_lines.append("")
+        if has_program_title and is_terminal_slice:
+            # Terminal slice — the merge-gate umbrella. Carries the
+            # program-level test plan / manual steps / obligations so
+            # the PR that people actually click "Merge" on has the
+            # execution-time concerns visible.
+            body_lines.append(
+                f"> **Program-level umbrella PR — terminal slice of pipeline `{pipeline_id}`.**"
+            )
+            body_lines.append(
+                "> Roll-up of the slice-PR chain; this PR is the merge gate "
+                "for the program. Pre-merge obligations (when present) live here."
+            )
+            body_lines.append("")
             if program_description and program_description.strip():
                 body_lines.append(program_description.strip())
                 body_lines.append("")
@@ -1372,38 +1585,42 @@ class GatewayClient:
             # scrolling past plan/steps). Same placement as the legacy
             # ``_auto_create_pr`` path.
             if program_deferred_actions:
-                try:
-                    from pr_obligations import render_obligations_section_from_normalized
-                except ImportError:
-                    from orchestrator.pr_obligations import (  # type: ignore[no-redef]
-                        render_obligations_section_from_normalized,
-                    )
-                obligations_section = render_obligations_section_from_normalized(
-                    program_deferred_actions
-                )
+                obligations_section = _render_pre_merge_obligations(program_deferred_actions)
                 if obligations_section:
                     body_lines.append(obligations_section)
                     body_lines.append("")
-            # Per-slice scope: slice name + task bullets. Sits between
-            # obligations and the test plan so reviewers see "what does
-            # the program do (and what's blocking merge)" → "what does
-            # this slice contribute" → "how do we verify the program"
-            # in reading order.
-            body_lines.append("## This slice")
-            body_lines.append("")
-            body_lines.append(slice_name)
-            if slice_tasks:
+            _append_this_slice_section(body_lines, slice_name, slice_files_affected, slice_tasks)
+            if program_test_plan and program_test_plan.strip():
+                body_lines.append("## Test Plan")
                 body_lines.append("")
-                body_lines.append("Tasks:")
-                for task in slice_tasks:
-                    desc = task.get("description") or task.get("id") or ""
-                    desc = " ".join(desc.split())  # collapse whitespace
-                    if len(desc) > 300:
-                        desc = desc[:297] + "..."
-                    task_id = task.get("id") or ""
-                    bullet_prefix = f"- {task_id}: " if task_id else "- "
-                    body_lines.append(f"{bullet_prefix}{desc}")
+                body_lines.append(program_test_plan.strip())
+                body_lines.append("")
+            if program_manual_steps and program_manual_steps.strip():
+                body_lines.append("## Manual Steps")
+                body_lines.append("")
+                body_lines.append(program_manual_steps.strip())
+                body_lines.append("")
+        elif has_program_title and not is_terminal_slice and has_base_pr:
+            # Non-terminal slice with a base/context PR opened: lean
+            # body. Defer the strategic narrative to the base PR.
+            blurb = _first_sentence(program_description) if program_description else ""
+            if blurb:
+                body_lines.append(blurb)
+                body_lines.append("")
+            body_lines.append(f"**Base PR:** #{context_pr_number}")
             body_lines.append("")
+            _append_this_slice_section(body_lines, slice_name, slice_files_affected, slice_tasks)
+        elif has_program_title and not is_terminal_slice and not has_base_pr:
+            # UX backstop for the #2744 regression: no base PR exists,
+            # so inline the program narrative so the slice PR is still
+            # reviewable as a standalone diff against ``/work``. NOTE:
+            # the stack is still unmergeable in this state — fixing the
+            # body here does not fix the missing-base-PR structural
+            # break.
+            if program_description and program_description.strip():
+                body_lines.append(program_description.strip())
+                body_lines.append("")
+            _append_this_slice_section(body_lines, slice_name, slice_files_affected, slice_tasks)
             if program_test_plan and program_test_plan.strip():
                 body_lines.append("## Test Plan")
                 body_lines.append("")
@@ -1418,22 +1635,24 @@ class GatewayClient:
             # Fallback: contract.pr missing or program_title empty.
             # Render the deterministic per-slice body with no narrative.
             body_lines.append(slice_name)
-            if slice_tasks:
-                body_lines.append("")
-                body_lines.append("Tasks in this slice:")
-                for task in slice_tasks:
-                    desc = task.get("description") or task.get("id") or ""
-                    desc = " ".join(desc.split())  # collapse whitespace
-                    if len(desc) > 300:
-                        desc = desc[:297] + "..."
-                    task_id = task.get("id") or ""
-                    bullet_prefix = f"- {task_id}: " if task_id else "- "
-                    body_lines.append(f"{bullet_prefix}{desc}")
+            _append_task_bullets(body_lines, slice_tasks, header="Tasks in this slice:")
             body_lines.append("")
 
-        body_lines.append(
-            f"Slice {slice_id} of pipeline {pipeline_id}. Stacked on top of `{base}`."
+        # ``## Stack`` block — parent PR + base PR + position. Replaces
+        # the old "Slice X of pipeline Y. Stacked on top of `<base>`."
+        # footer with structured links so reviewers can navigate the
+        # stack without leaving the PR.
+        stack_lines = _format_stack_block(
+            pipeline_id=pipeline_id,
+            slice_id=slice_id,
+            slice_index=slice_index,
+            slice_count=slice_count,
+            base_branch=base,
+            parent_pr_number=parent_pr_number,
+            context_pr_number=context_pr_number,
+            is_terminal_slice=is_terminal_slice,
         )
+        body_lines.extend(stack_lines)
         body = "\n".join(body_lines)
 
         return self.create_pr(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -15947,12 +15947,56 @@ def _run_implement_phase_slices(
                                 if is_terminal or not umbrella_has_program_block
                                 else chosen_terminal
                             )
+                            # #2745: derive 1-based slice position +
+                            # total slice count from declared contract
+                            # order so the slice PR title can carry
+                            # ``[slice-N/M]`` for non-terminal slices.
+                            slice_count = len(contract_post.slices)
+                            slice_index_lookup = next(
+                                (
+                                    i + 1
+                                    for i, s in enumerate(contract_post.slices)
+                                    if s.id == slice_id
+                                ),
+                                None,
+                            )
+                            # Union of ``task.files_affected`` across the
+                            # slice's tasks; rendered under
+                            # ``## This slice`` so reviewers see what
+                            # this slice actually touches without
+                            # opening the diff (#2745).
+                            slice_files_affected_list: list[str] = []
+                            seen_paths: set[str] = set()
+                            for t in slice_obj.tasks or []:
+                                for path in t.files_affected or []:
+                                    if path and path not in seen_paths:
+                                        seen_paths.add(path)
+                                        slice_files_affected_list.append(path)
                             slice_pr_data = {
                                 "slice_name": slice_obj.name or slice_id,
                                 "slice_tasks": [
-                                    {"id": t.id, "description": t.description}
+                                    {
+                                        "id": t.id,
+                                        "description": t.description,
+                                        "acceptance_criteria": t.acceptance_criteria,
+                                    }
                                     for t in (slice_obj.tasks or [])
                                 ],
+                                "slice_index": slice_index_lookup,
+                                "slice_count": slice_count,
+                                "slice_files_affected": slice_files_affected_list or None,
+                                # ``context_pr_number`` is populated by
+                                # ``_open_context_pr_for_pipeline`` after
+                                # the base/context PR opens (#2548). When
+                                # None — covers the #2744 regression where
+                                # the base PR is silently not opened —
+                                # ``create_slice_pr`` falls back to the
+                                # pre-#2745 inline-narrative body so the
+                                # slice PR stays reviewable as a
+                                # standalone diff against ``/work``.
+                                "context_pr_number": (
+                                    program_pr.context_pr_number if program_pr else None
+                                ),
                                 "program_title": (program_pr.title if program_pr else None),
                                 "program_description": (
                                     program_pr.description if program_pr else None
@@ -16048,6 +16092,10 @@ def _run_implement_phase_slices(
                             program_manual_steps=slice_pr_data["program_manual_steps"],
                             program_deferred_actions=slice_pr_data["program_deferred_actions"],
                             terminal_slice_id=slice_pr_data["terminal_slice_id"],
+                            slice_index=slice_pr_data["slice_index"],
+                            slice_count=slice_pr_data["slice_count"],
+                            slice_files_affected=slice_pr_data["slice_files_affected"],
+                            context_pr_number=slice_pr_data["context_pr_number"],
                         )
                     except Exception as pr_err:  # noqa: BLE001
                         logger.error(

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -1544,7 +1544,9 @@ class TestCreateSlicePR:
 
     def test_terminal_slice_truncates_long_title_to_70_chars(self, gateway_client):
         """Title-length cap (70 chars) is symmetric for the new
-        ``[<slug>][merge-gate] <program_title>`` shape."""
+        ``[<slug>][merge-gate] <program_title>`` shape. The slug + marker
+        prefix survives the truncation — only the subject is cut — so
+        reviewers can still tell it's the merge gate by title alone."""
         captured, ctx = self._capture(gateway_client)
         long_title = "A" * 90
         with ctx:
@@ -1562,6 +1564,10 @@ class TestCreateSlicePR:
             )
         assert len(captured["title"]) == 70
         assert captured["title"].endswith("...")
+        # Pin the new shape: slug + merge-gate marker must survive the
+        # 70-char truncation so reviewers can still tell it's the merge
+        # gate by title alone (#2746 review item 7).
+        assert captured["title"].startswith("[issue-42][merge-gate] ")
 
     def test_terminal_slice_renders_program_deferred_actions(self, gateway_client):
         """#2354: when the terminal slice receives ``program_deferred_actions``
@@ -1680,6 +1686,58 @@ class TestCreateSlicePR:
                 slice_tasks=[{"id": "task-1-1", "description": "do X"}],
                 head="egg/issue-42/slice-1",
                 base="egg/issue-42",
+                program_deferred_actions=[
+                    {"reviewer": "r1", "condition": "do X", "resolved_in_diff": ""},
+                ],
+            )
+
+    def test_non_terminal_slice_lean_branch_with_obligations_raises(self, gateway_client):
+        """#2746 review item 1: the lean non-terminal branch (program_title
+        set, base PR opened) must also reject mis-routed
+        ``program_deferred_actions``. The pre-fix code only asserted in
+        the no-program-title branch, so a non-terminal slice with a
+        program_title silently dropped obligations."""
+        captured, ctx = self._capture(gateway_client)
+        with ctx, pytest.raises(AssertionError, match="program_deferred_actions must be None"):
+            gateway_client.create_slice_pr(
+                pipeline_id="issue-42",
+                repo="owner/repo",
+                slice_id="slice-1",
+                slice_name="Pattern adoption",
+                slice_tasks=[{"id": "task-1-1", "description": "do X"}],
+                head="egg/issue-42/slice-1",
+                base="egg/issue-42/work",
+                program_title="Decompose oversize files",
+                terminal_slice_id="slice-3",
+                slice_index=1,
+                slice_count=3,
+                context_pr_number=99,  # lean branch
+                program_deferred_actions=[
+                    {"reviewer": "r1", "condition": "do X", "resolved_in_diff": ""},
+                ],
+            )
+
+    def test_non_terminal_slice_inline_fallback_branch_with_obligations_raises(
+        self, gateway_client
+    ):
+        """#2746 review item 1: the inline-fallback non-terminal branch
+        (program_title set, no base PR) must also reject mis-routed
+        ``program_deferred_actions`` — same reason as the lean branch."""
+        captured, ctx = self._capture(gateway_client)
+        with ctx, pytest.raises(AssertionError, match="program_deferred_actions must be None"):
+            gateway_client.create_slice_pr(
+                pipeline_id="issue-42",
+                repo="owner/repo",
+                slice_id="slice-1",
+                slice_name="Pattern adoption",
+                slice_tasks=[{"id": "task-1-1", "description": "do X"}],
+                head="egg/issue-42/slice-1",
+                base="egg/issue-42/work",
+                program_title="Decompose oversize files",
+                terminal_slice_id="slice-3",
+                slice_index=1,
+                slice_count=3,
+                context_pr_number=None,  # inline-fallback branch
                 program_deferred_actions=[
                     {"reviewer": "r1", "condition": "do X", "resolved_in_diff": ""},
                 ],

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -1342,7 +1342,7 @@ class TestCreatePR:
 
 
 class TestCreateSlicePR:
-    """Body / title composition for create_slice_pr (#2340)."""
+    """Body / title composition for create_slice_pr (#2340, #2538, #2745)."""
 
     def _capture(self, gateway_client):
         """Patch create_pr to capture (title, body) and return a dummy URL."""
@@ -1379,14 +1379,78 @@ class TestCreateSlicePR:
         assert "Program-level umbrella PR" not in captured["body"]
         assert "## This slice" not in captured["body"]
 
-    def test_non_terminal_slice_carries_program_narrative_with_slice_id_prefix(
+    def test_non_terminal_slice_with_base_pr_renders_lean_body(self, gateway_client):
+        """#2745: when the base/context PR (#2548) exists, non-terminal slice
+        bodies are lean — a 1-line program blurb + ``Base PR:`` link + the
+        per-slice ``## This slice`` scope. The duplicated program test plan
+        / manual steps that pre-#2745 every slice carried is gone."""
+        captured, ctx = self._capture(gateway_client)
+        with ctx:
+            gateway_client.create_slice_pr(
+                pipeline_id="issue-42",
+                repo="owner/repo",
+                slice_id="slice-1",
+                slice_name="Pattern adoption",
+                slice_tasks=[
+                    {
+                        "id": "task-1-1",
+                        "description": "Add the barrel re-export so callers route through it.",
+                        "acceptance_criteria": "Imports through the barrel succeed; mypy green.",
+                    },
+                ],
+                head="egg/issue-42/slice-1",
+                base="egg/issue-42/work",
+                program_title="Decompose oversize files; ratchet allowlist",
+                program_description=(
+                    "The lint added in #2250 caps Python files at 1500 lines. "
+                    "Multiple files cross that cap; this program decomposes them."
+                ),
+                program_test_plan="- Automated: make lint and make test-all green.",
+                program_manual_steps="Pre-merge (terminal slice only): verify seam tables.",
+                terminal_slice_id="slice-3",
+                slice_index=1,
+                slice_count=3,
+                slice_files_affected=["orchestrator/foo.py", "shared/bar.py"],
+                context_pr_number=99,
+            )
+        # Title: ``[<program-slug>][slice-N/M] <slice subject>``.
+        assert captured["title"] == "[issue-42][slice-1/3] Pattern adoption"
+        body = captured["body"]
+        # Program-wide rollups are GONE on lean non-terminal slices —
+        # they live on the base PR / terminal slice now.
+        assert "Program-level umbrella PR" not in body
+        assert "## Test Plan" not in body
+        assert "## Manual Steps" not in body
+        # First-sentence blurb is present; rest of the description is not.
+        assert "The lint added in #2250 caps Python files at 1500 lines." in body
+        assert "Multiple files cross that cap" not in body
+        # Base PR link is present and points to the context PR number.
+        assert "**Base PR:** #99" in body
+        # Per-slice scope: subject, files affected, full task + AC.
+        assert "## This slice" in body
+        assert "Pattern adoption" in body
+        assert "Files affected:" in body
+        assert "`orchestrator/foo.py`" in body
+        assert "`shared/bar.py`" in body
+        assert "- task-1-1: Add the barrel re-export so callers route through it." in body
+        assert "Acceptance criteria: Imports through the barrel succeed; mypy green." in body
+        # ``## Stack`` block names parent / base PR position.
+        assert "## Stack" in body
+        assert "- Base PR: #99" in body
+        assert "- Stacked on top of `egg/issue-42/work`" in body
+        assert "- Position: slice 1 of 3 in pipeline `issue-42`" in body
+        # Legacy footer string kept for tooling/scrapers.
+        assert "Slice slice-1 of pipeline issue-42" in body
+
+    def test_non_terminal_slice_without_base_pr_falls_back_to_inline_narrative(
         self, gateway_client
     ):
-        """#2538: every slice — including non-terminal ones — carries the
-        planner-authored narrative on its PR so reviewers see program
-        context on whichever slice they open first. Non-terminal slices
-        get a ``[<slice-id>] `` title prefix to disambiguate in the
-        GitHub PR list."""
+        """#2745 / #2744: UX backstop. When ``context_pr_number`` is None
+        (the base/context PR was not opened — #2744 regression), the slice
+        PR body falls back to the pre-#2745 inline-narrative shape so the
+        slice PR is still reviewable as a standalone diff against
+        ``/work``. NOTE: the stack is still structurally unmergeable in
+        this state; this is a body-rendering backstop, not a fix."""
         captured, ctx = self._capture(gateway_client)
         with ctx:
             gateway_client.create_slice_pr(
@@ -1396,46 +1460,46 @@ class TestCreateSlicePR:
                 slice_name="Pattern adoption",
                 slice_tasks=[{"id": "task-1-1", "description": "Add the barrel re-export"}],
                 head="egg/issue-42/slice-1",
-                base="egg/issue-42",
+                base="egg/issue-42/work",
                 program_title="Decompose oversize files; ratchet allowlist",
                 program_description="The lint added in #2250 caps Python files at 1500 lines.",
                 program_test_plan="- Automated: make lint and make test-all green.",
                 program_manual_steps="Pre-merge (terminal slice only): verify seam tables.",
                 terminal_slice_id="slice-3",
+                slice_index=1,
+                slice_count=3,
+                context_pr_number=None,
             )
-        assert captured["title"] == "[slice-1] Decompose oversize files; ratchet allowlist"
         body = captured["body"]
-        # No "umbrella" banner on non-terminals — that's the merge-gate marker
-        # and belongs only on the terminal slice.
-        assert "Program-level umbrella PR" not in body
-        # Program narrative is present.
-        assert "The lint added in #2250" in body
+        # Title still uses the new shape.
+        assert captured["title"] == "[issue-42][slice-1/3] Pattern adoption"
+        # Inline narrative is present because there's no base PR to defer to.
+        assert "The lint added in #2250 caps Python files at 1500 lines." in body
         assert "## Test Plan" in body
         assert "make lint" in body
         assert "## Manual Steps" in body
         assert "seam tables" in body
-        # Per-slice scope section appears after the program description and
-        # carries the slice name + task bullets.
+        # No Base PR pointer — there is no base PR in this state.
+        assert "**Base PR:**" not in body
+        assert "- Base PR:" not in body
+        # Per-slice scope is still rendered.
         assert "## This slice" in body
         assert "Pattern adoption" in body
-        assert "- task-1-1: Add the barrel re-export" in body
         # Section ordering: description → This slice → Test Plan → Manual Steps.
         assert body.index("The lint added in #2250") < body.index("## This slice")
         assert body.index("## This slice") < body.index("## Test Plan")
         assert body.index("## Test Plan") < body.index("## Manual Steps")
-        # Stack footer survives.
-        assert "Slice slice-1 of pipeline issue-42" in body
-        # Pointer line from the old non-terminal shape is gone — narrative is
-        # right here, no need to send reviewers elsewhere.
-        assert "program-level narrative" not in body
-        assert "carries the program-level" not in body
 
-    def test_terminal_slice_uses_program_title_and_planner_authored_body(self, gateway_client):
-        """When ``program_title`` is set and ``terminal_slice_id`` is None
-        (the terminal slice itself), the helper emits the planner-authored
-        title + description / per-slice / test plan / manual steps body,
-        prefixed with the umbrella banner so reviewers can tell the PR is
-        the program merge gate."""
+    def test_terminal_slice_keeps_umbrella_rollup_and_uses_merge_gate_marker(self, gateway_client):
+        """#2745: terminal slice keeps the umbrella treatment — program
+        description + ``## Test Plan`` + ``## Manual Steps`` + pre-merge
+        obligations — because the base/context PR (#2548) is a strategic-
+        direction surface (analysis + plan + BRC history), not a merge-the-
+        whole-stack rollup. Execution-time concerns live on the merge gate.
+
+        Title now uses the ``[<slug>][merge-gate] <program_title>`` shape so
+        the terminal PR is still distinguishable from the program-level
+        base PR by title alone (the original #2745 complaint)."""
         captured, ctx = self._capture(gateway_client)
         with ctx:
             gateway_client.create_slice_pr(
@@ -1450,9 +1514,13 @@ class TestCreateSlicePR:
                 program_description="The lint added in #2250 caps Python files at 1500 lines.",
                 program_test_plan="- Automated: make lint and make test-all green.",
                 program_manual_steps="Pre-merge (terminal slice only): verify seam tables.",
+                slice_index=3,
+                slice_count=3,
+                context_pr_number=99,
             )
-        # Terminal title is bare program_title (no slice-id prefix).
-        assert captured["title"] == "Decompose oversize files; ratchet allowlist"
+        assert captured["title"] == (
+            "[issue-42][merge-gate] Decompose oversize files; ratchet allowlist"
+        )
         body = captured["body"]
         assert "Program-level umbrella PR" in body
         assert "issue-42" in body
@@ -1461,18 +1529,22 @@ class TestCreateSlicePR:
         assert "## This slice" in body
         assert "Apply the ratchet" in body
         assert "- task-3-1: Bump the allowlist" in body
+        # Program test plan / manual steps still rendered on terminal —
+        # this is the merge gate; execution-time concerns live here.
         assert "## Test Plan" in body
         assert "make lint" in body
         assert "## Manual Steps" in body
         assert "seam tables" in body
-        # Slice-context footer survives so reviewers still see chain position.
+        # ``## Stack`` block names the merge-gate position.
+        assert "## Stack" in body
+        assert "- Base PR: #99" in body
+        assert "- Position: merge-gate (slice 3 of 3) in pipeline `issue-42`" in body
+        # Legacy footer string survives.
         assert "Slice slice-3 of pipeline issue-42" in body
-        # No "see <terminal-slice-id>'s PR" pointer on the terminal PR itself.
-        assert "program-level narrative" not in body
 
-    def test_terminal_slice_truncates_long_program_title_to_70_chars(self, gateway_client):
-        """Title-length cap is symmetric for planner-authored titles so the
-        existing PR-title guidance still holds."""
+    def test_terminal_slice_truncates_long_title_to_70_chars(self, gateway_client):
+        """Title-length cap (70 chars) is symmetric for the new
+        ``[<slug>][merge-gate] <program_title>`` shape."""
         captured, ctx = self._capture(gateway_client)
         long_title = "A" * 90
         with ctx:
@@ -1485,6 +1557,8 @@ class TestCreateSlicePR:
                 head="egg/issue-42/slice-3",
                 base="egg/issue-42/slice-2",
                 program_title=long_title,
+                slice_index=3,
+                slice_count=3,
             )
         assert len(captured["title"]) == 70
         assert captured["title"].endswith("...")
@@ -1523,6 +1597,8 @@ class TestCreateSlicePR:
                         "resolved_in_diff": "2c319626a",
                     },
                 ],
+                slice_index=3,
+                slice_count=3,
             )
         body = captured["body"]
         assert "## ⚠️ Pre-merge Obligations" in body
@@ -1635,6 +1711,65 @@ class TestCreateSlicePR:
                     {"reviewer": "r1", "condition": "do X", "resolved_in_diff": ""},
                 ],
             )
+
+    def test_task_descriptions_not_truncated_and_acceptance_criteria_rendered(self, gateway_client):
+        """#2745: drop the 300-char task description truncation introduced
+        in pre-#2745 ``create_slice_pr`` (cuts task descriptions
+        mid-sentence with ``...``). Slice PR bodies surface full task
+        descriptions and per-task acceptance criteria when present."""
+        long_desc = "x" * 500
+        long_ac = "y" * 400
+        captured, ctx = self._capture(gateway_client)
+        with ctx:
+            gateway_client.create_slice_pr(
+                pipeline_id="issue-42",
+                repo="owner/repo",
+                slice_id="slice-1",
+                slice_name="Pattern adoption",
+                slice_tasks=[
+                    {
+                        "id": "task-1-1",
+                        "description": long_desc,
+                        "acceptance_criteria": long_ac,
+                    },
+                ],
+                head="egg/issue-42/slice-1",
+                base="egg/issue-42/work",
+                program_title="Decompose oversize files",
+                program_description="A long-form description.",
+                terminal_slice_id="slice-3",
+                slice_index=1,
+                slice_count=3,
+                context_pr_number=99,
+            )
+        body = captured["body"]
+        assert long_desc in body  # full description, no ``...`` truncation
+        assert long_ac in body  # full acceptance criteria
+
+    def test_pipeline_hash_id_truncates_slug_in_title(self, gateway_client):
+        """Pipelines opened via ``submit_task`` without an issue number get
+        identifiers like ``pipeline-f4c7d780``. The program slug truncates
+        long identifiers so the title stays scannable."""
+        captured, ctx = self._capture(gateway_client)
+        with ctx:
+            gateway_client.create_slice_pr(
+                pipeline_id="pipeline-f4c7d780abc123",
+                repo="owner/repo",
+                slice_id="slice-2",
+                slice_name="Bring up the orchestrator wire",
+                slice_tasks=None,
+                head="egg/pipeline-f4c7d780abc123/slice-2",
+                base="egg/pipeline-f4c7d780abc123/slice-1",
+                program_title="Actionable Plan Framework MVP",
+                terminal_slice_id="slice-15",
+                slice_index=2,
+                slice_count=15,
+                context_pr_number=5,
+            )
+        # Slug should be truncated to the configured max (18 chars).
+        assert captured["title"].startswith("[pipeline-f4c7d780")
+        assert "[slice-2/15]" in captured["title"]
+        assert "Bring up the orchestrator wire" in captured["title"]
 
 
 class TestSelfIpResolution:

--- a/orchestrator/tests/test_slice_run_loop_integration.py
+++ b/orchestrator/tests/test_slice_run_loop_integration.py
@@ -778,11 +778,33 @@ class TestRunImplementPhaseSlices:
             assert "seam tables" in kwargs["program_manual_steps"]
 
         # The terminal slice gets terminal_slice_id=None (it IS the
-        # merge gate); non-terminals get the terminal id so the
-        # gateway prefixes their title with [<slice-id>].
+        # merge gate); non-terminals get the terminal id so the gateway
+        # selects the ``[<program-slug>][slice-N/M] <subject>`` shape
+        # for non-terminals and ``[<program-slug>][merge-gate]
+        # <program_title>`` for the terminal (#2745).
         assert pr_calls_by_slice["slice-3"]["terminal_slice_id"] is None
         for non_terminal_id in ("slice-1", "slice-2"):
             assert pr_calls_by_slice[non_terminal_id]["terminal_slice_id"] == "slice-3"
+
+        # #2745 wiring: ``slice_index`` / ``slice_count`` /
+        # ``slice_files_affected`` / ``context_pr_number`` are threaded
+        # from ``_run_one_slice_inner`` into ``create_slice_pr`` so the
+        # title and body can render the new shape. Pin them here so a
+        # regression in the wiring (e.g. dropping a kwarg) fails the
+        # integration test, not just the unit test (#2746 review item 3).
+        assert pr_calls_by_slice["slice-1"]["slice_index"] == 1
+        assert pr_calls_by_slice["slice-2"]["slice_index"] == 2
+        assert pr_calls_by_slice["slice-3"]["slice_index"] == 3
+        for slice_id in ("slice-1", "slice-2", "slice-3"):
+            kwargs = pr_calls_by_slice[slice_id]
+            assert kwargs["slice_count"] == 3
+            # ``_make_task`` builds tasks with ``files_affected=[]``, so
+            # the derived list is empty and the wiring sends ``None``.
+            assert kwargs["slice_files_affected"] is None
+            # No context PR is opened in this fixture, so the slice PRs
+            # see ``context_pr_number=None`` (the #2744 regression
+            # backstop path inside ``create_slice_pr``).
+            assert kwargs["context_pr_number"] is None
 
     def test_terminal_slice_pr_carries_program_deferred_actions(
         self,


### PR DESCRIPTION
## Summary

- Reshape `create_slice_pr` titles to `[<program-slug>][slice-N/M] <slice subject>` (non-terminal) and `[<program-slug>][merge-gate] <program_title>` (terminal) so reviewers can tell slice PRs apart at a glance, and the terminal stops being indistinguishable from a program-level PR by title alone.
- Drop the duplicated program-level rollup (`pr.description`, `## Test Plan`, `## Manual Steps`) from non-terminal slice bodies. Replace with a 1-line program blurb + `**Base PR:** #<context_pr_number>` link + `## This slice` (subject, files affected, full task descriptions + acceptance criteria) + `## Stack` (parent / base PR pointers).
- Terminal slice keeps the umbrella body unchanged (merge-gate banner + program description + obligations + program test plan / manual steps) — the base/context PR (#2548) is a *strategic-direction* surface (analysis + plan + BRC history), not a merge-the-whole-stack rollup, so execution-time concerns stay on the merge gate.
- Drop the 300-char task description truncation; surface full task descriptions and per-task acceptance criteria.
- UX backstop for the #2744 regression: when `context_pr_number` is `None` (base PR silently not opened), non-terminal bodies fall back to the pre-#2745 inline-narrative shape. The stack is still structurally unmergeable in that state — this is body-rendering, not a structural fix.

Fixes #2745.

## Test plan

- [x] `pytest orchestrator/tests/test_gateway_client.py::TestCreateSlicePR` — 12 tests pass (existing 8 updated for new shape + 4 new: lean non-terminal body, fallback-when-no-base-PR, no-truncation/AC rendering, slug truncation).
- [ ] `make test` — broader changeset-aware suite (skipped locally per request).
- [ ] CI green on the PR.
- [ ] Manual: next slice-DAG pipeline run — verify slice PR titles disambiguate in the GitHub PR list, non-terminal bodies link back to the base PR, and the terminal still renders the umbrella + obligations.

## Deliberately out of scope (follow-ups)

- Per-slice planner-emitted PR title / test plan / manual steps (would need a `Slice.pr` or `Slice.pr_subject` model field; MVP uses `slice.name`).
- Child-PR backlinks on parent slice PRs (would need a post-hoc update sweep after children open).
- Parent-PR-number lookup in `## Stack` (requires persisting slice PR numbers on the contract; currently only the base PR # is rendered).