### PR TITLE
build(k3s-import): skip+retag unchanged images instead of re-importing (#2999 lever A)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -660,9 +660,9 @@ sudo-keepalive:
 		sudo -n -v 2>/dev/null; sleep 60; i=$$((i + 1)); \
 	done ) >/dev/null 2>&1 </dev/null &
 
-# Run this recipe under bash: the `${var//pat/repl}` parameter expansion and
-# `set -o pipefail` are bash builtins, both unsupported under dash (the default
-# /bin/sh on Debian/Ubuntu).
+# Run this recipe under bash: the `${var//pat/repl}` parameter expansion, the
+# `<<<` here-string, and `set -o pipefail` are bash builtins, all unsupported
+# under dash (the default /bin/sh on Debian/Ubuntu).
 #
 # Import via temp file rather than `docker save ... | sudo k3s ctr images
 # import -`. The stdin path silently drops the layer payload for some images
@@ -674,6 +674,19 @@ sudo-keepalive:
 # half-imported tag that surfaces hours later as ImagePullBackOff in
 # await-egg-deploy.sh. Tarballs go in /var/tmp (disk-backed) -- the sandbox
 # image is ~12 GB, so /tmp (tmpfs) would consume that much RAM.
+#
+# Skip-and-tag unchanged images (issue #2999 lever A). `docker save` +
+# `ctr import` of the ~12 GB egg-sandbox every redeploy is the dominant churn
+# that fragments btrfs and pushes the root fs into DiskPressure, after which
+# kubelet's image GC evicts the freshly-imported (not-yet-referenced) tags
+# mid-run and check-egg-images-present.sh fails. So per image we compare the
+# current docker image id against a marker of the last id we imported (under
+# ${XDG_CACHE_HOME:-$HOME/.cache}/egg/k3s-import-ids/<image>.id); when it is
+# unchanged AND containerd still holds docker.io/library/<image>:latest we
+# just `ctr images tag` the wanted tags off :latest instead of re-importing.
+# The :latest-present guard is load-bearing: if GC already evicted the image
+# we fall through to a real import. reap-stale-egg-images.sh deliberately
+# keeps :latest, so it stays a stable retag source across deploys.
 k3s-import: SHELL := /bin/bash
 k3s-import: sudo-keepalive  ## Import built images into k3s
 	@set -euo pipefail; \
@@ -681,16 +694,35 @@ k3s-import: sudo-keepalive  ## Import built images into k3s
 	trap 'rm -rf "$$tmp"' EXIT; \
 	tags="latest"; \
 	if [ "$(EGG_IMAGE_TAG)" != "latest" ]; then tags="$$tags $(EGG_IMAGE_TAG)"; fi; \
+	id_dir="$${XDG_CACHE_HOME:-$$HOME/.cache}/egg/k3s-import-ids"; \
+	mkdir -p "$$id_dir"; \
 	for image in egg-gateway egg-orchestrator egg-sandbox egg-litellm; do \
+		cur_id=$$(docker image inspect "$$image:$(EGG_IMAGE_TAG)" --format '{{.Id}}'); \
+		marker="$$id_dir/$$image.id"; \
+		prev_id=$$(cat "$$marker" 2>/dev/null || true); \
+		present=$$(sudo k3s ctr images list -q); \
+		if [ "$$cur_id" = "$$prev_id" ] && grep -qx "docker.io/library/$$image:latest" <<<"$$present"; then \
+			echo ">>> $$image unchanged ($$cur_id), :latest present in containerd; retagging instead of re-importing"; \
+			for tag in $$tags; do \
+				if ! grep -qx "docker.io/library/$$image:$$tag" <<<"$$present"; then \
+					echo "    tag docker.io/library/$$image:latest -> :$$tag"; \
+					sudo k3s ctr images tag "docker.io/library/$$image:latest" "docker.io/library/$$image:$$tag"; \
+				fi; \
+			done; \
+		else \
+			for tag in $$tags; do \
+				img="$$image:$$tag"; \
+				f="$$tmp/$${img//[:\/]/_}.tar"; \
+				echo ">>> importing $$img"; \
+				docker save "$$img" -o "$$f"; \
+				sudo k3s ctr images import "$$f"; \
+				rm -f "$$f"; \
+			done; \
+			printf '%s\n' "$$cur_id" > "$$marker"; \
+		fi; \
 		for tag in $$tags; do \
-			img="$$image:$$tag"; \
-			f="$$tmp/$${img//[:\/]/_}.tar"; \
-			echo ">>> importing $$img"; \
-			docker save "$$img" -o "$$f"; \
-			sudo k3s ctr images import "$$f"; \
-			rm -f "$$f"; \
-			if ! sudo k3s ctr images list -q | grep -qx "docker.io/library/$$img"; then \
-				echo "ERROR: $$img import returned 0 but tag is not present in k3s containerd" >&2; \
+			if ! sudo k3s ctr images list -q | grep -qx "docker.io/library/$$image:$$tag"; then \
+				echo "ERROR: $$image:$$tag not present in k3s containerd after import/retag" >&2; \
 				exit 1; \
 			fi; \
 		done; \

