### PR TITLE
Fix #2770: emit decision.created for bridged contract decisions

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -18897,6 +18897,13 @@ def _queue_and_await_contract_decisions(
     them as a single batch.  Callers can then prompt for up to 4 at a time
     and submit answers in parallel, collapsing what was previously N prompts
     and N polling cycles into ~⌈N/4⌉ prompts and one cycle (issue #1956).
+
+    Once the batch is queued, a single ``decision.created`` event is
+    published to the EventBus so event-driven watchers (the ``wait-status``
+    monitor long-polling ``/status/wait``) wake immediately.
+    ``DecisionQueue.queue_decision`` itself emits no event, so without this
+    the bridged decisions are created silently and the operator only
+    discovers them via a manual ``get_status`` (issue #2770).
     """
     try:
         from egg_contracts.loader import load_contract, save_contract
@@ -18995,6 +19002,19 @@ def _queue_and_await_contract_decisions(
             decision_type="feedback",
             questions=questions_payload,
             phase=phase,
+        )
+
+    # Surface the freshly-queued batch to event-driven watchers before
+    # blocking on resolution. ``DecisionQueue.queue_decision`` emits no
+    # EventBus event, so without this the bridged decisions are created
+    # silently — the operator's ``wait-status`` monitor never wakes and
+    # only finds them via a manual ``get_status`` (#2770). The phase_gate
+    # decision emits ``decision.created`` the same way.
+    if _emit_event is not None:
+        _emit_event(
+            EventType.DECISION_CREATED,
+            pipeline_id,
+            data={"phase": phase_value},
         )
 
     # Pass 2: wait for each to resolve and persist back to the contract.

--- a/orchestrator/tests/test_contract_decision_bridge.py
+++ b/orchestrator/tests/test_contract_decision_bridge.py
@@ -450,3 +450,102 @@ def test_bridge_queues_all_decisions_before_waiting(tmp_path: Path) -> None:
     fb = data["feedback"]
     assert fb["submitted"] is True
     assert fb["questions"][0]["answer"] == "ok"
+
+
+def test_bridge_emits_decision_created_event(tmp_path: Path, monkeypatch: Any) -> None:
+    """The bridged batch must emit a ``decision.created`` EventBus event.
+
+    ``DecisionQueue.queue_decision`` emits no event, so without an explicit
+    emission the operator's ``wait-status`` monitor never wakes on the
+    bridged decisions and only finds them via a manual ``get_status``
+    (regression test for #2770).
+    """
+    import routes.pipelines as rp
+    from events import EventType
+
+    captured: list[tuple[Any, str]] = []
+    monkeypatch.setattr(
+        rp,
+        "_emit_event",
+        lambda event_type, pipeline_id, data=None, source="orchestrator": captured.append(
+            (event_type, pipeline_id)
+        ),
+    )
+
+    identifier = "issue-42"
+    _make_contract_file(
+        tmp_path,
+        identifier,
+        decisions=[
+            {
+                "id": "decision-1",
+                "question": "Which database?",
+                "type": "hitl",
+                "phase": "refine",
+                "options": [{"id": "opt-1", "label": "Postgres", "description": None}],
+                "resolved": False,
+                "resolution": None,
+                "resolved_by": None,
+                "resolved_at": None,
+                "debounce_until": None,
+            },
+        ],
+    )
+    dq = _FakeQueue(resolutions=["Postgres"])
+
+    rp._queue_and_await_contract_decisions(
+        dq,
+        tmp_path,
+        "pipeline-id",
+        identifier,
+        PipelinePhase.REFINE,
+    )
+
+    assert (EventType.DECISION_CREATED, "pipeline-id") in captured
+
+
+def test_bridge_emits_no_event_when_nothing_queued(tmp_path: Path, monkeypatch: Any) -> None:
+    """No ``decision.created`` event fires when there is nothing to bridge."""
+    import routes.pipelines as rp
+    from events import EventType
+
+    captured: list[Any] = []
+    monkeypatch.setattr(
+        rp,
+        "_emit_event",
+        lambda event_type, pipeline_id, data=None, source="orchestrator": captured.append(
+            event_type
+        ),
+    )
+
+    identifier = "issue-42"
+    # A plan-scoped decision — nothing to bridge at the refine gate.
+    _make_contract_file(
+        tmp_path,
+        identifier,
+        decisions=[
+            {
+                "id": "decision-1",
+                "question": "For plan phase only",
+                "type": "hitl",
+                "phase": "plan",
+                "options": [],
+                "resolved": False,
+                "resolution": None,
+                "resolved_by": None,
+                "resolved_at": None,
+                "debounce_until": None,
+            }
+        ],
+    )
+    dq = _FakeQueue(resolutions=[])
+
+    rp._queue_and_await_contract_decisions(
+        dq,
+        tmp_path,
+        "pipeline-id",
+        identifier,
+        PipelinePhase.REFINE,
+    )
+
+    assert EventType.DECISION_CREATED not in captured

--- a/orchestrator/tests/test_contract_decision_bridge.py
+++ b/orchestrator/tests/test_contract_decision_bridge.py
@@ -368,15 +368,32 @@ class _OrderTrackingQueue(_FakeQueue):
         return super().wait_for_decision(decision_id)
 
 
-def test_bridge_queues_all_decisions_before_waiting(tmp_path: Path) -> None:
+def test_bridge_queues_all_decisions_before_waiting(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
     """All queue_decision calls must precede the first wait_for_decision.
 
     Regression test for #1956: previously the bridge queued and waited on
     decisions one at a time, so ``get_status`` only ever surfaced a single
     pending decision even when the contract had many. The fix batches the
     queue pass so the skill can prompt for up to 4 decisions at once.
+
+    Also pins the #2770 contract for a *mixed* batch: a contract carrying
+    both choice decisions and a feedback entry must still emit exactly one
+    ``decision.created`` event for the whole batch.
     """
+    import routes.pipelines as rp
+    from events import EventType
     from routes.pipelines import _queue_and_await_contract_decisions
+
+    captured: list[tuple[Any, str, Any]] = []
+    monkeypatch.setattr(
+        rp,
+        "_emit_event",
+        lambda event_type, pipeline_id, data=None, source="orchestrator": captured.append(
+            (event_type, pipeline_id, data)
+        ),
+    )
 
     identifier = "issue-42"
     _make_contract_file(
@@ -450,6 +467,12 @@ def test_bridge_queues_all_decisions_before_waiting(tmp_path: Path) -> None:
     fb = data["feedback"]
     assert fb["submitted"] is True
     assert fb["questions"][0]["answer"] == "ok"
+
+    # A mixed decisions+feedback batch still emits exactly one event (#2770).
+    decision_events = [e for e in captured if e[0] == EventType.DECISION_CREATED]
+    assert len(decision_events) == 1, f"expected exactly one event, got {decision_events}"
+    assert decision_events[0][1] == "pipeline-id"
+    assert decision_events[0][2] == {"phase": "refine"}
 
 
 def test_bridge_emits_decision_created_event(tmp_path: Path, monkeypatch: Any) -> None:

--- a/orchestrator/tests/test_contract_decision_bridge.py
+++ b/orchestrator/tests/test_contract_decision_bridge.py
@@ -453,22 +453,24 @@ def test_bridge_queues_all_decisions_before_waiting(tmp_path: Path) -> None:
 
 
 def test_bridge_emits_decision_created_event(tmp_path: Path, monkeypatch: Any) -> None:
-    """The bridged batch must emit a ``decision.created`` EventBus event.
+    """The bridged batch must emit exactly one ``decision.created`` event.
 
     ``DecisionQueue.queue_decision`` emits no event, so without an explicit
     emission the operator's ``wait-status`` monitor never wakes on the
     bridged decisions and only finds them via a manual ``get_status``
-    (regression test for #2770).
+    (regression test for #2770). A single event covers the whole batch —
+    one watcher wake re-fetches ``get_status`` and surfaces every queued
+    decision — and the payload carries the gate phase.
     """
     import routes.pipelines as rp
     from events import EventType
 
-    captured: list[tuple[Any, str]] = []
+    captured: list[tuple[Any, str, Any]] = []
     monkeypatch.setattr(
         rp,
         "_emit_event",
         lambda event_type, pipeline_id, data=None, source="orchestrator": captured.append(
-            (event_type, pipeline_id)
+            (event_type, pipeline_id, data)
         ),
     )
 
@@ -478,7 +480,7 @@ def test_bridge_emits_decision_created_event(tmp_path: Path, monkeypatch: Any) -
         identifier,
         decisions=[
             {
-                "id": "decision-1",
+                "id": f"decision-{i}",
                 "question": "Which database?",
                 "type": "hitl",
                 "phase": "refine",
@@ -488,10 +490,11 @@ def test_bridge_emits_decision_created_event(tmp_path: Path, monkeypatch: Any) -
                 "resolved_by": None,
                 "resolved_at": None,
                 "debounce_until": None,
-            },
+            }
+            for i in range(1, 3)
         ],
     )
-    dq = _FakeQueue(resolutions=["Postgres"])
+    dq = _FakeQueue(resolutions=["Postgres", "Postgres"])
 
     rp._queue_and_await_contract_decisions(
         dq,
@@ -501,7 +504,12 @@ def test_bridge_emits_decision_created_event(tmp_path: Path, monkeypatch: Any) -
         PipelinePhase.REFINE,
     )
 
-    assert (EventType.DECISION_CREATED, "pipeline-id") in captured
+    decision_events = [e for e in captured if e[0] == EventType.DECISION_CREATED]
+    # One event for the whole batch — not one per queued decision.
+    assert len(decision_events) == 1, f"expected exactly one event, got {decision_events}"
+    _event_type, event_pipeline_id, event_data = decision_events[0]
+    assert event_pipeline_id == "pipeline-id"
+    assert event_data == {"phase": "refine"}
 
 
 def test_bridge_emits_no_event_when_nothing_queued(tmp_path: Path, monkeypatch: Any) -> None:
@@ -549,3 +557,56 @@ def test_bridge_emits_no_event_when_nothing_queued(tmp_path: Path, monkeypatch: 
     )
 
     assert EventType.DECISION_CREATED not in captured
+
+
+def test_bridge_emits_decision_created_event_for_feedback_only(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """A feedback-only batch (no choice decisions) still emits the event.
+
+    The emit fires once Pass 1 has queued *something* — a contract with
+    only a pending feedback entry and no decisions still bridges, so the
+    ``wait-status`` watcher must wake for it too (#2770).
+    """
+    import routes.pipelines as rp
+    from events import EventType
+
+    captured: list[tuple[Any, str, Any]] = []
+    monkeypatch.setattr(
+        rp,
+        "_emit_event",
+        lambda event_type, pipeline_id, data=None, source="orchestrator": captured.append(
+            (event_type, pipeline_id, data)
+        ),
+    )
+
+    identifier = "issue-42"
+    _make_contract_file(
+        tmp_path,
+        identifier,
+        feedback={
+            "id": "feedback-1",
+            "phase": "refine",
+            "questions": [{"id": "Q1", "question": "Notes?", "answer": None}],
+            "submitted": False,
+            "submitted_by": None,
+            "submitted_at": None,
+            "comment_id": None,
+            "debounce_until": None,
+        },
+    )
+    dq = _FakeQueue(
+        resolutions=[json.dumps({"action": "submit_feedback", "answers": {"Q1": "ok"}})]
+    )
+
+    rp._queue_and_await_contract_decisions(
+        dq,
+        tmp_path,
+        "pipeline-id",
+        identifier,
+        PipelinePhase.REFINE,
+    )
+
+    decision_events = [e for e in captured if e[0] == EventType.DECISION_CREATED]
+    assert len(decision_events) == 1, f"expected exactly one event, got {decision_events}"
+    assert decision_events[0][2] == {"phase": "refine"}

--- a/orchestrator/tests/test_contract_decision_bridge.py
+++ b/orchestrator/tests/test_contract_decision_bridge.py
@@ -368,9 +368,7 @@ class _OrderTrackingQueue(_FakeQueue):
         return super().wait_for_decision(decision_id)
 
 
-def test_bridge_queues_all_decisions_before_waiting(
-    tmp_path: Path, monkeypatch: Any
-) -> None:
+def test_bridge_queues_all_decisions_before_waiting(tmp_path: Path, monkeypatch: Any) -> None:
     """All queue_decision calls must precede the first wait_for_decision.
 
     Regression test for #1956: previously the bridge queued and waited on


### PR DESCRIPTION
## Summary

Fixes #2770. At the refine→plan (and plan→implement) HITL gate, the deferred contract decisions never surfaced to the operator's `wait-status` monitor — the pipeline sat silently in `awaiting_human` until a manual `get_status`.

**Root cause** — not a `/status/wait` route bug as the issue hypothesized. `_queue_and_await_contract_decisions` (the bridge that promotes agent-registered `register_open_question` / `request_feedback` entries into the orchestrator decision queue after phase_gate approval) calls `DecisionQueue.queue_decision()` for each decision but never emits a `decision.created` EventBus event. `queue_decision()` itself emits no event — only the phase_gate path (`pipelines.py:21697`) explicitly calls `_emit_pipeline_event(..., "decision.created")`. So the bridged decisions were created with no event at all; the `wait-status` watcher had nothing to wake on.

This matches the issue's observed timeline exactly: the phase_gate `decision.created` surfaced fine (it emits), the bridged batch never did (it didn't), and the next event the watcher saw was `pipeline.cancelled`.

## Change

- `_queue_and_await_contract_decisions` now emits one `decision.created` event to the EventBus once the batch is queued (Pass 1 complete, before blocking on resolution), mirroring the phase_gate path. One event is sufficient — the watcher wakes and re-fetches `get_status`, which surfaces all pending decisions as a batch.
- Two regression tests in `test_contract_decision_bridge.py`: the event fires when decisions are bridged, and does not fire when there is nothing to bridge.

## Test plan

- [x] `make test` — 2867 passed
- [x] `make lint` — passed
- [x] New tests in `orchestrator/tests/test_contract_decision_bridge.py` pass