### PR TITLE
feat(orchestrator): answer_feedback MCP tool for pre-proposal contract feedback (#3007)

### DIFF
--- a/docs/architecture/orchestrator.md
+++ b/docs/architecture/orchestrator.md
@@ -684,7 +684,7 @@ NetworkPolicies (enforced by Cilium CNI):
 - `GET /health` - MCP server health check
 - `POST /mcp` - Streamable HTTP transport endpoint (MCP protocol via JSON-RPC)
 
-Available MCP tools (orchestrator-backed): `submit_task`, `get_status`, `provide_input`, `list_tasks`, `cancel_task`, `check_health`, `list_containers`, `get_container_logs`, `send_message`, `get_consensus_status`, `get_phase`, `get_pipeline_snapshot`, `get_contract`, `validate_config`, `restart_agent`, `restart_phase`, `advance_phase`, `start_phase`, `complete_phase`, `populate_contract`
+Available MCP tools (orchestrator-backed): `submit_task`, `get_status`, `provide_input`, `answer_feedback`, `list_tasks`, `cancel_task`, `check_health`, `list_containers`, `get_container_logs`, `send_message`, `get_consensus_status`, `get_phase`, `get_pipeline_snapshot`, `get_contract`, `validate_config`, `restart_agent`, `restart_phase`, `advance_phase`, `start_phase`, `complete_phase`, `populate_contract`
 
 Blocking host-side waits run via the `egg-orch pipeline wait-status` Bash CLI rather than an MCP tool (issue [#2211](https://github.com/jwbron/egg/issues/2211)). The CLI loops the orchestrator's `/api/v1/pipelines/<id>/status/wait` route server-side and emits one JSON-line per pipeline-relevant event. See [Host-Side Waits](../reference/agent-wait-patterns.md#7-host-side-waits--egg-orch-pipeline-wait-status) for the envelope, exit-code contract, and cursor protocol. The route itself stays — the CLI is a wrapper.
 

--- a/docs/hitl-decisions.md
+++ b/docs/hitl-decisions.md
@@ -136,6 +136,45 @@ When you're done, check the box below to submit.
 | Multiple questions | No (one per decision) | Yes (consolidated comment) |
 | Workflow job | `handle-decision` | `handle-feedback` |
 
+### Answering contract feedback from the host (`answer_feedback`)
+
+Agents register feedback by writing `contract.feedback` (id `feedback-N`) via
+`register_feedback_request` (`mcp__sdlc__request_feedback`). That write touches
+only the gateway-backed contract — it is **not** an orchestrator decision. It
+is promoted into the orchestrator decision queue only **after the phase_gate is
+approved**, by the server-side bridge `_queue_and_await_contract_decisions`
+(see [Contract Decision Bridge](#contract-decision-bridge)).
+
+That post-gate promotion is fine for the normal flow (refiner embeds questions
+in its draft, operator approves the draft, then answers the deferred
+questions). But an agent can also register feedback **pre-proposal** and block
+on the answer before producing any draft — e.g. a refiner asking the operator
+to supply a goal on an empty contract. No phase_gate is ever reached, so:
+
+- the feedback never appears in `get_status(...).pending_decisions`;
+- `provide_input(decision_id="feedback-N", ...)` returns **HTTP 404** (no such
+  orchestrator decision);
+- the pipeline deadlocks (the overseer emits a `stuck-phase-transition` alert).
+
+The host operator answers this via the **`answer_feedback` MCP tool**, which
+posts to `POST /api/v1/pipelines/<pipeline_id>/feedback/answer`
+(`orchestrator/routes/decisions.py`). The route writes the answers straight
+into `contract.feedback` and marks it submitted — mirroring the bridge's
+write-back — so the blocked agent unblocks on its next contract poll:
+
+```
+answer_feedback(
+  task_id="issue-1059",
+  answers={"Q1": "Add retry logic to the API client", "Q2": "p99 < 200ms"},
+  feedback_id="feedback-1",   # optional staleness guard
+)
+```
+
+The endpoint is lifecycle-secret guarded, so only the operator/MCP can answer —
+an agent cannot submit answers to its own feedback (parity with decision
+resolve; see #1769). Inspect the pending questions first with
+`get_contract(task_id).feedback`. See #3007.
+
 ## Phase Approval
 
 Phase approval is a simpler mechanism for advancing the pipeline at HITL gates.
@@ -309,7 +348,7 @@ Both `OrchClient.create_decision()` and the underlying orchestrator API (`POST /
 
 ## `/sdlc` Skill: Auto-Resolving Repeated Questions
 
-The `/sdlc` Claude Code skill (defined by `skills/sdlc/SKILL.md`) handles HITL via MCP calls to `get_status` / `provide_input`. Decisions surface in **two waves**: when a phase first reaches `awaiting_human`, `pending_decisions` contains only the `phase_gate`; after it is approved, the [server-side bridge](#contract-decision-bridge) promotes any deferred `choice`/`feedback` decisions into `pending_decisions` and the pipeline stays in `awaiting_human` until they are resolved (see [Two-wave surfacing](../skills/sdlc/SKILL.md#two-wave-surfacing)). Because the refiner commonly embeds those same questions directly in the analysis/plan draft as `<!-- egg-hitl-decision id=cq-N -->` markers, the answers given during the phase_gate step would otherwise be re-asked in Wave 2.
+The `/sdlc` Claude Code skill (defined by `skills/sdlc/SKILL.md`) handles HITL via MCP calls to `get_status` / `provide_input` (orchestrator decisions) plus `answer_feedback` (contract-scoped pre-proposal feedback that never enters the decision queue — see [Answering contract feedback from the host](#answering-contract-feedback-from-the-host-answer_feedback)). Decisions surface in **two waves**: when a phase first reaches `awaiting_human`, `pending_decisions` contains only the `phase_gate`; after it is approved, the [server-side bridge](#contract-decision-bridge) promotes any deferred `choice`/`feedback` decisions into `pending_decisions` and the pipeline stays in `awaiting_human` until they are resolved (see [Two-wave surfacing](../skills/sdlc/SKILL.md#two-wave-surfacing)). Because the refiner commonly embeds those same questions directly in the analysis/plan draft as `<!-- egg-hitl-decision id=cq-N -->` markers, the answers given during the phase_gate step would otherwise be re-asked in Wave 2.
 
 Without special handling the skill would re-prompt the user for every draft-embedded question a second time once those standalone decisions arrive — the user answers each question twice. Phase 4 of the skill avoids this via a session-scoped **`resolved_questions_map`**.
 
@@ -399,7 +438,8 @@ This recovery fires at three sites:
 - `orchestrator/mcp_tools.py` — MCP `get_status` tool; enriches all pending decisions with `draft_content`; enriches `phase_gate` decisions additionally with `completed_agents_summary` and `reviewer_feedback`
 - `orchestrator/models.py` — `HITLDecision` model with `decision_type`, `questions`, `phase`, and `content_changed` fields; `content_changed` is set by the orchestrator on re-run phase gates to indicate whether the draft changed since the previous resolved decision (literal string comparison; `None` on first decision, `True`/`False` on subsequent ones). Also contains `OperatorDirective` (a single timestamped operator directive stored on kickback) and `IterationSummary` (BRC verdict snapshot for a kicked-back iteration), both accumulated on `PhaseExecution.operator_directives` / `PhaseExecution.iteration_history`.
 - `orchestrator/decision_queue.py` — Decision queue handling typed decisions
-- `orchestrator/routes/decisions.py` — Decision API endpoints (create, list, resolve)
+- `orchestrator/routes/decisions.py` — Decision API endpoints (create, list, resolve) and the operator `POST .../feedback/answer` route that answers contract-scoped feedback (`answer_feedback` MCP tool; #3007)
+- `orchestrator/mcp_tools.py` — `answer_feedback` MCP tool (`_handle_answer_feedback`) for host-side answering of pre-proposal contract feedback
 - `orchestrator/routes/pipelines.py` — Phase gate resolution with JSON payload parsing
 - `sandbox/egg_lib/sdlc_hitl.py` — Type-aware terminal HITL handler
 - `skills/sdlc/SKILL.md` — `/sdlc` Claude Code skill defining Phase 4 HITL handling: **two-wave surfacing** (phase_gate alone in Wave 1, deferred `choice`/`feedback` in Wave 2 after approval) and the session-scoped `resolved_questions_map` that handles cross-wave deduplication

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -1029,6 +1029,47 @@ PIPELINE_TOOLS = [
             },
         },
     },
+    {
+        "name": "answer_feedback",
+        "description": (
+            "Answer an open-ended feedback request an agent registered on the "
+            "SDLC contract. Pre-proposal feedback (e.g. a refiner asking for a "
+            "goal on an empty contract) lives on the contract as `feedback-N` "
+            "and is NOT an orchestrator decision, so `provide_input` returns "
+            "404 for it. Use this tool instead — "
+            "`get_contract(task_id).feedback` shows the pending questions. "
+            "Writing the answers marks the feedback submitted and unblocks the "
+            "waiting agent on its next contract poll. Operator-only "
+            "(lifecycle-secret guarded)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "Pipeline/task ID",
+                },
+                "answers": {
+                    "type": "object",
+                    "description": (
+                        "Map of feedback question id to answer text, e.g. "
+                        '{"Q1": "Add retry logic to the API client"}. Question '
+                        "ids come from `get_contract(task_id).feedback.questions`."
+                    ),
+                    "additionalProperties": {"type": "string"},
+                },
+                "feedback_id": {
+                    "type": "string",
+                    "description": (
+                        "Optional feedback id (e.g. `feedback-1`) guarding "
+                        "against answering a stale request; when supplied it "
+                        "must match the contract's pending feedback."
+                    ),
+                },
+            },
+            "required": ["task_id", "answers"],
+        },
+    },
 ]
 
 
@@ -1060,6 +1101,7 @@ class PipelineToolHandler:
             "submit_task": self._handle_submit_task,
             "get_status": self._handle_get_status,
             "provide_input": self._handle_provide_input,
+            "answer_feedback": self._handle_answer_feedback,
             "list_tasks": self._handle_list_tasks,
             "cancel_task": self._handle_cancel_task,
             "check_health": self._handle_check_health,
@@ -1664,6 +1706,25 @@ class PipelineToolHandler:
             data=data,
         )
         return result
+
+    def _handle_answer_feedback(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Answer an agent-registered contract feedback request (#3007).
+
+        Routes to the pipeline-scoped ``/feedback/answer`` endpoint, which
+        writes the answers into the contract feedback so a refiner blocked
+        on pre-proposal feedback unblocks. Unlike ``provide_input``, this
+        resolves against the gateway-backed contract, not the orchestrator
+        decision queue.
+        """
+        task_id = quote(args["task_id"], safe="")
+        data: dict[str, Any] = {"answers": args["answers"]}
+        if args.get("feedback_id"):
+            data["feedback_id"] = args["feedback_id"]
+        return self._make_request(
+            f"/api/v1/pipelines/{task_id}/feedback/answer",
+            method="POST",
+            data=data,
+        )
 
     def _handle_list_tasks(self, args: dict[str, Any]) -> dict[str, Any]:
         """List pipelines."""

--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -8,6 +8,7 @@ human-in-the-loop decisions.
 import json
 import re
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -950,6 +951,175 @@ def cancel_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]:
             f"Decision {decision_id} not found",
             status_code=404,
         )
+
+
+@decisions_bp.route("/<pipeline_id>/feedback/answer", methods=["POST"])
+@require_lifecycle_secret
+def answer_feedback(pipeline_id: str) -> tuple[Response, int]:
+    """Answer a contract-scoped feedback request from the host operator.
+
+    Agents register open-ended feedback via ``register_feedback_request``
+    (``mcp__sdlc__request_feedback``).  Pre-proposal feedback — e.g. a
+    refiner asking for a goal on an empty contract — is written only to
+    the gateway-backed contract as ``contract.feedback`` (id
+    ``feedback-N``).  It is **never** queued as an orchestrator decision
+    until *after* the phase_gate is approved by the post-gate bridge
+    (:func:`routes.pipelines._queue_and_await_contract_decisions`), so a
+    refiner that blocks on the answer before producing any proposal
+    deadlocks the pipeline: ``provide_input`` 404s (no such decision in
+    the queue) and the only documented answer path
+    (``egg-contract``) runs inside agent containers, unreachable from
+    the host (#3007).
+
+    This endpoint gives the host operator a first-class answer path. It
+    writes the answers straight into the contract and marks the feedback
+    submitted — mirroring the write-back the post-gate bridge performs —
+    so the waiting agent unblocks on its next contract poll. It is
+    lifecycle-secret guarded: only the operator/MCP carry the secret, so
+    an agent cannot answer its own feedback (parity with decision
+    resolve; see #1769).
+
+    URL params:
+        pipeline_id: Pipeline ID
+
+    Request body:
+        {
+            "answers": {"Q1": "...", "Q2": "..."},   # question id -> answer
+            "feedback_id": "feedback-1"                # optional guard
+        }
+    """
+    raw = request.get_json(silent=True)
+    if raw is not None and not isinstance(raw, dict):
+        return make_error_response("Request body must be a JSON object")
+    data = raw if raw is not None else {}
+
+    raw_answers = data.get("answers")
+    if not isinstance(raw_answers, dict) or not raw_answers:
+        return make_error_response("Missing 'answers' (object mapping question id to answer text)")
+    answers = {str(k): str(v) for k, v in raw_answers.items()}
+    requested_feedback_id = data.get("feedback_id")
+    repo_hint = data.get("repo")
+
+    try:
+        _store, pipeline = get_state_store_for_pipeline(pipeline_id)
+    except InvalidPipelineIdError:
+        return make_error_response(
+            f"Invalid pipeline ID format: {pipeline_id}",
+            status_code=400,
+        )
+    except PipelineNotFoundError:
+        return make_error_response(
+            f"Pipeline {pipeline_id} not found",
+            status_code=404,
+        )
+
+    # Lazy imports: ``contract_store`` and ``routes.pipelines`` pull in
+    # heavy state-store / docker dependencies; importing them at module
+    # top would couple decisions.py to initialisation order. Same pattern
+    # as contracts.py's ``_branch_read_contract``.
+    import contract_store
+    from egg_contracts import (
+        ContractNotFoundError,
+        ContractValidationError,
+        load_contract,
+        save_contract,
+    )
+    from routes.pipelines import _pipeline_identifier
+
+    worktree = contract_store.resolve_pipeline_worktree(pipeline_id, repo_hint)
+    if worktree is None:
+        return make_error_response(
+            f"Pipeline worktree not found for {pipeline_id}",
+            status_code=404,
+        )
+
+    identifier = _pipeline_identifier(getattr(pipeline, "issue_number", None), pipeline_id)
+
+    with contract_store.lock_for(identifier):
+        try:
+            contract = load_contract(identifier, worktree)
+        except ContractNotFoundError:
+            return make_error_response(
+                f"Contract for {pipeline_id} not found",
+                status_code=404,
+            )
+        except ContractValidationError as exc:
+            return make_error_response(
+                f"Contract validation failed: {exc}",
+                status_code=500,
+            )
+
+        feedback = contract.feedback
+        if feedback is None:
+            return make_error_response(
+                "No feedback request is pending on this contract",
+                status_code=404,
+            )
+        if requested_feedback_id and feedback.id != requested_feedback_id:
+            return make_error_response(
+                f"Feedback {requested_feedback_id} not found "
+                f"(pending feedback on this contract is {feedback.id})",
+                status_code=404,
+            )
+        if feedback.submitted:
+            return make_error_response(
+                f"Feedback {feedback.id} has already been submitted",
+                status_code=409,
+            )
+
+        valid_ids = {q.id for q in feedback.questions}
+        unknown_ids = sorted(qid for qid in answers if qid not in valid_ids)
+        if unknown_ids:
+            return make_error_response(
+                f"Unknown question id(s) {unknown_ids}; "
+                f"valid ids for {feedback.id}: {sorted(valid_ids)}",
+                status_code=400,
+            )
+
+        for question in feedback.questions:
+            if question.id in answers:
+                question.answer = answers[question.id]
+        # Mark submitted after applying answers — even a partial answer
+        # set counts as the human responding, matching the bridge's
+        # write-back so the agent isn't re-prompted.
+        feedback.submitted = True
+        feedback.submitted_by = "human"
+        feedback.submitted_at = datetime.now(UTC)
+
+        try:
+            save_contract(contract, worktree)
+        except Exception as exc:
+            logger.error(
+                "Failed to save contract after answering feedback",
+                pipeline_id=pipeline_id,
+                feedback_id=feedback.id,
+                error=str(exc),
+            )
+            return make_error_response(
+                f"Failed to save contract: {exc}",
+                status_code=500,
+            )
+
+        answered_feedback = {
+            "id": feedback.id,
+            "submitted": feedback.submitted,
+            "questions": [
+                {"id": q.id, "question": q.question, "answer": q.answer} for q in feedback.questions
+            ],
+        }
+
+    logger.info(
+        "Contract feedback answered by operator",
+        pipeline_id=pipeline_id,
+        feedback_id=answered_feedback["id"],
+        answered_questions=sorted(answers.keys()),
+        source=getattr(request, "egg_source", "unknown"),
+    )
+
+    return make_success_response(
+        "Feedback answered",
+        data={"feedback": answered_feedback},
+    )
 
 
 @decisions_bp.route("/<pipeline_id>/decisions/status", methods=["GET"])

--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -996,9 +996,14 @@ def answer_feedback(pipeline_id: str) -> tuple[Response, int]:
     raw_answers = data.get("answers")
     if not isinstance(raw_answers, dict) or not raw_answers:
         return make_error_response("Missing 'answers' (object mapping question id to answer text)")
-    answers = {str(k): str(v) for k, v in raw_answers.items()}
+    non_string = sorted(str(k) for k, v in raw_answers.items() if not isinstance(v, str))
+    if non_string:
+        return make_error_response(
+            "Answer values must be strings; non-string values for question id(s) "
+            f"{non_string}. To leave a question unanswered, omit its id from 'answers'.",
+        )
+    answers = {str(k): v for k, v in raw_answers.items()}
     requested_feedback_id = data.get("feedback_id")
-    repo_hint = data.get("repo")
 
     try:
         _store, pipeline = get_state_store_for_pipeline(pipeline_id)
@@ -1016,17 +1021,32 @@ def answer_feedback(pipeline_id: str) -> tuple[Response, int]:
     # Lazy imports: ``contract_store`` and ``routes.pipelines`` pull in
     # heavy state-store / docker dependencies; importing them at module
     # top would couple decisions.py to initialisation order. Same pattern
-    # as contracts.py's ``_branch_read_contract``.
+    # as contracts.py's ``_branch_read_contract``. The ``egg_contracts``
+    # try/except mirrors the post-gate bridge in
+    # ``_queue_and_await_contract_decisions`` so grepping for
+    # ``egg_contracts`` ImportError handling finds both sites.
     import contract_store
-    from egg_contracts import (
-        ContractNotFoundError,
-        ContractValidationError,
-        load_contract,
-        save_contract,
-    )
+
+    try:
+        from egg_contracts import (
+            ContractNotFoundError,
+            ContractValidationError,
+            load_contract,
+            save_contract,
+        )
+    except ImportError as exc:
+        logger.error(
+            "egg_contracts not available; cannot answer contract feedback",
+            pipeline_id=pipeline_id,
+            error=str(exc),
+        )
+        return make_error_response(
+            "Contract subsystem (egg_contracts) is not available on this host",
+            status_code=500,
+        )
     from routes.pipelines import _pipeline_identifier
 
-    worktree = contract_store.resolve_pipeline_worktree(pipeline_id, repo_hint)
+    worktree = contract_store.resolve_pipeline_worktree(pipeline_id)
     if worktree is None:
         return make_error_response(
             f"Pipeline worktree not found for {pipeline_id}",

--- a/orchestrator/tests/test_answer_feedback_route.py
+++ b/orchestrator/tests/test_answer_feedback_route.py
@@ -1,0 +1,218 @@
+"""Tests for POST /api/v1/pipelines/<id>/feedback/answer (#3007).
+
+The route lets the host operator answer a contract-scoped feedback
+request (``contract.feedback`` / ``feedback-N``) that an agent registered
+via ``register_feedback_request``.  Such pre-proposal feedback never
+becomes an orchestrator decision, so ``provide_input`` 404s; this route
+writes the answers straight into the contract and marks it submitted so
+the waiting agent unblocks.
+
+These tests exercise the real contract load/save against a temp worktree
+so the on-disk write-back is covered end to end.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mirror the docker/k8s mocking the other orchestrator tests rely on so the
+# lazy ``from routes.pipelines import _pipeline_identifier`` import inside the
+# handler does not require a real docker SDK.
+_docker_mock = MagicMock()
+sys.modules.setdefault("docker", _docker_mock)
+sys.modules.setdefault("docker.errors", _docker_mock.errors)
+sys.modules.setdefault("docker.types", _docker_mock.types)
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+
+PIPELINE_ID = "test-pipeline"
+
+
+@pytest.fixture
+def client():
+    from flask import Flask
+    from routes.decisions import decisions_bp
+
+    app = Flask(__name__)
+    app.register_blueprint(decisions_bp)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def _write_contract(worktree: Path, *, feedback=True, submitted=False):
+    """Create + persist a contract with (optionally) a pending feedback."""
+    from egg_contracts import Contract, Feedback, FeedbackQuestion, save_contract
+    from egg_contracts.models import PipelinePhase
+
+    contract = Contract(pipeline_id=PIPELINE_ID, current_phase=PipelinePhase.REFINE)
+    if feedback:
+        contract.feedback = Feedback(
+            id="feedback-1",
+            phase=PipelinePhase.REFINE,
+            questions=[
+                FeedbackQuestion(id="Q1", question="What problem should be refined?"),
+                FeedbackQuestion(id="Q2", question="Any success criteria?"),
+            ],
+            submitted=submitted,
+        )
+    save_contract(contract, worktree)
+    return contract
+
+
+def _patch_resolution(tmp_path, *, issue_number=None):
+    """Patch store + worktree resolution for the route to the temp worktree."""
+    store_mock = MagicMock(repo_path=tmp_path)
+    pipeline_mock = MagicMock(issue_number=issue_number)
+    return (
+        patch(
+            "routes.decisions.get_state_store_for_pipeline",
+            return_value=(store_mock, pipeline_mock),
+        ),
+        patch("contract_store.resolve_pipeline_worktree", return_value=tmp_path),
+    )
+
+
+def _post(client, body):
+    return client.post(f"/api/v1/pipelines/{PIPELINE_ID}/feedback/answer", json=body)
+
+
+def test_answers_feedback_writes_contract_and_marks_submitted(client, tmp_path):
+    from egg_contracts import load_contract
+
+    _write_contract(tmp_path)
+    store_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, worktree_patch:
+        resp = _post(client, {"answers": {"Q1": "Add retry logic", "Q2": "p99 < 200ms"}})
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["data"]["feedback"]["submitted"] is True
+
+    # The write-back must hit disk so the agent's next contract poll sees it.
+    contract = load_contract(PIPELINE_ID, tmp_path)
+    assert contract.feedback.submitted is True
+    assert contract.feedback.submitted_by == "human"
+    assert contract.feedback.submitted_at is not None
+    assert contract.feedback.get_question("Q1").answer == "Add retry logic"
+    assert contract.feedback.get_question("Q2").answer == "p99 < 200ms"
+
+
+def test_partial_answer_still_marks_submitted(client, tmp_path):
+    from egg_contracts import load_contract
+
+    _write_contract(tmp_path)
+    store_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, worktree_patch:
+        resp = _post(client, {"answers": {"Q1": "just the goal"}})
+
+    assert resp.status_code == 200
+    contract = load_contract(PIPELINE_ID, tmp_path)
+    assert contract.feedback.submitted is True
+    assert contract.feedback.get_question("Q1").answer == "just the goal"
+    # Unanswered question stays None — operator chose to leave it blank.
+    assert contract.feedback.get_question("Q2").answer is None
+
+
+def test_no_pending_feedback_returns_404(client, tmp_path):
+    _write_contract(tmp_path, feedback=False)
+    store_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, worktree_patch:
+        resp = _post(client, {"answers": {"Q1": "x"}})
+
+    assert resp.status_code == 404
+    assert "no feedback" in resp.get_json()["message"].lower()
+
+
+def test_already_submitted_returns_409(client, tmp_path):
+    _write_contract(tmp_path, submitted=True)
+    store_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, worktree_patch:
+        resp = _post(client, {"answers": {"Q1": "x"}})
+
+    assert resp.status_code == 409
+    assert "already" in resp.get_json()["message"].lower()
+
+
+def test_unknown_question_id_returns_400(client, tmp_path):
+    _write_contract(tmp_path)
+    store_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, worktree_patch:
+        resp = _post(client, {"answers": {"Q9": "nonexistent"}})
+
+    assert resp.status_code == 400
+    assert "Q9" in resp.get_json()["message"]
+
+
+def test_feedback_id_mismatch_returns_404(client, tmp_path):
+    _write_contract(tmp_path)
+    store_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, worktree_patch:
+        resp = _post(client, {"answers": {"Q1": "x"}, "feedback_id": "feedback-2"})
+
+    assert resp.status_code == 404
+    msg = resp.get_json()["message"]
+    assert "feedback-2" in msg and "feedback-1" in msg
+
+
+def test_missing_answers_returns_400(client, tmp_path):
+    _write_contract(tmp_path)
+    store_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, worktree_patch:
+        resp = _post(client, {})
+
+    assert resp.status_code == 400
+    assert "answers" in resp.get_json()["message"].lower()
+
+
+def test_worktree_not_found_returns_404(client, tmp_path):
+    store_mock = MagicMock(repo_path=tmp_path)
+    pipeline_mock = MagicMock(issue_number=None)
+    with (
+        patch(
+            "routes.decisions.get_state_store_for_pipeline",
+            return_value=(store_mock, pipeline_mock),
+        ),
+        patch("contract_store.resolve_pipeline_worktree", return_value=None),
+    ):
+        resp = _post(client, {"answers": {"Q1": "x"}})
+
+    assert resp.status_code == 404
+    assert "worktree" in resp.get_json()["message"].lower()
+
+
+def test_requires_lifecycle_secret(client, tmp_path):
+    """Agents (no bearer token) must not be able to answer feedback."""
+    _write_contract(tmp_path)
+    store_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, worktree_patch:
+        resp = client.post(
+            f"/api/v1/pipelines/{PIPELINE_ID}/feedback/answer",
+            json={"answers": {"Q1": "x"}},
+            _lifecycle_auth=False,
+        )
+
+    assert resp.status_code == 401
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/orchestrator/tests/test_answer_feedback_route.py
+++ b/orchestrator/tests/test_answer_feedback_route.py
@@ -214,5 +214,57 @@ def test_requires_lifecycle_secret(client, tmp_path):
     assert resp.status_code == 401
 
 
+def test_non_string_answer_value_returns_400(client, tmp_path):
+    """JSON null / object / int answers are rejected, not coerced to ``str()``.
+
+    Without this, ``None`` would be written as the literal string ``"None"``
+    and ``{"x": 1}`` as its repr. The MCP schema declares answer values as
+    strings; raw HTTP callers must abide by the same contract.
+    """
+    from egg_contracts import load_contract
+
+    _write_contract(tmp_path)
+    store_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, worktree_patch:
+        resp = _post(client, {"answers": {"Q1": None, "Q2": {"nested": True}}})
+
+    assert resp.status_code == 400
+    msg = resp.get_json()["message"]
+    assert "must be strings" in msg
+    assert "Q1" in msg and "Q2" in msg
+
+    # And nothing was written — the contract is untouched.
+    contract = load_contract(PIPELINE_ID, tmp_path)
+    assert contract.feedback.submitted is False
+    assert contract.feedback.get_question("Q1").answer is None
+    assert contract.feedback.get_question("Q2").answer is None
+
+
+def test_repo_field_in_body_is_ignored(client, tmp_path):
+    """A stray ``repo`` field in the body must not influence worktree resolution.
+
+    The MCP schema does not expose ``repo`` and the route now ignores it,
+    so ``resolve_pipeline_worktree`` is invoked with the pipeline id only.
+    """
+    _write_contract(tmp_path)
+    store_mock = MagicMock(repo_path=tmp_path)
+    pipeline_mock = MagicMock(issue_number=None)
+    resolve_mock = MagicMock(return_value=tmp_path)
+
+    with (
+        patch(
+            "routes.decisions.get_state_store_for_pipeline",
+            return_value=(store_mock, pipeline_mock),
+        ),
+        patch("contract_store.resolve_pipeline_worktree", resolve_mock),
+    ):
+        resp = _post(client, {"answers": {"Q1": "x"}, "repo": "should-be-ignored"})
+
+    assert resp.status_code == 200
+    # Single positional pipeline_id argument — no repo hint forwarded.
+    resolve_mock.assert_called_once_with(PIPELINE_ID)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -940,6 +940,7 @@ class TestToolRouting:
             "submit_task",
             "get_status",
             "provide_input",
+            "answer_feedback",
             "list_tasks",
             "cancel_task",
             "check_health",
@@ -2942,3 +2943,61 @@ class TestToolOutputCap:
         handler._handle_list_containers = boom  # type: ignore[assignment]
         result = handler.handle_tool_call("list_containers", {})
         assert result == {"error": "kaboom"}
+
+
+class TestAnswerFeedback:
+    """answer_feedback MCP tool — answers contract-scoped feedback (#3007)."""
+
+    def test_routes_to_feedback_answer_endpoint(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {"success": True, "data": {"feedback": {}}}
+            handler.handle_tool_call(
+                "answer_feedback",
+                {
+                    "task_id": "issue-42-v2",
+                    "answers": {"Q1": "Add retry logic", "Q2": "yes"},
+                },
+            )
+
+        mock_req.assert_called_once()
+        url = mock_req.call_args[0][0]
+        # task_id is URL-encoded into the path
+        assert url == "/api/v1/pipelines/issue-42-v2/feedback/answer"
+        assert mock_req.call_args[1]["method"] == "POST"
+        data = mock_req.call_args[1]["data"]
+        assert data["answers"] == {"Q1": "Add retry logic", "Q2": "yes"}
+        # No feedback_id supplied -> key omitted, not sent as None
+        assert "feedback_id" not in data
+
+    def test_forwards_optional_feedback_id(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {"success": True}
+            handler.handle_tool_call(
+                "answer_feedback",
+                {
+                    "task_id": "issue-7",
+                    "answers": {"Q1": "ship it"},
+                    "feedback_id": "feedback-1",
+                },
+            )
+
+        data = mock_req.call_args[1]["data"]
+        assert data["feedback_id"] == "feedback-1"
+
+    def test_task_id_is_url_encoded(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {"success": True}
+            handler.handle_tool_call(
+                "answer_feedback",
+                {"task_id": "weird/id", "answers": {"Q1": "x"}},
+            )
+
+        assert mock_req.call_args[0][0] == "/api/v1/pipelines/weird%2Fid/feedback/answer"
+
+    def test_registered_in_pipeline_tools_schema(self):
+        from mcp_tools import PIPELINE_TOOLS
+
+        tool = next(t for t in PIPELINE_TOOLS if t["name"] == "answer_feedback")
+        required = tool["inputSchema"]["required"]
+        assert "task_id" in required
+        assert "answers" in required

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -3,7 +3,7 @@ name: sdlc
 description: "Run an egg SDLC pipeline: full lifecycle (default) or lightweight coder+reviewer with --short."
 disable-model-invocation: true
 argument-hint: "[--short] [--qualifier <name>] [JIRA-1234 or issue# or description] [--repo owner/name]"
-allowed-tools: Monitor TaskStop Bash(${CLAUDE_SKILL_DIR}/bin/wait-status:*) Bash(gh issue view:*) Bash(gh issue list:*) Bash(gh pr list:*) Bash(gh pr view:*) Bash(git remote:*) Bash(git -C * remote:*) AskUserQuestion mcp__egg__submit_task mcp__egg__get_status mcp__egg__provide_input mcp__egg__list_tasks mcp__egg__cancel_task mcp__egg__check_health mcp__egg__list_containers mcp__egg__get_container_logs mcp__egg__send_message mcp__egg__get_consensus_status mcp__egg__get_phase mcp__egg__get_pipeline_snapshot mcp__egg__get_contract
+allowed-tools: Monitor TaskStop Bash(${CLAUDE_SKILL_DIR}/bin/wait-status:*) Bash(gh issue view:*) Bash(gh issue list:*) Bash(gh pr list:*) Bash(gh pr view:*) Bash(git remote:*) Bash(git -C * remote:*) AskUserQuestion mcp__egg__submit_task mcp__egg__get_status mcp__egg__provide_input mcp__egg__answer_feedback mcp__egg__list_tasks mcp__egg__cancel_task mcp__egg__check_health mcp__egg__list_containers mcp__egg__get_container_logs mcp__egg__send_message mcp__egg__get_consensus_status mcp__egg__get_phase mcp__egg__get_pipeline_snapshot mcp__egg__get_contract
 ---
 
 # SDLC Pipeline
@@ -468,7 +468,38 @@ Handle each response:
 - **Acknowledge** → Resume monitoring. Track acknowledged alerts to avoid re-prompting for the same alert.
 - **Cancel pipeline** → Confirm with the user, then call `cancel_task` with `task_id` and `cleanup: true`.
 
+**Before offering the generic options above**, if the alert subject is `stuck-phase-transition` (or its body otherwise says a HITL gate is awaiting operator input / names an unanswered `feedback-N` / `Q<n>`), first check for **unanswered contract feedback** per [Answering pre-proposal contract feedback](#answering-pre-proposal-contract-feedback) below — that is usually the actionable resolution, and neither "Check agent logs" nor "Acknowledge" will clear it.
+
 **Deduplication** — Maintain a set of seen alert message `id` values (UUIDs from the `Message` model) across poll cycles. Only prompt the user for alerts not previously seen or acknowledged. Do not use subject strings for deduplication — distinct alerts may share the same anomaly type, role, and priority.
+
+### Answering pre-proposal contract feedback
+
+An agent can register an open-ended **feedback request** on the SDLC contract before it produces any draft — most commonly a refiner asking the operator to supply a goal/success criteria when the contract is empty (free-text / Confluence / no-issue submissions). This pre-proposal feedback is written to the contract as `feedback-N` and the agent then **blocks** waiting for the answer, so no phase_gate is ever reached.
+
+**This feedback does NOT appear in `pending_decisions`.** It only becomes an orchestrator decision *after* a phase_gate is approved (Wave 2 of [two-wave surfacing](#two-wave-surfacing)) — which never happens here because the agent is blocked before the gate. As a result:
+
+- It never shows up in a `get_status` snapshot's `pending_decisions`, so Phase 4's normal HITL flow won't surface it.
+- `provide_input(decision_id="feedback-N", ...)` returns **HTTP 404** — there is no such orchestrator decision.
+- The pipeline deadlocks; the overseer detects this and emits a `stuck-phase-transition` `OVERSEER_ALERT`.
+
+**Detection.** When a `stuck-phase-transition` alert fires (or whenever a pipeline sits blocked with an empty `pending_decisions`), call `get_contract(task_id)` and inspect the `feedback` field. If it is non-null with `submitted: false`, its `questions[]` are awaiting the operator.
+
+**Answer it via `answer_feedback`, NOT `provide_input`:**
+
+1. Display the questions to the user. Present them with `AskUserQuestion`, batching up to 4 per call (same as the `feedback` decision_type handler). For a refiner-on-empty-contract request, the user's answer is the task goal / constraints — give them an "Other" field to type it.
+2. Collect answers into a dict keyed by each question's `id` (e.g. `{"Q1": "Add retry logic to the API client", "Q2": "p99 < 200ms"}`).
+3. Call the `answer_feedback` MCP tool:
+
+   ```
+   Tool: answer_feedback
+   Arguments:
+     task_id: <task_id>
+     answers: {"Q1": "<answer>", "Q2": "<answer>"}
+     feedback_id: <contract feedback id, e.g. "feedback-1">   # optional staleness guard
+   ```
+
+   `answer_feedback` writes the answers into the contract and marks the feedback submitted, so the blocked agent unblocks on its next contract poll and proceeds to produce its proposal. A partial answer set is allowed — the feedback is still marked submitted, so don't leave a question blank unless the user intends to skip it.
+4. Resume monitoring (Phase 3). Re-arm the Monitor, stopping the prior one first per [HITL-driven re-arms](#hitl-driven-re-arms-stop-the-prior-monitor-first) — the agent producing its proposal will emit the next `phase.*` event.
 
 ### Host detector migration (issue #1962)
 
@@ -1047,6 +1078,7 @@ All orchestrator and gateway interactions use the MCP tool surface. Never call R
 | `get_status` | One-shot status snapshot (no cursor) — use for first poll and after `provide_input` |
 | `${CLAUDE_SKILL_DIR}/bin/wait-status` (via Monitor) | Long-poll for status changes; emits JSON-lines on stdout — Monitor surfaces each line as its own notification, so the LLM wakes on every event. Self-contained stdlib client (no egg checkout; only `EGG_ORCHESTRATOR_URL` needed). Replaces the prior `wait_for_status_change` MCP tool (#2211). Bash is a fallback only (events batch at exit). |
 | `provide_input` | Respond to HITL decisions (serialize JSON payload as string) |
+| `answer_feedback` | Answer pre-proposal contract feedback (`feedback-N`) that never enters the decision queue — see [Answering pre-proposal contract feedback](#answering-pre-proposal-contract-feedback). Use instead of `provide_input`, which 404s on it |
 | `list_tasks` | List tasks for a repository |
 | `cancel_task` | Cancel a running task |
 | `check_health` | Verify orchestrator + gateway health |


### PR DESCRIPTION
## Summary

Closes #3007.

A `refine`-phase pipeline **hard-deadlocks** when a refiner registers a pre-proposal feedback request on an empty SDLC contract. The feedback is written to the gateway-backed contract as `feedback-N`, but it is **never registered as an orchestrator decision**, so the host operator/driver has no way to answer it:

- `provide_input(decision_id="feedback-N", ...)` returns **HTTP 404** (the orchestrator has no such decision — contract feedback is only promoted into the decision queue *after* a phase_gate is approved, by `_queue_and_await_contract_decisions`, which never runs when the agent blocks pre-proposal).
- The only documented answer path (`egg-contract`) runs **inside agent containers** (needs the egg venv/PYTHONPATH), so it is unreachable from a host session driving the pipeline from another repo via MCP.

Net effect: the refiner waits forever for an answer that cannot be delivered through any host-available interface.

This PR gives the host session a **first-class MCP answer path** — closing the "all SDLC tools the host session needs must be MCP-reachable from any repo" gap.

## Changes

- **`orchestrator/routes/decisions.py`** — new operator-authenticated route `POST /api/v1/pipelines/<pipeline_id>/feedback/answer`. Resolves the shared pipeline worktree, writes the answers into `contract.feedback`, and marks it submitted — reusing the exact write-back the post-gate bridge (`_queue_and_await_contract_decisions`) already performs — so the blocked agent unblocks on its next contract poll. Lifecycle-secret guarded, so an agent cannot answer its own feedback (parity with decision resolve, #1769). Returns 404 (no pending / id mismatch), 409 (already submitted), 400 (unknown question id / missing answers).
- **`orchestrator/mcp_tools.py`** — new `answer_feedback` MCP tool (`task_id`, `answers` = question id → text, optional `feedback_id` staleness guard), wired into `PIPELINE_TOOLS` and the handler dispatch.
- **`skills/sdlc/SKILL.md`** — added `mcp__egg__answer_feedback` to `allowed-tools`; a new "Answering pre-proposal contract feedback" recovery subsection (detect via `get_contract(task_id).feedback`, answer via `answer_feedback`, not `provide_input`); and routed the `stuck-phase-transition` overseer alert to it.
- **Docs** — `docs/hitl-decisions.md` (host answer path + when it applies) and `docs/architecture/orchestrator.md` (tool list).

## Why a new tool (not a `provide_input` fallback)

`provide_input` resolves the orchestrator decision queue; pre-proposal contract feedback never enters that queue. A dedicated, explicit `answer_feedback` tool keeps the two surfaces unambiguous (decision queue vs. gateway-backed contract) and is what the `/sdlc` skill now reaches for on the deadlock path. The scope addressed here is the evidenced **feedback** deadlock; contract open-questions (`cq-N`) already have a post-gate host path via the bridge + `provide_input`.

## Testing

- `orchestrator/tests/test_answer_feedback_route.py` — exercises the real contract load/save against a temp worktree (write-back persists to disk so the agent's next poll sees it), partial-answer submission, and the 404/409/400/auth edge cases.
- `TestAnswerFeedback` in `orchestrator/tests/test_mcp_tools.py` — handler routing, optional `feedback_id` forwarding, task_id URL-encoding, schema registration; plus the `test_all_tools_registered` expected-set update.
- `make lint` green (mypy: no issues). Targeted suites (`test_answer_feedback_route`, `test_mcp_tools`, `test_decisions_routes`, `test_mcp_server`) pass; the full changeset-selected suite passed with zero failures.