### PR TITLE
fix(deploy): reap stale egg image tags from containerd post-deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -599,6 +599,12 @@ deploy: check-egg-images-present  ## Deploy egg to k3s
 		kubectl apply -f - && \
 	scripts/clear-stuck-egg-pods.sh && \
 	scripts/await-egg-deploy.sh "$(EGG_IMAGE_TAG)"
+	@# Rollout confirmed on $(EGG_IMAGE_TAG): drop older egg image tags from
+	@# containerd so it does not accumulate a ~12 GB sandbox image per deployed
+	@# commit and push the root fs over kubelet's image-GC threshold (which would
+	@# evict the next redeploy's freshly-imported, not-yet-referenced images
+	@# mid-run). Best-effort -- a reap hiccup must not fail an otherwise-green deploy.
+	@scripts/reap-stale-egg-images.sh "$(EGG_IMAGE_TAG)" || true
 	@$(MAKE) --no-print-directory litellm-config
 	@echo "Deployment complete"
 

--- a/Makefile
+++ b/Makefile
@@ -570,14 +570,22 @@ litellm-config:  ## Apply host-side LiteLLM model_list from ~/.config/egg/litell
 check-egg-images-present:
 	@scripts/check-egg-images-present.sh "$(EGG_IMAGE_TAG)"
 
