### PR TITLE
Fix #2869: retry transient gateway connection failures during slice spawn

### DIFF
--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -19,6 +19,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from http.client import HTTPException
 from pathlib import Path
 from typing import Any, Literal, TypeVar
 from urllib.error import HTTPError, URLError
@@ -580,9 +581,24 @@ class GatewayClient:
             # deliberately NOT a GatewayConnectionError, since a
             # response-phase disconnect may mean the gateway already
             # processed the request and so must not be blindly retried.
-            # Must stay LAST: URLError and TimeoutError both subclass
-            # OSError and are handled by their dedicated branches above.
+            # Must stay LAST among the OSError-derived branches: URLError
+            # and TimeoutError both subclass OSError and are handled by
+            # their dedicated branches above.
             raise GatewayError(f"Gateway connection error: {e}") from e
+        except HTTPException as e:
+            # Defense-in-depth for response-phase protocol errors that are
+            # NOT an OSError — most notably http.client.IncompleteRead, when
+            # the connection drops mid-``response.read()`` (line above).
+            # ``IncompleteRead``/``BadStatusLine`` subclass HTTPException,
+            # not OSError, so without this branch they would propagate raw
+            # and slip past callers' ``except GatewayError`` handlers (e.g.
+            # the spawner's KubernetesSpawnError wrap).  Wrap as a plain
+            # GatewayError — deliberately NOT a GatewayConnectionError, since
+            # a partial response means the gateway already received and may
+            # have processed the request, so it must not be blindly retried.
+            # (http.client.RemoteDisconnected is also an OSError and so is
+            # caught by the branch above before reaching here.)
+            raise GatewayError(f"Gateway response error: {e}") from e
 
     def _retry_transient(
         self,
@@ -3599,12 +3615,14 @@ class GatewayConnectionError(GatewayError):
     connection refused, DNS resolution failure ([Errno -3]), host
     unreachable — i.e. cases where the request was not delivered/processed
     and is therefore safe to retry regardless of HTTP-method idempotency.
-    A response-phase disconnect (http.client.RemoteDisconnected, a
-    ``ConnectionResetError`` — NOT a ``URLError``) deliberately does *not*
-    map to this subclass: it falls through to ``_make_request``'s trailing
-    ``except OSError`` branch as a plain :class:`GatewayError`, because such
-    a disconnect may mean the gateway already processed the request and so
-    must not be blindly retried.
+    A response-phase failure deliberately does *not* map to this subclass:
+    a disconnect (http.client.RemoteDisconnected, a ``ConnectionResetError``
+    — NOT a ``URLError``) falls through to ``_make_request``'s ``except
+    OSError`` branch, and a partial read (http.client.IncompleteRead, an
+    ``HTTPException``) falls through to the trailing ``except HTTPException``
+    branch — both as a plain :class:`GatewayError`, because such a failure
+    may mean the gateway already processed the request and so must not be
+    blindly retried.
 
     Subclasses :class:`GatewayError` so callers that broadly catch
     ``GatewayError`` (e.g. the spawner's session-registration handler)

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -549,9 +549,15 @@ class GatewayClient:
                 raise GatewayError(str(e), status_code=e.code) from e
         except URLError as e:
             # Connection-level failure: DNS resolution failure
-            # ([Errno -3]), connection refused, host unreachable, etc.
-            # The request never reached the gateway, so it is always safe
-            # to retry regardless of HTTP-method idempotency.  Raise the
+            # ([Errno -3]), connection refused, host unreachable, send-phase
+            # OSError, etc.  These correspond to the request not being
+            # delivered/processed, so it is safe to retry regardless of
+            # HTTP-method idempotency.  Note this is specifically the
+            # ``URLError`` family — a response-phase disconnect surfaces as
+            # http.client.RemoteDisconnected (a ConnectionResetError, NOT a
+            # URLError) and deliberately does NOT land here (see the trailing
+            # ``except OSError`` below), because such a disconnect may mean
+            # the gateway already processed the request.  Raise the
             # GatewayConnectionError subclass so callers that opt into
             # transient retry (spawn-time session registration,
             # integration-branch creation — #2869) can distinguish these
@@ -564,6 +570,19 @@ class GatewayClient:
             # gateway and been processed, so a blind retry could duplicate
             # a non-idempotent operation (e.g. a second session).
             raise GatewayError("Gateway request timed out") from e
+        except OSError as e:
+            # Defense-in-depth for connection-level OSErrors that are NOT a
+            # URLError — most notably http.client.RemoteDisconnected
+            # (ConnectionResetError) from a response-phase disconnect.
+            # Without this, such an error would propagate raw and slip past
+            # callers' ``except GatewayError`` handlers (e.g. the spawner's
+            # KubernetesSpawnError wrap).  Wrap it as a plain GatewayError —
+            # deliberately NOT a GatewayConnectionError, since a
+            # response-phase disconnect may mean the gateway already
+            # processed the request and so must not be blindly retried.
+            # Must stay LAST: URLError and TimeoutError both subclass
+            # OSError and are handled by their dedicated branches above.
+            raise GatewayError(f"Gateway connection error: {e}") from e
 
     def _retry_transient(
         self,
@@ -3578,9 +3597,14 @@ class GatewayConnectionError(GatewayError):
 
     Raised by :meth:`GatewayClient._make_request` for ``URLError`` —
     connection refused, DNS resolution failure ([Errno -3]), host
-    unreachable — i.e. cases where the request never reached the gateway
-    and is therefore always safe to retry regardless of HTTP-method
-    idempotency.
+    unreachable — i.e. cases where the request was not delivered/processed
+    and is therefore safe to retry regardless of HTTP-method idempotency.
+    A response-phase disconnect (http.client.RemoteDisconnected, a
+    ``ConnectionResetError`` — NOT a ``URLError``) deliberately does *not*
+    map to this subclass: it falls through to ``_make_request``'s trailing
+    ``except OSError`` branch as a plain :class:`GatewayError`, because such
+    a disconnect may mean the gateway already processed the request and so
+    must not be blindly retried.
 
     Subclasses :class:`GatewayError` so callers that broadly catch
     ``GatewayError`` (e.g. the spawner's session-registration handler)

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -10,14 +10,17 @@ Provides coordination between the orchestrator and gateway sidecar for:
 
 import json
 import os
+import random
 import re
 import socket
 import subprocess
 import sys
+import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypeVar
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
@@ -47,6 +50,18 @@ except ImportError:
     GATEWAY_PORT = 9848  # noqa: EGG002
 
 logger = get_logger("orchestrator.gateway_client")
+
+T = TypeVar("T")
+
+# Bounded retry budget for transient gateway connection failures (#2869).
+# Worst case ≈ 1 + 2 + 4 = 7s of backoff across 3 retries (plus jitter)
+# before giving up — enough to ride out a brief DNS/connection blip
+# without papering over a sustained gateway outage (the #2806 auto-fail
+# safety net still owns that case).
+_TRANSIENT_MAX_ATTEMPTS = 4
+_TRANSIENT_BASE_DELAY = 1.0
+_TRANSIENT_MAX_DELAY = 8.0
+_TRANSIENT_JITTER = 0.2
 
 
 _REBASE_REF_RE = re.compile(r"^[A-Za-z0-9._/+-][A-Za-z0-9._/+-]*$")
@@ -533,9 +548,78 @@ class GatewayClient:
             except json.JSONDecodeError:
                 raise GatewayError(str(e), status_code=e.code) from e
         except URLError as e:
-            raise GatewayError(f"Failed to connect to gateway: {e.reason}") from e
+            # Connection-level failure: DNS resolution failure
+            # ([Errno -3]), connection refused, host unreachable, etc.
+            # The request never reached the gateway, so it is always safe
+            # to retry regardless of HTTP-method idempotency.  Raise the
+            # GatewayConnectionError subclass so callers that opt into
+            # transient retry (spawn-time session registration,
+            # integration-branch creation — #2869) can distinguish these
+            # from permanent failures; ``except GatewayError`` handlers
+            # still catch it unchanged.
+            raise GatewayConnectionError(f"Failed to connect to gateway: {e.reason}") from e
         except TimeoutError as e:
+            # A timeout is NOT classified as transient-retryable: unlike a
+            # connection-level failure, the request may have reached the
+            # gateway and been processed, so a blind retry could duplicate
+            # a non-idempotent operation (e.g. a second session).
             raise GatewayError("Gateway request timed out") from e
+
+    def _retry_transient(
+        self,
+        fn: Callable[[], T],
+        *,
+        operation: str,
+    ) -> T:
+        """Run ``fn`` with bounded retry-with-backoff on transient gateway
+        connection failures (#2869).
+
+        Only :class:`GatewayConnectionError` (connection refused, DNS
+        resolution failure, host unreachable — the request never landed)
+        is retried; permanent failures (4xx/5xx :class:`GatewayError`,
+        auth, timeouts) propagate on the first attempt.  After the retry
+        budget is exhausted the original ``GatewayConnectionError`` is
+        re-raised so existing ``except GatewayError`` handlers keep
+        working.
+
+        Args:
+            fn: Zero-argument callable performing the gateway request.
+            operation: Short label for logging (e.g. ``"register session"``).
+        """
+        last_err: GatewayConnectionError | None = None
+        for attempt in range(_TRANSIENT_MAX_ATTEMPTS):
+            try:
+                return fn()
+            except GatewayConnectionError as e:
+                last_err = e
+                if attempt + 1 < _TRANSIENT_MAX_ATTEMPTS:
+                    delay = min(
+                        _TRANSIENT_BASE_DELAY * (2**attempt),
+                        _TRANSIENT_MAX_DELAY,
+                    )
+                    # Symmetric jitter to avoid synchronized retries when
+                    # several concurrent spawns hit the same blip.
+                    delay += delay * _TRANSIENT_JITTER * random.uniform(-1, 1)
+                    delay = max(0.0, delay)
+                    logger.warning(
+                        "Transient gateway connection failure; retrying",
+                        operation=operation,
+                        attempt=attempt + 1,
+                        max_attempts=_TRANSIENT_MAX_ATTEMPTS,
+                        delay_seconds=round(delay, 2),
+                        error=str(e),
+                    )
+                    time.sleep(delay)
+                else:
+                    logger.error(
+                        "Transient gateway connection failure; retries exhausted",
+                        operation=operation,
+                        attempts=attempt + 1,
+                        error=str(e),
+                    )
+        # Loop only exits without returning when every attempt raised.
+        assert last_err is not None  # narrows the type for the re-raise
+        raise last_err
 
     def check_health(self) -> GatewayHealth:
         """Check gateway health status.
@@ -620,6 +704,7 @@ class GatewayClient:
         synthetic: bool = False,
         upstream: str | None = None,
         upstream_model: str | None = None,
+        retry_transient: bool = False,
     ) -> SessionInfo:
         """Register a session for a container.
 
@@ -710,12 +795,23 @@ class GatewayClient:
             request_data["upstream"] = upstream
         if upstream_model is not None:
             request_data["upstream_model"] = upstream_model
-        result = self._make_request(
-            "/api/v1/sessions/create",
-            method="POST",
-            data=request_data,
-            use_launcher_auth=True,
-        )
+
+        def _do_request() -> dict[str, Any]:
+            return self._make_request(
+                "/api/v1/sessions/create",
+                method="POST",
+                data=request_data,
+                use_launcher_auth=True,
+            )
+
+        # #2869 — spawn-time session registration tolerates a brief
+        # DNS/connection blip when the caller opts in (the spawner and
+        # slice integration-branch creation), instead of hard-failing the
+        # whole pipeline on the first transient error.
+        if retry_transient:
+            result = self._retry_transient(_do_request, operation="register gateway session")
+        else:
+            result = _do_request()
 
         if not result.get("success"):
             raise GatewayError(result.get("message", "Session registration failed"))
@@ -2163,6 +2259,10 @@ class GatewayClient:
                 agent_role=agent_role,
                 branch=integration_branch,
                 synthetic=True,
+                # #2869 — ride out a transient DNS/connection blip rather
+                # than hard-failing the slice (and cascading to the whole
+                # phase) before any agent is spawned.
+                retry_transient=True,
             )
             session_token = session.session_token
 
@@ -2180,6 +2280,7 @@ class GatewayClient:
                 args=[f"+refs/heads/{parent_branch}:refs/remotes/origin/{parent_branch}"],
                 mode=mode,
                 bearer_token=session_token,
+                retry_transient=True,
             )
 
             # Resolve the parent to a SHA on origin.  Failing fast
@@ -2191,6 +2292,7 @@ class GatewayClient:
                 f"refs/heads/{parent_branch}",
                 mode=mode,
                 bearer_token=session_token,
+                retry_transient=True,
             )
             if not parent_sha:
                 logger.warning(
@@ -2221,6 +2323,7 @@ class GatewayClient:
                 f"refs/heads/{integration_branch}",
                 mode=mode,
                 bearer_token=session_token,
+                retry_transient=True,
             )
             if existing_sha and existing_sha != parent_sha:
                 # Fetch the integration branch so its tip object is
@@ -2242,6 +2345,7 @@ class GatewayClient:
                     ],
                     mode=mode,
                     bearer_token=session_token,
