### PR TITLE
feat(orchestrator): resolve contract-resident cq-* decisions via provide_input fallback

### DIFF
--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -210,7 +210,16 @@ PIPELINE_TOOLS = [
     },
     {
         "name": "provide_input",
-        "description": "Provide human input for a pipeline decision.",
+        "description": (
+            "Provide human input for a pipeline decision. Resolves "
+            "orchestrator-queued decisions (phase gates, overseer "
+            "escalations); when the id is not in the queue it falls back to "
+            "contract-resident HITL decisions (`cq-N`, registered by agents "
+            "via `register_open_question` or impasse escalation) and writes "
+            "the resolution onto the contract so the blocked agent unblocks "
+            "on its next poll (#3071). For contract `feedback-N` requests "
+            "use `answer_feedback` instead."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {

--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -888,12 +888,174 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
         )
 
     except DecisionNotFoundError:
-        return make_error_response(
-            f"Decision {decision_id} not found",
-            status_code=404,
+        # Not in the orchestrator queue — fall back to contract-resident
+        # decisions (#3071).  Agents register HITL questions on the SDLC
+        # contract (``cq-N``, via ``register_open_question`` or the
+        # impasse-escalation router); those reach this queue only through
+        # the post-gate bridge (``_queue_and_await_contract_decisions``),
+        # which runs after phase_gate approval.  A producer blocked
+        # *pre-propose* therefore deadlocked with no operator channel:
+        # this endpoint 404'd and ``answer_feedback`` covers only
+        # ``contract.feedback`` (#3007).  Mirror ``answer_feedback``'s
+        # direct contract write-back so the blocked agent unblocks on its
+        # next contract poll.
+        return _resolve_contract_decision(
+            pipeline_id=pipeline_id,
+            decision_id=decision_id,
+            resolution=resolution,
+            pipeline=_pipeline,
         )
     except DecisionAlreadyResolvedError as e:
         return make_error_response(str(e), status_code=409)
+
+
+def _resolve_contract_decision(
+    pipeline_id: str,
+    decision_id: str,
+    resolution: str,
+    pipeline: Any,
+) -> tuple[Response, int]:
+    """Resolve a contract-resident HITL decision (``cq-N``) directly (#3071).
+
+    Contract decisions are registered by agents
+    (``mcp__sdlc__register_open_question``) or by the orchestrator's
+    impasse-escalation router (:func:`impasse_routing.route_impasses`);
+    they live only in ``.egg-state/contracts/{identifier}.json`` and are
+    bridged into the orchestrator decision queue only *after* phase_gate
+    approval.  An agent blocked on such a decision before proposing never
+    reaches the gate, so the bridge never runs and the operator had no
+    resolution channel — the producer respawn loop burned cost with no
+    pause (#3071, observed on pipeline-c2faf164).
+
+    This fallback gives the operator a first-class path for that pre-gate
+    window, mirroring :func:`answer_feedback` (#3007): write the
+    resolution fields straight onto the contract decision so the blocked
+    agent unblocks on its next contract poll.  The write-back shape
+    (``resolved_by="human"``, raw resolution string) matches the
+    post-gate bridge's, so downstream consumers see one format.  The
+    caller's route decorator is lifecycle-secret guarded, so an agent
+    cannot resolve its own question (parity with queue decisions, #1769).
+    """
+    # Lazy imports — same seam and rationale as ``answer_feedback``:
+    # ``contract_store`` / ``routes.pipelines`` pull in heavy state-store
+    # dependencies that must not bind at module import time.
+    import contract_store
+
+    try:
+        from egg_contracts import (
+            ContractNotFoundError,
+            ContractValidationError,
+            load_contract,
+            save_contract,
+        )
+    except ImportError as exc:
+        logger.error(
+            "egg_contracts not available; cannot resolve contract decision",
+            pipeline_id=pipeline_id,
+            decision_id=decision_id,
+            error=str(exc),
+        )
+        return make_error_response(
+            "Contract subsystem (egg_contracts) is not available on this host",
+            status_code=500,
+        )
+    from routes.pipelines import _pipeline_identifier
+
+    worktree = contract_store.resolve_pipeline_worktree(pipeline_id)
+    if worktree is None:
+        return make_error_response(
+            f"Decision {decision_id} not found (not in the orchestrator "
+            f"queue, and no pipeline worktree exists to check the contract)",
+            status_code=404,
+        )
+
+    identifier = _pipeline_identifier(getattr(pipeline, "issue_number", None), pipeline_id)
+
+    with contract_store.lock_for(identifier):
+        try:
+            contract = load_contract(identifier, worktree)
+        except ContractNotFoundError:
+            return make_error_response(
+                f"Decision {decision_id} not found (not in the orchestrator "
+                f"queue; no contract exists for {pipeline_id})",
+                status_code=404,
+            )
+        except ContractValidationError as exc:
+            return make_error_response(
+                f"Contract validation failed: {exc}",
+                status_code=500,
+            )
+
+        decision = next((d for d in (contract.decisions or []) if d.id == decision_id), None)
+        if decision is None:
+            return make_error_response(
+                f"Decision {decision_id} not found (neither in the "
+                f"orchestrator queue nor on the contract)",
+                status_code=404,
+            )
+        if decision.resolved:
+            return make_error_response(
+                f"Decision {decision_id} has already been resolved",
+                status_code=409,
+            )
+
+        resolved_at = datetime.now(UTC)
+        decision.resolved = True
+        decision.resolution = resolution
+        decision.resolved_by = "human"
+        decision.resolved_at = resolved_at
+
+        try:
+            save_contract(contract, worktree)
+        except Exception as exc:
+            logger.error(
+                "Failed to save contract after resolving contract decision",
+                pipeline_id=pipeline_id,
+                decision_id=decision_id,
+                error=str(exc),
+            )
+            return make_error_response(
+                f"Failed to save contract: {exc}",
+                status_code=500,
+            )
+
+    logger.info(
+        "Contract decision resolved by operator",
+        pipeline_id=pipeline_id,
+        decision_id=decision_id,
+        source=getattr(request, "egg_source", "unknown"),
+    )
+
+    try:
+        emit_event(
+            EventType.DECISION_RESOLVED,
+            pipeline_id=pipeline_id,
+            data={
+                "decision_id": decision_id,
+                "resolution": resolution,
+                "scope": "contract",
+            },
+        )
+    except Exception:
+        logger.warning(
+            "Failed to emit DECISION_RESOLVED event",
+            pipeline_id=pipeline_id,
+            decision_id=decision_id,
+            exc_info=True,
+        )
+
+    return make_success_response(
+        "Decision resolved",
+        data={
+            "decision": {
+                "id": decision_id,
+                "status": "resolved",
+                "resolution": resolution,
+                "resolved_at": resolved_at.isoformat(),
+                "scope": "contract",
+            }
+        },
+    )
 
 
 @decisions_bp.route("/<pipeline_id>/decisions/<decision_id>/cancel", methods=["POST"])

--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -809,6 +809,7 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
                 data={
                     "decision_id": decision_id,
                     "resolution": decision.resolution,
+                    "scope": "queue",
                 },
             )
         except Exception:
@@ -883,6 +884,7 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
                     "resolved_at": decision.resolved_at.isoformat()
                     if decision.resolved_at
                     else None,
+                    "scope": "queue",
                 }
             },
         )
