### PR TITLE
Fix #2817: route LiteLLM subagent calls to the upstream model (CLAUDE_CODE_SUBAGENT_MODEL)

### DIFF
--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -134,7 +134,7 @@ command, the agent's env, and the gateway session-create call:
 
 | Spawn site | Threads `--model` + env to | Threads `upstream` / `upstream_model` to |
 |------------|----------------------------|-------------------------------------------|
-| Initial spawn in `orchestrator/concurrent_executor.py` (`_spawn_agent`) | `build_consensus_wrapped_command(model=decision.claude_code_alias, …)` plus `decision.env_vars()` merged into `extra_env` (sets `ANTHROPIC_CUSTOM_MODEL_OPTION` + `…_OPTION_NAME` + `ANTHROPIC_AUTH_METHOD` on the LiteLLM path) | `GatewayClient.register_session(upstream=…, upstream_model=…)` via the spawner |
+| Initial spawn in `orchestrator/concurrent_executor.py` (`_spawn_agent`) | `build_consensus_wrapped_command(model=decision.claude_code_alias, …)` plus `decision.env_vars()` merged into `extra_env` (sets `ANTHROPIC_CUSTOM_MODEL_OPTION` + `…_OPTION_NAME` + `ANTHROPIC_AUTH_METHOD` + `CLAUDE_CODE_SUBAGENT_MODEL` + `ANTHROPIC_DEFAULT_HAIKU_MODEL` / `ANTHROPIC_SMALL_FAST_MODEL` on the LiteLLM path) | `GatewayClient.register_session(upstream=…, upstream_model=…)` via the spawner |
 | Restart path in `orchestrator/routes/pipelines.py` (`restart_agent`) | Same `--model` resolution; `decision.env_vars()` merged into `extra_env` so the restarted Job re-registers the custom model and skips OAuth | `restart_agent_job` → `spawn_agent_job` → `register_session(upstream=…, upstream_model=…)` — a restart respawns the Job and registers a **new** gateway session carrying the resolved decision |
 
 When the resolved decision is the default Claude case
