### PR TITLE
fix(gateway): authenticate worktree base-branch fetches and use remote tip (#3021)

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -7727,6 +7727,7 @@ def worktree_create() -> tuple[Response, int] | Response:
                 uid=uid,
                 gid=gid,
                 assigned_branch=assigned_branch,
+                repo_slug=repo,
             )
             # Translate container path to host path for egg launcher mount sources
             worktrees[repo_name] = translate_to_host_path(str(info.worktree_path))
@@ -8481,6 +8482,7 @@ def session_create() -> tuple[Response, int] | Response:
                     uid=uid,
                     gid=gid,
                     assigned_branch=branch,
+                    repo_slug=repo,
                 )
             # Capture the first worktree's gateway-side path for the session's repo context
             if first_worktree_path is None:

--- a/gateway/tests/test_phase_worktree.py
+++ b/gateway/tests/test_phase_worktree.py
@@ -50,6 +50,7 @@ class TestCreatePhaseWorktree:
                 base_branch="egg/issue-732",
                 uid=None,
                 gid=None,
+                repo_slug=None,
             )
             assert result is mock_info
 
@@ -89,6 +90,7 @@ class TestCreatePhaseWorktree:
                 base_branch="HEAD",
                 uid=1001,
                 gid=1001,
+                repo_slug=None,
             )
 
     def test_invalid_container_id_raises(self, manager: WorktreeManager):

--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -652,11 +652,16 @@ class TestWorktreeManagerDockerGitDir:
         if result.returncode == 0:
             assert not result.stdout.strip().startswith("refs/heads/egg/")
 
-    def test_worktree_reuse_resets_to_safe_remote_ref(self, tmp_path):
+    @patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", ""))
+    def test_worktree_reuse_resets_to_safe_remote_ref(self, _mock_get_token, tmp_path):
         """When a valid worktree is reused, the helper resets HEAD to a
         known-good remote ref so a stale local HEAD from a prior pipeline
         run on the same container_id (deterministic ID collision, see
         #2222) doesn't get inherited.
+
+        ``get_token_for_repo`` is patched to return no token so the
+        credentialed reuse fetch (#3021) falls back to the plain
+        environment against the local-file origin used by this test.
 
         Reproduction of the pre-fix shape:
         - First create_worktree creates the worktree at origin/main.
@@ -910,21 +915,23 @@ class TestWorktreeManagerRemoteBranchFetch:
         manager = WorktreeManager(worktree_base=worktree_base, repos_base=repos_base)
         return manager, repos_base, repo_dir, worktree_base
 
-    def test_fetches_remote_when_base_branch_not_local(self, manager_with_repo):
-        """When base_branch doesn't exist locally, fetch from origin and use origin/<branch>."""
+    def test_fetches_remote_with_credentials_and_uses_remote_tip(self, manager_with_repo):
+        """The base branch is fetched (authenticated) and the worktree is
+        branched from ``origin/<branch>`` — even when the branch is absent
+        locally.  See #3021 failure mode 2."""
         manager, repos_base, repo_dir, worktree_base = manager_with_repo
 
         call_log = []
 
         def mock_run(args, **kwargs):
-            call_log.append(list(args))
+            call_log.append((list(args), kwargs))
             result = MagicMock()
             result.returncode = 0
             result.stderr = ""
             result.stdout = ""
 
             if "rev-parse" in args and "--verify" in args:
-                # Neither branch_name nor base_branch exist locally
+                # branch_name (the per-worktree work branch) does not exist yet
                 result.returncode = 1
             elif "fetch" in args and "origin" in args:
                 result.returncode = 0
@@ -945,34 +952,48 @@ class TestWorktreeManagerRemoteBranchFetch:
 
             return result
 
-        with patch("subprocess.run", side_effect=mock_run):
-            with patch.object(
-                manager, "_find_worktree_git_dir", return_value=Path("/fake/git/dir")
-            ):
-                with patch.object(manager, "_chown_recursive"):
-                    with patch.object(manager, "_chown_single"):
-                        info = manager.create_worktree(
-                            "test-repo", "issue-1495-coder", base_branch="egg/issue-1495"
-                        )
+        with patch("worktree_manager.get_token_for_repo", return_value=("fake-token", "user", "")):
+            with patch("subprocess.run", side_effect=mock_run):
+                with patch.object(
+                    manager, "_find_worktree_git_dir", return_value=Path("/fake/git/dir")
+                ):
+                    with patch.object(manager, "_chown_recursive"):
+                        with patch.object(manager, "_chown_single"):
+                            info = manager.create_worktree(
+                                "test-repo",
+                                "issue-1495-coder",
+                                base_branch="egg/issue-1495",
+                                repo_slug="Khan/test-repo",
+                            )
 
         assert info.container_id == "issue-1495-coder"
-        # Verify fetch was called
-        fetch_calls = [c for c in call_log if "fetch" in c and "origin" in c]
+        # Verify fetch was called for the base branch
+        fetch_calls = [c for c in call_log if "fetch" in c[0] and "origin" in c[0]]
         assert len(fetch_calls) == 1
