### PR TITLE
fix(orchestrator): export EGG_BASE_BRANCH on spawn — BRC slice-3 delta on non-main repos (#2967)

### DIFF
--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -167,6 +167,14 @@ _PROTECTED_ENV_KEYS: frozenset[str] = frozenset(
         # cause the agent to sleep through legitimate ACK/NACK/PROPOSE
         # events without surfacing the misconfiguration.
         "EGG_WAIT_PRODUCER_ALLOWLIST",
+        # Base branch for the BRC event-pump git-log delta (#2967). The
+        # spawner derives this from the same resolved base branch used to
+        # create the worktree and to build the agent prompt's diff commands,
+        # so it must stay consistent across all three. An ``extra_env``
+        # override could otherwise point the ``--not origin/<base>`` delta at
+        # a different branch than the worktree was based on, silently
+        # corrupting the re-review scope.
+        "EGG_BASE_BRANCH",
         # Same single-source-of-truth shape (#2428). The agent's
         # ``egg-orch push`` retargets the refspec to ``HEAD:$EGG_BRANCH``
         # (sandbox/egg_lib/cli_push.py); the gateway's session-scoped
@@ -923,6 +931,21 @@ class KubernetesSpawner:
             # are also derived from this same ``slice_id`` parameter.
             if slice_id is not None:
                 environment["EGG_SLICE_ID"] = slice_id
+
+            # Base branch for the BRC event-pump's per-producer
+            # ``git log {sha}..HEAD --not origin/<base> -p`` delta (#2967).
+            # Both consumers — the consensus wrapper and the event-prompt
+            # composer — read ``EGG_BASE_BRANCH`` and default to ``main`` when
+            # it's unset; nothing exported it before, so the delta errored on
+            # every non-``main`` repo and reviewers silently lost the slice-3
+            # diff. The caller (``_run_concurrent_phase``) hands us the
+            # already-resolved branch (explicit base, else the repo's detected
+            # default), so this is the single source of truth. Protected below
+            # so an ``extra_env`` override can't desync it from the worktree
+            # base. Left unset when unresolved (None) so the consumers' own
+            # documented ``main`` default still applies rather than an empty.
+            if base_branch:
+                environment["EGG_BASE_BRANCH"] = base_branch
 
             # #2725: pre-resolve the producer allowlist for this role +
             # phase so the wait-loop CLI auto-applies it. The allowlist

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2652,6 +2652,49 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
     # Compute gateway mode from pipeline config (not hardcoded "public")
     gateway_mode, _ = _compute_gateway_mode(pipeline)
 
+    # Resolve the per-agent worktree path and the default branch once,
+    # so the pipeline-level / root-slice / parent-complete branches of
+    # the slice-aware fallback below can substitute a concrete branch
+    # name when ``pipeline.base_branch`` is ``None`` (auto-detect).
+    # Without this, the spawner's ``EGG_BASE_BRANCH`` env-injection guard
+    # (``if base_branch:``) skips the export, the BRC event-pump's
+    # per-producer ``git log {sha}..HEAD --not origin/<base>`` delta
+    # falls back to ``origin/main`` in both consumers, and the diff
+    # errors out on every non-``main`` repo (#2967) — the exact failure
+    # mode the initial-spawn path was fixed for, surfacing on every
+    # health-monitor-triggered or operator-driven restart. The resolved
+    # value is also threaded into the prompt's ``base_branch=`` argument
+    # below so the prompt's diff base and the spawner's worktree base
+    # cannot diverge within the restart path.
+    #
+    # ``worktree_repo_path`` and the default-branch lookup can fail on a
+    # pipeline with no resolvable repo (e.g. ``pipeline.repo`` is ``None``
+    # or the worktree was pruned). Preserve pre-#2967 restart availability
+    # by catching and falling back to the raw ``pipeline.base_branch`` —
+    # restart was unconditional before this resolution was added, so
+    # failing the resolution must not regress that.
+    _restart_env_path = os.environ.get("EGG_REPO_PATH", "/home/egg/repos")
+    _restart_base_path = Path(_restart_env_path)
+    _restart_repo_name = (pipeline.repo or "").split("/")[-1]
+    worktree_repo_path: Path | None
+    try:
+        worktree_repo_path = resolve_worktree_repo_path(_restart_base_path, _restart_repo_name)
+    except Exception as _wt_err:
+        logger.warning(
+            "Could not resolve worktree repo path for restart base-branch "
+            "resolution; falling back to raw pipeline.base_branch",
+            pipeline_id=pipeline_id,
+            agent_role=agent_role,
+            error=str(_wt_err),
+        )
+        worktree_repo_path = None
+    _resolved_base_branch_for_restart: str | None = pipeline.base_branch
+    if not _resolved_base_branch_for_restart and worktree_repo_path is not None:
+        try:
+            _resolved_base_branch_for_restart = get_default_branch(worktree_repo_path)
+        except Exception:
+            _resolved_base_branch_for_restart = None
+
     # Slice-aware restart branch (#2428). When the restart targets a
     # slice agent, the spawner must register the gateway session
     # against the slice integration branch (``<root>/<slice_id>``); the
@@ -2668,22 +2711,26 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
     # if the worktree is absent at restart time, forking from the
     # pipeline tip pulls sibling slices' commits into the rebuilt
     # worktree. The right base depends on context:
-    #   - Pipeline-level restart: ``pipeline.base_branch`` (matches
-    #     the rest of the codebase: every other call site uses
-    #     ``pipeline.base_branch`` for spawner ``base_branch``).
+    #   - Pipeline-level restart: ``_resolved_base_branch_for_restart``
+    #     (``pipeline.base_branch`` if explicit, else the worktree's
+    #     ``get_default_branch`` so the spawner exports a concrete
+    #     ``EGG_BASE_BRANCH`` on master-default repos — #2967 follow-up).
     #   - Slice restart with a parent in the contract's slice forest:
     #     the parent slice's integration branch
     #     (``<root>/<parent_slice_id>``), mirroring ``parent_branch``
     #     in :func:`_run_one_slice_inner`.
     #   - Root-slice restart, or slice restart when the contract
-    #     can't be loaded: ``pipeline.base_branch`` (fallback).
+    #     can't be loaded: ``_resolved_base_branch_for_restart`` (fallback,
+    #     same resolution as the pipeline-level case).
     #
     # Note: this intentionally diverges from the initial-spawn path at
-    # :func:`_run_concurrent_phase` (line ~12398), which always passes
-    # ``base_branch=pipeline.base_branch`` regardless of slice forest
-    # position. #2439 specifically asks for the parent-slice fork on
-    # the *restart* path so a worktree-absent restart of a child slice
-    # rebuilds atop its parent slice rather than re-forking from
+    # :func:`_run_concurrent_phase` for the parent-slice cases —
+    # ``_run_concurrent_phase`` now passes the resolved
+    # ``_resolved_base_branch`` (the same shape this path uses for
+    # pipeline-level / root-slice / parent-complete restarts), but #2439
+    # specifically asks for the parent-slice fork on the *restart* path
+    # so a worktree-absent restart of a child slice rebuilds atop its
+    # parent slice rather than re-forking from
     # ``pipeline.base_branch`` and losing the parent's commits. Don't
     # "fix" this asymmetry by aligning the two paths without first
     # re-reading #2439.
@@ -2711,11 +2758,14 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
         if parent_slice_id is not None and parent_slice_complete:
             # #2470: parent slice's PR has plausibly been merged and its
             # branch deleted by GitHub auto-cleanup. Falling back to
-            # ``pipeline.base_branch`` is safe: ``complete`` means the
-            # parent's commits have been integrated upstream (either via
-            # PR merge or via the cascade), and prefer letting the
-            # restart proceed over wedging on a missing-branch fetch.
-            base_branch_for_restart = pipeline.base_branch
+            # ``_resolved_base_branch_for_restart`` is safe: ``complete``
+            # means the parent's commits have been integrated upstream
+            # (either via PR merge or via the cascade), and prefer
+            # letting the restart proceed over wedging on a missing-
+            # branch fetch. Resolved (rather than raw
+            # ``pipeline.base_branch``) so the spawner exports
+            # ``EGG_BASE_BRANCH`` on auto-detect repos (#2967 follow-up).
+            base_branch_for_restart = _resolved_base_branch_for_restart
         elif parent_slice_id is not None:
             if parent_branch_recorded:
                 # Prefer the literal branch the parent slice was
@@ -2748,10 +2798,18 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
                     )
                 base_branch_for_restart = f"{_issue_branch}/{parent_slice_id}"
         else:
-            base_branch_for_restart = pipeline.base_branch
+            # Root slice (no parent edge): same shape as the pipeline-level
+            # case below — resolved so a ``None`` ``pipeline.base_branch``
+            # still reaches the spawner as a concrete branch name
+            # (#2967 follow-up).
+            base_branch_for_restart = _resolved_base_branch_for_restart
     else:
         agent_branch = pipeline.branch
-        base_branch_for_restart = pipeline.base_branch
+        # Pipeline-level restart: resolved so the spawner exports
+        # ``EGG_BASE_BRANCH`` and the BRC delta works on auto-detect repos
+        # (master-default), matching the initial-spawn path's behavior at
+        # ``_run_concurrent_phase`` (#2967 follow-up).
+        base_branch_for_restart = _resolved_base_branch_for_restart
 
     # Reconstruct command and extra_env for concurrent agents.
     # In concurrent mode, agents need a consensus-wrapped prompt command
@@ -2812,18 +2870,20 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
             executor = ConcurrentPhaseExecutor(pipeline, spawn_fn=lambda **kw: None)  # type: ignore[arg-type]
             extra_env = executor.get_agent_env(role)
 
-            # Reconstruct the agent prompt and wrap it for consensus
+            # Reconstruct the agent prompt and wrap it for consensus.
+            # ``worktree_repo_path`` and ``_resolved_base_branch_for_restart``
+            # were already computed above the slice-aware fallback so the
+            # prompt's diff base, the spawner's ``base_branch`` argument
+            # (and thus the exported ``EGG_BASE_BRANCH``), and the worktree
+            # base cannot diverge within this restart path (#2967 follow-up).
+            # ``worktree_repo_path`` is ``None`` only when the hoisted
+            # resolution failed (logged above); skip prompt reconstruction
+            # in that case rather than passing ``"None"`` as ``repo_path``.
             try:
-                env_path = os.environ.get("EGG_REPO_PATH", "/home/egg/repos")
-                base_path = Path(env_path)
-                repo_name = (pipeline.repo or "").split("/")[-1]
-                worktree_repo_path = resolve_worktree_repo_path(base_path, repo_name)
-                _resolved_base = None
-                try:
-                    _resolved_base = get_default_branch(worktree_repo_path)
-                except Exception:
-                    pass
-
+                if worktree_repo_path is None:
+                    raise RuntimeError(
+                        "worktree_repo_path unavailable; skipping prompt reconstruction"
+                    )
                 prompt_text = _build_agent_prompt(
                     role_value=agent_role,
                     phase=current_phase,
@@ -2833,7 +2893,7 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
                     issue_number=pipeline.issue_number,
                     repo=pipeline.repo,
                     branch=pipeline.branch,
-                    base_branch=_resolved_base,
+                    base_branch=_resolved_base_branch_for_restart,
                     repo_path=str(worktree_repo_path),
                     concurrent=True,
                     network_mode=gateway_mode,

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -17062,7 +17062,16 @@ def _run_concurrent_phase(
         phase=phase_str,
         sandbox_env=sandbox_env,
         certs_volume=certs_volume,
-        base_branch=pipeline.base_branch,
+        # Pass the *resolved* base branch (above) rather than the raw
+        # ``pipeline.base_branch`` so a ``None`` (auto-detect) base still
+        # reaches the spawner as a concrete branch name. The spawner exports
+        # it as ``EGG_BASE_BRANCH`` for the BRC event-pump's per-producer
+        # ``git log --not origin/<base>`` delta (#2967); without a concrete
+        # value the wrapper + composer fall back to ``origin/main`` and the
+        # delta errors out on every non-``main`` repo. Worktree creation is
+        # unaffected: the gateway resolves the same default branch when handed
+        # ``None``, so resolving one layer up here is equivalent.
+        base_branch=_resolved_base_branch,
         spawn_max_retries=pipeline.config.spawn_max_retries,
         spawn_retry_initial_backoff_seconds=pipeline.config.spawn_retry_initial_backoff_seconds,
         slice_id=slice_id,

--- a/orchestrator/tests/test_consensus_complete_with_failures.py
+++ b/orchestrator/tests/test_consensus_complete_with_failures.py
@@ -293,6 +293,80 @@ class TestConsensusCompleteWithFailures:
         assert exit_code == 1, f"Expected exit code 1 (no consensus, has failures), got {exit_code}"
 
 
+class TestRunConcurrentPhaseResolvedBaseBranch:
+    """``_run_concurrent_phase`` threads the resolved base branch into the
+    spawner so the spawner can export ``EGG_BASE_BRANCH`` for the BRC
+    event-pump's per-producer ``git log {sha}..HEAD --not origin/<base>``
+    delta (#2967).
+
+    The unit-level tests in ``test_kubernetes_spawner.py`` cover the
+    spawner-side env injection given a literal ``base_branch=``; this
+    integration assertion covers the call chain: a pipeline with
+    ``base_branch=None`` exercises the
+    ``_resolved_base_branch = pipeline.base_branch or get_default_branch(...)``
+    ladder and the resolved value reaches
+    ``spawner.create_concurrent_spawn_fn`` instead of leaking ``None``
+    through to the spawner's env-injection guard.
+    """
+
+    @patch("routes.pipelines.get_default_branch", return_value="master")
+    @patch("routes.pipelines.time.sleep")
+    @patch("routes.pipelines.time.monotonic", return_value=10.0)
+    @patch("routes.pipelines._emit_event")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
+    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
+    def test_none_base_branch_resolves_to_default_and_reaches_spawner(
+        self,
+        MockExecutor,
+        mock_prompt,
+        mock_lock,
+        mock_emit,
+        mock_monotonic,
+        mock_sleep,
+        mock_get_default,
+    ):
+        """``pipeline.base_branch=None`` triggers ``get_default_branch`` and
+        the result is forwarded as the spawner's ``base_branch`` kwarg."""
+        executions = [_make_execution(AgentRole.CODER, "coder-1")]
+        pipeline, mock_store, mock_spawner, mock_docker = _base_mocks(executions)
+        # Defense: the fixture leaves base_branch unset so the auto-detect
+        # ladder fires; assert it explicitly so a fixture change doesn't
+        # silently turn this into a different test.
+        assert pipeline.base_branch is None
+
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        mock_executor_instance.check_consensus.return_value = {
+            "is_complete": True,
+            "has_objections": False,
+            "blocking_agents": [],
+        }
+        MockExecutor.return_value = mock_executor_instance
+
+        mock_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        _run_concurrent_phase(
+            pipeline_id="issue-1495",
+            pipeline=pipeline,
+            phase="implement",
+            spawner=mock_spawner,
+            store=mock_store,
+            **_CALL_ARGS,
+        )
+
+        # get_default_branch was called with the worktree path (auto-detect path).
+        mock_get_default.assert_called_once_with(_CALL_ARGS["worktree_repo_path"])
+        # The resolved branch flowed into the spawner's spawn-fn factory.
+        spawn_kwargs = mock_spawner.create_concurrent_spawn_fn.call_args.kwargs
+        assert spawn_kwargs.get("base_branch") == "master", (
+            "Expected the resolved default branch ('master') to flow into "
+            "create_concurrent_spawn_fn so the spawner can export "
+            "EGG_BASE_BRANCH for the BRC delta (#2967)."
+        )
+
+
 class TestConsensusCompleteUpdatesAgents:
     """When consensus is_complete=True, _update_agents_complete should mark
     all agents as COMPLETE regardless of container exit codes."""

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -480,6 +480,65 @@ class TestSpawnAgentJob:
         create_kwargs = mock_k8s_client.create_container.call_args.kwargs
         assert "EGG_SLICE_ID" not in create_kwargs["environment"]
 
+    def test_spawn_with_base_branch_sets_egg_base_branch_env(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """``base_branch=`` propagates into ``EGG_BASE_BRANCH`` (#2967).
+
+        The BRC event-pump's per-producer ``git log --not origin/<base>``
+        delta reads this env var (via the consensus wrapper and the
+        event-prompt composer). Nothing exported it before, so both
+        consumers fell back to ``origin/main`` and the delta errored on any
+        non-``main`` repo, silently dropping the slice-3 diff reviewers audit.
+        """
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+            base_branch="jwbron-claude-md",
+        )
+        assert result.environment.get("EGG_BASE_BRANCH") == "jwbron-claude-md"
+        create_kwargs = mock_k8s_client.create_container.call_args.kwargs
+        assert create_kwargs["environment"].get("EGG_BASE_BRANCH") == "jwbron-claude-md"
+
+    def test_spawn_without_base_branch_does_not_set_egg_base_branch(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """An unresolved (None) base leaves ``EGG_BASE_BRANCH`` unset (#2967).
+
+        The consumers carry their own documented ``main`` default, so the
+        spawner leaves the key absent rather than injecting an empty string
+        when the caller couldn't resolve a concrete branch.
+        """
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+        )
+        assert "EGG_BASE_BRANCH" not in result.environment
+
+    def test_extra_env_cannot_override_egg_base_branch(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """``extra_env`` cannot override ``EGG_BASE_BRANCH`` — protected key (#2967).
+
+        The spawner is the single source of truth: the same resolved base
+        branch creates the worktree, builds the prompt's diff commands, and
+        is exported here. An ``extra_env`` override could point the
+        ``--not origin/<base>`` delta at a different branch than the worktree
+        was based on, silently corrupting the re-review scope.
+        """
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+            base_branch="develop",
+            extra_env={"EGG_BASE_BRANCH": "attacker-supplied"},
+        )
+        assert result.environment.get("EGG_BASE_BRANCH") == "develop"
+        create_kwargs = mock_k8s_client.create_container.call_args.kwargs
+        assert create_kwargs["environment"].get("EGG_BASE_BRANCH") == "develop"
+
     def test_spawn_sets_egg_wait_producer_allowlist_for_reviewer(
         self, spawner, mock_k8s_client, mock_gateway
     ):

--- a/orchestrator/tests/test_restart_agent.py
+++ b/orchestrator/tests/test_restart_agent.py
@@ -763,6 +763,202 @@ class TestRestartAgentEndpoint:
 
 
 # ---------------------------------------------------------------------------
+# Issue #2967 follow-up: restart path resolves ``pipeline.base_branch=None``
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _HAS_FLASK, reason="Flask not available")
+class TestRestartAgentBaseBranchResolution:
+    """The restart path resolves the default branch when
+    ``pipeline.base_branch`` is ``None`` so the spawner receives a concrete
+    branch name. Without this, the spawner's ``EGG_BASE_BRANCH``
+    env-injection guard skips the export, the BRC event-pump's per-producer
+    ``git log {sha}..HEAD --not origin/<base>`` delta falls back to
+    ``origin/main`` in both consumers, and the diff errors out on every
+    non-``main`` repo (mirrors the initial-spawn fix at
+    ``test_kubernetes_spawner.py::test_spawn_with_base_branch_sets_egg_base_branch_env``).
+    """
+
+    @patch("routes.pipelines.get_default_branch")
+    @patch("routes.pipelines.resolve_worktree_repo_path")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_restart_resolves_base_branch_when_pipeline_base_is_none(
+        self,
+        mock_repo,
+        mock_resolve,
+        mock_spawner_fn,
+        mock_lock_fn,
+        mock_resolve_worktree,
+        mock_get_default,
+        client,
+    ):
+        """A ``None`` ``pipeline.base_branch`` resolves to ``get_default_branch``
+        and is forwarded as the spawner's ``base_branch`` argument."""
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        mock_resolve_worktree.return_value = Path("/repo/worktree")
+        mock_get_default.return_value = "master"
+
+        pipeline = _make_pipeline_with_running_agent()
+        assert pipeline.base_branch is None, (
+            "fixture must leave base_branch unset to exercise the auto-detect path"
+        )
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        new_container = SpawnedContainer(
+            container_info=ContainerInfo(
+                container_id="new-container-xyz",
+                container_name="egg-issue-100-coder",
+                status=ContainerStatus.RUNNING,
+            ),
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-100",
+            environment={},
+        )
+        mock_spawner.restart_agent_container.return_value = new_container
+        mock_spawner.get_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart",
+            json={"reason": "auto-detect base branch"},
+        )
+
+        assert response.status_code == 200
+        restart_kwargs = mock_spawner.restart_agent_container.call_args.kwargs
+        assert restart_kwargs.get("base_branch") == "master", (
+            "Restart must thread the resolved default branch into the spawner's "
+            "base_branch kwarg so EGG_BASE_BRANCH is exported and the BRC delta "
+            "works on non-main repos (#2967 follow-up)."
+        )
+
+    @patch("routes.pipelines.get_default_branch")
+    @patch("routes.pipelines.resolve_worktree_repo_path")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_restart_preserves_explicit_pipeline_base_branch(
+        self,
+        mock_repo,
+        mock_resolve,
+        mock_spawner_fn,
+        mock_lock_fn,
+        mock_resolve_worktree,
+        mock_get_default,
+        client,
+    ):
+        """An explicit ``pipeline.base_branch`` is forwarded unchanged — the
+        ``get_default_branch`` fallback only fires when it's ``None``."""
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        mock_resolve_worktree.return_value = Path("/repo/worktree")
+        # If this fires, the explicit ``base_branch`` was wrongly discarded.
+        mock_get_default.side_effect = AssertionError(
+            "get_default_branch must not fire when pipeline.base_branch is set"
+        )
+
+        pipeline = _make_pipeline_with_running_agent()
+        pipeline.base_branch = "jwbron-claude-md"
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        new_container = SpawnedContainer(
+            container_info=ContainerInfo(
+                container_id="new-container-xyz",
+                container_name="egg-issue-100-coder",
+                status=ContainerStatus.RUNNING,
+            ),
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-100",
+            environment={},
+        )
+        mock_spawner.restart_agent_container.return_value = new_container
+        mock_spawner.get_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart",
+            json={"reason": "explicit base branch"},
+        )
+
+        assert response.status_code == 200
+        restart_kwargs = mock_spawner.restart_agent_container.call_args.kwargs
+        assert restart_kwargs.get("base_branch") == "jwbron-claude-md"
+
+    @patch("routes.pipelines.get_default_branch")
+    @patch("routes.pipelines.resolve_worktree_repo_path")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_restart_tolerates_worktree_resolution_failure(
+        self,
+        mock_repo,
+        mock_resolve,
+        mock_spawner_fn,
+        mock_lock_fn,
+        mock_resolve_worktree,
+        mock_get_default,
+        client,
+    ):
+        """If the worktree path cannot be resolved (e.g. pruned), the restart
+        still proceeds with the raw ``pipeline.base_branch`` — preserving
+        pre-#2967 restart availability rather than blocking on resolution."""
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        mock_resolve_worktree.side_effect = RuntimeError("worktree pruned")
+
+        pipeline = _make_pipeline_with_running_agent()
+        # Leave base_branch=None so the resolution would normally fire.
+        assert pipeline.base_branch is None
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        new_container = SpawnedContainer(
+            container_info=ContainerInfo(
+                container_id="new-container-xyz",
+                container_name="egg-issue-100-coder",
+                status=ContainerStatus.RUNNING,
+            ),
+            session_info=None,
+            agent_role=AgentRole.CODER,
+            pipeline_id="issue-100",
+            environment={},
+        )
+        mock_spawner.restart_agent_container.return_value = new_container
+        mock_spawner.get_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        response = client.post(
+            "/api/v1/pipelines/issue-100/agents/coder/restart",
+            json={"reason": "worktree pruned"},
+        )
+
+        assert response.status_code == 200
+        # get_default_branch must not be called when worktree resolution fails.
+        mock_get_default.assert_not_called()
+        # Restart still happens with the raw (None) pipeline.base_branch.
+        restart_kwargs = mock_spawner.restart_agent_container.call_args.kwargs
+        assert restart_kwargs.get("base_branch") is None
+
+
+# ---------------------------------------------------------------------------
 # Issue #2410: slice_id forwarding through the operator restart route
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #2967. The slice-3 BRC event-pump per-producer delta — `git log {sha}..HEAD --not origin/{base} -p` — reads `EGG_BASE_BRANCH` in **both** consumers (`consensus_wrapper.py:399`, `event_prompt.py:903`), each defaulting to `main`. **Nothing ever exported the var into the agent container env at spawn**, so it always fell back to `main`. On any repo whose base isn't literally `main` (e.g. a repo whose default branch is `master`, or a pipeline based on `jwbron-claude-md`), `git log … --not origin/main` errors on an unknown ref (rc=128) and the per-producer diff is lost.

