### PR TITLE
fix(orchestrator): revive propose-time validation disabled by unauthenticated fetch (#3081)

### DIFF
--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -353,13 +353,109 @@ def handle_signal(pipeline_id: str) -> tuple[Response, int]:
     return handler(pipeline_id, data, repo_path)
 
 
+def _gateway_fetch_tracking_ref(
+    pipeline_id: str,
+    branch: str,
+    worktree_path: Path,
+    pipeline_state: Any | None,
+) -> bool:
+    """Fetch ``branch`` into ``refs/remotes/origin/<branch>`` via the gateway.
+
+    The orchestrator pod holds no GitHub credentials (only the gateway does),
+    so a raw ``git fetch origin`` from here fails on *every* call with
+    "could not read Username" — which made ``_verify_commit_on_branch``
+    return ``None`` on every propose and silently disabled the entire
+    propose-time validation layer (#1473 commit-on-branch, #3016 / #3026
+    draft presence + parseability) in the k8s deployment (#3081). Route the
+    fetch through the gateway's authenticated ``/api/v1/git/fetch`` instead —
+    the same plumbing ``_sync_worktree_with_remote`` already uses.
+
+    Uses an explicit tracking refspec so the ``git branch -r --contains``
+    read that follows sees a fresh ``origin/<branch>`` even on
+    narrow-refspec mirrors (#3072 / #3075) — a bare-name fetch updates only
+    ``FETCH_HEAD`` there, leaving the tracking ref stale and turning the
+    contains-check into a wrongful 409 for freshly-pushed commits.
+
+    Best-effort: returns ``False`` on any failure (caller degrades to the
+    tri-state ``None`` path).
+    """
+    try:
+        # Lazy imports: keep the ~2.4k-line gateway_client and ~24k-line
+        # routes.pipelines modules out of ``signals`` import time (matches
+        # the ``_get_draft_path`` pattern in the validators below).
+        try:
+            from gateway_client import get_gateway_client
+        except ImportError:
+            from ..gateway_client import get_gateway_client  # type: ignore[no-redef]
+
+        mode = "public"
+        if pipeline_state is not None:
+            try:
+                from routes.pipelines import _compute_gateway_mode
+            except ImportError:
+                from .pipelines import _compute_gateway_mode  # type: ignore[no-redef]
+            mode, _vis = _compute_gateway_mode(pipeline_state)
+
+        refspec = f"+refs/heads/{branch}:refs/remotes/origin/{branch}"
+        return get_gateway_client().fetch_branch(
+            pipeline_id,
+            str(worktree_path),
+            args=[refspec],
+            mode=mode,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Gateway tracking-ref fetch failed (non-blocking)",
+            pipeline_id=pipeline_id,
+            branch=branch,
+            error=str(exc),
+        )
+        return False
+
+
+def _commit_object_resolvable(worktree_path: Path, commit_sha: str) -> bool:
+    """True when ``commit_sha`` resolves to a commit object locally.
+
+    Lets the draft validators keep checking when branch verification was
+    inconclusive: with the object present, a non-zero ``git show
+    {sha}:{path}`` reliably means "path absent at commit", not "commit
+    unknown". In the shared-object-store deployment (all agent worktrees
+    share the base repo's ``.git``) a producer's commit is locally visible
+    the moment it is created, no fetch required (#3081).
+    """
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(worktree_path),
+                "cat-file",
+                "-e",
+                f"{commit_sha}^{{commit}}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
 def _verify_commit_on_branch(
     commit: str,
     branch: str,
     worktree_path: Path,
     pipeline_id: str,
+    pipeline_state: Any | None = None,
 ) -> bool | None:
     """Check if a commit exists on the expected branch.
+
+    ``pipeline_state`` (when available at the call site) feeds
+    ``_compute_gateway_mode`` so the authenticated fetch uses the
+    pipeline's network mode; without it the fetch defaults to public and
+    private-repo fetches degrade to ``None``.
 
     Returns:
         True if commit is on the branch.
@@ -367,20 +463,21 @@ def _verify_commit_on_branch(
         None if verification failed (best-effort, non-blocking).
     """
     try:
-        # Fetch first to ensure we have the latest remote state
-        result = subprocess.run(
-            ["git", "-C", str(worktree_path), "fetch", "origin", "--", branch],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            check=False,
-        )
-        if result.returncode != 0:
-            logger.warning(
-                "Branch fetch failed during completion verification (non-blocking)",
+        # Authenticated fetch via the gateway, with an explicit tracking
+        # refspec (#3081 — see _gateway_fetch_tracking_ref). The OVERSEER_ALERT
+        # below is the visibility guard: when this fetch fails persistently,
+        # every downstream propose-time validator degrades to non-blocking,
+        # and that must not be silent again.
+        if not _gateway_fetch_tracking_ref(pipeline_id, branch, worktree_path, pipeline_state):
+            logger.error(
+                "OVERSEER_ALERT commit_verification_fetch_failed",
                 pipeline_id=pipeline_id,
                 branch=branch,
-                error=result.stderr.strip(),
+                note=(
+                    "gateway-authenticated fetch failed; commit-on-branch "
+                    "verification and propose-time draft validation degrade "
+                    "to non-blocking (#3081)"
+                ),
             )
             return None  # Can't verify — don't block
 
@@ -517,6 +614,7 @@ def handle_complete_signal(
                 pipeline.branch,
                 contract_path,
                 pipeline_id,
+                pipeline_state=pipeline,
             )
             if branch_verified is False:
                 # Hard-block: commit not found on expected branch.
@@ -1008,26 +1106,23 @@ def _validate_plan_proposal(
     directly (e.g. from unit tests).
 
     Graceful degradation: returns silently when the proposal carries no commit
-    SHA, branch verification was inconclusive (``branch_verified is None`` — an
-    orchestrator-side fetch glitch, not a producer fault; a non-zero ``git show``
-    could then mean "commit not in local cache" rather than "path absent"), the
-    pipeline has no branch / no resolvable draft path, ``git show`` errors for an
-    infrastructure reason (timeout / git failure), the parser raises, or
-    ``to_contract_slices`` raises (e.g. a future Pydantic field tightening). It
-    raises only when it can positively confirm — at a resolved, branch-verified
-    commit — that the draft is absent/empty, unparseable, or role-misassigned.
-    ``branch_verified`` defaults to ``True`` so direct callers (unit tests) that
-    don't run ``_verify_commit_on_branch`` still get the check.
+    SHA, the pipeline has no branch / no resolvable draft path, ``git show``
+    errors for an infrastructure reason (timeout / git failure), the parser
+    raises, or ``to_contract_slices`` raises (e.g. a future Pydantic field
+    tightening). Inconclusive branch verification (``branch_verified is None``
+    — an orchestrator-side fetch glitch, not a producer fault) skips the
+    checks only when the commit object is *also* absent locally
+    (``_commit_object_resolvable``); with the object present, a non-zero
+    ``git show`` reliably means "path absent at commit", so validation
+    proceeds — an unconditional skip-on-``None`` let a persistent fetch
+    failure disable this validator entirely (#3081). It raises only when it
+    can positively confirm — at a locally-resolved commit — that the draft is
+    absent/empty, unparseable, or role-misassigned. ``branch_verified``
+    defaults to ``True`` so direct callers (unit tests) that don't run
+    ``_verify_commit_on_branch`` still get the check.
     """
     commit_sha = (payload.get("commit_sha") or "").strip()
     if not commit_sha:
-        return
-
-    # Orchestrator-side commit verification was inconclusive — a non-zero
-    # ``git show`` below could be "commit not in local object cache" rather than
-    # "path absent at commit", so skip rather than false-blame the producer (the
-    # same tri-state guard ``_validate_producer_draft_present`` uses, #3016).
-    if branch_verified is None:
         return
 
     if pipeline_state is None:
@@ -1058,6 +1153,23 @@ def _validate_plan_proposal(
 
     if worktree_path is None:
         worktree_path = resolve_worktree_path(pipeline_id, repo_path)
+
+    # Orchestrator-side commit verification was inconclusive — a non-zero
+    # ``git show`` below could be "commit not in local object cache" rather
+    # than "path absent at commit". But that ambiguity only exists when the
+    # commit object is actually absent: when it resolves locally (always, in
+    # the shared-object-store deployment), the checks below stay sound, so
+    # keep validating. Skipping unconditionally on ``None`` is how #3081
+    # shipped a full consensus with no canonical draft — the fetch failure
+    # was persistent, so the "transient glitch" skip became "never validate".
+    if branch_verified is None and not _commit_object_resolvable(worktree_path, commit_sha):
+        logger.warning(
+            "plan proposal validation skipped: branch verification "
+            "inconclusive and commit not in local object store",
+            pipeline_id=pipeline_id,
+            commit_sha=commit_sha,
+        )
+        return
 
     # Read plan content as committed at the proposed SHA, not from the working
     # tree (which can lag HEAD — #2723). The preceding ``_verify_commit_on_branch``
@@ -1221,12 +1333,12 @@ def _validate_producer_draft_present(
     Graceful degradation: when the proposal carries no commit SHA, the pipeline has
     no branch, the draft path can't be derived, ``git show`` errors for an
     infrastructure reason (timeout / git failure), or branch verification was
-    inconclusive (``branch_verified is None`` — see below), this returns silently. It
-    raises only when it can positively confirm the draft is absent (or empty) at a
-    resolved, branch-verified commit — ``handle_consensus_propose_signal`` has
-    already run ``_verify_commit_on_branch`` (which fetches the commit), so a
-    non-zero ``git show`` here reliably means "path absent at commit", not "commit
-    unknown".
+    inconclusive *and* the commit object is not locally resolvable (see below),
+    this returns silently. It raises only when it can positively confirm the
+    draft is absent (or empty) at a locally-resolved commit — either
+    ``_verify_commit_on_branch`` fetched it, or it already exists in the shared
+    object store — so a non-zero ``git show`` here reliably means "path absent
+    at commit", not "commit unknown".
 
     ``pipeline_state`` / ``worktree_path`` are threaded in by
     ``handle_consensus_propose_signal`` to reuse the lookups it already performed for
@@ -1237,24 +1349,18 @@ def _validate_producer_draft_present(
     ``True`` (commit is on the branch — fetch + ``--contains`` succeeded), ``False``
     (commit is *not* on the branch — the caller already 409'd, so this is
     unreachable in practice), or ``None`` (verification was inconclusive because
-    ``git fetch`` or ``git branch -r --contains`` errored — orchestrator-side
-    glitch, not a producer fault). When ``None`` is passed, the presence check is
-    skipped because a non-zero ``git show`` could legitimately mean the commit
-    isn't in the local object cache rather than the path being absent — false-
-    rejecting in that case would burn a producer turn on an orchestrator glitch
-    (matches the existing "could not verify branch" non-blocking warning at the
-    handler level). Defaults to ``True`` so direct callers (unit tests) that
-    don't run ``_verify_commit_on_branch`` still get the check.
+    the gateway fetch or ``git branch -r --contains`` errored — orchestrator-side
+    glitch, not a producer fault). When ``None`` is passed, the presence check
+    is skipped only if the commit object is *also* absent locally
+    (``_commit_object_resolvable``) — with the object present, a non-zero
+    ``git show`` reliably means the path is absent at the commit, so the check
+    proceeds; an unconditional skip let a persistent fetch failure disable
+    this validator entirely (#3081). Defaults to ``True`` so direct callers
+    (unit tests) that don't run ``_verify_commit_on_branch`` still get the
+    check.
     """
     commit_sha = (payload.get("commit_sha") or "").strip()
     if not commit_sha:
-        return
-
-    # Orchestrator-side verification of the commit was inconclusive (fetch or
-    # branch-contains errored). A non-zero ``git show`` below could legitimately
-    # be "commit not in local object cache" rather than "path absent at commit",
-    # so skip rather than risk a false 400.
-    if branch_verified is None:
         return
 
     if pipeline_state is None:
@@ -1286,6 +1392,21 @@ def _validate_producer_draft_present(
 
     if worktree_path is None:
         worktree_path = resolve_worktree_path(pipeline_id, repo_path)
+
+    # Branch verification inconclusive (fetch or branch-contains errored).
+    # Skip only when the commit object is also absent locally — when it
+    # resolves, the ``git show`` below stays sound (see the same guard in
+    # ``_validate_plan_proposal``; unconditional skip-on-None is the #3081
+    # hole).
+    if branch_verified is None and not _commit_object_resolvable(worktree_path, commit_sha):
+        logger.warning(
+            "producer draft presence check skipped: branch verification "
+            "inconclusive and commit not in local object store",
+            pipeline_id=pipeline_id,
+            phase=phase,
+            commit_sha=commit_sha,
+        )
+        return
 
     # Read the draft as committed at the proposed SHA, not from the working tree
     # (which can lag HEAD — see #2723). The preceding ``_verify_commit_on_branch``
@@ -1508,6 +1629,7 @@ def handle_consensus_propose_signal(
                     pipeline_state.branch,
                     worktree_path,
                     pipeline_id,
+                    pipeline_state=pipeline_state,
                 )
                 if branch_verified is False:
                     return make_error_response(

--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -378,25 +378,34 @@ def _gateway_fetch_tracking_ref(
 
     Best-effort: returns ``False`` on any failure (caller degrades to the
     tri-state ``None`` path).
+
+    On unset ``pipeline.network_mode``, ``_compute_gateway_mode`` issues a
+    synchronous gateway RTT (``get_repo_visibility``) — intentional
+    per-propose re-resolution. Most pipelines set ``network_mode`` at
+    submission time so this is a no-op; callers that want to elide the
+    roundtrip should set ``pipeline.network_mode`` upstream.
     """
+    # Lazy imports: keep the ~2.4k-line gateway_client and ~24k-line
+    # routes.pipelines modules out of ``signals`` import time (matches
+    # the ``_get_draft_path`` pattern in the validators below). Done
+    # outside the ``try`` so an import / mode-resolution failure does not
+    # masquerade as a fetch failure in the warning below (and the
+    # OVERSEER_ALERT it triggers in the caller).
     try:
-        # Lazy imports: keep the ~2.4k-line gateway_client and ~24k-line
-        # routes.pipelines modules out of ``signals`` import time (matches
-        # the ``_get_draft_path`` pattern in the validators below).
+        from gateway_client import get_gateway_client
+    except ImportError:
+        from ..gateway_client import get_gateway_client  # type: ignore[no-redef]
+
+    mode = "public"
+    if pipeline_state is not None:
         try:
-            from gateway_client import get_gateway_client
+            from routes.pipelines import _compute_gateway_mode
         except ImportError:
-            from ..gateway_client import get_gateway_client  # type: ignore[no-redef]
+            from .pipelines import _compute_gateway_mode  # type: ignore[no-redef]
+        mode, _vis = _compute_gateway_mode(pipeline_state)
 
-        mode = "public"
-        if pipeline_state is not None:
-            try:
-                from routes.pipelines import _compute_gateway_mode
-            except ImportError:
-                from .pipelines import _compute_gateway_mode  # type: ignore[no-redef]
-            mode, _vis = _compute_gateway_mode(pipeline_state)
-
-        refspec = f"+refs/heads/{branch}:refs/remotes/origin/{branch}"
+    refspec = f"+refs/heads/{branch}:refs/remotes/origin/{branch}"
+    try:
         return get_gateway_client().fetch_branch(
             pipeline_id,
             str(worktree_path),
@@ -468,6 +477,13 @@ def _verify_commit_on_branch(
         # below is the visibility guard: when this fetch fails persistently,
         # every downstream propose-time validator degrades to non-blocking,
         # and that must not be silent again.
+        #
+        # NOTE: this is a logger-only signal — intentionally not broadcast to
+        # agents via ``mcp__progress__overseer_alert``. Per-propose alerts on
+        # every signal handler would be both noisy on the consensus stream and
+        # the wrong granularity (a sustained-failure detector belongs in the
+        # overseer monitor). Operator-side dashboards filter on the prefixed
+        # log line; sustained-failure detection lives in the monitor.
         if not _gateway_fetch_tracking_ref(pipeline_id, branch, worktree_path, pipeline_state):
             logger.error(
                 "OVERSEER_ALERT commit_verification_fetch_failed",
@@ -1346,18 +1362,24 @@ def _validate_producer_draft_present(
     (e.g. from unit tests).
 
     ``branch_verified`` mirrors the tri-state from ``_verify_commit_on_branch``:
-    ``True`` (commit is on the branch — fetch + ``--contains`` succeeded), ``False``
-    (commit is *not* on the branch — the caller already 409'd, so this is
-    unreachable in practice), or ``None`` (verification was inconclusive because
-    the gateway fetch or ``git branch -r --contains`` errored — orchestrator-side
-    glitch, not a producer fault). When ``None`` is passed, the presence check
-    is skipped only if the commit object is *also* absent locally
+    ``True`` (commit is on the branch — fetch + ``--contains`` succeeded),
+    ``False`` (commit is *not* on the branch), or ``None`` (verification was
+    inconclusive because the gateway fetch or ``git branch -r --contains``
+    errored — orchestrator-side glitch, not a producer fault). The current
+    handler short-circuits with a 409 before calling this validator when it
+    sees ``False``, so the ``False`` path is unreachable from production
+    today; the function has no explicit guard and falls through to the
+    ``git show`` path, which is correct (a non-zero ``git show`` still
+    reliably means "path absent at commit"). Callers wiring this validator
+    in without that 409 short-circuit must short-circuit the ``False``
+    verdict themselves. When ``None`` is passed, the presence check is
+    skipped only if the commit object is *also* absent locally
     (``_commit_object_resolvable``) — with the object present, a non-zero
-    ``git show`` reliably means the path is absent at the commit, so the check
-    proceeds; an unconditional skip let a persistent fetch failure disable
-    this validator entirely (#3081). Defaults to ``True`` so direct callers
-    (unit tests) that don't run ``_verify_commit_on_branch`` still get the
-    check.
+    ``git show`` reliably means the path is absent at the commit, so the
+    check proceeds; an unconditional skip let a persistent fetch failure
+    disable this validator entirely (#3081). Defaults to ``True`` so direct
+    callers (unit tests) that don't run ``_verify_commit_on_branch`` still
+    get the check.
     """
     commit_sha = (payload.get("commit_sha") or "").strip()
     if not commit_sha:

--- a/orchestrator/tests/test_brc_content_validation.py
+++ b/orchestrator/tests/test_brc_content_validation.py
@@ -380,6 +380,7 @@ class TestProposeContentValidation:
         data = json.loads(response.data)
         assert "boilerplate" in data["message"]
 
+    @patch("routes.signals._gateway_fetch_tracking_ref", return_value=True)
     @patch("routes.signals.subprocess.run")
     @patch("routes.signals.resolve_worktree_path", return_value=Path("/tmp/wt"))
     @patch("routes.signals.get_state_store")
@@ -390,6 +391,7 @@ class TestProposeContentValidation:
         mock_get_store,
         mock_resolve_wt,
         mock_subprocess_run,
+        mock_gateway_fetch,
         app,
         mock_pipeline,
     ):
@@ -408,7 +410,6 @@ class TestProposeContentValidation:
         mock_get_tracker.return_value = mock_tracker
 
         mock_subprocess_run.side_effect = [
-            MagicMock(returncode=0),  # fetch
             MagicMock(stdout="  origin/egg/issue-42\n"),  # branch --contains
         ]
 
@@ -544,6 +545,7 @@ class TestReProposeContentValidation:
         data = json.loads(response.data)
         assert "chars" in data["message"]
 
+    @patch("routes.signals._gateway_fetch_tracking_ref", return_value=True)
     @patch("routes.signals.subprocess.run")
     @patch("routes.signals.resolve_worktree_path", return_value=Path("/tmp/wt"))
     @patch("routes.signals.get_state_store")
@@ -554,6 +556,7 @@ class TestReProposeContentValidation:
         mock_get_store,
         mock_resolve_wt,
         mock_subprocess_run,
+        mock_gateway_fetch,
         app,
         mock_pipeline,
     ):
@@ -569,7 +572,6 @@ class TestReProposeContentValidation:
         mock_get_tracker.return_value = mock_tracker
 
         mock_subprocess_run.side_effect = [
-            MagicMock(returncode=0),
             MagicMock(stdout="  origin/egg/issue-42\n"),
         ]
 

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -2886,6 +2886,79 @@ class TestProducerDraftPresentValidation:
             # threading guarantee under test.
             assert mock_run.call_count == 1
 
+    def test_refiner_proposal_rejected_when_fetch_fails_but_commit_local(self):
+        """End-to-end #3081 regression: gateway fetch fails AND the commit is
+        in the shared object store AND the canonical draft is missing →
+        ``handle_consensus_propose_signal`` still returns 400 and does not
+        mutate the tracker.
+
+        This is the exact production-incident shape the unit tests cover at
+        the validator level (see
+        ``TestValidateProducerDraftPresent.test_validates_when_branch_verified_none_but_commit_local``):
+        a persistent (credential) gateway-fetch failure made every propose
+        arrive with ``branch_verified=None``, and the pre-#3081 unconditional
+        skip turned the presence check off. With #3081 in place, the
+        validator probes the local object store via
+        ``_commit_object_resolvable`` and proceeds when the object is
+        present, so a non-zero ``git show`` reliably means "path absent at
+        commit". This handler-level test locks the full threading
+        (handler → ``_verify_commit_on_branch`` returns ``None`` →
+        ``_validate_producer_draft_present`` receives that ``None`` →
+        ``_commit_object_resolvable`` returns ``True`` → ``git show`` runs
+        and 128s → 400) so a future refactor cannot re-introduce the
+        unconditional skip at the handler level instead of the validator
+        level.
+        """
+        from flask import Flask
+        from routes.signals import handle_consensus_propose_signal
+
+        mock_tracker = MagicMock()
+        mock_tracker.handle_propose = MagicMock(return_value={"version": 1})
+
+        # One subprocess call runs: the presence validator's ``git show``
+        # — non-zero (path absent at commit). Branch verification's
+        # ``git branch --contains`` is unreachable because the gateway
+        # fetch failed (``_verify_commit_on_branch`` short-circuits to
+        # ``None`` before running it), and ``_commit_object_resolvable``
+        # is patched to True so cat-file doesn't run either.
+        side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=128, stdout="", stderr=""),
+        ]
+
+        app = Flask(__name__)
+        with (
+            app.app_context(),
+            self._patched_store(),
+            self._patched_worktree(),
+            patch("routes.signals._gateway_fetch_tracking_ref", return_value=False),
+            patch("routes.signals._commit_object_resolvable", return_value=True),
+            patch("routes.signals.subprocess.run", side_effect=side_effect) as mock_run,
+            patch("peer_consensus.get_peer_consensus_tracker", return_value=mock_tracker),
+        ):
+            data = {
+                "agent_role": "refiner",
+                "payload": {
+                    "summary": (
+                        "Analysis v1: evaluated three options for the deterministic "
+                        "draft-path guard and recommended option A"
+                    ),
+                    "artifacts": [".egg-state/agent-outputs/refiner-refine.md"],
+                    "commit_sha": "abc1234",
+                },
+            }
+            response, status_code = handle_consensus_propose_signal(
+                "issue-3016", data, Path("/tmp/repo")
+            )
+            assert status_code == 400
+            data_out = response.get_json()
+            assert "no analysis draft found" in data_out.get("message", "")
+            mock_tracker.handle_propose.assert_not_called()
+            # Exactly one subprocess call — the presence ``git show``.
+            # ``git branch --contains`` is unreachable past the gateway-fetch
+            # failure, and ``git cat-file`` is replaced by the patched
+            # ``_commit_object_resolvable``.
+            assert mock_run.call_count == 1
+
     def test_refiner_proposal_rejected_when_analysis_missing_does_not_mutate_tracker(self):
         """End-to-end: a refiner proposal whose analysis draft is missing at the
         proposed commit is rejected at ``handle_consensus_propose_signal`` with a

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -2392,16 +2392,18 @@ class TestPlanProposalValidation:
             with pytest.raises(ValueError, match="no plan draft found"):
                 _validate_plan_proposal("issue-2527", payload, Path("/tmp/repo"))
 
-    def test_skips_when_branch_verified_is_none(self):
-        """``branch_verified=None`` (orchestrator-side fetch/contains glitch) →
-        graceful skip without touching git, so a transient fetch failure isn't
-        mis-blamed on the producer as a missing/unparseable draft.
+    def test_skips_when_branch_verified_none_and_commit_not_local(self):
+        """``branch_verified=None`` + commit object absent locally → graceful
+        skip, so a transient fetch failure isn't mis-blamed on the producer as
+        a missing/unparseable draft (a non-zero ``git show`` could mean
+        "commit unknown", not "path absent").
         """
         from routes.signals import _validate_plan_proposal
 
         with (
             self._patched_store(),
             self._patched_worktree(),
+            patch("routes.signals._commit_object_resolvable", return_value=False),
             patch("routes.signals.subprocess.run") as mock_run,
         ):
             _validate_plan_proposal(
@@ -2411,6 +2413,32 @@ class TestPlanProposalValidation:
                 branch_verified=None,
             )
             mock_run.assert_not_called()
+
+    def test_validates_when_branch_verified_none_but_commit_local(self):
+        """The #3081 regression: ``branch_verified=None`` must NOT skip
+        validation when the commit object is locally resolvable — with the
+        object present, a non-zero ``git show`` reliably means the canonical
+        draft is absent at the commit. In the incident, a persistent
+        (credential) fetch failure made every propose arrive with
+        ``branch_verified=None``, the validator skipped unconditionally, and a
+        full plan consensus completed with no canonical parseable draft
+        anywhere.
+        """
+        from routes.signals import _validate_plan_proposal
+
+        with (
+            self._patched_store(),
+            self._patched_worktree(),
+            patch("routes.signals._commit_object_resolvable", return_value=True),
+            self._patched_subprocess("", returncode=128),  # path absent at commit
+            pytest.raises(ValueError, match="no plan draft found"),
+        ):
+            _validate_plan_proposal(
+                "issue-2527",
+                {"commit_sha": "abc1234"},
+                Path("/tmp/repo"),
+                branch_verified=None,
+            )
 
     def test_skips_when_git_show_errors(self):
         """An infra failure (timeout, not a clean non-zero exit) → graceful skip,
@@ -2473,15 +2501,13 @@ class TestPlanProposalValidation:
         mock_tracker = MagicMock()
         mock_tracker.handle_propose = MagicMock(return_value={"version": 1})
 
-        # Three subprocess calls happen in this path (task_planner) — the
-        # consolidated ``_validate_plan_proposal`` reads the plan once, not
-        # twice as the former presence+alignment pair did:
-        #   1. _verify_commit_on_branch's git fetch
-        #   2. _verify_commit_on_branch's git branch --contains
-        #   3. _validate_plan_proposal's single git show — returns the
+        # Two subprocess calls happen in this path (task_planner) — the fetch
+        # leg now goes through the gateway (#3081), so only the local reads
+        # hit subprocess:
+        #   1. _verify_commit_on_branch's git branch --contains
+        #   2. _validate_plan_proposal's single git show — returns the
         #      misassigned plan, so the alignment check raises
         side_effect = [
-            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
             subprocess.CompletedProcess(
                 args=[],
                 returncode=0,
@@ -2501,6 +2527,7 @@ class TestPlanProposalValidation:
             app.app_context(),
             self._patched_store(),
             self._patched_worktree(),
+            patch("routes.signals._gateway_fetch_tracking_ref", return_value=True),
             patch("routes.signals.subprocess.run", side_effect=side_effect),
             patch("peer_consensus.get_peer_consensus_tracker", return_value=mock_tracker),
         ):
@@ -2539,10 +2566,10 @@ class TestPlanProposalValidation:
         mock_tracker = MagicMock()
         mock_tracker.handle_propose = MagicMock(return_value={"version": 1})
 
-        # 1. fetch, 2. branch --contains, 3. _validate_plan_proposal's git show
-        # (present but fence-less → parse fails → raise).
+        # 1. branch --contains, 2. _validate_plan_proposal's git show
+        # (present but fence-less → parse fails → raise). The fetch leg goes
+        # through the gateway (#3081), not subprocess.
         side_effect = [
-            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
             subprocess.CompletedProcess(
                 args=[], returncode=0, stdout="  origin/egg/issue-2527\n", stderr=""
             ),
@@ -2556,6 +2583,7 @@ class TestPlanProposalValidation:
             app.app_context(),
             self._patched_store(),
             self._patched_worktree(),
+            patch("routes.signals._gateway_fetch_tracking_ref", return_value=True),
             patch("routes.signals.subprocess.run", side_effect=side_effect),
             patch("peer_consensus.get_peer_consensus_tracker", return_value=mock_tracker),
         ):
@@ -2685,28 +2713,26 @@ class TestProducerDraftPresentValidation:
                 "refine", "issue-3016", {"commit_sha": "abc1234"}, Path("/tmp/repo")
             )
 
-    def test_skips_when_branch_verified_is_none(self):
-        """``branch_verified=None`` (orchestrator-side fetch/contains glitch) →
-        graceful skip.
+    def test_skips_when_branch_verified_none_and_commit_not_local(self):
+        """``branch_verified=None`` + commit object absent locally → graceful
+        skip.
 
-        Regression guard for the PR-1 review concern: when
-        ``_verify_commit_on_branch`` returns ``None`` (fetch failed, or
-        ``git branch -r --contains`` failed), the commit may not be in the
-        local object cache. A subsequent ``git show {commit}:{path}`` would
+        When ``_verify_commit_on_branch`` returns ``None`` (gateway fetch
+        failed, or ``git branch -r --contains`` failed) AND the commit isn't
+        in the local object store, a ``git show {commit}:{path}`` would
         return 128 with "bad revision" — *not* "path absent at commit" — so
-        running the presence check in that state would mis-blame the producer
-        for an orchestrator-side glitch. The handler threads the tri-state
-        through; we verify the validator honours it by skipping git access
-        entirely.
+        running the presence check would mis-blame the producer for an
+        orchestrator-side glitch.
         """
         from routes.signals import _validate_producer_draft_present
 
         with (
             self._patched_store(),
             self._patched_worktree(),
+            patch("routes.signals._commit_object_resolvable", return_value=False),
             patch("routes.signals.subprocess.run") as mock_run,
         ):
-            # Should not raise — and should not even reach git.
+            # Should not raise — and should not even reach git show.
             _validate_producer_draft_present(
                 "refine",
                 "issue-3016",
@@ -2715,6 +2741,29 @@ class TestProducerDraftPresentValidation:
                 branch_verified=None,
             )
             mock_run.assert_not_called()
+
+    def test_validates_when_branch_verified_none_but_commit_local(self):
+        """#3081: an inconclusive branch verification must not disable the
+        presence check when the commit object is locally resolvable — the
+        unconditional skip is how a persistent fetch failure turned the whole
+        propose-time validation layer off.
+        """
+        from routes.signals import _validate_producer_draft_present
+
+        with (
+            self._patched_store(),
+            self._patched_worktree(),
+            patch("routes.signals._commit_object_resolvable", return_value=True),
+            self._patched_subprocess("", returncode=128),  # path absent at commit
+            pytest.raises(ValueError, match="no analysis draft found"),
+        ):
+            _validate_producer_draft_present(
+                "refine",
+                "issue-3016",
+                {"commit_sha": "abc1234"},
+                Path("/tmp/repo"),
+                branch_verified=None,
+            )
 
     def test_skips_when_git_show_errors(self):
         """A git/infra failure (not a clean non-zero exit) → graceful skip.
@@ -2758,9 +2807,10 @@ class TestProducerDraftPresentValidation:
         This locks the threading wired by the previous review item: the handler
         captures the tri-state from ``_verify_commit_on_branch``, threads it into
         ``_validate_producer_draft_present`` via ``branch_verified``, and the
-        validator short-circuits on ``None`` so a transient orchestrator-side fetch
-        failure isn't mis-blamed on the producer as a missing draft. Mirrors the
-        wiring guarantee that
+        validator short-circuits on ``None`` (when the commit object is not
+        locally resolvable either — #3081) so a transient orchestrator-side
+        fetch failure isn't mis-blamed on the producer as a missing draft.
+        Mirrors the wiring guarantee that
         ``test_refiner_proposal_rejected_when_analysis_missing_does_not_mutate_tracker``
         provides for the rejection path.
         """
@@ -2770,19 +2820,18 @@ class TestProducerDraftPresentValidation:
         mock_tracker = MagicMock()
         mock_tracker.handle_propose = MagicMock(return_value={"version": 1})
 
-        # Two subprocess calls happen and only the first one runs (fetch returns
-        # non-zero → ``_verify_commit_on_branch`` short-circuits to ``None``,
-        # then the presence validator skips git access entirely because
-        # ``branch_verified is None``):
-        #   1. _verify_commit_on_branch's git fetch — returncode=1 (fetch failed)
-        #   2. (would be) _verify_commit_on_branch's git branch --contains —
-        #      not reached because fetch failed
+        # One subprocess call runs (the gateway fetch — patched below — fails →
+        # ``_verify_commit_on_branch`` short-circuits to ``None``; the presence
+        # validator then probes the local object store and skips because the
+        # commit isn't resolvable there either):
+        #   1. _validate_producer_draft_present's git cat-file — returncode=1
+        #      (commit object absent locally)
         side_effect = [
             subprocess.CompletedProcess(
                 args=[],
                 returncode=1,
                 stdout="",
-                stderr="fatal: unable to access remote: connection reset",
+                stderr="",
             ),
         ]
 
@@ -2807,6 +2856,7 @@ class TestProducerDraftPresentValidation:
             app.app_context(),
             patch("routes.signals.get_state_store", return_value=mock_store),
             self._patched_worktree(),
+            patch("routes.signals._gateway_fetch_tracking_ref", return_value=False),
             patch("routes.signals.subprocess.run", side_effect=side_effect) as mock_run,
             patch("peer_consensus.get_peer_consensus_tracker", return_value=mock_tracker),
             patch("message_store.get_message_store", return_value=mock_message_store),
@@ -2830,8 +2880,10 @@ class TestProducerDraftPresentValidation:
             assert status_code == 200
             # The tracker WAS called — the proposal made it past both validators.
             mock_tracker.handle_propose.assert_called_once()
-            # Only the fetch ran — branch-contains and the presence ``git show``
-            # were skipped, which is the threading guarantee under test.
+            # Only the local cat-file probe ran — branch-contains never runs
+            # after a failed fetch, and the presence ``git show`` was skipped
+            # because the commit isn't locally resolvable. That pairing is the
+            # threading guarantee under test.
             assert mock_run.call_count == 1
 
     def test_refiner_proposal_rejected_when_analysis_missing_does_not_mutate_tracker(self):
@@ -2845,12 +2897,11 @@ class TestProducerDraftPresentValidation:
         mock_tracker = MagicMock()
         mock_tracker.handle_propose = MagicMock(return_value={"version": 1})
 
-        # Three subprocess calls in the refiner path:
-        #   1. _verify_commit_on_branch's git fetch
-        #   2. _verify_commit_on_branch's git branch --contains
-        #   3. _validate_producer_draft_present's git show — non-zero (absent)
+        # Two subprocess calls in the refiner path (the fetch leg goes through
+        # the gateway — patched below):
+        #   1. _verify_commit_on_branch's git branch --contains
+        #   2. _validate_producer_draft_present's git show — non-zero (absent)
         side_effect = [
-            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
             subprocess.CompletedProcess(
                 args=[], returncode=0, stdout="  origin/egg/issue-3016\n", stderr=""
             ),
@@ -2862,6 +2913,7 @@ class TestProducerDraftPresentValidation:
             app.app_context(),
             self._patched_store(),
             self._patched_worktree(),
+            patch("routes.signals._gateway_fetch_tracking_ref", return_value=True),
             patch("routes.signals.subprocess.run", side_effect=side_effect),
             patch("peer_consensus.get_peer_consensus_tracker", return_value=mock_tracker),
         ):

--- a/orchestrator/tests/test_signals.py
+++ b/orchestrator/tests/test_signals.py
@@ -690,24 +690,26 @@ def _make_subprocess_result(
 
 
 class TestVerifyCommitOnBranch:
-    """Unit tests for _verify_commit_on_branch helper."""
+    """Unit tests for _verify_commit_on_branch helper.
 
+    The fetch leg goes through ``_gateway_fetch_tracking_ref`` (gateway-
+    authenticated, #3081) — patched here so only the local
+    ``git branch -r --contains`` read hits ``subprocess.run``.
+    """
+
+    @patch("routes.signals._gateway_fetch_tracking_ref", return_value=True)
     @patch("routes.signals.subprocess.run")
-    def test_returns_none_when_branch_contains_fails(self, mock_run):
+    def test_returns_none_when_branch_contains_fails(self, mock_run, mock_fetch):
         """branch --contains failure returns None (non-blocking)."""
         from routes.signals import _verify_commit_on_branch
 
-        mock_run.side_effect = [
-            _make_subprocess_result(returncode=0),  # fetch ok
-            _make_subprocess_result(
-                returncode=128, stderr="not a valid commit"
-            ),  # branch --contains fails
-        ]
+        mock_run.return_value = _make_subprocess_result(returncode=128, stderr="not a valid commit")
         result = _verify_commit_on_branch("abc123", "egg/issue-42", Path("/tmp/wt"), "pipe-1")
         assert result is None
 
+    @patch("routes.signals._gateway_fetch_tracking_ref", return_value=True)
     @patch("routes.signals.subprocess.run")
-    def test_returns_none_on_unexpected_exception(self, mock_run):
+    def test_returns_none_on_unexpected_exception(self, mock_run, mock_fetch):
         """Unexpected exception returns None (non-blocking)."""
         from routes.signals import _verify_commit_on_branch
 
@@ -715,50 +717,122 @@ class TestVerifyCommitOnBranch:
         result = _verify_commit_on_branch("abc123", "egg/issue-42", Path("/tmp/wt"), "pipe-1")
         assert result is None
 
+    @patch("routes.signals._gateway_fetch_tracking_ref", return_value=True)
     @patch("routes.signals.subprocess.run")
-    def test_returns_true_when_multiple_branches_include_expected(self, mock_run):
+    def test_returns_true_when_multiple_branches_include_expected(self, mock_run, mock_fetch):
         """Returns True when expected branch is among multiple branches."""
         from routes.signals import _verify_commit_on_branch
 
-        mock_run.side_effect = [
-            _make_subprocess_result(returncode=0),  # fetch ok
-            _make_subprocess_result(stdout="  origin/egg/issue-42\n  origin/main\n"),
-        ]
+        mock_run.return_value = _make_subprocess_result(
+            stdout="  origin/egg/issue-42\n  origin/main\n"
+        )
         result = _verify_commit_on_branch("abc123", "egg/issue-42", Path("/tmp/wt"), "pipe-1")
         assert result is True
 
+    @patch("routes.signals._gateway_fetch_tracking_ref", return_value=True)
     @patch("routes.signals.subprocess.run")
-    def test_returns_false_when_branch_not_in_output(self, mock_run):
+    def test_returns_false_when_branch_not_in_output(self, mock_run, mock_fetch):
         """Returns False when commit exists but not on expected branch."""
         from routes.signals import _verify_commit_on_branch
 
-        mock_run.side_effect = [
-            _make_subprocess_result(returncode=0),  # fetch ok
-            _make_subprocess_result(stdout="  origin/egg/other-branch\n"),
-        ]
+        mock_run.return_value = _make_subprocess_result(stdout="  origin/egg/other-branch\n")
         result = _verify_commit_on_branch("abc123", "egg/issue-42", Path("/tmp/wt"), "pipe-1")
         assert result is False
 
+    @patch("routes.signals._gateway_fetch_tracking_ref", return_value=True)
     @patch("routes.signals.subprocess.run")
-    def test_returns_false_on_empty_branch_output(self, mock_run):
+    def test_returns_false_on_empty_branch_output(self, mock_run, mock_fetch):
         """Returns False when branch --contains returns empty output."""
         from routes.signals import _verify_commit_on_branch
 
-        mock_run.side_effect = [
-            _make_subprocess_result(returncode=0),  # fetch ok
-            _make_subprocess_result(stdout=""),  # empty - commit on no branches
-        ]
+        mock_run.return_value = _make_subprocess_result(stdout="")
         result = _verify_commit_on_branch("abc123", "egg/issue-42", Path("/tmp/wt"), "pipe-1")
         assert result is False
 
+    @patch("routes.signals._gateway_fetch_tracking_ref", return_value=False)
     @patch("routes.signals.subprocess.run")
-    def test_returns_none_on_fetch_timeout(self, mock_run):
-        """Fetch timeout returns None (non-blocking)."""
+    def test_returns_none_when_gateway_fetch_fails(self, mock_run, mock_fetch):
+        """Gateway fetch failure returns None without touching git (#3081).
+
+        This is the path that silently disabled all propose-time validation
+        when the (pre-#3081) raw ``git fetch`` failed on every call for lack
+        of credentials — now gateway-authenticated and alarmed via
+        OVERSEER_ALERT, but still non-blocking.
+        """
         from routes.signals import _verify_commit_on_branch
 
-        mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=30)
         result = _verify_commit_on_branch("abc123", "egg/issue-42", Path("/tmp/wt"), "pipe-1")
         assert result is None
+        mock_run.assert_not_called()
+
+    @patch("routes.signals.subprocess.run")
+    def test_gateway_fetch_uses_explicit_tracking_refspec(self, mock_run):
+        """The fetch leg sends an explicit ``+refs/heads/X:refs/remotes/origin/X``
+        refspec through the gateway, so the contains-check below reads a fresh
+        tracking ref even on narrow-refspec mirrors (#3072 / #3075)."""
+        from routes.signals import _gateway_fetch_tracking_ref
+
+        mock_client = MagicMock()
+        mock_client.fetch_branch.return_value = True
+        mock_pipeline = MagicMock()
+
+        with (
+            patch("gateway_client.get_gateway_client", return_value=mock_client),
+            patch(
+                "routes.pipelines._compute_gateway_mode",
+                return_value=("private", "private"),
+            ),
+        ):
+            ok = _gateway_fetch_tracking_ref(
+                "pipe-1", "egg/issue-42", Path("/tmp/wt"), mock_pipeline
+            )
+
+        assert ok is True
+        mock_client.fetch_branch.assert_called_once_with(
+            "pipe-1",
+            "/tmp/wt",
+            args=["+refs/heads/egg/issue-42:refs/remotes/origin/egg/issue-42"],
+            mode="private",
+        )
+
+    def test_gateway_fetch_degrades_to_false_on_exception(self):
+        """Client construction / mode resolution failures degrade to False
+        (caller maps that to the non-blocking ``None`` tri-state)."""
+        from routes.signals import _gateway_fetch_tracking_ref
+
+        with patch(
+            "gateway_client.get_gateway_client",
+            side_effect=RuntimeError("no gateway"),
+        ):
+            ok = _gateway_fetch_tracking_ref("pipe-1", "egg/issue-42", Path("/tmp/wt"), None)
+        assert ok is False
+
+
+class TestCommitObjectResolvable:
+    """Unit tests for _commit_object_resolvable helper (#3081)."""
+
+    @patch("routes.signals.subprocess.run")
+    def test_true_when_cat_file_succeeds(self, mock_run):
+        from routes.signals import _commit_object_resolvable
+
+        mock_run.return_value = _make_subprocess_result(returncode=0)
+        assert _commit_object_resolvable(Path("/tmp/wt"), "abc123") is True
+        cmd = mock_run.call_args[0][0]
+        assert cmd[-2:] == ["-e", "abc123^{commit}"]
+
+    @patch("routes.signals.subprocess.run")
+    def test_false_when_object_absent(self, mock_run):
+        from routes.signals import _commit_object_resolvable
+
+        mock_run.return_value = _make_subprocess_result(returncode=1)
+        assert _commit_object_resolvable(Path("/tmp/wt"), "abc123") is False
+
+    @patch("routes.signals.subprocess.run")
+    def test_false_on_exception(self, mock_run):
+        from routes.signals import _commit_object_resolvable
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=10)
+        assert _commit_object_resolvable(Path("/tmp/wt"), "abc123") is False
 
 
 class TestCheckBranchProgress:
@@ -808,6 +882,7 @@ class TestCheckBranchProgress:
 class TestCompletionBranchVerification:
     """Verify commit location when agent signals completion with a commit SHA."""
 
+    @patch("routes.signals._gateway_fetch_tracking_ref", return_value=True)
     @patch("routes.signals.subprocess.run")
     @patch("routes.signals.resolve_worktree_path")
     @patch("routes.signals.get_state_store")
@@ -822,6 +897,7 @@ class TestCompletionBranchVerification:
         mock_get_store,
         mock_resolve_wt,
         mock_subprocess_run,
+        mock_gateway_fetch,
         app,
         mock_pipeline,
     ):
@@ -834,10 +910,10 @@ class TestCompletionBranchVerification:
         mock_orch = _mock_contract_orchestrator(is_complete=False)
         mock_create_orchestrator.return_value = mock_orch
 
-        # subprocess.run calls: fetch succeeds, branch --contains returns origin/egg/issue-42
-        # (no rev-parse for progress check — mock_pipeline has no phase_start_sha)
+        # subprocess.run calls: branch --contains returns origin/egg/issue-42
+        # (fetch goes through the gateway — patched above; no rev-parse for
+        # progress check — mock_pipeline has no phase_start_sha)
         mock_subprocess_run.side_effect = [
-            _make_subprocess_result(returncode=0),  # fetch
             _make_subprocess_result(stdout="  origin/egg/issue-42\n"),  # branch --contains
         ]
 
@@ -852,6 +928,7 @@ class TestCompletionBranchVerification:
 
         assert status_code == 200
 
+    @patch("routes.signals._gateway_fetch_tracking_ref", return_value=True)
     @patch("routes.signals.subprocess.run")
     @patch("routes.signals.resolve_worktree_path")
     @patch("routes.signals.get_state_store")
@@ -860,6 +937,7 @@ class TestCompletionBranchVerification:
         mock_get_store,
         mock_resolve_wt,
         mock_subprocess_run,
+        mock_gateway_fetch,
         app,
         mock_pipeline,
     ):
