### PR TITLE
Fix #2755: stop committing per-slice BRC files to work

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -22641,8 +22641,12 @@ def _run_pipeline(
             # ``write_per_slice=False`` (see #2755), so per-slice
             # implement-phase transcripts are on the slice integration
             # branches, and the work commit picks up only the
-            # unattributed sibling (plus any non-implement aggregate)
-            # before we wipe the message store here.
+            # unattributed sibling plus whatever aggregate the writer
+            # still emits — refine/plan/pr aggregates, and the
+            # non-slice-implement aggregate that babysit_pr (and any
+            # other implement-phase run without slice scope) lands on
+            # work via the ``not buckets`` branch — before we wipe the
+            # message store here.
             from routes.phases import _clear_concurrent_state
 
             _clear_concurrent_state(pipeline_id)

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -8949,6 +8949,8 @@ def _write_brc_history(
     pipeline_id: str,
     phase: str,
     identifier: int | str,
+    *,
+    write_per_slice: bool = True,
 ) -> None:
     """Write BRC consensus message history for a phase to .egg-state.
 
@@ -8992,6 +8994,17 @@ def _write_brc_history(
         pipeline_id: The pipeline ID to retrieve messages for
         phase: The pipeline phase name (e.g. "implement", "plan")
         identifier: The pipeline identifier for file naming
+        write_per_slice: When False and ``phase == "implement"`` in a
+            slice-aware pipeline, skip writing the per-slice
+            ``{identifier}-implement-{slice_id}.{md,json}`` files. The
+            ``unattributed`` sibling and any non-slice aggregate file
+            are still written. Per-slice files are owned by their
+            slice's integration branch (committed by
+            :func:`_commit_slice_brc_history_to_integration_branch`);
+            duplicating them onto ``work`` causes add/add merge
+            conflicts when slice PRs target ``work`` (#2755). Default
+            ``True`` preserves the historical behavior for the slice
+            hook itself and for any out-of-tree callers.
     """
     logger.info(
         "_write_brc_history: entering",
@@ -9150,6 +9163,21 @@ def _write_brc_history(
                 slice_id="unattributed",
             )
 
+        if not write_per_slice:
+            # Caller opted out of per-slice writes (#2755). The
+            # ``unattributed`` sibling has already been written above
+            # (when ``unattributed_other`` was non-empty); skip the
+            # per-slice bucket loop so we don't add files that the
+            # slice branches already own. See the docstring's
+            # ``write_per_slice`` arg for the merge-conflict rationale.
+            logger.info(
+                "_write_brc_history: skipping per-slice writes (write_per_slice=False)",
+                pipeline_id=pipeline_id,
+                phase=phase,
+                slice_bucket_count=len(buckets),
+            )
+            return
+
         # Natural sort by the integer suffix so a 12-slice pipeline iterates
         # `slice-1, slice-2, ..., slice-12` rather than the lexicographic
         # `slice-1, slice-10, slice-11, slice-12, slice-2`. Every key is
@@ -9216,6 +9244,12 @@ def _rewrite_brc_history_for_pr(
                     pipeline_id,
                     phase_name,
                     identifier,
+                    # Per-slice implement-phase files are owned by each
+                    # slice's integration branch (#2548 D2/D5); committing
+                    # them onto ``work`` would re-introduce the add/add
+                    # merge conflict from #2755. Only the aggregate /
+                    # unattributed sibling lands on ``work``.
+                    write_per_slice=False,
                 )
             except Exception as brc_err:
                 logger.warning(
@@ -9295,6 +9329,13 @@ def _persist_phase_brc_history(
             pipeline.id,
             phase,
             _brc_history_identifier(pipeline),
+            # Per-slice implement-phase files are owned by the slice's
+            # integration branch (committed by
+            # :func:`_commit_slice_brc_history_to_integration_branch`);
+            # the work-branch worktree must not duplicate them, otherwise
+            # slice PRs targeting ``work`` hit add/add merge conflicts
+            # (#2755). The parameter is a no-op for non-implement phases.
+            write_per_slice=False,
         )
     except Exception as brc_err:
         logger.warning(
@@ -11281,23 +11322,23 @@ def _commit_slice_brc_history_to_integration_branch(
 
     Steps:
 
-    1. Refresh the per-slice BRC history files
-       (``.egg-state/brc-history/<identifier>-implement-<slice_id>.{json,md}``)
-       on the **work worktree** via :func:`_write_brc_history`.  The
-       writer pulls messages from the message store and re-renders the
-       canonical files; running it again on each slice's consensus is
-       idempotent and ensures any messages that landed since the last
-       phase-boundary write are captured.
+    1. Materialise a per-tick temp directory under
+       ``WORKTREE_BASE_DIR`` (gateway-allowlisted; see #2684) and
+       render the per-slice BRC history files into a ``staging/``
+       subdirectory via :func:`_write_brc_history`. The writer pulls
+       messages from the message store; the staging directory is
+       scoped to this hook tick so concurrent slice hooks do not
+       cross-write each other (#2755).
     2. Materialise a temporary git worktree on
        ``origin/<integration_branch>`` (the slice's integration branch).
        ``-B`` re-points the local branch ref so a prior tick that
        crashed mid-flight can re-enter cleanly.
     3. Copy ONLY this slice's per-slice BRC files
-       (``<identifier>-implement-<slice_id>.{json,md}``) from the work
-       worktree to the integration worktree.  Other slices' files (or
-       the unattributed sibling) are deliberately not copied — each
-       slice PR carries only its own BRC transcript per D2 / D5 of
-       #2548.
+       (``<identifier>-implement-<slice_id>.{json,md}``) from the
+       staging directory to the integration worktree. Other slices'
+       files (or the unattributed sibling) are deliberately not
+       copied — each slice PR carries only its own BRC transcript per
+       D2 / D5 of #2548.
     4. Commit via :func:`_commit_statefiles_to_worktree`
        (orchestrator-authored, ``--no-verify``, idempotent: skips when
        staged is empty).
@@ -11308,8 +11349,10 @@ def _commit_slice_brc_history_to_integration_branch(
     Returns ``True`` on success or no-op (files already committed and
     push is a fast-forward no-op).  Returns ``False`` on any failure;
     the caller treats this as best-effort and proceeds with PR
-    creation, since the BRC files remain on the work worktree as a
-    fallback audit trail.
+    creation. The per-slice BRC files do not exist on the work
+    worktree under this design (#2755) — the integration branch is
+    the only on-disk surface that carries them, so a failure here
+    means the slice PR opens without its consensus transcript.
 
     Idempotency: every step is convergent — re-running mid-flight
     against an already-committed integration branch produces no new
@@ -11318,16 +11361,11 @@ def _commit_slice_brc_history_to_integration_branch(
 
     Concurrency: this hook runs from ``_run_one_slice_inner``, which
     is itself invoked concurrently across slices in a thread pool.
-    Two slices reaching consensus near-simultaneously will both call
-    ``_write_brc_history`` on the same work worktree, and the writer
-    iterates every bucket — so slice-N's hook re-writes slice-(N-1)'s
-    per-slice files even though only slice-N's files are then copied
-    onto the integration branch.  This is safe because post-consensus
-    BRC messages are immutable: both writers stage byte-identical
-    content, and a torn ``Path.write_text`` produces the same result
-    as a clean one.  Only the per-slice files for *this* slice are
-    copied to the integration worktree (Step 3), so concurrent writes
-    do not cross-pollinate slice PRs.
+    Each invocation creates its own ``mkdtemp``-rooted staging
+    directory, so two slices reaching consensus near-simultaneously
+    do not share any filesystem state (#2755 fix). Each slice copies
+    only its own per-slice files to its integration worktree
+    (Step 3), so concurrent writes do not cross-pollinate slice PRs.
     """
     pipeline_id = pipeline.id
 
@@ -11341,58 +11379,6 @@ def _commit_slice_brc_history_to_integration_branch(
 
     identifier = _brc_history_identifier(pipeline)
 
-    # --- Step 1: refresh per-slice BRC files on the work worktree ---
-    try:
-        _write_brc_history(
-            worktree_repo_path,
-            pipeline_id,
-            "implement",
-            identifier,
-        )
-    except Exception as brc_err:  # noqa: BLE001
-        logger.warning(
-            "Per-slice BRC commit: failed to refresh BRC history on work "
-            "worktree, skipping integration-branch commit (#2548)",
-            pipeline_id=pipeline_id,
-            slice_id=slice_id,
-            error=str(brc_err),
-        )
-        return False
-
-    # The per-slice files we will copy onto the integration worktree.
-    # Both files are produced by ``_write_brc_history`` (markdown and
-    # JSON companion).  Missing files are tolerated — the writer logs
-    # at warning level but still succeeds on the other format, so we
-    # copy whichever exists.
-    history_dir = worktree_repo_path / ".egg-state" / "brc-history"
-    per_slice_files: list[Path] = []
-    for ext in ("md", "json"):
-        candidate = history_dir / f"{identifier}-implement-{slice_id}.{ext}"
-        if candidate.is_symlink():
-            # Defense-in-depth: a planted symlink could point outside
-            # ``.egg-state/`` and leak unrelated content onto the slice
-            # PR.  Mirrors the symlink defense in
-            # :func:`_gather_context_pr_files`.
-            logger.warning(
-                "Per-slice BRC commit: skipping symlink in brc-history (#2548)",
-                pipeline_id=pipeline_id,
-                slice_id=slice_id,
-                path=str(candidate),
-            )
-            continue
-        if candidate.is_file():
-            per_slice_files.append(candidate)
-
-    if not per_slice_files:
-        logger.warning(
-            "Per-slice BRC commit: no per-slice BRC files produced "
-            "for slice — skipping integration-branch commit (#2548)",
-            pipeline_id=pipeline_id,
-            slice_id=slice_id,
-            identifier=str(identifier),
-        )
-        return False
-
     import shutil
     import tempfile
 
@@ -11405,28 +11391,6 @@ def _commit_slice_brc_history_to_integration_branch(
         "-C",
         str(worktree_repo_path),
     ]
-
-    # --- Step 2: refresh the local remote-tracking ref for the
-    # integration branch.  The slice's agents pushed directly to
-    # ``origin/<integration_branch>`` during the run, so the work
-    # worktree's local tracking ref may lag.  Best-effort: a failure
-    # here usually means the agent-side push has not yet propagated;
-    # the worktree-add below would then fail and we'd return False.
-    try:
-        spawner.gateway.fetch_branch(
-            pipeline_id,
-            str(worktree_repo_path),
-            args=[f"+refs/heads/{integration_branch}:refs/remotes/origin/{integration_branch}"],
-            mode=gateway_mode,  # type: ignore[arg-type]
-        )
-    except Exception as fetch_err:  # noqa: BLE001
-        logger.warning(
-            "Per-slice BRC commit: fetch of integration branch failed (continuing) (#2548)",
-            pipeline_id=pipeline_id,
-            slice_id=slice_id,
-            integration_branch=integration_branch,
-            error=str(fetch_err),
-        )
 
     # Root under WORKTREE_BASE_DIR so the temp path falls inside the
     # gateway's repo-path allowlist (gateway/git_client.py
@@ -11457,9 +11421,99 @@ def _commit_slice_brc_history_to_integration_branch(
             dir=tmp_dir_base,
         )
     )
+    # Per-tick staging directory so concurrent slice hooks do not
+    # share the writer's output (#2755). ``_write_brc_history``
+    # renders into ``<staging>/.egg-state/brc-history/`` — same
+    # relative layout it uses against a worktree — so the
+    # ``Path.relative_to(staging)`` step below preserves the
+    # canonical on-disk path when copying onto the integration
+    # worktree.
+    staging = tmp_worktree / "staging"
     wt_path = tmp_worktree / "wt"
 
     try:
+        # --- Step 1: render the per-slice BRC files into the staging
+        # directory.  The writer pulls messages from the message store
+        # and writes all per-slice files for the implement phase; we
+        # filter to this slice's files below.
+        try:
+            _write_brc_history(
+                staging,
+                pipeline_id,
+                "implement",
+                identifier,
+            )
+        except Exception as brc_err:  # noqa: BLE001
+            logger.warning(
+                "Per-slice BRC commit: failed to render BRC history into "
+                "staging dir, skipping integration-branch commit (#2548)",
+                pipeline_id=pipeline_id,
+                slice_id=slice_id,
+                error=str(brc_err),
+            )
+            return False
+
+        # The per-slice files we will copy onto the integration worktree.
+        # Both files are produced by ``_write_brc_history`` (markdown and
+        # JSON companion).  Missing files are tolerated — the writer logs
+        # at warning level but still succeeds on the other format, so we
+        # copy whichever exists.
+        history_dir = staging / ".egg-state" / "brc-history"
+        per_slice_files: list[Path] = []
+        for ext in ("md", "json"):
+            candidate = history_dir / f"{identifier}-implement-{slice_id}.{ext}"
+            if candidate.is_symlink():
+                # Defense-in-depth: a planted symlink could point outside
+                # ``.egg-state/`` and leak unrelated content onto the slice
+                # PR. The staging directory is freshly minted under
+                # ``tempfile.mkdtemp`` per hook tick, so a symlink at this
+                # path would have to come from the writer itself — but the
+                # check is cheap, mirrors the defense in
+                # :func:`_gather_context_pr_files`, and protects against
+                # any future writer change that might honour an attacker-
+                # controlled metadata blob when synthesising the filename.
+                logger.warning(
+                    "Per-slice BRC commit: skipping symlink in brc-history (#2548)",
+                    pipeline_id=pipeline_id,
+                    slice_id=slice_id,
+                    path=str(candidate),
+                )
+                continue
+            if candidate.is_file():
+                per_slice_files.append(candidate)
+
+        if not per_slice_files:
+            logger.warning(
+                "Per-slice BRC commit: no per-slice BRC files produced "
+                "for slice — skipping integration-branch commit (#2548)",
+                pipeline_id=pipeline_id,
+                slice_id=slice_id,
+                identifier=str(identifier),
+            )
+            return False
+
+        # --- Step 2: refresh the local remote-tracking ref for the
+        # integration branch.  The slice's agents pushed directly to
+        # ``origin/<integration_branch>`` during the run, so the work
+        # worktree's local tracking ref may lag.  Best-effort: a failure
+        # here usually means the agent-side push has not yet propagated;
+        # the worktree-add below would then fail and we'd return False.
+        try:
+            spawner.gateway.fetch_branch(
+                pipeline_id,
+                str(worktree_repo_path),
+                args=[f"+refs/heads/{integration_branch}:refs/remotes/origin/{integration_branch}"],
+                mode=gateway_mode,  # type: ignore[arg-type]
+            )
+        except Exception as fetch_err:  # noqa: BLE001
+            logger.warning(
+                "Per-slice BRC commit: fetch of integration branch failed (continuing) (#2548)",
+                pipeline_id=pipeline_id,
+                slice_id=slice_id,
+                integration_branch=integration_branch,
+                error=str(fetch_err),
+            )
+
         try:
             subprocess.run(
                 [
@@ -11488,13 +11542,13 @@ def _commit_slice_brc_history_to_integration_branch(
 
         # --- Step 3: copy ONLY this slice's BRC files onto the integration
         # worktree.  Each file lands at the same relative path it occupies
-        # on the work worktree (``.egg-state/brc-history/...``).
+        # in the staging dir (``.egg-state/brc-history/...``).
         for src in per_slice_files:
             try:
-                rel = src.relative_to(worktree_repo_path)
+                rel = src.relative_to(staging)
             except ValueError:
                 logger.warning(
-                    "Per-slice BRC commit: file outside work worktree, skipping it (#2548)",
+                    "Per-slice BRC commit: file outside staging dir, skipping it (#2548)",
                     pipeline_id=pipeline_id,
                     slice_id=slice_id,
                     src=str(src),
@@ -11556,7 +11610,7 @@ def _commit_slice_brc_history_to_integration_branch(
             pipeline_id=pipeline_id,
             slice_id=slice_id,
             integration_branch=integration_branch,
-            files=[str(p.relative_to(worktree_repo_path)) for p in per_slice_files],
+            files=[str(p.relative_to(staging)) for p in per_slice_files],
         )
         return True
     finally:
@@ -22033,6 +22087,13 @@ def _run_pipeline(
                     pipeline_id,
                     current_phase.value,
                     _brc_history_identifier(pipeline),
+                    # Per-slice implement-phase files are owned by each
+                    # slice's integration branch; committing them onto
+                    # ``work`` here would conflict with the slice
+                    # branches' add of the same paths and break slice
+                    # PR merges (#2755). The parameter is a no-op for
+                    # non-implement phases.
+                    write_per_slice=False,
                 )
             except Exception as brc_err:
                 logger.debug(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -22636,10 +22636,13 @@ def _run_pipeline(
             # a stale plan-phase tracker keyed under the bare
             # ``pipeline_id`` for ``_get_concurrent_status`` to find and
             # report as ``is_complete: True`` long after the implement
-            # phase had started.  ``_write_brc_history`` already ran
-            # earlier in this iteration (line ~16753) so the BRC
-            # transcript is already on disk by the time we wipe the
-            # message store here.
+            # phase had started.  ``_write_brc_history`` runs at the
+            # bottom of each phase iteration with
+            # ``write_per_slice=False`` (see #2755), so per-slice
+            # implement-phase transcripts are on the slice integration
+            # branches, and the work commit picks up only the
+            # unattributed sibling (plus any non-implement aggregate)
+            # before we wipe the message store here.
             from routes.phases import _clear_concurrent_state
 
             _clear_concurrent_state(pipeline_id)

--- a/orchestrator/tests/test_brc_history.py
+++ b/orchestrator/tests/test_brc_history.py
@@ -2429,16 +2429,185 @@ class TestPerSliceImplementBrcHistory:
         ], f"Expected natural-sort iteration order, got {slice_ids_in_order}"
 
 
-class TestPerSliceImplementBrcHistoryRewriteForPr:
-    """The PR-phase safety-net rewrite (``_rewrite_brc_history_for_pr``)
-    inherits the per-slice partitioning from ``_write_brc_history`` (#2548).
-    These tests verify the rewrite path treats per-slice files correctly
-    and never produces an aggregate.
+class TestWritePerSliceFlag:
+    """Tests for the ``write_per_slice`` keyword arg on ``_write_brc_history`` (#2755).
+
+    The flag lets callers writing to the work worktree opt out of the
+    per-slice bucketing loop. Per-slice files live on each slice's
+    integration branch (committed by
+    :func:`_commit_slice_brc_history_to_integration_branch`);
+    duplicating them onto ``work`` causes add/add merge conflicts
+    when slice PRs try to merge.
+
+    The flag has no effect outside ``phase == "implement"`` and no
+    effect on non-slice pipelines (where the writer falls back to the
+    aggregate ``{identifier}-implement.{md,json}`` filename).
     """
 
-    def test_rewrite_for_pr_emits_per_slice_implement_files(self, tmp_path):
-        """When the PR phase rewrites BRC history, the implement-phase
-        rewrite produces per-slice files and no aggregate file."""
+    def test_default_writes_per_slice_files(self, tmp_path):
+        """Default ``write_per_slice=True`` produces the per-slice files,
+        same as pre-#2755 behavior — preserved so the slice hook and any
+        out-of-tree callers do not need to be updated."""
+        from routes.pipelines import _write_brc_history
+
+        messages = _make_brc_messages(pipeline_id="issue-42", phase="implement", slice_id="slice-1")
+        messages.extend(
+            _make_brc_messages(pipeline_id="issue-42", phase="implement", slice_id="slice-2")
+        )
+
+        mock_store = MagicMock(spec=MessageStore)
+        mock_store.get_messages.return_value = messages
+
+        with patch("message_store.get_message_store", return_value=mock_store):
+            _write_brc_history(tmp_path, "issue-42", "implement", 42)
+
+        history_dir = tmp_path / ".egg-state" / "brc-history"
+        assert (history_dir / "42-implement-slice-1.md").exists()
+        assert (history_dir / "42-implement-slice-2.md").exists()
+        assert (history_dir / "42-implement-slice-1.json").exists()
+        assert (history_dir / "42-implement-slice-2.json").exists()
+
+    def test_write_per_slice_false_skips_per_slice_files(self, tmp_path):
+        """With ``write_per_slice=False`` the writer skips the per-slice
+        bucketing loop for slice-aware implement-phase messages, so
+        ``{identifier}-implement-{slice_id}.{md,json}`` files are not
+        produced (#2755)."""
+        from routes.pipelines import _write_brc_history
+
+        messages = _make_brc_messages(pipeline_id="issue-42", phase="implement", slice_id="slice-1")
+        messages.extend(
+            _make_brc_messages(pipeline_id="issue-42", phase="implement", slice_id="slice-2")
+        )
+
+        mock_store = MagicMock(spec=MessageStore)
+        mock_store.get_messages.return_value = messages
+
+        with patch("message_store.get_message_store", return_value=mock_store):
+            _write_brc_history(tmp_path, "issue-42", "implement", 42, write_per_slice=False)
+
+        history_dir = tmp_path / ".egg-state" / "brc-history"
+        assert not (history_dir / "42-implement-slice-1.md").exists(), (
+            "per-slice .md leaked despite write_per_slice=False (#2755)"
+        )
+        assert not (history_dir / "42-implement-slice-2.md").exists(), (
+            "per-slice .md leaked despite write_per_slice=False (#2755)"
+        )
+        assert not (history_dir / "42-implement-slice-1.json").exists()
+        assert not (history_dir / "42-implement-slice-2.json").exists()
+        # And no aggregate file either — slice-aware pipelines never
+        # produce one (#2548 hard switchover).
+        assert not (history_dir / "42-implement.md").exists()
+        assert not (history_dir / "42-implement.json").exists()
+
+    def test_write_per_slice_false_still_writes_unattributed_sibling(self, tmp_path):
+        """The ``{identifier}-implement-unattributed.{md,json}`` sibling
+        holds non-CONSENSUS BRC messages that lack slice scope
+        (HEARTBEAT, AGENT_FAILED, etc.). It is owned by ``work``, not
+        any slice, so ``write_per_slice=False`` must still produce it
+        when relevant messages exist (#2755)."""
+        from message_store import MessageType
+        from routes.pipelines import _write_brc_history
+
+        # One slice-attributed CONSENSUS message (forces slice-aware
+        # mode) plus one unattributed HEARTBEAT (lands in the
+        # unattributed sibling).
+        messages = [
+            _make_brc_message(
+                pipeline_id="issue-42",
+                phase="implement",
+                message_type=MessageType.CONSENSUS_PROPOSE,
+                slice_id="slice-1",
+            ),
+            _make_brc_message(
+                pipeline_id="issue-42",
+                phase="implement",
+                from_role="health_monitor",
+                message_type=MessageType.HEARTBEAT,
+                subject="heartbeat",
+                body="",
+                slice_id=None,
+            ),
+        ]
+
+        mock_store = MagicMock(spec=MessageStore)
+        mock_store.get_messages.return_value = messages
+
+        with patch("message_store.get_message_store", return_value=mock_store):
+            _write_brc_history(tmp_path, "issue-42", "implement", 42, write_per_slice=False)
+
+        history_dir = tmp_path / ".egg-state" / "brc-history"
+        # Unattributed sibling MUST exist — it carries the orchestrator-
+        # owned signals that have no slice scope.
+        assert (history_dir / "42-implement-unattributed.md").exists(), (
+            "unattributed sibling missing despite present unattributed messages (#2755)"
+        )
+        assert (history_dir / "42-implement-unattributed.json").exists()
+        # Per-slice files must NOT exist.
+        assert not (history_dir / "42-implement-slice-1.md").exists()
+
+    def test_write_per_slice_false_non_slice_pipeline_still_writes_aggregate(self, tmp_path):
+        """Non-slice pipelines (babysit_pr, custom phases) never produce
+        per-slice files — they hit the ``not buckets`` branch and write
+        the aggregate ``{identifier}-implement.{md,json}`` file. The
+        ``write_per_slice`` flag only gates the per-slice bucket loop,
+        so the aggregate path is unaffected (#2755)."""
+        from routes.pipelines import _write_brc_history
+
+        # All messages explicitly lack slice metadata → non-slice pipeline.
+        messages = _make_brc_messages(pipeline_id="issue-42", phase="implement", slice_id=None)
+
+        mock_store = MagicMock(spec=MessageStore)
+        mock_store.get_messages.return_value = messages
+
+        with patch("message_store.get_message_store", return_value=mock_store):
+            _write_brc_history(tmp_path, "issue-42", "implement", 42, write_per_slice=False)
+
+        history_dir = tmp_path / ".egg-state" / "brc-history"
+        # Aggregate file MUST exist — this is the babysit_pr artifact
+        # path and the flag does not gate it.
+        assert (history_dir / "42-implement.md").exists()
+        assert (history_dir / "42-implement.json").exists()
+
+    def test_write_per_slice_false_is_noop_for_non_implement_phases(self, tmp_path):
+        """The flag only affects implement-phase writes. Refine, plan,
+        and PR phases always produce a single aggregate file regardless
+        of ``write_per_slice`` (#2755)."""
+        from routes.pipelines import _write_brc_history
+
+        messages = _make_brc_messages(pipeline_id="issue-42", phase="refine")
+
+        mock_store = MagicMock(spec=MessageStore)
+        mock_store.get_messages.return_value = messages
+
+        with patch("message_store.get_message_store", return_value=mock_store):
+            _write_brc_history(tmp_path, "issue-42", "refine", 42, write_per_slice=False)
+
+        history_dir = tmp_path / ".egg-state" / "brc-history"
+        assert (history_dir / "42-refine.md").exists()
+        assert (history_dir / "42-refine.json").exists()
+
+
+class TestPerSliceImplementBrcHistoryRewriteForPr:
+    """The PR-phase safety-net rewrite (``_rewrite_brc_history_for_pr``)
+    calls ``_write_brc_history`` against the work worktree.
+
+    Pre-#2755 it produced per-slice ``{identifier}-implement-{slice_id}.{md,json}``
+    files there too, but those duplicated the files committed onto each
+    slice's integration branch by
+    :func:`_commit_slice_brc_history_to_integration_branch` and caused
+    add/add merge conflicts when slice PRs tried to merge into ``work``.
+
+    Post-#2755 the rewrite passes ``write_per_slice=False`` so per-slice
+    files no longer land on the work worktree. The unattributed sibling
+    and any aggregate non-implement files are still produced.
+    """
+
+    def test_rewrite_for_pr_skips_per_slice_implement_files_on_work(self, tmp_path):
+        """When the PR phase rewrites BRC history on the work worktree,
+        the implement-phase rewrite must NOT produce per-slice files
+        (#2755). Each slice owns its own per-slice file on its
+        integration branch; duplicating onto ``work`` would conflict
+        when the slice PR merges."""
         from routes.pipelines import _rewrite_brc_history_for_pr
 
         messages = _make_brc_messages(pipeline_id="issue-42", phase="implement", slice_id="slice-1")
@@ -2460,14 +2629,24 @@ class TestPerSliceImplementBrcHistoryRewriteForPr:
             _rewrite_brc_history_for_pr(tmp_path, "issue-42", phases, 42)
 
         history_dir = tmp_path / ".egg-state" / "brc-history"
-        assert (history_dir / "42-implement-slice-1.md").exists()
-        assert (history_dir / "42-implement-slice-2.md").exists()
+        # Per-slice files MUST NOT land on the work worktree (#2755).
+        assert not (history_dir / "42-implement-slice-1.md").exists(), (
+            "per-slice file leaked onto work worktree — would conflict with slice PR (#2755)"
+        )
+        assert not (history_dir / "42-implement-slice-2.md").exists(), (
+            "per-slice file leaked onto work worktree — would conflict with slice PR (#2755)"
+        )
+        assert not (history_dir / "42-implement-slice-1.json").exists()
+        assert not (history_dir / "42-implement-slice-2.json").exists()
+        # Aggregate implement file also must not exist — #2548 hard
+        # switchover; slice-aware pipelines do not produce one.
         assert not (history_dir / "42-implement.md").exists()
         assert not (history_dir / "42-implement.json").exists()
 
-    def test_rewrite_for_pr_mixes_aggregate_refine_and_per_slice_implement(self, tmp_path):
+    def test_rewrite_for_pr_emits_aggregate_refine_only(self, tmp_path):
         """Mixed multi-phase rewrite: refine emits aggregate, implement
-        emits per-slice — both shapes coexist in the same brc-history dir."""
+        emits **nothing** on the work worktree (#2755 — per-slice files
+        live on each slice's integration branch instead)."""
         from routes.pipelines import _rewrite_brc_history_for_pr
 
         all_messages = []
@@ -2491,12 +2670,13 @@ class TestPerSliceImplementBrcHistoryRewriteForPr:
             _rewrite_brc_history_for_pr(tmp_path, "issue-42", phases, 42)
 
         history_dir = tmp_path / ".egg-state" / "brc-history"
-        # Refine: aggregate. Implement: per-slice.
+        # Refine: aggregate still lands on work (refine is not partitioned
+        # per slice and the conflict pattern only applies to implement).
         assert (history_dir / "42-refine.md").exists()
         assert (history_dir / "42-refine.json").exists()
-        assert (history_dir / "42-implement-slice-1.md").exists()
-        assert (history_dir / "42-implement-slice-1.json").exists()
-        # No aggregate implement file.
+        # Implement: nothing on work (#2755).
+        assert not (history_dir / "42-implement-slice-1.md").exists()
+        assert not (history_dir / "42-implement-slice-1.json").exists()
         assert not (history_dir / "42-implement.md").exists()
         assert not (history_dir / "42-implement.json").exists()
         # Refine never partitions by slice.

--- a/orchestrator/tests/test_diagnostic_logging_1633.py
+++ b/orchestrator/tests/test_diagnostic_logging_1633.py
@@ -534,12 +534,17 @@ class TestIntegrationBrcHistory:
         with patch("message_store.get_message_store", return_value=mock_store):
             mod._rewrite_brc_history_for_pr(worktree, pipeline_id, phases, identifier)
 
-        # Assertion (a): BRC history files written for both COMPLETE phases.
-        # #2548: implement phase is per-slice; aggregate file is gone.
+        # Assertion (a): BRC history files written for refine on the
+        # work worktree. Implement phase: NO per-slice files on work
+        # (#2755 — they're owned by each slice's integration branch
+        # and committed there by the slice hook; duplicating onto
+        # ``work`` would conflict with slice PR merges).
         brc_dir = worktree / ".egg-state" / "brc-history"
         assert (brc_dir / "42-refine.md").exists(), "BRC history for refine should exist"
         impl_file = brc_dir / f"42-implement-{_DEFAULT_IMPLEMENT_SLICE_ID}.md"
-        assert impl_file.exists(), "Per-slice BRC history for implement should exist"
+        assert not impl_file.exists(), (
+            "Per-slice implement file leaked onto work worktree (#2755 regression)"
+        )
         assert not (brc_dir / "42-implement.md").exists(), (
             "Aggregate implement.md leaked through hard switchover"
         )
@@ -551,10 +556,6 @@ class TestIntegrationBrcHistory:
         assert "Pipeline: issue-42" in refine_content
         assert "CONSENSUS_PROPOSE" in refine_content
         assert "CONSENSUS_ACK" in refine_content
-
-        implement_content = impl_file.read_text()
-        assert "implement phase" in implement_content
-        assert "Tests pass" in implement_content
 
         # Assertion (c): _commit_statefiles_to_worktree was called (git commands issued)
         commit_cmds = [c for c in git_commands if "commit" in c]
@@ -575,7 +576,15 @@ class TestIntegrationBrcHistory:
         assert (drafts_dir / "99-analysis.md").exists(), "Pipeline 99's draft should be preserved"
 
     def test_brc_history_file_content(self, worktree, monkeypatch):
-        """BRC history files contain expected markdown content."""
+        """BRC history files contain expected markdown content.
+
+        Uses the refine phase because implement-phase BRC history no
+        longer lands on the work worktree (#2755) — per-slice files
+        are owned by each slice's integration branch. Refine still
+        writes an aggregate file to ``work``, so it's the right
+        surface for verifying the writer's markdown rendering on
+        the work-worktree path.
+        """
         import routes.pipelines as mod
 
         messages = [
@@ -585,7 +594,7 @@ class TestIntegrationBrcHistory:
                 message_type=MessageType.CONSENSUS_PROPOSE,
                 subject="Feature proposal",
                 body="Implementation details",
-                phase="implement",
+                phase="refine",
             ),
         ]
 
@@ -593,7 +602,7 @@ class TestIntegrationBrcHistory:
         mock_store.get_messages.return_value = messages
 
         phases = {
-            "implement": MagicMock(status=PipelineStatus.COMPLETE),
+            "refine": MagicMock(status=PipelineStatus.COMPLETE),
         }
 
         def fake_run(cmd, **kwargs):
@@ -606,18 +615,12 @@ class TestIntegrationBrcHistory:
         with patch("message_store.get_message_store", return_value=mock_store):
             mod._rewrite_brc_history_for_pr(worktree, "issue-42", phases, 42)
 
-        # #2548: implement is per-slice — the aggregate file is gone.
-        history_file = (
-            worktree
-            / ".egg-state"
-            / "brc-history"
-            / f"42-implement-{_DEFAULT_IMPLEMENT_SLICE_ID}.md"
-        )
+        history_file = worktree / ".egg-state" / "brc-history" / "42-refine.md"
         assert history_file.exists(), "BRC history file should exist on disk"
 
         content = history_file.read_text()
         assert "# BRC Consensus History" in content
-        assert "implement phase" in content
+        assert "refine phase" in content
         assert "Pipeline: issue-42" in content
         assert "coder" in content
         assert "CONSENSUS_PROPOSE" in content

--- a/orchestrator/tests/test_per_slice_brc_commit.py
+++ b/orchestrator/tests/test_per_slice_brc_commit.py
@@ -309,7 +309,7 @@ class TestHappyPath:
             # per-slice files at the staging path on its scan step.
             stub = _writer_stub(tmp_path)
             stub(worktree, pipeline_id, phase, identifier, **kwargs)
-            writer_calls.append((str(worktree), pipeline_id, phase, identifier))
+            writer_calls.append((str(worktree), pipeline_id, phase, identifier, dict(kwargs)))
 
         with patch("routes.pipelines._write_brc_history", _spy_writer):
             _commit_slice_brc_history_to_integration_branch(
@@ -321,7 +321,7 @@ class TestHappyPath:
             )
 
         assert len(writer_calls) == 1, "writer must be called exactly once per hook tick"
-        wt, pid, phase, identifier = writer_calls[0]
+        wt, pid, phase, identifier, kwargs = writer_calls[0]
         # Writer must NOT be called against the work worktree (#2755).
         # The hook stages into a temp directory so concurrent slice hooks
         # do not leave per-slice files on ``work`` that would conflict
@@ -335,6 +335,16 @@ class TestHappyPath:
         # Identifier resolves via ``_brc_history_identifier`` — for an
         # issue pipeline that's the issue number (2548).
         assert identifier == 2548
+        # The slice hook depends on per-slice file rendering — passing
+        # ``write_per_slice=False`` here would silently skip the per-slice
+        # bucket loop and break the feature (the downstream scan would
+        # find no files and the hook would return False). Pin the kwarg
+        # so a future regression that flips the default cannot escape
+        # via ``_writer_stub``'s ``**kwargs`` permissiveness.
+        assert kwargs.get("write_per_slice", True) is True, (
+            f"slice hook must not pass write_per_slice=False to the writer (#2755); "
+            f"got kwargs={kwargs!r}"
+        )
 
     def test_fetches_integration_branch_before_worktree_add(self, tmp_path, pipeline, make_spawner):
         """Step 2: the local remote-tracking ref is refreshed via

--- a/orchestrator/tests/test_per_slice_brc_commit.py
+++ b/orchestrator/tests/test_per_slice_brc_commit.py
@@ -9,22 +9,28 @@ approved the slice's code.
 
 Key invariants this file pins:
 
-* Happy path: writer is called, files are copied to the integration
-  worktree, the orchestrator-authored commit is recorded, and the
-  branch is pushed via ``push_worktree_branch``.
+* Happy path: writer is called against a per-tick **staging
+  directory** (not the work worktree, #2755), files are copied to
+  the integration worktree, the orchestrator-authored commit is
+  recorded, and the branch is pushed via ``push_worktree_branch``.
 * Best-effort failure semantics: every step (writer, fetch, worktree
   add, commit, push) returns ``False`` on failure rather than raising
-  — so PR creation can still proceed with the work-worktree files as
-  a fallback audit trail.
+  — so PR creation can still proceed (the slice PR opens without
+  its consensus transcript in that case).
 * Idempotency: the hook is safe to re-run mid-flight.  The commit
   step skips when nothing is staged, and the push fast-forwards on
   no-op.
 * Per-slice scoping: ONLY the named slice's files are copied; other
-  slices' BRC files (and the unattributed sibling) stay on the work
-  worktree alone.
+  slices' BRC files (and the unattributed sibling) stay in the
+  per-tick staging directory and are cleaned up with it.
+* Staging isolation: the writer's output lives in a ``mkdtemp``-rooted
+  staging directory created per hook tick (#2755); the work worktree
+  is never written to, so concurrent slice hooks cannot leave
+  per-slice files on ``work`` that would later conflict with slice
+  PR merges.
 * Symlink defense: a planted symlink in
   ``.egg-state/brc-history/`` is skipped — never copied or staged —
-  so an attacker-controlled symlink can't smuggle unrelated content
+  so a future writer change cannot leak attacker-controlled content
   onto the slice PR.
 * No-op short-circuit: pipeline without a remote ``repo`` returns
   ``False`` without touching git or the gateway.
@@ -162,10 +168,17 @@ def _seed_per_slice_brc_files(
     *,
     slice_ids: list[str],
 ) -> dict[str, Path]:
-    """Populate ``.egg-state/brc-history/`` with per-slice BRC files.
+    """Pre-seed ``<repo_root>/.egg-state/brc-history/`` with per-slice BRC files.
 
     Returns a mapping of ``"<slice_id>-md"`` / ``"<slice_id>-json"``
     keys to the absolute file paths so individual tests can introspect.
+
+    Note: after the #2755 refactor, the hook reads per-slice files from
+    a per-tick staging directory (not the work worktree). Tests pair
+    this seed with :func:`_writer_stub` patched in for
+    ``_write_brc_history``; the stub copies the seeded files into the
+    staging directory the hook passes to the writer, so the hook's
+    scan-and-copy logic sees them at the expected staging path.
     """
     brc = repo_root / ".egg-state" / "brc-history"
     brc.mkdir(parents=True, exist_ok=True)
@@ -180,13 +193,73 @@ def _seed_per_slice_brc_files(
     return paths
 
 
-def _no_op_write_brc_history(*args, **kwargs):
-    """Replacement for the writer — leaves the seeded files untouched.
+def _writer_stub(seed_root: Path):
+    """Build a ``_write_brc_history`` replacement that mirrors seeds into staging.
 
-    The real ``_write_brc_history`` re-renders the per-slice files from
-    the message store, but our tests seed the files directly so the
-    writer is a noop.  Tests that need to exercise writer-failure paths
-    override this with their own patch.
+    The real writer renders per-slice files from the message store into
+    ``<worktree>/.egg-state/brc-history/``. After #2755 the slice hook
+    passes a per-tick staging directory as that worktree argument.
+
+    This stub:
+
+    * Records the staging path the hook passed (tests can inspect
+      ``stub.staging_paths`` to assert the hook did NOT pass the work
+      worktree).
+    * Mirrors anything in ``<seed_root>/.egg-state/brc-history/`` into
+      ``<staging>/.egg-state/brc-history/``, preserving symlinks so the
+      symlink-defense path can be exercised.
+
+    The factory returns the stub callable; the callable carries the
+    ``staging_paths`` attribute for assertions.
+    """
+    import os
+
+    seen: list[str] = []
+
+    def _stub(*args, **kwargs):
+        # The writer's first positional arg is the destination path. We
+        # accept any extra args/kwargs so adding parameters to
+        # ``_write_brc_history`` (e.g. ``write_per_slice``) doesn't break
+        # patched tests.
+        if not args:
+            return
+        staging_path = Path(args[0])
+        seen.append(str(staging_path))
+        src_brc = seed_root / ".egg-state" / "brc-history"
+        if not src_brc.exists():
+            return
+        dst_brc = staging_path / ".egg-state" / "brc-history"
+        dst_brc.mkdir(parents=True, exist_ok=True)
+        for src in src_brc.iterdir():
+            dst = dst_brc / src.name
+            if src.is_symlink():
+                # Preserve as a symlink so the hook's symlink defense
+                # can be exercised in a path that mirrors production
+                # (where the writer would have to be coerced into
+                # producing a symlink for the defense to fire).
+                target = os.readlink(src)
+                if dst.exists() or dst.is_symlink():
+                    dst.unlink()
+                os.symlink(target, dst)
+            elif src.is_file():
+                # Use raw bytes I/O rather than ``shutil.copy2`` so tests
+                # that spy on ``shutil.copy2`` only see the hook's own
+                # copy calls (staging → integration worktree), not the
+                # stub's internal seed mirror (seed root → staging).
+                dst.write_bytes(src.read_bytes())
+
+    _stub.staging_paths = seen  # type: ignore[attr-defined]
+    return _stub
+
+
+def _no_op_write_brc_history(*args, **kwargs):
+    """Replacement for the writer that does nothing.
+
+    Used by tests that explicitly want NO files in the hook's staging
+    directory (e.g. the "no per-slice files produced" path that must
+    return False). Tests that DO want files staged use
+    :func:`_writer_stub` instead, which mirrors pre-seeded files into
+    the staging directory the hook passes to the writer.
     """
 
 
@@ -202,7 +275,7 @@ class TestHappyPath:
         gateway, and the helper returns True."""
         _seed_per_slice_brc_files(tmp_path, identifier=2548, slice_ids=["slice-1"])
         spawner = make_spawner()
-        with patch("routes.pipelines._write_brc_history", _no_op_write_brc_history):
+        with patch("routes.pipelines._write_brc_history", _writer_stub(tmp_path)):
             ok = _commit_slice_brc_history_to_integration_branch(
                 pipeline,
                 spawner,
@@ -223,13 +296,19 @@ class TestHappyPath:
         assert push_kwargs["base_branch"] == "main"
 
     def test_calls_write_brc_history_to_refresh_files(self, tmp_path, pipeline, make_spawner):
-        """Step 1: the writer is invoked so messages that landed since
-        the last phase-boundary write are captured."""
+        """Step 1: the writer is invoked against a per-tick **staging
+        directory** (#2755) so messages that landed since the last
+        phase-boundary write are captured without touching the work
+        worktree."""
         _seed_per_slice_brc_files(tmp_path, identifier=2548, slice_ids=["slice-1"])
         spawner = make_spawner()
         writer_calls: list[tuple] = []
 
-        def _spy_writer(worktree, pipeline_id, phase, identifier):
+        def _spy_writer(worktree, pipeline_id, phase, identifier, **kwargs):
+            # Mirror real writer side-effects so the hook can find the
+            # per-slice files at the staging path on its scan step.
+            stub = _writer_stub(tmp_path)
+            stub(worktree, pipeline_id, phase, identifier, **kwargs)
             writer_calls.append((str(worktree), pipeline_id, phase, identifier))
 
         with patch("routes.pipelines._write_brc_history", _spy_writer):
@@ -243,7 +322,14 @@ class TestHappyPath:
 
         assert len(writer_calls) == 1, "writer must be called exactly once per hook tick"
         wt, pid, phase, identifier = writer_calls[0]
-        assert wt == str(tmp_path)
+        # Writer must NOT be called against the work worktree (#2755).
+        # The hook stages into a temp directory so concurrent slice hooks
+        # do not leave per-slice files on ``work`` that would conflict
+        # with the slice PRs' add of the same paths.
+        assert wt != str(tmp_path), (
+            f"writer must not be called against the work worktree (#2755); "
+            f"got {wt!r} which is the work-worktree path"
+        )
         assert pid == "issue-2548"
         assert phase == "implement"
         # Identifier resolves via ``_brc_history_identifier`` — for an
@@ -256,7 +342,7 @@ class TestHappyPath:
         stale tip."""
         _seed_per_slice_brc_files(tmp_path, identifier=2548, slice_ids=["slice-1"])
         spawner = make_spawner()
-        with patch("routes.pipelines._write_brc_history", _no_op_write_brc_history):
+        with patch("routes.pipelines._write_brc_history", _writer_stub(tmp_path)):
             _commit_slice_brc_history_to_integration_branch(
                 pipeline,
                 spawner,
@@ -281,7 +367,7 @@ class TestHappyPath:
         _seed_per_slice_brc_files(tmp_path, identifier=2548, slice_ids=["slice-1"])
         spawner = make_spawner()
         spawner.gateway.fetch_branch.side_effect = RuntimeError("network blip")
-        with patch("routes.pipelines._write_brc_history", _no_op_write_brc_history):
+        with patch("routes.pipelines._write_brc_history", _writer_stub(tmp_path)):
             _commit_slice_brc_history_to_integration_branch(
                 pipeline,
                 spawner,
@@ -360,7 +446,7 @@ class TestPerSliceScoping:
             return original_copy(src, dst, *args, **kwargs)
 
         with (
-            patch("routes.pipelines._write_brc_history", _no_op_write_brc_history),
+            patch("routes.pipelines._write_brc_history", _writer_stub(tmp_path)),
             patch("shutil.copy2", _spy_copy),
         ):
             _commit_slice_brc_history_to_integration_branch(
@@ -391,7 +477,7 @@ class TestPerSliceScoping:
         brc = tmp_path / ".egg-state" / "brc-history"
         brc.mkdir(parents=True, exist_ok=True)
         spawner = make_spawner()
-        with patch("routes.pipelines._write_brc_history", _no_op_write_brc_history):
+        with patch("routes.pipelines._write_brc_history", _writer_stub(tmp_path)):
             ok = _commit_slice_brc_history_to_integration_branch(
                 pipeline,
                 spawner,
@@ -410,11 +496,16 @@ class TestPerSliceScoping:
 
 class TestSymlinkDefense:
     def test_symlink_brc_file_is_skipped(self, tmp_path, pipeline, make_spawner):
-        """A planted symlink in ``.egg-state/brc-history/`` must not be
-        copied onto the integration worktree.  Without this defense an
-        attacker-controlled metadata blob could plant a symlink to a
-        secret file outside the worktree, then claim it as the BRC
-        transcript and leak its contents into the slice PR diff."""
+        """A symlink in the staged ``.egg-state/brc-history/`` directory
+        must not be copied onto the integration worktree.
+
+        After #2755 the hook scans a per-tick staging directory rather
+        than the work worktree, so the seeded symlink lives at the
+        seed root and ``_writer_stub`` mirrors it (as a symlink) into
+        staging. The defense is defense-in-depth — even though staging
+        is freshly ``mkdtemp``'d per hook tick, a future writer change
+        that synthesised a symlink from attacker-controlled metadata
+        would otherwise smuggle unrelated content onto the slice PR."""
         brc = tmp_path / ".egg-state" / "brc-history"
         brc.mkdir(parents=True, exist_ok=True)
 
@@ -440,7 +531,7 @@ class TestSymlinkDefense:
             return original_copy(src, dst, *args, **kwargs)
 
         with (
-            patch("routes.pipelines._write_brc_history", _no_op_write_brc_history),
+            patch("routes.pipelines._write_brc_history", _writer_stub(tmp_path)),
             patch("shutil.copy2", _spy_copy),
         ):
             _commit_slice_brc_history_to_integration_branch(
@@ -451,12 +542,14 @@ class TestSymlinkDefense:
                 integration_branch="egg/issue-2548/slice-1",
             )
 
-        # The symlinked .md must NOT have been copied.
-        for src, _dst in copy_calls:
-            assert ".md" not in src or "secret" not in src, f"symlink leaked into copy_calls: {src}"
-        # And the symlinked filename literally must not appear as a src.
-        assert not any(str(sym_md) == src for src, _ in copy_calls), (
-            "symlinked .md was copied — symlink defense broken"
+        # No ``.md`` file should appear in copy_calls — the only ``.md``
+        # path under the staged ``brc-history`` directory is a symlink,
+        # and the defense must skip it. The ``.json`` companion (a real
+        # file) is still copied, so the hook is not a no-op.
+        md_srcs = [src for src, _ in copy_calls if src.endswith(".md")]
+        assert not md_srcs, f"symlinked .md leaked into copy_calls (defense broken): {md_srcs}"
+        assert any(src.endswith(".json") for src, _ in copy_calls), (
+            "the real .json companion should still have been copied"
         )
 
 
@@ -507,7 +600,7 @@ class TestFailureSemantics:
             return result
 
         with (
-            patch("routes.pipelines._write_brc_history", _no_op_write_brc_history),
+            patch("routes.pipelines._write_brc_history", _writer_stub(tmp_path)),
             patch("subprocess.run", _selective_run),
         ):
             ok = _commit_slice_brc_history_to_integration_branch(
@@ -527,7 +620,7 @@ class TestFailureSemantics:
         the best-effort semantics promise to prevent."""
         _seed_per_slice_brc_files(tmp_path, identifier=2548, slice_ids=["slice-1"])
         spawner = make_spawner(push_raise=RuntimeError("gateway unavailable"))
-        with patch("routes.pipelines._write_brc_history", _no_op_write_brc_history):
+        with patch("routes.pipelines._write_brc_history", _writer_stub(tmp_path)):
             ok = _commit_slice_brc_history_to_integration_branch(
                 pipeline,
                 spawner,
@@ -545,7 +638,7 @@ class TestFailureSemantics:
         spawner = make_spawner(
             push_result=PushResult(ok=False, category="non_fast_forward", detail="rejected")
         )
-        with patch("routes.pipelines._write_brc_history", _no_op_write_brc_history):
+        with patch("routes.pipelines._write_brc_history", _writer_stub(tmp_path)):
             ok = _commit_slice_brc_history_to_integration_branch(
                 pipeline,
                 spawner,
@@ -566,7 +659,7 @@ class TestFailureSemantics:
             raise RuntimeError("git add failed")
 
         with (
-            patch("routes.pipelines._write_brc_history", _no_op_write_brc_history),
+            patch("routes.pipelines._write_brc_history", _writer_stub(tmp_path)),
             patch("routes.pipelines._commit_statefiles_to_worktree", _raising_commit),
         ):
             ok = _commit_slice_brc_history_to_integration_branch(
@@ -603,7 +696,7 @@ class TestIdempotencyAndCleanup:
             return result
 
         with (
-            patch("routes.pipelines._write_brc_history", _no_op_write_brc_history),
+            patch("routes.pipelines._write_brc_history", _writer_stub(tmp_path)),
             patch("subprocess.run", _spy_run),
         ):
             _commit_slice_brc_history_to_integration_branch(
@@ -636,7 +729,7 @@ class TestIdempotencyAndCleanup:
             return result
 
         with (
-            patch("routes.pipelines._write_brc_history", _no_op_write_brc_history),
+            patch("routes.pipelines._write_brc_history", _writer_stub(tmp_path)),
             patch("subprocess.run", _spy_run),
         ):
             ok = _commit_slice_brc_history_to_integration_branch(
@@ -659,7 +752,7 @@ class TestIdempotencyAndCleanup:
         re-run."""
         _seed_per_slice_brc_files(tmp_path, identifier=2548, slice_ids=["slice-1"])
         spawner = make_spawner()
-        with patch("routes.pipelines._write_brc_history", _no_op_write_brc_history):
+        with patch("routes.pipelines._write_brc_history", _writer_stub(tmp_path)):
             ok1 = _commit_slice_brc_history_to_integration_branch(
                 pipeline,
                 spawner,
@@ -692,9 +785,10 @@ class TestIdentifierResolution:
         """The hook uses ``_brc_history_identifier(pipeline)`` to build
         the per-slice filename.  For an issue pipeline, that's the
         issue number (int) — the path interpolation must produce
-        ``2548-implement-slice-1.md`` etc."""
-        # Seed under the issue-number identifier.
-        paths = _seed_per_slice_brc_files(tmp_path, identifier=2548, slice_ids=["slice-1"])
+        ``2548-implement-slice-1.md`` etc., regardless of whether the
+        source is the work worktree (pre-#2755) or the per-tick
+        staging directory (post-#2755)."""
+        _seed_per_slice_brc_files(tmp_path, identifier=2548, slice_ids=["slice-1"])
         spawner = make_spawner()
 
         copy_srcs: list[str] = []
@@ -707,7 +801,7 @@ class TestIdentifierResolution:
             return original_copy(src, dst, *args, **kwargs)
 
         with (
-            patch("routes.pipelines._write_brc_history", _no_op_write_brc_history),
+            patch("routes.pipelines._write_brc_history", _writer_stub(tmp_path)),
             patch("shutil.copy2", _spy_copy),
         ):
             _commit_slice_brc_history_to_integration_branch(
@@ -718,9 +812,17 @@ class TestIdentifierResolution:
                 integration_branch="egg/issue-2548/slice-1",
             )
 
-        # The seeded files should have been picked up.
-        assert str(paths["slice-1-md"]) in copy_srcs
-        assert str(paths["slice-1-json"]) in copy_srcs
+        # The canonical filename ``2548-implement-slice-1.{md,json}``
+        # must appear as a copy source (which lives under the staging
+        # directory post-#2755 — the test does not pin the directory
+        # prefix because that is implementation detail).
+        copy_basenames = [Path(s).name for s in copy_srcs]
+        assert "2548-implement-slice-1.md" in copy_basenames, (
+            f"slice-1 .md must be copied; got copies {copy_basenames!r}"
+        )
+        assert "2548-implement-slice-1.json" in copy_basenames, (
+            f"slice-1 .json must be copied; got copies {copy_basenames!r}"
+        )
 
 
 # ----------------------------------------------------------------------
@@ -751,7 +853,7 @@ class TestGatewayAllowlistCompatibility:
 
         _seed_per_slice_brc_files(tmp_path, identifier=2548, slice_ids=["slice-1"])
         spawner = make_spawner()
-        with patch("routes.pipelines._write_brc_history", _no_op_write_brc_history):
+        with patch("routes.pipelines._write_brc_history", _writer_stub(tmp_path)):
             _commit_slice_brc_history_to_integration_branch(
                 pipeline,
                 spawner,
@@ -786,3 +888,100 @@ class TestGatewayAllowlistCompatibility:
         candidate = str(WORKTREE_BASE_DIR / "egg-slice-brc-pipeline-x-slice-y-abc" / "wt")
         ok, error = validate_repo_path(candidate)
         assert ok, f"WORKTREE_BASE_DIR drifted out of gateway ALLOWED_REPO_PATHS: {error}"
+
+
+# ----------------------------------------------------------------------
+# Work-worktree isolation (#2755 regression)
+# ----------------------------------------------------------------------
+
+
+class TestWorkWorktreeIsolation:
+    """Regression coverage for #2755.
+
+    Pre-fix, the slice hook called ``_write_brc_history`` against the
+    work worktree directly, leaving per-slice files on
+    ``work/.egg-state/brc-history/``. The end-of-implement-phase
+    commit then picked those up and committed them to ``work``,
+    causing add/add merge conflicts when slice PRs (slice → work)
+    tried to merge the same files.
+
+    Post-fix the hook stages to a per-tick temp directory; the work
+    worktree's ``.egg-state/brc-history/`` directory is never
+    written to by this hook.
+    """
+
+    def test_work_worktree_brc_history_untouched_by_slice_hook(
+        self, tmp_path, pipeline, make_spawner
+    ):
+        """After the slice hook runs against a clean work worktree,
+        ``<work>/.egg-state/brc-history/`` must contain no per-slice
+        files (#2755). The staged copy lives under a temp directory
+        rooted in ``WORKTREE_BASE_DIR`` and is cleaned up after the
+        hook returns."""
+        _seed_per_slice_brc_files(tmp_path, identifier=2548, slice_ids=["slice-1"])
+        # Capture the work-worktree brc-history state BEFORE the hook
+        # runs so we can compare against the AFTER state. The seed
+        # above writes into ``tmp_path/.egg-state/brc-history/`` to
+        # supply the ``_writer_stub`` source — but the hook's writer
+        # call (against staging) must not echo any new files back to
+        # this directory.
+        brc_dir = tmp_path / ".egg-state" / "brc-history"
+        before_files = sorted(p.name for p in brc_dir.iterdir())
+
+        spawner = make_spawner()
+        stub = _writer_stub(tmp_path)
+        with patch("routes.pipelines._write_brc_history", stub):
+            _commit_slice_brc_history_to_integration_branch(
+                pipeline,
+                spawner,
+                tmp_path,
+                slice_id="slice-1",
+                integration_branch="egg/issue-2548/slice-1",
+            )
+
+        after_files = sorted(p.name for p in brc_dir.iterdir())
+        # The work-worktree directory contents must be exactly what we
+        # seeded — the hook must not have added anything to it.
+        assert after_files == before_files, (
+            "slice hook touched the work-worktree brc-history dir (#2755 regression); "
+            f"before={before_files!r}, after={after_files!r}"
+        )
+
+        # And the writer must have been called against a path that is
+        # NOT the work worktree.
+        assert stub.staging_paths, "writer was never called"
+        for staging in stub.staging_paths:
+            assert staging != str(tmp_path), (
+                f"writer was called against the work worktree (#2755 regression): {staging}"
+            )
+
+    def test_staging_dir_cleaned_up_after_hook(self, tmp_path, pipeline, make_spawner, monkeypatch):
+        """The per-tick staging directory must be removed when the hook
+        returns, so pipelines do not accumulate stale staging dirs
+        under ``WORKTREE_BASE_DIR`` across slices (#2755)."""
+        import routes.pipelines as pipelines_mod
+
+        fake_base = tmp_path / "egg-worktrees-root"
+        fake_base.mkdir()
+        monkeypatch.setattr(pipelines_mod, "WORKTREE_BASE_DIR", fake_base)
+
+        _seed_per_slice_brc_files(tmp_path, identifier=2548, slice_ids=["slice-1"])
+        spawner = make_spawner()
+        stub = _writer_stub(tmp_path)
+        with patch("routes.pipelines._write_brc_history", stub):
+            _commit_slice_brc_history_to_integration_branch(
+                pipeline,
+                spawner,
+                tmp_path,
+                slice_id="slice-1",
+                integration_branch="egg/issue-2548/slice-1",
+            )
+
+        # The staging path was used; after cleanup it must no longer
+        # exist on disk (``shutil.rmtree(tmp_worktree, ignore_errors=True)``
+        # in the hook's ``finally`` clause).
+        assert stub.staging_paths, "writer was never called"
+        for staging in stub.staging_paths:
+            assert not Path(staging).exists(), (
+                f"staging directory {staging!r} leaked after hook returned"
+            )

--- a/orchestrator/tests/test_pr_phase_brc_rewrite.py
+++ b/orchestrator/tests/test_pr_phase_brc_rewrite.py
@@ -332,7 +332,12 @@ class TestRewriteBrcHistoryForPr:
         ):
             _rewrite_brc_history_for_pr(tmp_path, "issue-99", phases, 1599)
 
-        mock_write.assert_called_once_with(tmp_path, "issue-99", "implement", 1599)
+        # ``write_per_slice=False`` is passed (#2755) so per-slice
+        # implement-phase files do not duplicate onto the work
+        # worktree, where they would conflict with slice PR merges.
+        mock_write.assert_called_once_with(
+            tmp_path, "issue-99", "implement", 1599, write_per_slice=False
+        )
 
     def test_commits_after_rewrite(self, tmp_path):
         """_commit_statefiles_to_worktree is called after history writes."""


### PR DESCRIPTION
## Summary

Closes #2755.

- **Root cause.** `_write_brc_history` always wrote per-slice
  `{identifier}-implement-{slice_id}.{md,json}` files into the worktree
  it was called against. The slice hook (`_commit_slice_brc_history_to_integration_branch`) used the work worktree as scratch space and committed those per-slice files onto each slice's integration branch (correct), but the end-of-implement-phase and PR-phase commits then *also* committed them onto `work` — so both sides of every slice → work merge added the identical paths and GitHub reported add/add conflicts. The latent bug fires on every multi-slice pipeline that fans out from `work`.
- **Fix.** Per-slice files now live only on slice integration branches. The slice hook stages `_write_brc_history` output to a per-tick `mkdtemp`-rooted directory (still under `WORKTREE_BASE_DIR` for gateway-allowlist compatibility, #2684) and copies its slice's files from staging to the integration worktree. The work-worktree commit sites — the inline write in `_run_pipeline`, `_persist_phase_brc_history`, and `_rewrite_brc_history_for_pr` — pass a new `write_per_slice=False` kwarg so the writer skips the per-slice bucketing loop. The `unattributed` sibling and any non-slice-aware aggregate file are still produced.

## Why option (b), not the smaller patch

A minimal fix (skip per-slice writes plus unlink leftovers before committing to work) would have left the "use work worktree as scratch space" pattern in place and encoded the slice naming convention into two places — the writer skip and the unlink — neither of which is centrally documented. Moving the slice hook to its own staging directory makes `write_per_slice=False` sufficient on its own: nothing else writes per-slice files to the work worktree, so there is nothing to unlink. The concurrency commentary at the top of the slice hook simplifies as a result.

## Behavior change

When the umbrella `work → main` PR opens, the work branch's `.egg-state/brc-history/` no longer contains the per-slice transcripts up-front. They arrive on `work` naturally as slice PRs merge in (each slice PR's diff includes its own per-slice file). The umbrella PR's final state matches what's merged, which is the intended contract.

## Test plan

- [x] `make test` (full suite — 3055 passed)
- [x] `make lint` (clean)
- [x] `orchestrator/tests/test_per_slice_brc_commit.py` — slice-hook tests updated for staging behavior plus two new regression tests pinning work-worktree isolation and staging-dir cleanup
- [x] `orchestrator/tests/test_brc_history.py` — new `TestWritePerSliceFlag` class covers the four observable behaviors of the new kwarg (default writes per-slice; `False` skips per-slice; `False` still writes unattributed when relevant; `False` still writes the babysit_pr aggregate; flag is a no-op outside the implement phase)
- [x] `orchestrator/tests/test_pr_phase_brc_rewrite.py` and `test_diagnostic_logging_1633.py` — updated to assert the new "per-slice files do NOT land on work" invariant