### PR TITLE
fix(orchestrator): resolve base_branch=None in context-PR opener (#3031)

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -54,11 +54,15 @@ class ContextPrCreationReason(StrEnum):
     PIPELINE_LOAD_FAILED = "pipeline_load_failed"
     ROUTES_UNAVAILABLE = "routes_unavailable"
     LOADER_UNAVAILABLE = "loader_unavailable"
-    # Pipeline misconfiguration (cq-4 hard-required: ``repo`` and
-    # ``base_branch`` must BOTH be set OR BOTH empty).
+    # Pipeline misconfiguration. ``base_branch`` left unset alongside a
+    # ``repo`` is NOT a misconfiguration — it is the normal "auto-detect
+    # the repo's default branch" state (#3031), so the opener resolves it
+    # rather than raising. The remaining genuine misconfigurations are a
+    # ``base_branch`` with no ``repo`` to open a PR against
+    # (``missing_repo``) and a remote pipeline with no work branch
+    # (``missing_branch``).
     MISSING_BRANCH = "missing_branch"
     MISSING_REPO = "missing_repo"
-    MISSING_BASE_BRANCH = "missing_base_branch"
     # Contract / PR-metadata failures encountered after the pipeline
     # passed the misconfiguration check.
     CONTRACT_LOAD_FAILED = "contract_load_failed"
@@ -9590,11 +9594,16 @@ def _open_context_pr_at_implement_start(
     Behaviour:
 
     1. Look up the pipeline + worktree from ``pipeline_id``.
-    2. If the pipeline has no ``repo`` or ``base_branch`` set (local
-       mode), return ``None`` without raising — there is no remote PR
-       to open. This matches the legacy wrapper's silent-skip behaviour
-       for local pipelines so the new hard-required contract does not
-       regress in-house test pipelines.
+    2. If the pipeline has neither ``repo`` nor ``base_branch`` set
+       (local mode), return ``None`` without raising — there is no
+       remote PR to open. This matches the legacy wrapper's silent-skip
+       behaviour for local pipelines so the new hard-required contract
+       does not regress in-house test pipelines. A ``repo`` with no
+       ``base_branch`` is the normal "auto-detect the default branch"
+       state (#3031), NOT a misconfiguration: the base is resolved via
+       :func:`_detect_default_branch` and used for the lookup + create.
+       A ``base_branch`` with no ``repo`` is a genuine misconfiguration
+       and raises ``ContextPrCreationError(reason="missing_repo")``.
     3. Otherwise call ``GatewayClient.lookup_open_pr(head, base)`` — the
        same control-plane idempotency primitive ``create_slice_pr`` uses
        — to find the open PR whose head is the pipeline's work branch and
@@ -9663,12 +9672,27 @@ def _open_context_pr_at_implement_start(
             cause=load_err,
         ) from load_err
 
-    # Step 2: local-mode short-circuit. ``repo`` AND ``base_branch``
-    # MUST BOTH be empty to qualify as local-mode; a remote pipeline
-    # that has ``repo`` set but ``base_branch`` empty (or vice versa)
-    # is a misconfiguration, not a local pipeline, and the soft-skip
-    # below would silently mask the cq-4 hard-required contract
-    # (reviewer_code_holistic blocker 3). Surface the misconfig as a
+    # Step 2: local-mode short-circuit + base-branch resolution.
+    #
+    # ``repo`` AND ``base_branch`` both empty ⇒ local mode (no remote PR
+    # to open); return ``None`` without raising.
+    #
+    # ``repo`` set but ``base_branch`` empty is the NORMAL state, not a
+    # misconfiguration: ``Pipeline.base_branch`` defaults to ``None``
+    # ("auto-detected from repo's default branch") and the standard
+    # ``submit_task`` path never populates it, so essentially every
+    # remote pipeline reaches here with ``base_branch=None``. #2777 cq-4
+    # collapsed the final ``work → main`` PR into this up-front opener
+    # but dropped the default-branch resolution the deleted PR phase did,
+    # making the opener the only ``base_branch`` consumer that hard-
+    # raised on ``None`` instead of resolving it — stranding every
+    # standard pipeline's slice stack on ``/work`` (#3031). Resolve it
+    # here the way every other consumer does
+    # (``base_branch or _detect_default_branch``) and thread the resolved
+    # value through both the idempotency lookup and ``create_pr``.
+    #
+    # A ``base_branch`` set with no ``repo`` IS a genuine
+    # misconfiguration (nothing to open a PR against); surface it as a
     # typed error so the operator notices.
     repo_set = bool(pipeline.repo)
     base_set = bool(pipeline.base_branch)
@@ -9678,14 +9702,12 @@ def _open_context_pr_at_implement_start(
             pipeline_id=pipeline_id,
         )
         return None
-    if repo_set != base_set:
-        # Partial-config pipeline. Raise so the operator sees the
-        # asymmetry rather than silently skipping the context PR.
+    if base_set and not repo_set:
         raise ContextPrCreationError(
-            f"pipeline {pipeline_id!r} has asymmetric remote config "
-            f"(repo={pipeline.repo!r}, base_branch={pipeline.base_branch!r}); "
-            "both must be set for a remote PR or neither for local mode",
-            reason="missing_base_branch" if repo_set else "missing_repo",
+            f"pipeline {pipeline_id!r} has a base_branch "
+            f"({pipeline.base_branch!r}) but no repo; cannot open a context "
+            "PR with no remote",
+            reason="missing_repo",
         )
 
     if not pipeline.branch:
@@ -9699,6 +9721,12 @@ def _open_context_pr_at_implement_start(
         )
 
     worktree_repo_path = resolve_worktree_path(pipeline_id, store.repo_path)
+    # Resolve ``base_branch=None`` to the repo's default branch (#3031).
+    # ``_detect_default_branch`` reads ``origin/HEAD`` from the worktree
+    # and falls back to ``main``/``master`` then the literal ``"main"``,
+    # so it never raises and always yields a concrete base ref for the
+    # lookup + create_pr calls below.
+    effective_base = pipeline.base_branch or _detect_default_branch(worktree_repo_path)
     identifier = _pipeline_identifier(pipeline.issue_number, pipeline_id)
     gateway_mode, _vis = _compute_gateway_mode(pipeline)
 
@@ -9723,7 +9751,7 @@ def _open_context_pr_at_implement_start(
             pipeline_id=pipeline_id,
             repo=pipeline.repo,
             head=pipeline.branch,
-            base=pipeline.base_branch,
+            base=effective_base,
         )
     except Exception as lookup_err:
         raise ContextPrCreationError(
@@ -9748,7 +9776,7 @@ def _open_context_pr_at_implement_start(
             pipeline_id=pipeline_id,
             pr_number=existing_pr_number,
             head=pipeline.branch,
-            base=pipeline.base_branch,
+            base=effective_base,
         )
         return existing_pr_number
 
@@ -9788,7 +9816,7 @@ def _open_context_pr_at_implement_start(
             title=pr_title,
             body=pr_description,
             head=pipeline.branch,
-            base=pipeline.base_branch,
+            base=effective_base,
             issue_number=pipeline.issue_number,
             mode=gateway_mode,
         )
@@ -9841,7 +9869,7 @@ def _open_context_pr_at_implement_start(
         pipeline_id=pipeline_id,
         pr_number=new_pr_number,
         head=pipeline.branch,
-        base=pipeline.base_branch,
+        base=effective_base,
         url=pr_url,
     )
     return new_pr_number

--- a/orchestrator/tests/test_context_pr_opener.py
+++ b/orchestrator/tests/test_context_pr_opener.py
@@ -217,6 +217,49 @@ class TestOpenContextPrHappyPath:
         assert lookup_kwargs["head"] == pipeline.branch
         assert lookup_kwargs["base"] == "release/v2"
 
+    def test_base_branch_unset_resolves_default_branch(self, tmp_path):
+        """``repo`` set + ``base_branch`` unset is the NORMAL state, not a
+        misconfig: ``Pipeline.base_branch`` defaults to ``None`` and the
+        standard ``submit_task`` path never populates it. #2777 cq-4
+        collapsed the resolving PR phase into this up-front opener but
+        dropped the default-branch resolution, so the opener hard-raised
+        ``missing_base_branch`` and stranded every standard pipeline's
+        slice stack on ``/work`` (#3031). The opener MUST instead resolve
+        the default branch via ``_detect_default_branch`` and open the PR
+        against it. A non-``main`` resolved value proves it is genuinely
+        detected (not hardcoded) and is threaded into both the
+        idempotency lookup and ``create_pr``."""
+        pipeline = _make_pipeline(base_branch=None)
+        contract = _make_contract()
+        spawner = MagicMock()
+        spawner.gateway.lookup_open_pr.return_value = None
+        spawner.gateway.create_pr.return_value = "https://github.com/owner/repo/pull/555"
+
+        with (
+            patch(
+                "routes.get_state_store_for_pipeline",
+                return_value=(MagicMock(repo_path=tmp_path), pipeline),
+            ),
+            patch("routes.resolve_worktree_path", return_value=tmp_path),
+            patch("routes.pipelines._get_spawner", return_value=spawner),
+            patch(
+                "routes.pipelines._compute_gateway_mode",
+                return_value=("public", "public"),
+            ),
+            patch(
+                "routes.pipelines._detect_default_branch",
+                return_value="develop",
+            ) as detect,
+            patch("egg_contracts.loader.load_contract", return_value=contract),
+            patch("routes.pipelines._persist_context_pr_number"),
+        ):
+            result = _open_context_pr_at_implement_start(pipeline.id)
+
+        assert result == 555
+        detect.assert_called_once_with(tmp_path)
+        assert spawner.gateway.lookup_open_pr.call_args.kwargs["base"] == "develop"
+        assert spawner.gateway.create_pr.call_args.kwargs["base"] == "develop"
+
 
 # ---------------------------------------------------------------------------
 # Idempotent path — existing PR is returned without a create_pr call
@@ -355,49 +398,6 @@ class TestOpenContextPrHardRequiredRaises:
         ):
             _open_context_pr_at_implement_start(pipeline.id)
         assert exc_info.value.reason == ContextPrCreationReason.MISSING_REPO.value
-
-    def test_base_branch_unset_resolves_default_branch(self, tmp_path):
-        """``repo`` set + ``base_branch`` unset is the NORMAL state, not a
-        misconfig: ``Pipeline.base_branch`` defaults to ``None`` and the
-        standard ``submit_task`` path never populates it. #2777 cq-4
-        collapsed the resolving PR phase into this up-front opener but
-        dropped the default-branch resolution, so the opener hard-raised
-        ``missing_base_branch`` and stranded every standard pipeline's
-        slice stack on ``/work`` (#3031). The opener MUST instead resolve
-        the default branch via ``_detect_default_branch`` and open the PR
-        against it. A non-``main`` resolved value proves it is genuinely
-        detected (not hardcoded) and is threaded into both the
-        idempotency lookup and ``create_pr``."""
-        pipeline = _make_pipeline(base_branch=None)
-        contract = _make_contract()
-        spawner = MagicMock()
-        spawner.gateway.lookup_open_pr.return_value = None
-        spawner.gateway.create_pr.return_value = "https://github.com/owner/repo/pull/555"
-
-        with (
-            patch(
-                "routes.get_state_store_for_pipeline",
-                return_value=(MagicMock(repo_path=tmp_path), pipeline),
-            ),
-            patch("routes.resolve_worktree_path", return_value=tmp_path),
-            patch("routes.pipelines._get_spawner", return_value=spawner),
-            patch(
-                "routes.pipelines._compute_gateway_mode",
-                return_value=("public", "public"),
-            ),
-            patch(
-                "routes.pipelines._detect_default_branch",
-                return_value="develop",
-            ) as detect,
-            patch("egg_contracts.loader.load_contract", return_value=contract),
-            patch("routes.pipelines._persist_context_pr_number"),
-        ):
-            result = _open_context_pr_at_implement_start(pipeline.id)
-
-        assert result == 555
-        detect.assert_called_once_with(tmp_path)
-        assert spawner.gateway.lookup_open_pr.call_args.kwargs["base"] == "develop"
-        assert spawner.gateway.create_pr.call_args.kwargs["base"] == "develop"
 
     def test_missing_branch_raises(self, tmp_path):
         """A remote pipeline must have ``branch`` set; an empty branch

--- a/orchestrator/tests/test_context_pr_opener.py
+++ b/orchestrator/tests/test_context_pr_opener.py
@@ -23,8 +23,10 @@ This file pins the three paths task-3-8 calls out:
    that the legacy wrapper used is gone. Each of the cq-4 hard-required
    failure modes raises a typed :class:`ContextPrCreationError` with a
    structured ``reason`` value. The local-mode (no repo, no base_branch)
-   short-circuit is the ONLY ``return None`` path; the partial-config
-   asymmetric case (only one of ``repo`` / ``base_branch`` set) raises.
+   short-circuit is the ONLY ``return None`` path. A ``base_branch`` set
+   with no ``repo`` raises ``missing_repo``; but ``repo`` set with no
+   ``base_branch`` is the normal auto-detect state (#3031) and resolves
+   the default branch rather than raising.
 
 The naming follows the orchestrator-tests feature-split convention
 (``test_<feature>_<topic>.py``) — there is no monolithic
@@ -67,13 +69,14 @@ def _make_pipeline(
     pipeline_id: str = "issue-2777",
     repo: str = "owner/repo",
     branch: str = "egg/issue-2777/work",
-    base_branch: str = "main",
+    base_branch: str | None = "main",
     issue_number: int | None = 2777,
 ) -> Pipeline:
     """Build a Pipeline with the remote-mode fields set by default.
 
     Tests override ``repo`` / ``base_branch`` to exercise the local-mode
-    short-circuit and the partial-config asymmetric raise.
+    short-circuit, the ``base_branch=None`` default-branch resolution
+    (#3031), and the ``base_branch``-without-``repo`` misconfig raise.
     """
     return Pipeline(
         id=pipeline_id,
@@ -333,23 +336,16 @@ class TestOpenContextPrHardRequiredRaises:
             result = _open_context_pr_at_implement_start(pipeline.id)
         assert result is None
 
-    @pytest.mark.parametrize(
-        ("repo", "base_branch", "expected_reason"),
-        [
-            ("owner/repo", "", ContextPrCreationReason.MISSING_BASE_BRANCH.value),
-            ("", "main", ContextPrCreationReason.MISSING_REPO.value),
-        ],
-    )
-    def test_partial_remote_config_raises_typed_error(
-        self, tmp_path, repo, base_branch, expected_reason
-    ):
-        """A pipeline with ``repo`` set but no ``base_branch`` (or vice
-        versa) is a misconfiguration — the new opener raises rather than
-        silently skipping (the legacy wrapper would silently
-        ``return None`` and leave the slice stack stranded on /work).
-        Reviewer-blocker-3 of slice-1 reviewer_code_holistic pinned
-        this asymmetric-config raise."""
-        pipeline = _make_pipeline(repo=repo, base_branch=base_branch)
+    def test_base_branch_without_repo_raises_missing_repo(self, tmp_path):
+        """A ``base_branch`` set with no ``repo`` is a genuine
+        misconfiguration — there is no remote to open a PR against — so
+        the opener raises ``missing_repo`` rather than silently skipping.
+
+        Note the asymmetry: ``repo`` set with no ``base_branch`` is NOT
+        an error (see ``test_base_branch_unset_resolves_default_branch``)
+        — that is the normal auto-detect state #3031 fixes. Only the
+        ``base_branch``-without-``repo`` direction is a misconfig."""
+        pipeline = _make_pipeline(repo="", base_branch="main")
         with (
             patch(
                 "routes.get_state_store_for_pipeline",
@@ -358,7 +354,50 @@ class TestOpenContextPrHardRequiredRaises:
             pytest.raises(ContextPrCreationError) as exc_info,
         ):
             _open_context_pr_at_implement_start(pipeline.id)
-        assert exc_info.value.reason == expected_reason
+        assert exc_info.value.reason == ContextPrCreationReason.MISSING_REPO.value
+
+    def test_base_branch_unset_resolves_default_branch(self, tmp_path):
+        """``repo`` set + ``base_branch`` unset is the NORMAL state, not a
+        misconfig: ``Pipeline.base_branch`` defaults to ``None`` and the
+        standard ``submit_task`` path never populates it. #2777 cq-4
+        collapsed the resolving PR phase into this up-front opener but
+        dropped the default-branch resolution, so the opener hard-raised
+        ``missing_base_branch`` and stranded every standard pipeline's
+        slice stack on ``/work`` (#3031). The opener MUST instead resolve
+        the default branch via ``_detect_default_branch`` and open the PR
+        against it. A non-``main`` resolved value proves it is genuinely
+        detected (not hardcoded) and is threaded into both the
+        idempotency lookup and ``create_pr``."""
+        pipeline = _make_pipeline(base_branch=None)
+        contract = _make_contract()
+        spawner = MagicMock()
+        spawner.gateway.lookup_open_pr.return_value = None
+        spawner.gateway.create_pr.return_value = "https://github.com/owner/repo/pull/555"
+
+        with (
+            patch(
+                "routes.get_state_store_for_pipeline",
+                return_value=(MagicMock(repo_path=tmp_path), pipeline),
+            ),
+            patch("routes.resolve_worktree_path", return_value=tmp_path),
+            patch("routes.pipelines._get_spawner", return_value=spawner),
+            patch(
+                "routes.pipelines._compute_gateway_mode",
+                return_value=("public", "public"),
+            ),
+            patch(
+                "routes.pipelines._detect_default_branch",
+                return_value="develop",
+            ) as detect,
+            patch("egg_contracts.loader.load_contract", return_value=contract),
+            patch("routes.pipelines._persist_context_pr_number"),
+        ):
+            result = _open_context_pr_at_implement_start(pipeline.id)
+
+        assert result == 555
+        detect.assert_called_once_with(tmp_path)
+        assert spawner.gateway.lookup_open_pr.call_args.kwargs["base"] == "develop"
+        assert spawner.gateway.create_pr.call_args.kwargs["base"] == "develop"
 
     def test_missing_branch_raises(self, tmp_path):
         """A remote pipeline must have ``branch`` set; an empty branch

--- a/orchestrator/tests/test_context_pr_opener.py
+++ b/orchestrator/tests/test_context_pr_opener.py
@@ -357,18 +357,17 @@ class TestOpenContextPrIdempotent:
 
 
 # ---------------------------------------------------------------------------
-# Hard-required raises — every failure mode raises ContextPrCreationError
+# Local mode — both repo and base_branch empty: returns None without raising
 # ---------------------------------------------------------------------------
 
 
-class TestOpenContextPrHardRequiredRaises:
-    """The legacy soft-fail ``return None`` swallow path is gone. Every
-    cq-4 failure mode raises a typed ``ContextPrCreationError`` with a
-    structured ``reason`` value."""
+class TestOpenContextPrLocalMode:
+    """The ONLY ``return None`` path: both ``repo`` and ``base_branch``
+    empty means a local pipeline with no remote target. The opener
+    short-circuits without raising — distinct from the hard-required
+    failure modes below, which all raise ``ContextPrCreationError``."""
 
     def test_local_mode_returns_none_without_raise(self, tmp_path):
-        """The ONLY ``return None`` survivor — both ``repo`` and
-        ``base_branch`` empty means local mode, no remote PR to open."""
         pipeline = _make_pipeline(repo="", base_branch="")
         with (
             patch(
@@ -378,6 +377,17 @@ class TestOpenContextPrHardRequiredRaises:
         ):
             result = _open_context_pr_at_implement_start(pipeline.id)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Hard-required raises — every failure mode raises ContextPrCreationError
+# ---------------------------------------------------------------------------
+
+
+class TestOpenContextPrHardRequiredRaises:
+    """The legacy soft-fail ``return None`` swallow path is gone. Every
+    cq-4 failure mode raises a typed ``ContextPrCreationError`` with a
+    structured ``reason`` value."""
 
     def test_base_branch_without_repo_raises_missing_repo(self, tmp_path):
         """A ``base_branch`` set with no ``repo`` is a genuine

--- a/orchestrator/tests/test_open_context_pr_at_implement_start.py
+++ b/orchestrator/tests/test_open_context_pr_at_implement_start.py
@@ -63,7 +63,7 @@ from routes.pipelines import (  # noqa: E402
 def _make_pipeline(
     *,
     repo: str = "owner/repo",
-    base_branch: str = "main",
+    base_branch: str | None = "main",
     branch: str = "egg/issue-2777/work",
 ) -> Pipeline:
     """Pipeline with the fields the opener reads (repo, base_branch, branch)."""
@@ -250,18 +250,51 @@ class TestOpenContextPRAtImplementStartTypedErrors:
         ):
             assert _open_context_pr_at_implement_start("issue-2777") is None
 
-    def test_asymmetric_missing_base_branch_raises(self, store, spawner_factory):
-        """Repo set but base_branch empty → typed error."""
-        pipeline = _make_pipeline(repo="owner/repo", base_branch="")
+    def test_base_branch_unset_resolves_default_branch(self, tmp_path, store, spawner_factory):
+        """Repo set but base_branch unset is the NORMAL auto-detect state
+        (#3031), NOT a misconfiguration. ``Pipeline.base_branch`` defaults
+        to ``None`` and the standard ``submit_task`` path never populates
+        it, so the opener MUST resolve the repo's default branch via
+        ``_detect_default_branch`` and open the context PR against it —
+        rather than hard-raising ``missing_base_branch`` and stranding the
+        slice stack on ``/work`` (the #2777 regression #3031 fixes). A
+        non-``main`` default proves the base is genuinely resolved rather
+        than hardcoded, and both the idempotency lookup and ``create_pr``
+        must receive the resolved value."""
+        pipeline = _make_pipeline(repo="owner/repo", base_branch=None)
+        spawner = spawner_factory(
+            lookup_open_pr_return=None,
+            create_pr_return="https://github.com/owner/repo/pull/7777",
+        )
+        contract = _make_contract()
+        save_calls: list = []
+
+        def _fake_save(c, _root):
+            save_calls.append(c.pr.context_pr_number)
+
         with (
             patch(
                 "routes.get_state_store_for_pipeline",
                 return_value=(store, pipeline),
             ),
+            patch("routes.resolve_worktree_path", return_value=tmp_path),
+            patch("routes.pipelines._get_spawner", return_value=spawner),
+            patch(
+                "routes.pipelines._detect_default_branch",
+                return_value="develop",
+            ) as detect,
+            patch("egg_contracts.loader.load_contract", return_value=contract),
+            patch("egg_contracts.loader.save_contract", side_effect=_fake_save),
+            patch("state_store.get_state_store", return_value=store),
         ):
-            with pytest.raises(ContextPrCreationError) as exc_info:
-                _open_context_pr_at_implement_start("issue-2777")
-            assert exc_info.value.reason == ContextPrCreationReason.MISSING_BASE_BRANCH.value
+            store.load_pipeline.return_value = MagicMock(repo="owner/repo")
+            result = _open_context_pr_at_implement_start("issue-2777")
+
+        assert result == 7777
+        detect.assert_called_once_with(tmp_path)
+        assert spawner.gateway.lookup_open_pr.call_args.kwargs["base"] == "develop"
+        assert spawner.gateway.create_pr.call_args.kwargs["base"] == "develop"
+        assert save_calls == [7777]
 
     def test_asymmetric_missing_repo_raises(self, store, spawner_factory):
         """Base branch set but repo empty → typed error."""


### PR DESCRIPTION
Fixes #3031.

## Root cause (contradicts the issue's leading hypothesis)

The issue guessed a transient gateway/credential error swallowed by the runner-driven soft-fail sites. The actual failure is **deterministic**. Live on `issue-3023` the opener logged:

```
Context PR opener: ... failed ... reason=missing_base_branch
  error="pipeline 'issue-3023' has asymmetric remote config (repo='jwbron/egg', base_b…"
```

`_open_context_pr_at_implement_start` treated `repo` set + `base_branch` empty as an **asymmetric-config misconfiguration** and hard-raised `missing_base_branch`. But:

- `Pipeline.base_branch` defaults to `None` ("auto-detected from repo's default branch"), and the standard `submit_task` path never populates it (`mcp_tools.py` only forwards `base_branch` when explicitly supplied). Nothing writes a resolved value back to the record — so **essentially every remote pipeline reaches the opener with `base_branch=None`** (verified across the live state store).
- Every *other* `base_branch` consumer resolves `None → default` (`base_branch or _detect_default_branch(...)`, `get_default_branch(...)`, `_resolve_origin_ref`). The opener was the lone consumer that raised instead.

### Why it regressed in #2777
Work→main context PRs were created cleanly through issue-2769, then stopped for every later issue. Pre-#2777 the context PR was a dedicated `egg/<id>/context` branch and the `work → main` PR was the **final PR opened by the (now-deleted) PR phase**, which resolved `base_branch=None → default`. #2777 cq-4 collapsed `work → main` into this up-front opener and **lost that resolution**. The four runner-driven opener sites soft-fail and the one hard-fail `advance_phase` REST path is `not force`-gated and never hit by resumes — so the failure was swallowed and the slice stack stranded on `/work` with no base PR.

The `could not read Username` error the issue cited is a **separate** real bug on a sibling user-auth external-repo pipeline, not the trigger here (`jwbron/egg` is bot-App auth).

## Fix

In `_open_context_pr_at_implement_start`:
- When `repo` is set but `base_branch` is empty, resolve `effective_base = pipeline.base_branch or _detect_default_branch(worktree_repo_path)` and thread it through **both** `lookup_open_pr` and `create_pr` (and the log lines) — instead of raising.
- The genuine asymmetry (`base_branch` set with **no** `repo`) still raises `missing_repo`.
- Removed the now-unreachable `MISSING_BASE_BRANCH` reason from the closed `ContextPrCreationReason` enum.

## Recovery

The opener is idempotent and re-fires at every runner-driven implement entry, so once this deploys a plain `restart_phase implement` self-heals already-stranded pipelines (including `issue-3023`) — no new operator tool needed.

## Scope notes (the issue's other asks)

- **Soft-fail vs hard-fail at runner sites:** intentionally *not* changed. Flipping soft→hard would wedge the pipeline on any transient blip (the soft-fail's whole purpose) and doesn't address this bug. The narrower "hard-required enforced only on a `not force`-gated path resumes skip" robustness gap is better closed by an idempotent backstop — left as a separate follow-up.
- **Submit-time base_branch persistence** (resolve+store on the record, the #2967 family) is a broader change deliberately not bundled here.

## Tests

- `test_context_pr_opener.py` / `test_open_context_pr_at_implement_start.py`: replaced the `missing_base_branch`-raise assertions (which encoded the bug) with positive tests asserting the opener resolves a non-`main` default (`develop`) and threads it through `lookup_open_pr` + `create_pr`. Kept the `missing_repo` (base-set-without-repo) raise.
- `.venv/bin/pytest` on both opener files: **37 passed**. (Full `make test` not run — scoped per request.)
