### PR TITLE
Fix #2743: yaml-tasks fence truncation + depends_on alias

### DIFF
--- a/.github/scripts/checks/plan_yaml_check.py
+++ b/.github/scripts/checks/plan_yaml_check.py
@@ -81,22 +81,32 @@ class PlanYamlCheck(CheckRunner):
         if not isinstance(parsed, dict):
             errors.append("yaml-tasks must be a dictionary")
         else:
-            # Check for required fields
-            if "phases" not in parsed:
-                errors.append("Missing 'phases' field")
-            elif not isinstance(parsed["phases"], list):
-                errors.append("'phases' must be a list")
+            # Canonical key is ``slices`` (#2137); ``phases`` is the
+            # legacy alias still accepted by every other parser. Accept
+            # either; ``slices`` wins when both are present so the check
+            # mirrors ``parse_phases_from_yaml``.
+            if "slices" in parsed:
+                top_key = "slices"
+            elif "phases" in parsed:
+                top_key = "phases"
             else:
-                for i, phase in enumerate(parsed["phases"]):
-                    if not isinstance(phase, dict):
-                        errors.append(f"Phase {i + 1} must be a dictionary")
-                        continue
-                    if "id" not in phase:
-                        errors.append(f"Phase {i + 1} missing 'id' field")
-                    if "tasks" not in phase:
-                        errors.append(f"Phase {i + 1} missing 'tasks' field")
-                    elif not isinstance(phase.get("tasks"), list):
-                        errors.append(f"Phase {i + 1} 'tasks' must be a list")
+                top_key = None
+                errors.append("Missing 'slices' (or legacy 'phases') field")
+            if top_key is not None:
+                top_value = parsed[top_key]
+                if not isinstance(top_value, list):
+                    errors.append(f"'{top_key}' must be a list")
+                else:
+                    for i, slice_entry in enumerate(top_value):
+                        if not isinstance(slice_entry, dict):
+                            errors.append(f"Slice {i + 1} must be a dictionary")
+                            continue
+                        if "id" not in slice_entry:
+                            errors.append(f"Slice {i + 1} missing 'id' field")
+                        if "tasks" not in slice_entry:
+                            errors.append(f"Slice {i + 1} missing 'tasks' field")
+                        elif not isinstance(slice_entry.get("tasks"), list):
+                            errors.append(f"Slice {i + 1} 'tasks' must be a list")
 
         if errors:
             return self.create_result(
@@ -106,11 +116,12 @@ class PlanYamlCheck(CheckRunner):
                 fixable=False,
             )
 
+        slices_count = len(parsed.get("slices", parsed.get("phases", [])))
         return self.create_result(
             status=CheckStatus.PASS,
             message="Plan yaml-tasks block is valid",
             details={
-                "phases_count": len(parsed.get("phases", [])),
+                "slices_count": slices_count,
                 "has_pr_metadata": "pr" in parsed,
             },
         )

--- a/.github/scripts/checks/plan_yaml_check.py
+++ b/.github/scripts/checks/plan_yaml_check.py
@@ -46,8 +46,13 @@ class PlanYamlCheck(CheckRunner):
 
         # Extract yaml-tasks block
         # Pattern: ```yaml followed by # yaml-tasks comment, then content, then ```
-        yaml_pattern = r"```yaml\s*\n\s*#\s*yaml-tasks\s*\n(.*?)```"
-        match = re.search(yaml_pattern, content, re.DOTALL)
+        # The closing ``` must start at a line boundary (#2743) — otherwise
+        # a nested fence inside a YAML block scalar truncates the capture.
+        yaml_pattern = (
+            r"```yaml\s*\n\s*#\s*yaml-tasks\s*\n"
+            r"((?:.*\n)*?)[ ]{0,3}```\s*(?:\n|$)"
+        )
+        match = re.search(yaml_pattern, content)
 
         if not match:
             return self.create_result(

--- a/plugins/refine-plan/skills/refine-plan/bin/emit-contract
+++ b/plugins/refine-plan/skills/refine-plan/bin/emit-contract
@@ -103,7 +103,11 @@ def _slice_number_from_id(raw_id: object, fallback: int) -> int:
             break
     try:
         return int(s)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError):  # fmt: skip
+        # Keep parens explicit: this script is portable by design (see module
+        # docstring) and may run under Python <3.14, where the unparenthesized
+        # form is a SyntaxError. The file has no .py extension today so ruff
+        # format skips it, but a future rename would silently strip the parens.
         return fallback
 
 

--- a/plugins/refine-plan/skills/refine-plan/bin/emit-contract
+++ b/plugins/refine-plan/skills/refine-plan/bin/emit-contract
@@ -103,7 +103,7 @@ def _slice_number_from_id(raw_id: object, fallback: int) -> int:
             break
     try:
         return int(s)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return fallback
 
 