+                    retry_transient=True,
                 )
                 if self._sha_is_ancestor(
                     pipeline_id,
@@ -2285,15 +2389,18 @@ class GatewayClient:
                 )
 
             refspec = f"{parent_sha}:refs/heads/{integration_branch}"
-            self._make_request(
-                "/api/v1/git/push",
-                method="POST",
-                data={
-                    "repo_path": repo_path,
-                    "remote": "origin",
-                    "refspec": refspec,
-                },
-                bearer_token=session_token,
+            self._retry_transient(
+                lambda: self._make_request(
+                    "/api/v1/git/push",
+                    method="POST",
+                    data={
+                        "repo_path": repo_path,
+                        "remote": "origin",
+                        "refspec": refspec,
+                    },
+                    bearer_token=session_token,
+                ),
+                operation="push integration branch",
             )
             logger.info(
                 "Created slice integration branch",
@@ -2824,6 +2931,7 @@ class GatewayClient:
         mode: Literal["public", "private"] = "public",
         *,
         bearer_token: str | None = None,
+        retry_transient: bool = False,
     ) -> bool:
         """Fetch with custom args using a temporary session.
 
@@ -2859,22 +2967,29 @@ class GatewayClient:
                     mode=mode,
                     pipeline_id=pipeline_id,
                     synthetic=True,
+                    retry_transient=retry_transient,
                 )
                 session_token = session.session_token
 
             # Do NOT include container_id — repo_path is already the
             # resolved path; the synthetic container_id has no real
             # worktree and would trigger a "worktree not found" error.
-            self._make_request(
-                "/api/v1/git/fetch",
-                method="POST",
-                data={
-                    "repo_path": repo_path,
-                    "remote": "origin",
-                    "args": args or [],
-                },
-                bearer_token=session_token,
-            )
+            def _do_fetch() -> dict[str, Any]:
+                return self._make_request(
+                    "/api/v1/git/fetch",
+                    method="POST",
+                    data={
+                        "repo_path": repo_path,
+                        "remote": "origin",
+                        "args": args or [],
+                    },
+                    bearer_token=session_token,
+                )
+
+            if retry_transient:
+                self._retry_transient(_do_fetch, operation="fetch branch")
+            else:
+                _do_fetch()
 
             logger.info(
                 "Fetched branch from remote",
@@ -2967,6 +3082,7 @@ class GatewayClient:
         mode: Literal["public", "private"] = "public",
         *,
         bearer_token: str | None = None,
+        retry_transient: bool = False,
     ) -> str | None:
         """Resolve a remote ref to its commit SHA via ``git ls-remote``.
 
@@ -2995,20 +3111,27 @@ class GatewayClient:
                     mode=mode,
                     pipeline_id=pipeline_id,
                     synthetic=True,
+                    retry_transient=retry_transient,
                 )
                 session_token = session.session_token
 