-        assert "egg/issue-1495" in fetch_calls[0]
+        assert "egg/issue-1495" in fetch_calls[0][0]
+        # The fetch must carry the gateway credential helper (#3021 Fix A):
+        # the mirror's origin is HTTPS, so an unauthenticated fetch fails.
+        fetch_env = fetch_calls[0][1].get("env") or {}
+        assert fetch_env.get("GIT_ASKPASS"), "fetch must run with a GIT_ASKPASS credential helper"
+        assert fetch_env.get("GIT_PASSWORD") == "fake-token"
+        assert fetch_env.get("GIT_USERNAME") == "x-access-token"
         # Verify worktree add used origin/<branch> as effective base
-        wt_add_calls = [c for c in call_log if "worktree" in c and "add" in c and "-b" in c]
+        wt_add_calls = [
+            c for c in call_log if "worktree" in c[0] and "add" in c[0] and "-b" in c[0]
+        ]
         assert len(wt_add_calls) == 1
-        assert "origin/egg/issue-1495" in wt_add_calls[0]
+        assert "origin/egg/issue-1495" in wt_add_calls[0][0]
 
-    def test_skips_fetch_when_base_branch_exists_locally(self, manager_with_repo):
-        """When base_branch exists locally, no fetch needed."""
+    def test_fetches_remote_tip_even_when_base_branch_exists_locally(self, manager_with_repo):
+        """When base_branch exists locally, still fetch and branch from the
+        remote tip rather than the (possibly stale) local ref.  See #3021
+        failure mode 1."""
         manager, repos_base, repo_dir, worktree_base = manager_with_repo
 
         call_log = []
 
         def mock_run(args, **kwargs):
-            call_log.append(list(args))
+            call_log.append((list(args), kwargs))
             result = MagicMock()
             result.returncode = 0
             result.stderr = ""
@@ -980,9 +1001,11 @@ class TestWorktreeManagerRemoteBranchFetch:
 
             if "rev-parse" in args:
                 if args[-1] == "egg/my-branch":
-                    result.returncode = 0  # base_branch exists locally
+                    result.returncode = 0  # base_branch exists locally (but stale)
                 elif args[-1] == "egg/my-container/work":
                     result.returncode = 1  # branch_name doesn't exist yet
+            elif "fetch" in args and "origin" in args:
+                result.returncode = 0
             elif "worktree" in args and "add" in args:
                 wt_path = None
                 for i, a in enumerate(args):
@@ -997,24 +1020,122 @@ class TestWorktreeManagerRemoteBranchFetch:
 
             return result
 
-        with patch("subprocess.run", side_effect=mock_run):
-            with patch.object(
-                manager, "_find_worktree_git_dir", return_value=Path("/fake/git/dir")
-            ):
-                with patch.object(manager, "_chown_recursive"):
-                    with patch.object(manager, "_chown_single"):
-                        manager.create_worktree(
-                            "test-repo", "my-container", base_branch="egg/my-branch"
-                        )
+        with patch("worktree_manager.get_token_for_repo", return_value=("fake-token", "bot", "")):
+            with patch("subprocess.run", side_effect=mock_run):
+                with patch.object(
+                    manager, "_find_worktree_git_dir", return_value=Path("/fake/git/dir")
+                ):
+                    with patch.object(manager, "_chown_recursive"):
+                        with patch.object(manager, "_chown_single"):
+                            manager.create_worktree(
+                                "test-repo", "my-container", base_branch="egg/my-branch"
+                            )
 
-        # No fetch should have been called
-        fetch_calls = [c for c in call_log if "fetch" in c]
-        assert len(fetch_calls) == 0
-        # worktree add should use the original base_branch directly
-        wt_add_calls = [c for c in call_log if "worktree" in c and "add" in c and "-b" in c]
+        # Fetch IS called even though the branch exists locally (freshness).
+        fetch_calls = [c for c in call_log if "fetch" in c[0] and "origin" in c[0]]
+        assert len(fetch_calls) == 1
+        assert "egg/my-branch" in fetch_calls[0][0]
+        # worktree add must branch from the remote tip, not the stale local ref.
+        wt_add_calls = [
+            c for c in call_log if "worktree" in c[0] and "add" in c[0] and "-b" in c[0]
+        ]
         assert len(wt_add_calls) == 1
