### PR TITLE
fix(orchestrator): preserve committed contract decisions when post-phase push fails (#2972)

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7033,8 +7033,14 @@ def _sync_worktree_with_remote(
     compatibility with non-pipeline scripts.
 
     When local is ahead of remote:
-    - If the prior phase succeeded, push local commits to remote first,
-      then reset to origin (preserves completed work).
+    - If the prior phase succeeded, push local commits to remote first.
+      On a successful push, reset to origin (a no-op fast-forward that
+      keeps the worktree clean).  If the push FAILS, the local commits
+      are preserved as-is and the function returns without resetting —
+      ``remote_ahead == 0`` means origin holds nothing to incorporate, so
+      a ``reset --hard origin`` would only discard completed, committed
+      work (e.g. agent-registered HITL contract decisions) before the
+      phase_gate decision bridge could surface them (#2972).
     - If the prior phase failed or was killed, discard local commits and
       reset to remote (discards incomplete work).
 
@@ -7255,6 +7261,24 @@ def _sync_worktree_with_remote(
                 )
                 return WorktreeSyncOutcome(case="local_ahead_pushed")
             else:
+                # Push failed.  ``remote_ahead == 0`` in this branch, so
+                # origin holds nothing the worktree lacks — resetting to
+                # origin here would discard the completed, committed local
+                # work (e.g. the agent-registered HITL contract decisions
+                # the pre-sync ``_commit_statefiles_to_worktree`` just
+                # committed) for ZERO reconcile benefit, then advance
+                # silently.  That is exactly how #2972 dropped a refiner's
+                # ``register_open_question`` / ``request_feedback`` items
+                # before the phase_gate decision bridge could surface them:
+                # the prior code fell through to the Step-4 ``reset --hard``
+                # and returned ``reset_succeeded`` (``hard_reset_performed``
+                # False), so no operator signal fired.  Preserve the local
+                # commits instead — they remain in the worktree for
+                # downstream reads (the decision bridge, populator) and for
+                # the next push attempt.  The WARNING below is the loud
+                # breadcrumb that the tip is unpushed; unlike the divergence
+                # path (``remote_ahead > 0``) there is no remote work to
+                # rebase onto, so non-destructive preservation is correct.
                 logger.warning(
                     "worktree_sync_outcome",
                     pipeline_id=pipeline_id,
@@ -7266,6 +7290,7 @@ def _sync_worktree_with_remote(
                     category=push_result.category,
                     error=push_result.detail,
                 )
+                return WorktreeSyncOutcome(case="local_ahead_push_failed")
         else:
             # Prior phase failed — incomplete local work will be discarded by
             # the step-4 reset. Emit a distinct case so operators can grep
@@ -7280,8 +7305,10 @@ def _sync_worktree_with_remote(
                 local_ahead=local_ahead,
                 remote_ahead=remote_ahead,
             )
-        # Fall through to reset (Step 4) — discards local work when prior phase
-        # failed, or recovers via reset after a push failure.
+        # Fall through to reset (Step 4) — discards incomplete local work
+        # from a failed/killed prior phase.  (The successful-phase
+        # push-failure case returns above without resetting so completed
+        # work is never silently dropped — #2972.)
 
     elif local_ahead > 0 and remote_ahead > 0:
         # True divergence.  Reconcile by rebasing local commits onto

--- a/orchestrator/tests/test_contract_preserved_across_post_phase_sync.py
+++ b/orchestrator/tests/test_contract_preserved_across_post_phase_sync.py
@@ -8,24 +8,35 @@ contract file in the *shared* pipeline worktree at
 on disk.
 
 At phase end, the orchestrator runs ``_sync_worktree_with_remote`` to
-incorporate agent-pushed drafts/code from origin.  Two paths through that
-helper run ``git reset --hard origin/<branch>`` and so will discard
-uncommitted working-tree changes:
+incorporate agent-pushed drafts/code from origin.  Historically two
+paths through that helper ran ``git reset --hard origin/<branch>`` and
+so discarded the agent's contract writes:
 
 * ``local_ahead == 0 and remote_ahead > 0`` (local-behind) — falls
-  through to the step-4 reset.
+  through to the step-4 reset.  **Fixed by #2488**: committing
+  ``.egg-state/`` ahead of the sync turns this into a "diverged"
+  (``local_ahead > 0 and remote_ahead > 0``) state, which the helper
+  resolves via rebase rather than reset — preserving the change in the
+  canonical way.
 * ``local_ahead > 0 and remote_ahead == 0`` plus ``prior_phase_succeeded``
-  with a failed push — also falls through to the step-4 reset.
+  with a failed push — fell through to the step-4 reset even though the
+  contract decisions were already committed, silently discarding
+  completed work for zero reconcile benefit (origin had nothing the
+  worktree lacked).  This is what dropped a refiner's registered
+  decisions in ``pipeline-8cf1f000`` before the bridge could surface
+  them.  **Fixed by #2972**: the helper now returns without resetting on
+  a failed push when ``remote_ahead == 0``, preserving the committed
+  local commits in place.
 
 Without intervention, the agent's contract decisions are wiped on those
 paths before the bridge (``_queue_and_await_contract_decisions``) has a
 chance to surface them.
 
-The fix: commit ``.egg-state/`` ahead of the sync so the agent's contract
-writes become part of the local branch tip and survive any subsequent
-reset/rebase.  The pre-sync commit also turns a "local-behind" state
-into a "diverged" state, which the helper resolves via rebase rather
-than reset — preserving the change in the canonical way.
+The #2488 fix is to commit ``.egg-state/`` ahead of the sync so the
+agent's contract writes become part of the local branch tip and survive
+any subsequent reset/rebase.  The #2972 fix complements it by keeping
+the helper from resetting that committed tip away when the post-phase
+push fails and there is no remote work to reconcile against.
 
 These tests use real git plumbing (no subprocess mocks) so the
 commit/sync interaction is verified against ground truth.  Test 1
@@ -220,6 +231,45 @@ def _make_gateway_stub_with_real_git(worktree: Path) -> MagicMock:
     return spawner
 
 
+def _make_gateway_stub_with_failing_push(worktree: Path) -> MagicMock:  # noqa: ARG001
+    """``spawner`` mock with a real fetch but a push that always fails.
+
+    Mirrors the ``pipeline-8cf1f000`` condition where the gateway's push
+    reconcile could not authenticate (``could not read Username for
+    'https://github.com'``) and returned a failed ``PushResult`` — so the
+    local-ahead, ``remote_ahead == 0`` branch must not reset committed
+    work away (#2972).
+    """
+    spawner = MagicMock()
+
+    def real_fetch(pipeline_id: str, repo_path: str, mode: str) -> bool:  # noqa: ARG001
+        result = subprocess.run(
+            ["git", "-C", repo_path, "fetch", "origin"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        return result.returncode == 0
+
+    def failing_push(
+        pipeline_id: str,  # noqa: ARG001
+        repo_path: str,  # noqa: ARG001
+        branch: str,  # noqa: ARG001
+        mode: str,  # noqa: ARG001
+        base_branch: str | None = None,  # noqa: ARG001
+    ) -> PushResult:
+        return PushResult(
+            ok=False,
+            category="reconcile_fetch_failed",
+            detail="fatal: could not read Username for 'https://github.com'",
+        )
+
+    spawner.gateway.fetch_worktree_branch.side_effect = real_fetch
+    spawner.gateway.push_worktree_branch.side_effect = failing_push
+    return spawner
+
+
 def test_uncommitted_contract_decisions_lost_when_sync_resets_without_pre_commit(
     tmp_path: Path,
 ) -> None:
@@ -338,3 +388,59 @@ def test_real_sync_helper_loses_decisions_without_pre_sync_commit(
         "local-behind path resets to origin and discards the agent's "
         "uncommitted contract decision — the bug fixed in #2488."
     )
+
+
+def test_push_failure_preserves_committed_decisions_without_reset(
+    tmp_path: Path,
+) -> None:
+    """Regression for #2972: a failed post-phase push must not reset away
+    committed contract decisions when ``remote_ahead == 0``.
+
+    Reproduces the ``pipeline-8cf1f000`` refine boundary: the agent's
+    decision is committed by the pre-sync ``_commit_statefiles_to_worktree``
+    (#2488), so the worktree is ``local_ahead == 1``.  No agent draft
+    advances origin, so ``remote_ahead == 0``.  The gateway push then
+    fails (credential error).  Previously the helper fell through to
+    ``git reset --hard origin/<branch>`` and silently discarded the
+    decision commit (``reset_succeeded``, ``hard_reset_performed`` False),
+    leaving the decision bridge nothing to surface.  The fix returns
+    ``local_ahead_push_failed`` without resetting, so the decision
+    survives in the worktree for the bridge.
+    """
+    worktree, _remote, branch, identifier = _setup_repo_with_remote(tmp_path)
+    # Deliberately do NOT push an agent draft to origin: origin stays at
+    # the bootstrap contract so the worktree is local-ahead / remote==0.
+
+    contract_path = _agent_writes_decision_to_contract(worktree, identifier)
+    expected_body = contract_path.read_text()
+
+    # Pre-sync commit (the #2488 step) — captures the decision into the tip.
+    _commit_statefiles_to_worktree(
+        worktree,
+        "Persist agent statefile writes before refine sync",
+        pipeline_identifier=42,
+        pipeline_id=identifier,
+    )
+    head_before = _git("rev-parse", "HEAD", cwd=worktree).stdout.strip()
+
+    spawner = _make_gateway_stub_with_failing_push(worktree)
+    outcome = _sync_worktree_with_remote(
+        spawner,
+        identifier,
+        worktree,
+        prior_phase_succeeded=True,
+        gateway_mode="public",
+        base_branch="main",
+        pipeline_branch=branch,
+    )
+
+    # The push was attempted and failed.
+    spawner.gateway.push_worktree_branch.assert_called_once()
+    # The committed decision survived — no destructive reset ran.
+    assert outcome.case == "local_ahead_push_failed"
+    assert outcome.hard_reset_performed is False
+    assert contract_path.read_text() == expected_body
+    assert "decision-1" in contract_path.read_text()
+    # HEAD is unchanged: the local-ahead commit was preserved, not reset.
+    head_after = _git("rev-parse", "HEAD", cwd=worktree).stdout.strip()
+    assert head_after == head_before

--- a/orchestrator/tests/test_sync_worktree.py
+++ b/orchestrator/tests/test_sync_worktree.py
@@ -164,8 +164,16 @@ class TestSyncWorktreeWithRemote:
             # Already-in-sync skips the step-4 reset entirely.
             assert mock_run.call_count == 3
 
-    def test_push_fails_continues_with_reset(self):
-        """(e) push fails → logs warning, continues with reset."""
+    def test_push_fails_preserves_local_without_reset(self):
+        """(e) push fails + prior phase succeeded → preserve local, NO reset.
+
+        Regression for #2972: ``remote_ahead == 0`` means origin holds
+        nothing the worktree lacks, so a ``reset --hard origin`` after a
+        failed push would silently discard the completed, committed local
+        work (e.g. the agent-registered HITL contract decisions the
+        pre-sync commit just persisted) before the phase_gate decision
+        bridge could surface them.  The function must NOT reset here.
+        """
         spawner = _make_spawner(push_ok=False)
         with (
             patch("routes.pipelines.subprocess.run") as mock_run,
@@ -178,10 +186,8 @@ class TestSyncWorktreeWithRemote:
                 _make_subprocess_result(returncode=0),
                 # Step 3b: local is 2 ahead, 0 behind
                 _make_subprocess_result(stdout="2\t0\n"),
-                # Step 4: reset succeeds (after push failure)
-                _make_subprocess_result(returncode=0),
             ]
-            _sync_worktree_with_remote(
+            outcome = _sync_worktree_with_remote(
                 spawner,
                 "pipe-1",
                 Path("/tmp/repo"),
@@ -189,10 +195,16 @@ class TestSyncWorktreeWithRemote:
             )
             # Push was attempted but failed
             spawner.gateway.push_worktree_branch.assert_called_once()
-            # Warning logged about push failure
+            # Warning logged about the unpushed tip
             mock_logger.warning.assert_called()
-            # Reset still happened
-            assert mock_run.call_count == 4
+            # No reset — the local-ahead commits are preserved (only steps
+            # 2, 3, 3b ran; step 4 reset would be call #4).
+            assert mock_run.call_count == 3
+            reset_calls = [c for c in mock_run.call_args_list if "reset" in c[0][0]]
+            assert reset_calls == []
+            # Outcome reports the failed push without a destructive reset.
+            assert outcome.case == "local_ahead_push_failed"
+            assert outcome.hard_reset_performed is False
 
     def test_diverged_attempts_rebase(self):
         """(f) diverged → calls the rebase helper (#2337)."""
@@ -586,8 +598,15 @@ class TestSyncWorktreeOutcomeTaxonomy:
             )
         assert _outcome_cases(mock_logger) == ["local_ahead_pushed"]
 
-    def test_case_local_ahead_push_failed_falls_through_to_reset(self):
-        """Push failure emits local_ahead_push_failed, then step 4 emits reset_succeeded."""
+    def test_case_local_ahead_push_failed_preserves_without_reset(self):
+        """Push failure emits local_ahead_push_failed and returns — no reset (#2972).
+
+        ``remote_ahead == 0`` means origin holds nothing the worktree
+        lacks, so resetting after a failed push would only discard the
+        committed local work.  The taxonomy must therefore show
+        ``local_ahead_push_failed`` alone, with no trailing
+        ``reset_succeeded``.
+        """
         spawner = _make_spawner(push_ok=False)
         with (
             patch("routes.pipelines.subprocess.run") as mock_run,
@@ -597,15 +616,15 @@ class TestSyncWorktreeOutcomeTaxonomy:
                 _make_subprocess_result(stdout="egg/issue-42\n"),
                 _make_subprocess_result(returncode=0),
                 _make_subprocess_result(stdout="2\t0\n"),
-                _make_subprocess_result(returncode=0),
             ]
-            _sync_worktree_with_remote(
+            outcome = _sync_worktree_with_remote(
                 spawner, "pipe-1", Path("/tmp/repo"), prior_phase_succeeded=True
             )
-        assert _outcome_cases(mock_logger) == [
-            "local_ahead_push_failed",
-            "reset_succeeded",
-        ]
+        assert _outcome_cases(mock_logger) == ["local_ahead_push_failed"]
+        assert outcome.case == "local_ahead_push_failed"
+        assert outcome.hard_reset_performed is False
+        # No step-4 reset ran (only steps 2, 3, 3b).
+        assert mock_run.call_count == 3
         # PushResult diagnostics are propagated into the structured log so
         # operators don't need to pull gateway-side logs for the failure mode.
         push_failed_call = next(


### PR DESCRIPTION
## Summary

Closes the silent data-loss path behind #2972: refiner-registered HITL decisions (`register_open_question` / `request_feedback`) were dropped before the phase_gate decision bridge could surface them, so the operator never got Wave 2 and the pipeline advanced straight to `plan`.

**Two-wave surfacing was never broken** — `_queue_and_await_contract_decisions()` is implemented and is called inline right after the phase_gate `approve`, before the phase advances. It just read an **empty contract**, because the decisions had already been wiped out of the shared worktree by the post-phase worktree sync.

## Root cause (confirmed against `pipeline-8cf1f000`)

The decisions *were* persisted to the shared worktree (the reviewer confirmed them mid-refine) and *were* committed before the sync by the #2488 "commit before sync" guard. They were then discarded by `_sync_worktree_with_remote`:

- At the **refine** boundary: `local_ahead=1, remote_ahead=0`, and the push to origin **failed** (`reconcile_fetch_failed` — `fatal: could not read Username for 'https://github.com'`). The helper fell through to the Step-4 `git reset --hard origin/<branch>` and returned `reset_succeeded` with `hard_reset_performed=False` → **no operator signal**, decisions gone, advance to `plan`.
- At the **plan** boundary the *same* underlying divergence (`remote_ahead=5`) routed through `divergence_recovered_via_reset` → `hard_reset_performed=True` → a **loud** HITL ack (decision-2, `hard_reset_recovery:plan`). 

That contrast pinpoints the gap: the divergence-rebase-failed reset is loud, but the **push-failed / local-ahead reset is silent**, even though both discard committed work.

The #2488 guard only protected the *rebase* path (it turns local-behind into diverged → rebase). When `remote_ahead == 0` and the push fails, origin has nothing the worktree lacks, so the reset is **pure data loss for zero reconcile benefit**.

## Fix

In `_sync_worktree_with_remote`, when the prior phase succeeded, `local_ahead > 0`, `remote_ahead == 0`, and the push **fails**: return `local_ahead_push_failed` **without resetting**. The committed local commits stay in the worktree for downstream reads (the decision bridge, populator) and the next push attempt; the existing `WARNING` log remains the breadcrumb that the tip is unpushed. The intended-discard case (prior phase failed) still falls through to the Step-4 reset.

This is non-destructive and matches the codebase's "fail loud, don't silently destroy" posture (#2337 / #2627 / #2792).

## Tests

- `test_sync_worktree.py`: flip `test_push_fails_*` and the outcome-taxonomy test to assert **no reset** on push failure (`mock_run.call_count == 3`, outcome `local_ahead_push_failed`, `hard_reset_performed is False`).
- `test_contract_preserved_across_post_phase_sync.py`: add a **real-git** regression (`test_push_failure_preserves_committed_decisions_without_reset`) that commits a decision, fails the push with `remote_ahead == 0`, and asserts the decision and HEAD survive. Module docstring updated to record that the push-failed path is now fixed (#2972) alongside the #2488 pre-commit fix.

`make test` (changeset-aware) green: 17508 passed, 0 failed. `make lint` clean.

## Out of scope / follow-ups

- The **trigger** in `pipeline-8cf1f000` was an environmental git-credential failure on the gateway push reconcile (`could not read Username for https://github.com`) plus an unresolvable PR base branch (`jwbron-claude-md`). That's a separate gateway/credential concern; this PR only stops the silent decision loss it caused.
- The `rev_list_failed` Step-4 fall-through can also reset away local-ahead work, but it can't determine `local_ahead` (that's what failed), so it's left as-is — a rarer, separately-tracked gap.