### PR TITLE
fix(orchestrator): unwedge confirm when a reviewer's producer already CONFIRMED (#3043)

### DIFF
--- a/orchestrator/action_guards.py
+++ b/orchestrator/action_guards.py
@@ -424,8 +424,9 @@ def check_confirm_guard(
 
     # --- Reviewer confirmation guards ---
     if is_reviewer:
-        # Exclude two classes of producer from the reviewer guards below
-        # (has-reviewed / zero-proposal / stale-verdict / unresolved-NACK):
+        # Exclude two classes of producer from the four reviewer guards
+        # below (has-reviewed / zero-proposal / stale-ACK / stale-NACK /
+        # unresolved-NACK):
         #
         #   * Generic no-op producers (#3027): the producer declared it has
         #     no work, so there is nothing for the reviewer to review and it
@@ -433,14 +434,19 @@ def check_confirm_guard(
         #   * Already-CONFIRMED producers (#3043): a producer only reaches
         #     the confirmed set after its CRITICAL reviewers have ACKed it,
         #     so its work is settled. A reviewer still carrying a missing
-        #     review or a NACK against an un-re-proposed version of that
-        #     producer (e.g. because this reviewer's edge was advisory or
-        #     stall-demoted) would otherwise be blocked from confirming
-        #     FOREVER — the producer will never re-propose to clear the
-        #     guard. The reviewer's verdict on a settled producer is moot,
-        #     so exclude it. This is the post-BRC "slice never closes"
-        #     deadlock: the lone holdout reviewer can never confirm, so
-        #     is_complete (all-confirmed) never trips and the slice hangs.
+        #     review, a stale ACK/NACK, or an unresolved NACK against an
+        #     un-re-proposed version of that producer (e.g. because this
+        #     reviewer's edge was advisory or stall-demoted) would otherwise
+        #     be blocked from confirming FOREVER — the producer will never
+        #     re-propose to clear the guard. The reviewer's verdict on a
+        #     settled producer is moot, so exclude it. This is the post-BRC
+        #     "slice never closes" deadlock: the lone holdout reviewer can
+        #     never confirm, so is_complete (all-confirmed) never trips and
+        #     the slice hangs. The recovery-path gaps that surfaced in the
+        #     same incident (overseer can-only-log / HITL 403,
+        #     advance_phase(force=true) tripping #2806) are tracked
+        #     separately in #3051; this filter is the tactical root-cause
+        #     fix only and intentionally does not patch the recovery path.
         producers = [
             p
             for p in graph.producers_for(agent_role)

--- a/orchestrator/action_guards.py
+++ b/orchestrator/action_guards.py
@@ -424,13 +424,27 @@ def check_confirm_guard(
 
     # --- Reviewer confirmation guards ---
     if is_reviewer:
-        # Exclude producers whose current proposal is a generic no-op
-        # (#3027): the reviewer is not expected to review a no-op (the
-        # producer declared it has no work), so it must not block this
-        # reviewer's confirm via the has-reviewed / zero-proposal /
-        # stale-verdict guards below.
+        # Exclude two classes of producer from the reviewer guards below
+        # (has-reviewed / zero-proposal / stale-verdict / unresolved-NACK):
+        #
+        #   * Generic no-op producers (#3027): the producer declared it has
+        #     no work, so there is nothing for the reviewer to review and it
+        #     must not block the reviewer's confirm.
+        #   * Already-CONFIRMED producers (#3043): a producer only reaches
+        #     the confirmed set after its CRITICAL reviewers have ACKed it,
+        #     so its work is settled. A reviewer still carrying a missing
+        #     review or a NACK against an un-re-proposed version of that
+        #     producer (e.g. because this reviewer's edge was advisory or
+        #     stall-demoted) would otherwise be blocked from confirming
+        #     FOREVER — the producer will never re-propose to clear the
+        #     guard. The reviewer's verdict on a settled producer is moot,
+        #     so exclude it. This is the post-BRC "slice never closes"
+        #     deadlock: the lone holdout reviewer can never confirm, so
+        #     is_complete (all-confirmed) never trips and the slice hangs.
         producers = [
-            p for p in graph.producers_for(agent_role) if not matrix.is_no_changes_proposal(p)
+            p
+            for p in graph.producers_for(agent_role)
+            if not matrix.is_no_changes_proposal(p) and p not in confirmed
         ]
 
         # Guard 1: Must have reviewed all producers

--- a/orchestrator/tests/test_action_guards.py
+++ b/orchestrator/tests/test_action_guards.py
@@ -500,6 +500,45 @@ class TestCheckConfirmGuardReviewer:
         result = check_confirm_guard("reviewer_code", graph, matrix, confirmed={"coder"})
         assert result.allowed is True
 
+    def test_confirmed_producer_excluded_from_stale_acks(self, graph, matrix):
+        """#3043 variant: a reviewer's ACK is stale (producer re-proposed after the
+        ACK) but the producer then CONFIRMED via an advisory / stall-demoted edge
+        without the reviewer re-ACKing. The stale_acks guard must not block the
+        reviewer's own confirm once the producer settles.
+
+        Locks in stale_acks exclusion symmetry with must_have_reviewed /
+        unresolved_nacks — a future refactor that hoists the ``p not in confirmed``
+        check into individual guards must keep this case covered.
+        """
+        v1 = matrix.record_proposal("coder")
+        matrix.record_ack("reviewer_code", "coder", v1)
+        # coder re-proposes — reviewer_code's ACK is now stale at v1
+        matrix.record_proposal("coder")  # v2
+        t_version = matrix.record_proposal("tester")
+        matrix.record_ack("reviewer_code", "tester", t_version)
+
+        result = check_confirm_guard("reviewer_code", graph, matrix, confirmed={"coder"})
+        assert result.allowed is True
+
+    def test_confirmed_producer_excluded_from_stale_nacks(self, graph, matrix):
+        """#3043 variant: a reviewer's NACK is stale (producer re-proposed after the
+        NACK) but the producer then CONFIRMED via an advisory / stall-demoted edge
+        without the reviewer re-reviewing. The stale_nacks guard must not block
+        the reviewer's own confirm once the producer settles.
+
+        Locks in stale_nacks exclusion symmetry — see
+        ``test_confirmed_producer_excluded_from_stale_acks`` for the rationale.
+        """
+        v1 = matrix.record_proposal("coder")
+        matrix.record_nack("reviewer_code", "coder", v1, reason="Bug found")
+        # coder re-proposes — reviewer_code's NACK is now stale at v1
+        matrix.record_proposal("coder")  # v2
+        t_version = matrix.record_proposal("tester")
+        matrix.record_ack("reviewer_code", "tester", t_version)
+
+        result = check_confirm_guard("reviewer_code", graph, matrix, confirmed={"coder"})
+        assert result.allowed is True
+
     def test_unconfirmed_unreviewed_producer_still_blocks(self, graph, matrix):
         """Negative control for #3043: the exclusion is scoped to CONFIRMED
         producers only. An un-confirmed producer the reviewer hasn't reviewed

--- a/orchestrator/tests/test_action_guards.py
+++ b/orchestrator/tests/test_action_guards.py
@@ -468,6 +468,52 @@ class TestCheckConfirmGuardReviewer:
         assert stale[0]["nack_version"] == 1
         assert stale[0]["current_version"] == 2
 
+    def test_confirmed_producer_excluded_from_must_have_reviewed(self, graph, matrix):
+        """#3043: a producer that already CONFIRMED must not block a lagging
+        reviewer's own confirm, even if that reviewer never reviewed it.
+
+        A producer only reaches the confirmed set after its CRITICAL reviewers
+        ACK it, so its work is settled. A reviewer whose edge to it is advisory
+        (or stall-demoted) may never have reviewed it — without the exclusion it
+        would be stuck on the must_have_reviewed guard forever (the producer
+        will never re-propose to clear it), wedging the slice.
+        """
+        # coder is settled (confirmed via its critical reviewers); reviewer_code
+        # never reviewed it. reviewer_code's other producer (tester) is reviewed.
+        matrix.record_proposal("coder")
+        t_version = matrix.record_proposal("tester")
+        matrix.record_ack("reviewer_code", "tester", t_version)
+
+        result = check_confirm_guard("reviewer_code", graph, matrix, confirmed={"coder"})
+        assert result.allowed is True
+
+    def test_confirmed_producer_excluded_from_unresolved_nack(self, graph, matrix):
+        """#3043 variant: a reviewer NACKed a producer that then CONFIRMED via an
+        advisory edge / stall-demotion without re-proposing. The unresolved-NACK
+        guard must not block the reviewer's own confirm once the producer settles.
+        """
+        version = matrix.record_proposal("coder")
+        matrix.record_nack("reviewer_code", "coder", version, reason="Bug found")
+        t_version = matrix.record_proposal("tester")
+        matrix.record_ack("reviewer_code", "tester", t_version)
+
+        result = check_confirm_guard("reviewer_code", graph, matrix, confirmed={"coder"})
+        assert result.allowed is True
+
+    def test_unconfirmed_unreviewed_producer_still_blocks(self, graph, matrix):
+        """Negative control for #3043: the exclusion is scoped to CONFIRMED
+        producers only. An un-confirmed producer the reviewer hasn't reviewed
+        still blocks confirm via the must_have_reviewed guard.
+        """
+        matrix.record_proposal("coder")
+        t_version = matrix.record_proposal("tester")
+        matrix.record_ack("reviewer_code", "tester", t_version)
+
+        result = check_confirm_guard("reviewer_code", graph, matrix, confirmed=set())
+        assert result.allowed is False
+        assert result.details["guard"] == "must_have_reviewed"
+        assert result.details["producer"] == "coder"
+
     def test_guard_priority_zero_proposal_before_stale_acks(self, graph, matrix):
         """Zero-proposal guard fires before stale_acks guard.
 

--- a/orchestrator/tests/test_consensus_next_action.py
+++ b/orchestrator/tests/test_consensus_next_action.py
@@ -100,6 +100,31 @@ def dual_tracker(dual_role_graph):
 
 
 @pytest.fixture
+def advisory_holdout_graph():
+    """#3043 shape: coder's only CRITICAL reviewer is reviewer_security, with
+    reviewer_code ADVISORY on coder (e.g. a stall-demoted edge). reviewer_code
+    also CRITICALLY reviews tester. coder can therefore confirm on
+    reviewer_security's ACK alone, leaving reviewer_code as a lagging holdout
+    that never reviewed coder.
+    """
+    return ReviewGraph(
+        [
+            ReviewEdge("reviewer_security", "coder", ReviewCriticality.CRITICAL),
+            ReviewEdge("reviewer_code", "coder", ReviewCriticality.ADVISORY),
+            ReviewEdge("reviewer_code", "tester", ReviewCriticality.CRITICAL),
+        ]
+    )
+
+
+@pytest.fixture
+def advisory_holdout_tracker(advisory_holdout_graph):
+    t = PeerConsensusTracker(PIPELINE_ID, advisory_holdout_graph, cooldown_seconds=0)
+    for role in ("coder", "tester", "reviewer_security", "reviewer_code"):
+        t.register_agent(role)
+    return t
+
+
+@pytest.fixture
 def app():
     """Flask app with the next-action route blueprint.
 
@@ -531,6 +556,40 @@ def test_next_action_role_complete(client, simple_tracker):
     simple_tracker.handle_confirmed("reviewer_security")
     resp = _post_next_action(client, "coder", tracker=simple_tracker)
     _assert_action(resp, "complete")
+
+
+def test_advisory_reviewer_can_confirm_after_producer_confirmed(client, advisory_holdout_tracker):
+    """#3043 regression: a lagging advisory reviewer must be routed to
+    ``confirm`` once the producer it never reviewed has CONFIRMED.
+
+    Field repro (issue-3023 slice-3): coder confirmed via its critical
+    reviewers while reviewer_code (advisory on coder) was the lone holdout.
+    Because ``_has_pending_peer_proposals`` skips a CONFIRMED producer,
+    reviewer_code was never routed back to ``ack`` coder; and ``check_confirm_guard``
+    blocked its ``confirm`` on the must_have_reviewed guard. Result: a permanent
+    ``wait`` → ``is_complete`` (all-confirmed) never trips → the slice never
+    closes. The fix excludes already-CONFIRMED producers from the reviewer
+    guards, so the holdout can confirm and consensus completes.
+    """
+    t = advisory_holdout_tracker
+    _propose(t, "coder")
+    _propose(t, "tester")
+    # coder's CRITICAL reviewer ACKs; reviewer_code (advisory) never reviews coder.
+    _ack(t, "reviewer_security", "coder", version=1)
+    # reviewer_code reviews its CRITICAL producer (tester).
+    _ack(t, "reviewer_code", "tester", version=1)
+    # Producers + the fully-reviewed pure reviewer confirm, leaving reviewer_code.
+    t.handle_confirmed("coder")
+    t.handle_confirmed("tester")
+    t.handle_confirmed("reviewer_security")
+
+    # The lone holdout: its next action must be ``confirm``, not a terminal ``wait``.
+    resp = _post_next_action(client, "reviewer_code", tracker=t)
+    _assert_action(resp, "confirm")
+
+    # Confirming it completes global consensus — the slice can now close.
+    t.handle_confirmed("reviewer_code")
+    assert t.evaluate()["is_complete"] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #3043 — a slice-DAG `implement` slice could reach near-consensus and then **never close**, hanging the phase (observed live on `issue-3023` slice-3, ~36 min before operator intervention).

The issue's "event-pump containers won't exit" framing is a **misdiagnosis**: `_run_concurrent_phase` short-circuits the moment BRC `is_complete` is true (it does *not* wait for container exit), and `_stop_running_containers()` SIGKILLs at a 30s timeout. So a multi-minute hang is only possible if `is_complete` (= **all** agents confirmed) never trips. It didn't — because a lone holdout reviewer was stuck in a terminal `wait` and could never confirm.

## Root cause

`check_confirm_guard`'s reviewer guards (`must_have_reviewed` / `stale_acks` / `unresolved_nacks`) keyed on **every** assigned producer, with no exception for a producer that has already `CONFIRMED`.

A producer only enters the confirmed set after its **critical** reviewers ACK it, so its work is settled. But a reviewer whose edge to that producer is **advisory or stall-demoted** may have never reviewed it (or NACKed a version it never re-proposed). That reviewer's `confirm` was then blocked **forever** — the settled producer will never re-propose to clear the guard. And `_has_pending_peer_proposals` skips a `CONFIRMED` producer, so the reviewer was never routed back to `ack` it either. `_derive_next_action` returned a permanent `wait` → `is_complete` never reached all-confirmed → the slice hung.

The existing "ready-to-confirm" nudge (`_collect_newly_ready_producers`) is **producer-only**, so there was no self-heal for a stuck reviewer; `restart_agent` doesn't help (guard state is unchanged).

## Fix

Exclude already-`CONFIRMED` producers from the reviewer confirm-guards — exactly as #3027 already excludes generic no-op producers. A settled producer's review is moot and must not block the holdout reviewer's own confirm.

```python
producers = [
    p for p in graph.producers_for(agent_role)
    if not matrix.is_no_changes_proposal(p) and p not in confirmed
]
```

**No BRC weakening:** a producer can only confirm once its *critical* reviewers ACK it, so a reviewer still blocked on it is by definition non-critical/advisory for it — its verdict is genuinely moot. The producer-side guard (`is_fully_acked`) and the global zero-proposal guard are untouched (a confirmed producer is at version ≥ 1).

## Tests

- **Guard-level** (`test_action_guards.py`): a confirmed producer is excluded from both `must_have_reviewed` and `unresolved_nacks`; negative control confirms an **un**-confirmed unreviewed producer still blocks (the exclusion is scoped to confirmed producers only).
- **End-to-end** (`test_consensus_next_action.py`): reproduces the field shape — an advisory reviewer is routed to `confirm` after the producer it never reviewed confirms, and global consensus then completes.

All three new tests **fail without the fix** (the end-to-end one reproduces the exact symptom: `action='wait'`, `"hasn't reviewed coder"`).

## Scope / follow-ups

This is the tactical root-cause fix for the deployed in-pod event-pump model; it lives in `consensus.py`/`action_guards.py` and does **not** touch `consensus_wrapper.py`. The issue's secondary recovery-path gaps (overseer can-only-log / HITL 403, `advance_phase(force=true)` tripping #2806 + implement re-entry thrash) are tracked separately in #3051.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