-        assert "egg/my-branch" in wt_add_calls[0]
-        assert "origin/egg/my-branch" not in wt_add_calls[0]
+        assert "origin/egg/my-branch" in wt_add_calls[0][0]
+
+    def test_strips_origin_prefix_before_fetch(self, manager_with_repo):
+        """An ``origin/``-prefixed base (e.g. resolve_default_branch ->
+        ``origin/main``) fetches the bare branch name and branches from the
+        remote tip."""
+        manager, repos_base, repo_dir, worktree_base = manager_with_repo
+
+        call_log = []
+
+        def mock_run(args, **kwargs):
+            call_log.append((list(args), kwargs))
+            result = MagicMock()
+            result.returncode = 0
+            result.stderr = ""
+            result.stdout = ""
+
+            if "rev-parse" in args and "--verify" in args:
+                result.returncode = 1  # work branch doesn't exist yet
+            elif "fetch" in args and "origin" in args:
+                result.returncode = 0
+            elif "worktree" in args and "add" in args:
+                wt_path = None
+                for i, a in enumerate(args):
+                    if a == "-b" and i + 2 < len(args):
+                        wt_path = Path(args[i + 2])
+                        break
+                if wt_path:
+                    wt_path.mkdir(parents=True, exist_ok=True)
+                    (wt_path / ".git").write_text("gitdir: /fake/git/dir")
+
+            return result
+
+        with patch("worktree_manager.get_token_for_repo", return_value=("fake-token", "bot", "")):
+            with patch("subprocess.run", side_effect=mock_run):
+                with patch.object(
+                    manager, "_find_worktree_git_dir", return_value=Path("/fake/git/dir")
+                ):
+                    with patch.object(manager, "_chown_recursive"):
+                        with patch.object(manager, "_chown_single"):
+                            manager.create_worktree(
+                                "test-repo", "main-container", base_branch="origin/main"
+                            )
+
+        fetch_calls = [c for c in call_log if "fetch" in c[0] and "origin" in c[0]]
+        assert len(fetch_calls) == 1
+        # The bare branch name is fetched, not "origin/main".
+        assert fetch_calls[0][0][-1] == "main"
+        wt_add_calls = [
+            c for c in call_log if "worktree" in c[0] and "add" in c[0] and "-b" in c[0]
+        ]
+        assert "origin/main" in wt_add_calls[0][0]
+
+    def test_fetch_proceeds_without_helper_when_no_token(self, manager_with_repo):
+        """When no token is available the fetch still runs (best effort) so a
+        local-file remote keeps working; git's own credential error surfaces
+        for HTTPS remotes."""
+        manager, repos_base, repo_dir, worktree_base = manager_with_repo
+
+        call_log = []
+
+        def mock_run(args, **kwargs):
+            call_log.append((list(args), kwargs))
+            result = MagicMock()
+            result.returncode = 0
+            result.stderr = ""
+            result.stdout = ""
+            if "rev-parse" in args and "--verify" in args:
+                result.returncode = 1
+            elif "worktree" in args and "add" in args:
+                wt_path = None
+                for i, a in enumerate(args):
+                    if a == "-b" and i + 2 < len(args):
+                        wt_path = Path(args[i + 2])
+                        break
+                if wt_path:
+                    wt_path.mkdir(parents=True, exist_ok=True)
+                    (wt_path / ".git").write_text("gitdir: /fake/git/dir")
+            return result
+
+        with patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", "no token")):
+            with patch("subprocess.run", side_effect=mock_run):
+                with patch.object(
+                    manager, "_find_worktree_git_dir", return_value=Path("/fake/git/dir")
+                ):
+                    with patch.object(manager, "_chown_recursive"):
+                        with patch.object(manager, "_chown_single"):
+                            manager.create_worktree(
+                                "test-repo", "no-token-container", base_branch="egg/x"
+                            )
+
+        fetch_calls = [c for c in call_log if "fetch" in c[0] and "origin" in c[0]]
+        assert len(fetch_calls) == 1
+        # No credential helper was injected by us (token unavailable).
+        fetch_env = fetch_calls[0][1].get("env") or {}
+        assert fetch_env.get("GIT_PASSWORD") != "fake-token"
 
     def test_skips_fetch_for_head(self, manager_with_repo):
         """HEAD should never trigger a fetch."""
@@ -1077,24 +1198,69 @@ class TestWorktreeManagerRemoteBranchFetch:
 
             return result
 
-        with patch("subprocess.run", side_effect=mock_run):
-            with patch.object(
-                manager, "_find_worktree_git_dir", return_value=Path("/fake/git/dir")
-            ):
-                with patch.object(manager, "_chown_recursive"):
-                    with patch.object(manager, "_chown_single"):
-                        with pytest.raises(
-                            RuntimeError,
-                            match="Failed to fetch base branch 'egg/nonexistent' from remote",
-                        ):
-                            manager.create_worktree(
-                                "test-repo", "fail-container", base_branch="egg/nonexistent"
-                            )
+        with patch("worktree_manager.get_token_for_repo", return_value=("fake-token", "bot", "")):
+            with patch("subprocess.run", side_effect=mock_run):
+                with patch.object(
+                    manager, "_find_worktree_git_dir", return_value=Path("/fake/git/dir")
+                ):
+                    with patch.object(manager, "_chown_recursive"):
+                        with patch.object(manager, "_chown_single"):
+                            with pytest.raises(
+                                RuntimeError,
+                                match="Failed to fetch base branch 'egg/nonexistent' from remote",
+                            ):
+                                manager.create_worktree(
+                                    "test-repo", "fail-container", base_branch="egg/nonexistent"
+                                )
 
         # Verify fetch was attempted
         fetch_calls = [c for c in call_log if "fetch" in c and "origin" in c]
         assert len(fetch_calls) == 1
         # Verify worktree add was NOT attempted (we raise before reaching it)
