### PR TITLE
Fix #2839 + #2838: vendored LiteLLM image with qwen/deepseek cache_control passthrough

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,7 @@ lint-docker:
 	@if command -v hadolint >/dev/null 2>&1; then \
 		hadolint --config .hadolint.yaml gateway/Dockerfile; \
 		hadolint --config .hadolint.yaml sandbox/Dockerfile; \
+		hadolint --config .hadolint.yaml litellm/Dockerfile; \
 	else \
 		echo "SKIP: hadolint not installed"; \
 	fi
@@ -468,6 +469,8 @@ build: sync-venv-if-uv
 	docker build -t egg-orchestrator:latest -t egg-orchestrator:$(EGG_IMAGE_TAG) -f orchestrator/Dockerfile .
 	@echo "==> Building sandbox container..."
 	docker build -t egg-sandbox:latest -t egg-sandbox:$(EGG_IMAGE_TAG) -f sandbox/Dockerfile .
+	@echo "==> Building litellm container (vendored cache_control patches, #2839)..."
+	docker build -t egg-litellm:latest -t egg-litellm:$(EGG_IMAGE_TAG) -f litellm/Dockerfile .
 
 # ============================================================================
 # Kubernetes (k3s) targets
@@ -575,7 +578,8 @@ deploy: k3s-secrets  ## Deploy egg to k3s
 		sed -E "/name: EGG_HOST_REPO_MAP$$/{N;s|^(\s*- name: EGG_HOST_REPO_MAP\s*\n\s*value: )(\{.*\})$$|\1'\2'|}" | \
 		sed -e "s|egg-orchestrator:latest|egg-orchestrator:$(EGG_IMAGE_TAG)|g" \
 		    -e "s|egg-gateway:latest|egg-gateway:$(EGG_IMAGE_TAG)|g" \
-		    -e "s|egg-sandbox:latest|egg-sandbox:$(EGG_IMAGE_TAG)|g" | \
+		    -e "s|egg-sandbox:latest|egg-sandbox:$(EGG_IMAGE_TAG)|g" \
+		    -e "s|egg-litellm:latest|egg-litellm:$(EGG_IMAGE_TAG)|g" | \
 		kubectl apply -f - && \
 	scripts/clear-stuck-egg-pods.sh && \
 	scripts/await-egg-deploy.sh "$(EGG_IMAGE_TAG)"
@@ -618,7 +622,7 @@ k3s-import: sudo-keepalive  ## Import built images into k3s
 	trap 'rm -rf "$$tmp"' EXIT; \
 	tags="latest"; \
 	if [ "$(EGG_IMAGE_TAG)" != "latest" ]; then tags="$$tags $(EGG_IMAGE_TAG)"; fi; \
-	for image in egg-gateway egg-orchestrator egg-sandbox; do \
+	for image in egg-gateway egg-orchestrator egg-sandbox egg-litellm; do \
 		for tag in $$tags; do \
 			img="$$image:$$tag"; \
 			f="$$tmp/$${img//[:\/]/_}.tar"; \

--- a/k8s/base/litellm-deployment.yaml
+++ b/k8s/base/litellm-deployment.yaml
@@ -34,7 +34,7 @@ spec:
           # Pinned image — bump via overlay when intentionally updating.
           # LiteLLM's Anthropic-translation interface is the contract the
           # gateway depends on; do not float ``latest`` (cq-1, feedback Q3).
-          image: ghcr.io/berriai/litellm:main-v1.55.10
+          image: ghcr.io/berriai/litellm:main-v1.86.2
           imagePullPolicy: IfNotPresent
           args:
             - --config

--- a/k8s/base/litellm-deployment.yaml
+++ b/k8s/base/litellm-deployment.yaml
@@ -31,10 +31,13 @@ spec:
         fsGroup: 1000
       containers:
         - name: litellm
-          # Pinned image — bump via overlay when intentionally updating.
-          # LiteLLM's Anthropic-translation interface is the contract the
-          # gateway depends on; do not float ``latest`` (cq-1, feedback Q3).
-          image: ghcr.io/berriai/litellm:main-v1.86.2
+          # Vendored image: bases on ``ghcr.io/berriai/litellm:v1.86.2`` and
+          # patches in cache_control passthrough for qwen/deepseek upstreams
+          # (issue #2839). Built by ``make build`` from ``litellm/Dockerfile``
+          # and loaded into k3s by ``make k3s-import``. Bump the upstream
+          # pin in ``litellm/Dockerfile``; the Anthropic-translation surface
+          # is the gateway's contract, do not float ``latest`` (cq-1).
+          image: egg-litellm:latest
           imagePullPolicy: IfNotPresent
           args:
             - --config

