### PR TITLE
feat(orchestrator): server-side filtering for get_service_logs (#3032)

### DIFF
--- a/orchestrator/log_filter.py
+++ b/orchestrator/log_filter.py
@@ -3,8 +3,14 @@
 The gateway/orchestrator pods emit one structured JSON log object per line
 (see ``shared/egg_logging/formatters.py``): severity lives in the ``severity``
 field (GCP strings ``DEBUG``/``INFO``/``WARNING``/``ERROR``/``CRITICAL``) and
-the pipeline id is nested at ``context.task_id`` — there is no top-level
-``pipeline_id`` field.
+the pipeline id is carried in one of three places depending on how the call
+site spelled it. The ``JsonFormatter`` only allowlists ``task_id`` /
+``repository`` / ``pr_number`` into the nested ``context`` block; any other
+kwarg — including ``pipeline_id``, which is the spelling 25+ orchestrator
+call sites actually use — lands in the ``extra`` block instead. The
+pipeline-id filter therefore checks ``context.task_id`` **and**
+``extra.pipeline_id`` **and** ``extra.task_id`` (in that order); matching
+any one of them keeps the line.
 
 ``filter_log_lines`` lets an operator scope a noisy multi-pipeline pod tail to
 the lines they actually want ("WARNING+ for pipeline X in the last 5 min")
@@ -57,6 +63,32 @@ def _parse_json_line(line: str) -> dict | None:
     return obj if isinstance(obj, dict) else None
 
 
+def _extract_pipeline_id(obj: dict | None) -> str:
+    """Pull a pipeline/task id from a parsed log object.
+
+    Checks the three places the JSON formatter can land an id (the formatter's
+    context allowlist only includes ``task_id``; everything else falls into
+    ``extra``). Returns ``""`` when none of them are set so the caller can
+    treat ``""`` as "no determinable id".
+    """
+    if obj is None:
+        return ""
+    ctx = obj.get("context")
+    if isinstance(ctx, dict):
+        task_id = ctx.get("task_id")
+        if task_id:
+            return str(task_id)
+    extra = obj.get("extra")
+    if isinstance(extra, dict):
+        # Production call sites use ``pipeline_id=...``; ``task_id`` is the
+        # defensive companion for any caller that picked the other spelling.
+        for key in ("pipeline_id", "task_id"):
+            value = extra.get(key)
+            if value:
+                return str(value)
+    return ""
+
+
 def filter_log_lines(
     raw: str,
     *,
@@ -69,27 +101,44 @@ def filter_log_lines(
 
     Each line is parsed as a structured JSON log object. Filters are ANDed:
 
-    * ``pipeline_id`` — keep lines whose ``context.task_id`` equals it. A line
-      with no determinable task id fails this filter (dropped).
+    * ``pipeline_id`` — keep lines whose pipeline/task id matches. A line's id
+      is read from ``context.task_id``, ``extra.pipeline_id`` or
+      ``extra.task_id`` (the three places the JSON formatter can land it); a
+      line with none of them set fails this filter (dropped).
     * ``min_level`` — keep lines whose ``severity`` rank is ``>=`` the floor. A
       line with no determinable severity fails this filter (dropped). An
-      unrecognised ``min_level`` is treated as no severity filter; callers
-      should validate it up front.
+      unrecognised ``min_level`` raises ``ValueError`` — silently dropping the
+      filter on a deliberately-set parameter is the footgun this guard avoids;
+      callers should still validate up front to surface a useful error.
     * ``pattern`` — keep lines the compiled regex finds (``re.search``) anywhere
       in the raw line text.
 
     When at least one filter is active, only the last ``limit`` *matching* lines
     are returned (the most recent), preserving order. With no active filter the
-    input is returned unchanged aside from the ``limit`` tail.
+    input is returned unchanged aside from the ``limit`` tail. ``limit <= 0``
+    returns the empty string (Python's ``lines[-0:]`` gotcha would otherwise
+    return everything).
     """
-    min_rank = severity_rank(min_level)
+    if min_level is not None:
+        min_rank = severity_rank(min_level)
+        if min_rank is None:
+            raise ValueError(f"min_level must be one of {known_severities()}; got {min_level!r}")
+    else:
+        min_rank = None
     have_filter = bool(pipeline_id) or min_rank is not None or pattern is not None
+
+    def _tail(items: list[str]) -> list[str]:
+        if limit is None:
+            return items
+        if limit <= 0:
+            return []
+        if len(items) > limit:
+            return items[-limit:]
+        return items
 
     lines = raw.splitlines()
     if not have_filter:
-        if limit is not None and len(lines) > limit:
-            lines = lines[-limit:]
-        return "\n".join(lines)
+        return "\n".join(_tail(lines))
 
     kept: list[str] = []
     for line in lines:
@@ -97,20 +146,12 @@ def filter_log_lines(
             continue
         if pipeline_id or min_rank is not None:
             obj = _parse_json_line(line)
-            if pipeline_id:
-                task_id = ""
-                if obj is not None:
-                    ctx = obj.get("context")
-                    if isinstance(ctx, dict):
-                        task_id = str(ctx.get("task_id") or "")
-                if task_id != pipeline_id:
-                    continue
+            if pipeline_id and _extract_pipeline_id(obj) != pipeline_id:
+                continue
             if min_rank is not None:
                 rank = severity_rank(obj.get("severity") if obj else None)
                 if rank is None or rank < min_rank:
                     continue
         kept.append(line)
 
-    if limit is not None and len(kept) > limit:
-        kept = kept[-limit:]
-    return "\n".join(kept)
+    return "\n".join(_tail(kept))

--- a/orchestrator/log_filter.py
+++ b/orchestrator/log_filter.py
@@ -1,0 +1,116 @@
+"""Server-side filtering for the ``get_service_logs`` tool (#3032).
+
+The gateway/orchestrator pods emit one structured JSON log object per line
+(see ``shared/egg_logging/formatters.py``): severity lives in the ``severity``
+field (GCP strings ``DEBUG``/``INFO``/``WARNING``/``ERROR``/``CRITICAL``) and
+the pipeline id is nested at ``context.task_id`` — there is no top-level
+``pipeline_id`` field.
+
+``filter_log_lines`` lets an operator scope a noisy multi-pipeline pod tail to
+the lines they actually want ("WARNING+ for pipeline X in the last 5 min")
+*before* the response is truncated to the MCP token cap, instead of fetching a
+raw tail that is mostly health-check noise and watching the one line they need
+scroll out of the window they can afford to fetch.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+# Python ``logging`` numeric levels keyed by the GCP severity strings the JSON
+# formatter emits. Backs the ``level`` (minimum-severity) filter.
+_SEVERITY_RANK: dict[str, int] = {
+    "DEBUG": 10,
+    "INFO": 20,
+    "WARNING": 30,
+    "ERROR": 40,
+    "CRITICAL": 50,
+}
+
+
+def severity_rank(name: str | None) -> int | None:
+    """Return the numeric rank for a GCP severity string, or ``None`` if unknown.
+
+    Case-insensitive. ``None`` doubles as the "not a recognised severity"
+    signal callers use to reject an invalid ``level`` param.
+    """
+    if not name:
+        return None
+    return _SEVERITY_RANK.get(name.strip().upper())
+
+
+def known_severities() -> list[str]:
+    """Return the recognised severity names (for error messages / schema enums)."""
+    return sorted(_SEVERITY_RANK, key=lambda s: _SEVERITY_RANK[s])
+
+
+def _parse_json_line(line: str) -> dict | None:
+    """Parse a single log line as a JSON object, or ``None`` if it isn't one."""
+    stripped = line.strip()
+    if not stripped or stripped[0] != "{":
+        return None
+    try:
+        obj = json.loads(stripped)
+    except ValueError, TypeError:
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+def filter_log_lines(
+    raw: str,
+    *,
+    pipeline_id: str | None = None,
+    min_level: str | None = None,
+    pattern: re.Pattern[str] | None = None,
+    limit: int | None = None,
+) -> str:
+    """Filter a pod's raw log tail to the lines an operator asked for.
+
+    Each line is parsed as a structured JSON log object. Filters are ANDed:
+
+    * ``pipeline_id`` — keep lines whose ``context.task_id`` equals it. A line
+      with no determinable task id fails this filter (dropped).
+    * ``min_level`` — keep lines whose ``severity`` rank is ``>=`` the floor. A
+      line with no determinable severity fails this filter (dropped). An
+      unrecognised ``min_level`` is treated as no severity filter; callers
+      should validate it up front.
+    * ``pattern`` — keep lines the compiled regex finds (``re.search``) anywhere
+      in the raw line text.
+
+    When at least one filter is active, only the last ``limit`` *matching* lines
+    are returned (the most recent), preserving order. With no active filter the
+    input is returned unchanged aside from the ``limit`` tail.
+    """
+    min_rank = severity_rank(min_level)
+    have_filter = bool(pipeline_id) or min_rank is not None or pattern is not None
+
+    lines = raw.splitlines()
+    if not have_filter:
+        if limit is not None and len(lines) > limit:
+            lines = lines[-limit:]
+        return "\n".join(lines)
+
+    kept: list[str] = []
+    for line in lines:
+        if pattern is not None and not pattern.search(line):
+            continue
+        if pipeline_id or min_rank is not None:
+            obj = _parse_json_line(line)
+            if pipeline_id:
+                task_id = ""
+                if obj is not None:
+                    ctx = obj.get("context")
+                    if isinstance(ctx, dict):
+                        task_id = str(ctx.get("task_id") or "")
+                if task_id != pipeline_id:
+                    continue
+            if min_rank is not None:
+                rank = severity_rank(obj.get("severity") if obj else None)
+                if rank is None or rank < min_rank:
+                    continue
+        kept.append(line)
+
+    if limit is not None and len(kept) > limit:
+        kept = kept[-limit:]
+    return "\n".join(kept)

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -64,6 +64,7 @@ except ImportError:  # pragma: no cover - shared path always present in prod
 # practice, never trips the cap because its output is bounded by design.
 _TOOL_NARROW_HINTS: dict[str, str] = {
     "get_service_logs": (
+        "scope with `pipeline_id`, `level`, or `pattern` (applied before truncation), "
         "lower `lines` or set a smaller `since_seconds` window, or fetch a single service at a time"
     ),
     "get_container_logs": (
@@ -976,7 +977,11 @@ PIPELINE_TOOLS = [
             "containers) so operators can cross-reference gateway-side spawn "
             "failures — 'Connection refused', 'Remote end closed connection', "
             "'push_worktree_branch returned False' — without shelling into the "
-            "cluster. Only available on the Kubernetes runtime."
+            "cluster. Only available on the Kubernetes runtime. Use the "
+            "`pipeline_id`, `level`, and `pattern` filters (applied server-side "
+            "before truncation) to scope a noisy multi-pipeline tail to the "
+            "lines you want — e.g. WARNING+ for one pipeline in the last 5 min "
+            "— instead of fetching a raw tail that's mostly health-check noise."
         ),
         "inputSchema": {
             "type": "object",
@@ -988,7 +993,11 @@ PIPELINE_TOOLS = [
                 },
                 "lines": {
                     "type": "integer",
-                    "description": "Number of log lines to return (default 100).",
+                    "description": (
+                        "Number of log lines to return (default 100). With a "
+                        "filter active this caps the matching lines returned, "
+                        "not the raw tail scanned."
+                    ),
                     "default": 100,
                 },
                 "since_seconds": {
@@ -996,6 +1005,27 @@ PIPELINE_TOOLS = [
                     "description": (
                         "Only return logs newer than this many seconds — useful for "
                         "scoping to 'logs around when my pipeline failed at HH:MM'."
+                    ),
+                },
+                "pipeline_id": {
+                    "type": "string",
+                    "description": (
+                        "Keep only lines emitted for this pipeline/task id "
+                        "(matched against the log's `context.task_id`)."
+                    ),
+                },
+                "level": {
+                    "type": "string",
+                    "description": (
+                        "Minimum severity to return; drops lower-severity and unstructured lines."
+                    ),
+                    "enum": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+                },
+                "pattern": {
+                    "type": "string",
+                    "description": (
+                        "Python regular expression; keep only lines it matches "
+                        "(`re.search`). A plain substring is a valid pattern."
                     ),
                 },
             },
@@ -2634,6 +2664,16 @@ class PipelineToolHandler:
         since_seconds = args.get("since_seconds")
         if since_seconds is not None:
             params.append(f"since_seconds={int(since_seconds)}")
+        # Server-side filters (#3032) — applied before truncation.
+        pipeline_id = args.get("pipeline_id")
+        if pipeline_id:
+            params.append(f"pipeline_id={quote(str(pipeline_id), safe='')}")
+        level = args.get("level")
+        if level:
+            params.append(f"level={quote(str(level), safe='')}")
+        pattern = args.get("pattern")
+        if pattern:
+            params.append(f"pattern={quote(str(pattern), safe='')}")
 
         endpoint = "/api/v1/deployment/logs?" + "&".join(params)
         try:

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -1010,8 +1010,12 @@ PIPELINE_TOOLS = [
                 "pipeline_id": {
                     "type": "string",
                     "description": (
-                        "Keep only lines emitted for this pipeline/task id "
-                        "(matched against the log's `context.task_id`)."
+                        "Keep only lines emitted for this pipeline/task id. "
+                        "Matched against the log's `context.task_id`, with "
+                        "`extra.pipeline_id` and `extra.task_id` as fallbacks "
+                        "— production call sites use `pipeline_id=...`, which "
+                        "the JsonFormatter lands in `extra` rather than the "
+                        "context-allowlisted `task_id` slot."
                     ),
                 },
                 "level": {

--- a/orchestrator/routes/deployment.py
+++ b/orchestrator/routes/deployment.py
@@ -53,6 +53,7 @@ except ImportError:
 
 
 from lifecycle_auth import require_lifecycle_secret
+from log_filter import filter_log_lines, known_severities, severity_rank
 
 logger = get_logger("orchestrator.deployment")
 
@@ -464,8 +465,20 @@ def get_service_logs() -> tuple[Response, int]:
 
     Query params:
         service: one of _SERVICE_LOG_ALLOWLIST (required).
-        lines: tail length, default 100, capped at _MAX_LOG_LINES.
+        lines: tail length, default 100, capped at _MAX_LOG_LINES. When a
+            filter (``pipeline_id``/``level``/``pattern``) is active this caps
+            the *matching* lines returned rather than the raw tail.
         since_seconds: only return logs newer than this many seconds.
+        pipeline_id: keep only lines whose ``context.task_id`` matches (#3032).
+        level: minimum severity (DEBUG..CRITICAL); drops lower-severity and
+            unstructured lines (#3032).
+        pattern: Python regex; keep only lines it finds via ``re.search`` (#3032).
+
+    Filters are applied server-side **before** truncation, so a targeted query
+    returns the relevant lines instead of a raw tail that's mostly health-check
+    noise. When any filter is set, the backing pod is scanned over a wider
+    window (``_MAX_LOG_LINES``, still bounded by ``since_seconds``) so the
+    filter has material to match, and ``lines`` caps the matches returned.
     """
     if _current_runtime() != "kubernetes":
         return _not_available_on_runtime()
@@ -507,6 +520,34 @@ def get_service_logs() -> tuple[Response, int]:
         if since_seconds <= 0:
             since_seconds = None
 
+    # Server-side filters (#3032). Applied below, before truncation.
+    pipeline_id = (request.args.get("pipeline_id") or "").strip() or None
+    level = (request.args.get("level") or "").strip().upper() or None
+    if level is not None and severity_rank(level) is None:
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "message": f"level must be one of {known_severities()}; got {level!r}",
+                }
+            ),
+            400,
+        )
+    pattern_raw = request.args.get("pattern") or None
+    compiled_pattern: re.Pattern[str] | None = None
+    if pattern_raw:
+        try:
+            compiled_pattern = re.compile(pattern_raw)
+        except re.error as exc:
+            return (
+                jsonify({"success": False, "message": f"pattern is not a valid regex: {exc}"}),
+                400,
+            )
+    filters_active = bool(pipeline_id) or level is not None or compiled_pattern is not None
+    # With a filter active, scan a wider window so the filter has material to
+    # match; ``lines`` then caps the matches returned, not the raw tail.
+    fetch_lines = _MAX_LOG_LINES if filters_active else lines
+
     namespace = os.environ.get("EGG_K8S_NAMESPACE", "egg-system")
 
     try:
@@ -530,7 +571,7 @@ def get_service_logs() -> tuple[Response, int]:
         payload = k8s.get_service_logs(
             service=service,
             namespace=namespace,
-            tail_lines=lines,
+            tail_lines=fetch_lines,
             since_seconds=since_seconds,
         )
     except PodNotFoundError as exc:
@@ -540,6 +581,23 @@ def get_service_logs() -> tuple[Response, int]:
     except Exception as exc:  # pragma: no cover - defensive
         logger.error("get_service_logs failed", service=service, error=str(exc))
         return jsonify({"success": False, "message": f"failed: {exc}"}), 500
+
+    if filters_active:
+        for chunk in payload.get("pods", []):
+            chunk["logs"] = filter_log_lines(
+                chunk.get("logs", ""),
+                pipeline_id=pipeline_id,
+                min_level=level,
+                pattern=compiled_pattern,
+                limit=lines,
+            )
+        payload["filter"] = {
+            "pipeline_id": pipeline_id,
+            "level": level,
+            "pattern": pattern_raw,
+            "returned_line_cap": lines,
+            "scanned_line_budget": fetch_lines,
+        }
 
     return jsonify({"success": True, "data": payload}), 200
 

--- a/orchestrator/routes/deployment.py
+++ b/orchestrator/routes/deployment.py
@@ -53,7 +53,7 @@ except ImportError:
 
 
 from lifecycle_auth import require_lifecycle_secret
-from log_filter import filter_log_lines, known_severities, severity_rank
+from log_filter import filter_log_lines, known_severities
 
 logger = get_logger("orchestrator.deployment")
 
@@ -468,17 +468,32 @@ def get_service_logs() -> tuple[Response, int]:
         lines: tail length, default 100, capped at _MAX_LOG_LINES. When a
             filter (``pipeline_id``/``level``/``pattern``) is active this caps
             the *matching* lines returned rather than the raw tail.
-        since_seconds: only return logs newer than this many seconds.
-        pipeline_id: keep only lines whose ``context.task_id`` matches (#3032).
-        level: minimum severity (DEBUG..CRITICAL); drops lower-severity and
-            unstructured lines (#3032).
-        pattern: Python regex; keep only lines it finds via ``re.search`` (#3032).
+        since_seconds: only return logs newer than this many seconds. When
+            filters are active this is the only knob that bounds the
+            per-pod scan window — the backing fetch is widened to
+            ``_MAX_LOG_LINES`` so the filter has material to match.
+        pipeline_id: keep only lines whose pipeline/task id matches; checks
+            ``context.task_id`` and the ``extra.pipeline_id`` /
+            ``extra.task_id`` fallbacks the JsonFormatter lands kwargs in
+            (#3032).
+        level: minimum severity (case-sensitive; ``DEBUG`` … ``CRITICAL``);
+            drops lower-severity and unstructured lines. The MCP ``level``
+            enum is the source of truth — the HTTP route rejects lowercase
+            for parity (#3032).
+        pattern: Python regex; keep only lines it finds via ``re.search``.
+            Compiled with no complexity guardrail — pathological patterns
+            (catastrophic backtracking) can spin a request thread per pod
+            line. This endpoint is gated behind ``require_lifecycle_secret``
+            and called from trusted operator tooling, so the trust model
+            here is "operator can hose their own request"; widen with a
+            timeout if this surface ever opens up (#3032).
 
     Filters are applied server-side **before** truncation, so a targeted query
     returns the relevant lines instead of a raw tail that's mostly health-check
     noise. When any filter is set, the backing pod is scanned over a wider
     window (``_MAX_LOG_LINES``, still bounded by ``since_seconds``) so the
-    filter has material to match, and ``lines`` caps the matches returned.
+    filter has material to match, and ``lines`` caps the matches returned —
+    use ``since_seconds`` to keep the per-pod scan cost bounded.
     """
     if _current_runtime() != "kubernetes":
         return _not_available_on_runtime()
@@ -522,8 +537,13 @@ def get_service_logs() -> tuple[Response, int]:
 
     # Server-side filters (#3032). Applied below, before truncation.
     pipeline_id = (request.args.get("pipeline_id") or "").strip() or None
-    level = (request.args.get("level") or "").strip().upper() or None
-    if level is not None and severity_rank(level) is None:
+    # Case-sensitive on purpose: the MCP `level` enum is uppercase-only, and
+    # accepting lowercase here would diverge HTTP behavior from what the
+    # schema advertises. ``severity_rank`` itself is case-insensitive so the
+    # filter helper works for any direct caller; the strict check is the
+    # route's contract with its operator-facing schema.
+    level = (request.args.get("level") or "").strip() or None
+    if level is not None and level not in known_severities():
         return (
             jsonify(
                 {

--- a/orchestrator/tests/test_deployment_routes.py
+++ b/orchestrator/tests/test_deployment_routes.py
@@ -1601,6 +1601,78 @@ class TestGetServiceLogsRoute:
         assert response.status_code == 400
         assert "level" in response.get_json()["message"]
 
+    def test_lowercase_level_returns_400(self, client, monkeypatch):
+        """Route is case-sensitive on ``level`` to match the MCP enum (#3032)."""
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+        response = client.get("/api/v1/deployment/logs?service=gateway&level=warning")
+        assert response.status_code == 400
+        assert "warning" in response.get_json()["message"]
+
+    def test_filter_matches_production_extra_pipeline_id_shape(self, client, monkeypatch):
+        """The pipeline filter matches lines whose id lives at ``extra.pipeline_id``
+        — that's the shape every orchestrator production call site emits.
+
+        Pre-fix the filter only checked ``context.task_id`` and would return
+        an empty result for this input. The motivating example from #3032
+        (``Context PR opener … failed`` at ``orchestrator/routes/phases.py``)
+        is one such call.
+        """
+        import json as _json
+
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+
+        raw = "\n".join(
+            [
+                _json.dumps(
+                    {
+                        "severity": "WARNING",
+                        "message": "Context PR opener failed at advance_phase",
+                        "extra": {"pipeline_id": "issue-123", "reason": "X"},
+                    }
+                ),
+                _json.dumps(
+                    {
+                        "severity": "INFO",
+                        "message": "routine poll",
+                        "extra": {"pipeline_id": "issue-123"},
+                    }
+                ),
+                _json.dumps(
+                    {
+                        "severity": "ERROR",
+                        "message": "other-pipeline boom",
+                        "extra": {"pipeline_id": "issue-999"},
+                    }
+                ),
+            ]
+        )
+        fake_k8s = MagicMock()
+        fake_k8s.get_service_logs.return_value = {
+            "service": "orchestrator",
+            "namespace": "egg-system",
+            "pods": [{"pod": "orchestrator-abc", "logs": raw}],
+        }
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "kubernetes_client": MagicMock(
+                    get_kubernetes_client=MagicMock(return_value=fake_k8s),
+                    PodNotFoundError=type("PodNotFoundError", (Exception,), {}),
+                    JobOperationError=type("JobOperationError", (Exception,), {}),
+                )
+            },
+        ):
+            response = client.get(
+                "/api/v1/deployment/logs?service=orchestrator&pipeline_id=issue-123&level=WARNING"
+            )
+
+        assert response.status_code == 200
+        logs = response.get_json()["data"]["pods"][0]["logs"]
+        assert "Context PR opener" in logs
+        assert "routine poll" not in logs  # below WARNING
+        assert "other-pipeline boom" not in logs  # wrong pipeline
+
     def test_invalid_pattern_returns_400(self, client, monkeypatch):
         monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
         response = client.get("/api/v1/deployment/logs?service=gateway&pattern=%5B")

--- a/orchestrator/tests/test_deployment_routes.py
+++ b/orchestrator/tests/test_deployment_routes.py
@@ -1533,6 +1533,108 @@ class TestGetServiceLogsRoute:
 
         assert fake_k8s.get_service_logs.call_args.kwargs["tail_lines"] == _MAX_LOG_LINES
 
+    def test_filter_scans_wider_window_and_caps_matches(self, client, monkeypatch):
+        """With a filter active, the pod is scanned over the max window and the
+        result is filtered to matching lines, capped by ``lines`` (#3032)."""
+        import json as _json
+
+        from routes.deployment import _MAX_LOG_LINES
+
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+
+        raw = "\n".join(
+            [
+                _json.dumps({"severity": "INFO", "message": "poll", "context": {"task_id": "p-1"}}),
+                _json.dumps(
+                    {
+                        "severity": "WARNING",
+                        "message": "opener failed",
+                        "context": {"task_id": "p-1"},
+                    }
+                ),
+                _json.dumps(
+                    {"severity": "ERROR", "message": "boom", "context": {"task_id": "p-2"}}
+                ),
+                "plain non-json health line",
+            ]
+        )
+        fake_k8s = MagicMock()
+        fake_k8s.get_service_logs.return_value = {
+            "service": "orchestrator",
+            "namespace": "egg-system",
+            "pods": [{"pod": "orchestrator-abc", "logs": raw}],
+        }
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "kubernetes_client": MagicMock(
+                    get_kubernetes_client=MagicMock(return_value=fake_k8s),
+                    PodNotFoundError=type("PodNotFoundError", (Exception,), {}),
+                    JobOperationError=type("JobOperationError", (Exception,), {}),
+                )
+            },
+        ):
+            response = client.get(
+                "/api/v1/deployment/logs?service=orchestrator&lines=10"
+                "&pipeline_id=p-1&level=WARNING"
+            )
+
+        assert response.status_code == 200
+        # The wider scan window is used for the backing fetch, not ``lines``.
+        assert fake_k8s.get_service_logs.call_args.kwargs["tail_lines"] == _MAX_LOG_LINES
+        data = response.get_json()["data"]
+        logs = data["pods"][0]["logs"]
+        # Only the WARNING line for p-1 survives: INFO is below the floor, the
+        # ERROR is p-2, the plain line has no severity/task_id.
+        assert "opener failed" in logs
+        assert "poll" not in logs
+        assert "boom" not in logs
+        assert "health line" not in logs
+        assert data["filter"]["pipeline_id"] == "p-1"
+        assert data["filter"]["level"] == "WARNING"
+        assert data["filter"]["returned_line_cap"] == 10
+
+    def test_invalid_level_returns_400(self, client, monkeypatch):
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+        response = client.get("/api/v1/deployment/logs?service=gateway&level=LOUD")
+        assert response.status_code == 400
+        assert "level" in response.get_json()["message"]
+
+    def test_invalid_pattern_returns_400(self, client, monkeypatch):
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+        response = client.get("/api/v1/deployment/logs?service=gateway&pattern=%5B")
+        assert response.status_code == 400
+        assert "regex" in response.get_json()["message"]
+
+    def test_no_filter_preserves_existing_behavior(self, client, monkeypatch):
+        """Without a filter, the raw tail is returned and ``lines`` drives the fetch."""
+        monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
+
+        fake_k8s = MagicMock()
+        fake_k8s.get_service_logs.return_value = {
+            "service": "gateway",
+            "namespace": "egg-system",
+            "pods": [{"pod": "gateway-abc", "logs": "raw line\n"}],
+        }
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "kubernetes_client": MagicMock(
+                    get_kubernetes_client=MagicMock(return_value=fake_k8s),
+                    PodNotFoundError=type("PodNotFoundError", (Exception,), {}),
+                    JobOperationError=type("JobOperationError", (Exception,), {}),
+                )
+            },
+        ):
+            response = client.get("/api/v1/deployment/logs?service=gateway&lines=42")
+
+        assert fake_k8s.get_service_logs.call_args.kwargs["tail_lines"] == 42
+        data = response.get_json()["data"]
+        assert data["pods"][0]["logs"] == "raw line\n"
+        assert "filter" not in data
+
     def test_pod_not_found_returns_404(self, client, monkeypatch):
         monkeypatch.setenv("EGG_RUNTIME", "kubernetes")
 

--- a/orchestrator/tests/test_log_filter.py
+++ b/orchestrator/tests/test_log_filter.py
@@ -1,0 +1,113 @@
+"""Unit tests for the ``get_service_logs`` server-side filter (#3032)."""
+
+from __future__ import annotations
+
+import json
+import re
+
+from log_filter import filter_log_lines, known_severities, severity_rank
+
+
+def _line(severity: str, message: str, task_id: str | None = None) -> str:
+    obj: dict = {"severity": severity, "message": message}
+    if task_id is not None:
+        obj["context"] = {"task_id": task_id}
+    return json.dumps(obj)
+
+
+class TestSeverityRank:
+    def test_known_levels_ordered(self):
+        ranks = [severity_rank(s) for s in known_severities()]
+        assert ranks == sorted(ranks)
+        assert severity_rank("WARNING") > severity_rank("INFO")
+
+    def test_case_insensitive(self):
+        assert severity_rank("warning") == severity_rank("WARNING")
+
+    def test_unknown_is_none(self):
+        assert severity_rank("LOUD") is None
+        assert severity_rank(None) is None
+        assert severity_rank("") is None
+
+
+class TestFilterLogLines:
+    def test_no_filter_returns_input_with_tail_limit(self):
+        raw = "\n".join(f"line {i}" for i in range(5))
+        assert filter_log_lines(raw) == raw
+        assert filter_log_lines(raw, limit=2) == "line 3\nline 4"
+
+    def test_level_floor_drops_lower_and_unstructured(self):
+        raw = "\n".join(
+            [
+                _line("INFO", "info"),
+                _line("WARNING", "warn"),
+                _line("ERROR", "err"),
+                "plain non-json line",
+            ]
+        )
+        out = filter_log_lines(raw, min_level="WARNING")
+        assert "warn" in out
+        assert "err" in out
+        assert "info" not in out
+        assert "plain non-json" not in out
+
+    def test_pipeline_id_scopes_to_task(self):
+        raw = "\n".join(
+            [
+                _line("INFO", "mine", task_id="p-1"),
+                _line("INFO", "theirs", task_id="p-2"),
+                _line("INFO", "untagged"),  # no context.task_id
+            ]
+        )
+        out = filter_log_lines(raw, pipeline_id="p-1")
+        # Only the p-1 line survives; the others (wrong / missing task_id) drop.
+        assert out == _line("INFO", "mine", task_id="p-1")
+
+    def test_pattern_is_regex_search(self):
+        raw = "\n".join(
+            [
+                _line("INFO", "Context PR opener failed reason=x"),
+                _line("INFO", "routine poll"),
+            ]
+        )
+        out = filter_log_lines(raw, pattern=re.compile(r"opener failed reason="))
+        assert "Context PR opener" in out
+        assert "routine poll" not in out
+
+    def test_pattern_matches_plain_substring(self):
+        raw = "\n".join([_line("INFO", "alpha"), _line("INFO", "beta")])
+        out = filter_log_lines(raw, pattern=re.compile("alpha"))
+        assert "alpha" in out
+        assert "beta" not in out
+
+    def test_filters_are_anded(self):
+        raw = "\n".join(
+            [
+                _line("WARNING", "keep me", task_id="p-1"),
+                _line("WARNING", "wrong pipeline", task_id="p-2"),
+                _line("INFO", "too quiet", task_id="p-1"),
+            ]
+        )
+        out = filter_log_lines(
+            raw,
+            pipeline_id="p-1",
+            min_level="WARNING",
+            pattern=re.compile("keep"),
+        )
+        assert out == _line("WARNING", "keep me", task_id="p-1")
+
+    def test_limit_keeps_most_recent_matches(self):
+        raw = "\n".join(_line("ERROR", f"e{i}", task_id="p-1") for i in range(5))
+        out = filter_log_lines(raw, min_level="ERROR", limit=2)
+        assert out.splitlines() == [
+            _line("ERROR", "e3", task_id="p-1"),
+            _line("ERROR", "e4", task_id="p-1"),
+        ]
+
+    def test_unrecognised_min_level_is_inert(self):
+        """A bad ``min_level`` is treated as no severity filter (route validates it)."""
+        raw = "\n".join([_line("INFO", "keep-this"), _line("ERROR", "drop-this")])
+        # Only the pattern is genuinely active here; the bogus level is ignored,
+        # so the INFO line is not filtered out by severity.
+        out = filter_log_lines(raw, min_level="LOUD", pattern=re.compile("keep-this"))
+        assert out == _line("INFO", "keep-this")

--- a/orchestrator/tests/test_log_filter.py
+++ b/orchestrator/tests/test_log_filter.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 
+import pytest
 from log_filter import filter_log_lines, known_severities, severity_rank
 
 
@@ -13,6 +15,22 @@ def _line(severity: str, message: str, task_id: str | None = None) -> str:
     if task_id is not None:
         obj["context"] = {"task_id": task_id}
     return json.dumps(obj)
+
+
+def _line_extra_pipeline(severity: str, message: str, pipeline_id: str) -> str:
+    """Production-shape line: the kwarg landed in ``extra`` (not ``context``).
+
+    The ``JsonFormatter`` only allowlists ``task_id``/``repository``/``pr_number``
+    into ``context``; ``pipeline_id=`` kwargs (what the orchestrator actually
+    uses) land in ``extra`` instead.
+    """
+    return json.dumps(
+        {
+            "severity": severity,
+            "message": message,
+            "extra": {"pipeline_id": pipeline_id},
+        }
+    )
 
 
 class TestSeverityRank:
@@ -63,6 +81,88 @@ class TestFilterLogLines:
         # Only the p-1 line survives; the others (wrong / missing task_id) drop.
         assert out == _line("INFO", "mine", task_id="p-1")
 
+    def test_pipeline_id_matches_extra_pipeline_id(self):
+        """Production lines use ``extra.pipeline_id`` (not ``context.task_id``)."""
+        raw = "\n".join(
+            [
+                _line_extra_pipeline("WARNING", "mine via extra", "p-1"),
+                _line_extra_pipeline("WARNING", "theirs", "p-2"),
+            ]
+        )
+        out = filter_log_lines(raw, pipeline_id="p-1")
+        assert "mine via extra" in out
+        assert "theirs" not in out
+
+    def test_pipeline_id_matches_extra_task_id_fallback(self):
+        """A caller spelling the kwarg ``task_id`` (not on the formatter's
+        allowlist) lands at ``extra.task_id``; the filter still matches."""
+        raw = json.dumps(
+            {
+                "severity": "ERROR",
+                "message": "via extra.task_id",
+                "extra": {"task_id": "p-1"},
+            }
+        )
+        assert "via extra.task_id" in filter_log_lines(raw, pipeline_id="p-1")
+        assert filter_log_lines(raw, pipeline_id="p-2") == ""
+
+    def test_pipeline_id_end_to_end_via_json_formatter(self):
+        """Producer/consumer parity: lines produced by the real
+        ``JsonFormatter`` (the thing every orchestrator log call goes through)
+        must be matchable by the filter when callers use ``pipeline_id=``.
+
+        This is the test that would have caught the bug — the hand-built
+        ``_line()`` fixture nests ``context.task_id`` correctly, but
+        ``logger.warning("...", pipeline_id=...)`` actually lands the id in
+        ``extra.pipeline_id``.
+        """
+        from egg_logging.formatters import JsonFormatter
+
+        formatter = JsonFormatter(service="orchestrator")
+
+        def _emit(level: int, message: str, **kwargs: object) -> str:
+            record = logging.LogRecord(
+                name="orchestrator.deployment",
+                level=level,
+                pathname=__file__,
+                lineno=1,
+                msg=message,
+                args=(),
+                exc_info=None,
+            )
+            for key, value in kwargs.items():
+                setattr(record, key, value)
+            return formatter.format(record)
+
+        raw = "\n".join(
+            [
+                _emit(
+                    logging.WARNING,
+                    "Context PR opener failed at advance_phase",
+                    pipeline_id="issue-123",
+                    reason="upstream",
+                ),
+                _emit(logging.INFO, "routine poll", pipeline_id="issue-123"),
+                _emit(logging.ERROR, "boom", pipeline_id="other-456"),
+                _emit(logging.WARNING, "global warn"),  # no pipeline_id
+            ]
+        )
+
+        # The motivating example from the PR description: WARNING+ for a
+        # specific pipeline. Pre-fix this returned "".
+        out = filter_log_lines(raw, pipeline_id="issue-123", min_level="WARNING")
+        assert "Context PR opener" in out
+        assert "routine poll" not in out  # below floor
+        assert "boom" not in out  # wrong pipeline
+        assert "global warn" not in out  # no pipeline_id
+
+        # pipeline_id alone (no level floor) keeps INFO too.
+        out = filter_log_lines(raw, pipeline_id="issue-123")
+        assert "Context PR opener" in out
+        assert "routine poll" in out
+        assert "boom" not in out
+        assert "global warn" not in out
+
     def test_pattern_is_regex_search(self):
         raw = "\n".join(
             [
@@ -104,10 +204,23 @@ class TestFilterLogLines:
             _line("ERROR", "e4", task_id="p-1"),
         ]
 
-    def test_unrecognised_min_level_is_inert(self):
-        """A bad ``min_level`` is treated as no severity filter (route validates it)."""
-        raw = "\n".join([_line("INFO", "keep-this"), _line("ERROR", "drop-this")])
-        # Only the pattern is genuinely active here; the bogus level is ignored,
-        # so the INFO line is not filtered out by severity.
-        out = filter_log_lines(raw, min_level="LOUD", pattern=re.compile("keep-this"))
-        assert out == _line("INFO", "keep-this")
+    def test_unrecognised_min_level_raises(self):
+        """A bad ``min_level`` raises so the footgun isn't silent.
+
+        Pre-fix this filter silently dropped on an unknown level — a
+        deliberately-set parameter producing no signal is the exact failure
+        mode the review rules guard against.
+        """
+        raw = _line("INFO", "anything")
+        with pytest.raises(ValueError, match="min_level must be one of"):
+            filter_log_lines(raw, min_level="LOUD")
+
+    def test_limit_zero_returns_empty(self):
+        """``lines[-0:]`` is ``lines[:]`` — guard against the slice gotcha."""
+        raw = "\n".join(_line("INFO", f"m{i}") for i in range(3))
+        assert filter_log_lines(raw, limit=0) == ""
+        assert filter_log_lines(raw, pattern=re.compile("m"), limit=0) == ""
+
+    def test_limit_negative_returns_empty(self):
+        raw = "\n".join(_line("INFO", f"m{i}") for i in range(3))
+        assert filter_log_lines(raw, limit=-5) == ""

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -2784,6 +2784,40 @@ class TestGetServiceLogsTool:
         endpoint = mock_req.call_args.args[0]
         assert "service=a%2Fb%20c" in endpoint
 
+    def test_forwards_filter_params(self, handler):
+        """``pipeline_id``/``level``/``pattern`` are forwarded, url-encoded (#3032)."""
+        with patch.object(
+            handler,
+            "_make_request",
+            return_value={"success": True, "data": {"pods": []}},
+        ) as mock_req:
+            handler.handle_tool_call(
+                "get_service_logs",
+                {
+                    "service": "orchestrator",
+                    "pipeline_id": "pipeline-f8/1884",
+                    "level": "WARNING",
+                    "pattern": "Context PR opener",
+                },
+            )
+        endpoint = mock_req.call_args.args[0]
+        assert "pipeline_id=pipeline-f8%2F1884" in endpoint
+        assert "level=WARNING" in endpoint
+        assert "pattern=Context%20PR%20opener" in endpoint
+
+    def test_omits_filter_params_when_absent(self, handler):
+        """Unset filters don't append empty query params."""
+        with patch.object(
+            handler,
+            "_make_request",
+            return_value={"success": True, "data": {"pods": []}},
+        ) as mock_req:
+            handler.handle_tool_call("get_service_logs", {"service": "gateway"})
+        endpoint = mock_req.call_args.args[0]
+        assert "pipeline_id=" not in endpoint
+        assert "level=" not in endpoint
+        assert "pattern=" not in endpoint
+
     def test_http_failure_wraps_into_error(self, handler):
         with patch.object(handler, "_make_request", side_effect=RuntimeError("gateway down")):
             result = handler.handle_tool_call("get_service_logs", {"service": "gateway"})
@@ -2857,6 +2891,16 @@ class TestPipelineToolsSchemasForDeployment:
         assert schema.get("required") == ["service"]
         assert set(props["service"].get("enum", [])) == {"gateway", "orchestrator"}
         assert props["lines"]["default"] == 100
+        # #3032 server-side filter params.
+        assert "pipeline_id" in props
+        assert "pattern" in props
+        assert set(props["level"].get("enum", [])) == {
+            "DEBUG",
+            "INFO",
+            "WARNING",
+            "ERROR",
+            "CRITICAL",
+        }
 
     def test_get_service_logs_enum_matches_route_allowlist(self):
         """MCP schema enum and route allowlist must stay in sync."""
@@ -2868,6 +2912,17 @@ class TestPipelineToolsSchemasForDeployment:
             tools_by_name["get_service_logs"]["inputSchema"]["properties"]["service"]["enum"]
         )
         assert schema_enum == _SERVICE_LOG_ALLOWLIST
+
+    def test_get_service_logs_level_enum_matches_log_filter(self):
+        """MCP `level` enum and the route's severity ranks must stay in sync (#3032)."""
+        from log_filter import known_severities
+        from mcp_tools import PIPELINE_TOOLS
+
+        tools_by_name = {t["name"]: t for t in PIPELINE_TOOLS}
+        schema_enum = set(
+            tools_by_name["get_service_logs"]["inputSchema"]["properties"]["level"]["enum"]
+        )
+        assert schema_enum == set(known_severities())
 
     def test_validate_network_isolation_requires_pipeline_id(self):
         from mcp_tools import PIPELINE_TOOLS


### PR DESCRIPTION
## What

Adds server-side filter params to the `get_service_logs` MCP tool, applied **before** truncation, so an operator can scope a noisy multi-pipeline pod tail to the lines they actually want instead of fetching a raw tail that's mostly health-check noise.

This is **item 1** (the high-value one) of #3032. Items 2 (`slice_state`/`gated_on` on `get_consensus_status`) and 3 (`cq-N` open-questions in the HITL surface) are left as follow-ups.

## The problem (from #3032)

Driving one pipeline while a second ran concurrently, `get_service_logs(orchestrator)` returned the raw pod tail with no way to scope it:

- `lines=300, since_seconds=220` → **62,509 chars**, over the tool's token cap → forced a file-dump + `jq` extraction.
- `lines=80` covered only ~30s of wall-clock (two pipelines emit ~3–4 lines/s of consensus-poll + health spam).
- The single `WARNING` line actually needed (`Context PR opener … failed reason=`) had already scrolled out of any affordable window.

There was no `pipeline_id`, no `level`, no `pattern` — so the operator couldn't ask the question they had ("show me WARNING+ lines for pipeline X in the last 5 min").

## The change

Three new params on `get_service_logs` / `GET /api/v1/deployment/logs`:

| Param | Effect |
|-------|--------|
| `pipeline_id` | Keep lines whose structured-log `context.task_id` matches |
| `level` | Minimum severity (`DEBUG`…`CRITICAL`); drops lower-severity **and** unstructured lines |
| `pattern` | Python regex (`re.search`); a plain substring is a valid pattern |

Filters are ANDed and applied **server-side, before truncation**. When any filter is active, the backing pod is scanned over a wider window (`_MAX_LOG_LINES`, still bounded by `since_seconds`) so the filter has material to match, and `lines` caps the *matches* returned rather than the raw tail. The response gains a `filter` block echoing what was applied.

Logs are one JSON object per line (`shared/egg_logging/formatters.py`): severity is `severity` (GCP strings), pipeline id is nested at `context.task_id` — the filter keys off those.

## Design notes

- Filtering lives in a pure, unit-tested helper (`orchestrator/log_filter.py`) — no k8s/Flask deps, easy to test in isolation.
- The route validates `level` and `pattern` up front (`400` on an unknown severity or an invalid regex).
- The MCP `level` enum is kept in sync with the helper's severity set via a guard test.
- No-filter calls are byte-for-byte unchanged (existing path untouched; new behavior gated on `filters_active`).

## Tests

- `orchestrator/tests/test_log_filter.py` — new: severity ranking, level floor (incl. dropping unstructured lines), `pipeline_id` scoping, regex/substring matching, AND-ing, most-recent `limit` tail, inert bad level.
- `orchestrator/tests/test_deployment_routes.py` — wider-window scan + match cap + `filter` echo; `400` on bad `level`/`pattern`; no-filter path preserved.
- `orchestrator/tests/test_mcp_tools.py` — param forwarding + URL-encoding; schema/enum guards.

38 targeted tests pass; `ruff check`/`format` clean.

Closes part of #3032 (item 1).