### PR TITLE
Fix #2744: slice-loop entry context-PR safety net

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -10989,7 +10989,7 @@ def _maybe_open_base_pr_for_plan_to_implement(
 ) -> None:
     """Open the doc-only base/context PR for the plan→implement transition (#2548, #2593).
 
-    Single call site for every plan→implement code path:
+    Shared wrapper for every plan→implement code path:
 
     * the inline auto-advance in :func:`_run_pipeline` (the path #2548
       originally wired up);

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -11005,7 +11005,17 @@ def _maybe_open_base_pr_for_plan_to_implement(
       ``routes/phases.py:379``) bypass the backstop and so must call
       the wrapper directly; the inner short-circuit on
       ``context_pr_number`` makes any path that DOES re-enter the
-      backstop a no-op).
+      backstop a no-op);
+    * the slice-loop entry in :func:`_run_implement_phase_slices`
+      (#2744) — a defensive safety net for pipeline shapes where the
+      four earlier paths silently missed.  Slice-1 base resolution
+      reads ``contract.pr.context_branch`` and falls back to
+      ``pipeline_branch`` when it is empty, leaving the whole slice
+      stack stranded on ``/work`` with no path to ``main``.  Calling
+      the wrapper here, before any slice provisions, converts that
+      failure mode into "context PR opens at the last second."  The
+      inner short-circuit makes the call cheap when an earlier path
+      already opened the PR.
 
     CUSTOM-mode pipelines run a single phase and terminate (#1762) —
     they never advance to implement, so opening a context PR for them
@@ -15451,6 +15461,35 @@ def _run_implement_phase_slices(
             error=str(exc),
         )
         return 1, f"slice scheduler validation failed: {exc}"
+
+    # #2744 — defensive context-PR safety net at slice-loop entry.
+    # The four plan→implement transition paths (``_run_pipeline``
+    # auto-advance, ``advance_phase`` REST, ``start_pipeline`` HITL
+    # recovery, IMPLEMENT entry backstop) should each have opened the
+    # context PR before we reach the slice loop.  But #2593 / #2744
+    # show those paths can silently miss on specific pipeline shapes
+    # (most recently a non-issue-keyed ``pipeline-<hex>`` pipeline),
+    # and the only failure signal is slice-1 stacking on
+    # ``pipeline_branch`` instead of the context branch — exactly the
+    # stranded-stack symptom this hook exists to prevent.
+    #
+    # The wrapper is idempotent: its inner
+    # ``contract.pr.context_pr_number`` fast-path makes a fifth call
+    # cheap (one contract read) when one of the earlier paths already
+    # ran.  Failures here are logged and swallowed by the wrapper, so
+    # this never strands the slice loop.  Adding the safety net here —
+    # before any slice provisions, so slice-1's
+    # ``_resolve_slice_1_context_branch_from_contract`` lookup at
+    # ``_run_one_slice_inner`` finds the populated context_branch —
+    # converts "every slice PR stranded on /work" into "context PR
+    # opens at the last second."
+    _maybe_open_base_pr_for_plan_to_implement(
+        pipeline,
+        spawner,
+        worktree_repo_path,
+        gateway_mode=gateway_mode,  # type: ignore[arg-type]
+        source="slice_loop_entry",
+    )
 
     def _contract_loader() -> Any:
         try:

--- a/orchestrator/tests/test_context_pr_transition_paths.py
+++ b/orchestrator/tests/test_context_pr_transition_paths.py
@@ -867,16 +867,16 @@ class TestCallSiteWiring:
 
     def test_pipelines_py_has_expected_call_sites(self):
         """``pipelines.py`` calls the helper from auto-advance,
-        implement-entry backstop, and HITL resume — three call sites
-        with three distinct, recognised source values.  The wrapper
-        definition itself is an ``ast.FunctionDef`` and is excluded
-        by the AST filter."""
+        implement-entry backstop, HITL resume, and the slice-loop
+        entry safety net (#2744) — four call sites with four distinct,
+        recognised source values.  The wrapper definition itself is an
+        ``ast.FunctionDef`` and is excluded by the AST filter."""
         pl_path = _orchestrator_path / "routes" / "pipelines.py"
         sources = _collect_helper_call_sources(pl_path)
-        assert len(sources) == 3, (
-            f"expected 3 call sites in pipelines.py (auto-advance, "
-            f"implement-entry backstop, HITL resume), got {len(sources)} "
-            f"with sources {sources!r}"
+        assert len(sources) == 4, (
+            f"expected 4 call sites in pipelines.py (auto-advance, "
+            f"implement-entry backstop, HITL resume, slice-loop entry), "
+            f"got {len(sources)} with sources {sources!r}"
         )
         # No call site should pass a non-literal ``source`` — that
         # would defeat the per-path log tagging.
@@ -887,6 +887,7 @@ class TestCallSiteWiring:
             "run_pipeline_autoadvance",
             "implement_entry_backstop",
             "hitl_resume",
+            "slice_loop_entry",
         }, f"unexpected source values in pipelines.py: {sources!r}"
 
     def test_phases_py_has_expected_call_site(self):

