### PR TITLE
Add AGENTS.md symlinks aliasing CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/docs/development/STRUCTURE.md
+++ b/docs/development/STRUCTURE.md
@@ -471,7 +471,7 @@ config/
 | Shell scripts | kebab-case | `entrypoint.sh`, `create-networks.sh` |
 | Config files | `.yaml` (not `.yml`) | `repositories.yaml` |
 | Documentation | UPPERCASE.md for guides, lowercase.md for READMEs | `STRUCTURE.md`, `README.md` |
-| Agent navigation | `CLAUDE.md` at component root | `gateway/CLAUDE.md`, `orchestrator/CLAUDE.md`, `sandbox/CLAUDE.md` |
+| Agent navigation | `CLAUDE.md` at component root (with `AGENTS.md` symlink alias) | `gateway/CLAUDE.md`, `orchestrator/CLAUDE.md`, `sandbox/CLAUDE.md` |
 
 ## Documentation Organization
 

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/orchestrator/AGENTS.md
+++ b/orchestrator/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/sandbox/AGENTS.md
+++ b/sandbox/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/sandbox/agent-config/rules/README.md
+++ b/sandbox/agent-config/rules/README.md
@@ -8,10 +8,13 @@ Claude Code reads `CLAUDE.md` files automatically when starting. During containe
 
 **Installation:**
 - `~/.claude/CLAUDE.md` → All rules combined (user-level global config)
+- `~/.claude/AGENTS.md` → Symlink to `CLAUDE.md` (cross-tool industry-norm alias)
+
+A matching `AGENTS.md` symlink is also created in the agent's CWD next to the project-level `CLAUDE.md` symlink, so AGENTS.md-aware frontends discover the same rules without a second source of truth.
 
 **Why one file?** Since `~/repos/` is mounted from the host (not copied), we can't reliably write to it during container startup. Combining all rules into `~/.claude/CLAUDE.md` ensures they're always available regardless of CWD.
 