-            result = self._make_request(
-                "/api/v1/git/fetch",
-                method="POST",
-                data={
-                    "repo_path": repo_path,
-                    "remote": "origin",
-                    "operation": "ls-remote",
-                    "args": ["--heads", ref],
-                },
-                bearer_token=session_token,
-            )
+            def _do_ls_remote() -> dict[str, Any]:
+                return self._make_request(
+                    "/api/v1/git/fetch",
+                    method="POST",
+                    data={
+                        "repo_path": repo_path,
+                        "remote": "origin",
+                        "operation": "ls-remote",
+                        "args": ["--heads", ref],
+                    },
+                    bearer_token=session_token,
+                )
+
+            if retry_transient:
+                result = self._retry_transient(_do_ls_remote, operation="resolve remote SHA")
+            else:
+                result = _do_ls_remote()
 
             stdout = result.get("data", {}).get("stdout", "")
             if not stdout.strip():
@@ -3448,6 +3571,24 @@ class GatewayError(Exception):
         self.message = message
         self.status_code = status_code
         self.details = details
+
+
+class GatewayConnectionError(GatewayError):
+    """Transient connection-level failure talking to the gateway.
+
+    Raised by :meth:`GatewayClient._make_request` for ``URLError`` —
+    connection refused, DNS resolution failure ([Errno -3]), host
+    unreachable — i.e. cases where the request never reached the gateway
+    and is therefore always safe to retry regardless of HTTP-method
+    idempotency.
+
+    Subclasses :class:`GatewayError` so callers that broadly catch
+    ``GatewayError`` (e.g. the spawner's session-registration handler)
+    keep working unchanged; callers that want bounded retry-with-backoff
+    on a brief networking blip before hard-failing (#2869) route the call
+    through :meth:`GatewayClient._retry_transient`, which retries only on
+    this subclass.
+    """
 
 
 class ContextBranchDiverged(GatewayError):

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -778,6 +778,11 @@ class KubernetesSpawner:
                     # identical to the pre-#2769 wire shape.
                     upstream=upstream,
                     upstream_model=upstream_model,
