### PR TITLE
gateway: allow --not and -p/--patch in git log allowlist (#2905)

### DIFF
--- a/gateway/git_client.py
+++ b/gateway/git_client.py
@@ -1003,9 +1003,11 @@ FLAG_NORMALIZATION = {
     "worktree": {"-v": "--verbose"},
     "ls-remote": {"-q": "--quiet"},
     "update-index": {"-q": "--quiet"},
+    # log: -p normalizes to --patch so the BRC re-review delta command
+    # (`git log <sha>..HEAD --not origin/<base> -p`) matches the allowlist. #2905
+    "log": {"-p": "--patch"},
     # Subcommands with no short-flag normalization needed (included for completeness):
     "status": {},
-    "log": {"-p": "--patch"},
     "diff": {},
     "show": {},
     "rev-parse": {},

--- a/gateway/git_client.py
+++ b/gateway/git_client.py
@@ -355,6 +355,16 @@ GIT_ALLOWED_COMMANDS: dict[str, dict[str, list[str]]] = {
             "--first-parent",
             "--reverse",
             "--max-count",
+            # --patch (-p) and --not power the canonical BRC re-review delta
+            # command documented in REVIEWER-SYNC.md:110 and emitted by
+            # _build_review_prompt() in orchestrator/routes/pipelines.py
+            # (`git log <sha>..HEAD --not origin/<base> -p`). Both are read-only.
+            # --not mirrors the ^ref exclude syntax the revision-range parser
+            # already accepts (see agent_salvage.py _resolve_anchor / list_unpushed_commits).
+            # Without these, reviewers on the LiteLLM route burn their turn
+            # budget retrying and exit without a v2+ verdict (#2905).
+            "--patch",
+            "--not",
             # ``-n N``, ``-n=N``, ``-nN``, and ``-<N>`` (e.g. ``-3``) are
             # accepted as aliases for ``--max-count=N`` via special cases in
             # ``validate_git_args`` (search for "issue #2480"). We don't put
@@ -994,7 +1004,7 @@ FLAG_NORMALIZATION = {
     "update-index": {"-q": "--quiet"},
     # Subcommands with no short-flag normalization needed (included for completeness):
     "status": {},
-    "log": {},
+    "log": {"-p": "--patch"},
     "diff": {},
     "show": {},
     "rev-parse": {},

--- a/gateway/git_client.py
+++ b/gateway/git_client.py
@@ -338,6 +338,23 @@ GIT_ALLOWED_COMMANDS: dict[str, dict[str, list[str]]] = {
             "-s",
         ],
     },
+    # ``--patch`` (``-p``) and ``--not`` power the canonical BRC re-review
+    # delta command documented in REVIEWER-SYNC.md:110 and emitted by
+    # ``_build_review_prompt()`` in ``orchestrator/routes/pipelines.py``
+    # (``git log <sha>..HEAD --not origin/<base> -p``). Both are read-only.
+    # ``--not`` mirrors the ``^ref`` exclude syntax the revision-range parser
+    # already accepts (see ``agent_salvage.py`` ``_resolve_anchor`` /
+    # ``list_unpushed_commits``). Without these, reviewers on the LiteLLM
+    # route burn their turn budget retrying and exit without a v2+ verdict
+    # (#2905).
+    #
+    # ``-n N``, ``-n=N``, ``-nN``, and ``-<N>`` (e.g. ``-3``) are accepted as
+    # aliases for ``--max-count=N`` via special cases in ``validate_git_args``
+    # (search for "issue #2480"). We don't put ``-n`` in the ``log`` entry of
+    # ``FLAG_NORMALIZATION`` because its value is a separate argument, which
+    # the per-flag normalizer can't see. Both special cases also apply to the
+    # ``reflog`` allowlist below — reflog is internally a log walker and
+    # shares the same ``--max-count`` semantics for both forms.
     "log": {
         "allowed_flags": [
             "--oneline",
@@ -355,24 +372,8 @@ GIT_ALLOWED_COMMANDS: dict[str, dict[str, list[str]]] = {
             "--first-parent",
             "--reverse",
             "--max-count",
-            # --patch (-p) and --not power the canonical BRC re-review delta
-            # command documented in REVIEWER-SYNC.md:110 and emitted by
-            # _build_review_prompt() in orchestrator/routes/pipelines.py
-            # (`git log <sha>..HEAD --not origin/<base> -p`). Both are read-only.
-            # --not mirrors the ^ref exclude syntax the revision-range parser
-            # already accepts (see agent_salvage.py _resolve_anchor / list_unpushed_commits).
-            # Without these, reviewers on the LiteLLM route burn their turn
-            # budget retrying and exit without a v2+ verdict (#2905).
             "--patch",
             "--not",
-            # ``-n N``, ``-n=N``, ``-nN``, and ``-<N>`` (e.g. ``-3``) are
-            # accepted as aliases for ``--max-count=N`` via special cases in
-            # ``validate_git_args`` (search for "issue #2480"). We don't put
-            # ``-n`` in the log entry of FLAG_NORMALIZATION because its value
-            # is a separate argument, which the per-flag normalizer can't see.
-            # Both special cases also apply to the ``reflog`` allowlist below —
-            # reflog is internally a log walker and shares the same
-            # ``--max-count`` semantics for both forms.
             "--since",
             "--until",
             "--author",

--- a/gateway/tests/test_git_validation.py
+++ b/gateway/tests/test_git_validation.py
@@ -226,6 +226,52 @@ class TestGitArgsValidation:
         assert valid is True
         assert error == ""
 
+    def test_log_not_flag_allowed(self):
+        """git log accepts --not for revision-range excludes.
+
+        --not powers the canonical BRC re-review delta command documented in
+        REVIEWER-SYNC.md:110 (`git log <sha>..HEAD --not origin/<base> -p`).
+        Mirrors the `^ref` exclude syntax the revision-range parser already
+        permits (see agent_salvage.py list_unpushed_commits).
+        Issue #2905.
+        """
+        valid, error, args = git_client.validate_git_args(
+            "log", ["abc123..HEAD", "--not", "origin/main"]
+        )
+        assert valid is True
+        assert error == ""
+        assert "--not" in args
+        assert "origin/main" in args
+
+    def test_log_patch_flag_allowed(self):
+        """git log accepts -p / --patch for commit diffs.
+
+        -p / --patch is required by the documented re-review delta command.
+        The short form -p normalizes to --patch before the allowlist check
+        (see FLAG_NORMALIZATION['log']).
+        Issue #2905.
+        """
+        for flag in ("-p", "--patch"):
+            valid, error, args = git_client.validate_git_args("log", [flag, "HEAD"])
+            assert valid is True, f"{flag} rejected: {error}"
+            assert error == ""
+            assert "--patch" in args
+
+    def test_log_delta_review_command(self):
+        """The full BRC re-review delta command from REVIEWER-SYNC.md:110 passes.
+
+        This is the exact command that burned reviewer cycles to
+        retry-and-exhaust on the #2270 Qwen pilot (reviewer exited
+        success=True at 30 turns without emitting a v2 verdict).
+        Issue #2905.
+        """
+        valid, error, args = git_client.validate_git_args(
+            "log", ["abc123..HEAD", "--not", "origin/main", "-p"]
+        )
+        assert valid is True
+        assert error == ""
+        assert args == ["abc123..HEAD", "--not", "origin/main", "--patch"]
+
     def test_format_patch_allowed_flags(self):
         """git format-patch accepts its allowed flags."""
         valid, error, args = git_client.validate_git_args("format-patch", ["--stdout", "HEAD~1"])
@@ -278,6 +324,14 @@ class TestFlagNormalization:
         assert git_client.normalize_flag("-a", "fetch") == "--all"
         assert git_client.normalize_flag("-t", "fetch") == "--tags"
         assert git_client.normalize_flag("-p", "fetch") == "--prune"
+
+    def test_short_p_to_patch_in_log(self):
+        """git log -p normalizes to --patch so the allowlist accepts it.
+
+        Required by the BRC re-review delta command (`git log <sha>..HEAD
+        --not origin/<base> -p`). Issue #2905.
+        """
+        assert git_client.normalize_flag("-p", "log") == "--patch"
         assert git_client.normalize_flag("-v", "fetch") == "--verbose"
         assert git_client.normalize_flag("-q", "fetch") == "--quiet"
         assert git_client.normalize_flag("-j", "fetch") == "--jobs"

--- a/gateway/tests/test_git_validation.py
+++ b/gateway/tests/test_git_validation.py
@@ -324,6 +324,9 @@ class TestFlagNormalization:
         assert git_client.normalize_flag("-a", "fetch") == "--all"
         assert git_client.normalize_flag("-t", "fetch") == "--tags"
         assert git_client.normalize_flag("-p", "fetch") == "--prune"
+        assert git_client.normalize_flag("-v", "fetch") == "--verbose"
+        assert git_client.normalize_flag("-q", "fetch") == "--quiet"
+        assert git_client.normalize_flag("-j", "fetch") == "--jobs"
 
     def test_short_p_to_patch_in_log(self):
         """git log -p normalizes to --patch so the allowlist accepts it.
@@ -332,9 +335,6 @@ class TestFlagNormalization:
         --not origin/<base> -p`). Issue #2905.
         """
         assert git_client.normalize_flag("-p", "log") == "--patch"
-        assert git_client.normalize_flag("-v", "fetch") == "--verbose"
-        assert git_client.normalize_flag("-q", "fetch") == "--quiet"
-        assert git_client.normalize_flag("-j", "fetch") == "--jobs"
 
     def test_short_to_long_push(self):
         """Short flags are normalized to long form for push."""


### PR DESCRIPTION
## Summary

Fixes #2905

The gateway's `git log` allowlist rejected `--not` and `-p`/`--patch`, breaking the canonical BRC re-review delta command documented in `REVIEWER-SYNC.md:110` and generated by `_build_review_prompt()`:

```bash
git log <sha>..HEAD --not origin/<base> -p
```

This caused reviewers (especially on the LiteLLM/Qwen route) to burn turn budgets retrying and exit without v2+ verdicts, triggering consensus restarts.

## Changes

### gateway/git_client.py
- Added `--patch` and `--not` to `log` `allowed_flags` (lines 367-368)
- Added `-p` → `--patch` normalization at `FLAG_NORMALIZATION['log']` (line 997)
- Documented both changes with inline comments referencing #2905

Both flags are read-only. `--patch` mirrors the documented `-p` short form. `--not` mirrors the `^ref` exclude syntax the revision-range parser already permits (`agent_salvage.py list_unpushed_commits`).

### gateway/tests/test_git_validation.py
Four new test cases:
- `test_log_not_flag_allowed` — validates `--not` alone
- `test_log_patch_flag_allowed` — validates both `-p` and `--patch` forms
- `test_log_delta_review_command` — full canonical command from REVIEWER-SYNC.md:110
- `test_short_p_to_patch_in_log` — normalization mapping

## Verification

- ✅ `make lint` — clean (warnings are pre-existing)
- ✅ `make test` — 584 passed, 0 failed, 89 warnings (445s, changeset-aware)

The 584 passed tests cover all gateway functionality (git validation, client operations, restrictions). No regressions detected.

## Scope

Per `feedback_scope_no_bundling.md`: this fix is scoped to the reported surface. I did **not** widen the `reflog` allowlist (symmetric but uncited) or modify action-side review scripts (they run outside the gateway).

## Why this approach

The issue presented two options:
1. **Widen the allowlist** (chosen) — doc/prompt/gateway agreement, minimal surprise
2. **Rewrite prompts** to use gateway-compatible syntax — creates a doc/prompt/gateway mismatch that will bite again

Option 1 is least surprising and keeps the documented command as the canonical form. Both flags are read-only with no side effects.