-**Note**: `CLAUDE.md` is the [official Claude Code format](https://www.anthropic.com/engineering/claude-code-best-practices) for providing context and instructions to the agent.
+**Note**: `CLAUDE.md` is the [official Claude Code format](https://www.anthropic.com/engineering/claude-code-best-practices) for providing context and instructions to the agent. `AGENTS.md` is the convention adopted by other agent tools — keeping both names as symlinks to the same content makes the rules portable.
 
 ## File Guide
 

--- a/sandbox/agent-config/rules/README.md
+++ b/sandbox/agent-config/rules/README.md
@@ -16,6 +16,8 @@ A matching `AGENTS.md` symlink is also created in the agent's CWD next to the pr
 
 **Note**: `CLAUDE.md` is the [official Claude Code format](https://www.anthropic.com/engineering/claude-code-best-practices) for providing context and instructions to the agent. `AGENTS.md` is the convention adopted by other agent tools — keeping both names as symlinks to the same content makes the rules portable.
 
+**Windows checkouts**: Git on Windows defaults `core.symlinks` to `false` unless Developer Mode (or admin rights) is on. Without it, the committed `AGENTS.md` symlinks at the repo root and under `gateway/`, `orchestrator/`, `sandbox/` materialize as one-line text files containing the literal string `CLAUDE.md`. That degrades to harmless noise (the file is no longer a discoverable rules alias) rather than breaking anything; egg's runtime path is Linux containers, so the symlinks behave correctly there.
+
 ## File Guide
 
 ### Core Agent Instructions

--- a/sandbox/entrypoint.py
+++ b/sandbox/entrypoint.py
@@ -981,6 +981,14 @@ def setup_agent_rules(config: Config, logger: Logger) -> None:
     # _chdir_to_single_repo() re-creates symlinks at CWD later when the session
     # starts; this cleanup ensures a fresh state.
     # Covers all three CWD scenarios: home, repos_dir, and single-repo.
+    #
+    # Inside a repo subdir we must NOT touch a symlink that doesn't point at
+    # our global rules file — a repo can legitimately commit
+    # ``AGENTS.md -> CLAUDE.md`` (relative target) as a cross-tool alias, and
+    # that file is tracked content we must preserve. Only unlink subdir
+    # symlinks that resolve to ``~/.claude/CLAUDE.md`` (the absolute target
+    # we wrote on a previous startup).
+    global_target = (config.claude_dir / "CLAUDE.md").resolve()
     for name in ("CLAUDE.md", "AGENTS.md"):
         stale_home = config.user_home / name
         if stale_home.exists() or stale_home.is_symlink():
@@ -994,7 +1002,13 @@ def setup_agent_rules(config: Config, logger: Logger) -> None:
                 if subdir.is_dir() and (subdir / ".git").exists():
                     stale_repo = subdir / name
                     if stale_repo.is_symlink():
-                        stale_repo.unlink()
+                        try:
+                            if stale_repo.resolve(strict=False) == global_target:
+                                stale_repo.unlink()
+                        except OSError:
+                            # Cycles or permission errors — leave the symlink
+                            # in place rather than risk deleting tracked content.
+                            pass
 
     logger.success("AI agent rules installed: ~/.claude/CLAUDE.md (+ AGENTS.md alias)")
     logger.info(f"  Combined {len(rules_order)} rule files (index-based per LLM Doc architecture)")
@@ -1896,20 +1910,31 @@ def _chdir_to_single_repo(config: Config) -> None:
     EGG_REPO_PATH so git/gh commands auto-detect the repository context.
     Falls back to user home if repos_dir doesn't exist.
 
-    After setting CWD, creates a project-level CLAUDE.md symlink pointing to
-    the global ~/.claude/CLAUDE.md so Claude Code detects it in the working
-    directory (suppresses the "Run /init" welcome message).
+    After setting CWD, creates project-level ``CLAUDE.md`` and ``AGENTS.md``
+    symlinks pointing to the global ``~/.claude/CLAUDE.md`` so Claude Code
+    detects the rules in the working directory (suppresses the "Run /init"
+    welcome message) and AGENTS.md-aware tools find the same content.
 
-    The symlink is a container-local artifact and must not be committed to
-    user repositories. The authoritative filter is in gateway/post_agent_commit.py
-    which skips symlinks during auto-commit on the host side. As defense-in-depth,
-    _exclude_from_git() also writes to .git/info/exclude when accessible.
+    The symlinks are container-local artifacts and must not be committed to
+    user repositories — the target is an absolute container path
+    (``/home/agent/.claude/CLAUDE.md``) that would be broken on any host
+    checkout. ``_exclude_from_git()`` writes both names to
+    ``.git/info/exclude`` so ``git status`` ignores them.
 
-    Known limitation: the auto-commit filter does not protect against the agent
-    explicitly committing the symlink via ``git add CLAUDE.md && git commit``.
-    The gateway's commit-time phase validation does not check for symlinks.
-    Risk is low (agent instructions use ``git add <files>``, not ``git add -A``)
-    but nonzero. See gateway/post_agent_commit.py for details.
+    Known limitation: nothing prevents an agent from explicitly committing
+    one of these symlinks via ``git add CLAUDE.md`` / ``git add AGENTS.md``
+    followed by ``git commit``. ``gateway/post_agent_commit.py`` no longer
+    auto-commits (it has been a logged no-op since #1481, when per-agent
+    worktrees made auto-commit unnecessary), and the gateway's commit-time
+    phase validation does not check for symlink content. Risk is low —
+    agent instructions consistently use ``git add <files>``, not
+    ``git add -A`` — but nonzero. Protection here is the per-agent
+    cleanup convention plus ``.git/info/exclude``.
+
+    Cleanup in ``setup_agent_rules()`` is target-aware in repo subdirs: it
+    only unlinks symlinks that resolve to the global ``~/.claude/CLAUDE.md``,
+    so a repo that legitimately commits ``AGENTS.md`` as a relative symlink
+    to its own ``CLAUDE.md`` is preserved.
     """
     if config.repos_dir.exists():
         os.chdir(config.repos_dir)

--- a/sandbox/entrypoint.py
+++ b/sandbox/entrypoint.py
@@ -970,25 +970,33 @@ def setup_agent_rules(config: Config, logger: Logger) -> None:
     claude_md.write_text("\n\n---\n\n".join(content_parts))
     os.chown(claude_md, config.runtime_uid, config.runtime_gid)
 
-    # Clean up stale CLAUDE.md files from previous container runs.
-    # _chdir_to_single_repo() re-creates a symlink at CWD/CLAUDE.md later
-    # when the session starts; this cleanup ensures a fresh state.
-    # Covers all three CWD scenarios: home, repos_dir, and single-repo.
-    stale_home = config.user_home / "CLAUDE.md"
-    if stale_home.exists() or stale_home.is_symlink():
-        stale_home.unlink()
-    stale_repos = config.repos_dir / "CLAUDE.md"
-    if stale_repos.exists() or stale_repos.is_symlink():
-        stale_repos.unlink()
-    # Single-repo case: symlink is inside repos_dir/<repo>/CLAUDE.md
-    if config.repos_dir.exists():
-        for subdir in config.repos_dir.iterdir():
-            if subdir.is_dir() and (subdir / ".git").exists():
-                stale_repo = subdir / "CLAUDE.md"
-                if stale_repo.is_symlink():
-                    stale_repo.unlink()
+    # AGENTS.md is the cross-tool industry alias for CLAUDE.md; expose both
+    # so non-Claude agent frontends can discover the same rules.
+    agents_md = config.claude_dir / "AGENTS.md"
+    if agents_md.exists() or agents_md.is_symlink():
+        agents_md.unlink()
+    agents_md.symlink_to(claude_md.name)
 
-    logger.success("AI agent rules installed: ~/.claude/CLAUDE.md (global)")
+    # Clean up stale CLAUDE.md / AGENTS.md files from previous container runs.
+    # _chdir_to_single_repo() re-creates symlinks at CWD later when the session
+    # starts; this cleanup ensures a fresh state.
+    # Covers all three CWD scenarios: home, repos_dir, and single-repo.
+    for name in ("CLAUDE.md", "AGENTS.md"):
+        stale_home = config.user_home / name
+        if stale_home.exists() or stale_home.is_symlink():
+            stale_home.unlink()
+        stale_repos = config.repos_dir / name
+        if stale_repos.exists() or stale_repos.is_symlink():
+            stale_repos.unlink()
+        # Single-repo case: symlink is inside repos_dir/<repo>/<name>
+        if config.repos_dir.exists():
+            for subdir in config.repos_dir.iterdir():
+                if subdir.is_dir() and (subdir / ".git").exists():
+                    stale_repo = subdir / name
+                    if stale_repo.is_symlink():
+                        stale_repo.unlink()
+
+    logger.success("AI agent rules installed: ~/.claude/CLAUDE.md (+ AGENTS.md alias)")
     logger.info(f"  Combined {len(rules_order)} rule files (index-based per LLM Doc architecture)")
     logger.info("  Note: Reference docs at $EGG_REPO_PATH/docs/ (fetched on-demand)")
 
@@ -1913,22 +1921,26 @@ def _chdir_to_single_repo(config: Config) -> None:
     else:
         os.chdir(config.user_home)
 
-    # Create project-level CLAUDE.md symlink so Claude Code detects it
-    # in the working directory (suppresses "Run /init" welcome message).
+    # Create project-level CLAUDE.md / AGENTS.md symlinks so Claude Code
+    # (and other AGENTS.md-aware tools) detect the rules in the working
+    # directory (and suppresses Claude's "Run /init" welcome message).
     # The actual rules live in ~/.claude/CLAUDE.md (global config).
     #
-    # Note: setup_agent_rules() cleans up stale CLAUDE.md files from previous
-    # container runs earlier in startup. This symlink is re-created fresh each
-    # time the session starts — the cleanup and creation are intentionally
-    # separate phases.
-    cwd_claude_md = Path.cwd() / "CLAUDE.md"
+    # Note: setup_agent_rules() cleans up stale CLAUDE.md/AGENTS.md files from
+    # previous container runs earlier in startup. These symlinks are re-created
+    # fresh each time the session starts — the cleanup and creation are
+    # intentionally separate phases.
     global_claude_md = config.claude_dir / "CLAUDE.md"
-    if global_claude_md.exists() and not cwd_claude_md.exists() and not cwd_claude_md.is_symlink():
-        cwd_claude_md.symlink_to(global_claude_md)
-        # If CWD is inside a git repo, exclude the symlink from git tracking
-        # to prevent it from being committed (the symlink target is a
-        # container-local absolute path that would be broken elsewhere).
-        _exclude_from_git(cwd_claude_md)
+    if global_claude_md.exists():
+        for name in ("CLAUDE.md", "AGENTS.md"):
+            cwd_link = Path.cwd() / name
+            if not cwd_link.exists() and not cwd_link.is_symlink():
+                cwd_link.symlink_to(global_claude_md)
+                # If CWD is inside a git repo, exclude the symlink from git
+                # tracking to prevent it from being committed (the symlink
+                # target is a container-local absolute path that would be
+                # broken elsewhere).
+                _exclude_from_git(cwd_link)
 
 
 def run_exec(config: Config, logger: Logger, args: list[str]) -> int:

--- a/sandbox/entrypoint.py
+++ b/sandbox/entrypoint.py
@@ -1917,7 +1917,7 @@ def _chdir_to_single_repo(config: Config) -> None:
 
     The symlinks are container-local artifacts and must not be committed to
     user repositories — the target is an absolute container path
-    (``/home/agent/.claude/CLAUDE.md``) that would be broken on any host
+    (``/home/egg/.claude/CLAUDE.md``) that would be broken on any host
     checkout. ``_exclude_from_git()`` writes both names to
     ``.git/info/exclude`` so ``git status`` ignores them.
 

--- a/tests/sandbox/test_entrypoint.py
+++ b/tests/sandbox/test_entrypoint.py
@@ -1198,6 +1198,102 @@ class TestSetupAgentRules:
         assert not real_file.is_symlink()
         assert real_file.read_text() == "# Project rules"
 
+    @patch("os.chown")
+    def test_creates_agents_md_alias(self, mock_chown, temp_dir, monkeypatch):
+        """AGENTS.md symlink is created next to CLAUDE.md in claude_dir."""
+        monkeypatch.delenv("EGG_PIPELINE_ID", raising=False)
+
+        rules_dir = temp_dir / "opt-claude-rules"
+        rules_dir.mkdir()
+        (rules_dir / "mission.md").write_text("# Mission")
+
+        claude_dir = temp_dir / ".claude"
+        claude_dir.mkdir()
+
+        config = MagicMock()
+        config.user_home = temp_dir
+        config.claude_dir = claude_dir
+        config.repos_dir = temp_dir / "repos"
+        config.runtime_uid = 1000
+        config.runtime_gid = 1000
+
+        logger = entrypoint.Logger(quiet=True)
+
+        with patch.object(entrypoint, "_CLAUDE_RULES_DIR", rules_dir):
+            entrypoint.setup_agent_rules(config, logger)
+
+        agents_md = claude_dir / "AGENTS.md"
+        claude_md = claude_dir / "CLAUDE.md"
+        assert agents_md.is_symlink()
+        assert agents_md.resolve() == claude_md.resolve()
+        # Relative target so the alias travels with the rules file
+        assert os.readlink(agents_md) == "CLAUDE.md"
+
+    @patch("os.chown")
+    def test_replaces_stale_agents_md_alias(self, mock_chown, temp_dir, monkeypatch):
+        """Pre-existing AGENTS.md symlink/file in claude_dir is replaced."""
+        monkeypatch.delenv("EGG_PIPELINE_ID", raising=False)
+
+        rules_dir = temp_dir / "opt-claude-rules"
+        rules_dir.mkdir()
+        (rules_dir / "mission.md").write_text("# Mission")
+
+        claude_dir = temp_dir / ".claude"
+        claude_dir.mkdir()
+        # Stale AGENTS.md pointing somewhere bogus
+        stale = claude_dir / "AGENTS.md"
+        stale.symlink_to(temp_dir / "nonexistent")
+
+        config = MagicMock()
+        config.user_home = temp_dir
+        config.claude_dir = claude_dir
+        config.repos_dir = temp_dir / "repos"
+        config.runtime_uid = 1000
+        config.runtime_gid = 1000
+
+        logger = entrypoint.Logger(quiet=True)
+
+        with patch.object(entrypoint, "_CLAUDE_RULES_DIR", rules_dir):
+            entrypoint.setup_agent_rules(config, logger)
+
+        assert stale.is_symlink()
+        assert stale.resolve() == (claude_dir / "CLAUDE.md").resolve()
+
+    @patch("os.chown")
+    def test_cleans_up_stale_agents_md_in_single_repo(self, mock_chown, temp_dir):
+        """Stale AGENTS.md symlink inside a single repo is cleaned up."""
+        repos_dir = temp_dir / "repos"
+        repos_dir.mkdir()
+        repo = repos_dir / "my-project"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        stale = repo / "AGENTS.md"
+        stale.symlink_to(temp_dir / "nonexistent" / "AGENTS.md")
+        assert stale.is_symlink()
+
+        claude_dir = temp_dir / ".claude"
+        claude_dir.mkdir()
+
+        config = MagicMock()
+        config.user_home = temp_dir
+        config.claude_dir = claude_dir
+        config.repos_dir = repos_dir
+        config.runtime_uid = 1000
+        config.runtime_gid = 1000
+
+        rules_dir = temp_dir / "opt-claude-rules"
+        rules_dir.mkdir()
+        (rules_dir / "mission.md").write_text("# Mission")
+
+        logger = entrypoint.Logger(quiet=True)
+
+        with patch.object(entrypoint, "_CLAUDE_RULES_DIR", rules_dir):
+            entrypoint.setup_agent_rules(config, logger)
+
+        assert not stale.exists()
+        assert not stale.is_symlink()
+
 
 class TestSetupEggSymlink:
     """Tests for the setup_egg_symlink function."""
@@ -1572,10 +1668,17 @@ class TestChdirToSingleRepo:
         assert symlink.is_symlink()
         assert symlink.resolve() == global_claude_md.resolve()
 
-        # Symlink should be excluded from git tracking via .git/info/exclude
+        # AGENTS.md alias is created alongside CLAUDE.md for cross-tool compat
+        agents_alias = repo / "AGENTS.md"
+        assert agents_alias.is_symlink()
+        assert agents_alias.resolve() == global_claude_md.resolve()
+
+        # Both symlinks should be excluded from git tracking via .git/info/exclude
         exclude_file = repo / ".git" / "info" / "exclude"
         assert exclude_file.exists()
-        assert "CLAUDE.md" in exclude_file.read_text()
+        exclude_contents = exclude_file.read_text()
+        assert "CLAUDE.md" in exclude_contents
+        assert "AGENTS.md" in exclude_contents
 
     def test_existing_claude_md_not_overwritten(self, tmp_path, monkeypatch):
         """Existing CLAUDE.md in repo is not replaced with a symlink."""

--- a/tests/sandbox/test_entrypoint.py
+++ b/tests/sandbox/test_entrypoint.py
@@ -1126,20 +1126,21 @@ class TestSetupAgentRules:
 
     @patch("os.chown")
     def test_cleans_up_stale_single_repo_symlink(self, mock_chown, temp_dir):
-        """Stale CLAUDE.md symlink inside a single repo is cleaned up."""
+        """Stale CLAUDE.md symlink pointing at the global rules file is cleaned up."""
         repos_dir = temp_dir / "repos"
         repos_dir.mkdir()
         repo = repos_dir / "my-project"
         repo.mkdir()
         (repo / ".git").mkdir()
 
-        # Create a stale symlink inside the repo (from a previous container run)
-        stale = repo / "CLAUDE.md"
-        stale.symlink_to(temp_dir / "nonexistent" / "CLAUDE.md")
-        assert stale.is_symlink()
-
         claude_dir = temp_dir / ".claude"
         claude_dir.mkdir()
+
+        # Stale symlink left behind by a previous container run — points at the
+        # global rules file, which is exactly what the cleanup target-matches on.
+        stale = repo / "CLAUDE.md"
+        stale.symlink_to(claude_dir / "CLAUDE.md")
+        assert stale.is_symlink()
 
         config = MagicMock()
         config.user_home = temp_dir
@@ -1261,16 +1262,63 @@ class TestSetupAgentRules:
 
     @patch("os.chown")
     def test_cleans_up_stale_agents_md_in_single_repo(self, mock_chown, temp_dir):
-        """Stale AGENTS.md symlink inside a single repo is cleaned up."""
+        """Stale AGENTS.md symlink pointing at the global rules file is cleaned up."""
         repos_dir = temp_dir / "repos"
         repos_dir.mkdir()
         repo = repos_dir / "my-project"
         repo.mkdir()
         (repo / ".git").mkdir()
 
+        claude_dir = temp_dir / ".claude"
+        claude_dir.mkdir()
+
+        # Stale AGENTS.md symlink left behind by a previous container run.
         stale = repo / "AGENTS.md"
-        stale.symlink_to(temp_dir / "nonexistent" / "AGENTS.md")
+        stale.symlink_to(claude_dir / "CLAUDE.md")
         assert stale.is_symlink()
+
+        config = MagicMock()
+        config.user_home = temp_dir
+        config.claude_dir = claude_dir
+        config.repos_dir = repos_dir
+        config.runtime_uid = 1000
+        config.runtime_gid = 1000
+
+        rules_dir = temp_dir / "opt-claude-rules"
+        rules_dir.mkdir()
+        (rules_dir / "mission.md").write_text("# Mission")
+
+        logger = entrypoint.Logger(quiet=True)
+
+        with patch.object(entrypoint, "_CLAUDE_RULES_DIR", rules_dir):
+            entrypoint.setup_agent_rules(config, logger)
+
+        assert not stale.exists()
+        assert not stale.is_symlink()
+
+    @patch("os.chown")
+    def test_preserves_committed_agents_md_alias_in_repo(self, mock_chown, temp_dir):
+        """Committed relative ``AGENTS.md -> CLAUDE.md`` symlink survives cleanup.
+
+        Regression test for the case where a repo (e.g. egg itself in the
+        dogfood scenario) commits ``AGENTS.md`` as a relative symlink to its
+        own ``CLAUDE.md`` for cross-tool agent discovery. The entrypoint must
+        not delete this symlink — it's tracked content, not container-local
+        state from a previous run.
+        """
+        repos_dir = temp_dir / "repos"
+        repos_dir.mkdir()
+        repo = repos_dir / "my-project"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        # Committed repo content: real CLAUDE.md + relative AGENTS.md alias.
+        real_claude = repo / "CLAUDE.md"
+        real_claude.write_text("# Project rules")
+        committed_alias = repo / "AGENTS.md"
+        committed_alias.symlink_to("CLAUDE.md")  # relative, like the repo commit
+        assert committed_alias.is_symlink()
+        assert os.readlink(committed_alias) == "CLAUDE.md"
 
         claude_dir = temp_dir / ".claude"
         claude_dir.mkdir()
@@ -1291,8 +1339,12 @@ class TestSetupAgentRules:
         with patch.object(entrypoint, "_CLAUDE_RULES_DIR", rules_dir):
             entrypoint.setup_agent_rules(config, logger)
 
-        assert not stale.exists()
-        assert not stale.is_symlink()
+        # The committed alias and its target must be intact and unchanged.
+        assert committed_alias.is_symlink()
+        assert os.readlink(committed_alias) == "CLAUDE.md"
+        assert real_claude.exists()
+        assert not real_claude.is_symlink()
+        assert real_claude.read_text() == "# Project rules"
 
 
 class TestSetupEggSymlink:


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` symlinks pointing at `CLAUDE.md` in the repo root, `gateway/`, `orchestrator/`, and `sandbox/` so the rules are discoverable under the cross-tool industry-norm filename without duplicating content.
- Extend `sandbox/entrypoint.py` to create matching `AGENTS.md` aliases for the runtime-generated rules at `~/.claude/CLAUDE.md` and the CWD project-level symlink (with parallel stale-file cleanup and `.git/info/exclude` handling).
- Update the rules README and `docs/development/STRUCTURE.md` to mention the alias.

CLAUDE.md stays the source of truth — AGENTS.md is purely an additive alias.

## Test plan
- [x] `pytest tests/sandbox/test_entrypoint.py` — 119 passed (incl. 3 new AGENTS.md tests in `TestSetupAgentRules` and an extended assertion in `TestChdirToSingleRepo`)
- [ ] CI green