### PR TITLE
feat(orchestrator): pin --effort high on fable-routed agents (re-land #3063)

### DIFF
--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -117,7 +117,12 @@ in `orchestrator/agent_model_resolution.py` walks the chain:
 > rebuilt.
 
 The result is an `AgentModelDecision` dataclass with fields
-`(claude_code_alias: str, upstream: str, upstream_model: str | None)`.
+`(claude_code_alias: str, upstream: str, upstream_model: str | None,
+effort: str | None)`. `effort` is pinned to `"high"` for fable-routed
+decisions and threaded to the agent command as `--effort high`
+(via `ClaudeAgentOptions.effort` in `egg_agent`); it is `None` for
+every other model, which omits the flag so the session inherits
+Claude Code's per-model default effort.
 
 ### Classifier — Claude alias vs. LiteLLM upstream
 

--- a/orchestrator/agent_model_resolution.py
+++ b/orchestrator/agent_model_resolution.py
@@ -61,6 +61,17 @@ DEFAULT_AGENT_MODEL = "opus"
 # unchanged — this only splits the tier-3 built-in by role).
 FABLE_DEFAULT_MODEL = "fable"
 
+# Effort level pinned on fable-routed agents (threaded to ``--effort``
+# on the ``python3 -m egg_agent`` command). Claude Code's built-in
+# default for fable is currently also "high", but that table is whatever
+# the image's installed Claude Code build says at build time — pinning
+# keeps token spend deliberate if a future stable release changes the
+# default (the way opus moved xhigh→high across 4.7→4.8). Every other
+# model gets ``effort=None`` and keeps inheriting Claude Code's
+# per-model default, so opus agents are byte-identical to today.
+FABLE_EFFORT = "high"
+_FABLE_ALIASES = frozenset({"fable", "fable[1m]"})
+
 # Role values that pick up FABLE_DEFAULT_MODEL at tier 3. Derived from
 # the phase→role tables so new refine/plan roles inherit the default
 # without a parallel list here. ``repo=EGG_REPO`` includes the egg-only
@@ -140,11 +151,16 @@ class AgentModelDecision:
             not rewrite the request body — Claude Code already sends the
             bare name once the ``[1m]`` suffix is stripped — so this is
             now an audit field rather than a routing input.
+        effort: Effort level passed to the agent command as ``--effort``,
+            or ``None`` to omit the flag and inherit Claude Code's
+            per-model default. Currently :data:`FABLE_EFFORT` for
+            fable-routed decisions and ``None`` for everything else.
     """
 
     claude_code_alias: str
     upstream: str
     upstream_model: str | None
+    effort: str | None = None
 
     def env_vars(self) -> dict[str, str]:
         """Env vars to inject into the agent's sandbox for this decision.
@@ -228,6 +244,7 @@ def classify_model(model: str) -> AgentModelDecision:
             claude_code_alias=model,
             upstream=UPSTREAM_ANTHROPIC,
             upstream_model=None,
+            effort=FABLE_EFFORT if model in _FABLE_ALIASES else None,
         )
     # LiteLLM path (#2832): the operator may pass the bare upstream name
     # (e.g. ``qwen3-coder-30b``) or pre-suffix it (``qwen3-coder-30b[1m]``).