@@ -869,9 +947,8 @@ class TestCompletionBranchVerification:
         mock_get_store.return_value = mock_store
         mock_resolve_wt.return_value = Path("/tmp/worktree")
 
-        # fetch succeeds, but branch --contains shows different branch
+        # gateway fetch succeeds, but branch --contains shows different branch
         mock_subprocess_run.side_effect = [
-            _make_subprocess_result(returncode=0),  # fetch
             _make_subprocess_result(stdout="  origin/egg/wrong-branch\n"),  # branch --contains
         ]
 
@@ -1104,6 +1181,7 @@ class TestCompletionBranchVerificationEdgeCases:
 class TestConsensusProposeBranchVerification:
     """Verify commit SHA on branch when agent sends CONSENSUS_PROPOSE (#1473)."""
 
+    @patch("routes.signals._gateway_fetch_tracking_ref", return_value=True)
     @patch("routes.signals.subprocess.run")
     @patch("routes.signals.resolve_worktree_path")
     @patch("routes.signals.get_state_store")
@@ -1114,6 +1192,7 @@ class TestConsensusProposeBranchVerification:
         mock_get_store,
         mock_resolve_wt,
         mock_subprocess_run,
+        mock_gateway_fetch,
         app,
         mock_pipeline,
     ):
@@ -1126,9 +1205,8 @@ class TestConsensusProposeBranchVerification:
         mock_tracker = MagicMock()
         mock_get_tracker.return_value = mock_tracker
 
