### PR TITLE
fix(deploy): bound docker store before k3s-import so GC stops evicting fresh images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -676,6 +676,18 @@ sudo-keepalive:
 # image is ~12 GB, so /tmp (tmpfs) would consume that much RAM.
 k3s-import: SHELL := /bin/bash
 k3s-import: sudo-keepalive  ## Import built images into k3s
+	@# Reclaim docker disk BEFORE the import. The loop below does, per image,
+	@# `docker save > /var/tmp/*.tar` + `ctr images import` -- briefly a second
+	@# AND third copy of the ~12 GB sandbox image on the shared root fs. If
+	@# docker's accumulated old tags + unbounded BuildKit cache already sit near
+	@# kubelet's image-GC high-water mark (~85%), that spike trips GC, which
+	@# evicts the freshly-imported, not-yet-referenced egg images mid-run and
+	@# aborts the deploy (see check-egg-images-present.sh). Bounding docker here,
+	@# keyed on the tag we are about to import, keeps the spike under the line.
+	@# Best-effort: a reclaim hiccup must not fail the import. Complements the
+	@# post-deploy reap-stale-egg-images.sh, which bounds the OTHER store (k3s
+	@# containerd); this one bounds docker.
+	@scripts/reclaim-docker-disk.sh "$(EGG_IMAGE_TAG)" || true
 	@set -euo pipefail; \
 	tmp=$$(mktemp -d -p /var/tmp egg-k3s-import.XXXXXX); \
 	trap 'rm -rf "$$tmp"' EXIT; \

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -436,20 +436,29 @@ If the state-store worktree is wedged (for example, after a state-volume reset t
    than `imageMinimumGCAge` (~2 min) and thus GC-eligible, while sandbox/litellm
    are still inside the immunity window.
 
-   The disk hog lives in **k3s's containerd** (`/var/lib/rancher/k3s/agent/containerd`),
-   a *different* store from docker's — so `docker system prune` frees the wrong
-   space and the next redeploy's import spike re-crosses the threshold. Reclaim
-   containerd space, then redeploy (which re-imports everything):
+   The disk hog is the **docker store** (`/var/lib/docker`, typically tens of GB
+   of old `egg-*:<tag>` images plus an unbounded BuildKit cache), NOT k3s's
+   containerd (`/var/lib/rancher/k3s/agent/containerd`, typically a few GB).
+   They live on the same root filesystem, and `k3s-import` briefly holds the
+   ~12 GB sandbox image in BOTH stores plus a tar in `/var/tmp` — that spike
+   crosses the GC threshold. `sudo k3s crictl rmi --prune` only drains the
+   smaller containerd store, so the disk needle never moves and the symptom
+   recurs on the next redeploy.
+
+   Reclaim **docker** disk, then redeploy (which re-imports everything):
 
    ```bash
-   sudo k3s crictl rmi --prune   # safe immediately before a redeploy
+   scripts/reclaim-docker-disk.sh "$(git describe --always --dirty)"
    df -h /                       # confirm well under 80%
    make redeploy
    ```
 
-   A successful deploy now reaps older egg tags from containerd automatically
-   (`scripts/reap-stale-egg-images.sh`), keeping it bounded to the current tag
-   so the threshold isn't crossed on subsequent redeploys.
+   `make k3s-import` now runs `scripts/reclaim-docker-disk.sh` automatically
+   before every import — it reaps stale `egg-*:<tag>` docker images (keeping
+   the current tag + `:latest`), prunes dangling images, and caps the BuildKit
+   cache (default 20 GB, override with `EGG_DOCKER_CACHE_MAX` set to a docker
+   byte-size string like `30GB`). A successful deploy ALSO reaps older egg tags from containerd
+   via `scripts/reap-stale-egg-images.sh`, so both stores stay bounded.
 
 ### Claude binary not found
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -457,8 +457,9 @@ If the state-store worktree is wedged (for example, after a state-volume reset t
    before every import — it reaps stale `egg-*:<tag>` docker images (keeping
    the current tag + `:latest`), prunes dangling images, and caps the BuildKit
    cache (default 20 GB, override with `EGG_DOCKER_CACHE_MAX` set to a docker
-   byte-size string like `30GB`). A successful deploy ALSO reaps older egg tags from containerd
-   via `scripts/reap-stale-egg-images.sh`, so both stores stay bounded.
+   byte-size string like `30GB`). A successful deploy ALSO reaps older egg tags
+   from containerd via `scripts/reap-stale-egg-images.sh`, so both stores stay
+   bounded.
 
 ### Claude binary not found
 

--- a/scripts/check-egg-images-present.sh
+++ b/scripts/check-egg-images-present.sh
@@ -47,12 +47,17 @@ if [ "${#missing[@]}" -gt 0 ]; then
   echo "          before 'deploy' repointed the pods at the new tag -- they sit" >&2
   echo "          unreferenced until then, so under disk pressure (root fs over" >&2
   echo "          imageGCHighThresholdPercent, ~85%) they get collected mid-run." >&2
-  echo "          Fix: reclaim space in k3s's containerd -- NOT docker, a separate" >&2
-  echo "          store 'docker system prune' does not touch -- then redeploy, which" >&2
-  echo "          re-imports everything:" >&2
-  echo "              sudo k3s crictl rmi --prune   # safe immediately before redeploy" >&2
-  echo "          'df -h /' should sit well under 80% before the import. A green deploy" >&2
-  echo "          now reaps older egg tags automatically (reap-stale-egg-images.sh)." >&2
+  echo "          The disk hog is the DOCKER store (/var/lib/docker, tens of GB of" >&2
+  echo "          old egg tags + BuildKit cache), NOT k3s's containerd (~4 GB) --" >&2
+  echo "          'docker save' + 'ctr import' briefly hold the sandbox image in" >&2
+  echo "          BOTH stores plus a tar in /var/tmp on the same root fs." >&2
+  echo "          Fix: reclaim docker disk, then redeploy (which re-imports):" >&2
+  echo "              scripts/reclaim-docker-disk.sh \"\$(git describe --always --dirty)\"" >&2
+  echo "              df -h /                       # should sit well under 80%" >&2
+  echo "              make redeploy" >&2
+  echo "          k3s-import now runs reclaim-docker-disk.sh automatically before" >&2
+  echo "          every import; if the spike still trips GC, lower the BuildKit cache" >&2
+  echo "          cap with EGG_DOCKER_CACHE_MAX (default 20GB)." >&2
   exit 1
 fi
 

--- a/scripts/reclaim-docker-disk.sh
+++ b/scripts/reclaim-docker-disk.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# reclaim-docker-disk.sh - Bound the *docker* image + BuildKit cache store so a
+# subsequent `make k3s-import` does not push the shared root filesystem over
+# kubelet's image-GC high-water mark.
+#
+# Why this exists (and why reap-stale-egg-images.sh is not enough):
+# egg keeps TWO image stores on ONE shared root filesystem --
+#   * k3s containerd  (/var/lib/rancher/k3s/agent/containerd) -- a few GB
+#   * docker          (/var/lib/docker)                       -- tens of GB
+# reap-stale-egg-images.sh bounds the FIRST after every deploy. Nothing bounded
+# the SECOND, so docker accumulated a full egg image set (incl. the ~12 GB
+# egg-sandbox) for every `git describe` tag ever built, plus an unbounded
+# BuildKit cache. That docker bloat alone keeps the root fs near
+# imageGCHighThresholdPercent (~85%). Then `make k3s-import` does, per image,
+# `docker save <img> > /var/tmp/*.tar` (a second ~12 GB copy of sandbox) AND
+# `k3s ctr images import` (a third copy, in containerd) -- a transient spike
+# that crosses the threshold, and kubelet image GC evicts the freshly-imported,
+# not-yet-referenced egg images mid-import. check-egg-images-present.sh then
+# aborts the deploy. The operator-facing symptom is a redeploy that "imported
+# fine" yet reports the tag's images missing from k3s. Reclaiming docker disk
+# BEFORE the import keeps that spike below the line.
+#
+# Two reclaims, both keyed on the about-to-be-imported KEEP_TAG:
+#   1. Stale egg-*:<tag> docker images (tag != KEEP_TAG and != latest).
+#   2. BuildKit cache capped to CACHE_MAX (keeps a hot working set for fast
+#      incremental builds while bounding unbounded growth).
+# A dangling-image prune mops up untagged layers left by rebuilds.
+#
+# Tag-scoped removal, UNLIKE the containerd reap -- and this difference is
+# load-bearing, do not "unify" the two scripts:
+#   * `crictl rmi <ref>` removes by image ID: a stale tag that shares an ID with
+#     KEEP_TAG would take the current image down with it, so that script needs a
+#     digest guard.
+#   * `docker image rm <repo:tag>` removes by NAME: if KEEP_TAG and a stale tag
+#     share an image ID, removing the stale tag merely untags it and the image
+#     survives under KEEP_TAG. So no digest guard is needed here.
+# We still require all KEEP_TAG refs present first, so a half-built tag never
+# leaves us with nothing to import.
+#
+# Best-effort: never fail the build/deploy (the Makefile guards the call with
+# `|| true`, and each removal below is individually tolerant). Needs NO sudo --
+# the docker socket is group-accessible, unlike the root-only containerd socket.
+#
+set -euo pipefail
+
+: "${1:?usage: $0 <egg-image-tag-to-keep>}"
+KEEP_TAG="$1"
+
+# Cap for the BuildKit cache. Big enough to keep a working set of layers for
+# fast incremental builds, small enough that it cannot creep the root fs toward
+# the GC threshold on its own. Override with EGG_DOCKER_CACHE_MAX (a docker
+# byte-size string, e.g. "30GB").
+CACHE_MAX="${EGG_DOCKER_CACHE_MAX:-20GB}"
+
+# The egg image set. Keep in sync ACROSS scripts with
+# check-egg-images-present.sh, the k3s-import image list, and
+# reap-stale-egg-images.sh.
+IMAGES=(egg-gateway egg-orchestrator egg-sandbox egg-litellm)
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "==> docker reclaim: docker not found on PATH; nothing to reclaim."
+  exit 0
+fi
+
+# Safety gate: only reap stale tags once EVERY egg-*:KEEP_TAG image is actually
+# built and present. An interrupted/failed build that left, say, egg-sandbox
+# untagged for KEEP_TAG must not let us reap the prior egg-sandbox tag -- that
+# would strand k3s-import with no sandbox image to save. Mirror of the
+# containerd reap's four-image gate.
+missing_keep=()
+for img in "${IMAGES[@]}"; do
+  if ! docker image inspect "${img}:${KEEP_TAG}" >/dev/null 2>&1; then
+    missing_keep+=("${img}:${KEEP_TAG}")
+  fi
+done
+
+if [ "${#missing_keep[@]}" -gt 0 ]; then
+  echo "==> docker reclaim: not all egg-*:${KEEP_TAG} images present (${missing_keep[*]}); skipping stale-tag reap."
+else
+  removed=0
+  for img in "${IMAGES[@]}"; do
+    # Every tag for this repo except KEEP_TAG and :latest. `docker image ls`
+    # with a repo argument lists only that repo; --format keeps it parseable.
+    while IFS= read -r ref; do
+      [ -z "$ref" ] && continue
+      tag="${ref##*:}"
+      if [ "$tag" = "$KEEP_TAG" ] || [ "$tag" = "latest" ]; then
+        continue
+      fi
+      if docker image rm "$ref" >/dev/null 2>&1; then
+        echo "   reaped $ref"
+        removed=$((removed + 1))
+      else
+        echo "   rm failed for $ref (in use or already gone); leaving it" >&2
+      fi
+    done < <(docker image ls --format '{{.Repository}}:{{.Tag}}' "$img" 2>/dev/null)
+  done
+  echo "==> docker reclaim: removed ${removed} stale egg image tag(s) beyond '${KEEP_TAG}'/latest."
+fi
+
+# Mop up untagged layers orphaned by rebuilds (an old image ID whose tag was
+# moved to a freshly-built image). No docker containers run on this host -- k3s
+# runs the pods -- so any dangling image is genuinely unreferenced.
+if docker image prune -f >/dev/null 2>&1; then
+  echo "==> docker reclaim: pruned dangling images."
+fi
+
+# Bound the BuildKit cache. --max-used-space (docker/buildx 23+) supersedes the
+# removed --keep-storage. Fall back to a plain dangling-cache prune on a docker
+# old enough to lack the flag.
+if docker builder prune -f --max-used-space "$CACHE_MAX" >/dev/null 2>&1; then
+  echo "==> docker reclaim: build cache capped at ${CACHE_MAX}."
+elif docker builder prune -f >/dev/null 2>&1; then
+  echo "==> docker reclaim: build cache pruned (dangling; --max-used-space unsupported)."
+fi

--- a/scripts/reclaim-docker-disk.sh
+++ b/scripts/reclaim-docker-disk.sh
@@ -100,15 +100,20 @@ else
 fi
 
 # Mop up untagged layers orphaned by rebuilds (an old image ID whose tag was
-# moved to a freshly-built image). No docker containers run on this host -- k3s
-# runs the pods -- so any dangling image is genuinely unreferenced.
+# moved to a freshly-built image). `docker image prune -f` is HOST-WIDE -- it
+# prunes any dangling image on this docker daemon, not just egg-* repos. That
+# is safe here only because no docker containers run on this host (k3s runs the
+# pods, see file header), so every dangling image is genuinely unreferenced. If
+# this script is ever reused on a workstation or any host with non-egg docker
+# workloads, narrow this to an egg-repo-scoped loop (e.g. iterate IMAGES and
+# run `docker image ls -qf dangling=true <repo>` per repo).
 if docker image prune -f >/dev/null 2>&1; then
   echo "==> docker reclaim: pruned dangling images."
 fi
 
-# Bound the BuildKit cache. --max-used-space (docker/buildx 23+) supersedes the
-# removed --keep-storage. Fall back to a plain dangling-cache prune on a docker
-# old enough to lack the flag.
+# Bound the BuildKit cache. --max-used-space (Buildx 0.17+, shipped with Docker
+# Engine 27.x and later) supersedes the now-deprecated --keep-storage. Fall
+# back to a plain dangling-cache prune on a docker old enough to lack it.
 if docker builder prune -f --max-used-space "$CACHE_MAX" >/dev/null 2>&1; then
   echo "==> docker reclaim: build cache capped at ${CACHE_MAX}."
 elif docker builder prune -f >/dev/null 2>&1; then

--- a/tests/scripts/test_reclaim_docker_disk.py
+++ b/tests/scripts/test_reclaim_docker_disk.py
@@ -33,7 +33,12 @@ BASH = shutil.which("bash") or "bash"
 
 
 def _write_docker_shim(
-    bindir: Path, images_file: Path, removed_file: Path, fail_ref: str = ""
+    bindir: Path,
+    images_file: Path,
+    removed_file: Path,
+    builder_args_file: Path,
+    fail_ref: str = "",
+    fail_max_used_space: bool = False,
 ) -> None:
     """Write a `docker` shim covering the subcommands the script invokes.
 
@@ -41,9 +46,13 @@ def _write_docker_shim(
     - `image ls --format .. <repo>`-> print images_file lines for <repo>
     - `image rm <ref>`             -> record <ref>; exit 1 iff <ref>==fail_ref
     - `image prune -f`             -> no-op success
-    - `builder prune ...`          -> no-op success
+    - `builder prune ...`          -> record args; exit 1 iff fail_max_used_space
+                                       AND `--max-used-space` is in the args
+                                       (simulates an old docker that lacks the
+                                       flag). Otherwise success.
     """
     docker = bindir / "docker"
+    fail_mus = "1" if fail_max_used_space else "0"
     docker.write_text(
         "#!/usr/bin/env bash\n"
         "set -u\n"
@@ -59,7 +68,18 @@ def _write_docker_shim(
         f'    if [ -n "{fail_ref}" ] && [ "$3" = "{fail_ref}" ]; then exit 1; fi\n'
         "    exit 0 ;;\n"
         '  "image prune") exit 0 ;;\n'
-        '  "builder prune") exit 0 ;;\n'
+        '  "builder prune")\n'
+        # Record every builder-prune invocation's args, one per line, so the
+        # test can assert what flags (and what value of --max-used-space) the
+        # script actually passed.
+        f'    echo "$*" >> "{builder_args_file}"\n'
+        # Simulate an old docker that does not understand --max-used-space.
+        f'    if [ "{fail_mus}" = "1" ]; then\n'
+        '      for arg in "$@"; do\n'
+        '        if [ "$arg" = "--max-used-space" ]; then exit 1; fi\n'
+        "      done\n"
+        "    fi\n"
+        "    exit 0 ;;\n"
         '  *) echo "unexpected docker args: $*" >&2; exit 99 ;;\n'
         "esac\n"
     )
@@ -67,11 +87,18 @@ def _write_docker_shim(
 
 
 def _run_script(
-    tmp_path: Path, present: list[str], keep: str, fail_ref: str = ""
-) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    tmp_path: Path,
+    present: list[str],
+    keep: str,
+    fail_ref: str = "",
+    fail_max_used_space: bool = False,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], list[str], list[str]]:
     """Run reclaim-docker-disk.sh with `docker` shimmed to `present`.
 
-    Returns (completed_process, list_of_refs_the_script_asked_to_remove).
+    Returns (completed_process, refs_asked_to_remove, builder_prune_invocations)
+    where the third element is the list of arg-strings the script passed to
+    `docker builder prune ...`, one per invocation in call order.
     """
     bindir = tmp_path / "bin"
     bindir.mkdir()
@@ -79,9 +106,20 @@ def _run_script(
     images_file.write_text("\n".join(present) + "\n")
     removed_file = tmp_path / "removed.txt"
     removed_file.write_text("")
-    _write_docker_shim(bindir, images_file, removed_file, fail_ref=fail_ref)
+    builder_args_file = tmp_path / "builder_args.txt"
+    builder_args_file.write_text("")
+    _write_docker_shim(
+        bindir,
+        images_file,
+        removed_file,
+        builder_args_file,
+        fail_ref=fail_ref,
+        fail_max_used_space=fail_max_used_space,
+    )
 
     env = {"PATH": f"{bindir}:/usr/bin:/bin", "HOME": str(tmp_path)}
+    if extra_env:
+        env.update(extra_env)
     proc = subprocess.run(
         [BASH, str(SCRIPT), keep],
         capture_output=True,
@@ -90,7 +128,8 @@ def _run_script(
         check=False,
     )
     removed = [line for line in removed_file.read_text().splitlines() if line]
-    return proc, removed
+    builder_invocations = [line for line in builder_args_file.read_text().splitlines() if line]
+    return proc, removed, builder_invocations
 
 
 # A complete, healthy image set for KEEP_TAG=v2 plus :latest for every repo.
@@ -114,7 +153,7 @@ class TestSafetyGate:
             "egg-gateway:v1",
             "egg-sandbox:v1",
         ]
-        proc, removed = _run_script(tmp_path, present, keep="v2")
+        proc, removed, _ = _run_script(tmp_path, present, keep="v2")
         assert proc.returncode == 0, proc.stderr
         assert "skipping stale-tag reap" in proc.stdout
         assert "egg-sandbox:v2" in proc.stdout
@@ -144,7 +183,7 @@ class TestStaleTagReap:
             "egg-sandbox:v1",
             "egg-orchestrator:v0",
         ]
-        proc, removed = _run_script(tmp_path, present, keep="v2")
+        proc, removed, _ = _run_script(tmp_path, present, keep="v2")
         assert proc.returncode == 0, proc.stderr
         assert sorted(removed) == sorted(
             ["egg-gateway:v1", "egg-sandbox:v1", "egg-orchestrator:v0"]
@@ -155,14 +194,14 @@ class TestStaleTagReap:
             assert not ref.endswith(":latest")
 
     def test_no_stale_tags_is_a_noop(self, tmp_path: Path) -> None:
-        proc, removed = _run_script(tmp_path, _KEEP_V2, keep="v2")
+        proc, removed, _ = _run_script(tmp_path, _KEEP_V2, keep="v2")
         assert proc.returncode == 0, proc.stderr
         assert removed == []
         assert "removed 0 stale egg image tag(s)" in proc.stdout
 
     def test_rm_failure_is_tolerated_and_does_not_abort(self, tmp_path: Path) -> None:
         present = _KEEP_V2 + ["egg-gateway:v1", "egg-sandbox:v1"]
-        proc, removed = _run_script(tmp_path, present, keep="v2", fail_ref="egg-gateway:v1")
+        proc, removed, _ = _run_script(tmp_path, present, keep="v2", fail_ref="egg-gateway:v1")
         # Best-effort: a failed rm must not fail the script, and the OTHER
         # stale tag must still be attempted.
         assert proc.returncode == 0, proc.stderr
@@ -171,9 +210,66 @@ class TestStaleTagReap:
         assert "rm failed for egg-gateway:v1" in proc.stderr
 
     def test_build_cache_is_capped(self, tmp_path: Path) -> None:
-        proc, _ = _run_script(tmp_path, _KEEP_V2, keep="v2")
+        proc, _, _ = _run_script(tmp_path, _KEEP_V2, keep="v2")
         assert proc.returncode == 0, proc.stderr
         assert "build cache capped at" in proc.stdout
+
+
+class TestBuildKitCacheCap:
+    """Regression coverage for the BuildKit-cache cap and its fallback path.
+
+    Two invariants are load-bearing:
+      1. `--max-used-space` carries the CACHE_MAX value -- defaulting to "20GB"
+         and overridable via EGG_DOCKER_CACHE_MAX. Without coverage, a typo or
+         dropped variable substitution would silently uncap the cache.
+      2. On a docker old enough to lack `--max-used-space`, the script falls
+         back to a plain `docker builder prune -f` rather than failing or
+         skipping the cache prune entirely. Without coverage, deleting the
+         fallback (or inverting the if/elif) would go unnoticed.
+    """
+
+    def test_default_cache_max_is_passed_to_builder_prune(self, tmp_path: Path) -> None:
+        proc, _, builder_invocations = _run_script(tmp_path, _KEEP_V2, keep="v2")
+        assert proc.returncode == 0, proc.stderr
+        # Exactly one invocation expected (the --max-used-space path succeeds).
+        assert len(builder_invocations) == 1, builder_invocations
+        args = builder_invocations[0].split()
+        assert "--max-used-space" in args
+        idx = args.index("--max-used-space")
+        # Default cap is 20GB; the env override path is tested below.
+        assert args[idx + 1] == "20GB"
+        assert "build cache capped at 20GB" in proc.stdout
+
+    def test_env_override_substitutes_into_builder_prune(self, tmp_path: Path) -> None:
+        proc, _, builder_invocations = _run_script(
+            tmp_path,
+            _KEEP_V2,
+            keep="v2",
+            extra_env={"EGG_DOCKER_CACHE_MAX": "30GB"},
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert len(builder_invocations) == 1, builder_invocations
+        args = builder_invocations[0].split()
+        idx = args.index("--max-used-space")
+        assert args[idx + 1] == "30GB"
+        assert "build cache capped at 30GB" in proc.stdout
+
+    def test_fallback_to_plain_prune_when_max_used_space_unsupported(self, tmp_path: Path) -> None:
+        # Simulate a docker old enough to lack --max-used-space: that invocation
+        # exits 1, the script must then re-invoke `docker builder prune -f`
+        # WITHOUT the flag and report it as a dangling-only prune.
+        proc, _, builder_invocations = _run_script(
+            tmp_path, _KEEP_V2, keep="v2", fail_max_used_space=True
+        )
+        assert proc.returncode == 0, proc.stderr
+        # Two invocations: the failed --max-used-space attempt + the fallback.
+        assert len(builder_invocations) == 2, builder_invocations
+        assert "--max-used-space" in builder_invocations[0].split()
+        assert "--max-used-space" not in builder_invocations[1].split()
+        assert "build cache pruned (dangling; --max-used-space unsupported)" in proc.stdout
+        # And the "capped at" line must NOT be printed -- otherwise we'd be
+        # claiming a cap that the daemon did not enforce.
+        assert "build cache capped at" not in proc.stdout
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_reclaim_docker_disk.py
+++ b/tests/scripts/test_reclaim_docker_disk.py
@@ -1,0 +1,180 @@
+"""Tests for scripts/reclaim-docker-disk.sh.
+
+This script bounds the *docker* image + BuildKit cache store before a
+`make k3s-import`, so the import's transient `docker save` + `ctr import`
+spike does not push the shared root fs over kubelet's image-GC high-water
+mark and get the freshly-imported egg images evicted mid-run.
+
+Two invariants are load-bearing and tested end-to-end via a PATH-shimmed
+`docker`:
+
+1. The four-image safety gate: stale tags are reaped ONLY when every
+   egg-*:KEEP_TAG image is present. A half-built tag must strand nothing.
+2. Tag-scoped reap: stale egg tags (tag != KEEP_TAG, != latest) are removed
+   by `docker image rm <repo:tag>`, while KEEP_TAG and :latest are kept.
+   Unlike the containerd reap there is deliberately NO digest guard --
+   `docker image rm` is name-scoped, so a shared image ID is untagged, not
+   deleted.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+SCRIPT = PROJECT_ROOT / "scripts" / "reclaim-docker-disk.sh"
+# Exec bash by absolute path so the test's PATH governs only what the *script*
+# sees (notably whether `docker` is resolvable), not whether bash itself is.
+BASH = shutil.which("bash") or "bash"
+
+
+def _write_docker_shim(
+    bindir: Path, images_file: Path, removed_file: Path, fail_ref: str = ""
+) -> None:
+    """Write a `docker` shim covering the subcommands the script invokes.
+
+    - `image inspect <ref>`        -> exit 0 iff <ref> is in images_file
+    - `image ls --format .. <repo>`-> print images_file lines for <repo>
+    - `image rm <ref>`             -> record <ref>; exit 1 iff <ref>==fail_ref
+    - `image prune -f`             -> no-op success
+    - `builder prune ...`          -> no-op success
+    """
+    docker = bindir / "docker"
+    docker.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -u\n"
+        'case "$1 $2" in\n'
+        '  "image inspect")\n'
+        f'    grep -qxF "$3" "{images_file}" && exit 0 || exit 1 ;;\n'
+        '  "image ls")\n'
+        # The repo filter is the last positional arg.
+        '    repo="${@: -1}"\n'
+        f'    grep -E "^${{repo}}:" "{images_file}" || true ; exit 0 ;;\n'
+        '  "image rm")\n'
+        f'    echo "$3" >> "{removed_file}"\n'
+        f'    if [ -n "{fail_ref}" ] && [ "$3" = "{fail_ref}" ]; then exit 1; fi\n'
+        "    exit 0 ;;\n"
+        '  "image prune") exit 0 ;;\n'
+        '  "builder prune") exit 0 ;;\n'
+        '  *) echo "unexpected docker args: $*" >&2; exit 99 ;;\n'
+        "esac\n"
+    )
+    docker.chmod(0o755)
+
+
+def _run_script(
+    tmp_path: Path, present: list[str], keep: str, fail_ref: str = ""
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    """Run reclaim-docker-disk.sh with `docker` shimmed to `present`.
+
+    Returns (completed_process, list_of_refs_the_script_asked_to_remove).
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    images_file = tmp_path / "images.txt"
+    images_file.write_text("\n".join(present) + "\n")
+    removed_file = tmp_path / "removed.txt"
+    removed_file.write_text("")
+    _write_docker_shim(bindir, images_file, removed_file, fail_ref=fail_ref)
+
+    env = {"PATH": f"{bindir}:/usr/bin:/bin", "HOME": str(tmp_path)}
+    proc = subprocess.run(
+        [BASH, str(SCRIPT), keep],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    removed = [line for line in removed_file.read_text().splitlines() if line]
+    return proc, removed
+
+
+# A complete, healthy image set for KEEP_TAG=v2 plus :latest for every repo.
+_KEEP_V2 = [
+    "egg-gateway:v2",
+    "egg-orchestrator:v2",
+    "egg-sandbox:v2",
+    "egg-litellm:v2",
+    "egg-gateway:latest",
+    "egg-orchestrator:latest",
+    "egg-sandbox:latest",
+    "egg-litellm:latest",
+]
+
+
+class TestSafetyGate:
+    def test_skips_reap_when_a_kept_image_is_missing(self, tmp_path: Path) -> None:
+        # egg-sandbox:v2 absent -> gate must trip and reap nothing, even though
+        # a stale egg-sandbox:v1 (and others) are present.
+        present = [r for r in _KEEP_V2 if r != "egg-sandbox:v2"] + [
+            "egg-gateway:v1",
+            "egg-sandbox:v1",
+        ]
+        proc, removed = _run_script(tmp_path, present, keep="v2")
+        assert proc.returncode == 0, proc.stderr
+        assert "skipping stale-tag reap" in proc.stdout
+        assert "egg-sandbox:v2" in proc.stdout
+        assert removed == []
+
+    def test_missing_docker_is_a_clean_noop(self, tmp_path: Path) -> None:
+        # No docker on PATH at all -> exit 0, reclaim nothing.
+        bindir = tmp_path / "bin"
+        bindir.mkdir()
+        # PATH is the empty bindir only -> the script's `command -v docker`
+        # resolves nothing. bash is exec'd by absolute path, so it still runs.
+        proc = subprocess.run(
+            [BASH, str(SCRIPT), "v2"],
+            capture_output=True,
+            text=True,
+            env={"PATH": str(bindir), "HOME": str(tmp_path)},
+            check=False,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert "docker not found" in proc.stdout
+
+
+class TestStaleTagReap:
+    def test_reaps_stale_tags_keeps_keep_and_latest(self, tmp_path: Path) -> None:
+        present = _KEEP_V2 + [
+            "egg-gateway:v1",
+            "egg-sandbox:v1",
+            "egg-orchestrator:v0",
+        ]
+        proc, removed = _run_script(tmp_path, present, keep="v2")
+        assert proc.returncode == 0, proc.stderr
+        assert sorted(removed) == sorted(
+            ["egg-gateway:v1", "egg-sandbox:v1", "egg-orchestrator:v0"]
+        )
+        # Neither the kept tag nor :latest may ever be handed to `image rm`.
+        for ref in removed:
+            assert not ref.endswith(":v2")
+            assert not ref.endswith(":latest")
+
+    def test_no_stale_tags_is_a_noop(self, tmp_path: Path) -> None:
+        proc, removed = _run_script(tmp_path, _KEEP_V2, keep="v2")
+        assert proc.returncode == 0, proc.stderr
+        assert removed == []
+        assert "removed 0 stale egg image tag(s)" in proc.stdout
+
+    def test_rm_failure_is_tolerated_and_does_not_abort(self, tmp_path: Path) -> None:
+        present = _KEEP_V2 + ["egg-gateway:v1", "egg-sandbox:v1"]
+        proc, removed = _run_script(tmp_path, present, keep="v2", fail_ref="egg-gateway:v1")
+        # Best-effort: a failed rm must not fail the script, and the OTHER
+        # stale tag must still be attempted.
+        assert proc.returncode == 0, proc.stderr
+        assert "egg-gateway:v1" in removed  # attempted
+        assert "egg-sandbox:v1" in removed  # not blocked by the failure above
+        assert "rm failed for egg-gateway:v1" in proc.stderr
+
+    def test_build_cache_is_capped(self, tmp_path: Path) -> None:
+        proc, _ = _run_script(tmp_path, _KEEP_V2, keep="v2")
+        assert proc.returncode == 0, proc.stderr
+        assert "build cache capped at" in proc.stdout
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

`make redeploy` intermittently fails `check-egg-images-present` reporting the freshly-built `egg-*:<tag>` images are *not in k3s* — **even when HEAD hasn't moved** (the tag is current). Re-running the recommended `sudo k3s crictl rmi --prune` and redeploying fixes it briefly, then it recurs.

## Root cause — the wrong store was being drained

egg keeps **two** image stores on **one shared root fs**:

| Store | Typical size |
|---|---|
| k3s containerd (`/var/lib/rancher/k3s/agent/containerd`) | ~4 GB |
| docker (`/var/lib/docker`) | **tens of GB** |

`reap-stale-egg-images.sh` bounds the **first** after every deploy. Nothing bounded the **second**. So docker accumulates a full egg image set (including the ~12 GB `egg-sandbox`) for every `git describe` tag ever built, plus an unbounded BuildKit cache — keeping the root fs parked near kubelet's `imageGCHighThresholdPercent` (~85%).

`k3s-import` then does, per image, `docker save > /var/tmp/*.tar` **+** `k3s ctr images import` — briefly a *second and third* copy of the sandbox image on the same root fs. That transient spike crosses 85%, kubelet image GC evicts the freshly-imported, **not-yet-referenced** egg images mid-import (the running pods are still on the old tag), and `check-egg-images-present.sh` aborts the deploy.

The previously-recommended `k3s crictl rmi --prune` only reclaims the ~4 GB k3s store, so it never moved the disk needle — hence the recurrence. Diagnostic on the affected host: root fs 82%, docker 77 GB with ~33 GB reclaimable vs. k3s containerd 4.3 GB; only `egg-litellm` (imported *last*, after the spike cleared) survived in containerd while gateway/orchestrator/sandbox were evicted — the signature of GC eviction, not import failure.

## Fix

Add `scripts/reclaim-docker-disk.sh` and call it at the top of `k3s-import`, keyed on the tag about to be imported:

- reap stale `egg-*:<tag>` docker images (keep the import tag + `:latest`)
- prune dangling images
- cap the BuildKit cache via `--max-used-space` (default 20 GB, override `EGG_DOCKER_CACHE_MAX`)

This frees the prior tag's ~12 GB and excess cache **before** the import spike, so it stays under the GC line, and runs on every redeploy — bounding docker the way the containerd reap bounds k3s.

### Notes
- **Tag-scoped removal, no digest guard (by design).** `docker image rm repo:tag` untags rather than deleting a shared image ID, so — unlike the containerd reap, which removes by image ID and *needs* its digest guard — this one is inherently safe without one. Documented in both scripts so neither gets "unified" into the other.
- **Four-image safety gate.** Skips the reap unless every `egg-*:<tag>` image is present, so a half-built tag never strands the import with nothing to save.
- **Best-effort.** A reclaim hiccup never fails the import (`|| true`, plus per-removal tolerance). Needs no sudo — the docker socket is group-accessible.

## Testing
- `tests/scripts/test_reclaim_docker_disk.py` — 6 tests via a PATH-shimmed `docker`: safety gate, stale-tag reap, keep-tag/`:latest` protection, rm-failure tolerance, cache cap, no-docker no-op. All green.
- `ruff`, `shellcheck --severity=warning`, and `shfmt -i 2 -ci -bn` clean on the new files.