### PR TITLE
fix(orchestrator): resume slice in place on crash/restart with additively-advanced parent (#2947)

### DIFF
--- a/gateway/tests/test_pipeline_push_block.py
+++ b/gateway/tests/test_pipeline_push_block.py
@@ -735,23 +735,31 @@ class TestSliceIntegrationBranchExemption:
         is never consulted on this path.
 
         To actually pin the exemption-precedence invariant — that the
-        ``is_infrastructure_push = True`` flip at
-        ``gateway.py:1349`` wins over the role-keyed restriction gate
-        at ``gateway.py:1610`` — the test overrides ``_push_context``'s
-        empty-diff default with a non-empty changed-file list and stubs
-        attribution to fail-closed (empty range with error).  Under
-        attribution_fallback every file is treated as own-authored, and
-        the real ``partition_files_by_role`` consulted at
-        ``gateway.py:1714`` returns the full diff in ``blocked_own``
-        because the orchestrator role's ``allowed_patterns == []``
-        deny-all rule rejects every path.  The only thing that makes
-        this push 200 instead of 403 is the synthetic+slice exemption
-        flipping ``is_infrastructure_push`` *before* the gate evaluates
-        its ``not is_infrastructure_push`` clause — so a regression
-        removing that flip for the orchestrator-role path would surface
-        here as a ``restricted_path_modified`` 403 (the same shape
+        ``is_infrastructure_push = True`` flip inside the
+        ``_SLICE_INTEGRATION_BRANCH_RE`` branch wins over the role-keyed
+        restriction gate (``if session_role and changed_files and not
+        is_infrastructure_push:``) — the test overrides
+        ``_push_context``'s empty-diff default with a non-empty
+        changed-file list and stubs attribution to fail-closed (empty
+        range with error).  Under ``attribution_fallback`` every file
+        is treated as own-authored, and the real
+        ``partition_files_by_role`` returns the full diff in
+        ``blocked_own`` because the orchestrator role's
+        ``allowed_patterns == []`` deny-all rule rejects every path.
+        The only thing that makes this push 200 instead of 403 is the
+        synthetic+slice exemption flipping ``is_infrastructure_push``
+        *before* the gate evaluates its ``not is_infrastructure_push``
+        clause — so a regression removing that flip for the
+        orchestrator-role path would surface here as a
+        ``restricted_path_modified`` 403 (the same shape
         ``test_coder_role_blocked_from_contracts`` asserts in
         ``test_push_error_enrichment.py``), not a silent 200.
+
+        Symbol references rather than line numbers are used throughout
+        because ``gateway.py`` is queued for decomposition in
+        ``#2261`` slice-14 (see ``gateway/CLAUDE.md`` Submodule seam
+        tables) — line numbers will rot, named symbols will move with
+        the code.
         """
         session = _make_session(
             role="orchestrator",
@@ -759,9 +767,11 @@ class TestSliceIntegrationBranchExemption:
             assigned_branch="egg/issue-2919/slice-1",
         )
         patches = _push_context(session)
-        # Force the role-keyed restriction gate at gateway.py:1610 to
-        # be reachable: it short-circuits on empty ``changed_files``,
-        # so without a non-empty diff the ``is_infrastructure_push``
+        # Force the role-keyed restriction gate (the
+        # ``if session_role and changed_files and not
+        # is_infrastructure_push:`` block in ``gateway.py``) to be
+        # reachable: it short-circuits on empty ``changed_files``, so
+        # without a non-empty diff the ``is_infrastructure_push``
         # clause is never load-bearing and the test would pass even
         # under a regression that removed the orchestrator-role flip.
         diff_files = ["orchestrator/synthetic_slice_push.py"]
@@ -778,12 +788,15 @@ class TestSliceIntegrationBranchExemption:
                 "get_changed_files_in_push",
                 return_value=(diff_files, None),
             ),
-            # Force ``attribution_fallback`` so every file in the diff is
-            # treated as own-authored and reaches ``partition_files_by_role``
-            # under the orchestrator role's deny-all pattern.  If the
-            # ``is_infrastructure_push`` short-circuit ever stopped firing
-            # for this path, that partition would reject every file and the
-            # gate would return 403, not 200.
+            # Force ``attribution_fallback`` (the
+            # ``bool(attributed_push.error or not attributed_push.commits)``
+            # gate) so every file in the diff is treated as own-authored
+            # and reaches ``partition_files_by_role`` under the
+            # orchestrator role's deny-all pattern.  If the
+            # ``is_infrastructure_push`` short-circuit inside the
+            # ``_SLICE_INTEGRATION_BRANCH_RE`` branch ever stopped
+            # firing for this path, that partition would reject every
+            # file and the gate would return 403, not 200.
             patch.object(
                 git_client,
                 "get_attributed_changed_files_in_push",

--- a/gateway/tests/test_pipeline_push_block.py
+++ b/gateway/tests/test_pipeline_push_block.py
@@ -28,8 +28,10 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+import git_client
 import pytest
 import session_manager
+from git_client import AttributedPushRange
 from policy import PolicyResult
 from private_repo_policy import PrivateRepoPolicyResult
 from session_manager import SessionValidationResult
@@ -731,6 +733,25 @@ class TestSliceIntegrationBranchExemption:
         sets ``is_infrastructure_push`` and short-circuits before the
         role's file-pattern check would ever run, so the deny-all pattern
         is never consulted on this path.
+
+        To actually pin the exemption-precedence invariant — that the
+        ``is_infrastructure_push = True`` flip at
+        ``gateway.py:1349`` wins over the role-keyed restriction gate
+        at ``gateway.py:1610`` — the test overrides ``_push_context``'s
+        empty-diff default with a non-empty changed-file list and stubs
+        attribution to fail-closed (empty range with error).  Under
+        attribution_fallback every file is treated as own-authored, and
+        the real ``partition_files_by_role`` consulted at
+        ``gateway.py:1714`` returns the full diff in ``blocked_own``
+        because the orchestrator role's ``allowed_patterns == []``
+        deny-all rule rejects every path.  The only thing that makes
+        this push 200 instead of 403 is the synthetic+slice exemption
+        flipping ``is_infrastructure_push`` *before* the gate evaluates
+        its ``not is_infrastructure_push`` clause — so a regression
+        removing that flip for the orchestrator-role path would surface
+        here as a ``restricted_path_modified`` 403 (the same shape
+        ``test_coder_role_blocked_from_contracts`` asserts in
+        ``test_push_error_enrichment.py``), not a silent 200.
         """
         session = _make_session(
             role="orchestrator",
@@ -738,6 +759,12 @@ class TestSliceIntegrationBranchExemption:
             assigned_branch="egg/issue-2919/slice-1",
         )
         patches = _push_context(session)
+        # Force the role-keyed restriction gate at gateway.py:1610 to
+        # be reachable: it short-circuits on empty ``changed_files``,
+        # so without a non-empty diff the ``is_infrastructure_push``
+        # clause is never load-bearing and the test would pass even
+        # under a regression that removed the orchestrator-role flip.
+        diff_files = ["orchestrator/synthetic_slice_push.py"]
         with (
             patches[0],
             patches[1],
@@ -746,6 +773,22 @@ class TestSliceIntegrationBranchExemption:
             patches[4],
             patches[5],
             patches[6],
+            patch.object(
+                gateway,
+                "get_changed_files_in_push",
+                return_value=(diff_files, None),
+            ),
+            # Force ``attribution_fallback`` so every file in the diff is
+            # treated as own-authored and reaches ``partition_files_by_role``
+            # under the orchestrator role's deny-all pattern.  If the
+            # ``is_infrastructure_push`` short-circuit ever stopped firing
+            # for this path, that partition would reject every file and the
+            # gate would return 403, not 200.
+            patch.object(
+                git_client,
+                "get_attributed_changed_files_in_push",
+                return_value=AttributedPushRange(error="attribution unavailable in test"),
+            ),
         ):
             response = _do_push(
                 client,

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -2323,6 +2323,7 @@ class GatewayClient:
         *,
         integration_branch: str,
         parent_branch: str,
+        integration_base_sha: str | None = None,
         agent_role: str = "coder",
         mode: Literal["public", "private"] = "public",
     ) -> bool:
@@ -2347,6 +2348,17 @@ class GatewayClient:
         ``gateway/gateway.py``.  The branch itself still passes the
         normal ``egg/`` prefix branch-ownership check, so no
         orchestrator-role push surface is introduced.
+
+        ``integration_base_sha`` is the fork base recorded at the
+        slice's creation (#2871). When supplied it unlocks the #2947
+        resume-in-place path below: a crash / ``restart_phase`` that
+        lands while the slice already has committed work *and* the
+        parent advanced additively is recognised as a resumable branch
+        (rather than non-fast-forward-rejected) by checking that the
+        recorded base is still an ancestor of both the existing tip and
+        the advanced parent. ``None`` (slices provisioned before #2871,
+        or whose base was never recorded) degrades to the prior
+        behaviour — the rejection surfaces.
 
         Returns ``True`` on success, ``False`` on any error (the
         caller logs and surfaces a clear error to the run loop).
@@ -2480,6 +2492,83 @@ class GatewayClient:
                         parent_branch=parent_branch,
                         parent_sha=parent_sha,
                         existing_sha=existing_sha,
+                    )
+                    return True
+                # #2947 — crash / restart mid-slice resume-in-place. The
+                # existing tip is NOT a descendant of the (advanced)
+                # parent, so the #2512 fast-path above did not fire — but
+                # that does not necessarily mean diverged/unknown history.
+                # When a host crash or ``restart_phase`` lands while the
+                # slice already has its own committed work AND the parent
+                # moved forward *additively* (no history rewrite), the
+                # slice is a legitimate, resumable branch that simply has
+                # not picked up the parent's new commits yet. The #2914
+                # "treat as fresh to force re-spawn" path then routes it
+                # back through here, and a plain
+                # ``parent_sha:refs/heads/<int>`` push would be
+                # non-fast-forward — failing the slice and cascading the
+                # whole phase (the exact 2026-06-02 issue-2908-impl2
+                # slice-3 incident).
+                #
+                # We can recognise this case precisely using the fork
+                # base recorded at creation (#2871): if the slice's own
+                # recorded base is a *strict* ancestor of the existing tip
+                # (the branch genuinely carries this slice's commits built
+                # on its base) AND that base is also an ancestor of the
+                # advanced parent (the parent moved forward without
+                # rewriting the base out of its history), then the slice
+                # and the parent differ only by additive commits on each
+                # side of a shared base. Preserve the branch as-is and
+                # short-circuit success: the cohort re-spawns onto the
+                # existing tip, and the parent's new commits reconcile at
+                # slice-PR / merge time exactly as they would for a slice
+                # whose parent advanced while it was running normally. We
+                # never reset or force-push, so no committed work is
+                # destroyed.
+                #
+                # Gating on the slice's *own* recorded base (not a generic
+                # merge-base of the two tips) is what keeps this safe: a
+                # genuinely unrelated stale branch would not descend from
+                # this slice's recorded base, so it still falls through to
+                # the push and surfaces the rejection (preserving the
+                # #2512/#2549 "don't silently overwrite unknown work"
+                # instinct). A true history rewrite of the parent (rebase)
+                # drops the base out of the parent's ancestry, so the
+                # second check fails and we likewise fall through — that
+                # harder class is deliberately left to the operator. The
+                # ``existing_sha != integration_base_sha`` guard keeps an
+                # *un-started* branch still sitting at its base on the
+                # fast-forward push path (advancing it to the new parent
+                # tip) rather than pinning it to the stale base.
+                if (
+                    integration_base_sha
+                    and existing_sha != integration_base_sha
+                    and self._sha_is_ancestor(
+                        pipeline_id,
+                        repo_path,
+                        integration_base_sha,
+                        existing_sha,
+                        bearer_token=session_token,
+                    )
+                    and self._sha_is_ancestor(
+                        pipeline_id,
+                        repo_path,
+                        integration_base_sha,
+                        parent_sha,
+                        bearer_token=session_token,
+                    )
+                ):
+                    logger.info(
+                        "Slice integration branch carries its own commits "
+                        "and the parent advanced additively since creation "
+                        "— preserving the branch and resuming in place "
+                        "(#2947 crash/restart recovery)",
+                        pipeline_id=pipeline_id,
+                        integration_branch=integration_branch,
+                        parent_branch=parent_branch,
+                        parent_sha=parent_sha,
+                        existing_sha=existing_sha,
+                        integration_base_sha=integration_base_sha,
                     )
                     return True
                 # Could not verify ancestry: parent_sha is either not

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -2540,6 +2540,11 @@ class GatewayClient:
                 # *un-started* branch still sitting at its base on the
                 # fast-forward push path (advancing it to the new parent
                 # tip) rather than pinning it to the stale base.
