### PR TITLE
Fix #2817: inject session-token placeholder in k8s spawner (entrypoint is bypassed)

### DIFF
--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -45,7 +45,7 @@ COPY orchestrator/*.py ./
 COPY orchestrator/routes/ ./routes/
 COPY orchestrator/health_checks/ ./health_checks/
 
-# Copy shared modules (egg_logging, egg_config, egg_contracts, egg_restrictions, egg_container, egg_agent, egg_git, egg_anchor, egg_health)
+# Copy shared modules (egg_logging, egg_config, egg_contracts, egg_restrictions, egg_container, egg_agent, egg_git, egg_anchor, egg_health, egg_session_placeholder)
 COPY shared/egg_logging/ ./egg_logging/
 COPY shared/egg_config/ ./egg_config/
 COPY shared/egg_contracts/ ./egg_contracts/
@@ -56,6 +56,12 @@ COPY shared/egg_orchestrator/ ./egg_orchestrator/
 COPY shared/egg_git/ ./egg_git/
 COPY shared/egg_anchor/ ./egg_anchor/
 COPY shared/egg_health/ ./egg_health/
+# #2817: kubernetes_spawner injects the session-token placeholder
+# (to_placeholder) into the agent pod env, since the k8s container
+# command overrides the image ENTRYPOINT and setup_anthropic_api()
+# never runs. Without this COPY the lazy import in spawn_agent_job
+# raises ModuleNotFoundError and no agent ever starts.
+COPY shared/egg_session_placeholder/ ./egg_session_placeholder/
 
 # Copy config module (#2528: orchestrator reads per-repo role_patterns
 # from repositories.yaml so plan-time validation and the planner prompt

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -812,16 +812,48 @@ class KubernetesSpawner:
                 "NO_PROXY": "gateway.egg-system.svc.cluster.local,orchestrator.egg-system.svc.cluster.local",
                 "AGENT_ANCHOR_ID": agent_anchor_id,
                 # Route Anthropic API calls through the gateway for
-                # credential injection. The sandbox's setup_anthropic_api
-                # derives CLAUDE_CODE_OAUTH_TOKEN from EGG_SESSION_TOKEN at
-                # boot (issue #2829) — a placeholder envelope around the
-                # session token so the gateway's /v1/messages proxy can
-                # identify the session from the request header. Real
-                # credentials never enter the sandbox environment.
+                # credential injection. The session-token placeholder that
+                # lets the gateway's /v1/messages proxy identify the session
+                # from the request header (issue #2829) is set just below,
+                # alongside EGG_SESSION_TOKEN — under k8s the sandbox's
+                # setup_anthropic_api() never runs (the container command
+                # overrides the image ENTRYPOINT). Real credentials never
+                # enter the sandbox environment.
                 "ANTHROPIC_BASE_URL": GATEWAY_K8S_URL,
             }
             if session_token:
                 environment["EGG_SESSION_TOKEN"] = session_token
+
+                # Inject the session-token placeholder credential.
+                #
+                # In k8s the container ``command`` (the consensus wrapper /
+                # ``python3 -m egg_agent``) overrides the image ENTRYPOINT, so
+                # ``sandbox/entrypoint.py::setup_anthropic_api()`` — which
+                # normally derives this placeholder from EGG_SESSION_TOKEN at
+                # boot — never runs. Without a credential in its env, Claude
+                # Code aborts every turn with the synthetic "Not logged in ·
+                # Please run /login" before any request reaches the gateway,
+                # and the producer crash-loops to permanent death (#2817).
+                #
+                # This is NOT a real credential: it's the session-token
+                # envelope (``sk-ant-oat01-PROXY-INJECTED-egg-session-<token>``)
+                # whose payload is the same session token already present in
+                # EGG_SESSION_TOKEN above. The gateway strips it and injects
+                # the real upstream credential at proxy time — real secrets
+                # never enter the sandbox. On the LiteLLM path Claude Code
+                # sends api_key auth via x-api-key (ANTHROPIC_API_KEY); on the
+                # Anthropic path it sends OAuth via the Anthropic-Header
+                # (CLAUDE_CODE_OAUTH_TOKEN). Both reach the gateway's x-api-key
+                # extraction. Mirrors setup_anthropic_api (PR #2864) on the
+                # only code path that runs under k8s. See #2829.
+                from agent_model_resolution import UPSTREAM_LITELLM
+                from egg_session_placeholder import to_placeholder
+
+                placeholder = to_placeholder(session_token)
+                if upstream == UPSTREAM_LITELLM:
+                    environment["ANTHROPIC_API_KEY"] = placeholder
+                else:
+                    environment["CLAUDE_CODE_OAUTH_TOKEN"] = placeholder
             if pipeline_repo:
                 # owner/repo string used by the overseer auto-issue verb
                 # (issue #1962) and the gateway's overseer guardrails.

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -179,6 +179,16 @@ _PROTECTED_ENV_KEYS: frozenset[str] = frozenset(
         # default, leaving slice agents pushing to ``<pid>/work``
         # instead of ``<pid>/<slice>`` — every coder push was rejected.
         "EGG_BRANCH",
+        # Session-token placeholder credential (#2817). The spawner is the
+        # single source of truth: both keys are derived from the same
+        # ``session_token`` below (one is set per spawn, keyed on
+        # ``upstream``). Protecting them matches the ``EGG_SESSION_TOKEN``
+        # treatment — an ``extra_env`` override could otherwise desync the
+        # credential header from the session the gateway resolves, leaving
+        # the session unauthenticatable. No current caller passes either
+        # via ``extra_env``; this is defense in depth.
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
     }
 )
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -19055,6 +19055,15 @@ def _spawn_and_wait(
     if spawn_retry_initial_backoff_seconds is not None:
         retry_kwargs["spawn_retry_initial_backoff_seconds"] = spawn_retry_initial_backoff_seconds
 
+    # NOTE: this helper only supports the default Anthropic auth path. It
+    # does not forward ``upstream``/``upstream_model``, so ``spawn_agent_job``
+    # falls back to the Anthropic branch and injects the session-token
+    # placeholder into ``CLAUDE_CODE_OAUTH_TOKEN`` (#2817). It has no
+    # production callers today (only test references). If this path is ever
+    # revived for a LiteLLM agent, plumb ``upstream``/``upstream_model``
+    # through here — otherwise Claude Code would send ``x-api-key`` (api_key
+    # auth) while the placeholder lands in the OAuth header, leaving the
+    # credential header empty and the session unresolvable.
     spawned = spawner.spawn_agent_job(
         pipeline_id=pipeline_id,
         agent_role=agent_role,

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -367,6 +367,35 @@ class TestSpawnAgentJob:
         assert env["ANTHROPIC_API_KEY"] == expected
         assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
 
+    def test_extra_env_cannot_override_credential_placeholder(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """``extra_env`` cannot override the credential placeholder keys (#2817).
+
+        The spawner is the single source of truth: the placeholder is
+        derived from the session token and injected into
+        ``CLAUDE_CODE_OAUTH_TOKEN`` (or ``ANTHROPIC_API_KEY`` on the
+        LiteLLM path). A caller that tried to ship a different value via
+        ``extra_env`` would desync the credential header from the session
+        the gateway resolves; protecting both keys catches that.
+        """
+        from egg_session_placeholder import to_placeholder
+
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+            extra_env={
+                "CLAUDE_CODE_OAUTH_TOKEN": "attacker-supplied",
+                "ANTHROPIC_API_KEY": "attacker-supplied",
+            },
+        )
+        env = result.environment
+        expected = to_placeholder(env["EGG_SESSION_TOKEN"])
+        # Spawner's placeholder wins; the attacker value is dropped.
+        assert env["CLAUDE_CODE_OAUTH_TOKEN"] == expected
+        assert "ANTHROPIC_API_KEY" not in env
+
     def test_spawn_extra_env_overrides(self, spawner, mock_k8s_client):
         """extra_env overrides default environment."""
         result = spawner.spawn_agent_job(

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -317,6 +317,56 @@ class TestSpawnAgentJob:
         assert "GATEWAY_URL" in env
         assert "EGG_ORCHESTRATOR_URL" in env
 
+    def test_spawn_injects_oauth_placeholder_on_anthropic_path(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """Default (Anthropic) spawns carry the session-token placeholder in
+        CLAUDE_CODE_OAUTH_TOKEN.
+
+        The k8s container command overrides the image ENTRYPOINT, so
+        ``setup_anthropic_api()`` never runs to derive the placeholder; the
+        spawner must inject it or Claude Code aborts with "Not logged in"
+        (#2817). The payload is the session token already in
+        EGG_SESSION_TOKEN — no real credential enters the sandbox.
+        """
+        from egg_session_placeholder import to_placeholder
+
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-anthropic",
+            agent_role=AgentRole.TESTER,
+            repos=["owner/repo"],
+        )
+        env = result.environment
+        expected = to_placeholder(env["EGG_SESSION_TOKEN"])
+        assert env["CLAUDE_CODE_OAUTH_TOKEN"] == expected
+        assert env["CLAUDE_CODE_OAUTH_TOKEN"].startswith("sk-ant-oat01-")
+        assert "ANTHROPIC_API_KEY" not in env
+
+    def test_spawn_injects_api_key_placeholder_on_litellm_path(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """LiteLLM spawns carry the placeholder in ANTHROPIC_API_KEY.
+
+        On the LiteLLM path Claude Code uses api_key auth and sends the
+        credential via x-api-key, so the placeholder must land in
+        ANTHROPIC_API_KEY (not CLAUDE_CODE_OAUTH_TOKEN) for the session
+        token to reach the gateway. Mirrors setup_anthropic_api (#2864) at
+        the layer that actually runs under k8s.
+        """
+        from egg_session_placeholder import to_placeholder
+
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-litellm",
+            agent_role=AgentRole.TESTER,
+            repos=["owner/repo"],
+            upstream="litellm",
+            upstream_model="qwen3.7-max",
+        )
+        env = result.environment
+        expected = to_placeholder(env["EGG_SESSION_TOKEN"])
+        assert env["ANTHROPIC_API_KEY"] == expected
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+
     def test_spawn_extra_env_overrides(self, spawner, mock_k8s_client):
         """extra_env overrides default environment."""
         result = spawner.spawn_agent_job(


### PR DESCRIPTION
## Root cause

LiteLLM (and in fact **all**) sandbox agents in the k8s deployment crash-loop to permanent death with the synthetic assistant message:

```
Not logged in · Please run /login
```

(`model=<synthetic>`, `num_turns=1`, ~15ms, before any request leaves the pod).

The credential never reaches the agent. In the k8s agent path the pod's container `command` — `["bash", "-c", <consensus-wrapper>]` for producers, `["python3", "-m", "egg_agent", …]` for the overseer — **overrides the image ENTRYPOINT** (`python3 /usr/local/bin/entrypoint.py`). So `sandbox/entrypoint.py::setup_anthropic_api()`, the *only* code that derives the session-token placeholder from `EGG_SESSION_TOKEN` and sets `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`, **never runs**. Verified on a live pod: PID 1 is the wrapper bash (not `entrypoint.py`), and `/proc/1/environ` carries `ANTHROPIC_BASE_URL`, `EGG_SESSION_TOKEN`, `ANTHROPIC_AUTH_METHOD`, `ANTHROPIC_CUSTOM_MODEL_OPTION` — **but no credential of any kind**.

`#2864` (entrypoint) and `#2862` (model resolution) patched layers that are **dead code on the k8s path**, which is why the agents kept failing after those merges.

### Empirical proof (in the deployed `egg-sandbox:5f2b9b548` image)

Replaying the exact pod env against the SDK's bundled `claude`:

| env | result |
|-----|--------|
| pod env, **no credential** | `Not logged in · Please run /login` (exit 1) — reproduces |
| pod env **+ `ANTHROPIC_API_KEY=sk-ant-oat01-PROXY-INJECTED-egg-session-…`** | passes the auth gate, request attempted (exit 124 on a dead URL) — fixed |

## Fix

Inject the session-token placeholder in the **orchestrator spawner** (`kubernetes_spawner.spawn_agent_job`) — the layer that actually runs under k8s — right where `EGG_SESSION_TOKEN` is set. Choose the env var by upstream:

- **LiteLLM path** → `ANTHROPIC_API_KEY` (Claude Code uses api_key auth, sends via `x-api-key`)
- **Anthropic path** → `CLAUDE_CODE_OAUTH_TOKEN` (OAuth via the Anthropic-Header)

This is **not** a real credential: it's the same `sk-ant-oat01-PROXY-INJECTED-egg-session-<token>` envelope `setup_anthropic_api` produces, and its payload — the session token — is already present in `EGG_SESSION_TOKEN`. The gateway strips it (`from_placeholder`, `#2829`) and injects the real upstream credential at proxy time, so **no real secret enters the sandbox**.

`entrypoint.py::setup_anthropic_api` is left intact for the Docker Compose path, where the entrypoint *does* run.

## Tests

- `test_spawn_injects_oauth_placeholder_on_anthropic_path` — default spawn sets `CLAUDE_CODE_OAUTH_TOKEN` to the placeholder, no `ANTHROPIC_API_KEY`.
- `test_spawn_injects_api_key_placeholder_on_litellm_path` — `upstream="litellm"` sets `ANTHROPIC_API_KEY` to the placeholder, no `CLAUDE_CODE_OAUTH_TOKEN`.

All 13 env-related spawner unit tests pass; `ruff check` / `ruff format` clean.

## Not verified here

End-to-end against the live cluster — `rebuild_and_rollout` is a production deploy and wasn't authorized for this change. The fix is proven at the credential-gate level (table above) + unit tests; the gateway's placeholder→real-credential injection on the LiteLLM path already shipped in #2829/#2831.