### PR TITLE
make k3s-import: keep sudo cache warm, fail on docker save errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ EGG_IMAGE_TAG := $(shell git describe --always --dirty 2>/dev/null || echo lates
         test-integration test-security smoketest-long-poll \
         lint-fix lint-python-fix lint-shell-fix lint-yaml-fix \
         build \
-        k3s-setup k3s-secrets deploy redeploy k3s-teardown k3s-import
+        k3s-setup k3s-secrets deploy redeploy k3s-teardown k3s-import sudo-keepalive
 
 # Default target
 help:
@@ -541,16 +541,18 @@ deploy: k3s-secrets  ## Deploy egg to k3s
 	scripts/await-egg-deploy.sh "$(EGG_IMAGE_TAG)"
 	@echo "Deployment complete"
 
-redeploy: build k3s-import deploy  ## Rebuild, re-import, and redeploy in one step
+redeploy: sudo-keepalive build k3s-import deploy  ## Rebuild, re-import, and redeploy in one step
 
-k3s-import:  ## Import built images into k3s
-	@# Prime sudo and refresh it in the background: the long docker-save
-	@# streams between calls can outlast the credential cache otherwise.
+# Prompt for the sudo password immediately so `make redeploy` can be left
+# unattended through the long `build` step; the background loop refreshes the
+# credential cache every 60s and exits when this make run does.
+sudo-keepalive:
 	@sudo -v
+	@make_pid=$$PPID; \
+	( while kill -0 "$$make_pid" 2>/dev/null; do sudo -n true 2>/dev/null; sleep 60; done ) &
+
+k3s-import: sudo-keepalive  ## Import built images into k3s
 	@set -o pipefail; \
-	( while true; do sudo -n true; sleep 60; kill -0 "$$$$" 2>/dev/null || exit; done ) & \
-	keepalive=$$!; \
-	trap 'kill "$$keepalive" 2>/dev/null' EXIT; \
 	docker save egg-gateway:latest | sudo k3s ctr images import - && \
 	docker save egg-gateway:$(EGG_IMAGE_TAG) | sudo k3s ctr images import - && \
 	docker save egg-orchestrator:latest | sudo k3s ctr images import - && \

--- a/Makefile
+++ b/Makefile
@@ -544,11 +544,18 @@ deploy: k3s-secrets  ## Deploy egg to k3s
 redeploy: build k3s-import deploy  ## Rebuild, re-import, and redeploy in one step
 
 k3s-import:  ## Import built images into k3s
-	docker save egg-gateway:latest | sudo k3s ctr images import -
-	docker save egg-gateway:$(EGG_IMAGE_TAG) | sudo k3s ctr images import -
-	docker save egg-orchestrator:latest | sudo k3s ctr images import -
-	docker save egg-orchestrator:$(EGG_IMAGE_TAG) | sudo k3s ctr images import -
-	docker save egg-sandbox:latest | sudo k3s ctr images import -
+	@# Prime sudo and refresh it in the background: the long docker-save
+	@# streams between calls can outlast the credential cache otherwise.
+	@sudo -v
+	@set -o pipefail; \
+	( while true; do sudo -n true; sleep 60; kill -0 "$$$$" 2>/dev/null || exit; done ) & \
+	keepalive=$$!; \
+	trap 'kill "$$keepalive" 2>/dev/null' EXIT; \
+	docker save egg-gateway:latest | sudo k3s ctr images import - && \
+	docker save egg-gateway:$(EGG_IMAGE_TAG) | sudo k3s ctr images import - && \
+	docker save egg-orchestrator:latest | sudo k3s ctr images import - && \
+	docker save egg-orchestrator:$(EGG_IMAGE_TAG) | sudo k3s ctr images import - && \
+	docker save egg-sandbox:latest | sudo k3s ctr images import - && \
 	docker save egg-sandbox:$(EGG_IMAGE_TAG) | sudo k3s ctr images import -
 
 k3s-teardown:  ## Remove k3s

--- a/Makefile
+++ b/Makefile
@@ -544,13 +544,21 @@ deploy: k3s-secrets  ## Deploy egg to k3s
 redeploy: sudo-keepalive build k3s-import deploy  ## Rebuild, re-import, and redeploy in one step
 
 # Prompt for the sudo password immediately so `make redeploy` can be left
-# unattended through the long `build` step; the background loop refreshes the
-# credential cache every 60s and exits when this make run does.
+# unattended through the long `build` step. A detached background loop refreshes
+# the credential cache every 60s; it stops within ~60s of this make run exiting,
+# and is hard-capped at 120 iterations (~2h) so a recycled make PID cannot keep
+# it alive indefinitely. Its standard streams are redirected away from make's so
+# it never holds make's output pipe open past make's own exit.
 sudo-keepalive:
 	@sudo -v
 	@make_pid=$$PPID; \
-	( while kill -0 "$$make_pid" 2>/dev/null; do sudo -n true 2>/dev/null; sleep 60; done ) &
+	( i=0; while [ $$i -lt 120 ] && kill -0 "$$make_pid" 2>/dev/null; do \
+		sudo -n -v 2>/dev/null; sleep 60; i=$$((i + 1)); \
+	done ) >/dev/null 2>&1 </dev/null &
 
+# Run this recipe under bash: `set -o pipefail` is a bash builtin and aborts
+# immediately under dash (the default /bin/sh on Debian/Ubuntu).
+k3s-import: SHELL := /bin/bash
 k3s-import: sudo-keepalive  ## Import built images into k3s
 	@set -o pipefail; \
 	docker save egg-gateway:latest | sudo k3s ctr images import - && \


### PR DESCRIPTION
## Summary
- `make redeploy` (`build` → `k3s-import` → `deploy`) could prompt for the sudo password partway through `k3s-import`: the long `build` step plus multi-GB `docker save` streams between the six `sudo k3s ctr images import` calls can outlast the sudo credential cache.
- Adds a `sudo-keepalive` target that runs `sudo -v` and starts a background loop refreshing the credential cache every 60s. It's wired as the **first prerequisite** of both `redeploy` and `k3s-import`, so the password prompt happens **immediately** — before the long `build` step — and `make redeploy` can be left unattended.
- The keepalive loop watches the `make` process (`PPID`) and exits when the run does, so one refresher spans `build` + `k3s-import` + `deploy` with no leaked background process.
- The six import calls are joined into one shell invocation under `set -o pipefail`, so a failing `docker save` aborts the import instead of being masked by the succeeding `ctr import` at the end of the pipe.

## Test plan
- [ ] `make -n redeploy` / `make -n k3s-import` parse cleanly with `sudo -v` ordered first (verified locally).
- [ ] `make redeploy` on a k3s host prompts for the sudo password exactly once, immediately at the start, and completes without a re-prompt.
- [ ] Forcing a `docker save` failure (e.g. a missing image tag) aborts `k3s-import` non-zero rather than continuing.