### PR TITLE
fix(gateway): actionable error on Confluence upstream 3xx (#2970)

### DIFF
--- a/gateway/confluence_client.py
+++ b/gateway/confluence_client.py
@@ -221,13 +221,26 @@ _SPACE_CACHE_MAX_ENTRIES: int = 256
 class ConfluenceUpstreamError(RuntimeError):
     """Raised when Atlassian returns a non-2xx response that isn't a 404 on
     the endpoints where 404 is modelled as a ``not_found`` envelope.
+
+    ``location`` carries the upstream ``Location`` response header for 3xx
+    responses (e.g. ``/login`` on the login bounce) so the gateway can
+    surface it in the actionable-error envelope without needing to refetch.
+    It is ``None`` for non-3xx responses and for 3xx responses that omit
+    the header.
     """
 
-    def __init__(self, status_code: int, body: Any, path: str):
+    def __init__(
+        self,
+        status_code: int,
+        body: Any,
+        path: str,
+        location: str | None = None,
+    ):
         super().__init__(f"Confluence upstream returned {status_code} for {path}")
         self.status_code = status_code
         self.body = body
         self.path = path
+        self.location = location
 
 
 class ConfluenceUpstreamForbidden(RuntimeError):
@@ -986,7 +999,12 @@ def _raise_for_status(response: httpx.Response, path: str) -> None:
         body = response.json()
     except Exception:
         body = response.text
-    raise ConfluenceUpstreamError(response.status_code, body, path)
+    # Carry the ``Location`` header on 3xx so the gateway translator can
+    # surface "redirected to /login" in the operator-facing envelope.
+    location: str | None = None
+    if 300 <= response.status_code < 400:
+        location = response.headers.get("Location")
+    raise ConfluenceUpstreamError(response.status_code, body, path, location)
 
 
 def _safe_response_body(response: httpx.Response) -> Any:

--- a/gateway/confluence_client.py
+++ b/gateway/confluence_client.py
@@ -1020,7 +1020,11 @@ def _safe_json(response: httpx.Response, path: str) -> dict[str, Any]:
     try:
         data = response.json()
     except Exception as exc:  # pragma: no cover — Atlassian always returns JSON
-        raise ConfluenceUpstreamError(response.status_code, response.text, path) from exc
+        # 2xx-with-non-JSON-body: no ``Location`` to capture, pass ``None``
+        # explicitly so the kwarg's intent is obvious to future readers.
+        raise ConfluenceUpstreamError(
+            response.status_code, response.text, path, location=None
+        ) from exc
     if not isinstance(data, dict):
         return {"data": data}
     return data

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -6921,21 +6921,27 @@ def _confluence_error_from_upstream(exc: ConfluenceUpstreamError) -> tuple[Respo
         # ``/wiki`` suffix). Surface that pointedly instead of an opaque 502 so
         # operators don't have to reverse-engineer the redirect. Still 502
         # (bad upstream response), distinct from the 503 "creds absent" path.
-        return make_error(
+        message = (
             f"Confluence upstream returned {exc.status_code} (redirect) — the "
             "gateway received a login redirect instead of a REST response. "
             "This usually means the gateway's Atlassian credentials are "
             "missing/invalid or the base URL is wrong (e.g. ATLASSIAN_BASE_URL "
             "must be the bare tenant origin, or CONFLUENCE_BASE_URL must include "
-            "the /wiki suffix).",
-            status_code=502,
-            details={
-                "upstream_status": exc.status_code,
-                "upstream_body": _redact_upstream_error_body(exc.body),
-                "path": exc.path,
-                "likely_cause": "missing_or_invalid_atlassian_credentials_or_base_url",
-            },
+            "the /wiki suffix)."
         )
+        details: dict[str, Any] = {
+            "upstream_status": exc.status_code,
+            "upstream_body": _redact_upstream_error_body(exc.body),
+            "path": exc.path,
+            "likely_cause": "missing_or_invalid_atlassian_credentials_or_base_url",
+        }
+        # Surface the upstream ``Location`` when present so the operator can
+        # confirm the bounce target (typically ``/login`` or the tenant root)
+        # without reproducing.
+        if exc.location:
+            message += f" Upstream redirected to: {exc.location}"
+            details["upstream_location"] = exc.location
+        return make_error(message, status_code=502, details=details)
     if 400 <= exc.status_code < 500:
         status = exc.status_code
     else:

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -6912,6 +6912,30 @@ def _confluence_error_from_upstream(exc: ConfluenceUpstreamError) -> tuple[Respo
     redactor only runs on 2xx bodies, so we apply it here too before the
     upstream body crosses the gateway/sandbox boundary.
     """
+    if 300 <= exc.status_code < 400:
+        # A 3xx is never a valid read response from the Atlassian REST API —
+        # it's the signature of an unauthenticated/misrouted request being
+        # bounced to the login page. The usual cause is a missing/invalid
+        # gateway Atlassian token or a wrong base URL (e.g. ATLASSIAN_BASE_URL
+        # set to a page browser URL, or CONFLUENCE_BASE_URL missing the
+        # ``/wiki`` suffix). Surface that pointedly instead of an opaque 502 so
+        # operators don't have to reverse-engineer the redirect. Still 502
+        # (bad upstream response), distinct from the 503 "creds absent" path.
+        return make_error(
+            f"Confluence upstream returned {exc.status_code} (redirect) — the "
+            "gateway received a login redirect instead of a REST response. "
+            "This usually means the gateway's Atlassian credentials are "
+            "missing/invalid or the base URL is wrong (e.g. ATLASSIAN_BASE_URL "
+            "must be the bare tenant origin, or CONFLUENCE_BASE_URL must include "
+            "the /wiki suffix).",
+            status_code=502,
+            details={
+                "upstream_status": exc.status_code,
+                "upstream_body": _redact_upstream_error_body(exc.body),
+                "path": exc.path,
+                "likely_cause": "missing_or_invalid_atlassian_credentials_or_base_url",
+            },
+        )
     if 400 <= exc.status_code < 500:
         status = exc.status_code
     else:

--- a/gateway/tests/test_confluence_client.py
+++ b/gateway/tests/test_confluence_client.py
@@ -273,6 +273,36 @@ class TestGetPage:
         with pytest.raises(ConfluenceUpstreamError) as exc_info:
             client.get_page("12345")
         assert exc_info.value.status_code == 500
+        # ``location`` only carries a value for 3xx responses (see below).
+        assert exc_info.value.location is None
+
+    def test_3xx_captures_location_header(self, fake_creds: ConfluenceCredentials):
+        """3xx → ``ConfluenceUpstreamError(location=...)`` so the gateway
+        translator can surface the bounce target in the operator-facing
+        envelope without refetching. See #2970."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(302, headers={"Location": "/login"})
+
+        client = _make_client(handler, fake_creds)
+        with pytest.raises(ConfluenceUpstreamError) as exc_info:
+            client.get_page("12345")
+        assert exc_info.value.status_code == 302
+        assert exc_info.value.location == "/login"
+
+    def test_3xx_without_location_header(self, fake_creds: ConfluenceCredentials):
+        """3xx with no ``Location`` header → ``location is None``. The
+        translator still emits the actionable message; the field is just
+        absent from the details."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(302)
+
+        client = _make_client(handler, fake_creds)
+        with pytest.raises(ConfluenceUpstreamError) as exc_info:
+            client.get_page("12345")
+        assert exc_info.value.status_code == 302
+        assert exc_info.value.location is None
 
     def test_expand_list_round_trips(self, fake_creds: ConfluenceCredentials):
         captured: list[httpx.Request] = []

--- a/gateway/tests/test_confluence_routes.py
+++ b/gateway/tests/test_confluence_routes.py
@@ -393,26 +393,52 @@ class TestPageGet:
         assert "upstream_location" not in details
 
     @pytest.mark.parametrize(
-        "route,client_method,body",
+        "route,client_method,body,extra_setup",
         [
-            ("/api/v1/confluence/page/get", "get_page", {"pageId": "12345"}),
+            ("/api/v1/confluence/page/get", "get_page", {"pageId": "12345"}, None),
             (
                 "/api/v1/confluence/page/descendants",
                 "get_page_descendants",
                 {"pageId": "12345"},
+                None,
             ),
             (
                 "/api/v1/confluence/page/footer-comments",
                 "get_page_footer_comments",
                 {"pageId": "12345"},
+                None,
             ),
             (
                 "/api/v1/confluence/page/inline-comments",
                 "get_page_inline_comments",
                 {"pageId": "12345"},
+                None,
             ),
-            ("/api/v1/confluence/space/list", "list_spaces", {}),
-            ("/api/v1/confluence/search", "search_cql", {"cql": "space = ENG"}),
+            ("/api/v1/confluence/space/list", "list_spaces", {}, None),
+            ("/api/v1/confluence/search", "search_cql", {"cql": "space = ENG"}, None),
+            # ``space/pages`` resolves ``spaceKey → spaceId`` before calling
+            # ``get_space_pages``.  Seed the cache so we exercise the
+            # post-resolve translator call site (gateway.py:7701) rather than
+            # the populate-cache one (7663).
+            (
+                "/api/v1/confluence/space/pages",
+                "get_space_pages",
+                {"spaceKey": "ENG"},
+                lambda fake: setattr(
+                    fake.space_cache,
+                    "id_for_key",
+                    lambda k: "1" if k == "ENG" else None,
+                ),
+            ),
+            # ``execute`` funnels every whitelisted path through
+            # ``execute_raw``; use a page-scoped path so the allowlist gate
+            # doesn't short-circuit before the upstream call.
+            (
+                "/api/v1/confluence/execute",
+                "execute_raw",
+                {"method": "GET", "path": "api/v2/pages/12345"},
+                None,
+            ),
         ],
     )
     def test_upstream_redirect_translator_applies_to_all_routes(
@@ -424,6 +450,7 @@ class TestPageGet:
         route,
         client_method,
         body,
+        extra_setup,
     ):
         """Regression guard for the shared translator (#2970).
 
@@ -433,8 +460,13 @@ class TestPageGet:
         is added that bypasses the funnel (and therefore the actionable-3xx
         branch), this regression test will catch it. Asserting on each route
         rather than just one would let a route quietly fall back to the
-        generic ``Confluence upstream error 302`` envelope."""
+        generic ``Confluence upstream error 302`` envelope.
+
+        Covers all eight ``/api/v1/confluence/*`` routes that funnel
+        through ``_confluence_error_from_upstream``."""
         fake = MagicMock()
+        if extra_setup is not None:
+            extra_setup(fake)
         getattr(fake, client_method).side_effect = ConfluenceUpstreamError(
             302, "", "api/v2/some-path", location="/login"
         )

--- a/gateway/tests/test_confluence_routes.py
+++ b/gateway/tests/test_confluence_routes.py
@@ -336,6 +336,32 @@ class TestPageGet:
         # Non-redacted fields pass through.
         assert upstream_body["errorMessages"] == ["upstream blew up"]
 
+    def test_upstream_redirect_surfaces_actionable_error(
+        self, client, private_headers, allow_eng, captured_audit
+    ):
+        """A 3xx from Atlassian (login redirect — the signature of missing/
+        invalid gateway credentials or a wrong base URL) must surface a
+        pointed, actionable message + ``likely_cause`` rather than the opaque
+        ``Confluence upstream error 302``. Still HTTP 502 (bad upstream
+        response), distinct from the 503 credentials-absent path. See #2970."""
+        fake = MagicMock()
+        fake.get_page.side_effect = ConfluenceUpstreamError(302, "", "api/v2/pages/12345")
+        with _patch_client(fake):
+            resp = client.post(
+                "/api/v1/confluence/page/get",
+                headers=private_headers,
+                data=json.dumps({"pageId": "12345"}),
+                content_type="application/json",
+            )
+        assert resp.status_code == 502
+        body = json.loads(resp.data)
+        # Actionable message, not the opaque "Confluence upstream error 302".
+        assert "redirect" in body["message"].lower()
+        assert "Confluence upstream error" not in body["message"]
+        details = body["data"]
+        assert details["upstream_status"] == 302
+        assert details["likely_cause"] == "missing_or_invalid_atlassian_credentials_or_base_url"
+
 
 # -----------------------------------------------------------------------------
 # /api/v1/confluence/space/list — list_spaces filtering end-to-end (risk R13)

--- a/gateway/tests/test_confluence_routes.py
+++ b/gateway/tests/test_confluence_routes.py
@@ -343,9 +343,14 @@ class TestPageGet:
         invalid gateway credentials or a wrong base URL) must surface a
         pointed, actionable message + ``likely_cause`` rather than the opaque
         ``Confluence upstream error 302``. Still HTTP 502 (bad upstream
-        response), distinct from the 503 credentials-absent path. See #2970."""
+        response), distinct from the 503 credentials-absent path. The
+        upstream ``Location`` header — when the client captured it — must be
+        surfaced so the operator can confirm the bounce target without
+        reproducing. See #2970."""
         fake = MagicMock()
-        fake.get_page.side_effect = ConfluenceUpstreamError(302, "", "api/v2/pages/12345")
+        fake.get_page.side_effect = ConfluenceUpstreamError(
+            302, "", "api/v2/pages/12345", location="/login"
+        )
         with _patch_client(fake):
             resp = client.post(
                 "/api/v1/confluence/page/get",
@@ -358,7 +363,98 @@ class TestPageGet:
         # Actionable message, not the opaque "Confluence upstream error 302".
         assert "redirect" in body["message"].lower()
         assert "Confluence upstream error" not in body["message"]
+        assert "/login" in body["message"]
         details = body["data"]
+        assert details["upstream_status"] == 302
+        assert details["likely_cause"] == "missing_or_invalid_atlassian_credentials_or_base_url"
+        assert details["upstream_location"] == "/login"
+
+    def test_upstream_redirect_without_location_header(
+        self, client, private_headers, allow_eng, captured_audit
+    ):
+        """When the upstream 3xx omits the ``Location`` header, the actionable
+        message and ``likely_cause`` still fire — ``upstream_location`` is
+        simply absent from the details. The translator must not crash on a
+        ``None`` location."""
+        fake = MagicMock()
+        fake.get_page.side_effect = ConfluenceUpstreamError(302, "", "api/v2/pages/12345")
+        with _patch_client(fake):
+            resp = client.post(
+                "/api/v1/confluence/page/get",
+                headers=private_headers,
+                data=json.dumps({"pageId": "12345"}),
+                content_type="application/json",
+            )
+        assert resp.status_code == 502
+        body = json.loads(resp.data)
+        assert "redirect" in body["message"].lower()
+        details = body["data"]
+        assert details["likely_cause"] == "missing_or_invalid_atlassian_credentials_or_base_url"
+        assert "upstream_location" not in details
+
+    @pytest.mark.parametrize(
+        "route,client_method,body",
+        [
+            ("/api/v1/confluence/page/get", "get_page", {"pageId": "12345"}),
+            (
+                "/api/v1/confluence/page/descendants",
+                "get_page_descendants",
+                {"pageId": "12345"},
+            ),
+            (
+                "/api/v1/confluence/page/footer-comments",
+                "get_page_footer_comments",
+                {"pageId": "12345"},
+            ),
+            (
+                "/api/v1/confluence/page/inline-comments",
+                "get_page_inline_comments",
+                {"pageId": "12345"},
+            ),
+            ("/api/v1/confluence/space/list", "list_spaces", {}),
+            ("/api/v1/confluence/search", "search_cql", {"cql": "space = ENG"}),
+        ],
+    )
+    def test_upstream_redirect_translator_applies_to_all_routes(
+        self,
+        client,
+        private_headers,
+        allow_eng,
+        captured_audit,
+        route,
+        client_method,
+        body,
+    ):
+        """Regression guard for the shared translator (#2970).
+
+        ``_confluence_error_from_upstream`` is the single funnel every
+        ``/api/v1/confluence/*`` route uses. The single-route test proves the
+        translator's logic; this one proves the *wiring* — if a future route
+        is added that bypasses the funnel (and therefore the actionable-3xx
+        branch), this regression test will catch it. Asserting on each route
+        rather than just one would let a route quietly fall back to the
+        generic ``Confluence upstream error 302`` envelope."""
+        fake = MagicMock()
+        getattr(fake, client_method).side_effect = ConfluenceUpstreamError(
+            302, "", "api/v2/some-path", location="/login"
+        )
+        with _patch_client(fake):
+            resp = client.post(
+                route,
+                headers=private_headers,
+                data=json.dumps(body),
+                content_type="application/json",
+            )
+        assert resp.status_code == 502, f"route {route} did not return 502"
+        envelope = json.loads(resp.data)
+        assert "redirect" in envelope["message"].lower(), (
+            f"route {route} did not get the actionable redirect message — "
+            "likely bypassed _confluence_error_from_upstream"
+        )
+        assert "Confluence upstream error" not in envelope["message"], (
+            f"route {route} fell through to the opaque generic message"
+        )
+        details = envelope["data"]
         assert details["upstream_status"] == 302
         assert details["likely_cause"] == "missing_or_invalid_atlassian_credentials_or_base_url"
 


### PR DESCRIPTION
## Summary

Closes the **code-side ask (#2)** of #2970. When the Atlassian REST API returns a 3xx, the Confluence gateway routes previously surfaced the opaque `Confluence upstream error 302` → HTTP 502, leaving operators to reverse-engineer what a redirect meant.

A 3xx is never a valid read response — it's the signature of an unauthenticated/misrouted request being bounced to the login page, i.e. **missing/invalid gateway Atlassian credentials or a wrong base URL**. `_confluence_error_from_upstream` now special-cases 3xx (ahead of the 4xx/else branches) with a pointed message naming the likely cause, plus a structured `likely_cause` detail. The change lives in the single translator all eight `/api/v1/confluence/*` routes funnel through, so it covers every route.

Kept HTTP **502** (bad upstream response) — deliberately distinct from the **503** "credentials absent" path (`ConfluenceCredentialsUnavailable`), which fires when creds are missing entirely rather than present-but-rejected.

The agent now sees:

> Confluence upstream returned 302 (redirect) — the gateway received a login redirect instead of a REST response. This usually means the gateway's Atlassian credentials are missing/invalid or the base URL is wrong (e.g. ATLASSIAN_BASE_URL must be the bare tenant origin, or CONFLUENCE_BASE_URL must include the /wiki suffix).

## Not in scope (and why)

- **`follow_redirects` stays off.** Following the 302 would chase the Basic-auth header to the login page and hand the agent an HTML form as "data" — strictly worse. Surfacing the redirect as an actionable error is the correct behavior.
- **Ask #1 (provision/verify credentials) is operational, not code.** The deployment's actual 302 was a misconfigured `ATLASSIAN_BASE_URL` (set to a Confluence *page* browser URL instead of the tenant origin, so the loader's `/wiki` append produced a garbage REST base). That was fixed out-of-band by correcting the secret + `make k3s-secrets` + a `POST /api/v1/config/reload`. This PR makes the *next* such misconfig diagnose itself.

## Testing

- `gateway/tests/test_confluence_routes.py`: **60 passed** (incl. new `test_upstream_redirect_surfaces_actionable_error` asserting 502 + `likely_cause` + non-opaque message).
- `ruff check` / `ruff format --check`: clean. Pre-commit hooks pass.

Related: #1931 (Confluence gateway v1), #1556 (Jira gateway — shares the Atlassian credential infra and has the symmetric opaque-3xx gap; left for a follow-up).