@@ -333,6 +350,7 @@ __all__ = [
     "AgentModelDecision",
     "DEFAULT_AGENT_MODEL",
     "FABLE_DEFAULT_MODEL",
+    "FABLE_EFFORT",
     "UPSTREAM_ANTHROPIC",
     "UPSTREAM_LITELLM",
     "classify_model",

--- a/orchestrator/agent_model_resolution.py
+++ b/orchestrator/agent_model_resolution.py
@@ -69,6 +69,14 @@ FABLE_DEFAULT_MODEL = "fable"
 # default (the way opus moved xhigh→high across 4.7→4.8). Every other
 # model gets ``effort=None`` and keeps inheriting Claude Code's
 # per-model default, so opus agents are byte-identical to today.
+#
+# The pin is keyed on the exact ``fable`` / ``fable[1m]`` aliases, NOT on
+# the versioned ``claude-fable-*`` family. An operator who configures
+# ``agent_models[role] = "claude-fable-5"`` matches the generic
+# ``^claude-`` regex in ``_is_claude_alias`` and gets ``effort=None`` —
+# i.e. the versioned name escapes the drift defense the alias was pinned
+# to provide. Use the bare ``fable`` alias (or add the versioned name to
+# ``_FABLE_ALIASES``) if you want the pin to apply.
 FABLE_EFFORT = "high"
 _FABLE_ALIASES = frozenset({"fable", "fable[1m]"})
 

--- a/orchestrator/concurrent_executor.py
+++ b/orchestrator/concurrent_executor.py
@@ -463,7 +463,9 @@ class ConcurrentPhaseExecutor:
 
         command: list[str] | None = None
         if prompt_text:
-            command = build_consensus_wrapped_command(prompt_text, model=decision.claude_code_alias)
+            command = build_consensus_wrapped_command(
+                prompt_text, model=decision.claude_code_alias, effort=decision.effort
+            )
 
         # On the LiteLLM path Claude Code needs the ANTHROPIC_CUSTOM_MODEL_OPTION
         # env vars to opt into 1M-context compaction math (#2832). The decision's

--- a/orchestrator/consensus_wrapper.py
+++ b/orchestrator/consensus_wrapper.py
@@ -729,6 +729,7 @@ def build_event_pump_wrapped_command(
     idle_budget_min: int = EVENT_PUMP_IDLE_BUDGET_MIN_DEFAULT,
     heartbeat_interval_secs: int = EVENT_PUMP_HEARTBEAT_INTERVAL_SECS_DEFAULT,
     wait_timeout_secs: int = EVENT_PUMP_WAIT_TIMEOUT_SECS_DEFAULT,
+    effort: str | None = None,
 ) -> list[str]:
     """Compose the event-pump wrapper bash command (#2908 task-2-1).
 
@@ -756,6 +757,10 @@ def build_event_pump_wrapped_command(
         "--max-turns",
         str(max_turns),
     ]
+    if effort is not None:
+        # Pin the reasoning effort instead of inheriting the installed
+        # Claude Code build's per-model default (AgentModelDecision.effort).
+        agent_prefix_parts.extend(["--effort", effort])
     agent_command_prefix = " ".join(shlex.quote(p) for p in agent_prefix_parts)
 
     script = _EVENT_PUMP_WRAPPER_TEMPLATE.format(
@@ -771,6 +776,7 @@ def build_consensus_wrapped_command(
     prompt_text: str,
     model: str = "opus",
     max_turns: int = 1000,
+    effort: str | None = None,
 ) -> list[str]:
     """Build a shell command that runs the agent under the BRC event-pump wrapper.
 
@@ -791,6 +797,9 @@ def build_consensus_wrapped_command(
         model: Agent model to use.
         max_turns: Maximum number of tool-call turns per agent
             invocation.
+        effort: Reasoning effort to pin via ``--effort`` (e.g.
+            ``"high"``), or ``None`` to inherit Claude Code's
+            per-model default.
 
     Returns:
         Command list suitable for container spawning (``bash -c "..."``).
@@ -799,4 +808,5 @@ def build_consensus_wrapped_command(
         prompt_text,
         model=model,
         max_turns=max_turns,
+        effort=effort,
     )

--- a/orchestrator/kubernetes_spawner.py
+++ b/orchestrator/kubernetes_spawner.py
@@ -1725,7 +1725,14 @@ class KubernetesSpawner:
         Returns:
             SpawnedContainer with overseer Job and session info.
         """
+        # Classify the overseer's decision model so that ``AgentModelDecision.effort``
+        # threads to ``--effort`` for fable-routed overseers — same drift defense as
+        # the refine/plan path. Default ``sonnet`` yields ``effort=None`` (no behavior
+        # change); only ``overseer_decision_maker_model=fable`` flips the pin on.
+        from agent_model_resolution import classify_model
         from egg_agent import build_agent_command
+
+        overseer_decision = classify_model(decision_model)
 
         extra_env = {
             "EGG_OVERSEER_MODE": "true",
@@ -1759,6 +1766,7 @@ class KubernetesSpawner:
             prompt=overseer_prompt,
             model=decision_model,
             max_turns=max_turns,
+            effort=overseer_decision.effort,
         )
 
         return self.spawn_agent_job(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2943,7 +2943,9 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
                     from consensus_wrapper import build_consensus_wrapped_command
 
                     command = build_consensus_wrapped_command(
-                        prompt_text, model=_model_decision.claude_code_alias
+                        prompt_text,
+                        model=_model_decision.claude_code_alias,
+                        effort=_model_decision.effort,
                     )
             except Exception as prompt_err:
                 logger.warning(

--- a/orchestrator/tests/test_agent_model_resolution.py
+++ b/orchestrator/tests/test_agent_model_resolution.py
@@ -98,11 +98,14 @@ def _pipeline_config(**overrides):
 
 
 class TestAgentModelDecisionShape:
-    """The decision triple is the resolver's contract.
+    """The decision tuple is the resolver's contract.
 
-    Downstream callers (``concurrent_executor`` / ``routes.pipelines``)
-    unpack it into ``--model`` (Claude-Code-facing) and the
-    ``register_session(upstream=..., upstream_model=...)`` payload.
+    Four named fields: ``claude_code_alias``, ``upstream``,
+    ``upstream_model``, ``effort``. Downstream callers
+    (``concurrent_executor`` / ``routes.pipelines``) unpack it into
+    ``--model`` (Claude-Code-facing), the
+    ``register_session(upstream=..., upstream_model=...)`` payload, and
+    the ``--effort`` flag on the spawned agent.
     """
 
     def test_decision_has_four_named_fields(self):

--- a/orchestrator/tests/test_agent_model_resolution.py
+++ b/orchestrator/tests/test_agent_model_resolution.py
@@ -822,3 +822,52 @@ class TestDefaultPathRegression:
         assert d.claude_code_alias == "sonnet"
         assert d.upstream == "anthropic"
         assert d.upstream_model is None
+
+
+# =============================================================================
+# Effort pinning: fable decisions carry effort="high", everything else None
+# =============================================================================
+
+
+class TestEffortPinning:
+    """Fable-routed decisions pin ``effort="high"`` (FABLE_EFFORT); every
+    other decision carries ``effort=None`` so the agent inherits Claude
+    Code's per-model default (notably opus stays on its existing
+    default-effort baseline).
+    """
+
+    @pytest.mark.parametrize("model", ["fable", "fable[1m]"])
+    def test_fable_aliases_pin_high_effort(self, model):
+        from agent_model_resolution import classify_model
+
+        d = classify_model(model)
+        assert d.effort == "high"
+        assert d.upstream == "anthropic"
+
+    @pytest.mark.parametrize(
+        "model",
+        ["opus", "opus[1m]", "sonnet", "sonnet[1m]", "haiku", "claude-sonnet-4-5"],
+    )
+    def test_other_claude_aliases_inherit_default_effort(self, model):
+        from agent_model_resolution import classify_model
+
+        assert classify_model(model).effort is None
+
+    def test_litellm_models_inherit_default_effort(self):
+        from agent_model_resolution import classify_model
+
+        assert classify_model("qwen3-max").effort is None
+
+    def test_refine_plan_default_decision_carries_high_effort(self):
+        """The built-in fable default for refine/plan roles flows through
+        ``resolve_agent_model`` with the pinned effort attached."""
+        resolve_agent_model = _resolver()
+        AgentRole = _agent_role()
+        config = _pipeline_config()
+
+        with patch("config.repo_config.get_default_agent_model", return_value=None):
+            refiner = resolve_agent_model(AgentRole.REFINER, config, "any/repo")
+            coder = resolve_agent_model(AgentRole.CODER, config, "any/repo")
+
+        assert refiner.effort == "high"
+        assert coder.effort is None

--- a/orchestrator/tests/test_agent_model_resolution.py
+++ b/orchestrator/tests/test_agent_model_resolution.py
@@ -105,7 +105,7 @@ class TestAgentModelDecisionShape:
     ``register_session(upstream=..., upstream_model=...)`` payload.
     """
 
-    def test_decision_has_three_named_fields(self):
+    def test_decision_has_four_named_fields(self):
         decision_cls = _decision_cls()
         d = decision_cls(
             claude_code_alias="opus",
@@ -115,6 +115,7 @@ class TestAgentModelDecisionShape:
         assert d.claude_code_alias == "opus"
         assert d.upstream == "anthropic"
         assert d.upstream_model is None
+        assert d.effort is None
 
     def test_decision_accepts_upstream_model_string(self):
         decision_cls = _decision_cls()

--- a/orchestrator/tests/test_agent_model_resolution.py
+++ b/orchestrator/tests/test_agent_model_resolution.py
@@ -850,7 +850,15 @@ class TestEffortPinning:
 
     @pytest.mark.parametrize(
         "model",
-        ["opus", "opus[1m]", "sonnet", "sonnet[1m]", "haiku", "claude-sonnet-4-5"],
+        [
+            "opus",
+            "opus[1m]",
+            "sonnet",
+            "sonnet[1m]",
+            "haiku",
+            "claude-sonnet-4-5",
+            "claude-fable-5",
+        ],
     )
     def test_other_claude_aliases_inherit_default_effort(self, model):
         from agent_model_resolution import classify_model

--- a/orchestrator/tests/test_consensus_wrapper.py
+++ b/orchestrator/tests/test_consensus_wrapper.py
@@ -1297,3 +1297,23 @@ class TestEventPumpInvokesComposer:
     # and ``invoke_agent_for_event``. See
     # ``test_invokes_event_prompt_composer_script`` (above) for the
     # post-deletion positive invariant.
+
+
+class TestEffortFlag:
+    """``effort`` threads into the agent command prefix as ``--effort``.
+
+    The decision's effort (AgentModelDecision.effort — currently pinned
+    only for fable-routed agents) must reach the ``python3 -m egg_agent``
+    invocation; omitting it must leave the flag off entirely so every
+    other model keeps inheriting Claude Code's per-model default.
+    """
+
+    def test_effort_appends_flag_to_agent_prefix(self):
+        cmd = build_consensus_wrapped_command("Prompt", model="fable", effort="high")
+        script = cmd[2]
+        assert "--model fable --max-turns 1000 --effort high" in script
+
+    def test_no_effort_omits_flag(self):
+        cmd = build_consensus_wrapped_command("Prompt", model="opus")
+        script = cmd[2]
+        assert "--effort" not in script

--- a/orchestrator/tests/test_overseer_max_turns.py
+++ b/orchestrator/tests/test_overseer_max_turns.py
@@ -314,6 +314,46 @@ class TestSpawnOverseerMaxTurns:
         assert command[max_turns_idx + 1] == "100"
 
 
+class TestSpawnOverseerEffort:
+    """Verify spawn_overseer_container threads ``AgentModelDecision.effort``
+    into the agent command — fable-routed overseers get ``--effort high``
+    so they share the refine/plan drift defense; every other model omits
+    the flag and inherits Claude Code's per-model default.
+    """
+
+    def test_default_sonnet_omits_effort_flag(self, spawner, mock_docker_client):
+        """Default ``decision_model='sonnet'`` carries ``effort=None``,
+        which must NOT add ``--effort`` to the command — the overseer
+        keeps inheriting Claude Code's per-model default exactly as
+        before this change."""
+        spawner.spawn_overseer_container(
+            pipeline_id="issue-1562-sonnet",
+            issue_number=1562,
+        )
+
+        create_call = mock_docker_client.create_container.call_args
+        command = create_call.kwargs.get("command", [])
+        assert "--effort" not in command, (
+            "sonnet-routed overseer must inherit Claude Code's default effort"
+        )
+
+    def test_fable_decision_model_pins_high_effort(self, spawner, mock_docker_client):
+        """An operator who sets ``overseer_decision_maker_model='fable'``
+        gets ``--effort high`` threaded through, matching the refine/plan
+        path's drift defense."""
+        spawner.spawn_overseer_container(
+            pipeline_id="issue-1562-fable",
+            issue_number=1562,
+            decision_model="fable",
+        )
+
+        create_call = mock_docker_client.create_container.call_args
+        command = create_call.kwargs.get("command", [])
+        assert "--effort" in command, "fable-routed overseer must pin --effort high"
+        effort_idx = command.index("--effort")
+        assert command[effort_idx + 1] == "high"
+
+
 # ---------------------------------------------------------------------------
 # Scenario 3: _check_and_respawn_overseer passes max_turns from config
 # ---------------------------------------------------------------------------

--- a/shared/egg_agent/__main__.py
+++ b/shared/egg_agent/__main__.py
@@ -36,6 +36,12 @@ def main() -> int:
     parser.add_argument("--max-turns", type=int, default=None, help="Max conversation turns.")
     parser.add_argument("--system-prompt", default=None, help="System prompt override.")
     parser.add_argument("--timeout", type=int, default=7200, help="Timeout in seconds.")
+    parser.add_argument(
+        "--effort",
+        default=None,
+        choices=["low", "medium", "high", "max"],
+        help=("Reasoning effort for the session. Omit to inherit Claude Code's per-model default."),
+    )
 
     args = parser.parse_args()
 
@@ -56,6 +62,7 @@ def main() -> int:
         system_prompt=args.system_prompt,
         timeout=args.timeout,
         on_output=_stream_to_stdout,
+        effort=args.effort,
     )
 
     if result.stderr:

--- a/shared/egg_agent/client.py
+++ b/shared/egg_agent/client.py
@@ -168,6 +168,7 @@ async def run_agent_async(
     on_output: Callable[[str], None] | None = None,
     env: dict[str, str] | None = None,
     intercept_tools: bool = True,
+    effort: str | None = None,
 ) -> AgentResult:
     """Run a Claude agent using the Agent SDK.
 
@@ -184,6 +185,10 @@ async def run_agent_async(
             calls that violate role-based file restrictions. Blocked tools
             return an error to the LLM instead of executing.
             Only active when EGG_AGENT_ROLE is set.
+        effort: Reasoning effort level (``low`` / ``medium`` / ``high`` /
+            ``max``), passed to the CLI as ``--effort``. ``None``
+            (default) omits the flag so the session inherits Claude
+            Code's per-model default.
 
     Returns:
         :class:`AgentResult` with response text and metadata.
@@ -295,6 +300,9 @@ async def run_agent_async(
         options.max_turns = max_turns
     if system_prompt is not None:
         options.system_prompt = system_prompt
+    if effort is not None:
+        # The SDK passes this to the spawned CLI as ``--effort <level>``.
+        options.effort = effort
 
     # --- Register in-process SDK MCP servers with egg's agent tools ---
     # Default-on since issue #1942.  Set ``EGG_MCP_TOOLS=false`` (or
@@ -484,6 +492,7 @@ async def run_agent_async(
         event_type="system",
         event_subtype="init",
         model=model,
+        effort=effort,
         cwd=effective_cwd,
         permission_mode="bypassPermissions",
         max_turns=max_turns,

--- a/shared/egg_agent/command.py
+++ b/shared/egg_agent/command.py
@@ -14,6 +14,7 @@ def build_agent_command(
     model: str = "opus",
     max_turns: int = 200,
     system_prompt: str | None = None,
+    effort: str | None = None,
 ) -> list[str]:
     """Build a container command list for running a Claude agent.
 