--- a/litellm/Dockerfile
+++ b/litellm/Dockerfile
@@ -1,0 +1,32 @@
+# Vendored LiteLLM image: bases on upstream and patches in cache_control
+# passthrough for qwen/deepseek upstreams (issue #2839).
+#
+# Two stale allowlists in upstream LiteLLM strip cache_control before the
+# request reaches OpenRouter, even though OpenRouter has supported caching
+# for Qwen and DeepSeek since early 2026:
+#
+#   1. litellm/llms/openrouter/chat/transformation.py:
+#      CacheControlSupportedModels enum -- adds QWEN, DEEPSEEK.
+#   2. litellm/llms/anthropic/experimental_pass_through/adapters/
+#      transformation.py: is_anthropic_claude_model() -- extends the
+#      substring check to also pass through for qwen and deepseek.
+#
+# Net effect today: each turn re-bills the full bootstrap (~30k tokens of
+# CLAUDE.md + tools + skills + agent prompt) at full price instead of
+# cache_read. Empirically host-side this was a ~5x per-turn cost driver on
+# non-Claude routes.
+#
+# Long-term path is upstream-merged, not vendored -- file an upstream PR
+# alongside.
+FROM ghcr.io/berriai/litellm:v1.86.2
+
+USER root
+COPY litellm/patch-cache-control.py /tmp/patch-cache-control.py
+RUN python /tmp/patch-cache-control.py \
+    && rm /tmp/patch-cache-control.py
+
+# Drop back to a non-root UID -- the k8s podSpec sets runAsUser: 1000 via
+# securityContext anyway, but ending the image on a non-root USER keeps
+# hadolint (DL3002) happy and matches the runtime contract. Patched files
+# are world-readable.
+USER 1000