## Correction to the issue's mechanism

The issue states the composer "falls back to the slice-2 minimal stub." It doesn't. `_run_git_log` (`event_prompt.py:563`) catches rc≠0 and **returns a sentinel string** (`(git log returned rc=128: …unknown revision origin/main…)`); the composer renders the *full* slice-3 prompt around it and exits 0, so the wrapper's stub fallback (rc≠0 **or** empty prompt) never fires. Reviewers get the complete prompt with the delta body replaced by the sentinel — which is exactly why the live evidence shows the agent reasoning *"the wrapper couldn't compute the diff"* (a stub never mentions a diff at all). Net effect on reviewers (lost delta → hand-inspect artifacts) and silence is the same; the caching impact (#2 in the issue) is overstated since the cache-optimized prompt path *is* exercised.

## Fix

Supply the missing producer, threading the **resolved** base branch:

- **`kubernetes_spawner.py`** — `spawn_agent_job()` exports `EGG_BASE_BRANCH` (when resolved) into the agent container env, and the key is added to `_PROTECTED_ENV_KEYS` so an `extra_env` override can't desync it from the worktree base.
- **`routes/pipelines.py:17065`** — `_run_concurrent_phase` passes the already-computed `_resolved_base_branch` (explicit base, else `get_default_branch()` of the repo) to the spawner instead of the raw, possibly-`None` `pipeline.base_branch`. This covers both the explicit-non-`main` case *and* the `None`/auto-detect (master-vs-main) secondary concern the issue calls out. Worktree creation is unaffected — the gateway resolves the same default branch when handed `None` (per its docstring), so resolving one layer up is equivalent. It also aligns the worktree base with the prompt's diff base, which previously diverged (prompt used resolved, worktree used raw).

`EGG_BASE_BRANCH` is a bare branch name (consumers prepend `origin/`); both `pipeline.base_branch` and `get_default_branch()` return bare names, so no prefix mismatch.

## Tests

Three regression tests in `test_kubernetes_spawner.py`: env injected when base is set, left unset on `None` (consumers keep their documented `main` default), and override-protected. Closes the prior gap — coverage was consumer-only (`test_consensus_wrapper.py`, `test_compose_event_prompt.py`), nothing asserted the spawner *produces* the var.

- `make test` — 17510 passed, 34 skipped, exit 0
- `make lint` — exit 0 (only pre-existing soft-cap warnings)

## Related

- #2918 (slice-3 introduced the pre-fetched delta)
- #2950 (slice-3 follow-up: pre-fetched delta vs agent-side fetch — distinct)
- #2306 (rebase guard / non-main bases — same "assumes `main`" class)
