### PR TITLE
fix(gateway): fetch with explicit tracking refspec so narrow-refspec mirrors see fresh tips

### DIFF
--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -812,14 +812,24 @@ class TestWorktreeManagerDockerGitDir:
                     repo_slug="Khan/test-repo",
                 )
 
+        # One targeted explicit-refspec fetch per candidate branch
+        # (assigned + base) — see #3068; a bare ``git fetch origin``
+        # honours the mirror's configured refspec and leaves the
+        # candidate tracking refs stale on narrow-refspec mirrors.
         fetch_calls = [c for c in call_log if "fetch" in c[0] and "origin" in c[0]]
-        assert len(fetch_calls) == 1, "reuse path must fetch origin before resetting"
-        fetch_env = fetch_calls[0][1].get("env") or {}
-        assert "git-askpass-" in fetch_env.get("GIT_ASKPASS", ""), (
-            "credential helper must be wired up when a token is available"
-        )
-        assert fetch_env.get("GIT_PASSWORD") == "fake-token"
-        assert fetch_env.get("GIT_USERNAME") == "x-access-token"
+        assert len(fetch_calls) == 2, "reuse path must fetch assigned + base before resetting"
+        fetched_refspecs = [c[0][-1] for c in fetch_calls]
+        assert fetched_refspecs == [
+            "+refs/heads/egg/issue-99:refs/remotes/origin/egg/issue-99",
+            "+refs/heads/main:refs/remotes/origin/main",
+        ]
+        for fetch_call in fetch_calls:
+            fetch_env = fetch_call[1].get("env") or {}
+            assert "git-askpass-" in fetch_env.get("GIT_ASKPASS", ""), (
+                "credential helper must be wired up when a token is available"
+            )
+            assert fetch_env.get("GIT_PASSWORD") == "fake-token"
+            assert fetch_env.get("GIT_USERNAME") == "x-access-token"
 
     def test_create_worktree_reapplies_upstream_on_reuse(self, git_repo):
         """When a valid worktree is reused, upstream config is re-applied.
@@ -1019,10 +1029,12 @@ class TestWorktreeManagerRemoteBranchFetch:
                             )
 
         assert info.container_id == "issue-1495-coder"
-        # Verify fetch was called for the base branch
+        # Verify fetch was called for the base branch — with an explicit
+        # tracking refspec so the remote-tracking ref moves even on
+        # narrow-refspec mirrors (#3068).
         fetch_calls = [c for c in call_log if "fetch" in c[0] and "origin" in c[0]]
         assert len(fetch_calls) == 1
-        assert "egg/issue-1495" in fetch_calls[0][0]
+        assert "+refs/heads/egg/issue-1495:refs/remotes/origin/egg/issue-1495" in fetch_calls[0][0]
         # The fetch must carry the gateway credential helper (#3021 Fix A):
         # the mirror's origin is HTTPS, so an unauthenticated fetch fails.
         fetch_env = fetch_calls[0][1].get("env") or {}
@@ -1083,10 +1095,11 @@ class TestWorktreeManagerRemoteBranchFetch:
                                 "test-repo", "my-container", base_branch="egg/my-branch"
                             )
 
-        # Fetch IS called even though the branch exists locally (freshness).
+        # Fetch IS called even though the branch exists locally (freshness),
+        # with an explicit tracking refspec (#3068).
         fetch_calls = [c for c in call_log if "fetch" in c[0] and "origin" in c[0]]
         assert len(fetch_calls) == 1
-        assert "egg/my-branch" in fetch_calls[0][0]
+        assert "+refs/heads/egg/my-branch:refs/remotes/origin/egg/my-branch" in fetch_calls[0][0]
         # worktree add must branch from the remote tip, not the stale local ref.
         wt_add_calls = [
             c for c in call_log if "worktree" in c[0] and "add" in c[0] and "-b" in c[0]
@@ -1138,8 +1151,8 @@ class TestWorktreeManagerRemoteBranchFetch:
 
         fetch_calls = [c for c in call_log if "fetch" in c[0] and "origin" in c[0]]
         assert len(fetch_calls) == 1
-        # The bare branch name is fetched, not "origin/main".
-        assert fetch_calls[0][0][-1] == "main"
+        # The bare branch name feeds the refspec, not "origin/main".
+        assert fetch_calls[0][0][-1] == "+refs/heads/main:refs/remotes/origin/main"
         wt_add_calls = [
             c for c in call_log if "worktree" in c[0] and "add" in c[0] and "-b" in c[0]
         ]
@@ -1343,6 +1356,154 @@ class TestWorktreeManagerRemoteBranchFetch:
         # Did NOT fall back to creating a worktree from the stale local ref.
         wt_add_calls = [c for c in call_log if "worktree" in c and "add" in c]
         assert len(wt_add_calls) == 0
+
+
+class TestNarrowRefspecMirror:
+    """Worktree creation/reuse against a mirror with a narrow fetch refspec.
+
+    Regression tests for #3068: mirrors of large monorepos are commonly
+    configured with a single-branch fetch refspec (e.g.
+    ``+refs/heads/main:refs/remotes/origin/main``).  A bare-name
+    ``git fetch origin <branch>`` then updates only ``FETCH_HEAD`` — it
+    never moves ``refs/remotes/origin/<branch>`` — so the subsequent
+    ``origin/<branch>`` resolution silently used a stale tracking ref and
+    worktrees were created (or reused-and-reset) behind the real remote
+    tip.  The explicit tracking refspec makes the fetch update the
+    tracking ref regardless of the mirror's configuration.
+    """
+
+    GIT_ENV = {
+        **__import__("os").environ,
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+
+    def _commit(self, repo: Path, filename: str, message: str) -> str:
+        """Write a file, commit it, return the commit sha."""
+        (repo / filename).write_text(f"{message}\n")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-m", message], cwd=repo, check=True, env=self.GIT_ENV)
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+        ).stdout.strip()
+
+    @pytest.fixture
+    def narrow_mirror(self, tmp_path):
+        """Bare origin + seed pusher + narrow-refspec mirror under repos_base.
+
+        Layout:
+        - ``origin.git``: bare remote with ``main`` and ``side-branch``
+          (both at their initial tips).
+        - ``seed``: working clone used to push new commits to origin.
+        - ``repos/test-repo``: full clone whose fetch refspec is then
+          narrowed to ``main`` only — its ``origin/side-branch`` tracking
+          ref is left stale on purpose once origin advances.
+        """
+        origin = tmp_path / "origin.git"
+        subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)], check=True)
+
+        seed = tmp_path / "seed"
+        seed.mkdir()
+        subprocess.run(["git", "init", "-b", "main"], cwd=seed, check=True)
+        subprocess.run(["git", "remote", "add", "origin", str(origin)], cwd=seed, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=seed, check=True)
+        subprocess.run(["git", "config", "user.name", "test"], cwd=seed, check=True)
+        self._commit(seed, "README.md", "init")
+        subprocess.run(["git", "push", "origin", "main"], cwd=seed, check=True)
+        subprocess.run(["git", "checkout", "-b", "side-branch"], cwd=seed, check=True)
+        stale_tip = self._commit(seed, "side.md", "side tip 1")
+        subprocess.run(["git", "push", "origin", "side-branch"], cwd=seed, check=True)
+
+        repos_base = tmp_path / "repos"
+        repos_base.mkdir()
+        repo_dir = repos_base / "test-repo"
+        # Full clone first (tracking refs for both branches at the current
+        # tips), then narrow the refspec to main only — mimicking a
+        # monorepo mirror that once knew the branch but no longer
+        # refreshes it on bare-name fetches.
+        subprocess.run(["git", "clone", str(origin), str(repo_dir)], check=True)
+        subprocess.run(
+            [
+                "git",
+                "config",
+                "remote.origin.fetch",
+                "+refs/heads/main:refs/remotes/origin/main",
+            ],
+            cwd=repo_dir,
+            check=True,
+        )
+
+        # Advance side-branch on origin; the mirror's tracking ref is now
+        # stale at ``stale_tip``.
+        fresh_tip = self._commit(seed, "side2.md", "side tip 2")
+        subprocess.run(["git", "push", "origin", "side-branch"], cwd=seed, check=True)
+
+        manager = WorktreeManager(worktree_base=tmp_path / "worktrees", repos_base=repos_base)
+        return manager, repo_dir, stale_tip, fresh_tip, seed
+
+    @patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", ""))
+    def test_fresh_create_uses_remote_tip_despite_narrow_refspec(
+        self, _mock_get_token, narrow_mirror
+    ):
+        """A fresh worktree must fork from origin's real tip, not the
+        mirror's stale tracking ref (#3068, observed on pipeline-1c8998c5 /
+        pipeline-a19a9e3c: gateway logged a successful fetch, agents still
+        forked from the stale base)."""
+        manager, repo_dir, stale_tip, fresh_tip, _seed = narrow_mirror
+
+        info = manager.create_worktree("test-repo", "narrow-c1", base_branch="side-branch")
+
+        head = subprocess.run(
+            ["git", "-C", str(info.worktree_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert head == fresh_tip, (
+            f"worktree should fork from the fresh remote tip {fresh_tip}; "
+            f"got {head} (stale tracking ref was {stale_tip})"
+        )
+
+    @patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", ""))
+    def test_reuse_resets_to_remote_tip_despite_narrow_refspec(
+        self, _mock_get_token, narrow_mirror
+    ):
+        """Worktree reuse must reset to the assigned branch's real remote
+        tip — the reuse-path bare ``git fetch origin`` honoured the narrow
+        refspec and left ``origin/<assigned>`` stale (#3068)."""
+        manager, repo_dir, stale_tip, fresh_tip, seed = narrow_mirror
+
+        # First creation binds the worktree to the (stale) assigned tip.
+        info1 = manager.create_worktree(
+            "test-repo",
+            "narrow-reuse-c1",
+            base_branch="main",
+            assigned_branch="side-branch",
+        )
+
+        # Reuse: same container_id.  The reset candidates prefer
+        # ``origin/side-branch``, which the targeted refspec fetch must
+        # refresh to the real remote tip first.
+        info2 = manager.create_worktree(
+            "test-repo",
+            "narrow-reuse-c1",
+            base_branch="main",
+            assigned_branch="side-branch",
+        )
+        assert info2.worktree_path == info1.worktree_path
+
+        head = subprocess.run(
+            ["git", "-C", str(info2.worktree_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert head == fresh_tip, (
+            f"reuse should reset HEAD to the fresh remote tip {fresh_tip}; "
+            f"got {head} (stale tracking ref was {stale_tip})"
+        )
 
 
 class TestFindWorktreeGitDir:

--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -1,5 +1,6 @@
 """Tests for worktree_manager.py."""
 
+import os
 import shutil
 import subprocess
 import sys
@@ -482,7 +483,7 @@ class TestWorktreeManagerDockerGitDir:
             capture_output=True,
             check=True,
             env={
-                **__import__("os").environ,
+                **os.environ,
                 "GIT_AUTHOR_NAME": "test",
                 "GIT_AUTHOR_EMAIL": "t@t",
                 "GIT_COMMITTER_NAME": "test",
@@ -675,7 +676,7 @@ class TestWorktreeManagerDockerGitDir:
         import subprocess as sp
 
         env = {
-            **__import__("os").environ,
+            **os.environ,
             "GIT_AUTHOR_NAME": "test",
             "GIT_AUTHOR_EMAIL": "t@t",
             "GIT_COMMITTER_NAME": "test",
@@ -889,7 +890,7 @@ class TestLookupWorktree:
             capture_output=True,
             check=True,
             env={
-                **__import__("os").environ,
+                **os.environ,
                 "GIT_AUTHOR_NAME": "test",
                 "GIT_AUTHOR_EMAIL": "t@t",
                 "GIT_COMMITTER_NAME": "test",
@@ -1373,7 +1374,7 @@ class TestNarrowRefspecMirror:
     """
 
     GIT_ENV = {
-        **__import__("os").environ,
+        **os.environ,
         "GIT_AUTHOR_NAME": "test",
         "GIT_AUTHOR_EMAIL": "t@t",
         "GIT_COMMITTER_NAME": "test",
@@ -1472,7 +1473,15 @@ class TestNarrowRefspecMirror:
     ):
         """Worktree reuse must reset to the assigned branch's real remote
         tip — the reuse-path bare ``git fetch origin`` honoured the narrow
-        refspec and left ``origin/<assigned>`` stale (#3068)."""
+        refspec and left ``origin/<assigned>`` stale (#3068).
+
+        Exercises the *primary* candidate (``origin/{assigned_branch}``):
+        ``side-branch`` exists on origin so the primary resolves and the
+        secondary (``origin/{base_branch}``) is never walked here.  The
+        sibling ``test_reuse_secondary_candidate_handles_origin_prefixed_base``
+        covers the secondary candidate path with the production-shape
+        ``base_branch="origin/main"``.
+        """
         manager, repo_dir, stale_tip, fresh_tip, seed = narrow_mirror
 
         # First creation binds the worktree to the (stale) assigned tip.
@@ -1503,6 +1512,76 @@ class TestNarrowRefspecMirror:
         assert head == fresh_tip, (
             f"reuse should reset HEAD to the fresh remote tip {fresh_tip}; "
             f"got {head} (stale tracking ref was {stale_tip})"
+        )
+
+    @patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", ""))
+    def test_reuse_secondary_candidate_handles_origin_prefixed_base(
+        self, _mock_get_token, narrow_mirror
+    ):
+        """Reuse must reset to ``origin/main`` when ``base_branch`` arrives
+        ``origin/``-prefixed (the production shape — ``gateway.py`` sets
+        ``worktree_base_branch = f"origin/{...}"`` and
+        ``resolve_default_branch`` returns ``"origin/main"``).
+
+        Exercises the *secondary* candidate path: the assigned branch is
+        absent from origin (fresh pipeline, first agent — nothing pushed
+        yet), so the primary ``origin/{assigned_branch}`` candidate fails
+        to resolve and the reset must fall through to
+        ``origin/{base_branch}``.  Without the candidate-side ``origin/``
+        strip, the candidate is built as ``origin/origin/main``, fails to
+        resolve, and the function silently no-ops to ``preserving HEAD``
+        — even though the fetch loop above did refresh ``origin/main``
+        with the targeted refspec.  This is the inconsistency the
+        candidate construction needs to mirror (#3068).
+        """
+        manager, repo_dir, _stale_tip, _fresh_tip, seed = narrow_mirror
+
+        # First creation: assigned branch is never on origin (mimics the
+        # first-agent spawn for a brand-new pipeline before any push).
+        # The worktree forks from origin's current ``main`` tip.
+        info1 = manager.create_worktree(
+            "test-repo",
+            "narrow-prod-c1",
+            base_branch="origin/main",
+            assigned_branch="egg/never-pushed/work",
+        )
+        initial_main_tip = subprocess.run(
+            ["git", "-C", str(info1.worktree_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        # Advance ``main`` on origin so the mirror's ``origin/main``
+        # tracking ref is stale until the next refspec fetch refreshes it.
+        subprocess.run(["git", "checkout", "main"], cwd=seed, check=True)
+        fresh_main_tip = self._commit(seed, "main2.md", "main tip 2")
+        subprocess.run(["git", "push", "origin", "main"], cwd=seed, check=True)
+        assert fresh_main_tip != initial_main_tip
+
+        # Reuse: same container_id.  ``origin/egg/never-pushed/work``
+        # still does not resolve, so the reset walks the secondary
+        # ``origin/{base}`` candidate.
+        info2 = manager.create_worktree(
+            "test-repo",
+            "narrow-prod-c1",
+            base_branch="origin/main",
+            assigned_branch="egg/never-pushed/work",
+        )
+        assert info2.worktree_path == info1.worktree_path
+
+        head = subprocess.run(
+            ["git", "-C", str(info2.worktree_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert head == fresh_main_tip, (
+            f"reuse should reset HEAD via the ``origin/main`` secondary "
+            f"candidate to {fresh_main_tip}; got {head} (initial tip was "
+            f"{initial_main_tip}). If HEAD matches the initial tip, the "
+            f"candidate was built as ``origin/origin/main`` and the reset "
+            f"fell through to the no-op ``preserving HEAD`` branch."
         )
 
 
@@ -1697,7 +1776,7 @@ class TestWorktreeManagerConcurrency:
             capture_output=True,
             check=True,
             env={
-                **__import__("os").environ,
+                **os.environ,
                 "GIT_AUTHOR_NAME": "test",
                 "GIT_AUTHOR_EMAIL": "t@t",
                 "GIT_COMMITTER_NAME": "test",
@@ -2047,7 +2126,7 @@ class TestResolveDefaultBranch:
         if result.returncode != 0:
             pytest.skip(f"git init not available: {result.stderr.strip()}")
         git_env = {
-            **__import__("os").environ,
+            **os.environ,
             "GIT_AUTHOR_NAME": "test",
             "GIT_AUTHOR_EMAIL": "t@t",
             "GIT_COMMITTER_NAME": "test",

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -825,7 +825,8 @@ class WorktreeManager:
         # caller holds it across this whole method) so the timeout
         # caps how long every other state-store commit / worktree
         # create on this repo can be blocked by a slow remote — keep
-        # it tight.
+        # it tight.  Two candidate branches max (assigned + base) at
+        # 15s each preserves the prior ~30s cumulative ceiling.
         #
         # Each candidate branch is fetched with an explicit tracking
         # refspec, one fetch per branch.  The previous bare ``git fetch
@@ -837,9 +838,18 @@ class WorktreeManager:
         # pipeline, first agent — nothing pushed yet) from failing the
         # base-branch fetch, and are cheaper than a full all-refs fetch
         # on large mirrors.
+        #
+        # ``base_branch`` may arrive ``origin/``-prefixed in pipeline
+        # mode (``gateway.py`` sets ``worktree_base_branch =
+        # f"origin/{...}"`` and ``resolve_default_branch`` returns
+        # ``"origin/main"``).  Strip the prefix so the fetch refspec and
+        # the candidate-ref lookup below agree on the bare name —
+        # otherwise the secondary candidate is built as
+        # ``origin/origin/main`` and fails to resolve.
         fetch_branches: list[str] = []
         if assigned_branch:
             fetch_branches.append(assigned_branch)
+        base_name: str | None = None
         if base_branch and base_branch != "HEAD":
             base_name = base_branch.removeprefix("origin/")
             if base_name not in fetch_branches:
@@ -853,7 +863,7 @@ class WorktreeManager:
                         capture_output=True,
                         text=True,
                         check=False,
-                        timeout=30,
+                        timeout=15,
                         env=fetch_env,
                     )
         except (subprocess.TimeoutExpired, OSError) as exc:
@@ -868,8 +878,8 @@ class WorktreeManager:
         candidates: list[str] = []
         if assigned_branch:
             candidates.append(f"origin/{assigned_branch}")
-        if base_branch and base_branch != "HEAD":
-            candidates.append(f"origin/{base_branch}")
+        if base_name is not None:
+            candidates.append(f"origin/{base_name}")
         for candidate in candidates:
             verify = subprocess.run(
                 git_cmd("rev-parse", "--verify", candidate),

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -149,6 +149,28 @@ def validate_branch_ref(value: str, name: str = "base_branch") -> None:
         raise ValueError(f"Invalid {name}: must be alphanumeric with ._-/ allowed")
 
 
+def _tracking_refspec(branch: str) -> str:
+    """Forced fetch refspec that pins ``refs/remotes/origin/<branch>``.
+
+    ``git fetch origin <branch>`` only updates the remote-tracking ref
+    opportunistically when the repo's *configured* fetch refspec covers
+    that branch.  Mirrors of large monorepos are commonly configured with
+    a narrow single-branch refspec (e.g.
+    ``+refs/heads/master:refs/remotes/origin/master``), under which a
+    bare-name fetch writes only ``FETCH_HEAD`` — the subsequent
+    ``origin/<branch>`` lookup then silently resolves a stale (or
+    missing) tracking ref and the worktree is created behind the real
+    remote tip (#3068).  Fetching with an explicit refspec updates the
+    tracking ref regardless of the repo's configuration.  The leading
+    ``+`` permits non-fast-forward tracking-ref moves (rebased or
+    force-pushed base branches).
+
+    ``branch`` must be a bare branch name (no ``origin/`` prefix);
+    callers strip the prefix before building the refspec.
+    """
+    return f"+refs/heads/{branch}:refs/remotes/origin/{branch}"
+
+
 class WorktreeManager:
     """
     Manages git worktrees for container isolation.
@@ -474,10 +496,15 @@ class WorktreeManager:
                     # (post-#3021) rather than just cold-cache misses, so keep
                     # it tight.  Mirrors the reuse-path fetch in
                     # ``_reset_reused_worktree_to_safe_ref``.
+                    #
+                    # The explicit refspec (rather than the bare branch name)
+                    # is what makes the ``origin/<fetch_ref>`` resolution
+                    # below see the fresh tip on narrow-refspec mirrors —
+                    # see ``_tracking_refspec`` (#3068).
                     with self._git_credential_env(repo_slug) as fetch_env:
                         try:
                             fetch_result = subprocess.run(
-                                git_cmd("fetch", "origin", fetch_ref),
+                                git_cmd("fetch", "origin", _tracking_refspec(fetch_ref)),
                                 cwd=main_repo,
                                 capture_output=True,
                                 text=True,
@@ -799,17 +826,36 @@ class WorktreeManager:
         # caps how long every other state-store commit / worktree
         # create on this repo can be blocked by a slow remote — keep
         # it tight.
+        #
+        # Each candidate branch is fetched with an explicit tracking
+        # refspec, one fetch per branch.  The previous bare ``git fetch
+        # origin`` honoured the repo's configured refspec — on
+        # narrow-refspec mirrors that refreshes only the configured
+        # branch, so the ``origin/{assigned}`` / ``origin/{base}``
+        # candidates below resolved stale tracking refs (#3068).
+        # Per-branch fetches also keep an absent assigned branch (fresh
+        # pipeline, first agent — nothing pushed yet) from failing the
+        # base-branch fetch, and are cheaper than a full all-refs fetch
+        # on large mirrors.
+        fetch_branches: list[str] = []
+        if assigned_branch:
+            fetch_branches.append(assigned_branch)
+        if base_branch and base_branch != "HEAD":
+            base_name = base_branch.removeprefix("origin/")
+            if base_name not in fetch_branches:
+                fetch_branches.append(base_name)
         try:
             with self._git_credential_env(repo_slug, best_effort=True) as fetch_env:
-                subprocess.run(
-                    git_cmd("fetch", "origin"),
-                    cwd=worktree_path,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                    timeout=30,
-                    env=fetch_env,
-                )
+                for fetch_branch in fetch_branches:
+                    subprocess.run(
+                        git_cmd("fetch", "origin", _tracking_refspec(fetch_branch)),
+                        cwd=worktree_path,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                        timeout=30,
+                        env=fetch_env,
+                    )
         except (subprocess.TimeoutExpired, OSError) as exc:
             logger.warning(
                 "Fetch before worktree-reuse reset failed (continuing)",


### PR DESCRIPTION
## Summary

Fixes the second root cause on #3068 (the narrow-refspec fetch gap, affecting the #3021 fetch fix generally).

`git fetch origin <branch>` only updates `refs/remotes/origin/<branch>` opportunistically when the mirror's *configured* fetch refspec covers that branch. Mirrors of large monorepos (our mirror of a large external monorepo) use a narrow single-branch refspec (`+refs/heads/master:refs/remotes/origin/master`), so the fetch wrote only `FETCH_HEAD` — `create_worktree` then resolved a **stale** tracking ref and created agent worktrees behind the real remote tip, even though the gateway logged a successful fetch (observed on pipeline-1c8998c5 and pipeline-a19a9e3c).

## Changes

- **Create path** (`create_worktree`): fetch with an explicit forced tracking refspec `+refs/heads/<b>:refs/remotes/origin/<b>` instead of the bare branch name. The `origin/<b>` resolution below now sees the fresh tip regardless of mirror refspec config. Chosen over the FETCH_HEAD alternative because the explicit refspec repairs the tracking ref that *all* downstream consumers read (reuse-reset candidates, rev-parse verifies), not just this one call site.
- **Reuse path** (`_reset_reused_worktree_to_safe_ref`): the bare `git fetch origin` had the same hole in worse form — under a narrow refspec it refreshes only the configured branch, leaving the `origin/{assigned}` / `origin/{base}` reset candidates stale. Replaced with one targeted refspec fetch per candidate branch (still best-effort). Per-branch fetches also keep an absent assigned branch (fresh pipeline, first agent) from failing the base fetch, and are cheaper than an all-refs fetch on large mirrors.
- **Tests**: real-git narrow-refspec mirror fixture exercising both paths end-to-end; both regression tests verified to fail against the pre-fix code. Updated existing fetch-shape assertions to the refspec form.

## Test plan

- Automated: `gateway/tests/test_worktree_manager.py` (111 pass; 2 new regression tests verified red pre-fix), plus `test_assigned_branch.py` / `test_worktree_isolation.py` / `test_phase_worktree.py` / `test_worktree_prune_route.py` (190 total).
- Manual: on a narrow-refspec mirror, push a new tip to a non-configured branch and confirm `create_worktree` forks from it (pre-fix it forks from the stale tracking ref).

## Notes

- Stacked PR follows: fork fresh worktrees from `origin/{assigned_branch}` (the work-branch tip) so contract-init artifacts reach agent worktrees — the first root cause on #3068. It depends on this refspec fix to fetch the assigned branch reliably.
- The same `fetch origin <branch>` → read `origin/<branch>` pattern exists at other sites (`gateway_client.py:1400,1440`, `git_client.py:1445,1518,1794`, `pipelines.py:5484,8362`); audit tracked separately.

Refs #3068
