### PR TITLE
feat(prompts): add permissive subagent-exploration guidance for producers (#2814)

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -11951,6 +11951,36 @@ _YAML_TASKS_SAFETY_GUIDANCE = [
     "values on the same line as the key.",
 ]
 
+# Permissive subagent-use guidance for producer-role prompts (#2814).
+# Framed as "may" with example signals, not a mandate — the producer
+# keeps full judgment over when delegation pays off. The goal is to
+# keep deep exploration (many grep/read turns, walking call sites on
+# a very large file) out of the producer's main context window so the
+# Agent SDK 1MB JSON buffer bug (#2804) doesn't lose uncommitted work.
+_SUBAGENT_EXPLORATION_SECTION = [
+    "## Subagent use for exploration (#2814)",
+    "",
+    "You **may** use the Agent tool (e.g. `subagent_type: Explore` or "
+    "`general-purpose`) when exploration would otherwise dominate your "
+    "context window. Use your judgment — a one-off grep or short read "
+    "doesn't need a subagent; deep investigation of a large file or many "
+    "call sites usually does. The producer's main context stays lean for "
+    "synthesis; the subagent returns a focused summary.",
+    "",
+    "Example signals where subagent use often pays off:",
+    "- More than ~3 grep/read calls on the same target file or directory.",
+    "- Walking a primitive's call sites — delegate; ask for `file:line` "
+    "citations + a few lines of context.",
+    "- Reading large files (> ~500 lines) — get a subagent summary first; "
+    "only `Read` the main file yourself if the summary identifies specific "
+    "line ranges you need to author at.",
+    "",
+    "Subagent summaries are part of your authoritative work. Verify "
+    "critical claims (e.g. `file:line` citations) before committing them "
+    "to your output.",
+    "",
+]
+
 
 def _build_phase_iteration_context(
     operator_directives: list[OperatorDirective] | None,
@@ -12734,6 +12764,14 @@ def _build_phase_prompt(
 
     else:
         lines.append(f"Execute the {phase} phase.\n")
+
+    # --- Subagent use for exploration (coder + refiner) (#2814) ---
+    # Both roles share this prompt assembly path; a single insert here
+    # pins the property for both without duplicating the text. Distinct
+    # from the cycle-0 "Parallel Execution with Subagents" block above —
+    # that one is about parallel implementation across non-overlapping
+    # files; this one is about context isolation during exploration.
+    lines.extend(_SUBAGENT_EXPLORATION_SECTION)
 
     # --- Phase restrictions ---
     lines.append("## Phase Restrictions\n")
@@ -14976,6 +15014,14 @@ def _build_agent_prompt(
                 "",
             ]
         )
+
+    # Subagent use for exploration (#2814) — applies to every producer
+    # role that flows through this function (tester, documenter,
+    # architect, task_planner, risk_analyst). Refiner and coder return
+    # early above via `_build_phase_prompt`, which carries the same
+    # block. A single insert here pins the property for all five roles
+    # without duplicating the text.
+    lines.extend(_SUBAGENT_EXPLORATION_SECTION)
 
     # Phase restrictions
     _recovery_base_ref = _resolve_origin_ref(base_branch)

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -11967,19 +11967,35 @@ _SUBAGENT_EXPLORATION_SECTION = [
     "call sites usually does. The producer's main context stays lean for "
     "synthesis; the subagent returns a focused summary.",
     "",
+    "Distinct from the `## Parallel Execution with Subagents` block (when "
+    "present, cycle-0 implement-phase coder only) — that one is about "
+    "parallel implementation across non-overlapping files; this section "
+    "is about context isolation during exploration.",
+    "",
     "Example signals where subagent use often pays off:",
     "- More than ~3 grep/read calls on the same target file or directory.",
     "- Walking a primitive's call sites — delegate; ask for `file:line` "
     "citations + a few lines of context.",
-    "- Reading large files (> ~500 lines) — get a subagent summary first; "
-    "only `Read` the main file yourself if the summary identifies specific "
-    "line ranges you need to author at.",
+    "- Reading large files (files that would consume more than ~5% of "
+    "your context window, e.g. > ~1500 lines in this codebase) — get a "
+    "subagent summary first; only `Read` the main file yourself if the "
+    "summary identifies specific line ranges you need to author at.",
     "",
     "Subagent summaries are part of your authoritative work. Verify "
     "critical claims (e.g. `file:line` citations) before committing them "
     "to your output.",
     "",
 ]
+
+# The set of producer roles that flow through ``_build_agent_prompt``
+# and should receive ``_SUBAGENT_EXPLORATION_SECTION``. Coder and
+# refiner return early via ``_build_phase_prompt`` (which inserts the
+# section there), and reviewer_* roles return early before role
+# dispatch and never accumulate ``lines``. APPLIER (Jira mutations)
+# is intentionally excluded — it doesn't do code exploration.
+_SUBAGENT_EXPLORATION_ROLES = frozenset(
+    {"tester", "documenter", "architect", "task_planner", "risk_analyst"}
+)
 
 
 def _build_phase_iteration_context(
@@ -15019,9 +15035,12 @@ def _build_agent_prompt(
     # role that flows through this function (tester, documenter,
     # architect, task_planner, risk_analyst). Refiner and coder return
     # early above via `_build_phase_prompt`, which carries the same
-    # block. A single insert here pins the property for all five roles
-    # without duplicating the text.
-    lines.extend(_SUBAGENT_EXPLORATION_SECTION)
+    # block. A single guarded insert here pins the property for all
+    # five roles without duplicating the text. APPLIER also flows
+    # through the `else` fallthrough above but is intentionally
+    # excluded — it drives Jira mutations, not code exploration.
+    if role_value in _SUBAGENT_EXPLORATION_ROLES:
+        lines.extend(_SUBAGENT_EXPLORATION_SECTION)
 
     # Phase restrictions
     _recovery_base_ref = _resolve_origin_ref(base_branch)

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -11968,9 +11968,10 @@ _SUBAGENT_EXPLORATION_SECTION = [
     "synthesis; the subagent returns a focused summary.",
     "",
     "Distinct from the `## Parallel Execution with Subagents` block (when "
-    "present, cycle-0 implement-phase coder only) — that one is about "
-    "parallel implementation across non-overlapping files; this section "
-    "is about context isolation during exploration.",
+    "present — the cycle-0 implement-phase coder, and the tester role) — "
+    "that one is about parallel implementation/test authoring across "
+    "non-overlapping files; this section is about context isolation "
+    "during exploration.",
     "",
     "Example signals where subagent use often pays off:",
     "- More than ~3 grep/read calls on the same target file or directory.",

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -4796,6 +4796,41 @@ class TestAdversarialReReviewPriming:
         assert "do not negotiate" not in respond_block.lower()
 
 
+class TestProducerSubagentExplorationGuidance:
+    """All 7 producer roles must receive the subagent exploration guidance (#2814).
+
+    The guidance is permissive ("may use") and framed around example signals,
+    not mandates — the producer keeps judgment over when delegation pays off.
+    The goal is to keep deep exploration out of the producer's main context
+    window so the Agent SDK 1MB JSON buffer bug (#2804) doesn't lose work.
+
+    Parametrized over all producer roles to pin the property: every role
+    that produces a prompt must carry this block. The coder and refiner
+    roles flow through `_build_phase_prompt`; the other five flow through
+    the `elif role_value` branches in `_build_agent_prompt`.
+    """
+
+    @pytest.mark.parametrize(("role", "phase"), _PRODUCER_ROLES_BY_PHASE)
+    def test_subagent_exploration_block_present(self, role, phase):
+        """Every producer prompt must include the subagent exploration section."""
+        prompt = _build_agent_prompt(
+            role_value=role,
+            phase=phase,
+            pipeline_id="test-pipeline-123",
+            pipeline_mode="issue",
+            prompt="# Test Feature\n\nTest detail.",
+            issue_number=1,
+        )
+        # The section header must be present
+        assert "## Subagent use for exploration (#2814)" in prompt
+        # The permissive framing ("**may**") must be present (with markdown bold)
+        assert "**may**" in prompt.lower()
+        # At least one example signal must be present
+        assert "example signals" in prompt.lower()
+        # The verification caveat must be present
+        assert "verify critical claims" in prompt.lower()
+
+
 class TestInitialReviewOperatorCopyPasteFraming:
     """The operator-copy-paste framing and the pre-existing-broken-behavior
     procedural step must fire on **initial** reviews, not just re-reviews.

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -4829,6 +4829,31 @@ class TestProducerSubagentExplorationGuidance:
         assert "example signals" in prompt.lower()
         # The verification caveat must be present
         assert "verify critical claims" in prompt.lower()
+        # Ordering: the section must render *before* `## Phase Restrictions`
+        # so a future refactor that moves it (e.g. above `## Context`)
+        # is caught here, not silently. The two H2 headers must both
+        # exist for the comparison to be meaningful.
+        section_idx = prompt.index("## Subagent use for exploration (#2814)")
+        phase_restrictions_idx = prompt.index("## Phase Restrictions")
+        assert section_idx < phase_restrictions_idx, (
+            "Subagent exploration section must appear before Phase Restrictions"
+        )
+
+    def test_applier_role_does_not_receive_section(self):
+        """APPLIER drives Jira mutations, not code exploration — the
+        guidance is intentionally not appended for it. This pins the
+        property so a future refactor that drops the explicit role
+        guard in ``_build_agent_prompt`` (e.g. via an unconditional
+        ``lines.extend(...)`` in the fallthrough) is caught here."""
+        prompt = _build_agent_prompt(
+            role_value="applier",
+            phase="apply",
+            pipeline_id="test-pipeline-123",
+            pipeline_mode="issue",
+            prompt="# Test Feature\n\nTest detail.",
+            issue_number=1,
+        )
+        assert "## Subagent use for exploration (#2814)" not in prompt
 
 
 class TestInitialReviewOperatorCopyPasteFraming:

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -390,7 +390,10 @@ class TestBuildPhasePromptRevisionMode:
         )
         assert "## Task Description" not in result
         assert "Build a widget with many features" not in result
-        assert "## Parallel Execution with Subagents" not in result
+        # The subagent-exploration section (#2814) prose-references this
+        # header by name (in backticks), so match the header form with a
+        # trailing newline to avoid that false positive.
+        assert "## Parallel Execution with Subagents\n" not in result
 
     def test_revision_cycle_contains_revision_instructions(self):
         """Cycle 2+ contains revision-focused instructions."""
@@ -433,7 +436,7 @@ class TestBuildPhasePromptRevisionMode:
         )
         assert "## Task Description" in result
         assert "Build a widget with many features" in result
-        assert "## Parallel Execution with Subagents" in result
+        assert "## Parallel Execution with Subagents\n" in result
 
     def test_revision_cycle_without_feedback_includes_task_description(self):
         """Cycle 2+ with no feedback falls back to including the task description."""
@@ -955,7 +958,7 @@ class TestBuildAgentPromptRoleContext:
         assert "## Task Description" not in result
         assert "## For More Context" in result
         assert "TESTER" in result
-        assert "## Parallel Execution with Subagents" in result
+        assert "## Parallel Execution with Subagents\n" in result
 
     def test_documenter_prompt_has_background_not_task_description(self):
         """Documenter prompt uses Background section, not Task Description."""


### PR DESCRIPTION
## Summary

Adds permissive subagent-exploration guidance to all 7 producer roles in the SDLC pipeline.

## Problem

Producer agents accumulate large context windows during deep code exploration (grep chains, multi-file analysis, AST traversal), which can trigger the Agent SDK 1MB JSON buffer limit (#2804) and lose work. Offloading exploration to subagents (Explore, Plan, etc.) isolates context accumulation in their own windows.

## Solution

- **Single source of truth**: `_SUBAGENT_EXPLORATION_SECTION` constant in `orchestrator/routes/pipelines.py`
- **Inserted for all producer roles**:
  - `refiner` via `_build_phase_prompt`
  - `architect`, `task_planner`, `risk_analyst` via `_build_agent_prompt`
  - `coder`, `tester`, `documenter` via `_build_agent_prompt`
- **Parametrized test**: `TestProducerSubagentExplorationGuidance` covers all 7 roles

Guidance is judgment-based (not mandatory) — producers decide when to delegate based on their context window state.

## Test plan

- [x] `make test` passes (all 7 parametrized test cases green)
- [x] `make lint` clean (ruff, mypy)
- [x] Prompt assembly verified for both `_build_phase_prompt` and `_build_agent_prompt` paths

## Related

- Fixes #2814
- Mitigates #2804 (SDK buffer limit)
- Splits from #2809 (architect composition authority)

## Meta

Generated with qwen3.7-max (9% context window, $4.65).