### PR TITLE
fix(orchestrator): attribute orchestrator-driven git ops to "orchestrator" (#2919)

### DIFF
--- a/gateway/tests/test_pipeline_push_block.py
+++ b/gateway/tests/test_pipeline_push_block.py
@@ -714,6 +714,48 @@ class TestSliceIntegrationBranchExemption:
                 f"got {response.status_code}: {response.data!r}"
             )
 
+    def test_synthetic_orchestrator_role_slice_branch_push_allowed(self, client):
+        """Orchestrator-role synthetic slice-integration push is allowed (#2919).
+
+        The stacked-PR reconciler's ``rebase_onto`` force-push and the
+        slice-loop's ``create_slice_integration_branch`` push now register
+        their synthetic sessions as ``agent_role="orchestrator"`` so the
+        audit log attributes orchestrator-driven git activity to the
+        orchestrator rather than a phantom coder.
+
+        The slice-integration exemption is keyed on the session's
+        ``synthetic`` flag plus the branch shape — NOT on the role — so
+        the attribution flip must not start 403'ing the push.  This
+        matters because the orchestrator role's file pattern is deny-all
+        (``ORCHESTRATOR_PATTERNS.allowed_patterns == []``); the exemption
+        sets ``is_infrastructure_push`` and short-circuits before the
+        role's file-pattern check would ever run, so the deny-all pattern
+        is never consulted on this path.
+        """
+        session = _make_session(
+            role="orchestrator",
+            synthetic=True,
+            assigned_branch="egg/issue-2919/slice-1",
+        )
+        patches = _push_context(session)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+        ):
+            response = _do_push(
+                client,
+                refspec="egg/issue-2919:refs/heads/egg/issue-2919/slice-1",
+            )
+            assert response.status_code == 200, (
+                f"Expected 200 for synthetic orchestrator-role slice "
+                f"integration push, got {response.status_code}: {response.data!r}"
+            )
+
     def test_synthetic_session_qualified_slice_branch_push_allowed(self, client):
         """Qualifier-suffixed branches (#2368 bonus) — ``egg/issue-N-v3/slice-M`` — pass."""
         session = _make_session(synthetic=True, assigned_branch="egg/issue-2261-v3/slice-7")

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -15818,7 +15818,10 @@ def _start_stacked_pr_reconciler(
     def _list_extant_branches() -> set[str]:
         # Lists remote branches via ``git ls-remote --heads origin``
         # so the reconciler can detect deleted parents. Routes through
-        # the existing per-agent ``git ls-remote`` allowlist.
+        # the existing per-agent ``git ls-remote`` allowlist. The
+        # synthetic session uses ``agent_role="orchestrator"`` so this
+        # orchestrator-driven ls-remote is attributed to the orchestrator
+        # in the audit log instead of a phantom coder (#2919).
         if not repo_path_str:
             return set()
         try:
@@ -15826,7 +15829,7 @@ def _start_stacked_pr_reconciler(
                 gateway.list_remote_branches(
                     pipeline_id,
                     repo_path_str,
-                    agent_role="coder",
+                    agent_role="orchestrator",
                 )
             )
         except Exception as exc:  # noqa: BLE001
@@ -15852,7 +15855,13 @@ def _start_stacked_pr_reconciler(
                     old_base=orphan.deleted_base,
                     pr_number=orphan.pr_number,
                     repo=pr_repo or None,
-                    agent_role="coder",
+                    # Orchestrator-driven heal (rebase + force-push +
+                    # pr-edit); attribute to the orchestrator, not a
+                    # phantom coder (#2919). The force-push targets the
+                    # slice integration branch on a synthetic session, so
+                    # the slice-integration exemption admits it regardless
+                    # of role.
+                    agent_role="orchestrator",
                 )
             )
         except Exception:  # noqa: BLE001
@@ -16139,7 +16148,10 @@ def _run_implement_phase_slices(
                     # (un-started) slice branch whose tip is still at its
                     # creation base is not mistaken for merged work.
                     integration_base_sha=slice_obj.integration_base_sha,
-                    agent_role="coder",
+                    # Read-only ancestry check run by the orchestrator's
+                    # slice-loop scheduler; attribute to the orchestrator
+                    # in the audit log, not a phantom coder (#2919).
+                    agent_role="orchestrator",
                     mode=gateway_mode,  # type: ignore[arg-type]
                 )
             except Exception as detect_err:  # noqa: BLE001
@@ -16524,7 +16536,10 @@ def _run_implement_phase_slices(
                             integration_branch=integration_branch,
                             parent_branch=parent_branch,
                             integration_base_sha=recorded_base_sha,
-                            agent_role="coder",
+                            # Read-only ancestry check run by the
+                            # orchestrator's slice-loop scheduler; attribute
+                            # to the orchestrator, not a phantom coder (#2919).
+                            agent_role="orchestrator",
                             mode=gateway_mode,  # type: ignore[arg-type]
                         )
                     except Exception as detect_err:  # noqa: BLE001