+        wt_add_calls = [c for c in call_log if "worktree" in c and "add" in c]
+        assert len(wt_add_calls) == 0
+
+    def test_raises_when_fetch_fails_even_if_base_branch_exists_locally(self, manager_with_repo):
+        """#3021 hard-fail policy: a failed fetch must raise rather than fall
+        back to a possibly-stale local copy of the base branch."""
+        manager, repos_base, repo_dir, worktree_base = manager_with_repo
+
+        call_log = []
+
+        def mock_run(args, **kwargs):
+            call_log.append(list(args))
+            result = MagicMock()
+            result.returncode = 0
+            result.stderr = ""
+            result.stdout = ""
+
+            if "rev-parse" in args and "--verify" in args:
+                if args[-1] == "egg/local-stale":
+                    result.returncode = 0  # base branch DOES exist locally
+                else:
+                    result.returncode = 1  # work branch doesn't exist yet
+            elif "fetch" in args and "origin" in args:
+                result.returncode = 128
+                result.stderr = "fatal: unable to access remote (network blip)"
+
+            return result
+
+        with patch("worktree_manager.get_token_for_repo", return_value=("fake-token", "bot", "")):
+            with patch("subprocess.run", side_effect=mock_run):
+                with patch.object(
+                    manager, "_find_worktree_git_dir", return_value=Path("/fake/git/dir")
+                ):
+                    with patch.object(manager, "_chown_recursive"):
+                        with patch.object(manager, "_chown_single"):
+                            with pytest.raises(
+                                RuntimeError,
+                                match="Failed to fetch base branch 'egg/local-stale' from remote",
+                            ):
+                                manager.create_worktree(
+                                    "test-repo", "stale-container", base_branch="egg/local-stale"
+                                )
+
+        # Did NOT fall back to creating a worktree from the stale local ref.
         wt_add_calls = [c for c in call_log if "worktree" in c and "add" in c]
         assert len(wt_add_calls) == 0
 

--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -1145,11 +1145,24 @@ class TestWorktreeManagerRemoteBranchFetch:
         ]
         assert "origin/main" in wt_add_calls[0][0]
 
