### PR TITLE
feat(orchestrator): default refine and plan phase agents to fable

### DIFF
--- a/config/repositories.yaml.example
+++ b/config/repositories.yaml.example
@@ -107,14 +107,17 @@ readable_repos:
 #   - default_agent_model: Repository-level default for the per-agent
 #     model knob added in #2769. Used by every agent role unless the
 #     pipeline submission overrides it via ``agent_models``. A recognised
-#     Claude alias (opus, opus[1m], sonnet, sonnet[1m], haiku, claude-*)
+#     Claude alias (opus, opus[1m], sonnet, sonnet[1m], haiku, fable,
+#     fable[1m], claude-*)
 #     routes through the Anthropic upstream; anything else routes through the
 #     in-cluster LiteLLM proxy with the recognised alias "opus" presented
 #     to Claude Code (cq-5 mitigation). Precedence:
 #       PipelineConfig.agent_models[role]
 #         > this default_agent_model
-#           > built-in "opus" default
-#     Default: not set (every role runs on built-in "opus").
+#           > built-in default ("fable" for refine/plan roles, "opus"
+#             otherwise)
+#     Default: not set (refine/plan roles run on built-in "fable",
+#     every other role on built-in "opus").
 repo_settings:
   # Example:
   # YOUR_USERNAME/egg:

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -68,7 +68,8 @@ PipelineConfig(
 
 Default-constructed `PipelineConfig.agent_models` is `{}` — every
 existing pipeline continues to spawn every role on the built-in
-`"opus"` Claude default with `upstream="anthropic"`.
+Claude default with `upstream="anthropic"` (`"fable"` for the
+refine/plan phase roles, `"opus"` for everything else).
 
 ### Repository-level default — `default_agent_model`
 
@@ -101,8 +102,9 @@ in `orchestrator/agent_model_resolution.py` walks the chain:
 1. `pipeline_config.agent_models.get(role.value)` — per-pipeline,
    per-role override
 2. `get_default_agent_model(repo)` — repository-level default
-3. Built-in `"opus"` — the historical default; preserves today's
-   behavior unchanged
+3. Built-in default — `"fable"` for the refine and plan phase roles
+   (producers and reviewers, `_FABLE_DEFAULT_ROLES`), `"opus"` for
+   everything else
 
 The result is an `AgentModelDecision` dataclass with fields
 `(claude_code_alias: str, upstream: str, upstream_model: str | None)`.
@@ -113,7 +115,7 @@ The resolver's classifier divides model strings into two camps:
 
 | Model string pattern | `upstream` | `claude_code_alias` | `upstream_model` |
 |----------------------|------------|---------------------|------------------|
-| `opus`, `opus[1m]`, `sonnet`, `sonnet[1m]`, `haiku` | `"anthropic"` | the model string verbatim | `None` |
+| `opus`, `opus[1m]`, `sonnet`, `sonnet[1m]`, `haiku`, `fable`, `fable[1m]` | `"anthropic"` | the model string verbatim | `None` |
 | `claude-*` (e.g. `claude-3-5-sonnet-20241022`) | `"anthropic"` | the model string verbatim | `None` |
 | Everything else with a real window ≥1M (e.g. `qwen3.7-max`, `deepseek-v4-*`) | `"litellm"` | `<model>[1m]` (the bare upstream name plus the 1M-context opt-in suffix) | the bare upstream name |
 | Sub-1M-window models (`_SUB_1M_CONTEXT_MODELS`: `kimi-k2.6` 256K, `glm-5.1` 202K) | `"litellm"` | `<model>` — bare, **no** `[1m]` (takes Claude Code's 200K default) | the bare upstream name |
@@ -524,7 +526,8 @@ optional `branch` override:
 
 Per-pipeline `agent_models` entries **override** the repo-level
 `default_agent_model`. Both can be unset — the resolver falls back to
-the built-in `"opus"`.
+the built-in default (`"fable"` for refine/plan roles, `"opus"`
+otherwise).
 
 ### 4. Run the pipeline and observe routing
 
@@ -602,7 +605,8 @@ invariant](../architecture/upstream-routing.md#no-op-by-default-invariant)):
 3. **`agent_models` default is empty.** Both
    `PipelineConfig.agent_models` and repo-level
    `default_agent_model` default to nothing — the resolver returns
-   the built-in `"opus"` Anthropic path.
+   the built-in Anthropic path (`"fable"` for refine/plan roles,
+   `"opus"` otherwise).
 
 Any single guard suffices. All three are independent; a
 misconfiguration on one does not silently activate the LiteLLM path.

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -106,6 +106,16 @@ in `orchestrator/agent_model_resolution.py` walks the chain:
    (producers and reviewers, `_FABLE_DEFAULT_ROLES`), `"opus"` for
    everything else
 
+> **Minimum sandbox Claude Code version.** The `fable` / `fable[1m]`
+> aliases require Claude Code ≥ 2.1.170. The sandbox's
+> `CLAUDE_CODE_VERSION` build-arg in `sandbox/Dockerfile` defaults to
+> `stable`, which satisfies this on a fresh build. Deployments that
+> pin an older `CLAUDE_CODE_VERSION` will see refine/plan agent spawns
+> fail with an "unknown model" error from Claude Code — either bump
+> the pinned version or set a repo-level `default_agent_model: opus`
+> to opt back out of the fable default until the sandbox image is
+> rebuilt.
+
 The result is an `AgentModelDecision` dataclass with fields
 `(claude_code_alias: str, upstream: str, upstream_model: str | None)`.
 

--- a/orchestrator/agent_model_resolution.py
+++ b/orchestrator/agent_model_resolution.py
@@ -11,11 +11,13 @@ Precedence (highest first), matching #2769 task-2-3:
    :class:`AgentRole` at construction time.
 2. ``repositories.yaml`` ``default_agent_model`` — repository-level
    default surfaced via :func:`config.repo_config.get_default_agent_model`.
-3. Built-in ``"opus"`` default — preserves today's Claude-only behaviour.
+3. Built-in default — ``"fable"`` for the refine and plan phase roles
+   (:data:`_FABLE_DEFAULT_ROLES`), ``"opus"`` for everything else.
 
 Classifier: a model string matching one of the recognised Claude
 aliases (``opus``, ``opus[1m]``, ``sonnet``, ``sonnet[1m]``, ``haiku``,
-``claude-*``) routes through the Anthropic upstream — the agent's
+``fable``, ``fable[1m]``, ``claude-*``) routes through the Anthropic
+upstream — the agent's
 ``--model`` flag is set to that alias verbatim and the gateway
 forwards the request body byte-for-byte. Any other string is treated
 as a LiteLLM-side model name (#2832): the upstream is ``"litellm"``,
@@ -42,7 +44,7 @@ import logging
 import re
 from dataclasses import dataclass
 
-from egg_contracts.agent_roles import AgentRole
+from egg_contracts.agent_roles import EGG_REPO, AgentRole, get_roles_for_phase
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +52,25 @@ logger = logging.getLogger(__name__)
 # repository-level default_agent_model is set. Matches today's hardcoded
 # default in ``orchestrator/consensus_wrapper.py::build_consensus_wrapped_command``.
 DEFAULT_AGENT_MODEL = "opus"
+
+# Built-in default for the refine and plan phases. The drafting-heavy
+# upstream phases (analysis, slice DAG, contract shape) run on the
+# highest-capability tier; implement and downstream phases stay on
+# DEFAULT_AGENT_MODEL. Both pipeline-level ``agent_models`` and the
+# repo-level ``default_agent_model`` still override this (precedence
+# unchanged — this only splits the tier-3 built-in by role).
+FABLE_DEFAULT_MODEL = "fable"
+
+# Role values that pick up FABLE_DEFAULT_MODEL at tier 3. Derived from
+# the phase→role tables so new refine/plan roles inherit the default
+# without a parallel list here. ``repo=EGG_REPO`` includes the egg-only
+# reviewers (e.g. reviewer_agent_design) — membership is keyed by role
+# only, and roles that never spawn for a repo are simply never resolved.
+_FABLE_DEFAULT_ROLES: frozenset[str] = frozenset(
+    role.value
+    for phase in ("refine", "plan")
+    for role in get_roles_for_phase(phase, include_reviewers=True, repo=EGG_REPO)
+)
 
 # Upstream identifiers used by the gateway's UpstreamRegistry
 # (gateway/upstream_registry.py).
@@ -91,6 +112,8 @@ _CLAUDE_EXACT_ALIASES = frozenset(
         "sonnet",
         "sonnet[1m]",
         "haiku",
+        "fable",
+        "fable[1m]",
     }
 )
 _CLAUDE_VERSIONED_RE = re.compile(r"^claude-")
@@ -299,13 +322,17 @@ def resolve_agent_model(
         if repo_default:
             return classify_model(repo_default)
 
-    # Tier 3: built-in default.
+    # Tier 3: built-in default — refine/plan roles run the
+    # highest-capability tier, everything else stays on opus.
+    if role_value in _FABLE_DEFAULT_ROLES:
+        return classify_model(FABLE_DEFAULT_MODEL)
     return classify_model(DEFAULT_AGENT_MODEL)
 
 
 __all__ = [
     "AgentModelDecision",
     "DEFAULT_AGENT_MODEL",
+    "FABLE_DEFAULT_MODEL",
     "UPSTREAM_ANTHROPIC",
     "UPSTREAM_LITELLM",
     "classify_model",

--- a/orchestrator/concurrent_executor.py
+++ b/orchestrator/concurrent_executor.py
@@ -431,9 +431,10 @@ class ConcurrentPhaseExecutor:
 
         # Per-agent model resolution (#2769 slice-2). The decision is a
         # pure function over (role, pipeline_config, repo); when no
-        # override is configured the resolver returns the built-in
-        # ``opus`` Anthropic decision so the wire shape stays identical
-        # to the pre-#2769 path.
+        # override is configured the resolver returns a built-in
+        # Anthropic decision — ``fable`` for the refine/plan phase
+        # roles (``_FABLE_DEFAULT_ROLES``), ``opus`` for every other
+        # role — so the wire shape stays Anthropic-only.
         #
         # Defensive wrap: a future regression in the resolver (e.g. a
         # broken lazy import for the repo-default tier) would otherwise
@@ -441,7 +442,10 @@ class ConcurrentPhaseExecutor:
         # path's ``classify_model(DEFAULT_AGENT_MODEL)`` fallback at
         # ``routes/pipelines.py:2683-2699`` so spawn degrades to the
         # built-in opus / anthropic decision and logs the resolver
-        # failure rather than crashing.
+        # failure rather than crashing. (The fallback stays on opus
+        # uniformly — refine/plan agents whose resolver call raised
+        # silently downgrade from fable to opus rather than failing
+        # to spawn at all.)
         try:
             decision: AgentModelDecision = resolve_agent_model(
                 role=role,

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -920,7 +920,8 @@ class PipelineConfig(BaseModel):
             "such as overseer or autofixer are rejected at construction "
             "time because their spawn paths never consult the resolver. "
             "The value is the upstream-side model name: a Claude alias "
-            "(opus / opus[1m] / sonnet / sonnet[1m] / haiku / claude-*) "
+            "(opus / opus[1m] / sonnet / sonnet[1m] / haiku / fable / "
+            "fable[1m] / claude-*) "
             "routes through the Anthropic upstream, anything else routes "
             "through the in-cluster LiteLLM proxy with the "
             "ANTHROPIC_CUSTOM_MODEL_OPTION env-var registration set on "
@@ -929,7 +930,8 @@ class PipelineConfig(BaseModel):
             "recognized-alias mitigation). When a role is absent from "
             "this mapping the resolver falls back to the "
             "repository-level default_agent_model setting and then to the "
-            "built-in 'opus' default. See #2769."
+            "built-in default ('fable' for refine/plan phase roles, "
+            "'opus' otherwise). See #2769."
         ),
     )
 

--- a/orchestrator/tests/test_agent_model_resolution.py
+++ b/orchestrator/tests/test_agent_model_resolution.py
@@ -9,12 +9,14 @@ Precedence (highest wins):
 
     1. ``pipeline_config.agent_models.get(role.value)``  — per-pipeline
     2. ``get_default_agent_model(repo)``                 — per-repo
-    3. ``"opus"`` built-in default
+    3. Built-in default — ``"fable"`` for refine/plan phase roles,
+       ``"opus"`` for everything else
 
 Classifier (model string → upstream):
 
     * ``"opus"``, ``"opus[1m]"``, ``"sonnet"``, ``"sonnet[1m]"``,
-      ``"haiku"``, ``"claude-*"``  → ``upstream="anthropic"``,
+      ``"haiku"``, ``"fable"``, ``"fable[1m]"``, ``"claude-*"``
+      → ``upstream="anthropic"``,
       ``claude_code_alias=<the string>``, ``upstream_model=None``.
     * anything else → ``upstream="litellm"``,
       ``claude_code_alias="<model>[1m]"`` (#2832: the [1m] suffix
@@ -251,7 +253,7 @@ class TestAnthropicClassification:
 
     @pytest.mark.parametrize(
         "model",
-        ["opus", "opus[1m]", "sonnet", "sonnet[1m]", "haiku"],
+        ["opus", "opus[1m]", "sonnet", "sonnet[1m]", "haiku", "fable", "fable[1m]"],
     )
     def test_short_claude_alias_is_anthropic(self, model):
         resolve_agent_model = _resolver()
@@ -750,10 +752,12 @@ class TestDualImportRepoConfig:
 
 class TestDefaultPathRegression:
     """With ``agent_models={}`` and no repo default, EVERY role resolves
-    to the Anthropic default — this is the slice-2 no-op invariant.
+    to an Anthropic-route built-in: ``fable`` for the refine/plan phase
+    roles, ``opus`` for everything else. ``upstream_model`` stays
+    ``None`` on every default path — the slice-2 no-op invariant.
     """
 
-    def test_every_assigned_role_defaults_to_anthropic_opus(self):
+    def test_implement_phase_roles_default_to_anthropic_opus(self):
         resolve_agent_model = _resolver()
         AgentRole = _agent_role()
         config = _pipeline_config()
@@ -763,10 +767,6 @@ class TestDefaultPathRegression:
                 AgentRole.CODER,
                 AgentRole.TESTER,
                 AgentRole.DOCUMENTER,
-                AgentRole.REFINER,
-                AgentRole.ARCHITECT,
-                AgentRole.TASK_PLANNER,
-                AgentRole.RISK_ANALYST,
                 AgentRole.REVIEWER_CODE,
                 AgentRole.REVIEWER_CONTRACT,
                 AgentRole.REVIEWER_CODE_HOLISTIC,
@@ -781,3 +781,44 @@ class TestDefaultPathRegression:
                     f"upstream_model={d.upstream_model!r} — slice-2 "
                     f"regression: default config must be Anthropic-only"
                 )
+
+    def test_refine_and_plan_roles_default_to_anthropic_fable(self):
+        """Refine/plan producers and reviewers pick up the built-in
+        ``fable`` default while staying on the Anthropic upstream."""
+        resolve_agent_model = _resolver()
+        AgentRole = _agent_role()
+        config = _pipeline_config()
+
+        with patch("config.repo_config.get_default_agent_model", return_value=None):
+            for role in (
+                AgentRole.REFINER,
+                AgentRole.REVIEWER_REFINE,
+                AgentRole.REVIEWER_AGENT_DESIGN,
+                AgentRole.ARCHITECT,
+                AgentRole.TASK_PLANNER,
+                AgentRole.RISK_ANALYST,
+                AgentRole.REVIEWER_PLAN,
+            ):
+                d = resolve_agent_model(role, config, "any/repo")
+                assert d.claude_code_alias == "fable", (
+                    f"{role.value} should default to fable, got {d.claude_code_alias!r}"
+                )
+                assert d.upstream == "anthropic"
+                assert d.upstream_model is None
+
+    def test_repo_default_overrides_fable_builtin(self):
+        """A repo-level ``default_agent_model`` still beats the built-in
+        fable default — precedence is unchanged, only tier 3 split."""
+        resolve_agent_model = _resolver()
+        AgentRole = _agent_role()
+        config = _pipeline_config()
+
+        with patch(
+            "config.repo_config.get_default_agent_model",
+            return_value="sonnet",
+        ):
+            d = resolve_agent_model(AgentRole.REFINER, config, "owner/repo")
+
+        assert d.claude_code_alias == "sonnet"
+        assert d.upstream == "anthropic"
+        assert d.upstream_model is None

--- a/orchestrator/tests/test_concurrent_executor.py
+++ b/orchestrator/tests/test_concurrent_executor.py
@@ -1047,6 +1047,40 @@ class TestSpawnDefaultAgentModelPath:
             f"consensus wrapper; got {captured.get('model')!r}"
         )
 
+    def test_default_config_passes_fable_for_refine_plan_role(self):
+        """``agent_models == {}`` → refiner spawn passes ``model="fable"``
+        to ``build_consensus_wrapped_command``.
+
+        Symmetric to ``test_default_config_passes_opus_to_consensus_wrapper``
+        — guards the role→model wiring in ``_spawn_agent`` against a
+        future change that breaks the fable default for the refine/plan
+        roles (post-PR #3062 split of tier-3 built-in by role).
+        """
+        from concurrent_executor import ConcurrentPhaseExecutor
+        from egg_orchestrator.types import AgentRole
+
+        pipeline = _make_pipeline()
+        captured: dict[str, object] = {}
+
+        def _capture_command(prompt_text, **kwargs):
+            captured["prompt_text"] = prompt_text
+            captured["model"] = kwargs.get("model")
+            return ["bash", "-c", "true"]
+
+        mock_spawn = MagicMock(return_value=_kubernetes_spawn_result("refiner"))
+        executor = ConcurrentPhaseExecutor(pipeline, spawn_fn=mock_spawn)
+
+        with patch(
+            "concurrent_executor.build_consensus_wrapped_command",
+            side_effect=_capture_command,
+        ):
+            executor._spawn_agent(AgentRole.REFINER, prompt_text="run task")
+
+        assert captured.get("model") == "fable", (
+            f"Default-config refiner spawn MUST pass model='fable' to "
+            f"the consensus wrapper; got {captured.get('model')!r}"
+        )
+
     def test_default_config_omits_upstream_kwargs_on_spawn_fn(self):
         """The spawn_fn must NOT receive upstream/upstream_model kwargs
         when ``agent_models == {}`` — that would be a wire-shape change


### PR DESCRIPTION
## Summary

Switches the built-in default model for the **refine** and **plan** phases to `fable` (Claude Fable 5), while the implement/apply phases and every other role stay on `opus`.

Built on the per-agent model resolution mechanism from #2769/#2832:

- **`orchestrator/agent_model_resolution.py`**
  - `fable` and `fable[1m]` added to `_CLAUDE_EXACT_ALIASES` so they classify as Anthropic-route aliases (previously they would have fallen through to the LiteLLM route).
  - Tier-3 built-in default is now split by role: roles in `_FABLE_DEFAULT_ROLES` (derived from the refine/plan phase tables — refiner, reviewer_refine, reviewer_agent_design, architect, task_planner, risk_analyst, reviewer_plan) resolve to `FABLE_DEFAULT_MODEL = "fable"`; everything else keeps `DEFAULT_AGENT_MODEL = "opus"`.
  - Precedence is unchanged: per-pipeline `agent_models` > repo-level `default_agent_model` > built-in. The split applies only at tier 3.
- **`orchestrator/models.py`** — `agent_models` field description updated for the new aliases and default.
- **Tests** — default-path regression split into implement-phase (opus) and refine/plan (fable) cases, plus a precedence test that a repo-level default still overrides the fable built-in; classifier parametrize extended with the fable aliases.
- **Docs** — `docs/guides/per-agent-models.md` and `config/repositories.yaml.example` updated to match.

The sandbox installs Claude Code `stable`, which recognises the `fable` / `fable[1m]` model aliases (verified against 2.1.170).

## Notes

- The role set is derived via `get_roles_for_phase("refine"/"plan", repo=EGG_REPO)` so new refine/plan roles inherit the default without a parallel hardcoded list.
- `make test` was not run locally before opening; relying on CI.