### PR TITLE
fix(gateway): fork fresh worktrees from the assigned branch tip so seeded artifacts reach agents

### DIFF
--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -1640,6 +1640,40 @@ class TestAssignedBranchForkPoint:
 
         assert result is None
 
+    def test_assigned_rev_parse_failure_falls_back_to_base(self, tmp_path):
+        """If the fetch succeeds but ``rev-parse --verify origin/<branch>``
+        fails (the tracking ref is somehow not resolvable post-fetch — a
+        theoretical narrow-refspec edge case), the helper returns None and
+        the caller falls back to the base branch rather than handing git a
+        bad fork point."""
+        manager = WorktreeManager(
+            worktree_base=tmp_path / "worktrees",
+            repos_base=tmp_path / "repos",
+        )
+
+        def mock_run(args, **kwargs):
+            if "fetch" in args:
+                return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+            if "rev-parse" in args:
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=128,
+                    stdout="",
+                    stderr="fatal: Needed a single revision\n",
+                )
+            raise AssertionError(f"unexpected subprocess call: {args}")
+
+        with patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", "")):
+            with patch("subprocess.run", side_effect=mock_run):
+                result = manager._resolve_assigned_fork_point(
+                    main_repo=tmp_path / "repos" / "test-repo",
+                    assigned_branch="egg/pipe-4/work",
+                    repo_slug="Khan/test-repo",
+                    container_id="pipe-4-coder",
+                )
+
+        assert result is None
+
 
 class TestFindWorktreeGitDir:
     """Tests for _find_worktree_git_dir admin dir resolution."""

--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -1506,6 +1506,141 @@ class TestNarrowRefspecMirror:
         )
 
 