-    def test_fetch_proceeds_without_helper_when_no_token(self, manager_with_repo):
+    def test_fetch_proceeds_without_helper_when_no_token(self, manager_with_repo, monkeypatch):
         """When no token is available the fetch still runs (best effort) so a
         local-file remote keeps working; git's own credential error surfaces
-        for HTTPS remotes."""
+        for HTTPS remotes.
+
+        Also verifies that ``GIT_USERNAME`` / ``GIT_PASSWORD`` / ``GIT_ASKPASS``
+        keys inherited from the gateway process env are explicitly scrubbed
+        from the yielded env in the no-token branch — otherwise a stale value
+        could silently authenticate the fetch and undermine the documented
+        "fails loudly with git's own credential error" outcome.
+        """
         manager, repos_base, repo_dir, worktree_base = manager_with_repo
+
+        # Seed the gateway process env with stale credential keys to verify
+        # the no-token branch explicitly removes them.
+        monkeypatch.setenv("GIT_USERNAME", "stale-user")
+        monkeypatch.setenv("GIT_PASSWORD", "stale-pass")
+        monkeypatch.setenv("GIT_ASKPASS", "/tmp/stale-askpass.sh")
 
         call_log = []
 
@@ -1196,6 +1209,13 @@ class TestWorktreeManagerRemoteBranchFetch:
             f"credential helper should not be wired up when no token is "
             f"available; got GIT_ASKPASS={askpass!r}"
         )
+        # Stale credential keys must be scrubbed so they cannot silently
+        # authenticate the fetch.
+        for key in ("GIT_USERNAME", "GIT_PASSWORD", "GIT_ASKPASS"):
+            assert key not in fetch_env, (
+                f"stale {key} must be scrubbed from the no-token fetch env; "
+                f"got {key}={fetch_env.get(key)!r}"
+            )
 
     def test_skips_fetch_for_head(self, manager_with_repo):
         """HEAD should never trigger a fetch."""
@@ -2466,21 +2486,27 @@ class TestCreateWorktreeFetchTimeout:
             if "rev-parse" in args and "--verify" in args:
                 result.returncode = 1  # branch not found locally
             elif "fetch" in args and "origin" in args:
-                raise subprocess.TimeoutExpired(cmd=args, timeout=120)
+                raise subprocess.TimeoutExpired(cmd=args, timeout=30)
             return result
 
-        with patch("subprocess.run", side_effect=mock_run):
-            with patch.object(
-                manager, "_find_worktree_git_dir", return_value=Path("/fake/git/dir")
-            ):
-                with patch.object(manager, "_chown_recursive"):
-                    with patch.object(manager, "_chown_single"):
-                        with pytest.raises(RuntimeError, match="Timed out fetching base branch"):
-                            manager.create_worktree(
-                                "test-repo",
-                                "timeout-container",
-                                base_branch="egg/slow-branch",
-                            )
+        # Patch ``get_token_for_repo`` for symmetry with the other create-path
+        # tests so the credentialed branch is exercised and no benign "no token"
+        # warning fires during the run.
+        with patch("worktree_manager.get_token_for_repo", return_value=("fake-token", "bot", "")):
+            with patch("subprocess.run", side_effect=mock_run):
+                with patch.object(
+                    manager, "_find_worktree_git_dir", return_value=Path("/fake/git/dir")
+                ):
+                    with patch.object(manager, "_chown_recursive"):
+                        with patch.object(manager, "_chown_single"):
+                            with pytest.raises(
+                                RuntimeError, match="Timed out fetching base branch"
+                            ):
+                                manager.create_worktree(
+                                    "test-repo",
+                                    "timeout-container",
+                                    base_branch="egg/slow-branch",
+                                )
 
 
 if __name__ == "__main__":

--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -769,6 +769,58 @@ class TestWorktreeManagerDockerGitDir:
             f"got {head_after} (still on stale local commit)"
         )
 
+    def test_reused_worktree_fetch_carries_credentials(self, tmp_path):
+        """When a token is available, the reuse-path fetch inside
+        ``_reset_reused_worktree_to_safe_ref`` runs under the gateway
+        credential helper (#3021 Fix A).
+
+        Complements ``test_worktree_reuse_resets_to_safe_remote_ref``,
+        which exercises the token-absent fallback against a local-file
+        origin — the credentialed branch on the reuse path is genuinely
+        new in #3021 and would otherwise be uncovered.
+        """
+        manager = WorktreeManager(
+            worktree_base=tmp_path / "worktrees",
+            repos_base=tmp_path / "repos",
+        )
+
+        worktree_path = tmp_path / "worktrees" / "test-repo" / "egg-coder"
+        worktree_path.mkdir(parents=True)
+        (worktree_path / ".git").write_text("gitdir: /fake/git/dir")
+
+        call_log: list[tuple[list[str], dict]] = []
+
+        def mock_run(args, **kwargs):
+            call_log.append((list(args), kwargs))
+            result = MagicMock()
+            result.returncode = 1  # no candidate ref resolves -> early bail
+            result.stderr = ""
+            result.stdout = ""
+            return result
+
+        with patch(
+            "worktree_manager.get_token_for_repo",
+            return_value=("fake-token", "user", ""),
+        ):
+            with patch("subprocess.run", side_effect=mock_run):
+                manager._reset_reused_worktree_to_safe_ref(
+                    worktree_path=worktree_path,
+                    main_repo=tmp_path / "repos" / "test-repo",
+                    container_id="egg-coder",
+                    assigned_branch="egg/issue-99",
+                    base_branch="main",
+                    repo_slug="Khan/test-repo",
+                )
+
+        fetch_calls = [c for c in call_log if "fetch" in c[0] and "origin" in c[0]]
+        assert len(fetch_calls) == 1, "reuse path must fetch origin before resetting"
+        fetch_env = fetch_calls[0][1].get("env") or {}
+        assert "git-askpass-" in fetch_env.get("GIT_ASKPASS", ""), (
+            "credential helper must be wired up when a token is available"
+        )
+        assert fetch_env.get("GIT_PASSWORD") == "fake-token"
+        assert fetch_env.get("GIT_USERNAME") == "x-access-token"
+
     def test_create_worktree_reapplies_upstream_on_reuse(self, git_repo):
         """When a valid worktree is reused, upstream config is re-applied.
 
@@ -1133,9 +1185,17 @@ class TestWorktreeManagerRemoteBranchFetch:
 
         fetch_calls = [c for c in call_log if "fetch" in c[0] and "origin" in c[0]]
         assert len(fetch_calls) == 1
-        # No credential helper was injected by us (token unavailable).
+        # No credential helper was wired up by the gateway (token unavailable):
+        # assert the gateway-installed askpass shim is absent rather than the
+        # weaker "GIT_PASSWORD != <literal>", which would pass for any stale
+        # or inherited value.  ``create_credential_helper`` writes a temp
+        # ``git-askpass-*`` shim into ``GIT_ASKPASS`` whenever it's wired up.
         fetch_env = fetch_calls[0][1].get("env") or {}
-        assert fetch_env.get("GIT_PASSWORD") != "fake-token"
+        askpass = fetch_env.get("GIT_ASKPASS", "")
+        assert "git-askpass-" not in askpass, (
+            f"credential helper should not be wired up when no token is "
+            f"available; got GIT_ASKPASS={askpass!r}"
+        )
 
     def test_skips_fetch_for_head(self, manager_with_repo):
         """HEAD should never trigger a fetch."""

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -468,6 +468,12 @@ class WorktreeManager:
                         fetch_ref=fetch_ref,
                         container_id=container_id,
                     )
+                    # Timeout caps how long every other state-store commit /
+                    # worktree create on this repo can be blocked by a slow
+                    # remote — this fetch now runs on *every* non-HEAD spawn
+                    # (post-#3021) rather than just cold-cache misses, so keep
+                    # it tight.  Mirrors the reuse-path fetch in
+                    # ``_reset_reused_worktree_to_safe_ref``.
                     with self._git_credential_env(repo_slug) as fetch_env:
                         try:
                             fetch_result = subprocess.run(
@@ -476,7 +482,7 @@ class WorktreeManager:
                                 capture_output=True,
                                 text=True,
                                 check=False,
-                                timeout=120,
+                                timeout=30,
                                 env=fetch_env,
                             )
                         except subprocess.TimeoutExpired as e:

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -703,7 +703,9 @@ class WorktreeManager:
                 return
 
     @contextlib.contextmanager
