### PR TITLE
make deploy: recreate egg pods stuck in ImagePullBackOff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -538,6 +538,7 @@ deploy: k3s-secrets  ## Deploy egg to k3s
 		    -e "s|egg-gateway:latest|egg-gateway:$(EGG_IMAGE_TAG)|g" \
 		    -e "s|egg-sandbox:latest|egg-sandbox:$(EGG_IMAGE_TAG)|g" | \
 		kubectl apply -f - && \
+	scripts/clear-stuck-egg-pods.sh && \
 	scripts/await-egg-deploy.sh "$(EGG_IMAGE_TAG)"
 	@echo "Deployment complete"
 

--- a/scripts/clear-stuck-egg-pods.sh
+++ b/scripts/clear-stuck-egg-pods.sh
@@ -31,12 +31,18 @@ NS="egg-system"
 # images are egg-built and tag-rewritten by `make deploy`. Third-party
 # pods (e.g. the LiteLLM proxy) pull from an external registry, so
 # recreating them would not clear a registry-side pull failure.
-mapfile -t stuck < <(
+#
+# Capture kubectl's output into a variable first: a process substitution
+# hides its child's exit status from the parent and `mapfile` succeeds on
+# empty input, so feeding `kubectl` straight into `mapfile < <(...)` would
+# turn a transient kubectl failure (API hiccup, RBAC) into a silent no-op.
+# A plain assignment lets `set -e` abort on a real failure.
+pods=$(
   kubectl -n "$NS" get pods \
     -l 'app.kubernetes.io/component in (orchestrator,gateway)' \
-    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .status.containerStatuses[*]}{.state.waiting.reason}{" "}{end}{"\n"}{end}' \
-    | awk '/ImagePullBackOff|ErrImagePull/ { print $1 }'
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .status.containerStatuses[*]}{.state.waiting.reason}{" "}{end}{"\n"}{end}'
 )
+mapfile -t stuck < <(awk '/ImagePullBackOff|ErrImagePull/ { print $1 }' <<<"$pods")
 
 if [ "${#stuck[@]}" -eq 0 ]; then
   exit 0

--- a/scripts/clear-stuck-egg-pods.sh
+++ b/scripts/clear-stuck-egg-pods.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# clear-stuck-egg-pods.sh - Delete egg orchestrator/gateway pods stuck in
+# ImagePullBackOff/ErrImagePull so their ReplicaSet recreates them.
+#
+# `make redeploy` builds images, imports them into k3s, then deploys --
+# in that order, so a redeploy's own pods are always created after their
+# image exists. But `kubectl apply` is a no-op when the rendered manifest
+# is unchanged (EGG_IMAGE_TAG has not moved), so a pod left in
+# ImagePullBackOff by an earlier bare `make deploy` -- run when HEAD had
+# moved and the tag's images were not yet imported -- survives a
+# subsequent `make redeploy` untouched. It then keeps failing until its
+# exponential image-pull backoff (up to ~5 min between retries) happens
+# to fire.
+#
+# Deleting the stuck pod lets its ReplicaSet recreate it immediately;
+# with the image now in containerd it pulls cleanly. This is what lets
+# `make redeploy` converge a stuck cluster -- the remedy
+# await-egg-deploy.sh tells the operator to run.
+#
+# A no-op when nothing is stuck. Safe on the bare-`make deploy` path too:
+# a recreated pod simply re-sticks if the image genuinely is not
+# imported, and await-egg-deploy.sh then fast-fails with the tag-drift
+# message.
+#
+set -euo pipefail
+
+NS="egg-system"
+
+# Scoped to egg's own deployments, matching await-egg-deploy.sh: their
+# images are egg-built and tag-rewritten by `make deploy`. Third-party
+# pods (e.g. the LiteLLM proxy) pull from an external registry, so
+# recreating them would not clear a registry-side pull failure.
+mapfile -t stuck < <(
+  kubectl -n "$NS" get pods \
+    -l 'app.kubernetes.io/component in (orchestrator,gateway)' \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .status.containerStatuses[*]}{.state.waiting.reason}{" "}{end}{"\n"}{end}' \
+    | awk '/ImagePullBackOff|ErrImagePull/ { print $1 }'
+)
+
+if [ "${#stuck[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+echo "Recreating egg pods stuck on image pull: ${stuck[*]}"
+kubectl -n "$NS" delete pod "${stuck[@]}" --ignore-not-found


### PR DESCRIPTION
## Problem

`await-egg-deploy.sh` fast-fails the moment an orchestrator/gateway pod is in `ImagePullBackOff`, printing "a commit/pull/rebase moved EGG_IMAGE_TAG — run `make redeploy`". But running `make redeploy` does **not** recover the cluster:

- `make redeploy` is `build` → `k3s-import` → `deploy`, so by the time `deploy` runs the images for the current tag are in containerd.
- If an earlier bare `make deploy` (HEAD moved, images not yet imported) already left pods in `ImagePullBackOff`, `deploy`'s `kubectl apply` is a **no-op** — the rendered manifest is unchanged (same `EGG_IMAGE_TAG`), so no rollout happens and the stuck pods linger.
- They sit in `ImagePullBackOff` until their exponential image-pull backoff (up to ~5 min) happens to retry — but `await-egg-deploy.sh` fast-fails long before that.

Net effect: the guard tells you to run `make redeploy`, and `make redeploy` fails on the very pods it was supposed to fix. (`imagePullPolicy: IfNotPresent` on both deployments confirms the image isn't the problem — a stuck pod recovers on its own once it retries.)

## Fix

Add `scripts/clear-stuck-egg-pods.sh`, invoked by the `deploy` recipe between `kubectl apply` and `await-egg-deploy.sh`. It deletes orchestrator/gateway pods in `ImagePullBackOff`/`ErrImagePull` so their ReplicaSet recreates them immediately against the now-imported image — making `make redeploy` actually converge a stuck cluster.

- **No-op when nothing is stuck** — the common case adds one cheap `kubectl get`.
- **Correct on the bare-`make deploy` path** — a recreated pod simply re-sticks if the image genuinely isn't imported, and the guard then fast-fails with the accurate tag-drift message.
- Scoped to orchestrator/gateway (egg-built images), matching `await-egg-deploy.sh`; third-party pods like the LiteLLM proxy are left alone.
- The guard (`await-egg-deploy.sh`) is unchanged — it stays read-only.

## Test plan

- [ ] `make -n deploy` shows `apply && clear-stuck-egg-pods.sh && await-egg-deploy.sh` (verified).
- [ ] `shellcheck` clean; matches repo `shfmt -i 2 -ci -bn` style (verified).
- [ ] On a cluster with orchestrator/gateway pods stuck in `ImagePullBackOff` for the current tag: `make redeploy` recreates them and the deploy goes green.
- [ ] On a healthy cluster: `make deploy` is a no-op for the new step (no pods deleted).
- [ ] Bare `make deploy` after HEAD moved still fast-fails with the tag-drift message.