+                    # #2869 — a transient DNS/connection blip to the gateway
+                    # during spawn-time session registration must not hard-
+                    # fail the whole pipeline; retry with bounded backoff
+                    # before raising SpawnFailureError.
+                    retry_transient=True,
                 )
                 session_token = session_info.session_token
 

--- a/orchestrator/tests/test_gateway_transient_retry.py
+++ b/orchestrator/tests/test_gateway_transient_retry.py
@@ -102,6 +102,22 @@ class TestMakeRequestClassification:
         assert not isinstance(exc_info.value, GatewayConnectionError)
         assert "Gateway connection error" in str(exc_info.value)
 
+    def test_incomplete_read_wrapped_but_not_transient(self, gateway_client):
+        """A connection drop *during* ``response.read()`` surfaces as
+        http.client.IncompleteRead — an ``HTTPException``, NOT an
+        ``OSError`` — so it must be wrapped as a plain ``GatewayError``
+        (caught by callers' ``except GatewayError`` handlers) rather than
+        propagating raw.  It is NOT classified transient: a partial read
+        means the gateway already received the request, so it must not be
+        blindly retried."""
+        from http.client import IncompleteRead
+
+        with patch.object(gc, "urlopen", side_effect=IncompleteRead(b"partial")):
+            with pytest.raises(GatewayError) as exc_info:
+                gateway_client._make_request("/api/v1/health")
+        assert not isinstance(exc_info.value, GatewayConnectionError)
+        assert "Gateway response error" in str(exc_info.value)
+
 
 class TestRetryTransientHelper:
     def test_retries_then_succeeds(self, gateway_client):

