### PR TITLE
Fast-fail 'make deploy' before applying when tag's images aren't in k3s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ EGG_IMAGE_TAG := $(shell git describe --always --dirty 2>/dev/null || echo lates
         test-integration test-security smoketest-long-poll \
         lint-fix lint-python-fix lint-shell-fix lint-yaml-fix \
         build \
-        k3s-setup k3s-secrets litellm-config deploy redeploy k3s-teardown k3s-import sudo-keepalive
+        k3s-setup k3s-secrets litellm-config deploy redeploy k3s-teardown k3s-import sudo-keepalive \
+        check-egg-images-present
 
 # Default target
 help:
@@ -562,13 +563,19 @@ litellm-config:  ## Apply host-side LiteLLM model_list from ~/.config/egg/litell
 		kubectl rollout status deployment litellm -n egg-system --timeout=180s; \
 	fi
 
-deploy: k3s-secrets  ## Deploy egg to k3s
+check-egg-images-present:
+	@scripts/check-egg-images-present.sh "$(EGG_IMAGE_TAG)"
+
+# Order of prerequisites matters: check-egg-images-present runs before
+# k3s-secrets so the deploy aborts on tag drift WITHOUT touching the cluster.
+# k3s-secrets reconciles namespaces + the gateway-secrets Secret and would
+# otherwise mutate the cluster before the image check could fail.
+deploy: check-egg-images-present k3s-secrets  ## Deploy egg to k3s
 	@echo "Deploying to k3s with tag $(EGG_IMAGE_TAG)..."
 	@command -v envsubst >/dev/null 2>&1 || { \
 		echo "ERROR: envsubst not found. Install GNU gettext: 'dnf install gettext' or 'brew install gettext'." >&2; \
 		exit 1; \
 	}
-	@scripts/check-egg-images-present.sh "$(EGG_IMAGE_TAG)"
 	export KUBECONFIG=$${KUBECONFIG:-/etc/rancher/k3s/k3s.yaml} && \
 	export EGG_HOST_HOME="$${EGG_HOST_HOME:-$$HOME}" && \
 	export EGG_HOST_REPO_MAP="$${EGG_HOST_REPO_MAP:-$$(scripts/build-host-repo-map.py)}" && \

--- a/Makefile
+++ b/Makefile
@@ -566,11 +566,15 @@ litellm-config:  ## Apply host-side LiteLLM model_list from ~/.config/egg/litell
 check-egg-images-present:
 	@scripts/check-egg-images-present.sh "$(EGG_IMAGE_TAG)"
 
-# Order of prerequisites matters: check-egg-images-present runs before
-# k3s-secrets so the deploy aborts on tag drift WITHOUT touching the cluster.
-# k3s-secrets reconciles namespaces + the gateway-secrets Secret and would
-# otherwise mutate the cluster before the image check could fail.
-deploy: check-egg-images-present k3s-secrets  ## Deploy egg to k3s
+# check-egg-images-present is the lone prerequisite and k3s-secrets is
+# invoked from the recipe body so the ordering survives `make -j`: two
+# prerequisites of the same target may run in parallel under -j, but recipe
+# lines never do. The check MUST run before k3s-secrets — k3s-secrets
+# reconciles namespaces + the gateway-secrets Secret and would otherwise
+# mutate the cluster before the image check could fail, defeating the
+# zero-mutation abort this guard exists to provide.
+deploy: check-egg-images-present  ## Deploy egg to k3s
+	@$(MAKE) --no-print-directory k3s-secrets
 	@echo "Deploying to k3s with tag $(EGG_IMAGE_TAG)..."
 	@command -v envsubst >/dev/null 2>&1 || { \
 		echo "ERROR: envsubst not found. Install GNU gettext: 'dnf install gettext' or 'brew install gettext'." >&2; \

--- a/Makefile
+++ b/Makefile
@@ -568,6 +568,7 @@ deploy: k3s-secrets  ## Deploy egg to k3s
 		echo "ERROR: envsubst not found. Install GNU gettext: 'dnf install gettext' or 'brew install gettext'." >&2; \
 		exit 1; \
 	}
+	@scripts/check-egg-images-present.sh "$(EGG_IMAGE_TAG)"
 	export KUBECONFIG=$${KUBECONFIG:-/etc/rancher/k3s/k3s.yaml} && \
 	export EGG_HOST_HOME="$${EGG_HOST_HOME:-$$HOME}" && \
 	export EGG_HOST_REPO_MAP="$${EGG_HOST_REPO_MAP:-$$(scripts/build-host-repo-map.py)}" && \

--- a/scripts/check-egg-images-present.sh
+++ b/scripts/check-egg-images-present.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# check-egg-images-present.sh - Fail fast, BEFORE `make deploy` mutates the
+# cluster, when the egg-*:<EGG_IMAGE_TAG> images are not in k3s's containerd.
+#
+# EGG_IMAGE_TAG is `git describe --always --dirty`, so it tracks HEAD and
+# changes on every commit, pull, rebase, or branch checkout. `make redeploy`
+# builds, imports, and deploys on one self-consistent tag — but a bare
+# `make deploy` after HEAD has moved references a tag whose images were never
+# imported.
+#
+# await-egg-deploy.sh already detects that, but only AFTER `kubectl apply` has
+# repointed the live deployments at the missing tag — so a failed bare deploy
+# leaves the running cluster broken until the operator runs `make redeploy`.
+# This pre-flight runs the same authoritative containerd check that k3s-import
+# uses (sudo k3s ctr images list), so deploy aborts with the redeploy hint
+# without touching the cluster.
+#
+# The check is branch-agnostic: it only asks whether images for the *current*
+# tag are present, regardless of how HEAD arrived there. Requires sudo because
+# k3s's containerd socket is root-only — same as k3s-import.
+#
+set -euo pipefail
+
+: "${1:?usage: $0 <egg-image-tag>}"
+TAG="$1"
+
+# egg-built images rewritten onto the manifests by `make deploy`. Keep in sync
+# with the sed rewrites in the deploy target and the k3s-import image list.
+IMAGES=(egg-gateway egg-orchestrator egg-sandbox egg-litellm)
+
+# One listing, reused for every image — k3s ctr is the slow part and needs sudo.
+present=$(sudo k3s ctr images list -q)
+
+missing=()
+for img in "${IMAGES[@]}"; do
+  grep -qx "docker.io/library/$img:$TAG" <<<"$present" || missing+=("$img:$TAG")
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "ERROR: egg-system images for tag '${TAG}' are not in k3s: ${missing[*]}" >&2
+  echo "       A commit, pull, rebase, or branch checkout since your last build" >&2
+  echo "       moved EGG_IMAGE_TAG. 'make deploy' alone only deploys; run" >&2
+  echo "       'make redeploy' to rebuild + re-import + deploy on the current tag." >&2
+  exit 1
+fi
+
+echo "All egg-system images for tag '${TAG}' are present in k3s."


### PR DESCRIPTION
## Problem

`EGG_IMAGE_TAG` is `git describe --always --dirty`, so it tracks `HEAD` and changes on every commit, pull, rebase, **or branch checkout**. k3s's containerd only holds images for the commit you last built+imported, so bare `make deploy` is only valid while `HEAD` still equals that commit.

After any `HEAD` movement, `make deploy` references `egg-*:<tag>` images that were never imported. Today that only surfaces *after* `kubectl apply` has already repointed the live deployments at the missing tag — `await-egg-deploy.sh` then detects the `ImagePullBackOff`, but the running cluster is already broken until the operator runs `make redeploy`.

This is also what makes deploying from non-`main` branches feel unsupported: switching branches is the most reliable way to move `HEAD`, so a bare `deploy` drifts on nearly every switch. Nothing is actually `main`-specific — the tag is branch-agnostic — but the failure mode is loud and the cluster gets mutated first.

## Change

Add a pre-flight guard, `scripts/check-egg-images-present.sh`, that runs the same authoritative `sudo k3s ctr images list` check `k3s-import` already uses (`Makefile:633`), verifying all four `egg-{gateway,orchestrator,sandbox,litellm}:<tag>` images are in containerd. It's wired into the `deploy` target **before** the kustomize/apply pipeline.

- **Tag present** → silent pass; deploy proceeds unchanged.
- **Tag drifted** → `deploy` aborts with the `make redeploy` hint, *without* touching the cluster.

The check is branch-agnostic: it only asks whether images for the *current* tag are present, regardless of how `HEAD` arrived there. `await-egg-deploy.sh` remains the post-apply backstop.

## Cost

`make deploy` now prompts for sudo once (k3s's containerd socket is root-only — same requirement as `k3s-import`). `make redeploy` already primes sudo via `sudo-keepalive`, so that path is unchanged.

## Testing

- `shellcheck` clean on the new script.
- Verified the exact-match (`grep -qx`) logic accepts the present tag, ignores the `:latest` entry, and reports all four images missing on a drifted tag.
- `make -n deploy` confirms the guard runs after the `envsubst` check and before `kubectl apply`.