### PR TITLE
Fix #2817: skip OAuth on LiteLLM path via ANTHROPIC_AUTH_METHOD=api_key

### DIFF
--- a/orchestrator/agent_model_resolution.py
+++ b/orchestrator/agent_model_resolution.py
@@ -104,15 +104,20 @@ class AgentModelDecision:
         model exists (``ANTHROPIC_CUSTOM_MODEL_OPTION``) and what its
         wire-name should be (``…_OPTION_NAME``) — without these,
         compaction math falls back to the 200k Claude default and the
-        agent throws away >80% of a 1M-window upstream's capacity. The
-        Anthropic path returns an empty dict so default-Claude spawns
-        carry no extra env (the existing pre-#2832 wire shape).
+        agent throws away >80% of a 1M-window upstream's capacity. We
+        also set ``ANTHROPIC_AUTH_METHOD=api_key`` so the entrypoint
+        skips the OAuth token setup; LiteLLM-routed agents talk to
+        the gateway, not anthropic.com, and the gateway injects its
+        own credentials at proxy time. The Anthropic path returns an
+        empty dict so default-Claude spawns carry no extra env (the
+        existing pre-#2832 wire shape).
         """
         if self.upstream == UPSTREAM_ANTHROPIC or self.upstream_model is None:
             return {}
         return {
             "ANTHROPIC_CUSTOM_MODEL_OPTION": self.claude_code_alias,
             "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME": self.upstream_model,
+            "ANTHROPIC_AUTH_METHOD": "api_key",
         }
 
 

--- a/orchestrator/tests/test_agent_model_resolution.py
+++ b/orchestrator/tests/test_agent_model_resolution.py
@@ -376,7 +376,9 @@ class TestLiteLLMClassification:
     def test_litellm_env_vars_register_custom_model(self):
         """``AgentModelDecision.env_vars()`` returns the
         ``ANTHROPIC_CUSTOM_MODEL_OPTION`` pair that Claude Code reads at
-        startup to opt the custom model into 1M compaction math (#2832).
+        startup to opt the custom model into 1M compaction math (#2832),
+        plus ``ANTHROPIC_AUTH_METHOD=api_key`` so the entrypoint skips
+        OAuth on the LiteLLM path (#2817).
         """
         resolve_agent_model = _resolver()
         AgentRole = _agent_role()
@@ -388,6 +390,7 @@ class TestLiteLLMClassification:
         assert d.env_vars() == {
             "ANTHROPIC_CUSTOM_MODEL_OPTION": "qwen3-coder-30b[1m]",
             "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME": "qwen3-coder-30b",
+            "ANTHROPIC_AUTH_METHOD": "api_key",
         }
 
     def test_anthropic_env_vars_empty(self):


### PR DESCRIPTION
## Summary
- Add `ANTHROPIC_AUTH_METHOD=api_key` to env vars on the LiteLLM routing path so the entrypoint skips OAuth setup
- Fixes the "Not logged in · Please run /login" crash that prevented refiner and reviewer agents from starting when using qwen3.7-max via LiteLLM
- The gateway injects its own credentials at proxy time, so agents talking to LiteLLM don't need OAuth tokens

## Context
Issue #2817 is testing all-agent Qwen routing through LiteLLM. The orchestrator correctly sets `ANTHROPIC_CUSTOM_MODEL_OPTION=qwen3.7-max[1m]` and routes requests to the gateway, but the entrypoint's `setup_anthropic_api()` was still demanding OAuth tokens. This caused all three refine-phase agents (refiner, reviewer_agent_design, reviewer_refine) to crash immediately with exit code 1.

When an agent is on the LiteLLM path, it talks to `gateway.egg-system.svc.cluster.local` (via `ANTHROPIC_BASE_URL`), not `api.anthropic.com`. The gateway identifies the session from the request header and injects LiteLLM credentials — the agent itself needs no Anthropic auth. Setting `ANTHROPIC_AUTH_METHOD=api_key` tells the entrypoint to skip the OAuth flow and trust the gateway to handle auth.

## Test plan
- [ ] Cancel pipeline `issue-2817` and resubmit with `agent_models: { refiner: "qwen3.7-max", ... }`
- [ ] Verify refiner and reviewer agents start successfully and produce refine-phase output
- [ ] Confirm model routing works end-to-end: requests hit LiteLLM, gateway logs show `upstream=litellm upstream_model=qwen3.7-max`
- [ ] Ensure this doesn't break the default Anthropic path (agents without `agent_models` override should still use OAuth)