### PR TITLE
Fix #2807: auto-salvage uncommitted work during agent restart

### DIFF
--- a/orchestrator/agent_salvage.py
+++ b/orchestrator/agent_salvage.py
@@ -78,6 +78,16 @@ RECOVERY_BRANCH_PREFIX = "egg/recovered"
 # group so the caller can validate it against the AgentRole allowlist.
 _SLICE_WORKTREE_RE = re.compile(r"^(slice-[0-9]+)-(.+)$")
 
+# Message + identity for the synthetic commit that captures a crashed
+# agent's uncommitted working-tree state (#2807). Operators grep the
+# message prefix to tell a salvaged dirty-tree snapshot apart from the
+# agent's own commits. The orchestrator runs git on the agent's worktree
+# without a configured user, so an explicit identity is required for the
+# commit to succeed.
+_UNCOMMITTED_SALVAGE_MESSAGE = "[salvage] pre-crash working-tree state (#2807)"
+_SALVAGE_COMMIT_NAME = "egg-salvage"
+_SALVAGE_COMMIT_EMAIL = "egg-salvage@localhost"
+
 
 @dataclass(frozen=True)
 class AgentWorktree:
@@ -556,19 +566,106 @@ def _recovery_ref(
     return f"{RECOVERY_BRANCH_PREFIX}/{pipeline_id}/{scope_label}/{short}"
 
 
+def _has_uncommitted_changes(repo_path: Path) -> bool:
+    """Return True when the worktree has staged, unstaged, or untracked changes."""
+    try:
+        result = _run_git("status", "--porcelain", cwd=repo_path, check=False)
+    except OSError, subprocess.SubprocessError:
+        return False
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def commit_working_tree(worktree: AgentWorktree) -> str | None:
+    """Commit a crashed agent's uncommitted working-tree state (#2807).
+
+    The coder commits at consensus-propose time, not per task, so a crash
+    in the ``Edit``→``git commit`` window leaves valuable work only in the
+    dirty working tree. The respawn path reuses the on-disk worktree and
+    hard-resets it to a remote ref (gateway
+    ``_reset_reused_worktree_to_safe_ref``), which would discard that
+    state. Staging and committing it onto the local work branch *before*
+    salvage lets the recovery-ref push capture it.
+
+    Best-effort: returns the new commit SHA on success, ``None`` when
+    there is nothing to commit or the commit fails. Never raises — a
+    failure here must not stop the committed-but-unpushed salvage that
+    follows.
+    """
+    if not _is_git_worktree(worktree.repo_path):
+        return None
+    if not _has_uncommitted_changes(worktree.repo_path):
+        return None
+    try:
+        add = _run_git("add", "-A", cwd=worktree.repo_path, check=False)
+        if add.returncode != 0:
+            logger.warning(
+                "Salvage: git add -A failed; skipping uncommitted capture",
+                worktree_id=worktree.worktree_id,
+                stderr=(add.stderr or "").strip(),
+            )
+            return None
+        commit = _run_git(
+            "-c",
+            f"user.name={_SALVAGE_COMMIT_NAME}",
+            "-c",
+            f"user.email={_SALVAGE_COMMIT_EMAIL}",
+            "commit",
+            "-m",
+            _UNCOMMITTED_SALVAGE_MESSAGE,
+            cwd=worktree.repo_path,
+            check=False,
+        )
+        if commit.returncode != 0:
+            logger.warning(
+                "Salvage: commit of uncommitted working tree failed",
+                worktree_id=worktree.worktree_id,
+                stderr=(commit.stderr or "").strip(),
+            )
+            return None
+        head = _run_git("rev-parse", "HEAD", cwd=worktree.repo_path, check=False)
+        head_sha = (head.stdout or "").strip() if head.returncode == 0 else None
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.warning(
+            "Salvage: capturing uncommitted working tree raised; continuing",
+            worktree_id=worktree.worktree_id,
+            error=str(e),
+        )
+        return None
+
+    logger.info(
+        "Salvage: committed uncommitted working-tree state before recovery push",
+        pipeline_id=worktree.pipeline_id,
+        worktree_id=worktree.worktree_id,
+        agent_role=worktree.agent_role,
+        head_sha=head_sha,
+    )
+    return head_sha
+
+
 def salvage_worktree(
     gateway: GatewayClient,
     worktree: AgentWorktree,
     *,
     base_branch: str | None = None,
     mode: str = "public",
+    salvage_uncommitted: bool = False,
 ) -> SalvageResult:
     """Push ``worktree``'s HEAD to a recovery ref, if it has unpushed work.
 
     Returns a ``SalvageResult`` with ``ok=True`` when a push succeeded or
     when there was nothing to salvage (``n_commits=0``). ``ok=False``
     only on push failure or worktree corruption.
+
+    When ``salvage_uncommitted`` is set, the worktree's dirty state is
+    committed onto the local work branch (via :func:`commit_working_tree`)
+    *before* enumeration, so the recovery push also captures uncommitted
+    edits — the #2807 crash window where a respawn's ``git reset --hard``
+    would otherwise destroy them. Callers on the cleanup path leave it
+    ``False`` to avoid turning routine untracked build artifacts into
+    recovery refs.
     """
+    if salvage_uncommitted:
+        commit_working_tree(worktree)
     report = list_unpushed_commits(worktree, base_branch=base_branch)
     if report.error:
         return SalvageResult(
@@ -665,6 +762,7 @@ def auto_salvage_pipeline(
     base_branch: str | None = None,
     mode: str = "public",
     worktree_filter: set[str] | None = None,
+    salvage_uncommitted: bool = False,
 ) -> list[SalvageResult]:
     """Best-effort salvage of every per-agent worktree for a pipeline.
 
@@ -677,6 +775,11 @@ def auto_salvage_pipeline(
     the given set, so the caller can pass exactly the ids it is about
     to delete and skip stale on-disk worktrees from a prior pipeline
     re-use.
+
+    ``salvage_uncommitted`` (set by the restart-recovery caller, #2807)
+    commits each worktree's dirty state onto its work branch before the
+    recovery push so uncommitted edits survive the respawn's
+    ``git reset --hard``. Left ``False`` on the cleanup path.
     """
     results: list[SalvageResult] = []
     try:
@@ -698,6 +801,7 @@ def auto_salvage_pipeline(
                 wt,
                 base_branch=base_branch,
                 mode=mode,
+                salvage_uncommitted=salvage_uncommitted,
             )
         except Exception as e:
             # salvage_worktree is supposed to catch its own failures, but

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -1411,17 +1411,22 @@ class KubernetesSpawner:
                     error=str(e),
                 )
 
-            # Salvage uncommitted agent work before respawning (#2807).
-            # The restarted container starts from branch HEAD, so any
-            # uncommitted edits in the worktree would be orphaned until
-            # pipeline cleanup. Auto-salvage pushes committed-but-unpushed
-            # work to egg/recovered/<pipeline>/<scope>/<sha> so operators
-            # can triage it manually.
-            agent_worktree_id = (
-                f"{pipeline_id}-{slice_id}-{agent_role.value}"
-                if slice_id
-                else f"{pipeline_id}-{agent_role.value}"
-            )
+            # Salvage agent work before respawning (#2807). The respawn
+            # reuses the on-disk worktree and hard-resets it to a remote
+            # ref (gateway _reset_reused_worktree_to_safe_ref), destroying
+            # both unpushed commits and the dirty working tree. The modal
+            # #2807 crash window is mid-Edit, before any commit, so
+            # salvage_uncommitted=True commits the dirty tree onto the work
+            # branch first; auto-salvage then pushes everything to
+            # egg/recovered/<pipeline>/<scope>/<sha> for manual triage.
+            #
+            # This runs on the respawn critical path while the restart lock
+            # is held. It is scoped to just this agent's own worktree, the
+            # working-tree commit is local git, and the gateway push carries
+            # its own HTTP timeout, so the added lock-hold is bounded. The
+            # best-effort try/except keeps a salvage failure from blocking
+            # the respawn.
+            agent_worktree_id = self._build_agent_worktree_id(pipeline_id, agent_role, slice_id)
             try:
                 agent_salvage.auto_salvage_pipeline(
                     self.gateway,
@@ -1429,6 +1434,7 @@ class KubernetesSpawner:
                     worktree_filter={agent_worktree_id},
                     mode=mode,
                     base_branch=base_branch,
+                    salvage_uncommitted=True,
                 )
             except Exception as e:
                 logger.warning(

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -1411,6 +1411,34 @@ class KubernetesSpawner:
                     error=str(e),
                 )
 
+            # Salvage uncommitted agent work before respawning (#2807).
+            # The restarted container starts from branch HEAD, so any
+            # uncommitted edits in the worktree would be orphaned until
+            # pipeline cleanup. Auto-salvage pushes committed-but-unpushed
+            # work to egg/recovered/<pipeline>/<scope>/<sha> so operators
+            # can triage it manually.
+            agent_worktree_id = (
+                f"{pipeline_id}-{slice_id}-{agent_role.value}"
+                if slice_id
+                else f"{pipeline_id}-{agent_role.value}"
+            )
+            try:
+                agent_salvage.auto_salvage_pipeline(
+                    self.gateway,
+                    pipeline_id,
+                    worktree_filter={agent_worktree_id},
+                    mode=mode,
+                    base_branch=base_branch,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Auto-salvage failed during agent restart; proceeding",
+                    pipeline_id=pipeline_id,
+                    agent_role=agent_role.value,
+                    worktree_id=agent_worktree_id,
+                    error=str(e),
+                )
+
             # Respawn — gateway's create_worktrees() is idempotent.
             # ``slice_id`` is forwarded so spawn_agent_job builds the
             # slice-scoped Job + worktree id and sets ``EGG_SLICE_ID``

--- a/orchestrator/tests/test_agent_salvage.py
+++ b/orchestrator/tests/test_agent_salvage.py
@@ -8,12 +8,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from agent_salvage import (
+    _UNCOMMITTED_SALVAGE_MESSAGE,
     RECOVERY_BRANCH_PREFIX,
     AgentWorktree,
     SalvageResult,
     UnpushedCommit,
     WorktreeCommitReport,
     auto_salvage_pipeline,
+    commit_working_tree,
     enumerate_agent_worktrees,
     list_unpushed_commits,
     salvage_worktree,
@@ -432,6 +434,124 @@ class TestSalvageWorktree:
         result = salvage_worktree(gateway, wt)
         assert result.ok is False
         gateway.push_worktree_branch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# commit_working_tree / salvage_uncommitted (#2807)
+# ---------------------------------------------------------------------------
+
+
+class TestSalvageUncommitted:
+    """The restart path commits the dirty working tree before pushing so a
+    crash in the Edit→commit window survives the respawn's reset --hard.
+    """
+
+    def _clean_worktree(self, tmp_path: Path) -> AgentWorktree:
+        """A worktree whose HEAD is fully pushed (no unpushed commits)."""
+        repo, local_branch = _make_worktree_layout(
+            tmp_path, "issue-99", agent_role="coder", slice_id=None
+        )
+        anchor = _git("rev-parse", "HEAD", cwd=repo).stdout.strip()
+        _set_assigned_branch(repo, local_branch, "egg/issue-99/work")
+        _create_remote_tracking(repo, "egg/issue-99/work", anchor)
+        return AgentWorktree(
+            worktree_id="issue-99-coder",
+            pipeline_id="issue-99",
+            agent_role="coder",
+            slice_id=None,
+            repo_path=repo,
+            local_branch=local_branch,
+        )
+
+    @staticmethod
+    def _dirty(repo: Path) -> None:
+        """Apply a tracked edit + an untracked add — the #2807 crash state."""
+        (repo / "README.md").write_text("seed\nmid-Edit change\n")
+        (repo / "new_feature.py").write_text("def added():\n    return 42\n")
+
+    def test_commit_working_tree_returns_none_when_clean(self, tmp_path: Path) -> None:
+        wt = self._clean_worktree(tmp_path)
+        assert commit_working_tree(wt) is None
+
+    def test_commit_working_tree_captures_dirty_state(self, tmp_path: Path) -> None:
+        wt = self._clean_worktree(tmp_path)
+        self._dirty(wt.repo_path)
+
+        sha = commit_working_tree(wt)
+
+        assert sha is not None
+        # New commit is HEAD, carries the salvage message, and includes both
+        # the tracked edit and the previously-untracked file.
+        assert _git("rev-parse", "HEAD", cwd=wt.repo_path).stdout.strip() == sha
+        assert (
+            _git("log", "-1", "--format=%s", cwd=wt.repo_path).stdout.strip()
+            == _UNCOMMITTED_SALVAGE_MESSAGE
+        )
+        assert (
+            _git("show", "HEAD:new_feature.py", cwd=wt.repo_path).stdout
+            == "def added():\n    return 42\n"
+        )
+        # Working tree is clean again — everything was captured.
+        assert _git("status", "--porcelain", cwd=wt.repo_path).stdout.strip() == ""
+
+    def test_salvage_pushes_uncommitted_edits_when_flag_set(self, tmp_path: Path) -> None:
+        """salvage_uncommitted=True: dirty edits land in the pushed HEAD."""
+        wt = self._clean_worktree(tmp_path)
+        self._dirty(wt.repo_path)
+        gateway = MagicMock()
+        gateway.push_worktree_branch.return_value = PushResult(ok=True)
+
+        result = salvage_worktree(gateway, wt, mode="public", salvage_uncommitted=True)
+
+        assert result.ok is True
+        assert result.n_commits == 1
+        head_sha = _git("rev-parse", "HEAD", cwd=wt.repo_path).stdout.strip()
+        assert result.head_sha == head_sha
+        expected_ref = f"{RECOVERY_BRANCH_PREFIX}/issue-99/coder/{head_sha[:12]}"
+        assert result.recovery_ref == expected_ref
+
+        # The push targets the recovery ref and pushes HEAD (ref=None), so the
+        # captured edits are reachable from the recovery ref.
+        kwargs = gateway.push_worktree_branch.call_args.kwargs
+        assert kwargs["branch"] == expected_ref
+        assert kwargs["ref"] is None
+        assert (
+            _git("show", "HEAD:new_feature.py", cwd=wt.repo_path).stdout
+            == "def added():\n    return 42\n"
+        )
+
+    def test_default_does_not_capture_uncommitted(self, tmp_path: Path) -> None:
+        """salvage_uncommitted defaults False: dirty tree is left untouched."""
+        wt = self._clean_worktree(tmp_path)
+        self._dirty(wt.repo_path)
+        gateway = MagicMock()
+
+        result = salvage_worktree(gateway, wt)
+
+        # No commit made, nothing to push, working tree still dirty.
+        assert result.n_commits == 0
+        gateway.push_worktree_branch.assert_not_called()
+        assert _git("status", "--porcelain", cwd=wt.repo_path).stdout.strip() != ""
+
+    def test_auto_salvage_forwards_flag(self, tmp_path: Path) -> None:
+        """auto_salvage_pipeline threads salvage_uncommitted to the push."""
+        wt = self._clean_worktree(tmp_path)
+        self._dirty(wt.repo_path)
+        gateway = MagicMock()
+        gateway.push_worktree_branch.return_value = PushResult(ok=True)
+
+        with patch("agent_salvage.WORKTREE_BASE_DIR", tmp_path):
+            results = auto_salvage_pipeline(
+                gateway,
+                "issue-99",
+                worktree_filter={"issue-99-coder"},
+                salvage_uncommitted=True,
+            )
+
+        assert len(results) == 1
+        assert results[0].ok is True
+        assert results[0].n_commits == 1
+        gateway.push_worktree_branch.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_restart_agent_job_salvage.py
+++ b/orchestrator/tests/test_restart_agent_job_salvage.py
@@ -1,0 +1,297 @@
+"""Verify restart_agent_job auto-salvages before respawning (#2807).
+
+When an agent crashes mid-task with uncommitted edits, the worktree
+persists on disk. Before respawning a fresh container (which starts
+from branch HEAD), restart_agent_job must salvage any unpushed commits
+to egg/recovered/<pipeline>/<scope>/<sha> so operators can triage them.
+
+Without this hook, uncommitted work sits in the worktree until pipeline
+cleanup (which may never happen if the pipeline keeps running), and the
+new agent never sees it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def mock_k8s_client():
+    from kubernetes_client import PodNotFoundError
+    from models import ContainerInfo, ContainerStatus
+
+    client = MagicMock()
+    client.delete_job.side_effect = PodNotFoundError("No existing job")
+    client.wait_for_job_gone.return_value = True
+    client.list_containers.return_value = []
+    client.remove_container.return_value = None
+    client.create_container.return_value = ContainerInfo(
+        container_id="uid-x",
+        container_name="egg-x",
+        job_name="egg-x",
+        status=ContainerStatus.PENDING,
+    )
+    return client
+
+
+class _FakeWorktreeResult:
+    def __init__(self, **kwargs):
+        self.worktrees = kwargs.get("worktrees", {})
+        self.errors = kwargs.get("errors", [])
+        self.success = kwargs.get("success", True)
+
+
+class _FakeGatewayHealth:
+    healthy = True
+    details = ""
+
+
+class _FakeSessionInfo:
+    container_id = "x"
+    session_token = "tok"
+    container_ip = "127.0.0.1"
+
+
+class _FakeGatewayError(Exception):
+    pass
+
+
+@pytest.fixture()
+def mock_gateway():
+    gw = MagicMock()
+    gw.check_health.return_value = _FakeGatewayHealth()
+    gw.register_session.return_value = _FakeSessionInfo()
+    gw.delete_session.return_value = True
+    gw.delete_session_by_container.return_value = True
+    gw.create_worktrees.return_value = _FakeWorktreeResult()
+    gw.delete_worktrees.return_value = _FakeWorktreeResult(worktrees={})
+    return gw
+
+
+@pytest.fixture()
+def spawner(mock_k8s_client, mock_gateway):
+    from kubernetes_spawner import KubernetesSpawner
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "gateway_client": MagicMock(
+                GatewayClient=MagicMock,
+                GatewayError=_FakeGatewayError,
+                SessionInfo=_FakeSessionInfo,
+                get_gateway_client=MagicMock(return_value=mock_gateway),
+            ),
+        },
+    ):
+        return KubernetesSpawner(k8s_client=mock_k8s_client, gateway_client=mock_gateway)
+
+
+class TestRestartAgentJobSalvageHook:
+    """restart_agent_job invokes auto_salvage_pipeline before respawning (#2807)."""
+
+    def test_salvage_runs_before_respawn(self, spawner, mock_gateway):
+        """auto_salvage_pipeline is invoked before spawn_agent_job."""
+        call_order: list[str] = []
+
+        def fake_salvage(*_args, **_kwargs):
+            call_order.append("salvage")
+            return []
+
+        def fake_spawn(*_args, **_kwargs):
+            call_order.append("spawn")
+            from kubernetes_spawner import SpawnedContainer
+            from models import ContainerInfo, ContainerStatus
+
+            return SpawnedContainer(
+                container_info=ContainerInfo(
+                    container_id="new-container",
+                    container_name="egg-new-container",
+                    status=ContainerStatus.RUNNING,
+                ),
+                session_info=None,
+                agent_role=None,
+                pipeline_id="pipe-1",
+                environment={},
+            )
+
+        with (
+            patch("agent_salvage.auto_salvage_pipeline", side_effect=fake_salvage),
+            patch.object(spawner, "spawn_agent_job", side_effect=fake_spawn),
+        ):
+            from models import AgentRole
+
+            spawner.restart_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                mode="public",
+            )
+
+        # Salvage must come before spawn.
+        assert "salvage" in call_order
+        assert "spawn" in call_order
+        assert call_order.index("salvage") < call_order.index("spawn")
+
+    def test_salvage_failure_does_not_block_respawn(self, spawner, mock_gateway):
+        """A salvage exception logs and continues — respawn still proceeds."""
+        spawn_called = False
+
+        def fake_spawn(*_args, **_kwargs):
+            nonlocal spawn_called
+            spawn_called = True
+            from kubernetes_spawner import SpawnedContainer
+            from models import ContainerInfo, ContainerStatus
+
+            return SpawnedContainer(
+                container_info=ContainerInfo(
+                    container_id="new-container",
+                    container_name="egg-new-container",
+                    status=ContainerStatus.RUNNING,
+                ),
+                session_info=None,
+                agent_role=None,
+                pipeline_id="pipe-1",
+                environment={},
+            )
+
+        with (
+            patch(
+                "agent_salvage.auto_salvage_pipeline",
+                side_effect=RuntimeError("salvage exploded"),
+            ),
+            patch.object(spawner, "spawn_agent_job", side_effect=fake_spawn),
+        ):
+            from models import AgentRole
+
+            # Must not raise.
+            result = spawner.restart_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                mode="public",
+            )
+
+        assert spawn_called
+        assert result is not None
+
+    def test_salvage_filter_scoped_to_agent_worktree(self, spawner, mock_gateway):
+        """The salvage filter receives exactly the agent's worktree id."""
+        captured: dict[str, object] = {}
+
+        def fake_salvage(_gateway, pipeline_id, *, worktree_filter=None, **_kw):
+            captured["pipeline_id"] = pipeline_id
+            captured["filter"] = worktree_filter
+            return []
+
+        def fake_spawn(*_args, **_kwargs):
+            from kubernetes_spawner import SpawnedContainer
+            from models import ContainerInfo, ContainerStatus
+
+            return SpawnedContainer(
+                container_info=ContainerInfo(
+                    container_id="new-container",
+                    container_name="egg-new-container",
+                    status=ContainerStatus.RUNNING,
+                ),
+                session_info=None,
+                agent_role=None,
+                pipeline_id="pipe-1",
+                environment={},
+            )
+
+        with (
+            patch("agent_salvage.auto_salvage_pipeline", side_effect=fake_salvage),
+            patch.object(spawner, "spawn_agent_job", side_effect=fake_spawn),
+        ):
+            from models import AgentRole
+
+            spawner.restart_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                mode="public",
+            )
+
+        assert captured["pipeline_id"] == "pipe-1"
+        assert captured["filter"] == {"pipe-1-coder"}
+
+    def test_salvage_filter_scoped_to_slice_worktree(self, spawner, mock_gateway):
+        """Slice-scoped restart scopes the salvage filter to the slice worktree."""
+        captured: dict[str, object] = {}
+
+        def fake_salvage(_gateway, pipeline_id, *, worktree_filter=None, **_kw):
+            captured["pipeline_id"] = pipeline_id
+            captured["filter"] = worktree_filter
+            return []
+
+        def fake_spawn(*_args, **_kwargs):
+            from kubernetes_spawner import SpawnedContainer
+            from models import ContainerInfo, ContainerStatus
+
+            return SpawnedContainer(
+                container_info=ContainerInfo(
+                    container_id="new-container",
+                    container_name="egg-new-container",
+                    status=ContainerStatus.RUNNING,
+                ),
+                session_info=None,
+                agent_role=None,
+                pipeline_id="pipe-1",
+                environment={},
+            )
+
+        with (
+            patch("agent_salvage.auto_salvage_pipeline", side_effect=fake_salvage),
+            patch.object(spawner, "spawn_agent_job", side_effect=fake_spawn),
+        ):
+            from models import AgentRole
+
+            spawner.restart_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                slice_id="slice-2",
+                mode="public",
+            )
+
+        assert captured["pipeline_id"] == "pipe-1"
+        assert captured["filter"] == {"pipe-1-slice-2-coder"}
+
+    def test_salvage_mode_and_base_branch_threaded_through(self, spawner, mock_gateway):
+        """mode and base_branch reach the salvage hook."""
+        captured: dict[str, object] = {}
+
+        def fake_salvage(_gateway, _pipeline_id, *, mode=None, base_branch=None, **_kw):
+            captured["mode"] = mode
+            captured["base_branch"] = base_branch
+            return []
+
+        def fake_spawn(*_args, **_kwargs):
+            from kubernetes_spawner import SpawnedContainer
+            from models import ContainerInfo, ContainerStatus
+
+            return SpawnedContainer(
+                container_info=ContainerInfo(
+                    container_id="new-container",
+                    container_name="egg-new-container",
+                    status=ContainerStatus.RUNNING,
+                ),
+                session_info=None,
+                agent_role=None,
+                pipeline_id="pipe-1",
+                environment={},
+            )
+
+        with (
+            patch("agent_salvage.auto_salvage_pipeline", side_effect=fake_salvage),
+            patch.object(spawner, "spawn_agent_job", side_effect=fake_spawn),
+        ):
+            from models import AgentRole
+
+            spawner.restart_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                mode="private",
+                base_branch="main",
+            )
+
+        assert captured["mode"] == "private"
+        assert captured["base_branch"] == "main"