-        # fetch succeeds, branch --contains returns different branch
+        # gateway fetch succeeds, branch --contains returns different branch
         mock_subprocess_run.side_effect = [
-            _make_subprocess_result(returncode=0),  # fetch
             _make_subprocess_result(stdout="  origin/other-branch\n"),  # no match
         ]
 
@@ -1152,6 +1230,7 @@ class TestConsensusProposeBranchVerification:
         data = response.get_json()
         assert "not found on expected branch" in data.get("message", "")
 
+    @patch("routes.signals._gateway_fetch_tracking_ref", return_value=True)
     @patch("routes.signals.subprocess.run")
     @patch("routes.signals.resolve_worktree_path")
     @patch("routes.signals.get_state_store")
@@ -1162,6 +1241,7 @@ class TestConsensusProposeBranchVerification:
         mock_get_store,
         mock_resolve_wt,
         mock_subprocess_run,
+        mock_gateway_fetch,
         app,
         mock_pipeline,
     ):
@@ -1181,9 +1261,8 @@ class TestConsensusProposeBranchVerification:
         }
         mock_get_tracker.return_value = mock_tracker
 
-        # fetch succeeds, branch --contains returns correct branch
+        # gateway fetch succeeds, branch --contains returns correct branch
         mock_subprocess_run.side_effect = [
-            _make_subprocess_result(returncode=0),  # fetch
             _make_subprocess_result(stdout="  origin/egg/issue-42\n"),  # match
         ]
 

