### PR TITLE
Fix #2805: cap egg-owned MCP tool output at the tool layer

### DIFF
--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -212,6 +212,26 @@ sized to keep a worst-case page under the SDK's 60 s MCP timeout; if
 you know your dataset is small, raise `limit` to skip the second
 round-trip.
 
+### Output-size cap (`EGG_TOOL_OUTPUT_CAP_BYTES`, #2805)
+
+Every egg-owned tool result is bounded before it crosses the Claude
+Agent SDK's hard 1 MB JSON reader buffer — an oversized result kills the
+agent with exit 255 (#2804). The cap is applied at two chokepoints: the
+orchestrator MCP server (`handle_tool_call` → `cap_result_dict`) and
+every sandbox `@tool` wrapper (`invoke_handler` → `cap_text`), both via
+the shared `shared/egg_tool_output.py` helper.
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `EGG_TOOL_OUTPUT_CAP_BYTES` | `102400` (100 KB) | Max serialized size of a single tool result. Output above the cap is replaced with a structured head-preview marker (`_egg_truncated`) that names how to narrow the call, or — for unpaginated content like a full checkpoint transcript — spilled to a temp file (`_egg_output_spilled`) the agent can `Read`/`grep`, with a small inline preview. |
+
+The default leaves ~10× headroom under the 1 MB buffer. A non-positive
+or non-integer value is **ignored with a logged warning** (the operator
+is not left believing a cap is in effect when it isn't); the helper
+falls back to the 100 KB default. The orchestrator measures the cap
+against `indent=2`-serialized JSON (matching what its MCP server ships),
+so raising the cap toward the buffer size stays safe.
+
 ### `cli_command=None` rationale pattern (decision-13)
 
 A `ToolRegistration` declares `cli_command=None` for verbs that have

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -1184,12 +1184,15 @@ class PipelineToolHandler:
         # Bound the result before mcp_server.py serializes it across the
         # operator's Agent SDK 1 MB reader buffer (#2805). Oversized output
         # is replaced with a head-preview marker naming how to narrow the
-        # call; bounded tools never trip this.
+        # call; bounded tools never trip this. ``indent=2`` matches
+        # mcp_server.py's ``json.dumps(result, indent=2)`` so the cap is
+        # measured against the real on-wire size, not compact JSON.
         if isinstance(result, dict):
             return cap_result_dict(
                 result,
                 tool=tool_name,
                 narrow_hint=_TOOL_NARROW_HINTS.get(tool_name),
+                indent=2,
             )
         return result
 

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -49,6 +49,36 @@ try:
 except ImportError:
     _SLICE_ID_PATTERN = re.compile(r"^slice-[0-9]+$")
 
+try:
+    from egg_tool_output import cap_result_dict
+except ImportError:  # pragma: no cover - shared path always present in prod
+
+    def cap_result_dict(result, **_kwargs):  # type: ignore[no-redef]
+        return result
+
+
+# Per-tool "how to narrow this call" hints, surfaced in the truncation
+# marker when a result exceeds the tool-output cap (#2805). These tools'
+# output scales with cluster/repo state rather than the caller's params, so
+# they are the at-risk set; anything not listed gets a generic hint and, in
+# practice, never trips the cap because its output is bounded by design.
+_TOOL_NARROW_HINTS: dict[str, str] = {
+    "get_service_logs": (
+        "lower `lines` or set a smaller `since_seconds` window, or fetch a single service at a time"
+    ),
+    "get_container_logs": (
+        "lower `lines` or set a smaller `since_seconds` window, or target a single container"
+    ),
+    "list_containers": (
+        "request a single pipeline/phase if the API supports it; otherwise "
+        "this result is proportional to the running container count"
+    ),
+    "list_tasks": "use `limit` (and any status/phase filter) to page results",
+    "list_checkpoints": "use `limit` + `cursor` pagination or add filters",
+    "search_checkpoints": "use `limit` + `cursor` pagination or a narrower query",
+    "list_agent_local_commits": "target a single agent/branch or use `limit`",
+}
+
 
 logger = get_logger("orchestrator.mcp_tools")
 
@@ -1147,10 +1177,21 @@ class PipelineToolHandler:
             return {"error": f"Unknown tool: {tool_name}"}
 
         try:
-            return handler(arguments)
+            result = handler(arguments)
         except Exception as e:
             logger.error("Tool call failed", tool=tool_name, error=str(e))
             return {"error": str(e)}
+        # Bound the result before mcp_server.py serializes it across the
+        # operator's Agent SDK 1 MB reader buffer (#2805). Oversized output
+        # is replaced with a head-preview marker naming how to narrow the
+        # call; bounded tools never trip this.
+        if isinstance(result, dict):
+            return cap_result_dict(
+                result,
+                tool=tool_name,
+                narrow_hint=_TOOL_NARROW_HINTS.get(tool_name),
+            )
+        return result
 
     def _make_request(
         self,

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -3059,7 +3059,9 @@ class TestToolOutputCap:
 
         assert result["_egg_truncated"] is True
         assert result["tool"] == "list_containers"
-        assert len(json.dumps(result).encode("utf-8")) <= 200 * 1024
+        # Measure against the indent=2 serialization mcp_server.py actually
+        # ships, and hold the marker to the real 100 KB cap (not a loose 2×).
+        assert len(json.dumps(result, indent=2).encode("utf-8")) <= 100 * 1024
         # The narrow-hint for this tool is surfaced in the marker note.
         assert "container" in result["note"]
 

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -3043,3 +3043,37 @@ class TestPipelineToolsSchemasForDeployment:
         tools_by_name = {t["name"]: t for t in PIPELINE_TOOLS}
         props = tools_by_name["rebuild_and_rollout"]["inputSchema"]["properties"]
         assert props["wait"]["default"] is False
+
+
+class TestToolOutputCap:
+    """Output-size caps (#2805): handle_tool_call must bound any result
+    before mcp_server.py serializes it across the operator's 1 MB SDK
+    reader buffer."""
+
+    def test_oversized_result_truncated_to_marker(self, handler):
+        # A list_containers result proportional to a huge cluster.
+        huge = {"containers": [{"id": f"c{i}", "log": "x" * 200} for i in range(20000)]}
+        handler._handle_list_containers = lambda args: huge  # type: ignore[assignment]
+
+        result = handler.handle_tool_call("list_containers", {})
+
+        assert result["_egg_truncated"] is True
+        assert result["tool"] == "list_containers"
+        assert len(json.dumps(result).encode("utf-8")) <= 200 * 1024
+        # The narrow-hint for this tool is surfaced in the marker note.
+        assert "container" in result["note"]
+
+    def test_small_result_passes_through(self, handler):
+        small = {"containers": [{"id": "c1"}]}
+        handler._handle_list_containers = lambda args: small  # type: ignore[assignment]
+
+        result = handler.handle_tool_call("list_containers", {})
+        assert result == small
+
+    def test_error_dict_not_inflated(self, handler):
+        def boom(args):
+            raise RuntimeError("kaboom")
+
+        handler._handle_list_containers = boom  # type: ignore[assignment]
+        result = handler.handle_tool_call("list_containers", {})
+        assert result == {"error": "kaboom"}

--- a/sandbox/egg_agent_tools/tools/_common.py
+++ b/sandbox/egg_agent_tools/tools/_common.py
@@ -69,8 +69,11 @@ def _success_payload(response: dict[str, Any], tool_name: str | None = None) -> 
 
 
 def _error_payload(exc: BaseException) -> dict[str, Any]:
+    # Defense-in-depth (#2805): _format_error clamps GatewayError.details but
+    # not message/hint, so a large upstream error body could still cross the
+    # 1 MB SDK reader buffer. Cap the rendered error text too.
     return {
-        "content": [{"type": "text", "text": _format_error(exc)}],
+        "content": [{"type": "text", "text": cap_text(_format_error(exc))}],
         "is_error": True,
     }
 
@@ -113,8 +116,11 @@ async def invoke_handler(
         return _error_payload(exc)
     name = tool_name or getattr(handler, "__name__", None)
     if spill:
+        # Serialize with indent=2 so the spilled file has real line breaks —
+        # the descriptor tells the agent to navigate it with Read's line-based
+        # offset/limit, which is useless against one giant physical line.
         try:
-            text = json.dumps(response, default=str)
+            text = json.dumps(response, indent=2, default=str)
         except Exception:
             text = str(response)
         descriptor = spill_to_file(text, tool=name or "tool")

--- a/sandbox/egg_agent_tools/tools/_common.py
+++ b/sandbox/egg_agent_tools/tools/_common.py
@@ -20,6 +20,8 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
+from egg_tool_output import cap_text, spill_to_file
+
 from egg_agent_tools.handlers.errors import GatewayError, HandlerError
 
 # Prefer the structured logger used by shared/egg_agent/client.py so
@@ -53,11 +55,16 @@ def _format_error(exc: BaseException) -> str:
     return f"{type(exc).__name__}: {exc}"
 
 
-def _success_payload(response: dict[str, Any]) -> dict[str, Any]:
+def _success_payload(response: dict[str, Any], tool_name: str | None = None) -> dict[str, Any]:
     try:
         text = json.dumps(response, default=str)
     except Exception:
         text = str(response)
+    # Defense-in-depth (#2805): bound the payload before it crosses the
+    # Agent SDK's 1 MB JSON reader buffer. Oversized output is replaced with
+    # a structured head-preview marker telling the agent how to narrow the
+    # call. Bounded/paginated tools never trip this.
+    text = cap_text(text, tool=tool_name)
     return {"content": [{"type": "text", "text": text}]}
 
 
@@ -71,6 +78,9 @@ def _error_payload(exc: BaseException) -> dict[str, Any]:
 async def invoke_handler(
     handler: Callable[[dict[str, Any]], dict[str, Any]],
     args: dict[str, Any],
+    *,
+    tool_name: str | None = None,
+    spill: bool = False,
 ) -> dict[str, Any]:
     """Run ``handler(args)`` in a thread and wrap the result for the SDK.
 
@@ -78,6 +88,12 @@ async def invoke_handler(
     wrappers around urllib).  If the handler raises, the error is
     serialised into an ``is_error`` SDK tool-result rather than
     propagated — a gateway flake must never crash the agent loop.
+
+    Output is bounded before it crosses the Agent SDK's 1 MB JSON reader
+    buffer (#2805). When ``spill`` is set (large, unpaginated content such
+    as a full checkpoint transcript), an oversized result is written to a
+    file the agent can re-``Read``/``grep`` and replaced with a small
+    preview descriptor; otherwise it is truncated to a head-preview marker.
     """
     try:
         response = await asyncio.to_thread(handler, args or {})
@@ -95,4 +111,13 @@ async def invoke_handler(
             exc,
         )
         return _error_payload(exc)
-    return _success_payload(response)
+    name = tool_name or getattr(handler, "__name__", None)
+    if spill:
+        try:
+            text = json.dumps(response, default=str)
+        except Exception:
+            text = str(response)
+        descriptor = spill_to_file(text, tool=name or "tool")
+        if descriptor is not None:
+            return _success_payload(descriptor, name)
+    return _success_payload(response, name)

--- a/sandbox/egg_agent_tools/tools/checkpoint.py
+++ b/sandbox/egg_agent_tools/tools/checkpoint.py
@@ -112,7 +112,11 @@ async def checkpoint_list(args: dict[str, Any]) -> dict[str, Any]:
     _SHOW_SCHEMA,
 )
 async def checkpoint_show(args: dict[str, Any]) -> dict[str, Any]:
-    return await invoke_handler(handlers.checkpoint_show, args)
+    # A single checkpoint is a full agent transcript — unpaginated and often
+    # MB-scale, with the relevant detail anywhere in it. Spill an oversized
+    # result to a file the agent can Read/grep rather than truncating the
+    # tail away (#2805).
+    return await invoke_handler(handlers.checkpoint_show, args, spill=True)
 
 
 @tool(

--- a/shared/egg_tool_output.py
+++ b/shared/egg_tool_output.py
@@ -273,9 +273,14 @@ def spill_to_file(
 
     preview = "\n".join(text.splitlines()[:preview_lines])
     # Bound the inline preview to a small fixed budget (a single huge line can
-    # otherwise blow it). The full content is on disk; this is just a sample.
-    if _utf8_len(preview) > _SPILL_PREVIEW_BYTES:
-        preview = preview.encode("utf-8")[:_SPILL_PREVIEW_BYTES].decode("utf-8", errors="ignore")
+    # otherwise blow it). Also clamp to the cap itself: under a pathologically
+    # small cap, a fixed 4 KB preview would dominate the descriptor so the
+    # caller's outer cap_text re-truncates it and drops output_path — the one
+    # field that makes the spill useful. Scaling the preview with the cap keeps
+    # the descriptor proportional. The full content is on disk; this is a sample.
+    preview_budget = min(_SPILL_PREVIEW_BYTES, limit)
+    if _utf8_len(preview) > preview_budget:
+        preview = preview.encode("utf-8")[:preview_budget].decode("utf-8", errors="ignore")
     return {
         SPILL_KEY: True,
         "tool": tool,

--- a/shared/egg_tool_output.py
+++ b/shared/egg_tool_output.py
@@ -250,8 +250,9 @@ def spill_to_file(
     For ``Read``'s line-based ``offset``/``limit`` to be useful the spilled
     text must have real line breaks, so callers should serialize with
     ``indent=2`` (or spill raw multi-line content) rather than compact JSON.
-    The inline ``preview`` is a small fixed-size head sample, independent of
-    the cap, so the descriptor stays tiny.
+    The inline ``preview`` is a small head sample bounded by
+    ``min(_SPILL_PREVIEW_BYTES, cap)``, so the descriptor stays tiny and
+    shrinks proportionally under a pathologically small cap.
 
     Only appropriate when the caller and the agent share a filesystem
     (in-sandbox tools). On any write failure, returns ``None`` so the

--- a/shared/egg_tool_output.py
+++ b/shared/egg_tool_output.py
@@ -1,0 +1,205 @@
+"""Tool-output size caps for egg-owned MCP tools (issue #2805).
+
+The Claude Agent SDK message reader has a hard 1 MB JSON buffer; a tool
+result that exceeds it kills the agent with exit 255 (#2804). #2810 made
+that crash observable and terminal, but the *prevention* — never producing
+an oversized payload in the first place — lives here.
+
+This module is the shared helper referenced by #2805's "consistent across
+tools" requirement. It is deliberately a flat, stdlib-only module (no
+package ``__init__`` side effects, no ``claude_agent_sdk`` import) so both
+sides of the boundary can import it once ``shared/`` is on ``sys.path``:
+
+* the **orchestrator** MCP server (operator-facing tools in
+  ``orchestrator/mcp_tools.py``), and
+* the **sandbox** agent ``@tool`` wrappers
+  (``sandbox/egg_agent_tools/tools/_common.py``).
+
+Two strategies are exposed:
+
+* :func:`cap_result_dict` / :func:`cap_text` — *truncate + structured
+  marker*. The tail is replaced with a JSON object that names what was cut
+  and how to narrow the call. Simple; the right fit for paginated or
+  structured tools where a head preview plus a "narrow it" hint is enough.
+* :func:`spill_to_file` — *write full result to disk + return a preview*.
+  Mirrors Claude Code's own ``Bash`` tool (inline preview, full output
+  spilled to a file the model can re-``Read`` / ``grep``). The right fit
+  for large, unpaginated raw content (e.g. a full checkpoint transcript)
+  where the tail matters and truncation would lose it. Only usable when
+  the caller and the reader share a filesystem (in-sandbox agent tools),
+  so the orchestrator MCP server uses truncation only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import uuid
+from typing import Any
+
+# Default cap, well under the SDK's 1 MB reader buffer so the serialized
+# result still has headroom for the surrounding SDK/MCP framing. Override
+# with ``EGG_TOOL_OUTPUT_CAP_BYTES`` (issue #2805 "configurable").
+DEFAULT_CAP_BYTES = 100 * 1024
+
+# Reserve for the non-preview marker fields so the assembled marker still
+# fits under the cap; the preview is then shrunk to fit if needed.
+_MARKER_RESERVE_BYTES = 2048
+
+# Sentinel keys so callers/tests can recognize a capped payload.
+TRUNCATION_KEY = "_egg_truncated"
+SPILL_KEY = "_egg_output_spilled"
+
+
+def cap_bytes_from_env(default: int = DEFAULT_CAP_BYTES) -> int:
+    """Resolve the configured cap, falling back to ``default`` on bad input."""
+    raw = os.environ.get("EGG_TOOL_OUTPUT_CAP_BYTES")
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except TypeError, ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _utf8_len(text: str) -> int:
+    return len(text.encode("utf-8"))
+
+
+def _truncation_marker(
+    text: str,
+    *,
+    cap_bytes: int,
+    tool: str | None,
+    narrow_hint: str | None,
+) -> dict[str, Any]:
+    """Build a structured marker dict that fits under ``cap_bytes`` serialized.
+
+    The preview is the head of ``text`` shrunk (by bytes, re-checking the
+    serialized size) until the whole marker fits — robust to JSON escape
+    expansion of the preview.
+    """
+    original_bytes = _utf8_len(text)
+    hint = narrow_hint or (
+        "narrow the call (e.g. a smaller limit/lines window, a more "
+        "specific filter, or pagination) and retry"
+    )
+    note = (
+        f"Result was {original_bytes} bytes; it exceeded the {cap_bytes}-byte "
+        "tool-output cap and was truncated to avoid the Agent SDK 1 MB "
+        "message-buffer crash (#2804/#2805). Only the head is shown below — "
+        f"to see the rest, {hint}."
+    )
+    budget = max(cap_bytes - _MARKER_RESERVE_BYTES, 256)
+    preview = text.encode("utf-8")[:budget].decode("utf-8", errors="ignore")
+    marker: dict[str, Any] = {
+        TRUNCATION_KEY: True,
+        "tool": tool,
+        "original_bytes": original_bytes,
+        "cap_bytes": cap_bytes,
+        "note": note,
+        "preview": preview,
+    }
+    # Shrink the preview until the serialized marker fits. JSON-escaping can
+    # expand the preview past the byte budget, so check the real size.
+    while _utf8_len(json.dumps(marker, default=str)) > cap_bytes and preview:
+        preview = preview[: len(preview) // 2]
+        marker["preview"] = preview
+    return marker
+
+
+def cap_text(
+    text: str,
+    *,
+    tool: str | None = None,
+    narrow_hint: str | None = None,
+    cap_bytes: int | None = None,
+) -> str:
+    """Cap an already-serialized text payload.
+
+    Returns ``text`` unchanged when it is within the cap, otherwise a JSON
+    string holding the truncation marker (head preview + how to narrow).
+    """
+    limit = cap_bytes if cap_bytes is not None else cap_bytes_from_env()
+    if _utf8_len(text) <= limit:
+        return text
+    marker = _truncation_marker(text, cap_bytes=limit, tool=tool, narrow_hint=narrow_hint)
+    return json.dumps(marker, default=str)
+
+
+def cap_result_dict(
+    result: dict[str, Any],
+    *,
+    tool: str | None = None,
+    narrow_hint: str | None = None,
+    cap_bytes: int | None = None,
+) -> dict[str, Any]:
+    """Cap a result *dict* by its serialized size.
+
+    Returns ``result`` unchanged when within the cap, otherwise the
+    truncation marker dict (a small, well-formed replacement). Used at the
+    orchestrator MCP chokepoint, where the result is re-serialized by the
+    server; the marker dict keeps that serialization small.
+    """
+    limit = cap_bytes if cap_bytes is not None else cap_bytes_from_env()
+    try:
+        text = json.dumps(result, default=str)
+    except TypeError, ValueError:
+        text = str(result)
+    if _utf8_len(text) <= limit:
+        return result
+    return _truncation_marker(text, cap_bytes=limit, tool=tool, narrow_hint=narrow_hint)
+
+
+def spill_to_file(
+    text: str,
+    *,
+    tool: str,
+    preview_lines: int = 50,
+    cap_bytes: int | None = None,
+    spill_dir: str | None = None,
+) -> dict[str, Any] | None:
+    """Spill an oversized payload to a file and return a preview descriptor.
+
+    Returns ``None`` when ``text`` is within the cap (caller should use the
+    payload as-is). Otherwise writes the full ``text`` to a file the agent
+    can re-read with ``Read`` (offset/limit) or ``grep`` via ``Bash``, and
+    returns ``{output_path, total_bytes, preview, ...}``.
+
+    Only appropriate when the caller and the agent share a filesystem
+    (in-sandbox tools). On any write failure, returns ``None`` so the
+    caller falls back to truncation rather than failing the tool call.
+    """
+    limit = cap_bytes if cap_bytes is not None else cap_bytes_from_env()
+    total_bytes = _utf8_len(text)
+    if total_bytes <= limit:
+        return None
+
+    target_dir = spill_dir or tempfile.gettempdir()
+    path = os.path.join(target_dir, f"egg-tool-out-{tool}-{uuid.uuid4().hex}.txt")
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(text)
+    except OSError:
+        return None
+
+    preview = "\n".join(text.splitlines()[:preview_lines])
+    # Keep the preview itself under the cap (a single huge line can blow it).
+    preview = cap_text(preview, tool=tool, cap_bytes=limit)
+    return {
+        SPILL_KEY: True,
+        "tool": tool,
+        "output_path": path,
+        "total_bytes": total_bytes,
+        "cap_bytes": limit,
+        "note": (
+            f"Result was {total_bytes} bytes (over the {limit}-byte tool-output "
+            "cap), so the full output was written to `output_path` to avoid the "
+            "Agent SDK 1 MB buffer crash (#2804/#2805). Read it with the `Read` "
+            "tool (use `offset`/`limit`) or `grep` it via `Bash`. Only the first "
+            f"{preview_lines} lines are inlined below."
+        ),
+        "preview": preview,
+    }

--- a/shared/egg_tool_output.py
+++ b/shared/egg_tool_output.py
@@ -33,10 +33,14 @@ Two strategies are exposed:
 from __future__ import annotations
 
 import json
+import logging
 import os
 import tempfile
+import time
 import uuid
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 # Default cap, well under the SDK's 1 MB reader buffer so the serialized
 # result still has headroom for the surrounding SDK/MCP framing. Override
@@ -47,21 +51,50 @@ DEFAULT_CAP_BYTES = 100 * 1024
 # fits under the cap; the preview is then shrunk to fit if needed.
 _MARKER_RESERVE_BYTES = 2048
 
+# Inline preview budget for a spill descriptor — small and fixed, so the
+# descriptor stays tiny regardless of the configured cap. The full content
+# lives in the spilled file; the preview is just a head sample.
+_SPILL_PREVIEW_BYTES = 4 * 1024
+
+# Best-effort age threshold for pruning stale spill files. Old enough that
+# the agent has almost certainly finished reading any earlier spill.
+_SPILL_TTL_SECONDS = 60 * 60
+
 # Sentinel keys so callers/tests can recognize a capped payload.
 TRUNCATION_KEY = "_egg_truncated"
 SPILL_KEY = "_egg_output_spilled"
 
 
 def cap_bytes_from_env(default: int = DEFAULT_CAP_BYTES) -> int:
-    """Resolve the configured cap, falling back to ``default`` on bad input."""
+    """Resolve the configured cap, falling back to ``default`` on bad input.
+
+    ``EGG_TOOL_OUTPUT_CAP_BYTES`` is operator-facing config; if it is set to
+    something we cannot honor we warn rather than silently swallowing it, so
+    the operator isn't left believing a cap is in effect when it isn't.
+    """
     raw = os.environ.get("EGG_TOOL_OUTPUT_CAP_BYTES")
     if not raw:
         return default
     try:
         value = int(raw)
-    except TypeError, ValueError:
+    except ValueError:
+        # ``raw`` is a non-empty str here, so int() can only raise ValueError.
+        logger.warning(
+            "Ignoring invalid EGG_TOOL_OUTPUT_CAP_BYTES=%r (not an integer); "
+            "falling back to the %d-byte default cap.",
+            raw,
+            default,
+        )
         return default
-    return value if value > 0 else default
+    if value <= 0:
+        logger.warning(
+            "Ignoring non-positive EGG_TOOL_OUTPUT_CAP_BYTES=%r; "
+            "falling back to the %d-byte default cap.",
+            raw,
+            default,
+        )
+        return default
+    return value
 
 
 def _utf8_len(text: str) -> int:
@@ -74,12 +107,15 @@ def _truncation_marker(
     cap_bytes: int,
     tool: str | None,
     narrow_hint: str | None,
+    indent: int | None = None,
 ) -> dict[str, Any]:
     """Build a structured marker dict that fits under ``cap_bytes`` serialized.
 
     The preview is the head of ``text`` shrunk (by bytes, re-checking the
     serialized size) until the whole marker fits — robust to JSON escape
-    expansion of the preview.
+    expansion of the preview. ``indent`` must match the indent the caller
+    will re-serialize the marker with (the orchestrator ships ``indent=2``),
+    so the fit check measures the real on-wire size.
     """
     original_bytes = _utf8_len(text)
     hint = narrow_hint or (
@@ -102,11 +138,22 @@ def _truncation_marker(
         "note": note,
         "preview": preview,
     }
-    # Shrink the preview until the serialized marker fits. JSON-escaping can
-    # expand the preview past the byte budget, so check the real size.
-    while _utf8_len(json.dumps(marker, default=str)) > cap_bytes and preview:
+
+    def _serialized_len() -> int:
+        return _utf8_len(json.dumps(marker, default=str, indent=indent))
+
+    # Shrink the preview until the serialized marker fits. JSON-escaping (and
+    # any indent the caller re-serializes with) can expand the preview past
+    # the byte budget, so check the real size.
+    while _serialized_len() > cap_bytes and preview:
         preview = preview[: len(preview) // 2]
         marker["preview"] = preview
+    # Pathological tiny cap: even an empty preview leaves the fixed fields
+    # over the cap. Drop the preview entirely so the marker is as small as it
+    # can be — still sub-KB, so it can never threaten the 1 MB SDK buffer the
+    # cap exists to protect.
+    if _serialized_len() > cap_bytes:
+        marker.pop("preview", None)
     return marker
 
 
@@ -135,6 +182,7 @@ def cap_result_dict(
     tool: str | None = None,
     narrow_hint: str | None = None,
     cap_bytes: int | None = None,
+    indent: int | None = None,
 ) -> dict[str, Any]:
     """Cap a result *dict* by its serialized size.
 
@@ -142,15 +190,46 @@ def cap_result_dict(
     truncation marker dict (a small, well-formed replacement). Used at the
     orchestrator MCP chokepoint, where the result is re-serialized by the
     server; the marker dict keeps that serialization small.
+
+    Pass the same ``indent`` the caller serializes with so the measurement
+    matches the real on-wire size — the orchestrator ships ``indent=2``,
+    which roughly doubles a nested payload's size versus compact JSON.
     """
     limit = cap_bytes if cap_bytes is not None else cap_bytes_from_env()
     try:
-        text = json.dumps(result, default=str)
-    except TypeError, ValueError:
+        text = json.dumps(result, default=str, indent=indent)
+    except Exception:
+        # Mirror _success_payload: any serialization failure (e.g. a
+        # non-str dict key) falls back to str() rather than crashing.
         text = str(result)
     if _utf8_len(text) <= limit:
         return result
-    return _truncation_marker(text, cap_bytes=limit, tool=tool, narrow_hint=narrow_hint)
+    return _truncation_marker(
+        text, cap_bytes=limit, tool=tool, narrow_hint=narrow_hint, indent=indent
+    )
+
+
+def _prune_old_spills(target_dir: str) -> None:
+    """Best-effort removal of stale ``egg-tool-out-*`` spill files.
+
+    Bounds accumulation over a long session. Files newer than the TTL are
+    kept (the agent may still be reading them). Never raises — pruning is a
+    courtesy, not a correctness requirement.
+    """
+    cutoff = time.time() - _SPILL_TTL_SECONDS
+    try:
+        entries = os.listdir(target_dir)
+    except OSError:
+        return
+    for name in entries:
+        if not (name.startswith("egg-tool-out-") and name.endswith(".txt")):
+            continue
+        candidate = os.path.join(target_dir, name)
+        try:
+            if os.path.getmtime(candidate) < cutoff:
+                os.remove(candidate)
+        except OSError:
+            continue
 
 
 def spill_to_file(
@@ -168,6 +247,12 @@ def spill_to_file(
     can re-read with ``Read`` (offset/limit) or ``grep`` via ``Bash``, and
     returns ``{output_path, total_bytes, preview, ...}``.
 
+    For ``Read``'s line-based ``offset``/``limit`` to be useful the spilled
+    text must have real line breaks, so callers should serialize with
+    ``indent=2`` (or spill raw multi-line content) rather than compact JSON.
+    The inline ``preview`` is a small fixed-size head sample, independent of
+    the cap, so the descriptor stays tiny.
+
     Only appropriate when the caller and the agent share a filesystem
     (in-sandbox tools). On any write failure, returns ``None`` so the
     caller falls back to truncation rather than failing the tool call.
@@ -178,6 +263,7 @@ def spill_to_file(
         return None
 
     target_dir = spill_dir or tempfile.gettempdir()
+    _prune_old_spills(target_dir)
     path = os.path.join(target_dir, f"egg-tool-out-{tool}-{uuid.uuid4().hex}.txt")
     try:
         with open(path, "w", encoding="utf-8") as fh:
@@ -186,8 +272,10 @@ def spill_to_file(
         return None
 
     preview = "\n".join(text.splitlines()[:preview_lines])
-    # Keep the preview itself under the cap (a single huge line can blow it).
-    preview = cap_text(preview, tool=tool, cap_bytes=limit)
+    # Bound the inline preview to a small fixed budget (a single huge line can
+    # otherwise blow it). The full content is on disk; this is just a sample.
+    if _utf8_len(preview) > _SPILL_PREVIEW_BYTES:
+        preview = preview.encode("utf-8")[:_SPILL_PREVIEW_BYTES].decode("utf-8", errors="ignore")
     return {
         SPILL_KEY: True,
         "tool": tool,
@@ -198,8 +286,8 @@ def spill_to_file(
             f"Result was {total_bytes} bytes (over the {limit}-byte tool-output "
             "cap), so the full output was written to `output_path` to avoid the "
             "Agent SDK 1 MB buffer crash (#2804/#2805). Read it with the `Read` "
-            "tool (use `offset`/`limit`) or `grep` it via `Bash`. Only the first "
-            f"{preview_lines} lines are inlined below."
+            "tool (use `offset`/`limit`) or `grep` it via `Bash`. A head sample "
+            "of the output is inlined below as `preview`."
         ),
         "preview": preview,
     }

--- a/tests/sandbox/egg_agent_tools/test_tools.py
+++ b/tests/sandbox/egg_agent_tools/test_tools.py
@@ -120,6 +120,50 @@ class TestInvokeHandlerErrorTranslation:
         assert resp["is_error"] is True
 
 
+class TestInvokeHandlerOutputCap:
+    """Output-size caps (#2805): a handler returning a megabyte-scale dict
+    must never produce a tool-result that overflows the SDK reader."""
+
+    def test_oversized_result_truncated_to_marker(self):
+        def handler(req):
+            return {"rows": ["x" * 100 for _ in range(20000)]}  # ~2 MB serialized
+
+        resp = _run(invoke_handler(handler, {}, tool_name="big_tool"))
+        text = resp["content"][0]["text"]
+        assert len(text.encode("utf-8")) <= 200 * 1024
+        marker = json.loads(text)
+        assert marker["_egg_truncated"] is True
+        assert marker["tool"] == "big_tool"
+
+    def test_small_result_not_truncated(self):
+        def handler(req):
+            return {"ok": True, "value": 42}
+
+        resp = _run(invoke_handler(handler, {}))
+        assert json.loads(resp["content"][0]["text"]) == {"ok": True, "value": 42}
+
+    def test_spill_writes_file_and_returns_preview(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+
+        def handler(req):
+            return {"ok": True, "transcript": "L" * (300 * 1024)}
+
+        resp = _run(invoke_handler(handler, {}, tool_name="checkpoint_show", spill=True))
+        desc = json.loads(resp["content"][0]["text"])
+        assert desc["_egg_output_spilled"] is True
+        assert Path(desc["output_path"]).exists()
+        # The full payload is preserved on disk, not lost to truncation.
+        assert desc["total_bytes"] > 300 * 1024
+
+    def test_spill_skipped_for_small_result(self):
+        def handler(req):
+            return {"ok": True, "transcript": "short"}
+
+        resp = _run(invoke_handler(handler, {}, tool_name="checkpoint_show", spill=True))
+        body = json.loads(resp["content"][0]["text"])
+        assert body == {"ok": True, "transcript": "short"}
+
+
 class TestSdkToolShape:
     """Every registration declares a stub SDK tool (or real SdkMcpTool)
     carrying name/description/input_schema and the handler reference."""

--- a/tests/sandbox/egg_agent_tools/test_tools.py
+++ b/tests/sandbox/egg_agent_tools/test_tools.py
@@ -130,7 +130,10 @@ class TestInvokeHandlerOutputCap:
 
         resp = _run(invoke_handler(handler, {}, tool_name="big_tool"))
         text = resp["content"][0]["text"]
-        assert len(text.encode("utf-8")) <= 200 * 1024
+        # _success_payload serializes compact; hold the marker to the real
+        # 100 KB cap (not a loose 2×) so a marker that lands between 100–200
+        # KB would fail the test.
+        assert len(text.encode("utf-8")) <= 100 * 1024
         marker = json.loads(text)
         assert marker["_egg_truncated"] is True
         assert marker["tool"] == "big_tool"
@@ -162,6 +165,17 @@ class TestInvokeHandlerOutputCap:
         resp = _run(invoke_handler(handler, {}, tool_name="checkpoint_show", spill=True))
         body = json.loads(resp["content"][0]["text"])
         assert body == {"ok": True, "transcript": "short"}
+
+    def test_oversized_error_payload_capped(self):
+        # _format_error doesn't clamp GatewayError.message/hint, so a huge
+        # upstream error body must still be bounded before it crosses the
+        # 1 MB SDK reader buffer (#2805 defense-in-depth).
+        def handler(req):
+            raise GatewayError("E" * (2 * 1024 * 1024), hint="H" * (2 * 1024 * 1024))
+
+        resp = _run(invoke_handler(handler, {}, tool_name="big_error"))
+        assert resp["is_error"] is True
+        assert len(resp["content"][0]["text"].encode("utf-8")) <= 200 * 1024
 
 
 class TestSdkToolShape:

--- a/tests/sandbox/egg_agent_tools/test_tools.py
+++ b/tests/sandbox/egg_agent_tools/test_tools.py
@@ -175,7 +175,9 @@ class TestInvokeHandlerOutputCap:
 
         resp = _run(invoke_handler(handler, {}, tool_name="big_error"))
         assert resp["is_error"] is True
-        assert len(resp["content"][0]["text"].encode("utf-8")) <= 200 * 1024
+        # Hold the capped error to the real 100 KB cap (not a loose 2×) so a
+        # payload that lands between 100–200 KB would fail the test.
+        assert len(resp["content"][0]["text"].encode("utf-8")) <= 100 * 1024
 
 
 class TestSdkToolShape:

--- a/tests/shared/test_egg_tool_output.py
+++ b/tests/shared/test_egg_tool_output.py
@@ -1,0 +1,133 @@
+"""Unit tests for the shared tool-output cap helper (issue #2805).
+
+The Agent SDK message reader crashes the agent when a tool result exceeds
+its 1 MB JSON buffer (#2804). These helpers bound the payload before it
+gets there. The invariants under test:
+
+* small payloads pass through untouched,
+* oversized payloads are replaced with a structured marker that itself
+  fits under the cap (no point capping if the marker overflows),
+* the marker carries a head preview + a "how to narrow" hint,
+* the file-spill path writes the full output and returns a small preview.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "shared"))
+
+from egg_tool_output import (  # noqa: E402
+    SPILL_KEY,
+    TRUNCATION_KEY,
+    cap_bytes_from_env,
+    cap_result_dict,
+    cap_text,
+    spill_to_file,
+)
+
+
+def _utf8(s: str) -> int:
+    return len(s.encode("utf-8"))
+
+
+class TestCapText:
+    def test_small_text_passes_through(self):
+        assert cap_text("hello", cap_bytes=1000) == "hello"
+
+    def test_oversized_text_truncated_to_marker(self):
+        big = "x" * 5000
+        out = cap_text(big, tool="t", cap_bytes=1000)
+        assert out != big
+        marker = json.loads(out)
+        assert marker[TRUNCATION_KEY] is True
+        assert marker["tool"] == "t"
+        assert marker["original_bytes"] == 5000
+
+    def test_marker_fits_under_cap(self):
+        # Even a pathological payload of escape-heavy chars must not produce
+        # a marker that itself exceeds the cap.
+        big = '"\n' * 50000
+        out = cap_text(big, cap_bytes=2000)
+        assert _utf8(out) <= 2000
+
+    def test_preview_is_head_of_original(self):
+        big = "HEAD-MARKER" + "z" * 5000
+        marker = json.loads(cap_text(big, cap_bytes=1000))
+        assert marker["preview"].startswith("HEAD-MARKER")
+
+    def test_custom_hint_in_note(self):
+        marker = json.loads(cap_text("y" * 5000, cap_bytes=2000, narrow_hint="use frobnicate"))
+        assert "use frobnicate" in marker["note"]
+
+    def test_generic_hint_when_unset(self):
+        marker = json.loads(cap_text("y" * 5000, cap_bytes=2000))
+        assert "narrow the call" in marker["note"]
+
+
+class TestCapResultDict:
+    def test_small_dict_passes_through(self):
+        d = {"ok": True, "n": 1}
+        assert cap_result_dict(d, cap_bytes=1000) is d
+
+    def test_oversized_dict_becomes_marker(self):
+        d = {"rows": ["x" * 100 for _ in range(1000)]}
+        out = cap_result_dict(d, tool="list_tasks", cap_bytes=1000)
+        assert out[TRUNCATION_KEY] is True
+        assert out["tool"] == "list_tasks"
+        assert _utf8(json.dumps(out)) <= 1000
+
+    def test_non_serializable_falls_back_to_str(self):
+        class Weird:
+            def __repr__(self) -> str:
+                return "W" * 5000
+
+        out = cap_result_dict({"x": Weird()}, cap_bytes=1000)
+        # default=str makes it serializable, so it still caps cleanly.
+        assert out[TRUNCATION_KEY] is True
+
+
+class TestSpillToFile:
+    def test_small_payload_returns_none(self, tmp_path):
+        assert spill_to_file("small", tool="t", cap_bytes=1000) is None
+
+    def test_oversized_payload_spilled(self, tmp_path):
+        big = "\n".join(f"line-{i}" for i in range(5000))
+        desc = spill_to_file(big, tool="checkpoint_show", cap_bytes=1000, spill_dir=str(tmp_path))
+        assert desc is not None
+        assert desc[SPILL_KEY] is True
+        assert desc["total_bytes"] == _utf8(big)
+        path = Path(desc["output_path"])
+        assert path.exists()
+        assert path.read_text(encoding="utf-8") == big
+        # Preview is bounded and holds the head lines.
+        assert "line-0" in desc["preview"]
+        assert _utf8(json.dumps(desc)) <= 1000 + 4096  # descriptor stays small
+
+    def test_unwritable_dir_returns_none(self):
+        # A bogus spill dir must not raise — caller falls back to truncation.
+        big = "x" * 5000
+        assert (
+            spill_to_file(big, tool="t", cap_bytes=1000, spill_dir="/nonexistent/egg/dir") is None
+        )
+
+
+class TestCapFromEnv:
+    def test_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("EGG_TOOL_OUTPUT_CAP_BYTES", raising=False)
+        assert cap_bytes_from_env(default=123) == 123
+
+    def test_override(self, monkeypatch):
+        monkeypatch.setenv("EGG_TOOL_OUTPUT_CAP_BYTES", "4096")
+        assert cap_bytes_from_env() == 4096
+
+    def test_bad_value_falls_back(self, monkeypatch):
+        monkeypatch.setenv("EGG_TOOL_OUTPUT_CAP_BYTES", "not-a-number")
+        assert cap_bytes_from_env(default=777) == 777
+
+    def test_nonpositive_falls_back(self, monkeypatch):
+        monkeypatch.setenv("EGG_TOOL_OUTPUT_CAP_BYTES", "0")
+        assert cap_bytes_from_env(default=777) == 777

--- a/tests/shared/test_egg_tool_output.py
+++ b/tests/shared/test_egg_tool_output.py
@@ -144,6 +144,17 @@ class TestSpillToFile:
         assert Path(desc["output_path"]).exists()
         assert _utf8(json.dumps(desc)) <= 1000 + 4096
 
+    def test_preview_budget_scales_with_small_cap(self, tmp_path):
+        # Under a cap smaller than the fixed 4 KB preview budget, the preview
+        # must shrink to the cap rather than staying 4 KB (which would make the
+        # descriptor dwarf the cap and risk the outer cap_text dropping
+        # output_path). The full content is still preserved on disk.
+        big = "z" * (300 * 1024)
+        desc = spill_to_file(big, tool="checkpoint_show", cap_bytes=2000, spill_dir=str(tmp_path))
+        assert desc is not None
+        assert _utf8(desc["preview"]) <= 2000
+        assert Path(desc["output_path"]).exists()
+
     def test_stale_spills_pruned(self, tmp_path, monkeypatch):
         # An old spill file is best-effort removed when a new one is written.
         stale = tmp_path / "egg-tool-out-old-deadbeef.txt"

--- a/tests/shared/test_egg_tool_output.py
+++ b/tests/shared/test_egg_tool_output.py
@@ -14,7 +14,9 @@ gets there. The invariants under test:
 from __future__ import annotations
 
 import json
+import os
 import sys
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -67,6 +69,15 @@ class TestCapText:
         marker = json.loads(cap_text("y" * 5000, cap_bytes=2000))
         assert "narrow the call" in marker["note"]
 
+    def test_pathological_tiny_cap_drops_preview(self):
+        # A cap smaller than the fixed marker scaffolding can't hold a preview;
+        # the marker must stay minimal (sub-KB) rather than carry a preview.
+        marker = json.loads(cap_text("x" * 5000, cap_bytes=50))
+        assert marker[TRUNCATION_KEY] is True
+        assert "preview" not in marker
+        # Still tiny in absolute terms — never a threat to the 1 MB buffer.
+        assert _utf8(json.dumps(marker)) < 1024
+
 
 class TestCapResultDict:
     def test_small_dict_passes_through(self):
@@ -88,6 +99,14 @@ class TestCapResultDict:
         out = cap_result_dict({"x": Weird()}, cap_bytes=1000)
         # default=str makes it serializable, so it still caps cleanly.
         assert out[TRUNCATION_KEY] is True
+
+    def test_marker_fits_under_cap_at_caller_indent(self):
+        # The orchestrator re-serializes the marker with indent=2; measuring
+        # with the same indent guarantees the on-wire size honors the cap.
+        d = {"rows": ["x" * 100 for _ in range(2000)]}
+        out = cap_result_dict(d, tool="list_tasks", cap_bytes=4000, indent=2)
+        assert out[TRUNCATION_KEY] is True
+        assert _utf8(json.dumps(out, indent=2)) <= 4000
 
 
 class TestSpillToFile:
@@ -114,6 +133,31 @@ class TestSpillToFile:
             spill_to_file(big, tool="t", cap_bytes=1000, spill_dir="/nonexistent/egg/dir") is None
         )
 
+    def test_single_huge_line_preview_bounded(self, tmp_path):
+        # A compact (one physical line) payload must still yield a small,
+        # well-formed descriptor — the preview can't blow past its budget.
+        big = "z" * (300 * 1024)
+        desc = spill_to_file(big, tool="checkpoint_show", cap_bytes=1000, spill_dir=str(tmp_path))
+        assert desc is not None
+        assert _utf8(desc["preview"]) <= 4 * 1024
+        # output_path survives — it's the field that makes spill useful.
+        assert Path(desc["output_path"]).exists()
+        assert _utf8(json.dumps(desc)) <= 1000 + 4096
+
+    def test_stale_spills_pruned(self, tmp_path, monkeypatch):
+        # An old spill file is best-effort removed when a new one is written.
+        stale = tmp_path / "egg-tool-out-old-deadbeef.txt"
+        stale.write_text("old", encoding="utf-8")
+        old_time = time.time() - (2 * 60 * 60)
+        os.utime(stale, (old_time, old_time))
+
+        big = "\n".join(f"line-{i}" for i in range(5000))
+        desc = spill_to_file(big, tool="checkpoint_show", cap_bytes=1000, spill_dir=str(tmp_path))
+        assert desc is not None
+        assert not stale.exists()
+        # The fresh spill is kept.
+        assert Path(desc["output_path"]).exists()
+
 
 class TestCapFromEnv:
     def test_default_when_unset(self, monkeypatch):
@@ -131,3 +175,17 @@ class TestCapFromEnv:
     def test_nonpositive_falls_back(self, monkeypatch):
         monkeypatch.setenv("EGG_TOOL_OUTPUT_CAP_BYTES", "0")
         assert cap_bytes_from_env(default=777) == 777
+
+    def test_bad_value_warns(self, monkeypatch, caplog):
+        # Operator-set config that we can't honor must not vanish silently
+        # (#2805 blocking item): warn so the operator knows it was dropped.
+        monkeypatch.setenv("EGG_TOOL_OUTPUT_CAP_BYTES", "banana")
+        with caplog.at_level("WARNING", logger="egg_tool_output"):
+            assert cap_bytes_from_env(default=777) == 777
+        assert any("EGG_TOOL_OUTPUT_CAP_BYTES" in r.message for r in caplog.records)
+
+    def test_nonpositive_warns(self, monkeypatch, caplog):
+        monkeypatch.setenv("EGG_TOOL_OUTPUT_CAP_BYTES", "-5")
+        with caplog.at_level("WARNING", logger="egg_tool_output"):
+            assert cap_bytes_from_env(default=777) == 777
+        assert any("EGG_TOOL_OUTPUT_CAP_BYTES" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Fixes #2805. Defense-in-depth follow-up to #2804/#2810: cap the output of
egg-owned MCP tools **at the tool layer**, so an oversized payload never
reaches the Claude Agent SDK's 1 MB JSON reader buffer (which crashes the
agent with exit 255). #2810 made that crash observable and terminal; this
PR is the prevention for the tools we own.

## What changed

New shared helper **`shared/egg_tool_output.py`** — flat, stdlib-only (no
package `__init__` side effects, no `claude_agent_sdk` import) so both the
orchestrator and the sandbox can import it once `shared/` is on the path.
It exposes two strategies (the "per-tool mix" from the issue):

- **truncate + structured marker** (`cap_text` / `cap_result_dict`): the
  tail is replaced with a small, well-formed JSON marker carrying a head
  preview, the original size, and a per-tool *"how to narrow this call"*
  hint. The marker is guaranteed to fit under the cap (the preview is
  shrunk, by bytes, re-checking the serialized size to survive JSON escape
  expansion). Right fit for paginated/structured tools.
- **write-to-file + preview** (`spill_to_file`): writes the full result to
  a file the agent can re-`Read` (offset/limit) or `grep` via `Bash`, and
  returns `{output_path, total_bytes, preview, …}`. Mirrors Claude Code's
  own `Bash` inline-preview-spill pattern. Right fit for large,
  *unpaginated* content where the tail matters and truncation would lose
  it. Only used in-sandbox (caller and agent share a filesystem); on any
  write failure it returns `None` and the caller falls back to truncation.

Wired at both egg chokepoints:

- **Layer 1 — operator-facing orchestrator MCP** (`orchestrator/mcp_tools.py`):
  `PipelineToolHandler.handle_tool_call` caps every dict result before
  `mcp_server.py` serializes it across the operator's SDK buffer, with
  per-tool narrow hints for the at-risk set (`get_service_logs`,
  `get_container_logs`, `list_containers`, `list_tasks`,
  `list_checkpoints`, `search_checkpoints`, `list_agent_local_commits`).
- **Layer 2 — sandbox agent `@tool`** (`sandbox/egg_agent_tools/tools/_common.py`):
  `invoke_handler` / `_success_payload` truncate by default;
  `checkpoint_show` opts into file-spill (`spill=True`) because a single
  checkpoint is a full, unpaginated agent transcript.

Cap defaults to **100 KB**, override via `EGG_TOOL_OUTPUT_CAP_BYTES`.

## Scope

This covers the two layers of tools **we own**. The built-in Claude Code
tools (`Read`/`Edit`/`Grep`) — which are the actual blocker behind #2777's
crashes on 24k-line files — are a fundamentally different mechanism
(PreToolUse *predictive* deny, since PostToolUse can't suppress a payload
and the SDK buffer bump was rejected in #2810). That's tracked separately
in **#2876** to avoid conflating two mechanisms in one change, which is
what churned #2804 → #2810.

## Tests

- `tests/shared/test_egg_tool_output.py` — helper unit tests:
  passthrough, truncation, marker-fits-under-cap (incl. escape-heavy
  pathological input), file-spill round-trip, unwritable-dir fallback,
  env override.
- `orchestrator/tests/test_mcp_tools.py::TestToolOutputCap` — layer-1
  `handle_tool_call` caps an oversized result, passes small results
  through, and doesn't inflate error dicts.
- `tests/sandbox/egg_agent_tools/test_tools.py::TestInvokeHandlerOutputCap`
  — layer-2 truncation + spill paths.

203 passed across the three suites. `ruff` + targeted `mypy` clean;
`scripts/check-file-sizes.py` green.

## Related

- #2805 — this issue.
- #2804 / #2810 — the SDK buffer-overflow crash and its fail-fast backstop.
- #2876 — built-in tool (`Read`/`Edit`/`Grep`) PreToolUse cap; the #2777 blocker.
- #2777 — the sliced-implement cleanup that #2876 (not this PR) unblocks.
