### PR TITLE
make k3s-import: import via temp file + verify the tag landed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -557,17 +557,38 @@ sudo-keepalive:
 		sudo -n -v 2>/dev/null; sleep 60; i=$$((i + 1)); \
 	done ) >/dev/null 2>&1 </dev/null &
 
-# Run this recipe under bash: `set -o pipefail` is a bash builtin and aborts
-# immediately under dash (the default /bin/sh on Debian/Ubuntu).
+# Run this recipe under bash: the `${var//pat/repl}` parameter expansion and
+# `set -o pipefail` are bash builtins, both unsupported under dash (the default
+# /bin/sh on Debian/Ubuntu).
+#
+# Import via temp file rather than `docker save ... | sudo k3s ctr images
+# import -`. The stdin path silently drops the layer payload for some images
+# on this host (observed for orchestrator/sandbox under aarch64+16k-pages on
+# Fedora Asahi): ctr prints "saved" with the manifest digest, exits 0, and
+# the tag never appears in `ctr images list`. The same image imports cleanly
+# from a file. After each import we re-list and grep for the tag, so a
+# silent drop fails the recipe instead of poisoning the cluster with a
+# half-imported tag that surfaces hours later as ImagePullBackOff in
+# await-egg-deploy.sh. Tarballs go in /var/tmp (disk-backed) -- the sandbox
+# image is ~12 GB, so /tmp (tmpfs) would consume that much RAM.
 k3s-import: SHELL := /bin/bash
 k3s-import: sudo-keepalive  ## Import built images into k3s
-	@set -o pipefail; \
-	docker save egg-gateway:latest | sudo k3s ctr images import - && \
-	docker save egg-gateway:$(EGG_IMAGE_TAG) | sudo k3s ctr images import - && \
-	docker save egg-orchestrator:latest | sudo k3s ctr images import - && \
-	docker save egg-orchestrator:$(EGG_IMAGE_TAG) | sudo k3s ctr images import - && \
-	docker save egg-sandbox:latest | sudo k3s ctr images import - && \
-	docker save egg-sandbox:$(EGG_IMAGE_TAG) | sudo k3s ctr images import -
+	@set -euo pipefail; \
+	tmp=$$(mktemp -d -p /var/tmp egg-k3s-import.XXXXXX); \
+	trap 'rm -rf "$$tmp"' EXIT; \
+	for img in egg-gateway:latest egg-gateway:$(EGG_IMAGE_TAG) \
+	           egg-orchestrator:latest egg-orchestrator:$(EGG_IMAGE_TAG) \
+	           egg-sandbox:latest egg-sandbox:$(EGG_IMAGE_TAG); do \
+		f="$$tmp/$${img//[:\/]/_}.tar"; \
+		echo ">>> importing $$img"; \
+		docker save "$$img" -o "$$f"; \
+		sudo k3s ctr images import "$$f"; \
+		rm -f "$$f"; \
+		if ! sudo k3s ctr images list -q | grep -qx "docker.io/library/$$img"; then \
+			echo "ERROR: $$img import returned 0 but tag is not present in k3s containerd" >&2; \
+			exit 1; \
+		fi; \
+	done
 
 k3s-teardown:  ## Remove k3s
 	/usr/local/bin/k3s-uninstall.sh || true

--- a/Makefile
+++ b/Makefile
@@ -576,18 +576,21 @@ k3s-import: sudo-keepalive  ## Import built images into k3s
 	@set -euo pipefail; \
 	tmp=$$(mktemp -d -p /var/tmp egg-k3s-import.XXXXXX); \
 	trap 'rm -rf "$$tmp"' EXIT; \
-	for img in egg-gateway:latest egg-gateway:$(EGG_IMAGE_TAG) \
-	           egg-orchestrator:latest egg-orchestrator:$(EGG_IMAGE_TAG) \
-	           egg-sandbox:latest egg-sandbox:$(EGG_IMAGE_TAG); do \
-		f="$$tmp/$${img//[:\/]/_}.tar"; \
-		echo ">>> importing $$img"; \
-		docker save "$$img" -o "$$f"; \
-		sudo k3s ctr images import "$$f"; \
-		rm -f "$$f"; \
-		if ! sudo k3s ctr images list -q | grep -qx "docker.io/library/$$img"; then \
-			echo "ERROR: $$img import returned 0 but tag is not present in k3s containerd" >&2; \
-			exit 1; \
-		fi; \
+	tags="latest"; \
+	if [ "$(EGG_IMAGE_TAG)" != "latest" ]; then tags="$$tags $(EGG_IMAGE_TAG)"; fi; \
+	for image in egg-gateway egg-orchestrator egg-sandbox; do \
+		for tag in $$tags; do \
+			img="$$image:$$tag"; \
+			f="$$tmp/$${img//[:\/]/_}.tar"; \
+			echo ">>> importing $$img"; \
+			docker save "$$img" -o "$$f"; \
+			sudo k3s ctr images import "$$f"; \
+			rm -f "$$f"; \
+			if ! sudo k3s ctr images list -q | grep -qx "docker.io/library/$$img"; then \
+				echo "ERROR: $$img import returned 0 but tag is not present in k3s containerd" >&2; \
+				exit 1; \
+			fi; \
+		done; \
 	done
 
 k3s-teardown:  ## Remove k3s


