### PR TITLE
feat(orchestrator): validate producer draft at canonical path on propose (#3016)

### DIFF
--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -1001,7 +1001,7 @@ def _validate_planner_role_alignment(
         return
 
     # Build the plan draft path. Imported lazily to avoid pulling the
-    # 16k-line ``routes.pipelines`` module into ``signals`` import time.
+    # ~24k-line ``routes.pipelines`` module into ``signals`` import time.
     try:
         from routes.pipelines import _get_draft_path
     except ImportError:
@@ -1033,7 +1033,18 @@ def _validate_planner_role_alignment(
             check=False,
         )
         if result.returncode != 0:
-            return  # Plan not present at this commit — nothing to validate.
+            # Plan absent at this commit — nothing to validate. Note: on the
+            # production handler path this branch is unreachable for
+            # task_planner because ``_validate_producer_draft_present`` (#3016)
+            # now runs first in ``handle_consensus_propose_signal`` and rejects
+            # an absent plan with 400 before this validator is invoked. The
+            # silent-skip here is retained as a safety net for direct callers
+            # (tests, future re-orderings) — but the two guards have opposite
+            # responses to the same ``returncode != 0`` signal, so any
+            # refactor that moves the alignment guard ahead of the presence
+            # guard would silently re-introduce the #3016 bug. Keep
+            # ``_validate_producer_draft_present`` upstream of this call.
+            return
         plan_text = result.stdout
     except Exception as exc:
         logger.warning(
@@ -1094,6 +1105,7 @@ def _validate_producer_draft_present(
     *,
     pipeline_state: Any | None = None,
     worktree_path: Path | None = None,
+    branch_verified: bool | None = True,
 ) -> None:
     """Reject a producer proposal whose canonical phase draft is absent at the
     proposed commit (#3016).
@@ -1132,9 +1144,29 @@ def _validate_producer_draft_present(
     ``handle_consensus_propose_signal`` to reuse the lookups it already performed for
     ``_verify_commit_on_branch``; the function loads them itself when called directly
     (e.g. from unit tests).
+
+    ``branch_verified`` mirrors the tri-state from ``_verify_commit_on_branch``:
+    ``True`` (commit is on the branch — fetch + ``--contains`` succeeded), ``False``
+    (commit is *not* on the branch — the caller already 409'd, so this is
+    unreachable in practice), or ``None`` (verification was inconclusive because
+    ``git fetch`` or ``git branch -r --contains`` errored — orchestrator-side
+    glitch, not a producer fault). When ``None`` is passed, the presence check is
+    skipped because a non-zero ``git show`` could legitimately mean the commit
+    isn't in the local object cache rather than the path being absent — false-
+    rejecting in that case would burn a producer turn on an orchestrator glitch
+    (matches the existing "could not verify branch" non-blocking warning at the
+    handler level). Defaults to ``True`` so direct callers (unit tests) that
+    don't run ``_verify_commit_on_branch`` still get the check.
     """
     commit_sha = (payload.get("commit_sha") or "").strip()
     if not commit_sha:
+        return
+
+    # Orchestrator-side verification of the commit was inconclusive (fetch or
+    # branch-contains errored). A non-zero ``git show`` below could legitimately
+    # be "commit not in local object cache" rather than "path absent at commit",
+    # so skip rather than risk a false 400.
+    if branch_verified is None:
         return
 
     if pipeline_state is None:
@@ -1146,7 +1178,7 @@ def _validate_producer_draft_present(
     if not pipeline_state.branch:
         return
 
-    # Lazy import to avoid pulling the ~21k-line ``routes.pipelines`` module into
+    # Lazy import to avoid pulling the ~24k-line ``routes.pipelines`` module into
     # ``signals`` import time (matches ``_validate_planner_role_alignment``).
     try:
         from routes.pipelines import _get_draft_path
@@ -1362,6 +1394,14 @@ def handle_consensus_propose_signal(
     commit_sha = payload.get("commit_sha", "")
     pipeline_state = None
     worktree_path = None
+    # Tri-state mirroring ``_verify_commit_on_branch``: True (commit on
+    # branch), False (commit NOT on branch — 409 short-circuit below), or
+    # None (verification inconclusive — fetch or branch-contains errored).
+    # Threaded into ``_validate_producer_draft_present`` so that a glitch
+    # in our fetch doesn't get blamed on the producer as a missing draft
+    # (a non-zero ``git show`` after a failed fetch could be "commit not
+    # in local object cache" rather than "path absent at commit").
+    branch_verified: bool | None = True
     if commit_sha:
         try:
             store_mod = get_state_store(repo_path)
@@ -1393,6 +1433,10 @@ def handle_consensus_propose_signal(
                 commit_sha=commit_sha,
                 error=str(e),
             )
+            # Verification raised — same posture as ``_verify_commit_on_branch``
+            # returning None: skip the downstream presence check rather than
+            # blame the producer for an orchestrator-side glitch.
+            branch_verified = None
 
     try:
         # Validate tester proposals cover all configured repo checks (#1459).
@@ -1412,6 +1456,7 @@ def handle_consensus_propose_signal(
                 repo_path,
                 pipeline_state=pipeline_state,
                 worktree_path=worktree_path,
+                branch_verified=branch_verified,
             )
         # Validate task_planner proposals: (a) the plan draft is present at the
         # canonical path (#3016 — same deterministic-input guard as refine), and
@@ -1425,6 +1470,7 @@ def handle_consensus_propose_signal(
                 repo_path,
                 pipeline_state=pipeline_state,
                 worktree_path=worktree_path,
+                branch_verified=branch_verified,
             )
             _validate_planner_role_alignment(
                 pipeline_id,

--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -1133,12 +1133,14 @@ def _validate_producer_draft_present(
     backstop.
 
     Graceful degradation: when the proposal carries no commit SHA, the pipeline has
-    no branch, the draft path can't be derived, or ``git show`` errors for an
-    infrastructure reason (timeout / git failure), this returns silently. It raises
-    only when it can positively confirm the draft is absent (or empty) at a resolved,
-    branch-verified commit — ``handle_consensus_propose_signal`` has already run
-    ``_verify_commit_on_branch`` (which fetches the commit), so a non-zero ``git
-    show`` here reliably means "path absent at commit", not "commit unknown".
+    no branch, the draft path can't be derived, ``git show`` errors for an
+    infrastructure reason (timeout / git failure), or branch verification was
+    inconclusive (``branch_verified is None`` — see below), this returns silently. It
+    raises only when it can positively confirm the draft is absent (or empty) at a
+    resolved, branch-verified commit — ``handle_consensus_propose_signal`` has
+    already run ``_verify_commit_on_branch`` (which fetches the commit), so a
+    non-zero ``git show`` here reliably means "path absent at commit", not "commit
+    unknown".
 
     ``pipeline_state`` / ``worktree_path`` are threaded in by
     ``handle_consensus_propose_signal`` to reuse the lookups it already performed for

--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -1086,6 +1086,122 @@ def _validate_planner_role_alignment(
     )
 
 
+def _validate_producer_draft_present(
+    phase: str,
+    pipeline_id: str,
+    payload: dict[str, Any],
+    repo_path: Path,
+    *,
+    pipeline_state: Any | None = None,
+    worktree_path: Path | None = None,
+) -> None:
+    """Reject a producer proposal whose canonical phase draft is absent at the
+    proposed commit (#3016).
+
+    The refine/plan operator gate, the contract populator, and the resume path all
+    read the phase artifact from the canonical
+    ``.egg-state/drafts/{prefix}-{analysis|plan}.md`` path (``_get_draft_path``). A
+    producer that commits its draft to some other path — or not at all — still
+    reaches BRC consensus and completes the phase; only later does the gate report
+    "No <analysis|plan> draft was found on the work branch", a silent
+    deterministic-input failure. (Observed: a refiner that committed
+    ``.egg-state/agent-outputs/refiner-refine.md`` — a path no code reads — instead
+    of ``.egg-state/drafts/<n>-analysis.md``.)
+
+    refine and plan are always concurrent, so the producer always issues
+    ``consensus_propose``. Validating here — before ``handle_propose`` records the
+    proposal — turns a missing draft into a 400 the producer (still alive) can fix by
+    re-proposing with the draft at the right path, instead of the failure surfacing a
+    phase later. The caller's ``except`` block maps the raised ``ValueError`` to a
+    400, so no reviewer cycle is wasted on a structurally-broken proposal.
+
+    Existence-only by design. Format/template conformance is intentionally *not*
+    enforced here — that would risk false-rejecting a legitimate-but-differently-
+    structured draft (see #3016 / #3017); the gate and reviewers remain the content
+    backstop.
+
+    Graceful degradation: when the proposal carries no commit SHA, the pipeline has
+    no branch, the draft path can't be derived, or ``git show`` errors for an
+    infrastructure reason (timeout / git failure), this returns silently. It raises
+    only when it can positively confirm the draft is absent (or empty) at a resolved,
+    branch-verified commit — ``handle_consensus_propose_signal`` has already run
+    ``_verify_commit_on_branch`` (which fetches the commit), so a non-zero ``git
+    show`` here reliably means "path absent at commit", not "commit unknown".
+
+    ``pipeline_state`` / ``worktree_path`` are threaded in by
+    ``handle_consensus_propose_signal`` to reuse the lookups it already performed for
+    ``_verify_commit_on_branch``; the function loads them itself when called directly
+    (e.g. from unit tests).
+    """
+    commit_sha = (payload.get("commit_sha") or "").strip()
+    if not commit_sha:
+        return
+
+    if pipeline_state is None:
+        try:
+            pipeline_state = get_state_store(repo_path).load_pipeline(pipeline_id)
+        except StateStoreError:
+            return
+
+    if not pipeline_state.branch:
+        return
+
+    # Lazy import to avoid pulling the ~21k-line ``routes.pipelines`` module into
+    # ``signals`` import time (matches ``_validate_planner_role_alignment``).
+    try:
+        from routes.pipelines import _get_draft_path
+    except ImportError:
+        try:
+            from .pipelines import _get_draft_path  # type: ignore[no-redef]
+        except ImportError:
+            return
+
+    draft_rel = _get_draft_path(
+        phase,
+        issue_number=pipeline_state.issue_number,
+        pipeline_id=pipeline_id,
+    )
+    if not draft_rel:
+        return
+
+    if worktree_path is None:
+        worktree_path = resolve_worktree_path(pipeline_id, repo_path)
+
+    # Read the draft as committed at the proposed SHA, not from the working tree
+    # (which can lag HEAD — see #2723). The preceding ``_verify_commit_on_branch``
+    # already fetched the commit, so it is reachable in the worktree.
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(worktree_path), "show", f"{commit_sha}:{draft_rel}"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except Exception as exc:
+        logger.warning(
+            "producer draft presence check: git show failed (non-blocking)",
+            pipeline_id=pipeline_id,
+            phase=phase,
+            commit_sha=commit_sha,
+            error=str(exc),
+        )
+        return
+
+    if result.returncode == 0 and result.stdout.strip():
+        return  # Draft present and non-empty — nothing to reject.
+
+    label = "analysis" if phase == "refine" else phase
+    raise ValueError(
+        f"{phase.capitalize()} proposal rejected: no {label} draft found at "
+        f"`{draft_rel}` in the proposed commit ({commit_sha[:8]}). The phase gate, "
+        f"contract population, and resume all read the {label} from this exact path "
+        f"— a draft committed to a different path (or an empty one) is invisible to "
+        f"them. Write your {label} to `{draft_rel}`, commit and push it, then "
+        f"re-propose."
+    )
+
+
 def _resolve_pipeline_phase(pipeline_id: str, repo_path: Path) -> str:
     """Resolve the current phase for a pipeline, with graceful fallback.
 
@@ -1284,10 +1400,32 @@ def handle_consensus_propose_signal(
         # rejected proposals.
         if agent_role == "tester":
             _validate_tester_check_coverage(pipeline_id, payload, repo_path)
-        # Validate task_planner proposals don't misassign tasks to roles
-        # whose blocklist forbids their files (#2527). Same placement
-        # rule: BEFORE handle_propose so the tracker isn't mutated.
+        # Reject a refine producer whose analysis draft is missing at the
+        # canonical path the gate reads — before handle_propose records it, so
+        # the gate can't later false-negative on a draft committed off-path
+        # (#3016). Same placement rule: BEFORE handle_propose.
+        elif agent_role == "refiner":
+            _validate_producer_draft_present(
+                "refine",
+                pipeline_id,
+                payload,
+                repo_path,
+                pipeline_state=pipeline_state,
+                worktree_path=worktree_path,
+            )
+        # Validate task_planner proposals: (a) the plan draft is present at the
+        # canonical path (#3016 — same deterministic-input guard as refine), and
+        # (b) no task is misassigned to a role whose blocklist forbids its files
+        # (#2527). Both run BEFORE handle_propose so the tracker isn't mutated.
         elif agent_role == "task_planner":
+            _validate_producer_draft_present(
+                "plan",
+                pipeline_id,
+                payload,
+                repo_path,
+                pipeline_state=pipeline_state,
+                worktree_path=worktree_path,
+            )
             _validate_planner_role_alignment(
                 pipeline_id,
                 payload,

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -2383,17 +2383,27 @@ class TestPlannerRoleAlignmentValidation:
         mock_tracker = MagicMock()
         mock_tracker.handle_propose = MagicMock(return_value={"version": 1})
 
-        # Two subprocess calls happen in this path:
+        # Four subprocess calls happen in this path (task_planner):
         #   1. _verify_commit_on_branch's git fetch
         #   2. _verify_commit_on_branch's git branch --contains
-        #   3. _validate_planner_role_alignment's git show
-        # The first two return success; the third returns the misassigned plan.
+        #   3. _validate_producer_draft_present's git show (#3016) — plan
+        #      present at the commit, so the presence guard passes
+        #   4. _validate_planner_role_alignment's git show — returns the
+        #      misassigned plan, so the alignment guard raises
+        # The first two return success; calls 3 and 4 both read the plan draft
+        # at the proposed commit, so both return the (misassigned) plan.
         side_effect = [
             subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
             subprocess.CompletedProcess(
                 args=[],
                 returncode=0,
                 stdout="  origin/egg/issue-2527\n",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=self._PLAN_WITH_MISASSIGNED_TASK,
                 stderr="",
             ),
             subprocess.CompletedProcess(
@@ -2435,6 +2445,188 @@ class TestPlannerRoleAlignmentValidation:
             # never mutates tracker state. This is the regression
             # guarantee the PR-1 review flagged as the missing
             # production-sequence test.
+            mock_tracker.handle_propose.assert_not_called()
+
+
+class TestProducerDraftPresentValidation:
+    """Tests for ``_validate_producer_draft_present`` in ``signals.py`` (#3016).
+
+    A refine/plan producer that commits its draft to a non-canonical path (or not
+    at all) used to reach BRC consensus and complete the phase, after which the
+    operator gate — which reads ``.egg-state/drafts/{prefix}-{analysis|plan}.md``
+    via ``_get_draft_path`` — reported "No <analysis|plan> draft was found". This
+    validator runs at ``CONSENSUS_PROPOSE`` (always issued in concurrent refine/
+    plan), reads the draft at the proposed commit via ``git show``, and rejects
+    (400) when it is absent so the still-alive producer re-proposes with the draft
+    at the right path.
+    """
+
+    @staticmethod
+    def _patched_store(issue_number: int | None = 3016, branch: str = "egg/issue-3016"):
+        mock_pipeline = MagicMock()
+        mock_pipeline.issue_number = issue_number
+        mock_pipeline.branch = branch
+        mock_pipeline.mode = None
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = mock_pipeline
+        return patch("routes.signals.get_state_store", return_value=mock_store)
+
+    @staticmethod
+    def _patched_subprocess(stdout: str, returncode: int = 0):
+        result = subprocess.CompletedProcess(
+            args=[], returncode=returncode, stdout=stdout, stderr=""
+        )
+        return patch("routes.signals.subprocess.run", return_value=result)
+
+    @staticmethod
+    def _patched_worktree():
+        return patch("routes.signals.resolve_worktree_path", return_value=Path("/tmp/wt"))
+
+    def test_skips_when_commit_sha_missing(self):
+        """No commit SHA on payload → nothing to validate against."""
+        from routes.signals import _validate_producer_draft_present
+
+        # No other patches needed — the bail-out happens before any git access.
+        _validate_producer_draft_present("refine", "issue-3016", {}, Path("/tmp"))
+        _validate_producer_draft_present("refine", "issue-3016", {"commit_sha": ""}, Path("/tmp"))
+
+    def test_accepts_when_refine_draft_present(self):
+        """Analysis draft present and non-empty at the proposed commit → no raise."""
+        from routes.signals import _validate_producer_draft_present
+
+        with (
+            self._patched_store(),
+            self._patched_worktree(),
+            self._patched_subprocess("# Analysis: something real\n\n## Problem\n..."),
+        ):
+            _validate_producer_draft_present(
+                "refine", "issue-3016", {"commit_sha": "abc1234"}, Path("/tmp/repo")
+            )
+
+    def test_rejects_when_refine_draft_absent(self):
+        """``git show`` non-zero (analysis draft absent at commit) → raises."""
+        from routes.signals import _validate_producer_draft_present
+
+        with (
+            self._patched_store(),
+            self._patched_worktree(),
+            self._patched_subprocess("", returncode=128),
+        ):
+            with pytest.raises(ValueError, match="no analysis draft found"):
+                _validate_producer_draft_present(
+                    "refine", "issue-3016", {"commit_sha": "abc1234"}, Path("/tmp/repo")
+                )
+
+    def test_rejects_when_refine_draft_empty(self):
+        """Draft exists but is empty/whitespace-only → still rejected."""
+        from routes.signals import _validate_producer_draft_present
+
+        with (
+            self._patched_store(),
+            self._patched_worktree(),
+            self._patched_subprocess("   \n  \n"),
+        ):
+            with pytest.raises(ValueError, match="no analysis draft found"):
+                _validate_producer_draft_present(
+                    "refine", "issue-3016", {"commit_sha": "abc1234"}, Path("/tmp/repo")
+                )
+
+    def test_rejects_when_plan_draft_absent_names_plan_path(self):
+        """Plan-phase rejection names the plan draft, not analysis."""
+        from routes.signals import _validate_producer_draft_present
+
+        with (
+            self._patched_store(),
+            self._patched_worktree(),
+            self._patched_subprocess("", returncode=128),
+        ):
+            with pytest.raises(ValueError, match=r"no plan draft found.*-plan\.md"):
+                _validate_producer_draft_present(
+                    "plan", "issue-3016", {"commit_sha": "abc1234"}, Path("/tmp/repo")
+                )
+
+    def test_skips_when_git_show_errors(self):
+        """A git/infra failure (not a clean non-zero exit) → graceful skip.
+
+        Distinguishes infrastructure failure (don't false-reject) from a
+        definitive absent-at-commit signal (a clean non-zero return, which the
+        ``test_rejects_*`` cases cover).
+        """
+        from routes.signals import _validate_producer_draft_present
+
+        with (
+            self._patched_store(),
+            self._patched_worktree(),
+            patch(
+                "routes.signals.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="git", timeout=15),
+            ),
+        ):
+            # Should not raise — infra failures degrade gracefully.
+            _validate_producer_draft_present(
+                "refine", "issue-3016", {"commit_sha": "abc1234"}, Path("/tmp/repo")
+            )
+
+    def test_skips_when_pipeline_has_no_branch(self):
+        """A pipeline with ``branch=None`` → graceful skip (no git context)."""
+        from routes.signals import _validate_producer_draft_present
+
+        with (
+            self._patched_store(branch=None),
+            self._patched_worktree(),
+        ):
+            _validate_producer_draft_present(
+                "refine", "issue-3016", {"commit_sha": "abc1234"}, Path("/tmp/repo")
+            )
+
+    def test_refiner_proposal_rejected_when_analysis_missing_does_not_mutate_tracker(self):
+        """End-to-end: a refiner proposal whose analysis draft is missing at the
+        proposed commit is rejected at ``handle_consensus_propose_signal`` with a
+        400 BEFORE the tracker is mutated (mirrors the planner guarantee #2527).
+        """
+        from flask import Flask
+        from routes.signals import handle_consensus_propose_signal
+
+        mock_tracker = MagicMock()
+        mock_tracker.handle_propose = MagicMock(return_value={"version": 1})
+
+        # Three subprocess calls in the refiner path:
+        #   1. _verify_commit_on_branch's git fetch
+        #   2. _verify_commit_on_branch's git branch --contains
+        #   3. _validate_producer_draft_present's git show — non-zero (absent)
+        side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="  origin/egg/issue-3016\n", stderr=""
+            ),
+            subprocess.CompletedProcess(args=[], returncode=128, stdout="", stderr=""),
+        ]
+
+        app = Flask(__name__)
+        with (
+            app.app_context(),
+            self._patched_store(),
+            self._patched_worktree(),
+            patch("routes.signals.subprocess.run", side_effect=side_effect),
+            patch("peer_consensus.get_peer_consensus_tracker", return_value=mock_tracker),
+        ):
+            data = {
+                "agent_role": "refiner",
+                "payload": {
+                    "summary": (
+                        "Analysis v1: evaluated three options for the deterministic "
+                        "draft-path guard and recommended option A"
+                    ),
+                    "artifacts": [".egg-state/agent-outputs/refiner-refine.md"],
+                    "commit_sha": "abc1234",
+                },
+            }
+            response, status_code = handle_consensus_propose_signal(
+                "issue-3016", data, Path("/tmp/repo")
+            )
+            assert status_code == 400
+            data_out = response.get_json()
+            assert "no analysis draft found" in data_out.get("message", "")
             mock_tracker.handle_propose.assert_not_called()
 
 

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -2545,6 +2545,77 @@ class TestProducerDraftPresentValidation:
                     "plan", "issue-3016", {"commit_sha": "abc1234"}, Path("/tmp/repo")
                 )
 
+    def test_accepts_when_plan_draft_present(self):
+        """Plan draft present and non-empty at the proposed commit → no raise.
+
+        Mirrors ``test_accepts_when_refine_draft_present`` to lock the symmetry
+        between the two producer phases — the end-to-end planner test exercises
+        the present-plan path indirectly (call 3 returning non-empty stdout),
+        but this is the direct unit-level confirmation.
+        """
+        from routes.signals import _validate_producer_draft_present
+
+        with (
+            self._patched_store(),
+            self._patched_worktree(),
+            self._patched_subprocess("# Plan: issue-3016\n\n## Task 1\nDo the thing.\n"),
+        ):
+            _validate_producer_draft_present(
+                "plan", "issue-3016", {"commit_sha": "abc1234"}, Path("/tmp/repo")
+            )
+
+    def test_skips_when_pipeline_lookup_fails(self):
+        """State store load failure → graceful skip.
+
+        Covers the ``except StateStoreError: return`` branch — an orchestrator-
+        side glitch loading the pipeline shouldn't blame the producer.
+        """
+        from routes.signals import _validate_producer_draft_present
+        from state_store import StateValidationError
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.side_effect = StateValidationError("corrupt state")
+
+        with (
+            patch("routes.signals.get_state_store", return_value=mock_store),
+            self._patched_worktree(),
+        ):
+            # Should not raise — graceful degradation.
+            _validate_producer_draft_present(
+                "refine", "issue-3016", {"commit_sha": "abc1234"}, Path("/tmp/repo")
+            )
+
+    def test_skips_when_branch_verified_is_none(self):
+        """``branch_verified=None`` (orchestrator-side fetch/contains glitch) →
+        graceful skip.
+
+        Regression guard for the PR-1 review concern: when
+        ``_verify_commit_on_branch`` returns ``None`` (fetch failed, or
+        ``git branch -r --contains`` failed), the commit may not be in the
+        local object cache. A subsequent ``git show {commit}:{path}`` would
+        return 128 with "bad revision" — *not* "path absent at commit" — so
+        running the presence check in that state would mis-blame the producer
+        for an orchestrator-side glitch. The handler threads the tri-state
+        through; we verify the validator honours it by skipping git access
+        entirely.
+        """
+        from routes.signals import _validate_producer_draft_present
+
+        with (
+            self._patched_store(),
+            self._patched_worktree(),
+            patch("routes.signals.subprocess.run") as mock_run,
+        ):
+            # Should not raise — and should not even reach git.
+            _validate_producer_draft_present(
+                "refine",
+                "issue-3016",
+                {"commit_sha": "abc1234"},
+                Path("/tmp/repo"),
+                branch_verified=None,
+            )
+            mock_run.assert_not_called()
+
     def test_skips_when_git_show_errors(self):
         """A git/infra failure (not a clean non-zero exit) → graceful skip.
 

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -2650,6 +2650,90 @@ class TestProducerDraftPresentValidation:
                 "refine", "issue-3016", {"commit_sha": "abc1234"}, Path("/tmp/repo")
             )
 
+    def test_refiner_proposal_accepted_when_branch_verification_inconclusive(self):
+        """End-to-end: a refiner proposal whose ``_verify_commit_on_branch`` glitch
+        (fetch failure → ``None``) **must not** be rejected by the presence check —
+        the proposal reaches ``tracker.handle_propose`` instead of being 400'd.
+
+        This locks the threading wired by the previous review item: the handler
+        captures the tri-state from ``_verify_commit_on_branch``, threads it into
+        ``_validate_producer_draft_present`` via ``branch_verified``, and the
+        validator short-circuits on ``None`` so a transient orchestrator-side fetch
+        failure isn't mis-blamed on the producer as a missing draft. Mirrors the
+        wiring guarantee that
+        ``test_refiner_proposal_rejected_when_analysis_missing_does_not_mutate_tracker``
+        provides for the rejection path.
+        """
+        from flask import Flask
+        from routes.signals import handle_consensus_propose_signal
+
+        mock_tracker = MagicMock()
+        mock_tracker.handle_propose = MagicMock(return_value={"version": 1})
+
+        # Two subprocess calls happen and only the first one runs (fetch returns
+        # non-zero → ``_verify_commit_on_branch`` short-circuits to ``None``,
+        # then the presence validator skips git access entirely because
+        # ``branch_verified is None``):
+        #   1. _verify_commit_on_branch's git fetch — returncode=1 (fetch failed)
+        #   2. (would be) _verify_commit_on_branch's git branch --contains —
+        #      not reached because fetch failed
+        side_effect = [
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr="fatal: unable to access remote: connection reset",
+            ),
+        ]
+
+        mock_message_store = MagicMock()
+        mock_message_store.add_message = MagicMock()
+
+        # Build a state store mock that also satisfies ``_resolve_pipeline_phase``'s
+        # ``pipeline.current_phase.value`` access (the success path emits a
+        # CONSENSUS_PROPOSE message whose ``phase`` field is string-validated by
+        # Pydantic). The shared ``_patched_store`` doesn't set this because the
+        # other end-to-end test reaches the error path before message emission.
+        mock_pipeline = MagicMock()
+        mock_pipeline.issue_number = 3016
+        mock_pipeline.branch = "egg/issue-3016"
+        mock_pipeline.mode = None
+        mock_pipeline.current_phase.value = "refine"
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = mock_pipeline
+
+        app = Flask(__name__)
+        with (
+            app.app_context(),
+            patch("routes.signals.get_state_store", return_value=mock_store),
+            self._patched_worktree(),
+            patch("routes.signals.subprocess.run", side_effect=side_effect) as mock_run,
+            patch("peer_consensus.get_peer_consensus_tracker", return_value=mock_tracker),
+            patch("message_store.get_message_store", return_value=mock_message_store),
+        ):
+            data = {
+                "agent_role": "refiner",
+                "payload": {
+                    "summary": (
+                        "Analysis v1: evaluated three options for the deterministic "
+                        "draft-path guard and recommended option A"
+                    ),
+                    "artifacts": [".egg-state/drafts/3016-analysis.md"],
+                    "commit_sha": "abc1234",
+                },
+            }
+            response, status_code = handle_consensus_propose_signal(
+                "issue-3016", data, Path("/tmp/repo")
+            )
+            # 200 — the proposal was accepted by the tracker, not 400'd by the
+            # presence validator. (Status defaults to 200 in make_success_response.)
+            assert status_code == 200
+            # The tracker WAS called — the proposal made it past both validators.
+            mock_tracker.handle_propose.assert_called_once()
+            # Only the fetch ran — branch-contains and the presence ``git show``
+            # were skipped, which is the threading guarantee under test.
+            assert mock_run.call_count == 1
+
     def test_refiner_proposal_rejected_when_analysis_missing_does_not_mutate_tracker(self):
         """End-to-end: a refiner proposal whose analysis draft is missing at the
         proposed commit is rejected at ``handle_consensus_propose_signal`` with a


### PR DESCRIPTION
## What

Make the refine/plan phase-gate input **deterministic**: validate at `consensus_propose` that the producer's canonical phase draft exists at the path every downstream reader uses, and reject (400) when it is missing — so a producer that commits its draft off-path can no longer silently complete the phase and leave the operator gate reporting *"No analysis draft was found on the work branch."*

Closes #3016.

## Why

A refiner committed its analysis to `.egg-state/agent-outputs/refiner-refine.md` — a path **no orchestrator/sandbox code reads**. The canonical path everything reads (gate `_read_phase_draft`, `pipeline.analysis` repopulation, contract population) is `.egg-state/drafts/{issue}-analysis.md`. Result: BRC consensus CONFIRMed, the phase completed, and only *then* did the gate come up empty. This is not caught by the read-side hardening in #2992 / #2723 — a draft at a path nobody reads is invisible to `git show HEAD:.egg-state/drafts/…` too.

`refine` / `plan` are always concurrent, so every producer issues `consensus_propose` — a universal choke point. The orchestrator already validates proposals there (`_validate_tester_check_coverage`, `_validate_planner_role_alignment`) **before** `handle_propose` records them; `_validate_planner_role_alignment` even already `git show`s the plan draft at the proposed commit — but treated a *missing* draft as "nothing to validate" and passed. This PR closes that hole and adds the equivalent guard for refine (which had none).

## How

- New `_validate_producer_draft_present(phase, …)` in `orchestrator/routes/signals.py`: runs `git show {commit}:{_get_draft_path(phase, …)}` against the orchestrator worktree at the proposed commit; raises `ValueError` (→ 400) when the draft is absent or empty, with an actionable message naming the canonical path. **Existence-only** — format/template conformance is deliberately left to reviewers and the gate, to avoid false-rejecting a legitimate-but-differently-structured draft (see #3017).
- Wired into `handle_consensus_propose_signal` before `handle_propose`, for `refiner` (phase `refine`) and `task_planner` (phase `plan`, alongside the existing role-alignment check). task_planner is the canonical plan-draft owner — architect/risk_analyst write agent-outputs JSON; `_synthesize_plan_draft`'s docstring confirms task_planner writes `drafts/{id}-plan.md` directly.
- **Graceful degradation preserved**: no commit SHA, no branch, an underivable draft path, or a git/infra error all skip silently. It rejects *only* on a positively-confirmed-absent (or empty) draft at a branch-verified commit — `_verify_commit_on_branch` (which fetches the commit) runs first, so a non-zero `git show` here reliably means "path absent at commit", not "commit unknown".

## Scope notes

- **Orchestrator-only by design.** The optional sandbox-side pre-flight mirror in `brc_propose` (issue #3016 item 3) is a latency optimization, not correctness — the agent already receives the orchestrator's actionable 400 (surfaced by `brc_propose`'s `GatewayError`) and re-proposes. Deferred to keep this focused.
- Structurally subsumed by #3017 (declarative phase abstraction): once a phase declares its output-artifact spec in one place, this guard reads from that declaration instead of a hardcoded role→phase mapping.

## Test

- New `TestProducerDraftPresentValidation` (8 cases): missing-SHA skip, present / absent / empty draft, plan-vs-analysis message wording, infra-error graceful skip, no-branch skip, and an end-to-end `handle_consensus_propose_signal` refiner-reject asserting the tracker is **not** mutated.
- Updated the existing task_planner integration test for the extra presence-check `git show` call now in its path.
- `make test` (changeset-aware) + `make lint` green.
