### PR TITLE
fix(gateway): land #3073 fork-from-assigned-tip on main; honest restart_phase contract (#3080)

### DIFF
--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -1694,6 +1694,70 @@ class TestAssignedBranchForkPoint:
             f"unpushed assigned branch should fall back to base tip {main_tip}; got {head}"
         )
 
+    @patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", ""))
+    def test_restart_recreated_worktree_forks_from_advanced_assigned_tip(
+        self, _mock_get_token, pipeline_remote
+    ):
+        """``restart_phase`` deletes per-agent worktrees *and* their local
+        branches, then respawns through the fresh-create path (#3080).  The
+        re-created worktree must fork from the assigned branch tip — which
+        carries the drafts the agents pushed during the phase — not from
+        base, or every respawned producer is stranded from its own prior
+        work and reviewers re-arm the phantom-NACK loop (#3076)."""
+        manager, seed, main_tip = pipeline_remote
+
+        # First spawn: nothing pushed to the assigned branch yet, so the
+        # worktree forks at base (the documented fallback).
+        info = manager.create_worktree(
+            "test-repo",
+            "pipe-3-architect",
+            base_branch="main",
+            assigned_branch="egg/pipe-3/work",
+        )
+        head = subprocess.run(
+            ["git", "-C", str(info.worktree_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert head == main_tip
+
+        # During the phase, producer pushes advance the assigned branch
+        # with committed drafts (agents' default push upstream targets it).
+        subprocess.run(["git", "checkout", "-b", "egg/pipe-3/work"], cwd=seed, check=True)
+        draft_tip = self._commit(
+            seed, ".egg-state/drafts/pipe-3-plan.md", "architect plan draft v7"
+        )
+        subprocess.run(["git", "push", "origin", "egg/pipe-3/work"], cwd=seed, check=True)
+
+        # restart_phase: delete_worktrees(force=True) → remove_worktree with
+        # the default delete_branch=True, so the local per-agent branch dies
+        # with the worktree and re-creation cannot take the branch-reuse path.
+        removal = manager.remove_worktree(
+            container_id="pipe-3-architect", repo_name="test-repo", force=True
+        )
+        assert removal.success
+        assert removal.branch_deleted
+
+        # Respawn: the fresh worktree must materialise the preserved drafts.
+        info2 = manager.create_worktree(
+            "test-repo",
+            "pipe-3-architect",
+            base_branch="main",
+            assigned_branch="egg/pipe-3/work",
+        )
+        head2 = subprocess.run(
+            ["git", "-C", str(info2.worktree_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert head2 == draft_tip, (
+            f"restart-recreated worktree should fork from the advanced assigned "
+            f"tip {draft_tip}; got {head2}"
+        )
+        assert (info2.worktree_path / ".egg-state" / "drafts" / "pipe-3-plan.md").exists()
+
     def test_assigned_fetch_timeout_falls_back_to_base(self, tmp_path):
         """A timeout on the assigned-branch fetch is best-effort: the
         helper returns None (caller falls back to base) instead of raising

--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -1585,6 +1585,175 @@ class TestNarrowRefspecMirror:
         )
 
 
+class TestAssignedBranchForkPoint:
+    """Fresh worktrees fork from the assigned branch's remote tip (#3068).
+
+    The orchestrator's contract-init commit (SDLC contract + seeded
+    analysis/plan drafts) lands on the assigned branch and is pushed
+    before agents spawn.  Forking fresh worktrees from the base branch
+    left agents one-plus commits behind that tip, so seeded artifacts
+    never reached agent worktrees.  Fresh creation now mirrors the reuse
+    path's candidate order: ``origin/{assigned}`` first, base as
+    fallback.
+    """
+
+    GIT_ENV = TestNarrowRefspecMirror.GIT_ENV
+
+    def _commit(self, repo: Path, filename: str, message: str) -> str:
+        (repo / filename).parent.mkdir(parents=True, exist_ok=True)
+        (repo / filename).write_text(f"{message}\n")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-m", message], cwd=repo, check=True, env=self.GIT_ENV)
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+        ).stdout.strip()
+
+    @pytest.fixture
+    def pipeline_remote(self, tmp_path):
+        """Bare origin (main) + seed pusher + mirror clone under repos_base."""
+        origin = tmp_path / "origin.git"
+        subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)], check=True)
+
+        seed = tmp_path / "seed"
+        seed.mkdir()
+        subprocess.run(["git", "init", "-b", "main"], cwd=seed, check=True)
+        subprocess.run(["git", "remote", "add", "origin", str(origin)], cwd=seed, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=seed, check=True)
+        subprocess.run(["git", "config", "user.name", "test"], cwd=seed, check=True)
+        main_tip = self._commit(seed, "README.md", "init")
+        subprocess.run(["git", "push", "origin", "main"], cwd=seed, check=True)
+
+        repos_base = tmp_path / "repos"
+        repos_base.mkdir()
+        repo_dir = repos_base / "test-repo"
+        subprocess.run(["git", "clone", str(origin), str(repo_dir)], check=True)
+
+        manager = WorktreeManager(worktree_base=tmp_path / "worktrees", repos_base=repos_base)
+        return manager, seed, main_tip
+
+    @patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", ""))
+    def test_fresh_worktree_forks_from_assigned_tip(self, _mock_get_token, pipeline_remote):
+        """When ``origin/{assigned}`` exists (contract-init pushed), a fresh
+        worktree forks from its tip and the seeded artifact is present —
+        even when the tip moved after the mirror's last fetch."""
+        manager, seed, _main_tip = pipeline_remote
+
+        # Simulate the orchestrator: contract-init commit on the pipeline
+        # work branch, pushed to origin AFTER the mirror's clone-time fetch.
+        subprocess.run(["git", "checkout", "-b", "egg/pipe-1/work"], cwd=seed, check=True)
+        assigned_tip = self._commit(
+            seed, ".egg-state/drafts/pipe-1-analysis.md", "Initialize SDLC contract"
+        )
+        subprocess.run(["git", "push", "origin", "egg/pipe-1/work"], cwd=seed, check=True)
+
+        info = manager.create_worktree(
+            "test-repo",
+            "pipe-1-architect",
+            base_branch="main",
+            assigned_branch="egg/pipe-1/work",
+        )
+
+        head = subprocess.run(
+            ["git", "-C", str(info.worktree_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert head == assigned_tip, (
+            f"fresh worktree should fork from the assigned tip {assigned_tip}; got {head}"
+        )
+        # The seeded artifact is what the fork point is for — assert it
+        # materialised in the agent's checkout.
+        assert (info.worktree_path / ".egg-state" / "drafts" / "pipe-1-analysis.md").exists()
+        # The per-worktree local branch is unchanged by the fork point.
+        assert info.branch == "egg/pipe-1-architect/work"
+
+    @patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", ""))
+    def test_fresh_worktree_falls_back_to_base_when_assigned_unpushed(
+        self, _mock_get_token, pipeline_remote
+    ):
+        """An assigned branch with nothing pushed yet (fresh pipeline /
+        slice integration branch) must not block creation — fall back to
+        the base branch, the pre-#3068 behaviour."""
+        manager, _seed, main_tip = pipeline_remote
+
+        info = manager.create_worktree(
+            "test-repo",
+            "pipe-2-coder",
+            base_branch="main",
+            assigned_branch="egg/pipe-2/work",
+        )
+
+        head = subprocess.run(
+            ["git", "-C", str(info.worktree_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert head == main_tip, (
+            f"unpushed assigned branch should fall back to base tip {main_tip}; got {head}"
+        )
+
+    def test_assigned_fetch_timeout_falls_back_to_base(self, tmp_path):
+        """A timeout on the assigned-branch fetch is best-effort: the
+        helper returns None (caller falls back to base) instead of raising
+        — unlike the base-branch fetch, which hard-fails per #3021."""
+        manager = WorktreeManager(
+            worktree_base=tmp_path / "worktrees",
+            repos_base=tmp_path / "repos",
+        )
+
+        def mock_run(args, **kwargs):
+            if "fetch" in args:
+                raise subprocess.TimeoutExpired(cmd=args, timeout=30)
+            raise AssertionError(f"unexpected subprocess call: {args}")
+
+        with patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", "")):
+            with patch("subprocess.run", side_effect=mock_run):
+                result = manager._resolve_assigned_fork_point(
+                    main_repo=tmp_path / "repos" / "test-repo",
+                    assigned_branch="egg/pipe-3/work",
+                    repo_slug="Khan/test-repo",
+                    container_id="pipe-3-coder",
+                )
+
+        assert result is None
+
+    def test_assigned_rev_parse_failure_falls_back_to_base(self, tmp_path):
+        """If the fetch succeeds but ``rev-parse --verify origin/<branch>``
+        fails (the tracking ref is somehow not resolvable post-fetch — a
+        theoretical narrow-refspec edge case), the helper returns None and
+        the caller falls back to the base branch rather than handing git a
+        bad fork point."""
+        manager = WorktreeManager(
+            worktree_base=tmp_path / "worktrees",
+            repos_base=tmp_path / "repos",
+        )
+
+        def mock_run(args, **kwargs):
+            if "fetch" in args:
+                return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+            if "rev-parse" in args:
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=128,
+                    stdout="",
+                    stderr="fatal: Needed a single revision\n",
+                )
+            raise AssertionError(f"unexpected subprocess call: {args}")
+
+        with patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", "")):
+            with patch("subprocess.run", side_effect=mock_run):
+                result = manager._resolve_assigned_fork_point(
+                    main_repo=tmp_path / "repos" / "test-repo",
+                    assigned_branch="egg/pipe-4/work",
+                    repo_slug="Khan/test-repo",
+                    container_id="pipe-4-coder",
+                )
+
+        assert result is None
+
+
 class TestFindWorktreeGitDir:
     """Tests for _find_worktree_git_dir admin dir resolution."""
 

--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -1767,9 +1767,12 @@ class TestAssignedBranchForkPoint:
             repos_base=tmp_path / "repos",
         )
 
+        observed_timeouts: list[int | None] = []
+
         def mock_run(args, **kwargs):
             if "fetch" in args:
-                raise subprocess.TimeoutExpired(cmd=args, timeout=15)
+                observed_timeouts.append(kwargs.get("timeout"))
+                raise subprocess.TimeoutExpired(cmd=args, timeout=kwargs.get("timeout"))
             raise AssertionError(f"unexpected subprocess call: {args}")
 
         with patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", "")):
@@ -1782,6 +1785,14 @@ class TestAssignedBranchForkPoint:
                 )
 
         assert result is None
+        # The assigned-branch fetch budget must match the reuse path's
+        # 15s per-fetch budget in ``_reset_reused_worktree_to_safe_ref``
+        # — pin the literal so a regression of the production timeout
+        # is caught by this test rather than slipping through silently.
+        assert observed_timeouts == [15], (
+            f"expected assigned-fetch to use a 15s timeout (matching the "
+            f"reuse path); observed {observed_timeouts}"
+        )
 
     def test_assigned_rev_parse_failure_falls_back_to_base(self, tmp_path):
         """If the fetch succeeds but ``rev-parse --verify origin/<branch>``

--- a/gateway/tests/test_worktree_manager.py
+++ b/gateway/tests/test_worktree_manager.py
@@ -1769,7 +1769,7 @@ class TestAssignedBranchForkPoint:
 
         def mock_run(args, **kwargs):
             if "fetch" in args:
-                raise subprocess.TimeoutExpired(cmd=args, timeout=30)
+                raise subprocess.TimeoutExpired(cmd=args, timeout=15)
             raise AssertionError(f"unexpected subprocess call: {args}")
 
         with patch("worktree_manager.get_token_for_repo", return_value=(None, "bot", "")):

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -294,7 +294,12 @@ class WorktreeManager:
                 the sandbox's push client builds a refspec that targets the
                 assigned branch instead of the per-worktree local branch
                 (which the gateway would reject as push_denied_wrong_branch).
-                See #1809.
+                See #1809.  Also the preferred fork point for *fresh*
+                worktrees: when ``origin/{assigned_branch}`` exists, the
+                worktree forks from its tip (which carries the
+                orchestrator's contract-init commit and any seeded
+                drafts) rather than from ``base_branch`` — see #3068 and
+                :meth:`_resolve_assigned_fork_point`.
             repo_slug: Full ``owner/repo`` slug used to resolve the GitHub
                 token for the authenticated base-branch fetch (#3021).
                 Defaults to ``repo_name`` when omitted, which makes token
@@ -522,6 +527,28 @@ class WorktreeManager:
                             f"{fetch_result.stderr.strip()}"
                         )
                     effective_base = f"origin/{fetch_ref}"
+
+                # Prefer the assigned branch's remote tip over the base
+                # branch when it exists (#3068).  The orchestrator's
+                # contract-init commit (SDLC contract + any seeded
+                # analysis/plan drafts) lands on the assigned branch and is
+                # pushed before agents spawn; forking from the base left
+                # every fresh agent worktree behind that commit, so seeded
+                # artifacts never reached agents.  Mirrors the reuse path's
+                # candidate order (``origin/{assigned}`` -> ``origin/{base}``
+                # in ``_reset_reused_worktree_to_safe_ref``).  Best-effort:
+                # an assigned branch with nothing pushed yet falls back to
+                # the base branch (the prior behaviour); the base fetch
+                # above keeps its #3021 hard-fail semantics either way.
+                if assigned_branch:
+                    assigned_fork_point = self._resolve_assigned_fork_point(
+                        main_repo=main_repo,
+                        assigned_branch=assigned_branch,
+                        repo_slug=repo_slug,
+                        container_id=container_id,
+                    )
+                    if assigned_fork_point:
+                        effective_base = assigned_fork_point
 
                 # Create new branch from the freshly fetched remote tip
                 result = self._run_git_worktree_add(
@@ -786,6 +813,122 @@ class WorktreeManager:
         finally:
             cleanup_credential_helper(cred_path)
 
+    def _resolve_assigned_fork_point(
+        self,
+        main_repo: Path,
+        assigned_branch: str,
+        repo_slug: str,
+        container_id: str,
+    ) -> str | None:
+        """Resolve ``origin/{assigned_branch}`` as the fork point, if pushed.
+
+        Fresh worktrees historically forked from ``origin/{base_branch}``
+        only — but the orchestrator commits pipeline state (the SDLC
+        contract plus any seeded analysis/plan drafts) to the assigned
+        branch and pushes it *before* agents spawn (the contract-init push
+        is mandatory; see "Worktree State Synchronization" in
+        ``docs/guides/sdlc-pipeline.md``).  Forking from the base left
+        every fresh agent worktree behind that commit, so seeded artifacts
+        never reached agent worktrees (#3068).
+
+        This mirrors the reuse path's candidate order in
+        :meth:`_reset_reused_worktree_to_safe_ref` (``origin/{assigned}``
+        first, ``origin/{base}`` as fallback) — and the same safety
+        argument carries over: the orchestrator's create-pipeline
+        stale-branch check (#2222 Phase 3a) refuses re-submits where
+        ``origin/{assigned}`` carries prior-pipeline commits.
+
+        Best-effort by design: a spawn can legitimately precede any push
+        of the assigned branch (e.g. a slice integration branch that the
+        first push creates), in which case the fetch finds nothing, this
+        returns ``None``, and the caller falls back to the base branch —
+        the pre-#3068 behaviour.  Contrast the base-branch fetch, which
+        hard-fails per #3021 because the base must exist on origin.
+
+        Returns:
+            ``origin/{fetch_ref}`` (the input with any ``origin/`` prefix
+            stripped) when the branch exists on origin (tracking ref
+            freshly fetched), else ``None``.
+        """
+        # ``_tracking_refspec`` requires a bare branch name; mirror the
+        # base-branch path's defensive strip in case a future caller drifts
+        # to passing ``origin/<name>`` (today's callers pass bare names).
+        fetch_ref = (
+            assigned_branch[len("origin/") :]
+            if assigned_branch.startswith("origin/")
+            else assigned_branch
+        )
+        try:
+            with self._git_credential_env(repo_slug, best_effort=True) as fetch_env:
+                # Force C locale so the "couldn't find remote ref" stderr
+                # heuristic below isn't translated by gettext under e.g.
+                # ``LANG=de_DE.UTF-8``.  Without this, a translated error
+                # would misclassify the "branch not pushed yet" case as a
+                # transient failure (the WARNING branch).  Fallback
+                # behaviour is correct either way; only log level/message
+                # changes.
+                fetch_env = {**fetch_env, "LC_ALL": "C"}
+                fetch_result = subprocess.run(
+                    git_cmd("fetch", "origin", _tracking_refspec(fetch_ref)),
+                    cwd=main_repo,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=30,
+                    env=fetch_env,
+                )
+        except Exception as exc:
+            # Best-effort: any failure (timeout, OSError, credential-helper
+            # error from _git_credential_env, etc.) falls back to the base
+            # branch.  A narrower catch would surface unexpected exception
+            # types as a hard spawn failure, which is the opposite of the
+            # "best-effort fallback" contract this helper advertises.
+            logger.warning(
+                "Assigned-branch fetch before worktree create failed (falling back to base)",
+                container_id=container_id,
+                assigned_branch=assigned_branch,
+                error=str(exc),
+            )
+            return None
+        if fetch_result.returncode != 0:
+            # git fetch on a missing branch emits "couldn't find remote ref"
+            # — that's the expected "not pushed yet" case and not an error.
+            # Anything else (transient 5xx, auth, network) is worth flagging
+            # at a higher level so an operator triaging "why didn't my seed
+            # reach the agent?" sees the real cause.
+            stderr = fetch_result.stderr.strip()
+            if "couldn't find remote ref" in stderr:
+                logger.info(
+                    "Assigned branch not on origin yet — forking worktree from base",
+                    container_id=container_id,
+                    assigned_branch=assigned_branch,
+                )
+            else:
+                logger.warning(
+                    "Assigned-branch fetch failed (falling back to base)",
+                    container_id=container_id,
+                    assigned_branch=assigned_branch,
+                    stderr=stderr[:200],
+                )
+            return None
+
+        candidate = f"origin/{fetch_ref}"
+        verify = subprocess.run(
+            git_cmd("rev-parse", "--verify", candidate),
+            cwd=main_repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if verify.returncode != 0:
+            return None
+        logger.info(
+            "Forking worktree from assigned branch tip",
+            container_id=container_id,
+            assigned_branch=assigned_branch,
+        )
+        return candidate
+
     def _reset_reused_worktree_to_safe_ref(
         self,
         worktree_path: Path,
@@ -839,16 +982,20 @@ class WorktreeManager:
         # base-branch fetch, and are cheaper than a full all-refs fetch
         # on large mirrors.
         #
-        # ``base_branch`` may arrive ``origin/``-prefixed in pipeline
-        # mode (``gateway.py`` sets ``worktree_base_branch =
-        # f"origin/{...}"`` and ``resolve_default_branch`` returns
-        # ``"origin/main"``).  Strip the prefix so the fetch refspec and
-        # the candidate-ref lookup below agree on the bare name —
-        # otherwise the secondary candidate is built as
-        # ``origin/origin/main`` and fails to resolve.
+        # ``_tracking_refspec`` requires a bare branch name; mirror the
+        # base-branch and create-path defensive strips for drift-resistance
+        # against future callers passing ``origin/<name>`` (today's callers
+        # pass bare names).  ``base_branch`` may also arrive
+        # ``origin/``-prefixed in pipeline mode (``gateway.py`` sets
+        # ``worktree_base_branch = f"origin/{...}"`` and
+        # ``resolve_default_branch`` returns ``"origin/main"``).  Strip
+        # the prefix on both so the fetch refspec and the candidate-ref
+        # lookup below agree on the bare name — otherwise the secondary
+        # candidate is built as ``origin/origin/main`` and fails to resolve.
+        assigned_name = assigned_branch.removeprefix("origin/") if assigned_branch else None
         fetch_branches: list[str] = []
-        if assigned_branch:
-            fetch_branches.append(assigned_branch)
+        if assigned_name:
+            fetch_branches.append(assigned_name)
         base_name: str | None = None
         if base_branch and base_branch != "HEAD":
             base_name = base_branch.removeprefix("origin/")
@@ -866,7 +1013,14 @@ class WorktreeManager:
                         timeout=15,
                         env=fetch_env,
                     )
-        except (subprocess.TimeoutExpired, OSError) as exc:
+        except Exception as exc:
+            # Best-effort: any failure (timeout, OSError, credential-helper
+            # error from ``_git_credential_env``, etc.) is logged and we
+            # still attempt the reset against whatever local state we have.
+            # A narrower catch would surface unexpected exception types as
+            # a hard worktree-reuse failure, contradicting this helper's
+            # best-effort contract — mirrors the create-path's catch in
+            # ``_resolve_assigned_fork_point``.
             logger.warning(
                 "Fetch before worktree-reuse reset failed (continuing)",
                 container_id=container_id,
@@ -876,8 +1030,8 @@ class WorktreeManager:
 
         target_ref: str | None = None
         candidates: list[str] = []
-        if assigned_branch:
-            candidates.append(f"origin/{assigned_branch}")
+        if assigned_name:
+            candidates.append(f"origin/{assigned_name}")
         if base_name is not None:
             candidates.append(f"origin/{base_name}")
         for candidate in candidates:

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -874,7 +874,15 @@ class WorktreeManager:
                     capture_output=True,
                     text=True,
                     check=False,
-                    timeout=30,
+                    # Matches the reuse path's per-fetch budget at
+                    # ``_reset_reused_worktree_to_safe_ref`` (line 1013) so
+                    # the worst-case create-path latency under
+                    # ``_get_repo_lock`` is bounded by ``base (30s) +
+                    # assigned (15s) = 45s`` rather than 60s.  The base
+                    # fetch keeps its 30s budget because it hard-fails per
+                    # #3021; the assigned fetch is best-effort and falls
+                    # back to the base branch on timeout.
+                    timeout=15,
                     env=fetch_env,
                 )
         except Exception as exc:

--- a/gateway/worktree_manager.py
+++ b/gateway/worktree_manager.py
@@ -874,9 +874,9 @@ class WorktreeManager:
                     capture_output=True,
                     text=True,
                     check=False,
-                    # Matches the reuse path's per-fetch budget at
-                    # ``_reset_reused_worktree_to_safe_ref`` (line 1013) so
-                    # the worst-case create-path latency under
+                    # Matches the reuse path's per-fetch budget in
+                    # ``_reset_reused_worktree_to_safe_ref`` so the
+                    # worst-case create-path latency under
                     # ``_get_repo_lock`` is bounded by ``base (30s) +
                     # assigned (15s) = 45s`` rather than 60s.  The base
                     # fetch keeps its 30s budget because it hard-fails per

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -538,14 +538,16 @@ PIPELINE_TOOLS = [
         "description": (
             "Restart all agents in a pipeline phase. Stops all phase containers, "
             "resets consensus and review cycle state, deletes every per-agent "
-            "worktree (salvaging unpushed commits to egg/recovered/* first), and "
-            "respawns all agents. Per-role branch tips are NOT preserved: fresh "
-            "worktrees re-fork from the shared work branch tip "
-            "(origin/<assigned_branch>), so only artifacts that were pushed "
-            "there survive into the respawned agents' trees (#3080). Contrast "
-            "restart_agent, which keeps the agent's worktree intact. Works on "
-            "pipelines in running, awaiting-human, failed, or cancelled state "
-            "(cancelled pipelines come from cancel_task with cleanup=false)."
+            "worktree (best-effort salvage of unpushed commits to "
+            "egg/recovered/* first; worktrees with a corrupted .git marker "
+            "may be skipped without salvage), and respawns all agents. "
+            "Per-role branch tips are NOT preserved: fresh worktrees re-fork "
+            "from the shared work branch tip (origin/<assigned_branch>), so "
+            "only artifacts that were pushed there survive into the "
+            "respawned agents' trees (#3080). Contrast restart_agent, which "
+            "keeps the agent's worktree intact. Works on pipelines in "
+            "running, awaiting-human, failed, or cancelled state (cancelled "
+            "pipelines come from cancel_task with cleanup=false)."
         ),
         "inputSchema": {
             "type": "object",

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -537,10 +537,15 @@ PIPELINE_TOOLS = [
         "name": "restart_phase",
         "description": (
             "Restart all agents in a pipeline phase. Stops all phase containers, "
-            "resets consensus and review cycle state, and respawns all agents. "
-            "Prior phase artifacts are preserved. Works on pipelines in running, "
-            "awaiting-human, failed, or cancelled state (cancelled pipelines come "
-            "from cancel_task with cleanup=false)."
+            "resets consensus and review cycle state, deletes every per-agent "
+            "worktree (salvaging unpushed commits to egg/recovered/* first), and "
+            "respawns all agents. Per-role branch tips are NOT preserved: fresh "
+            "worktrees re-fork from the shared work branch tip "
+            "(origin/<assigned_branch>), so only artifacts that were pushed "
+            "there survive into the respawned agents' trees (#3080). Contrast "
+            "restart_agent, which keeps the agent's worktree intact. Works on "
+            "pipelines in running, awaiting-human, failed, or cancelled state "
+            "(cancelled pipelines come from cancel_task with cleanup=false)."
         ),
         "inputSchema": {
             "type": "object",

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -3161,13 +3161,16 @@ def restart_phase(pipeline_id: str, phase: str) -> tuple[Response, int]:
     Preservation semantics (#3080): per-agent worktrees AND their local
     branches are deleted, so per-role branch tips do not survive a phase
     restart.  Unpushed commits are salvaged to ``egg/recovered/*`` refs
-    first (#2429); the respawned agents' fresh worktrees re-fork from the
-    shared work branch tip (``origin/<assigned_branch>``, base-branch
-    fallback when unpushed — see #3068).  Anything that lived only on a
-    per-role branch (e.g. a reviewer's merge history) is therefore
-    discarded from agent trees; only state pushed to the shared work
-    branch is re-materialised on respawn.  Operators needing per-worktree
-    retention should use ``restart_agent`` instead.
+    on a best-effort basis (#2429) — ``auto_salvage_pipeline``
+    re-enumerates worktrees with ``validate_git=True``, so worktrees
+    with a corrupted ``.git`` marker (the #1723 failure class) may be
+    skipped without salvage.  The respawned agents' fresh worktrees
+    re-fork from the shared work branch tip (``origin/<assigned_branch>``,
+    base-branch fallback when unpushed — see #3068).  Anything that
+    lived only on a per-role branch (e.g. a reviewer's merge history)
+    is therefore discarded from agent trees; only state pushed to the
+    shared work branch is re-materialised on respawn.  Operators needing
+    per-worktree retention should use ``restart_agent`` instead.
 
     URL params:
         pipeline_id: Pipeline ID

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -3158,6 +3158,17 @@ def restart_phase(pipeline_id: str, phase: str) -> tuple[Response, int]:
     review cycle state, and respawns all agents.  Prior phase artifacts
     (from earlier phases) are preserved.
 
+    Preservation semantics (#3080): per-agent worktrees AND their local
+    branches are deleted, so per-role branch tips do not survive a phase
+    restart.  Unpushed commits are salvaged to ``egg/recovered/*`` refs
+    first (#2429); the respawned agents' fresh worktrees re-fork from the
+    shared work branch tip (``origin/<assigned_branch>``, base-branch
+    fallback when unpushed — see #3068).  Anything that lived only on a
+    per-role branch (e.g. a reviewer's merge history) is therefore
+    discarded from agent trees; only state pushed to the shared work
+    branch is re-materialised on respawn.  Operators needing per-worktree
+    retention should use ``restart_agent`` instead.
+
     URL params:
         pipeline_id: Pipeline ID
         phase: Phase name to restart (e.g. "implement")


### PR DESCRIPTION
## Summary

Fixes #3080: `restart_phase` re-forked every per-role agent branch from the base branch, discarding the drafts and merge history the \"prior phase artifacts are preserved\" contract promised. Combined with #3076, a phase restart stranded every producer from its own prior work and re-armed the phantom-NACK conditions the restart was meant to escape (observed live on pipeline-2b3d8b0b, external monorepo).

Two parts:

### 1. Land the stranded #3073 fix on main (cherry-pick `b5611a2cc`)

PR #3073 (fork fresh worktrees from `origin/<assigned_branch>` tip, base fallback) merged at 22:02Z on 2026-06-10 — but into its stack base branch `egg/3068-explicit-refspec-fetch`, **after** that branch had already been squash-merged to main as #3072 at 21:14Z. The reviewed fix never reached main and no open PR carried it. This cherry-picks the squashed #3073 commit verbatim (`git diff` against the stack branch's gateway files is empty).

This is the issue's Expected option (a): restart_phase deletes per-agent worktrees with `delete_branch=True`, so respawn always takes the gateway's fresh-create path — which on main today forks from `origin/<base>` only. With #3073, fresh creation prefers the assigned-branch tip, which carries the drafts agents pushed during the phase (their default push upstream targets it), so respawned worktrees re-materialise the preserved artifacts.

### 2. Restart-shaped regression test + honest contract (Expected option (c))

- **Test** (`TestAssignedBranchForkPoint::test_restart_recreated_worktree_forks_from_advanced_assigned_tip`): pins the full restart cycle — first spawn forks at base, assigned branch advances with a committed draft, `remove_worktree(force=True)` with the default `delete_branch=True` (exactly what restart_phase's `delete_worktrees` does), recreate → asserts the fresh worktree forks at the advanced assigned tip with the draft materialised.
- **Contract**: `restart_phase` route docstring and MCP tool description now state the real semantics — per-role branch tips are destroyed; unpushed commits are salvaged to `egg/recovered/*` (#2429); fresh worktrees re-fork from the shared work branch tip; operators needing worktree retention should use `restart_agent`. This resolves the asymmetry with `restart_agent`'s retention language called out in the issue.

### Deliberately not done

- Option (b) (orchestrator materialises drafts into worktrees) — redundant once fork-from-assigned lands.
- Re-forking per-role worktrees from their *own* per-role remote tips — re-opens the #2222 resubmit-collision staleness class that `_reset_reused_worktree_to_safe_ref` guards against; the assigned tip is the curated source of truth, now documented as intentional.

## Testing

- `gateway/tests/test_worktree_manager.py` — 117 passed (includes the new restart-cycle test and #3073's real-git fixtures)
- `orchestrator/tests/test_restart_phase.py`, `test_restart_mcp_tools.py`, `test_mcp_tools.py` — 221 passed
- ruff check + format clean

Related: #3080, #3076 (what makes the loss fatal), #3068/#3072/#3073 (the fork-from-base lineage), #2806 (why restart_phase gets reached for instead of restart_agent).
