### PR TITLE
fix(orchestrator): base non-root slices on dependency parent, not work branch (#2928)

### DIFF
--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -3123,6 +3123,59 @@ class GatewayClient:
                 except Exception:
                     pass
 
+    def ls_remote_branch_strict(
+        self,
+        pipeline_id: str,
+        repo_path: str,
+        ref: str,
+        mode: Literal["public", "private"] = "public",
+    ) -> bool:
+        """Check if a remote branch exists using ls-remote.
+
+        Strict variant of :meth:`ls_remote_branch`: a gateway / network
+        / policy failure RAISES rather than collapsing to ``False``.
+        Use this when the caller needs to distinguish "branch absent
+        on origin" from "probe could not be performed" — for example,
+        ``_resolve_slice_base_branch`` (#2928) routes a confirmed
+        absent parent onto ``pipeline_branch`` but treats a raised
+        probe as "assume parent exists" so a flaky gateway never
+        silently swaps a real slice onto ``work``. The lenient
+        :meth:`ls_remote_branch` collapses those two outcomes and is
+        unsafe for that gate.
+        """
+        temp_container_id = f"{pipeline_id}-state-ls-remote-strict"
+        session_token: str | None = None
+        try:
+            session = self.register_session(
+                container_id=temp_container_id,
+                container_ip=self.self_ip,
+                mode=mode,
+                pipeline_id=pipeline_id,
+                synthetic=True,
+            )
+            session_token = session.session_token
+
+            result = self._make_request(
+                "/api/v1/git/fetch",
+                method="POST",
+                data={
+                    "repo_path": repo_path,
+                    "remote": "origin",
+                    "operation": "ls-remote",
+                    "args": ["--heads", ref],
+                },
+                bearer_token=session_token,
+            )
+
+            stdout = (result or {}).get("data", {}).get("stdout", "")
+            return bool(stdout.strip())
+        finally:
+            if session_token:
+                try:
+                    self.delete_session(session_token)
+                except Exception:
+                    pass
+
     def get_remote_branch_sha(
         self,
         pipeline_id: str,

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -3061,24 +3061,23 @@ class GatewayClient:
                 except Exception:
                     pass
 
-    def ls_remote_branch(
+    def _ls_remote_branch_impl(
         self,
         pipeline_id: str,
         repo_path: str,
         ref: str,
-        mode: Literal["public", "private"] = "public",
+        mode: Literal["public", "private"],
+        container_id_suffix: str,
     ) -> bool:
-        """Check if a remote branch exists using ls-remote.
+        """Shared implementation of the ls-remote branch-existence probe.
 
-        Args:
-            pipeline_id: Pipeline ID (used as container_id for the temp session)
-            repo_path: Path to the repo directory
-            ref: Branch ref to check (e.g., "refs/heads/egg/pipeline-state")
-
-        Returns:
-            True if the remote branch exists, False otherwise
+        Raises on any gateway / network / policy failure — including a
+        ``{"success": false, ...}`` envelope returned at HTTP 200. Public
+        wrappers apply their respective error policies at the outer
+        layer: :meth:`ls_remote_branch` swallows and returns ``False``;
+        :meth:`ls_remote_branch_strict` propagates.
         """
-        temp_container_id = f"{pipeline_id}-state-ls-remote"
+        temp_container_id = f"{pipeline_id}-{container_id_suffix}"
         session_token: str | None = None
         try:
             session = self.register_session(
@@ -3105,9 +3104,57 @@ class GatewayClient:
                 bearer_token=session_token,
             )
 
+            # A {"success": false, ...} envelope returned at HTTP 200 is
+            # a gateway-side failure surfaced via the envelope rather
+            # than the status code. Without this guard the strict
+            # variant would silently collapse such a response to "branch
+            # absent", contradicting its propagate-any-failure contract.
+            if not result.get("success", True):
+                raise GatewayError(
+                    result.get("message", "ls-remote envelope reported success=false")
+                )
+
             # ls-remote returns output in data.stdout; non-empty means branch exists
             stdout = result.get("data", {}).get("stdout", "")
             return bool(stdout.strip())
+        finally:
+            if session_token:
+                try:
+                    self.delete_session(session_token)
+                except Exception:
+                    pass
+
+    def ls_remote_branch(
+        self,
+        pipeline_id: str,
+        repo_path: str,
+        ref: str,
+        mode: Literal["public", "private"] = "public",
+    ) -> bool:
+        """Check if a remote branch exists using ls-remote.
+
+        Lenient variant: collapses gateway / network / policy failures
+        to ``False``. Callers that need to distinguish "branch absent
+        on origin" from "probe could not be performed" — notably the
+        ``_resolve_slice_base_branch`` parent-existence gate (#2928) —
+        must use :meth:`ls_remote_branch_strict` instead.
+
+        Args:
+            pipeline_id: Pipeline ID (used as container_id for the temp session)
+            repo_path: Path to the repo directory
+            ref: Branch ref to check (e.g., "refs/heads/egg/pipeline-state")
+
+        Returns:
+            True if the remote branch exists, False otherwise (or on error).
+        """
+        try:
+            return self._ls_remote_branch_impl(
+                pipeline_id=pipeline_id,
+                repo_path=repo_path,
+                ref=ref,
+                mode=mode,
+                container_id_suffix="state-ls-remote",
+            )
         except Exception as e:
             logger.warning(
                 "ls-remote check failed",
@@ -3116,12 +3163,6 @@ class GatewayClient:
                 error=str(e),
             )
             return False
-        finally:
-            if session_token:
-                try:
-                    self.delete_session(session_token)
-                except Exception:
-                    pass
 
     def ls_remote_branch_strict(
         self,
@@ -3143,38 +3184,13 @@ class GatewayClient:
         :meth:`ls_remote_branch` collapses those two outcomes and is
         unsafe for that gate.
         """
-        temp_container_id = f"{pipeline_id}-state-ls-remote-strict"
-        session_token: str | None = None
-        try:
-            session = self.register_session(
-                container_id=temp_container_id,
-                container_ip=self.self_ip,
-                mode=mode,
-                pipeline_id=pipeline_id,
-                synthetic=True,
-            )
-            session_token = session.session_token
-
-            result = self._make_request(
-                "/api/v1/git/fetch",
-                method="POST",
-                data={
-                    "repo_path": repo_path,
-                    "remote": "origin",
-                    "operation": "ls-remote",
-                    "args": ["--heads", ref],
-                },
-                bearer_token=session_token,
-            )
-
-            stdout = (result or {}).get("data", {}).get("stdout", "")
-            return bool(stdout.strip())
-        finally:
-            if session_token:
-                try:
-                    self.delete_session(session_token)
-                except Exception:
-                    pass
+        return self._ls_remote_branch_impl(
+            pipeline_id=pipeline_id,
+            repo_path=repo_path,
+            ref=ref,
+            mode=mode,
+            container_id_suffix="state-ls-remote-strict",
+        )
 
     def get_remote_branch_sha(
         self,

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -2094,15 +2094,12 @@ class GatewayClient:
         ambient slice/pipeline pass their token through ``bearer_token``
         to avoid a redundant register/delete round-trip.
 
-        Used by slice-4 TASK-4-3's ``_resolve_slice_base_branch``
-        merge-base fallback: legacy slices whose
-        ``parent_branch_at_creation`` is empty AND whose integration
-        branch still exists on origin compute their fork SHA against
-        ``origin/main`` to confirm the slice has a valid divergence
-        point before the resolver returns the dependency-derived
-        parent branch. A ``None`` result signals "no fork point" and
-        the resolver routes onto ``pipeline_branch`` (the safe
-        root-stack fallback).
+        General ancestry/fork-point primitive. (Slice-4 TASK-4-3
+        once wired this into ``_resolve_slice_base_branch`` to
+        validate a slice's fork point, but #2928 replaced that with a
+        parent-branch-existence probe — probing the slice's own
+        not-yet-created integration branch mis-based fresh slices. The
+        method is retained as a general gateway utility.)
         """
         if not ref_a or not ref_b:
             return None

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -10317,7 +10317,7 @@ def _resolve_slice_base_branch(
     pipeline_id: str,
     pipeline_branch: str,
     extant_branches: set[str] | None = None,
-    merge_base_lookup: Callable[[str, str], str | None] | None = None,
+    parent_branch_exists: Callable[[str], bool] | None = None,
 ) -> str:
     """Return the parent branch for a slice's integration branch (#2777, cq-9).
 
@@ -10332,34 +10332,40 @@ def _resolve_slice_base_branch(
        return it. This is the primary path post-slice-4 — slices
        created after the eager persist landed always go through
        this arm.
-    2. **Merge-base fallback (slice-4 TASK-4-3)**. For legacy /
-       orphaned slices whose ``parent_branch_at_creation`` is empty,
-       when a ``merge_base_lookup`` callback is provided, compute
-       the merge-base SHA of the slice's integration branch against
-       the dependency-derived parent. If the merge-base resolves
-       (slice has a valid fork point and ancestor exists), the
-       slice has real commits — fall through to the dependency-
-       derived parent below as the legacy-correct stack target.
-       If the merge-base does NOT resolve (no fork point — either
-       the integration branch never existed on origin, or its
-       parent has been deleted), fall back to ``pipeline_branch``.
-       The merge-base SHA is logged for audit but not returned as
-       the resolver's value: downstream consumers
-       (``create_slice_integration_branch``,
-       ``is_slice_branch_merged_into_parent``) take branch names
-       and resolve to SHA via ``get_remote_branch_sha`` on the
-       gateway side, so returning a SHA here would break the
-       ``refs/heads/<name>`` ls-remote step at
-       ``gateway_client.py:~2288``. The merge-base call's role
-       is to VALIDATE the legacy ancestor before returning the
-       branch name — a structural improvement over the
-       pre-TASK-4-3 path which blindly returned the derived
-       parent.
+    2. **Dependency-derived parent, gated on parent existence
+       (#2928)**. For a non-root slice whose
+       ``parent_branch_at_creation`` is empty (the normal first-run
+       case), the stack target is its dependency parent's
+       integration branch ``{issue_branch}/{dependencies[0]}``. When
+       a ``parent_branch_exists`` callback is provided, the resolver
+       probes whether that parent branch is still present on origin:
+
+       * parent branch **exists** → return the dependency-derived
+         parent. This is the correct target for both fresh slices
+         (whose own integration branch does not exist yet) and
+         legacy slices.
+       * parent branch **absent** → the parent slice's PR was merged
+         into ``work`` and its branch deleted by the cascade, so
+         ``work`` already contains the parent's commits. Fall back
+         to ``pipeline_branch``.
+       * probe **raises** → conservative default: assume the parent
+         exists and return the derived parent. Never silently swap a
+         real slice onto ``work`` because of a flaky gateway.
+
+       This replaces the pre-#2928 merge-base check, which probed the
+       *slice's own* integration branch for a fork point and routed a
+       ``None`` result (no fork point) to ``pipeline_branch``. That
+       conflated a FRESH slice (integration branch not yet created —
+       the common first-run case) with a genuinely orphaned slice,
+       silently mis-basing fresh slices onto ``work`` whenever
+       ``work`` had advanced ahead of the parent (the wedge in
+       #2928).
     3. **Final fallback** to ``pipeline_branch`` (``egg/<id>/work``)
        when (a) no eager-persisted parent, (b) the slice is a root
-       (no dependencies), OR (c) the merge-base lookup reports no
-       fork point. Root-targeted branches are never deleted by the
-       cascade so this is always a safe terminal candidate.
+       (no dependencies), OR (c) the slice's dependency parent branch
+       is absent from origin. Root-targeted branches are never
+       deleted by the cascade so this is always a safe terminal
+       candidate.
 
     **Orphan-reconciler mode (``extant_branches`` non-None)**: the
     stacked-PR reconciler at ``orchestrator/stacked_pr_reconciler.py``
@@ -10388,17 +10394,17 @@ def _resolve_slice_base_branch(
             this set and skips any that are absent. The reconciler
             uses this to escape from the deleted parent branch up the
             DAG until an extant ancestor is reached.
-        merge_base_lookup: Optional callback used by slice-4
-            TASK-4-3's merge-base fallback. When provided, the
-            resolver invokes ``merge_base_lookup(ref_a, ref_b)``
-            with the slice's integration branch and the derived
-            parent's ``refs/remotes/origin/<parent_branch>``-shaped
-            ref. A non-None SHA return validates the legacy
-            ancestor; a ``None`` return indicates no fork point
-            and routes to ``pipeline_branch``. The default
-            ``_run_one_slice_inner`` caller wires this against
-            ``spawner.gateway.merge_base``; the stacked-PR
-            reconciler leaves it ``None`` (it has already
+        parent_branch_exists: Optional callback (#2928) used to
+            decide whether a non-root slice's dependency parent
+            branch is still on origin. When provided, the resolver
+            invokes ``parent_branch_exists(parent_branch)`` with the
+            dependency-derived parent branch name. ``True`` returns
+            the derived parent; ``False`` routes to
+            ``pipeline_branch`` (parent merged + cascade-deleted); a
+            raised exception is treated conservatively as ``True``.
+            The default ``_run_one_slice_inner`` caller wires this
+            against ``spawner.gateway.get_remote_branch_sha``; the
+            stacked-PR reconciler leaves it ``None`` (it has already
             verified extant branches via the ``extant_branches``
             set).
 
@@ -10458,66 +10464,62 @@ def _resolve_slice_base_branch(
     # the existing ``f"{issue_branch}/{parent_slice_id}"`` convention
     # at the legacy slice-loop call site.
     issue_branch = _slice_namespace_root(pipeline_branch)
+    derived_parent = f"{issue_branch}/{parent_slice_id}"
 
-    # Slice-4 TASK-4-3: merge-base fallback for orphaned / legacy
-    # slices. When eager-persist did not land (``parent_recorded``
-    # empty above) AND a ``merge_base_lookup`` callback is provided,
-    # compute ``git merge-base <integration_branch> <derived_parent>``
-    # to validate the legacy ancestor. A non-None SHA confirms the
-    # slice has a real fork point — fall through to the
-    # dependency-derived parent below as the legacy-correct stack
-    # target. A None SHA means no fork point (the slice's branch
-    # never existed on origin, OR its parent has been deleted, OR
-    # the two refs share no common history). In that case fall
-    # back to ``pipeline_branch`` so downstream
-    # ``create_slice_integration_branch`` has a stable parent.
-    if merge_base_lookup is not None:
-        integration_branch = f"{issue_branch}/{slice_id}"
-        derived_parent_ref = f"refs/remotes/origin/{issue_branch}/{parent_slice_id}"
-        integration_ref = f"refs/remotes/origin/{integration_branch}"
+    # #2928: parent-existence gate. When eager-persist did not land
+    # (``parent_recorded`` empty above) AND a ``parent_branch_exists``
+    # callback is provided, decide between the dependency-derived
+    # parent and ``pipeline_branch`` by probing whether the parent
+    # slice's integration branch is still on origin — NOT by probing
+    # the slice's own branch for a fork point.
+    #
+    # The pre-#2928 implementation computed
+    # ``merge_base(integration_branch, derived_parent)`` and routed a
+    # ``None`` result to ``pipeline_branch``. That conflated a FRESH
+    # slice (its integration branch is created *after* this resolver
+    # runs, so it has no fork point on the first run — the common
+    # case) with a genuinely orphaned slice, silently mis-basing
+    # fresh slices onto ``work`` whenever ``work`` had advanced ahead
+    # of the parent (e.g. a stray contract-state commit on ``work``).
+    # The correct discriminator is parent-branch existence:
+    #
+    #   * parent exists  → stack on it (fresh OR legacy slice).
+    #   * parent absent  → the parent PR merged into ``work`` and its
+    #     branch was cascade-deleted, so ``work`` already contains the
+    #     parent's commits → ``pipeline_branch`` is the right base.
+    #   * probe raises    → conservative: assume the parent exists and
+    #     return the derived parent; never silently swap a real slice
+    #     onto ``work`` because the gateway was flaky.
+    if parent_branch_exists is not None:
         try:
-            mb_sha = merge_base_lookup(integration_ref, derived_parent_ref)
+            exists = parent_branch_exists(derived_parent)
         except Exception as probe_err:  # noqa: BLE001
-            # Probe failure (gateway down, transient HTTP, missing
-            # local odb). Conservative default: assume the slice
-            # has a fork point and fall through to the derived
-            # parent — never silently swap to ``pipeline_branch``
-            # if we can't confirm the slice is truly orphaned.
             logger.warning(
-                "merge_base_lookup probe raised; falling through "
-                "to dependency-derived parent (slice-4 TASK-4-3)",
+                "parent_branch_exists probe raised; assuming parent "
+                "exists and returning dependency-derived parent (#2928)",
                 pipeline_id=pipeline_id,
                 slice_id=slice_id,
-                integration_ref=integration_ref,
-                derived_parent_ref=derived_parent_ref,
+                derived_parent=derived_parent,
                 error=str(probe_err),
             )
-            mb_sha = "skipped"  # sentinel: treat as "has fork point"
-        if mb_sha is None:
-            logger.info(
-                "Slice has no merge-base with derived parent; falling back "
-                "to pipeline branch (slice-4 TASK-4-3)",
+            exists = True
+        if not exists:
+            logger.warning(
+                "Dependency-parent branch absent on origin; parent "
+                "appears merged into work — basing slice on pipeline "
+                "branch (#2928)",
                 pipeline_id=pipeline_id,
                 slice_id=slice_id,
-                integration_ref=integration_ref,
-                derived_parent_ref=derived_parent_ref,
+                derived_parent=derived_parent,
                 pipeline_branch=pipeline_branch,
             )
             return pipeline_branch
-        if mb_sha != "skipped":
-            logger.debug(
-                "Merge-base validated for legacy slice; using derived parent (slice-4 TASK-4-3)",
-                pipeline_id=pipeline_id,
-                slice_id=slice_id,
-                merge_base_sha=mb_sha,
-                derived_parent=f"{issue_branch}/{parent_slice_id}",
-            )
 
     # Default mode (no extant filter): return the immediate parent
     # branch synthesised from the slice DAG. This is the unchanged
     # pre-extant-kwarg behaviour.
     if extant_branches is None:
-        return f"{issue_branch}/{parent_slice_id}"
+        return derived_parent
 
     # Orphan-reconciler mode: walk up the DAG via ``dependencies[0]``
     # until an extant ancestor branch is found. The forest constraint
@@ -16357,77 +16359,37 @@ def _run_implement_phase_slices(
                 # ``pipeline_branch`` like every other root slice — the
                 # work-branch context PR's diff already encompasses the
                 # slice-1 integration branch via ancestry.
-                # Slice-4 TASK-4-3: wire a merge-base lookup callback
-                # so the resolver can validate the legacy ancestor
-                # when ``parent_branch_at_creation`` is empty. The
-                # callback FETCHES both refs first (reviewer_code v2
-                # blocker 5 — without the prior fetch, a transient
-                # local-odb-lag returns None and silently swaps the
-                # slice's stack target onto ``pipeline_branch``).
-                # ``fetch_branch`` is best-effort (returns False on
-                # gateway failure but does not raise); the merge-base
-                # call then operates on whatever the local odb has
-                # post-fetch. A non-None SHA confirms the slice has a
-                # real fork point; a None SHA (after the fetch
-                # succeeded) tells the resolver to fall back to
-                # ``pipeline_branch``. Repoless test scaffolds short-
-                # circuit before the fetch and return None directly
-                # (matches the Layer-C classifier's behaviour for
-                # ``pipeline_repo is None``).
-                def _probe_merge_base(ref_a: str, ref_b: str) -> str | None:
+                # #2928: wire a parent-branch-existence probe so the
+                # resolver can tell a FRESH non-root slice (whose
+                # dependency parent branch is still on origin → stack
+                # on it) apart from an orphaned one (parent merged
+                # into ``work`` and cascade-deleted → base on
+                # ``pipeline_branch``). This replaces the pre-#2928
+                # merge-base probe, which probed the slice's OWN
+                # integration branch — non-existent on a first run —
+                # and so mis-routed every fresh non-root slice onto
+                # ``work`` whenever ``work`` had advanced ahead of the
+                # parent. Repoless test scaffolds short-circuit to
+                # ``True`` (no origin to check; the derived parent is
+                # the correct DAG target), mirroring the resolver's
+                # conservative "assume parent exists" default.
+                def _probe_parent_branch_exists(parent_branch: str) -> bool:
                     if not pipeline.repo:
-                        return None
-                    # Best-effort fetch of both refs into the local
-                    # odb so ``git merge-base`` can find them. Each
-                    # fetch_branch call is wrapped in try/except so a
-                    # gateway error on one ref doesn't skip the
-                    # second; the merge-base call below tolerates a
-                    # missing ref via returncode 1 → None return.
-                    for _ref in (ref_a, ref_b):
-                        # Strip ``refs/remotes/origin/`` to derive the
-                        # branch name the fetch refspec wants; the
-                        # merge-base call uses the remote-tracking ref
-                        # (which the fetch populates), not the bare
-                        # branch name.
-                        _branch = _ref
-                        for _pfx in (
-                            "refs/remotes/origin/",
-                            "refs/heads/",
-                        ):
-                            if _branch.startswith(_pfx):
-                                _branch = _branch[len(_pfx) :]
-                                break
-                        try:
-                            spawner.gateway.fetch_branch(
-                                pipeline_id,
-                                str(worktree_repo_path),
-                                args=[f"+refs/heads/{_branch}:refs/remotes/origin/{_branch}"],
-                                mode=gateway_mode,  # type: ignore[arg-type]
-                            )
-                        except Exception as fetch_err:  # noqa: BLE001
-                            logger.debug(
-                                "Pre-merge-base fetch failed (best-effort); "
-                                "merge_base will proceed against the existing "
-                                "local odb (slice-4 TASK-4-3)",
-                                pipeline_id=pipeline_id,
-                                slice_id=slice_id,
-                                ref=_branch,
-                                error=str(fetch_err),
-                            )
-                    return spawner.gateway.merge_base(
+                        return True
+                    sha = spawner.gateway.get_remote_branch_sha(
                         pipeline_id,
                         str(worktree_repo_path),
-                        ref_a,
-                        ref_b,
+                        f"refs/heads/{parent_branch}",
                         mode=gateway_mode,  # type: ignore[arg-type]
                     )
+                    return bool(sha)
 
                 parent_branch = _resolve_slice_base_branch(
                     contract,
                     slice_id,
                     pipeline_id=pipeline_id,
                     pipeline_branch=pipeline_branch,
-                    merge_base_lookup=_probe_merge_base,
+                    parent_branch_exists=_probe_parent_branch_exists,
                 )
                 integration_branch = f"{issue_branch}/{slice_id}"
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -10403,10 +10403,24 @@ def _resolve_slice_base_branch(
             ``pipeline_branch`` (parent merged + cascade-deleted); a
             raised exception is treated conservatively as ``True``.
             The default ``_run_one_slice_inner`` caller wires this
-            against ``spawner.gateway.get_remote_branch_sha``; the
+            against ``spawner.gateway.ls_remote_branch_strict`` — the
+            strict variant is required so a gateway / network /
+            policy failure RAISES into this resolver's ``try/except``
+            instead of being collapsed to ``False`` (which would
+            silently route a real slice onto ``pipeline_branch`` on
+            any gateway flake — re-creating the #2928 wedge). The
             stacked-PR reconciler leaves it ``None`` (it has already
             verified extant branches via the ``extant_branches``
             set).
+
+            Mutually exclusive with ``extant_branches`` in practice:
+            the production caller (``_run_one_slice_inner``) passes
+            only this gate, and the stacked-PR reconciler passes only
+            ``extant_branches``. If a future caller passed both, this
+            gate would short-circuit to ``pipeline_branch`` on a
+            ``False`` return BEFORE the ``extant_branches`` walk
+            could find an extant ancestor; callers that have already
+            built the extant set should leave this ``None``.
 
     Returns:
         The branch name to use as the slice integration branch's
@@ -16373,16 +16387,27 @@ def _run_implement_phase_slices(
                 # ``True`` (no origin to check; the derived parent is
                 # the correct DAG target), mirroring the resolver's
                 # conservative "assume parent exists" default.
+                #
+                # IMPORTANT: this wrapper calls the STRICT ls-remote
+                # variant (``ls_remote_branch_strict``) so a gateway /
+                # network / policy failure RAISES into the resolver's
+                # ``try/except`` instead of being collapsed to
+                # ``False``. The lenient ``ls_remote_branch`` /
+                # ``get_remote_branch_sha`` helpers swallow all
+                # exceptions and return ``False`` / ``None`` for both
+                # "branch absent" AND "gateway error" — using either
+                # here would silently route a real slice onto
+                # ``pipeline_branch`` on a flaky gateway, re-creating
+                # the #2928 wedge that this PR claims to fix.
                 def _probe_parent_branch_exists(parent_branch: str) -> bool:
                     if not pipeline.repo:
                         return True
-                    sha = spawner.gateway.get_remote_branch_sha(
+                    return spawner.gateway.ls_remote_branch_strict(
                         pipeline_id,
                         str(worktree_repo_path),
                         f"refs/heads/{parent_branch}",
                         mode=gateway_mode,  # type: ignore[arg-type]
                     )
-                    return bool(sha)
 
                 parent_branch = _resolve_slice_base_branch(
                     contract,

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -2063,6 +2063,133 @@ class TestListRemoteBranchesWithShasOperationTag:
         assert registered_id == "pipeline-1-stacked-pr-ls-remote"
 
 
+class TestLsRemoteBranchStrict:
+    """Tests for ``ls_remote_branch_strict`` — the strict tri-state
+    ls-remote helper (#2928).
+
+    The lenient ``ls_remote_branch`` swallows gateway/network/policy
+    failures and returns ``False`` — collapsing "branch absent on
+    origin" with "probe could not be performed". That is unsafe for
+    the ``_resolve_slice_base_branch`` parent-existence gate, which
+    treats ``False`` as "parent merged + cascade-deleted → route the
+    slice onto ``pipeline_branch``" but a raised probe as "conservative
+    default: assume the parent exists". The strict variant exists to
+    preserve that distinction.
+    """
+
+    def test_present_branch_returns_true(self, gateway_client):
+        session = MagicMock()
+        session.session_token = "synthetic-token-xyz"
+        with (
+            patch.object(gateway_client, "register_session", return_value=session),
+            patch.object(gateway_client, "delete_session"),
+            patch.object(
+                gateway_client,
+                "_make_request",
+                return_value={"data": {"stdout": "abc123\trefs/heads/egg/issue-X/slice-1\n"}},
+            ),
+        ):
+            result = gateway_client.ls_remote_branch_strict(
+                pipeline_id="issue-X",
+                repo_path="/tmp/x",
+                ref="refs/heads/egg/issue-X/slice-1",
+            )
+        assert result is True
+
+    def test_absent_branch_returns_false(self, gateway_client):
+        """An empty ls-remote stdout means the ref is absent on origin —
+        this is the canonical FALSE return the resolver uses to route
+        onto ``pipeline_branch``."""
+        session = MagicMock()
+        session.session_token = "synthetic-token-xyz"
+        with (
+            patch.object(gateway_client, "register_session", return_value=session),
+            patch.object(gateway_client, "delete_session"),
+            patch.object(
+                gateway_client,
+                "_make_request",
+                return_value={"data": {"stdout": ""}},
+            ),
+        ):
+            result = gateway_client.ls_remote_branch_strict(
+                pipeline_id="issue-X",
+                repo_path="/tmp/x",
+                ref="refs/heads/egg/issue-X/slice-1",
+            )
+        assert result is False
+
+    def test_gateway_error_raises(self, gateway_client):
+        """The strict contract: a GatewayError from the underlying
+        ``/git/fetch`` call MUST propagate to the caller — NOT be
+        swallowed and returned as ``False``. This is what makes the
+        method usable as the parent-existence probe in
+        ``_resolve_slice_base_branch``: the resolver's ``try/except``
+        catches the raised error and applies the conservative
+        "assume parent exists" default, instead of mis-routing a
+        real slice onto ``pipeline_branch`` on a flaky gateway (#2928).
+        """
+        session = MagicMock()
+        session.session_token = "synthetic-token-xyz"
+        with (
+            patch.object(gateway_client, "register_session", return_value=session),
+            patch.object(gateway_client, "delete_session"),
+            patch.object(
+                gateway_client,
+                "_make_request",
+                side_effect=GatewayError("gateway is down", status_code=502),
+            ),
+            pytest.raises(GatewayError, match="gateway is down"),
+        ):
+            gateway_client.ls_remote_branch_strict(
+                pipeline_id="issue-X",
+                repo_path="/tmp/x",
+                ref="refs/heads/egg/issue-X/slice-1",
+            )
+
+    def test_register_session_error_raises(self, gateway_client):
+        """A failure during session bootstrap (auth / network) MUST
+        propagate. Lenient ``ls_remote_branch`` would log + return
+        ``False``; the strict variant must NOT."""
+        with (
+            patch.object(
+                gateway_client,
+                "register_session",
+                side_effect=GatewayError("register failed", status_code=500),
+            ),
+            patch.object(gateway_client, "delete_session"),
+            pytest.raises(GatewayError, match="register failed"),
+        ):
+            gateway_client.ls_remote_branch_strict(
+                pipeline_id="issue-X",
+                repo_path="/tmp/x",
+                ref="refs/heads/egg/issue-X/slice-1",
+            )
+
+    def test_session_deleted_on_error(self, gateway_client):
+        """Even when ``_make_request`` raises, the synthetic session
+        MUST be torn down in the ``finally`` block — otherwise we leak
+        gateway state every time the probe encounters a flaky network.
+        """
+        session = MagicMock()
+        session.session_token = "synthetic-token-xyz"
+        with (
+            patch.object(gateway_client, "register_session", return_value=session),
+            patch.object(gateway_client, "delete_session") as mock_del,
+            patch.object(
+                gateway_client,
+                "_make_request",
+                side_effect=GatewayError("boom", status_code=502),
+            ),
+        ):
+            with pytest.raises(GatewayError):
+                gateway_client.ls_remote_branch_strict(
+                    pipeline_id="issue-X",
+                    repo_path="/tmp/x",
+                    ref="refs/heads/egg/issue-X/slice-1",
+                )
+        mock_del.assert_called_once_with("synthetic-token-xyz")
+
+
 class TestSingletonClient:
     """Tests for singleton client."""
 

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -2078,11 +2078,18 @@ class TestLsRemoteBranchStrict:
     """
 
     def test_present_branch_returns_true(self, gateway_client):
+        """Success path: present branch returns True AND the synthetic
+        session is torn down. Pinning the teardown on the success path
+        — not just the error path (``test_session_deleted_on_error``) —
+        guards against a future refactor that drops the ``finally``
+        block and silently leaks gateway sessions on every successful
+        probe.
+        """
         session = MagicMock()
         session.session_token = "synthetic-token-xyz"
         with (
             patch.object(gateway_client, "register_session", return_value=session),
-            patch.object(gateway_client, "delete_session"),
+            patch.object(gateway_client, "delete_session") as mock_del,
             patch.object(
                 gateway_client,
                 "_make_request",
@@ -2095,6 +2102,7 @@ class TestLsRemoteBranchStrict:
                 ref="refs/heads/egg/issue-X/slice-1",
             )
         assert result is True
+        mock_del.assert_called_once_with("synthetic-token-xyz")
 
     def test_absent_branch_returns_false(self, gateway_client):
         """An empty ls-remote stdout means the ref is absent on origin —
@@ -2188,6 +2196,38 @@ class TestLsRemoteBranchStrict:
                     ref="refs/heads/egg/issue-X/slice-1",
                 )
         mock_del.assert_called_once_with("synthetic-token-xyz")
+
+    def test_envelope_success_false_raises(self, gateway_client):
+        """A ``{"success": false, ...}`` envelope returned at HTTP 200 is
+        a gateway-side failure surfaced via the response body rather
+        than the status code. Without the envelope-success guard, the
+        strict variant would silently collapse such a response to
+        "branch absent" (empty ``stdout`` → ``False``) — directly
+        contradicting its propagate-any-failure contract. Pin the
+        invariant that envelope-level failures raise like HTTPError
+        failures do.
+        """
+        session = MagicMock()
+        session.session_token = "synthetic-token-xyz"
+        with (
+            patch.object(gateway_client, "register_session", return_value=session),
+            patch.object(gateway_client, "delete_session"),
+            patch.object(
+                gateway_client,
+                "_make_request",
+                return_value={
+                    "success": False,
+                    "message": "git fetch failed: policy denied",
+                    "data": {"stdout": ""},
+                },
+            ),
+            pytest.raises(GatewayError, match="policy denied"),
+        ):
+            gateway_client.ls_remote_branch_strict(
+                pipeline_id="issue-X",
+                repo_path="/tmp/x",
+                ref="refs/heads/egg/issue-X/slice-1",
+            )
 
 
 class TestSingletonClient:

--- a/orchestrator/tests/test_slice_4_restart_hardening.py
+++ b/orchestrator/tests/test_slice_4_restart_hardening.py
@@ -18,17 +18,19 @@ Covers the five sub-tasks of slice-4 (#2777):
   Idempotent on re-entry: only PENDING is flipped; COMPLETE / BLOCKED
   / IN_PROGRESS are left untouched.
 
-* **TASK-4-3** — Merge-base fallback in
+* **TASK-4-3 / #2928** — Parent-existence gate in
   ``_resolve_slice_base_branch``: an optional
-  ``merge_base_lookup(integration_ref, derived_parent_ref) -> str | None``
-  callback validates the legacy ancestor of orphaned non-root slices.
-  A non-None SHA confirms a real fork point → fall through to the
-  dependency-derived parent. A ``None`` return → no fork point → fall
-  back to ``pipeline_branch`` (safe root-stack target for a slice
-  that was never created OR whose parent has been deleted). Probe
-  failure raises inside the callback and is caught by the resolver,
-  defaulting to the derived-parent path (conservative: never silently
-  swap on a flaky gateway).
+  ``parent_branch_exists(parent_branch) -> bool`` callback decides
+  the base for a non-root slice with no recorded parent. ``True`` →
+  the dependency-derived parent (correct for fresh AND legacy
+  slices). ``False`` → ``pipeline_branch`` (the parent PR merged into
+  ``work`` and its branch was cascade-deleted, so ``work`` already
+  contains its commits). A raised probe is caught and treated
+  conservatively as ``True`` (never silently swap a real slice onto
+  ``work`` on a flaky gateway). #2928 replaced the original
+  merge-base probe, which probed the slice's OWN not-yet-created
+  integration branch and so mis-based every fresh non-root slice onto
+  ``work`` whenever ``work`` had advanced ahead of the parent.
 
 * **TASK-4-4** — Bootstrap reconciliation 5-way classification.
   Module-level ``_classify_non_complete_slice`` returns one of five
@@ -73,10 +75,10 @@ the coder have missed?" list):
   restart.
 * TASK-4-2 PENDING → IN_PROGRESS flip is idempotent: COMPLETE /
   BLOCKED / IN_PROGRESS slices keep their status across a re-entry.
-* TASK-4-3 fallback only fires when ``merge_base_lookup`` explicitly
-  returns ``None``; a probe exception falls through to the
-  derived-parent path (never silently swaps to ``pipeline_branch``
-  on a flaky gateway).
+* TASK-4-3 / #2928 fallback to ``pipeline_branch`` only fires when
+  ``parent_branch_exists`` returns ``False``; a probe exception is
+  treated as ``True`` and falls through to the derived-parent path
+  (never silently swaps to ``pipeline_branch`` on a flaky gateway).
 * TASK-4-4 case 5: PENDING + commits-on-origin is impossible (TASK-4-2
   flips before commits could land) — the classifier must return
   ``"corrupt"`` so the operator is woken instead of the scheduler
@@ -712,13 +714,13 @@ class TestResolveSliceBaseBranchPreservesExistingBehaviour:
                 )
             ]
         )
-        probe = MagicMock(name="merge_base_lookup")
+        probe = MagicMock(name="parent_branch_exists")
         result = _resolve_slice_base_branch(
             contract,
             "slice-1",
             pipeline_id="issue-2777-slice-4",
             pipeline_branch="egg/issue-2777-slice-4/work",
-            merge_base_lookup=probe,
+            parent_branch_exists=probe,
         )
         assert result == "egg/issue-2777-slice-4/recorded-parent"
         # Probe NOT consulted (short-circuit).
@@ -772,25 +774,29 @@ class TestResolveSliceBaseBranchPreservesExistingBehaviour:
         assert result == "egg/issue-2777-slice-4/slice-1"
 
 
-class TestResolveSliceBaseBranchMergeBaseLookupFallback:
-    """The new ``merge_base_lookup`` arm: a non-root slice with no
-    recorded parent invokes ``merge_base(integration_ref,
-    derived_parent_ref)`` to validate the legacy ancestor.
+class TestResolveSliceBaseBranchParentExistenceGate:
+    """The ``parent_branch_exists`` arm (#2928): a non-root slice with
+    no recorded parent invokes ``parent_branch_exists(parent_branch)``
+    to decide between the dependency-derived parent and
+    ``pipeline_branch``.
 
-    * Non-None SHA → real fork point → fall through to the
-      dependency-derived parent (legacy-correct stack target).
-    * ``None`` return → no fork point → fall back to
-      ``pipeline_branch`` (slice was never created OR its parent has
-      been deleted).
-    * Probe raises → conservative default ("has fork point") → fall
-      through to the derived parent so a flaky gateway never silently
-      swaps the parent.
+    * ``True`` → dependency-derived parent (correct for fresh AND
+      legacy slices).
+    * ``False`` → ``pipeline_branch`` (the parent PR merged into
+      ``work`` and its branch was cascade-deleted).
+    * Probe raises → conservative default (treated as ``True``) → the
+      derived parent, so a flaky gateway never silently swaps the
+      parent.
     """
 
-    def test_no_merge_base_falls_back_to_pipeline_branch(self) -> None:
-        """Headline TASK-4-3 case: probe returns ``None`` (no fork
-        point) ⇒ resolver returns ``pipeline_branch`` instead of the
-        dependency-derived parent."""
+    def test_fresh_slice_with_existing_parent_uses_derived_parent(self) -> None:
+        """#2928 headline regression: a FRESH non-root slice (its own
+        integration branch does not exist yet) whose dependency parent
+        branch IS on origin must stack on the derived parent — NOT on
+        ``pipeline_branch``. This is the case the old merge-base probe
+        mis-routed onto ``work`` (the slice's own branch had no fork
+        point because it had not been created yet).
+        """
         from routes.pipelines import _resolve_slice_base_branch
 
         contract = _make_contract(
@@ -804,57 +810,56 @@ class TestResolveSliceBaseBranchMergeBaseLookupFallback:
                 ),
             ]
         )
-        probe = MagicMock(name="merge_base_lookup", return_value=None)
+        probe = MagicMock(name="parent_branch_exists", return_value=True)
         result = _resolve_slice_base_branch(
             contract,
             "slice-2",
             pipeline_id="issue-2777-slice-4",
             pipeline_branch="egg/issue-2777-slice-4/work",
-            merge_base_lookup=probe,
+            parent_branch_exists=probe,
         )
-        # The probe is called with the slice's integration ref AND the
-        # derived parent ref, both as ``refs/remotes/origin/<name>``.
-        probe.assert_called_with(
-            "refs/remotes/origin/egg/issue-2777-slice-4/slice-2",
-            "refs/remotes/origin/egg/issue-2777-slice-4/slice-1",
-        )
-        assert result == "egg/issue-2777-slice-4/work", (
-            "non-root slice with no merge-base against derived parent "
-            "must fall back to pipeline_branch (slice-4 TASK-4-3)"
-        )
-
-    def test_merge_base_resolved_keeps_derived_parent(self) -> None:
-        """Probe returns a SHA ⇒ derived parent is preserved. The
-        slice has a real fork point; the dependency-derived parent
-        is the legacy-correct stack target."""
-        from routes.pipelines import _resolve_slice_base_branch
-
-        contract = _make_contract(
-            slices=[
-                _make_slice("slice-1", parent_branch_at_creation=None),
-                _make_slice(
-                    "slice-2",
-                    deps=["slice-1"],
-                    parent_branch_at_creation=None,
-                    task_idx=2,
-                ),
-            ]
-        )
-        probe = MagicMock(return_value="deadbeefdeadbeef")
-        result = _resolve_slice_base_branch(
-            contract,
-            "slice-2",
-            pipeline_id="issue-2777-slice-4",
-            pipeline_branch="egg/issue-2777-slice-4/work",
-            merge_base_lookup=probe,
-        )
+        # Probe is asked about the DEPENDENCY PARENT branch (bare
+        # name), never the slice's own integration branch.
+        probe.assert_called_once_with("egg/issue-2777-slice-4/slice-1")
         assert result == "egg/issue-2777-slice-4/slice-1"
+
+    def test_absent_parent_falls_back_to_pipeline_branch(self) -> None:
+        """Parent branch gone from origin (merged into ``work`` and
+        cascade-deleted) ⇒ resolver returns ``pipeline_branch``, which
+        already contains the parent's commits."""
+        from routes.pipelines import _resolve_slice_base_branch
+
+        contract = _make_contract(
+            slices=[
+                _make_slice("slice-1", parent_branch_at_creation=None),
+                _make_slice(
+                    "slice-2",
+                    deps=["slice-1"],
+                    parent_branch_at_creation=None,
+                    task_idx=2,
+                ),
+            ]
+        )
+        probe = MagicMock(name="parent_branch_exists", return_value=False)
+        result = _resolve_slice_base_branch(
+            contract,
+            "slice-2",
+            pipeline_id="issue-2777-slice-4",
+            pipeline_branch="egg/issue-2777-slice-4/work",
+            parent_branch_exists=probe,
+        )
+        probe.assert_called_once_with("egg/issue-2777-slice-4/slice-1")
+        assert result == "egg/issue-2777-slice-4/work", (
+            "non-root slice whose dependency parent branch is absent "
+            "must fall back to pipeline_branch (#2928)"
+        )
 
     def test_probe_failure_falls_through_to_derived_parent(self) -> None:
         """Adversarial probe: a flaky gateway raises mid-probe. The
-        resolver MUST fall through to the derived-parent path rather
-        than silently swap to ``pipeline_branch`` (which would re-stack
-        a real slice onto the wrong base).
+        resolver MUST treat the parent as existing and return the
+        derived-parent path rather than silently swap to
+        ``pipeline_branch`` (which would re-stack a real slice onto the
+        wrong base).
         """
         from routes.pipelines import _resolve_slice_base_branch
 
@@ -870,7 +875,7 @@ class TestResolveSliceBaseBranchMergeBaseLookupFallback:
             ]
         )
 
-        def _flaky(_ref_a: str, _ref_b: str) -> str | None:
+        def _flaky(_parent_branch: str) -> bool:
             raise RuntimeError("gateway down")
 
         result = _resolve_slice_base_branch(
@@ -878,9 +883,9 @@ class TestResolveSliceBaseBranchMergeBaseLookupFallback:
             "slice-2",
             pipeline_id="issue-2777-slice-4",
             pipeline_branch="egg/issue-2777-slice-4/work",
-            merge_base_lookup=_flaky,
+            parent_branch_exists=_flaky,
         )
-        # Conservative default ("has fork point") preserves the derived
+        # Conservative default ("parent exists") preserves the derived
         # parent — never silently swap on a flaky probe.
         assert result == "egg/issue-2777-slice-4/slice-1"
 


### PR DESCRIPTION
Fixes #2928.

## Problem

`_resolve_slice_base_branch` could create a non-root slice's integration branch off the pipeline **`work`** branch instead of its **dependency parent's** integration branch, silently breaking the stacked-PR invariant (observed on `issue-2908-impl2` slice-3).

The slice-4 TASK-4-3 arm computed `merge_base(slice_integration_branch, derived_parent)` and routed a `None` result to `pipeline_branch`. But a slice's integration branch is created **after** the resolver runs, so on a slice's first run the branch doesn't exist yet and has no fork point — `merge_base` returns `None` for a **fresh** slice exactly as it does for a genuinely **orphaned** one. The two cases were conflated, mis-basing fresh non-root slices onto `work`.

This was harmless only while `work` sat at the parent slice's tip. Once `work` advanced ahead (e.g. a stray contract-state commit from #2923), the mis-based slice lost its parent's commits and tripped `restricted_path_modified` downstream (#2927) — wedging the slice and restart-looping the producer.

## Fix

Replace the merge-base check (which probed the slice's *own*, not-yet-created branch) with a **parent-branch-existence** probe:

- parent branch **exists** on origin → stack on the dependency-derived parent (correct for fresh **and** legacy slices)
- parent branch **absent** → the parent PR merged into `work` and its branch was cascade-deleted, so `work` already contains the parent's commits → `pipeline_branch` fallback
- probe **raises** → conservatively assume the parent exists; never silently swap a real slice onto `work` on a flaky gateway

This matches the issue's "Expected": when the parent slice is known, resolve to `{issue_branch}/{dependencies[0]}` rather than falling back to `pipeline_branch`.

The orphan-reconciler mode (`extant_branches`) is untouched. The gateway `merge_base` method is retained as a general utility (no longer wired into the resolver).

## Testing

- Rewrote `TestResolveSliceBaseBranch*` to the parent-existence semantics, including a **regression test for the fresh-slice case** the old probe mis-routed (`test_fresh_slice_with_existing_parent_uses_derived_parent`), the cascade-deleted-parent fallback, and the flaky-probe conservative default.
- `make test` green: 17089 passed, 34 skipped.
- `ruff check` clean on all changed files.