### PR TITLE
gateway: control-plane find_open_pr route; stop modeling orchestrator as an AgentRole (#2893)

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -4909,22 +4909,25 @@ def gh_find_open_pr() -> tuple[Response, int] | Response:
     if not data:
         return make_error("Missing request body")
 
-    repo = data.get("repo")
-    head = data.get("head")
-    base = data.get("base")
-
-    for name, value in (("repo", repo), ("head", head), ("base", base)):
+    # Validate and bind stripped values in one pass so mypy sees ``repo``
+    # / ``head`` / ``base`` as ``str`` (not the ``Any`` returned by
+    # ``data.get(...)``) below.
+    fields: dict[str, str] = {}
+    for name, value in (
+        ("repo", data.get("repo")),
+        ("head", data.get("head")),
+        ("base", data.get("base")),
+    ):
         if not isinstance(value, str) or not value.strip():
             return make_error(f"Missing or invalid {name}: must be a non-empty string")
+        fields[name] = value.strip()
+    repo, head, base = fields["repo"], fields["head"], fields["base"]
 
     # ``OWNER_REPO_PATTERN`` is stricter than ``parse_owner_repo`` (which
     # also accepts full GitHub URLs); the docstring and the validation
     # error below both promise the literal ``owner/name`` shape, so we
     # match against the pattern directly rather than the URL-permissive
     # helper.
-    repo = repo.strip()
-    head = head.strip()
-    base = base.strip()
     if OWNER_REPO_PATTERN.match(repo) is None:
         return make_error("Invalid repo: must be 'owner/name'")
 

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -4874,6 +4874,109 @@ def gh_execute() -> tuple[Response, int] | Response:
         )
 
 
+@app.route("/api/v1/gh/find_open_pr", methods=["POST"])
+@require_launcher_auth
+def gh_find_open_pr() -> tuple[Response, int] | Response:
+    """Control-plane idempotency lookup: return the open ``head → base`` PR number.
+
+    This is an **orchestrator-only** route, gated by ``@require_launcher_auth``
+    rather than ``@require_session_auth``: the caller is the control plane
+    (the orchestrator holds the launcher secret), not a sandboxed agent. It
+    exists so the orchestrator's slice-PR idempotency pre-flight (#2777 cq-8)
+    does not have to register a synthetic *agent* session and impersonate a
+    role on ``/api/v1/gh/execute`` — the conflation that #2893 papered over by
+    adding a bogus ``AgentRole.ORCHESTRATOR``. The orchestrator is not an
+    agent role; it is the server that manages pipelines, so it authenticates
+    as the control plane and uses a purpose-built read-only endpoint.
+
+    Unlike ``/api/v1/gh/execute`` (arbitrary allowlisted argv), this route
+    accepts only ``repo``/``head``/``base`` and constructs the fixed
+    read-only argv server-side, so there is no general gh-command surface on
+    the launcher-auth path.
+
+    Request body:
+        {"repo": "owner/name", "head": "<branch>", "base": "<branch>"}
+
+    Returns:
+        ``{"number": <int>}`` on hit, ``{"number": null}`` on miss. The GH
+        API documents at most one open PR per (head, base) tuple, so the
+        lookup is ``--limit 1``.
+    """
+    data = request.get_json()
+    if not data:
+        return make_error("Missing request body")
+
+    repo = data.get("repo")
+    head = data.get("head")
+    base = data.get("base")
+
+    for name, value in (("repo", repo), ("head", head), ("base", base)):
+        if not isinstance(value, str) or not value:
+            return make_error(f"Missing or invalid {name}: must be a non-empty string")
+
+    repo_info = parse_owner_repo(repo)
+    if repo_info is None:
+        return make_error("Invalid repo: must be 'owner/name'")
+
+    args = [
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--head",
+        head,
+        "--base",
+        base,
+        "--state",
+        "open",
+        "--limit",
+        "1",
+        "--json",
+        "number",
+    ]
+
+    auth_mode = get_auth_mode(repo)
+    github = get_github_client(mode=auth_mode)
+    result = github.execute(args, timeout=60, mode=auth_mode)
+
+    if not result.success:
+        audit_log(
+            "gh_find_open_pr_failed",
+            "gh_find_open_pr",
+            success=False,
+            details={"repo": repo, "head": head, "base": base, "stderr": result.stderr},
+        )
+        return make_error(
+            f"Command failed: {result.stderr}",
+            status_code=500,
+            details=result.to_dict(),
+        )
+
+    number: int | None = None
+    stdout = (result.stdout or "").strip()
+    if stdout:
+        try:
+            items = json.loads(stdout)
+        except ValueError, TypeError:
+            items = None
+        if isinstance(items, list):
+            for item in items:
+                if isinstance(item, dict) and item.get("number") is not None:
+                    try:
+                        number = int(item["number"])
+                    except TypeError, ValueError:
+                        number = None
+                    break
+
+    audit_log(
+        "gh_find_open_pr",
+        "gh_find_open_pr",
+        success=True,
+        details={"repo": repo, "head": head, "base": base, "number": number},
+    )
+    return make_success("Open PR lookup complete", {"number": number})
+
+
 # =============================================================================
 # Jira REST Endpoints
 # =============================================================================

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -198,7 +198,7 @@ try:
         check_heartbeat_rate_limit,
         record_failed_lookup,
     )
