### PR TITLE
fix(ci): run contract verification on sliced PRs (#3040)

### DIFF
--- a/.github/workflows/on-pull-request-contract-verify.yml
+++ b/.github/workflows/on-pull-request-contract-verify.yml
@@ -1,6 +1,7 @@
 name: "egg: Contract Verification"
 
-# Trigger on PRs with the sdlc:pr label or a new contract file in the diff
+# Trigger on PRs with the sdlc:pr label, a new contract file in the diff, or a
+# slice PR (egg/<id>/slice-N -> egg/<id>/work) whose work branch carries a contract.
 # This workflow verifies that implementation matches the SDLC contract
 on:
   pull_request:
@@ -115,7 +116,34 @@ jobs:
               exit 0
             fi
 
-            echo "No sdlc:pr label and no new contract file in diff, skipping"
+            # Slice PRs (egg/<pipeline_id>/slice-<N> -> egg/<pipeline_id>/work)
+            # carry agent:<role> labels (not sdlc:pr) and inherit the contract
+            # from the work branch rather than *adding* it, so neither trigger
+            # above fires (#3040). Detect them by the head-branch topology — a
+            # docs/normal PR's head never has the egg/<id>/slice-<N> shape — then
+            # confirm the contract is present on the pipeline's work branch.
+            #
+            # NOTE: do NOT trigger on bare "a contract file exists on the
+            # branch": every PR inherits the contracts accumulated on the
+            # default branch, which is exactly why #1134 removed the
+            # branch-level existence check. The slice-branch head match is the
+            # real discriminator; the work-branch contract check is a sanity
+            # guard. Deriving the work branch from the head (not the PR base)
+            # also covers stacked slices whose base is another slice branch.
+            if [[ "$branch_name" =~ ^egg/(.+)/slice-[0-9]+$ ]]; then
+              work_branch="egg/${BASH_REMATCH[1]}/work"
+              work_contracts=$(
+                gh api "repos/${{ github.repository }}/contents/.egg-state/contracts?ref=${work_branch}" \
+                  --jq '[.[] | select(.name | endswith(".json"))] | length' 2>/dev/null || echo 0)
+              if [[ "${work_contracts:-0}" -gt 0 ]]; then
+                echo "Slice PR ${branch_name}: contract present on ${work_branch}, running contract verification"
+                echo "run=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              echo "Slice PR but no contract found on work branch ${work_branch}; skipping"
+            fi
+
+            echo "No sdlc:pr label, no new contract file, and not a slice PR with a contract; skipping"
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/docs/guides/github-automation.md
+++ b/docs/guides/github-automation.md
@@ -317,12 +317,13 @@ Verifies that PR implementations match their SDLC pipeline contracts. This workf
 
 ### Trigger Conditions
 
-The workflow runs on pull requests when **either** of these conditions is met:
+The workflow runs on pull requests when **any** of these conditions is met:
 
 1. **Label-based trigger** — PR has the `sdlc:pr` label
 2. **Contract file detection** — PR adds a new file to `.egg-state/contracts/` (detected via the PR files diff API)
+3. **Slice-PR trigger** — the PR's head branch is a slice branch (`egg/<pipeline_id>/slice-<N>`) and the pipeline's work branch (`egg/<pipeline_id>/work`) carries a contract file
 
-This dual-trigger approach ensures contract verification runs even when the label is missing but a new contract file is being introduced by the PR.
+This multi-trigger approach ensures contract verification runs for both the work→main context PR (which *adds* the contract, condition 2) and every slice→work PR (condition 3). Slice PRs inherit the contract from the work branch rather than adding it, and they carry `agent:<role>` labels rather than `sdlc:pr`, so neither of the first two conditions fires for them (#3040). Detection keys off the slice-branch *topology* — not bare contract presence, since every PR inherits the contracts accumulated on the default branch (#1134) — so docs-only and other normal PRs are never matched.
 
 ### How It Works
 
@@ -331,6 +332,7 @@ This dual-trigger approach ensures contract verification runs even when the labe
    - Extracts issue number from branch name, PR body, or contract filename (used downstream for contract lookup)
    - For labeled PRs, runs immediately
    - For unlabeled PRs, queries the PR files API to check if any new file was added under `.egg-state/contracts/`
+   - For unlabeled slice PRs (head `egg/<pipeline_id>/slice-<N>`), derives the work branch and runs if a contract is present on it
 2. **Contract verification** — Uses the reusable review framework with a contract-specific prompt:
    - Reads the contract from `.egg-state/contracts/{issue_number}.json`
    - Compares implementation against contract tasks

--- a/tests/config/test_contract_verify_workflow.py
+++ b/tests/config/test_contract_verify_workflow.py
@@ -90,15 +90,51 @@ def test_slice_trigger_is_topology_keyed_not_bare_existence(check_script: str) -
     #1134 removed a branch-level "contract exists" check because every PR
     inherits the default branch's accumulated contracts, so it over-fired on
     docs-only PRs. The slice trigger must therefore guard the contract-presence
-    check behind the `egg/<id>/slice-N` head match — i.e. the regex must appear
-    before (and gate) the work-branch contract lookup in the script.
+    check structurally — i.e. the work-branch contract lookup must sit *inside*
+    the `if [[ "$branch_name" =~ ^egg/(.+)/slice-N$ ]]; then ... fi` block. A
+    refactor that hoisted the lookup out of that block (while leaving the
+    regex string in a comment) would reintroduce the #1134 over-fire even
+    though a literal-position assertion would still pass.
     """
-    slice_regex_pos = check_script.find("slice-[0-9]+$")
-    contracts_lookup_pos = check_script.rfind("contents/.egg-state/contracts?ref=${work_branch}")
-    assert slice_regex_pos != -1, "slice-branch head match missing"
-    assert contracts_lookup_pos != -1, "work-branch contract lookup missing"
-    assert slice_regex_pos < contracts_lookup_pos, (
-        "the work-branch contract lookup is not gated behind the slice-branch "
-        "head match — this risks reintroducing the #1134 over-fire on PRs that "
-        "merely inherit the default branch's contracts"
+    lines = check_script.splitlines()
+
+    slice_if_idx = next(
+        (
+            i
+            for i, line in enumerate(lines)
+            if line.lstrip().startswith("if [[") and "slice-[0-9]+$" in line
+        ),
+        None,
+    )
+    assert slice_if_idx is not None, (
+        "no `if [[ ... slice-[0-9]+$ ... ]]; then` line found — the slice "
+        "trigger is not gated by a head-topology if-block"
+    )
+
+    # Walk forward counting `if` opens and `fi` closes from the slice-if line.
+    # `elif` does not open a new block (matched by an outer `fi`), and `fi`
+    # never appears mid-expression in this gate's bash, so simple stripped-line
+    # matching is sufficient.
+    depth = 0
+    slice_fi_idx: int | None = None
+    for i in range(slice_if_idx, len(lines)):
+        stripped = lines[i].lstrip()
+        if stripped.startswith("if "):
+            depth += 1
+        if stripped == "fi" or stripped.startswith("fi "):
+            depth -= 1
+            if depth == 0:
+                slice_fi_idx = i
+                break
+    assert slice_fi_idx is not None, (
+        "no matching `fi` found for the slice-branch `if` — the gate's "
+        "bash block structure is malformed"
+    )
+
+    inside_block = "\n".join(lines[slice_if_idx + 1 : slice_fi_idx])
+    assert "contents/.egg-state/contracts?ref=${work_branch}" in inside_block, (
+        "the work-branch contract lookup is not inside the "
+        "`if [[ ... slice-[0-9]+$ ... ]]; then ... fi` block — this risks "
+        "reintroducing the #1134 over-fire on PRs that merely inherit the "
+        "default branch's contracts"
     )

--- a/tests/config/test_contract_verify_workflow.py
+++ b/tests/config/test_contract_verify_workflow.py
@@ -1,0 +1,104 @@
+"""Structural assertions over the contract-verification trigger gate.
+
+`.github/workflows/on-pull-request-contract-verify.yml` decides — in the
+`should-run` job's `check` step (a bash-in-YAML gate) — whether contract
+verification runs for a given PR. That gate is a proven regression magnet:
+
+* #680 first added a "contract file exists on the branch" trigger.
+* #1134 narrowed it to "PR *adds* a new contract file" because the original
+  over-fired on docs-only PRs (every PR inherits the contracts accumulated on
+  the default branch).
+* #3040: that narrowing silently dropped *slice* PRs
+  (`egg/<id>/slice-N -> egg/<id>/work`) — they inherit the contract from the
+  work branch rather than adding it, and carry `agent:<role>` labels (not
+  `sdlc:pr`), so neither surviving trigger fired and a descope shipped
+  unverified.
+
+These assertions lock in all three trigger conditions so a future "cleanup"
+cannot silently drop the slice trigger (or reintroduce the #1134 over-fire) without
+the suite going red.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "on-pull-request-contract-verify.yml"
+
+
+@pytest.fixture
+def check_script() -> str:
+    """Return the bash body of the `should-run` job's `check` step."""
+    if not WORKFLOW.exists():
+        pytest.skip(f"{WORKFLOW} not found — repo is in an unexpected state")
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    jobs = data.get("jobs", {})
+    should_run = jobs.get("should-run")
+    assert should_run is not None, "missing `should-run` job in contract-verify workflow"
+    steps = should_run.get("steps", [])
+    check_steps = [s for s in steps if isinstance(s, dict) and s.get("id") == "check"]
+    assert check_steps, "missing `check` step (id: check) in the should-run job"
+    return check_steps[0].get("run", "")
+
+
+def test_label_trigger_present(check_script: str) -> None:
+    """Condition 1: the `sdlc:pr` label still triggers verification."""
+    assert 'grep -q "^sdlc:pr$"' in check_script, (
+        "should-run gate no longer checks for the `sdlc:pr` label — "
+        "the label-based trigger (condition 1) was dropped"
+    )
+
+
+def test_added_contract_file_trigger_present(check_script: str) -> None:
+    """Condition 2: a PR that *adds* a contract file still triggers verification.
+
+    This is what fires for the work->main context PR (it adds the contract
+    relative to the default branch).
+    """
+    assert 'status == "added"' in check_script and ".egg-state/contracts/" in check_script, (
+        "should-run gate no longer detects a newly-added contract file via the "
+        "PR files diff — the added-contract trigger (condition 2) was dropped"
+    )
+
+
+def test_slice_pr_trigger_present(check_script: str) -> None:
+    """Condition 3 (#3040): slice PRs trigger verification.
+
+    A slice PR's head is `egg/<pipeline_id>/slice-<N>`; it inherits the
+    contract from the work branch rather than adding it, so neither condition
+    1 nor 2 fires. The gate must detect the slice-branch head and derive the
+    work branch.
+    """
+    assert "slice-[0-9]+$" in check_script, (
+        "should-run gate has no slice-branch head match — slice PRs "
+        "(egg/<id>/slice-N -> egg/<id>/work) will skip contract verification (#3040)"
+    )
+    assert "/work" in check_script, (
+        "slice-PR trigger does not derive the pipeline work branch — the "
+        "contract presence check must target egg/<pipeline_id>/work (#3040)"
+    )
+
+
+def test_slice_trigger_is_topology_keyed_not_bare_existence(check_script: str) -> None:
+    """The slice trigger must be gated on slice-branch *topology*, not bare
+    contract presence.
+
+    #1134 removed a branch-level "contract exists" check because every PR
+    inherits the default branch's accumulated contracts, so it over-fired on
+    docs-only PRs. The slice trigger must therefore guard the contract-presence
+    check behind the `egg/<id>/slice-N` head match — i.e. the regex must appear
+    before (and gate) the work-branch contract lookup in the script.
+    """
+    slice_regex_pos = check_script.find("slice-[0-9]+$")
+    contracts_lookup_pos = check_script.rfind("contents/.egg-state/contracts?ref=${work_branch}")
+    assert slice_regex_pos != -1, "slice-branch head match missing"
+    assert contracts_lookup_pos != -1, "work-branch contract lookup missing"
+    assert slice_regex_pos < contracts_lookup_pos, (
+        "the work-branch contract lookup is not gated behind the slice-branch "
+        "head match — this risks reintroducing the #1134 over-fire on PRs that "
+        "merely inherit the default branch's contracts"
+    )


### PR DESCRIPTION
## Summary

The **"egg: Contract Verification"** workflow's `should-run` gate fired only when a PR (a) carried the `sdlc:pr` label, or (b) *added* a new `.egg-state/contracts/` file. Slice PRs (`egg/<id>/slice-N → egg/<id>/work`) do **neither**:

- they carry `egg` + `agent:<role>` labels, never `sdlc:pr` (which is in fact unapplied today — a vestige of the #402 plan), and
- they **inherit** the contract from the `work` branch rather than adding it, so the slice→work diff shows no added contract file.

So verification silently **skipped** — e.g. #3023's slice-2 was descoped from 12 tasks to 1 on #3037 and shipped with no contract gate.

## Fix

Add a third trigger to the `should-run` gate, keyed on slice-branch **topology**: when the head branch matches `egg/<pipeline_id>/slice-<N>`, derive the work branch (`egg/<pipeline_id>/work`) and run verification if a contract is present there.

Keying on the slice-branch head — **not** bare contract presence — is what keeps this from reintroducing the [#1134](https://github.com/jwbron/egg/pull/1134) over-fire: every PR inherits the default branch's accumulated contracts, so "a contract exists on the branch" is not a discriminator (a docs-only PR's head never has the `egg/<id>/slice-N` shape). Deriving the work branch from the head (rather than reading the PR base) also covers **stacked** slices whose base is another slice branch.

## Already handled (no change needed)

- **Re-review base-ref delta** — `reusable-review.yml` already threads the PR's actual `.base.ref` into `BASE_REF`, so `git log … --not origin/<base>` uses `egg/issue-N/work`, not `main` (covered by `test_custom_base_ref_threaded_through`).
- **Contract on slice checkout** — a slice branch is created by pushing the parent/work branch, so `.egg-state/contracts/<id>.json` is present and `egg-contract show` finds it.

## Tests / docs

- New `tests/config/test_contract_verify_workflow.py` — structural guard locking in all three trigger conditions and asserting the slice trigger stays gated behind the head-topology match (this gate has regressed across #680 → #1134 → #3040).
- Updated `docs/guides/github-automation.md` trigger conditions.

## Known limitation (follow-up, not bundled)

For **qualified** pipelines (`issue-N-v2`, `issue-N-replan`), the issue-number extraction yields bare `N`, so the reviewer's `egg-contract show` looks for `issue-N.json` while the file is `issue-N-v2.json`. This is pre-existing (it also affects today's context-PR trigger) and orthogonal to the slice-trigger gap. #3023 is unqualified, so this PR fully resolves the reported case; I'll file a follow-up for the qualified-pipeline identifier threading.

Closes #3040.

— Authored by egg