--- a/orchestrator/tests/test_slice_1_context_branch_base_resolution.py
+++ b/orchestrator/tests/test_slice_1_context_branch_base_resolution.py
@@ -624,9 +624,13 @@ class TestSliceLoopEntryContextPRSafetyNet:
         so the test pins the call itself rather than its effect."""
         pipeline = _make_pipeline()
         slice_obj = _make_slice("slice-1", tasks=[_make_task()])
+        # ``context_branch`` is intentionally None: the wrapper is
+        # patched, so its value is never read.  Setting it to None
+        # makes the test honest about what it pins (the call wiring,
+        # not the wrapper's effect on contract state).
         contract = _make_contract(
             slices=[slice_obj],
-            context_branch="egg/issue-2548/context",
+            context_branch=None,
         )
 
         with (

--- a/orchestrator/tests/test_slice_1_context_branch_base_resolution.py
+++ b/orchestrator/tests/test_slice_1_context_branch_base_resolution.py
@@ -595,3 +595,125 @@ class TestPerSliceBrcCommitHookInvocation:
         slice_to_branch = dict(zip(slice_ids, integration_branches, strict=True))
         assert slice_to_branch["slice-1"] == "egg/issue-2548/slice-1"
         assert slice_to_branch["slice-2"] == "egg/issue-2548/slice-2"
+
+
+# ---------------------------------------------------------------------------
+# Slice-loop entry context-PR safety net (#2744)
+# ---------------------------------------------------------------------------
+
+
+class TestSliceLoopEntryContextPRSafetyNet:
+    """#2744 — slice-loop entry calls ``_maybe_open_base_pr_for_plan_to_implement``
+    as a fifth safety net before any slice provisions.
+
+    The four upstream call sites (``_run_pipeline`` auto-advance,
+    ``advance_phase`` REST, HITL recovery, IMPLEMENT entry backstop)
+    should each open the context PR before the slice loop runs.  But
+    #2593 / #2744 show those paths can silently miss on specific
+    pipeline shapes (non-issue-keyed ``pipeline-<hex>`` pipelines),
+    leaving slice-1 to stack on ``pipeline_branch`` instead of the
+    context branch.  The safety net at the slice-loop entry converts
+    that failure mode into "context PR opens at the last second."
+    """
+
+    def test_wrapper_invoked_at_slice_loop_entry(self) -> None:
+        """The wrapper is called with ``source='slice_loop_entry'`` when
+        the slice loop starts, regardless of whether the contract
+        already has ``context_pr_number`` populated.  Idempotency lives
+        inside the wrapper (the inner ``context_pr_number`` short-circuit),
+        so the test pins the call itself rather than its effect."""
+        pipeline = _make_pipeline()
+        slice_obj = _make_slice("slice-1", tasks=[_make_task()])
+        contract = _make_contract(
+            slices=[slice_obj],
+            context_branch="egg/issue-2548/context",
+        )
+
+        with (
+            patch("egg_contracts.loader.load_contract", return_value=contract),
+            patch("egg_contracts.loader.save_contract"),
+            patch("routes.pipelines._start_stacked_pr_reconciler") as mock_start_recon,
+            patch("routes.pipelines._run_concurrent_phase", return_value=(0, "ok")),
+            patch("orchestrator.peer_consensus.remove_peer_consensus_tracker"),
+            patch("routes.pipelines._commit_slice_brc_history_to_integration_branch"),
+            patch("routes.pipelines._maybe_open_base_pr_for_plan_to_implement") as mock_wrapper,
+        ):
+            mock_start_recon.return_value = (MagicMock(), threading.Event())
+            spawner = _make_spawner()
+            _run_implement_phase_slices(
+                pipeline_id=pipeline.id,
+                pipeline=pipeline,
+                spawner=spawner,
+                repo_volumes={},
+                gateway_mode="public",
+                repos=["owner/repo"],
+                sandbox_env={},
+                store=MagicMock(),
+                certs_volume=None,
+                worktree_repo_path=Path("/tmp/x"),
+            )
+
+        # Exactly one call with source='slice_loop_entry' — not zero
+        # (regression of #2744) and not many (slice loop must invoke
+        # the wrapper at entry, not per-slice).
+        slice_loop_calls = [
+            c for c in mock_wrapper.call_args_list if c.kwargs.get("source") == "slice_loop_entry"
+        ]
+        assert len(slice_loop_calls) == 1, (
+            f"expected exactly one wrapper call with source='slice_loop_entry'; "
+            f"got {mock_wrapper.call_args_list!r}"
+        )
+
+    def test_wrapper_invoked_for_non_issue_keyed_pipeline(self) -> None:
+        """Pin the #2744 repro shape directly: a pipeline whose id is
+        ``pipeline-<hex>`` (not ``issue-<N>``) — submitted via
+        ``submit_task`` without an issue number — still has the
+        slice-loop entry safety net fire.  This is the regression case
+        the four upstream paths silently missed on."""
+        pipeline_id = "pipeline-f4c7d780"
+        pipeline = _make_pipeline(pipeline_id=pipeline_id, issue_number=None)
+        slice_obj = _make_slice("slice-1", tasks=[_make_task()])
+        contract = _make_contract(
+            pipeline_id=pipeline_id,
+            issue_number=2548,  # irrelevant — contract is keyed by pipeline_id
+            slices=[slice_obj],
+            context_branch=f"egg/{pipeline_id}/context",
+        )
+
+        with (
+            patch("egg_contracts.loader.load_contract", return_value=contract),
+            patch("egg_contracts.loader.save_contract"),
+            patch("routes.pipelines._start_stacked_pr_reconciler") as mock_start_recon,
+            patch("routes.pipelines._run_concurrent_phase", return_value=(0, "ok")),
+            patch("orchestrator.peer_consensus.remove_peer_consensus_tracker"),
+            patch("routes.pipelines._commit_slice_brc_history_to_integration_branch"),
+            patch("routes.pipelines._maybe_open_base_pr_for_plan_to_implement") as mock_wrapper,
+        ):
+            mock_start_recon.return_value = (MagicMock(), threading.Event())
+            spawner = _make_spawner()
+            _run_implement_phase_slices(
+                pipeline_id=pipeline.id,
+                pipeline=pipeline,
+                spawner=spawner,
+                repo_volumes={},
+                gateway_mode="public",
+                repos=["owner/repo"],
+                sandbox_env={},
+                store=MagicMock(),
+                certs_volume=None,
+                worktree_repo_path=Path("/tmp/x"),
+            )
+
+        slice_loop_calls = [
+            c for c in mock_wrapper.call_args_list if c.kwargs.get("source") == "slice_loop_entry"
+        ]
+        assert len(slice_loop_calls) == 1, (
+            f"expected slice-loop entry wrapper call for non-issue-keyed pipeline "
+            f"{pipeline_id!r}; got {mock_wrapper.call_args_list!r}"
+        )
+        # The pipeline object handed to the wrapper carries the
+        # non-issue-keyed id — confirms we're not accidentally
+        # short-circuiting on issue_number elsewhere.
+        passed_pipeline = slice_loop_calls[0].args[0]
+        assert passed_pipeline.id == pipeline_id
+        assert passed_pipeline.issue_number is None


### PR DESCRIPTION
## Summary

- Adds a fifth idempotent call to `_maybe_open_base_pr_for_plan_to_implement` at `_run_implement_phase_slices` entry, before any slice provisions.
- The four existing transition paths (auto-advance, `advance_phase` REST, HITL recovery, IMPLEMENT entry backstop) silently missed on the #2744 repro pipeline (non-issue-keyed `pipeline-<hex>`), stranding every slice PR on `/work` with no path to `main`. Without orchestrator logs the specific missed path is undiagnosable; this safety net converts the symptom into "context PR opens at the last second" regardless of which earlier path failed.
- The wrapper's inner `contract.pr.context_pr_number` short-circuit makes a fifth call cheap (one contract read) when an earlier path already opened the PR; failures are logged-and-swallowed by the wrapper so this can't strand the slice loop.

## Why here

The slice loop's existing slice-1 base resolver (`_run_one_slice_inner`) reads `contract.pr.context_branch` and falls back to `pipeline_branch` when it is empty — exactly the stranded-stack failure mode this hook exists to prevent. Firing the wrapper at slice-loop entry, before any slice provisions, gives slice-1's lookup a populated `context_branch` to find.

## Diagnostic note

Root cause for #2744 (which of the four upstream paths missed and why) is still unknown — orchestrator pod logs are not retained long enough to grep. The `context_pr.skipped` / `context_pr.failed` bus events from #2611 will disambiguate on the next occurrence; until then the safety net prevents the user-visible bug.

## Test plan

- [x] `pytest orchestrator/tests/test_context_pr_transition_paths.py orchestrator/tests/test_slice_1_context_branch_base_resolution.py` — 28 passed
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] AST-based call-site count assertion in `TestCallSiteWiring` updated from 3 to 4 and includes `slice_loop_entry`
- [x] New `TestSliceLoopEntryContextPRSafetyNet` covers (a) wrapper fires once at slice-loop entry and (b) wrapper fires for the #2744 repro shape (non-issue-keyed `pipeline-<hex>` pipeline)
- [ ] Operator validation on the next multi-slice pipeline run: confirm `context_pr.skipped` / `context_pr.failed` does NOT fire from `source=slice_loop_entry` on a healthy run (the inner short-circuit should win)

Closes #2744.