--- a/plugins/refine-plan/skills/refine-plan/bin/emit-contract
+++ b/plugins/refine-plan/skills/refine-plan/bin/emit-contract
@@ -51,9 +51,11 @@ except ImportError:
     print("error: PyYAML not installed (try: python3 -m pip install pyyaml)", file=sys.stderr)
     sys.exit(2)
 
+# Closing ``` must start at a line boundary — see issue #2743. A nested
+# code fence inside a YAML block scalar would otherwise terminate the
+# non-greedy capture early and emit-contract would silently drop slices.
 FENCE_RE = re.compile(
-    r"```(?:yaml|yml)\s*\n\s*#\s*yaml-tasks\s*\n(.*?)```",
-    re.DOTALL,
+    r"```(?:yaml|yml)\s*\n\s*#\s*yaml-tasks\s*\n((?:.*\n)*?)[ ]{0,3}```\s*(?:\n|$)",
 )
 TASK_ID_RE = re.compile(r"^TASK-(\d+)-(\d+)$", re.IGNORECASE)
 VALID_PHASES = {"refine", "plan", "implement", "pr"}
@@ -101,7 +103,7 @@ def _slice_number_from_id(raw_id: object, fallback: int) -> int:
             break
     try:
         return int(s)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return fallback
 
 
@@ -140,9 +142,25 @@ def _emit_task(t: dict, slice_number: int) -> dict | None:
 
 def _emit_slice(sl: dict, slice_number: int) -> dict:
     """Build the Slice dict matching shared/egg_contracts/models.py::Slice."""
-    raw_deps = sl.get("dependencies", [])
-    if isinstance(raw_deps, str):
+    # #2743 — accept ``depends_on`` as an alias for ``dependencies`` and
+    # handle integer / scalar values. Pipeline-8b81ed32 declared
+    # ``depends_on: <int>`` on every slice and the emitted contract came
+    # back with empty ``dependencies`` because this emitter only read
+    # ``dependencies`` and never coerced a bare int.
+    if "dependencies" in sl:
+        raw_deps = sl["dependencies"]
+    else:
+        raw_deps = sl.get("depends_on", [])
+    if isinstance(raw_deps, bool):
+        # ``bool`` is a subclass of ``int`` — reject explicitly to avoid
+        # silently converting ``True`` to ``slice-1``.
+        raw_deps = []
+    elif isinstance(raw_deps, int):
+        raw_deps = [raw_deps]
+    elif isinstance(raw_deps, str):
         raw_deps = [d.strip() for d in raw_deps.split(",") if d.strip()]
+    elif not isinstance(raw_deps, list):
+        raw_deps = []
     deps: list[str] = []
     for d in raw_deps:
         norm = _normalise_dep(d)
@@ -201,10 +219,7 @@ def _emit_pr(pr: dict | None) -> dict | None:
 
 
 def main(argv: list[str]) -> int:
-    usage = (
-        f"usage: {argv[0]} <plan.md> <contract.json> <pipeline_id> "
-        "[--current-phase <phase>]"
-    )
+    usage = f"usage: {argv[0]} <plan.md> <contract.json> <pipeline_id> [--current-phase <phase>]"
     if len(argv) not in (4, 6):
         print(usage, file=sys.stderr)
         return 2
@@ -218,8 +233,7 @@ def main(argv: list[str]) -> int:
         current_phase = argv[5]
         if current_phase not in VALID_PHASES:
             print(
-                f"invalid --current-phase {current_phase!r}; "
-                f"must be one of {sorted(VALID_PHASES)}",
+                f"invalid --current-phase {current_phase!r}; must be one of {sorted(VALID_PHASES)}",
                 file=sys.stderr,
             )
             return 2

--- a/plugins/refine-plan/skills/refine-plan/bin/validate-yaml-tasks
+++ b/plugins/refine-plan/skills/refine-plan/bin/validate-yaml-tasks
@@ -150,16 +150,33 @@ def validate(plan_path: str) -> tuple[int, list[str], list[str]]:
             if canonical in seen_slice_ids:
                 errors.append(f"duplicate slice id {slice_id!r} (canonical {canonical!r})")
             seen_slice_ids.add(canonical)
