### PR TITLE
fix(gateway): persist session store on hostPath so a gateway pod recreation can't wipe live worktrees (#3005)

### DIFF
--- a/k8s/base/gateway-deployment.yaml
+++ b/k8s/base/gateway-deployment.yaml
@@ -147,15 +147,28 @@ spec:
               mountPath: /shared/certs
             - name: home
               mountPath: /home/egg
-            - name: egg-state
-              mountPath: /home/egg/.egg-state
       volumes:
+        # The gateway session store lives under /home/egg/.egg-state
+        # (gateway/session_manager.py). It is intentionally NOT declared as a
+        # dedicated volume here: in the base it falls into the ``home`` emptyDir
+        # below (ephemeral, fine for a stateless base deploy).
+        #
+        # IMPORTANT (#3005): any overlay that makes worktrees host-backed
+        # (e.g. the local overlay's hostPath worktrees) MUST also host-back the
+        # session store on a volume with the SAME persistence lifetime — see
+        # k8s/overlays/local/patches/gateway-volumes.yaml. Otherwise a gateway
+        # *pod* recreation boots with the worktrees still on disk but an empty
+        # session store, so startup worktree cleanup derives active_containers=0
+        # (the #1874 session-anchor protection has nothing to protect) and
+        # deletes every live pipeline's worktree out from under its running
+        # phase agents, deadlocking consensus. An emptyDir session store paired
+        # with hostPath worktrees is the exact trap; the
+        # ``session-store-not-persistent`` rule in
+        # orchestrator/routes/deployment.py guards against reintroducing it.
         - name: secrets
           secret:
             secretName: gateway-secrets
         - name: shared-certs
           emptyDir: {}
         - name: home
-          emptyDir: {}
-        - name: egg-state
           emptyDir: {}

--- a/k8s/overlays/local/patches/gateway-volumes.yaml
+++ b/k8s/overlays/local/patches/gateway-volumes.yaml
@@ -1,6 +1,7 @@
-# Strategic merge patch: add local-dev-only host mounts for repos and
-# worktrees. These append to the base's volumes/volumeMounts by name
-# (no conflicts, so strategic merge does the right thing here).
+# Strategic merge patch: add local-dev-only host mounts for repos,
+# worktrees, and the gateway session store. These append to the base's
+# volumes/volumeMounts by name (no conflicts, so strategic merge does the
+# right thing here).
 #
 # ``${EGG_HOST_HOME}`` is expanded by ``envsubst`` in the Makefile's
 # ``deploy`` target — defaults to ``$HOME`` on the machine running the
@@ -24,6 +25,20 @@ spec:
               mountPath: /home/egg/repos
             - name: worktrees
               mountPath: /home/egg/.egg-worktrees
+            # Session store (gateway/session_manager.py writes
+            # /home/egg/.egg-state/sessions/sessions.json). MUST be
+            # host-backed because worktrees above are: the gateway's startup
+            # worktree cleanup protects a live pipeline's worktrees only if it
+            # can see the owning sessions (the #1874 anchor derivation). With
+            # an emptyDir session store, a gateway *pod* recreation boots with
+            # the worktrees still on the host but zero sessions, so cleanup
+            # runs with active_containers=0 and deletes every live worktree out
+            # from under its running phase agents (#3005). hostPath gives the
+            # session store the same survive-pod-recreation lifetime as the
+            # worktrees it protects. The container entrypoint already chowns
+            # /home/egg/.egg-state to HOST_UID:HOST_GID (gateway/entrypoint.sh).
+            - name: egg-state
+              mountPath: /home/egg/.egg-state
       volumes:
         - name: repos
           hostPath:
@@ -32,4 +47,8 @@ spec:
         - name: worktrees
           hostPath:
             path: ${EGG_HOST_HOME}/.egg-worktrees
+            type: DirectoryOrCreate
+        - name: egg-state
+          hostPath:
+            path: ${EGG_HOST_HOME}/.egg-state
             type: DirectoryOrCreate