--- a/orchestrator/tests/test_signals.py
+++ b/orchestrator/tests/test_signals.py
@@ -795,15 +795,24 @@ class TestVerifyCommitOnBranch:
             mode="private",
         )
 
-    def test_gateway_fetch_degrades_to_false_on_exception(self):
-        """Client construction / mode resolution failures degrade to False
-        (caller maps that to the non-blocking ``None`` tri-state)."""
+    def test_gateway_fetch_degrades_to_false_on_fetch_exception(self):
+        """A ``fetch_branch`` raise → False (caller maps that to the
+        non-blocking ``None`` tri-state).
+
+        Only the fetch call itself is wrapped in the function's try/except —
+        a deliberate narrowing so a lazy-import or ``_compute_gateway_mode``
+        failure does not mis-log "Gateway tracking-ref fetch failed" (and
+        through it, the upstream ``OVERSEER_ALERT``) when no fetch was
+        actually attempted. Those rarer failure modes propagate to the
+        outer ``_verify_commit_on_branch`` try/except, which still degrades
+        to ``None`` (same end-to-end posture, accurate logs).
+        """
         from routes.signals import _gateway_fetch_tracking_ref
 
-        with patch(
-            "gateway_client.get_gateway_client",
-            side_effect=RuntimeError("no gateway"),
-        ):
+        mock_client = MagicMock()
+        mock_client.fetch_branch.side_effect = RuntimeError("fetch boom")
+
+        with patch("gateway_client.get_gateway_client", return_value=mock_client):
             ok = _gateway_fetch_tracking_ref("pipe-1", "egg/issue-42", Path("/tmp/wt"), None)
         assert ok is False
 


