### PR TITLE
fix(orchestrator): unwrap choice envelope in hard-reset recovery HITL dispatch (#2978)

### DIFF
--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -88,7 +88,7 @@ Before each pipeline phase starts, the orchestrator syncs the agent worktree wit
 
 - **Prior phase succeeded + local ahead of remote:** Local commits are pushed to remote before resetting, preserving completed work.
 - **Prior phase failed + local ahead of remote:** Local commits are discarded and the worktree is reset to remote, removing incomplete work.
-- **Local and remote diverged:** A fast-forward merge is attempted. If the merge fails, the orchestrator logs an error and leaves the worktree unchanged (may require manual intervention).
+- **Local and remote diverged:** Local commits are rebased onto `origin/<branch>`, auto-resolving conflicts confined to `.egg-state/agent-outputs/` in favor of the remote. If the rebase cannot reconcile (a conflict outside that path), the orchestrator pins the local-only commits under a backup ref (`refs/egg-backup/sync-recovery/<pipeline_id>/<ts>`), hard-resets the worktree to `origin/<branch>`, marks the pipeline FAILED, and surfaces a hard-reset recovery HITL ack (#2792/#2797). _Note: this destructive recovery is being redesigned to reconcile non-destructively — see #2979._
 - **Local behind or in-sync with remote:** Standard reset to remote tip.
 
 ### HITL Decisions

--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -162,6 +162,14 @@ def _normalize_choice_resolution(resolution: str) -> str:
     reads as an unrecognized option.  Bare-string resolutions (legacy /
     direct-API callers) and any other shape pass through unchanged so
     the caller's existing matching still runs.
+
+    Audit-trail note: this is a dispatch-side unwrap only.  The
+    persisted ``decision.resolution`` (and the ``DECISION_RESOLVED``
+    event / API response payload) still carries the raw envelope JSON
+    as the operator sent it.  Only the in-process value routed to the
+    Restart-agent / Continue-without / conditional-ACK / hard-reset
+    dispatch helpers — and any subsequent log line that echoes it — is
+    the normalized form.
     """
     if not resolution:
         return resolution
@@ -232,6 +240,8 @@ def _handle_hard_reset_recovery_resolution(
     # (routes.pipelines imports routes.decisions via the blueprint
     # registration path in some test setups).
     from routes.pipelines import (
+        _HARD_RESET_RECOVERY_ABORT,
+        _HARD_RESET_RECOVERY_CONTINUE,
         abort_pipeline_after_hard_reset_ack,
         resume_pipeline_after_hard_reset_ack,
     )
@@ -251,7 +261,7 @@ def _handle_hard_reset_recovery_resolution(
             f"(received: {resolution[:80]!r}; available: {valid_options!r})"
         )
 
-    if option_mismatch_reason is None and resolution == "Continue with post-reset state":
+    if option_mismatch_reason is None and resolution == _HARD_RESET_RECOVERY_CONTINUE:
         ok = resume_pipeline_after_hard_reset_ack(
             pipeline_id,
             phase_value=phase_value,
@@ -262,7 +272,7 @@ def _handle_hard_reset_recovery_resolution(
                 pipeline_id=pipeline_id,
                 phase=phase_value,
             )
-    elif option_mismatch_reason is None and resolution == "Abort pipeline":
+    elif option_mismatch_reason is None and resolution == _HARD_RESET_RECOVERY_ABORT:
         ok = abort_pipeline_after_hard_reset_ack(pipeline_id)
         if not ok:
             logger.warning(
@@ -297,7 +307,8 @@ def _handle_hard_reset_recovery_resolution(
                 alert_body = (
                     "Hard-reset recovery HITL resolved with an unrecognized "
                     f"option (received: {resolution[:80]!r}). Expected one of "
-                    "'Continue with post-reset state' or 'Abort pipeline'. The "
+                    f"{_HARD_RESET_RECOVERY_CONTINUE!r} or "
+                    f"{_HARD_RESET_RECOVERY_ABORT!r}. The "
                     "decision is marked RESOLVED but no dispatch ran; the "
                     "pipeline will stay in failed_pending_hitl until the "
                     "operator re-resolves with a valid option."
@@ -930,6 +941,16 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
             source=getattr(request, "egg_source", "unknown"),
         )
 
+        # #2978: normalize the choice envelope once at the dispatch
+        # boundary so every dispatch hook below sees the bare option
+        # label instead of the ``{"action": "select", "selected": ...}``
+        # envelope the SDLC HITL CLI sends.  ``decision.resolution``
+        # (persisted on disk, emitted on ``DECISION_RESOLVED``, and
+        # returned in the API response) is intentionally unchanged —
+        # the audit trail keeps the raw envelope while dispatch routes
+        # on the unwrapped label.
+        dispatch_resolution = _normalize_choice_resolution(decision.resolution or "")
+
         try:
             emit_event(
                 EventType.DECISION_RESOLVED,
@@ -952,17 +973,17 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
         #   "Agent <role> issue: <message>"
         # When the human resolves with "Restart agent", stop the old
         # container and respawn a replacement.
-        if decision.resolution == "Restart agent":
+        if dispatch_resolution == "Restart agent":
             _handle_restart_agent(pipeline_id, decision.question)
 
         # Handle the conditional-ACK 3-way HITL gate (#2004). Context
         # prefix is the discriminator — the question text is arbitrary
         # prose and mustn't be relied on for dispatch.
-        if decision.context and decision.resolution:
+        if decision.context and dispatch_resolution:
             _handle_conditional_ack_gate(
                 pipeline_id,
                 decision.context,
-                decision.resolution,
+                dispatch_resolution,
                 store.repo_path,
             )
 
@@ -970,7 +991,7 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
         # The concurrent executor stores "failed_role:<role>" in the decision
         # context when a reviewer crashes. Excuse the reviewer so consensus
         # can proceed without their ACK.
-        if decision.resolution == "Continue without" and decision.context.startswith(
+        if dispatch_resolution == "Continue without" and decision.context.startswith(
             "failed_role:"
         ):
             failed_role = decision.context.removeprefix("failed_role:")
@@ -1006,7 +1027,7 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
             _handle_hard_reset_recovery_resolution(
                 pipeline_id,
                 decision.context,
-                decision.resolution or "",
+                dispatch_resolution,
                 valid_options=list(decision.options or []),
             )
 

--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -150,6 +150,32 @@ def _handle_restart_agent(pipeline_id: str, question: str) -> None:
         )
 
 
+def _normalize_choice_resolution(resolution: str) -> str:
+    """Unwrap a structured ``choice`` envelope to its bare option label (#2978).
+
+    The local SDLC HITL CLI resolves a ``choice`` decision by sending
+    ``{"action": "select", "selected": "<option>"}`` (see
+    ``sandbox/egg_lib/sdlc_hitl.py``); :func:`resolve_decision`
+    JSON-serializes that dict into ``decision.resolution``.  Dispatch
+    hooks that compare the resolution against bare option labels must
+    unwrap the envelope first — otherwise every structured selection
+    reads as an unrecognized option.  Bare-string resolutions (legacy /
+    direct-API callers) and any other shape pass through unchanged so
+    the caller's existing matching still runs.
+    """
+    if not resolution:
+        return resolution
+    try:
+        payload = json.loads(resolution)
+    except json.JSONDecodeError, TypeError:
+        return resolution
+    if isinstance(payload, dict) and payload.get("action") == "select":
+        selected = payload.get("selected")
+        if isinstance(selected, str):
+            return selected
+    return resolution
+
+
 def _handle_hard_reset_recovery_resolution(
     pipeline_id: str,
     context: str,
@@ -190,6 +216,17 @@ def _handle_hard_reset_recovery_resolution(
     will stay stuck in ``failed_pending_hitl`` until someone intervenes.
     """
     phase_value = context.removeprefix("hard_reset_recovery:")
+
+    # #2978: the SDLC HITL CLI resolves a ``choice`` decision by sending a
+    # ``{"action": "select", "selected": "<option>"}`` envelope, which
+    # ``resolve_decision`` serializes into ``decision.resolution``.  Unwrap
+    # it to the bare option label BEFORE the ``valid_options`` cross-check
+    # and the Continue/Abort compares below — otherwise the JSON string
+    # matches neither, every structured selection routes to the
+    # unrecognized-option path, and the pipeline stays wedged in
+    # ``failed_pending_hitl`` (the phase-gate path already unwraps this
+    # envelope in ``routes.pipelines``).
+    resolution = _normalize_choice_resolution(resolution)
 
     # Local import to avoid circular import at module load
     # (routes.pipelines imports routes.decisions via the blueprint

--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -175,7 +175,7 @@ def _normalize_choice_resolution(resolution: str) -> str:
         return resolution
     try:
         payload = json.loads(resolution)
-    except json.JSONDecodeError, TypeError:
+    except json.JSONDecodeError:
         return resolution
     if isinstance(payload, dict) and payload.get("action") == "select":
         selected = payload.get("selected")
@@ -381,6 +381,13 @@ def _handle_conditional_ack_gate(
         CONDITIONAL_ACK_GATE_MARKER,
         CONDITIONAL_ACK_REJECT,
     )
+
+    # #2978: defense-in-depth — unwrap the ``choice`` envelope so a future
+    # direct caller bypassing ``resolve_decision``'s dispatch-boundary
+    # normalization still sees the bare option label below.  Idempotent on
+    # already-unwrapped strings; mirrors the same call in
+    # ``_handle_hard_reset_recovery_resolution``.
+    resolution = _normalize_choice_resolution(resolution)
 
     if not context.startswith(CONDITIONAL_ACK_GATE_MARKER):
         return

--- a/orchestrator/tests/test_conditional_ack_hitl_gate.py
+++ b/orchestrator/tests/test_conditional_ack_hitl_gate.py
@@ -362,6 +362,115 @@ class TestResolutionDispatch:
         mock_invalidate.assert_called_once_with("pipeline-x", conditions)
 
     @patch("routes.decisions._persist_deferred_actions")
+    @patch("routes.decisions.get_state_store_for_pipeline")
+    @patch("routes.decisions.get_decision_queue")
+    def test_approve_envelope_persists_deferred_actions(
+        self,
+        mock_get_queue,
+        mock_get_store_for_pipeline,
+        mock_persist,
+        client,
+        tmp_path,
+    ):
+        """#2978: the SDLC HITL CLI wraps the choice as
+        ``{"action": "select", "selected": "<option>"}``.  The dispatch
+        must unwrap that envelope before comparing against
+        ``CONDITIONAL_ACK_APPROVE`` — otherwise the operator's selection
+        falls into the unrecognized-option branch and the obligations
+        are never written to ``contract.pr.deferred_actions``.
+        """
+        conditions = [
+            {"reviewer": "reviewer_code", "producer": "coder", "condition": "git mv X Y"},
+        ]
+        envelope = json.dumps({"action": "select", "selected": CONDITIONAL_ACK_APPROVE})
+        resolved = HITLDecision(
+            id="decision-1",
+            question="conditional ACK",
+            status=DecisionStatus.RESOLVED,
+            resolution=envelope,
+            context=self._gate_context(conditions),
+        )
+        mock_store = MagicMock(repo_path=tmp_path)
+        mock_get_store_for_pipeline.return_value = (mock_store, MagicMock())
+        mock_get_queue.return_value.resolve_decision.return_value = resolved
+
+        resp = client.post(
+            "/api/v1/pipelines/pipeline-x/decisions/decision-1/resolve",
+            json={"resolution": {"action": "select", "selected": CONDITIONAL_ACK_APPROVE}},
+        )
+        assert resp.status_code == 200
+        mock_persist.assert_called_once_with("pipeline-x", conditions, tmp_path)
+
+    @patch("routes.decisions._force_nack_conditional_edges")
+    @patch("routes.decisions.get_state_store_for_pipeline")
+    @patch("routes.decisions.get_decision_queue")
+    def test_reject_envelope_force_nacks_edges(
+        self,
+        mock_get_queue,
+        mock_get_store_for_pipeline,
+        mock_force_nack,
+        client,
+        tmp_path,
+    ):
+        """Reject through the envelope must still drive force-NACK."""
+        conditions = [
+            {"reviewer": "reviewer_code", "producer": "coder", "condition": "git mv X Y"},
+        ]
+        envelope = json.dumps({"action": "select", "selected": CONDITIONAL_ACK_REJECT})
+        resolved = HITLDecision(
+            id="decision-1",
+            question="conditional ACK",
+            status=DecisionStatus.RESOLVED,
+            resolution=envelope,
+            context=self._gate_context(conditions),
+        )
+        mock_store = MagicMock(repo_path=tmp_path)
+        mock_get_store_for_pipeline.return_value = (mock_store, MagicMock())
+        mock_get_queue.return_value.resolve_decision.return_value = resolved
+
+        resp = client.post(
+            "/api/v1/pipelines/pipeline-x/decisions/decision-1/resolve",
+            json={"resolution": {"action": "select", "selected": CONDITIONAL_ACK_REJECT}},
+        )
+        assert resp.status_code == 200
+        mock_force_nack.assert_called_once_with("pipeline-x", conditions)
+
+    @patch("routes.decisions._invalidate_conditional_acks")
+    @patch("routes.decisions.get_state_store_for_pipeline")
+    @patch("routes.decisions.get_decision_queue")
+    def test_address_envelope_invalidates_acks(
+        self,
+        mock_get_queue,
+        mock_get_store_for_pipeline,
+        mock_invalidate,
+        client,
+        tmp_path,
+    ):
+        """Address-in-pipeline through the envelope must still
+        invalidate the conditioning ACK so the producer re-proposes."""
+        conditions = [
+            {"reviewer": "reviewer_code", "producer": "coder", "condition": "git mv X Y"},
+        ]
+        envelope = json.dumps({"action": "select", "selected": CONDITIONAL_ACK_ADDRESS})
+        resolved = HITLDecision(
+            id="decision-1",
+            question="conditional ACK",
+            status=DecisionStatus.RESOLVED,
+            resolution=envelope,
+            context=self._gate_context(conditions),
+        )
+        mock_store = MagicMock(repo_path=tmp_path)
+        mock_get_store_for_pipeline.return_value = (mock_store, MagicMock())
+        mock_get_queue.return_value.resolve_decision.return_value = resolved
+
+        resp = client.post(
+            "/api/v1/pipelines/pipeline-x/decisions/decision-1/resolve",
+            json={"resolution": {"action": "select", "selected": CONDITIONAL_ACK_ADDRESS}},
+        )
+        assert resp.status_code == 200
+        mock_invalidate.assert_called_once_with("pipeline-x", conditions)
+
+    @patch("routes.decisions._persist_deferred_actions")
     @patch("routes.decisions._force_nack_conditional_edges")
     @patch("routes.decisions._invalidate_conditional_acks")
     @patch("routes.decisions.get_state_store_for_pipeline")

--- a/orchestrator/tests/test_decisions_routes.py
+++ b/orchestrator/tests/test_decisions_routes.py
@@ -819,6 +819,160 @@ class TestContinueWithoutExcusesReviewer:
         mock_get_tracker.assert_not_called()
 
 
+class TestChoiceEnvelopeDispatchNormalization:
+    """#2978: dispatch must unwrap the ``{"action": "select", "selected": ...}``
+    envelope before comparing against bare option labels.
+
+    The SDLC HITL CLI (`sandbox/egg_lib/sdlc_hitl.py`) wraps every
+    `choice` resolution in that envelope; ``resolve_decision`` serializes
+    it into ``decision.resolution``.  Bare-string compares against
+    ``"Restart agent"`` / ``"Continue without"`` would otherwise miss
+    every structured operator selection and silently drop the dispatch
+    while still marking the decision RESOLVED — wedging the pipeline.
+
+    The persisted ``decision.resolution`` (and the ``DECISION_RESOLVED``
+    event payload) intentionally still carry the raw envelope so the
+    audit trail records what the operator actually sent.
+    """
+
+    @patch("routes.decisions._handle_restart_agent")
+    @patch("routes.decisions.emit_event")
+    @patch("routes.decisions.get_state_store_for_pipeline")
+    @patch("routes.decisions.get_decision_queue")
+    def test_restart_agent_envelope_triggers_restart(
+        self,
+        mock_get_queue,
+        mock_get_store_for_pipeline,
+        mock_emit,
+        mock_handle_restart,
+        client,
+        tmp_path,
+    ):
+        """An envelope-wrapped ``Restart agent`` resolution must invoke
+        ``_handle_restart_agent``; bare-string compare misses it."""
+        import json
+
+        mock_get_store_for_pipeline.return_value = _mock_store_for_pipeline(tmp_path)
+        mock_queue = MagicMock()
+        envelope = json.dumps({"action": "select", "selected": "Restart agent"})
+        resolved_decision = _make_decision(
+            question="Agent reviewer_code issue: stalled",
+            status="resolved",
+            resolution=envelope,
+        )
+        resolved_decision.context = ""
+        mock_queue.resolve_decision.return_value = resolved_decision
+        mock_get_queue.return_value = mock_queue
+
+        response = client.post(
+            "/api/v1/pipelines/test-pipeline/decisions/decision-1/resolve",
+            json={"resolution": {"action": "select", "selected": "Restart agent"}},
+        )
+
+        assert response.status_code == 200
+        mock_handle_restart.assert_called_once_with(
+            "test-pipeline", "Agent reviewer_code issue: stalled"
+        )
+
+    @patch("routes.decisions._handle_restart_agent")
+    @patch("routes.decisions.emit_event")
+    @patch("routes.decisions.get_state_store_for_pipeline")
+    @patch("routes.decisions.get_decision_queue")
+    def test_resolution_persisted_as_envelope_for_audit_trail(
+        self,
+        mock_get_queue,
+        mock_get_store_for_pipeline,
+        mock_emit,
+        mock_handle_restart,
+        client,
+        tmp_path,
+    ):
+        """Even when dispatch unwraps the envelope, the persisted
+        ``decision.resolution`` and the ``DECISION_RESOLVED`` event keep
+        the raw envelope so the audit trail records exactly what the
+        operator sent.
+        """
+        import json
+
+        from events import EventType
+
+        mock_get_store_for_pipeline.return_value = _mock_store_for_pipeline(tmp_path)
+        mock_queue = MagicMock()
+        envelope = json.dumps({"action": "select", "selected": "Restart agent"})
+        resolved_decision = _make_decision(
+            question="Agent reviewer_code issue: stalled",
+            status="resolved",
+            resolution=envelope,
+        )
+        resolved_decision.context = ""
+        mock_queue.resolve_decision.return_value = resolved_decision
+        mock_get_queue.return_value = mock_queue
+
+        response = client.post(
+            "/api/v1/pipelines/test-pipeline/decisions/decision-1/resolve",
+            json={"resolution": {"action": "select", "selected": "Restart agent"}},
+        )
+
+        assert response.status_code == 200
+        # Dispatch ran on the unwrapped label.
+        mock_handle_restart.assert_called_once()
+        # The persisted/emitted payload kept the raw envelope.
+        assert response.get_json()["data"]["decision"]["resolution"] == envelope
+        mock_emit.assert_called_once_with(
+            EventType.DECISION_RESOLVED,
+            pipeline_id="test-pipeline",
+            data={
+                "decision_id": "decision-1",
+                "resolution": envelope,
+            },
+        )
+
+    @patch("routes.decisions.get_peer_consensus_tracker")
+    @patch("routes.decisions.emit_event")
+    @patch("routes.decisions.get_state_store_for_pipeline")
+    @patch("routes.decisions.get_decision_queue")
+    def test_continue_without_envelope_calls_excuse_reviewer(
+        self,
+        mock_get_queue,
+        mock_get_store_for_pipeline,
+        mock_emit,
+        mock_get_tracker,
+        client,
+        tmp_path,
+    ):
+        """An envelope-wrapped ``Continue without`` on a
+        ``failed_role:<role>`` decision must still excuse the reviewer
+        so BRC consensus can proceed."""
+        import json
+
+        mock_get_store_for_pipeline.return_value = _mock_store_for_pipeline(tmp_path)
+        mock_queue = MagicMock()
+        envelope = json.dumps({"action": "select", "selected": "Continue without"})
+        resolved_decision = _make_decision(
+            status="resolved",
+            resolution=envelope,
+        )
+        resolved_decision.context = "failed_role:reviewer_code"
+        mock_queue.resolve_decision.return_value = resolved_decision
+        mock_get_queue.return_value = mock_queue
+
+        mock_tracker = MagicMock()
+        mock_tracker.excuse_reviewer.return_value = {
+            "status": "excused",
+            "role": "reviewer_code",
+            "affected_producers": ["coder"],
+        }
+        mock_get_tracker.return_value = mock_tracker
+
+        response = client.post(
+            "/api/v1/pipelines/test-pipeline/decisions/decision-1/resolve",
+            json={"resolution": {"action": "select", "selected": "Continue without"}},
+        )
+
+        assert response.status_code == 200
+        mock_tracker.excuse_reviewer.assert_called_once_with("reviewer_code")
+
+
 class TestCancelDecisionEndpoint:
     """Tests for POST cancel-decision endpoint."""
 

--- a/orchestrator/tests/test_hard_reset_recovery.py
+++ b/orchestrator/tests/test_hard_reset_recovery.py
@@ -17,6 +17,7 @@ dispatch wiring so a regression in either is caught by a unit test that
 doesn't need a real git worktree.
 """
 
+import json
 import subprocess
 import sys
 import threading
@@ -416,6 +417,109 @@ class TestDispatchResolution:
             )
 
         mock_resume.assert_called_once()
+
+
+class TestDispatchResolutionChoiceEnvelope:
+    """#2978: the dispatch must accept the structured ``choice`` envelope.
+
+    The SDLC HITL CLI resolves a choice decision by sending
+    ``{"action": "select", "selected": "<option>"}`` (see
+    ``sandbox/egg_lib/sdlc_hitl.py``); ``resolve_decision`` serializes that
+    into ``decision.resolution`` and the dispatch hook receives the JSON
+    string with the decision's ``options`` as ``valid_options``.  Before
+    #2978 the bare-string compare (and the ``valid_options`` cross-check)
+    matched neither, so every operator selection routed to the
+    unrecognized-option path and left the pipeline wedged in
+    ``failed_pending_hitl``.  These tests drive the real envelope through
+    the dispatch helper so that regression is caught without a live CLI.
+    """
+
+    def test_select_continue_envelope_triggers_resume_helper(self):
+        from routes.decisions import _handle_hard_reset_recovery_resolution
+
+        with (
+            patch(
+                "routes.pipelines.resume_pipeline_after_hard_reset_ack",
+                return_value=True,
+            ) as mock_resume,
+            patch(
+                "routes.pipelines.abort_pipeline_after_hard_reset_ack",
+                return_value=True,
+            ) as mock_abort,
+        ):
+            _handle_hard_reset_recovery_resolution(
+                "pipeline-abc",
+                "hard_reset_recovery:plan",
+                json.dumps({"action": "select", "selected": "Continue with post-reset state"}),
+                valid_options=["Continue with post-reset state", "Abort pipeline"],
+            )
+
+        mock_resume.assert_called_once()
+        assert mock_resume.call_args.kwargs["phase_value"] == "plan"
+        mock_abort.assert_not_called()
+
+    def test_select_abort_envelope_triggers_abort_helper(self):
+        from routes.decisions import _handle_hard_reset_recovery_resolution
+
+        with (
+            patch(
+                "routes.pipelines.resume_pipeline_after_hard_reset_ack",
+                return_value=True,
+            ) as mock_resume,
+            patch(
+                "routes.pipelines.abort_pipeline_after_hard_reset_ack",
+                return_value=True,
+            ) as mock_abort,
+        ):
+            _handle_hard_reset_recovery_resolution(
+                "pipeline-abc",
+                "hard_reset_recovery:plan",
+                json.dumps({"action": "select", "selected": "Abort pipeline"}),
+                # Doubly-failed HITL collapses options to Abort-only — the
+                # envelope must still dispatch through the cross-check.
+                valid_options=["Abort pipeline"],
+            )
+
+        mock_abort.assert_called_once_with("pipeline-abc")
+        mock_resume.assert_not_called()
+
+
+class TestNormalizeChoiceResolution:
+    """#2978: ``_normalize_choice_resolution`` unwraps the select envelope
+    and passes everything else through untouched."""
+
+    def test_unwraps_select_envelope(self):
+        from routes.decisions import _normalize_choice_resolution
+
+        assert (
+            _normalize_choice_resolution(
+                json.dumps({"action": "select", "selected": "Abort pipeline"})
+            )
+            == "Abort pipeline"
+        )
+
+    def test_bare_string_passes_through(self):
+        from routes.decisions import _normalize_choice_resolution
+
+        assert _normalize_choice_resolution("Abort pipeline") == "Abort pipeline"
+
+    def test_non_select_action_passes_through(self):
+        from routes.decisions import _normalize_choice_resolution
+
+        # A request_changes envelope isn't a bare label — leave it intact so
+        # the caller's existing (non-)matching is unchanged.
+        payload = json.dumps({"action": "request_changes", "feedback": "no"})
+        assert _normalize_choice_resolution(payload) == payload
+
+    def test_malformed_json_passes_through(self):
+        from routes.decisions import _normalize_choice_resolution
+
+        assert _normalize_choice_resolution("{not json") == "{not json"
+
+    def test_empty_string_passes_through(self):
+        from routes.decisions import _normalize_choice_resolution
+
+        assert _normalize_choice_resolution("") == ""
 
 
 class TestEmptyContractHitlWordingNoLongerNamesPriorPopulator:

--- a/orchestrator/tests/test_hard_reset_recovery.py
+++ b/orchestrator/tests/test_hard_reset_recovery.py
@@ -483,6 +483,51 @@ class TestDispatchResolutionChoiceEnvelope:
         mock_abort.assert_called_once_with("pipeline-abc")
         mock_resume.assert_not_called()
 
+    def test_select_continue_envelope_blocked_when_only_abort_allowed(self):
+        """#2978 coverage: envelope-form mirror of
+        ``test_continue_rejected_when_not_in_valid_options``.
+
+        The doubly-failed HITL collapses options to ``["Abort pipeline"]``
+        only.  A "Continue with post-reset state" selection wrapped in
+        the envelope must still be refused by the ``valid_options``
+        cross-check (the normalization runs *before* the cross-check),
+        and neither dispatch helper must be called.  This guards against
+        regression if normalization is ever moved or removed.
+        """
+        from routes.decisions import _handle_hard_reset_recovery_resolution
+
+        mock_store = MagicMock()
+        with (
+            patch(
+                "routes.pipelines.resume_pipeline_after_hard_reset_ack",
+                return_value=True,
+            ) as mock_resume,
+            patch(
+                "routes.pipelines.abort_pipeline_after_hard_reset_ack",
+                return_value=True,
+            ) as mock_abort,
+            patch("routes.decisions.logger") as mock_logger,
+            patch("message_store.get_message_store", return_value=mock_store),
+        ):
+            _handle_hard_reset_recovery_resolution(
+                "pipeline-abc",
+                "hard_reset_recovery:plan",
+                json.dumps({"action": "select", "selected": "Continue with post-reset state"}),
+                valid_options=["Abort pipeline"],
+            )
+
+        mock_resume.assert_not_called()
+        mock_abort.assert_not_called()
+        mock_logger.warning.assert_called()
+        mock_store.add_message.assert_called_once()
+        sent_msg = mock_store.add_message.call_args.args[0]
+        assert sent_msg.message_type == "OVERSEER_ALERT"
+        assert sent_msg.metadata.get("anomaly") == "hard_reset_recovery_unknown_resolution"
+        # Body should report the *unwrapped* label, not the envelope JSON,
+        # so the operator sees a recognizable option name in the alert.
+        assert "Continue with post-reset state" in sent_msg.body
+        assert "Abort pipeline" in sent_msg.body
+
 
 class TestNormalizeChoiceResolution:
     """#2978: ``_normalize_choice_resolution`` unwraps the select envelope


### PR DESCRIPTION
## Summary

Slice A of #2978: the hard-reset recovery HITL ack was **undispatchable** through
the standard SDLC flow, leaving pipelines wedged in `failed_pending_hitl`.

The SDLC HITL CLI resolves a `choice` decision by sending
`{"action": "select", "selected": "<option>"}` (`sandbox/egg_lib/sdlc_hitl.py:716`),
which `resolve_decision` serializes into `decision.resolution`. But
`_handle_hard_reset_recovery_resolution` (`orchestrator/routes/decisions.py`) did a
**bare-string** compare against `"Continue with post-reset state"` / `"Abort pipeline"`
*and* cross-checked the raw resolution against `valid_options`. The JSON envelope
matched neither → `OVERSEER_ALERT: hard-reset-recovery-unknown-resolution`, decision
marked RESOLVED, **no dispatch ran**, pipeline stuck (live repro on pipeline-8cf1f000:
the operator had to fall back to `cancel_task`).

The phase-gate path already unwraps this envelope (`routes/pipelines.py:18573`,
`22783`); the hard-reset dispatch was the one place that didn't.

## Changes

- **`routes/decisions.py`** — add `_normalize_choice_resolution`, which unwraps the
  `{"action": "select", "selected": ...}` envelope to its bare option label. Call it
  at the top of `_handle_hard_reset_recovery_resolution`, **before** the
  `valid_options` cross-check and the Continue/Abort compares. Bare-string (legacy /
  direct-API) and any non-`select` shape pass through unchanged.
- **`README.md`** — reconcile the stale pre-#2797 worktree-sync contract ("fast-forward
  merge … leaves the worktree unchanged") with the current
  rebase-then-hard-reset-recovery behavior, and point at the #2979 redesign.
- **`tests/test_hard_reset_recovery.py`** — drive the real JSON envelope through the
  dispatch helper (Continue + Abort, including the Abort-only doubly-failed
  `valid_options`), plus direct unit coverage of the normalizer. The prior dispatch
  tests only fed already-extracted bare strings, which is why the bug shipped green.

## Out of scope (tracked in #2979)

The destructive hard-reset reconcile itself — discarding committed work to a backup
ref and marking the pipeline FAILED post-consensus — and the self-inflicted plan-sync
divergence at the source. This PR only makes the *existing* recovery ack reachable.

## Test plan

- [x] `.venv/bin/pytest orchestrator/tests/test_hard_reset_recovery.py` — 36 passed
  (5 new envelope/normalizer tests).
- [x] `ruff check` + `ruff format --check` clean; pre-commit hooks pass.

Closes #2978.
