### PR TITLE
fix(orchestrator): drop [1m] for sub-1M custom models so Kimi/GLM are routable (#2987)

### DIFF
--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -115,7 +115,8 @@ The resolver's classifier divides model strings into two camps:
 |----------------------|------------|---------------------|------------------|
 | `opus`, `opus[1m]`, `sonnet`, `sonnet[1m]`, `haiku` | `"anthropic"` | the model string verbatim | `None` |
 | `claude-*` (e.g. `claude-3-5-sonnet-20241022`) | `"anthropic"` | the model string verbatim | `None` |
-| Everything else (e.g. `qwen3-coder-30b`, `mistral-large`) | `"litellm"` | `<model>[1m]` (the bare upstream name plus the 1M-context opt-in suffix) | the bare upstream name |
+| Everything else with a real window ≥1M (e.g. `qwen3.7-max`, `deepseek-v4-*`) | `"litellm"` | `<model>[1m]` (the bare upstream name plus the 1M-context opt-in suffix) | the bare upstream name |
+| Sub-1M-window models (`_SUB_1M_CONTEXT_MODELS`: `kimi-k2.6` 256K, `glm-5.1` 202K) | `"litellm"` | `<model>` — bare, **no** `[1m]` (takes Claude Code's 200K default) | the bare upstream name |
 
 Two consequences:
 
@@ -249,14 +250,20 @@ registration.
 > override flow (see [#2832](https://github.com/jwbron/egg/issues/2832)
 > for the follow-up).
 
-> **Sub-1M-window upstreams.** The resolver appends `[1m]`
-> unconditionally on the LiteLLM path. The current pilot upstreams
-> (Qwen3.7-max, DeepSeek-v4-*) are all 1M; smaller upstreams (e.g.
-> the original qwen3-coder-30b at 32k) would see Claude Code defer
-> compaction past their real window. A per-entry context_window
-> declaration is the natural extension when those backends graduate
-> past pilot — left out of this change deliberately to keep the
-> seam minimal.
+> **Sub-1M-window upstreams (#2987).** Claude Code exposes a custom
+> model only two compaction profiles — the 1M window (the `[1m]`
+> suffix; its qualifier in Claude Code is literally `/\[1m\]/i`) or
+> its 200K default. There is no arbitrary `[256k]` size suffix, and
+> `CLAUDE_CODE_MAX_CONTEXT_TOKENS` only takes effect under
+> `DISABLE_COMPACT` (which egg never sets). So the resolver appends
+> `[1m]` only for genuine ≥1M upstreams and **withholds it** for
+> models whose real window is below 1M — `_SUB_1M_CONTEXT_MODELS` in
+> `agent_model_resolution.py` (Kimi K2.6 256K, GLM-5.1 202K). Those
+> take Claude Code's 200K default, which auto-compacts safely below
+> their real limit instead of deferring compaction toward 1M and
+> overflowing the upstream mid-turn. The cost is the unused headroom
+> above 200K (e.g. ~56K for Kimi); Claude Code offers no in-between
+> profile. Add a model to the set when its real window is <1M.
 
 ### Web tool availability on the LiteLLM path (#2856)
 

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -124,9 +124,12 @@ Two consequences:
   model is a Claude alias — `upstream_model` is `None`, so the gateway
   forwards the body verbatim.
 - The LiteLLM path threads `<model>[1m]` into `--model` and the
-  `ANTHROPIC_CUSTOM_MODEL_OPTION` env var. Claude Code strips the
-  suffix before sending, so LiteLLM keys on the bare upstream name —
-  the gateway does not rewrite the body.
+  `ANTHROPIC_CUSTOM_MODEL_OPTION` env var for the standard ≥1M case,
+  or the **bare** `<model>` (no suffix) for `_SUB_1M_CONTEXT_MODELS`
+  — see the *Sub-1M-window upstreams (#2987)* callout below. Claude
+  Code strips the suffix before sending (when present), so LiteLLM
+  keys on the bare upstream name — the gateway does not rewrite the
+  body.
 
 ## How the resolved decision threads through spawn
 
@@ -243,7 +246,9 @@ two env vars (plus one egg-side auth marker):
 The resolver builds these values from the decided upstream string and
 the spawn sites merge them into the agent's `extra_env`
 (see `AgentModelDecision.env_vars()`). The resolver also pins the
-agent's `--model` flag to `<upstream>[1m]` so the harness's
+agent's `--model` flag to `<upstream>[1m]` for the standard ≥1M case
+(or the bare `<upstream>` for `_SUB_1M_CONTEXT_MODELS` — see the
+*Sub-1M-window upstreams (#2987)* callout below) so the harness's
 ``--model``-keyed pathway also routes through the custom-model
 registration.
 
@@ -623,7 +628,7 @@ Routing → Files](../architecture/upstream-routing.md#files).
 |----------|------------|-------------------|
 | `cq-3` | Per-role field on `PipelineConfig` **and** `repositories.yaml` default | Two-knob config above; precedence chain in the resolver |
 | `cq-4` | No agent-flip in this pipeline; operator smoke-test deferred | Smoke-test section is operator-driven, not gating merge |
-| `cq-5` | Keep Claude Code; superseded by env-var registration (#2832) | Resolver pins `claude_code_alias = "<upstream>[1m]"` and threads `ANTHROPIC_CUSTOM_MODEL_OPTION` into the agent env — no gateway body rewrite |
+| `cq-5` | Keep Claude Code; superseded by env-var registration (#2832) | Resolver pins `claude_code_alias = "<upstream>[1m]"` for ≥1M upstreams (bare `<upstream>` for `_SUB_1M_CONTEXT_MODELS` per #2987) and threads `ANTHROPIC_CUSTOM_MODEL_OPTION` into the agent env — no gateway body rewrite |
 | `cq-6` | First validation backend is hosted Qwen | Step 2 example uses hosted Qwen; self-hosted deferred |
 | `cq-8` | Fail closed on LiteLLM errors (502, no fallback) | Step 4 error-path note; same behavior as today's Anthropic upstream errors |
 | `cq-11` | Leave `[1m]` for Claude | Non-Claude model strings simply do not carry `[1m]`; the resolver routes them via the LiteLLM path |

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -199,7 +199,10 @@ two env vars (plus one egg-side auth marker):
 
 - `ANTHROPIC_CUSTOM_MODEL_OPTION=<upstream>[1m]` — registers the
   custom model ID and tells Claude Code to use 1M-context
-  compaction math.
+  compaction math. For models in `_SUB_1M_CONTEXT_MODELS` (Kimi
+  K2.6, GLM-5.1) this is set to the **bare** `<upstream>` without
+  the `[1m]` suffix; see the *Sub-1M-window upstreams (#2987)*
+  callout below.
 - `ANTHROPIC_CUSTOM_MODEL_OPTION_NAME=<upstream>` — the bare
   on-the-wire name. Claude Code strips the `[1m]` suffix from the
   registered ID before sending the `"model"` field, so LiteLLM sees
@@ -221,8 +224,12 @@ two env vars (plus one egg-side auth marker):
   (e.g. `Explore`) route to the configured upstream instead of
   emitting `claude-haiku-…` — a name absent from the proxy's
   `model_list` that would otherwise 400 with
-  `ProxyModelNotFoundError`. Carries the `[1m]` suffix so subagents
-  share the main agent's 1M-context compaction profile.
+  `ProxyModelNotFoundError`. Pinned to the main agent's resolved
+  `claude_code_alias` so subagents share its compaction profile —
+  the `[1m]` 1M-window profile for the standard LiteLLM path, or
+  the bare alias (Claude Code's 200K default) for
+  `_SUB_1M_CONTEXT_MODELS`; see
+  the *Sub-1M-window upstreams (#2987)* callout below.
 - `ANTHROPIC_DEFAULT_HAIKU_MODEL=<upstream>` (and its deprecated
   alias `ANTHROPIC_SMALL_FAST_MODEL=<upstream>`, set for older
   Claude Code builds) — the model the `haiku` alias and Claude

--- a/orchestrator/agent_model_resolution.py
+++ b/orchestrator/agent_model_resolution.py
@@ -22,9 +22,14 @@ as a LiteLLM-side model name (#2832): the upstream is ``"litellm"``,
 the agent is spawned with ``--model <upstream>[1m]`` and the
 ``ANTHROPIC_CUSTOM_MODEL_OPTION`` / ``…_OPTION_NAME`` env vars set so
 Claude Code registers the custom model with a 1M-context-window
-compaction profile. The gateway no longer rewrites the request body;
-Claude Code strips the ``[1m]`` suffix before sending, and LiteLLM
-matches the resulting bare name against its ``model_list``.
+compaction profile. Models whose real context window is below 1M
+(``_SUB_1M_CONTEXT_MODELS`` — e.g. Kimi 256K, GLM 202K) are the
+exception: they get the bare ``<upstream>`` alias so Claude Code uses
+its 200K default and compacts before their true limit, since Claude
+Code has no sub-1M custom-model profile (#2987). The gateway no longer
+rewrites the request body; Claude Code strips the ``[1m]`` suffix
+before sending, and LiteLLM matches the resulting bare name against
+its ``model_list``.
 
 The resolver is a pure function over its three inputs (role,
 PipelineConfig, repo) so callers can use it from spawn, restart, and
@@ -54,6 +59,24 @@ UPSTREAM_LITELLM = "litellm"
 # in ``litellm-configmap.yaml`` as a defensive guard against the documented
 # startup-probe leak path.
 _CONTEXT_1M_SUFFIX = "[1m]"
+
+# Non-Claude models whose REAL upstream context window is below 1M. Claude Code
+# offers a custom model (registered via ``ANTHROPIC_CUSTOM_MODEL_OPTION``) only
+# TWO compaction profiles: the 1M window — opted into by the ``[1m]`` suffix,
+# whose qualifier in Claude Code is literally ``/\[1m\]/i`` — or its 200K
+# default. There is no arbitrary ``[256k]`` size suffix, and
+# ``CLAUDE_CODE_MAX_CONTEXT_TOKENS`` only takes effect under ``DISABLE_COMPACT``
+# (which we never set). So a model whose true window sits between 200K and 1M
+# cannot be expressed exactly; for these we WITHHOLD ``[1m]`` and take the 200K
+# default, which auto-compacts safely below their real limit. Appending ``[1m]``
+# instead would make Claude Code treat them as 1M and defer compaction to ~1M,
+# overflowing the upstream mid-turn. Keyed by bare upstream name; the value
+# documents the real window (only membership is used). Add a model here when its
+# window is <1M. See #2987.
+_SUB_1M_CONTEXT_MODELS: dict[str, int] = {
+    "kimi-k2.6": 256_000,
+    "glm-5.1": 202_752,
+}
 
 # Recognised Claude aliases that route through the Anthropic upstream.
 # Exact-match set plus a regex for the version-pinned ``claude-*`` family
@@ -179,12 +202,21 @@ def classify_model(model: str) -> AgentModelDecision:
         )
     # LiteLLM path (#2832): the operator may pass the bare upstream name
     # (e.g. ``qwen3-coder-30b``) or pre-suffix it (``qwen3-coder-30b[1m]``).
-    # Normalise so ``upstream_model`` is always the bare name LiteLLM keys
-    # on and ``claude_code_alias`` always carries the suffix Claude Code
-    # needs to opt into 1M-context compaction math.
+    # Normalise so ``upstream_model`` is always the bare name LiteLLM keys on.
     bare = model.removesuffix(_CONTEXT_1M_SUFFIX) if model.endswith(_CONTEXT_1M_SUFFIX) else model
+    # ``claude_code_alias`` carries the ``[1m]`` suffix so Claude Code opts the
+    # custom model into 1M-context compaction math — EXCEPT for models whose
+    # real window is below 1M (``_SUB_1M_CONTEXT_MODELS``): those take the bare
+    # name so Claude Code uses its 200K default and compacts before their true
+    # limit instead of overflowing it. A pre-suffixed sub-1M model (e.g.
+    # ``kimi-k2.6[1m]``) is normalised back to bare here — the registry is
+    # authoritative over an operator's stray suffix.
+    if bare in _SUB_1M_CONTEXT_MODELS:
+        claude_code_alias = bare
+    else:
+        claude_code_alias = f"{bare}{_CONTEXT_1M_SUFFIX}"
     return AgentModelDecision(
-        claude_code_alias=f"{bare}{_CONTEXT_1M_SUFFIX}",
+        claude_code_alias=claude_code_alias,
         upstream=UPSTREAM_LITELLM,
         upstream_model=bare,
     )

--- a/orchestrator/agent_model_resolution.py
+++ b/orchestrator/agent_model_resolution.py
@@ -38,10 +38,13 @@ test paths without further plumbing.
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 
 from egg_contracts.agent_roles import AgentRole
+
+logger = logging.getLogger(__name__)
 
 # Built-in fallback when neither PipelineConfig.agent_models nor the
 # repository-level default_agent_model is set. Matches today's hardcoded
@@ -149,9 +152,12 @@ class AgentModelDecision:
           subagents (``Explore`` etc.) hardcode a versioned ``haiku``
           model in their ``model`` frontmatter; this var overrides that
           frontmatter so they route to the configured upstream instead.
-          Pinned to the suffixed alias so subagents share the main
-          agent's 1M-context compaction profile. Mirrors the host
-          ``cllm`` wrapper's ``CLAUDE_CODE_SUBAGENT_MODEL`` export.
+          Pinned to the main agent's resolved ``claude_code_alias`` so
+          subagents share its compaction profile — the ``[1m]``-suffixed
+          1M-window profile for the standard LiteLLM path, the bare
+          alias (Claude Code's 200K default) for ``_SUB_1M_CONTEXT_MODELS``.
+          Mirrors the host ``cllm`` wrapper's
+          ``CLAUDE_CODE_SUBAGENT_MODEL`` export.
         - ``ANTHROPIC_DEFAULT_HAIKU_MODEL`` (and its deprecated alias
           ``ANTHROPIC_SMALL_FAST_MODEL``, set for older Claude Code
           builds where the rename hasn't landed) — the model the
@@ -203,7 +209,8 @@ def classify_model(model: str) -> AgentModelDecision:
     # LiteLLM path (#2832): the operator may pass the bare upstream name
     # (e.g. ``qwen3-coder-30b``) or pre-suffix it (``qwen3-coder-30b[1m]``).
     # Normalise so ``upstream_model`` is always the bare name LiteLLM keys on.
-    bare = model.removesuffix(_CONTEXT_1M_SUFFIX) if model.endswith(_CONTEXT_1M_SUFFIX) else model
+    had_suffix = model.endswith(_CONTEXT_1M_SUFFIX)
+    bare = model.removesuffix(_CONTEXT_1M_SUFFIX) if had_suffix else model
     # ``claude_code_alias`` carries the ``[1m]`` suffix so Claude Code opts the
     # custom model into 1M-context compaction math — EXCEPT for models whose
     # real window is below 1M (``_SUB_1M_CONTEXT_MODELS``): those take the bare
@@ -213,6 +220,19 @@ def classify_model(model: str) -> AgentModelDecision:
     # authoritative over an operator's stray suffix.
     if bare in _SUB_1M_CONTEXT_MODELS:
         claude_code_alias = bare
+        if had_suffix:
+            # Surface the override so an operator who deliberately requested
+            # ``[1m]`` for a sub-1M model can see from the logs why it was
+            # dropped, rather than chasing a silent compaction discrepancy.
+            logger.warning(
+                "Ignoring [1m] suffix on sub-1M model %r: %r is in "
+                "_SUB_1M_CONTEXT_MODELS (real window <1M), so the bare alias "
+                "is used to keep Claude Code on its 200K compaction profile "
+                "(appending [1m] would defer compaction toward 1M and "
+                "overflow the upstream mid-turn). See #2987.",
+                model,
+                bare,
+            )
     else:
         claude_code_alias = f"{bare}{_CONTEXT_1M_SUFFIX}"
     return AgentModelDecision(

--- a/orchestrator/tests/test_agent_model_resolution.py
+++ b/orchestrator/tests/test_agent_model_resolution.py
@@ -459,25 +459,29 @@ class TestSubOneMContextModels:
         assert d.upstream_model == model
         assert d.claude_code_alias == model
 
-    def test_sub_1m_env_vars_carry_bare_name(self):
+    @pytest.mark.parametrize("model", ["kimi-k2.6", "glm-5.1"])
+    def test_sub_1m_env_vars_carry_bare_name(self, model):
         """Every custom-model env var for a sub-1M model carries the bare
         name — none may leak the ``[1m]`` suffix (which would re-trigger the
-        1M profile for the main agent or its Task-tool subagents).
+        1M profile for the main agent or its Task-tool subagents). Parametrized
+        over both registry entries so a future drift that only broke ``glm-5.1``
+        (e.g. a ``.lower()`` or escape that special-cased the hyphen-period in
+        ``k2.6``) is caught here, not in the field.
         """
         resolve_agent_model = _resolver()
         AgentRole = _agent_role()
-        config = _pipeline_config(agent_models={"coder": "kimi-k2.6"})
+        config = _pipeline_config(agent_models={"coder": model})
 
         with patch("config.repo_config.get_default_agent_model", return_value=None):
             d = resolve_agent_model(AgentRole.CODER, config, None)
 
         assert d.env_vars() == {
-            "ANTHROPIC_CUSTOM_MODEL_OPTION": "kimi-k2.6",
-            "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME": "kimi-k2.6",
+            "ANTHROPIC_CUSTOM_MODEL_OPTION": model,
+            "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME": model,
             "ANTHROPIC_AUTH_METHOD": "api_key",
-            "CLAUDE_CODE_SUBAGENT_MODEL": "kimi-k2.6",
-            "ANTHROPIC_DEFAULT_HAIKU_MODEL": "kimi-k2.6",
-            "ANTHROPIC_SMALL_FAST_MODEL": "kimi-k2.6",
+            "CLAUDE_CODE_SUBAGENT_MODEL": model,
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": model,
+            "ANTHROPIC_SMALL_FAST_MODEL": model,
         }
 
     @pytest.mark.parametrize("model", ["deepseek-v4-flash", "deepseek-v4-pro", "qwen3.7-max"])
@@ -527,10 +531,17 @@ class TestSubOneMContextModels:
             d = classify_model("kimi-k2.6[1m]")
 
         assert d.claude_code_alias == "kimi-k2.6"
+        # The warning's %r formatting puts repr quotes around the input alias and
+        # the normalised bare name; assert both quoted forms appear so a future
+        # drift that swapped the format args (e.g. logged ``bare`` twice instead
+        # of ``model, bare``) would still fail this test rather than passing on
+        # the substring ``"[1m]"`` in the static format string alone.
         assert any(
-            "kimi-k2.6" in record.message and "[1m]" in record.message for record in caplog.records
+            "'kimi-k2.6[1m]'" in record.message and "'kimi-k2.6'" in record.message
+            for record in caplog.records
         ), (
-            f"expected override warning for kimi-k2.6[1m]; got {[r.message for r in caplog.records]!r}"
+            f"expected override warning naming both 'kimi-k2.6[1m]' and 'kimi-k2.6'; "
+            f"got {[r.message for r in caplog.records]!r}"
         )
 
     def test_bare_sub_1m_emits_no_warning(self, caplog):

--- a/orchestrator/tests/test_agent_model_resolution.py
+++ b/orchestrator/tests/test_agent_model_resolution.py
@@ -419,6 +419,84 @@ class TestLiteLLMClassification:
         assert d.env_vars() == {}
 
 
+class TestSubOneMContextModels:
+    """Models whose real context window is below 1M (``_SUB_1M_CONTEXT_MODELS``)
+    must NOT get the ``[1m]`` suffix: Claude Code would treat them as 1M and
+    defer compaction past their true limit, overflowing the upstream mid-turn.
+    They take the bare alias → Claude Code's 200K default, which compacts
+    safely below their window. See #2987.
+    """
+
+    @pytest.mark.parametrize("model", ["kimi-k2.6", "glm-5.1"])
+    def test_sub_1m_model_drops_1m_suffix(self, model):
+        resolve_agent_model = _resolver()
+        AgentRole = _agent_role()
+        config = _pipeline_config(agent_models={"coder": model})
+
+        with patch("config.repo_config.get_default_agent_model", return_value=None):
+            d = resolve_agent_model(AgentRole.CODER, config, None)
+
+        assert d.upstream == "litellm"
+        assert d.upstream_model == model
+        assert d.claude_code_alias == model, (
+            f"sub-1M model {model!r} MUST present the bare name to Claude Code "
+            f"(no [1m]) so it uses the 200K default and compacts before the "
+            f"model's real limit; got {d.claude_code_alias!r}"
+        )
+
+    @pytest.mark.parametrize("model", ["kimi-k2.6", "glm-5.1"])
+    def test_pre_suffixed_sub_1m_model_normalized_to_bare(self, model):
+        """A stray operator ``[1m]`` on a sub-1M model is overridden — the
+        registry is authoritative, so the alias is still bare.
+        """
+        resolve_agent_model = _resolver()
+        AgentRole = _agent_role()
+        config = _pipeline_config(agent_models={"coder": f"{model}[1m]"})
+
+        with patch("config.repo_config.get_default_agent_model", return_value=None):
+            d = resolve_agent_model(AgentRole.CODER, config, None)
+
+        assert d.upstream_model == model
+        assert d.claude_code_alias == model
+
+    def test_sub_1m_env_vars_carry_bare_name(self):
+        """Every custom-model env var for a sub-1M model carries the bare
+        name — none may leak the ``[1m]`` suffix (which would re-trigger the
+        1M profile for the main agent or its Task-tool subagents).
+        """
+        resolve_agent_model = _resolver()
+        AgentRole = _agent_role()
+        config = _pipeline_config(agent_models={"coder": "kimi-k2.6"})
+
+        with patch("config.repo_config.get_default_agent_model", return_value=None):
+            d = resolve_agent_model(AgentRole.CODER, config, None)
+
+        assert d.env_vars() == {
+            "ANTHROPIC_CUSTOM_MODEL_OPTION": "kimi-k2.6",
+            "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME": "kimi-k2.6",
+            "ANTHROPIC_AUTH_METHOD": "api_key",
+            "CLAUDE_CODE_SUBAGENT_MODEL": "kimi-k2.6",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": "kimi-k2.6",
+            "ANTHROPIC_SMALL_FAST_MODEL": "kimi-k2.6",
+        }
+
+    @pytest.mark.parametrize("model", ["deepseek-v4-flash", "deepseek-v4-pro", "qwen3.7-max"])
+    def test_one_m_models_still_carry_1m_suffix(self, model):
+        """Regression guard: genuine >=1M cost-center models are unaffected —
+        they still get ``[1m]`` so they use their full 1M window.
+        """
+        resolve_agent_model = _resolver()
+        AgentRole = _agent_role()
+        config = _pipeline_config(agent_models={"coder": model})
+
+        with patch("config.repo_config.get_default_agent_model", return_value=None):
+            d = resolve_agent_model(AgentRole.CODER, config, None)
+
+        assert d.upstream == "litellm"
+        assert d.claude_code_alias == f"{model}[1m]"
+        assert d.upstream_model == model
+
+
 # =============================================================================
 # PipelineConfig.agent_models validation (TASK-2-1)
 # =============================================================================

--- a/orchestrator/tests/test_agent_model_resolution.py
+++ b/orchestrator/tests/test_agent_model_resolution.py
@@ -496,6 +496,59 @@ class TestSubOneMContextModels:
         assert d.claude_code_alias == f"{model}[1m]"
         assert d.upstream_model == model
 
+    def test_registry_entries_all_below_1m(self):
+        """Every entry in ``_SUB_1M_CONTEXT_MODELS`` must declare a real
+        window <1M. If a future upstream (e.g. a "Kimi K4 1.5M" successor)
+        is added with a >=1M window, it belongs on the standard ``[1m]``
+        path and adding it here would force it onto the 200K profile —
+        wasting >800K of headroom. This test asserts the dict values
+        aren't dead data; bumping a value to >=1M is the bug signal.
+        """
+        from agent_model_resolution import _SUB_1M_CONTEXT_MODELS
+
+        for name, window in _SUB_1M_CONTEXT_MODELS.items():
+            assert window < 1_000_000, (
+                f"_SUB_1M_CONTEXT_MODELS[{name!r}] = {window:_}, which is "
+                f">=1M. Models with a >=1M real window belong on the standard "
+                f"[1m] path; remove this entry."
+            )
+
+    def test_pre_suffixed_sub_1m_emits_override_warning(self, caplog):
+        """When an operator passes ``kimi-k2.6[1m]`` (sub-1M model with a
+        stray [1m] suffix), the resolver overrides the suffix and emits a
+        warning — silent overrides leave operators chasing why their
+        requested 1M profile isn't being applied.
+        """
+        import logging
+
+        from agent_model_resolution import classify_model
+
+        with caplog.at_level(logging.WARNING, logger="agent_model_resolution"):
+            d = classify_model("kimi-k2.6[1m]")
+
+        assert d.claude_code_alias == "kimi-k2.6"
+        assert any(
+            "kimi-k2.6" in record.message and "[1m]" in record.message for record in caplog.records
+        ), (
+            f"expected override warning for kimi-k2.6[1m]; got {[r.message for r in caplog.records]!r}"
+        )
+
+    def test_bare_sub_1m_emits_no_warning(self, caplog):
+        """The common case (operator passes the bare ``kimi-k2.6`` name)
+        must NOT emit the override warning — the warning is reserved for
+        the actual override.
+        """
+        import logging
+
+        from agent_model_resolution import classify_model
+
+        with caplog.at_level(logging.WARNING, logger="agent_model_resolution"):
+            classify_model("kimi-k2.6")
+
+        assert not caplog.records, (
+            f"bare sub-1M model must not warn; got {[r.message for r in caplog.records]!r}"
+        )
+
 
 # =============================================================================
 # PipelineConfig.agent_models validation (TASK-2-1)


### PR DESCRIPTION
## Problem

`classify_model` (orchestrator/agent_model_resolution.py) appended the `[1m]`
context-window opt-in suffix to **every** non-Claude model unconditionally. Claude
Code's 1M qualifier is literally `/\[1m\]/i`, so Kimi K2.6 (256K) and GLM-5.1 (202K)
were registered as 1M models → auto-compaction deferred toward ~1M → the conversation
grew past their real window and **overflowed the upstream mid-turn**. That made
Kimi/GLM unsafe to route an SDLC role at (they were registered/available but
"not SDLC-routable").

## Why this approach

Verified against the installed Claude Code (2.1.162) bundle: a custom model
(registered via `ANTHROPIC_CUSTOM_MODEL_OPTION`) gets exactly **two** compaction
profiles — the 1M window (the `[1m]` suffix) or the **200K default**. There is no
arbitrary `[256k]`/`[200k]` size suffix, and `CLAUDE_CODE_MAX_CONTEXT_TOKENS` only
applies under `DISABLE_COMPACT` (which egg never sets, and which would disable
compaction entirely). So the fix is to **withhold `[1m]`** for sub-1M models: they
take the 200K default, which compacts safely below their real limit. The cost is
the unused headroom above 200K (~56K for Kimi); Claude Code offers no in-between.

## Change

- New `_SUB_1M_CONTEXT_MODELS = {kimi-k2.6: 256000, glm-5.1: 202752}` registry.
- `classify_model` emits the **bare** alias for these (and normalizes a stray
  operator `kimi-k2.6[1m]` back to bare — the registry is authoritative).
  `env_vars()` therefore carries the bare name across
  `ANTHROPIC_CUSTOM_MODEL_OPTION` / `CLAUDE_CODE_SUBAGENT_MODEL` / etc.
- ≥1M models (qwen3.7-max, deepseek-v4-flash/pro) are **unchanged** — still `[1m]`.
- 8 new resolver tests (sub-1M drops suffix; pre-suffixed normalized; env vars bare;
  regression guard that 1M models keep `[1m]`).
- `docs/guides/per-agent-models.md`: classifier table + the (previously stale)
  "Sub-1M-window upstreams" note updated to describe the fix.

## Testing

- `pytest orchestrator/tests/test_agent_model_resolution.py` → 44 passed.
- `ruff check` clean; pre-commit `ruff-format` clean.
- Full `make test` skipped locally (per operator); CI `make test-all` covers it.

Part of #2987.