### PR TITLE
fix(orchestrator): persist resolved base_branch at submit time (#3038)

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -1614,11 +1614,11 @@ def create_pipeline() -> tuple[Response, int]:
     # local/fast helper (``git symbolic-ref``) and is the same resolution
     # the stale-branch reuse check below already performs.
     #
-    # Only resolve when ``repo`` is set and no explicit ``base_branch`` was
-    # supplied: a local pipeline (no repo) must keep ``base_branch=None`` so
-    # the opener's local-mode short-circuit still fires, and an explicit
-    # base is passed through untouched.
-    if repo and not base_branch:
+    # An explicit ``base_branch`` (validated above) is passed through
+    # untouched; ``repo`` is already guaranteed non-empty by the early
+    # ``Missing repo`` guard, so only the ``base_branch`` side needs a
+    # check here.
+    if not base_branch:
         base_branch = _detect_default_branch(repo_path)
 
     # Check that the target branch does not already exist on the remote.

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -1598,6 +1598,29 @@ def create_pipeline() -> tuple[Response, int]:
 
     repo_path = get_repo_path()
 
+    # #3038: resolve the repo's default branch ONCE at submit time and
+    # persist it on the pipeline record, so every downstream consumer
+    # (the context-PR opener, the restart/spawn paths, the gateway
+    # ``register_session`` base, the spawner ``EGG_BASE_BRANCH`` export)
+    # reads a concrete base off the record instead of re-deriving it on
+    # every invocation. Re-deriving each time opened a narrow race the
+    # #3035 reviewer flagged: a single flaky ``git symbolic-ref
+    # origin/HEAD`` read drops the opener into the ``origin/main →
+    # origin/master → "main"`` fallback chain, which can pick the wrong
+    # default on a ``master`` repo and 422 a second ``create_pr``.
+    # Persisting closes the race because the consumers' ``base_branch or
+    # _detect_default_branch(...)`` short-circuits on the stored value and
+    # never reaches the subprocess. ``_detect_default_branch`` is the
+    # local/fast helper (``git symbolic-ref``) and is the same resolution
+    # the stale-branch reuse check below already performs.
+    #
+    # Only resolve when ``repo`` is set and no explicit ``base_branch`` was
+    # supplied: a local pipeline (no repo) must keep ``base_branch=None`` so
+    # the opener's local-mode short-circuit still fires, and an explicit
+    # base is passed through untouched.
+    if repo and not base_branch:
+        base_branch = _detect_default_branch(repo_path)
+
     # Check that the target branch does not already exist on the remote.
     # This catches conflicts early (before spawning agents).  However,
     # allow branch reuse when the pipeline is in a terminal state

--- a/orchestrator/tests/test_pipelines_api.py
+++ b/orchestrator/tests/test_pipelines_api.py
@@ -326,15 +326,17 @@ class TestDeletePipelineBranchCleanup:
 class TestCreatePipelineMultiRepo:
     """Tests that create_pipeline resolves repo paths in multi-repo setups (#1323)."""
 
+    @patch("routes.pipelines._detect_default_branch")
     @patch("routes.pipelines.get_gateway_client")
     @patch("routes.pipelines.get_state_store")
     @patch("routes.pipelines.get_repo_path")
     def test_create_pipeline_uses_get_repo_path(
-        self, mock_repo_path, mock_get_store, mock_gw, client
+        self, mock_repo_path, mock_get_store, mock_gw, mock_detect, client
     ):
         """create_pipeline should call get_repo_path() for all pipeline types."""
         mock_repo_path.return_value = Path("/home/egg/repos/webapp")
         mock_gw.return_value.ls_remote_branch.return_value = False
+        mock_detect.return_value = "main"
         mock_store = MagicMock()
         mock_pipeline = MagicMock()
         mock_pipeline.id = "issue-42"
@@ -354,14 +356,16 @@ class TestCreatePipelineMultiRepo:
         mock_repo_path.assert_called_once()
         mock_get_store.assert_called_once_with(Path("/home/egg/repos/webapp"))
 
+    @patch("routes.pipelines._detect_default_branch")
     @patch("routes.pipelines.get_gateway_client")
     @patch("routes.pipelines.get_state_store")
     @patch("routes.pipelines.get_repo_path")
     def test_create_prompt_pipeline_uses_get_repo_path(
-        self, mock_repo_path, mock_get_store, mock_gw, client
+        self, mock_repo_path, mock_get_store, mock_gw, mock_detect, client
     ):
         """Prompt-driven pipelines (no issue_number) also use get_repo_path()."""
         mock_repo_path.return_value = Path("/home/egg/repos/webapp")
+        mock_detect.return_value = "main"
         mock_store = MagicMock()
         mock_pipeline = MagicMock()
         mock_pipeline.id = "prompt-abc"

--- a/orchestrator/tests/test_pipelines_api.py
+++ b/orchestrator/tests/test_pipelines_api.py
@@ -400,6 +400,81 @@ class TestCreatePipelineMultiRepo:
         assert "webapp" in msg or "webapp" in response.get_data(as_text=True)
 
 
+class TestCreatePipelineBaseBranchPersistence:
+    """``base_branch`` is resolved once at submit time and persisted (#3038).
+
+    Re-deriving the default branch on every downstream invocation opened a
+    narrow race (the #3035 reviewer's flag): a single flaky
+    ``git symbolic-ref origin/HEAD`` read could pick the wrong default on a
+    ``master`` repo. Resolving + storing once at submit closes it — the
+    consumers' ``base_branch or _detect_default_branch(...)`` short-circuits
+    on the stored value.
+    """
+
+    @patch("routes.pipelines._detect_default_branch")
+    @patch("routes.pipelines.get_gateway_client")
+    @patch("routes.pipelines.get_state_store")
+    @patch("routes.pipelines.get_repo_path")
+    def test_resolves_and_persists_base_branch_when_none(
+        self, mock_repo_path, mock_get_store, mock_gw, mock_detect, client
+    ):
+        """repo set + base_branch omitted → resolve via _detect_default_branch
+        and pass the concrete value to store.create_pipeline."""
+        mock_repo_path.return_value = Path("/home/egg/repos/webapp")
+        mock_gw.return_value.ls_remote_branch.return_value = False
+        mock_detect.return_value = "develop"
+        mock_store = MagicMock()
+        mock_pipeline = MagicMock()
+        mock_pipeline.id = "issue-42"
+        mock_pipeline.model_dump.return_value = {"id": "issue-42"}
+        mock_store.create_pipeline.return_value = mock_pipeline
+        mock_get_store.return_value = mock_store
+
+        response = client.post(
+            "/api/v1/pipelines",
+            json={
+                "issue_number": 42,
+                "repo": "Khan/webapp",
+                "branch": "egg/issue-42",
+            },
+        )
+        assert response.status_code == 200
+        mock_detect.assert_called_once_with(Path("/home/egg/repos/webapp"))
+        call_kwargs = mock_store.create_pipeline.call_args[1]
+        assert call_kwargs["base_branch"] == "develop"
+
+    @patch("routes.pipelines._detect_default_branch")
+    @patch("routes.pipelines.get_gateway_client")
+    @patch("routes.pipelines.get_state_store")
+    @patch("routes.pipelines.get_repo_path")
+    def test_explicit_base_branch_passed_through_unchanged(
+        self, mock_repo_path, mock_get_store, mock_gw, mock_detect, client
+    ):
+        """An explicit base_branch is persisted as-is; no resolution happens."""
+        mock_repo_path.return_value = Path("/home/egg/repos/webapp")
+        mock_gw.return_value.ls_remote_branch.return_value = False
+        mock_store = MagicMock()
+        mock_pipeline = MagicMock()
+        mock_pipeline.id = "issue-42"
+        mock_pipeline.model_dump.return_value = {"id": "issue-42"}
+        mock_store.create_pipeline.return_value = mock_pipeline
+        mock_get_store.return_value = mock_store
+
+        response = client.post(
+            "/api/v1/pipelines",
+            json={
+                "issue_number": 42,
+                "repo": "Khan/webapp",
+                "branch": "egg/issue-42",
+                "base_branch": "release-1",
+            },
+        )
+        assert response.status_code == 200
+        mock_detect.assert_not_called()
+        call_kwargs = mock_store.create_pipeline.call_args[1]
+        assert call_kwargs["base_branch"] == "release-1"
+
+
 def _make_cancellable_pipeline(pipeline_id="test-pipeline"):
     """Create a pipeline with running containers and agents for cancellation tests."""
     pipeline = Pipeline(


### PR DESCRIPTION
Fixes #3038.

## Problem

PR #3035 (fixing #3031) had the context-PR opener resolve `base_branch=None → default` via `_detect_default_branch()` **on every invocation** rather than computing-once-and-storing. The #3035 reviewer flagged the resulting smell + a narrow race:

> if the symbolic-ref read on `origin/HEAD` flakes once … the fallback chain hits `origin/main → origin/master → "main"`. A repo whose default is `master` would have an existing PR found on the happy path, but a flaky tick later would look for `head → main`, miss, and `create_pr` would fail server-side → opener raises `gateway_error` / the canonical `advance_phase` site 422s.

Root cause: the standard `submit_task` path never populates `base_branch`, so essentially every remote pipeline persists `base_branch=None`, and **every** consumer (opener, restart, spawn, gateway `register_session`, spawner `EGG_BASE_BRANCH`) re-derives the default independently.

## Fix

Resolve the repo's default branch **once at submit time** and persist it on the pipeline record, in the `create_pipeline` route — the server-side handler for the `submit_task` MCP tool. (`mcp_tools.py`, named in the issue's AC, is a thin HTTP client with no git clone; the route is where `repo_path` is already in scope and `_detect_default_branch` is already called for the stale-branch check, so it's the faithful place.)

```python
repo_path = get_repo_path()

# #3038: resolve once at submit, persist on the record.
if repo and not base_branch:
    base_branch = _detect_default_branch(repo_path)
```

The resolved value flows into both the stale-branch reuse check and `store.create_pipeline(base_branch=…)`.

**Why this closes the race:** consumers keep their `base_branch or _detect_default_branch(...)` form, but for new pipelines `base_branch` is now non-`None`, so the `or` short-circuits and the flaky `git symbolic-ref` subprocess is **never reached**.

**Side benefit:** the gateway `register_session` base (#3024) and the spawner `EGG_BASE_BRANCH` export (#2967) now receive the concrete base instead of `None`, making the resolved base orchestrator-authoritative end-to-end — consistent with #3024's "base must be orchestrator-authoritative" model.

## Back-compat

- The downstream `or _detect_default_branch(...)` / `get_default_branch(...)` fallbacks are **kept** as a safety net for pre-change records still carrying `base_branch=None` (AC item 3). No migration needed — existing pipelines keep working, and pick up a concrete value naturally on resubmit.
- Resolution only runs when `repo` is set and no explicit `base_branch` was supplied: local pipelines keep `base_branch=None` (so the opener's local-mode short-circuit still fires), and an explicit base passes through untouched.

## Acceptance criteria

- [x] `submit_task` path resolves and persists `base_branch` when `repo` is set and `base_branch` is `None` (done in the route handler).
- [x] Downstream consumers read the persisted value (the `or _detect_default_branch` short-circuit means `_detect_default_branch` is no longer reached at use time for new pipelines). The resolve-fallback is retained as the transition safety net.
- [x] Existing `base_branch=None` pipelines continue to work via the retained fallbacks.

## Scope notes

- `orchestrator/cli.py` (the other `store.create_pipeline` caller — a local-repo operator entry point) is **out of scope** per the issue's `submit_task` framing.

## Tests

`TestCreatePipelineBaseBranchPersistence` (`test_pipelines_api.py`):
- repo set + `base_branch` omitted → `_detect_default_branch` (patched → `develop`) → `create_pipeline` called with `base_branch="develop"`.
- explicit `base_branch` → passed through unchanged, no resolution.

Targeted run: `TestCreatePipelineBaseBranchPersistence` + `TestCreatePipelineMultiRepo` → **5 passed** (the existing multi-repo tests POST without `base_branch` and still pass, confirming the unconditional resolve degrades gracefully). Full changeset-aware `make test` was still running at PR-open time; CI `make test-all` is ground truth.

## Refs
- PR #3035 — the narrow fix this defers from
- Issue #3031 — the regression #3035 fixed
- Issue family #2967 / #3024 — related submit-time / orchestrator-authoritative base work