### PR TITLE
Fix #2795: structured operator directives + iteration history on HITL kickback

### DIFF
--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -360,6 +360,61 @@ class AgentExitInfo(BaseModel):
     )
 
 
+class OperatorDirective(BaseModel):
+    """An operator-issued directive recorded at an HITL phase-gate kickback.
+
+    Replaces the single ``PhaseExecution.hitl_feedback`` string with a
+    chronologically accumulated record. Each kickback on a phase appends
+    one ``OperatorDirective``; the list is never cleared, so iteration
+    N+1's prompt can render all prior directives in order with explicit
+    precedence prose. See issue #2795.
+    """
+
+    iteration_n: int = Field(
+        ..., ge=0, description="Zero-based index of the iteration this directive kicked back"
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="When the operator issued the directive",
+    )
+    feedback_text: str = Field(..., description="Operator-provided feedback text")
+
+
+class IterationSummary(BaseModel):
+    """Frozen snapshot of a kicked-back iteration's BRC outcome.
+
+    Captured before ``_clear_concurrent_state`` wipes the consensus
+    tracker so reviewers in iteration N+1 can see what tripped the rubric
+    last round. See issue #2795.
+    """
+
+    iteration_n: int = Field(..., ge=0, description="Zero-based iteration index")
+    completed_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="When the iteration's consensus closed",
+    )
+    final_proposal_commit: dict[str, str] = Field(
+        default_factory=dict,
+        description="Map of producer role to final proposal commit SHA, if any",
+    )
+    verdict_matrix: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Per-edge BRC verdict at iteration close, keyed by "
+            "'reviewer_role->producer_role' → ApprovalState value "
+            "(e.g. 'acked', 'nacked')"
+        ),
+    )
+    nack_reasons: list[str] = Field(
+        default_factory=list,
+        description="Collected NACK rationales, prefixed by reviewer role",
+    )
+    artifacts_snapshot: dict[str, str] = Field(
+        default_factory=dict,
+        description="Snapshot of PhaseExecution.artifacts at iteration close",
+    )
+
+
 class PhaseExecution(BaseModel):
     """State of a single phase execution."""
 
@@ -383,9 +438,22 @@ class PhaseExecution(BaseModel):
         default_factory=dict, description="Produced artifacts (file paths)"
     )
     error: str | None = Field(default=None, description="Error if failed")