--- a/orchestrator/routes/deployment.py
+++ b/orchestrator/routes/deployment.py
@@ -625,7 +625,7 @@ def _deployment_volumes(doc: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _validate_deployment_docs(docs: list[dict[str, Any]], *, is_k3s: bool) -> list[dict[str, Any]]:
-    """Apply the five warning rules from the #1759 validation session.
+    """Apply the warning rules from the #1759 validation session.
 
     Rules:
 
@@ -640,6 +640,9 @@ def _validate_deployment_docs(docs: list[dict[str, Any]], *, is_k3s: bool) -> li
     4. Service selector labels not matching deployment template labels.
     5. Env-var name collision: same name declared twice in a single
        container's ``env`` list.
+    6. Gateway session store not host-backed while worktrees are (#3005):
+       an emptyDir ``egg-state`` paired with hostPath ``worktrees`` lets a
+       gateway pod recreation wipe live pipeline worktrees.
     """
     warnings: list[dict[str, Any]] = []
 
@@ -774,6 +777,48 @@ def _validate_deployment_docs(docs: list[dict[str, Any]], *, is_k3s: bool) -> li
                         "more than once"
                     ),
                 )
+
+    # Rule 6: gateway session store must share the worktrees' persistence
+    # lifetime (#3005). When an overlay host-backs a gateway's worktrees
+    # (hostPath), the gateway session store — the ``egg-state`` volume mounted
+    # at /home/egg/.egg-state (gateway/session_manager.py) — MUST also be
+    # host-backed. The two are coupled: startup worktree cleanup
+    # (gateway/worktree_manager.py:cleanup_orphaned_worktrees) only protects a
+    # live pipeline's worktrees if it can see the owning sessions (the #1874
+    # session-anchor derivation). If the session store is an emptyDir while the
+    # worktrees survive on a hostPath, a gateway *pod* recreation boots with the
+    # worktrees still on disk but zero sessions, so cleanup runs with
+    # active_containers=0 and deletes every live worktree out from under its
+    # running phase agents, deadlocking BRC consensus. Self-gated on the
+    # gateway actually host-backing its worktrees so it stays silent on
+    # all-emptyDir base/cloud deploys (where nothing survives a pod recreation,
+    # so there is no asymmetry to exploit).
+    for dep in deployments:
+        name = dep.get("metadata", {}).get("name", "<unknown>")
+        if "gateway" not in name:
+            continue
+        vols = _deployment_volumes(dep)
+        worktrees_host_backed = any(
+            (v or {}).get("name") == "worktrees" and "hostPath" in (v or {}) for v in vols
+        )
+        if not worktrees_host_backed:
+            continue
+        session_store_host_backed = any(
+            (v or {}).get("name") == "egg-state" and "hostPath" in (v or {}) for v in vols
+        )
+        if not session_store_host_backed:
+            _warn(
+                warnings,
+                rule="session-store-not-persistent",
+                severity="error",
+                resource=f"Deployment/{name}",
+                message=(
+                    "gateway host-mounts its worktrees but its session store "
+                    "(egg-state volume, /home/egg/.egg-state) is not hostPath-backed; "
+                    "a gateway pod recreation will boot with an empty session store "
+                    "and delete live pipeline worktrees during startup cleanup (#3005)"
+                ),
+            )
 
     return warnings
 

--- a/orchestrator/routes/deployment.py
+++ b/orchestrator/routes/deployment.py
@@ -640,9 +640,10 @@ def _validate_deployment_docs(docs: list[dict[str, Any]], *, is_k3s: bool) -> li
     4. Service selector labels not matching deployment template labels.
     5. Env-var name collision: same name declared twice in a single
        container's ``env`` list.
-    6. Gateway session store not host-backed while worktrees are (#3005):
-       an emptyDir ``egg-state`` paired with hostPath ``worktrees`` lets a
-       gateway pod recreation wipe live pipeline worktrees.
+    6. Gateway session store ephemeral while worktrees are persistent
+       (#3005): an ephemeral ``egg-state`` (emptyDir, or absent so it falls
+       inside the ``home`` emptyDir) paired with a persistent ``worktrees``
+       lets a gateway pod recreation wipe live pipeline worktrees.
     """
     warnings: list[dict[str, Any]] = []
 
@@ -779,46 +780,71 @@ def _validate_deployment_docs(docs: list[dict[str, Any]], *, is_k3s: bool) -> li
                 )
 
     # Rule 6: gateway session store must share the worktrees' persistence
-    # lifetime (#3005). When an overlay host-backs a gateway's worktrees
-    # (hostPath), the gateway session store — the ``egg-state`` volume mounted
-    # at /home/egg/.egg-state (gateway/session_manager.py) — MUST also be
-    # host-backed. The two are coupled: startup worktree cleanup
+    # lifetime (#3005). When an overlay gives a gateway's worktrees a volume
+    # that survives pod recreation, the gateway session store — the
+    # ``egg-state`` volume mounted at /home/egg/.egg-state
+    # (gateway/session_manager.py) — MUST also survive. The two are coupled:
+    # startup worktree cleanup
     # (gateway/worktree_manager.py:cleanup_orphaned_worktrees) only protects a
     # live pipeline's worktrees if it can see the owning sessions (the #1874
-    # session-anchor derivation). If the session store is an emptyDir while the
-    # worktrees survive on a hostPath, a gateway *pod* recreation boots with the
-    # worktrees still on disk but zero sessions, so cleanup runs with
+    # session-anchor derivation). If the session store is ephemeral
+    # (``emptyDir`` or absent — in which case /home/egg/.egg-state falls
+    # inside the ``home`` emptyDir) while the worktrees survive on a
+    # persistent volume, a gateway *pod* recreation boots with the worktrees
+    # still on disk but zero sessions, so cleanup runs with
     # active_containers=0 and deletes every live worktree out from under its
-    # running phase agents, deadlocking BRC consensus. Self-gated on the
-    # gateway actually host-backing its worktrees so it stays silent on
-    # all-emptyDir base/cloud deploys (where nothing survives a pod recreation,
-    # so there is no asymmetry to exploit).
+    # running phase agents, deadlocking BRC consensus. The rule is expressed
+    # against ``emptyDir`` (the ephemeral side) rather than ``hostPath`` (one
+    # specific persistent backing) so it generalizes to PVC / NFS / CSI
+    # backings a future cloud overlay might use — the real invariant is
+    # "session store has at least the same persistence class as worktrees,"
+    # not "both are hostPath." Self-gated on the worktrees actually being
+    # persistent so it stays silent on all-emptyDir base/cloud deploys (where
+    # nothing survives a pod recreation, so there is no asymmetry to exploit).
     for dep in deployments:
         name = dep.get("metadata", {}).get("name", "<unknown>")
-        if "gateway" not in name:
+        # Match the gateway deployment by exact name or ``gateway-*`` prefix
+        # so the rule fires on canary / rollout variants but not on unrelated
+        # deployments that happen to contain ``gateway`` as a substring
+        # (e.g. a hypothetical ``litellm-gateway``).
+        if name != "gateway" and not name.startswith("gateway-"):
             continue
         vols = _deployment_volumes(dep)
-        worktrees_host_backed = any(
-            (v or {}).get("name") == "worktrees" and "hostPath" in (v or {}) for v in vols
-        )
-        if not worktrees_host_backed:
+        worktrees_vol = next((v for v in vols if (v or {}).get("name") == "worktrees"), None)
+        # Worktrees survive a pod recreation only if declared AND not an
+        # emptyDir. Absence / emptyDir both count as ephemeral, so there is
+        # nothing for an empty session store to wrongly orphan — no asymmetry.
+        if worktrees_vol is None or "emptyDir" in worktrees_vol:
             continue
-        session_store_host_backed = any(
-            (v or {}).get("name") == "egg-state" and "hostPath" in (v or {}) for v in vols
-        )
-        if not session_store_host_backed:
-            _warn(
-                warnings,
-                rule="session-store-not-persistent",
-                severity="error",
-                resource=f"Deployment/{name}",
-                message=(
-                    "gateway host-mounts its worktrees but its session store "
-                    "(egg-state volume, /home/egg/.egg-state) is not hostPath-backed; "
-                    "a gateway pod recreation will boot with an empty session store "
-                    "and delete live pipeline worktrees during startup cleanup (#3005)"
-                ),
+        egg_state_vol = next((v for v in vols if (v or {}).get("name") == "egg-state"), None)
+        # Session store is persistent iff declared AND not emptyDir.
+        egg_state_persistent = egg_state_vol is not None and "emptyDir" not in egg_state_vol
+        if egg_state_persistent:
+            continue
+        if egg_state_vol is None:
+            detail = (
+                "gateway worktrees survive pod recreation but no "
+                "``egg-state`` volume is declared, so /home/egg/.egg-state "
+                "falls inside the ``home`` emptyDir and the session store is "
+                "ephemeral"
             )
+        else:
+            detail = (
+                "gateway worktrees survive pod recreation but its session "
+                "store (egg-state volume, /home/egg/.egg-state) is an "
+                "emptyDir and does not"
+            )
+        _warn(
+            warnings,
+            rule="session-store-not-persistent",
+            severity="error",
+            resource=f"Deployment/{name}",
+            message=(
+                f"{detail}; a gateway pod recreation will boot with an empty "
+                "session store and delete live pipeline worktrees during "
+                "startup cleanup (#3005)"
+            ),
+        )
 
     return warnings
 

--- a/orchestrator/tests/test_deployment_routes.py
+++ b/orchestrator/tests/test_deployment_routes.py
@@ -645,21 +645,25 @@ class TestValidateDeploymentDocsRules:
         errors = [w for w in warnings if w.get("severity") == "error"]
         assert errors == []
 
-    def _gateway_doc(self, *, worktrees_vol, egg_state_vol):
-        """Gateway Deployment fixture with explicit worktrees/egg-state volumes.
+    def _gateway_doc(self, *, name="gateway", worktrees_vol, egg_state_vol):
+        """Gateway Deployment fixture with optional worktrees/egg-state volumes.
 
         Shapes the #3005 trap: the session store (egg-state) and the worktrees
-        it protects must share a persistence class.
+        it protects must share a persistence class. Pass ``None`` for either
+        volume to omit it (e.g. the post-fix base shape where ``egg-state`` is
+        not declared and /home/egg/.egg-state falls inside the ``home``
+        emptyDir).
         """
+        volumes = [v for v in (worktrees_vol, egg_state_vol) if v is not None]
         return {
             "kind": "Deployment",
-            "metadata": {"name": "gateway"},
+            "metadata": {"name": name},
             "spec": {
                 "template": {
                     "metadata": {"labels": {"app": "gateway"}},
                     "spec": {
                         "containers": [{"name": "gw", "image": "egg-gateway:dev"}],
-                        "volumes": [worktrees_vol, egg_state_vol],
+                        "volumes": volumes,
                     },
                 }
             },
@@ -681,6 +685,9 @@ class TestValidateDeploymentDocsRules:
         assert fired[0]["severity"] == "error"
         assert fired[0]["resource"] == "Deployment/gateway"
         assert "#3005" in fired[0]["message"]
+        # Wording should be specific to the emptyDir case (not the absent-volume
+        # case below) so the engineer reading the warning sees the actual shape.
+        assert "emptyDir" in fired[0]["message"]
 
     def test_session_store_persistent_is_clean(self):
         """hostPath worktrees + hostPath egg-state — the fixed shape — is clean."""
@@ -714,6 +721,132 @@ class TestValidateDeploymentDocsRules:
         warnings = _validate_deployment_docs(docs, is_k3s=True)
         fired = [w for w in warnings if w.get("rule") == "session-store-not-persistent"]
         assert fired == []
+
+    def test_session_store_rule_fires_when_egg_state_volume_absent(self):
+        """hostPath worktrees + NO egg-state volume is the realistic overlay slip.
+
+        The post-fix base declares no ``egg-state`` volume (it falls inside the
+        ``home`` emptyDir). An overlay author who adds the hostPath
+        ``worktrees`` volume but forgets to also add an ``egg-state`` hostPath
+        re-introduces the #3005 trap: worktrees survive a pod recreation but
+        the session store doesn't. The rule must fire on absence the same way
+        it fires on emptyDir, and the message must be specific enough that the
+        author understands /home/egg/.egg-state is landing inside the ``home``
+        emptyDir.
+        """
+        from routes.deployment import _validate_deployment_docs
+
+        docs = [
+            self._gateway_doc(
+                worktrees_vol={"name": "worktrees", "hostPath": {"path": "/host/wt"}},
+                egg_state_vol=None,
+            )
+        ]
+        warnings = _validate_deployment_docs(docs, is_k3s=True)
+        fired = [w for w in warnings if w.get("rule") == "session-store-not-persistent"]
+        assert len(fired) == 1
+        assert fired[0]["severity"] == "error"
+        assert fired[0]["resource"] == "Deployment/gateway"
+        # Wording must reflect the absent-volume shape, not the emptyDir shape.
+        msg = fired[0]["message"]
+        assert "no ``egg-state`` volume is declared" in msg or "not declared" in msg
+        assert "``home`` emptyDir" in msg or "home" in msg
+
+    def test_session_store_rule_clean_when_both_pvc_backed(self):
+        """PVC worktrees + PVC egg-state is clean (rule generalizes beyond hostPath).
+
+        Locks in that the rule expresses "session store has at least the same
+        persistence class as worktrees" via emptyDir-checking, not via
+        hostPath-checking — so PVC / NFS / CSI futures work without a code
+        change. Both volumes survive pod recreation; no asymmetry; silent.
+        """
+        from routes.deployment import _validate_deployment_docs
+
+        docs = [
+            self._gateway_doc(
+                worktrees_vol={
+                    "name": "worktrees",
+                    "persistentVolumeClaim": {"claimName": "wt-pvc"},
+                },
+                egg_state_vol={
+                    "name": "egg-state",
+                    "persistentVolumeClaim": {"claimName": "state-pvc"},
+                },
+            )
+        ]
+        warnings = _validate_deployment_docs(docs, is_k3s=True)
+        fired = [w for w in warnings if w.get("rule") == "session-store-not-persistent"]
+        assert fired == []
+
+    def test_session_store_rule_fires_when_pvc_worktrees_emptydir_state(self):
+        """PVC worktrees + emptyDir egg-state is the hypothetical cloud-overlay trap.
+
+        Same #3005 failure mode as hostPath/emptyDir: worktrees survive a pod
+        recreation (PVC) but the session store doesn't (emptyDir). The rule
+        must fire here too — that's the whole point of expressing the check
+        against emptyDir rather than against the specific hostPath backing the
+        local overlay uses today.
+        """
+        from routes.deployment import _validate_deployment_docs
+
+        docs = [
+            self._gateway_doc(
+                worktrees_vol={
+                    "name": "worktrees",
+                    "persistentVolumeClaim": {"claimName": "wt-pvc"},
+                },
+                egg_state_vol={"name": "egg-state", "emptyDir": {}},
+            )
+        ]
+        warnings = _validate_deployment_docs(docs, is_k3s=True)
+        fired = [w for w in warnings if w.get("rule") == "session-store-not-persistent"]
+        assert len(fired) == 1
+        assert fired[0]["severity"] == "error"
+
+    def test_session_store_rule_ignores_unrelated_substring_match(self):
+        """A ``litellm-gateway`` deployment is not the gateway and must not match.
+
+        The previous condition (``"gateway" not in name``) would fire on any
+        deployment whose name *contained* ``gateway``. Lock in the
+        exact-match-or-``gateway-*``-prefix scope so a hypothetical
+        ``litellm-gateway`` (or any other unrelated deployment) doesn't
+        inherit the gateway's session-store invariant.
+        """
+        from routes.deployment import _validate_deployment_docs
+
+        # litellm-gateway in the same shape that WOULD fire for the gateway
+        # deployment — but it's not the gateway, so the rule must stay silent.
+        docs = [
+            self._gateway_doc(
+                name="litellm-gateway",
+                worktrees_vol={"name": "worktrees", "hostPath": {"path": "/host/wt"}},
+                egg_state_vol={"name": "egg-state", "emptyDir": {}},
+            )
+        ]
+        warnings = _validate_deployment_docs(docs, is_k3s=True)
+        fired = [w for w in warnings if w.get("rule") == "session-store-not-persistent"]
+        assert fired == []
+
+    def test_session_store_rule_fires_on_gateway_dash_variant(self):
+        """A ``gateway-canary`` deployment IS a gateway variant and must match.
+
+        Counterpart to the litellm-gateway negative test: the exact-or-prefix
+        scope is ``gateway`` exactly or ``gateway-*``, so a canary / rollout
+        variant still inherits the invariant.
+        """
+        from routes.deployment import _validate_deployment_docs
+
+        docs = [
+            self._gateway_doc(
+                name="gateway-canary",
+                worktrees_vol={"name": "worktrees", "hostPath": {"path": "/host/wt"}},
+                egg_state_vol={"name": "egg-state", "emptyDir": {}},
+            )
+        ]
+        warnings = _validate_deployment_docs(docs, is_k3s=True)
+        fired = [w for w in warnings if w.get("rule") == "session-store-not-persistent"]
+        assert len(fired) == 1
+        assert fired[0]["resource"] == "Deployment/gateway-canary"
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_deployment_routes.py
+++ b/orchestrator/tests/test_deployment_routes.py
@@ -645,6 +645,76 @@ class TestValidateDeploymentDocsRules:
         errors = [w for w in warnings if w.get("severity") == "error"]
         assert errors == []
 
+    def _gateway_doc(self, *, worktrees_vol, egg_state_vol):
+        """Gateway Deployment fixture with explicit worktrees/egg-state volumes.
+
+        Shapes the #3005 trap: the session store (egg-state) and the worktrees
+        it protects must share a persistence class.
+        """
+        return {
+            "kind": "Deployment",
+            "metadata": {"name": "gateway"},
+            "spec": {
+                "template": {
+                    "metadata": {"labels": {"app": "gateway"}},
+                    "spec": {
+                        "containers": [{"name": "gw", "image": "egg-gateway:dev"}],
+                        "volumes": [worktrees_vol, egg_state_vol],
+                    },
+                }
+            },
+        }
+
+    def test_session_store_not_persistent_triggers_error(self):
+        """hostPath worktrees + emptyDir egg-state is the #3005 trap."""
+        from routes.deployment import _validate_deployment_docs
+
+        docs = [
+            self._gateway_doc(
+                worktrees_vol={"name": "worktrees", "hostPath": {"path": "/host/wt"}},
+                egg_state_vol={"name": "egg-state", "emptyDir": {}},
+            )
+        ]
+        warnings = _validate_deployment_docs(docs, is_k3s=True)
+        fired = [w for w in warnings if w.get("rule") == "session-store-not-persistent"]
+        assert len(fired) == 1
+        assert fired[0]["severity"] == "error"
+        assert fired[0]["resource"] == "Deployment/gateway"
+        assert "#3005" in fired[0]["message"]
+
+    def test_session_store_persistent_is_clean(self):
+        """hostPath worktrees + hostPath egg-state — the fixed shape — is clean."""
+        from routes.deployment import _validate_deployment_docs
+
+        docs = [
+            self._gateway_doc(
+                worktrees_vol={"name": "worktrees", "hostPath": {"path": "/host/wt"}},
+                egg_state_vol={"name": "egg-state", "hostPath": {"path": "/host/state"}},
+            )
+        ]
+        warnings = _validate_deployment_docs(docs, is_k3s=True)
+        fired = [w for w in warnings if w.get("rule") == "session-store-not-persistent"]
+        assert fired == []
+
+    def test_session_store_rule_silent_when_worktrees_not_host_backed(self):
+        """All-emptyDir base/cloud shape has no asymmetry to exploit, so silent.
+
+        Without a host-backed worktree that survives a pod recreation there is
+        nothing for an empty session store to wrongly orphan, so the rule must
+        not fire (avoids false positives on stateless base deploys).
+        """
+        from routes.deployment import _validate_deployment_docs
+
+        docs = [
+            self._gateway_doc(
+                worktrees_vol={"name": "worktrees", "emptyDir": {}},
+                egg_state_vol={"name": "egg-state", "emptyDir": {}},
+            )
+        ]
+        warnings = _validate_deployment_docs(docs, is_k3s=True)
+        fired = [w for w in warnings if w.get("rule") == "session-store-not-persistent"]
+        assert fired == []
+
 
 # ---------------------------------------------------------------------------
 # prune_stale_worktrees


### PR DESCRIPTION
Fixes #3005.

## Root cause (proven from the live incident)

The gateway's startup worktree cleanup (`gateway/worktree_manager.py:cleanup_orphaned_worktrees`) deletes any worktree under `~/.egg-worktrees` whose **owning session it can't see** — the "active containers" set it protects against is derived entirely from the persisted session store (the #1874 session-anchor protection: `{pipeline_id}`, `{pipeline_id}-{role}`, slice anchors).

In the local overlay the two pieces of state had **mismatched persistence lifetimes**:

| volume | mount | backing | survives pod recreation? |
|---|---|---|---|
| `worktrees` | `/home/egg/.egg-worktrees` | **hostPath** | ✅ yes |
| `egg-state` (sessions) | `/home/egg/.egg-state` | **emptyDir** | ❌ no |

So when the gateway **pod** is recreated (redeploy, eviction, node event), it boots with the worktrees still on the host but an **empty** session store. Startup cleanup runs with `active_containers=0`, treats every live worktree as an orphan, and deletes them out from under the running phase agents — which then crashloop on the deleted CWD and deadlock BRC consensus.

### Live smoking gun (`pipeline-0adb4641`)

The current gateway pod was recreated at `20:33:49Z` (mid-incident) and its own logs show:

```
20:33:51 Running startup worktree cleanup active_containers=0
20:33:53 Worktree removed container_id=pipeline-0adb4641 ...
20:33:54 Worktree removed container_id=pipeline-0adb4641-overseer ...
20:33:55 Worktree removed container_id=pipeline-0adb4641-reviewer_refine ...
20:33:56 Worktree removed container_id=pipeline-0adb4641-refiner ...
20:33:56 Cleaned up 4 orphaned worktree(s)
20:37:11 Worktree created container_id=pipeline-0adb4641-overseer   <- only overseer respawned
```

All four worktrees were deleted; only the overseer (auto-respawned) got its worktree recreated, leaving `refiner`/`reviewer_refine` wedged. A later `20:55` dry-run prune showed `active_containers_count=3` (sessions had repopulated) and `orphan_dirs=[]` — matching the report's "clean after the incident." The **"overseer respawn" framing in the issue is the visible symptom**; the trigger is the empty session store on pod recreation.

## Fix

Give the session store the **same survive-pod-recreation lifetime as the worktrees it protects.**

- **`k8s/overlays/local/patches/gateway-volumes.yaml`** — mount `egg-state` as a `hostPath` (`${EGG_HOST_HOME}/.egg-state`), mirroring `repos`/`worktrees`. The container entrypoint already chowns `/home/egg/.egg-state` to `HOST_UID:HOST_GID` (`gateway/entrypoint.sh`), and the host dir already exists — this volume was simply missed when worktrees were made host-backed.
- **`k8s/base/gateway-deployment.yaml`** — drop the gateway's `egg-state` emptyDir volume + mount so the overlay can append a single-source hostPath cleanly (a strategic-merge override would otherwise produce an invalid dual-source `emptyDir`+`hostPath` volume). Base-only deploys fall back to the `home` emptyDir (unchanged ephemeral behavior). Adds a comment documenting the invariant.
- **`orchestrator/routes/deployment.py`** — new static validation rule **`session-store-not-persistent`** (surfaced by `validate_deployment_manifests`) that flags hostPath `worktrees` paired with a non-hostPath `egg-state`. Self-gated on the gateway actually host-backing its worktrees, so it stays silent on all-emptyDir base/cloud deploys (no asymmetry to exploit).

## Verification

- Rendered local overlay now produces a **single hostPath** `egg-state` (no dual-source); base still builds standalone with no dangling mount→volume reference.
- New rule run against the **real rendered overlay**: fires once (`severity=error`, `Deployment/gateway`) on a simulated pre-fix emptyDir render, clean on the fix.
- `orchestrator/tests/test_deployment_routes.py` — 89 passed (incl. 3 new Rule-6 tests); ruff + ruff-format + yamllint clean.
- Not applied to the live cluster (shared-infra deploy is out of scope for this change); it lands via the normal `make deploy` flow.

## Deliberately out of scope (follow-ups)

The issue lists additional hardenings that are separate from this root cause and not bundled here:
- Runtime liveness gate on every worktree removal (issue suggestion #1) / container-id namespace reconciliation (#3).
- Event-pump "CWD deleted" detection → auto-recreate/respawn instead of 500+ crashloops (#4).
- The orchestrator's own `egg-state` is likewise an emptyDir in base; persisting orchestrator pipeline-state is a distinct decision (resurrection semantics) and intentionally not touched here.