--- a/litellm/patch-cache-control.py
+++ b/litellm/patch-cache-control.py
@@ -1,0 +1,65 @@
+# Vendored-image patcher: adds qwen/deepseek to the two LiteLLM allowlists
+# that gate cache_control passthrough. See litellm/Dockerfile and #2839.
+#
+# We patch by string-replacement (not whole-file COPY) so the patches
+# survive minor upstream edits to surrounding code. The asserts below fail
+# the build loudly if either anchor goes missing, instead of producing an
+# unpatched image that silently re-bills the bootstrap on every turn.
+
+import pathlib
+
+LITELLM_ROOT = pathlib.Path("/app/litellm")
+
+OPENROUTER_TRANSFORM = LITELLM_ROOT / "llms/openrouter/chat/transformation.py"
+ANTHROPIC_ADAPTER = (
+    LITELLM_ROOT / "llms/anthropic/experimental_pass_through/adapters/transformation.py"
+)
+
+
+def patch_openrouter_enum() -> None:
+    needle = '    ZAI = "z-ai"\n'
+    addition = '    QWEN = "qwen"\n    DEEPSEEK = "deepseek"\n'
+    s = OPENROUTER_TRANSFORM.read_text()
+    if addition in s:
+        raise SystemExit(f"{OPENROUTER_TRANSFORM}: patch already present")
+    if needle not in s:
+        raise SystemExit(
+            f'{OPENROUTER_TRANSFORM}: anchor `ZAI = "z-ai"` not found; '
+            f"upstream LiteLLM layout shifted -- update the patcher"
+        )
+    OPENROUTER_TRANSFORM.write_text(s.replace(needle, needle + addition, 1))
+
+
+def patch_anthropic_adapter() -> None:
+    old = 'return "anthropic" in model_lower or "claude" in model_lower'
+    new = 'return any(s in model_lower for s in ("anthropic", "claude", "qwen", "deepseek"))'
+    s = ANTHROPIC_ADAPTER.read_text()
+    if new in s:
+        raise SystemExit(f"{ANTHROPIC_ADAPTER}: patch already present")
+    if old not in s:
+        raise SystemExit(
+            f"{ANTHROPIC_ADAPTER}: anchor `is_anthropic_claude_model` "
+            f"return line not found; upstream LiteLLM layout shifted -- "
+            f"update the patcher"
+        )
+    ANTHROPIC_ADAPTER.write_text(s.replace(old, new, 1))
+
+
+def verify() -> None:
+    s1 = OPENROUTER_TRANSFORM.read_text()
+    if 'QWEN = "qwen"' not in s1 or 'DEEPSEEK = "deepseek"' not in s1:
+        raise SystemExit(f"verification failed: enum patch missing in {OPENROUTER_TRANSFORM}")
+    s2 = ANTHROPIC_ADAPTER.read_text()
+    if '"qwen"' not in s2 or '"deepseek"' not in s2:
+        raise SystemExit(f"verification failed: adapter patch missing in {ANTHROPIC_ADAPTER}")
+
+
+def main() -> None:
+    patch_openrouter_enum()
+    patch_anthropic_adapter()
+    verify()
+    print("LiteLLM cache_control passthrough patches applied (qwen, deepseek)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Replaces the cluster's `ghcr.io/berriai/litellm:main-v1.55.10` pin with a
vendored `egg-litellm:latest` image (built locally, loaded into k3s
containerd by `make k3s-import` alongside the other `egg-*` images). The
vendored image bases on `ghcr.io/berriai/litellm:v1.86.2` and applies two
small patches that extend LiteLLM's stale `cache_control` allowlists to
include `qwen` and `deepseek` upstreams.

Closes #2839 and subsumes #2838 (the bare image bump): #2838 is a
no-op without the cache_control patches in this PR, and the vendored
Dockerfile pin is the only place a future bump now needs to happen.

## Why

Two stale allowlists in upstream LiteLLM strip `cache_control` before
the request reaches OpenRouter, even though OpenRouter has supported
prompt caching for Qwen and DeepSeek since early 2026:

- `litellm/llms/openrouter/chat/transformation.py` —
  `CacheControlSupportedModels` enum (`CLAUDE`, `GEMINI`, `MINIMAX`,
  `GLM`, `ZAI` only — patched to add `QWEN`, `DEEPSEEK`).
- `litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py` —
  `is_anthropic_claude_model()` substring check (patched to also pass
  through for `qwen` / `deepseek`).

Empirical impact host-side: each agent turn re-bills the full bootstrap
(~30k tokens of CLAUDE.md tree + tools + skills + agent prompt) at full
price on non-Claude routes instead of `cache_read` — about a 5x per-turn
cost driver. The same two-file patch was applied to a host-side LiteLLM
install and validated end-to-end (outgoing OpenAI-format body to
OpenRouter contains `cache_control` blocks; OpenRouter Activity
dashboard shows `cached_tokens > 0` on subsequent turns).

## Notable

- **Bad tag fix.** The prior commit on this branch pinned
  `ghcr.io/berriai/litellm:main-v1.86.2`, but upstream dropped the
  `main-` prefix around v1.83 — that tag does not exist (`docker pull`
  errors with `manifest unknown`). The vendored Dockerfile uses
  `v1.86.2`.
- **Patcher resilience.** `litellm/patch-cache-control.py` uses
  string-replacement with anchor asserts (`raise SystemExit` if the
  needle goes missing or the patch is already present). A major LiteLLM
  refactor of either file fails the build loudly instead of silently
  producing an unpatched image.
- **Upstream PR.** Long-term path is upstream-merged, not vendored —
  filing the upstream PR is tracked as a separate follow-up.

## Local verification

```text
$ docker build -t egg-litellm:test -f litellm/Dockerfile .
[+] Building ...
 => RUN python /tmp/patch-cache-control.py
 => LiteLLM cache_control passthrough patches applied (qwen, deepseek)

$ docker run --rm --entrypoint=python egg-litellm:test -c '
    from litellm.llms.openrouter.chat.transformation import CacheControlSupportedModels
    print([m.value for m in CacheControlSupportedModels])
    from litellm.llms.anthropic.experimental_pass_through.adapters.transformation \
        import LiteLLMAnthropicMessagesAdapter as A
    for m in ("openrouter/qwen/qwen3-max",
              "openrouter/deepseek/deepseek-chat",
              "openrouter/openai/gpt-4o"):
        print(m, A.is_anthropic_claude_model(m))
'
['claude', 'gemini', 'minimax', 'glm', 'z-ai', 'qwen', 'deepseek']
openrouter/qwen/qwen3-max         True
openrouter/deepseek/deepseek-chat True
openrouter/openai/gpt-4o          False
```

All `make lint*` targets clean (hadolint, ruff check + format, mypy,
yamllint, custom checks).

## Test plan

- [ ] `make redeploy` on a host with `~/.config/egg/litellm-models.yaml`
      registering a qwen/deepseek upstream; confirm the LiteLLM pod
      comes up Ready on the new vendored image.
- [ ] Drive a multi-turn agent session through the LiteLLM-routed
      upstream and confirm OpenRouter Activity reports
      `cached_tokens > 0` on turns ≥ 2.
- [ ] Sanity-check Claude path is unaffected (no-op `agent_models={}`
      pipeline reaches Anthropic normally).
- [x] `docker build -f litellm/Dockerfile .` succeeds; patched modules
      import cleanly; gate functions return expected values for
      qwen/deepseek/non-target model strings.
- [x] Full `make lint` is green.

## Files

- `litellm/Dockerfile` — new; vendored image FROM `v1.86.2` + patcher.
- `litellm/patch-cache-control.py` — new; two-file string-replace patcher
  with anchor asserts.
- `Makefile` — wires `egg-litellm` into `build`, `k3s-import`, `deploy`
  (tag substitution), and `lint-docker`.
- `k8s/base/litellm-deployment.yaml` — image now `egg-litellm:latest`;
  comment updated to point at the vendored Dockerfile for future bumps.

## Related

- #2769 — original LiteLLM proxy integration.
- #2832 — host-side `ANTHROPIC_CUSTOM_MODEL_OPTION` work that validated
  the same two patches in the host-side install.
- #2839 — original issue (closed by this PR).
- #2838 — image-bump issue (subsumed by this PR).
- Upstream LiteLLM PR — follow-up, not in this PR.