### PR TITLE
Fix #2829: token-keyed session lookup in /v1/messages proxy

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -66,13 +66,14 @@ WORKDIR /app
 # Copy gateway code
 COPY gateway/*.py ./
 
-# Copy shared modules (egg_logging for logging, egg_config for config parsing, egg_contracts for contract API, egg_restrictions for agent role enforcement, egg_health for health tracking, egg_git for cross-process git locking)
+# Copy shared modules (egg_logging for logging, egg_config for config parsing, egg_contracts for contract API, egg_restrictions for agent role enforcement, egg_health for health tracking, egg_git for cross-process git locking, egg_session_placeholder for /v1/messages token-keyed session lookup)
 COPY shared/egg_logging/ ./egg_logging/
 COPY shared/egg_config/ ./egg_config/
 COPY shared/egg_contracts/ ./egg_contracts/
 COPY shared/egg_restrictions/ ./egg_restrictions/
 COPY shared/egg_health/ ./egg_health/
 COPY shared/egg_git/ ./egg_git/
+COPY shared/egg_session_placeholder/ ./egg_session_placeholder/
 
 # Copy config module (repo_config needed by github_client for user mode)
 # Copy to both /config/ (for package-style imports) and /app/ (for PYTHONPATH)

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -71,6 +71,7 @@ if _shared_path.exists():
 from egg_health import HealthTracker
 from egg_logging import get_logger
 from egg_restrictions.hints import derive_hint as _derive_push_denied_hint
+from egg_session_placeholder import from_placeholder as _session_token_from_placeholder
 
 # Module-level health tracker. Updated every time the /api/v1/health
 # endpoint is evaluated so callers can distinguish "healthy since process
@@ -9519,6 +9520,70 @@ BLOCKED_TOOLS_PRIVATE_MODE = {"web_search", "WebSearch", "web_fetch", "WebFetch"
 RAW_INPUT_TRUNCATE_SIZE = 1000
 
 
+def _resolve_proxy_session(
+    request_headers: Any,
+    remote_addr: str | None,
+) -> tuple[Any, tuple[Response, int] | None]:
+    """
+    Resolve the session for a ``/v1/messages`` (or ``/count_tokens``) proxy
+    request.
+
+    Order of resolution (issue #2829):
+
+    1. **Token-keyed.** Extract the session token from ``x-api-key`` /
+       ``Authorization`` if the value carries the egg placeholder
+       envelope. The orchestrator wraps the session token in this
+       placeholder so Claude Code's local OAuth-token format check
+       passes while the gateway can still identify the session. This
+       is the load-bearing path for agent traffic.
+    2. **IP-keyed.** When the placeholder is absent, fall back to
+       source-IP lookup. Pod IPs are ephemeral in k8s so this is a
+       compat path for non-agent clients only (health probes, host
+       dev tools). The slice-1 "no session → anthropic" invariant for
+       non-agent probes is preserved.
+
+    Defense-in-depth: when the placeholder IS present but the session
+    lookup misses, return a 502. Silently falling through to the
+    anthropic default would silently mis-route per-agent inference
+    (the routing bug) and disable private-mode web-tool filtering (the
+    filter-bypass bug). Both were invisible at runtime before the fix.
+
+    Returns ``(session_or_none, error_response_or_none)``. On error the
+    caller MUST return the error response; on success ``session`` may
+    be ``None`` for non-placeholder probes and the caller falls back
+    to the anthropic default.
+    """
+    raw_auth = request_headers.get("x-api-key") or request_headers.get("Authorization")
+    placeholder_token = _session_token_from_placeholder(raw_auth)
+    session_manager = get_session_manager()
+
+    if placeholder_token:
+        session = session_manager.get_session(placeholder_token)
+        if session is None:
+            logger.warning(
+                "Session placeholder present but lookup missed",
+                event_type="session_lookup_miss",
+                remote_addr=remote_addr,
+            )
+            return None, (
+                jsonify(
+                    {
+                        "error": {
+                            "type": "api_error",
+                            "message": "Unknown or expired session",
+                        }
+                    }
+                ),
+                502,
+            )
+        return session, None
+
+    # Non-agent probe (no placeholder). Try IP-keyed lookup for
+    # backwards compatibility but failure here is non-fatal — the
+    # caller falls through to the anthropic default.
+    return session_manager.get_session_by_ip(remote_addr or ""), None
+
+
 def _filter_blocked_tools(request_body: bytes, session_mode: str | None) -> bytes:
     """
     Remove blocked tools from API request when in private mode.
@@ -9926,14 +9991,20 @@ def proxy_anthropic_messages() -> tuple[Response, int] | Response:
     This endpoint allows Claude Code to use ANTHROPIC_BASE_URL to route
     API traffic through the gateway for credential injection.
 
-    Uses IP-based session lookup for mode detection (Claude Code doesn't send session tokens).
-    API request/response pairs are captured to a per-session buffer for checkpoint creation.
+    Session lookup is token-keyed via a placeholder embedded in the
+    ``x-api-key`` header (issue #2829). The orchestrator wraps the
+    session token in ``sk-ant-oat01-PROXY-INJECTED-egg-session-<token>``
+    so Claude Code's local format check passes; the gateway extracts
+    the token and looks the session up. Non-agent probes (no
+    placeholder) keep the legacy IP-keyed compat path. API
+    request/response pairs are captured to a per-session buffer for
+    checkpoint creation.
     """
     start_time = time.time()
 
-    # Look up session by IP to determine mode (Claude Code doesn't send session tokens)
-    session_manager = get_session_manager()
-    session = session_manager.get_session_by_ip(request.remote_addr or "")
+    session, lookup_error = _resolve_proxy_session(request.headers, request.remote_addr)
+    if lookup_error:
+        return lookup_error
     session_mode = session.mode if session else None
     container_id = session.container_id if session else None
     # Resolve per-session upstream (issue #2769). With no session, default to
@@ -10231,11 +10302,12 @@ def proxy_count_tokens() -> tuple[Response, int] | Response:
     This endpoint allows Claude Code to use ANTHROPIC_BASE_URL to route
     token counting requests through the gateway.
     """
-    # Mirror the per-session upstream lookup used by proxy_anthropic_messages
-    # so count_tokens and messages always agree on which backend serves a
-    # given agent (issue #2769).
-    session_manager = get_session_manager()
-    session = session_manager.get_session_by_ip(request.remote_addr or "")
+    # Mirror the per-session lookup used by proxy_anthropic_messages so
+    # count_tokens and messages always agree on which backend serves a
+    # given agent (issues #2769, #2829).
+    session, lookup_error = _resolve_proxy_session(request.headers, request.remote_addr)
+    if lookup_error:
+        return lookup_error
     upstream_name = session.upstream if session else "anthropic"
 
     headers = _get_forwarded_headers(request.headers)

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -9548,6 +9548,14 @@ def _resolve_proxy_session(
     (the routing bug) and disable private-mode web-tool filtering (the
     filter-bypass bug). Both were invisible at runtime before the fix.
 
+    Side effect: ``get_session`` delegates to ``validate_session``,
+    which calls ``session.extend_ttl`` on every successful lookup. The
+    proxy is therefore no longer a read-only consumer of the session —
+    each ``/v1/messages`` (or ``/count_tokens``) call bumps the
+    session's ``last_seen``, so active agent inference keeps the
+    session alive without a separate heartbeat. The legacy
+    ``get_session_by_ip`` fallback is still read-only.
+
     Returns ``(session_or_none, error_response_or_none)``. On error the
     caller MUST return the error response; on success ``session`` may
     be ``None`` for non-placeholder probes and the caller falls back
@@ -9560,11 +9568,12 @@ def _resolve_proxy_session(
     if placeholder_token:
         session = session_manager.get_session(placeholder_token)
         if session is None:
-            logger.warning(
-                "Session placeholder present but lookup missed",
-                event_type="session_lookup_miss",
-                remote_addr=remote_addr,
-            )
+            # ``validate_session`` (called via ``get_session``) already
+            # logs ``event_type=session_auth_failed`` with the token
+            # hash; emitting a second warning here would double-count
+            # any "auth failure rate" alert keyed off the first event.
+            # Caller's ``remote_addr`` shows up in standard request
+            # logs for correlation.
             return None, (
                 jsonify(
                     {

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -813,17 +813,13 @@ class KubernetesSpawner:
                 "NO_PROXY": "gateway.egg-system.svc.cluster.local,orchestrator.egg-system.svc.cluster.local",
                 "AGENT_ANCHOR_ID": agent_anchor_id,
                 # Route Anthropic API calls through the gateway for
-                # credential injection. Matches what sandbox/entrypoint.py
-                # sets in the Compose flow — the placeholder token is a
-                # deliberately-invalid string that satisfies Claude CLI's
-                # local "am I logged in" check; the gateway strips it and
-                # injects the real credential server-side. Real credentials
-                # never enter the sandbox environment.
+                # credential injection. The sandbox's setup_anthropic_api
+                # derives CLAUDE_CODE_OAUTH_TOKEN from EGG_SESSION_TOKEN at
+                # boot (issue #2829) — a placeholder envelope around the
+                # session token so the gateway's /v1/messages proxy can
+                # identify the session from the request header. Real
+                # credentials never enter the sandbox environment.
                 "ANTHROPIC_BASE_URL": GATEWAY_K8S_URL,
-                "CLAUDE_CODE_OAUTH_TOKEN": (
-                    "sk-ant-oat01-PROXY-INJECTED-gateway-handles-real-credential-"
-                    "00000000000000000000000000000000000000000000000000000000000000-000000AAAA"
-                ),
             }
             if session_token:
                 environment["EGG_SESSION_TOKEN"] = session_token

--- a/sandbox/entrypoint.py
+++ b/sandbox/entrypoint.py
@@ -722,7 +722,18 @@ def setup_anthropic_api(config: Config, logger: Logger) -> None:
     A placeholder OAuth token is set to satisfy Claude Code's startup validation.
     The gateway strips this placeholder and injects real credentials.
 
-    Reference: PR #701 - ANTHROPIC_BASE_URL credential injection plan
+    Security note: when ``EGG_SESSION_TOKEN`` is set (the k8s/Compose
+    orchestrator path), the placeholder envelope embeds the session
+    token verbatim. The token therefore appears in *two* env vars
+    inside the sandbox — ``EGG_SESSION_TOKEN`` and
+    ``CLAUDE_CODE_OAUTH_TOKEN``. Net attack surface is unchanged (any
+    in-sandbox process that could read one could already read the
+    other) and Claude Code requires the placeholder in this env var,
+    but readers grepping for the session secret should know it lives
+    in both places.
+
+    Reference: PR #701 - ANTHROPIC_BASE_URL credential injection plan;
+    issue #2829 - token-keyed session lookup in /v1/messages proxy.
     """
     gateway_url = os.environ.get("GATEWAY_URL", f"http://egg-gateway:{GATEWAY_PORT}")
 

--- a/sandbox/entrypoint.py
+++ b/sandbox/entrypoint.py
@@ -726,13 +726,25 @@ def setup_anthropic_api(config: Config, logger: Logger) -> None:
     """
     gateway_url = os.environ.get("GATEWAY_URL", f"http://egg-gateway:{GATEWAY_PORT}")
 
-    # Placeholder OAuth token to satisfy Claude Code's startup validation
-    # Must match sk-ant-oat01-* format for Claude Code to accept it
-    # Gateway strips this and injects real credentials from secrets.env
-    oauth_placeholder = (
-        "sk-ant-oat01-PROXY-INJECTED-gateway-handles-real-credential-"
-        "00000000000000000000000000000000000000000000000000000000000000-000000AAAA"
-    )
+    # Placeholder OAuth token to satisfy Claude Code's startup validation.
+    # Must match sk-ant-oat01-* format for Claude Code to accept it.
+    # Gateway strips this and injects real credentials.
+    #
+    # When EGG_SESSION_TOKEN is present (k8s + Compose orchestrator paths)
+    # the placeholder wraps the session token so the gateway's /v1/messages
+    # proxy can identify the session from the request header rather than
+    # falling back to ephemeral pod-IP lookup (issue #2829). The static
+    # fallback covers dev/host flows where no session has been registered.
+    session_token = os.environ.get("EGG_SESSION_TOKEN")
+    if session_token:
+        from egg_session_placeholder import to_placeholder
+
+        oauth_placeholder = to_placeholder(session_token)
+    else:
+        oauth_placeholder = (
+            "sk-ant-oat01-PROXY-INJECTED-gateway-handles-real-credential-"
+            "00000000000000000000000000000000000000000000000000000000000000-000000AAAA"
+        )
 
     # Set ANTHROPIC_BASE_URL to route API calls through gateway
     os.environ["ANTHROPIC_BASE_URL"] = gateway_url

--- a/shared/egg_session_placeholder/__init__.py
+++ b/shared/egg_session_placeholder/__init__.py
@@ -1,0 +1,45 @@
+"""Session-token placeholder codec for the gateway's ``/v1/messages`` proxy.
+
+Claude Code controls its own ``x-api-key`` / ``Authorization`` headers and
+will not send the gateway's ``EGG_SESSION_TOKEN``. To keep ``/v1/messages``
+token-authed like every other gateway endpoint, the orchestrator wraps the
+real session token in a ``sk-ant-oat01-`` placeholder that satisfies Claude
+Code's local format check; the gateway parses the placeholder back into the
+session token before injecting upstream credentials. See issue #2829.
+
+The placeholder shape is internal contract between the sandbox and the
+gateway. The prefix carries enough self-description that a reader (or a
+redaction scanner) recognises it on sight; the suffix is the verbatim
+session token. Format::
+
+    sk-ant-oat01-PROXY-INJECTED-egg-session-<session_token>
+"""
+
+from __future__ import annotations
+
+PLACEHOLDER_PREFIX = "sk-ant-oat01-PROXY-INJECTED-egg-session-"
+
+
+def to_placeholder(session_token: str) -> str:
+    """Wrap *session_token* in the placeholder envelope Claude Code accepts."""
+    return f"{PLACEHOLDER_PREFIX}{session_token}"
+
+
+def from_placeholder(value: str | None) -> str | None:
+    """Return the session token embedded in *value*, or ``None`` if absent.
+
+    Accepts the raw header value (``x-api-key``) or a ``Bearer <value>``
+    string (``Authorization``). Any value that doesn't carry the
+    placeholder prefix returns ``None`` so callers can fall through to
+    the legacy (non-placeholder) path.
+    """
+    if not value:
+        return None
+    if value.startswith("Bearer "):
+        value = value[len("Bearer ") :]
+    if value.startswith(PLACEHOLDER_PREFIX):
+        return value[len(PLACEHOLDER_PREFIX) :] or None
+    return None
+
+
+__all__ = ["PLACEHOLDER_PREFIX", "to_placeholder", "from_placeholder"]

--- a/shared/egg_session_placeholder/__init__.py
+++ b/shared/egg_session_placeholder/__init__.py
@@ -35,8 +35,12 @@ def from_placeholder(value: str | None) -> str | None:
     """
     if not value:
         return None
-    if value.startswith("Bearer "):
-        value = value[len("Bearer ") :]
+    # RFC 7235 §2.1: the auth scheme name is case-insensitive. Claude Code
+    # always sends ``Bearer `` capitalized, but accept any case so a future
+    # client that ships lowercase ``bearer `` doesn't silently fall through
+    # to IP-keyed lookup (and then fail closed on a non-IP-registered agent).
+    if value[:7].lower() == "bearer ":
+        value = value[7:]
     if value.startswith(PLACEHOLDER_PREFIX):
         return value[len(PLACEHOLDER_PREFIX) :] or None
     return None

--- a/shared/pyproject.toml
+++ b/shared/pyproject.toml
@@ -10,4 +10,4 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["beads*", "egg_agent*", "egg_anchor*", "egg_config*", "egg_container*", "egg_git*", "egg_health*", "egg_logging*", "egg_orchestrator*", "egg_overseer*", "egg_restrictions*", "enrichment*", "git_utils*", "notifications*", "text_utils*"]
+include = ["beads*", "egg_agent*", "egg_anchor*", "egg_config*", "egg_container*", "egg_git*", "egg_health*", "egg_logging*", "egg_orchestrator*", "egg_overseer*", "egg_restrictions*", "egg_session_placeholder*", "enrichment*", "git_utils*", "notifications*", "text_utils*"]

--- a/shared/tests/test_egg_session_placeholder.py
+++ b/shared/tests/test_egg_session_placeholder.py
@@ -27,6 +27,17 @@ def test_from_placeholder_strips_bearer_prefix() -> None:
     assert from_placeholder(f"Bearer {placeholder}") == token
 
 
+def test_from_placeholder_strips_bearer_prefix_case_insensitive() -> None:
+    # RFC 7235 §2.1: HTTP auth scheme names are case-insensitive.
+    # Claude Code happens to send capitalized ``Bearer ``, but any
+    # client that ships lowercase ``bearer `` must still resolve.
+    token = "xK7-aB_dEfGhIjKlMnOpQrStUvWxYz0123456789AbC"
+    placeholder = to_placeholder(token)
+    assert from_placeholder(f"bearer {placeholder}") == token
+    assert from_placeholder(f"BEARER {placeholder}") == token
+    assert from_placeholder(f"BeArEr {placeholder}") == token
+
+
 def test_from_placeholder_returns_none_for_real_oauth_token() -> None:
     # A real Claude OAuth token (or any header value that doesn't match
     # the placeholder envelope) must not be misread as a session token.

--- a/shared/tests/test_egg_session_placeholder.py
+++ b/shared/tests/test_egg_session_placeholder.py
@@ -1,0 +1,43 @@
+"""Unit tests for :mod:`egg_session_placeholder` codec."""
+
+from __future__ import annotations
+
+from egg_session_placeholder import (
+    PLACEHOLDER_PREFIX,
+    from_placeholder,
+    to_placeholder,
+)
+
+
+def test_to_placeholder_starts_with_sk_ant_oat01() -> None:
+    # Claude Code accepts ``sk-ant-oat01-*`` tokens by prefix; anything
+    # else fails its local format check at startup.
+    placeholder = to_placeholder("abc123")
+    assert placeholder.startswith("sk-ant-oat01-")
+
+
+def test_roundtrip() -> None:
+    token = "xK7-aB_dEfGhIjKlMnOpQrStUvWxYz0123456789AbC"
+    assert from_placeholder(to_placeholder(token)) == token
+
+
+def test_from_placeholder_strips_bearer_prefix() -> None:
+    token = "xK7-aB_dEfGhIjKlMnOpQrStUvWxYz0123456789AbC"
+    placeholder = to_placeholder(token)
+    assert from_placeholder(f"Bearer {placeholder}") == token
+
+
+def test_from_placeholder_returns_none_for_real_oauth_token() -> None:
+    # A real Claude OAuth token (or any header value that doesn't match
+    # the placeholder envelope) must not be misread as a session token.
+    assert from_placeholder("sk-ant-oat01-actualrealoauthtokencontents") is None
+
+
+def test_from_placeholder_returns_none_for_empty_and_none() -> None:
+    assert from_placeholder("") is None
+    assert from_placeholder(None) is None
+
+
+def test_from_placeholder_returns_none_when_suffix_empty() -> None:
+    # The prefix alone is not a valid session marker.
+    assert from_placeholder(PLACEHOLDER_PREFIX) is None

--- a/tests/gateway/test_anthropic_proxy.py
+++ b/tests/gateway/test_anthropic_proxy.py
@@ -2890,8 +2890,127 @@ class TestSessionLookupViaPlaceholder:
             )
 
             assert response.status_code == 200
-            sm.get_session_by_ip.assert_called_once()
+            # Pin the contract: ``_resolve_proxy_session`` passes
+            # ``remote_addr or ""``, and Flask's test client uses
+            # ``127.0.0.1`` as the default ``remote_addr``.
+            sm.get_session_by_ip.assert_called_once_with("127.0.0.1")
             assert mock_client.post.called
+
+    def test_count_tokens_resolves_via_placeholder(self, client):
+        """Bug 1 parity (issue #2829, #2769): the count_tokens endpoint
+        shares ``_resolve_proxy_session`` with ``/v1/messages`` and must
+        route per ``session.upstream`` looked up by token, not by IP.
+
+        ``proxy_count_tokens`` is independently registered, so even
+        though it calls the same helper, a regression of the call site
+        (e.g. forgetting to swap in the helper, or short-circuiting it)
+        wouldn't be caught by the ``/v1/messages`` tests alone.
+        """
+        from httpx import Headers
+
+        litellm_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = json.dumps({"input_tokens": 7}).encode()
+        mock_response.status_code = 200
+        mock_response.headers = Headers([("content-type", "application/json")])
+        litellm_client.post.return_value = mock_response
+
+        anthropic_client = MagicMock()
+        anthropic_client.post.side_effect = AssertionError(
+            "Anthropic client must NOT be invoked for a LiteLLM-routed session"
+        )
+
+        def _registry_get(upstream):
+            if upstream == "litellm":
+                return (
+                    litellm_client,
+                    lambda: MagicMock(header_name="x-api-key", header_value="litellm-key"),
+                )
+            if upstream == "anthropic":
+                return (
+                    anthropic_client,
+                    lambda: MagicMock(header_name="x-api-key", header_value="sk-ant-test"),
+                )
+            raise KeyError(upstream)
+
+        fake_registry = MagicMock()
+        fake_registry.get.side_effect = _registry_get
+        fake_registry.is_known.return_value = True
+
+        with (
+            patch("gateway.gateway.get_credentials_manager") as mock_creds_get,
+            patch("gateway.gateway.get_session_manager") as mock_sm_get,
+            patch(
+                "gateway.gateway.get_upstream_registry",
+                return_value=fake_registry,
+            ),
+            patch("gateway.gateway.get_anthropic_client", return_value=anthropic_client),
+            patch("gateway.gateway.get_litellm_credentials_manager") as mock_litellm_get,
+        ):
+            mock_creds_get.return_value.get_credential.return_value = MagicMock(
+                header_name="x-api-key", header_value="sk-ant-test"
+            )
+            mock_litellm_get.return_value.get_credential.return_value = MagicMock(
+                header_name="x-api-key", header_value="litellm-key"
+            )
+
+            sm = MagicMock()
+            # IP lookup MUST NOT resolve count_tokens either.
+            sm.get_session_by_ip.side_effect = AssertionError(
+                "count_tokens fell back to IP lookup when placeholder was present"
+            )
+            sm.get_session.return_value = _build_mock_session(
+                upstream="litellm", upstream_model="qwen3-coder-30b"
+            )
+            mock_sm_get.return_value = sm
+
+            response = client.post(
+                "/v1/messages/count_tokens",
+                data=json.dumps({"model": "opus", "messages": []}),
+                content_type="application/json",
+                headers={"x-api-key": self._placeholder("agent-qwen")},
+            )
+
+            assert response.status_code == 200
+            sm.get_session.assert_called_once_with("agent-qwen")
+            assert litellm_client.post.called, (
+                "LiteLLM client was not invoked for a LiteLLM-routed count_tokens session"
+            )
+
+    def test_count_tokens_placeholder_with_unknown_session_fails_closed(self, client):
+        """count_tokens parity for the fail-closed defense-in-depth rule.
+
+        A placeholder present but lookup-miss must 502, not silently
+        route to Anthropic — same invariant as ``/v1/messages``.
+        """
+        with (
+            patch("gateway.gateway.get_credentials_manager") as mock_creds_get,
+            patch("gateway.gateway.get_session_manager") as mock_sm_get,
+            patch("gateway.gateway.get_anthropic_client") as mock_anthropic_get,
+        ):
+            mock_creds_get.return_value.get_credential.return_value = MagicMock(
+                header_name="x-api-key", header_value="sk-ant-test"
+            )
+
+            sm = MagicMock()
+            sm.get_session.return_value = None
+            mock_sm_get.return_value = sm
+
+            mock_anthropic_get.side_effect = AssertionError(
+                "Anthropic client must NOT be reached when placeholder session is unknown"
+            )
+
+            response = client.post(
+                "/v1/messages/count_tokens",
+                data=json.dumps({"model": "claude-3"}),
+                content_type="application/json",
+                headers={"x-api-key": self._placeholder("stale-token")},
+            )
+
+            assert response.status_code == 502, (
+                f"Unknown placeholder session must fail closed on count_tokens, "
+                f"got {response.status_code}: {response.data!r}"
+            )
 
     def test_private_session_strips_web_tools_via_placeholder(self, client):
         """Bug 2 (issue #2829): private-mode session resolved by token must
@@ -2999,12 +3118,9 @@ class TestSessionLookupViaPlaceholder:
             patch(
                 "gateway.gateway.get_upstream_registry",
                 return_value=fake_registry,
-                create=True,
             ),
             patch("gateway.gateway.get_anthropic_client", return_value=anthropic_client),
-            patch(
-                "gateway.gateway.get_litellm_credentials_manager", create=True
-            ) as mock_litellm_get,
+            patch("gateway.gateway.get_litellm_credentials_manager") as mock_litellm_get,
         ):
             mock_creds_get.return_value.get_credential.return_value = MagicMock(
                 header_name="x-api-key", header_value="sk-ant-test"

--- a/tests/gateway/test_anthropic_proxy.py
+++ b/tests/gateway/test_anthropic_proxy.py
@@ -2748,3 +2748,285 @@ class TestRewriteUpstreamModelMalformedBodyResilience:
                 f"(should pass through unchanged like the Anthropic "
                 f"path); got 500 with {response.data!r}"
             )
+
+
+class TestSessionLookupViaPlaceholder:
+    """``proxy_anthropic_messages`` looks up sessions by the egg session-token
+    placeholder embedded in ``x-api-key`` (issue #2829).
+
+    Before this fix, ``proxy_anthropic_messages`` only consulted
+    ``get_session_by_ip``. Agent sessions register with ``container_ip=None``
+    (token-only k8s auth) and the orchestrator never backfills the pod IP, so
+    the lookup always missed — silently routing every agent inference to the
+    Anthropic upstream regardless of ``session.upstream`` (the routing bug)
+    and disabling the private-mode ``_filter_blocked_tools`` web-tool stripper
+    because ``session_mode`` resolved to ``None`` (the filter-bypass bug).
+    """
+
+    @pytest.fixture
+    def client(self):
+        from gateway.gateway import app
+
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            yield client
+
+    def _placeholder(self, token: str = "fake-session-token") -> str:
+        from egg_session_placeholder import to_placeholder
+
+        return to_placeholder(token)
+
+    def test_placeholder_header_resolves_session_by_token(self, client):
+        """A request carrying the placeholder routes per ``session.upstream``
+        looked up by token, not by source IP."""
+        from httpx import Headers
+
+        with (
+            patch("gateway.gateway.get_credentials_manager") as mock_creds_get,
+            patch("gateway.gateway.get_session_manager") as mock_sm_get,
+            patch("gateway.gateway.get_anthropic_client") as mock_anthropic_get,
+        ):
+            cred = MagicMock(header_name="x-api-key", header_value="sk-ant-test")
+            mock_creds_get.return_value.get_credential.return_value = cred
+
+            sm = MagicMock()
+            # IP lookup MUST NOT be the one that resolves this — fail
+            # loudly if the proxy still routes through it.
+            sm.get_session_by_ip.side_effect = AssertionError(
+                "Proxy fell back to IP lookup when placeholder was present"
+            )
+            sm.get_session.return_value = _build_mock_session(upstream="anthropic")
+            mock_sm_get.return_value = sm
+
+            mock_client = MagicMock()
+            mock_response = MagicMock()
+            mock_response.content = json.dumps({"content": "ok"}).encode()
+            mock_response.status_code = 200
+            mock_response.headers = Headers([("content-type", "application/json")])
+            mock_client.post.return_value = mock_response
+            mock_anthropic_get.return_value = mock_client
+
+            response = client.post(
+                "/v1/messages",
+                data=json.dumps({"model": "claude-3"}),
+                content_type="application/json",
+                headers={"x-api-key": self._placeholder("agent-session-xyz")},
+            )
+
+            assert response.status_code == 200
+            sm.get_session.assert_called_once_with("agent-session-xyz")
+            assert mock_client.post.called
+
+    def test_placeholder_with_unknown_session_fails_closed(self, client):
+        """Placeholder present but session lookup misses → 502.
+
+        Failing closed prevents the silent fallback to Anthropic that
+        previously masked both the routing and filter-bypass bugs.
+        """
+        with (
+            patch("gateway.gateway.get_credentials_manager") as mock_creds_get,
+            patch("gateway.gateway.get_session_manager") as mock_sm_get,
+            patch("gateway.gateway.get_anthropic_client") as mock_anthropic_get,
+        ):
+            mock_creds_get.return_value.get_credential.return_value = MagicMock(
+                header_name="x-api-key", header_value="sk-ant-test"
+            )
+
+            sm = MagicMock()
+            sm.get_session.return_value = None
+            mock_sm_get.return_value = sm
+
+            mock_anthropic_get.side_effect = AssertionError(
+                "Anthropic client must NOT be reached when placeholder session is unknown"
+            )
+
+            response = client.post(
+                "/v1/messages",
+                data=json.dumps({"model": "claude-3"}),
+                content_type="application/json",
+                headers={"x-api-key": self._placeholder("stale-token")},
+            )
+
+            assert response.status_code == 502, (
+                f"Unknown placeholder session must fail closed, got {response.status_code}: "
+                f"{response.data!r}"
+            )
+
+    def test_no_placeholder_falls_back_to_ip_lookup(self, client):
+        """Requests without the placeholder (e.g. non-agent probes) keep the
+        legacy IP-keyed lookup path. The slice-1 ``no-session → anthropic``
+        invariant is preserved.
+        """
+        from httpx import Headers
+
+        with (
+            patch("gateway.gateway.get_credentials_manager") as mock_creds_get,
+            patch("gateway.gateway.get_session_manager") as mock_sm_get,
+            patch("gateway.gateway.get_anthropic_client") as mock_anthropic_get,
+        ):
+            cred = MagicMock(header_name="x-api-key", header_value="sk-ant-test")
+            mock_creds_get.return_value.get_credential.return_value = cred
+
+            sm = MagicMock()
+            sm.get_session_by_ip.return_value = None
+            # Token lookup must not be consulted when no placeholder is present.
+            sm.get_session.side_effect = AssertionError(
+                "Proxy attempted token lookup with no placeholder header"
+            )
+            mock_sm_get.return_value = sm
+
+            mock_client = MagicMock()
+            mock_response = MagicMock()
+            mock_response.content = json.dumps({"content": "ok"}).encode()
+            mock_response.status_code = 200
+            mock_response.headers = Headers([("content-type", "application/json")])
+            mock_client.post.return_value = mock_response
+            mock_anthropic_get.return_value = mock_client
+
+            response = client.post(
+                "/v1/messages",
+                data=json.dumps({"model": "claude-3"}),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 200
+            sm.get_session_by_ip.assert_called_once()
+            assert mock_client.post.called
+
+    def test_private_session_strips_web_tools_via_placeholder(self, client):
+        """Bug 2 (issue #2829): private-mode session resolved by token must
+        strip ``web_search`` from the forwarded request body.
+
+        Before the fix, the IP-lookup miss left ``session_mode=None`` so
+        ``_filter_blocked_tools`` no-opped — the documented data-exfiltration
+        backstop. This test pins the integration so a future regression of
+        the lookup path can't silently disable the filter again.
+        """
+        from httpx import Headers
+
+        captured: dict[str, bytes] = {}
+
+        def _capture_post(*args, **kwargs):
+            captured["body"] = kwargs.get("content") or (args[2] if len(args) > 2 else b"")
+            resp = MagicMock()
+            resp.content = json.dumps({"content": "ok"}).encode()
+            resp.status_code = 200
+            resp.headers = Headers([("content-type", "application/json")])
+            return resp
+
+        with (
+            patch("gateway.gateway.get_credentials_manager") as mock_creds_get,
+            patch("gateway.gateway.get_session_manager") as mock_sm_get,
+            patch("gateway.gateway.get_anthropic_client") as mock_anthropic_get,
+        ):
+            mock_creds_get.return_value.get_credential.return_value = MagicMock(
+                header_name="x-api-key", header_value="sk-ant-test"
+            )
+
+            private_session = _build_mock_session(upstream="anthropic")
+            private_session.mode = "private"
+
+            sm = MagicMock()
+            sm.get_session.return_value = private_session
+            mock_sm_get.return_value = sm
+
+            mock_client = MagicMock()
+            mock_client.post.side_effect = _capture_post
+            mock_anthropic_get.return_value = mock_client
+
+            request_body = {
+                "model": "claude-3",
+                "tools": [
+                    {"name": "web_search", "description": "search the web"},
+                    {"name": "Bash", "description": "run a shell command"},
+                ],
+            }
+            response = client.post(
+                "/v1/messages",
+                data=json.dumps(request_body),
+                content_type="application/json",
+                headers={"x-api-key": self._placeholder("private-agent")},
+            )
+
+            assert response.status_code == 200
+            forwarded = json.loads(captured["body"])
+            forwarded_tool_names = [t["name"] for t in forwarded["tools"]]
+            assert "web_search" not in forwarded_tool_names, (
+                f"web_search not stripped in private mode: {forwarded_tool_names}"
+            )
+            assert "Bash" in forwarded_tool_names, "Non-blocked tool was incorrectly stripped"
+
+    def test_placeholder_resolves_litellm_upstream(self, client):
+        """Bug 1 (issue #2829): a placeholder-keyed session with
+        ``upstream='litellm'`` must route to the LiteLLM client, not the
+        silent Anthropic fallback.
+        """
+        from httpx import Headers
+
+        litellm_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = json.dumps({"content": "ok"}).encode()
+        mock_response.status_code = 200
+        mock_response.headers = Headers([("content-type", "application/json")])
+        litellm_client.post.return_value = mock_response
+        litellm_client.send = litellm_client.post
+
+        anthropic_client = MagicMock()
+        anthropic_client.post.side_effect = AssertionError(
+            "Anthropic client must NOT be invoked for a LiteLLM-routed session"
+        )
+
+        def _registry_get(upstream):
+            if upstream == "litellm":
+                return (
+                    litellm_client,
+                    lambda: MagicMock(header_name="x-api-key", header_value="litellm-key"),
+                )
+            if upstream == "anthropic":
+                return (
+                    anthropic_client,
+                    lambda: MagicMock(header_name="x-api-key", header_value="sk-ant-test"),
+                )
+            raise KeyError(upstream)
+
+        fake_registry = MagicMock()
+        fake_registry.get.side_effect = _registry_get
+        fake_registry.is_known.return_value = True
+
+        with (
+            patch("gateway.gateway.get_credentials_manager") as mock_creds_get,
+            patch("gateway.gateway.get_session_manager") as mock_sm_get,
+            patch(
+                "gateway.gateway.get_upstream_registry",
+                return_value=fake_registry,
+                create=True,
+            ),
+            patch("gateway.gateway.get_anthropic_client", return_value=anthropic_client),
+            patch(
+                "gateway.gateway.get_litellm_credentials_manager", create=True
+            ) as mock_litellm_get,
+        ):
+            mock_creds_get.return_value.get_credential.return_value = MagicMock(
+                header_name="x-api-key", header_value="sk-ant-test"
+            )
+            mock_litellm_get.return_value.get_credential.return_value = MagicMock(
+                header_name="x-api-key", header_value="litellm-key"
+            )
+
+            sm = MagicMock()
+            sm.get_session.return_value = _build_mock_session(
+                upstream="litellm", upstream_model="qwen3-coder-30b"
+            )
+            mock_sm_get.return_value = sm
+
+            response = client.post(
+                "/v1/messages",
+                data=json.dumps({"model": "opus", "messages": []}),
+                content_type="application/json",
+                headers={"x-api-key": self._placeholder("agent-qwen")},
+            )
+
+            assert response.status_code == 200
+            assert litellm_client.post.called, (
+                "LiteLLM client was not invoked for a LiteLLM-routed session"
+            )

--- a/tests/sandbox/test_entrypoint.py
+++ b/tests/sandbox/test_entrypoint.py
@@ -1355,6 +1355,26 @@ class TestSetupAnthropicApi:
 
         assert "ANTHROPIC_API_KEY" not in os.environ
 
+    def test_placeholder_embeds_egg_session_token_when_set(self, monkeypatch):
+        """When EGG_SESSION_TOKEN is set (k8s/Compose agent path), the
+        placeholder wraps it so the gateway's /v1/messages proxy can
+        identify the session from the request header instead of falling
+        back to ephemeral pod-IP lookup (issue #2829).
+        """
+        from egg_session_placeholder import from_placeholder
+
+        monkeypatch.setenv("GATEWAY_URL", f"http://test-gateway:{GATEWAY_PORT}")
+        monkeypatch.setenv("EGG_SESSION_TOKEN", "agent-session-xyz")
+
+        config = MagicMock()
+        logger = entrypoint.Logger(quiet=True)
+
+        entrypoint.setup_anthropic_api(config, logger)
+
+        placeholder = os.environ["CLAUDE_CODE_OAUTH_TOKEN"]
+        assert placeholder.startswith("sk-ant-oat01-")
+        assert from_placeholder(placeholder) == "agent-session-xyz"
+
 
 class TestConfigAuthMethod:
     """Tests for Config anthropic_auth_method handling."""


### PR DESCRIPTION
## Summary

Closes #2829. The gateway's `proxy_anthropic_messages` resolved the session by source IP. Agent sessions are pre-registered with `container_ip=None` and the orchestrator never backfilled the pod IP, so the lookup always missed. Both fall-throughs fired on every agent inference call:

- `upstream_name` silently defaulted to `"anthropic"` — every `agent_models` config dead-routed to Claude regardless of the configured upstream.
- `session_mode` silently defaulted to `None`, no-op'ing `_filter_blocked_tools` — the documented data-exfiltration backstop that strips `web_search` / `web_fetch` from private-mode requests before Anthropic processes them server-side.

The fix is to identify sessions by the request header instead of by pod IP. The orchestrator already controls `CLAUDE_CODE_OAUTH_TOKEN`; this PR makes that placeholder a per-session envelope that wraps the session token. Claude Code keeps accepting it (validates the `sk-ant-oat01-` prefix only), the gateway extracts the token from `x-api-key`, and looks the session up by token — the same auth path every other gateway endpoint already uses.

### Why not just backfill the IP

The architecture doc already calls out that pod IPs are ephemeral in k8s (`session_manager.py:741`). Backfilling closes today's miss but leaves the lookup brittle to pod restarts and reschedules. Token-keyed lookup removes the entire parallel auth surface — no race, no IP polling.

### Sandboxes still hold no real credentials

The placeholder envelope is internal contract. The sandbox entrypoint still deletes `ANTHROPIC_API_KEY` from env, and the gateway still strips client auth and injects the real upstream credential server-side. Real Anthropic keys never enter the sandbox.

### Defense-in-depth

When the placeholder IS present but the session lookup misses (stale token, expired session), the proxy now returns 502 instead of silently routing to Anthropic. Any future regression of the lookup is loud, not invisible. Non-placeholder probes (host dev tools, gateway health checks) keep the legacy IP-keyed compat path so the slice-1 "no-session → anthropic" invariant is preserved for non-agent clients.

## What changed

- `shared/egg_session_placeholder/` — new tiny package with `to_placeholder` / `from_placeholder` codec. Single source of truth for the envelope format.
- `sandbox/entrypoint.py::setup_anthropic_api` — derives `CLAUDE_CODE_OAUTH_TOKEN` from `EGG_SESSION_TOKEN` when present, falls back to the fixed placeholder for dev/host flows.
- `orchestrator/kubernetes_spawner.py` — stops setting the duplicate fixed placeholder in the Job env; the sandbox owns the derivation now.
- `gateway/gateway.py` — new `_resolve_proxy_session` helper, used by both `proxy_anthropic_messages` and `proxy_count_tokens`. Tries token-keyed lookup first, falls back to IP-keyed for non-placeholder probes, fails closed when a placeholder doesn't resolve.

## Test plan

- [x] Unit tests for the codec (`shared/tests/test_egg_session_placeholder.py`) — 6 tests covering roundtrip, Bearer prefix stripping, real-OAuth-token non-collision, empty/None edge cases.
- [x] Sandbox entrypoint test (`tests/sandbox/test_entrypoint.py`) — verifies the placeholder embeds `EGG_SESSION_TOKEN` when set.
- [x] New gateway integration tests (`TestSessionLookupViaPlaceholder`, 5 tests) covering:
  - placeholder header → session looked up by token (not IP)
  - placeholder with unknown session → 502 (defense-in-depth)
  - no placeholder → legacy IP-keyed fallback works
  - **Bug 2 regression guard**: private-mode session resolved via placeholder strips `web_search` from the forwarded body
  - **Bug 1 regression guard**: `upstream=litellm` session resolved via placeholder routes to the LiteLLM client, not the silent Anthropic fallback
- [x] Existing `proxy_anthropic` suite (84 tests) still green.
- [x] Existing `kubernetes_spawner` suite (106 tests) still green.
- [x] Existing `setup_anthropic_api` tests (3 tests) still green.
- [x] `make lint` green.
- [ ] `make test-all` (deferred to CI).
- [ ] Manual smoke: submit a pipeline with `agent_models: {refiner: "qwen3-coder-30b"}` and confirm LiteLLM pod logs show non-probe `POST /v1/messages` within the refiner's first 30s.
- [ ] Manual smoke: submit a private-mode pipeline and confirm the forwarded `/v1/messages` body has `web_search` / `web_fetch` stripped.