### PR DESCRIPTION
## Root cause (#3081)

The propose-time validation layer — #1473 commit-on-branch, #3016 refine draft presence, #3026 plan presence + parseability + role-alignment — was **permanently inert in the k8s deployment**. `_verify_commit_on_branch` ran a raw `git fetch origin` from the orchestrator pod, which holds no GitHub credentials by design (only the gateway does), so the fetch failed on *every* call:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

That made `branch_verified=None` on every propose, and every validator hit its "transient orchestrator-side glitch, don't blame the producer" skip — silently. In pipeline-2b3d8b0b a plan phase reached full BRC consensus with no canonical parseable plan draft on any branch; the first enforcement to actually execute was populate's fail-loud (#2627), 3 minutes after phase completion, after the whole phase's compute was spent. Live logs show the same fetch failure on every propose across three pipelines on 2026-06-10.

A second latent bug at the same call site (the #3075 pattern): the bare-name fetch doesn't update `refs/remotes/origin/<branch>` under a narrow fetch refspec (narrow mirrors track `master` only — the tracking ref for the incident pipeline's work branch was stale at the *first run's* tip). Fixing credentials alone would have made `git branch -r --contains` read stale refs and wrongly 409 freshly-pushed proposals, so both are fixed together.

## Changes

1. **`_gateway_fetch_tracking_ref`** — the fetch leg now goes through the gateway's authenticated `/api/v1/git/fetch` (the same plumbing `_sync_worktree_with_remote` already uses, via `GatewayClient.fetch_branch`), with an explicit `+refs/heads/X:refs/remotes/origin/X` tracking refspec (#3072 shape) so the contains-check reads a fresh `origin/<branch>` even on narrow-refspec mirrors. Mode is resolved via `_compute_gateway_mode` from the threaded pipeline state.
2. **`OVERSEER_ALERT commit_verification_fetch_failed`** when the fetch fails — a degraded validation layer can no longer hide. Posture stays fail-open on transients (fail-closed would deadlock pipelines on outages); populate's fail-loud remains the backstop.
3. **`_commit_object_resolvable` hardening** — when branch verification is inconclusive but the commit *object* resolves locally (`git cat-file -e`; always true in the shared-object-store topology), the draft presence/parse checks proceed instead of skipping: a non-zero `git show {sha}:{path}` then reliably means "path absent at commit", not "commit unknown". This alone would have caught the incident even with the credential gap. When the object is absent too (e.g. non-shared-store deployments, #3002), behavior is unchanged: skip with a warning.

Both `_verify_commit_on_branch` call sites (consensus propose, completion) thread `pipeline_state` for mode resolution.

## Out of scope

- Canonical path/format in per-event agent prompts — #3076/#3078's prompt-channel track.
- Populate fallback to role-named drafts (issue's expected-fix #3) — unnecessary once this gate actually runs.
- `PRODUCER_ATTESTATION_MODELS` missing plan-phase producer roles (the 19:23 `No attestation schema for role 'task_planner'` 400) — separate small gap.

## Testing

Targeted: `orchestrator/tests/test_signals.py`, `test_pipeline_prompts.py`, `test_brc_content_validation.py`, `test_brc_phase_propagation.py` (636 passed) plus the full consensus/BRC test sweep (562 passed). New tests: gateway-fetch refspec/mode construction, fetch-failure → `None` without touching git, `_commit_object_resolvable` tri-state, and the #3081 regression pair on both validators (`branch_verified=None` + commit local → still rejects a missing draft; + commit absent → still skips gracefully).

Fixes #3081