@@ -16581,7 +16596,14 @@ def _run_implement_phase_slices(
                                 str(worktree_repo_path),
                                 integration_branch=integration_branch,
                                 parent_branch=parent_branch,
-                                agent_role="coder",
+                                # Orchestrator pre-creates the slice
+                                # integration branch on a synthetic session
+                                # before agents spawn; attribute to the
+                                # orchestrator, not a phantom coder (#2919).
+                                # The push rides the slice-integration
+                                # exemption (synthetic + branch shape), not a
+                                # role gate.
+                                agent_role="orchestrator",
                                 mode=gateway_mode,  # type: ignore[arg-type]
                             )
                         )

--- a/orchestrator/tests/test_slice_run_loop_integration.py
+++ b/orchestrator/tests/test_slice_run_loop_integration.py
@@ -355,9 +355,12 @@ class TestStartStackedPrReconciler:
         # actually retargets the PR on origin (without it the PR stays
         # orphaned on a deleted base).
         assert call_args.kwargs["pr_number"] == 4242
-        # agent_role is fixed to "coder" so the gateway accepts the
-        # request through the existing per-agent /git endpoint.
-        assert call_args.kwargs["agent_role"] == "coder"
+        # agent_role is "orchestrator" so the audit log attributes this
+        # orchestrator-driven heal (rebase + force-push + pr-edit) to the
+        # orchestrator rather than a phantom coder (#2919). The force-push
+        # rides the slice-integration exemption (synthetic session + branch
+        # shape), so the attribution flip does not change push acceptance.
+        assert call_args.kwargs["agent_role"] == "orchestrator"
 
     def test_rebase_onto_returns_false_on_gateway_exception(self) -> None:
         pipeline = _make_pipeline()


### PR DESCRIPTION
## What

Finish the audit-attribution cleanup PR #2910 started on the gh-route side. Five orchestrator-driven **git-route** call sites in `orchestrator/routes/pipelines.py` still passed `agent_role="coder"`, so the gateway audit log attributed orchestrator-side git activity to a phantom `coder`. Flip all five to `agent_role="orchestrator"`.

| Call | Helper | Op |
|------|--------|-----|
| `list_remote_branches` | stacked-PR reconciler `_list_extant_branches` | ls-remote (read-only) |
| `rebase_onto` | stacked-PR reconciler `_rebase_onto` | rebase + force-push + pr-edit |
| `is_slice_branch_merged_into_parent` | slice-loop bootstrap | merge-base ancestry (read-only) |
| `is_slice_branch_merged_into_parent` | slice-loop steady-state | merge-base ancestry (read-only) |
| `create_slice_integration_branch` | slice-loop integration-branch creation | branch-create push |

## Why this is the whole fix (re: issue suggestions #1 & #3)

The issue suggested (1) adding `ORCHESTRATOR` to a "git-route restriction surface" and (3) mirroring `TestOrchestratorRole` for a git-route gate. Investigation shows **neither is needed, because no role-keyed git-route gate exists**:

- Unlike the gh route (`check_agent_gh_operation` / `AGENT_GH_RESTRICTIONS`), the git routes (`/api/v1/git/{execute,push,fetch}`) do **not** gate on `agent_role`.
- `register_session` accepts any non-empty role string (≤64 chars); it does not reject `orchestrator`.
- `orchestrator` already exists in the `AgentRole` enum **and** `AGENT_PATTERNS` (both added by #2910).

So flipping the literals **is** the fix — there is no allowlist surface to extend and no git-route gate to test.

## Safety

- The three **read-only** calls (ls-remote, merge-base ancestry) never push → pure attribution change.
- The two **push-bearing** calls target `egg/<id>/slice-N` on **synthetic** sessions. That sets `is_infrastructure_push=True`, which short-circuits **before** the role's file-pattern check runs — so the orchestrator role's deny-all pattern (`ORCHESTRATOR_PATTERNS.allowed_patterns == []`) is never consulted. This is the **same exemption** these calls already rode under `"coder"`; the exemption keys on `synthetic` + branch shape, not on role.
- The orchestrator-role synthetic-session path is already proven in production by #2910's `list_open_prs` (default `agent_role="orchestrator"`).

## Tests

- **`gateway/tests/test_pipeline_push_block.py`** — new `test_synthetic_orchestrator_role_slice_branch_push_allowed`: the on-target version of suggestion #3. Locks in that the attribution flip does not start 403'ing the synthetic slice-integration push under the orchestrator role.
- **`orchestrator/tests/test_slice_run_loop_integration.py`** — updated the `rebase_onto` call-site role assertion (`coder` → `orchestrator`).

## Scope note

Method defaults (`agent_role: str = "coder"` in `gateway_client.py`) are intentionally left unchanged: the issue scopes to the call-site literals, all production callers pass the role explicitly, and flipping the defaults would churn `test_default_agent_role_is_coder` for no production benefit.

## Verification

- `make lint` ✅
- `make test` (expanded to the full suite — `pipelines.py` is imported broadly): **17187 passed, 34 skipped, 1 xfailed, 9 xpassed** ✅

Closes #2919.