-    def _git_credential_env(self, repo_slug: str) -> Generator[dict[str, str]]:
+    def _git_credential_env(
+        self, repo_slug: str, *, best_effort: bool = False
+    ) -> Generator[dict[str, str]]:
         """Yield an environment carrying GitHub credentials for a git fetch.
 
         The gateway's local mirror talks to GitHub over HTTPS (SSH URLs are
@@ -718,6 +720,24 @@ class WorktreeManager:
         so best-effort callers still run; the fetch then fails loudly with
         git's own credential error, which the caller can surface.  The temp
         credential file is always cleaned up on exit.
+
+        Args:
+            repo_slug: Full ``owner/repo`` slug for token resolution.
+            best_effort: When True, the caller treats the fetch as best
+                effort (e.g. the reuse-path reset, which falls back to a
+                local ref on fetch failure); a missing token then logs at
+                ``info`` rather than ``warning`` to avoid spamming
+                local-file-origin scenarios (tests, cold-start before the
+                token refresher initialises) where the absence is benign.
+                The create path leaves this False because a missing token
+                yields a hard ``RuntimeError`` on fetch failure.
+
+        In the no-token branch the ``GIT_USERNAME`` / ``GIT_PASSWORD`` /
+        ``GIT_ASKPASS`` keys are explicitly scrubbed from the yielded env so
+        a stale value inherited from a parent process (operator-set, leaked
+        from a container env, etc.) doesn't accidentally authenticate the
+        fetch — the documented "fails loudly with git's own credential
+        error" behaviour only holds when those vars are genuinely absent.
         """
         token_str, _auth_mode, token_error = get_token_for_repo(repo_slug)
         cred_path: str | None = None
@@ -725,12 +745,16 @@ class WorktreeManager:
             if token_str:
                 cred_path, env = create_credential_helper(token_str, os.environ.copy())
             else:
-                logger.warning(
+                log = logger.info if best_effort else logger.warning
+                log(
                     "No GitHub token available for authenticated fetch",
                     repo_slug=repo_slug,
                     token_error=token_error,
+                    best_effort=best_effort,
                 )
                 env = os.environ.copy()
+                for key in ("GIT_USERNAME", "GIT_PASSWORD", "GIT_ASKPASS"):
+                    env.pop(key, None)
             yield env
         finally:
             cleanup_credential_helper(cred_path)
@@ -776,7 +800,7 @@ class WorktreeManager:
         # create on this repo can be blocked by a slow remote — keep
         # it tight.
         try:
-            with self._git_credential_env(repo_slug) as fetch_env:
+            with self._git_credential_env(repo_slug, best_effort=True) as fetch_env:
                 subprocess.run(
                     git_cmd("fetch", "origin"),
                     cwd=worktree_path,

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -34,11 +34,23 @@ from collections.abc import Generator
 from egg_git.cross_process_lock import bare_repo_lock
 from egg_logging import get_logger
 
-# Import git_cmd helper
+# Import git helpers.  ``get_token_for_repo`` + the credential-helper pair are
+# used to authenticate on-demand base-branch fetches against the mirror's HTTPS
+# origin (the same credential path git_push uses).  See #3021.
 try:
-    from .git_client import git_cmd
+    from .git_client import (
+        cleanup_credential_helper,
+        create_credential_helper,
+        get_token_for_repo,
+        git_cmd,
+    )
 except ImportError:
-    from git_client import git_cmd  # type: ignore[no-redef, import-untyped]
+    from git_client import (  # type: ignore[no-redef, import-untyped]
+        cleanup_credential_helper,
+        create_credential_helper,
+        get_token_for_repo,
+        git_cmd,
+    )
 
 
 logger = get_logger("gateway.worktree-manager")
@@ -244,6 +256,7 @@ class WorktreeManager:
         uid: int | None = None,
         gid: int | None = None,
         assigned_branch: str | None = None,
+        repo_slug: str | None = None,
     ) -> WorktreeInfo:
         """
         Create an isolated worktree for a container.
@@ -260,6 +273,10 @@ class WorktreeManager:
                 assigned branch instead of the per-worktree local branch
                 (which the gateway would reject as push_denied_wrong_branch).
                 See #1809.
+            repo_slug: Full ``owner/repo`` slug used to resolve the GitHub
+                token for the authenticated base-branch fetch (#3021).
+                Defaults to ``repo_name`` when omitted, which makes token
+                resolution fall through to bot mode.
 
         Returns:
             WorktreeInfo with paths and branch information
@@ -286,6 +303,13 @@ class WorktreeManager:
         validate_branch_ref(base_branch, "base_branch")
         if assigned_branch is not None:
             validate_branch_ref(assigned_branch, "assigned_branch")
+
+        # Full ``owner/repo`` slug for token resolution on the authenticated
+        # base-branch fetch (#3021).  Callers that know the slug (the
+        # worktree-create / session routes) pass it so the fetch uses the
+        # correct bot/user token; otherwise fall back to ``repo_name``.
+        if repo_slug is None:
+            repo_slug = repo_name
 
         # Find main repo
         main_repo = self.repos_base / repo_name
@@ -340,6 +364,7 @@ class WorktreeManager:
                     container_id=container_id,
                     assigned_branch=assigned_branch,
                     base_branch=base_branch,
+                    repo_slug=repo_slug,
                 )
             # Return info about existing worktree
             return WorktreeInfo(
@@ -411,49 +436,61 @@ class WorktreeManager:
                     worktree_path=worktree_path,
                 )
             else:
-                # Resolve the base ref: if base_branch is not available
-                # locally (e.g. a pipeline branch that only exists on the
-                # remote), fetch it first and use origin/<base_branch>.
+                # Resolve the base ref.  Always fetch the base branch from
+                # origin and branch the worktree from the *remote tip*
+                # (``origin/<base_branch>``) rather than any local copy.
+                # This fixes both #3021 failure modes:
+                #   1. A branch present in the mirror at a stale SHA would
+                #      otherwise be used silently — the local ref is never
+                #      refreshed against origin.
+                #   2. A branch absent from the mirror must be fetched on
+                #      demand.
+                # The fetch is authenticated with the repo's token via the
+                # gateway credential helper (the same one git_push uses): the
+                # mirror's origin is HTTPS — SSH URLs are rewritten to HTTPS
+                # via ``insteadOf`` — so an unauthenticated fetch fails with
+                # "could not read Username for https://github.com".  We fail
+                # loudly on any fetch error rather than fall back to a
+                # possibly-stale local ref.
                 effective_base = base_branch
                 if base_branch != "HEAD":
-                    local_ref_exists = (
-                        subprocess.run(
-                            git_cmd("rev-parse", "--verify", base_branch),
-                            cwd=main_repo,
-                            capture_output=True,
-                            text=True,
-                            check=False,
-                        ).returncode
-                        == 0
+                    # ``base_branch`` may arrive already ``origin/``-prefixed
+                    # (e.g. resolve_default_branch -> "origin/main"); fetch the
+                    # underlying branch name in that case.
+                    fetch_ref = (
+                        base_branch[len("origin/") :]
+                        if base_branch.startswith("origin/")
+                        else base_branch
                     )
-                    if not local_ref_exists:
-                        logger.info(
-                            "Base branch not found locally, fetching from remote",
-                            base_branch=base_branch,
-                            container_id=container_id,
-                        )
+                    logger.info(
+                        "Fetching base branch from remote before worktree create",
+                        base_branch=base_branch,
+                        fetch_ref=fetch_ref,
+                        container_id=container_id,
+                    )
+                    with self._git_credential_env(repo_slug) as fetch_env:
                         try:
                             fetch_result = subprocess.run(
-                                git_cmd("fetch", "origin", base_branch),
+                                git_cmd("fetch", "origin", fetch_ref),
                                 cwd=main_repo,
                                 capture_output=True,
                                 text=True,
                                 check=False,
                                 timeout=120,
+                                env=fetch_env,
                             )
                         except subprocess.TimeoutExpired as e:
                             raise RuntimeError(
                                 f"Timed out fetching base branch '{base_branch}' from remote"
                             ) from e
-                        if fetch_result.returncode == 0:
-                            effective_base = f"origin/{base_branch}"
-                        else:
-                            raise RuntimeError(
-                                f"Failed to fetch base branch '{base_branch}' from remote: "
-                                f"{fetch_result.stderr.strip()}"
-                            )
+                    if fetch_result.returncode != 0:
+                        raise RuntimeError(
+                            f"Failed to fetch base branch '{base_branch}' from remote: "
+                            f"{fetch_result.stderr.strip()}"
+                        )
+                    effective_base = f"origin/{fetch_ref}"
 
-                # Create new branch from base
+                # Create new branch from the freshly fetched remote tip
                 result = self._run_git_worktree_add(
                     git_cmd(
                         "worktree",
@@ -659,6 +696,39 @@ class WorktreeManager:
                 )
                 return
 
+    @contextlib.contextmanager
+    def _git_credential_env(self, repo_slug: str) -> Generator[dict[str, str]]:
+        """Yield an environment carrying GitHub credentials for a git fetch.
+
+        The gateway's local mirror talks to GitHub over HTTPS (SSH URLs are
+        rewritten via ``insteadOf``), so an unauthenticated ``git fetch``
+        fails with ``could not read Username for 'https://github.com'``.
+        This wires the same credential helper (``GIT_ASKPASS`` +
+        ``GIT_USERNAME``/``GIT_PASSWORD``) that the push path uses
+        (``gateway.git_push``), resolving the repo's bot/user token via
+        :func:`get_token_for_repo`.  See #3021.
+
+        When no token is available the plain process environment is yielded
+        so best-effort callers still run; the fetch then fails loudly with
+        git's own credential error, which the caller can surface.  The temp
+        credential file is always cleaned up on exit.
+        """
+        token_str, _auth_mode, token_error = get_token_for_repo(repo_slug)
+        cred_path: str | None = None
+        try:
+            if token_str:
+                cred_path, env = create_credential_helper(token_str, os.environ.copy())
+            else:
+                logger.warning(
+                    "No GitHub token available for authenticated fetch",
+                    repo_slug=repo_slug,
+                    token_error=token_error,
+                )
+                env = os.environ.copy()
+            yield env
+        finally:
+            cleanup_credential_helper(cred_path)
+
     def _reset_reused_worktree_to_safe_ref(
         self,
         worktree_path: Path,
@@ -666,6 +736,7 @@ class WorktreeManager:
         container_id: str,
         assigned_branch: str | None,
         base_branch: str,
+        repo_slug: str,
     ) -> None:
         """Hard-reset a reused worktree to a known-good remote ref.
 