--- a/orchestrator/tests/test_gateway_transient_retry.py
+++ b/orchestrator/tests/test_gateway_transient_retry.py
@@ -85,6 +85,23 @@ class TestMakeRequestClassification:
                 gateway_client._make_request("/api/v1/health")
         assert not isinstance(exc_info.value, GatewayConnectionError)
 
+    def test_response_phase_disconnect_wrapped_but_not_transient(self, gateway_client):
+        """A response-phase disconnect (http.client.RemoteDisconnected, a
+        ``ConnectionResetError`` — an ``OSError`` but NOT a ``URLError``)
+        is wrapped as a plain ``GatewayError`` so callers' ``except
+        GatewayError`` handlers catch it, but is NOT classified transient:
+        the gateway may have already processed the request, so it must not
+        be blindly retried."""
+        from http.client import RemoteDisconnected
+
+        with patch.object(
+            gc, "urlopen", side_effect=RemoteDisconnected("Remote end closed connection")
+        ):
+            with pytest.raises(GatewayError) as exc_info:
+                gateway_client._make_request("/api/v1/health")
+        assert not isinstance(exc_info.value, GatewayConnectionError)
+        assert "Gateway connection error" in str(exc_info.value)
+
 
 class TestRetryTransientHelper:
     def test_retries_then_succeeds(self, gateway_client):