+                # ``existing_sha`` and ``integration_base_sha`` both
+                # originate from ``get_remote_branch_sha`` (full 40-char
+                # SHAs), so an exact compare is correct (same invariant as
+                # the #2871 un-started-branch guard in
+                # ``is_slice_branch_merged_into_parent``).
                 if (
                     integration_base_sha
                     and existing_sha != integration_base_sha

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -16581,6 +16581,13 @@ def _run_implement_phase_slices(
                                 str(worktree_repo_path),
                                 integration_branch=integration_branch,
                                 parent_branch=parent_branch,
+                                # #2947 — hand the slice's recorded fork
+                                # base to the gateway so a crash/restart
+                                # over a branch that already carries this
+                                # slice's commits (with an additively
+                                # advanced parent) resumes in place
+                                # instead of non-fast-forward-failing.
+                                integration_base_sha=recorded_base_sha,
                                 agent_role="coder",
                                 mode=gateway_mode,  # type: ignore[arg-type]
                             )

--- a/orchestrator/tests/test_create_slice_integration_branch.py
+++ b/orchestrator/tests/test_create_slice_integration_branch.py
@@ -726,6 +726,248 @@ class TestCreateSliceIntegrationBranchRestartRecovery:
         assert fetch_calls[0][0] == ("+refs/heads/egg/issue-1:refs/remotes/origin/egg/issue-1")
 
 
+def _ancestry_make_request(
+    ancestry: dict[tuple[str, str], bool],
+    *,
+    push_invoked: list[dict],
+    merge_base_args: list[list[str]],
+):
+    """Build a ``_make_request`` side effect that answers
+    ``merge-base --is-ancestor`` from an ``(ancestor, descendant) -> bool``
+    map and records pushes.
+
+    A ``True`` mapping returns the gateway's success shape; a ``False`` (or
+    missing) mapping raises the ``returncode=1`` ``GatewayError`` that
+    ``_sha_is_ancestor`` interprets as "not an ancestor" — exactly how the
+    real gateway surfaces ``git merge-base --is-ancestor``'s non-zero exit.
+    """
+
+    def fake_make_request(endpoint, method=None, data=None, **kwargs):
+        if endpoint == "/api/v1/git/push":
+            push_invoked.append(dict(data or {}))
+            return {"success": True, "data": {}}
+        if endpoint == "/api/v1/git/execute":
+            args = list((data or {}).get("args", []))
+            merge_base_args.append(args)
+            ancestor, descendant = args[1], args[2]
+            if ancestry.get((ancestor, descendant), False):
+                return {"success": True, "data": {"returncode": 0}}
+            raise GatewayError(
+                "git merge-base failed",
+                status_code=500,
+                details={"returncode": 1, "stdout": "", "stderr": ""},
+            )
+        return {"success": True, "data": {}}
+
+    return fake_make_request
+
+
+class TestCreateSliceIntegrationBranchResumeInPlace:
+    """#2947 — crash / ``restart_phase`` mid-slice over a branch that
+    already carries the slice's own commits while the parent advanced
+    *additively*.
+
+    The #2512 fast-path only preserves a branch whose tip *descends from*
+    the parent. The crash-mid-slice incident (2026-06-02
+    ``issue-2908-impl2`` slice-3) produced the unhandled fourth state:
+    committed slice work + an additively-advanced parent + no live agents.
+    The #2914 "treat as fresh to force re-spawn" path then routed it back
+    into ``create_slice_integration_branch``, whose plain
+    ``parent_sha:refs/heads/<int>`` push is non-fast-forward → slice
+    failed → whole phase cascade-failed.
+
+    These tests pin the resume-in-place path: gated on the slice's own
+    recorded fork base (#2871), recognise the additive-advance shape and
+    short-circuit success WITHOUT pushing (preserving the committed work),
+    while still falling through to the rejection for genuinely diverged
+    history, parent rebases, and slices with no recorded base.
+    """
+
+    _PIPE = "issue-2908-impl2"
+    _INT = "egg/issue-2908-impl2/slice-3"
+    _PARENT = "egg/issue-2908-impl2/slice-2"
+
+    def _remotes(self, parent_sha: str, existing_sha: str | None):
+        def fake_get_remote_branch_sha(pipeline_id, repo_path, ref, **kwargs):
+            if ref == f"refs/heads/{self._INT}":
+                return existing_sha
+            if ref == f"refs/heads/{self._PARENT}":
+                return parent_sha
+            return None
+
+        return fake_get_remote_branch_sha
+
+    def _create(self, gateway_client, fake_make_request, remotes, *, base_sha):
+        with (
+            patch.object(gateway_client, "register_session", return_value=_session_info()),
+            patch.object(gateway_client, "delete_session", return_value=True),
+            patch.object(gateway_client, "fetch_branch", return_value=True),
+            patch.object(gateway_client, "get_remote_branch_sha", side_effect=remotes),
+            patch.object(gateway_client, "_make_request", side_effect=fake_make_request),
+        ):
+            return gateway_client.create_slice_integration_branch(
+                self._PIPE,
+                "/repo",
+                integration_branch=self._INT,
+                parent_branch=self._PARENT,
+                integration_base_sha=base_sha,
+            )
+
+    def test_additively_advanced_parent_with_own_commits_resumes_in_place(self, gateway_client):
+        """The incident itself: slice has its own commits built on the
+        recorded base, parent advanced additively (base ancestor of both,
+        neither tip an ancestor of the other). Must preserve the branch
+        and return True WITHOUT pushing."""
+        base_sha = "b0b0b0b0" * 5  # slice-2 tip when slice-3 was created
+        existing_sha = "e1e1e1e1" * 5  # slice-3 tip (documenter commits)
+        parent_sha = "a2a2a2a2" * 5  # slice-2 tip, advanced additively
+        push_invoked: list[dict] = []
+        merge_base_args: list[list[str]] = []
+        ancestry = {
+            (parent_sha, existing_sha): False,  # #2512: parent NOT ancestor of existing
+            (base_sha, existing_sha): True,  # base IS ancestor of existing (our branch)
+            (base_sha, parent_sha): True,  # base IS ancestor of parent (additive advance)
+        }
+        ok = self._create(
+            gateway_client,
+            _ancestry_make_request(
+                ancestry, push_invoked=push_invoked, merge_base_args=merge_base_args
+            ),
+            self._remotes(parent_sha, existing_sha),
+            base_sha=base_sha,
+        )
+
+        assert ok is True, "additive-advance + own commits must resume in place"
+        assert push_invoked == [], (
+            "must NOT push — a parent-tip push here is non-fast-forward and "
+            "would discard / fail the slice's committed work"
+        )
+        # #2512 parent->existing first, then base->existing, then base->parent.
+        assert [a[1:] for a in merge_base_args] == [
+            [parent_sha, existing_sha],
+            [base_sha, existing_sha],
+            [base_sha, parent_sha],
+        ]
+
+    def test_parent_rebase_falls_through_to_push(self, gateway_client):
+        """If the parent was *rewritten* (rebase) rather than advanced
+        additively, the recorded base is no longer an ancestor of the
+        parent tip. The harder rewrite class is out of scope — fall
+        through to the push so the rejection surfaces."""
+        base_sha = "b0b0b0b0" * 5
+        existing_sha = "e1e1e1e1" * 5
+        parent_sha = "a2a2a2a2" * 5
+        push_invoked: list[dict] = []
+        merge_base_args: list[list[str]] = []
+        ancestry = {
+            (parent_sha, existing_sha): False,
+            (base_sha, existing_sha): True,  # branch is genuinely ours
+            (base_sha, parent_sha): False,  # parent rebased the base out of history
+        }
+        ok = self._create(
+            gateway_client,
+            _ancestry_make_request(
+                ancestry, push_invoked=push_invoked, merge_base_args=merge_base_args
+            ),
+            self._remotes(parent_sha, existing_sha),
+            base_sha=base_sha,
+        )
+
+        assert ok is True, "diverged push (here) succeeds in the stub"
+        assert len(push_invoked) == 1, "rebase class must fall through to the push"
+        assert push_invoked[0]["refspec"] == f"{parent_sha}:refs/heads/{self._INT}"
+        assert [a[1:] for a in merge_base_args] == [
+            [parent_sha, existing_sha],
+            [base_sha, existing_sha],
+            [base_sha, parent_sha],
+        ]
+
+    def test_branch_not_descended_from_recorded_base_falls_through(self, gateway_client):
+        """A branch that does not even contain its own recorded base is
+        unknown/garbage work — fall through to the push (don't silently
+        preserve it). The base->parent check is short-circuited."""
+        base_sha = "b0b0b0b0" * 5
+        existing_sha = "feedface" * 5  # unrelated tip
+        parent_sha = "a2a2a2a2" * 5
+        push_invoked: list[dict] = []
+        merge_base_args: list[list[str]] = []
+        ancestry = {
+            (parent_sha, existing_sha): False,
+            (base_sha, existing_sha): False,  # existing does not descend from our base
+        }
+        # The push (here) succeeds in the stub; what this test pins is the
+        # *fall-through* — return value is incidental.
+        self._create(
+            gateway_client,
+            _ancestry_make_request(
+                ancestry, push_invoked=push_invoked, merge_base_args=merge_base_args
+            ),
+            self._remotes(parent_sha, existing_sha),
+            base_sha=base_sha,
+        )
+
+        assert len(push_invoked) == 1, "unknown work must fall through to the push"
+        # base->parent must NOT run — the conjunction short-circuits once
+        # base->existing is False.
+        assert [a[1:] for a in merge_base_args] == [
+            [parent_sha, existing_sha],
+            [base_sha, existing_sha],
+        ]
+
+    def test_absent_recorded_base_degrades_to_prior_behaviour(self, gateway_client):
+        """``integration_base_sha=None`` (slices provisioned before #2871,
+        or whose base was never recorded) must NOT enter the resume-in-
+        place path — it degrades to the pre-#2947 push-and-surface
+        behaviour, running only the #2512 ancestry check."""
+        existing_sha = "e1e1e1e1" * 5
+        parent_sha = "a2a2a2a2" * 5
+        push_invoked: list[dict] = []
+        merge_base_args: list[list[str]] = []
+        ancestry = {(parent_sha, existing_sha): False}
+        self._create(
+            gateway_client,
+            _ancestry_make_request(
+                ancestry, push_invoked=push_invoked, merge_base_args=merge_base_args
+            ),
+            self._remotes(parent_sha, existing_sha),
+            base_sha=None,
+        )
+
+        assert len(push_invoked) == 1, "no recorded base → push (prior behaviour)"
+        assert [a[1:] for a in merge_base_args] == [[parent_sha, existing_sha]], (
+            "with no recorded base the resume-in-place merge-base probes "
+            "must not run — only the #2512 check"
+        )
+
+    def test_unstarted_branch_at_base_still_fast_forwards(self, gateway_client):
+        """An un-started branch still sitting exactly at its recorded base
+        (no slice commits yet) must take the fast-forward push path that
+        advances it to the new parent tip — NOT resume-in-place, which
+        would pin it to the stale base. The ``existing_sha != base`` guard
+        is what keeps it off the resume path."""
+        base_sha = "b0b0b0b0" * 5
+        existing_sha = base_sha  # un-started: tip still at the creation base
+        parent_sha = "a2a2a2a2" * 5
+        push_invoked: list[dict] = []
+        merge_base_args: list[list[str]] = []
+        ancestry = {(parent_sha, existing_sha): False}  # parent not ancestor of base
+        ok = self._create(
+            gateway_client,
+            _ancestry_make_request(
+                ancestry, push_invoked=push_invoked, merge_base_args=merge_base_args
+            ),
+            self._remotes(parent_sha, existing_sha),
+            base_sha=base_sha,
+        )
+
+        assert ok is True
+        assert len(push_invoked) == 1, "un-started branch must fast-forward to parent"
+        assert push_invoked[0]["refspec"] == f"{parent_sha}:refs/heads/{self._INT}"
+        # Only the #2512 probe runs; the resume-in-place probes are gated
+        # off by ``existing_sha != integration_base_sha``.
+        assert [a[1:] for a in merge_base_args] == [[parent_sha, existing_sha]]
+
+
 class TestIsSliceBranchMergedIntoParent:
     """#2549 — detect whether a slice's PR has already merged into its
     parent. This is the inverse of the #2512 restart-recovery check:

--- a/orchestrator/tests/test_create_slice_integration_branch.py
+++ b/orchestrator/tests/test_create_slice_integration_branch.py
@@ -797,10 +797,26 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
 
         return fake_get_remote_branch_sha
 
-    def _create(self, gateway_client, fake_make_request, remotes, *, base_sha):
+    def _create(
+        self,
+        gateway_client,
+        fake_make_request,
+        remotes,
+        *,
+        base_sha,
+        delete_calls: list[str] | None = None,
+        session_token: str = "tok-resume",
+    ):
+        def fake_delete(token):
+            if delete_calls is not None:
+                delete_calls.append(token)
+            return True
+
         with (
-            patch.object(gateway_client, "register_session", return_value=_session_info()),
-            patch.object(gateway_client, "delete_session", return_value=True),
+            patch.object(
+                gateway_client, "register_session", return_value=_session_info(session_token)
+            ),
+            patch.object(gateway_client, "delete_session", side_effect=fake_delete),
             patch.object(gateway_client, "fetch_branch", return_value=True),
             patch.object(gateway_client, "get_remote_branch_sha", side_effect=remotes),
             patch.object(gateway_client, "_make_request", side_effect=fake_make_request),
@@ -823,6 +839,7 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
         parent_sha = "a2a2a2a2" * 5  # slice-2 tip, advanced additively
         push_invoked: list[dict] = []
         merge_base_args: list[list[str]] = []
+        delete_calls: list[str] = []
         ancestry = {
             (parent_sha, existing_sha): False,  # #2512: parent NOT ancestor of existing
             (base_sha, existing_sha): True,  # base IS ancestor of existing (our branch)
@@ -835,6 +852,8 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
             ),
             self._remotes(parent_sha, existing_sha),
             base_sha=base_sha,
+            delete_calls=delete_calls,
+            session_token="tok-resume-incident",
         )
 
         assert ok is True, "additive-advance + own commits must resume in place"
@@ -848,6 +867,18 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
             [base_sha, existing_sha],
             [base_sha, parent_sha],
         ]
+        # Symmetric coverage for ``test_push_failure_returns_false_and_cleans
+        # _up_session``: the new ``return True`` lives inside the outer
+        # ``try``, so ``delete_session`` must still fire from the ``finally``
+        # on this success path. Pinning it here freezes that — a future
+        # refactor that moved the early-return outside the try (or skipped
+        # session cleanup) would leak the synthetic session on every
+        # resume-in-place recovery.
+        assert delete_calls == ["tok-resume-incident"], (
+            "synthetic session must be deleted on the resume-in-place "
+            "success path (the ``finally`` must still fire despite the "
+            "early ``return True``)"
+        )
 
     def test_parent_rebase_falls_through_to_push(self, gateway_client):
         """If the parent was *rewritten* (rebase) rather than advanced
@@ -907,6 +938,11 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
         )
 
         assert len(push_invoked) == 1, "unknown work must fall through to the push"