@@ -699,14 +770,16 @@ class WorktreeManager:
         # create on this repo can be blocked by a slow remote — keep
         # it tight.
         try:
-            subprocess.run(
-                git_cmd("fetch", "origin"),
-                cwd=worktree_path,
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=30,
-            )
+            with self._git_credential_env(repo_slug) as fetch_env:
+                subprocess.run(
+                    git_cmd("fetch", "origin"),
+                    cwd=worktree_path,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=30,
+                    env=fetch_env,
+                )
         except (subprocess.TimeoutExpired, OSError) as exc:
             logger.warning(
                 "Fetch before worktree-reuse reset failed (continuing)",
@@ -997,6 +1070,7 @@ class WorktreeManager:
         base_branch: str = "HEAD",
         uid: int | None = None,
         gid: int | None = None,
+        repo_slug: str | None = None,
     ) -> WorktreeInfo:
         """Create a sub-worktree for a specific plan phase (Tier 3 parallel dispatch).
 
@@ -1029,6 +1103,7 @@ class WorktreeManager:
             base_branch=base_branch,
             uid=uid,
             gid=gid,
+            repo_slug=repo_slug,
         )
 
     def cleanup_phase_worktrees(


### PR DESCRIPTION
Fixes #3021.

## Problem

When a pipeline is submitted with a `base_branch`, the gateway's worktree creation produced two bad outcomes:

1. **Branch present in mirror → stale SHA used silently.** When the base branch existed in the local mirror, the worktree was branched from the mirror's ref as-is, never fetching origin — so a branch updated on GitHub ran on the old commit with no warning.
2. **Branch absent from mirror → hard failure.** When the base branch was missing locally, the gateway fetched it over the mirror's HTTPS origin **without credentials**, failing with `could not read Username for 'https://github.com'` and failing the whole pipeline at worktree creation.

## Root cause

Both `worktree_manager` fetch sites (`create_worktree`'s on-demand base fetch and `_reset_reused_worktree_to_safe_ref`'s reuse fetch) ran bare `subprocess.run` with no credential env. The gateway already holds a usable token for each repo — it's the same one `git_push` uses — but the fetch never wired it in. And the create path only fetched when the branch was missing locally, so a present-but-outdated branch was used at its stale SHA.

## Fix

- **Authenticate the fetches (Fix A).** New `_git_credential_env` context manager resolves the repo's token via `get_token_for_repo(owner/repo)` and builds the same `GIT_ASKPASS` credential helper the push path uses. Both fetch sites now run under it. The `owner/repo` slug is threaded down from the two route call sites (`worktree_create`, session worktrees) via a new `repo_slug` param.
- **Always branch from the remote tip (Fix B).** For a non-`HEAD` base, the worktree now *always* fetches `origin` and branches from `origin/<base_branch>` rather than any local copy — collapsing both failure modes into one fresh path. A leading `origin/` (e.g. `resolve_default_branch` → `origin/main`) is stripped before the fetch.
- **Fail loudly.** Any fetch error raises `RuntimeError` instead of silently falling back to a possibly-stale local ref.

When no token is available the fetch still runs best-effort (a warning is logged) so local-file remotes keep working; for HTTPS remotes git's own credential error surfaces.

## Scope

Gateway-side only. Per the issue's third suggestion, surfacing the specific fetch error in the `submit_task` response / pipeline status was left out: `submit_task` returns `started` before the async pipeline runs, and the failure already propagates to `pipeline.status=FAILED` / `pipeline.error`. The default-branch (`origin/main`) staleness path is unchanged (the orchestrator's post-phase sync already refreshes main).

## Tests

`gateway/tests/test_worktree_manager.py` updated/added:
- fetch is authenticated (asserts `GIT_ASKPASS` / `GIT_PASSWORD` wired) and branches from `origin/<base>`;
- fetches even when the base branch exists locally (freshness);
- strips an `origin/` prefix before fetching;
- best-effort fetch when no token is available;
- **hard-fail on fetch failure even when a local copy exists** (the chosen policy);
- reuse-path reset test patched for the now-credentialed fetch.

`gateway/tests/test_phase_worktree.py` delegation assertions updated for the new `repo_slug` kwarg.

Targeted suites: `test_worktree_manager.py` + `test_phase_worktree.py` — 118 passed.