--- a/orchestrator/tests/test_restart_agent_job_salvage.py
+++ b/orchestrator/tests/test_restart_agent_job_salvage.py
@@ -295,3 +295,47 @@ class TestRestartAgentJobSalvageHook:
 
         assert captured["mode"] == "private"
         assert captured["base_branch"] == "main"
+
+    def test_salvage_uncommitted_flag_forwarded(self, spawner, mock_gateway):
+        """The restart path requests uncommitted-work capture (#2807).
+
+        Without salvage_uncommitted=True the hook only salvages
+        committed-but-unpushed work; the modal #2807 crash window is
+        mid-Edit with nothing committed, so the flag is what makes the
+        dirty tree survive the respawn's reset --hard.
+        """
+        captured: dict[str, object] = {}
+
+        def fake_salvage(_gateway, _pipeline_id, *, salvage_uncommitted=False, **_kw):
+            captured["salvage_uncommitted"] = salvage_uncommitted
+            return []
+
+        def fake_spawn(*_args, **_kwargs):
+            from kubernetes_spawner import SpawnedContainer
+            from models import ContainerInfo, ContainerStatus
+
+            return SpawnedContainer(
+                container_info=ContainerInfo(
+                    container_id="new-container",
+                    container_name="egg-new-container",
+                    status=ContainerStatus.RUNNING,
+                ),
+                session_info=None,
+                agent_role=None,
+                pipeline_id="pipe-1",
+                environment={},
+            )
+
+        with (
+            patch("agent_salvage.auto_salvage_pipeline", side_effect=fake_salvage),
+            patch.object(spawner, "spawn_agent_job", side_effect=fake_spawn),
+        ):
+            from models import AgentRole
+
+            spawner.restart_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                mode="public",
+            )
+
+        assert captured["salvage_uncommitted"] is True


### PR DESCRIPTION
## Summary

When an agent crashes mid-task with uncommitted edits, the worktree persists on disk—but the respawned container starts from branch HEAD and never sees the orphaned work. Previously `cleanup_pipeline` and `restart_phase` salvaged unpushed commits, but `restart_agent_job` (the most common crash recovery path) did not.

## Fix

Calls `agent_salvage.auto_salvage_pipeline` before respawning in `restart_agent_job`, scoped to just the crashing agent's worktree. Unpushed commits land in `egg/recovered/<pipeline>/<scope>/<sha>` so operators can triage them manually.

- Scopes the filter to the agent's worktree ID (pipeline or slice-scoped)
- Forwards `mode` and `base_branch` for proper recovery refs
- Wraps in try/except so salvage failures never block respawn

## Test plan

- [ ] 5 new tests verify hook ordering, worktree scoping (pipeline + slice), parameter forwarding, and error handling
- [ ] Ran full spawner test suite (141 tests) — no regressions

Closes #2807