@@ -27,6 +28,13 @@ def build_agent_command(
         model: Model alias or ID (default: ``"opus"``).
         max_turns: Maximum conversation turns (default: 200).
         system_prompt: Optional system prompt override.
+        effort: Reasoning effort to pin via ``--effort`` (e.g.
+            ``"high"``), or ``None`` to inherit Claude Code's
+            per-model default. Mirrors the ``effort`` plumbing in
+            ``build_consensus_wrapped_command`` so the overseer Job
+            and other ``build_agent_command`` callers honour
+            ``AgentModelDecision.effort`` when the model is
+            fable-routed.
 
     Returns:
         Command list suitable for container execution.
@@ -40,6 +48,8 @@ def build_agent_command(
         "--max-turns",
         str(max_turns),
     ]
+    if effort is not None:
+        cmd.extend(["--effort", effort])
     if system_prompt is not None:
         cmd.extend(["--system-prompt", system_prompt])
     cmd.append(prompt)

--- a/tests/shared/egg_agent/test_command.py
+++ b/tests/shared/egg_agent/test_command.py
@@ -55,3 +55,18 @@ class TestBuildAgentCommand:
         """Test that prompt is last even with system prompt."""
         cmd = build_agent_command("my prompt", system_prompt="sys")
         assert cmd[-1] == "my prompt"
+
+    def test_effort_appends_flag(self):
+        """``effort`` threads ``--effort <level>`` into the command."""
+        cmd = build_agent_command("test", model="fable", effort="high")
+        assert "--effort" in cmd
+        idx = cmd.index("--effort")
+        assert cmd[idx + 1] == "high"
+        # Prompt remains last.
+        assert cmd[-1] == "test"
+
+    def test_no_effort_by_default(self):
+        """``--effort`` is omitted when ``effort`` is None so the spawned
+        CLI inherits Claude Code's per-model default."""
+        cmd = build_agent_command("test")
+        assert "--effort" not in cmd


### PR DESCRIPTION
Re-lands PR #3063, whose commits never reached main.

#3063 was stacked on `egg/fable-refine-plan-default` and merged into that branch at 19:02 UTC — after the base PR (#3062) had already squash-merged to main. The base branch was never re-merged, so the merge commit (`9bf2a70`) is unreachable from main (classic orphaned-stacked-PR).

This branch cherry-picks the three commits from #3063 onto current main (clean, no conflicts):

- `014259c` feat(orchestrator): pin --effort high on fable-routed agents
- `3ee6ce3` Address PR #3063 review feedback
- `bf8f6d3` docs(orchestrator): update TestAgentModelDecisionShape docstring for four fields

The diff against main is identical to the original PR's content (216 insertions / 9 deletions across 13 files).