### PR TITLE
fix(orchestrator): auto-populate contract at implement start (#2915)

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -19565,10 +19565,12 @@ def _auto_populate_contract_at_implement_start(
 
     # Push the populated contract
     try:
-        from gateway.client import GatewayClient
-
-        _gw = GatewayClient()
-        _gw.push_worktrees_branch(pipeline_id, pipeline_branch)
+        _gw = get_gateway_client()
+        _gw.push_worktree_branch(
+            pipeline_id=pipeline_id,
+            repo_path=str(worktree_repo_path),
+            branch=pipeline_branch,
+        )
     except Exception as _push_err:  # noqa: BLE001
         logger.warning(
             "Auto-populate: push failed (non-fatal, contract is committed locally)",

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -19482,6 +19482,109 @@ def _origin_has_plan_draft(repo_path: Path, branch: str, draft_rel: str) -> bool
         return False
 
 
+def _auto_populate_contract_at_implement_start(
+    worktree_repo_path: Path,
+    pipeline_id: str,
+    pipeline_mode: str,
+    issue_number: int | None,
+    current_phase: PipelinePhase,
+    pipeline_branch: str,
+) -> int:
+    """Attempt to auto-populate an empty contract at implement start (#2915).
+
+    When a pipeline enters the implement phase with zero slices in the
+    contract, this helper tries to populate it from the plan draft. On
+    success, commits and pushes the populated contract; on failure, logs
+    and returns 0 (still empty).
+
+    Returns the number of slices in the contract after the attempt.
+    """
+    logger.info(
+        "Attempting to auto-populate empty contract at implement start (#2915)",
+        pipeline_id=pipeline_id,
+        issue_number=issue_number,
+    )
+    try:
+        from routes.pipelines import _populate_contract_from_plan
+
+        _populate_result = _populate_contract_from_plan(
+            worktree_repo_path,
+            pipeline_id,
+            pipeline_mode,
+            issue_number,
+            current_phase=current_phase,
+        )
+    except ForestValidationError as _forest_err:
+        logger.warning(
+            "Auto-populate contract failed: forest validation error",
+            pipeline_id=pipeline_id,
+            errors=_forest_err.errors,
+        )
+        return 0
+    except Exception as _populate_err:  # noqa: BLE001
+        logger.warning(
+            "Auto-populate contract failed at implement start",
+            pipeline_id=pipeline_id,
+            error=str(_populate_err),
+            exc_info=True,
+        )
+        return 0
+
+    if _populate_result.outcome != PopulateOutcome.POPULATED or _populate_result.slice_count == 0:
+        logger.warning(
+            "Auto-populate contract returned empty or failed",
+            pipeline_id=pipeline_id,
+            outcome=_populate_result.outcome.value,
+            slice_count=_populate_result.slice_count,
+        )
+        return 0
+
+    # Commit the populated contract
+    try:
+        from routes.pipelines import _commit_statefiles_to_worktree
+
+        _committed = _commit_statefiles_to_worktree(
+            worktree_repo_path,
+            "Auto-populate contract at implement start (#2915)",
+            issue_number,
+            pipeline_id=pipeline_id,
+        )
+        if not _committed:
+            logger.warning(
+                "Auto-populate: commit returned False (nothing to commit)",
+                pipeline_id=pipeline_id,
+            )
+            return 0
+    except Exception as _commit_err:  # noqa: BLE001
+        logger.warning(
+            "Auto-populate: commit failed",
+            pipeline_id=pipeline_id,
+            error=str(_commit_err),
+        )
+        return 0
+
+    # Push the populated contract
+    try:
+        from gateway.client import GatewayClient
+
+        _gw = GatewayClient()
+        _gw.push_worktrees_branch(pipeline_id, pipeline_branch)
+    except Exception as _push_err:  # noqa: BLE001
+        logger.warning(
+            "Auto-populate: push failed (non-fatal, contract is committed locally)",
+            pipeline_id=pipeline_id,
+            error=str(_push_err),
+        )
+        # Push failure is not fatal — the contract is already committed locally
+
+    logger.info(
+        "Auto-populate contract succeeded",
+        pipeline_id=pipeline_id,
+        slice_count=_populate_result.slice_count,
+    )
+    return _populate_result.slice_count
+
+
 def _populate_contract_from_plan_safe(
     repo_path: Path,
     pipeline_id: str,
@@ -22051,6 +22154,25 @@ def _run_pipeline(
                             # the structured log when the populator dropped
                             # slices (#2337).
                             _use_slice_loop = _is_slice_dag_mode(_check_contract)
+
+                            # #2915: Auto-populate contract if empty at implement start
+                            # This fills the gap where start_phase=implement doesn't trigger
+                            # the plan-completion populate path, leaving agents with nothing to do.
+                            if _slice_count == 0:
+                                _slice_count = _auto_populate_contract_at_implement_start(
+                                    worktree_repo_path,
+                                    pipeline_id,
+                                    pipeline_mode,
+                                    pipeline.issue_number,
+                                    pipeline.current_phase,
+                                    pipeline.branch,
+                                )
+                                if _slice_count > 0:
+                                    # Reload contract after successful populate
+                                    _check_contract = _load_contract_for_slice_check(
+                                        pipeline_id, worktree_repo_path
+                                    )
+                                    _use_slice_loop = _is_slice_dag_mode(_check_contract)
 
                             # #2337 defensive recheck: if the contract has no
                             # slices but the on-disk plan draft parses to N>1

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -19489,6 +19489,10 @@ def _auto_populate_contract_at_implement_start(
     issue_number: int | None,
     current_phase: PipelinePhase,
     pipeline_branch: str,
+    *,
+    gateway: Any,
+    gateway_mode: str,
+    base_branch: str | None,
 ) -> int:
     """Attempt to auto-populate an empty contract at implement start (#2915).
 
@@ -19505,8 +19509,6 @@ def _auto_populate_contract_at_implement_start(
         issue_number=issue_number,
     )
     try:
-        from routes.pipelines import _populate_contract_from_plan
-
         _populate_result = _populate_contract_from_plan(
             worktree_repo_path,
             pipeline_id,
@@ -19541,12 +19543,10 @@ def _auto_populate_contract_at_implement_start(
 
     # Commit the populated contract
     try:
-        from routes.pipelines import _commit_statefiles_to_worktree
-
         _committed = _commit_statefiles_to_worktree(
             worktree_repo_path,
             "Auto-populate contract at implement start (#2915)",
-            issue_number,
+            _pipeline_identifier(issue_number, pipeline_id),
             pipeline_id=pipeline_id,
         )
         if not _committed:
@@ -19563,26 +19563,46 @@ def _auto_populate_contract_at_implement_start(
         )
         return 0
 
-    # Push the populated contract
+    # Push the populated contract. Failure is non-fatal — the contract is
+    # already committed locally — but mirror the canonical pattern from
+    # agent_salvage._push_recovery (try/except for transport, then check
+    # push_result.ok for gateway-reported rejections like non_fast_forward
+    # / auth_failed / gateway_unreachable). Thread gateway_mode and
+    # base_branch so private-mode pipelines route correctly and non-FF
+    # reconcile uses --onto and doesn't replay base-branch commits.
+    push_succeeded = False
     try:
-        _gw = get_gateway_client()
-        _gw.push_worktree_branch(
+        push_result = gateway.push_worktree_branch(
             pipeline_id=pipeline_id,
             repo_path=str(worktree_repo_path),
             branch=pipeline_branch,
+            mode=gateway_mode,
+            base_branch=base_branch,
         )
     except Exception as _push_err:  # noqa: BLE001
         logger.warning(
-            "Auto-populate: push failed (non-fatal, contract is committed locally)",
+            "Auto-populate: push transport failure (non-fatal, contract committed locally)",
             pipeline_id=pipeline_id,
             error=str(_push_err),
         )
-        # Push failure is not fatal — the contract is already committed locally
+    else:
+        if not push_result.ok:
+            logger.warning(
+                "Auto-populate: push rejected by gateway (non-fatal, contract committed locally)",
+                pipeline_id=pipeline_id,
+                category=push_result.category,
+                detail=push_result.detail,
+            )
+        else:
+            push_succeeded = True
 
     logger.info(
-        "Auto-populate contract succeeded",
+        "Auto-populate contract succeeded"
+        if push_succeeded
+        else "Auto-populate contract succeeded locally only (push did not land)",
         pipeline_id=pipeline_id,
         slice_count=_populate_result.slice_count,
+        push_succeeded=push_succeeded,
     )
     return _populate_result.slice_count
 
@@ -22168,6 +22188,9 @@ def _run_pipeline(
                                     pipeline.issue_number,
                                     pipeline.current_phase,
                                     pipeline.branch,
+                                    gateway=spawner.gateway,
+                                    gateway_mode=gateway_mode,
+                                    base_branch=pipeline.base_branch,
                                 )
                                 if _slice_count > 0:
                                     # Reload contract after successful populate

--- a/orchestrator/tests/test_auto_populate_contract.py
+++ b/orchestrator/tests/test_auto_populate_contract.py
@@ -49,7 +49,7 @@ def test_auto_populate_empty_contract_success(mock_pipeline_state):
         with (
             patch("routes.pipelines._populate_contract_from_plan") as mock_populate,
             patch("routes.pipelines._commit_statefiles_to_worktree"),
-            patch("gateway.client.GatewayClient"),
+            patch("routes.pipelines.get_gateway_client"),
         ):
             mock_populate.return_value = mock_populate_result
 
@@ -214,12 +214,12 @@ def test_auto_populate_empty_contract_push_fails(mock_pipeline_state):
         with (
             patch("routes.pipelines._populate_contract_from_plan") as mock_populate,
             patch("routes.pipelines._commit_statefiles_to_worktree"),
-            patch("gateway.client.GatewayClient") as mock_gateway_class,
+            patch("routes.pipelines.get_gateway_client") as mock_get_gateway,
         ):
             mock_populate.return_value = mock_populate_result
             mock_gateway = MagicMock()
-            mock_gateway.push_worktrees_branch.side_effect = Exception("Push failed")
-            mock_gateway_class.return_value = mock_gateway
+            mock_gateway.push_worktree_branch.side_effect = Exception("Push failed")
+            mock_get_gateway.return_value = mock_gateway
 
             result = _auto_populate_contract_at_implement_start(
                 worktree_repo_path=worktree_repo_path,
@@ -250,7 +250,7 @@ def test_auto_populate_empty_contract_no_commit_needed(mock_pipeline_state):
         with (
             patch("routes.pipelines._populate_contract_from_plan") as mock_populate,
             patch("routes.pipelines._commit_statefiles_to_worktree") as mock_commit,
-            patch("gateway.client.GatewayClient"),
+            patch("routes.pipelines.get_gateway_client"),
         ):
             mock_populate.return_value = mock_populate_result
             # _commit_statefiles_to_worktree returns True (success)

--- a/orchestrator/tests/test_auto_populate_contract.py
+++ b/orchestrator/tests/test_auto_populate_contract.py
@@ -1,0 +1,273 @@
+"""Tests for #2915: auto-populate contract at implement start.
+
+When a pipeline enters implement phase with an empty contract, the orchestrator
+should attempt to populate it from the plan draft before spawning agents.
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add orchestrator to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from routes.pipelines import (
+    ForestValidationError,
+    PopulateOutcome,
+    PopulateResult,
+    _auto_populate_contract_at_implement_start,
+)
+
+
+@pytest.fixture
+def mock_pipeline_state():
+    """Create a mock pipeline state for testing."""
+    return {
+        "pipeline_id": "test-pipeline-123",
+        "issue_number": 123,
+        "pipeline_mode": "plan",
+        "current_phase": "implement",
+        "branch": "test-branch",
+    }
+
+
+def test_auto_populate_empty_contract_success(mock_pipeline_state):
+    """Test successful auto-population of an empty contract."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        worktree_repo_path = Path(tmpdir)
+
+        # Mock successful populate
+        mock_populate_result = PopulateResult(
+            outcome=PopulateOutcome.POPULATED,
+            slice_count=3,
+            task_count=5,
+        )
+
+        with (
+            patch("routes.pipelines._populate_contract_from_plan") as mock_populate,
+            patch("routes.pipelines._commit_statefiles_to_worktree"),
+            patch("gateway.client.GatewayClient"),
+        ):
+            mock_populate.return_value = mock_populate_result
+
+            result = _auto_populate_contract_at_implement_start(
+                worktree_repo_path=worktree_repo_path,
+                pipeline_id=mock_pipeline_state["pipeline_id"],
+                pipeline_mode=mock_pipeline_state["pipeline_mode"],
+                issue_number=mock_pipeline_state["issue_number"],
+                current_phase=mock_pipeline_state["current_phase"],
+                pipeline_branch=mock_pipeline_state["branch"],
+            )
+
+        # Should return slice count
+        assert result == 3
+
+
+def test_auto_populate_empty_contract_populate_fails(mock_pipeline_state):
+    """Test auto-populate when populate raises an exception."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        worktree_repo_path = Path(tmpdir)
+
+        with patch("routes.pipelines._populate_contract_from_plan") as mock_populate:
+            mock_populate.side_effect = Exception("Parse error")
+
+            result = _auto_populate_contract_at_implement_start(
+                worktree_repo_path=worktree_repo_path,
+                pipeline_id=mock_pipeline_state["pipeline_id"],
+                pipeline_mode=mock_pipeline_state["pipeline_mode"],
+                issue_number=mock_pipeline_state["issue_number"],
+                current_phase=mock_pipeline_state["current_phase"],
+                pipeline_branch=mock_pipeline_state["branch"],
+            )
+
+        # Should return 0 on failure
+        assert result == 0
+
+
+def test_auto_populate_empty_contract_forest_validation_error(mock_pipeline_state):
+    """Test auto-populate when populate raises a ForestValidationError."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        worktree_repo_path = Path(tmpdir)
+
+        with patch("routes.pipelines._populate_contract_from_plan") as mock_populate:
+            mock_populate.side_effect = ForestValidationError(
+                "Invalid forest structure",
+                errors=["Slice 1 has multiple parents"],
+            )
+
+            result = _auto_populate_contract_at_implement_start(
+                worktree_repo_path=worktree_repo_path,
+                pipeline_id=mock_pipeline_state["pipeline_id"],
+                pipeline_mode=mock_pipeline_state["pipeline_mode"],
+                issue_number=mock_pipeline_state["issue_number"],
+                current_phase=mock_pipeline_state["current_phase"],
+                pipeline_branch=mock_pipeline_state["branch"],
+            )
+
+        # Should return 0 on forest validation error
+        assert result == 0
+
+
+def test_auto_populate_empty_contract_not_populated_outcome(mock_pipeline_state):
+    """Test auto-populate when populate returns a non-POPULATED outcome."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        worktree_repo_path = Path(tmpdir)
+
+        # Mock empty result
+        mock_populate_result = PopulateResult(
+            outcome=PopulateOutcome.EMPTY_RESULT,
+            slice_count=0,
+            task_count=0,
+        )
+
+        with patch("routes.pipelines._populate_contract_from_plan") as mock_populate:
+            mock_populate.return_value = mock_populate_result
+
+            result = _auto_populate_contract_at_implement_start(
+                worktree_repo_path=worktree_repo_path,
+                pipeline_id=mock_pipeline_state["pipeline_id"],
+                pipeline_mode=mock_pipeline_state["pipeline_mode"],
+                issue_number=mock_pipeline_state["issue_number"],
+                current_phase=mock_pipeline_state["current_phase"],
+                pipeline_branch=mock_pipeline_state["branch"],
+            )
+
+        # Should return 0 when outcome is not POPULATED
+        assert result == 0
+
+
+def test_auto_populate_empty_contract_populated_but_empty(mock_pipeline_state):
+    """Test auto-populate when populate returns POPULATED but with 0 slices."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        worktree_repo_path = Path(tmpdir)
+
+        # Mock populated but empty slices
+        mock_populate_result = PopulateResult(
+            outcome=PopulateOutcome.POPULATED,
+            slice_count=0,
+            task_count=0,
+        )
+
+        with patch("routes.pipelines._populate_contract_from_plan") as mock_populate:
+            mock_populate.return_value = mock_populate_result
+
+            result = _auto_populate_contract_at_implement_start(
+                worktree_repo_path=worktree_repo_path,
+                pipeline_id=mock_pipeline_state["pipeline_id"],
+                pipeline_mode=mock_pipeline_state["pipeline_mode"],
+                issue_number=mock_pipeline_state["issue_number"],
+                current_phase=mock_pipeline_state["current_phase"],
+                pipeline_branch=mock_pipeline_state["branch"],
+            )
+
+        # Should return 0 when slice count is 0
+        assert result == 0
+
+
+def test_auto_populate_empty_contract_commit_fails(mock_pipeline_state):
+    """Test auto-populate when commit fails (should return 0)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        worktree_repo_path = Path(tmpdir)
+
+        # Mock successful populate
+        mock_populate_result = PopulateResult(
+            outcome=PopulateOutcome.POPULATED,
+            slice_count=3,
+            task_count=5,
+        )
+
+        with (
+            patch("routes.pipelines._populate_contract_from_plan") as mock_populate,
+            patch("routes.pipelines._commit_statefiles_to_worktree") as mock_commit,
+        ):
+            mock_populate.return_value = mock_populate_result
+            mock_commit.side_effect = Exception("Commit failed")
+
+            result = _auto_populate_contract_at_implement_start(
+                worktree_repo_path=worktree_repo_path,
+                pipeline_id=mock_pipeline_state["pipeline_id"],
+                pipeline_mode=mock_pipeline_state["pipeline_mode"],
+                issue_number=mock_pipeline_state["issue_number"],
+                current_phase=mock_pipeline_state["current_phase"],
+                pipeline_branch=mock_pipeline_state["branch"],
+            )
+
+        # Should return 0 when commit fails
+        assert result == 0
+
+
+def test_auto_populate_empty_contract_push_fails(mock_pipeline_state):
+    """Test auto-populate when push fails (should still return slice count)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        worktree_repo_path = Path(tmpdir)
+
+        # Mock successful populate
+        mock_populate_result = PopulateResult(
+            outcome=PopulateOutcome.POPULATED,
+            slice_count=3,
+            task_count=5,
+        )
+
+        with (
+            patch("routes.pipelines._populate_contract_from_plan") as mock_populate,
+            patch("routes.pipelines._commit_statefiles_to_worktree"),
+            patch("gateway.client.GatewayClient") as mock_gateway_class,
+        ):
+            mock_populate.return_value = mock_populate_result
+            mock_gateway = MagicMock()
+            mock_gateway.push_worktrees_branch.side_effect = Exception("Push failed")
+            mock_gateway_class.return_value = mock_gateway
+
+            result = _auto_populate_contract_at_implement_start(
+                worktree_repo_path=worktree_repo_path,
+                pipeline_id=mock_pipeline_state["pipeline_id"],
+                pipeline_mode=mock_pipeline_state["pipeline_mode"],
+                issue_number=mock_pipeline_state["issue_number"],
+                current_phase=mock_pipeline_state["current_phase"],
+                pipeline_branch=mock_pipeline_state["branch"],
+            )
+
+        # Should still return slice count even if push fails
+        # (contract is already committed locally)
+        assert result == 3
+
+
+def test_auto_populate_empty_contract_no_commit_needed(mock_pipeline_state):
+    """Test auto-populate when commit returns True but nothing was committed."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        worktree_repo_path = Path(tmpdir)
+
+        # Mock successful populate
+        mock_populate_result = PopulateResult(
+            outcome=PopulateOutcome.POPULATED,
+            slice_count=3,
+            task_count=5,
+        )
+
+        with (
+            patch("routes.pipelines._populate_contract_from_plan") as mock_populate,
+            patch("routes.pipelines._commit_statefiles_to_worktree") as mock_commit,
+            patch("gateway.client.GatewayClient"),
+        ):
+            mock_populate.return_value = mock_populate_result
+            # _commit_statefiles_to_worktree returns True (success)
+            mock_commit.return_value = True
+
+            result = _auto_populate_contract_at_implement_start(
+                worktree_repo_path=worktree_repo_path,
+                pipeline_id=mock_pipeline_state["pipeline_id"],
+                pipeline_mode=mock_pipeline_state["pipeline_mode"],
+                issue_number=mock_pipeline_state["issue_number"],
+                current_phase=mock_pipeline_state["current_phase"],
+                pipeline_branch=mock_pipeline_state["branch"],
+            )
+
+        # Should return slice count
+        assert result == 3
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/orchestrator/tests/test_auto_populate_contract.py
+++ b/orchestrator/tests/test_auto_populate_contract.py
@@ -11,11 +11,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Add orchestrator to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
 
+from gateway_client import PushResult
 from routes.pipelines import (
     ForestValidationError,
+    PipelinePhase,
     PopulateOutcome,
     PopulateResult,
     _auto_populate_contract_at_implement_start,
@@ -29,17 +32,44 @@ def mock_pipeline_state():
         "pipeline_id": "test-pipeline-123",
         "issue_number": 123,
         "pipeline_mode": "plan",
-        "current_phase": "implement",
+        "current_phase": PipelinePhase.IMPLEMENT,
         "branch": "test-branch",
+        "base_branch": "main",
+        "gateway_mode": "public",
     }
+
+
+def _make_gateway(push_ok: bool = True, category: str = "ok", detail: str = "") -> MagicMock:
+    gateway = MagicMock()
+    gateway.push_worktree_branch.return_value = PushResult(
+        ok=push_ok, category=category, detail=detail
+    )
+    return gateway
+
+
+def _invoke(state, **overrides):
+    """Helper to call the SUT with kwargs derived from the fixture state."""
+    kwargs = {
+        "worktree_repo_path": overrides.pop("worktree_repo_path"),
+        "pipeline_id": state["pipeline_id"],
+        "pipeline_mode": state["pipeline_mode"],
+        "issue_number": state["issue_number"],
+        "current_phase": state["current_phase"],
+        "pipeline_branch": state["branch"],
+        "gateway": overrides.pop("gateway", _make_gateway()),
+        "gateway_mode": state["gateway_mode"],
+        "base_branch": state["base_branch"],
+    }
+    kwargs.update(overrides)
+    return _auto_populate_contract_at_implement_start(**kwargs)
 
 
 def test_auto_populate_empty_contract_success(mock_pipeline_state):
     """Test successful auto-population of an empty contract."""
     with tempfile.TemporaryDirectory() as tmpdir:
         worktree_repo_path = Path(tmpdir)
+        gateway = _make_gateway()
 
-        # Mock successful populate
         mock_populate_result = PopulateResult(
             outcome=PopulateOutcome.POPULATED,
             slice_count=3,
@@ -49,21 +79,22 @@ def test_auto_populate_empty_contract_success(mock_pipeline_state):
         with (
             patch("routes.pipelines._populate_contract_from_plan") as mock_populate,
             patch("routes.pipelines._commit_statefiles_to_worktree"),
-            patch("routes.pipelines.get_gateway_client"),
         ):
             mock_populate.return_value = mock_populate_result
 
-            result = _auto_populate_contract_at_implement_start(
+            result = _invoke(
+                mock_pipeline_state,
                 worktree_repo_path=worktree_repo_path,
-                pipeline_id=mock_pipeline_state["pipeline_id"],
-                pipeline_mode=mock_pipeline_state["pipeline_mode"],
-                issue_number=mock_pipeline_state["issue_number"],
-                current_phase=mock_pipeline_state["current_phase"],
-                pipeline_branch=mock_pipeline_state["branch"],
+                gateway=gateway,
             )
 
-        # Should return slice count
         assert result == 3
+        # Verify gateway_mode and base_branch were forwarded.
+        gateway.push_worktree_branch.assert_called_once()
+        push_kwargs = gateway.push_worktree_branch.call_args.kwargs
+        assert push_kwargs["mode"] == "public"
+        assert push_kwargs["base_branch"] == "main"
+        assert push_kwargs["branch"] == "test-branch"
 
 
 def test_auto_populate_empty_contract_populate_fails(mock_pipeline_state):
@@ -74,16 +105,8 @@ def test_auto_populate_empty_contract_populate_fails(mock_pipeline_state):
         with patch("routes.pipelines._populate_contract_from_plan") as mock_populate:
             mock_populate.side_effect = Exception("Parse error")
 
-            result = _auto_populate_contract_at_implement_start(
-                worktree_repo_path=worktree_repo_path,
-                pipeline_id=mock_pipeline_state["pipeline_id"],
-                pipeline_mode=mock_pipeline_state["pipeline_mode"],
-                issue_number=mock_pipeline_state["issue_number"],
-                current_phase=mock_pipeline_state["current_phase"],
-                pipeline_branch=mock_pipeline_state["branch"],
-            )
+            result = _invoke(mock_pipeline_state, worktree_repo_path=worktree_repo_path)
 
-        # Should return 0 on failure
         assert result == 0
 
 
@@ -98,16 +121,8 @@ def test_auto_populate_empty_contract_forest_validation_error(mock_pipeline_stat
                 errors=["Slice 1 has multiple parents"],
             )
 
-            result = _auto_populate_contract_at_implement_start(
-                worktree_repo_path=worktree_repo_path,
-                pipeline_id=mock_pipeline_state["pipeline_id"],
-                pipeline_mode=mock_pipeline_state["pipeline_mode"],
-                issue_number=mock_pipeline_state["issue_number"],
-                current_phase=mock_pipeline_state["current_phase"],
-                pipeline_branch=mock_pipeline_state["branch"],
-            )
+            result = _invoke(mock_pipeline_state, worktree_repo_path=worktree_repo_path)
 
-        # Should return 0 on forest validation error
         assert result == 0
 
 
@@ -116,7 +131,6 @@ def test_auto_populate_empty_contract_not_populated_outcome(mock_pipeline_state)
     with tempfile.TemporaryDirectory() as tmpdir:
         worktree_repo_path = Path(tmpdir)
 
-        # Mock empty result
         mock_populate_result = PopulateResult(
             outcome=PopulateOutcome.EMPTY_RESULT,
             slice_count=0,
@@ -126,16 +140,8 @@ def test_auto_populate_empty_contract_not_populated_outcome(mock_pipeline_state)
         with patch("routes.pipelines._populate_contract_from_plan") as mock_populate:
             mock_populate.return_value = mock_populate_result
 
-            result = _auto_populate_contract_at_implement_start(
-                worktree_repo_path=worktree_repo_path,
-                pipeline_id=mock_pipeline_state["pipeline_id"],
-                pipeline_mode=mock_pipeline_state["pipeline_mode"],
-                issue_number=mock_pipeline_state["issue_number"],
-                current_phase=mock_pipeline_state["current_phase"],
-                pipeline_branch=mock_pipeline_state["branch"],
-            )
+            result = _invoke(mock_pipeline_state, worktree_repo_path=worktree_repo_path)
 
-        # Should return 0 when outcome is not POPULATED
         assert result == 0
 
 
@@ -144,7 +150,6 @@ def test_auto_populate_empty_contract_populated_but_empty(mock_pipeline_state):
     with tempfile.TemporaryDirectory() as tmpdir:
         worktree_repo_path = Path(tmpdir)
 
-        # Mock populated but empty slices
         mock_populate_result = PopulateResult(
             outcome=PopulateOutcome.POPULATED,
             slice_count=0,
@@ -154,25 +159,16 @@ def test_auto_populate_empty_contract_populated_but_empty(mock_pipeline_state):
         with patch("routes.pipelines._populate_contract_from_plan") as mock_populate:
             mock_populate.return_value = mock_populate_result
 
-            result = _auto_populate_contract_at_implement_start(
-                worktree_repo_path=worktree_repo_path,
-                pipeline_id=mock_pipeline_state["pipeline_id"],
-                pipeline_mode=mock_pipeline_state["pipeline_mode"],
-                issue_number=mock_pipeline_state["issue_number"],
-                current_phase=mock_pipeline_state["current_phase"],
-                pipeline_branch=mock_pipeline_state["branch"],
-            )
+            result = _invoke(mock_pipeline_state, worktree_repo_path=worktree_repo_path)
 
-        # Should return 0 when slice count is 0
         assert result == 0
 
 
 def test_auto_populate_empty_contract_commit_fails(mock_pipeline_state):
-    """Test auto-populate when commit fails (should return 0)."""
+    """Test auto-populate when commit raises (should return 0)."""
     with tempfile.TemporaryDirectory() as tmpdir:
         worktree_repo_path = Path(tmpdir)
 
-        # Mock successful populate
         mock_populate_result = PopulateResult(
             outcome=PopulateOutcome.POPULATED,
             slice_count=3,
@@ -186,61 +182,16 @@ def test_auto_populate_empty_contract_commit_fails(mock_pipeline_state):
             mock_populate.return_value = mock_populate_result
             mock_commit.side_effect = Exception("Commit failed")
 
-            result = _auto_populate_contract_at_implement_start(
-                worktree_repo_path=worktree_repo_path,
-                pipeline_id=mock_pipeline_state["pipeline_id"],
-                pipeline_mode=mock_pipeline_state["pipeline_mode"],
-                issue_number=mock_pipeline_state["issue_number"],
-                current_phase=mock_pipeline_state["current_phase"],
-                pipeline_branch=mock_pipeline_state["branch"],
-            )
+            result = _invoke(mock_pipeline_state, worktree_repo_path=worktree_repo_path)
 
-        # Should return 0 when commit fails
         assert result == 0
 
 
-def test_auto_populate_empty_contract_push_fails(mock_pipeline_state):
-    """Test auto-populate when push fails (should still return slice count)."""
+def test_auto_populate_empty_contract_commit_returned_false(mock_pipeline_state):
+    """Cover the ``not _committed`` branch: commit short-circuited with no commit."""
     with tempfile.TemporaryDirectory() as tmpdir:
         worktree_repo_path = Path(tmpdir)
 
-        # Mock successful populate
-        mock_populate_result = PopulateResult(
-            outcome=PopulateOutcome.POPULATED,
-            slice_count=3,
-            task_count=5,
-        )
-
-        with (
-            patch("routes.pipelines._populate_contract_from_plan") as mock_populate,
-            patch("routes.pipelines._commit_statefiles_to_worktree"),
-            patch("routes.pipelines.get_gateway_client") as mock_get_gateway,
-        ):
-            mock_populate.return_value = mock_populate_result
-            mock_gateway = MagicMock()
-            mock_gateway.push_worktree_branch.side_effect = Exception("Push failed")
-            mock_get_gateway.return_value = mock_gateway
-
-            result = _auto_populate_contract_at_implement_start(
-                worktree_repo_path=worktree_repo_path,
-                pipeline_id=mock_pipeline_state["pipeline_id"],
-                pipeline_mode=mock_pipeline_state["pipeline_mode"],
-                issue_number=mock_pipeline_state["issue_number"],
-                current_phase=mock_pipeline_state["current_phase"],
-                pipeline_branch=mock_pipeline_state["branch"],
-            )
-
-        # Should still return slice count even if push fails
-        # (contract is already committed locally)
-        assert result == 3
-
-
-def test_auto_populate_empty_contract_no_commit_needed(mock_pipeline_state):
-    """Test auto-populate when commit returns True but nothing was committed."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        worktree_repo_path = Path(tmpdir)
-
-        # Mock successful populate
         mock_populate_result = PopulateResult(
             outcome=PopulateOutcome.POPULATED,
             slice_count=3,
@@ -250,22 +201,73 @@ def test_auto_populate_empty_contract_no_commit_needed(mock_pipeline_state):
         with (
             patch("routes.pipelines._populate_contract_from_plan") as mock_populate,
             patch("routes.pipelines._commit_statefiles_to_worktree") as mock_commit,
-            patch("routes.pipelines.get_gateway_client"),
         ):
             mock_populate.return_value = mock_populate_result
-            # _commit_statefiles_to_worktree returns True (success)
-            mock_commit.return_value = True
+            # _commit_statefiles_to_worktree returns False when nothing was staged
+            # (no .egg-state directory, no prefix match, or nothing staged after add).
+            mock_commit.return_value = False
 
-            result = _auto_populate_contract_at_implement_start(
+            result = _invoke(mock_pipeline_state, worktree_repo_path=worktree_repo_path)
+
+        assert result == 0
+
+
+def test_auto_populate_empty_contract_push_transport_failure(mock_pipeline_state):
+    """Test auto-populate when push raises a transport exception (non-fatal)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        worktree_repo_path = Path(tmpdir)
+
+        mock_populate_result = PopulateResult(
+            outcome=PopulateOutcome.POPULATED,
+            slice_count=3,
+            task_count=5,
+        )
+
+        gateway = MagicMock()
+        gateway.push_worktree_branch.side_effect = Exception("Push transport failed")
+
+        with (
+            patch("routes.pipelines._populate_contract_from_plan") as mock_populate,
+            patch("routes.pipelines._commit_statefiles_to_worktree"),
+        ):
+            mock_populate.return_value = mock_populate_result
+
+            result = _invoke(
+                mock_pipeline_state,
                 worktree_repo_path=worktree_repo_path,
-                pipeline_id=mock_pipeline_state["pipeline_id"],
-                pipeline_mode=mock_pipeline_state["pipeline_mode"],
-                issue_number=mock_pipeline_state["issue_number"],
-                current_phase=mock_pipeline_state["current_phase"],
-                pipeline_branch=mock_pipeline_state["branch"],
+                gateway=gateway,
             )
 
-        # Should return slice count
+        # Push transport failure does not abort — contract is committed locally.
+        assert result == 3
+
+
+def test_auto_populate_empty_contract_push_rejected_by_gateway(mock_pipeline_state):
+    """Test auto-populate when gateway returns PushResult(ok=False) (non-fatal)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        worktree_repo_path = Path(tmpdir)
+
+        mock_populate_result = PopulateResult(
+            outcome=PopulateOutcome.POPULATED,
+            slice_count=3,
+            task_count=5,
+        )
+
+        gateway = _make_gateway(push_ok=False, category="non_fast_forward", detail="...")
+
+        with (
+            patch("routes.pipelines._populate_contract_from_plan") as mock_populate,
+            patch("routes.pipelines._commit_statefiles_to_worktree"),
+        ):
+            mock_populate.return_value = mock_populate_result
+
+            result = _invoke(
+                mock_pipeline_state,
+                worktree_repo_path=worktree_repo_path,
+                gateway=gateway,
+            )
+
+        # Gateway-rejected push does not abort — contract is committed locally.
         assert result == 3
 
 

--- a/orchestrator/tests/test_auto_populate_contract.py
+++ b/orchestrator/tests/test_auto_populate_contract.py
@@ -39,7 +39,11 @@ def mock_pipeline_state():
     }
 
 
-def _make_gateway(push_ok: bool = True, category: str = "ok", detail: str = "") -> MagicMock:
+def _make_gateway(
+    push_ok: bool = True,
+    category: str | None = None,
+    detail: str | None = None,
+) -> MagicMock:
     gateway = MagicMock()
     gateway.push_worktree_branch.return_value = PushResult(
         ok=push_ok, category=category, detail=detail


### PR DESCRIPTION
## Summary

Automatically populate the SDLC contract when entering the implement phase with an empty contract (zero slices/tasks). This prevents the restart-storm failure mode where agents spawn with nothing to do, restart 3×, then fail with a confusing error.

## Problem

When a pipeline enters implement phase with an empty contract, agents have no tasks to work on. The consensus-wrapper interprets clean exits as transient failures and restarts agents 3× each, eventually marking the pipeline FAILED. The root cause (empty contract) is only discoverable by manually reading the contract file.

This typically happens with `start_phase=implement`, which skips the plan-completion populate hook. The existing `start_phase=implement` safety net only covers that specific path, not `advance_phase` into implement.

## Solution

Add `_auto_populate_contract_at_implement_start` helper that:
1. Attempts to populate the contract from the plan draft
2. Handles `ForestValidationError` and other exceptions gracefully
3. Only proceeds if populate succeeds with at least one slice
4. Commits and pushes the populated contract
5. Returns slice count (0 on any failure)

Integrated into the implement-start flow:
- Runs before the #2337 defensive recheck
- If populate succeeds, reloads contract and re-evaluates slice-DAG mode
- If still empty after populate, lets the existing slice-gate check handle it (which emits a clear HITL with recovery options)

## Changes

- **orchestrator/routes/pipelines.py**
  - Added `_auto_populate_contract_at_implement_start` helper (lines 19485-19600)
  - Integrated into implement-start flow (lines 22165-22175)

- **orchestrator/tests/test_auto_populate_contract.py**
  - Comprehensive test coverage for all code paths (success/failure scenarios)

## Testing

All new tests pass. The helper gracefully handles:
- Populate raising exceptions
- ForestValidationError (slice DAG violations)
- Non-POPULATED outcomes
- Empty results after populate
- Commit failures
- Push failures (non-fatal, contract already committed locally)

## Related Issues

- Closes #2915
- Relates to #2806 (restart budget exhaustion)
- Independent of #2908 (event-pump redesign)