-    hitl_feedback: str | None = Field(
-        default=None,
-        description="HITL revision feedback preserved across recovery restarts",
+    operator_directives: list[OperatorDirective] = Field(
+        default_factory=list,
+        description=(
+            "Chronologically accumulated operator directives from HITL "
+            "phase-gate kickbacks. Never cleared — replaces the single "
+            "hitl_feedback string so iteration N+1 prompts can render "
+            "every prior directive with precedence prose. See #2795."
+        ),
+    )
+    iteration_history: list[IterationSummary] = Field(
+        default_factory=list,
+        description=(
+            "One entry per kicked-back iteration. Captured before "
+            "_clear_concurrent_state wipes the BRC tracker so future "
+            "iterations can see prior verdicts/NACK reasons. See #2795."
+        ),
     )
     phase_start_sha: str | None = Field(
         default=None,

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -493,17 +493,30 @@ class PhaseExecution(BaseModel):
         if not legacy:
             return data
 
-        directives = list(data.get("operator_directives", []))
+        # ``data.get("operator_directives") or []`` (not the two-arg form):
+        # a persisted JSON record may carry an explicit ``null`` for the
+        # field even though Pydantic's ``default_factory=list`` prevents
+        # it on the write side. ``data.get(..., [])`` returns ``None`` on
+        # explicit null and ``list(None)`` then raises — defeating the
+        # migration's whole purpose.
+        directives = list(data.get("operator_directives") or [])
         # Synthesize the directive at the iteration index implied by the
         # cycle counter (the inline handler's old behaviour wrote
-        # hitl_feedback after incrementing hitl_review_cycles). Fall back
-        # to len(operator_directives) if the counter is unavailable so
-        # the index still increases monotonically with each migration.
+        # hitl_feedback after incrementing hitl_review_cycles). On
+        # collision with an existing entry, pick one past the current
+        # maximum so the floor is uniqueness regardless of how sparse
+        # the existing indices are (a ``len(directives)`` fallback can
+        # itself collide when entries are sparse — e.g. ``[0, 2]`` with
+        # primary collision at ``1`` would fall back to ``2``).
         hitl_cycles = data.get("hitl_review_cycles", 0) or 0
         iteration_n = max(hitl_cycles - 1, 0)
-        if any(isinstance(d, dict) and d.get("iteration_n") == iteration_n for d in directives):
-            # Avoid collisions if a writer somehow populated both fields.
-            iteration_n = len(directives)
+        existing_indices = [
+            d.get("iteration_n")
+            for d in directives
+            if isinstance(d, dict) and isinstance(d.get("iteration_n"), int)
+        ]
+        if iteration_n in existing_indices:
+            iteration_n = max(existing_indices) + 1
         directives.append(
             {
                 "iteration_n": iteration_n,
@@ -511,18 +524,14 @@ class PhaseExecution(BaseModel):
             }
         )
         data["operator_directives"] = directives
-        # Best-effort import to avoid pulling logger eagerly in model module.
-        try:
-            import logging as _logging
+        import logging as _logging
 
-            _logging.getLogger("orchestrator.models").warning(
-                "Migrated legacy PhaseExecution.hitl_feedback to operator_directives "
-                "(phase=%s, iteration_n=%s); the hitl_feedback field is removed in #2795.",
-                data.get("phase"),
-                iteration_n,
-            )
-        except Exception:  # noqa: BLE001 — migration must not fail on logging
-            pass
+        _logging.getLogger("orchestrator.models").warning(
+            "Migrated legacy PhaseExecution.hitl_feedback to operator_directives "
+            "(phase=%s, iteration_n=%s); the hitl_feedback field is removed in #2795.",
+            data.get("phase"),
+            iteration_n,
+        )
         return data
 
 

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -469,6 +469,62 @@ class PhaseExecution(BaseModel):
         ),
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_hitl_feedback(cls, data: Any) -> Any:
+        """Migrate persisted ``hitl_feedback`` strings to ``operator_directives``.
+
+        Before #2795 ``PhaseExecution`` carried a single ``hitl_feedback: str``
+        that the inline HITL handler and AWAITING_HUMAN recovery path each
+        wrote and consumed. #2795 replaces it with the chronological
+        ``operator_directives`` list. Pydantic's default ``extra='ignore'``
+        would silently drop a surviving ``hitl_feedback`` value on the first
+        load after deploy — for a pipeline paused at a HITL gate with the
+        operator's directive already on disk, that means the directive is
+        lost with no log, warning, or error.
+
+        Translate any non-empty ``hitl_feedback`` into a synthetic
+        ``OperatorDirective`` so the directive survives the deploy, and emit
+        a one-shot deprecation log so operators see the migration happen.
+        """
+        if not isinstance(data, dict):
+            return data
+        legacy = data.pop("hitl_feedback", None)
+        if not legacy:
+            return data
+
+        directives = list(data.get("operator_directives", []))
+        # Synthesize the directive at the iteration index implied by the
+        # cycle counter (the inline handler's old behaviour wrote
+        # hitl_feedback after incrementing hitl_review_cycles). Fall back
+        # to len(operator_directives) if the counter is unavailable so
+        # the index still increases monotonically with each migration.
+        hitl_cycles = data.get("hitl_review_cycles", 0) or 0
+        iteration_n = max(hitl_cycles - 1, 0)
+        if any(isinstance(d, dict) and d.get("iteration_n") == iteration_n for d in directives):
+            # Avoid collisions if a writer somehow populated both fields.
+            iteration_n = len(directives)
+        directives.append(
+            {
+                "iteration_n": iteration_n,
+                "feedback_text": legacy,
+            }
+        )
+        data["operator_directives"] = directives
+        # Best-effort import to avoid pulling logger eagerly in model module.
+        try:
+            import logging as _logging
+
+            _logging.getLogger("orchestrator.models").warning(
+                "Migrated legacy PhaseExecution.hitl_feedback to operator_directives "
+                "(phase=%s, iteration_n=%s); the hitl_feedback field is removed in #2795.",
+                data.get("phase"),
+                iteration_n,
+            )
+        except Exception:  # noqa: BLE001 — migration must not fail on logging
+            pass
+        return data
+
 
 class PipelineConfig(BaseModel):
     """Configuration for pipeline execution."""

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -489,16 +489,19 @@ class PhaseExecution(BaseModel):
         """
         if not isinstance(data, dict):
             return data
+        # Normalise an explicit ``null`` for ``operator_directives`` to an
+        # empty list before any early return: Pydantic's
+        # ``default_factory=list`` does not prevent a writer from emitting a
+        # literal ``null``, and the non-Optional ``list[OperatorDirective]``
+        # field validation would then reject the record entirely. Doing
+        # this here covers both the no-legacy-feedback fast path and the
+        # migration branch below.
+        if "operator_directives" in data and data["operator_directives"] is None:
+            data["operator_directives"] = []
         legacy = data.pop("hitl_feedback", None)
         if not legacy:
             return data
 
-        # ``data.get("operator_directives") or []`` (not the two-arg form):
-        # a persisted JSON record may carry an explicit ``null`` for the
-        # field even though Pydantic's ``default_factory=list`` prevents
-        # it on the write side. ``data.get(..., [])`` returns ``None`` on
-        # explicit null and ``list(None)`` then raises — defeating the
-        # migration's whole purpose.
         directives = list(data.get("operator_directives") or [])
         # Synthesize the directive at the iteration index implied by the
         # cycle counter (the inline handler's old behaviour wrote
@@ -510,6 +513,12 @@ class PhaseExecution(BaseModel):
         # primary collision at ``1`` would fall back to ``2``).
         hitl_cycles = data.get("hitl_review_cycles", 0) or 0
         iteration_n = max(hitl_cycles - 1, 0)
+        # The migration only sees raw JSON-loaded data, so entries are
+        # expected to be ``dict`` with an int ``iteration_n``. Any
+        # malformed entry (non-dict or non-int index) is silently skipped
+        # here from collision detection — downstream Pydantic field
+        # validation will reject it with a precise error rather than the
+        # migration trying to second-guess the shape.
         existing_indices = [
             d.get("iteration_n")
             for d in directives

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -12066,7 +12066,21 @@ def _apply_inline_hitl_kickback_to_phase(
     Returns the snapshot of containers that were running at kickback
     time, for the caller to issue the defensive stop on.
     """
-    iteration_n = len(phase_execution.iteration_history)
+    # Monotone across the legacy-hitl_feedback migration boundary: a
+    # pre-#2795 phase migrates with iteration_history empty but a
+    # synthetic OperatorDirective carrying iteration_n derived from
+    # hitl_review_cycles. ``len(iteration_history)`` alone would
+    # restart at 0 and label two distinct iterations identically; use
+    # one past the maximum existing directive index as the floor so
+    # the displayed "iteration X" labels stay monotone.
+    iteration_n = max(
+        len(phase_execution.iteration_history),
+        max(
+            (d.iteration_n for d in phase_execution.operator_directives),
+            default=-1,
+        )
+        + 1,
+    )
     phase_execution.operator_directives.append(
         OperatorDirective(
             iteration_n=iteration_n,
@@ -24192,11 +24206,22 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                     # this snapshot will typically have empty verdict
                     # detail — but the iteration index + artifacts are
                     # still useful context for iteration N+1's prompts.
-                    # Derive iteration_n from len(iteration_history) so it
-                    # stays monotone — the cycle counter is reset to 0 a
-                    # few lines below, which would otherwise collide with
-                    # subsequent inline-path kickbacks (#2795 review).
-                    _recovery_iteration_n = len(phase_execution.iteration_history)
+                    # Derive iteration_n monotonically — the cycle
+                    # counter is reset to 0 a few lines below, which
+                    # would otherwise collide with subsequent inline-
+                    # path kickbacks. Floor is one past the maximum
+                    # existing directive index so a legacy-hitl_feedback
+                    # migration (which synthesises a directive but
+                    # leaves iteration_history empty) doesn't restart
+                    # the index at 0 (#2795 review).
+                    _recovery_iteration_n = max(
+                        len(phase_execution.iteration_history),
+                        max(
+                            (d.iteration_n for d in phase_execution.operator_directives),
+                            default=-1,
+                        )
+                        + 1,
+                    )
                     _recovery_tracker = None
                     try:
                         from peer_consensus import (

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -105,12 +105,14 @@ try:
         AgentExitInfo,
         AgentRole,
         AggregatedReviewResult,
+        ContainerInfo,
         ContainerStatus,
         CycleTiming,
         DecisionStatus,
         HITLDecision,
         IterationSummary,
         OperatorDirective,
+        PhaseExecution,
         Pipeline,
         PipelineMode,
         PipelinePhase,
@@ -161,12 +163,14 @@ except ImportError:
         AgentExitInfo,
         AgentRole,
         AggregatedReviewResult,
+        ContainerInfo,
         ContainerStatus,
         CycleTiming,
         DecisionStatus,
         HITLDecision,
         IterationSummary,
         OperatorDirective,
+        PhaseExecution,
         Pipeline,
         PipelineMode,
         PipelinePhase,
@@ -11949,8 +11953,11 @@ def _build_phase_iteration_context(
             ts = summary.completed_at.isoformat()
             lines.append(f"**Iteration {summary.iteration_n}** (completed {ts}):")
             if summary.final_proposal_commit:
+                # SHAs are pre-filtered by _build_iteration_summary_from_tracker
+                # (empty + RECONSTRUCTED_NO_SHA dropped before the dict is
+                # populated), so every value here is a real commit.
                 commit_parts = [
-                    f"{producer}={sha[:12]}" if sha else f"{producer}=<none>"
+                    f"{producer}={sha[:12]}"
                     for producer, sha in sorted(summary.final_proposal_commit.items())
                 ]
                 lines.append(f"- Final proposal commits: {', '.join(commit_parts)}")
@@ -11999,10 +12006,23 @@ def _build_iteration_summary_from_tracker(
         matrix = getattr(tracker, "matrix", None)
         if matrix is None:
             return summary
-        entries = getattr(matrix, "_entries", {})
+        # Snapshot the matrix entries + commit SHAs under the tracker's
+        # lock so concurrent mutations from a still-live tracker can't
+        # tear the read. RLock means re-entry is safe if callers already
+        # hold it. Iteration below runs on the local copies.
+        lock = getattr(tracker, "_lock", None)
+        commits_snapshot: dict[str, str] = {}
+        if lock is not None:
+            with lock:
+                entries_snapshot = list(getattr(matrix, "_entries", {}).items())
+                commits_snapshot = dict(getattr(tracker, "_proposal_commit_shas", {}))
+        else:
+            entries_snapshot = list(getattr(matrix, "_entries", {}).items())
+            commits_snapshot = dict(getattr(tracker, "_proposal_commit_shas", {}))
+
         verdict_matrix: dict[str, str] = {}
         nack_reasons: list[str] = []
-        for (reviewer, producer), entry in entries.items():
+        for (reviewer, producer), entry in entries_snapshot:
             state = getattr(entry, "state", None)
             state_val = state.value if state is not None else "unknown"
             verdict_matrix[f"{reviewer}->{producer}"] = state_val
@@ -12011,13 +12031,10 @@ def _build_iteration_summary_from_tracker(
         summary.verdict_matrix = verdict_matrix
         summary.nack_reasons = nack_reasons
 
-        producers = {producer for _, producer in entries.keys()}
+        producers = {producer for _, producer in (k for k, _ in entries_snapshot)}
         commits: dict[str, str] = {}
         for producer in producers:
-            try:
-                sha = tracker.get_proposal_commit_sha(producer)
-            except Exception:
-                sha = ""
+            sha = commits_snapshot.get(producer, "")
             if sha and sha != "RECONSTRUCTED_NO_SHA":
                 commits[producer] = sha
         summary.final_proposal_commit = commits
@@ -12028,6 +12045,47 @@ def _build_iteration_summary_from_tracker(
             error=str(e),
         )
     return summary
+
+
+def _apply_inline_hitl_kickback_to_phase(
+    phase_execution: PhaseExecution,
+    revision_feedback: str,
+    tracker: Any = None,
+) -> list[ContainerInfo]:
+    """Apply the inline HITL kickback's phase-state mutations.
+
+    Extracted from the inline ``request_changes`` handler so tests can
+    drive the assertion through production code rather than constructing
+    a fixture by hand (#2795 review). The caller is still responsible for
+    the wrapping concerns: clearing the message store + consensus tracker
+    via ``_clear_concurrent_state``, persisting the pipeline via
+    ``store.save_pipeline``, and stopping the stale containers returned
+    here (the K8s delete is asynchronous so an explicit stop is required
+    to avoid iteration N+1 racing iteration N's still-terminating pods).
+
+    Returns the snapshot of containers that were running at kickback
+    time, for the caller to issue the defensive stop on.
+    """
+    iteration_n = len(phase_execution.iteration_history)
+    phase_execution.operator_directives.append(
+        OperatorDirective(
+            iteration_n=iteration_n,
+            feedback_text=revision_feedback,
+        )
+    )
+    phase_execution.iteration_history.append(
+        _build_iteration_summary_from_tracker(
+            tracker,
+            iteration_n=iteration_n,
+            artifacts=phase_execution.artifacts,
+        )
+    )
+    stale_containers = list(phase_execution.containers)
+    phase_execution.containers = []
+    phase_execution.agents = []
+    phase_execution.artifacts = {}
+    phase_execution.review_cycles = 0
+    return stale_containers
 
 
 def _build_phase_prompt(
@@ -13979,6 +14037,38 @@ def _build_agent_prompt(
             )
         return base_prompt
 
+    if role_value.startswith("reviewer_"):
+        # Reviewer prompts are fully built by _build_review_prompt with its
+        # own criteria/verdict format + iteration-context wiring; we don't
+        # accumulate the role-shared ``lines`` block for them. Dispatching
+        # here (rather than mid-function with an early return) prevents
+        # future drift where a "must always be included" line is added to
+        # the accumulation and silently never reaches reviewers (#2795).
+        reviewer_type = role_value.replace("reviewer_", "", 1).replace("_", "-")
+        review_prompt = _build_review_prompt(
+            phase=phase,
+            pipeline_id=pipeline_id,
+            pipeline_mode=pipeline_mode,
+            reviewer_type=reviewer_type,
+            issue_number=issue_number,
+            review_cycle=review_cycle + 1,
+            prior_feedback=review_feedback,
+            repo_path=repo_path,
+            base_branch=base_branch,
+            concurrent=concurrent,
+            operator_directives=operator_directives,
+            iteration_history=iteration_history,
+        )
+        if concurrent:
+            review_prompt += "\n" + _build_brc_preamble(
+                role_value,
+                phase,
+                repo=repo,
+                branch=branch,
+                base_branch=base_branch,
+            )
+        return review_prompt
+
     # Build context header (shared across all roles)
     lines = [f"You are the **{role_value.upper()}** agent in the **{phase}** phase.\n"]
     lines.append("## Context\n")
@@ -14673,32 +14763,6 @@ def _build_agent_prompt(
                 "",
             ]
         )
-    elif role_value.startswith("reviewer_"):
-        # Delegate to the detailed review prompt with criteria and verdict format
-        reviewer_type = role_value.replace("reviewer_", "", 1).replace("_", "-")
-        review_prompt = _build_review_prompt(
-            phase=phase,
-            pipeline_id=pipeline_id,
-            pipeline_mode=pipeline_mode,
-            reviewer_type=reviewer_type,
-            issue_number=issue_number,
-            review_cycle=review_cycle + 1,
-            prior_feedback=review_feedback,
-            repo_path=repo_path,
-            base_branch=base_branch,
-            concurrent=concurrent,
-            operator_directives=operator_directives,
-            iteration_history=iteration_history,
-        )
-        if concurrent:
-            review_prompt += "\n" + _build_brc_preamble(
-                role_value,
-                phase,
-                repo=repo,
-                branch=branch,
-                base_branch=base_branch,
-            )
-        return review_prompt
     else:
         lines.extend(
             [
@@ -23093,14 +23157,6 @@ def _run_pipeline(
                             # string. Both lists accumulate across kickbacks so
                             # iteration N+1's prompts can render them with
                             # explicit precedence prose.
-                            iteration_n = phase_execution.hitl_review_cycles - 1
-                            phase_execution.operator_directives.append(
-                                OperatorDirective(
-                                    iteration_n=iteration_n,
-                                    feedback_text=_revision_feedback,
-                                )
-                            )
-
                             # Capture the BRC tracker state BEFORE
                             # _clear_concurrent_state drops it — that's our
                             # only chance to snapshot iteration N's verdicts
@@ -23118,13 +23174,6 @@ def _run_pipeline(
                                     pipeline_id=pipeline_id,
                                     error=str(tracker_err),
                                 )
-                            phase_execution.iteration_history.append(
-                                _build_iteration_summary_from_tracker(
-                                    _kickback_tracker,
-                                    iteration_n=iteration_n,
-                                    artifacts=phase_execution.artifacts,
-                                )
-                            )
 
                             # Defensive teardown of iteration N's containers
                             # before we reset and respawn (#2795). The
@@ -23133,15 +23182,11 @@ def _run_pipeline(
                             # asynchronous — calling stop_container again here
                             # is idempotent and guarantees iteration N+1 will
                             # not race iteration N's still-terminating pods.
-                            _kickback_stale_containers = list(phase_execution.containers)
-
-                            # Reset containers/agents/artifacts so the re-run
-                            # starts clean, resetting the same container/agent/
-                            # artifact fields that the recovery path resets.
-                            phase_execution.containers = []
-                            phase_execution.agents = []
-                            phase_execution.artifacts = {}
-                            phase_execution.review_cycles = 0
+                            _kickback_stale_containers = _apply_inline_hitl_kickback_to_phase(
+                                phase_execution,
+                                _revision_feedback,
+                                tracker=_kickback_tracker,
+                            )
 
                             # Clear message store and consensus tracker so the
                             # re-run doesn't short-circuit on stale CONSENSUS_CONFIRMED
@@ -24147,7 +24192,11 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                     # this snapshot will typically have empty verdict
                     # detail — but the iteration index + artifacts are
                     # still useful context for iteration N+1's prompts.
-                    _recovery_iteration_n = phase_execution.hitl_review_cycles
+                    # Derive iteration_n from len(iteration_history) so it
+                    # stays monotone — the cycle counter is reset to 0 a
+                    # few lines below, which would otherwise collide with
+                    # subsequent inline-path kickbacks (#2795 review).
+                    _recovery_iteration_n = len(phase_execution.iteration_history)
                     _recovery_tracker = None
                     try:
                         from peer_consensus import (

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -24200,20 +24200,23 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                 else:
                     # request_changes/change_approach — reset phase for re-run
                     phase_execution = pipeline.get_phase_execution(pipeline.current_phase)
-                    # #2795: capture iteration N's BRC tracker BEFORE the
-                    # reset wipes the per-phase counters. The tracker is
-                    # in-memory only, so on a crash-recovery resolution
-                    # this snapshot will typically have empty verdict
-                    # detail — but the iteration index + artifacts are
-                    # still useful context for iteration N+1's prompts.
-                    # Derive iteration_n monotonically — the cycle
-                    # counter is reset to 0 a few lines below, which
-                    # would otherwise collide with subsequent inline-
-                    # path kickbacks. Floor is one past the maximum
-                    # existing directive index so a legacy-hitl_feedback
-                    # migration (which synthesises a directive but
-                    # leaves iteration_history empty) doesn't restart
-                    # the index at 0 (#2795 review).
+                    # #2795: derive iteration_n monotonically. The
+                    # ``max(len(iteration_history), max(directive_idx) + 1)``
+                    # form does not depend on ``hitl_review_cycles``, so
+                    # this expression is safe to evaluate either before
+                    # or after ``_clear_concurrent_state`` resets the
+                    # per-phase counter. What *is* order-sensitive is
+                    # the tracker snapshot a few lines below: the BRC
+                    # tracker is in-memory only and gets wiped by
+                    # ``_clear_concurrent_state``, so the snapshot MUST
+                    # happen first. On a crash-recovery resolution the
+                    # snapshot will typically have empty verdict detail,
+                    # but the iteration index + artifacts are still
+                    # useful context for iteration N+1's prompts.
+                    # The ``max(...) + 1`` floor ensures a legacy-
+                    # hitl_feedback migration (which synthesises a
+                    # directive but leaves iteration_history empty)
+                    # doesn't restart the index at 0.
                     _recovery_iteration_n = max(
                         len(phase_execution.iteration_history),
                         max(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -109,6 +109,8 @@ try:
         CycleTiming,
         DecisionStatus,
         HITLDecision,
+        IterationSummary,
+        OperatorDirective,
         Pipeline,
         PipelineMode,
         PipelinePhase,
@@ -163,6 +165,8 @@ except ImportError:
         CycleTiming,
         DecisionStatus,
         HITLDecision,
+        IterationSummary,
+        OperatorDirective,
         Pipeline,
         PipelineMode,
         PipelinePhase,
@@ -6206,6 +6210,8 @@ def _build_review_prompt(
     last_reviewed_commit: str | None = None,
     base_branch: str | None = None,
     concurrent: bool = False,
+    operator_directives: list[OperatorDirective] | None = None,
+    iteration_history: list[IterationSummary] | None = None,
 ) -> str:
     """Build a review prompt for the reviewer agent.
 
@@ -6479,6 +6485,13 @@ def _build_review_prompt(
             "Verify prior feedback was addressed AND review new code thoroughly."
         )
         lines.append("")
+
+    # Phase iteration context: operator directives + prior iteration
+    # history. Surfaced to reviewers so they cannot faithfully NACK a
+    # directive-driven change against a stale default rubric (#2795).
+    iteration_context = _build_phase_iteration_context(operator_directives, iteration_history)
+    if iteration_context:
+        lines.append(iteration_context)
 
     # Prior feedback for re-reviews
     if review_cycle > 1 and prior_feedback:
@@ -11886,6 +11899,137 @@ _YAML_TASKS_SAFETY_GUIDANCE = [
 ]
 
 
+def _build_phase_iteration_context(
+    operator_directives: list[OperatorDirective] | None,
+    iteration_history: list[IterationSummary] | None,
+) -> str:
+    """Render operator directives + prior iteration history as a prompt section.
+
+    Issued in iteration N+1 prompts (for **both** producers and reviewers)
+    after one or more HITL phase-gate kickbacks. Replaces the unstructured
+    ``## Review Feedback`` rendering that previously squatted on the
+    agentic-cycle feedback channel — operator directives now have their own
+    section with explicit precedence prose so reviewers cannot faithfully
+    NACK a directive-driven change against a stale default rubric (#2795).
+
+    Returns an empty string when there are no directives and no history
+    so the caller can unconditionally append the result.
+    """
+    directives = operator_directives or []
+    history = iteration_history or []
+    if not directives and not history:
+        return ""
+
+    lines: list[str] = ["## Phase Iteration Context\n"]
+    if directives:
+        lines.append(
+            "The operator has kicked this phase back through HITL one or "
+            "more times. The directives below **override prompt-template "
+            "defaults**. If a rubric item in your role's instructions "
+            "conflicts with a directive, the directive wins. Later "
+            "directives override earlier ones.\n"
+        )
+        lines.append("### Operator Directives (chronological)\n")
+        for idx, directive in enumerate(directives, start=1):
+            ts = directive.created_at.isoformat()
+            lines.append(f"**Directive {idx}** (iteration {directive.iteration_n}, {ts}):")
+            lines.append("")
+            lines.append(directive.feedback_text.rstrip())
+            lines.append("")
+
+    if history:
+        lines.append("### Prior Iteration History\n")
+        lines.append(
+            "Each entry below is a frozen snapshot of a previously kicked-"
+            "back iteration's BRC outcome — what the reviewers concluded "
+            "and why. Use it to see which rubric items tripped last round "
+            "so you do not repeat the same NACKs.\n"
+        )
+        for summary in history:
+            ts = summary.completed_at.isoformat()
+            lines.append(f"**Iteration {summary.iteration_n}** (completed {ts}):")
+            if summary.final_proposal_commit:
+                commit_parts = [
+                    f"{producer}={sha[:12]}" if sha else f"{producer}=<none>"
+                    for producer, sha in sorted(summary.final_proposal_commit.items())
+                ]
+                lines.append(f"- Final proposal commits: {', '.join(commit_parts)}")
+            if summary.verdict_matrix:
+                verdicts = "; ".join(
+                    f"{edge}: {state}" for edge, state in sorted(summary.verdict_matrix.items())
+                )
+                lines.append(f"- Verdict matrix: {verdicts}")
+            if summary.nack_reasons:
+                lines.append(f"- NACK reasons ({len(summary.nack_reasons)}):")
+                for reason in summary.nack_reasons:
+                    lines.append(f"  - {reason}")
+            if summary.artifacts_snapshot:
+                arts = ", ".join(sorted(summary.artifacts_snapshot.keys()))
+                lines.append(f"- Artifacts at iteration close: {arts}")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def _build_iteration_summary_from_tracker(
+    tracker: Any,
+    iteration_n: int,
+    artifacts: dict[str, str] | None = None,
+    completed_at: datetime | None = None,
+) -> IterationSummary:
+    """Capture an :class:`IterationSummary` from a live BRC tracker.
+
+    Called by the HITL kickback handler **before** ``_clear_concurrent_state``
+    wipes the tracker so the iteration N+1 prompt can render what tripped
+    iteration N. Tolerates a ``None`` tracker — returns a summary with only
+    the iteration index + completion timestamp populated, which still lets
+    downstream prompts mention that a kickback occurred without claiming
+    false verdict detail.
+    """
+    completion = completed_at or datetime.now(UTC)
+    summary = IterationSummary(
+        iteration_n=iteration_n,
+        completed_at=completion,
+        artifacts_snapshot=dict(artifacts or {}),
+    )
+    if tracker is None:
+        return summary
+
+    try:
+        matrix = getattr(tracker, "matrix", None)
+        if matrix is None:
+            return summary
+        entries = getattr(matrix, "_entries", {})
+        verdict_matrix: dict[str, str] = {}
+        nack_reasons: list[str] = []
+        for (reviewer, producer), entry in entries.items():
+            state = getattr(entry, "state", None)
+            state_val = state.value if state is not None else "unknown"
+            verdict_matrix[f"{reviewer}->{producer}"] = state_val
+            if state_val == "nacked" and getattr(entry, "reason", ""):
+                nack_reasons.append(f"{reviewer}→{producer}: {entry.reason}")
+        summary.verdict_matrix = verdict_matrix
+        summary.nack_reasons = nack_reasons
+
+        producers = {producer for _, producer in entries.keys()}
+        commits: dict[str, str] = {}
+        for producer in producers:
+            try:
+                sha = tracker.get_proposal_commit_sha(producer)
+            except Exception:
+                sha = ""
+            if sha and sha != "RECONSTRUCTED_NO_SHA":
+                commits[producer] = sha
+        summary.final_proposal_commit = commits
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "Failed to snapshot iteration summary from tracker",
+            iteration_n=iteration_n,
+            error=str(e),
+        )
+    return summary
+
+
 def _build_phase_prompt(
     phase: str,
     pipeline_id: str,
@@ -11897,6 +12041,8 @@ def _build_phase_prompt(
     review_feedback: str | None = None,
     review_cycle: int = 0,
     repo_path: str | None = None,
+    operator_directives: list[OperatorDirective] | None = None,
+    iteration_history: list[IterationSummary] | None = None,
 ) -> str:
     """Build a phase-specific prompt for the sandbox Claude invocation.
 
@@ -11916,11 +12062,18 @@ def _build_phase_prompt(
         lines.append(f"Issue: #{issue_number}")
     lines.append("")
 
-    # --- Prior review feedback (agentic revision cycles OR HITL phase reset) ---
-    # Feedback can arrive on cycle 0 when a human rejects a phase_gate with
-    # change_approach/request_changes — the HITL handler resets review_cycles
-    # to 0 and stores the feedback in phase_execution.hitl_feedback, which
-    # flows back here via the review_feedback parameter (#1915).
+    # --- Phase iteration context (HITL kickbacks) ---
+    # Operator directives have their own section with explicit precedence
+    # prose so reviewers cannot faithfully NACK a directive-driven change
+    # against a stale default rubric. See issue #2795.
+    iteration_context = _build_phase_iteration_context(operator_directives, iteration_history)
+    if iteration_context:
+        lines.append(iteration_context)
+
+    # --- Prior review feedback (agentic revision cycles only) ---
+    # Scoped to agentic-cycle review feedback since #2795 — HITL kickback
+    # feedback now flows through ``operator_directives`` / the iteration
+    # context section above.
     if review_feedback:
         if review_cycle > 0:
             lines.append(f"## Prior Review Feedback (Cycle {review_cycle})\n")
@@ -13740,6 +13893,8 @@ def _build_agent_prompt(
     all_phases=None,
     concurrent: bool = False,
     network_mode: str | None = None,
+    operator_directives: list[OperatorDirective] | None = None,
+    iteration_history: list[IterationSummary] | None = None,
     *,
     is_pre_seeded_empty_producer: bool = False,
 ) -> str:
@@ -13795,6 +13950,8 @@ def _build_agent_prompt(
             review_feedback=review_feedback,
             review_cycle=review_cycle,
             repo_path=repo_path,
+            operator_directives=operator_directives,
+            iteration_history=iteration_history,
         )
         # Surface file boundaries so agent knows what it can push (#1431).
         # Pass repo so the rendered patterns match per-repo overrides
@@ -13866,7 +14023,15 @@ def _build_agent_prompt(
     if role_context:
         lines.append(role_context)
 
-    # Review feedback from prior cycles
+    # Phase iteration context: operator directives + prior iteration history.
+    # Rendered for all roles (producers AND reviewers) so reviewers cannot
+    # NACK a directive-driven change against a stale default rubric (#2795).
+    iteration_context = _build_phase_iteration_context(operator_directives, iteration_history)
+    if iteration_context:
+        lines.append(iteration_context)
+
+    # Review feedback from prior agentic cycles (scoped to agentic NACKs
+    # since #2795 — HITL kickbacks render via the iteration context above).
     if review_feedback:
         lines.append("## Review Feedback\n")
         lines.append(review_feedback)
@@ -14522,6 +14687,8 @@ def _build_agent_prompt(
             repo_path=repo_path,
             base_branch=base_branch,
             concurrent=concurrent,
+            operator_directives=operator_directives,
+            iteration_history=iteration_history,
         )
         if concurrent:
             review_prompt += "\n" + _build_brc_preamble(
@@ -16801,6 +16968,8 @@ def _run_concurrent_phase_with_impasse_retry(
     worktree_repo_path: Path,
     review_feedback: str | None = None,
     slice_id: str | None = None,
+    operator_directives: list[OperatorDirective] | None = None,
+    iteration_history: list[IterationSummary] | None = None,
 ) -> tuple[int, str]:
     """Run a concurrent phase, auto-delegating impasses once before HITL.
 
@@ -16879,6 +17048,8 @@ def _run_concurrent_phase_with_impasse_retry(
             worktree_repo_path=worktree_repo_path,
             review_feedback=review_feedback,
             slice_id=slice_id,
+            operator_directives=operator_directives,
+            iteration_history=iteration_history,
         )
 
         try:
@@ -16981,6 +17152,8 @@ def _run_concurrent_phase(
     worktree_repo_path: Path,
     review_feedback: str | None = None,
     slice_id: str | None = None,
+    operator_directives: list[OperatorDirective] | None = None,
+    iteration_history: list[IterationSummary] | None = None,
 ) -> tuple[int, str]:
     """Run a phase using concurrent all-agents-at-once execution.
 
@@ -17145,6 +17318,8 @@ def _run_concurrent_phase(
             concurrent=True,
             review_feedback=review_feedback,
             network_mode=gateway_mode,
+            operator_directives=operator_directives,
+            iteration_history=iteration_history,
             is_pre_seeded_empty_producer=role.value in _pre_seeded_empty_producer_roles,
         )
         agent_prompts[role] = prompt
@@ -21267,23 +21442,10 @@ def _run_pipeline(
                     _emit_pipeline_event(pipeline, "pipeline.failed")
                     return
 
-        # Check for feedback preserved by the recovery path in start_pipeline
-        # or by the inline request_changes handler.  When either stores
-        # reviewer feedback in phase_execution.hitl_feedback, we read it
-        # here so it can be forwarded to the re-running agents.
-        _hitl_review_feedback: str | None = None
-        try:
-            with get_pipeline_state_lock(pipeline_id):
-                _recovery_pipeline = store.load_pipeline(pipeline_id)
-                _recovery_phase = _recovery_pipeline.get_phase_execution(
-                    _recovery_pipeline.current_phase
-                )
-                if _recovery_phase.hitl_feedback:
-                    _hitl_review_feedback = _recovery_phase.hitl_feedback
-                    _recovery_phase.hitl_feedback = None
-                    store.save_pipeline(_recovery_pipeline)
-        except Exception as e:
-            logger.debug("Failed to read hitl_feedback from recovery path", error=str(e))
+        # Operator directives + prior iteration history are persisted on
+        # ``PhaseExecution`` and accumulate across HITL kickbacks (#2795).
+        # They are read directly off the phase below each loop iteration —
+        # no separate "read once and clear" stash is needed.
 
         # Initialize the Tier 1 health monitor so deterministic tripwires
         # (heartbeat timeout, container exit, repeated errors, message rate,
@@ -22005,26 +22167,21 @@ def _run_pipeline(
                         mode=gateway_mode,
                     )
 
-                    # Read HITL feedback stored by the inline request_changes
-                    # handler or the AWAITING_HUMAN recovery path, and clear it
-                    # so it's only forwarded once.
-                    _phase_review_feedback: str | None = None
-                    if _hitl_review_feedback:
-                        _phase_review_feedback = _hitl_review_feedback
-                        _hitl_review_feedback = None
-                    else:
-                        # Re-read from persisted state in case the inline path
-                        # stored feedback and looped back via continue.
-                        try:
-                            with get_pipeline_state_lock(pipeline_id):
-                                _fb_pipeline = store.load_pipeline(pipeline_id)
-                                _fb_phase = _fb_pipeline.get_phase_execution(current_phase)
-                                if _fb_phase.hitl_feedback:
-                                    _phase_review_feedback = _fb_phase.hitl_feedback
-                                    _fb_phase.hitl_feedback = None
-                                    store.save_pipeline(_fb_pipeline)
-                        except Exception as e:
-                            logger.debug("Failed to read hitl_feedback for phase", error=str(e))
+                    # Read structured operator directives + prior iteration
+                    # history off the phase so iteration N+1 prompts can render
+                    # them with precedence prose (#2795). These lists accumulate
+                    # across kickbacks and are never cleared, so no read-and-
+                    # clear stash is needed.
+                    _phase_operator_directives: list[OperatorDirective] = []
+                    _phase_iteration_history: list[IterationSummary] = []
+                    try:
+                        with get_pipeline_state_lock(pipeline_id):
+                            _fb_pipeline = store.load_pipeline(pipeline_id)
+                            _fb_phase = _fb_pipeline.get_phase_execution(current_phase)
+                            _phase_operator_directives = list(_fb_phase.operator_directives)
+                            _phase_iteration_history = list(_fb_phase.iteration_history)
+                    except Exception as e:
+                        logger.debug("Failed to read operator directives for phase", error=str(e))
 
                     # #2137: route the implement phase through the slice
                     # DAG iterator when the contract has more than one
@@ -22137,7 +22294,8 @@ def _run_pipeline(
                                 store=store,
                                 certs_volume=certs_volume,
                                 worktree_repo_path=worktree_repo_path,
-                                review_feedback=_phase_review_feedback,
+                                operator_directives=_phase_operator_directives,
+                                iteration_history=_phase_iteration_history,
                             )
                     except (ContainerSpawnError, KubernetesSpawnError) as e:
                         with get_pipeline_state_lock(pipeline_id):
@@ -22930,8 +23088,52 @@ def _run_pipeline(
                             store.save_pipeline(pipeline)
                             # Fall through to the approval path below
                         else:
-                            # Store feedback so the re-running agents receive it.
-                            phase_execution.hitl_feedback = _revision_feedback
+                            # #2795: append the directive + frozen iteration
+                            # summary instead of writing a single hitl_feedback
+                            # string. Both lists accumulate across kickbacks so
+                            # iteration N+1's prompts can render them with
+                            # explicit precedence prose.
+                            iteration_n = phase_execution.hitl_review_cycles - 1
+                            phase_execution.operator_directives.append(
+                                OperatorDirective(
+                                    iteration_n=iteration_n,
+                                    feedback_text=_revision_feedback,
+                                )
+                            )
+
+                            # Capture the BRC tracker state BEFORE
+                            # _clear_concurrent_state drops it — that's our
+                            # only chance to snapshot iteration N's verdicts
+                            # for the iteration N+1 prompt.
+                            _kickback_tracker = None
+                            try:
+                                from peer_consensus import (
+                                    get_peer_consensus_tracker as _gpct_kickback,
+                                )
+
+                                _kickback_tracker = _gpct_kickback(pipeline_id)
+                            except Exception as tracker_err:  # noqa: BLE001
+                                logger.debug(
+                                    "Tracker lookup failed during kickback snapshot",
+                                    pipeline_id=pipeline_id,
+                                    error=str(tracker_err),
+                                )
+                            phase_execution.iteration_history.append(
+                                _build_iteration_summary_from_tracker(
+                                    _kickback_tracker,
+                                    iteration_n=iteration_n,
+                                    artifacts=phase_execution.artifacts,
+                                )
+                            )
+
+                            # Defensive teardown of iteration N's containers
+                            # before we reset and respawn (#2795). The
+                            # consensus-close path already SIGTERMs at the end
+                            # of _run_concurrent_phase, but the K8s delete is
+                            # asynchronous — calling stop_container again here
+                            # is idempotent and guarantees iteration N+1 will
+                            # not race iteration N's still-terminating pods.
+                            _kickback_stale_containers = list(phase_execution.containers)
 
                             # Reset containers/agents/artifacts so the re-run
                             # starts clean, resetting the same container/agent/
@@ -22949,6 +23151,21 @@ def _run_pipeline(
                             _clear_concurrent_state(pipeline_id)
 
                             store.save_pipeline(pipeline)
+
+                            for _ctr in _kickback_stale_containers:
+                                if _ctr.container_id and _ctr.status == ContainerStatus.RUNNING:
+                                    try:
+                                        spawner.backend.stop_container(
+                                            _ctr.container_id, timeout=10
+                                        )
+                                    except Exception as stop_err:  # noqa: BLE001
+                                        logger.debug(
+                                            "Best-effort kickback teardown failed",
+                                            pipeline_id=pipeline_id,
+                                            container_id=_ctr.container_id,
+                                            error=str(stop_err),
+                                        )
+
                             report_pipeline_status(
                                 pipeline,
                                 event_type="phase.revision_requested",
@@ -23924,6 +24141,32 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
                 else:
                     # request_changes/change_approach — reset phase for re-run
                     phase_execution = pipeline.get_phase_execution(pipeline.current_phase)
+                    # #2795: capture iteration N's BRC tracker BEFORE the
+                    # reset wipes the per-phase counters. The tracker is
+                    # in-memory only, so on a crash-recovery resolution
+                    # this snapshot will typically have empty verdict
+                    # detail — but the iteration index + artifacts are
+                    # still useful context for iteration N+1's prompts.
+                    _recovery_iteration_n = phase_execution.hitl_review_cycles
+                    _recovery_tracker = None
+                    try:
+                        from peer_consensus import (
+                            get_peer_consensus_tracker as _gpct_recovery,
+                        )
+
+                        _recovery_tracker = _gpct_recovery(pipeline_id)
+                    except Exception as tracker_err:  # noqa: BLE001
+                        logger.debug(
+                            "Tracker lookup failed during recovery snapshot",
+                            pipeline_id=pipeline_id,
+                            error=str(tracker_err),
+                        )
+                    _recovery_summary = _build_iteration_summary_from_tracker(
+                        _recovery_tracker,
+                        iteration_n=_recovery_iteration_n,
+                        artifacts=phase_execution.artifacts,
+                    )
+
                     if phase_execution.status in (
                         PipelineStatus.COMPLETE,
                         PipelineStatus.FAILED,
@@ -23953,10 +24196,18 @@ def start_pipeline(pipeline_id: str) -> tuple[Response, int]:
 
                     _clear_concurrent_state(pipeline_id)
 
-                    # Preserve the reviewer's feedback so the re-launched
-                    # _run_pipeline thread can pass it to the agent.
+                    # #2795: append the operator directive + iteration
+                    # summary so iteration N+1 prompts can render them
+                    # with precedence prose. Both lists accumulate
+                    # across kickbacks (no clear).
                     if revision_feedback:
-                        phase_execution.hitl_feedback = revision_feedback
+                        phase_execution.operator_directives.append(
+                            OperatorDirective(
+                                iteration_n=_recovery_iteration_n,
+                                feedback_text=revision_feedback,
+                            )
+                        )
+                        phase_execution.iteration_history.append(_recovery_summary)
 
                 pipeline.error = None
                 pipeline.run_epoch = datetime.now(UTC)

--- a/orchestrator/tests/test_hitl_revision.py
+++ b/orchestrator/tests/test_hitl_revision.py
@@ -1268,8 +1268,16 @@ class TestInlineRequestChangesStateReset:
     """
 
     def test_inline_rerun_resets_state_fields(self):
-        """The re-run (else) branch should reset containers/agents/artifacts/review_cycles."""
-        from models import AgentExecution, ContainerInfo, ContainerStatus, OperatorDirective
+        """The re-run (else) branch should reset containers/agents/artifacts/review_cycles.
+
+        Drives the assertion through the production helper
+        ``_apply_inline_hitl_kickback_to_phase`` so the test exercises the
+        same mutations the inline kickback handler runs (#2795 review).
+        Fixture-only setup that does not call the production code would
+        pass by construction and miss future regressions in the handler.
+        """
+        from models import AgentExecution, ContainerInfo, ContainerStatus
+        from routes.pipelines import _apply_inline_hitl_kickback_to_phase
 
         phase = PhaseExecution(phase=PipelinePhase.PLAN)
         phase.status = PipelineStatus.COMPLETE
@@ -1283,26 +1291,59 @@ class TestInlineRequestChangesStateReset:
         phase.agents = [AgentExecution(role="coder")]
         phase.artifacts = {"pr_url": "https://github.com/old"}
         phase.review_cycles = 2
-
-        # Simulate the re-run (else) branch of the inline request_changes handler.
-        # The reset only happens when the circuit breaker does NOT trip.
+        # The caller (the inline handler) does these two before invoking the
+        # helper, so mirror it here.
         phase.status = PipelineStatus.RUNNING
         phase.completed_at = None
         phase.hitl_review_cycles += 1
-        phase.operator_directives.append(
-            OperatorDirective(iteration_n=0, feedback_text="Fix the tests")
-        )
-        phase.containers = []
-        phase.agents = []
-        phase.artifacts = {}
-        phase.review_cycles = 0
 
+        stale = _apply_inline_hitl_kickback_to_phase(
+            phase,
+            revision_feedback="Fix the tests",
+            tracker=None,
+        )
+
+        # The helper returns the snapshot of containers that were running
+        # at kickback time so the caller can issue defensive stop calls.
+        assert len(stale) == 1
+        assert stale[0].container_id == "old-ctr"
+
+        # Directive + iteration summary are appended.
         assert phase.operator_directives[-1].feedback_text == "Fix the tests"
+        assert phase.operator_directives[-1].iteration_n == 0
+        assert len(phase.iteration_history) == 1
+        assert phase.iteration_history[-1].iteration_n == 0
+        # Phase state is reset for the re-run.
         assert phase.containers == []
         assert phase.agents == []
         assert phase.artifacts == {}
         assert phase.review_cycles == 0
         assert phase.hitl_review_cycles == 1
+
+    def test_inline_rerun_iteration_n_is_monotone(self):
+        """iteration_n derives from len(iteration_history) so it monotonically increases.
+
+        Guards against the inline path drifting back to
+        ``hitl_review_cycles - 1`` after the AWAITING_HUMAN recovery path
+        resets that counter to 0 (#2795 review).
+        """
+        from routes.pipelines import _apply_inline_hitl_kickback_to_phase
+
+        phase = PhaseExecution(phase=PipelinePhase.PLAN)
+        # Caller sets these before invoking the helper each kickback.
+        phase.hitl_review_cycles = 1
+        _apply_inline_hitl_kickback_to_phase(phase, "first", tracker=None)
+        assert phase.operator_directives[-1].iteration_n == 0
+        assert phase.iteration_history[-1].iteration_n == 0
+
+        # Simulate the recovery path's counter reset, then another inline kickback.
+        phase.hitl_review_cycles = 1  # back to 1 after a recovery reset → 0 → +1
+        _apply_inline_hitl_kickback_to_phase(phase, "second", tracker=None)
+        # Without the len(history) fix this would collide on iteration_n=0.
+        assert phase.operator_directives[-1].iteration_n == 1
+        assert phase.iteration_history[-1].iteration_n == 1
+        assert len(phase.operator_directives) == 2
+        assert len(phase.iteration_history) == 2
 
     def test_circuit_breaker_preserves_artifacts(self):
         """When the circuit breaker trips, containers/agents/artifacts must be preserved."""

--- a/orchestrator/tests/test_hitl_revision.py
+++ b/orchestrator/tests/test_hitl_revision.py
@@ -1261,14 +1261,15 @@ class TestSyncPipelineDecisionsToContract:
 class TestInlineRequestChangesStateReset:
     """Verify that inline request_changes resets phase state like the recovery path.
 
-    The inline path (inside _run_pipeline's HITL gate loop) must store
-    hitl_feedback and reset containers/agents/artifacts so the re-run
-    starts clean, matching the AWAITING_HUMAN recovery path in start_pipeline.
+    The inline path (inside _run_pipeline's HITL gate loop) must append
+    a structured OperatorDirective (#2795) and reset containers/agents/
+    artifacts so the re-run starts clean, matching the AWAITING_HUMAN
+    recovery path in start_pipeline.
     """
 
     def test_inline_rerun_resets_state_fields(self):
         """The re-run (else) branch should reset containers/agents/artifacts/review_cycles."""
-        from models import AgentExecution, ContainerInfo, ContainerStatus
+        from models import AgentExecution, ContainerInfo, ContainerStatus, OperatorDirective
 
         phase = PhaseExecution(phase=PipelinePhase.PLAN)
         phase.status = PipelineStatus.COMPLETE
@@ -1288,13 +1289,15 @@ class TestInlineRequestChangesStateReset:
         phase.status = PipelineStatus.RUNNING
         phase.completed_at = None
         phase.hitl_review_cycles += 1
-        phase.hitl_feedback = "Fix the tests"
+        phase.operator_directives.append(
+            OperatorDirective(iteration_n=0, feedback_text="Fix the tests")
+        )
         phase.containers = []
         phase.agents = []
         phase.artifacts = {}
         phase.review_cycles = 0
 
-        assert phase.hitl_feedback == "Fix the tests"
+        assert phase.operator_directives[-1].feedback_text == "Fix the tests"
         assert phase.containers == []
         assert phase.agents == []
         assert phase.artifacts == {}

--- a/orchestrator/tests/test_hitl_revision.py
+++ b/orchestrator/tests/test_hitl_revision.py
@@ -1345,6 +1345,36 @@ class TestInlineRequestChangesStateReset:
         assert len(phase.operator_directives) == 2
         assert len(phase.iteration_history) == 2
 
+    def test_inline_rerun_iteration_n_monotone_across_legacy_migration(self):
+        """iteration_n stays monotone when a legacy hitl_feedback migration seeded the directive list.
+
+        Pre-#2795 phases load with a synthetic OperatorDirective at
+        ``iteration_n = hitl_review_cycles - 1`` but an empty
+        iteration_history. A naive ``len(iteration_history)`` derivation
+        for the next inline kickback would restart at 0 and label two
+        distinct iterations identically. The ``max(...)+1`` floor on the
+        existing directive indices keeps the rendering monotone.
+        """
+        from routes.pipelines import _apply_inline_hitl_kickback_to_phase
+
+        # Simulate post-migration state: synthetic directive at
+        # iteration_n=1 (from hitl_review_cycles=2) with empty history.
+        phase = PhaseExecution.model_validate(
+            {
+                "phase": PipelinePhase.PLAN.value,
+                "hitl_review_cycles": 2,
+                "hitl_feedback": "Legacy operator directive.",
+            }
+        )
+        assert phase.operator_directives[0].iteration_n == 1
+        assert phase.iteration_history == []
+
+        _apply_inline_hitl_kickback_to_phase(phase, "post-migration", tracker=None)
+        # Without the max(...)+1 floor this would collide at iteration_n=0
+        # (len(iteration_history) at call time was 0).
+        assert phase.operator_directives[-1].iteration_n == 2
+        assert phase.iteration_history[-1].iteration_n == 2
+
     def test_circuit_breaker_preserves_artifacts(self):
         """When the circuit breaker trips, containers/agents/artifacts must be preserved."""
         from models import AgentExecution, ContainerInfo, ContainerStatus

--- a/orchestrator/tests/test_models.py
+++ b/orchestrator/tests/test_models.py
@@ -366,6 +366,63 @@ class TestPhaseExecution:
         assert restored.agent_exits[0].role == AgentRole.CODER
         assert restored.agent_exits[0].exit_code == 1
 
+    def test_legacy_hitl_feedback_migrates_to_operator_directive(self):
+        """A persisted hitl_feedback string is translated into operator_directives.
+
+        Pre-#2795 ``PhaseExecution`` carried a single ``hitl_feedback: str``
+        that the inline HITL handler and recovery path wrote and consumed.
+        #2795 replaced it with ``operator_directives``; without the migration,
+        Pydantic's default ``extra='ignore'`` would silently drop the
+        surviving value on the first load after deploy, losing the operator's
+        directive for any pipeline paused at a HITL gate.
+        """
+        raw = {
+            "phase": PipelinePhase.REFINE.value,
+            "hitl_feedback": "Drop the planner-scope sections.",
+            "hitl_review_cycles": 2,
+        }
+        restored = PhaseExecution.model_validate(raw)
+        assert len(restored.operator_directives) == 1
+        assert restored.operator_directives[0].feedback_text == "Drop the planner-scope sections."
+        # iteration_n is hitl_review_cycles - 1, matching the inline path.
+        assert restored.operator_directives[0].iteration_n == 1
+        # The legacy attribute is gone on the migrated model.
+        assert not hasattr(restored, "hitl_feedback")
+
+    def test_legacy_hitl_feedback_absent_or_empty_is_noop(self):
+        """No legacy field and an empty legacy field both leave directives unchanged."""
+        # Missing field — load is a plain construction.
+        restored = PhaseExecution.model_validate({"phase": PipelinePhase.REFINE.value})
+        assert restored.operator_directives == []
+
+        # Explicit empty string — treated as no-op, no synthetic directive.
+        restored = PhaseExecution.model_validate(
+            {"phase": PipelinePhase.REFINE.value, "hitl_feedback": ""}
+        )
+        assert restored.operator_directives == []
+
+    def test_legacy_hitl_feedback_appends_to_existing_directives(self):
+        """If operator_directives already has entries, migrated entry appends.
+
+        Guards against losing both pre-#2795 hitl_feedback and any
+        post-#2795 directives if a write path raced the migration.
+        """
+        raw = {
+            "phase": PipelinePhase.REFINE.value,
+            "hitl_review_cycles": 2,
+            "hitl_feedback": "Legacy directive",
+            "operator_directives": [
+                {"iteration_n": 0, "feedback_text": "Already-structured directive"},
+            ],
+        }
+        restored = PhaseExecution.model_validate(raw)
+        assert len(restored.operator_directives) == 2
+        assert restored.operator_directives[0].feedback_text == "Already-structured directive"
+        assert restored.operator_directives[1].feedback_text == "Legacy directive"
+        # Collides on iteration_n=1 because hitl_review_cycles=2 → 1, which
+        # doesn't conflict with the existing entry at iteration 0.
+        assert restored.operator_directives[1].iteration_n == 1
+
 
 class TestAgentExitInfo:
     """Tests for AgentExitInfo (issue #2205)."""

--- a/orchestrator/tests/test_models.py
+++ b/orchestrator/tests/test_models.py
@@ -423,6 +423,48 @@ class TestPhaseExecution:
         # doesn't conflict with the existing entry at iteration 0.
         assert restored.operator_directives[1].iteration_n == 1
 
+    def test_legacy_hitl_feedback_null_operator_directives_is_safe(self):
+        """An explicit ``null`` for ``operator_directives`` does not break the migration.
+
+        Pydantic's ``default_factory=list`` does not prevent a writer from
+        emitting a literal ``null`` on the JSON record. ``data.get(..., [])``
+        returns ``None`` in that case and ``list(None)`` would raise — the
+        ``or []`` guard ensures the migration survives.
+        """
+        raw = {
+            "phase": PipelinePhase.REFINE.value,
+            "hitl_feedback": "Drop the planner-scope sections.",
+            "hitl_review_cycles": 1,
+            "operator_directives": None,
+        }
+        restored = PhaseExecution.model_validate(raw)
+        assert len(restored.operator_directives) == 1
+        assert restored.operator_directives[0].feedback_text == "Drop the planner-scope sections."
+
+    def test_legacy_hitl_feedback_sparse_indices_collision_floor(self):
+        """Collision fallback picks one past the maximum, not ``len(directives)``.
+
+        With existing indices ``[0, 2]`` and a primary collision at
+        ``1`` (hitl_review_cycles=2 → 1 — actually no collision; force
+        it via an existing iteration_n=1 alongside the sparse 2), the
+        old ``len(directives)`` fallback would have landed on ``2`` and
+        collided again. The ``max(...)+1`` floor lands on ``3``.
+        """
+        raw = {
+            "phase": PipelinePhase.REFINE.value,
+            "hitl_review_cycles": 2,
+            "hitl_feedback": "Legacy directive",
+            "operator_directives": [
+                {"iteration_n": 1, "feedback_text": "First"},
+                {"iteration_n": 2, "feedback_text": "Sparse"},
+            ],
+        }
+        restored = PhaseExecution.model_validate(raw)
+        assert len(restored.operator_directives) == 3
+        # Primary candidate hitl_review_cycles-1 = 1 collides with existing
+        # entry at iteration_n=1 → fallback to max([1, 2]) + 1 = 3.
+        assert restored.operator_directives[2].iteration_n == 3
+
 
 class TestAgentExitInfo:
     """Tests for AgentExitInfo (issue #2205)."""

--- a/orchestrator/tests/test_models.py
+++ b/orchestrator/tests/test_models.py
@@ -427,9 +427,10 @@ class TestPhaseExecution:
         """An explicit ``null`` for ``operator_directives`` does not break the migration.
 
         Pydantic's ``default_factory=list`` does not prevent a writer from
-        emitting a literal ``null`` on the JSON record. ``data.get(..., [])``
-        returns ``None`` in that case and ``list(None)`` would raise — the
-        ``or []`` guard ensures the migration survives.
+        emitting a literal ``null`` on the JSON record. The validator
+        normalises ``operator_directives: None`` to ``[]`` before any
+        further work, so neither the migration branch nor the field
+        validation downstream raises.
         """
         raw = {
             "phase": PipelinePhase.REFINE.value,
@@ -441,14 +442,29 @@ class TestPhaseExecution:
         assert len(restored.operator_directives) == 1
         assert restored.operator_directives[0].feedback_text == "Drop the planner-scope sections."
 
+    def test_null_operator_directives_without_legacy_feedback_is_safe(self):
+        """``operator_directives: null`` is normalised even when no migration runs.
+
+        Without ``hitl_feedback`` the validator returns early; before the
+        normalisation moved above that early return, the non-Optional
+        ``list[OperatorDirective]`` field validation would reject the
+        record. This case guards that path.
+        """
+        raw = {
+            "phase": PipelinePhase.REFINE.value,
+            "operator_directives": None,
+        }
+        restored = PhaseExecution.model_validate(raw)
+        assert restored.operator_directives == []
+
     def test_legacy_hitl_feedback_sparse_indices_collision_floor(self):
         """Collision fallback picks one past the maximum, not ``len(directives)``.
 
-        With existing indices ``[0, 2]`` and a primary collision at
-        ``1`` (hitl_review_cycles=2 → 1 — actually no collision; force
-        it via an existing iteration_n=1 alongside the sparse 2), the
-        old ``len(directives)`` fallback would have landed on ``2`` and
-        collided again. The ``max(...)+1`` floor lands on ``3``.
+        With existing indices ``[1, 2]`` and ``hitl_review_cycles=2`` the
+        primary candidate ``hitl_review_cycles - 1 = 1`` collides with
+        the existing entry. The old ``len(directives)`` fallback would
+        have landed on ``2`` and collided again; the ``max(...) + 1``
+        floor lands on ``3``.
         """
         raw = {
             "phase": PipelinePhase.REFINE.value,

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -5929,6 +5929,7 @@ class TestPhaseIterationContext:
     def test_iteration_summary_from_live_tracker(self):
         """Snapshot pulls verdict matrix + NACK reasons + producer SHAs."""
         from approval_matrix import ApprovalState
+        from attestation_schemas import AttestationStrictness
         from peer_consensus import PeerConsensusTracker
         from review_graph import ReviewEdge, ReviewGraph
 
@@ -5938,22 +5939,40 @@ class TestPhaseIterationContext:
                 ReviewEdge(reviewer_role="reviewer_agent_design", producer_role="refiner"),
             ]
         )
-        tracker = PeerConsensusTracker("pid-x", graph)
+        # RELAXED strictness so handle_propose accepts a minimal payload
+        # without requiring full role-specific attestation. cooldown=0 so
+        # ACK/NACK ordering isn't gated on real time.
+        tracker = PeerConsensusTracker(
+            "pid-x",
+            graph,
+            attestation_strictness=AttestationStrictness.RELAXED,
+            cooldown_seconds=0,
+        )
         tracker.register_agent("refiner")
         tracker.register_agent("reviewer_refine")
         tracker.register_agent("reviewer_agent_design")
-        tracker.matrix.record_proposal("refiner")
-        tracker._proposal_commit_shas["refiner"] = "abc123def456"
-        tracker.matrix.record_nack(
-            reviewer="reviewer_refine",
-            producer="refiner",
-            version=1,
-            reason="missing planner sections",
+        # Drive through the public API rather than reaching into
+        # tracker._proposal_commit_shas (#2795 review).
+        tracker.handle_propose(
+            "refiner",
+            {
+                "summary": "Refine draft proposed",
+                "artifacts": [".egg-state/drafts/refine.md"],
+                "commit_sha": "abc123def456",
+            },
         )
-        tracker.matrix.record_ack(
-            reviewer="reviewer_agent_design",
-            producer="refiner",
-            version=1,
+        tracker.handle_nack(
+            "reviewer_refine",
+            "refiner",
+            {
+                "artifact_references": [".egg-state/drafts/refine.md"],
+                "reason": "missing planner sections",
+            },
+        )
+        tracker.handle_ack(
+            "reviewer_agent_design",
+            "refiner",
+            {"artifact_references": [".egg-state/drafts/refine.md"]},
         )
 
         summary = _build_iteration_summary_from_tracker(

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -22,6 +22,8 @@ from routes.pipelines import (
     _build_agent_roster,
     _build_brc_preamble,
     _build_file_boundary_section,
+    _build_iteration_summary_from_tracker,
+    _build_phase_iteration_context,
     _build_phase_prompt,
     _build_producer_orientation,
     _build_review_prompt,
@@ -457,13 +459,13 @@ class TestBuildPhasePromptRevisionMode:
         assert "no specific feedback was provided" in result
 
     def test_cycle_0_with_feedback_includes_review_feedback(self):
-        """Cycle 0 with HITL-reset feedback must surface it to the coder/refiner.
+        """Cycle 0 with agentic review feedback must surface it to the producer.
 
-        Regression for #1915: when a human rejects a phase_gate with
-        change_approach/request_changes, the inline handler resets
-        review_cycles to 0 and stores feedback in hitl_feedback, which
-        flows back as review_feedback. The producer prompt must include
-        that feedback — otherwise the refiner re-proposes the same draft.
+        Regression for #1915: when the agentic-cycle review feedback channel
+        carries content into the next cycle, the producer prompt must
+        include that feedback — otherwise the refiner re-proposes the
+        same draft. HITL kickback feedback flows through the separate
+        operator-directives channel since #2795.
         """
         result = _build_phase_prompt(
             phase="refine",
@@ -5788,3 +5790,177 @@ class TestRefinerOrientationSurfacesPrimitives:
         # The three execution contexts named in the criteria.
         assert "in-sandbox-agent" in orientation
         assert "trusted-CI-runner" in orientation
+
+
+class TestPhaseIterationContext:
+    """Tests for _build_phase_iteration_context and #2795 prompt wiring."""
+
+    def test_empty_inputs_return_empty_string(self):
+        assert _build_phase_iteration_context(None, None) == ""
+        assert _build_phase_iteration_context([], []) == ""
+
+    def test_single_directive_includes_precedence_prose(self):
+        from datetime import UTC, datetime
+
+        from models import OperatorDirective
+
+        directive = OperatorDirective(
+            iteration_n=0,
+            created_at=datetime(2026, 5, 27, 12, 0, tzinfo=UTC),
+            feedback_text="Drop the planner-scope sections from the refine draft.",
+        )
+        rendered = _build_phase_iteration_context([directive], [])
+
+        assert "## Phase Iteration Context" in rendered
+        # Precedence prose must be present so reviewers know the directive
+        # outranks rubric items in the prompt template.
+        assert "override prompt-template defaults" in rendered
+        assert "the directive wins" in rendered
+        assert "Later directives override earlier" in rendered
+        assert "Drop the planner-scope sections from the refine draft." in rendered
+        # Iteration index + ISO timestamp should be rendered.
+        assert "iteration 0" in rendered
+        assert "2026-05-27T12:00:00" in rendered
+
+    def test_multiple_directives_render_chronologically(self):
+        from datetime import UTC, datetime
+
+        from models import OperatorDirective
+
+        directives = [
+            OperatorDirective(
+                iteration_n=0,
+                created_at=datetime(2026, 5, 27, 12, 0, tzinfo=UTC),
+                feedback_text="First directive.",
+            ),
+            OperatorDirective(
+                iteration_n=1,
+                created_at=datetime(2026, 5, 27, 14, 0, tzinfo=UTC),
+                feedback_text="Second directive.",
+            ),
+        ]
+        rendered = _build_phase_iteration_context(directives, [])
+        first_idx = rendered.index("First directive.")
+        second_idx = rendered.index("Second directive.")
+        assert first_idx < second_idx
+        assert "**Directive 1**" in rendered
+        assert "**Directive 2**" in rendered
+
+    def test_iteration_history_renders_verdict_matrix_and_nacks(self):
+        from datetime import UTC, datetime
+
+        from models import IterationSummary
+
+        summary = IterationSummary(
+            iteration_n=0,
+            completed_at=datetime(2026, 5, 27, 13, 0, tzinfo=UTC),
+            final_proposal_commit={"refiner": "abc123def4567890"},
+            verdict_matrix={
+                "reviewer_refine->refiner": "nacked",
+                "reviewer_agent_design->refiner": "acked",
+            },
+            nack_reasons=["reviewer_refine→refiner: missing planner sections"],
+            artifacts_snapshot={"draft.md": ".egg-state/drafts/refine.md"},
+        )
+        rendered = _build_phase_iteration_context([], [summary])
+
+        assert "### Prior Iteration History" in rendered
+        assert "**Iteration 0**" in rendered
+        assert "abc123def456" in rendered  # truncated SHA
+        assert "reviewer_agent_design->refiner: acked" in rendered
+        assert "reviewer_refine->refiner: nacked" in rendered
+        assert "missing planner sections" in rendered
+        assert "draft.md" in rendered
+
+    def test_phase_prompt_threads_iteration_context_at_cycle_0(self):
+        """_build_phase_prompt must surface operator directives even on cycle 0."""
+        from models import OperatorDirective
+
+        rendered = _build_phase_prompt(
+            phase="refine",
+            pipeline_id="pid-1",
+            pipeline_mode="issue",
+            prompt="Analyze the issue",
+            review_cycle=0,
+            operator_directives=[
+                OperatorDirective(
+                    iteration_n=0,
+                    feedback_text="Drop the planner-scope sections.",
+                )
+            ],
+        )
+        assert "## Phase Iteration Context" in rendered
+        assert "override prompt-template defaults" in rendered
+        assert "Drop the planner-scope sections." in rendered
+
+    def test_agent_prompt_threads_iteration_context_for_reviewer(self):
+        """Reviewer prompts must also see the operator directive + precedence prose."""
+        from models import OperatorDirective
+
+        rendered = _build_agent_prompt(
+            role_value="reviewer_refine",
+            phase="refine",
+            pipeline_id="pid-1",
+            pipeline_mode="issue",
+            prompt="Analyze the issue",
+            operator_directives=[
+                OperatorDirective(
+                    iteration_n=0,
+                    feedback_text="Operator says: planner-scope sections are out of scope.",
+                )
+            ],
+        )
+        assert "## Phase Iteration Context" in rendered
+        assert "the directive wins" in rendered
+        assert "Operator says: planner-scope sections are out of scope." in rendered
+
+    def test_iteration_summary_from_none_tracker(self):
+        """_build_iteration_summary_from_tracker tolerates a missing tracker."""
+        summary = _build_iteration_summary_from_tracker(
+            None,
+            iteration_n=2,
+            artifacts={"draft.md": "/path/to/draft.md"},
+        )
+        assert summary.iteration_n == 2
+        assert summary.artifacts_snapshot == {"draft.md": "/path/to/draft.md"}
+        assert summary.verdict_matrix == {}
+        assert summary.nack_reasons == []
+
+    def test_iteration_summary_from_live_tracker(self):
+        """Snapshot pulls verdict matrix + NACK reasons + producer SHAs."""
+        from approval_matrix import ApprovalState
+        from peer_consensus import PeerConsensusTracker
+        from review_graph import ReviewEdge, ReviewGraph
+
+        graph = ReviewGraph(
+            [
+                ReviewEdge(reviewer_role="reviewer_refine", producer_role="refiner"),
+                ReviewEdge(reviewer_role="reviewer_agent_design", producer_role="refiner"),
+            ]
+        )
+        tracker = PeerConsensusTracker("pid-x", graph)
+        tracker.register_agent("refiner")
+        tracker.register_agent("reviewer_refine")
+        tracker.register_agent("reviewer_agent_design")
+        tracker.matrix.record_proposal("refiner")
+        tracker._proposal_commit_shas["refiner"] = "abc123def456"
+        tracker.matrix.record_nack(
+            reviewer="reviewer_refine",
+            producer="refiner",
+            version=1,
+            reason="missing planner sections",
+        )
+        tracker.matrix.record_ack(
+            reviewer="reviewer_agent_design",
+            producer="refiner",
+            version=1,
+        )
+
+        summary = _build_iteration_summary_from_tracker(
+            tracker, iteration_n=0, artifacts={"draft.md": "/p.md"}
+        )
+
+        assert summary.final_proposal_commit == {"refiner": "abc123def456"}
+        assert summary.verdict_matrix["reviewer_refine->refiner"] == ApprovalState.NACKED.value
+        assert summary.verdict_matrix["reviewer_agent_design->refiner"] == ApprovalState.ACKED.value
+        assert any("missing planner sections" in r for r in summary.nack_reasons)

--- a/orchestrator/tests/test_start_pipeline.py
+++ b/orchestrator/tests/test_start_pipeline.py
@@ -523,8 +523,9 @@ class TestStartAwaitingHumanPipeline:
         assert phase_exec.started_at is None
         assert pipeline.current_phase == PipelinePhase.REFINE
         assert pipeline.status == PipelineStatus.RUNNING
-        # Feedback should be preserved for the re-running agent
-        assert phase_exec.hitl_feedback == "Try a different strategy"
+        # Feedback should be appended as a structured operator directive (#2795)
+        assert phase_exec.operator_directives
+        assert phase_exec.operator_directives[-1].feedback_text == "Try a different strategy"
 
     @patch("routes.pipelines.get_pipeline_state_lock", side_effect=_noop_lock)
     @patch("routes.pipelines._run_pipeline")
@@ -576,7 +577,7 @@ class TestStartAwaitingHumanPipeline:
     def test_recovery_preserves_feedback(
         self, mock_get_repo, mock_resolve, mock_run, mock_lock, client
     ):
-        """request_changes feedback is stored in phase_execution.hitl_feedback."""
+        """request_changes feedback appends to operator_directives (#2795)."""
         pipeline = _make_awaiting_pipeline(
             phase=PipelinePhase.REFINE,
             resolution='{"action": "request_changes", "feedback": "Fix the tests"}',
@@ -587,7 +588,11 @@ class TestStartAwaitingHumanPipeline:
 
         assert resp.status_code == 200
         phase_exec = pipeline.get_phase_execution(PipelinePhase.REFINE)
-        assert phase_exec.hitl_feedback == "Fix the tests"
+        assert phase_exec.operator_directives
+        assert phase_exec.operator_directives[-1].feedback_text == "Fix the tests"
+        # An iteration summary is also appended (sparse on recovery path
+        # since the in-memory tracker is gone after restart).
+        assert phase_exec.iteration_history
 
     @patch("routes.pipelines.get_pipeline_state_lock", side_effect=_noop_lock)
     @patch("routes.pipelines._run_pipeline")


### PR DESCRIPTION
## Summary
- Replaces ``PhaseExecution.hitl_feedback: str | None`` with two accumulating lists — ``operator_directives: list[OperatorDirective]`` and ``iteration_history: list[IterationSummary]`` — preserving every kickback chronologically across the phase.
- Adds ``_build_phase_iteration_context`` which renders both lists into a new ``## Phase Iteration Context`` prompt section with explicit precedence prose (\"directives override prompt-template defaults\"). Wired into both ``_build_phase_prompt`` (producers) and ``_build_review_prompt`` (reviewers) via ``_build_agent_prompt`` so every role sees the directive plus prior-iteration verdict matrix + NACK reasons.
- ``IterationSummary`` is snapshotted from the live BRC tracker **before** ``_clear_concurrent_state`` wipes it; the AWAITING_HUMAN recovery path gets a sparse summary (in-memory tracker is gone after restart) but still records the iteration index + artifacts.
- The inline kickback handler now defensively SIGTERMs any still-RUNNING iteration-N containers from the just-completed cycle, closing the race where the K8s job-delete had not yet reaped pods before iteration N+1 spawned. The existing ``_stop_running_containers`` call inside ``_run_concurrent_phase`` stays — this is belt-and-suspenders for the kickback-and-immediately-respawn path.
- ``review_feedback`` parameter remains, now scoped to agentic-cycle NACKs only. HITL kickback prose stops squatting on it.

Closes #2795. Supersedes #2794 — once iteration-N containers are dead and the iteration N+1 reviewer prompt frames the directive as authoritative, the override-channel design space collapses on the HITL kickback path.

## Test plan
- [x] Unit tests for ``_build_phase_iteration_context`` rendering: empty/single/multi-directive, precedence prose presence, chronological ordering, verdict-matrix + NACK-reason rendering, truncated proposal-SHA rendering.
- [x] Unit test for ``_build_iteration_summary_from_tracker`` with both ``None`` tracker (recovery path) and a live ``PeerConsensusTracker``.
- [x] Producer (``_build_phase_prompt``) and reviewer (``_build_review_prompt``) prompt builders thread the new lists end-to-end.
- [x] Existing inline-kickback state-reset test updated to assert ``operator_directives`` append instead of ``hitl_feedback`` write.
- [x] Existing start_pipeline recovery-path tests updated to assert ``operator_directives`` + ``iteration_history`` append.
- [x] 698 targeted orchestrator tests pass (``test_pipeline_prompts``, ``test_hitl_revision``, ``test_start_pipeline``, ``test_models``, ``test_brc_nack_iteration``, ``test_pipelines_origin_main_parameterization``).
- [ ] CI green.