### PR TITLE
gateway: allow orchestrator role to execute read-only gh pr list (#2893)

### DIFF
--- a/gateway/agent_restrictions.py
+++ b/gateway/agent_restrictions.py
@@ -182,6 +182,8 @@ _OVERSEER_BLOCKED_GH_OPS = [
 
 # Orchestrator role: read-only access for idempotency pre-flights and diagnostics.
 # Blocked from all write operations (create, edit, comment, merge, approve, etc.)
+# Read-only ops left allowed: `pr list`, `pr view`, `pr checks`, `issue list`,
+# `issue view`, `run list`, `run view`, `workflow list`, `workflow view`.
 _ORCHESTRATOR_BLOCKED_GH_OPS = [
     "issue create *",
     "issue edit *",
@@ -198,12 +200,13 @@ _ORCHESTRATOR_BLOCKED_GH_OPS = [
     "pr merge *",
     "pr review *",
     "pr ready *",
-    "pr checks *",
     "pr comment *",
-    "run create *",
     "run cancel *",
     "run delete *",
+    "run rerun *",
     "workflow run *",
+    "workflow enable *",
+    "workflow disable *",
 ]
 
 AGENT_GH_RESTRICTIONS: dict[str, AgentGHRestriction] = {
@@ -241,11 +244,20 @@ AGENT_GH_RESTRICTIONS[AgentRole.OVERSEER] = AgentGHRestriction(
 
 # Add orchestrator with read-only restrictions for idempotency pre-flights.
 # The orchestrator issues `gh pr list` and `gh pr view` to check whether a slice
-# PR already exists before creating one (#2893).
+# PR already exists before creating one (#2893). The blocklist only applies to
+# the generic ``/api/v1/gh/execute`` path — the dedicated
+# ``/api/v1/gh/pr/create`` route does not call ``check_agent_gh_operation``,
+# so orchestrator-initiated slice-PR creation (the legitimate write path)
+# still works through that route.
 AGENT_GH_RESTRICTIONS[AgentRole.ORCHESTRATOR] = AgentGHRestriction(
     role=AgentRole.ORCHESTRATOR,
     blocked_operations=_ORCHESTRATOR_BLOCKED_GH_OPS,
-    description="Orchestrator role is read-only: cannot create/edit/merge PRs, issues, or workflows",
+    description=(
+        "Orchestrator role is read-only via /api/v1/gh/execute: blocks "
+        "create/edit/merge for PRs, issues, and workflows on that path. "
+        "Slice-PR creation still flows through the dedicated "
+        "/api/v1/gh/pr/create route, which is gated by the policy check."
+    ),
 )
 
 

--- a/gateway/agent_restrictions.py
+++ b/gateway/agent_restrictions.py
@@ -180,6 +180,32 @@ _OVERSEER_BLOCKED_GH_OPS = [
     "pr create *",
 ]
 
+# Orchestrator role: read-only access for idempotency pre-flights and diagnostics.
+# Blocked from all write operations (create, edit, comment, merge, approve, etc.)
+_ORCHESTRATOR_BLOCKED_GH_OPS = [
+    "issue create *",
+    "issue edit *",
+    "issue close *",
+    "issue delete *",
+    "issue comment *",
+    "issue pin *",
+    "issue unpin *",
+    "issue transfer *",
+    "pr create *",
+    "pr edit *",
+    "pr close *",
+    "pr reopen *",
+    "pr merge *",
+    "pr review *",
+    "pr ready *",
+    "pr checks *",
+    "pr comment *",
+    "run create *",
+    "run cancel *",
+    "run delete *",
+    "workflow run *",
+]
+
 AGENT_GH_RESTRICTIONS: dict[str, AgentGHRestriction] = {
     role: AgentGHRestriction(
         role=role,
@@ -211,6 +237,15 @@ AGENT_GH_RESTRICTIONS[AgentRole.OVERSEER] = AgentGHRestriction(
     role=AgentRole.OVERSEER,
     blocked_operations=_OVERSEER_BLOCKED_GH_OPS,
     description="Overseer agent cannot post issue comments, edit issues, merge PRs, or create PRs",
+)
+
+# Add orchestrator with read-only restrictions for idempotency pre-flights.
+# The orchestrator issues `gh pr list` and `gh pr view` to check whether a slice
+# PR already exists before creating one (#2893).
+AGENT_GH_RESTRICTIONS[AgentRole.ORCHESTRATOR] = AgentGHRestriction(
+    role=AgentRole.ORCHESTRATOR,
+    blocked_operations=_ORCHESTRATOR_BLOCKED_GH_OPS,
+    description="Orchestrator role is read-only: cannot create/edit/merge PRs, issues, or workflows",
 )
 
 

--- a/gateway/tests/test_agent_restrictions_gh.py
+++ b/gateway/tests/test_agent_restrictions_gh.py
@@ -160,3 +160,73 @@ class TestCheckAgentGHOperation:
         for role in roles:
             allowed, _ = check_agent_gh_operation(role, "issue comment 123")
             assert allowed is False, f"Role '{role}' should be blocked from issue comment"
+
+
+class TestOrchestratorRole:
+    """Tests for orchestrator role GH restrictions (#2893)."""
+
+    def test_orchestrator_registered(self):
+        """Orchestrator role is registered in AGENT_GH_RESTRICTIONS."""
+        assert AgentRole.ORCHESTRATOR in AGENT_GH_RESTRICTIONS
+
+    def test_orchestrator_allows_pr_list(self):
+        """Orchestrator can execute pr list (idempotency pre-flight)."""
+        allowed, reason = check_agent_gh_operation("orchestrator", "pr list")
+        assert allowed is True, f"Orchestrator should allow pr list: {reason}"
+
+    def test_orchestrator_allows_pr_view(self):
+        """Orchestrator can execute pr view."""
+        allowed, reason = check_agent_gh_operation("orchestrator", "pr view 123")
+        assert allowed is True, f"Orchestrator should allow pr view: {reason}"
+
+    def test_orchestrator_allows_issue_list(self):
+        """Orchestrator can enumerate open issues."""
+        allowed, reason = check_agent_gh_operation("orchestrator", "issue list")
+        assert allowed is True, f"Orchestrator should allow issue list: {reason}"
+
+    def test_orchestrator_allows_issue_view(self):
+        """Orchestrator can view issues."""
+        allowed, reason = check_agent_gh_operation("orchestrator", "issue view 456")
+        assert allowed is True, f"Orchestrator should allow issue view: {reason}"
+
+    def test_orchestrator_blocks_pr_create(self):
+        """Orchestrator cannot create PRs."""
+        allowed, reason = check_agent_gh_operation("orchestrator", "pr create --title test")
+        assert allowed is False
+
+    def test_orchestrator_blocks_pr_edit(self):
+        """Orchestrator cannot edit PRs."""
+        allowed, reason = check_agent_gh_operation("orchestrator", "pr edit 123")
+        assert allowed is False
+
+    def test_orchestrator_blocks_pr_merge(self):
+        """Orchestrator cannot merge PRs."""
+        allowed, reason = check_agent_gh_operation("orchestrator", "pr merge 123")
+        assert allowed is False
+
+    def test_orchestrator_blocks_pr_review(self):
+        """Orchestrator cannot review PRs."""
+        allowed, reason = check_agent_gh_operation("orchestrator", "pr review 123")
+        assert allowed is False
+
+    def test_orchestrator_blocks_issue_edit(self):
+        """Orchestrator cannot edit issues."""
+        allowed, reason = check_agent_gh_operation("orchestrator", "issue edit 456")
+        assert allowed is False
+
+    def test_orchestrator_blocks_issue_comment(self):
+        """Orchestrator cannot comment on issues."""
+        allowed, reason = check_agent_gh_operation("orchestrator", "issue comment 789")
+        assert allowed is False
+
+    def test_orchestrator_blocks_issue_create_close_pin(self):
+        """Orchestrator cannot create/close/pin issues."""
+        for cmd in ["issue create --title test", "issue close 123", "issue pin 456"]:
+            allowed, reason = check_agent_gh_operation("orchestrator", cmd)
+            assert allowed is False, f"Orchestrator should block {cmd}: {reason}"
+
+    def test_orchestrator_blocks_workflow_operations(self):
+        """Orchestrator cannot trigger/cancel workflows."""
+        for cmd in ["workflow run build.yaml", "run create", "run cancel"]:
+            allowed, reason = check_agent_gh_operation("orchestrator", cmd)
+            assert allowed is False, f"Orchestrator should block {cmd}: {reason}"

--- a/gateway/tests/test_agent_restrictions_gh.py
+++ b/gateway/tests/test_agent_restrictions_gh.py
@@ -189,8 +189,18 @@ class TestOrchestratorRole:
         allowed, reason = check_agent_gh_operation("orchestrator", "issue view 456")
         assert allowed is True, f"Orchestrator should allow issue view: {reason}"
 
-    def test_orchestrator_blocks_pr_create(self):
-        """Orchestrator cannot create PRs."""
+    def test_orchestrator_allows_pr_checks(self):
+        """Orchestrator can query check-run status (`pr checks` is read-only)."""
+        allowed, reason = check_agent_gh_operation("orchestrator", "pr checks 123")
+        assert allowed is True, f"Orchestrator should allow pr checks: {reason}"
+
+    def test_orchestrator_blocks_pr_create_via_execute_route(self):
+        """Orchestrator cannot create PRs through `/api/v1/gh/execute`.
+
+        Note: the dedicated `/api/v1/gh/pr/create` route does not call
+        `check_agent_gh_operation`, so legitimate slice-PR creation by the
+        orchestrator continues to work through that route.
+        """
         allowed, reason = check_agent_gh_operation("orchestrator", "pr create --title test")
         assert allowed is False
 
@@ -226,7 +236,7 @@ class TestOrchestratorRole:
             assert allowed is False, f"Orchestrator should block {cmd}: {reason}"
 
     def test_orchestrator_blocks_workflow_operations(self):
-        """Orchestrator cannot trigger/cancel workflows."""
-        for cmd in ["workflow run build.yaml", "run create", "run cancel"]:
+        """Orchestrator cannot trigger workflows or cancel/delete/rerun runs."""
+        for cmd in ["workflow run build.yaml", "run cancel 1", "run delete 2", "run rerun 3"]:
             allowed, reason = check_agent_gh_operation("orchestrator", cmd)
             assert allowed is False, f"Orchestrator should block {cmd}: {reason}"

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -2557,7 +2557,7 @@ class GatewayClient:
         pipeline_id: str,
         repo: str,
         *,
-        agent_role: str = "coder",
+        agent_role: str = "orchestrator",
         mode: Literal["public", "private"] = "public",
         limit: int = 200,
     ) -> list[dict[str, Any]]:
@@ -2571,6 +2571,12 @@ class GatewayClient:
         ``ALLOWED_GH_COMMANDS`` deny-by-default allowlist
         (gateway/github_client.py) so no privileged endpoint is introduced
         (decision-15).
+
+        The synthetic session defaults to ``agent_role="orchestrator"`` so the
+        audit log attributes these calls to the orchestrator (the actual
+        caller) instead of impersonating a coder. The gateway's
+        ``AGENT_GH_RESTRICTIONS`` allowlist accepts that role for read-only
+        ``gh pr list`` calls (#2893).
 
         On any error (gateway 4xx/5xx, JSON parse failure) the
         function logs and returns an empty list — the reconciler

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1778,15 +1778,10 @@ class GatewayClient:
         # (PR created server-side, transport blip on the response) from
         # cascading the slice to FAILED on the next tick.
         if repo:
-            # Hardcode synthetic role to "coder" — `_lookup_open_pr`'s
-            # `/api/v1/gh/execute` round-trip is gated by
-            # `check_agent_gh_operation`, and "orchestrator" is not in
-            # `AGENT_GH_RESTRICTIONS` so it 403s as an unknown role
-            # (see reviewer_code_holistic v3 NACK). Propagating the
-            # caller's `agent_role` (which `pipelines.py` passes as
-            # "orchestrator" for slice-PR creation) defeats the cq-8
-            # idempotency pre-flight because the swallowed 403 looks
-            # like a benign miss and `gh pr create` runs anyway.
+            # Idempotency pre-flight (#2777 cq-8). The synthetic session uses
+            # ``agent_role="orchestrator"`` — the gateway's
+            # ``AGENT_GH_RESTRICTIONS`` allowlist accepts that role for
+            # read-only ``gh pr list`` calls (#2893).
             existing_pr_number = self._lookup_open_pr(
                 pipeline_id=pipeline_id,
                 repo=repo,
@@ -2682,12 +2677,9 @@ class GatewayClient:
         broader ``list_open_prs`` shape because it needs to enumerate
         every open PR for the client-side filter.
 
-        The synthetic session is hardcoded to register with
-        ``agent_role="coder"`` because ``/api/v1/gh/execute`` is gated
-        by ``check_agent_gh_operation`` which only accepts roles in
-        ``AGENT_GH_RESTRICTIONS``; the orchestrator-side caller's
-        own role string (e.g. "orchestrator") would 403 as unknown
-        (see reviewer_code_holistic v3 NACK on #2777 slice-3).
+        The synthetic session registers with ``agent_role="orchestrator"``.
+        The gateway's ``AGENT_GH_RESTRICTIONS`` allowlist accepts that role
+        for read-only ``gh pr list`` calls (#2893).
 
         Returns:
             The integer PR number on hit, ``None`` on miss OR on any
@@ -2707,18 +2699,12 @@ class GatewayClient:
         temp_container_id = f"{pipeline_id}-pr-lookup"
         session_token: str | None = None
         try:
-            # TODO(#2893): use ``agent_role="orchestrator"`` once the
-            # gateway's ``AGENT_GH_RESTRICTIONS`` allowlist accepts that
-            # role for read-only ``gh pr list`` calls. The orchestrator
-            # is the actual caller here; "coder" is a temporary stand-in
-            # because the gateway currently rejects "orchestrator" at
-            # /api/v1/gh/execute.
             session = self.register_session(
                 container_id=temp_container_id,
                 container_ip=self.self_ip,
                 mode=mode,
                 pipeline_id=pipeline_id,
-                agent_role="coder",
+                agent_role="orchestrator",
                 synthetic=True,
             )
             session_token = session.session_token

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -15822,7 +15822,11 @@ def _start_stacked_pr_reconciler(
         if not pr_repo:
             return []
         try:
-            return list(gateway.list_open_prs(pipeline_id, pr_repo, agent_role="coder"))
+            # Stacked-PR reconciler is orchestrator-driven; the synthetic
+            # session uses ``agent_role="orchestrator"`` so the audit log
+            # attributes these `gh pr list` calls to the actual caller
+            # (the orchestrator) instead of impersonating a coder (#2893).
+            return list(gateway.list_open_prs(pipeline_id, pr_repo, agent_role="orchestrator"))
         except Exception as exc:  # noqa: BLE001
             logger.debug(
                 "stacked_pr_reconciler: list_open_prs raised — treating as empty",

--- a/orchestrator/tests/test_models.py
+++ b/orchestrator/tests/test_models.py
@@ -1106,10 +1106,14 @@ class TestAgentRole:
         assert AgentRole.OVERSEER in roles
         assert AgentRole.AUTOFIXER in roles
         assert AgentRole.CONFLICT_RESOLVER in roles
+        # Issue #2893 — ORCHESTRATOR joined the registry as an audit-log
+        # attribution role for read-only gh pre-flights (gh pr list /
+        # pr view) issued by the orchestrator itself.
+        assert AgentRole.ORCHESTRATOR in roles
         # Issue #1557: APPLIER asserted above next to the other execution
         # roles (CODER / TESTER / DOCUMENTER); count assertion below
-        # pins the registry size including APPLIER.
-        assert len(roles) == 19
+        # pins the registry size including APPLIER and ORCHESTRATOR.
+        assert len(roles) == 20
 
 
 class TestBackwardCompatibility:

--- a/orchestrator/tests/test_models.py
+++ b/orchestrator/tests/test_models.py
@@ -1110,9 +1110,10 @@ class TestAgentRole:
         # attribution role for read-only gh pre-flights (gh pr list /
         # pr view) issued by the orchestrator itself.
         assert AgentRole.ORCHESTRATOR in roles
-        # Issue #1557: APPLIER asserted above next to the other execution
-        # roles (CODER / TESTER / DOCUMENTER); count assertion below
-        # pins the registry size including APPLIER and ORCHESTRATOR.
+        # Registry-size pin. Count grew from the original 18 → 19 with
+        # APPLIER (#1557) → 20 with ORCHESTRATOR (#2893). Bump this and
+        # add the matching `assert AgentRole.X in roles` above whenever a
+        # new role lands.
         assert len(roles) == 20
 
 

--- a/shared/egg_contracts/agent_roles.py
+++ b/shared/egg_contracts/agent_roles.py
@@ -89,6 +89,8 @@ class AgentRole(StrEnum):
     # Utility roles (cross-cutting support)
     AUTOFIXER = "autofixer"
     CONFLICT_RESOLVER = "conflict_resolver"
+    # Infrastructure roles
+    ORCHESTRATOR = "orchestrator"
     # Interface roles (external system interaction)
     OVERSEER = "overseer"
 

--- a/shared/egg_contracts/agent_roles.py
+++ b/shared/egg_contracts/agent_roles.py
@@ -750,6 +750,43 @@ REVIEWER_CONCURRENCY_ROLE = AgentRoleDefinition(
 )
 
 
+# Orchestrator role (#2893) — central coordinator that issues read-only
+# gh pre-flights (e.g., `gh pr list`, `gh pr view`) on its own behalf.
+# Exists so audit logs attribute these calls to "orchestrator" instead of
+# impersonating a coder. The orchestrator is not spawned as an agent
+# session and writes no files through the agent-restriction surface.
+ORCHESTRATOR_ROLE = AgentRoleDefinition(
+    role=AgentRole.ORCHESTRATOR,
+    description="Central coordinator; issues read-only gh pre-flights on its own behalf",
+    category=AgentCategory.INTERFACE,
+    responsibilities=[
+        "Issue read-only gh pre-flights (gh pr list, gh pr view) for "
+        "idempotency checks before spawning agents",
+    ],
+    dependencies=[],
+    file_access=FileAccessPattern(
+        allowed_read=[],
+        allowed_write=[],
+        blocked_write=[
+            "src/",
+            "lib/",
+            "shared/",
+            "gateway/",
+            "sandbox/",
+            "action/",
+            "orchestrator/",
+            "docs/",
+            "tests/",
+            "test/",
+            ".egg-state/",
+            ".github/",
+        ],
+    ),
+    can_run_in_parallel=True,
+    produces_outputs=[],
+)
+
+
 # Overseer role — monitors pipeline health, classifies anomalies, escalates issues
 OVERSEER_ROLE = AgentRoleDefinition(
     role=AgentRole.OVERSEER,
@@ -938,6 +975,7 @@ AGENT_ROLES: dict[AgentRole, AgentRoleDefinition] = {
     AgentRole.CONFLICT_RESOLVER: CONFLICT_RESOLVER_ROLE,
     # Interface roles
     AgentRole.OVERSEER: OVERSEER_ROLE,
+    AgentRole.ORCHESTRATOR: ORCHESTRATOR_ROLE,
 }
 
 
@@ -980,6 +1018,8 @@ AGENT_ROLE_TO_CONTRACT_ROLE: dict[AgentRole, Role] = {
     AgentRole.CONFLICT_RESOLVER: Role.IMPLEMENTER,
     # Interface: observers, not contract authors
     AgentRole.OVERSEER: Role.SYSTEM,
+    # Orchestrator: central coordinator, not a contract author
+    AgentRole.ORCHESTRATOR: Role.SYSTEM,
 }
 
 

--- a/shared/egg_contracts/agent_roles.py
+++ b/shared/egg_contracts/agent_roles.py
@@ -89,10 +89,9 @@ class AgentRole(StrEnum):
     # Utility roles (cross-cutting support)
     AUTOFIXER = "autofixer"
     CONFLICT_RESOLVER = "conflict_resolver"
-    # Infrastructure roles
-    ORCHESTRATOR = "orchestrator"
     # Interface roles (external system interaction)
     OVERSEER = "overseer"
+    ORCHESTRATOR = "orchestrator"
 
 
 class AgentStatus(StrEnum):
@@ -767,6 +766,9 @@ ORCHESTRATOR_ROLE = AgentRoleDefinition(
     file_access=FileAccessPattern(
         allowed_read=[],
         allowed_write=[],
+        # Defense-in-depth list; `allowed_write=[]` already denies everything
+        # via `can_write`. These entries make the intent explicit for readers
+        # grepping the role for what it cannot touch.
         blocked_write=[
             "src/",
             "lib/",

--- a/shared/egg_restrictions/patterns.py
+++ b/shared/egg_restrictions/patterns.py
@@ -564,6 +564,32 @@ OVERSEER_PATTERNS = AgentFilePattern(
 )
 
 
+# Orchestrator role pattern (#2893)
+# The orchestrator role exists for audit-log attribution of read-only
+# gh pre-flights (e.g., `gh pr list`, `gh pr view`) issued by the
+# orchestrator itself. The orchestrator never pushes through the gateway's
+# agent restriction surface, so no file writes are allowed.
+ORCHESTRATOR_PATTERNS = AgentFilePattern(
+    role=AgentRole.ORCHESTRATOR,
+    description="read-only role for gh pre-flights; no file writes allowed",
+    allowed_patterns=[],
+    blocked_patterns=[
+        "src/",
+        "lib/",
+        "shared/",
+        "gateway/",
+        "sandbox/",
+        "action/",
+        "orchestrator/",
+        "docs/",
+        "tests/",
+        "test/",
+        ".egg-state/",
+        ".github/",
+    ],
+)
+
+
 # Autofixer agent pattern
 # The autofixer applies automated lint/type-check/formatting fixes to source
 # and config files.  It cannot modify docs or contracts.
@@ -716,6 +742,7 @@ AGENT_PATTERNS: dict[str, AgentFilePattern] = {
     AgentRole.OVERSEER: OVERSEER_PATTERNS,
     AgentRole.AUTOFIXER: AUTOFIXER_PATTERNS,
     AgentRole.CONFLICT_RESOLVER: CONFLICT_RESOLVER_PATTERNS,
+    AgentRole.ORCHESTRATOR: ORCHESTRATOR_PATTERNS,
 }
 
 
@@ -818,6 +845,7 @@ def build_agent_patterns(
         AgentRole.OVERSEER: OVERSEER_PATTERNS,
         AgentRole.AUTOFIXER: autofixer,
         AgentRole.CONFLICT_RESOLVER: conflict_resolver,
+        AgentRole.ORCHESTRATOR: ORCHESTRATOR_PATTERNS,
     }
 
 

--- a/shared/egg_restrictions/patterns.py
+++ b/shared/egg_restrictions/patterns.py
@@ -573,6 +573,9 @@ ORCHESTRATOR_PATTERNS = AgentFilePattern(
     role=AgentRole.ORCHESTRATOR,
     description="read-only role for gh pre-flights; no file writes allowed",
     allowed_patterns=[],
+    # Defense-in-depth list; `allowed_patterns=[]` already denies all writes.
+    # These entries make the intent explicit for readers grepping for what
+    # the role cannot touch.
     blocked_patterns=[
         "src/",
         "lib/",

--- a/shared/tests/test_egg_restrictions.py
+++ b/shared/tests/test_egg_restrictions.py
@@ -77,8 +77,9 @@ class TestAgentRole:
 class TestAgentPatterns:
     def test_registry_has_all_20_roles(self):
         # Issue #1557 — APPLIER joined the registry (Jira-epic SDLC
-        # support); the count grew from 19 to 20.
-        assert len(AGENT_PATTERNS) == 19
+        # support); the count grew from 19 to 20. Issue #2893 — ORCHESTRATOR
+        # joined for audit-log attribution of read-only gh pre-flights.
+        assert len(AGENT_PATTERNS) == 20
 
     def test_registry_keys_match_role_constants(self):
         expected_roles = {
@@ -102,6 +103,8 @@ class TestAgentPatterns:
             AgentRole.AUTOFIXER,
             AgentRole.CONFLICT_RESOLVER,
             AgentRole.OVERSEER,
+            # Issue #2893 — read-only audit attribution role for gh pre-flights.
+            AgentRole.ORCHESTRATOR,
         }
         assert set(AGENT_PATTERNS.keys()) == expected_roles
 

--- a/tests/shared/egg_contracts/test_agent_roles.py
+++ b/tests/shared/egg_contracts/test_agent_roles.py
@@ -91,10 +91,11 @@ class TestAgentRole:
         "overseer",
         "autofixer",
         "conflict_resolver",
+        "orchestrator",
     }
 
     def test_all_expected_roles_exist(self):
-        """All 19 expected roles should be present in the enum."""
+        """All 20 expected roles should be present in the enum."""
         actual = {r.value for r in AgentRole}
         assert self.EXPECTED_ROLES == actual, (
             f"Missing roles: {self.EXPECTED_ROLES - actual}, "
@@ -102,8 +103,8 @@ class TestAgentRole:
         )
 
     def test_role_count(self):
-        """Should have exactly 19 canonical roles."""
-        assert len(AgentRole) == 19
+        """Should have exactly 20 canonical roles."""
+        assert len(AgentRole) == 20
 
     def test_execution_roles(self):
         assert AgentRole.CODER == "coder"


### PR DESCRIPTION
Add orchestrator role to AGENT_GH_RESTRICTIONS with read-only allowlist for gh pr list and pr view operations. Update _lookup_open_pr to use agent_role="orchestrator" instead of hardcoding "coder".

This fixes audit log misattribution where the orchestrator was impersonating a coder for read-only pre-flights.

## Changes
- shared/egg_contracts/agent_roles.py: Add ORCHESTRATOR to AgentRole enum
- gateway/agent_restrictions.py: Add orchestrator entry to AGENT_GH_RESTRICTIONS with blocked ops list for write operations  
- orchestrator/gateway_client.py: Change _lookup_open_pr to use agent_role="orchestrator" and update related comments
- gateway/tests/test_agent_restrictions_gh.py: Add 14 tests for orchestrator role permissions

Closes #2893