@@ -213,8 +213,26 @@ two env vars (plus one egg-side auth marker):
   the gateway injects its own credentials at proxy time, so the
   Anthropic OAuth flow is irrelevant
   ([#2832](https://github.com/jwbron/egg/issues/2832)).
+- `CLAUDE_CODE_SUBAGENT_MODEL=<upstream>[1m]` — the model Claude
+  Code uses for **all** Task-tool subagents and agent teams. It
+  overrides each subagent's `model` frontmatter, so the built-in
+  subagents whose frontmatter hardcodes a versioned `haiku` model
+  (e.g. `Explore`) route to the configured upstream instead of
+  emitting `claude-haiku-…` — a name absent from the proxy's
+  `model_list` that would otherwise 400 with
+  `ProxyModelNotFoundError`. Carries the `[1m]` suffix so subagents
+  share the main agent's 1M-context compaction profile.
+- `ANTHROPIC_DEFAULT_HAIKU_MODEL=<upstream>` (and its deprecated
+  alias `ANTHROPIC_SMALL_FAST_MODEL=<upstream>`, set for older
+  Claude Code builds) — the model the `haiku` alias and Claude
+  Code's background / "small-fast" helper calls resolve to. Same
+  `ProxyModelNotFoundError` motivation as the subagent var, but for
+  the helper-call path. Set to the **bare** upstream name (no
+  `[1m]`): these vars are documented to take a model name and the
+  `[1m]` suffix is read per-variable, and small/fast calls don't
+  need the 1M window.
 
-The resolver builds both values from the decided upstream string and
+The resolver builds these values from the decided upstream string and
 the spawn sites merge them into the agent's `extra_env`
 (see `AgentModelDecision.env_vars()`). The resolver also pins the
 agent's `--model` flag to `<upstream>[1m]` so the harness's
@@ -578,7 +596,7 @@ misconfiguration on one does not silently activate the LiteLLM path.
 | `PipelineConfig.agent_models: dict[str, str]` | `orchestrator/models.py:757` (alongside the existing `PipelineConfig` fields) | Per-pipeline, per-role model override; Pydantic validator rejects keys outside the phase producer / reviewer set (`agent_roles.MODEL_OVERRIDE_ROLES`) |
 | `default_agent_model: str \| None` | `config/repositories.yaml.example` (documented schema) | Repository-level default applied when `agent_models` does not pin the role |
 | `get_default_agent_model(repo)` | `config/repo_config.py` (mirrors `get_repo_setting` at `config/repo_config.py:248`) | Reader for the repo-level default; returns `None` when absent |
-| `resolve_agent_model(role, pipeline_config, repo)` + `AgentModelDecision` | `orchestrator/agent_model_resolution.py` | Walks precedence + classifies into `(claude_code_alias, upstream, upstream_model)`; `AgentModelDecision.env_vars()` returns the `ANTHROPIC_CUSTOM_MODEL_OPTION` pair plus `ANTHROPIC_AUTH_METHOD=api_key` on the LiteLLM path |
+| `resolve_agent_model(role, pipeline_config, repo)` + `AgentModelDecision` | `orchestrator/agent_model_resolution.py` | Walks precedence + classifies into `(claude_code_alias, upstream, upstream_model)`; `AgentModelDecision.env_vars()` returns the `ANTHROPIC_CUSTOM_MODEL_OPTION` pair plus `ANTHROPIC_AUTH_METHOD=api_key`, `CLAUDE_CODE_SUBAGENT_MODEL`, and `ANTHROPIC_DEFAULT_HAIKU_MODEL` / `ANTHROPIC_SMALL_FAST_MODEL` on the LiteLLM path |
 | Spawn-side plumbing | `orchestrator/concurrent_executor.py` (`_spawn_agent`), `orchestrator/routes/pipelines.py` (`restart_agent`), `orchestrator/kubernetes_spawner.py` (`spawn_agent_job`) | Threads `--model` to the consensus wrapper, merges `decision.env_vars()` into `extra_env`, and forwards `upstream` / `upstream_model` to `GatewayClient.register_session` |
 
 The slice-1 primitives this guide builds on (`UpstreamRegistry`,

--- a/orchestrator/agent_model_resolution.py
+++ b/orchestrator/agent_model_resolution.py
@@ -114,6 +114,15 @@ class AgentModelDecision:
         injects its own credentials at proxy time. The Anthropic path
         returns an empty dict so default-Claude spawns carry no extra
         env (the existing pre-#2832 wire shape).
+
+        We also pin ``CLAUDE_CODE_SUBAGENT_MODEL`` to the same custom
+        alias. Claude Code's Task-tool subagents (and other small/fast
+        helper calls) otherwise default to a Claude family model
+        (``claude-haiku-4-5-…``); on the LiteLLM path that name isn't in
+        the proxy's ``model_list`` and the request fails with
+        ``ProxyModelNotFoundError`` (400). Routing subagents to the same
+        upstream the main agent uses keeps every call resolvable. Mirrors
+        the host ``cllm`` wrapper's ``CLAUDE_CODE_SUBAGENT_MODEL`` export.
         """
         if self.upstream == UPSTREAM_ANTHROPIC or self.upstream_model is None:
             return {}
@@ -121,6 +130,7 @@ class AgentModelDecision:
             "ANTHROPIC_CUSTOM_MODEL_OPTION": self.claude_code_alias,
             "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME": self.upstream_model,
             "ANTHROPIC_AUTH_METHOD": "api_key",
+            "CLAUDE_CODE_SUBAGENT_MODEL": self.claude_code_alias,
         }
 
 

--- a/orchestrator/agent_model_resolution.py
+++ b/orchestrator/agent_model_resolution.py
@@ -118,7 +118,7 @@ class AgentModelDecision:
         We also pin ``CLAUDE_CODE_SUBAGENT_MODEL`` to the same custom
         alias. Claude Code's Task-tool subagents (and other small/fast
         helper calls) otherwise default to a Claude family model
-        (``claude-haiku-4-5-…``); on the LiteLLM path that name isn't in
+        (a versioned ``haiku`` model name); on the LiteLLM path that name isn't in
         the proxy's ``model_list`` and the request fails with
         ``ProxyModelNotFoundError`` (400). Routing subagents to the same
         upstream the main agent uses keeps every call resolvable. Mirrors

--- a/orchestrator/agent_model_resolution.py
+++ b/orchestrator/agent_model_resolution.py
@@ -115,14 +115,28 @@ class AgentModelDecision:
         returns an empty dict so default-Claude spawns carry no extra
         env (the existing pre-#2832 wire shape).
 
-        We also pin ``CLAUDE_CODE_SUBAGENT_MODEL`` to the same custom
-        alias. Claude Code's Task-tool subagents (and other small/fast
-        helper calls) otherwise default to a Claude family model
-        (a versioned ``haiku`` model name); on the LiteLLM path that name isn't in
-        the proxy's ``model_list`` and the request fails with
-        ``ProxyModelNotFoundError`` (400). Routing subagents to the same
-        upstream the main agent uses keeps every call resolvable. Mirrors
-        the host ``cllm`` wrapper's ``CLAUDE_CODE_SUBAGENT_MODEL`` export.
+        We also redirect the other two resolution paths that would
+        otherwise emit a Claude model name the LiteLLM proxy can't
+        resolve — each 400s with ``ProxyModelNotFoundError`` on the
+        LiteLLM path, the exact symptom this covers:
+
+        - ``CLAUDE_CODE_SUBAGENT_MODEL`` — the model Claude Code uses
+          for all Task-tool subagents and agent teams. Generic Task
+          subagents inherit the main agent's model, but the **built-in**
+          subagents (``Explore`` etc.) hardcode a versioned ``haiku``
+          model in their ``model`` frontmatter; this var overrides that
+          frontmatter so they route to the configured upstream instead.
+          Pinned to the suffixed alias so subagents share the main
+          agent's 1M-context compaction profile. Mirrors the host
+          ``cllm`` wrapper's ``CLAUDE_CODE_SUBAGENT_MODEL`` export.
+        - ``ANTHROPIC_DEFAULT_HAIKU_MODEL`` (and its deprecated alias
+          ``ANTHROPIC_SMALL_FAST_MODEL``, set for older Claude Code
+          builds where the rename hasn't landed) — the model the
+          ``haiku`` alias and Claude Code's background / "small-fast"
+          helper calls resolve to. Pinned to the **bare** upstream name
+          rather than the ``[1m]`` alias: these vars are documented to
+          take a model name and the ``[1m]`` suffix is read per-variable,
+          and small/fast helper calls don't need the 1M window.
         """
         if self.upstream == UPSTREAM_ANTHROPIC or self.upstream_model is None:
             return {}
@@ -131,6 +145,8 @@ class AgentModelDecision:
             "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME": self.upstream_model,
             "ANTHROPIC_AUTH_METHOD": "api_key",
             "CLAUDE_CODE_SUBAGENT_MODEL": self.claude_code_alias,
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": self.upstream_model,
+            "ANTHROPIC_SMALL_FAST_MODEL": self.upstream_model,
         }
 
 

--- a/orchestrator/tests/test_agent_model_resolution.py
+++ b/orchestrator/tests/test_agent_model_resolution.py
@@ -378,7 +378,10 @@ class TestLiteLLMClassification:
         ``ANTHROPIC_CUSTOM_MODEL_OPTION`` pair that Claude Code reads at
         startup to opt the custom model into 1M compaction math (#2832),
         plus ``ANTHROPIC_AUTH_METHOD=api_key`` to mark the LiteLLM path
-        as api-key auth for config validation / startup logging (#2832).
+        as api-key auth for config validation / startup logging (#2832),
+        plus ``CLAUDE_CODE_SUBAGENT_MODEL`` so Task-tool subagents route
+        to the same upstream instead of defaulting to a Claude model the
+        LiteLLM proxy can't resolve (ProxyModelNotFoundError 400).
         """
         resolve_agent_model = _resolver()
         AgentRole = _agent_role()
@@ -391,6 +394,7 @@ class TestLiteLLMClassification:
             "ANTHROPIC_CUSTOM_MODEL_OPTION": "qwen3-coder-30b[1m]",
             "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME": "qwen3-coder-30b",
             "ANTHROPIC_AUTH_METHOD": "api_key",
+            "CLAUDE_CODE_SUBAGENT_MODEL": "qwen3-coder-30b[1m]",
         }
 
     def test_anthropic_env_vars_empty(self):

--- a/orchestrator/tests/test_agent_model_resolution.py
+++ b/orchestrator/tests/test_agent_model_resolution.py
@@ -380,8 +380,14 @@ class TestLiteLLMClassification:
         plus ``ANTHROPIC_AUTH_METHOD=api_key`` to mark the LiteLLM path
         as api-key auth for config validation / startup logging (#2832),
         plus ``CLAUDE_CODE_SUBAGENT_MODEL`` so Task-tool subagents route
-        to the same upstream instead of defaulting to a Claude model the
-        LiteLLM proxy can't resolve (ProxyModelNotFoundError 400).
+        to the same upstream, plus ``ANTHROPIC_DEFAULT_HAIKU_MODEL`` /
+        ``ANTHROPIC_SMALL_FAST_MODEL`` so the haiku alias and background
+        helper calls route there too — all to avoid defaulting to a
+        Claude model the LiteLLM proxy can't resolve
+        (ProxyModelNotFoundError 400). The subagent var carries the
+        ``[1m]`` alias; the haiku vars carry the bare upstream name
+        (the suffix is read per-variable and small/fast calls don't
+        need the 1M window).
         """
         resolve_agent_model = _resolver()
         AgentRole = _agent_role()
@@ -395,6 +401,8 @@ class TestLiteLLMClassification:
             "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME": "qwen3-coder-30b",
             "ANTHROPIC_AUTH_METHOD": "api_key",
             "CLAUDE_CODE_SUBAGENT_MODEL": "qwen3-coder-30b[1m]",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3-coder-30b",
+            "ANTHROPIC_SMALL_FAST_MODEL": "qwen3-coder-30b",
         }
 
     def test_anthropic_env_vars_empty(self):


### PR DESCRIPTION
## Problem

While verifying the auth fix (#2867) with a live LiteLLM (Qwen) pipeline, the agents authenticated and did real multi-turn work — but the egg-litellm proxy logged repeated:

```
litellm.proxy.route_llm_request.ProxyModelNotFoundError: 400:
{'error': 'anthropic_messages: Invalid model name passed in model=claude-haiku-4-5-20251001. ...'}
```

Claude Code's Task-tool subagents (and small/fast helper calls) default to a Claude family model (`claude-haiku-4-5-…`). On the LiteLLM path that name isn't in the proxy's `model_list`, so those calls 400. The main agent's `qwen3.7-max` turns work; only the subagent/background calls fail.

## Fix

`AgentModelDecision.env_vars()` now also sets `CLAUDE_CODE_SUBAGENT_MODEL` to the same custom alias the main agent uses (e.g. `qwen3.7-max[1m]`) on the LiteLLM path, so subagent calls resolve on the configured upstream instead of a Claude model the proxy doesn't have.

This mirrors the host `cllm` wrapper, which sets `CLAUDE_CODE_SUBAGENT_MODEL="$full"` for exactly this reason ("their haiku/sonnet/opus frontmatter isn't in the model_list and would 400"). The Anthropic path is unchanged — it still returns an empty env dict.

## Tests

`test_litellm_env_vars_register_custom_model` updated to assert `CLAUDE_CODE_SUBAGENT_MODEL` is present and equals the custom alias; `test_anthropic_env_vars_empty` still pins the empty-dict Anthropic shape. All 36 tests in the module pass; ruff clean.

## Relationship to #2867

Independent follow-up. #2867 fixed *authentication* (no credential reached the agent → "Not logged in"). This fixes the *subagent model routing* surfaced once auth worked. Stacks cleanly on merged main.