-# check-egg-images-present is the lone prerequisite and k3s-secrets is
-# invoked from the recipe body so the ordering survives `make -j`: two
-# prerequisites of the same target may run in parallel under -j, but recipe
-# lines never do. The check MUST run before k3s-secrets — k3s-secrets
-# reconciles namespaces + the gateway-secrets Secret and would otherwise
-# mutate the cluster before the image check could fail, defeating the
-# zero-mutation abort this guard exists to provide.
-deploy: check-egg-images-present  ## Deploy egg to k3s
+# Cluster-mutating steps (k3s-secrets, kubectl apply) are invoked from the
+# recipe body so the ordering survives `make -j`: two prerequisites of the
+# same target may run in parallel under -j, but recipe lines never do. The
+# check MUST run before k3s-secrets — k3s-secrets reconciles namespaces + the
+# gateway-secrets Secret and would otherwise mutate the cluster before the
+# image check could fail, defeating the zero-mutation abort this guard exists
+# to provide. sudo-keepalive is a sibling prerequisite (not a recipe line) so
+# `make deploy` standalone can leave the sudo credential cache fresh through
+# the tail of the deploy: check-egg-images-present uses sudo at the very
+# start, but the post-rollout reap (reap-stale-egg-images.sh) needs sudo
+# minutes later after the long kubectl apply / await-egg-deploy steps, and
+# the default sudo timestamp would otherwise have aged out, prompting on an
+# attended deploy and silently skipping the reap (via `|| true`) on an
+# unattended one. Neither sudo-keepalive nor check-egg-images-present
+# mutates the cluster, so running them in parallel under -j is safe.
+deploy: sudo-keepalive check-egg-images-present  ## Deploy egg to k3s
 	@$(MAKE) --no-print-directory k3s-secrets
 	@echo "Deploying to k3s with tag $(EGG_IMAGE_TAG)..."
 	@command -v envsubst >/dev/null 2>&1 || { \

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -409,6 +409,40 @@ If the state-store worktree is wedged (for example, after a state-volume reset t
 > guarantee. The manual steps below remain useful as a fallback when the
 > skills are unavailable.
 
+### `make redeploy` aborts: "images for tag 'X' are not in k3s"
+
+`check-egg-images-present.sh` failed the deploy because `egg-gateway:X` and/or
+`egg-orchestrator:X` are missing from k3s's containerd. There are two causes:
+
+1. **HEAD moved since your last build.** A bare `make deploy` after a
+   commit/pull/rebase/checkout references a tag that was never built+imported.
+   Fix: `make redeploy` (rebuild + re-import + deploy on the current tag).
+
+2. **kubelet image GC ate the freshly-imported images.** You *did* run
+   `make redeploy`, the import succeeded, but the images vanished before
+   `deploy` repointed the pods at the new tag. Until that repoint the new tag
+   is unreferenced, so under disk pressure — root filesystem over kubelet's
+   `imageGCHighThresholdPercent` (~85%) — kubelet image GC collects it. The
+   gateway/orchestrator images go first: they import before the ~12 GB sandbox
+   image, so by the time the long sandbox/litellm imports finish they're older
+   than `imageMinimumGCAge` (~2 min) and thus GC-eligible, while sandbox/litellm
+   are still inside the immunity window.
+
+   The disk hog lives in **k3s's containerd** (`/var/lib/rancher/k3s/agent/containerd`),
+   a *different* store from docker's — so `docker system prune` frees the wrong
+   space and the next redeploy's import spike re-crosses the threshold. Reclaim
+   containerd space, then redeploy (which re-imports everything):
+
+   ```bash
+   sudo k3s crictl rmi --prune   # safe immediately before a redeploy
+   df -h /                       # confirm well under 80%
+   make redeploy
+   ```
+
+   A successful deploy now reaps older egg tags from containerd automatically
+   (`scripts/reap-stale-egg-images.sh`), keeping it bounded to the current tag
+   so the threshold isn't crossed on subsequent redeploys.
+
 ### Claude binary not found
 
 If the sandbox exits with `Claude Code CLI not found in PATH`, the Claude binary is missing from the container (failed build or changed install path).

--- a/scripts/check-egg-images-present.sh
+++ b/scripts/check-egg-images-present.sh
@@ -39,9 +39,20 @@ done
 
 if [ "${#missing[@]}" -gt 0 ]; then
   echo "ERROR: egg-system images for tag '${TAG}' are not in k3s: ${missing[*]}" >&2
-  echo "       A commit, pull, rebase, or branch checkout since your last build" >&2
-  echo "       moved EGG_IMAGE_TAG. 'make deploy' alone only deploys; run" >&2
-  echo "       'make redeploy' to rebuild + re-import + deploy on the current tag." >&2
+  echo "       Two known causes:" >&2
+  echo "       1. HEAD moved (commit/pull/rebase/checkout) since your last build, so" >&2
+  echo "          'make deploy' alone references a tag that was never built+imported." >&2
+  echo "          Fix: 'make redeploy' rebuilds + re-imports + deploys on the current tag." >&2
+  echo "       2. 'make redeploy' DID import these, but kubelet image GC evicted them" >&2
+  echo "          before 'deploy' repointed the pods at the new tag -- they sit" >&2
+  echo "          unreferenced until then, so under disk pressure (root fs over" >&2
+  echo "          imageGCHighThresholdPercent, ~85%) they get collected mid-run." >&2
+  echo "          Fix: reclaim space in k3s's containerd -- NOT docker, a separate" >&2
+  echo "          store 'docker system prune' does not touch -- then redeploy, which" >&2
+  echo "          re-imports everything:" >&2
+  echo "              sudo k3s crictl rmi --prune   # safe immediately before redeploy" >&2
+  echo "          'df -h /' should sit well under 80% before the import. A green deploy" >&2
+  echo "          now reaps older egg tags automatically (reap-stale-egg-images.sh)." >&2
   exit 1
 fi
 

--- a/scripts/reap-stale-egg-images.sh
+++ b/scripts/reap-stale-egg-images.sh
@@ -33,15 +33,29 @@ set -euo pipefail
 : "${1:?usage: $0 <egg-image-tag-to-keep>}"
 KEEP_TAG="$1"
 
-# Keep in sync with check-egg-images-present.sh and the k3s-import image list.
+# The egg image set. This list is the single source of truth WITHIN this script
+# (both the safety-gate grep loop below and the awk match-pattern threaded via
+# -v image_re are driven from it). Keep in sync ACROSS scripts with
+# check-egg-images-present.sh and the k3s-import image list.
 IMAGES=(egg-gateway egg-orchestrator egg-sandbox egg-litellm)
+
+# Build the awk match alternation from IMAGES so the awk regex below tracks
+# additions/removals automatically (e.g. "egg-gateway|egg-orchestrator|...").
+IMAGE_RE="$(IFS='|'; echo "${IMAGES[*]}")"
+
+# Escape regex metacharacters in KEEP_TAG before interpolating into grep -E.
+# Real `git describe` outputs ("v1.2.3-4-gabc123") only contain `.` as a regex
+# metacharacter, and the literal-vs-regex false-positive scenario is fictional
+# in practice -- but escaping costs nothing and keeps a future tag scheme
+# (release candidates, "+" build metadata, etc.) from quietly breaking the gate.
+KEEP_TAG_RE="$(printf '%s' "$KEEP_TAG" | sed -e 's/[][\\.*^$+?(){}|/]/\\&/g')"
 
 # `k3s ctr images list` columns: REF TYPE DIGEST SIZE PLATFORMS LABELS.
 listing="$(sudo k3s ctr images list 2>/dev/null || true)"
 
-# Safety: require ALL four just-deployed egg-*:KEEP_TAG refs to be visible
-# before we reap anything. If even one is missing -- a swallowed sudo prompt,
-# a containerd hiccup, an out-of-band crictl rmi between pre-flight and reap,
+# Safety: require ALL just-deployed egg-*:KEEP_TAG refs to be visible before we
+# reap anything. If even one is missing -- a swallowed sudo prompt, a
+# containerd hiccup, an out-of-band crictl rmi between pre-flight and reap,
 # kubelet GC eating an unreferenced image -- the awk loop would not record
 # that image's KEEP_TAG digest, so every prior egg-<that-image>:* tag would
 # look stale and get reaped. That is the worst-case outcome of this whole
@@ -49,7 +63,7 @@ listing="$(sudo k3s ctr images list 2>/dev/null || true)"
 # to run. Skip the reap entirely instead.
 missing_keep=()
 for img in "${IMAGES[@]}"; do
-  if ! grep -qE "^docker\.io/library/${img}:${KEEP_TAG}([[:space:]]|\$)" <<<"$listing"; then
+  if ! grep -qE "^docker\.io/library/${img}:${KEEP_TAG_RE}([[:space:]]|\$)" <<<"$listing"; then
     missing_keep+=("${img}:${KEEP_TAG}")
   fi
 done
@@ -66,8 +80,12 @@ fi
 # such a stale tag by name would take the current image with it -- and the
 # sandbox image has no running pod to make crictl refuse the removal. Skipping
 # by digest leaves those harmless duplicate tags in place; they cost no disk.
-mapfile -t candidates < <(awk -v keep="$KEEP_TAG" '
-  $1 ~ /^docker\.io\/library\/egg-(gateway|orchestrator|sandbox|litellm):/ {
+#
+# The awk match pattern is built from IMAGE_RE (derived from IMAGES above) and
+# threaded in via -v so a fifth image added to IMAGES flows in automatically.
+mapfile -t candidates < <(awk -v keep="$KEEP_TAG" -v image_re="$IMAGE_RE" '
+  BEGIN { match_re = "^docker\\.io/library/(" image_re "):" }
+  $1 ~ match_re {
     ref = $1; dig = $3
     tag = ref; sub(/.*:/, "", tag)
     if (tag == keep || tag == "latest") { keepdig[dig] = 1; next }

--- a/scripts/reap-stale-egg-images.sh
+++ b/scripts/reap-stale-egg-images.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# reap-stale-egg-images.sh - After a successful deploy, drop the egg-*:<tag>
+# images in k3s's containerd that are NOT the just-deployed tag (and NOT the
+# floating :latest, which shares content with it).
+#
+# Without this, containerd keeps a full image set -- including the ~12 GB
+# egg-sandbox -- for every `git describe` tag ever imported, because
+# `make redeploy` only ever adds the new tag and never removes the old one.
+# That bloat drives the root filesystem over kubelet's
+# imageGCHighThresholdPercent (~85%), and kubelet image GC then evicts the
+# freshly-imported egg images mid-`make redeploy`: they are unreferenced until
+# `deploy` repoints the pods at the new tag, so they are prime GC fodder. The
+# gateway/orchestrator images -- imported first, so already older than
+# imageMinimumGCAge (~2 min) by the time the long sandbox/litellm imports
+# finish -- are the ones that vanish, while sandbox/litellm (still inside the
+# GC-immunity window) survive. check-egg-images-present.sh then aborts the
+# deploy. Reaping here bounds containerd so the next redeploy's import spike
+# stays under the GC threshold.
+#
+# NOTE: this is NOT `crictl rmi --prune`. Prune removes every image no running
+# container references -- but the egg-sandbox image is referenced only by
+# agent pods the orchestrator spawns on demand, so between runs no pod holds
+# it and prune would delete the *current* sandbox image. This reap explicitly
+# keeps the just-deployed tag for all four images.
+#
+# Best-effort: a reap failure never fails the deploy (the Makefile guards the
+# call with `|| true`, and each removal below is individually tolerant).
+# Requires sudo because the containerd socket is root-only, same as k3s-import.
+#
+set -euo pipefail
+
+: "${1:?usage: $0 <egg-image-tag-to-keep>}"
+KEEP_TAG="$1"
+
+# `k3s ctr images list` columns: REF TYPE DIGEST SIZE PLATFORMS LABELS.
+listing="$(sudo k3s ctr images list 2>/dev/null || true)"
+
+# Safety: if we cannot even see the just-deployed orchestrator image, the
+# listing is unreliable (a swallowed sudo password prompt, a containerd
+# hiccup). Skip the reap rather than delete against a partial view.
+if ! grep -qE "^docker\.io/library/egg-orchestrator:${KEEP_TAG}([[:space:]]|\$)" <<<"$listing"; then
+  echo "==> containerd reap: tag '${KEEP_TAG}' not visible in containerd; skipping (nothing reaped)."
+  exit 0
+fi
+
+# Reap candidates: every egg-* ref whose tag is neither KEEP_TAG nor latest AND
+# whose manifest digest differs from every kept ref's digest. The digest guard
+# matters because a commit that does not change an image's build inputs yields a
+# tag whose content is byte-identical to the current one -- same digest, same
+# image ID. crictl rmi removes by image ID (all of that ID's tags), so removing
+# such a stale tag by name would take the current image with it -- and the
+# sandbox image has no running pod to make crictl refuse the removal. Skipping
+# by digest leaves those harmless duplicate tags in place; they cost no disk.
+mapfile -t candidates < <(awk -v keep="$KEEP_TAG" '
+  $1 ~ /^docker\.io\/library\/egg-(gateway|orchestrator|sandbox|litellm):/ {
+    ref = $1; dig = $3
+    tag = ref; sub(/.*:/, "", tag)
+    if (tag == keep || tag == "latest") { keepdig[dig] = 1; next }
+    cand_ref[NR] = ref; cand_dig[NR] = dig
+  }
+  END {
+    for (nr in cand_ref) if (!(cand_dig[nr] in keepdig)) print cand_ref[nr]
+  }
+' <<<"$listing")
+
+if [ "${#candidates[@]}" -eq 0 ]; then
+  echo "==> containerd reap: no stale egg images beyond tag '${KEEP_TAG}'/latest."
+  exit 0
+fi
+
+removed=0
+kept=0
+for ref in "${candidates[@]}"; do
+  # crictl rmi is CRI-aware: it refuses an image still held by a live container
+  # (e.g. a sandbox agent pod from a prior deploy), so an in-use old tag is left
+  # alone instead of being yanked out from under the pod.
+  if sudo k3s crictl rmi "$ref" >/dev/null 2>&1; then
+    echo "   reaped $ref"
+    removed=$((removed + 1))
+  else
+    kept=$((kept + 1))
+  fi
+done
+
+echo "==> containerd reap: removed ${removed} stale egg image(s); kept ${kept} in-use/undeletable."

--- a/scripts/reap-stale-egg-images.sh
+++ b/scripts/reap-stale-egg-images.sh
@@ -33,14 +33,28 @@ set -euo pipefail
 : "${1:?usage: $0 <egg-image-tag-to-keep>}"
 KEEP_TAG="$1"
 
+# Keep in sync with check-egg-images-present.sh and the k3s-import image list.
+IMAGES=(egg-gateway egg-orchestrator egg-sandbox egg-litellm)
+
 # `k3s ctr images list` columns: REF TYPE DIGEST SIZE PLATFORMS LABELS.
 listing="$(sudo k3s ctr images list 2>/dev/null || true)"
 
-# Safety: if we cannot even see the just-deployed orchestrator image, the
-# listing is unreliable (a swallowed sudo password prompt, a containerd
-# hiccup). Skip the reap rather than delete against a partial view.
-if ! grep -qE "^docker\.io/library/egg-orchestrator:${KEEP_TAG}([[:space:]]|\$)" <<<"$listing"; then
-  echo "==> containerd reap: tag '${KEEP_TAG}' not visible in containerd; skipping (nothing reaped)."
+# Safety: require ALL four just-deployed egg-*:KEEP_TAG refs to be visible
+# before we reap anything. If even one is missing -- a swallowed sudo prompt,
+# a containerd hiccup, an out-of-band crictl rmi between pre-flight and reap,
+# kubelet GC eating an unreferenced image -- the awk loop would not record
+# that image's KEEP_TAG digest, so every prior egg-<that-image>:* tag would
+# look stale and get reaped. That is the worst-case outcome of this whole
+# script: the next agent-pod spawn (sandbox especially) cannot find an image
+# to run. Skip the reap entirely instead.
+missing_keep=()
+for img in "${IMAGES[@]}"; do
+  if ! grep -qE "^docker\.io/library/${img}:${KEEP_TAG}([[:space:]]|\$)" <<<"$listing"; then
+    missing_keep+=("${img}:${KEEP_TAG}")
+  fi
+done
+if [ "${#missing_keep[@]}" -gt 0 ]; then
+  echo "==> containerd reap: not all egg-*:${KEEP_TAG} refs visible (${missing_keep[*]}); skipping (nothing reaped)."
   exit 0
 fi
 
@@ -70,17 +84,26 @@ if [ "${#candidates[@]}" -eq 0 ]; then
 fi
 
 removed=0
-kept=0
+rmi_failed=0
 for ref in "${candidates[@]}"; do
-  # crictl rmi is CRI-aware: it refuses an image still held by a live container
-  # (e.g. a sandbox agent pod from a prior deploy), so an in-use old tag is left
-  # alone instead of being yanked out from under the pod.
-  if sudo k3s crictl rmi "$ref" >/dev/null 2>&1; then
+  # crictl rmi is best-effort here. The CRI RemoveImage RPC's behavior on an
+  # in-use image is implementation-defined -- containerd's CRI plugin generally
+  # allows the removal (the snapshot stays mounted under the running container
+  # until exit), and there have been "rmi removed image out from under running
+  # container" reports historically. We do not rely on a refusal: a non-zero
+  # exit here just means "this ref still exists; we did not remove it," and
+  # since the digest guard above already excluded any ref that shares an image
+  # ID with a kept ref, leaving it alone is safe either way. Do NOT relax the
+  # digest guard or the `|| true` on the Makefile call on the assumption that
+  # crictl will refuse in-use removals -- it may not.
+  err="$(sudo k3s crictl rmi "$ref" 2>&1 >/dev/null)" && rc=0 || rc=$?
+  if [ "$rc" -eq 0 ]; then
     echo "   reaped $ref"
     removed=$((removed + 1))
   else
-    kept=$((kept + 1))
+    echo "   rmi failed for $ref: ${err:-(no stderr)}" >&2
+    rmi_failed=$((rmi_failed + 1))
   fi
 done
 
-echo "==> containerd reap: removed ${removed} stale egg image(s); kept ${kept} in-use/undeletable."
+echo "==> containerd reap: removed ${removed} stale egg image(s); ${rmi_failed} rmi call(s) failed."

--- a/tests/scripts/test_reap_stale_egg_images.py
+++ b/tests/scripts/test_reap_stale_egg_images.py
@@ -33,17 +33,37 @@ def _extract_awk_program() -> str:
     run instead of letting a stale hardcoded copy mask a regression.
     """
     src = SCRIPT.read_text()
-    m = re.search(r"awk -v keep=\"\$KEEP_TAG\" '(.+?)'\s*<<<", src, re.DOTALL)
+    # The script invokes awk with two -v flags: `keep="$KEEP_TAG"` and
+    # `image_re="$IMAGE_RE"` (the latter is built from IMAGES via IFS join).
+    m = re.search(
+        r"awk -v keep=\"\$KEEP_TAG\" -v image_re=\"\$IMAGE_RE\" '(.+?)'\s*<<<",
+        src,
+        re.DOTALL,
+    )
     assert m, "could not find awk block in reap-stale-egg-images.sh"
     return m.group(1)
+
+
+def _extract_images() -> list[str]:
+    """Pull the IMAGES bash array out of the script.
+
+    Same rationale as _extract_awk_program: a future edit to IMAGES (adding
+    a fifth image, renaming one) flows into the test rather than letting a
+    stale hardcoded list mask a regression.
+    """
+    src = SCRIPT.read_text()
+    m = re.search(r"^IMAGES=\(([^)]+)\)", src, re.MULTILINE)
+    assert m, "could not find IMAGES=(...) in reap-stale-egg-images.sh"
+    return m.group(1).split()
 
 
 def _run_awk(listing: str, keep: str) -> list[str]:
     """Run the script's awk block against a synthetic listing."""
     awk = shutil.which("awk")
     assert awk, "awk binary not on PATH"
+    image_re = "|".join(_extract_images())
     result = subprocess.run(
-        [awk, "-v", f"keep={keep}", _extract_awk_program()],
+        [awk, "-v", f"keep={keep}", "-v", f"image_re={image_re}", _extract_awk_program()],
         input=listing,
         capture_output=True,
         text=True,

--- a/tests/scripts/test_reap_stale_egg_images.py
+++ b/tests/scripts/test_reap_stale_egg_images.py
@@ -1,0 +1,239 @@
+"""Tests for scripts/reap-stale-egg-images.sh.
+
+The script's awk block is the load-bearing logic: it walks a
+`sudo k3s ctr images list` listing and decides which egg-* refs are stale
+(not the just-deployed tag, not :latest) AND whose manifest digest does
+NOT match a kept ref's digest. The digest guard exists because a commit
+that does not change an image's build inputs yields a stale tag whose
+digest (and image ID) is identical to the current one -- `crictl rmi`
+removes by image ID, so removing such a stale tag by name would take the
+current image with it. This test extracts the awk program from the script
+and runs it directly against synthetic listings to lock the digest-guard
+invariant against future "simplifications" that drop it.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+SCRIPT = PROJECT_ROOT / "scripts" / "reap-stale-egg-images.sh"
+
+
+def _extract_awk_program() -> str:
+    """Pull the awk program literal out of the script.
+
+    Reading the program from the script (rather than hardcoding it here)
+    means any future edit to the awk block flows into the test on the next
+    run instead of letting a stale hardcoded copy mask a regression.
+    """
+    src = SCRIPT.read_text()
+    m = re.search(r"awk -v keep=\"\$KEEP_TAG\" '(.+?)'\s*<<<", src, re.DOTALL)
+    assert m, "could not find awk block in reap-stale-egg-images.sh"
+    return m.group(1)
+
+
+def _run_awk(listing: str, keep: str) -> list[str]:
+    """Run the script's awk block against a synthetic listing."""
+    awk = shutil.which("awk")
+    assert awk, "awk binary not on PATH"
+    result = subprocess.run(
+        [awk, "-v", f"keep={keep}", _extract_awk_program()],
+        input=listing,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _row(ref: str, digest: str) -> str:
+    """One `k3s ctr images list` row: REF TYPE DIGEST SIZE PLATFORMS LABELS."""
+    return f"{ref}\tapplication/vnd.oci.image.manifest.v1+json\t{digest}\t1.2 GiB\tlinux/amd64\t-"
+
+
+class TestReapAwkDigestGuard:
+    def test_skips_stale_tag_sharing_digest_with_kept_tag(self) -> None:
+        """A stale tag whose digest matches the kept tag MUST NOT be reaped.
+
+        crictl rmi removes by image ID; a shared digest means a shared ID,
+        and removing the stale tag by name would yank the current image too.
+        """
+        listing = "\n".join(
+            [
+                _row("docker.io/library/egg-gateway:v2", "sha256:aaa"),
+                _row("docker.io/library/egg-gateway:v1", "sha256:aaa"),  # shared
+                _row("docker.io/library/egg-orchestrator:v2", "sha256:bbb"),
+                _row("docker.io/library/egg-orchestrator:v1", "sha256:bbb"),  # shared
+                _row("docker.io/library/egg-sandbox:v2", "sha256:ccc"),
+                _row("docker.io/library/egg-litellm:v2", "sha256:ddd"),
+            ]
+        )
+        reaped = _run_awk(listing, keep="v2")
+        assert reaped == []
+
+    def test_reaps_stale_tag_with_distinct_digest(self) -> None:
+        """A stale tag whose digest differs from every kept ref IS reaped."""
+        listing = "\n".join(
+            [
+                _row("docker.io/library/egg-gateway:v2", "sha256:aaa"),
+                _row("docker.io/library/egg-gateway:v1", "sha256:old1"),
+                _row("docker.io/library/egg-orchestrator:v2", "sha256:bbb"),
+                _row("docker.io/library/egg-orchestrator:v1", "sha256:old2"),
+                _row("docker.io/library/egg-sandbox:v2", "sha256:ccc"),
+                _row("docker.io/library/egg-sandbox:v1", "sha256:old3"),
+                _row("docker.io/library/egg-litellm:v2", "sha256:ddd"),
+                _row("docker.io/library/egg-litellm:v1", "sha256:old4"),
+            ]
+        )
+        reaped = _run_awk(listing, keep="v2")
+        assert sorted(reaped) == sorted(
+            [
+                "docker.io/library/egg-gateway:v1",
+                "docker.io/library/egg-orchestrator:v1",
+                "docker.io/library/egg-sandbox:v1",
+                "docker.io/library/egg-litellm:v1",
+            ]
+        )
+
+    def test_latest_with_different_digest_is_kept_not_reaped(self) -> None:
+        """`:latest` is always kept, even if its digest differs from KEEP_TAG.
+
+        This covers a transient state during import: `docker save` produces
+        a `:latest` tag too, and on a freshly-imported v2 the `:latest`
+        digest may temporarily match an older content set. The script must
+        never reap `:latest` by name -- and its digest must additionally
+        protect any other ref that shares it.
+        """
+        listing = "\n".join(
+            [
+                _row("docker.io/library/egg-gateway:v2", "sha256:aaa"),
+                _row("docker.io/library/egg-gateway:latest", "sha256:zzz"),
+                _row("docker.io/library/egg-gateway:v1", "sha256:zzz"),  # shares :latest
+                _row("docker.io/library/egg-orchestrator:v2", "sha256:bbb"),
+                _row("docker.io/library/egg-sandbox:v2", "sha256:ccc"),
+                _row("docker.io/library/egg-litellm:v2", "sha256:ddd"),
+            ]
+        )
+        reaped = _run_awk(listing, keep="v2")
+        # :latest itself is filtered out by the `tag == "latest"` branch; v1
+        # is protected by sharing :latest's digest.
+        assert reaped == []
+
+    def test_no_latest_present_does_not_cause_false_reaps(self) -> None:
+        """Absence of `:latest` must not produce spurious reap candidates."""
+        listing = "\n".join(
+            [
+                _row("docker.io/library/egg-gateway:v2", "sha256:aaa"),
+                _row("docker.io/library/egg-orchestrator:v2", "sha256:bbb"),
+                _row("docker.io/library/egg-sandbox:v2", "sha256:ccc"),
+                _row("docker.io/library/egg-litellm:v2", "sha256:ddd"),
+            ]
+        )
+        reaped = _run_awk(listing, keep="v2")
+        assert reaped == []
+
+    def test_ignores_non_egg_refs(self) -> None:
+        """Refs outside the egg-(gateway|orchestrator|sandbox|litellm) set are untouched."""
+        listing = "\n".join(
+            [
+                _row("docker.io/library/egg-gateway:v2", "sha256:aaa"),
+                _row("docker.io/library/egg-orchestrator:v2", "sha256:bbb"),
+                _row("docker.io/library/egg-sandbox:v2", "sha256:ccc"),
+                _row("docker.io/library/egg-litellm:v2", "sha256:ddd"),
+                _row("docker.io/library/postgres:14", "sha256:pg14"),
+                _row("docker.io/library/redis:7", "sha256:redis7"),
+                _row("docker.io/library/egg-helper:v1", "sha256:helper"),  # not in set
+            ]
+        )
+        reaped = _run_awk(listing, keep="v2")
+        assert reaped == []
+
+
+class TestReapScriptSafetyGuard:
+    """End-to-end test of the four-image safety gate via PATH shimming.
+
+    The script gates the whole reap on all four egg-*:KEEP_TAG refs being
+    visible. If any one is missing, the script must exit 0 having reaped
+    nothing -- otherwise the awk loop would not record that image's
+    KEEP_TAG digest and every prior tag of that image would be reaped,
+    leaving no image to run the next agent pod.
+    """
+
+    def _run_script(
+        self, tmp_path: Path, listing: str, keep: str
+    ) -> subprocess.CompletedProcess[str]:
+        """Run reap-stale-egg-images.sh with `sudo k3s` shimmed to return `listing`."""
+        bindir = tmp_path / "bin"
+        bindir.mkdir()
+        # `sudo` shim: drop the leading `sudo` arg and exec the rest from our bindir.
+        sudo = bindir / "sudo"
+        sudo.write_text(f'#!/usr/bin/env bash\nexec "{bindir}/$1" "${{@:2}}"\n')
+        sudo.chmod(0o755)
+        # `k3s` shim: only the `ctr images list` form returns the synthetic listing.
+        k3s = bindir / "k3s"
+        listing_file = tmp_path / "listing.txt"
+        listing_file.write_text(listing)
+        k3s.write_text(
+            "#!/usr/bin/env bash\n"
+            'if [ "$1" = "ctr" ] && [ "$2" = "images" ] && [ "$3" = "list" ]; then\n'
+            f'  cat "{listing_file}"\n'
+            'elif [ "$1" = "crictl" ] && [ "$2" = "rmi" ]; then\n'
+            "  exit 0\n"  # pretend every rmi succeeds; not exercised in safety-gate tests
+            "else\n"
+            '  echo "unexpected k3s args: $*" >&2; exit 99\n'
+            "fi\n"
+        )
+        k3s.chmod(0o755)
+        env = {
+            "PATH": f"{bindir}:/usr/bin:/bin",
+            "HOME": str(tmp_path),
+        }
+        return subprocess.run(
+            ["bash", str(SCRIPT), keep],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+    def test_skips_reap_when_kept_tag_partially_missing(self, tmp_path: Path) -> None:
+        # egg-sandbox:v2 missing — three out of four present is not enough.
+        listing = "\n".join(
+            [
+                _row("docker.io/library/egg-gateway:v2", "sha256:aaa"),
+                _row("docker.io/library/egg-gateway:v1", "sha256:old"),
+                _row("docker.io/library/egg-orchestrator:v2", "sha256:bbb"),
+                _row("docker.io/library/egg-sandbox:v1", "sha256:oldsand"),
+                _row("docker.io/library/egg-litellm:v2", "sha256:ddd"),
+            ]
+        )
+        result = self._run_script(tmp_path, listing, keep="v2")
+        assert result.returncode == 0, result.stderr
+        assert "skipping" in result.stdout
+        assert "egg-sandbox:v2" in result.stdout
+        # No per-ref reap line emitted ("   reaped docker.io/...").
+        assert "   reaped " not in result.stdout
+
+    def test_proceeds_with_reap_when_all_four_kept_refs_present(self, tmp_path: Path) -> None:
+        listing = "\n".join(
+            [
+                _row("docker.io/library/egg-gateway:v2", "sha256:aaa"),
+                _row("docker.io/library/egg-gateway:v1", "sha256:old1"),
+                _row("docker.io/library/egg-orchestrator:v2", "sha256:bbb"),
+                _row("docker.io/library/egg-sandbox:v2", "sha256:ccc"),
+                _row("docker.io/library/egg-litellm:v2", "sha256:ddd"),
+            ]
+        )
+        result = self._run_script(tmp_path, listing, keep="v2")
+        assert result.returncode == 0, result.stderr
+        assert "reaped docker.io/library/egg-gateway:v1" in result.stdout
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #2944.

## Problem

`make redeploy` on a stable main aborts at `check-egg-images-present`, reproducibly, with **only** `egg-gateway` and `egg-orchestrator` reported missing for the current tag — even though `k3s-import` verified every image at import time.

It's **kubelet image GC**. containerd keeps a full image set (incl. the ~12 GB `egg-sandbox`) for every `git describe` tag ever imported, since redeploy only adds the new tag and never removes the old one. That bloat holds the root fs over `imageGCHighThresholdPercent` (~85%), so when redeploy imports the next tag — unreferenced until `deploy` repoints the pods — kubelet GC collects it. gateway/orchestrator import first and age past `imageMinimumGCAge` (~2 min) during the long sandbox/litellm imports, so they go while sandbox/litellm (still in the immunity window) survive. `docker system prune` doesn't help: the bloat is in k3s's containerd, a separate store.

See #2944 for the full diagnosis.

## Change

- **`scripts/reap-stale-egg-images.sh`** (new): after a confirmed rollout, drops `egg-*:<tag>` from containerd for every tag other than the just-deployed one and `:latest`, bounding the store so the next import spike stays under the GC threshold.
  - **Not** `crictl rmi --prune` — prune would delete the current `egg-sandbox` (no pod references it between agent runs). The reap keeps the current tag explicitly.
  - **Digest-guarded** — a commit that doesn't change an image's build inputs yields a tag whose content (and image ID) is identical to the current one; removing it by name would resolve to the shared ID and take the current image with it. Stale tags whose digest matches a kept ref are skipped.
  - Removal via `crictl rmi` (CRI-aware: in-use old tags, e.g. a lingering sandbox agent pod, are left alone).
  - Fail-safe: skips entirely if the just-deployed tag isn't visible in containerd; the Makefile guards the call with `|| true` so a reap hiccup never fails a green deploy.
- **`Makefile`**: invoke the reap after `await-egg-deploy.sh` confirms the rollout.
- **`scripts/check-egg-images-present.sh`**: the error message now names the GC-under-disk-pressure cause alongside tag drift, with the containerd-vs-docker distinction and the safe manual unblock.
- **`docs/guides/deployment.md`**: troubleshooting entry covering both causes.

## Test

- `shellcheck` clean on both scripts; `bash -n` clean (covered by `tests/test_bash_syntax.py`).
- `make -n redeploy` confirms the reap runs after `await-egg-deploy` and before `litellm-config`, guarded by `|| true`.

Note: an already-wedged cluster still needs a one-time `sudo k3s crictl rmi --prune` immediately before `make redeploy` to get the first green deploy; the reap keeps containerd bounded from then on.