--- a/Makefile
+++ b/Makefile
@@ -686,7 +686,11 @@ sudo-keepalive:
 # just `ctr images tag` the wanted tags off :latest instead of re-importing.
 # The :latest-present guard is load-bearing: if GC already evicted the image
 # we fall through to a real import. reap-stale-egg-images.sh deliberately
-# keeps :latest, so it stays a stable retag source across deploys.
+# keeps :latest, so it stays a stable retag source across deploys. The retag
+# path further assumes nothing else has re-pointed containerd's :latest to
+# non-egg content -- no tool in this repo does so, and an out-of-band retag
+# would only mismatch if :$(EGG_IMAGE_TAG) is also absent (the inner grep
+# guard skips when it is already present).
 k3s-import: SHELL := /bin/bash
 k3s-import: sudo-keepalive  ## Import built images into k3s
 	@set -euo pipefail; \
@@ -707,6 +711,7 @@ k3s-import: sudo-keepalive  ## Import built images into k3s
 				if ! grep -qx "docker.io/library/$$image:$$tag" <<<"$$present"; then \
 					echo "    tag docker.io/library/$$image:latest -> :$$tag"; \
 					sudo k3s ctr images tag "docker.io/library/$$image:latest" "docker.io/library/$$image:$$tag"; \
+					present="$$present"$$'\n'"docker.io/library/$$image:$$tag"; \
 				fi; \
 			done; \
 		else \
@@ -718,10 +723,11 @@ k3s-import: sudo-keepalive  ## Import built images into k3s
 				sudo k3s ctr images import "$$f"; \
 				rm -f "$$f"; \
 			done; \
-			printf '%s\n' "$$cur_id" > "$$marker"; \
+			printf '%s\n' "$$cur_id" > "$$marker.tmp" && mv -f "$$marker.tmp" "$$marker"; \
+			present=$$(sudo k3s ctr images list -q); \
 		fi; \
 		for tag in $$tags; do \
-			if ! sudo k3s ctr images list -q | grep -qx "docker.io/library/$$image:$$tag"; then \
+			if ! grep -qx "docker.io/library/$$image:$$tag" <<<"$$present"; then \
 				echo "ERROR: $$image:$$tag not present in k3s containerd after import/retag" >&2; \
 				exit 1; \
 			fi; \


### PR DESCRIPTION
## What

Implements **lever A** of #2999. The `k3s-import` Makefile target ran `docker save` + `sudo k3s ctr images import` for all four egg images (`egg-gateway`, `egg-orchestrator`, `egg-sandbox`, `egg-litellm`) on **every** `make redeploy`. Re-importing the ~12 GB `egg-sandbox` each run is the dominant churn that fragments btrfs → `DiskPressure` → kubelet image GC evicts the freshly-imported (not-yet-referenced) tags mid-run → `check-egg-images-present.sh` fails.

Now, per image:

- Read the current docker image id: `docker image inspect <image>:$(EGG_IMAGE_TAG) --format '{{.Id}}'`.
- Compare against a per-image marker of the last-imported id under `${XDG_CACHE_HOME:-$HOME/.cache}/egg/k3s-import-ids/<image>.id`.
- **Skip-and-tag** only when the id is unchanged **AND** containerd still holds `docker.io/library/<image>:latest`. For each wanted tag not already present, `sudo k3s ctr images tag docker.io/library/<image>:latest docker.io/library/<image>:<tag>` — no save, no import.
- **Otherwise** do the existing `/var/tmp` file-based `save`+`import` for every tag, then write the current id to the marker.
- Either path keeps the post-step verification that every `<image>:<tag>` is present in `ctr images list`, failing the recipe if not.

## Why the `:latest`-present guard matters

It's load-bearing: if image GC has already evicted the image, the skip condition is false and we fall through to a real import. `reap-stale-egg-images.sh` deliberately keeps `:latest` (alongside the kept tag), so `:latest` stays a stable retag source across deploys.

## Notes / scope

- Preserved the `/var/tmp` file-based import (stdin drops layers on this aarch64+16k-page Asahi host) and the bash `SHELL` / `set -euo pipefail`.
- Levers **B/C** from #2999 are intentionally out of scope.

## Testing

- `make lint` — exits 0 (shellcheck/ruff/mypy/yaml/custom all clean; only pre-existing soft-cap line-count warnings on unrelated files).
- `make -n k3s-import` expands cleanly; the expanded recipe passes `bash -n` and a standalone `shellcheck -s bash` run (the lone SC2050 is a false positive from substituting `$(EGG_IMAGE_TAG)` into a literal — it's a Make variable, not a shell constant, and is on a pre-existing line).

Refs #2999