--- a/orchestrator/tests/test_gateway_transient_retry.py
+++ b/orchestrator/tests/test_gateway_transient_retry.py
@@ -1,0 +1,236 @@
+"""Tests for bounded transient-connection retry on gateway calls (#2869).
+
+A brief DNS/connection blip during spawn-time session registration (and
+slice integration-branch creation) used to hard-fail the whole pipeline
+with no retry.  ``_make_request`` now classifies connection-level
+failures as :class:`GatewayConnectionError` (a :class:`GatewayError`
+subclass), and the spawn-critical call sites opt into
+``_retry_transient`` — bounded retry-with-backoff that retries *only*
+that subclass, leaving permanent failures (4xx/5xx, auth, timeouts) to
+propagate on the first attempt.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+from urllib.error import HTTPError, URLError
+
+import gateway_client as gc
+import pytest
+from gateway_client import (
+    GatewayClient,
+    GatewayConnectionError,
+    GatewayError,
+    SessionInfo,
+)
+
+
+@pytest.fixture
+def gateway_client():
+    return GatewayClient(
+        gateway_host="localhost",
+        gateway_port=19848,
+        launcher_secret="test-secret",
+        timeout=5,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    """Make backoff instantaneous so the retry tests stay fast."""
+    with patch.object(gc.time, "sleep", return_value=None):
+        yield
+
+
+def _session_payload() -> dict:
+    now = datetime.now()
+    return {
+        "success": True,
+        "data": {
+            "session_token": "tok-1",
+            "created_at": now.isoformat(),
+            "expires_at": (now + timedelta(hours=1)).isoformat(),
+        },
+    }
+
+
+class TestMakeRequestClassification:
+    def test_url_error_raises_connection_error(self, gateway_client):
+        """A connection-level failure (DNS/refused/unreachable) surfaces
+        as the transient ``GatewayConnectionError`` subclass."""
+        with patch.object(
+            gc, "urlopen", side_effect=URLError("[Errno -3] Temporary failure in name resolution")
+        ):
+            with pytest.raises(GatewayConnectionError) as exc_info:
+                gateway_client._make_request("/api/v1/health")
+        # Still an instance of the broad base type so existing handlers work.
+        assert isinstance(exc_info.value, GatewayError)
+        assert "Failed to connect to gateway" in str(exc_info.value)
+
+    def test_http_error_stays_permanent_gateway_error(self, gateway_client):
+        """A 4xx/5xx response is permanent — NOT a transient connection
+        error — so it must not be retried."""
+        http_err = HTTPError(url="http://x", code=403, msg="Forbidden", hdrs=None, fp=None)
+        with patch.object(gc, "urlopen", side_effect=http_err):
+            with pytest.raises(GatewayError) as exc_info:
+                gateway_client._make_request("/api/v1/health")
+        assert not isinstance(exc_info.value, GatewayConnectionError)
+        assert exc_info.value.status_code == 403
+
+    def test_timeout_is_not_classified_transient(self, gateway_client):
+        """A timeout may have reached the gateway and been processed, so
+        it stays a plain ``GatewayError`` (not retried) to avoid
+        duplicating a non-idempotent operation."""
+        with patch.object(gc, "urlopen", side_effect=TimeoutError("slow")):
+            with pytest.raises(GatewayError) as exc_info:
+                gateway_client._make_request("/api/v1/health")
+        assert not isinstance(exc_info.value, GatewayConnectionError)
+
+
+class TestRetryTransientHelper:
+    def test_retries_then_succeeds(self, gateway_client):
+        calls = {"n": 0}
+
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise GatewayConnectionError("blip")
+            return "ok"
+
+        result = gateway_client._retry_transient(flaky, operation="test")
+        assert result == "ok"
+        assert calls["n"] == 3
+
+    def test_reraises_original_connection_error_after_exhaustion(self, gateway_client):
+        calls = {"n": 0}
+
+        def always_blip():
+            calls["n"] += 1
+            raise GatewayConnectionError("persistent blip")
+
+        with pytest.raises(GatewayConnectionError) as exc_info:
+            gateway_client._retry_transient(always_blip, operation="test")
+        # Bounded: exactly _TRANSIENT_MAX_ATTEMPTS tries, no more.
+        assert calls["n"] == gc._TRANSIENT_MAX_ATTEMPTS
+        assert "persistent blip" in str(exc_info.value)
+
+    def test_does_not_retry_permanent_gateway_error(self, gateway_client):
+        calls = {"n": 0}
+
+        def permanent():
+            calls["n"] += 1
+            raise GatewayError("forbidden", status_code=403)
+
+        with pytest.raises(GatewayError) as exc_info:
+            gateway_client._retry_transient(permanent, operation="test")
+        assert not isinstance(exc_info.value, GatewayConnectionError)
+        assert calls["n"] == 1, "permanent failures must not be retried"
+
+
+class TestRegisterSessionRetry:
+    def test_retries_transient_then_registers(self, gateway_client):
+        attempts = {"n": 0}
+
+        def fake_make_request(*args, **kwargs):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise GatewayConnectionError("Failed to connect to gateway: name resolution")
+            return _session_payload()
+
+        with patch.object(gateway_client, "_make_request", side_effect=fake_make_request):
+            info = gateway_client.register_session(
+                container_id="egg-agent-pipe-1-coder",
+                pipeline_id="pipe-1",
+                retry_transient=True,
+            )
+        assert isinstance(info, SessionInfo)
+        assert info.session_token == "tok-1"
+        assert attempts["n"] == 2, "should retry once then succeed"
+
+    def test_default_does_not_retry(self, gateway_client):
+        attempts = {"n": 0}
+
+        def fake_make_request(*args, **kwargs):
+            attempts["n"] += 1
+            raise GatewayConnectionError("blip")
+
+        with patch.object(gateway_client, "_make_request", side_effect=fake_make_request):
+            with pytest.raises(GatewayConnectionError):
+                gateway_client.register_session(
+                    container_id="abc",
+                    pipeline_id="pipe-1",
+                )
+        assert attempts["n"] == 1, "retry must be opt-in (default off)"
+
+
+class TestCreateSliceIntegrationBranchRetry:
+    def _session_info(self) -> SessionInfo:
+        now = datetime.now()
+        return SessionInfo(
+            session_token="synthetic-tok",
+            container_id="temp",
+            container_ip=None,
+            mode="public",
+            created_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+
+    def test_push_retries_on_transient_then_succeeds(self, gateway_client):
+        """A transient connection blip on the integration-branch push is
+        retried rather than failing the slice."""
+        push_attempts = {"n": 0}
+
+        def fake_make_request(endpoint, method=None, data=None, **kwargs):
+            if endpoint == "/api/v1/git/push":
+                push_attempts["n"] += 1
+                if push_attempts["n"] == 1:
+                    raise GatewayConnectionError("Failed to connect to gateway: refused")
+            return {"success": True, "data": {}}
+
+        with (
+            patch.object(gateway_client, "register_session", return_value=self._session_info()),
+            patch.object(gateway_client, "delete_session", return_value=True),
+            patch.object(gateway_client, "fetch_branch", return_value=True),
+            patch.object(gateway_client, "get_remote_branch_sha", return_value="deadbeef" * 5),
+            patch.object(gateway_client, "_make_request", side_effect=fake_make_request),
+        ):
+            ok = gateway_client.create_slice_integration_branch(
+                "pipe-1",
+                "/repo",
+                integration_branch="egg/issue-2869/slice-1",
+                parent_branch="egg/issue-2869/work",
+            )
+
+        assert ok is True
+        assert push_attempts["n"] == 2, "push should retry once after the transient blip"
+
+    def test_permanent_push_rejection_still_fails_without_retry(self, gateway_client):
+        """A non-fast-forward rejection (permanent 5xx) is not retried —
+        it surfaces as ``ok is False`` on the first attempt."""
+        push_attempts = {"n": 0}
+
+        def fake_make_request(endpoint, method=None, data=None, **kwargs):
+            if endpoint == "/api/v1/git/push":
+                push_attempts["n"] += 1
+                raise GatewayError(
+                    "git push failed",
+                    status_code=500,
+                    details={"returncode": 1, "stderr": "! [rejected] (non-fast-forward)"},
+                )
+            return {"success": True, "data": {}}
+
+        with (
+            patch.object(gateway_client, "register_session", return_value=self._session_info()),
+            patch.object(gateway_client, "delete_session", return_value=True),
+            patch.object(gateway_client, "fetch_branch", return_value=True),
+            patch.object(gateway_client, "get_remote_branch_sha", return_value="feedface" * 5),
+            patch.object(gateway_client, "_make_request", side_effect=fake_make_request),
+        ):
+            ok = gateway_client.create_slice_integration_branch(
+                "pipe-1",
+                "/repo",
+                integration_branch="egg/issue-2869/slice-1",
+                parent_branch="egg/issue-2869/work",
+            )
+
+        assert ok is False
+        assert push_attempts["n"] == 1, "permanent rejection must not be retried"


### PR DESCRIPTION
## Summary

Fixes #2869. A brief DNS/connection blip to the gateway during agent **session registration** (and **slice integration-branch creation**) hard-failed the whole pipeline with no retry. During the `issue-2777-replan` implement phase a `[Errno -3] Temporary failure in name resolution` raised `SpawnFailureError` ~97s in and auto-failed the run.

## What changed

- **Classify transient connectivity failures.** `_make_request` now raises a new `GatewayConnectionError` (subclass of `GatewayError`) for `URLError` — DNS resolution failure, connection refused, host unreachable. These are cases where the request *never reached the gateway*, so retrying is always safe regardless of HTTP-method idempotency.
  - **Timeouts and 4xx/5xx stay permanent** (plain `GatewayError`, no retry): a timeout may have been processed (don't duplicate a non-idempotent op), and 4xx/5xx are real errors that should fail fast.
- **Bounded retry-with-backoff.** New `_retry_transient` helper retries *only* `GatewayConnectionError` — ~4 attempts, exponential backoff (~1+2+4s ≈ 7s) with jitter. After the budget is exhausted the **original** error propagates, so the #2806 auto-fail safety net still owns sustained outages.
- **Opt-in at the spawn-critical paths only:**
  - spawn-time `register_session` (the k8s spawner)
  - every network step of `create_slice_integration_branch` — session registration, parent/integration `ls-remote`, fetches, and the push.
  - Retry is `retry_transient=False` by default, so other gateway callers (health checks, etc.) keep their existing fail-fast behavior.

`GatewayConnectionError` subclasses `GatewayError`, so existing `except GatewayError` handlers are unchanged.

## Testing

New `orchestrator/tests/test_gateway_transient_retry.py` (10 tests): exception classification (URLError → connection error; HTTPError/timeout → permanent), the retry helper (retries-then-succeeds, bounded re-raise, no-retry on permanent), `register_session` opt-in retry, and the integration-branch push retrying a transient blip while a non-fast-forward rejection still fails fast.

All touched suites pass: `test_gateway_transient_retry` (10), `test_gateway_client` (104), `test_create_slice_integration_branch` (24), `test_kubernetes_spawner` (109), `test_create_context_branch` (7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)