+        # Symmetric with ``test_parent_rebase_falls_through_to_push``: pin the
+        # refspec so a hypothetical regression that pushed the wrong SHA in
+        # the garbage-branch case (e.g. ``existing_sha`` or ``base_sha``
+        # instead of ``parent_sha``) would surface here.
+        assert push_invoked[0]["refspec"] == f"{parent_sha}:refs/heads/{self._INT}"
         # base->parent must NOT run — the conjunction short-circuits once
         # base->existing is False.
         assert [a[1:] for a in merge_base_args] == [


### PR DESCRIPTION
## Problem

Closes #2947.

When a pipeline is restarted/resumed mid-slice and the slice's **integration branch already carries its own commits** while the slice's **parent branch has advanced additively**, the orchestrator tried to (re)create the integration branch with a **non-fast-forward push** of the parent tip, which origin rejects — so the slice was marked **failed** and its agents were never spawned, cascading to block all downstream slices and fail the phase. The operator's only recovery was a manual `git push --delete <slice-branch>` + restart, which **discards the slice's committed work**.

This is the exact 2026-06-02 `issue-2908-impl2` slice-3 incident: a host crash killed the slice mid-work; on `restart_phase implement` the `#2914` "no live agents → treat as fresh to force re-spawn" path routed the existing slice branch (documenter commits) through fresh-create, and `create_slice_integration_branch` non-force-pushed the advanced parent tip onto the slice ref → `! [rejected] non_fast_forward` → slice failed → cascade.

## Root cause

The `#2512` recovery in `create_slice_integration_branch` only preserves an existing slice branch when its tip **descends from** the (advanced) parent. The crash-mid-slice case is the unhandled **fourth state**: committed slice work **+** an additively-advanced parent **+** no live agents — where neither tip is an ancestor of the other, but **both share the slice's recorded fork base**. `#2914` conflated "no live agents" with "no committed work," and the fresh-create path's non-force push fails the slice.

## Fix — resume-in-place (issue direction #1)

Add a third path to `create_slice_integration_branch`, gated on the slice's own recorded fork base (`integration_base_sha`, #2871):

> If the existing tip **strictly descends from the recorded base** AND that base is **still an ancestor of the advanced parent** (additive advance, not a history rewrite) → preserve the branch as-is and short-circuit success.

The cohort re-spawns onto the existing tip; the parent's new commits reconcile at slice-PR / merge time exactly as they would for a slice whose parent advanced during normal (non-crashed) operation. **No reset, no force-push, no lost work.**

Gating on the slice's **own recorded base** (not a generic merge-base of the two tips) is what keeps this safe — it preserves the #2512/#2549 "don't silently overwrite unknown work" instinct:

- **Unrelated / garbage branch** (doesn't descend from this slice's recorded base) → falls through to the push, rejection surfaces.
- **True parent rebase** (base rewritten out of the parent's ancestry) → second check fails, falls through. That harder class is deliberately left to the operator.
- **Un-started branch** still sitting at its base → `existing_sha != integration_base_sha` guard keeps it on the fast-forward push path (advancing it to the new parent tip), not pinned to the stale base.
- **No recorded base** (pre-#2871 slices) → degrades to prior push-and-surface behaviour.

The caller in the implement-phase spawn loop threads `integration_base_sha=recorded_base_sha` through (it already reads the recorded base from the contract for the merge-detection race check).

## Why not change the `#2914` reclassification?

The reclassification to "fresh" (full cohort re-spawn) is correct after a crash — we don't know how far the cohort got, and a true "resume" would wedge precisely because there are no live agents (the `#2914` guard exists for that reason). The only bug was that the fresh path's branch-creation destroyed/failed on existing committed work. Making `create_slice_integration_branch` preserve-in-place fixes that at the exact site of the non-FF push, so the change stays surgical.

## Tests

5 new regression tests in `TestCreateSliceIntegrationBranchResumeInPlace`:

- the incident case (own commits + additive advance → preserve, **no push**),
- parent-rebase → fall through to push,
- branch not descended from recorded base (garbage) → fall through,
- absent recorded base → degrade to prior behaviour,
- un-started branch at base → still fast-forwards (resume-in-place gated off).

`make test` (changeset-aware): **17191 passed**, 34 skipped, 1 xfailed, 9 xpassed. Ruff check + format clean.

## Related

- #2914 — the "treat as fresh to force re-spawn" path that mis-fired here.
- #2512 / #2549 — prior (closed) instances of the restart non-FF integration-branch class; this extends the same `create_slice_integration_branch` recovery mechanism.
- #2871 — the recorded fork base this fix keys on.
- #2929 — the restart effort where this surfaced.
