### PR TITLE
fix(checkpoint): authenticate external checkpoint-store pushes with the checkpoint repo's token (#2969)

### DIFF
--- a/gateway/checkpoint_handler.py
+++ b/gateway/checkpoint_handler.py
@@ -367,6 +367,40 @@ def _resolve_github_token(repo_path: str) -> str | None:
         return None
 
 
+def _resolve_remote_token(
+    checkpoint_repo: str | None,
+    repo_path: str,
+    github_token: str | None,
+) -> str | None:
+    """Resolve the token to authenticate git ops against the checkpoint store.
+
+    When checkpoints are written to an external ``checkpoint_repo``, the
+    source repo's token is the wrong credential. A pipeline working on a
+    private external repo authenticates in ``user`` mode with a PAT scoped
+    to that customer repo, which has no access to the egg-owned checkpoint
+    store — so the push is rejected with ``remote: Write access to
+    repository not granted`` and the captured checkpoint is silently dropped
+    (#2969). Resolve a token scoped to the checkpoint repo itself instead:
+    ``get_token_for_repo`` returns the egg bot/App installation token for the
+    internal store (its ``auth_mode`` defaults to ``bot``), which does have
+    access.
+
+    Falls back to the source-repo token when no separate checkpoint repo is
+    set (same-repo storage) or when a dedicated token cannot be resolved.
+    """
+    if checkpoint_repo:
+        token_str, _auth_mode, error_msg = get_token_for_repo(checkpoint_repo)
+        if token_str:
+            return token_str
+        logger.warning(
+            "Could not resolve a token scoped to the checkpoint repo; falling "
+            "back to the source-repo token (remote checkpoint ops may be denied)",
+            checkpoint_repo=checkpoint_repo,
+            error=error_msg,
+        )
+    return github_token or _resolve_github_token(repo_path)
+
+
 class CheckpointError(Exception):
     """Error during checkpoint capture."""
 
@@ -884,6 +918,15 @@ class CheckpointHandler:
 
         target = _resolve_checkpoint_target(checkpoint_repo, remote, repo_path)
 
+        # #2969: authenticate every remote checkpoint-store op (ls-remote,
+        # fetch, push) with a token scoped to the checkpoint repo, not the
+        # source repo. The github_token passed in is the source-push token
+        # (e.g. a user-mode PAT for a private customer repo) and has no access
+        # to the egg-owned store, so the push is rejected with "Write access
+        # to repository not granted". The local worktree ops below target the
+        # source bare repo and need no token, so they are left untouched.
+        remote_token = _resolve_remote_token(checkpoint_repo, repo_path, github_token)
+
         try:
             with (
                 _get_store_lock(checkpoint_repo or repo_path),
@@ -894,7 +937,7 @@ class CheckpointHandler:
                 temp_path = Path(temp_dir)
 
                 branch_exists = self._branch_exists(
-                    repo_path, target, CHECKPOINT_BRANCH, github_token=github_token
+                    repo_path, target, CHECKPOINT_BRANCH, github_token=remote_token
                 )
 
                 # Wrap the worktree-add and the checkpoint work so that
@@ -924,7 +967,7 @@ class CheckpointHandler:
                                     repo_path,
                                     fetch_args,
                                     timeout=fetch_timeout,
-                                    github_token=github_token,
+                                    github_token=remote_token,
                                 )
                                 break
                             except (
@@ -1045,7 +1088,7 @@ class CheckpointHandler:
                                 str(temp_path),
                                 ["push", target, f"HEAD:{CHECKPOINT_BRANCH}"],
                                 timeout=120,
-                                github_token=github_token,
+                                github_token=remote_token,
                             )
                             break
                         except CheckpointError as push_err:
@@ -1081,7 +1124,7 @@ class CheckpointHandler:
                                 repo_path,
                                 ["fetch", target, f"+{CHECKPOINT_BRANCH}:{CHECKPOINT_BRANCH}"],
                                 timeout=60,