-        # #2743 — also walk ``depends_on`` so the planner gets a NACK if
-        # its non-canonical alias contains malformed entries. The contract
-        # emitter accepts ``depends_on`` as an alias for ``dependencies``.
-        if "depends_on" in sl and "dependencies" not in sl:
+        # #2743 — accept ``depends_on`` as a non-canonical alias for
+        # ``dependencies``. When both keys are present the canonical
+        # ``dependencies`` wins and ``depends_on`` is dropped (mirrors
+        # the emitter and ``parse_phases_from_yaml`` conflict policy);
+        # validating both would NACK on entries the emitter ignores.
+        if "depends_on" in sl and "dependencies" in sl:
+            warnings.append(
+                f"slice {slice_id}: declares both 'dependencies' and "
+                "'depends_on' — preferring 'dependencies' (canonical key "
+                "per yaml-tasks.schema.json). Remove 'depends_on' to "
+                "silence this warning."
+            )
+            dep_fields: tuple[str, ...] = ("dependencies",)
+        elif "depends_on" in sl:
             warnings.append(
                 f"slice {slice_id}: 'depends_on' is a non-canonical alias "
                 "for 'dependencies' (per yaml-tasks.schema.json). Accepted "
                 "for now, but please rename."
             )
-        for field in ("dependencies", "depends_on", "serialized_chain_order"):
+            dep_fields = ("depends_on",)
+        else:
+            dep_fields = ("dependencies",)
+        # Dependency fields accept int / str / list (the emitter and
+        # canonical parser both normalise a bare int to ``slice-<N>``);
+        # ``serialized_chain_order`` only accepts str / list to match
+        # the parser, which warns on any other type.
+        for field in dep_fields:
             if field not in sl:
                 continue
             raw = sl[field]
@@ -179,6 +196,17 @@ def validate(plan_path: str) -> tuple[int, list[str], list[str]]:
                 continue
             for entry in raw:
                 dep_refs.append((slice_id, field, entry))
+        if "serialized_chain_order" in sl:
+            raw = sl["serialized_chain_order"]
+            if isinstance(raw, str):
+                raw = [d.strip() for d in raw.split(",") if d.strip()]
+            elif not isinstance(raw, list):
+                errors.append(
+                    f"slice {slice_id}: 'serialized_chain_order' must be a list or comma string"
+                )
+                raw = []
+            for entry in raw:
+                dep_refs.append((slice_id, "serialized_chain_order", entry))
         for t in sl.get("tasks") or []:
             tid = str(t.get("id", "")) if isinstance(t, dict) else ""
             if not TASK_ID_RE.match(tid):

--- a/plugins/refine-plan/skills/refine-plan/bin/validate-yaml-tasks
+++ b/plugins/refine-plan/skills/refine-plan/bin/validate-yaml-tasks
@@ -26,9 +26,11 @@ except ImportError:
     print("FAIL: PyYAML not installed (try: python3 -m pip install pyyaml)", file=sys.stderr)
     sys.exit(2)
 
+# Closing ``` must start at a line boundary — see issue #2743. A nested
+# code fence inside a YAML block scalar would otherwise terminate the
+# non-greedy capture early and the validator would pass a truncated plan.
 FENCE_RE = re.compile(
-    r"```(?:yaml|yml)\s*\n\s*#\s*yaml-tasks\s*\n(.*?)```",
-    re.DOTALL,
+    r"```(?:yaml|yml)\s*\n\s*#\s*yaml-tasks\s*\n((?:.*\n)*?)[ ]{0,3}```\s*(?:\n|$)",
 )
 TASK_ID_RE = re.compile(r"^TASK-\d+-\d+$", re.IGNORECASE)
 SLICE_NUMBER_RE = re.compile(r"^(?:slice-|phase-)?(\d+)$", re.IGNORECASE)
@@ -80,6 +82,8 @@ def _normalise_dep(raw: object) -> str | None:
     if m:
         return f"slice-{m.group(1)}"
     return None
+
+
 VALID_ROLES = {"coder", "tester", "documenter"}
 # Mirrors .egg/schemas/yaml-tasks.schema.json: only `pr.title` is required;
 # description/test_plan/manual_steps are optional. shared/egg_contracts/
@@ -144,17 +148,33 @@ def validate(plan_path: str) -> tuple[int, list[str], list[str]]:
             )
         else:
             if canonical in seen_slice_ids:
-                errors.append(
-                    f"duplicate slice id {slice_id!r} (canonical {canonical!r})"
-                )
+                errors.append(f"duplicate slice id {slice_id!r} (canonical {canonical!r})")
             seen_slice_ids.add(canonical)
-        for field in ("dependencies", "serialized_chain_order"):
-            raw = sl.get(field, [])
-            if isinstance(raw, str):
+        # #2743 — also walk ``depends_on`` so the planner gets a NACK if
+        # its non-canonical alias contains malformed entries. The contract
+        # emitter accepts ``depends_on`` as an alias for ``dependencies``.
+        if "depends_on" in sl and "dependencies" not in sl:
+            warnings.append(
+                f"slice {slice_id}: 'depends_on' is a non-canonical alias "
+                "for 'dependencies' (per yaml-tasks.schema.json). Accepted "
+                "for now, but please rename."
+            )
+        for field in ("dependencies", "depends_on", "serialized_chain_order"):
+            if field not in sl:
+                continue
+            raw = sl[field]
+            if isinstance(raw, bool):
+                errors.append(
+                    f"slice {slice_id}: '{field}' must be an int, string, or list — got bool"
+                )
+                continue
+            if isinstance(raw, int):
+                raw = [raw]
+            elif isinstance(raw, str):
                 raw = [d.strip() for d in raw.split(",") if d.strip()]
             elif not isinstance(raw, list):
                 errors.append(
-                    f"slice {slice_id}: '{field}' must be a list or comma string"
+                    f"slice {slice_id}: '{field}' must be a list, comma string, or single int"
                 )
                 continue
             for entry in raw:
@@ -169,10 +189,7 @@ def validate(plan_path: str) -> tuple[int, list[str], list[str]]:
                 # Mirrors plan_parser.py's seen_contract_ids check (#1988).
                 contract_id = tid.lower()
                 if contract_id in seen_task_ids:
-                    errors.append(
-                        f"duplicate task id {contract_id!r} "
-                        f"(source id {tid!r})"
-                    )
+                    errors.append(f"duplicate task id {contract_id!r} (source id {tid!r})")
                 seen_task_ids.add(contract_id)
             role = t.get("role") if isinstance(t, dict) else None
             if role is not None and role not in VALID_ROLES:
@@ -187,8 +204,7 @@ def validate(plan_path: str) -> tuple[int, list[str], list[str]]:
         norm = _normalise_dep(entry)
         if norm is None:
             errors.append(
-                f"slice {src_slice}: {field} entry {entry!r} is not a "
-                "valid slice reference"
+                f"slice {src_slice}: {field} entry {entry!r} is not a valid slice reference"
             )
         elif norm not in seen_slice_ids:
             errors.append(

--- a/shared/egg_contracts/plan_parser.py
+++ b/shared/egg_contracts/plan_parser.py
@@ -684,7 +684,7 @@ def parse_phases_from_yaml(
         # Handle both numeric and string IDs
         try:
             phase_num = int(phase_id)
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             # Try extracting number from string like "phase-1" or "slice-1"
             id_match = re.search(r"(\d+)", str(phase_id))
             if id_match:

--- a/shared/egg_contracts/plan_parser.py
+++ b/shared/egg_contracts/plan_parser.py
@@ -248,13 +248,26 @@ class ParsedPhase:
         # Normalize dependencies to slice-N format
         normalized_deps: list[str] = []
         if self.dependencies:
-            raw_deps: str | list[str] = self.dependencies
-            # Handle both list and string formats
+            raw_deps: Any = self.dependencies
+            # Handle scalar (int / str), list, and integer formats. The
+            # bare-int branch (``depends_on: 3``) was added for #2743:
+            # pipeline-8b81ed32 declared ``depends_on: <int>`` on every
+            # slice and the contract came back with empty deps because
+            # the int fell through ``isinstance(dep_list, list)`` below.
             dep_list: list[str]
-            if isinstance(raw_deps, str):
+            if isinstance(raw_deps, bool):
+                # ``bool`` is a subclass of ``int`` in Python — reject
+                # explicitly to avoid silently converting ``True`` to
+                # ``slice-1``.
+                dep_list = []
+            elif isinstance(raw_deps, int):
+                dep_list = [str(raw_deps)]
+            elif isinstance(raw_deps, str):
                 dep_list = [d.strip() for d in raw_deps.split(",") if d.strip()]
+            elif isinstance(raw_deps, list):
+                dep_list = [str(d) for d in raw_deps]
             else:
-                dep_list = raw_deps
+                dep_list = []
             if isinstance(dep_list, list):
                 for dep in dep_list:
                     dep_str = str(dep).strip()
@@ -367,9 +380,17 @@ FILES_PATTERN = re.compile(r"\[([^\]]+)\]")
 
 # Pattern for YAML code fence with yaml-tasks marker
 # Matches: ```yaml\n# yaml-tasks\n...\n```
+#
+# The closing ``` must start at a line boundary (optionally preceded by 0–3
+# CommonMark-style spaces). Without that anchor the non-greedy capture stops
+# at the first inner ``` inside a YAML block scalar — e.g. a slice's ``goal:
+# |`` block that demonstrates a shell command — silently truncating the rest
+# of the slices block.  Issue #2743 (pipeline-f4c7d780): only 7 of 15 slices
+# made it into the contract because slice 7's goal embedded an indented
+# fenced example.
 YAML_FENCE_PATTERN = re.compile(
-    r"```(?:yaml|yml)\s*\n\s*#\s*yaml-tasks\s*\n(.*?)```",
-    re.DOTALL | re.IGNORECASE,
+    r"```(?:yaml|yml)\s*\n\s*#\s*yaml-tasks\s*\n((?:.*\n)*?)[ ]{0,3}```\s*(?:\n|$)",
+    re.IGNORECASE,
 )
 
 
@@ -691,7 +712,27 @@ def parse_phases_from_yaml(
 
         phase_name = phase_data.get("name", f"Slice {phase_num}")
         phase_goal = phase_data.get("goal", "")
-        phase_dependencies = phase_data.get("dependencies", "")
+        # #2743 — accept ``depends_on`` as an alias for ``dependencies``.
+        # Pipeline-8b81ed32 produced a plan that used ``depends_on: <int>``
+        # on every phase and the contract came back with empty deps because
+        # the parser only consulted ``dependencies``. ``dependencies`` is
+        # the schema-canonical key (.egg/schemas/yaml-tasks.schema.json);
+        # when both are present it wins and a warning is recorded.
+        if "dependencies" in phase_data and "depends_on" in phase_data:
+            warnings.append(
+                ParseWarning(
+                    line_number=None,
+                    message=(
+                        f"Slice {phase_num} declares both 'dependencies' "
+                        "and 'depends_on' — preferring 'dependencies' "
+                        "(canonical key per yaml-tasks.schema.json). "
+                        "Remove 'depends_on' to silence this warning."
+                    ),
+                )
+            )
+            phase_dependencies = phase_data["dependencies"]
+        else:
+            phase_dependencies = phase_data.get("dependencies", phase_data.get("depends_on", ""))
         phase_exit_criteria = phase_data.get("exit_criteria", "")
         # ``serialized_chain_order`` is a planner-emitted field added in
         # #2137. The planner uses it to record the deliberate ordering

--- a/shared/egg_contracts/plan_parser.py
+++ b/shared/egg_contracts/plan_parser.py
@@ -731,8 +731,29 @@ def parse_phases_from_yaml(
                 )
             )
             phase_dependencies = phase_data["dependencies"]
+            dep_source_key = "dependencies"
+        elif "depends_on" in phase_data:
+            phase_dependencies = phase_data["depends_on"]
+            dep_source_key = "depends_on"
         else:
-            phase_dependencies = phase_data.get("dependencies", phase_data.get("depends_on", ""))
+            phase_dependencies = phase_data.get("dependencies", "")
+            dep_source_key = "dependencies"
+        # #2743 — surface a parse-time warning for ``bool`` values so a
+        # ``parse_plan`` consumer sees that the dep was discarded. The
+        # ``to_contract_slice`` branch drops bools to ``[]`` (since
+        # ``bool`` is an ``int`` subclass and we don't want ``True`` to
+        # become ``slice-1``); this warning records the silent drop.
+        if isinstance(phase_dependencies, bool):
+            warnings.append(
+                ParseWarning(
+                    line_number=None,
+                    message=(
+                        f"Slice {phase_num} '{dep_source_key}' is a bool "
+                        f"({phase_dependencies!r}); dependencies dropped. "
+                        "Use an int, 'slice-N', or a list."
+                    ),
+                )
+            )
         phase_exit_criteria = phase_data.get("exit_criteria", "")
         # ``serialized_chain_order`` is a planner-emitted field added in
         # #2137. The planner uses it to record the deliberate ordering

--- a/shared/egg_contracts/plan_parser.py
+++ b/shared/egg_contracts/plan_parser.py
@@ -684,7 +684,7 @@ def parse_phases_from_yaml(
         # Handle both numeric and string IDs
         try:
             phase_num = int(phase_id)
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             # Try extracting number from string like "phase-1" or "slice-1"
             id_match = re.search(r"(\d+)", str(phase_id))
             if id_match:

--- a/tests/plugins/refine_plan/test_validate_yaml_tasks.py
+++ b/tests/plugins/refine_plan/test_validate_yaml_tasks.py
@@ -377,6 +377,67 @@ def test_dep_rejects_unparseable_entry(tmp_path: Path):
     assert any("'garbage' is not a valid slice reference" in e for e in errors), errors
 
 
+def test_both_dependencies_and_depends_on_validates_canonical_only(tmp_path: Path):
+    """When both ``dependencies`` and ``depends_on`` are present, the
+    emitter drops ``depends_on``; the validator must follow suit and
+    not NACK on data that's about to be ignored (#2748 review).
+    """
+    mod = _load_module()
+    plan = _write(
+        tmp_path,
+        """
+        ```yaml
+        # yaml-tasks
+        slices:
+          - id: 1
+            name: a
+            tasks:
+              - id: TASK-1-1
+                description: x
+                acceptance: y
+          - id: 2
+            name: b
+            dependencies: slice-1
+            depends_on: slice-99
+            tasks:
+              - id: TASK-2-1
+                description: x
+                acceptance: y
+        ```
+        """,
+    )
+    code, errors, warnings = mod.validate(str(plan))
+    assert code == 0, errors
+    assert any("both 'dependencies' and 'depends_on'" in w for w in warnings), warnings
+
+
+def test_serialized_chain_order_rejects_bare_int(tmp_path: Path):
+    """``serialized_chain_order`` must stay symmetric with the
+    canonical parser (which accepts only str / list and warns
+    otherwise). A bare int here is not coerced (#2748 review).
+    """
+    mod = _load_module()
+    plan = _write(
+        tmp_path,
+        """
+        ```yaml
+        # yaml-tasks
+        slices:
+          - id: 1
+            name: a
+            serialized_chain_order: 1
+            tasks:
+              - id: TASK-1-1
+                description: x
+                acceptance: y
+        ```
+        """,
+    )
+    code, errors, _ = mod.validate(str(plan))
+    assert code == 1
+    assert any("serialized_chain_order" in e for e in errors), errors
+
+
 def test_serialized_chain_order_unknown_slice(tmp_path: Path):
     """``serialized_chain_order`` entries are also validated against defined slices."""
     mod = _load_module()

--- a/tests/scripts/test_checks.py
+++ b/tests/scripts/test_checks.py
@@ -311,8 +311,8 @@ phases:
         assert result.status == CheckStatus.FAIL
         assert "Invalid YAML" in result.message
 
-    def test_missing_phases_fails(self, tmp_path):
-        """Test that YAML without phases field fails."""
+    def test_missing_slices_fails(self, tmp_path):
+        """Test that YAML without slices/phases field fails."""
         PlanYamlCheck = _import_check_module("plan_yaml_check").PlanYamlCheck
 
         drafts_dir = tmp_path / ".egg-state" / "drafts"
@@ -334,7 +334,38 @@ pr:
         result = check.run()
 
         assert result.status == CheckStatus.FAIL
-        assert "Missing 'phases' field" in result.details["errors"]
+        assert "Missing 'slices' (or legacy 'phases') field" in result.details["errors"]
+
+    def test_valid_slices_plan_passes(self, tmp_path):
+        """``slices:`` is the canonical key (#2137); the check must
+        accept it the same as legacy ``phases:``.
+        """
+        PlanYamlCheck = _import_check_module("plan_yaml_check").PlanYamlCheck
+
+        drafts_dir = tmp_path / ".egg-state" / "drafts"
+        drafts_dir.mkdir(parents=True)
+        plan_path = drafts_dir / "123-plan.md"
+        plan_path.write_text("""# Plan
+
+```yaml
+# yaml-tasks
+slices:
+  - id: 1
+    name: Setup
+    tasks:
+      - id: TASK-1-1
+        description: First task
+```
+""")
+
+        contract = Contract(
+            issue=IssueInfo(number=123, title="Test", url="https://example.com"),
+        )
+        check = PlanYamlCheck(contract, tmp_path)
+        result = check.run()
+
+        assert result.status == CheckStatus.PASS
+        assert result.details["slices_count"] == 1
 
 
 class TestLintCheck:

--- a/tests/shared/egg_contracts/test_plan_parser.py
+++ b/tests/shared/egg_contracts/test_plan_parser.py
@@ -788,6 +788,192 @@ After"""
         assert "Before" in remaining
         assert "After" in remaining
 
+    def test_nested_code_fence_inside_block_scalar_not_truncated(self):
+        """Regression for #2743 (pipeline-f4c7d780): a nested ``` fenced
+        block inside a YAML block scalar (e.g. an inline example in a
+        slice's ``goal``) must not terminate the outer yaml-tasks fence.
+
+        The pre-fix non-greedy regex stopped at the first inner ``` and
+        silently truncated the contract to whatever slices had been
+        parsed up to that point — 7 of 15 in the offending pipeline.
+        """
+        content = """# Plan
+
+```yaml
+# yaml-tasks
+slices:
+  - id: 1
+    name: First
+    tasks:
+      - id: TASK-1-1
+        description: First task
+        acceptance: ok
+  - id: 2
+    name: Second
+    goal: |
+      Show an inline example:
+      ```
+      $ run-it
+      ```
+    dependencies: slice-1
+    tasks:
+      - id: TASK-2-1
+        description: Second task
+        acceptance: ok
+  - id: 3
+    name: Third
+    dependencies: slice-2
+    tasks:
+      - id: TASK-3-1
+        description: Third task
+        acceptance: ok
+```
+
+Trailing prose."""
+        yaml_data, _, warnings = parse_yaml_code_fence(content)
+        assert yaml_data is not None
+        assert "slices" in yaml_data
+        assert [s["id"] for s in yaml_data["slices"]] == [1, 2, 3]
+        # Block scalar preserves the inner ``` lines verbatim.
+        assert "$ run-it" in yaml_data["slices"][1]["goal"]
+        assert len(warnings) == 0
+
+    def test_nested_code_fence_full_parse_pipeline(self):
+        """End-to-end #2743: ``parse_plan`` returns all slices and
+        preserves their declared dependencies despite a nested ``` in
+        one slice's goal block scalar.
+        """
+        content = """# Plan
+
+```yaml
+# yaml-tasks
+pr:
+  title: Test PR
+  description: Test
+  test_plan: Test
+  manual_steps: None
+slices:
+  - id: 1
+    name: First
+    tasks:
+      - id: TASK-1-1
+        description: First task
+        acceptance: ok
+  - id: 2
+    name: Second
+    goal: |
+      Inline example:
+      ```
+      $ demo
+      ```
+    dependencies: slice-1
+    tasks:
+      - id: TASK-2-1
+        description: Second task
+        acceptance: ok
+  - id: 3
+    name: Third
+    dependencies: slice-2
+    tasks:
+      - id: TASK-3-1
+        description: Third task
+        acceptance: ok
+```
+"""
+        result = parse_plan(content)
+        assert result.success, result.error
+        assert [p.number for p in result.phases] == [1, 2, 3]
+        # Dependencies survive the parse.
+        deps_by_id = {p.number: p.dependencies for p in result.phases}
+        assert deps_by_id[2] == "slice-1"
+        assert deps_by_id[3] == "slice-2"
+        # And the contract conversion preserves them.
+        slices = result.to_contract_slices()
+        assert [s.id for s in slices] == ["slice-1", "slice-2", "slice-3"]
+        assert slices[1].dependencies == ["slice-1"]
+        assert slices[2].dependencies == ["slice-2"]
+
+    def test_depends_on_alias_with_int_value(self):
+        """Regression for #2743 (pipeline-8b81ed32 follow-up): the
+        planner emitted ``depends_on: <int>`` on every slice and the
+        contract came back with empty dependencies because the parser
+        only consulted ``dependencies`` and never coerced a bare int.
+        ``depends_on`` is now accepted as an alias and integer values
+        normalise to ``slice-<N>``.
+        """
+        yaml_data, _, _ = parse_yaml_code_fence(
+            """```yaml
+# yaml-tasks
+slices:
+  - id: 1
+    name: First
+    tasks:
+      - id: TASK-1-1
+        description: First
+        acceptance: ok
+  - id: 2
+    name: Second
+    depends_on: 1
+    tasks:
+      - id: TASK-2-1
+        description: Second
+        acceptance: ok
+  - id: 3
+    name: Third
+    depends_on: 2
+    tasks:
+      - id: TASK-3-1
+        description: Third
+        acceptance: ok
+```
+"""
+        )
+        phases, _ = parse_phases_from_yaml(yaml_data)
+        slices = [p.to_contract_slice() for p in phases]
+        assert [s.id for s in slices] == ["slice-1", "slice-2", "slice-3"]
+        assert slices[0].dependencies == []
+        assert slices[1].dependencies == ["slice-1"]
+        assert slices[2].dependencies == ["slice-2"]
+
+    def test_depends_on_and_dependencies_both_present_warns(self):
+        """When both ``depends_on`` and ``dependencies`` are present the
+        canonical ``dependencies`` key wins and a warning is recorded —
+        matching the existing ``slices:`` / ``phases:`` conflict policy.
+        """
+        yaml_data = {
+            "slices": [
+                {
+                    "id": 1,
+                    "name": "A",
+                    "tasks": [{"id": "TASK-1-1", "description": "a", "acceptance": "ok"}],
+                },
+                {
+                    "id": 2,
+                    "name": "B",
+                    "dependencies": "slice-1",
+                    "depends_on": "slice-99",
+                    "tasks": [{"id": "TASK-2-1", "description": "b", "acceptance": "ok"}],
+                },
+            ]
+        }
+        phases, warnings = parse_phases_from_yaml(yaml_data)
+        slices = [p.to_contract_slice() for p in phases]
+        assert slices[1].dependencies == ["slice-1"]
+        assert any("both 'dependencies' and 'depends_on'" in w.message for w in warnings)
+
+    def test_depends_on_bool_is_rejected(self):
+        """``depends_on: true`` must not silently coerce to ``slice-1``
+        (``bool`` is a subclass of ``int`` in Python — we reject it
+        explicitly so the planner gets a NACK for the typo).
+        """
+        phase = ParsedPhase(
+            number=2,
+            name="X",
+            goal="",
+            dependencies=True,  # type: ignore[arg-type]
+        )
+        assert phase.to_contract_slice().dependencies == []
+
 
 class TestParsePhasesFromYaml:
     """Tests for parsing phases from structured YAML."""

--- a/tests/shared/egg_contracts/test_plan_parser.py
+++ b/tests/shared/egg_contracts/test_plan_parser.py
@@ -961,10 +961,11 @@ slices:
         assert slices[1].dependencies == ["slice-1"]
         assert any("both 'dependencies' and 'depends_on'" in w.message for w in warnings)
 
-    def test_depends_on_bool_is_rejected(self):
-        """``depends_on: true`` must not silently coerce to ``slice-1``
-        (``bool`` is a subclass of ``int`` in Python — we reject it
-        explicitly so the planner gets a NACK for the typo).
+    def test_to_contract_slice_drops_bool_dependencies(self):
+        """``bool`` is a subclass of ``int`` in Python; without an
+        explicit branch ``True`` would coerce to ``slice-1``. The
+        ``to_contract_slice`` path drops bools instead so a typo like
+        ``depends_on: true`` doesn't fabricate a fake dependency.
         """
         phase = ParsedPhase(
             number=2,
@@ -973,6 +974,35 @@ slices:
             dependencies=True,  # type: ignore[arg-type]
         )
         assert phase.to_contract_slice().dependencies == []
+
+    def test_parse_phases_from_yaml_warns_on_bool_depends_on(self):
+        """The production parse path must emit a ParseWarning when
+        ``depends_on`` (or ``dependencies``) is a bool — otherwise the
+        dropped dep is invisible to ``parse_plan`` consumers.
+        Companion to ``test_to_contract_slice_drops_bool_dependencies``
+        that exercises the same case end-to-end through the parser.
+        """
+        yaml_data = {
+            "slices": [
+                {
+                    "id": 1,
+                    "name": "A",
+                    "tasks": [{"id": "TASK-1-1", "description": "a", "acceptance": "ok"}],
+                },
+                {
+                    "id": 2,
+                    "name": "B",
+                    "depends_on": True,
+                    "tasks": [{"id": "TASK-2-1", "description": "b", "acceptance": "ok"}],
+                },
+            ]
+        }
+        phases, warnings = parse_phases_from_yaml(yaml_data)
+        slices = [p.to_contract_slice() for p in phases]
+        assert slices[1].dependencies == []
+        assert any(
+            "'depends_on' is a bool" in w.message and "Slice 2" in w.message for w in warnings
+        )
 
 
 class TestParsePhasesFromYaml:


### PR DESCRIPTION
## Summary

Two converter bugs surfaced by pipelines `pipeline-f4c7d780` and `pipeline-8b81ed32` (issue #2743) when populating the SDLC contract from a plan draft:

- **A — Silent slice-drop.** The yaml-tasks fence regex `(.*?)` `` ``` `` had no anchor on the closing fence, so the first nested ``` inside a YAML block scalar (e.g. a slice's `goal: |` block demonstrating a shell command) terminated the outer fence and truncated the YAML mid-document. `yaml.safe_load` then parsed the truncated body without error. pipeline-f4c7d780's 15-slice plan came back as 7 slices because slice 7's goal contained a fenced example. Fix: line-orient the body capture as `((?:.*\n)*?)` and require the closing ``` to start at a line boundary (CommonMark 0–3 space indent). Applied in all four copies of the regex: `shared/egg_contracts/plan_parser.py`, the `validate-yaml-tasks` and `emit-contract` plugin scripts, and the CI `plan_yaml_check.py`.
- **B — `depends_on` + integer values silently dropped.** The parser only consulted `dependencies` (schema-canonical key); a bare-int `depends_on: 3` fell through `isinstance(dep_list, list)` without producing any deps. pipeline-8b81ed32 declared `depends_on: <int>` on every successor and the contract landed with `dependencies: []` everywhere. Fix: accept `depends_on` as a lenient alias for `dependencies` (warning when both are present, matching the `slices:` / `phases:` conflict policy) and normalise bare-int / scalar values to `slice-<N>` in the canonical parser and both plugin scripts. `bool` is rejected explicitly since it's an `int` subclass.

Closes #2743.

## Test plan

- [x] `tests/shared/egg_contracts/test_plan_parser.py` — new regression tests cover nested-fence-in-block-scalar through `parse_plan`, the `depends_on`/int alias, and the `depends_on` + `dependencies` conflict warning (123/123 pass).
- [x] `tests/plugins/refine_plan/test_validate_yaml_tasks.py` + `test_emit_contract.py` — existing tests still pass against the rewritten regex and dep handling (24/24 pass).
- [x] `orchestrator/tests/test_populate_contract_endpoint.py` + `test_short_flow_contract_population.py` + `test_advance_phase_populate_on_plan_exit.py` — end-to-end populate-contract paths still green (48/48 pass).
- [x] End-to-end repro of both pipeline scenarios: a 15-slice plan with a nested fence at slice 8 now parses all 15 slices with declared deps preserved; an 8-slice flat plan using `depends_on: <int>` now lands with the linear chain intact.