-    from .repo_parser import parse_owner_repo
+    from .repo_parser import OWNER_REPO_PATTERN, parse_owner_repo
     from .repo_visibility import get_repo_visibility
     from .session_manager import (
         get_session_manager,
@@ -354,7 +354,10 @@ except ImportError:
         check_heartbeat_rate_limit,
         record_failed_lookup,
     )
-    from repo_parser import parse_owner_repo  # type: ignore[no-redef, import-untyped]
+    from repo_parser import (  # type: ignore[no-redef, import-untyped]
+        OWNER_REPO_PATTERN,
+        parse_owner_repo,
+    )
     from repo_visibility import get_repo_visibility  # type: ignore[no-redef]
     from session_manager import (  # type: ignore[no-redef, import-untyped]
         get_session_manager,
@@ -4911,11 +4914,18 @@ def gh_find_open_pr() -> tuple[Response, int] | Response:
     base = data.get("base")
 
     for name, value in (("repo", repo), ("head", head), ("base", base)):
-        if not isinstance(value, str) or not value:
+        if not isinstance(value, str) or not value.strip():
             return make_error(f"Missing or invalid {name}: must be a non-empty string")
 
-    repo_info = parse_owner_repo(repo)
-    if repo_info is None:
+    # ``OWNER_REPO_PATTERN`` is stricter than ``parse_owner_repo`` (which
+    # also accepts full GitHub URLs); the docstring and the validation
+    # error below both promise the literal ``owner/name`` shape, so we
+    # match against the pattern directly rather than the URL-permissive
+    # helper.
+    repo = repo.strip()
+    head = head.strip()
+    base = base.strip()
+    if OWNER_REPO_PATTERN.match(repo) is None:
         return make_error("Invalid repo: must be 'owner/name'")
 
     args = [
@@ -4940,11 +4950,15 @@ def gh_find_open_pr() -> tuple[Response, int] | Response:
     result = github.execute(args, timeout=60, mode=auth_mode)
 
     if not result.success:
+        # ``gh`` should not print credentials to stderr, but truncate
+        # defensively so we never page a giant stderr blob into the
+        # audit log.
+        stderr_excerpt = (result.stderr or "")[:500]
         audit_log(
             "gh_find_open_pr_failed",
             "gh_find_open_pr",
             success=False,
-            details={"repo": repo, "head": head, "base": base, "stderr": result.stderr},
+            details={"repo": repo, "head": head, "base": base, "stderr": stderr_excerpt},
         )
         return make_error(
             f"Command failed: {result.stderr}",

--- a/gateway/tests/test_find_open_pr_route.py
+++ b/gateway/tests/test_find_open_pr_route.py
@@ -177,10 +177,23 @@ class TestFindOpenPrValidation:
         )
         assert response.status_code == 400
 
-    def test_malformed_repo_returns_400(self, client, launcher_auth_headers):
+    @pytest.mark.parametrize(
+        "malformed_repo",
+        [
+            "not-owner-slash-repo",  # no slash
+            # Full GitHub URL form: ``parse_owner_repo`` would have accepted
+            # this via its ``parse_github_url`` fallback, but the route
+            # promises the literal ``owner/name`` shape and uses
+            # ``OWNER_REPO_PATTERN.match`` directly. Pinned so a future
+            # switch back to the URL-permissive helper would fail.
+            "https://github.com/owner/repo",
+            "owner/repo/extra",  # too many segments
+        ],
+    )
+    def test_malformed_repo_returns_400(self, client, launcher_auth_headers, malformed_repo):
         response = client.post(
             "/api/v1/gh/find_open_pr",
-            json={"repo": "not-owner-slash-repo", "head": "h", "base": "b"},
+            json={"repo": malformed_repo, "head": "h", "base": "b"},
             headers=launcher_auth_headers,
         )
         assert response.status_code == 400

--- a/gateway/tests/test_find_open_pr_route.py
+++ b/gateway/tests/test_find_open_pr_route.py
@@ -1,0 +1,205 @@
+"""Tests for the ``/api/v1/gh/find_open_pr`` control-plane route.
+
+This route is the orchestrator's slice-PR idempotency lookup. It is
+**launcher-authed** (control plane), not session-authed (agent): the
+orchestrator is the server that manages pipelines, not an ``AgentRole``,
+so it does not register a synthetic agent session or impersonate a role
+on the per-agent ``/api/v1/gh/execute`` surface. (This supersedes the
+#2893 approach of wedging ``AgentRole.ORCHESTRATOR`` into the agent
+allowlist.)
+
+Covers:
+- Launcher-bearer-token enforcement (401 on missing / wrong credentials).
+- Hit returns the matching PR number; miss returns ``null``.
+- Input validation (400 on missing/invalid repo/head/base).
+- The route constructs a *fixed* read-only argv server-side — there is
+  no arbitrary gh-command surface on the launcher-auth path.
+- Upstream gh failure surfaces as 500.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# conftest.py loads the gateway modules under bare names.
+import gateway
+
+TEST_LAUNCHER_SECRET = os.environ.get("EGG_LAUNCHER_SECRET", "test-launcher-secret-12345")
+
+
+@pytest.fixture
+def client():
+    gateway.app.config["TESTING"] = True
+    with gateway.app.test_client() as client:
+        yield client
+
+
+@pytest.fixture
+def launcher_auth_headers():
+    return {"Authorization": f"Bearer {TEST_LAUNCHER_SECRET}"}
+
+
+def _fake_github(stdout: str = "[]", *, success: bool = True, stderr: str = ""):
+    """A ``get_github_client`` substitute whose ``execute`` returns a
+    GitHubResult-shaped object."""
+    result = MagicMock()
+    result.success = success
+    result.stdout = stdout
+    result.stderr = stderr
+    result.to_dict.return_value = {"success": success, "stdout": stdout, "stderr": stderr}
+
+    github = MagicMock()
+    github.execute.return_value = result
+    return github
+
+
+class TestFindOpenPrAuth:
+    """Launcher auth is the only gate — agents must not reach this route."""
+
+    def test_missing_auth_returns_401(self, client):
+        response = client.post(
+            "/api/v1/gh/find_open_pr",
+            json={"repo": "owner/repo", "head": "h", "base": "b"},
+        )
+        assert response.status_code == 401
+
+    def test_wrong_bearer_token_returns_401(self, client):
+        response = client.post(
+            "/api/v1/gh/find_open_pr",
+            json={"repo": "owner/repo", "head": "h", "base": "b"},
+            headers={"Authorization": "Bearer nope"},
+        )
+        assert response.status_code == 401
+
+
+class TestFindOpenPrLookup:
+    def test_hit_returns_pr_number(self, client, launcher_auth_headers):
+        with (
+            patch.object(gateway, "get_auth_mode", return_value="bot"),
+            patch.object(
+                gateway,
+                "get_github_client",
+                return_value=_fake_github('[{"number": 4242}]'),
+            ),
+        ):
+            response = client.post(
+                "/api/v1/gh/find_open_pr",
+                json={
+                    "repo": "owner/repo",
+                    "head": "egg/issue-42/slice-1",
+                    "base": "egg/issue-42/work",
+                },
+                headers=launcher_auth_headers,
+            )
+        assert response.status_code == 200
+        assert response.get_json()["data"]["number"] == 4242
+
+    def test_miss_returns_null(self, client, launcher_auth_headers):
+        with (
+            patch.object(gateway, "get_auth_mode", return_value="bot"),
+            patch.object(gateway, "get_github_client", return_value=_fake_github("[]")),
+        ):
+            response = client.post(
+                "/api/v1/gh/find_open_pr",
+                json={"repo": "owner/repo", "head": "h", "base": "b"},
+                headers=launcher_auth_headers,
+            )
+        assert response.status_code == 200
+        assert response.get_json()["data"]["number"] is None
+
+    def test_constructs_fixed_readonly_argv(self, client, launcher_auth_headers):
+        """The route must NOT accept arbitrary argv — it builds the fixed
+        read-only ``gh pr list`` command server-side from repo/head/base."""
+        github = _fake_github("[]")
+        with (
+            patch.object(gateway, "get_auth_mode", return_value="bot"),
+            patch.object(gateway, "get_github_client", return_value=github),
+        ):
+            response = client.post(
+                "/api/v1/gh/find_open_pr",
+                json={"repo": "owner/repo", "head": "myhead", "base": "mybase"},
+                headers=launcher_auth_headers,
+            )
+        assert response.status_code == 200
+        called_args = github.execute.call_args[0][0]
+        assert called_args == [
+            "pr",
+            "list",
+            "--repo",
+            "owner/repo",
+            "--head",
+            "myhead",
+            "--base",
+            "mybase",
+            "--state",
+            "open",
+            "--limit",
+            "1",
+            "--json",
+            "number",
+        ]
+
+
+class TestFindOpenPrValidation:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {"head": "h", "base": "b"},  # missing repo
+            {"repo": "owner/repo", "base": "b"},  # missing head
+            {"repo": "owner/repo", "head": "h"},  # missing base
+            {"repo": "owner/repo", "head": "", "base": "b"},  # empty head
+            {"repo": "owner/repo", "head": "h", "base": ""},  # empty base
+            {"repo": 123, "head": "h", "base": "b"},  # non-string repo
+        ],
+    )
+    def test_invalid_inputs_return_400(self, client, launcher_auth_headers, body):
+        response = client.post(
+            "/api/v1/gh/find_open_pr",
+            json=body,
+            headers=launcher_auth_headers,
+        )
+        assert response.status_code == 400
+
+    def test_malformed_repo_returns_400(self, client, launcher_auth_headers):
+        response = client.post(
+            "/api/v1/gh/find_open_pr",
+            json={"repo": "not-owner-slash-repo", "head": "h", "base": "b"},
+            headers=launcher_auth_headers,
+        )
+        assert response.status_code == 400
+
+
+class TestFindOpenPrUpstreamFailure:
+    def test_gh_failure_returns_500(self, client, launcher_auth_headers):
+        with (
+            patch.object(gateway, "get_auth_mode", return_value="bot"),
+            patch.object(
+                gateway,
+                "get_github_client",
+                return_value=_fake_github("", success=False, stderr="boom"),
+            ),
+        ):
+            response = client.post(
+                "/api/v1/gh/find_open_pr",
+                json={"repo": "owner/repo", "head": "h", "base": "b"},
+                headers=launcher_auth_headers,
+            )
+        assert response.status_code == 500
+
+    def test_malformed_json_treated_as_miss(self, client, launcher_auth_headers):
+        """If gh returns non-JSON stdout (should not happen with --json,
+        but defensive), the route returns a miss rather than 500."""
+        with (
+            patch.object(gateway, "get_auth_mode", return_value="bot"),
+            patch.object(gateway, "get_github_client", return_value=_fake_github("not-json")),
+        ):
+            response = client.post(
+                "/api/v1/gh/find_open_pr",
+                json={"repo": "owner/repo", "head": "h", "base": "b"},
+                headers=launcher_auth_headers,
+            )
+        assert response.status_code == 200
+        assert response.get_json()["data"]["number"] is None

--- a/gateway/tests/test_find_open_pr_route.py
+++ b/gateway/tests/test_find_open_pr_route.py
@@ -112,7 +112,14 @@ class TestFindOpenPrLookup:
 
     def test_constructs_fixed_readonly_argv(self, client, launcher_auth_headers):
         """The route must NOT accept arbitrary argv — it builds the fixed
-        read-only ``gh pr list`` command server-side from repo/head/base."""
+        read-only ``gh pr list`` command server-side from repo/head/base.
+
+        Also pins the ``mode=auth_mode`` flow-through: the route resolves
+        ``auth_mode = get_auth_mode(repo)`` and forwards it as a kwarg to
+        ``github.execute`` so the gateway uses the right credentials for
+        the target repo. A regression that drops the ``mode`` keyword
+        would silently fall back to the default mode.
+        """
         github = _fake_github("[]")
         with (
             patch.object(gateway, "get_auth_mode", return_value="bot"),
@@ -141,6 +148,11 @@ class TestFindOpenPrLookup:
             "--json",
             "number",
         ]
+        # ``auth_mode`` from ``get_auth_mode(repo)`` must flow through to
+        # ``github.execute`` as the ``mode=`` kwarg (gateway uses it to
+        # select the right token for the target repo).
+        called_kwargs = github.execute.call_args[1]
+        assert called_kwargs.get("mode") == "bot"
 
 
 class TestFindOpenPrValidation:
@@ -152,6 +164,8 @@ class TestFindOpenPrValidation:
             {"repo": "owner/repo", "head": "h"},  # missing base
             {"repo": "owner/repo", "head": "", "base": "b"},  # empty head
             {"repo": "owner/repo", "head": "h", "base": ""},  # empty base
+            {"repo": "owner/repo", "head": "   ", "base": "b"},  # whitespace-only head
+            {"repo": "owner/repo", "head": "h", "base": "   "},  # whitespace-only base
             {"repo": 123, "head": "h", "base": "b"},  # non-string repo
         ],
     )

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1778,21 +1778,15 @@ class GatewayClient:
         # (PR created server-side, transport blip on the response) from
         # cascading the slice to FAILED on the next tick.
         if repo:
-            # Hardcode synthetic role to "coder" — `_lookup_open_pr`'s
-            # `/api/v1/gh/execute` round-trip is gated by
-            # `check_agent_gh_operation`, and "orchestrator" is not in
-            # `AGENT_GH_RESTRICTIONS` so it 403s as an unknown role
-            # (see reviewer_code_holistic v3 NACK). Propagating the
-            # caller's `agent_role` (which `pipelines.py` passes as
-            # "orchestrator" for slice-PR creation) defeats the cq-8
-            # idempotency pre-flight because the swallowed 403 looks
-            # like a benign miss and `gh pr create` runs anyway.
+            # Idempotency lookup runs on the control-plane route
+            # (``/api/v1/gh/find_open_pr``, launcher auth) — the
+            # orchestrator is the control plane, not an agent, so the
+            # caller's ``agent_role`` is irrelevant here (#2893 follow-up).
             existing_pr_number = self._lookup_open_pr(
                 pipeline_id=pipeline_id,
                 repo=repo,
                 head=head,
                 base=base,
-                mode=mode,
             )
             if existing_pr_number is not None:
                 existing_url = f"https://github.com/{repo}/pull/{existing_pr_number}"
@@ -2664,30 +2658,24 @@ class GatewayClient:
         *,
         head: str,
         base: str,
