### PR TITLE
cleanup: drop stale babysit_pr / custom-mode references in comments

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -22155,10 +22155,9 @@ def _run_pipeline(
             # branches, and the work commit picks up only the
             # unattributed sibling plus whatever aggregate the writer
             # still emits — refine/plan/pr aggregates, and the
-            # non-slice-implement aggregate that babysit_pr (and any
-            # other implement-phase run without slice scope) lands on
-            # work via the ``not buckets`` branch — before we wipe the
-            # message store here.
+            # non-slice-implement aggregate that any implement-phase
+            # run without slice scope lands on work via the ``not
+            # buckets`` branch — before we wipe the message store here.
             from routes.phases import _clear_concurrent_state
 
             _clear_concurrent_state(pipeline_id)

--- a/orchestrator/tests/test_brc_history.py
+++ b/orchestrator/tests/test_brc_history.py
@@ -2544,9 +2544,10 @@ class TestWritePerSliceFlag:
         assert not (history_dir / "42-implement-slice-1.md").exists()
 
     def test_write_per_slice_false_non_slice_pipeline_still_writes_aggregate(self, tmp_path):
-        """Non-slice pipelines (babysit_pr, custom phases) never produce
-        per-slice files — they hit the ``not buckets`` branch and write
-        the aggregate ``{identifier}-implement.{md,json}`` file. The
+        """A non-slice implement run (an issue not decomposed into
+        slices) never produces per-slice files — it hits the ``not
+        buckets`` branch and writes the aggregate
+        ``{identifier}-implement.{md,json}`` file. The
         ``write_per_slice`` flag only gates the per-slice bucket loop,
         so the aggregate path is unaffected (#2755)."""
         from routes.pipelines import _write_brc_history
@@ -2561,7 +2562,7 @@ class TestWritePerSliceFlag:
             _write_brc_history(tmp_path, "issue-42", "implement", 42, write_per_slice=False)
 
         history_dir = tmp_path / ".egg-state" / "brc-history"
-        # Aggregate file MUST exist — this is the babysit_pr artifact
+        # Aggregate file MUST exist — this is the non-slice artifact
         # path and the flag does not gate it.
         assert (history_dir / "42-implement.md").exists()
         assert (history_dir / "42-implement.json").exists()


### PR DESCRIPTION
## Summary

The babysit-pr workflow (#2757) and CUSTOM pipeline mode (#2765) were removed, but three comment/docstring references to them survived in the BRC-history code path. They cite removed features as illustrative examples — misleading to readers and noisy in repo-wide greps (an agent recently mistook these for live features).

- `orchestrator/routes/pipelines.py` — comment no longer cites `babysit_pr` as the example non-slice implement run; now describes "any implement-phase run without slice scope"
- `orchestrator/tests/test_brc_history.py` — docstring "Non-slice pipelines (babysit_pr, custom phases)" → "A non-slice implement run (an issue not decomposed into slices)"; comment "babysit_pr artifact path" → "non-slice artifact path"

Comment and docstring text only — no behavior change.

## Test plan

- [x] `py_compile` confirms both files parse
- [ ] CI runs the affected `test_brc_history.py` suite (no `.venv` in this worktree to run locally)