@@ -904,6 +906,7 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
             decision_id=decision_id,
             resolution=resolution,
             pipeline=_pipeline,
+            queue=queue,
         )
     except DecisionAlreadyResolvedError as e:
         return make_error_response(str(e), status_code=409)
@@ -914,6 +917,7 @@ def _resolve_contract_decision(
     decision_id: str,
     resolution: str,
     pipeline: Any,
+    queue: Any,
 ) -> tuple[Response, int]:
     """Resolve a contract-resident HITL decision (``cq-N``) directly (#3071).
 
@@ -931,10 +935,22 @@ def _resolve_contract_decision(
     window, mirroring :func:`answer_feedback` (#3007): write the
     resolution fields straight onto the contract decision so the blocked
     agent unblocks on its next contract poll.  The write-back shape
-    (``resolved_by="human"``, raw resolution string) matches the
-    post-gate bridge's, so downstream consumers see one format.  The
-    caller's route decorator is lifecycle-secret guarded, so an agent
-    cannot resolve its own question (parity with queue decisions, #1769).
+    (``resolved_by="human"``, stripped resolution string) matches the
+    post-gate bridge's (``_queue_and_await_contract_decisions``), so
+    downstream consumers see one format.  The caller's route decorator is
+    lifecycle-secret guarded, so an agent cannot resolve its own question
+    (parity with queue decisions, #1769).
+
+    **Post-gate guard.** Once the bridge has mirrored ``cq-N`` to a fresh
+    ``decision-M``, the pipeline thread is blocked on
+    ``wait_for_decision(decision-M)`` (no timeout — see
+    ``orchestrator/decision_queue.py``).  Resolving the contract ``cq-N``
+    here would unblock the agent on its next poll but strand the bridge
+    thread indefinitely.  Before falling back, scan pending queue
+    decisions for the bridge's context-string fingerprint
+    (``"Open contract question {cq-id},"``) and 409 with a pointer to
+    the mirror id so the operator resolves the queue-side decision
+    instead.
     """
     # Lazy imports — same seam and rationale as ``answer_feedback``:
     # ``contract_store`` / ``routes.pipelines`` pull in heavy state-store