-        mode: Literal["public", "private"] = "public",
     ) -> int | None:
         """Server-side idempotency check: return the open ``head → base`` PR number, or None.
 
-        Runs ``gh pr list --head <head> --base <base> --state open
-        --json number`` via the existing per-agent ``gh pr list``
-        allowlist (transport ``/api/v1/gh/execute``). The gateway
-        filters server-side so this is cheaper than the broader
-        :meth:`list_open_prs` + client-side filter that
-        :func:`_open_context_pr_at_implement_start` uses today.
+        Calls the orchestrator-only control-plane route
+        ``/api/v1/gh/find_open_pr`` with launcher auth. The gateway runs
+        ``gh pr list --head <head> --base <base> --state open --json
+        number`` server-side and returns the single matching PR number.
 
         Used by :meth:`create_slice_pr` to skip ``gh pr create`` when a
         slice PR with the same head + base is already open (#2777 cq-8
-        / task-3-2 idempotency pre-flight). May also be adopted by the
-        context-PR opener in a follow-up; today the opener uses the
-        broader ``list_open_prs`` shape because it needs to enumerate
-        every open PR for the client-side filter.
+        / task-3-2 idempotency pre-flight).
 
-        The synthetic session is hardcoded to register with
-        ``agent_role="coder"`` because ``/api/v1/gh/execute`` is gated
-        by ``check_agent_gh_operation`` which only accepts roles in
-        ``AGENT_GH_RESTRICTIONS``; the orchestrator-side caller's
-        own role string (e.g. "orchestrator") would 403 as unknown
-        (see reviewer_code_holistic v3 NACK on #2777 slice-3).
+        The orchestrator authenticates here as the **control plane** (the
+        launcher secret), not as an agent. This is the seam #2893 should
+        have used: the orchestrator is the server that manages pipelines,
+        not an ``AgentRole``, so it does not register a synthetic agent
+        session or impersonate a role on the per-agent ``/api/v1/gh/execute``
+        surface.
 
         Returns:
             The integer PR number on hit, ``None`` on miss OR on any
@@ -2704,76 +2692,20 @@ class GatewayClient:
             # first one, spuriously treating an unrelated PR as the
             # slice PR's idempotent hit).
             return None
-        temp_container_id = f"{pipeline_id}-pr-lookup"
-        session_token: str | None = None
         try:
-            # TODO(#2893): use ``agent_role="orchestrator"`` once the
-            # gateway's ``AGENT_GH_RESTRICTIONS`` allowlist accepts that
-            # role for read-only ``gh pr list`` calls. The orchestrator
-            # is the actual caller here; "coder" is a temporary stand-in
-            # because the gateway currently rejects "orchestrator" at
-            # /api/v1/gh/execute.
-            session = self.register_session(
-                container_id=temp_container_id,
-                container_ip=self.self_ip,
-                mode=mode,
-                pipeline_id=pipeline_id,
-                agent_role="coder",
-                synthetic=True,
-            )
-            session_token = session.session_token
-
-            args = [
-                "pr",
-                "list",
-                "--repo",
-                repo,
-                "--head",
-                head,
-                "--base",
-                base,
-                "--state",
-                "open",
-                # The idempotency contract only needs to know whether
-                # ANY open PR matches head + base; the GH API
-                # documents at most one open PR per (head, base) tuple.
-                # --limit 1 keeps the response payload minimal.
-                "--limit",
-                "1",
-                "--json",
-                "number",
-            ]
             result = self._make_request(
-                "/api/v1/gh/execute",
+                "/api/v1/gh/find_open_pr",
                 method="POST",
-                data={"args": args, "repo": repo},
-                bearer_token=session_token,
+                data={"repo": repo, "head": head, "base": base},
+                use_launcher_auth=True,
             )
-            stdout = (result.get("data", {}) or {}).get("stdout", "") or ""
+            number = (result.get("data", {}) or {}).get("number")
+            if number is None:
+                return None
             try:
-                items = json.loads(stdout) if stdout.strip() else []
-            except ValueError, TypeError:
-                logger.debug(
-                    "_lookup_open_pr: gh stdout not JSON",
-                    pipeline_id=pipeline_id,
-                    repo=repo,
-                    head=head,
-                    base=base,
-                )
+                return int(number)
+            except TypeError, ValueError:
                 return None
-            if not isinstance(items, list):
-                return None
-            for item in items:
-                if not isinstance(item, dict):
-                    continue
-                number = item.get("number")
-                if number is None:
-                    continue
-                try:
-                    return int(number)
-                except TypeError, ValueError:
-                    continue
-            return None
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "_lookup_open_pr: gateway request failed (treating as miss)",
@@ -2784,12 +2716,6 @@ class GatewayClient:
                 error=str(exc),
             )
             return None
-        finally:
-            if session_token:
-                try:
-                    self.delete_session(session_token)
-                except Exception:
-                    pass
 
     def list_remote_branches(
         self,

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -1753,35 +1753,37 @@ class TestCreateSlicePR:
 
 class TestLookupOpenPr:
     """#2777 cq-8 / task-3-2: ``GatewayClient._lookup_open_pr`` is the
