### PR TITLE
fix(sdlc skill): make wait-status a self-contained, clone-free launcher (#2971)

### DIFF
--- a/docs/reference/agent-wait-patterns.md
+++ b/docs/reference/agent-wait-patterns.md
@@ -903,7 +903,7 @@ Hosts invoke this via the SDLC skill's launcher,
 [#2971](https://github.com/jwbron/egg/issues/2971) the launcher is a
 **self-contained pure-stdlib client** — it carries a faithful vendored
 copy of `cmd_pipeline_wait_status` (pinned to this module by
-`sandbox/tests/test_skill_wait_status_standalone.py`) and needs no
+`tests/sandbox/test_skill_wait_status_standalone.py`) and needs no
 `.venv`, no `PYTHONPATH`, and no egg checkout. The skill can therefore
 be installed globally (`~/.claude/skills/sdlc/`) and driven from any
 working directory; its only requirement is a reachable orchestrator.

--- a/docs/reference/agent-wait-patterns.md
+++ b/docs/reference/agent-wait-patterns.md
@@ -899,15 +899,23 @@ egg-orch pipeline wait-status <pipeline_id> [--since <cursor>]
 ```
 
 Hosts invoke this via the SDLC skill's launcher,
-`skills/sdlc/bin/wait-status`, which sets `PYTHONPATH` and
-`EGG_ORCHESTRATOR_URL` so no host-side configuration is required
-beyond `make deps` ([#2232](https://github.com/jwbron/egg/issues/2232)).
+`skills/sdlc/bin/wait-status`. As of
+[#2971](https://github.com/jwbron/egg/issues/2971) the launcher is a
+**self-contained pure-stdlib client** — it carries a faithful vendored
+copy of `cmd_pipeline_wait_status` (pinned to this module by
+`sandbox/tests/test_skill_wait_status_standalone.py`) and needs no
+`.venv`, no `PYTHONPATH`, and no egg checkout. The skill can therefore
+be installed globally (`~/.claude/skills/sdlc/`) and driven from any
+working directory; its only requirement is a reachable orchestrator.
 The launcher's default URL (`http://localhost:9849`) relies on the
 `hostPort: 9849` binding in
-`k8s/overlays/local/patches/orchestrator-volumes.yaml`. The bare
+`k8s/overlays/local/patches/orchestrator-volumes.yaml`; set
+`EGG_ORCHESTRATOR_URL` to override (e.g. a port-forward or a remote
+cluster). Note `localhost:9849` is reachable from the host shell but
+**not** from inside the Claude Code Bash sandbox. The bare
 `egg-orch pipeline wait-status` invocation shown above is the
-in-sandbox / unit-test entry point; host callers should always go
-through the launcher.
+in-sandbox / unit-test entry point; host callers go through the
+launcher.
 
 The CLI loops `GET /api/v1/pipelines/<id>/status/wait?wait=25`,
 threading the cursor between successive calls. Stdout is **JSON-lines**
@@ -918,7 +926,7 @@ threading the cursor between successive calls. Stdout is **JSON-lines**
 | `0` | Pipeline reached terminal state (`complete` / `failed` / `cancelled`) or terminal-event wire value (`pipeline.completed` / `pipeline.failed` / `pipeline.cancelled`). |
 | `1` | `--max-iterations` cap hit (test harnesses only — default loops forever). |
 | `2` | Transient error budget exceeded (5xx / connection errors after backoff). Caller should retry. |
-| `3` | Permanent error (4xx, malformed cursor, unknown pipeline). Caller should surface to user, not retry. The `skills/sdlc/bin/wait-status` launcher also exits 3 on env-setup failures (missing `.venv/bin/python` or `sandbox/bin/egg-orch`); both signals collapse to "don't retry" from the caller's perspective. |
+| `3` | Permanent error (4xx, malformed cursor, unknown pipeline). Caller should surface to user, not retry. (The standalone `skills/sdlc/bin/wait-status` launcher no longer has the old `.venv`/`egg-orch` env-setup preconditions that previously also exited 3 — see [#2971](https://github.com/jwbron/egg/issues/2971).) |
 
 Each emitted JSON line is a stable subset of the route's Path-A
 envelope:
@@ -1159,8 +1167,8 @@ render_full_dashboard(last_status)
 last_cursor = ""   # no cursor yet — first wait-status snaps to tip
 
 # blocking wait via Bash; emits one JSON line per event, exits on terminal.
-# Host-side callers use the SDLC skill's launcher (#2232); it wraps
-# `egg-orch pipeline wait-status` with PYTHONPATH and EGG_ORCHESTRATOR_URL.
+# Host-side callers use the SDLC skill's self-contained launcher (#2232,
+# #2971) — pure stdlib, no egg checkout; only EGG_ORCHESTRATOR_URL is read.
 skills/sdlc/bin/wait-status $TASK_ID --since "$last_cursor" \
   | while IFS= read -r line; do
       cursor=$(jq -r .cursor <<< "$line")

--- a/sandbox/tests/test_skill_wait_status_standalone.py
+++ b/sandbox/tests/test_skill_wait_status_standalone.py
@@ -1,0 +1,302 @@
+"""Drift guard for the SDLC skill's standalone wait-status launcher (#2971).
+
+``skills/sdlc/bin/wait-status`` is a self-contained, pure-stdlib vendored
+copy of the ``egg-orch pipeline wait-status`` code path in
+``egg_lib.orch_cli`` — it carries its own ``cmd_pipeline_wait_status`` so
+the skill can run from any working directory with no ``.venv``,
+``PYTHONPATH``, or egg checkout.
+
+Because it's a fork, it can drift from the source of truth. This test
+pins the two together: it drives **both** ``cmd_pipeline_wait_status``
+implementations through identical mocked ``/status/wait`` response
+matrices and asserts identical **stdout JSON-lines and exit codes** —
+the wire contract the Monitor tool consumes (per
+``docs/reference/agent-wait-patterns.md`` §7). stderr is human-facing
+diagnostics and intentionally *not* part of the compared contract (the
+standalone launcher carries a friendlier unreachable-orchestrator hint).
+
+If you change the loop's observable behavior in ``orch_cli``, port the
+same change to ``skills/sdlc/bin/wait-status`` until this test passes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.machinery
+import importlib.util
+import re
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SANDBOX_PATH = str(_REPO_ROOT / "sandbox")
+if _SANDBOX_PATH not in sys.path:
+    sys.path.insert(0, _SANDBOX_PATH)
+
+from egg_lib import orch_cli  # noqa: E402
+
+_SKILL_SCRIPT = _REPO_ROOT / "skills" / "sdlc" / "bin" / "wait-status"
+
+
+def _load_skill_module() -> Any:
+    """Import the extension-less standalone script as a module."""
+    loader = importlib.machinery.SourceFileLoader("skill_wait_status", str(_SKILL_SCRIPT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+skill_wait_status = _load_skill_module()
+
+
+# ---------------------------------------------------------------------------
+# Envelope fixtures (plain dicts — module-agnostic)
+# ---------------------------------------------------------------------------
+
+
+def _no_change(cursor: str = "msg:|evt:0") -> dict[str, Any]:
+    return {"success": True, "data": {"changed": False, "no_change": True, "cursor": cursor}}
+
+
+def _phase_event(cursor: str, event_type: str = "phase.started") -> dict[str, Any]:
+    return {
+        "success": True,
+        "data": {
+            "changed": True,
+            "trigger": "event",
+            "event_type": event_type,
+            "cursor": cursor,
+            "current_phase": "implement",
+            "status": "running",
+            "phase_elapsed_seconds": 5,
+            "concurrent": {"consensus": {"is_complete": False}},
+        },
+    }
+
+
+def _terminal_event(cursor: str, event_type: str = "pipeline.completed") -> dict[str, Any]:
+    body = _phase_event(cursor, event_type=event_type)
+    body["data"]["status"] = "complete"
+    return body
+
+
+def _message_event(cursor: str, message_type: str = "OVERSEER_ALERT") -> dict[str, Any]:
+    return {
+        "success": True,
+        "data": {
+            "changed": True,
+            "trigger": "message",
+            "messages": [{"message_type": message_type, "subject": "stall"}],
+            "cursor": cursor,
+            "current_phase": "implement",
+            "status": "running",
+        },
+    }
+
+
+def _no_change_terminal(cursor: str, status: str) -> dict[str, Any]:
+    return {
+        "success": True,
+        "data": {
+            "changed": False,
+            "no_change": True,
+            "cursor": cursor,
+            "current_phase": "implement",
+            "status": status,
+        },
+    }
+
+
+# A scenario builds its response list from the *module's own* ApiError class
+# (each module defines its own, and each loop only catches its own).
+ResponsesFactory = Callable[[type], list[Any]]
+
+
+def _run(
+    module: Any, responses: list[Any], capsys: pytest.CaptureFixture[str], **ns_over: Any
+) -> tuple[int, str]:
+    """Run a module's ``cmd_pipeline_wait_status`` and return (rc, stdout)."""
+    ns = argparse.Namespace(pipeline_id="issue-42", since="", inner_timeout=1, max_iterations=None)
+    for key, value in ns_over.items():
+        setattr(ns, key, value)
+    # ``patch("time.sleep")`` covers both modules: orch_cli calls ``_time.sleep``
+    # and the standalone calls ``time.sleep`` — both resolve ``sleep`` on the
+    # same stdlib ``time`` module at call time.
+    with patch.object(module, "api_request", side_effect=list(responses)), patch("time.sleep"):
+        rc = module.cmd_pipeline_wait_status(ns)
+    return rc, capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Scenario matrix — exercised against BOTH modules for parity
+# ---------------------------------------------------------------------------
+
+_SCENARIOS: dict[str, tuple[ResponsesFactory, dict[str, Any]]] = {
+    "terminal_only": (lambda _Err: [_terminal_event("msg:|evt:1")], {"max_iterations": 5}),
+    "phase_then_terminal": (
+        lambda _Err: [_phase_event("msg:|evt:1"), _terminal_event("msg:|evt:2")],
+        {"max_iterations": 5},
+    ),
+    "no_change_then_terminal": (
+        lambda _Err: [_no_change("msg:|evt:1"), _terminal_event("msg:|evt:2")],
+        {"max_iterations": 5},
+    ),
+    "message_then_terminal": (
+        lambda _Err: [_message_event("msg:m-1|evt:1"), _terminal_event("msg:|evt:2")],
+        {"max_iterations": 5},
+    ),
+    "explicit_since_threaded": (
+        lambda _Err: [_phase_event("msg:|evt:7"), _terminal_event("msg:|evt:8")],
+        {"since": "msg:abc|evt:5", "max_iterations": 5},
+    ),
+    "http_400_permanent": (
+        lambda Err: [Err("Invalid 'since' cursor", status_code=400)],
+        {"max_iterations": 5},
+    ),
+    "http_404_permanent": (
+        lambda Err: [Err("Pipeline issue-42 not found", status_code=404)],
+        {"max_iterations": 5},
+    ),
+    "http_403_permanent": (
+        lambda Err: [Err("forbidden", status_code=403)],
+        {"max_iterations": 5},
+    ),
+    "transient_then_terminal": (
+        lambda Err: [
+            Err("server error", status_code=503),
+            Err("server error", status_code=503),
+            _terminal_event("msg:|evt:9"),
+        ],
+        {"max_iterations": 10},
+    ),
+    "transient_budget_exhausted": (
+        lambda Err: [Err("server error", status_code=500)] * 200,
+        {"max_iterations": 200},
+    ),
+    "network_error_then_terminal": (
+        lambda Err: [Err("Network error: connection refused"), _terminal_event("msg:|evt:1")],
+        {"max_iterations": 5},
+    ),
+    "path_b_terminal_failed": (
+        lambda _Err: [_no_change_terminal("msg:|evt:0", "failed")],
+        {"max_iterations": 5},
+    ),
+    "path_b_terminal_complete": (
+        lambda _Err: [_no_change_terminal("msg:|evt:0", "complete")],
+        {"max_iterations": 5},
+    ),
+    "path_b_terminal_cancelled": (
+        lambda _Err: [_no_change_terminal("msg:|evt:0", "cancelled")],
+        {"max_iterations": 5},
+    ),
+    "path_b_running_keeps_looping": (
+        lambda _Err: [
+            _no_change_terminal("msg:|evt:0", "running"),
+            _no_change_terminal("msg:|evt:1", "running"),
+            _terminal_event("msg:|evt:9"),
+        ],
+        {"max_iterations": 5},
+    ),
+    "max_iterations_cap": (
+        lambda _Err: [_no_change("msg:|evt:1"), _no_change("msg:|evt:2"), _no_change("msg:|evt:3")],
+        {"max_iterations": 2},
+    ),
+}
+
+
+@pytest.mark.parametrize("scenario", sorted(_SCENARIOS))
+def test_standalone_matches_orch_cli(scenario: str, capsys: pytest.CaptureFixture[str]) -> None:
+    """The vendored launcher emits byte-identical JSON-lines and the same
+    exit code as ``egg_lib.orch_cli`` across the full contract matrix."""
+    make_responses, ns_over = _SCENARIOS[scenario]
+
+    rc_ref, out_ref = _run(orch_cli, make_responses(orch_cli.ApiError), capsys, **ns_over)
+    rc_skill, out_skill = _run(
+        skill_wait_status, make_responses(skill_wait_status.ApiError), capsys, **ns_over
+    )
+
+    assert rc_skill == rc_ref, f"exit code drift in {scenario}: skill={rc_skill} ref={rc_ref}"
+    assert out_skill == out_ref, f"stdout drift in {scenario}"
+
+
+# ---------------------------------------------------------------------------
+# Absolute spot-checks — pin the actual contract values, not just parity
+# ---------------------------------------------------------------------------
+
+
+class TestAbsoluteContract:
+    def test_terminal_returns_zero_one_line(self, capsys: pytest.CaptureFixture[str]) -> None:
+        import json
+
+        rc, out = _run(skill_wait_status, [_terminal_event("msg:|evt:1")], capsys, max_iterations=5)
+        assert rc == 0
+        lines = out.strip().splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["event_type"] == "pipeline.completed"
+
+    def test_4xx_returns_three(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc, _ = _run(
+            skill_wait_status,
+            [skill_wait_status.ApiError("bad", status_code=400)],
+            capsys,
+            max_iterations=5,
+        )
+        assert rc == 3
+
+    def test_transient_budget_returns_two(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc, _ = _run(
+            skill_wait_status,
+            [skill_wait_status.ApiError("5xx", status_code=500)] * 200,
+            capsys,
+            max_iterations=200,
+        )
+        assert rc == 2
+
+    def test_path_b_terminal_emits_synthetic_line(self, capsys: pytest.CaptureFixture[str]) -> None:
+        import json
+
+        rc, out = _run(
+            skill_wait_status,
+            [_no_change_terminal("msg:|evt:0", "failed")],
+            capsys,
+            max_iterations=5,
+        )
+        assert rc == 0
+        line = json.loads(out.strip())
+        assert line["trigger"] == "synthetic-terminal"
+        assert line["event_type"] == "pipeline.failed"
+
+
+# ---------------------------------------------------------------------------
+# Self-contained property: no egg-package dependency, runnable as a script
+# ---------------------------------------------------------------------------
+
+
+class TestSelfContained:
+    def test_distinct_module_from_orch_cli(self) -> None:
+        assert skill_wait_status is not orch_cli
+        assert skill_wait_status.__file__ is None or "skills/sdlc/bin/wait-status" in str(
+            _SKILL_SCRIPT
+        )
+
+    def test_no_egg_imports(self) -> None:
+        """The whole point of #2971: the launcher must not import any egg
+        package (egg_lib, egg_config, egg_agent_tools, …) — that's what let
+        it require a checkout + venv. Pin it to stdlib-only imports."""
+        src = _SKILL_SCRIPT.read_text()
+        offending = re.findall(r"^\s*(?:from|import)\s+egg\w*", src, re.MULTILINE)
+        assert offending == [], f"standalone launcher imports egg packages: {offending}"
+
+    def test_has_python3_shebang_and_executable(self) -> None:
+        src = _SKILL_SCRIPT.read_text()
+        assert src.startswith("#!/usr/bin/env python3"), "missing python3 shebang"
+        import os
+
+        assert os.access(_SKILL_SCRIPT, os.X_OK), "launcher is not executable"

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -3,7 +3,7 @@ name: sdlc
 description: "Run an egg SDLC pipeline: full lifecycle (default) or lightweight coder+reviewer with --short."
 disable-model-invocation: true
 argument-hint: "[--short] [--qualifier <name>] [JIRA-1234 or issue# or description] [--repo owner/name]"
-allowed-tools: Monitor TaskStop Bash(skills/sdlc/bin/wait-status:*) Bash(gh issue view:*) Bash(gh issue list:*) Bash(gh pr list:*) Bash(gh pr view:*) Bash(git remote:*) Bash(git -C * remote:*) AskUserQuestion mcp__egg__submit_task mcp__egg__get_status mcp__egg__provide_input mcp__egg__list_tasks mcp__egg__cancel_task mcp__egg__check_health mcp__egg__list_containers mcp__egg__get_container_logs mcp__egg__send_message mcp__egg__get_consensus_status mcp__egg__get_phase mcp__egg__get_pipeline_snapshot mcp__egg__get_contract mcp__egg__list_checkpoints mcp__egg__search_checkpoints
+allowed-tools: Monitor TaskStop Bash(${CLAUDE_SKILL_DIR}/bin/wait-status:*) Bash(gh issue view:*) Bash(gh issue list:*) Bash(gh pr list:*) Bash(gh pr view:*) Bash(git remote:*) Bash(git -C * remote:*) AskUserQuestion mcp__egg__submit_task mcp__egg__get_status mcp__egg__provide_input mcp__egg__list_tasks mcp__egg__cancel_task mcp__egg__check_health mcp__egg__list_containers mcp__egg__get_container_logs mcp__egg__send_message mcp__egg__get_consensus_status mcp__egg__get_phase mcp__egg__get_pipeline_snapshot mcp__egg__get_contract mcp__egg__list_checkpoints mcp__egg__search_checkpoints
 ---
 
 # SDLC Pipeline
@@ -41,7 +41,7 @@ Collect the **repository**, **task description**, and optionally a **GitHub issu
 
 Before asking the user anything, try to detect the repo automatically:
 
-1. Run `git -C "$EGG_REPO_PATH" remote get-url origin 2>/dev/null` (or fall back to `git remote -v` from the working directory)
+1. Run `git remote get-url origin 2>/dev/null` (or `git remote -v`) in the working directory to detect the *target* repo to operate on — the repo the pipeline will act on, which is distinct from the egg checkout that hosts the orchestrator
 2. Parse the `owner/name` from the URL (e.g. `https://github.com/jwbron/egg.git` → `jwbron/egg`)
 3. If a `--repo` flag was passed, use that instead
 
@@ -317,13 +317,13 @@ Drive the pipeline through one Monitor invocation per quiet stretch. On entry:
 
 1. **First poll** — call the `get_status(task_id)` MCP tool to render the initial dashboard. `get_status` returns the full snapshot. It does **not** return a `cursor`; the cursor is produced by `wait-status` only. Cache the snapshot in conversation context as `last_status`. Initialize `last_cursor = ""` (empty — the first `wait-status` call snaps to the tip of both event sources).
 
-2. **Blocking wait** — invoke `skills/sdlc/bin/wait-status` through the **Monitor** tool, not Bash. The Monitor tool delivers each stdout line as a separate notification, so the LLM wakes on every emitted event in real time — exactly what the JSON-line streaming model assumes. Run from the repo root. The block below is pseudocode for the Monitor tool input — the actual call uses the Monitor tool's JSON parameter shape (`description`, `command`, `timeout_ms`, `persistent`):
+2. **Blocking wait** — invoke `${CLAUDE_SKILL_DIR}/bin/wait-status` through the **Monitor** tool, not Bash. The Monitor tool delivers each stdout line as a separate notification, so the LLM wakes on every emitted event in real time — exactly what the JSON-line streaming model assumes. The launcher is self-contained (pure stdlib, no egg checkout) and resolves from any working directory via `${CLAUDE_SKILL_DIR}`. The block below is pseudocode for the Monitor tool input — the actual call uses the Monitor tool's JSON parameter shape (`description`, `command`, `timeout_ms`, `persistent`):
 
    ```
    # pseudocode — see Monitor tool for the JSON parameter shape
    Monitor(
      description: "wait-status <task_id>",
-     command: "skills/sdlc/bin/wait-status <task_id> --since \"<last_cursor>\"",
+     command: "${CLAUDE_SKILL_DIR}/bin/wait-status <task_id> --since \"<last_cursor>\"",
      timeout_ms: 3600000,  # ignored while persistent: true — kept for reference
      persistent: true,
    )
@@ -335,7 +335,7 @@ Drive the pipeline through one Monitor invocation per quiet stretch. On entry:
 
    **Cache the Monitor's task_id as `monitor_task_id` in conversation context** (returned in the Monitor tool's invocation response). You'll need it to call `TaskStop` before re-arming a new Monitor after HITL (see [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first) below) — `wait-status` does not exit on `decision.created`, so without an explicit stop the prior CLI keeps polling in parallel and double-emits the next event.
 
-   The launcher wraps `sandbox/bin/egg-orch pipeline wait-status`, setting `PYTHONPATH` and `EGG_ORCHESTRATOR_URL` so no host-side configuration is required beyond `make deps`. It loops the orchestrator's `/status/wait` route server-side, threading the cursor between calls. Stdout is **JSON-lines** — one line per pipeline-relevant event, surfaced to the LLM as one notification per line. The CLI is silent on `no_change`, so the LLM only wakes when something happened. Exit codes (Monitor reports them as the watch's exit code):
+   The launcher is a self-contained stdlib client — no `.venv`, no `PYTHONPATH`, no egg checkout — that loops the orchestrator's `/status/wait` route server-side, threading the cursor between calls. It needs only a reachable orchestrator: set `EGG_ORCHESTRATOR_URL` if it isn't at the default `http://localhost:9849` (note: `localhost` is reachable from the host shell but **not** from inside the Claude Code Bash sandbox — disable the sandbox or point at a host-reachable address when driving from there). Stdout is **JSON-lines** — one line per pipeline-relevant event, surfaced to the LLM as one notification per line. The CLI is silent on `no_change`, so the LLM only wakes when something happened. Exit codes (Monitor reports them as the watch's exit code):
 
    | Exit code | Meaning | Skill action |
    |-----------|---------|--------------|
@@ -350,7 +350,7 @@ Drive the pipeline through one Monitor invocation per quiet stretch. On entry:
 
    **Why Monitor and not Bash?** `wait-status` is designed to emit one JSON-line per event over the lifetime of a single CLI invocation. Foreground Bash blocks the LLM until the command exits and batches all events emitted in that window into one wake — so a `decision.created` that lands 30 seconds in won't be visible until the next event flushes the buffer. Background Bash sends a single completion notification when the whole CLI exits and forces file-polling for stdout. Monitor's per-line notification semantics match the streaming-stdout contract directly.
 
-   **Bash fallback:** If Monitor is unavailable in the harness, fall back to a foreground Bash invocation (`skills/sdlc/bin/wait-status <task_id> --since "<last_cursor>"`) — but be aware that events emitted within a single 10-minute Bash window will be batched at exit, not surfaced as they arrive. On Bash-cap timeout, re-invoke with the latest `last_cursor` from the batched output.
+   **Bash fallback:** If Monitor is unavailable in the harness, fall back to a foreground Bash invocation (`${CLAUDE_SKILL_DIR}/bin/wait-status <task_id> --since "<last_cursor>"`) — but be aware that events emitted within a single 10-minute Bash window will be batched at exit, not surfaced as they arrive. On Bash-cap timeout, re-invoke with the latest `last_cursor` from the batched output.
 
 3. **Read each emitted JSON line** as it arrives. The line shape is:
 
@@ -1047,7 +1047,7 @@ All orchestrator and gateway interactions use the MCP tool surface. Never call R
 |------|---------|
 | `submit_task` | Submit a new pipeline task |
 | `get_status` | One-shot status snapshot (no cursor) — use for first poll and after `provide_input` |
-| `skills/sdlc/bin/wait-status` (via Monitor) | Long-poll for status changes; emits JSON-lines on stdout — Monitor surfaces each line as its own notification, so the LLM wakes on every event. Host-side launcher around `sandbox/bin/egg-orch pipeline wait-status`. Replaces the prior `wait_for_status_change` MCP tool (#2211). Bash is a fallback only (events batch at exit). |
+| `${CLAUDE_SKILL_DIR}/bin/wait-status` (via Monitor) | Long-poll for status changes; emits JSON-lines on stdout — Monitor surfaces each line as its own notification, so the LLM wakes on every event. Self-contained stdlib client (no egg checkout; only `EGG_ORCHESTRATOR_URL` needed). Replaces the prior `wait_for_status_change` MCP tool (#2211). Bash is a fallback only (events batch at exit). |
 | `provide_input` | Respond to HITL decisions (serialize JSON payload as string) |
 | `list_tasks` | List tasks for a repository |
 | `cancel_task` | Cancel a running task |
@@ -1062,12 +1062,12 @@ All orchestrator and gateway interactions use the MCP tool surface. Never call R
 | `list_checkpoints` | Browse prior agent session transcripts (gateway-backed) |
 | `search_checkpoints` | Search checkpoint metadata for keywords (gateway-backed) |
 
-**Polling protocol:** First poll uses `get_status(task_id)` (MCP). Every subsequent quiet stretch uses one **Monitor** invocation wrapping `skills/sdlc/bin/wait-status <task_id> --since "<last_cursor>"` so each emitted JSON-line wakes the LLM individually. Bash is a fallback (events batch at the 10-min Bash cap). See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the full envelope contract and trigger allowlist.
+**Polling protocol:** First poll uses `get_status(task_id)` (MCP). Every subsequent quiet stretch uses one **Monitor** invocation wrapping `${CLAUDE_SKILL_DIR}/bin/wait-status <task_id> --since "<last_cursor>"` so each emitted JSON-line wakes the LLM individually. Bash is a fallback (events batch at the 10-min Bash cap). See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the full envelope contract and trigger allowlist.
 
 ## Critical Rules
 
 - **Always use MCP tools** — never call orchestrator/gateway APIs or CLIs directly
-- **First poll uses `get_status(task_id)` (MCP); every subsequent quiet stretch wraps `skills/sdlc/bin/wait-status <task_id> --since "<last_cursor>"` in the Monitor tool** — Monitor turns each emitted JSON-line into its own notification, which is what the per-event wake semantics of this skill require. Bash is a fallback only (events emitted in a single 10-min Bash window batch at exit). Thread the `cursor` from each emitted JSON-line into the next Monitor invocation's `--since`. The first `wait-status` call after the `get_status` snapshot uses an empty `--since` (route snaps to tip); `get_status` itself does NOT return a cursor. See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the trigger allowlist, envelope, and exit-code contract.
+- **First poll uses `get_status(task_id)` (MCP); every subsequent quiet stretch wraps `${CLAUDE_SKILL_DIR}/bin/wait-status <task_id> --since "<last_cursor>"` in the Monitor tool** — Monitor turns each emitted JSON-line into its own notification, which is what the per-event wake semantics of this skill require. Bash is a fallback only (events emitted in a single 10-min Bash window batch at exit). Thread the `cursor` from each emitted JSON-line into the next Monitor invocation's `--since`. The first `wait-status` call after the `get_status` snapshot uses an empty `--since` (route snaps to tip); `get_status` itself does NOT return a cursor. See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the trigger allowlist, envelope, and exit-code contract.
 - **Read each emitted JSON-line as it arrives.** The CLI is silent on `no_change` — it only emits when something happened. Re-fetch the full snapshot via `get_status` whenever the dashboard needs fields not on the JSON-line (running_agents, completed_agents, recent_messages, enriched pending_decisions).
 - **Always serialize JSON payloads as strings** for `provide_input` — the `response` parameter is a string, not an object. Pass `'{"action": "approve"}'` not `{"action": "approve"}`
 - **Never skip HITL** — always present decisions to the user and wait for their response
@@ -1089,7 +1089,7 @@ Collect the **repository** and **task description**. Bare integers are treated a
 
 Before asking the user anything, try to detect the repo automatically:
 
-1. Run `git -C "$EGG_REPO_PATH" remote get-url origin 2>/dev/null` (or fall back to `git remote -v` from the working directory)
+1. Run `git remote get-url origin 2>/dev/null` (or `git remote -v`) in the working directory to detect the *target* repo to operate on — the repo the pipeline will act on, which is distinct from the egg checkout that hosts the orchestrator
 2. Parse the `owner/name` from the URL (e.g. `https://github.com/jwbron/egg.git` → `jwbron/egg`)
 3. If a `--repo` flag was passed, use that instead
 
@@ -1356,13 +1356,13 @@ Drive the pipeline through one Monitor invocation per quiet stretch. On entry:
 
 1. **First poll** — call the `get_status(task_id)` MCP tool to render the initial dashboard and cache the snapshot as `last_status`. `get_status` does not return a `cursor`; the cursor is produced by `wait-status` only. Initialize `last_cursor = ""` (empty — the first `wait-status` call snaps to the tip).
 
-2. **Blocking wait** — invoke `skills/sdlc/bin/wait-status` through the **Monitor** tool, not Bash. Monitor delivers each stdout line as its own notification, so the LLM wakes on every emitted event. Run from the repo root. The block below is pseudocode for the Monitor tool input — the actual call uses the Monitor tool's JSON parameter shape (`description`, `command`, `timeout_ms`, `persistent`):
+2. **Blocking wait** — invoke `${CLAUDE_SKILL_DIR}/bin/wait-status` through the **Monitor** tool, not Bash. Monitor delivers each stdout line as its own notification, so the LLM wakes on every emitted event. The launcher is self-contained (pure stdlib, no egg checkout) and resolves from any working directory via `${CLAUDE_SKILL_DIR}`. The block below is pseudocode for the Monitor tool input — the actual call uses the Monitor tool's JSON parameter shape (`description`, `command`, `timeout_ms`, `persistent`):
 
    ```
    # pseudocode — see Monitor tool for the JSON parameter shape
    Monitor(
      description: "wait-status <task_id>",
-     command: "skills/sdlc/bin/wait-status <task_id> --since \"<last_cursor>\"",
+     command: "${CLAUDE_SKILL_DIR}/bin/wait-status <task_id> --since \"<last_cursor>\"",
      timeout_ms: 3600000,  # ignored while persistent: true — kept for reference
      persistent: true,
    )
@@ -1374,7 +1374,7 @@ Drive the pipeline through one Monitor invocation per quiet stretch. On entry:
 
    **Cache the Monitor's task_id as `monitor_task_id` in conversation context** (returned in the Monitor tool's invocation response) — needed for `TaskStop` before re-arming after handling a decision (see [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first) in Phase 3; the same rule applies to the unexpected-decisions path below).
 
-   The launcher wraps `sandbox/bin/egg-orch pipeline wait-status` and loops `/status/wait` server-side, threading the cursor between calls. Stdout is **JSON-lines** — one line per pipeline-relevant event, silent on `no_change`, surfaced as one notification per line. Exit codes:
+   The launcher is a self-contained stdlib client (no egg checkout) that loops `/status/wait` server-side, threading the cursor between calls. Set `EGG_ORCHESTRATOR_URL` if the orchestrator isn't at the default `http://localhost:9849` (not reachable from inside the Bash sandbox). Stdout is **JSON-lines** — one line per pipeline-relevant event, silent on `no_change`, surfaced as one notification per line. Exit codes:
 
    | Exit code | Meaning | Skill action |
    |-----------|---------|--------------|
@@ -1389,7 +1389,7 @@ Drive the pipeline through one Monitor invocation per quiet stretch. On entry:
 
    **Why Monitor and not Bash?** Foreground Bash blocks until the CLI exits and batches every event in that window into one wake; background Bash emits only a single completion notification. Both break the per-event wake semantics this skill relies on (e.g. surfacing `decision.created` the moment the gate is created). Monitor's per-line notifications match the streaming-stdout contract.
 
-   **Bash fallback:** If Monitor isn't available, fall back to foreground Bash (`skills/sdlc/bin/wait-status <task_id> --since "<last_cursor>"`) — events will batch at the 10-min Bash cap, not stream as they arrive. On cap-elapsed exit, re-invoke with the latest `last_cursor` from the batched output.
+   **Bash fallback:** If Monitor isn't available, fall back to foreground Bash (`${CLAUDE_SKILL_DIR}/bin/wait-status <task_id> --since "<last_cursor>"`) — events will batch at the 10-min Bash cap, not stream as they arrive. On cap-elapsed exit, re-invoke with the latest `last_cursor` from the batched output.
 
 3. **Read each emitted JSON line** — same shape as Phase 3:
 
@@ -1507,7 +1507,7 @@ Phase: <phase where failure occurred>
 
 ## Short Flow Critical Rules
 
-- **Always use MCP tools for state-query operations** (`submit_task`, `get_status` for the first poll and one-shot snapshots, `provide_input`, `cancel_task`) — never call orchestrator APIs directly. **For blocking waits, wrap the host-side launcher `skills/sdlc/bin/wait-status` (host wrapper around `egg-orch pipeline wait-status`, issue #2211) in the Monitor tool** — the MCP transport caps tool calls below typical quiet-phase intervals, so an MCP-driven wait would burn an LLM turn on every cap-elapsed return; and Bash batches per-event JSON-lines into a single wake at exit, defeating the streaming-stdout design. Monitor surfaces each emitted line as its own notification. Thread the JSON-line `cursor` into the next Monitor invocation's `--since`. Bash is a fallback only when Monitor is unavailable. See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the contract.
+- **Always use MCP tools for state-query operations** (`submit_task`, `get_status` for the first poll and one-shot snapshots, `provide_input`, `cancel_task`) — never call orchestrator APIs directly. **For blocking waits, wrap the self-contained launcher `${CLAUDE_SKILL_DIR}/bin/wait-status` (a pure-stdlib client for the orchestrator's `/status/wait` route; no egg checkout — issues #2211/#2971) in the Monitor tool** — the MCP transport caps tool calls below typical quiet-phase intervals, so an MCP-driven wait would burn an LLM turn on every cap-elapsed return; and Bash batches per-event JSON-lines into a single wake at exit, defeating the streaming-stdout design. Monitor surfaces each emitted line as its own notification. Thread the JSON-line `cursor` into the next Monitor invocation's `--since`. Bash is a fallback only when Monitor is unavailable. See [Host-Side Waits](../../docs/reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the contract.
 - **Always serialize JSON payloads as strings** for `provide_input`
 - **Always pass `config`** with `{"start_phase": "implement", "hitl_gates": false, "overseer_enabled": true}` when calling `submit_task`
 - **Auto-approve phase gates** — this is a no-HITL flow; if a gate appears, approve it automatically and inform the user

--- a/skills/sdlc/bin/wait-status
+++ b/skills/sdlc/bin/wait-status
@@ -1,34 +1,328 @@
-#!/usr/bin/env bash
-# Host-side launcher for `egg-orch pipeline wait-status`. Lets the SDLC
-# skill drive its quiet-stretch monitoring loop without `make deps`-time
-# setup beyond the venv.
+#!/usr/bin/env python3
+# Self-contained host-side launcher for the SDLC skill's quiet-stretch
+# monitoring loop. Long-polls the orchestrator's
+# ``/api/v1/pipelines/<id>/status/wait`` route and emits JSON-lines on
+# stdout — one line per pipeline-relevant event — so the Monitor tool
+# wakes the LLM on every event.
 #
-# Defaults EGG_ORCHESTRATOR_URL to http://localhost:9849. That endpoint
-# is exposed by `hostPort: 9849` in
-# k8s/overlays/local/patches/orchestrator-volumes.yaml — keep both in
-# sync.
+# This script is **dependency-free**: pure Python stdlib, no virtualenv,
+# no ``PYTHONPATH``, and no egg checkout. The only requirement is a
+# reachable orchestrator. It is a faithful vendored copy of the
+# ``egg-orch pipeline wait-status`` code path in
+# ``sandbox/egg_lib/orch_cli.py``; a contract test
+# (``sandbox/tests/test_skill_wait_status_standalone.py``) pins this
+# copy's stdout JSON-lines and exit codes to that source so the two
+# can't drift.
 #
-# Issue: https://github.com/jwbron/egg/issues/2232
+# Configuration (env, both optional):
+#   EGG_ORCHESTRATOR_URL  base URL of the orchestrator
+#                         (default http://localhost:9849 — the host-side
+#                         hostPort binding from
+#                         k8s/overlays/local/patches/orchestrator-volumes.yaml).
+#                         NOTE: localhost is reachable from the host shell
+#                         but NOT from inside the Claude Code Bash sandbox;
+#                         disable the sandbox or point this at a
+#                         host-reachable address when driving from there.
+#   EGG_PIPELINE_ID       fallback pipeline id when none is passed as an arg.
+#
+# Exit codes (per docs/reference/agent-wait-patterns.md §7):
+#   0  terminal pipeline state (complete / failed / cancelled)
+#   1  --max-iterations cap hit (test harnesses only; loops forever otherwise)
+#   2  transient error budget exceeded after backoff (caller should retry)
+#   3  permanent error (4xx, malformed cursor, unknown pipeline; do not retry)
+#
+# Issues: https://github.com/jwbron/egg/issues/2211 (CLI),
+#         https://github.com/jwbron/egg/issues/2232 (launcher),
+#         https://github.com/jwbron/egg/issues/2971 (standalone / clone-free).
 
-set -euo pipefail
+from __future__ import annotations
 
-SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
-SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
-REPO_ROOT="$(cd -P "$SCRIPT_DIR/../../.." && pwd)"
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from http.client import HTTPException
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import ProxyHandler, Request, build_opener
 
-VENV_PYTHON="$REPO_ROOT/.venv/bin/python"
-if [[ ! -x "$VENV_PYTHON" ]]; then
-    echo "wait-status: $VENV_PYTHON not found — run 'make deps' first" >&2
-    exit 3
-fi
+# Validation pattern for IDs used in URL path segments.
+_SAFE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_\-\.]+$")
 
-EGG_ORCH_SCRIPT="$REPO_ROOT/sandbox/bin/egg-orch"
-if [[ ! -e "$EGG_ORCH_SCRIPT" ]]; then
-    echo "wait-status: $EGG_ORCH_SCRIPT not found" >&2
-    exit 3
-fi
+# Terminal pipeline statuses / events that end the loop (issue #2211).
+_WAIT_STATUS_TERMINAL_STATUSES = frozenset({"complete", "failed", "cancelled"})
+_WAIT_STATUS_TERMINAL_EVENTS = frozenset(
+    {"pipeline.completed", "pipeline.failed", "pipeline.cancelled"}
+)
+# Map terminal ``status`` strings to the Path-A ``event_type`` they
+# correspond to (Path-B defense-in-depth, issue #2378).
+_WAIT_STATUS_TO_EVENT_TYPE = {
+    "complete": "pipeline.completed",
+    "failed": "pipeline.failed",
+    "cancelled": "pipeline.cancelled",
+}
 
-export PYTHONPATH="$REPO_ROOT/sandbox:$REPO_ROOT/shared${PYTHONPATH:+:$PYTHONPATH}"
-export EGG_ORCHESTRATOR_URL="${EGG_ORCHESTRATOR_URL:-http://localhost:9849}"
+# Bypass proxy for internal network requests.
+_opener = build_opener(ProxyHandler({}))
 
-exec "$VENV_PYTHON" "$EGG_ORCH_SCRIPT" pipeline wait-status "$@"
+
+class ApiError(Exception):
+    """Error from an API request."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        details: dict[str, Any] | None = None,
+    ):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.details = details
+
+
+def get_orchestrator_url() -> str:
+    """Base URL of the orchestrator.
+
+    Defaults to the host-side ``hostPort`` binding (localhost:9849); set
+    ``EGG_ORCHESTRATOR_URL`` to override (e.g. a port-forward or a remote
+    cluster).
+    """
+    url = os.environ.get("EGG_ORCHESTRATOR_URL")
+    if url:
+        return url.rstrip("/")
+    return "http://localhost:9849"
+
+
+def validate_id(value: str, name: str) -> str:
+    """Validate that an ID is safe for use in URL paths and URL-encode it."""
+    if not value:
+        print(f"Error: {name} cannot be empty", file=sys.stderr)
+        sys.exit(1)
+    if not _SAFE_ID_PATTERN.match(value):
+        print(
+            f"Error: Invalid {name} '{value}': must contain only "
+            "alphanumeric characters, hyphens, underscores, and dots",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return quote(value, safe="")
+
+
+def require_pipeline_id(args: argparse.Namespace) -> str:
+    """Get pipeline_id from args or environment, validate, and return URL-safe value."""
+    pid = getattr(args, "pipeline_id", None) or os.environ.get("EGG_PIPELINE_ID")
+    if not pid:
+        print(
+            "Error: pipeline_id required. Provide as argument or set EGG_PIPELINE_ID.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return validate_id(pid, "pipeline_id")
+
+
+def api_request(base_url: str, endpoint: str, timeout: int = 15) -> dict[str, Any]:
+    """GET an internal API endpoint and return the decoded JSON.
+
+    Raises:
+        ApiError: on any HTTP, URL, timeout, protocol, or socket error.
+                  ``status_code`` is set only for HTTP responses (used by
+                  the caller to split 4xx-permanent from transient).
+    """
+    url = f"{base_url}{endpoint}"
+    req_headers = {"Content-Type": "application/json"}
+    try:
+        request = Request(url, headers=req_headers, method="GET")
+        with _opener.open(request, timeout=timeout) as response:
+            result: dict[str, Any] = json.loads(response.read().decode())
+            return result
+    except HTTPError as e:
+        error_body = e.read().decode()
+        try:
+            error_data = json.loads(error_body)
+            raise ApiError(
+                error_data.get("message", str(e)),
+                status_code=e.code,
+                details=error_data.get("details"),
+            ) from e
+        except json.JSONDecodeError:
+            raise ApiError(f"{e}: {error_body}", status_code=e.code) from e
+    except URLError as e:
+        raise ApiError(f"Connection error: {e.reason}") from e
+    except TimeoutError as e:
+        raise ApiError(f"Request timed out: {url}: {e}") from e
+    except HTTPException as e:
+        # ``http.client.RemoteDisconnected`` / ``IncompleteRead`` — raised
+        # when the peer closes the connection mid-flight (e.g. orch pod
+        # restart during a long-poll). Not wrapped by urllib (issue #2412).
+        raise ApiError(f"HTTP protocol error: {url}: {e}") from e
+    except OSError as e:
+        # ``ConnectionResetError``, ``ConnectionRefusedError``, and other
+        # socket-level errors that bypass the ``URLError`` wrapper.
+        raise ApiError(f"Network error: {url}: {e}") from e
+
+
+def cmd_pipeline_wait_status(args: argparse.Namespace) -> int:
+    """Long-poll for pipeline events; emit JSON-lines (issue #2211).
+
+    Loops the orchestrator's ``/api/v1/pipelines/<id>/status/wait`` route,
+    threading the response cursor between calls. On Path-A (changed) emits
+    one JSON-line on stdout with the dashboard-relevant subset of the
+    envelope; on Path-B (no_change) loops silently. Exits per the §7
+    contract in ``docs/reference/agent-wait-patterns.md``: 0 terminal,
+    1 max-iter, 2 transient, 3 permanent.
+    """
+    pid = require_pipeline_id(args)
+    cursor = (getattr(args, "since", "") or "").strip()
+    inner_timeout = max(int(getattr(args, "inner_timeout", 25) or 25), 1)
+    max_iterations = getattr(args, "max_iterations", None)
+    if not isinstance(max_iterations, int) or max_iterations <= 0:
+        max_iterations = sys.maxsize
+
+    orchestrator_url = get_orchestrator_url()
+    backoff = 1.0
+    # Cumulative *backoff sleep* time across consecutive transient failures
+    # (NOT wall-clock). Bounds how long the loop backs off before giving up;
+    # the operator always retains the option to re-invoke after exit 2.
+    backoff_sleep_total = 0.0
+    backoff_sleep_budget = 60.0
+
+    for _ in range(max_iterations):
+        endpoint = f"/api/v1/pipelines/{pid}/status/wait?wait={inner_timeout}"
+        if cursor:
+            endpoint += f"&since={quote(cursor, safe='')}"
+
+        try:
+            result = api_request(orchestrator_url, endpoint, timeout=inner_timeout + 15)
+        except ApiError as err:
+            status = err.status_code or 0
+            if status and 400 <= status < 500:
+                # 4xx — permanent.
+                print(f"wait-status: {status} {err.message}", file=sys.stderr)
+                return 3
+            # 5xx, network errors, timeouts — transient.
+            backoff_sleep_total += backoff
+            if backoff_sleep_total > backoff_sleep_budget:
+                print(
+                    "wait-status: transient error budget exceeded "
+                    f"({err.message}). Is the orchestrator reachable at "
+                    f"{orchestrator_url}? (Set EGG_ORCHESTRATOR_URL, or note "
+                    "that localhost is not reachable from inside the Bash sandbox.)",
+                    file=sys.stderr,
+                )
+                return 2
+            time.sleep(min(backoff, 5.0))
+            backoff = min(backoff * 2, 5.0)
+            continue
+
+        # Successful call resets the backoff window.
+        backoff = 1.0
+        backoff_sleep_total = 0.0
+
+        envelope = result.get("data") if isinstance(result.get("data"), dict) else result
+        if not isinstance(envelope, dict):
+            print("wait-status: unexpected envelope shape", file=sys.stderr)
+            return 3
+
+        new_cursor = envelope.get("cursor")
+        if isinstance(new_cursor, str) and new_cursor:
+            cursor = new_cursor
+
+        if envelope.get("changed") is True:
+            line: dict[str, Any] = {
+                "trigger": envelope.get("trigger"),
+                "cursor": envelope.get("cursor"),
+                "current_phase": envelope.get("current_phase"),
+                "status": envelope.get("status"),
+            }
+            if "phase_elapsed_seconds" in envelope:
+                line["phase_elapsed_seconds"] = envelope["phase_elapsed_seconds"]
+            if envelope.get("trigger") == "event":
+                line["event_type"] = envelope.get("event_type")
+            elif envelope.get("trigger") == "message":
+                line["messages"] = envelope.get("messages")
+            if "concurrent" in envelope:
+                line["concurrent"] = envelope["concurrent"]
+            print(json.dumps(line), flush=True)
+
+            status_str = envelope.get("status")
+            event_type = envelope.get("event_type") or ""
+            if (
+                isinstance(status_str, str) and status_str in _WAIT_STATUS_TERMINAL_STATUSES
+            ) or event_type in _WAIT_STATUS_TERMINAL_EVENTS:
+                return 0
+        else:
+            # Path B (no_change): defense-in-depth for issue #2378. If any
+            # code path leaves us subscribed past a terminal state, the
+            # envelope's ``status`` field still carries the truth — emit a
+            # synthetic terminal line and exit 0 instead of looping silently.
+            status_str = envelope.get("status")
+            if isinstance(status_str, str) and status_str in _WAIT_STATUS_TERMINAL_STATUSES:
+                line = {
+                    "trigger": "synthetic-terminal",
+                    "cursor": envelope.get("cursor"),
+                    "current_phase": envelope.get("current_phase"),
+                    "status": status_str,
+                    "event_type": _WAIT_STATUS_TO_EVENT_TYPE[status_str],
+                }
+                print(json.dumps(line), flush=True)
+                return 0
+
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="wait-status",
+        description=(
+            "Long-poll the orchestrator's /status/wait route, threading the "
+            "response cursor between calls. Emits one JSON line per "
+            "pipeline-relevant event (phase transition, terminal state, HITL "
+            "decision.created, OVERSEER_ALERT, consensus message) on stdout; "
+            "silent on no_change. Exits 0 on terminal pipeline state, 1 on "
+            "--max-iterations cap (test only), 2 on transient errors after the "
+            "backoff budget, 3 on permanent errors (4xx). Self-contained: "
+            "pure stdlib, no egg checkout required — only a reachable "
+            "orchestrator (EGG_ORCHESTRATOR_URL, default http://localhost:9849)."
+        ),
+    )
+    parser.add_argument("pipeline_id", nargs="?", help="Pipeline ID (or set EGG_PIPELINE_ID)")
+    parser.add_argument(
+        "--since",
+        default="",
+        help=(
+            "Opaque cursor from a prior wait-status JSON-line. Empty / absent "
+            "snaps to the tip of both event sources."
+        ),
+    )
+    parser.add_argument(
+        "--inner-timeout",
+        type=int,
+        default=25,
+        help=(
+            "Per-call server-side block timeout in seconds (default 25, "
+            "clamped server-side by GET_STATUS_MAX_WAIT)."
+        ),
+    )
+    parser.add_argument(
+        "--max-iterations",
+        type=int,
+        default=None,
+        help=(
+            "Safety cap on outer-loop iterations (test harnesses only). "
+            "Loops until terminal pipeline state by default."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return cmd_pipeline_wait_status(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/sdlc/bin/wait-status
+++ b/skills/sdlc/bin/wait-status
@@ -10,7 +10,7 @@
 # reachable orchestrator. It is a faithful vendored copy of the
 # ``egg-orch pipeline wait-status`` code path in
 # ``sandbox/egg_lib/orch_cli.py``; a contract test
-# (``sandbox/tests/test_skill_wait_status_standalone.py``) pins this
+# (``tests/sandbox/test_skill_wait_status_standalone.py``) pins this
 # copy's stdout JSON-lines and exit codes to that source so the two
 # can't drift.
 #

--- a/skills/sdlc/bin/wait-status
+++ b/skills/sdlc/bin/wait-status
@@ -153,7 +153,7 @@ def api_request(base_url: str, endpoint: str, timeout: int = 15) -> dict[str, An
     except URLError as e:
         raise ApiError(f"Connection error: {e.reason}") from e
     except TimeoutError as e:
-        raise ApiError(f"Request timed out: {url}: {e}") from e
+        raise ApiError(f"Request timed out: {url}") from e
     except HTTPException as e:
         # ``http.client.RemoteDisconnected`` / ``IncompleteRead`` — raised
         # when the peer closes the connection mid-flight (e.g. orch pod

--- a/tests/sandbox/test_pipeline_wait_status_cli.py
+++ b/tests/sandbox/test_pipeline_wait_status_cli.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 
 import pytest
 
-_sandbox_path = str(Path(__file__).parent.parent)
+_sandbox_path = str(Path(__file__).resolve().parents[2] / "sandbox")
 if _sandbox_path not in sys.path:
     sys.path.insert(0, _sandbox_path)
 

--- a/tests/sandbox/test_skill_wait_status_standalone.py
+++ b/tests/sandbox/test_skill_wait_status_standalone.py
@@ -283,7 +283,7 @@ class TestSelfContained:
     def test_distinct_module_from_orch_cli(self) -> None:
         assert skill_wait_status is not orch_cli
         assert skill_wait_status.__file__ is None or "skills/sdlc/bin/wait-status" in str(
-            _SKILL_SCRIPT
+            skill_wait_status.__file__
         )
 
     def test_no_egg_imports(self) -> None:


### PR DESCRIPTION
Fixes #2971.

## Problem

`/sdlc`'s blocking-wait launcher `skills/sdlc/bin/wait-status` resolved the egg repo root from its own path (`$SCRIPT_DIR/../../..`) and required `$REPO_ROOT/.venv/bin/python` + `sandbox`/`shared` on `PYTHONPATH`. That only holds when the script runs from inside the egg checkout. Installed as a **global/user skill** (`~/.claude/skills/sdlc/`) — the normal way to install a reusable skill — `../../..` resolves to `~/.claude`, so the launcher can't find a `.venv` or `egg-orch` and exits 3 (`run 'make deps' first`) from any non-egg working directory. The Phase-3/S5 Monitor loop is then unusable when driving a pipeline for another repo's checkout.

## Root cause: the egg-checkout coupling was incidental, not essential

`egg-orch pipeline wait-status` is just a **stdlib HTTP long-poll** over the orchestrator's `/status/wait` route (`urllib` + `json`). It has no third-party deps and no required egg-package imports on that path (the one module-level `egg_config.constants` import is already `try/except`-guarded). So the launcher's hard requirement on a full egg checkout (`.venv` + `PYTHONPATH` + `../../..`) was over-coupling — every other phase of the skill already talks to the orchestrator over the wire via `mcp__egg__*` tools with no local checkout.

## Fix: self-contained launcher

Replace the bash launcher with a **self-contained, pure-stdlib Python script** — a faithful vendored copy of `egg_lib.orch_cli.cmd_pipeline_wait_status` (same loop, exit codes 0/1/2/3, Path-A emit, Path-B synthetic-terminal #2378). It needs **no `.venv`, no `PYTHONPATH`, no egg checkout** — only a reachable orchestrator (`EGG_ORCHESTRATOR_URL`, default `http://localhost:9849`). The `/sdlc` skill is now a true clone-free thin client: installable globally (or as a plugin), runnable from any cwd.

## Changes

- **`skills/sdlc/bin/wait-status`** — bash launcher → standalone stdlib client (importable + executable). Clearer "orchestrator unreachable at `<url>`" message on the transient-budget path.
- **`skills/sdlc/SKILL.md`** —
  - Invoke via `${CLAUDE_SKILL_DIR}/bin/wait-status` (the canonical, cwd-independent skill-dir placeholder; works project-vendored, global, or plugin) in both the `allowed-tools` line and the Monitor commands.
  - Drop "Run from the repo root" and the "wraps `egg-orch` … no setup beyond `make deps`" framing; add the `EGG_ORCHESTRATOR_URL` note, including that `localhost` is not reachable from inside the Claude Code Bash sandbox.
  - Decouple Seed-phase repo auto-detect from `$EGG_REPO_PATH` → plain `git remote get-url origin` / `--repo`. (Seed needs the *target* repo; the launcher needs the *egg* checkout — binding both to one env var would mis-target. The two are now decoupled.)
- **`docs/reference/agent-wait-patterns.md` §7.1** — update the launcher contract (self-contained; only `EGG_ORCHESTRATOR_URL`) and the exit-3 note (the old `.venv`/`egg-orch` env-setup preconditions are gone).
- **`sandbox/tests/test_skill_wait_status_standalone.py`** — drift guard. Drives **both** `cmd_pipeline_wait_status` implementations (the reference `egg_lib.orch_cli` and the vendored script, loaded via `SourceFileLoader`) through an identical 16-scenario mocked-`/status/wait` matrix and asserts identical **stdout JSON-lines + exit codes** (the wire contract Monitor consumes). Plus a `no-egg-imports` source assertion that pins the self-contained property.

## Trade-off

The standalone script forks the route-contract logic from `egg_lib.orch_cli`. The drift-guard test pins the fork to the source of truth so behavioral drift fails CI; if you change the loop's observable behavior in `orch_cli`, port it here until the test passes.

## Testing

- `sandbox/tests/test_skill_wait_status_standalone.py` — 23 passed (16-scenario parity matrix + absolute spot-checks + self-contained property checks).
- `sandbox/tests/test_pipeline_wait_status_cli.py` (unchanged source) — 29 passed.
- `make lint` — clean.
- Smoke: the script runs `--help` under bare system `python3` from an unrelated cwd with no `PYTHONPATH`/`.venv`.

`make test` was not run at the maintainer's request.

## Out of scope (possible follow-up)

`egg_lib.orch_cli.create_parser()` unconditionally imports `egg_lib.cli_push`, which is why a stdlib-only `python3 egg-orch …` fails for unrelated commands. Guarding that import would make `egg-orch` itself standalone-runnable, but it isn't needed for this fix.