@@ -948,6 +964,7 @@ def _resolve_contract_decision(
             load_contract,
             save_contract,
         )
+        from egg_contracts.models import DecisionType
     except ImportError as exc:
         logger.error(
             "egg_contracts not available; cannot resolve contract decision",
@@ -961,6 +978,31 @@ def _resolve_contract_decision(
         )
     from routes.pipelines import _pipeline_identifier
 
+    # Post-gate guard: if the bridge has already mirrored this ``cq-N`` into
+    # the orchestrator queue, resolving the contract side here would leave
+    # the bridge's ``wait_for_decision`` polling indefinitely (no timeout,
+    # no automatic recovery on DECISION_RESOLVED).  Detect the mirror via
+    # the bridge's context-string fingerprint and steer the operator to
+    # the queue id instead.
+    bridge_context_prefix = f"Open contract question {decision_id},"
+    try:
+        for pending in queue.get_pending_decisions():
+            if pending.context and pending.context.startswith(bridge_context_prefix):
+                return make_error_response(
+                    f"Decision {decision_id} has been bridged into the "
+                    f"orchestrator queue as {pending.id}; resolve that id "
+                    f"instead so the pipeline thread blocked on the bridge's "
+                    f"wait_for_decision is also unblocked.",
+                    status_code=409,
+                )
+    except Exception:
+        logger.warning(
+            "Failed to scan queue for bridged contract decision; proceeding with fallback",
+            pipeline_id=pipeline_id,
+            decision_id=decision_id,
+            exc_info=True,
+        )
+
     worktree = contract_store.resolve_pipeline_worktree(pipeline_id)
     if worktree is None:
         return make_error_response(
@@ -970,6 +1012,12 @@ def _resolve_contract_decision(
         )
 
     identifier = _pipeline_identifier(getattr(pipeline, "issue_number", None), pipeline_id)
+
+    # Normalize for one-format parity with the post-gate bridge's
+    # ``(resolved.resolution or "").strip()`` (#3071 review): with
+    # free-form ``Other (explain in reply)``-style answers, an unstripped
+    # write here would diverge from the bridge's on-disk shape.
+    resolution = resolution.strip()
 
     with contract_store.lock_for(identifier):
         try:
@@ -997,6 +1045,18 @@ def _resolve_contract_decision(
             return make_error_response(
                 f"Decision {decision_id} has already been resolved",
                 status_code=409,
+            )
+        # Defense-in-depth: only HITL decisions are operator-resolvable
+        # (#3071 review).  ``AUTO`` decisions are auto-resolved by the
+        # orchestrator; nothing creates them outside the orchestrator
+        # today, but reject explicitly so a future code path that does
+        # cannot accidentally let the operator overwrite the auto-resolution.
+        if decision.type != DecisionType.HITL:
+            return make_error_response(
+                f"Decision {decision_id} is not operator-resolvable "
+                f"(type={getattr(decision.type, 'value', decision.type)}; "
+                f"only HITL decisions can be resolved via this endpoint)",
+                status_code=400,
             )
 
         resolved_at = datetime.now(UTC)

--- a/orchestrator/tests/test_decisions_routes.py
+++ b/orchestrator/tests/test_decisions_routes.py
@@ -708,12 +708,16 @@ class TestResolveEmitsEvent:
         )
 
         assert response.status_code == 200
+        # ``scope: "queue"`` is added for parity with the contract
+        # fallback's ``scope: "contract"`` so consumers can distinguish
+        # which write path resolved the decision (#3071 review item 5).
         mock_emit.assert_called_once_with(
             EventType.DECISION_RESOLVED,
             pipeline_id="test-pipeline",
             data={
                 "decision_id": "decision-1",
                 "resolution": '{"action": "approve"}',
+                "scope": "queue",
             },
         )
 
@@ -924,6 +928,7 @@ class TestChoiceEnvelopeDispatchNormalization:
             data={
                 "decision_id": "decision-1",
                 "resolution": envelope,
+                "scope": "queue",
             },
         )
 

--- a/orchestrator/tests/test_resolve_contract_decision_route.py
+++ b/orchestrator/tests/test_resolve_contract_decision_route.py
@@ -82,12 +82,15 @@ def _write_contract(worktree: Path, *, with_decision=True, resolved=False):
     return contract
 
 
-def _patch_resolution(tmp_path, *, issue_number=None):
+def _patch_resolution(tmp_path, *, issue_number=None, pending_queue_decisions=None):
     """Patch store + worktree resolution for the route to the temp worktree.
 
     ``get_decision_queue`` is patched to a queue that always raises
     DecisionNotFoundError — the pre-#3071 404 path — so requests exercise
-    the contract fallback.
+    the contract fallback.  The post-gate guard (#3071 review) scans
+    ``queue.get_pending_decisions()``; default it to an empty list so the
+    fallback proceeds, and inject mirrors via ``pending_queue_decisions``
+    when exercising the stranding guard.
     """
     from decision_queue import DecisionNotFoundError
 
@@ -95,6 +98,7 @@ def _patch_resolution(tmp_path, *, issue_number=None):
     pipeline_mock = MagicMock(issue_number=issue_number)
     queue_mock = MagicMock()
     queue_mock.resolve_decision.side_effect = DecisionNotFoundError("not in queue")
+    queue_mock.get_pending_decisions.return_value = pending_queue_decisions or []
     return (
         patch(
             "routes.decisions.get_state_store_for_pipeline",
@@ -245,6 +249,10 @@ def test_queue_decision_still_takes_precedence(client, tmp_path):
         resp = _post(client, "cq-1", {"resolution": "approve"})
 
     assert resp.status_code == 200
+    payload = resp.get_json()
+    # Queue path now tags ``scope: "queue"`` for parity with the contract
+    # fallback's ``scope: "contract"`` (#3071 review item 5).
+    assert payload["data"]["decision"]["scope"] == "queue"
     contract = load_contract(PIPELINE_ID, tmp_path)
     assert contract.decisions[0].resolved is False
 
@@ -263,6 +271,124 @@ def test_emits_decision_resolved_event(client, tmp_path):
     assert call_kwargs["pipeline_id"] == PIPELINE_ID
     assert call_kwargs["data"]["decision_id"] == "cq-1"
     assert call_kwargs["data"]["scope"] == "contract"
+
+
+def test_resolution_stripped_for_bridge_parity(client, tmp_path):
+    """Whitespace-padded resolutions are stripped to match the post-gate
+    bridge's ``(resolved.resolution or "").strip()`` write-back (#3071
+    review item 2).  Without this, free-form ``Other (explain in reply)``
+    answers would land on disk with different shapes depending on which
+    write path (pre-gate fallback vs. post-gate bridge) handled them."""
+    from egg_contracts import load_contract
+
+    _write_contract(tmp_path)
+    store_patch, queue_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, queue_patch, worktree_patch:
+        resp = _post(client, "cq-1", {"resolution": "   trimmed answer  \n"})
+
+    assert resp.status_code == 200
+    contract = load_contract(PIPELINE_ID, tmp_path)
+    assert contract.decisions[0].resolution == "trimmed answer"
+
+
+def test_post_gate_mirror_returns_409_with_pointer(client, tmp_path):
+    """If the post-gate bridge has already mirrored this ``cq-N`` into the
+    queue, the fallback must 409 with the queue id so the operator
+    resolves the queue side (which unblocks both the agent's contract poll
+    AND the bridge's ``wait_for_decision``). Without this guard the
+    bridge thread would be stranded indefinitely (#3071 review item 1)."""
+    _write_contract(tmp_path)
+
+    # Build a pending queue decision whose context carries the bridge's
+    # fingerprint: ``f"Open contract question {cq_id}, registered by an
+    # agent during the {phase} phase."`` (orchestrator/routes/pipelines.py).
+    mirror = MagicMock()
+    mirror.id = "decision-42"
+    mirror.context = "Open contract question cq-1, registered by an agent during the plan phase."
+
+    store_patch, queue_patch, worktree_patch = _patch_resolution(
+        tmp_path, pending_queue_decisions=[mirror]
+    )
+    with store_patch, queue_patch, worktree_patch:
+        resp = _post(client, "cq-1", {"resolution": "opt-1"})
+
+    assert resp.status_code == 409
+    msg = resp.get_json()["message"]
+    assert "decision-42" in msg
+    assert "bridged" in msg.lower()
+
+
+def test_post_gate_mirror_for_other_cq_does_not_block(client, tmp_path):
+    """The post-gate guard must be precise: a pending mirror for a
+    *different* ``cq-N`` must not 409 this request."""
+    from egg_contracts import load_contract
+
+    _write_contract(tmp_path)
+
+    other_mirror = MagicMock()
+    other_mirror.id = "decision-7"
+    other_mirror.context = (
+        "Open contract question cq-2, registered by an agent during the plan phase."
+    )
+
+    store_patch, queue_patch, worktree_patch = _patch_resolution(
+        tmp_path, pending_queue_decisions=[other_mirror]
+    )
+    with store_patch, queue_patch, worktree_patch:
+        resp = _post(client, "cq-1", {"resolution": "opt-1"})
+
+    assert resp.status_code == 200
+    contract = load_contract(PIPELINE_ID, tmp_path)
+    assert contract.decisions[0].resolved is True
+
+
+def test_auto_decision_rejected_with_400(client, tmp_path):
+    """Only HITL decisions are operator-resolvable; AUTO decisions are
+    auto-resolved by the orchestrator and must not be overwritable here
+    (#3071 review item 3, defense-in-depth)."""
+    from egg_contracts import Contract, save_contract
+    from egg_contracts.models import Decision, DecisionType, PipelinePhase
+
+    contract = Contract(pipeline_id=PIPELINE_ID, current_phase=PipelinePhase.PLAN)
+    contract.decisions = [
+        Decision(
+            id="cq-1",
+            question="auto-resolved question",
+            type=DecisionType.AUTO,
+            phase=PipelinePhase.PLAN,
+        )
+    ]
+    save_contract(contract, tmp_path)
+
+    store_patch, queue_patch, worktree_patch = _patch_resolution(tmp_path)
+    with store_patch, queue_patch, worktree_patch:
+        resp = _post(client, "cq-1", {"resolution": "x"})
+
+    assert resp.status_code == 400
+    assert "HITL" in resp.get_json()["message"]
+
+
+def test_contract_validation_error_returns_500(client, tmp_path):
+    """A malformed contract on disk surfaces as a 500 with a clear
+    message (#3071 review item 4) — mirrors how
+    ``test_answer_feedback_route.py`` covers the same branch."""
+    from egg_contracts import ContractValidationError
+
+    store_patch, queue_patch, worktree_patch = _patch_resolution(tmp_path)
+    with (
+        store_patch,
+        queue_patch,
+        worktree_patch,
+        patch(
+            "egg_contracts.load_contract",
+            side_effect=ContractValidationError(PIPELINE_ID, ["bad schema"]),
+        ),
+    ):
+        resp = _post(client, "cq-1", {"resolution": "x"})
+
+    assert resp.status_code == 500
+    assert "validation" in resp.get_json()["message"].lower()
 
 
 def test_requires_lifecycle_secret(client, tmp_path):

--- a/orchestrator/tests/test_resolve_contract_decision_route.py
+++ b/orchestrator/tests/test_resolve_contract_decision_route.py
@@ -1,0 +1,284 @@
+"""Tests for the contract-decision fallback on POST .../decisions/<id>/resolve (#3071).
+
+Agents register HITL questions on the SDLC contract (``cq-N``, via
+``register_open_question`` or the impasse-escalation router).  Those
+decisions are bridged into the orchestrator queue only *after* phase_gate
+approval, so an agent blocked pre-propose deadlocked with no operator
+channel: ``provide_input`` 404'd (not in the queue) and ``answer_feedback``
+covers only ``contract.feedback`` (#3007).  The resolve endpoint now falls
+back to contract-resident decisions when the queue misses, writing the
+resolution fields straight onto the contract.
+
+These tests exercise the real contract load/save against a temp worktree
+so the on-disk write-back is covered end to end — mirroring
+``test_answer_feedback_route.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mirror the docker/k8s mocking the other orchestrator tests rely on so the
+# lazy ``from routes.pipelines import _pipeline_identifier`` import inside the
+# handler does not require a real docker SDK.
+_docker_mock = MagicMock()
+sys.modules.setdefault("docker", _docker_mock)
+sys.modules.setdefault("docker.errors", _docker_mock.errors)
+sys.modules.setdefault("docker.types", _docker_mock.types)
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+
+PIPELINE_ID = "test-pipeline"
+
+
+@pytest.fixture
+def client():
+    from flask import Flask
+    from routes.decisions import decisions_bp
+
+    app = Flask(__name__)
+    app.register_blueprint(decisions_bp)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def _write_contract(worktree: Path, *, with_decision=True, resolved=False):
+    """Create + persist a contract with (optionally) a pending cq decision."""
+    from egg_contracts import Contract, save_contract
+    from egg_contracts.models import Decision, DecisionOption, DecisionType, PipelinePhase
+
+    contract = Contract(pipeline_id=PIPELINE_ID, current_phase=PipelinePhase.PLAN)
+    if with_decision:
+        contract.decisions = [
+            Decision(
+                id="cq-1",
+                question=(
+                    "Producer task_planner reported an impasse: the analysis "
+                    "draft referenced by the task description is missing."
+                ),
+                type=DecisionType.HITL,
+                phase=PipelinePhase.PLAN,
+                options=[
+                    DecisionOption(id="opt-1", label="Cancel the slice and re-plan"),
+                    DecisionOption(
+                        id="opt-2", label="Resolve the underlying blocker manually, then resume"
+                    ),
+                ],
+                resolved=resolved,
+            )
+        ]
+    save_contract(contract, worktree)
+    return contract
+
+
+def _patch_resolution(tmp_path, *, issue_number=None):
+    """Patch store + worktree resolution for the route to the temp worktree.
+
+    ``get_decision_queue`` is patched to a queue that always raises
+    DecisionNotFoundError — the pre-#3071 404 path — so requests exercise
+    the contract fallback.
+    """
+    from decision_queue import DecisionNotFoundError
+
+    store_mock = MagicMock(repo_path=tmp_path)
+    pipeline_mock = MagicMock(issue_number=issue_number)
+    queue_mock = MagicMock()
+    queue_mock.resolve_decision.side_effect = DecisionNotFoundError("not in queue")
+    return (
+        patch(
+            "routes.decisions.get_state_store_for_pipeline",
+            return_value=(store_mock, pipeline_mock),
+        ),
+        patch("routes.decisions.get_decision_queue", return_value=queue_mock),
+        patch("contract_store.resolve_pipeline_worktree", return_value=tmp_path),
+    )
+
+
+def _post(client, decision_id, body):
+    return client.post(
+        f"/api/v1/pipelines/{PIPELINE_ID}/decisions/{decision_id}/resolve",
+        json=body,
+    )
+
+
+def test_resolves_contract_decision_and_writes_contract(client, tmp_path):
+    from egg_contracts import load_contract
+
+    _write_contract(tmp_path)
+    store_patch, queue_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, queue_patch, worktree_patch:
+        resp = _post(client, "cq-1", {"resolution": "Resolve the underlying blocker manually"})
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["data"]["decision"]["id"] == "cq-1"
+    assert payload["data"]["decision"]["status"] == "resolved"
+    assert payload["data"]["decision"]["scope"] == "contract"
+
+    # The write-back must hit disk so the agent's next contract poll sees
+    # it.  Field shape matches the post-gate bridge's write-back
+    # (resolved_by="human", raw resolution string).
+    contract = load_contract(PIPELINE_ID, tmp_path)
+    decision = contract.decisions[0]
+    assert decision.resolved is True
+    assert decision.resolution == "Resolve the underlying blocker manually"
+    assert decision.resolved_by == "human"
+    assert decision.resolved_at is not None
+
+
+def test_dict_resolution_serialized_like_queue_path(client, tmp_path):
+    """A dict resolution body is serialized to a JSON string (#1635 parity)."""
+    import json
+
+    from egg_contracts import load_contract
+
+    _write_contract(tmp_path)
+    store_patch, queue_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, queue_patch, worktree_patch:
+        resp = _post(client, "cq-1", {"resolution": {"action": "select", "selected": "opt-2"}})
+
+    assert resp.status_code == 200
+    contract = load_contract(PIPELINE_ID, tmp_path)
+    assert json.loads(contract.decisions[0].resolution) == {
+        "action": "select",
+        "selected": "opt-2",
+    }
+
+
+def test_unknown_decision_returns_404_mentioning_both_misses(client, tmp_path):
+    """An id in neither the queue nor the contract still 404s."""
+    _write_contract(tmp_path)
+    store_patch, queue_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, queue_patch, worktree_patch:
+        resp = _post(client, "cq-99", {"resolution": "x"})
+
+    assert resp.status_code == 404
+    msg = resp.get_json()["message"]
+    assert "cq-99" in msg
+    assert "queue" in msg.lower() and "contract" in msg.lower()
+
+
+def test_already_resolved_contract_decision_returns_409(client, tmp_path):
+    _write_contract(tmp_path, resolved=True)
+    store_patch, queue_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, queue_patch, worktree_patch:
+        resp = _post(client, "cq-1", {"resolution": "x"})
+
+    assert resp.status_code == 409
+    assert "already" in resp.get_json()["message"].lower()
+
+
+def test_no_contract_returns_404(client, tmp_path):
+    """No contract on disk at all — the fallback degrades to a 404."""
+    store_patch, queue_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, queue_patch, worktree_patch:
+        resp = _post(client, "cq-1", {"resolution": "x"})
+
+    assert resp.status_code == 404
+
+
+def test_worktree_not_found_returns_404(client, tmp_path):
+    from decision_queue import DecisionNotFoundError
+
+    store_mock = MagicMock(repo_path=tmp_path)
+    pipeline_mock = MagicMock(issue_number=None)
+    queue_mock = MagicMock()
+    queue_mock.resolve_decision.side_effect = DecisionNotFoundError("not in queue")
+    with (
+        patch(
+            "routes.decisions.get_state_store_for_pipeline",
+            return_value=(store_mock, pipeline_mock),
+        ),
+        patch("routes.decisions.get_decision_queue", return_value=queue_mock),
+        patch("contract_store.resolve_pipeline_worktree", return_value=None),
+    ):
+        resp = _post(client, "cq-1", {"resolution": "x"})
+
+    assert resp.status_code == 404
+    assert "worktree" in resp.get_json()["message"].lower()
+
+
+def test_queue_decision_still_takes_precedence(client, tmp_path):
+    """A decision that IS in the queue resolves there — the contract
+    fallback never runs and the contract is untouched."""
+    from egg_contracts import load_contract
+
+    _write_contract(tmp_path)
+
+    store_mock = MagicMock(repo_path=tmp_path)
+    pipeline_mock = MagicMock(issue_number=None)
+    queue_mock = MagicMock()
+    resolved_decision = MagicMock()
+    resolved_decision.id = "cq-1"
+    resolved_decision.status.value = "resolved"
+    resolved_decision.resolution = "approve"
+    resolved_decision.resolved_at = None
+    resolved_decision.context = ""
+    resolved_decision.question = "q"
+    queue_mock.resolve_decision.return_value = resolved_decision
+
+    with (
+        patch(
+            "routes.decisions.get_state_store_for_pipeline",
+            return_value=(store_mock, pipeline_mock),
+        ),
+        patch("routes.decisions.get_decision_queue", return_value=queue_mock),
+        patch("contract_store.resolve_pipeline_worktree", return_value=tmp_path),
+    ):
+        resp = _post(client, "cq-1", {"resolution": "approve"})
+
+    assert resp.status_code == 200
+    contract = load_contract(PIPELINE_ID, tmp_path)
+    assert contract.decisions[0].resolved is False
+
+
+def test_emits_decision_resolved_event(client, tmp_path):
+    _write_contract(tmp_path)
+    store_patch, queue_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, queue_patch, worktree_patch:
+        with patch("routes.decisions.emit_event") as mock_emit:
+            resp = _post(client, "cq-1", {"resolution": "opt-1"})
+
+    assert resp.status_code == 200
+    assert mock_emit.called
+    call_kwargs = mock_emit.call_args[1]
+    assert call_kwargs["pipeline_id"] == PIPELINE_ID
+    assert call_kwargs["data"]["decision_id"] == "cq-1"
+    assert call_kwargs["data"]["scope"] == "contract"
+
+
+def test_requires_lifecycle_secret(client, tmp_path):
+    """Agents (no bearer token) must not be able to resolve their own cq."""
+    _write_contract(tmp_path)
+    store_patch, queue_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with store_patch, queue_patch, worktree_patch:
+        resp = client.post(
+            f"/api/v1/pipelines/{PIPELINE_ID}/decisions/cq-1/resolve",
+            json={"resolution": "x"},
+            _lifecycle_auth=False,
+        )
+
+    assert resp.status_code == 401
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Gives the operator a working resolution channel for agent-registered contract HITL decisions (`cq-N`) — expected-fix **#1** of #3071.

Contract decisions (registered via `register_open_question` or the impasse-escalation router) are bridged into the orchestrator decision queue only by the **post-gate** bridge (`_queue_and_await_contract_decisions`), which runs after phase_gate approval. An agent blocked on such a decision *before proposing* never reaches the gate, so the bridge never runs and the operator had no channel: `provide_input` 404'd (not in the queue) and `answer_feedback` covers only `contract.feedback` (#3007). On pipeline-c2faf164 the task_planner registered `cq-1` and then respawned in an impasse loop (~$0.2–0.35/cycle) with no pause and no operator-visible gate; the only way out was hand-editing the contract JSON in the gateway pod.

This is the safety net for the whole failure class: any future artifact-delivery gap (#3068 being this instance) becomes a resolvable HITL pause instead of an unresolvable burn loop.

## Changes

- `resolve_decision` (the route behind `provide_input`): on `DecisionNotFoundError`, fall back to contract-resident decisions — load the contract under `contract_store.lock_for`, write `resolved`/`resolution`/`resolved_by`/`resolved_at` (same shape as the post-gate bridge's write-back, `resolved_by="human"`), save, emit `DECISION_RESOLVED` with `scope: contract`. The blocked agent unblocks on its next contract poll.
- Queue decisions keep precedence; ids in neither place still 404; an already-resolved contract decision returns 409 (parity with `DecisionAlreadyResolvedError`). The lifecycle-secret guard is unchanged, so an agent cannot resolve its own question (#1769 parity).
- Mirrors the `answer_feedback` (#3007) design: same lazy-import seam, same direct contract write-back.
- Updated the `provide_input` MCP tool description to document the fallback.

## Test plan

- Automated: new `orchestrator/tests/test_resolve_contract_decision_route.py` (9 tests, real contract load/save against a temp worktree, mirroring `test_answer_feedback_route.py`; 6 verified red pre-fix). Related suites green: `test_decisions_routes.py`, `test_answer_feedback_route.py`, `test_contract_decision_bridge.py`, `test_decision_queue.py`, `test_mcp_tools.py` (292 total).
- Manual: register a `cq-N` on a live pipeline's contract pre-gate, call `provide_input(task_id, decision_id="cq-N", response=...)`, confirm 200 + the contract decision is resolved and the agent's next poll sees it.

## Remaining scope on #3071 (not in this PR)

Expected-fix #2 — promoting repeated `external_blocker` impasse reports into a queue decision **mid-phase** and pausing producer re-invocation until resolved — is a deeper change (the post-BRC impasse scan also only covers coder/tester/documenter and only runs after the BRC cycle exits). Tracked on the issue.

Refs #3071