### PR DESCRIPTION
## Summary

- `docker save <img> | sudo k3s ctr images import -` silently drops the layer payload for some images on aarch64+16k-pages (Fedora Asahi): ctr prints "saved" with the manifest digest, exits 0, the recipe chains onward via `&&`, and the tag never appears in `ctr images list`. Observed reproducibly for orchestrator/sandbox tars on this host while the same pipe pattern works for gateway. The half-imported state then surfaces minutes later as `ImagePullBackOff` in `await-egg-deploy.sh`, which mis-blames it on `EGG_IMAGE_TAG` drift and points the operator at `make redeploy` — the very command that just ran.
- Switch to file-based imports: `docker save -o <tmpfile>` then `sudo k3s ctr images import <tmpfile>`, then delete the tar. The same images that silently no-op'd via stdin import cleanly from a file. Tarballs go to `/var/tmp` instead of `/tmp` so the ~12 GB sandbox tar doesn't sit in tmpfs.
- Add the post-import invariant the recipe was missing: re-list and `grep -qx` for the tag, fail loud if the import returned 0 but containerd does not actually have it. This turns the silent drop into a hard failure at import time instead of letting it poison the cluster.

## Repro before this PR

```
$ set -o pipefail; docker save egg-orchestrator:b1522d58a | sudo k3s ctr images import - ; echo "exit=$?"
docker.io/library/egg orchestrator:b1522    saved
application/vnd.oci.image.manifest.v1+json sha256:134e3af04f21a39c981558b57e6c6b06df478676a0115fec8535b862f83e65f9
Importing    elapsed: 14.1s    total:   0.0 B    (0.0 B/s)
exit=0
$ sudo k3s ctr images list | grep egg-orchestrator
# (no output)
```

File-based import of the *same* tar then works:

```
$ docker save egg-orchestrator:b1522d58a -o /tmp/orch.tar
$ sudo k3s ctr images import /tmp/orch.tar
docker.io/library/egg orchestrator:b1522    saved
...
$ sudo k3s ctr images list | grep egg-orchestrator
docker.io/library/egg-orchestrator:b1522d58a   ...  385.5 MiB linux/arm64   io.cri-containerd.image=managed
```

Why stdin import drops the layers on this host I can't fully explain — likely a containerd quirk with how it handles stdin under specific manifest/layer layouts on aarch64+16k-pages — but the fix doesn't depend on the root cause: the file-based path is the documented `ctr` interface and avoids the bug.

## Relationship to #2784

Different scenario. #2784 fixes a *deploy-time* failure mode (a pod stuck in `ImagePullBackOff` surviving a re-deploy whose `kubectl apply` is a no-op) by deleting the stuck pod so the ReplicaSet recreates it. That doesn't help when the underlying image was never actually in containerd — the recreated pod just re-sticks. This PR fixes the *import-time* root cause so deploys never reach that broken state in the first place. The `clear-stuck-egg-pods.sh` script stays in place; it's still the right escape hatch for the scenario it was designed for.

## Test plan

- [ ] `make k3s-import` succeeds with all six tags (`egg-{gateway,orchestrator,sandbox}:{latest,$EGG_IMAGE_TAG}`) visible in `sudo k3s ctr images list` afterwards.
- [ ] Manually break one tag (`sudo k3s ctr images rm docker.io/library/egg-orchestrator:$EGG_IMAGE_TAG`) and re-run `make k3s-import` to confirm the post-import verification re-imports it cleanly.
- [ ] Simulate the silent-drop bug (`docker tag egg-orchestrator:$EGG_IMAGE_TAG egg-fake:foo` and patch the loop to import `egg-fake:foo` from an empty tar) to confirm the `grep -qx` guard fails the recipe with the expected error message rather than silently returning 0.
- [ ] `make redeploy` end-to-end on a clean tag (HEAD moved since last build) brings the orchestrator pod to `Running` instead of `ImagePullBackOff`.