### PR TITLE
fix(orchestrator): reject overlapping-but-unordered slices at plan ingestion (#3046)

### DIFF
--- a/docs/architecture/slice-dag.md
+++ b/docs/architecture/slice-dag.md
@@ -149,6 +149,58 @@ Multi-parent and cyclic violations are reported in the same returned
 list, so a single populator pass surfaces every structural defect at
 once.
 
+### File-overlap ordering validation (#3046)
+
+`validate_forest` checks the DAG's *shape* (≤1 parent, acyclic). A
+separate validator, `validate_slice_file_overlap(slices)`, checks a
+*file-semantic* property: **two slices that touch overlapping files must
+be ordered along the dependency DAG** — one a transitive `dependencies`
+ancestor of the other.
+
+The implement phase cuts each slice's integration branch off its
+dependency parent (root slices off `egg/<id>/work`) and ships it as a
+stacked PR — see [Per-slice branches](#per-slice-branches--brc-trackers).
+So when slice-A and slice-B touch the same file:
+
+- **Ordered** (one transitively depends on the other) → the later
+  slice's branch is forked from a base that already contains the
+  earlier slice's commits, so the edits stack cleanly. An intermediate
+  disjoint slice on the chain is fine — the fork point is still
+  transitive.
+- **Unordered** (both roots, or siblings in different subtrees) → both
+  branches fork independently off the shared base, and their edits to
+  the shared file collide at integration. This is a *guaranteed*
+  conflict, including unavoidable modify/delete when one slice deletes a
+  file the other modifies.
+
+This is the #3023 failure: three slices all declared `dependencies: []`
+(parallel roots) while all three touched `consensus_wrapper.py` — one
+*deleting* it. The git branch topology faithfully mirrored the DAG (all
+three forked off `work`); the **DAG itself** was the defect. The branches
+matched the slice DAG perfectly — the slice DAG just didn't encode the
+file-level dependency, and nothing rejected it.
+
+`files_affected` is read from each slice's tasks (the same
+planner-declared signal `validate_task_role_alignment` uses); slices with
+no declared files contribute no overlap signal. The reachability walk is
+cycle-safe (a cycle is reported by `validate_forest`, not here).
+
+The populator (`_populate_contract_from_plan`) runs this validator *after*
+`validate_forest` passes and gives it **identical handling**: the slices
+are not written to the contract, the structured errors are stashed on
+`Contract.plan_review_feedback`, and a `ForestValidationError` is raised
+with `reason="slice_overlap_violation"` (the safe-wrapper maps it to
+`PopulateOutcome.SLICE_OVERLAP_VIOLATION`, distinct from
+`FOREST_VIOLATION`, so the operator-facing HITL prose names the actual
+defect). The plan reviewer NACKs the **architect** (slice-composition
+authority, #2809) — see plan-review criteria §12.
+
+Because the forest constraint forbids a diamond (a slice cannot depend on
+two parents), the remediation is always to **serialise the overlapping
+cluster into one linear `dependencies` chain** — or merge the slices.
+Disjoint slices stay parallel, preserving the concurrency that slicing
+exists to provide.
+
 ## DependencyGraph generification
 
 `shared/egg_contracts/dependency_graph.py` was generified in #2137.

--- a/orchestrator/routes/phases.py
+++ b/orchestrator/routes/phases.py
@@ -1540,9 +1540,15 @@ def populate_contract(pipeline_id: str) -> tuple[Response, int]:
         if e.__class__.__name__ == "ForestValidationError":
             try:
                 body, status = e.to_response()  # type: ignore[attr-defined]
+                # #3046 — ForestValidationError covers both the forest-shape
+                # and file-overlap-ordering rejections. Use a
+                # discriminator-agnostic event name and include
+                # ``reason=`` so operators grepping the audit log catch
+                # both cases.
                 logger.warning(
-                    "contract_populate_forest_violation",
+                    "contract_populate_dag_rejection",
                     pipeline_id=pipeline_id,
+                    reason=getattr(e, "reason", None),
                     errors=getattr(e, "errors", None),
                 )
                 return jsonify(body), status

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -136,26 +136,40 @@ class ContextPrCreationError(Exception):
 
 
 class ForestValidationError(Exception):
-    """Raised by ``_populate_contract_from_plan`` when slice DAG is non-forest.
+    """Raised by ``_populate_contract_from_plan`` on slice-DAG structural rejection.
 
-    Added in #2137 (TASK-2-2). Any future Flask route that ingests a
-    plan in-band can catch this and ``return jsonify({"errors":
-    err.errors}), 422`` to surface the structured rejection per the
-    plan's acceptance criteria. Internal callers (``_populate_contract
-    _from_plan_safe`` and the pipeline run-loop helpers) catch this
-    exception and log a warning — the ``plan_review_feedback`` stash
-    placed on the contract by the populator is the durable signal
-    the plan reviewer prompt reads from to NACK the planner.
+    Added in #2137 (TASK-2-2) for the forest-shape violation (a slice
+    with >1 DAG parent). Generalised in #3046 to also signal the
+    file-overlap-ordering violation (two slices touching the same file
+    with no dependency edge between them — see
+    ``egg_contracts.validate_slice_file_overlap``). Both are slice-DAG
+    structural defects surfaced at plan ingestion with identical
+    handling: the slices are NOT written to the contract, the structured
+    errors are stashed on ``plan_review_feedback`` so the plan reviewer
+    NACKs the architect, and the exception is raised so HTTP callers can
+    return a 422.
+
+    The ``reason`` discriminator (``"forest_violation"`` or
+    ``"slice_overlap_violation"``) selects the operator-facing prose and
+    the :class:`PopulateOutcome` the safe wrapper maps to. Any future
+    Flask route that ingests a plan in-band can catch this and
+    ``return jsonify(*err.to_response())`` to surface the structured
+    rejection. Internal callers (``_populate_contract_from_plan_safe``
+    and the pipeline run-loop helpers) catch it and log a warning — the
+    ``plan_review_feedback`` stash is the durable NACK signal either way.
     """
 
-    def __init__(self, message: str, *, errors: list[str]) -> None:
+    def __init__(
+        self, message: str, *, errors: list[str], reason: str = "forest_violation"
+    ) -> None:
         super().__init__(message)
         self.errors: list[str] = list(errors)
+        self.reason: str = reason
         self.status_code: int = 422
 
     def to_response(self) -> tuple[dict[str, object], int]:
         """Serialise into a Flask-compatible (body, status) tuple."""
-        return ({"error": "forest_violation", "errors": self.errors}, 422)
+        return ({"error": self.reason, "errors": self.errors}, 422)
 
 
 # Add shared directory to path for egg_logging
@@ -4889,7 +4903,32 @@ def _get_plan_review_criteria() -> str:
         "schema migration that cannot be split safely) — in that "
         "case the architect should cite the override in the analysis "
         "and the reviewer can ACK once the rationale is on the "
-        "record.\n"
+        "record.\n\n"
+        "### 12. Slice File-Overlap Ordering (deterministic hard NACK — see #3046)\n"
+        "Complements §11. When slices are subdivided, any two that touch "
+        "the **same file** must be **ordered** along one dependency chain — "
+        "one a transitive ``dependencies`` ancestor of the other — never "
+        "left as parallel roots or siblings. The implement phase cuts each "
+        "slice's integration branch off its dependency parent (roots off "
+        "``work``), so two overlapping slices with no edge between them fork "
+        "independently off the shared base and their edits to the shared "
+        "file collide at integration (a guaranteed modify/delete conflict — "
+        "the #3023 incident, where three slices all touched "
+        "``consensus_wrapper.py``, one deleting it).\n"
+        "This is enforced **orchestrator-side at plan ingestion**: an "
+        "overlapping-but-unordered DAG is rejected before the slices are "
+        "written to the contract, surfacing as a ``slice_overlap_violation`` "
+        "discriminator (or a 'Plan ingestion REJECTED: slices touch "
+        "overlapping files' block on ``plan_review_feedback``). When you see "
+        "it, NACK the **architect** and quote the structured errors "
+        "verbatim; instruct it to serialise the overlapping cluster into one "
+        "linear ``dependencies`` chain — a slice that deletes/retires a file "
+        "depends on every slice that modifies it — or to merge the slices. "
+        "Disjoint slices stay parallel so they still run concurrently.\n"
+        "Belt-and-suspenders self-check: "
+        '`python3 -c "from egg_contracts.plan_parser import parse_plan_file, '
+        "validate_slice_file_overlap as v; r = parse_plan_file('<plan-path>'); "
+        "print('\\n'.join(v(r.to_contract_slices())))\"`.\n"
     )
 
 
@@ -11461,6 +11500,18 @@ def _build_phase_prompt(
                 "field. The list names the upstream slice IDs in their chosen "
                 "serialization order.",
                 "",
+                "**File-overlap rule (HARD, enforced at plan ingestion — "
+                "#3046)**: two slices that touch the SAME file must be ordered "
+                "on one dependency chain — one a transitive ``dependencies`` "
+                "ancestor of the other — never left as parallel roots or "
+                "siblings. The implement phase cuts each slice's branch off "
+                "its dependency parent, so an unordered overlapping pair forks "
+                "independently off the shared base and its edits to the shared "
+                "file collide at integration (a guaranteed modify/delete "
+                "conflict). Deletion/retirement slices are the classic trap: a "
+                "slice that removes a file must depend on every slice that "
+                "modifies it. Slices with disjoint file sets stay parallel.",
+                "",
                 "Worked example: if ``slice-3`` would naturally have "
                 "parents ``[slice-1, slice-2]``, instead emit:",
                 "",
@@ -12394,7 +12445,15 @@ def _build_reviewer_preparation(
                 "block), NACK the architect and cite the structured errors "
                 "verbatim. Instruct the architect to re-emit the slice "
                 "scaffold with ``serialized_chain_order`` populated on the "
-                "downstream slice. "
+                "downstream slice. The SAME NACK applies to a "
+                "``slice_overlap_violation`` rejection (#3046 — a 'Plan "
+                "ingestion REJECTED: slices touch overlapping files' block): "
+                "two or more slices touch the same file with no dependency "
+                "ordering, so their branches fork independently off the shared "
+                "base and collide at integration. Instruct the architect to "
+                "serialise the overlapping cluster into one linear "
+                "``dependencies`` chain (or merge the slices) so each later "
+                "slice's branch is cut from the earlier one. "
                 "(2) **Slice-sizing NACK (hard, judgment-based — #2809)**: "
                 "slice composition is owned by the **architect**, not the "
                 "task_planner. You ARE empowered and required to hard-NACK "
@@ -13390,6 +13449,17 @@ def _build_agent_prompt(
                 "chain and record the chosen ordering on the downstream "
                 "slice's ``serialized_chain_order`` field. See "
                 "``docs/architecture/slice-dag.md``.",
+                "- **File-overlap ⇒ dependency edge (HARD — #3046).** Any two "
+                "slices that touch the same file MUST be ordered on one "
+                "dependency chain (express the order in ``dependencies`` — a "
+                "single-parent id per slice — not just in "
+                "``serialized_chain_order``, which the scheduler does not read "
+                "for branch topology). Slices that edit a shared file but are "
+                "left as parallel roots/siblings fork independently off the "
+                "shared base and collide at integration — plan ingestion "
+                "hard-rejects this. A slice that deletes or retires a file "
+                "must depend on every slice that modifies it. Keep slices with "
+                "disjoint file sets parallel so they still run concurrently.",
                 "- **Sub-slicing.** When one slice would be too coarse, "
                 "subdivide it. Right-size slices for a single BRC cycle: "
                 "avoid bundling distinct file-category groups (e.g. "
@@ -13645,6 +13715,18 @@ def _build_agent_prompt(
                 "multi-parent slices and populating "
                 "``serialized_chain_order`` on the downstream slice. "
                 "Preserve that field verbatim from the scaffold.",
+                "",
+                "**File-overlap ⇒ ordering (HARD — #3046)**: you fill in each "
+                "slice's tasks and their ``files_affected``, so you see the "
+                "file sets first. If you find yourself assigning the SAME file "
+                "to two slices that the architect left unordered (parallel "
+                "roots or siblings), do NOT silently proceed — plan ingestion "
+                "hard-rejects overlapping slices with no dependency edge, "
+                "because their branches fork independently off the shared base "
+                "and collide at integration. Raise NACK pressure on the "
+                "architect (via the plan prose) to serialise the overlapping "
+                "cluster into one ``dependencies`` chain — or to merge the "
+                "slices. Do not re-shape the slice DAG yourself.",
                 "",
                 "Worked example: if ``slice-3`` would naturally have "
                 "parents ``[slice-1, slice-2]``, instead emit:",
@@ -18694,6 +18776,9 @@ class PopulateOutcome(StrEnum):
     CONTRACT_LOAD_FAILED = "contract_load_failed"
     EGG_CONTRACTS_UNAVAILABLE = "egg_contracts_unavailable"
     FOREST_VIOLATION = "forest_violation"
+    # #3046 — two slices touch overlapping files with no dependency edge
+    # between them; rejected at ingestion like a forest violation.
+    SLICE_OVERLAP_VIOLATION = "slice_overlap_violation"
     UNEXPECTED_EXCEPTION = "unexpected_exception"
 
 
@@ -18839,6 +18924,10 @@ _EMPTY_CONTRACT_HITL_OPTIONS = [
 _DIVERGENCE_LINE_BY_REASON: dict[str, str] = {
     "forest_violation": (
         "contract.slices is empty because the plan slice DAG was rejected as not a forest"
+    ),
+    "slice_overlap_violation": (
+        "contract.slices is empty because the plan slice DAG was rejected: two or more "
+        "slices touch overlapping files with no dependency ordering between them (#3046)"
     ),
     "contract_load_failed": (
         "contract.slices is empty because the parsed contract on disk failed to deserialize"
@@ -19109,8 +19198,9 @@ def _auto_populate_contract_at_implement_start(
         )
     except ForestValidationError as _forest_err:
         logger.warning(
-            "Auto-populate contract failed: forest validation error",
+            "Auto-populate contract failed: slice-DAG validation error",
             pipeline_id=pipeline_id,
+            reason=_forest_err.reason,
             errors=_forest_err.errors,
         )
         return 0
@@ -19299,20 +19389,27 @@ def _populate_contract_from_plan_safe(
             current_phase=current_phase,
         )
     except ForestValidationError as forest_err:
-        # Forest-validation rejection is the expected #2137 NACK
-        # path — log structurally so the discriminator shows up in
+        # Slice-DAG structural rejection is the expected #2137 / #3046
+        # NACK path — log structurally so the discriminator shows up in
         # operator audit, but don't propagate to the wrapper's
         # caller (the populator already stashed the structured
         # errors on contract.plan_review_feedback so the plan
-        # reviewer prompt can NACK the planner).
+        # reviewer prompt can NACK the architect). The exception's
+        # ``reason`` selects the matching outcome so operators see an
+        # accurate discriminator (forest shape vs file-overlap order).
+        _structural_outcome = (
+            PopulateOutcome.SLICE_OVERLAP_VIOLATION
+            if forest_err.reason == "slice_overlap_violation"
+            else PopulateOutcome.FOREST_VIOLATION
+        )
         logger.warning(
             "contract_phases_ingest_failed",
             pipeline_id=pipeline_id,
-            reason="forest_violation",
+            reason=forest_err.reason,
             source="safe_wrapper",
             errors=forest_err.errors,
         )
-        return PopulateResult(PopulateOutcome.FOREST_VIOLATION)
+        return PopulateResult(_structural_outcome)
     except Exception as pop_err:
         logger.warning(
             "contract_phases_ingest_failed",
@@ -19540,7 +19637,10 @@ def _populate_contract_from_plan(
             # failed; silently defaulting ``forest_errors = []`` would
             # let a broken-import multi-parent contract slip past the
             # gate (reviewer_code_holistic v2 finding #5).
-            from egg_contracts.plan_parser import validate_forest
+            from egg_contracts.plan_parser import (
+                validate_forest,
+                validate_slice_file_overlap,
+            )
 
             forest_errors = validate_forest(contract_slices)
 
@@ -19582,6 +19682,55 @@ def _populate_contract_from_plan(
                 # ``plan_review_feedback`` stash above is the durable
                 # signal the reviewer prompt picks up either way.
                 raise ForestValidationError("slice DAG is not a forest", errors=forest_errors)
+
+            # File-overlap ordering validation (#3046). The forest is
+            # valid (≤1 parent per slice), but the implement phase cuts
+            # each slice's integration branch off its dependency parent
+            # (roots off ``work``) — so two slices that touch the same
+            # file MUST be ordered along a dependency chain, or their
+            # branches fork independently off the shared base and their
+            # edits collide at integration (the guaranteed modify/delete
+            # conflict observed on #3023). Reject overlapping-but-unordered
+            # slices here, with the SAME NACK-the-architect handling as a
+            # forest violation: stash the structured errors on
+            # ``plan_review_feedback`` and leave ``contract.slices`` empty
+            # so the defect cannot silently leak into the implement phase.
+            overlap_errors = validate_slice_file_overlap(contract_slices)
+            if overlap_errors:
+                logger.warning(
+                    "contract_phases_ingest_failed",
+                    pipeline_id=pipeline_id,
+                    reason="slice_overlap_violation",
+                    errors=overlap_errors,
+                )
+                feedback_lines = [
+                    "Plan ingestion REJECTED: slices touch overlapping files "
+                    "without a dependency ordering.",
+                    "",
+                    "The implement phase cuts each slice's integration branch "
+                    "off its dependency parent (root slices off the ``work`` "
+                    "branch) and ships it as a stacked PR. Two slices that "
+                    "touch the same file must be ordered along a single "
+                    "dependency chain so the later slice's branch is forked "
+                    "from a base that already contains the earlier slice's "
+                    "commits — otherwise both branches fork independently off "
+                    "the shared base and their edits collide at integration "
+                    "(a guaranteed modify/delete conflict). The forest "
+                    "constraint means the fix is always to serialise the "
+                    "overlapping cluster into ONE linear ``dependencies`` "
+                    "chain (you cannot depend on two parents) — or merge the "
+                    "slices into one.",
+                    "",
+                    "Structured errors:",
+                ]
+                feedback_lines.extend(f"- {e}" for e in overlap_errors)
+                contract.plan_review_feedback = "\n".join(feedback_lines)
+                save_contract(contract, repo_path)
+                raise ForestValidationError(
+                    "slices share files without a dependency ordering",
+                    errors=overlap_errors,
+                    reason="slice_overlap_violation",
+                )
             # Preserve runtime slice/task progress across re-populates so
             # the safety-net populator (which fires on every
             # ``start_phase=implement`` restart) cannot reset COMPLETE
@@ -21229,14 +21378,21 @@ def _run_pipeline(
                         current_phase=pipeline.current_phase,
                     )
                 except ForestValidationError as forest_err:
+                    # #3046 — overlap violations map to their own outcome so
+                    # the empty-contract HITL prose matches the discriminator.
+                    _safety_net_outcome = (
+                        PopulateOutcome.SLICE_OVERLAP_VIOLATION
+                        if forest_err.reason == "slice_overlap_violation"
+                        else PopulateOutcome.FOREST_VIOLATION
+                    )
                     logger.warning(
                         "contract_phases_ingest_failed",
                         pipeline_id=pipeline_id,
-                        reason="forest_violation",
+                        reason=forest_err.reason,
                         source="safety_net",
                         errors=forest_err.errors,
                     )
-                    _safety_net_populate_result = PopulateResult(PopulateOutcome.FOREST_VIOLATION)
+                    _safety_net_populate_result = PopulateResult(_safety_net_outcome)
                 # #2627 follow-up: fail-fast whenever the safety-net populate
                 # did not produce a contract with tasks.  Without this guard
                 # the implement phase spawns into the same empty-contract

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -19032,6 +19032,28 @@ def _populate_outcome_to_hitl_reason(outcome: PopulateOutcome) -> str:
     return outcome.value
 
 
+# Single source of truth for ForestValidationError.reason → PopulateOutcome
+# mapping. Both ``_populate_contract_from_plan_safe`` and the
+# ``start_phase=implement`` safety net translate a structural NACK into an
+# outcome the empty-contract HITL prose dispatcher (#3046) can key off, so
+# centralising the table here keeps the two catch sites from drifting if a
+# third reason is added to :class:`ForestValidationError` (forest-shape vs.
+# file-overlap-ordering today). Unknown reasons fall back to
+# ``FOREST_VIOLATION`` — that's the conservative choice because the operator
+# prose for forest violations names the slice DAG generally rather than the
+# specific defect, so a new reason without a dedicated outcome still routes
+# to actionable (if generic) HITL prose.
+_FOREST_REASON_TO_OUTCOME: dict[str, PopulateOutcome] = {
+    "slice_overlap_violation": PopulateOutcome.SLICE_OVERLAP_VIOLATION,
+    "forest_violation": PopulateOutcome.FOREST_VIOLATION,
+}
+
+
+def _forest_error_to_outcome(err: ForestValidationError) -> PopulateOutcome:
+    """Map a :class:`ForestValidationError` to the matching populate outcome."""
+    return _FOREST_REASON_TO_OUTCOME.get(err.reason, PopulateOutcome.FOREST_VIOLATION)
+
+
 def _empty_contract_hitl_reason(
     err: PlanDraftMissingOnLocalError
     | PlanDraftMissingOnLocalAndOriginError
@@ -19397,11 +19419,6 @@ def _populate_contract_from_plan_safe(
         # reviewer prompt can NACK the architect). The exception's
         # ``reason`` selects the matching outcome so operators see an
         # accurate discriminator (forest shape vs file-overlap order).
-        _structural_outcome = (
-            PopulateOutcome.SLICE_OVERLAP_VIOLATION
-            if forest_err.reason == "slice_overlap_violation"
-            else PopulateOutcome.FOREST_VIOLATION
-        )
         logger.warning(
             "contract_phases_ingest_failed",
             pipeline_id=pipeline_id,
@@ -19409,7 +19426,7 @@ def _populate_contract_from_plan_safe(
             source="safe_wrapper",
             errors=forest_err.errors,
         )
-        return PopulateResult(_structural_outcome)
+        return PopulateResult(_forest_error_to_outcome(forest_err))
     except Exception as pop_err:
         logger.warning(
             "contract_phases_ingest_failed",
@@ -21380,11 +21397,6 @@ def _run_pipeline(
                 except ForestValidationError as forest_err:
                     # #3046 — overlap violations map to their own outcome so
                     # the empty-contract HITL prose matches the discriminator.
-                    _safety_net_outcome = (
-                        PopulateOutcome.SLICE_OVERLAP_VIOLATION
-                        if forest_err.reason == "slice_overlap_violation"
-                        else PopulateOutcome.FOREST_VIOLATION
-                    )
                     logger.warning(
                         "contract_phases_ingest_failed",
                         pipeline_id=pipeline_id,
@@ -21392,7 +21404,9 @@ def _run_pipeline(
                         source="safety_net",
                         errors=forest_err.errors,
                     )
-                    _safety_net_populate_result = PopulateResult(_safety_net_outcome)
+                    _safety_net_populate_result = PopulateResult(
+                        _forest_error_to_outcome(forest_err)
+                    )
                 # #2627 follow-up: fail-fast whenever the safety-net populate
                 # did not produce a contract with tasks.  Without this guard
                 # the implement phase spawns into the same empty-contract

--- a/orchestrator/tests/test_populate_contract_audit_events.py
+++ b/orchestrator/tests/test_populate_contract_audit_events.py
@@ -1369,11 +1369,17 @@ class TestSafetyNetForestViolationLandsOnEmptyContractHitl:
             "safety-net inner call must catch ForestValidationError to land on "
             "the dedicated empty-contract HITL (#2627 review)"
         )
-        # And it must synthesize a FOREST_VIOLATION PopulateResult so the
-        # downstream _populate_result_is_empty_contract check routes it.
-        assert "PopulateOutcome.FOREST_VIOLATION" in source, (
-            "safety-net forest-violation catch must synthesize "
-            "PopulateResult(FOREST_VIOLATION) so the empty-contract check fires"
+        # And it must synthesize an outcome via _forest_error_to_outcome so the
+        # downstream _populate_result_is_empty_contract check routes it.  The
+        # helper centralises the reason→outcome mapping shared with the safe
+        # wrapper (#3046 review follow-up); the prior shape inlined the
+        # ternary at both catch sites, which was the drift surface this
+        # extraction removes.
+        assert "_forest_error_to_outcome(forest_err)" in source, (
+            "safety-net forest-violation catch must synthesize the populate "
+            "outcome via _forest_error_to_outcome(forest_err) so the empty-"
+            "contract check fires AND the reason→outcome mapping stays "
+            "shared with the safe-wrapper translation (#3046 review)"
         )
 
     def test_safety_net_uses_dedicated_logger_warning_source(self):

--- a/orchestrator/tests/test_slice_overlap_ingest.py
+++ b/orchestrator/tests/test_slice_overlap_ingest.py
@@ -1,0 +1,148 @@
+"""Plan-ingestion rejection for slice file-overlap violations (#3046).
+
+Two slices that touch overlapping ``files_affected`` with no dependency
+ordering between them are a slice-DAG structural defect: their integration
+branches fork independently off the shared base and collide at
+integration (the #3023 modify/delete conflict). The populator
+(:func:`_populate_contract_from_plan`) rejects them with the same
+NACK-the-architect handling as a forest violation, but a distinct
+``slice_overlap_violation`` reason so operator-facing prose names the
+actual defect.
+
+These tests cover the orchestrator wiring around
+``egg_contracts.validate_slice_file_overlap`` (the validator's own unit
+tests live in ``shared/egg_contracts/tests/test_validate_slice_file_overlap.py``):
+
+* End-to-end: a plan whose slices overlap without ordering raises
+  ``ForestValidationError(reason="slice_overlap_violation")``, stashes a
+  'Plan ingestion REJECTED' block on ``plan_review_feedback``, and leaves
+  ``contract.slices`` empty.
+* The safe wrapper maps that reason onto
+  ``PopulateOutcome.SLICE_OVERLAP_VIOLATION``.
+* ``ForestValidationError.to_response`` keys the 422 body on the reason.
+* The empty-contract HITL question uses overlap-specific prose.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from egg_contracts.models import Slice, Task
+
+
+def _overlapping_roots() -> list[Slice]:
+    """Two root slices that both touch ``shared.py`` with no edge."""
+    wrapper = "orchestrator/consensus_wrapper.py"
+    return [
+        Slice(
+            id="slice-1",
+            name="A",
+            dependencies=[],
+            tasks=[Task(id="task-1", description="d", files_affected=[wrapper, "a.py"])],
+        ),
+        Slice(
+            id="slice-2",
+            name="B",
+            dependencies=[],
+            tasks=[Task(id="task-2", description="d", files_affected=[wrapper, "b.py"])],
+        ),
+    ]
+
+
+class TestPopulatorRejectsOverlap:
+    def test_overlap_raises_and_stashes_feedback(self, tmp_path):
+        from egg_contracts.loader import create_contract, load_contract
+        from routes.pipelines import (
+            ForestValidationError,
+            _populate_contract_from_plan,
+        )
+
+        pipeline_id = "issue-overlap"
+        create_contract(pipeline_id=pipeline_id, title="Test", repo_root=tmp_path)
+        drafts_dir = tmp_path / ".egg-state" / "drafts"
+        drafts_dir.mkdir(parents=True, exist_ok=True)
+        (drafts_dir / f"{pipeline_id}-plan.md").write_text("# Plan\n")
+
+        fake_result = MagicMock()
+        fake_result.success = True
+        fake_result.warnings = []
+        fake_result.to_contract_slices.return_value = _overlapping_roots()
+        fake_result.pr_title = None
+
+        with patch("egg_contracts.plan_parser.parse_plan", return_value=fake_result):
+            with pytest.raises(ForestValidationError) as exc_info:
+                _populate_contract_from_plan(tmp_path, pipeline_id, "local")
+
+        assert exc_info.value.reason == "slice_overlap_violation"
+        assert exc_info.value.errors  # structured errors carried for the NACK
+
+        # The slices were NOT written; the NACK feedback was stashed.
+        contract = load_contract(pipeline_id, tmp_path)
+        assert list(contract.slices) == []
+        assert contract.plan_review_feedback is not None
+        assert "Plan ingestion REJECTED" in contract.plan_review_feedback
+        assert "overlapping files" in contract.plan_review_feedback
+
+    def test_safe_wrapper_maps_overlap_reason_to_outcome(self, tmp_path):
+        from routes.pipelines import (
+            ForestValidationError,
+            PopulateOutcome,
+            _populate_contract_from_plan_safe,
+        )
+
+        with patch(
+            "routes.pipelines._populate_contract_from_plan",
+            side_effect=ForestValidationError(
+                "overlap", errors=["bad pair"], reason="slice_overlap_violation"
+            ),
+        ):
+            result = _populate_contract_from_plan_safe(tmp_path, "p-overlap", "local")
+        assert result.outcome == PopulateOutcome.SLICE_OVERLAP_VIOLATION
+
+    def test_safe_wrapper_still_maps_forest_reason(self, tmp_path):
+        # Regression guard: the default reason still routes to FOREST_VIOLATION.
+        from routes.pipelines import (
+            ForestValidationError,
+            PopulateOutcome,
+            _populate_contract_from_plan_safe,
+        )
+
+        with patch(
+            "routes.pipelines._populate_contract_from_plan",
+            side_effect=ForestValidationError("forest", errors=["bad"]),
+        ):
+            result = _populate_contract_from_plan_safe(tmp_path, "p-forest", "local")
+        assert result.outcome == PopulateOutcome.FOREST_VIOLATION
+
+
+class TestForestValidationErrorResponse:
+    def test_to_response_keys_on_reason(self):
+        from routes.pipelines import ForestValidationError
+
+        overlap = ForestValidationError("overlap", errors=["e1"], reason="slice_overlap_violation")
+        body, status = overlap.to_response()
+        assert status == 422
+        assert body == {"error": "slice_overlap_violation", "errors": ["e1"]}
+
+    def test_default_reason_preserves_forest_violation_key(self):
+        from routes.pipelines import ForestValidationError
+
+        forest = ForestValidationError("forest", errors=["e1"])
+        body, _ = forest.to_response()
+        assert body["error"] == "forest_violation"
+
+
+class TestEmptyContractHitlOverlapProse:
+    def test_overlap_violation_uses_specific_wording(self):
+        from routes.pipelines import _empty_contract_hitl_question
+
+        question = _empty_contract_hitl_question(
+            pipeline_id="p-overlap",
+            reason="slice_overlap_violation",
+            draft_slice_count=None,
+            gate="plan_complete",
+        )
+        assert "overlapping files" in question
+        assert "missing, unparseable, or yielded no tasks" not in question
+        assert "slice_overlap_violation" in question

--- a/shared/egg_contracts/__init__.py
+++ b/shared/egg_contracts/__init__.py
@@ -205,6 +205,7 @@ from .plan_parser import (
     parse_plan,
     parse_plan_file,
     validate_forest,
+    validate_slice_file_overlap,
     validate_task_role_alignment,
 )
 from .resilience import (
@@ -311,6 +312,7 @@ __all__ = [
     "parse_plan",
     "parse_plan_file",
     "validate_forest",
+    "validate_slice_file_overlap",
     "validate_task_role_alignment",
     # Phase Defaults
     "get_default_phase_config",

--- a/shared/egg_contracts/plan_parser.py
+++ b/shared/egg_contracts/plan_parser.py
@@ -1582,6 +1582,108 @@ def _detect_cycles(slices: list[Slice], known_ids: set[str]) -> list[list[str]]:
     return cycles
 
 
+def validate_slice_file_overlap(slices: list[Slice]) -> list[str]:
+    """Reject slice pairs that share files but lack a dependency ordering.
+
+    Added in #3046. The implement phase cuts each slice's integration
+    branch off its dependency parent (root slices off the pipeline
+    ``work`` branch) and ships it as a stacked PR. Two slices whose
+    ``files_affected`` sets intersect must therefore be **ordered** along
+    the dependency DAG — one a transitive ancestor of the other — so the
+    later slice's branch is forked from a base that already contains the
+    earlier slice's commits. When two overlapping slices are left
+    unordered (e.g. both declared as roots), their branches fork
+    independently off the shared base and their edits to the shared file
+    collide at integration time. This is the guaranteed modify/delete
+    conflict observed on #3023, where three slices all touched
+    ``consensus_wrapper.py`` (one deleting it) with no dependency edges —
+    the git topology faithfully mirrored a DAG that declared overlapping
+    work as parallel roots.
+
+    Slices with **disjoint** file sets are safe to branch in parallel off
+    the shared base — that concurrency is the whole point of slicing — so
+    only *overlapping, unordered* pairs are flagged. Two slices on the
+    same chain are fine even when an intermediate slice is disjoint: the
+    later branch is still cut transitively from the earlier one's tip.
+
+    The forest constraint (:func:`validate_forest`: ≤1 DAG parent per
+    slice) means the remediation is always to collapse the overlapping
+    cluster into a single linear ``dependencies`` chain — you cannot
+    express "depends on both A and B" as a diamond, so the architect
+    picks an order and stacks them. Each error names the shared files so
+    the architect's re-propose is actionable.
+
+    ``files_affected`` is read from each slice's tasks (the same
+    planner-declared signal :func:`validate_task_role_alignment` uses).
+    Slices with no declared files contribute no overlap signal and are
+    skipped. Cyclic / duplicate-id DAGs are reported separately by
+    :func:`validate_forest`; the reachability walk here is cycle-safe so a
+    cycle neither loops nor crashes this validator.
+
+    Args:
+        slices: The slice list extracted from the contract / plan.
+
+    Returns:
+        One structured-error string per offending unordered overlapping
+        pair, in deterministic (declared-order) order. An empty list
+        means no overlap-ordering violations.
+    """
+    # Deduplicate by id (duplicate ids are reported by validate_forest);
+    # preserve declared order for deterministic pair iteration.
+    ordered_ids: list[str] = []
+    files_by_id: dict[str, set[str]] = {}
+    deps_by_id: dict[str, list[str]] = {}
+    for slice_ in slices:
+        if slice_.id in files_by_id:
+            continue
+        ordered_ids.append(slice_.id)
+        files: set[str] = set()
+        for task in slice_.tasks:
+            files.update(task.files_affected or [])
+        files_by_id[slice_.id] = files
+        deps_by_id[slice_.id] = [d for d in (slice_.dependencies or []) if d]
+
+    known = set(ordered_ids)
+
+    # Transitive-ancestor set for each slice: every slice it depends on
+    # directly or transitively, following ``dependencies`` edges. The
+    # per-start visited set keeps the walk cycle-safe (a cyclic DAG is
+    # reported by validate_forest, not here).
+    def _ancestors(start: str) -> set[str]:
+        seen: set[str] = set()
+        stack = [d for d in deps_by_id.get(start, []) if d in known]
+        while stack:
+            cur = stack.pop()
+            if cur == start or cur in seen:
+                continue
+            seen.add(cur)
+            stack.extend(d for d in deps_by_id.get(cur, []) if d in known)
+        return seen
+
+    ancestors = {sid: _ancestors(sid) for sid in ordered_ids}
+
+    errors: list[str] = []
+    for i, a in enumerate(ordered_ids):
+        for b in ordered_ids[i + 1 :]:
+            shared = files_by_id[a] & files_by_id[b]
+            if not shared:
+                continue
+            # Ordered iff one is a transitive ancestor of the other.
+            if b in ancestors[a] or a in ancestors[b]:
+                continue
+            errors.append(
+                f"Slices '{a}' and '{b}' both touch {sorted(shared)!r} but "
+                "neither depends on the other; the implement phase branches "
+                "each slice independently off the shared base, so their edits "
+                "to the shared file(s) collide at integration (e.g. a "
+                "modify/delete conflict). Order them along one dependency "
+                "chain — add the earlier slice to the other's 'dependencies' "
+                "so the later slice's branch is cut from it — or merge them "
+                "into a single slice. See issue #3046."
+            )
+    return errors
+
+
 # ---------------------------------------------------------------------------
 # #2527 — task role ↔ files_affected alignment
 # ---------------------------------------------------------------------------

--- a/shared/egg_contracts/plan_parser.py
+++ b/shared/egg_contracts/plan_parser.py
@@ -1628,8 +1628,21 @@ def validate_slice_file_overlap(slices: list[Slice]) -> list[str]:
         pair, in deterministic (declared-order) order. An empty list
         means no overlap-ordering violations.
     """
+
     # Deduplicate by id (duplicate ids are reported by validate_forest);
-    # preserve declared order for deterministic pair iteration.
+    # preserve declared order for deterministic pair iteration. Paths are
+    # canonicalised (``posixpath.normpath`` + strip ``./``) so two slices
+    # that name the same logical file in different surface forms — e.g.
+    # ``orchestrator/x.py`` vs ``./orchestrator/x.py`` vs
+    # ``a/b/../c.py`` vs ``a/c.py`` — collide as expected. Mirrors
+    # :func:`_is_file_blocked_for_role`'s normalisation so plan-time
+    # validation and the gateway's push-time check see the same paths.
+    def _normalize(p: str) -> str:
+        n = posixpath.normpath(p)
+        if n.startswith("./"):
+            n = n[2:]
+        return n
+
     ordered_ids: list[str] = []
     files_by_id: dict[str, set[str]] = {}
     deps_by_id: dict[str, list[str]] = {}
@@ -1639,7 +1652,8 @@ def validate_slice_file_overlap(slices: list[Slice]) -> list[str]:
         ordered_ids.append(slice_.id)
         files: set[str] = set()
         for task in slice_.tasks:
-            files.update(task.files_affected or [])
+            for f in task.files_affected or []:
+                files.add(_normalize(f))
         files_by_id[slice_.id] = files
         deps_by_id[slice_.id] = [d for d in (slice_.dependencies or []) if d]
 
@@ -1672,8 +1686,8 @@ def validate_slice_file_overlap(slices: list[Slice]) -> list[str]:
             if b in ancestors[a] or a in ancestors[b]:
                 continue
             errors.append(
-                f"Slices '{a}' and '{b}' both touch {sorted(shared)!r} but "
-                "neither depends on the other; the implement phase branches "
+                f"Slices '{a}' and '{b}' both touch {', '.join(sorted(shared))} "
+                "but neither depends on the other; the implement phase branches "
                 "each slice independently off the shared base, so their edits "
                 "to the shared file(s) collide at integration (e.g. a "
                 "modify/delete conflict). Order them along one dependency "

--- a/shared/egg_contracts/tests/test_validate_slice_file_overlap.py
+++ b/shared/egg_contracts/tests/test_validate_slice_file_overlap.py
@@ -144,6 +144,36 @@ class TestOverlapRejection:
         assert len(errors) == 1
         assert "x.py" in errors[0] and "y.py" in errors[0]
 
+    def test_surface_form_aliases_count_as_overlap(self) -> None:
+        # ``./orchestrator/x.py`` and ``orchestrator/x.py`` are the same
+        # logical file; the implement phase would still hit a modify/delete
+        # collision if these were left unordered. Regression pin for the
+        # ``_normalize`` step inside ``validate_slice_file_overlap`` —
+        # without it, the set intersection would compare surface forms and
+        # silently miss this case. Mirrors ``_is_file_blocked_for_role``'s
+        # ``posixpath.normpath`` + strip ``./`` normalisation.
+        slices = [
+            _slice("slice-1", [], ["./orchestrator/x.py"]),
+            _slice("slice-2", [], ["orchestrator/x.py"]),
+        ]
+        errors = validate_slice_file_overlap(slices)
+        assert len(errors) == 1
+        # Error reports the canonical form, which is what a reader can grep.
+        assert "orchestrator/x.py" in errors[0]
+        assert "./orchestrator/x.py" not in errors[0]
+
+    def test_dotdot_segments_normalise_to_same_file(self) -> None:
+        # ``a/b/../c.py`` and ``a/c.py`` resolve to the same path after
+        # ``posixpath.normpath``; the validator must treat them as a single
+        # logical file and fire one ordering error.
+        slices = [
+            _slice("slice-1", [], ["a/b/../c.py"]),
+            _slice("slice-2", [], ["a/c.py"]),
+        ]
+        errors = validate_slice_file_overlap(slices)
+        assert len(errors) == 1
+        assert "a/c.py" in errors[0]
+
 
 class TestRobustness:
     """The validator must not crash on shapes validate_forest owns."""

--- a/shared/egg_contracts/tests/test_validate_slice_file_overlap.py
+++ b/shared/egg_contracts/tests/test_validate_slice_file_overlap.py
@@ -1,0 +1,181 @@
+"""Tests for ``plan_parser.validate_slice_file_overlap`` (#3046).
+
+The slice DAG must encode file-level dependencies: two slices that touch
+overlapping ``files_affected`` must be **ordered** along the dependency
+DAG (one a transitive ``dependencies`` ancestor of the other), so the
+later slice's integration branch is forked from a base that already
+contains the earlier slice's commits. Unordered overlapping slices fork
+independently off the shared base and collide at integration — the #3023
+modify/delete conflict.
+
+These tests cover:
+
+* Disjoint slices (any topology) pass cleanly — parallel slicing is the
+  point of the feature.
+* Overlapping slices left as parallel roots / siblings are rejected, one
+  error per offending pair, naming the shared file(s).
+* Overlapping slices ordered along a chain pass — including the
+  transitive case where an intermediate slice is disjoint.
+* The validator is cycle- and duplicate-id-safe (those are reported by
+  ``validate_forest``, not here).
+* The #3023 shape (three roots all touching ``consensus_wrapper.py``)
+  reproduces three pairwise errors.
+"""
+
+from __future__ import annotations
+
+from egg_contracts.models import Slice, Task
+from egg_contracts.plan_parser import validate_slice_file_overlap
+
+_TASK_SEQ = [0]
+
+
+def _slice(id_: str, deps: list[str] | None = None, files: list[str] | None = None) -> Slice:
+    """Build a slice whose single task declares ``files``.
+
+    ``files=None`` yields a slice with no tasks (no overlap signal);
+    ``files=[]`` yields a task with an empty file list (also no signal).
+    """
+    tasks: list[Task] = []
+    if files is not None:
+        _TASK_SEQ[0] += 1
+        tasks = [Task(id=f"task-{_TASK_SEQ[0]}", description="d", files_affected=files)]
+    return Slice(id=id_, name=f"slice {id_}", dependencies=deps or [], tasks=tasks)
+
+
+class TestNoViolation:
+    """Topologies that should pass overlap validation cleanly."""
+
+    def test_empty_input(self) -> None:
+        assert validate_slice_file_overlap([]) == []
+
+    def test_single_slice(self) -> None:
+        assert validate_slice_file_overlap([_slice("slice-1", [], ["a.py"])]) == []
+
+    def test_disjoint_roots_run_parallel(self) -> None:
+        # Two roots touching different files are safe to branch in parallel.
+        slices = [
+            _slice("slice-1", [], ["a.py"]),
+            _slice("slice-2", [], ["b.py"]),
+        ]
+        assert validate_slice_file_overlap(slices) == []
+
+    def test_overlap_with_direct_dependency_edge(self) -> None:
+        # slice-2 depends on slice-1; sharing a file is fine because
+        # slice-2's branch is cut from slice-1's tip.
+        slices = [
+            _slice("slice-1", [], ["x.py"]),
+            _slice("slice-2", ["slice-1"], ["x.py"]),
+        ]
+        assert validate_slice_file_overlap(slices) == []
+
+    def test_overlap_with_transitive_dependency_edge(self) -> None:
+        # slice-1 → slice-2(disjoint) → slice-3; slice-1 and slice-3 share
+        # a file but slice-3 transitively depends on slice-1, so the fork
+        # point is still correct.
+        slices = [
+            _slice("slice-1", [], ["x.py"]),
+            _slice("slice-2", ["slice-1"], ["y.py"]),
+            _slice("slice-3", ["slice-2"], ["x.py"]),
+        ]
+        assert validate_slice_file_overlap(slices) == []
+
+    def test_slices_without_files_have_no_signal(self) -> None:
+        # No declared files → nothing to compare. Both the no-task and
+        # empty-file-list shapes are silent.
+        slices = [
+            _slice("slice-1", [], None),
+            _slice("slice-2", [], []),
+        ]
+        assert validate_slice_file_overlap(slices) == []
+
+
+class TestOverlapRejection:
+    """Overlapping slices with no ordering between them are rejected."""
+
+    def test_two_unordered_roots_sharing_a_file(self) -> None:
+        slices = [
+            _slice("slice-1", [], ["shared.py", "a.py"]),
+            _slice("slice-2", [], ["shared.py", "b.py"]),
+        ]
+        errors = validate_slice_file_overlap(slices)
+        assert len(errors) == 1
+        msg = errors[0]
+        assert "slice-1" in msg and "slice-2" in msg
+        assert "shared.py" in msg
+        # The non-shared files must NOT appear — only the intersection.
+        assert "a.py" not in msg and "b.py" not in msg
+        assert "#3046" in msg
+
+    def test_siblings_in_different_subtrees_collide(self) -> None:
+        # slice-2 and slice-3 both depend on slice-1 (a tree, valid
+        # forest) but touch the same file — neither depends on the other,
+        # so they fork independently off slice-1 and collide.
+        slices = [
+            _slice("slice-1", [], ["root.py"]),
+            _slice("slice-2", ["slice-1"], ["shared.py"]),
+            _slice("slice-3", ["slice-1"], ["shared.py"]),
+        ]
+        errors = validate_slice_file_overlap(slices)
+        assert len(errors) == 1
+        assert "slice-2" in errors[0] and "slice-3" in errors[0]
+
+    def test_modify_delete_shape_from_3023(self) -> None:
+        # The #3023 incident: three roots, all touching
+        # consensus_wrapper.py (slice-3 deletes it). Every pair conflicts.
+        wrapper = "orchestrator/consensus_wrapper.py"
+        slices = [
+            _slice("slice-1", [], [wrapper, "orchestrator/phase_idle_budget.py"]),
+            _slice("slice-2", [], [wrapper, "orchestrator/on_demand_spawner.py"]),
+            _slice("slice-3", [], [wrapper, "orchestrator/startup_reconciliation.py"]),
+        ]
+        errors = validate_slice_file_overlap(slices)
+        # 3 choose 2 = 3 offending pairs.
+        assert len(errors) == 3
+        assert all(wrapper in e for e in errors)
+
+    def test_one_error_per_pair_not_per_file(self) -> None:
+        # Two slices sharing two files yield ONE error listing both.
+        slices = [
+            _slice("slice-1", [], ["x.py", "y.py"]),
+            _slice("slice-2", [], ["x.py", "y.py"]),
+        ]
+        errors = validate_slice_file_overlap(slices)
+        assert len(errors) == 1
+        assert "x.py" in errors[0] and "y.py" in errors[0]
+
+
+class TestRobustness:
+    """The validator must not crash on shapes validate_forest owns."""
+
+    def test_cycle_is_not_flagged_here(self) -> None:
+        # A 2-cycle makes the slices mutually reachable, so they count as
+        # ordered (no overlap error). The cycle itself is validate_forest's
+        # job — this validator must merely not loop forever.
+        slices = [
+            _slice("slice-1", ["slice-2"], ["x.py"]),
+            _slice("slice-2", ["slice-1"], ["x.py"]),
+        ]
+        assert validate_slice_file_overlap(slices) == []
+
+    def test_duplicate_ids_do_not_double_count(self) -> None:
+        # Duplicate ids are reported by validate_forest; here we just make
+        # sure the dedup keeps the pair walk well-defined.
+        slices = [
+            _slice("slice-1", [], ["x.py"]),
+            _slice("slice-1", [], ["x.py"]),
+            _slice("slice-2", [], ["x.py"]),
+        ]
+        errors = validate_slice_file_overlap(slices)
+        # slice-1 (deduped) vs slice-2 → exactly one pair.
+        assert len(errors) == 1
+
+    def test_unknown_dependency_is_treated_as_absent(self) -> None:
+        # slice-2 depends on a non-existent slice-9; that edge can't make
+        # it an ancestor of slice-1, so an overlap with slice-1 still fires.
+        slices = [
+            _slice("slice-1", [], ["x.py"]),
+            _slice("slice-2", ["slice-9"], ["x.py"]),
+        ]
+        errors = validate_slice_file_overlap(slices)
+        assert len(errors) == 1


### PR DESCRIPTION
## Summary

Closes #3046. Two slices that touch overlapping files but lack a dependency ordering are now **rejected at plan ingestion** with a NACK to the architect — the structural fix for the guaranteed merge conflicts observed on #3023.

## The diagnosis (the issue's framing is a misdiagnosis)

The issue title says *"dependent slices branch off frozen work base (not stacked)."* I pulled the #3023 contract and branches: **the git branches already mirror the slice DAG faithfully.** All three slices declared `dependencies: []` (parallel roots) while all three touched `consensus_wrapper.py` — one *deleting* it:

| Slice | `dependencies` | `parent_branch_at_creation` | touches `consensus_wrapper.py` |
|-------|---------------|------------------------------|-------------------------------|
| slice-1 | `[]` | `egg/issue-3023/work` | modifies |
| slice-2 | `[]` | `egg/issue-3023/work` | modifies |
| slice-3 | `[]` | `egg/issue-3023/work` | **deletes** |

The scheduler (`_resolve_slice_base_branch`) and `iter_ready`/`record_complete` already stack child slices on their dependency parent correctly — so given a *correct* DAG, the existing code produces a conflict-free stack. The defect was one layer up: the DAG declared overlapping work as independent roots, and **nothing rejected it**. `validate_forest` only checks DAG *shape* (≤1 parent, acyclic).

So `integrate-forward` in the scheduler (the issue's option b) is a bodge — it doesn't even fire for three roots in one wave, it would silently merge unreviewed work into `work`, and it kills parallelism. The clean fix enforces the missing invariant where every other slice-DAG invariant is enforced: **plan ingestion**.

## The invariant

> **Overlapping files ⇒ ordered slices.** If two slices touch the same file, one must be a transitive `dependencies` ancestor of the other, so the later branch is cut from a base that already contains the earlier's changes. Disjoint slices stay parallel.

The forest constraint (≤1 parent) means the remediation is always to serialize the overlapping cluster into one linear `dependencies` chain — or merge the slices.

## Changes

- **`validate_slice_file_overlap`** (`shared/egg_contracts/plan_parser.py`) — sibling of `validate_forest`; flags any slice pair whose `files_affected` intersect with no transitive dependency path. Cycle/duplicate-id safe; transitive ordering (intermediate disjoint slice on the chain) passes.
- **Plan-ingestion gate** (`_populate_contract_from_plan`) — runs after `validate_forest` passes, with identical NACK-the-architect handling (stash `plan_review_feedback`, leave `contract.slices` empty, raise) but a distinct `slice_overlap_violation` reason and `PopulateOutcome.SLICE_OVERLAP_VIOLATION` so the operator-facing empty-contract HITL prose names the actual defect. `ForestValidationError` now carries a `reason` discriminator (`to_response` keys the 422 body on it; safe-wrapper + safety-net map it to the right outcome).
- **Prompts** — the "shared files ⇒ one dependency chain, never parallel roots" rule threaded through the architect, planner (raise NACK pressure when it sees overlapping files), and reviewer_plan prompts, plus a new **plan-review criteria §12** counterbalancing §11's split-into-parallel-slices sizing guidance.
- **Docs** — `docs/architecture/slice-dag.md` gains a "File-overlap ordering validation" subsection.

No scheduler change, no branch plumbing — the branch topology already matches the DAG; this makes the DAG encode the file-level dependency so the topology it induces is conflict-free.

## Test plan

- `shared/egg_contracts/tests/test_validate_slice_file_overlap.py` — validator unit tests (disjoint/ordered/transitive pass; unordered overlap rejected; reproduces the #3023 three-roots shape → three pairwise errors; cycle/dup-id robustness).
- `orchestrator/tests/test_slice_overlap_ingest.py` — end-to-end populator rejection (raise + `plan_review_feedback` stash + empty slices), safe-wrapper reason→outcome mapping, `to_response` keying, overlap-specific HITL prose.
- Existing `test_validate_forest`, `test_populate_contract_audit_events`, `test_populate_contract_endpoint` suites still green (99 tests). `make lint` passes.