-    new server-side idempotency primitive used by ``create_slice_pr``
-    (and adoptable by the context-PR opener in a follow-up).
+    server-side idempotency primitive used by ``create_slice_pr``.
 
-    These tests exercise the helper's contract in isolation against a
-    mocked ``_make_request`` — the helper builds the ``gh pr list
-    --head <head> --base <base> --state open --json number`` call and
-    parses the stdout JSON. The wider call-site behaviour (no
-    ``gh pr create`` invoked when an existing PR matches) lives in the
-    ``TestCreateSlicePR`` block above; these tests pin the primitive's
-    own input/output contract.
+    The lookup runs on the **control-plane** route
+    ``/api/v1/gh/find_open_pr`` with launcher auth — the orchestrator is
+    the server that manages pipelines, not an agent, so it does not
+    register a synthetic agent session or impersonate a role on the
+    per-agent ``/api/v1/gh/execute`` surface (the #2893 conflation this
+    supersedes). These tests exercise the helper's contract in isolation
+    against a mocked ``_make_request``: it POSTs ``{repo, head, base}``
+    with ``use_launcher_auth=True`` and reads ``data.number`` from the
+    response. The wider call-site behaviour (no ``gh pr create`` invoked
+    when an existing PR matches) lives in the ``TestCreateSlicePR`` block
+    above; these tests pin the primitive's own input/output contract.
     """
 
-    def test_lookup_open_pr_returns_existing_pr_number_on_hit(self, gateway_client):
+    def test_lookup_open_pr_uses_control_plane_route_with_launcher_auth(self, gateway_client):
+        """The lookup must hit the launcher-authed control-plane route,
+        never register a synthetic agent session."""
         from unittest.mock import patch
 
-        def fake_make_request(endpoint, method, data, bearer_token):  # noqa: ARG001
-            return {
-                "success": True,
-                "data": {"stdout": '[{"number": 4242}]'},
-            }
+        captured: dict = {}
+
+        def fake_make_request(endpoint, method, data, **kwargs):  # noqa: ARG001
+            captured["endpoint"] = endpoint
+            captured["data"] = data
+            captured["use_launcher_auth"] = kwargs.get("use_launcher_auth")
+            return {"success": True, "data": {"number": 4242}}
 
         with (
-            patch.object(
-                gateway_client,
-                "register_session",
-                return_value=type("S", (), {"session_token": "tok"})(),
-            ),
+            patch.object(gateway_client, "register_session") as mock_register,
             patch.object(gateway_client, "_make_request", side_effect=fake_make_request),
-            patch.object(gateway_client, "delete_session"),
         ):
             result = gateway_client._lookup_open_pr(
                 pipeline_id="issue-42",
@@ -1790,25 +1792,25 @@ class TestLookupOpenPr:
                 base="egg/issue-42/work",
             )
         assert result == 4242
+        assert captured["endpoint"] == "/api/v1/gh/find_open_pr"
+        assert captured["use_launcher_auth"] is True
+        assert captured["data"] == {
+            "repo": "owner/repo",
+            "head": "egg/issue-42/slice-1",
+            "base": "egg/issue-42/work",
+        }
+        mock_register.assert_not_called()
 
     def test_lookup_open_pr_returns_none_on_miss(self, gateway_client):
-        """An empty ``gh pr list`` result (no PR matches the head + base
-        filter) is the canonical miss — ``_lookup_open_pr`` returns None
-        so the caller falls through to ``gh pr create``."""
+        """A ``null`` number (no PR matches the head + base filter) is the
+        canonical miss — ``_lookup_open_pr`` returns None so the caller
+        falls through to ``gh pr create``."""
         from unittest.mock import patch
 
-        def fake_make_request(endpoint, method, data, bearer_token):  # noqa: ARG001
-            return {"success": True, "data": {"stdout": "[]"}}
+        def fake_make_request(endpoint, method, data, **kwargs):  # noqa: ARG001
+            return {"success": True, "data": {"number": None}}
 
-        with (
-            patch.object(
-                gateway_client,
-                "register_session",
-                return_value=type("S", (), {"session_token": "tok"})(),
-            ),
-            patch.object(gateway_client, "_make_request", side_effect=fake_make_request),
-            patch.object(gateway_client, "delete_session"),
-        ):
+        with patch.object(gateway_client, "_make_request", side_effect=fake_make_request):
             result = gateway_client._lookup_open_pr(
                 pipeline_id="issue-42",
                 repo="owner/repo",
@@ -1818,17 +1820,14 @@ class TestLookupOpenPr:
         assert result is None
 
     def test_lookup_open_pr_returns_none_on_missing_head_or_base(self, gateway_client):
-        """Defence-in-depth: ``_lookup_open_pr`` must NOT invoke
-        ``gh pr list`` with an empty ``--head`` or ``--base`` filter
-        (would surface every open PR in the repo and the caller's
-        ``if existing is not None`` would match the first one,
-        spuriously treating an unrelated PR as the idempotent hit)."""
+        """Defence-in-depth: ``_lookup_open_pr`` must NOT invoke the lookup
+        with an empty ``head`` or ``base`` filter (would surface every open
+        PR in the repo and the caller's ``if existing is not None`` would
+        match the first one, spuriously treating an unrelated PR as the
+        idempotent hit)."""
         from unittest.mock import patch
 
-        with (
-            patch.object(gateway_client, "register_session") as mock_register,
-            patch.object(gateway_client, "_make_request") as mock_request,
-        ):
+        with patch.object(gateway_client, "_make_request") as mock_request:
             # Empty head.
             assert (
                 gateway_client._lookup_open_pr(
@@ -1849,27 +1848,18 @@ class TestLookupOpenPr:
                 )
                 is None
             )
-        mock_register.assert_not_called()
         mock_request.assert_not_called()
 
-    def test_lookup_open_pr_returns_none_on_malformed_json(self, gateway_client):
-        """Transport / parse failure: malformed JSON stdout returns
-        None and the caller falls through to ``gh pr create``. Never
-        raise — a transient lookup failure must not block PR creation."""
+    def test_lookup_open_pr_returns_none_on_transport_error(self, gateway_client):
+        """Transport failure returns None and the caller falls through to
+        ``gh pr create``. Never raise — a transient lookup failure must not
+        block PR creation."""
         from unittest.mock import patch
 
-        def fake_make_request(endpoint, method, data, bearer_token):  # noqa: ARG001
-            return {"success": True, "data": {"stdout": "not-json"}}
+        def fake_make_request(endpoint, method, data, **kwargs):  # noqa: ARG001
+            raise RuntimeError("gateway unreachable")
 
-        with (
-            patch.object(
-                gateway_client,
-                "register_session",
-                return_value=type("S", (), {"session_token": "tok"})(),
-            ),
-            patch.object(gateway_client, "_make_request", side_effect=fake_make_request),
-            patch.object(gateway_client, "delete_session"),
-        ):
+        with patch.object(gateway_client, "_make_request", side_effect=fake_make_request):
             result = gateway_client._lookup_open_pr(
                 pipeline_id="issue-42",
                 repo="owner/repo",


### PR DESCRIPTION
## Problem

The slice-PR idempotency pre-flight (#2777 cq-8) has the orchestrator register a **synthetic agent session** and run `gh pr list` on the per-agent `/api/v1/gh/execute` surface, hardcoding `agent_role="coder"` to satisfy that route's `check_agent_gh_operation` gate.

The earlier fix (branch `egg/2893-orchestrator-gh-pr-list`, never merged) addressed the resulting audit misattribution by adding `AgentRole.ORCHESTRATOR` to the canonical agent-role enum and a matching `AGENT_GH_RESTRICTIONS` allowlist entry. But **the orchestrator is the server that manages pipelines, not a spawnable agent.** Wedging it into `AgentRole`:

- makes it a half-member — in the enum but absent from the `AGENT_ROLES` registry, so `get_role_definition()` raises and `dependency_graph` silently drops it;
- leaks into every `for role in AgentRole` consumer (kubernetes-spawner pod-name suffixes, agent-salvage valid roles, …) as if it were spawnable;
- contradicts an already-documented decision in `routes/messages.py`: *"Kept separate from `AgentRole` because neither `overseer` nor `orchestrator` is a spawnable agent role."*

## Approach (Approach 2 — control-plane route)

Use the seam the codebase already has for trusted control-plane calls: launcher-secret auth (`require_session_or_launcher_auth`, `g.auth_actor="launcher"`, already used by `/api/v1/git/push`). Give the orchestrator a first-class, purpose-built endpoint and **delete the synthetic-session masquerade** — the orchestrator never appears as an `AgentRole`.

- **`gateway/gateway.py`** — new `POST /api/v1/gh/find_open_pr`, gated by `@require_launcher_auth`. Accepts only `{repo, head, base}` and constructs the fixed read-only `gh pr list --repo … --head … --base … --state open --limit 1 --json number` argv server-side — there is **no arbitrary gh-command surface** on the launcher-auth path. Returns `{"number": int|null}`.
- **`orchestrator/gateway_client.py`** — `_lookup_open_pr` now POSTs to the new route with `use_launcher_auth=True`; drops `register_session`/`delete_session`, the `agent_role="coder"` hardcode, and the now-unused `mode` param. `create_slice_pr` call site updated. Same error contract (any failure → miss → caller falls through to `gh pr create`).

## Notes

- **No `AgentRole` / `AGENT_GH_RESTRICTIONS` change is needed** — `main` never received the `#2893` additions, so this **supersedes** that branch rather than reverting it.
- `create_pr`/`create_slice_pr` still pass `agent_role="orchestrator"` as honest session *metadata* (session-create accepts free strings; that path uses the dedicated `/api/v1/gh/pr/create` route, never the role gate).

## Tests

- `gateway/tests/test_find_open_pr_route.py` (new): launcher-auth enforcement (401), hit/miss, input validation (400), fixed-argv assertion, upstream-failure (500).
- `orchestrator/tests/test_gateway_client.py::TestLookupOpenPr` rewritten: asserts the control-plane route + launcher auth and that **no agent session is registered**.
- `make test` (changeset-aware): **17072 passed, 34 skipped**, green.

Closes #2893.