+class TestAssignedBranchForkPoint:
+    """Fresh worktrees fork from the assigned branch's remote tip (#3068).
+
+    The orchestrator's contract-init commit (SDLC contract + seeded
+    analysis/plan drafts) lands on the assigned branch and is pushed
+    before agents spawn.  Forking fresh worktrees from the base branch
+    left agents one-plus commits behind that tip, so seeded artifacts
+    never reached agent worktrees.  Fresh creation now mirrors the reuse
+    path's candidate order: ``origin/{assigned}`` first, base as
+    fallback.
+    """
+
+    GIT_ENV = TestNarrowRefspecMirror.GIT_ENV
+
+    def _commit(self, repo: Path, filename: str, message: str) -> str:
+        (repo / filename).parent.mkdir(parents=True, exist_ok=True)
+        (repo / filename).write_text(f"{message}\n")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-m", message], cwd=repo, check=True, env=self.GIT_ENV)
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+        ).stdout.strip()
+
+    @pytest.fixture
+    def pipeline_remote(self, tmp_path):
+        """Bare origin (main) + seed pusher + mirror clone under repos_base."""
+        origin = tmp_path / "origin.git"
+        subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)], check=True)
+
+        seed = tmp_path / "seed"
+        seed.mkdir()
+        subprocess.run(["git", "init", "-b", "main"], cwd=seed, check=True)
+        subprocess.run(["git", "remote", "add", "origin", str(origin)], cwd=seed, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=seed, check=True)
+        subprocess.run(["git", "config", "user.name", "test"], cwd=seed, check=True)
+        main_tip = self._commit(seed, "README.md", "init")
+        subprocess.run(["git", "push", "origin", "main"], cwd=seed, check=True)
+
+        repos_base = tmp_path / "repos"
+        repos_base.mkdir()
+        repo_dir = repos_base / "test-repo"
+        subprocess.run(["git", "clone", str(origin), str(repo_dir)], check=True)
+
+        manager = WorktreeManager(worktree_base=tmp_path / "worktrees", repos_base=repos_base)
+        return manager, seed, main_tip
+
+    @patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", ""))
+    def test_fresh_worktree_forks_from_assigned_tip(self, _mock_get_token, pipeline_remote):
+        """When ``origin/{assigned}`` exists (contract-init pushed), a fresh
+        worktree forks from its tip and the seeded artifact is present —
+        even when the tip moved after the mirror's last fetch."""
+        manager, seed, _main_tip = pipeline_remote
+
+        # Simulate the orchestrator: contract-init commit on the pipeline
+        # work branch, pushed to origin AFTER the mirror's clone-time fetch.
+        subprocess.run(["git", "checkout", "-b", "egg/pipe-1/work"], cwd=seed, check=True)
+        assigned_tip = self._commit(
+            seed, ".egg-state/drafts/pipe-1-analysis.md", "Initialize SDLC contract"
+        )
+        subprocess.run(["git", "push", "origin", "egg/pipe-1/work"], cwd=seed, check=True)
+
+        info = manager.create_worktree(
+            "test-repo",
+            "pipe-1-architect",
+            base_branch="main",
+            assigned_branch="egg/pipe-1/work",
+        )
+
+        head = subprocess.run(
+            ["git", "-C", str(info.worktree_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert head == assigned_tip, (
+            f"fresh worktree should fork from the assigned tip {assigned_tip}; got {head}"
+        )
+        # The seeded artifact is what the fork point is for — assert it
+        # materialised in the agent's checkout.
+        assert (info.worktree_path / ".egg-state" / "drafts" / "pipe-1-analysis.md").exists()
+        # The per-worktree local branch is unchanged by the fork point.
+        assert info.branch == "egg/pipe-1-architect/work"
+
+    @patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", ""))
+    def test_fresh_worktree_falls_back_to_base_when_assigned_unpushed(
+        self, _mock_get_token, pipeline_remote
+    ):
+        """An assigned branch with nothing pushed yet (fresh pipeline /
+        slice integration branch) must not block creation — fall back to
+        the base branch, the pre-#3068 behaviour."""
+        manager, _seed, main_tip = pipeline_remote
+
+        info = manager.create_worktree(
+            "test-repo",
+            "pipe-2-coder",
+            base_branch="main",
+            assigned_branch="egg/pipe-2/work",
+        )
+
+        head = subprocess.run(
+            ["git", "-C", str(info.worktree_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert head == main_tip, (
+            f"unpushed assigned branch should fall back to base tip {main_tip}; got {head}"
+        )
+
+    def test_assigned_fetch_timeout_falls_back_to_base(self, tmp_path):
+        """A timeout on the assigned-branch fetch is best-effort: the
+        helper returns None (caller falls back to base) instead of raising
+        — unlike the base-branch fetch, which hard-fails per #3021."""
+        manager = WorktreeManager(
+            worktree_base=tmp_path / "worktrees",
+            repos_base=tmp_path / "repos",
+        )
+
+        def mock_run(args, **kwargs):
+            if "fetch" in args:
+                raise subprocess.TimeoutExpired(cmd=args, timeout=30)
+            raise AssertionError(f"unexpected subprocess call: {args}")
+
+        with patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", "")):
+            with patch("subprocess.run", side_effect=mock_run):
+                result = manager._resolve_assigned_fork_point(
+                    main_repo=tmp_path / "repos" / "test-repo",
+                    assigned_branch="egg/pipe-3/work",
+                    repo_slug="Khan/test-repo",
+                    container_id="pipe-3-coder",
+                )
+
+        assert result is None
+
+
 class TestFindWorktreeGitDir:
     """Tests for _find_worktree_git_dir admin dir resolution."""
 

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -992,9 +992,7 @@ class WorktreeManager:
         # the prefix on both so the fetch refspec and the candidate-ref
         # lookup below agree on the bare name — otherwise the secondary
         # candidate is built as ``origin/origin/main`` and fails to resolve.
-        assigned_name = (
-            assigned_branch.removeprefix("origin/") if assigned_branch else None
-        )
+        assigned_name = assigned_branch.removeprefix("origin/") if assigned_branch else None
         fetch_branches: list[str] = []
         if assigned_name:
             fetch_branches.append(assigned_name)

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -849,10 +849,18 @@ class WorktreeManager:
             ``origin/{assigned_branch}`` when the branch exists on origin
             (tracking ref freshly fetched), else ``None``.
         """
+        # ``_tracking_refspec`` requires a bare branch name; mirror the
+        # base-branch path's defensive strip in case a future caller drifts
+        # to passing ``origin/<name>`` (today's callers pass bare names).
+        fetch_ref = (
+            assigned_branch[len("origin/") :]
+            if assigned_branch.startswith("origin/")
+            else assigned_branch
+        )
         try:
             with self._git_credential_env(repo_slug, best_effort=True) as fetch_env:
                 fetch_result = subprocess.run(
-                    git_cmd("fetch", "origin", _tracking_refspec(assigned_branch)),
+                    git_cmd("fetch", "origin", _tracking_refspec(fetch_ref)),
                     cwd=main_repo,
                     capture_output=True,
                     text=True,
@@ -860,7 +868,12 @@ class WorktreeManager:
                     timeout=30,
                     env=fetch_env,
                 )
-        except (subprocess.TimeoutExpired, OSError) as exc:
+        except Exception as exc:
+            # Best-effort: any failure (timeout, OSError, credential-helper
+            # error from _git_credential_env, etc.) falls back to the base
+            # branch.  A narrower catch would surface unexpected exception
+            # types as a hard spawn failure, which is the opposite of the
+            # "best-effort fallback" contract this helper advertises.
             logger.warning(
                 "Assigned-branch fetch before worktree create failed (falling back to base)",
                 container_id=container_id,
@@ -869,15 +882,28 @@ class WorktreeManager:
             )
             return None
         if fetch_result.returncode != 0:
-            logger.info(
-                "Assigned branch not on origin yet — forking worktree from base",
-                container_id=container_id,
-                assigned_branch=assigned_branch,
-                stderr=fetch_result.stderr.strip()[:200],
-            )
+            # git fetch on a missing branch emits "couldn't find remote ref"
+            # — that's the expected "not pushed yet" case and not an error.
+            # Anything else (transient 5xx, auth, network) is worth flagging
+            # at a higher level so an operator triaging "why didn't my seed
+            # reach the agent?" sees the real cause.
+            stderr = fetch_result.stderr.strip()
+            if "couldn't find remote ref" in stderr:
+                logger.info(
+                    "Assigned branch not on origin yet — forking worktree from base",
+                    container_id=container_id,
+                    assigned_branch=assigned_branch,
+                )
+            else:
+                logger.warning(
+                    "Assigned-branch fetch failed (falling back to base)",
+                    container_id=container_id,
+                    assigned_branch=assigned_branch,
+                    stderr=stderr[:200],
+                )
             return None
 
-        candidate = f"origin/{assigned_branch}"
+        candidate = f"origin/{fetch_ref}"
         verify = subprocess.run(
             git_cmd("rev-parse", "--verify", candidate),
             cwd=main_repo,

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -294,7 +294,12 @@ class WorktreeManager:
                 the sandbox's push client builds a refspec that targets the
                 assigned branch instead of the per-worktree local branch
                 (which the gateway would reject as push_denied_wrong_branch).
-                See #1809.
+                See #1809.  Also the preferred fork point for *fresh*
+                worktrees: when ``origin/{assigned_branch}`` exists, the
+                worktree forks from its tip (which carries the
+                orchestrator's contract-init commit and any seeded
+                drafts) rather than from ``base_branch`` — see #3068 and
+                :meth:`_resolve_assigned_fork_point`.
             repo_slug: Full ``owner/repo`` slug used to resolve the GitHub
                 token for the authenticated base-branch fetch (#3021).
                 Defaults to ``repo_name`` when omitted, which makes token
@@ -522,6 +527,28 @@ class WorktreeManager:
                             f"{fetch_result.stderr.strip()}"
                         )
                     effective_base = f"origin/{fetch_ref}"
+
+                # Prefer the assigned branch's remote tip over the base
+                # branch when it exists (#3068).  The orchestrator's
+                # contract-init commit (SDLC contract + any seeded
+                # analysis/plan drafts) lands on the assigned branch and is
+                # pushed before agents spawn; forking from the base left
+                # every fresh agent worktree behind that commit, so seeded
+                # artifacts never reached agents.  Mirrors the reuse path's
+                # candidate order (``origin/{assigned}`` -> ``origin/{base}``
+                # in ``_reset_reused_worktree_to_safe_ref``).  Best-effort:
+                # an assigned branch with nothing pushed yet falls back to
+                # the base branch (the prior behaviour); the base fetch
+                # above keeps its #3021 hard-fail semantics either way.
+                if assigned_branch:
+                    assigned_fork_point = self._resolve_assigned_fork_point(
+                        main_repo=main_repo,
+                        assigned_branch=assigned_branch,
+                        repo_slug=repo_slug,
+                        container_id=container_id,
+                    )
+                    if assigned_fork_point:
+                        effective_base = assigned_fork_point
 
                 # Create new branch from the freshly fetched remote tip
                 result = self._run_git_worktree_add(
@@ -785,6 +812,87 @@ class WorktreeManager:
             yield env
         finally:
             cleanup_credential_helper(cred_path)
+
+    def _resolve_assigned_fork_point(
+        self,
+        main_repo: Path,
+        assigned_branch: str,
+        repo_slug: str,
+        container_id: str,
+    ) -> str | None:
+        """Resolve ``origin/{assigned_branch}`` as the fork point, if pushed.
+
+        Fresh worktrees historically forked from ``origin/{base_branch}``
+        only — but the orchestrator commits pipeline state (the SDLC
+        contract plus any seeded analysis/plan drafts) to the assigned
+        branch and pushes it *before* agents spawn (the contract-init push
+        is mandatory; see "Worktree State Synchronization" in
+        ``docs/guides/sdlc-pipeline.md``).  Forking from the base left
+        every fresh agent worktree behind that commit, so seeded artifacts
+        never reached agent worktrees (#3068).
+
+        This mirrors the reuse path's candidate order in
+        :meth:`_reset_reused_worktree_to_safe_ref` (``origin/{assigned}``
+        first, ``origin/{base}`` as fallback) — and the same safety
+        argument carries over: the orchestrator's create-pipeline
+        stale-branch check (#2222 Phase 3a) refuses re-submits where
+        ``origin/{assigned}`` carries prior-pipeline commits.
+
+        Best-effort by design: a spawn can legitimately precede any push
+        of the assigned branch (e.g. a slice integration branch that the
+        first push creates), in which case the fetch finds nothing, this
+        returns ``None``, and the caller falls back to the base branch —
+        the pre-#3068 behaviour.  Contrast the base-branch fetch, which
+        hard-fails per #3021 because the base must exist on origin.
+
+        Returns:
+            ``origin/{assigned_branch}`` when the branch exists on origin
+            (tracking ref freshly fetched), else ``None``.
+        """
+        try:
+            with self._git_credential_env(repo_slug, best_effort=True) as fetch_env:
+                fetch_result = subprocess.run(
+                    git_cmd("fetch", "origin", _tracking_refspec(assigned_branch)),
+                    cwd=main_repo,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=30,
+                    env=fetch_env,
+                )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            logger.warning(
+                "Assigned-branch fetch before worktree create failed (falling back to base)",
+                container_id=container_id,
+                assigned_branch=assigned_branch,
+                error=str(exc),
+            )
+            return None
+        if fetch_result.returncode != 0:
+            logger.info(
+                "Assigned branch not on origin yet — forking worktree from base",
+                container_id=container_id,
+                assigned_branch=assigned_branch,
+                stderr=fetch_result.stderr.strip()[:200],
+            )
+            return None
+
+        candidate = f"origin/{assigned_branch}"
+        verify = subprocess.run(
+            git_cmd("rev-parse", "--verify", candidate),
+            cwd=main_repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if verify.returncode != 0:
+            return None
+        logger.info(
+            "Forking worktree from assigned branch tip",
+            container_id=container_id,
+            assigned_branch=assigned_branch,
+        )
+        return candidate
 
     def _reset_reused_worktree_to_safe_ref(
         self,

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -846,8 +846,9 @@ class WorktreeManager:
         hard-fails per #3021 because the base must exist on origin.
 
         Returns:
-            ``origin/{assigned_branch}`` when the branch exists on origin
-            (tracking ref freshly fetched), else ``None``.
+            ``origin/{fetch_ref}`` (the input with any ``origin/`` prefix
+            stripped) when the branch exists on origin (tracking ref
+            freshly fetched), else ``None``.
         """
         # ``_tracking_refspec`` requires a bare branch name; mirror the
         # base-branch path's defensive strip in case a future caller drifts
@@ -859,6 +860,14 @@ class WorktreeManager:
         )
         try:
             with self._git_credential_env(repo_slug, best_effort=True) as fetch_env:
+                # Force C locale so the "couldn't find remote ref" stderr
+                # heuristic below isn't translated by gettext under e.g.
+                # ``LANG=de_DE.UTF-8``.  Without this, a translated error
+                # would misclassify the "branch not pushed yet" case as a
+                # transient failure (the WARNING branch).  Fallback
+                # behaviour is correct either way; only log level/message
+                # changes.
+                fetch_env = {**fetch_env, "LC_ALL": "C"}
                 fetch_result = subprocess.run(
                     git_cmd("fetch", "origin", _tracking_refspec(fetch_ref)),
                     cwd=main_repo,
@@ -971,9 +980,16 @@ class WorktreeManager:
         # pipeline, first agent — nothing pushed yet) from failing the
         # base-branch fetch, and are cheaper than a full all-refs fetch
         # on large mirrors.
+        # ``_tracking_refspec`` requires a bare branch name; mirror the
+        # base-branch and create-path defensive strips for drift-resistance
+        # against future callers passing ``origin/<name>`` (today's callers
+        # pass bare names).
+        assigned_name = (
+            assigned_branch.removeprefix("origin/") if assigned_branch else None
+        )
         fetch_branches: list[str] = []
-        if assigned_branch:
-            fetch_branches.append(assigned_branch)
+        if assigned_name:
+            fetch_branches.append(assigned_name)
         if base_branch and base_branch != "HEAD":
             base_name = base_branch.removeprefix("origin/")
             if base_name not in fetch_branches:
@@ -990,7 +1006,14 @@ class WorktreeManager:
                         timeout=30,
                         env=fetch_env,
                     )
-        except (subprocess.TimeoutExpired, OSError) as exc:
+        except Exception as exc:
+            # Best-effort: any failure (timeout, OSError, credential-helper
+            # error from ``_git_credential_env``, etc.) is logged and we
+            # still attempt the reset against whatever local state we have.
+            # A narrower catch would surface unexpected exception types as
+            # a hard worktree-reuse failure, contradicting this helper's
+            # best-effort contract — mirrors the create-path's catch in
+            # ``_resolve_assigned_fork_point``.
             logger.warning(
                 "Fetch before worktree-reuse reset failed (continuing)",
                 container_id=container_id,
@@ -1000,8 +1023,8 @@ class WorktreeManager:
 
         target_ref: str | None = None
         candidates: list[str] = []
-        if assigned_branch:
-            candidates.append(f"origin/{assigned_branch}")
+        if assigned_name:
+            candidates.append(f"origin/{assigned_name}")
         if base_branch and base_branch != "HEAD":
             candidates.append(f"origin/{base_branch}")
         for candidate in candidates:


### PR DESCRIPTION
## Summary

Fixes the primary root cause on #3068 (stacked on #3072 — the explicit-refspec fetch fix, which this depends on to fetch the assigned branch reliably on narrow-refspec mirrors).

Fresh per-agent worktrees forked from `origin/{base_branch}` only. But the orchestrator's contract-init commit — the SDLC contract plus any artifacts seeded via `submit_task`'s `analysis`/`plan` params — lands on the assigned branch `egg/<pipeline>/work` and is **pushed before agents spawn** (the contract-init push is mandatory, per "Worktree State Synchronization" in docs/guides/sdlc-pipeline.md). Every fresh agent worktree therefore started one-plus commits behind the work-branch tip, and seeded artifacts never reached agent worktrees. On pipeline-c2faf164 (`start_phase=plan` + 381-line seeded analysis) the task_planner correctly refused to plan against an analysis it couldn't see, and the plan phase wedged.

This is not specific to `start_phase=plan`: in the normal refine→plan flow, plan-phase agents' fresh worktrees also lack the refine analysis draft ("Review any prior analysis" finds nothing). The seeded case just made the silent gap loud.

## Changes

- New `_resolve_assigned_fork_point()`: best-effort explicit-refspec fetch of the assigned branch + `rev-parse --verify`; returns `origin/{assigned}` when it exists, else `None`.
- `create_worktree` prefers that fork point for fresh worktrees, mirroring the **reuse path's existing candidate order** (`_reset_reused_worktree_to_safe_ref`: `origin/{assigned}` → `origin/{base}`). Fresh creation forking from base was inconsistent with the gateway's own reuse semantics.
- Fallback preserves status quo: an unpushed assigned branch (fresh pipeline first spawn, slice integration branch) falls back to the base branch. The base-branch fetch keeps its #3021 hard-fail semantics.
- Safety: the #2222 Phase 3a stale-branch check already refuses re-submits where `origin/{assigned}` carries prior-pipeline commits — the same argument the reuse-path reset has relied on.

## Test plan

- Automated: new `TestAssignedBranchForkPoint` (real-git: forks at assigned tip with the seeded `.egg-state/drafts/` file materialised; falls back when assigned is unpushed; fetch timeout is best-effort). Fork-at-tip and timeout tests verified red against pre-fix code. Full `gateway/tests`: 3274 pass; the 3 `test_phase_api.py::TestPathTraversalProtection` failures pre-exist on origin/main (verified) and are unrelated.
- Manual: `submit_task(start_phase=plan, analysis=...)` against a pipeline repo; confirm agent worktrees contain `.egg-state/drafts/<pid>-analysis.md` at spawn.

## Notes for review

- Agents' first push to the assigned branch is now a fast-forward instead of requiring the gateway's non-FF reconcile — strictly less divergence.
- The BRC composer's per-producer `git log --not origin/<base>` delta (#2967) will include the contract-init commit from invocation one; it already appeared after the agent's first push-reconcile, so this is not a new shape.
- Forking slice worktrees from their slice integration branch tip (when pushed) comes for free here; slices whose integration branch is created by the first push keep today's base-fork via the fallback.

Fixes #3068