### PR TITLE
Fix #2756: canonicalize yaml-tasks dependencies to a slice-N string

### DIFF
--- a/.egg/schemas/yaml-tasks.schema.json
+++ b/.egg/schemas/yaml-tasks.schema.json
@@ -92,7 +92,15 @@
         },
         "dependencies": {
           "type": "string",
-          "description": "The single parent slice this slice depends on, written as a 'slice-<N>' id (e.g. 'slice-1'). The slice DAG is a forest, so a slice has at most one parent — this is one id, not a list."
+          "description": "The single parent slice this slice depends on, written as a 'slice-<N>' id (e.g. 'slice-1'). The slice DAG is a forest, so a slice has at most one parent — this is one id, not a list. The parser also tolerates a 'depends_on' alias; that alias is intentionally NOT in this schema, since a prescriptive schema teaches only the canonical key."
+        },
+        "serialized_chain_order": {
+          "type": "array",
+          "description": "When a would-be multi-parent slice is serialised into a chain (the slice DAG must be a forest), the chosen upstream order recorded as 'slice-<N>' ids (#2137). The parser also tolerates a comma-separated string, but an array is the canonical shape.",
+          "items": {
+            "type": "string"
+          },
+          "default": []
         },
         "exit_criteria": {
           "type": "string",

--- a/.egg/schemas/yaml-tasks.schema.json
+++ b/.egg/schemas/yaml-tasks.schema.json
@@ -65,7 +65,7 @@
         },
         "dependencies": {
           "type": "string",
-          "description": "What must be completed before this phase"
+          "description": "The single parent slice this phase depends on, written as a 'slice-<N>' id (e.g. 'slice-1'). The slice DAG is a forest, so a slice has at most one parent — this is one id, not a list."
         },
         "exit_criteria": {
           "type": "string",

--- a/.egg/schemas/yaml-tasks.schema.json
+++ b/.egg/schemas/yaml-tasks.schema.json
@@ -4,14 +4,25 @@
   "title": "YAML Tasks Schema",
   "description": "Schema for the structured yaml-tasks appendix in plan documents. This schema defines the machine-readable format that accompanies human-readable plan prose.",
   "type": "object",
-  "required": ["phases"],
+  "anyOf": [
+    { "required": ["slices"] },
+    { "required": ["phases"] }
+  ],
   "properties": {
-    "phases": {
+    "slices": {
       "type": "array",
-      "description": "Implementation phases with their tasks",
+      "description": "Implementation slices with their tasks. Canonical top-level key (post-#2137); each slice is independently implementable and gets its own integration branch, agent team, BRC consensus, and PR.",
       "minItems": 1,
       "items": {
-        "$ref": "#/$defs/phase"
+        "$ref": "#/$defs/slice"
+      }
+    },
+    "phases": {
+      "type": "array",
+      "description": "Legacy alias for 'slices' (pre-#2137). Accepted for backward compatibility; new plans should emit 'slices'. When both keys are present, 'slices' wins.",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/slice"
       }
     },
     "pr": {
@@ -27,6 +38,22 @@
         "description": {
           "type": "string",
           "description": "PR description/body explaining the context and changes"
+        },
+        "test_plan": {
+          "type": "string",
+          "description": "Test plan for the PR — which automated tests cover the changes and the manual steps a reviewer takes to verify them. Strongly recommended."
+        },
+        "manual_steps": {
+          "type": "string",
+          "description": "Manual steps required before merge (e.g. migrations, config changes) or after merge (e.g. deployments, cache invalidation)."
+        },
+        "context_title": {
+          "type": "string",
+          "description": "Optional title for the dedicated context PR (#2548). When omitted, the context PR reuses 'pr.title'."
+        },
+        "context_description": {
+          "type": "string",
+          "description": "Optional description for the dedicated context PR (#2548). When omitted, the context PR reuses 'pr.description'."
         }
       },
       "additionalProperties": false
@@ -34,9 +61,9 @@
   },
   "additionalProperties": false,
   "$defs": {
-    "phase": {
+    "slice": {
       "type": "object",
-      "description": "An implementation phase containing tasks",
+      "description": "An implementation slice containing tasks. Each slice is independently implementable with its own integration branch, agent team, BRC consensus, and PR.",
       "required": ["id", "name", "tasks"],
       "properties": {
         "id": {
@@ -44,36 +71,36 @@
             {
               "type": "integer",
               "minimum": 1,
-              "description": "Phase number (e.g., 1, 2, 3)"
+              "description": "Slice number (e.g., 1, 2, 3)"
             },
             {
               "type": "string",
-              "pattern": "^(phase-)?[0-9]+$",
-              "description": "Phase identifier (e.g., '1' or 'phase-1')"
+              "pattern": "^(slice-|phase-)?[0-9]+$",
+              "description": "Slice identifier (e.g., '1', 'slice-1', or 'phase-1')"
             }
           ],
-          "description": "Unique phase identifier"
+          "description": "Unique slice identifier"
         },
         "name": {
           "type": "string",
-          "description": "Human-readable phase name",
+          "description": "Human-readable slice name",
           "minLength": 1
         },
         "goal": {
           "type": "string",
-          "description": "What this phase achieves"
+          "description": "What this slice achieves"
         },
         "dependencies": {
           "type": "string",
-          "description": "The single parent slice this phase depends on, written as a 'slice-<N>' id (e.g. 'slice-1'). The slice DAG is a forest, so a slice has at most one parent — this is one id, not a list."
+          "description": "The single parent slice this slice depends on, written as a 'slice-<N>' id (e.g. 'slice-1'). The slice DAG is a forest, so a slice has at most one parent — this is one id, not a list."
         },
         "exit_criteria": {
           "type": "string",
-          "description": "How we know this phase is complete"
+          "description": "How we know this slice is complete"
         },
         "tasks": {
           "type": "array",
-          "description": "Tasks in this phase",
+          "description": "Tasks in this slice",
           "minItems": 1,
           "items": {
             "$ref": "#/$defs/task"
@@ -84,12 +111,12 @@
     },
     "task": {
       "type": "object",
-      "description": "A task within a phase",
+      "description": "A task within a slice",
       "required": ["id", "description", "acceptance"],
       "properties": {
         "id": {
           "type": "string",
-          "description": "Task identifier in TASK-{phase}-{number} format",
+          "description": "Task identifier in TASK-{slice}-{number} format",
           "pattern": "^[Tt][Aa][Ss][Kk]-[0-9]+-[0-9]+$"
         },
         "description": {

--- a/docs/templates/plan.md
+++ b/docs/templates/plan.md
@@ -97,7 +97,7 @@ slices:
           [Criteria for completion]
         role: coder           # Optional: coder | tester | documenter
         files:
-          - [path/to/file]
+          - "[path/to/file]"
       - id: TASK-1-2
         description: |-
           [Task description]
@@ -105,7 +105,7 @@ slices:
           [Criteria for completion]
         role: tester
         files:
-          - [path/to/test_file]
+          - "[path/to/test_file]"
   - id: 2
     name: |-
       [Phase Name]
@@ -120,7 +120,7 @@ slices:
           [Criteria for completion]
         role: coder
         files:
-          - [path/to/file]
+          - "[path/to/file]"
 ```
 
 > **YAML safety**: Always use block scalars (`|-`) for `name`, `goal`,

--- a/docs/templates/plan.md
+++ b/docs/templates/plan.md
@@ -111,7 +111,7 @@ slices:
       [Phase Name]
     goal: |-
       [What this phase achieves]
-    dependencies: [1]
+    dependencies: "slice-1"
     tasks:
       - id: TASK-2-1
         description: |-

--- a/tests/test_yaml_tasks_schema.py
+++ b/tests/test_yaml_tasks_schema.py
@@ -361,5 +361,9 @@ class TestPlanTemplateValidatesAgainstSchema:
             pytest.skip("plan template not found")
         schema = _load_schema()
         doc, _, _ = parse_yaml_code_fence(PLAN_TEMPLATE_PATH.read_text())
-        assert doc is not None, "no '# yaml-tasks' fenced block found in docs/templates/plan.md"
+        assert doc is not None, (
+            "no valid '# yaml-tasks' block parsed from docs/templates/plan.md "
+            "(parse_yaml_code_fence returns None when the fence is absent, empty, "
+            "non-dict, or malformed YAML)"
+        )
         jsonschema.validate(doc, schema)

--- a/tests/test_yaml_tasks_schema.py
+++ b/tests/test_yaml_tasks_schema.py
@@ -10,11 +10,11 @@ Covers:
 - The 'pr' block fields (title, description, test_plan, manual_steps,
   context_title, context_description)
 - The canonical 'slice-<N>' string shape for a slice's dependencies field
+- The 'serialized_chain_order' array field
 - The shipped plan template (docs/templates/plan.md) validates end-to-end
 """
 
 import json
-import re
 from pathlib import Path
 
 import pytest
@@ -25,19 +25,15 @@ except ImportError:
     jsonschema = None
 
 try:
-    import yaml
+    # Importing the production fence extractor also pulls in pyyaml (a
+    # plan_parser dependency); a missing pyyaml therefore lands here too.
+    from egg_contracts.plan_parser import parse_yaml_code_fence
 except ImportError:
-    yaml = None
+    parse_yaml_code_fence = None
 
 REPO_ROOT = Path(__file__).parent.parent
 SCHEMA_PATH = REPO_ROOT / ".egg" / "schemas" / "yaml-tasks.schema.json"
 PLAN_TEMPLATE_PATH = REPO_ROOT / "docs" / "templates" / "plan.md"
-
-# Mirrors the fence parser in plan_parser.py / validate-yaml-tasks (#2743):
-# the closing ``` must start at a line boundary.
-_YAML_TASKS_FENCE_RE = re.compile(
-    r"```(?:yaml|yml)\s*\n\s*#\s*yaml-tasks\s*\n((?:.*\n)*?)[ ]{0,3}```\s*(?:\n|$)"
-)
 
 
 def _load_schema():
@@ -243,8 +239,19 @@ class TestYamlTasksSchemaPrBlock:
             jsonschema.validate(doc, schema)
 
 
-def _doc_with_slice_dependencies(dependencies):
-    """Create a minimal yaml-tasks document whose second slice carries a dependencies value."""
+def _doc_with_slice_field(**slice2_fields):
+    """Create a minimal two-slice yaml-tasks document with extra fields on slice 2.
+
+    Slice 2 always carries id/name/tasks; ``slice2_fields`` are merged on top,
+    so a test can attach an arbitrary slice-level key (dependencies,
+    serialized_chain_order, ...) and assert how the schema treats it.
+    """
+    second_slice = {
+        "id": 2,
+        "name": "Second slice",
+        "tasks": [_minimal_task("TASK-2-1")],
+    }
+    second_slice.update(slice2_fields)
     return {
         "slices": [
             {
@@ -252,14 +259,14 @@ def _doc_with_slice_dependencies(dependencies):
                 "name": "First slice",
                 "tasks": [_minimal_task("TASK-1-1")],
             },
-            {
-                "id": 2,
-                "name": "Second slice",
-                "dependencies": dependencies,
-                "tasks": [_minimal_task("TASK-2-1")],
-            },
+            second_slice,
         ]
     }
+
+
+def _doc_with_slice_dependencies(dependencies):
+    """Create a minimal yaml-tasks document whose second slice carries a dependencies value."""
+    return _doc_with_slice_field(dependencies=dependencies)
 
 
 @pytest.mark.skipif(jsonschema is None, reason="jsonschema not installed")
@@ -288,20 +295,71 @@ class TestYamlTasksSchemaDependenciesField:
             jsonschema.validate(doc, schema)
 
 
-@pytest.mark.skipif(jsonschema is None or yaml is None, reason="jsonschema/pyyaml not installed")
+@pytest.mark.skipif(jsonschema is None, reason="jsonschema not installed")
+class TestYamlTasksSchemaSerializedChainOrder:
+    """Tests for the 'serialized_chain_order' slice field.
+
+    The slice DAG must be a forest, so a planner that hits a would-be
+    multi-parent slice serialises the upstream cluster into a chain and
+    records the chosen order on the downstream slice's
+    'serialized_chain_order' field (#2137). The schema prescribes the
+    canonical shape — an array of 'slice-<N>' id strings. The parser also
+    tolerates a comma-separated string, but the schema deliberately does
+    not, so a planner is taught only the canonical array form.
+    """
+
+    def test_serialized_chain_order_string_array_is_valid(self):
+        """The canonical array-of-strings shape should validate."""
+        schema = _load_schema()
+        jsonschema.validate(
+            _doc_with_slice_field(serialized_chain_order=["slice-1", "slice-2"]), schema
+        )
+
+    def test_serialized_chain_order_empty_array_is_valid(self):
+        """An empty array (the default) should validate."""
+        schema = _load_schema()
+        jsonschema.validate(_doc_with_slice_field(serialized_chain_order=[]), schema)
+
+    def test_serialized_chain_order_int_array_is_rejected(self):
+        """Non-string array items should be rejected (items: type string)."""
+        schema = _load_schema()
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(_doc_with_slice_field(serialized_chain_order=[1]), schema)
+
+    def test_serialized_chain_order_comma_string_is_rejected(self):
+        """The comma-string form the parser tolerates is rejected by the schema.
+
+        The schema is prescriptive: it teaches only the canonical array
+        shape even though the lenient parser also accepts a comma-separated
+        string.
+        """
+        schema = _load_schema()
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(
+                _doc_with_slice_field(serialized_chain_order="slice-1,slice-2"), schema
+            )
+
+
+@pytest.mark.skipif(
+    jsonschema is None or parse_yaml_code_fence is None,
+    reason="jsonschema/pyyaml not installed",
+)
 class TestPlanTemplateValidatesAgainstSchema:
     """Regression guard: the shipped plan template must satisfy the schema.
 
     PR #2779 surfaced that the schema rejected docs/templates/plan.md. This
-    test extracts the '# yaml-tasks' block from the template and validates it
-    end-to-end so the schema and the template cannot drift apart again.
+    test extracts the literal '# yaml-tasks' fenced block from the template
+    — using the production fence extractor, so it cannot drift from the real
+    parsing path — and validates it against the schema. The guarantee is
+    scoped to the literal block: fields documented only in the template
+    *prose* (e.g. 'serialized_chain_order', the 'depends_on' alias) are not
+    present in the block and are covered by the dedicated schema tests above.
     """
 
     def test_plan_template_yaml_tasks_block_validates(self):
         if not PLAN_TEMPLATE_PATH.exists():
             pytest.skip("plan template not found")
         schema = _load_schema()
-        match = _YAML_TASKS_FENCE_RE.search(PLAN_TEMPLATE_PATH.read_text())
-        assert match, "no '# yaml-tasks' fenced block found in docs/templates/plan.md"
-        doc = yaml.safe_load(match.group(1))
+        doc, _, _ = parse_yaml_code_fence(PLAN_TEMPLATE_PATH.read_text())
+        assert doc is not None, "no '# yaml-tasks' fenced block found in docs/templates/plan.md"
         jsonschema.validate(doc, schema)

--- a/tests/test_yaml_tasks_schema.py
+++ b/tests/test_yaml_tasks_schema.py
@@ -6,10 +6,15 @@ Covers:
 - Tasks without role field pass validation (backward compatibility)
 - Tasks with invalid role values are rejected by schema enum constraint
 - additionalProperties enforcement still works with role field
-- The canonical 'slice-<N>' string shape for a phase's dependencies field
+- The canonical 'slices:' top-level key and the legacy 'phases:' alias
+- The 'pr' block fields (title, description, test_plan, manual_steps,
+  context_title, context_description)
+- The canonical 'slice-<N>' string shape for a slice's dependencies field
+- The shipped plan template (docs/templates/plan.md) validates end-to-end
 """
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -19,7 +24,20 @@ try:
 except ImportError:
     jsonschema = None
 
-SCHEMA_PATH = Path(__file__).parent.parent / ".egg" / "schemas" / "yaml-tasks.schema.json"
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+REPO_ROOT = Path(__file__).parent.parent
+SCHEMA_PATH = REPO_ROOT / ".egg" / "schemas" / "yaml-tasks.schema.json"
+PLAN_TEMPLATE_PATH = REPO_ROOT / "docs" / "templates" / "plan.md"
+
+# Mirrors the fence parser in plan_parser.py / validate-yaml-tasks (#2743):
+# the closing ``` must start at a line boundary.
+_YAML_TASKS_FENCE_RE = re.compile(
+    r"```(?:yaml|yml)\s*\n\s*#\s*yaml-tasks\s*\n((?:.*\n)*?)[ ]{0,3}```\s*(?:\n|$)"
+)
 
 
 def _load_schema():
@@ -41,10 +59,15 @@ def _minimal_task(task_id="TASK-1-1", description="Do something", acceptance="Do
     return task
 
 
-def _minimal_doc(**task_kwargs):
-    """Create a minimal valid yaml-tasks document with one phase and one task."""
+def _minimal_doc(top_key="slices", **task_kwargs):
+    """Create a minimal valid yaml-tasks document with one slice and one task.
+
+    ``top_key`` selects the top-level key: ``slices`` (canonical, post-#2137)
+    or ``phases`` (legacy alias). Defaults to the canonical key so fixtures
+    exercise the shape the plan template teaches.
+    """
     return {
-        "phases": [
+        top_key: [
             {
                 "id": 1,
                 "name": "Implementation",
@@ -103,11 +126,11 @@ class TestYamlTasksSchemaRoleField:
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(doc, schema)
 
-    def test_mixed_roles_in_phase(self):
-        """Phase with tasks having different valid roles should validate."""
+    def test_mixed_roles_in_slice(self):
+        """Slice with tasks having different valid roles should validate."""
         schema = _load_schema()
         doc = {
-            "phases": [
+            "slices": [
                 {
                     "id": 1,
                     "name": "Implementation",
@@ -136,18 +159,102 @@ class TestYamlTasksSchemaRoleField:
             jsonschema.validate(doc, schema)
 
 
-def _doc_with_phase_dependencies(dependencies):
-    """Create a minimal yaml-tasks document whose second phase carries a dependencies value."""
+@pytest.mark.skipif(jsonschema is None, reason="jsonschema not installed")
+class TestYamlTasksSchemaTopLevelKey:
+    """Tests for the canonical 'slices:' key and the legacy 'phases:' alias.
+
+    Post-#2137 the canonical top-level key is 'slices'; 'phases' is retained
+    as a backward-compatible alias. The schema must accept either.
+    """
+
+    def test_slices_top_level_key_is_valid(self):
+        """The canonical 'slices:' top-level key should validate."""
+        schema = _load_schema()
+        jsonschema.validate(_minimal_doc(top_key="slices"), schema)
+
+    def test_phases_top_level_key_is_valid(self):
+        """The legacy 'phases:' alias should still validate."""
+        schema = _load_schema()
+        jsonschema.validate(_minimal_doc(top_key="phases"), schema)
+
+    def test_missing_both_keys_rejected(self):
+        """A document with neither 'slices' nor 'phases' should be rejected."""
+        schema = _load_schema()
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate({"pr": {"title": "x"}}, schema)
+
+    def test_unknown_top_level_key_rejected(self):
+        """An unknown top-level key should still be rejected (additionalProperties)."""
+        schema = _load_schema()
+        doc = _minimal_doc()
+        doc["unexpected"] = "bad"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+
+@pytest.mark.skipif(jsonschema is None, reason="jsonschema not installed")
+class TestYamlTasksSchemaPrBlock:
+    """Tests for the optional 'pr' metadata block.
+
+    The canonical planner-emittable shape carries title (required),
+    description, test_plan, manual_steps, and the #2548 context_title /
+    context_description fields. Orchestrator-populated fields
+    (context_branch, context_pr_number) are intentionally NOT in the schema
+    so a planner emitting them is rejected.
+    """
+
+    def test_pr_block_with_test_plan_and_manual_steps_is_valid(self):
+        """The pr block as taught by the plan template should validate."""
+        schema = _load_schema()
+        doc = _minimal_doc()
+        doc["pr"] = {
+            "title": "Concise PR title",
+            "description": "Why and what.",
+            "test_plan": "- Automated: pytest\n- Manual: click around",
+            "manual_steps": "Pre-merge: run migration",
+        }
+        jsonschema.validate(doc, schema)
+
+    def test_pr_block_with_context_fields_is_valid(self):
+        """The #2548 context_title / context_description fields should validate."""
+        schema = _load_schema()
+        doc = _minimal_doc()
+        doc["pr"] = {
+            "title": "Concise PR title",
+            "context_title": "Strategic plan for #123",
+            "context_description": "Carries the refine analysis.",
+        }
+        jsonschema.validate(doc, schema)
+
+    def test_pr_block_missing_title_rejected(self):
+        """A pr block without the required title should be rejected."""
+        schema = _load_schema()
+        doc = _minimal_doc()
+        doc["pr"] = {"description": "no title here"}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+    def test_pr_block_orchestrator_field_rejected(self):
+        """Orchestrator-populated pr fields are not planner-emittable and should be rejected."""
+        schema = _load_schema()
+        doc = _minimal_doc()
+        doc["pr"] = {"title": "Concise PR title", "context_branch": "egg/context-123"}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+
+def _doc_with_slice_dependencies(dependencies):
+    """Create a minimal yaml-tasks document whose second slice carries a dependencies value."""
     return {
-        "phases": [
+        "slices": [
             {
                 "id": 1,
-                "name": "First phase",
+                "name": "First slice",
                 "tasks": [_minimal_task("TASK-1-1")],
             },
             {
                 "id": 2,
-                "name": "Second phase",
+                "name": "Second slice",
                 "dependencies": dependencies,
                 "tasks": [_minimal_task("TASK-2-1")],
             },
@@ -157,17 +264,44 @@ def _doc_with_phase_dependencies(dependencies):
 
 @pytest.mark.skipif(jsonschema is None, reason="jsonschema not installed")
 class TestYamlTasksSchemaDependenciesField:
-    """Tests for the canonical dependencies field shape in the yaml-tasks schema."""
+    """Tests for the dependencies field shape in the yaml-tasks schema.
+
+    The schema enforces only ``type: string`` on ``dependencies`` — it does
+    NOT carry a ``pattern`` for the canonical ``slice-<N>`` shape (OQ-1 in
+    PR #2779). So an arbitrary string such as ``"banana"`` validates here;
+    the ``slice-<N>`` convention is taught by the field description and
+    enforced by the validate-yaml-tasks bin / plan_parser, not the schema.
+    These tests therefore guard the ``type`` constraint, not the pattern.
+    """
 
     def test_dependencies_slice_string_is_valid(self):
-        """A phase with dependencies='slice-1' (the canonical shape) should validate."""
+        """A slice with dependencies='slice-1' (the canonical shape) should validate."""
         schema = _load_schema()
-        doc = _doc_with_phase_dependencies("slice-1")
+        doc = _doc_with_slice_dependencies("slice-1")
         jsonschema.validate(doc, schema)
 
     def test_dependencies_int_array_is_rejected(self):
-        """A phase with dependencies=[1] (non-canonical array form) should be rejected."""
+        """A slice with dependencies=[1] (non-canonical array form) should be rejected."""
         schema = _load_schema()
-        doc = _doc_with_phase_dependencies([1])
+        doc = _doc_with_slice_dependencies([1])
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(doc, schema)
+
+
+@pytest.mark.skipif(jsonschema is None or yaml is None, reason="jsonschema/pyyaml not installed")
+class TestPlanTemplateValidatesAgainstSchema:
+    """Regression guard: the shipped plan template must satisfy the schema.
+
+    PR #2779 surfaced that the schema rejected docs/templates/plan.md. This
+    test extracts the '# yaml-tasks' block from the template and validates it
+    end-to-end so the schema and the template cannot drift apart again.
+    """
+
+    def test_plan_template_yaml_tasks_block_validates(self):
+        if not PLAN_TEMPLATE_PATH.exists():
+            pytest.skip("plan template not found")
+        schema = _load_schema()
+        match = _YAML_TASKS_FENCE_RE.search(PLAN_TEMPLATE_PATH.read_text())
+        assert match, "no '# yaml-tasks' fenced block found in docs/templates/plan.md"
+        doc = yaml.safe_load(match.group(1))
+        jsonschema.validate(doc, schema)

--- a/tests/test_yaml_tasks_schema.py
+++ b/tests/test_yaml_tasks_schema.py
@@ -1,11 +1,12 @@
 """
-Tests for the yaml-tasks JSON Schema — specifically the new optional 'role' field.
+Tests for the yaml-tasks JSON Schema.
 
 Covers:
 - Tasks with valid role values (coder, tester, documenter) pass validation
 - Tasks without role field pass validation (backward compatibility)
 - Tasks with invalid role values are rejected by schema enum constraint
 - additionalProperties enforcement still works with role field
+- The canonical 'slice-<N>' string shape for a phase's dependencies field
 """
 
 import json
@@ -131,5 +132,42 @@ class TestYamlTasksSchemaRoleField:
         """Additional unknown properties should still be rejected."""
         schema = _load_schema()
         doc = _minimal_doc(role="coder", unknown_field="bad")
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+
+def _doc_with_phase_dependencies(dependencies):
+    """Create a minimal yaml-tasks document whose second phase carries a dependencies value."""
+    return {
+        "phases": [
+            {
+                "id": 1,
+                "name": "First phase",
+                "tasks": [_minimal_task("TASK-1-1")],
+            },
+            {
+                "id": 2,
+                "name": "Second phase",
+                "dependencies": dependencies,
+                "tasks": [_minimal_task("TASK-2-1")],
+            },
+        ]
+    }
+
+
+@pytest.mark.skipif(jsonschema is None, reason="jsonschema not installed")
+class TestYamlTasksSchemaDependenciesField:
+    """Tests for the canonical dependencies field shape in the yaml-tasks schema."""
+
+    def test_dependencies_slice_string_is_valid(self):
+        """A phase with dependencies='slice-1' (the canonical shape) should validate."""
+        schema = _load_schema()
+        doc = _doc_with_phase_dependencies("slice-1")
+        jsonschema.validate(doc, schema)
+
+    def test_dependencies_int_array_is_rejected(self):
+        """A phase with dependencies=[1] (non-canonical array form) should be rejected."""
+        schema = _load_schema()
+        doc = _doc_with_phase_dependencies([1])
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(doc, schema)


### PR DESCRIPTION
## Summary

Resolves the schema-vs-template drift reported in #2756. The yaml-tasks
schema declares a phase's `dependencies` as a string, but the plan template
taught `dependencies: [1]` (an array of integers).

Per the decision recorded in the issue's PLAN-1488 (BL-1 resolved: prescribe
the ideal shape rather than describe current parser leniency):

- **Schema** — sharpened the `dependencies` field description in
  `.egg/schemas/yaml-tasks.schema.json` to name the canonical `slice-<N>`
  shape and the single-parent forest rule (#2137). Type stays `string`; no
  `pattern` added (deferred — OQ-1).
- **Template** — corrected the `docs/templates/plan.md` example from
  `dependencies: [1]` to `dependencies: "slice-1"`.
- **Test** — added a jsonschema regression to `tests/test_yaml_tasks_schema.py`:
  `dependencies: "slice-1"` validates; `dependencies: [1]` is rejected.

The lenient parser (`to_contract_slice`) and the `validate-yaml-tasks` bin are
intentionally left unchanged as a tolerance layer for legacy/varied producer
output.

## Test plan

- [x] `tests/test_yaml_tasks_schema.py` — 12 passed (10 existing role tests + 2 new dependencies tests)
- [x] `tests/plugins/refine_plan/test_validate_yaml_tasks.py -k dep` — 4 passed (bare-int / list-of-int normalisation unchanged)
- [x] `validate-yaml-tasks docs/templates/plan.md` reports `OK: yaml-tasks valid (key=slices, slices=2)`

Closes #2756.