-                                github_token=github_token,
+                                github_token=remote_token,
                             )
                             self._run_git(
                                 str(temp_path),
@@ -1206,8 +1249,11 @@ class CheckpointHandler:
         Returns:
             The parsed checkpoint index, or None if unavailable.
         """
-        if github_token is None:
-            github_token = _resolve_github_token(repo_path)
+        # #2969: read the external checkpoint store with a token scoped to the
+        # checkpoint repo, not the source repo (which may lack access to a
+        # private egg-owned store). Overrides an explicitly passed source token
+        # when a separate checkpoint_repo is configured.
+        github_token = _resolve_remote_token(checkpoint_repo, repo_path, github_token)
 
         target = _resolve_checkpoint_target(checkpoint_repo, "origin", repo_path)
 
@@ -1288,8 +1334,11 @@ class CheckpointHandler:
         Returns:
             A git ref string, or None if the branch doesn't exist.
         """
-        if github_token is None:
-            github_token = _resolve_github_token(repo_path)
+        # #2969: read the external checkpoint store with a token scoped to the
+        # checkpoint repo, not the source repo (which may lack access to a
+        # private egg-owned store). Overrides an explicitly passed source token
+        # when a separate checkpoint_repo is configured.
+        github_token = _resolve_remote_token(checkpoint_repo, repo_path, github_token)
 
         target = _resolve_checkpoint_target(checkpoint_repo, "origin", repo_path)
 

--- a/gateway/checkpoint_handler.py
+++ b/gateway/checkpoint_handler.py
@@ -385,6 +385,14 @@ def _resolve_remote_token(
     internal store (its ``auth_mode`` defaults to ``bot``), which does have
     access.
 
+    Deployment assumption: the checkpoint repo must be reachable by the egg
+    App installation (or, equivalently, by whatever identity backs the
+    repo's configured ``auth_mode`` in ``repositories.yaml``). If a
+    deployment ever configures the checkpoint repo with ``auth_mode=user``,
+    this helper will return that user PAT and the same scoping bug returns
+    — point ``checkpoint_repo`` at a store the App can write, or install
+    the App on that repo.
+
     Falls back to the source-repo token when no separate checkpoint repo is
     set (same-repo storage) or when a dedicated token cannot be resolved.
     """

--- a/gateway/tests/test_checkpoint_handler.py
+++ b/gateway/tests/test_checkpoint_handler.py
@@ -2504,3 +2504,87 @@ class TestStoreUsesCheckpointRepoToken:
             assert kwargs["github_token"] != "source-user-token", (
                 f"source token leaked to external store on: {args}"
             )
+
+
+class TestReadUsesCheckpointRepoToken:
+    """``fetch_and_read_index`` and ``ensure_ref`` must also read the external
+    store with the checkpoint repo's token (#2969).
+
+    The push fix is well-covered by ``TestStoreUsesCheckpointRepoToken``; the
+    read path uses the same ``_resolve_remote_token`` helper but its end-to-end
+    token wiring is not asserted elsewhere. A ``user``-mode source PAT cannot
+    read a private egg-owned store either, so reads from external repos must
+    authenticate with the checkpoint-scoped token at both the ``ls-remote``
+    (``_branch_exists``) and the ``fetch`` call sites.
+    """
+
+    def _capture_read_calls(self, method_name, checkpoint_repo, github_token):
+        import checkpoint_handler
+
+        handler = checkpoint_handler.CheckpointHandler(github_token=github_token)
+        git_calls = []
+
+        def track_run_git(cwd, args, **kwargs):
+            git_calls.append((cwd, args, kwargs))
+            # Non-empty stdout so _branch_exists() reports the branch exists,
+            # so the fetch path is exercised as well as the ls-remote.
+            return MagicMock(returncode=0, stdout="deadbeefcafef00d", stderr="")
+
+        handler._run_git = track_run_git
+
+        with patch(
+            "checkpoint_handler.get_token_for_repo",
+            return_value=("ckpt-bot-token", "bot", ""),
+        ) as mock_get:
+            try:
+                getattr(handler, method_name)(
+                    "/fake/repo",
+                    checkpoint_repo=checkpoint_repo,
+                    github_token=github_token,
+                )
+            except Exception:
+                pass
+
+        return git_calls, mock_get
+
+    def _assert_read_path_token(self, git_calls):
+        # ls-remote (issued by _branch_exists) must carry the checkpoint token.
+        ls_remote_calls = [c for c in git_calls if "ls-remote" in c[1]]
+        assert ls_remote_calls, f"Expected a ls-remote call, got: {[c[1] for c in git_calls]}"
+        for _cwd, _args, kwargs in ls_remote_calls:
+            assert kwargs.get("github_token") == "ckpt-bot-token", (
+                f"ls-remote authenticated with wrong token: {kwargs.get('github_token')!r}"
+            )
+
+        # fetch must carry the checkpoint token.
+        fetch_calls = [c for c in git_calls if "fetch" in c[1]]
+        assert fetch_calls, f"Expected a fetch call, got: {[c[1] for c in git_calls]}"
+        for _cwd, _args, kwargs in fetch_calls:
+            assert kwargs.get("github_token") == "ckpt-bot-token", (
+                f"fetch authenticated with wrong token: {kwargs.get('github_token')!r}"
+            )
+
+        # No tokenized remote op should leak the source token to the store.
+        for _cwd, args, kwargs in git_calls:
+            if "github_token" in kwargs:
+                assert kwargs["github_token"] != "source-user-token", (
+                    f"source token leaked to external store on: {args}"
+                )
+
+    def test_fetch_and_read_index_uses_checkpoint_repo_token(self):
+        git_calls, mock_get = self._capture_read_calls(
+            "fetch_and_read_index",
+            checkpoint_repo="jwbron/egg-checkpoints",
+            github_token="source-user-token",
+        )
+        mock_get.assert_called_once_with("jwbron/egg-checkpoints")
+        self._assert_read_path_token(git_calls)
+
+    def test_ensure_ref_uses_checkpoint_repo_token(self):
+        git_calls, mock_get = self._capture_read_calls(
+            "ensure_ref",
+            checkpoint_repo="jwbron/egg-checkpoints",
+            github_token="source-user-token",
+        )
+        mock_get.assert_called_once_with("jwbron/egg-checkpoints")
+        self._assert_read_path_token(git_calls)

--- a/gateway/tests/test_checkpoint_handler.py
+++ b/gateway/tests/test_checkpoint_handler.py
@@ -2371,3 +2371,136 @@ class TestMissingBufferWarning:
             f"Expected warning about missing buffer, got warnings: "
             f"{[str(c) for c in mock_logger.warning.call_args_list]}"
         )
+
+
+class TestResolveRemoteToken:
+    """Unit tests for ``_resolve_remote_token`` (#2969).
+
+    The checkpoint push/fetch against an external store must authenticate as
+    the checkpoint repo's identity (the egg bot/App installation), not the
+    source repo's token — a private external source repo authenticates in
+    ``user`` mode with a PAT that has no access to the egg-owned store, so the
+    push is rejected with "Write access to repository not granted".
+    """
+
+    def test_uses_checkpoint_repo_token_when_set(self):
+        import checkpoint_handler
+
+        with patch(
+            "checkpoint_handler.get_token_for_repo",
+            return_value=("ckpt-bot-token", "bot", ""),
+        ) as mock_get:
+            token = checkpoint_handler._resolve_remote_token(
+                checkpoint_repo="jwbron/egg-checkpoints",
+                repo_path="/fake/repo",
+                github_token="source-user-token",
+            )
+
+        # Resolved the checkpoint repo's own token, NOT the source token.
+        assert token == "ckpt-bot-token"
+        mock_get.assert_called_once_with("jwbron/egg-checkpoints")
+
+    def test_falls_back_to_source_token_when_checkpoint_token_unavailable(self):
+        import checkpoint_handler
+
+        with patch(
+            "checkpoint_handler.get_token_for_repo",
+            return_value=(None, "bot", "GitHub token not available"),
+        ):
+            token = checkpoint_handler._resolve_remote_token(
+                checkpoint_repo="jwbron/egg-checkpoints",
+                repo_path="/fake/repo",
+                github_token="source-user-token",
+            )
+
+        # No dedicated token → fall back to the source token rather than None.
+        assert token == "source-user-token"
+
+    def test_same_repo_uses_source_token_without_lookup(self):
+        import checkpoint_handler
+
+        with patch("checkpoint_handler.get_token_for_repo") as mock_get:
+            token = checkpoint_handler._resolve_remote_token(
+                checkpoint_repo=None,
+                repo_path="/fake/repo",
+                github_token="source-bot-token",
+            )
+
+        # Same-repo storage: no external repo to scope a token to.
+        assert token == "source-bot-token"
+        mock_get.assert_not_called()
+
+
+class TestStoreUsesCheckpointRepoToken:
+    """``store_checkpoint_v2`` must push to the external store with the
+    checkpoint repo's token, not the source repo's (#2969)."""
+
+    def _make_checkpoint(self):
+        from egg_contracts.checkpoints import (
+            CheckpointV2,
+            SessionMetadata,
+            TriggerType,
+        )
+
+        now = datetime.now(UTC)
+        return CheckpointV2(
+            id="ckpt-a1b2c3d4e5f67890",
+            trigger_type=TriggerType.COMMIT,
+            session_id="test-container",
+            commit_sha="abc123def456789012345678901234567890abcd",
+            session=SessionMetadata(session_id="test-container", started_at=now),
+            created_at=now,
+            session_started_at=now,
+        )
+
+    def test_push_uses_checkpoint_repo_token_not_source(self):
+        import checkpoint_handler
+
+        checkpoint_handler._store_locks.clear()
+        handler = checkpoint_handler.CheckpointHandler(github_token="source-user-token")
+
+        git_calls = []
+
+        def track_run_git(cwd, args, **kwargs):
+            git_calls.append((cwd, args, kwargs))
+            # Non-empty stdout so _branch_exists() reports the branch exists,
+            # exercising the fetch + push path.
+            return MagicMock(returncode=0, stdout="deadbeefcafef00d", stderr="")
+
+        handler._run_git = track_run_git
+
+        with patch(
+            "checkpoint_handler.get_token_for_repo",
+            return_value=("ckpt-bot-token", "bot", ""),
+        ) as mock_get:
+            try:
+                handler.store_checkpoint_v2(
+                    self._make_checkpoint(),
+                    "/fake/repo",
+                    checkpoint_repo="jwbron/egg-checkpoints",
+                    github_token="source-user-token",
+                )
+            except Exception:
+                # The fake /fake/repo path may raise downstream of the push;
+                # we only assert on the captured git invocations.
+                pass
+
+        mock_get.assert_called_once_with("jwbron/egg-checkpoints")
+
+        # The push to the external store must carry the checkpoint repo's
+        # token, never the source-repo token (the #2969 bug).
+        push_calls = [c for c in git_calls if "push" in c[1]]
+        assert len(push_calls) >= 1, f"Expected a push call, got: {[c[1] for c in git_calls]}"
+        for _cwd, _args, kwargs in push_calls:
+            assert kwargs.get("github_token") == "ckpt-bot-token", (
+                f"push authenticated with the wrong token: {kwargs.get('github_token')!r}"
+            )
+
+        # And no remote op (anything carrying a github_token) should leak the
+        # source token to the external store.
+        remote_calls = [c for c in git_calls if "github_token" in c[2]]
+        assert remote_calls, "Expected at least one tokenized remote op"
+        for _cwd, args, kwargs in remote_calls:
+            assert kwargs["github_token"] != "source-user-token", (
+                f"source token leaked to external store on: {args}"
+            )


### PR DESCRIPTION
## Summary

Fixes #2969. Closes the actual root cause behind "no checkpoints created" for pipelines on private/external repos — which is **not** the event-pump (#2918), but a credential-scoping bug in checkpoint storage.

Verified from live gateway logs on an external-repo pipeline (`pipeline-8cf1f000`):

```
Checkpoint captured checkpoint_id=ckpt-64a7ad87… trigger_type=commit
    message_count=926 tool_call_count=60 total_tokens=34187
Using external checkpoint repo checkpoint_repo=jwbron/egg-checkpoints
[ERROR] Failed to store checkpoint
    error="remote: Write access to repository not granted."
    checkpoint_repo=jwbron/egg-checkpoints
```

Capture works perfectly (the `COMMIT` trigger fires on every agent push, full transcripts). The **store** step is what fails: the push to the external store reused the *source* repo's token. For a private external repo that token is a **user-mode PAT** scoped to the customer repo, which has no access to the egg-owned `jwbron/egg-checkpoints` store → every push is rejected and the captured checkpoint is silently dropped.

(For egg's own `jwbron/egg` pipelines this never surfaced: their `bot`/App token already has write to `jwbron/egg-checkpoints` — same installation — which is why the store holds ~9,950 checkpoints, all `jwbron/egg`/`jwbron/testing`, and none for the external repo.)

## Fix

Resolve a token scoped to the **checkpoint repo** via `get_token_for_repo(checkpoint_repo)` (its `auth_mode` defaults to `bot` — the egg App installation that owns the internal store) and use it for every remote checkpoint-store operation:

- `store_checkpoint_v2` — `ls-remote` (`_branch_exists`), the force-fetch, the push, and the non-FF regenerate-fetch.
- Read path (`fetch_and_read_index`, `ensure_ref`) — same scoping bug; a `user`-mode source token can't read a private egg-owned store either.

Local bare-repo worktree ops need no token and are untouched. Same-repo storage (no `checkpoint_repo`) keeps using the source token, so behavior for repos that store checkpoints in-repo is unchanged.

New helper `_resolve_remote_token(checkpoint_repo, repo_path, github_token)` centralizes the decision and falls back to the source token if a dedicated token can't be resolved.

## Tests

- `TestResolveRemoteToken` — unit coverage for the helper (uses checkpoint-repo token when set; falls back to source token when unavailable; no lookup for same-repo).
- `TestStoreUsesCheckpointRepoToken` — asserts `store_checkpoint_v2` pushes to the external store with the checkpoint repo's token and never leaks the source token to it.

`gateway/tests/test_checkpoint_handler.py`: 90 passed.

## Note for the deployment

This fix relies on the gateway being able to mint a `bot`/App-installation token for `jwbron/egg-checkpoints`. That holds for the existing deployment (it already stores `jwbron/egg` checkpoints via that identity). If a deployment lacks the App installation on the checkpoint repo, point that repo's `checkpoint_repo` at a store the available credential can write, or install the App there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
