### PR TITLE
fix(orchestrator): reconcile diverged state-branch pushes and escalate persistent sync failure (#3088)

### DIFF
--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -1174,6 +1174,7 @@ class GatewayClient:
         ref: str | None = None,
         base_branch: str | None = None,
         force: bool = False,
+        force_with_lease: bool = False,
     ) -> PushResult:
         """Push a branch to remote with launcher-auth (orchestrator-trusted).
 
@@ -1217,6 +1218,15 @@ class GatewayClient:
                 helper to replace a stale ``origin/<branch>`` with a
                 rebased-onto-base version (#2098).  Skips reconcile on
                 failure since force-push has nothing to reconcile against.
+            force_with_lease: When ``True``, send ``--force-with-lease``
+                — overwrite a non-ancestor remote tip only if it still
+                matches the local tracking ref ``refs/remotes/origin/
+                {branch}`` at ``repo_path``.  The caller must have just
+                fetched that tracking ref with an explicit refspec (a
+                bare-name fetch leaves it stale on narrow-refspec
+                mirrors, #3072) or the lease will reject.  Used by the
+                state-branch divergence reconciler (#3088).  Skips
+                reconcile on failure, like ``force``.
 
         Returns:
             ``PushResult`` whose ``ok`` flag is ``True`` on success and
@@ -1235,6 +1245,7 @@ class GatewayClient:
             mode=mode,
             refspec=refspec,
             force=force,
+            force_with_lease=force_with_lease,
         )
         if first.ok:
             return first
@@ -1243,7 +1254,7 @@ class GatewayClient:
         # mutates the checkout at repo_path, which we only want to do when
         # that checkout is a dedicated pipeline worktree.  Force pushes
         # also skip reconcile — the caller has already decided to overwrite.
-        if ref is not None or force:
+        if ref is not None or force or force_with_lease:
             logger.warning(
                 "Push failed (no reconcile available)",
                 pipeline_id=pipeline_id,
@@ -1273,6 +1284,7 @@ class GatewayClient:
         mode: Literal["public", "private"],
         refspec: str,
         force: bool = False,
+        force_with_lease: bool = False,
     ) -> PushResult:
         """Send a single push request to the gateway with launcher auth.
 
@@ -1302,6 +1314,7 @@ class GatewayClient:
                     "refspec": refspec,
                     "mode": mode,
                     "force": force,
+                    "force_with_lease": force_with_lease,
                 },
                 use_launcher_auth=True,
             )

--- a/orchestrator/state_store.py
+++ b/orchestrator/state_store.py
@@ -123,10 +123,9 @@ class StateStore:
 
     PIPELINES_DIR = ".egg-state/pipelines"
 
-    # -- remote sync state -------------------------------------------------
-    _push_in_flight: ClassVar[bool] = False
-    _push_pending: ClassVar[bool] = False
-    _push_lock: ClassVar[threading.Lock] = threading.Lock()
+    # Consecutive sync_to_remote failures before an OVERSEER_ALERT fires
+    # (#3088 — a dead remote backstop must not stay invisible).
+    _SYNC_ALERT_THRESHOLD: ClassVar[int] = 5
 
     def __init__(
         self,
@@ -143,6 +142,18 @@ class StateStore:
         self.repo_path = repo_path
         self._worktree_dir = worktree_dir or _DEFAULT_WORKTREE_DIR
         self._worktree: Path | None = None  # lazily initialised
+
+        # -- remote sync state (per instance, i.e. per repo) -----------------
+        # These were ClassVars until #3088: with the debounce shared across
+        # all stores, a push for repo B arriving while repo A's push was in
+        # flight collapsed into A's pending flag — and the retry closure
+        # re-pushed A, silently dropping B's sync.  Pushes to different
+        # remotes have no reason to serialise.
+        self._push_in_flight = False
+        self._push_pending = False
+        self._push_lock = threading.Lock()
+        self._sync_consecutive_failures = 0
+        self._sync_last_error: str | None = None
 
     # -- cross-process locking ---------------------------------------------
 
@@ -862,6 +873,12 @@ class StateStore:
         and the state branch's commits and ref live in its ``.git/``
         object DB, so the push only needs the main repo path (see #1808).
 
+        A non-fast-forward rejection is reconciled via
+        :meth:`_reconcile_diverged_remote` (#3088) instead of failing
+        forever — without that, a single out-of-band write to the remote
+        state branch permanently kills this backstop.  Persistent failure
+        of any kind escalates through :meth:`_record_sync_outcome`.
+
         Returns:
             True on success, False on failure (logged, never raises)
         """
@@ -869,50 +886,196 @@ class StateStore:
             from gateway_client import get_gateway_client
 
             client = get_gateway_client()
-            return bool(
-                client.push_worktree_branch(
-                    pipeline_id="state-sync",
-                    repo_path=str(self.repo_path),
-                    branch=STATE_BRANCH,
-                    mode=self._detect_gateway_mode(),
-                    ref=STATE_BRANCH,
-                )
+            mode = self._detect_gateway_mode()
+            result = client.push_worktree_branch(
+                pipeline_id="state-sync",
+                repo_path=str(self.repo_path),
+                branch=STATE_BRANCH,
+                mode=mode,
+                ref=STATE_BRANCH,
             )
+            if result:
+                self._record_sync_outcome(ok=True)
+                return True
+
+            if getattr(result, "category", None) == "non_fast_forward":
+                ok = self._reconcile_diverged_remote(client, mode)
+                self._record_sync_outcome(
+                    ok=ok, detail=None if ok else "non_fast_forward: reconcile declined or failed"
+                )
+                return ok
+
+            self._record_sync_outcome(
+                ok=False,
+                detail=f"{getattr(result, 'category', 'unknown')}: {getattr(result, 'detail', '')}",
+            )
+            return False
         except Exception as e:
             logger.warning(
                 "Failed to sync state branch to remote: %s",
                 e,
             )
+            self._record_sync_outcome(ok=False, detail=str(e))
             return False
+
+    def _reconcile_diverged_remote(self, client: Any, mode: Literal["public", "private"]) -> bool:
+        """Heal a non-fast-forward state-branch push (#3088).
+
+        The state branch is single-writer by design — this orchestrator is
+        the only legitimate author — so divergence means an out-of-band
+        write landed on the remote (e.g. a manual plan edit pushed from an
+        isolated clone, the #3088 incident).  The local line has evolved
+        past that write and is authoritative: overwrite the remote with
+        ``--force-with-lease``.
+
+        Two shapes are never forced, only escalated:
+
+        * **Unrelated histories** (no merge-base): the local-wipe
+          signature (#3070) — the local branch was recreated as a fresh
+          orphan and the remote may hold the only surviving backup.
+        * **Remote strictly ahead** (local tip is the merge-base): the
+          remote is a superset of local — a local rollback.  Forcing
+          would delete records from the backup.
+
+        The lease checks the remote tip against the tracking ref the
+        explicit-refspec fetch below just updated; a bare-name fetch
+        would leave that ref stale on narrow-refspec mirrors (#3072) and
+        the lease would reject spuriously.
+
+        Returns:
+            True if the remote was reconciled (force-with-lease push
+            succeeded), False otherwise.
+        """
+        tracking_ref = f"refs/remotes/origin/{STATE_BRANCH}"
+        if not client.fetch_branch(
+            pipeline_id="state-sync",
+            repo_path=str(self.repo_path),
+            args=[f"+refs/heads/{STATE_BRANCH}:{tracking_ref}"],
+            mode=mode,
+        ):
+            logger.warning(
+                "State-branch reconcile aborted — could not fetch remote tip (repo=%s)",
+                self.repo_path,
+            )
+            return False
+
+        local = self._run_git(
+            "rev-parse", f"refs/heads/{STATE_BRANCH}", cwd=self.repo_path, check=False
+        )
+        remote = self._run_git("rev-parse", tracking_ref, cwd=self.repo_path, check=False)
+        if local.returncode != 0 or remote.returncode != 0:
+            logger.warning(
+                "State-branch reconcile aborted — could not resolve tips (repo=%s)",
+                self.repo_path,
+            )
+            return False
+        local_sha = local.stdout.strip()
+        remote_sha = remote.stdout.strip()
+
+        merge_base = self._run_git(
+            "merge-base", local_sha, remote_sha, cwd=self.repo_path, check=False
+        )
+        if merge_base.returncode != 0:
+            logger.error(
+                "OVERSEER_ALERT state_sync_unrelated_histories: local and remote "
+                "state branches share no history (repo=%s local=%s remote=%s) — "
+                "local-wipe signature (#3070); refusing to force-push over what "
+                "may be the only surviving backup",
+                self.repo_path,
+                local_sha,
+                remote_sha,
+            )
+            return False
+        if merge_base.stdout.strip() == local_sha:
+            logger.error(
+                "OVERSEER_ALERT state_sync_remote_ahead: remote state branch is "
+                "strictly ahead of local (repo=%s local=%s remote=%s) — local "
+                "rollback signature; refusing to force-push records away",
+                self.repo_path,
+                local_sha,
+                remote_sha,
+            )
+            return False
+
+        logger.info(
+            "State branch diverged from remote — overwriting out-of-band remote "
+            "write with force-with-lease (repo=%s local=%s remote=%s)",
+            self.repo_path,
+            local_sha,
+            remote_sha,
+        )
+        return bool(
+            client.push_worktree_branch(
+                pipeline_id="state-sync",
+                repo_path=str(self.repo_path),
+                branch=STATE_BRANCH,
+                mode=mode,
+                ref=STATE_BRANCH,
+                force_with_lease=True,
+            )
+        )
+
+    def _record_sync_outcome(self, ok: bool, detail: str | None = None) -> None:
+        """Track consecutive sync failures and escalate persistent ones (#3088).
+
+        Fires an ``OVERSEER_ALERT`` at ``_SYNC_ALERT_THRESHOLD`` consecutive
+        failures, then re-fires every 50th so a long outage stays visible
+        without per-attempt spam.  The #3088 incident ran 8 days / hundreds
+        of failed pushes with only per-attempt WARNINGs.
+        """
+        if ok:
+            if self._sync_consecutive_failures >= self._SYNC_ALERT_THRESHOLD:
+                logger.info(
+                    "State-branch remote sync recovered after %d consecutive failures (repo=%s)",
+                    self._sync_consecutive_failures,
+                    self.repo_path,
+                )
+            self._sync_consecutive_failures = 0
+            self._sync_last_error = None
+            return
+
+        self._sync_consecutive_failures += 1
+        self._sync_last_error = detail
+        n = self._sync_consecutive_failures
+        if n == self._SYNC_ALERT_THRESHOLD or n % 50 == 0:
+            logger.error(
+                "OVERSEER_ALERT state_sync_push_failing: %d consecutive state-branch "
+                "push failures (repo=%s last_error=%s) — the remote durability "
+                "backstop for this repo is dead until this is resolved",
+                n,
+                self.repo_path,
+                (detail or "")[:300],
+            )
 
     _MAX_PUSH_RETRIES: ClassVar[int] = 3
 
     def _sync_to_remote_async(self, _retry_depth: int = 0) -> None:
         """Push the state branch to remote in a daemon thread.
 
-        Debounces: if a push is already in flight, marks a pending flag so
-        the in-flight thread re-pushes after completing.  This ensures the
-        latest committed state always reaches the remote.
+        Debounces per instance (per repo, #3088): if this store's push is
+        already in flight, marks a pending flag so the in-flight thread
+        re-pushes after completing.  This ensures the latest committed
+        state always reaches the remote.
 
         Retries are capped at ``_MAX_PUSH_RETRIES`` to prevent unbounded
         recursion if commits arrive faster than pushes complete.
         """
-        with StateStore._push_lock:
-            if StateStore._push_in_flight:
-                StateStore._push_pending = True
+        with self._push_lock:
+            if self._push_in_flight:
+                self._push_pending = True
                 logger.debug("Push already in flight — marked pending for retry")
                 return
-            StateStore._push_in_flight = True
+            self._push_in_flight = True
 
         def _push() -> None:
             try:
                 self.sync_to_remote()
             finally:
                 retry = False
-                with StateStore._push_lock:
-                    StateStore._push_in_flight = False
-                    if StateStore._push_pending:
-                        StateStore._push_pending = False
+                with self._push_lock:
+                    self._push_in_flight = False
+                    if self._push_pending:
+                        self._push_pending = False
                         retry = True
                 if retry:
                     next_depth = _retry_depth + 1

--- a/orchestrator/state_store.py
+++ b/orchestrator/state_store.py
@@ -1090,21 +1090,19 @@ class StateStore:
         individual store ever crossed the threshold even when the repo's
         underlying remote was repeatedly failing.
         """
+        recovered_from = 0
+        log_recovery = False
         with _sync_failure_state_lock:
             failures, _ = _sync_failure_state.get(self.repo_path, (0, None))
             if ok:
                 if failures >= self._SYNC_ALERT_THRESHOLD:
                     recovered_from = failures
                     log_recovery = True
-                else:
-                    log_recovery = False
                 _sync_failure_state.pop(self.repo_path, None)
                 n = 0
             else:
                 n = failures + 1
                 _sync_failure_state[self.repo_path] = (n, detail)
-                log_recovery = False
-                recovered_from = 0
 
         if ok:
             if log_recovery:

--- a/orchestrator/state_store.py
+++ b/orchestrator/state_store.py
@@ -26,11 +26,14 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from egg_git.cross_process_lock import bare_repo_lock
 from models import Pipeline, PipelineMode, PipelinePhase, PipelineStatus
 from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from gateway_client import GatewayClient
 
 logger = logging.getLogger("orchestrator.state_store")
 
@@ -56,6 +59,16 @@ from egg_config.constants import PIPELINE_STATE_BRANCH as STATE_BRANCH
 _DEFAULT_WORKTREE_DIR = (
     Path(os.environ.get("EGG_STATE_DIR", "/home/egg/.egg-state")) / "pipeline-worktree"
 )
+
+
+# Per-repo consecutive-failure state for remote-sync escalation (#3088).
+# Module-level so the alert threshold tracks the *repo*, not a single
+# ``StateStore`` instance — route handlers re-create their store on each
+# call (via ``get_state_store_for_pipeline``), and a per-instance counter
+# would fragment such that no individual store ever crossed the threshold
+# even when the underlying remote was repeatedly failing.
+_sync_failure_state: dict[Path, tuple[int, str | None]] = {}
+_sync_failure_state_lock = threading.Lock()
 
 
 class StateStoreError(Exception):
@@ -126,6 +139,13 @@ class StateStore:
     # Consecutive sync_to_remote failures before an OVERSEER_ALERT fires
     # (#3088 — a dead remote backstop must not stay invisible).
     _SYNC_ALERT_THRESHOLD: ClassVar[int] = 5
+    # After the threshold fires, re-fire every Nth failure so a long outage
+    # stays visible without per-attempt spam.  Pinned independently of the
+    # threshold so bumping ``_SYNC_ALERT_THRESHOLD`` past this value cannot
+    # cause the re-fire branch to trigger before the initial alert (the
+    # ``n > _SYNC_ALERT_THRESHOLD`` guard in ``_record_sync_outcome``
+    # enforces this).
+    _SYNC_ALERT_RESPAM_PERIOD: ClassVar[int] = 50
 
     def __init__(
         self,
@@ -149,11 +169,19 @@ class StateStore:
         # flight collapsed into A's pending flag — and the retry closure
         # re-pushed A, silently dropping B's sync.  Pushes to different
         # remotes have no reason to serialise.
+        #
+        # Per-instance debounce coalesces within the lifetime of one store
+        # (e.g. the long-lived ``CommitAuthorshipStore`` singleton — the
+        # highest-volume caller).  Route handlers go through
+        # ``get_state_store_for_pipeline`` which constructs a fresh store
+        # per call, so debounce does not coalesce *across* such calls; that
+        # is acceptable because their per-repo push rate is far below the
+        # singleton path's.  Failure-counter state, in contrast, is kept
+        # module-level (see ``_sync_failure_state`` below) so the alert
+        # threshold cannot fragment across those short-lived instances.
         self._push_in_flight = False
         self._push_pending = False
         self._push_lock = threading.Lock()
-        self._sync_consecutive_failures = 0
-        self._sync_last_error: str | None = None
 
     # -- cross-process locking ---------------------------------------------
 
@@ -918,7 +946,9 @@ class StateStore:
             self._record_sync_outcome(ok=False, detail=str(e))
             return False
 
-    def _reconcile_diverged_remote(self, client: Any, mode: Literal["public", "private"]) -> bool:
+    def _reconcile_diverged_remote(
+        self, client: GatewayClient, mode: Literal["public", "private"]
+    ) -> bool:
         """Heal a non-fast-forward state-branch push (#3088).
 
         The state branch is single-writer by design — this orchestrator is
@@ -941,6 +971,22 @@ class StateStore:
         explicit-refspec fetch below just updated; a bare-name fetch
         would leave that ref stale on narrow-refspec mirrors (#3072) and
         the lease would reject spuriously.
+
+        The single-writer assumption is what justifies forcing local over
+        the remote.  If two orchestrators were ever pointed at the same
+        remote state branch, they would ping-pong force-with-leases at
+        each other and neither would alert from the shapes above; that
+        misconfiguration is out of scope here (it'd show up earlier as
+        cross-orchestrator state divergence).
+
+        TOCTOU note: the ``rev-parse`` reads below run inside the same
+        process but outside ``_git_op``, so the local tip could in
+        principle advance between the rev-parse and the
+        ``--force-with-lease`` push.  This is benign: the lease only
+        constrains the *remote* tip (against the tracking ref we just
+        fetched), and a local tip that has moved forward is still a
+        descendant of the rev-parsed sha — the merge-base classification
+        and the resulting force are still correct.
 
         Returns:
             True if the remote was reconciled (force-with-lease push
@@ -1015,29 +1061,68 @@ class StateStore:
             )
         )
 
+    @property
+    def _sync_consecutive_failures(self) -> int:
+        """Read the per-repo consecutive-failure counter (see #3088)."""
+        with _sync_failure_state_lock:
+            failures, _ = _sync_failure_state.get(self.repo_path, (0, None))
+            return failures
+
+    @property
+    def _sync_last_error(self) -> str | None:
+        """Read the per-repo last-error string (see #3088)."""
+        with _sync_failure_state_lock:
+            _, last_error = _sync_failure_state.get(self.repo_path, (0, None))
+            return last_error
+
     def _record_sync_outcome(self, ok: bool, detail: str | None = None) -> None:
         """Track consecutive sync failures and escalate persistent ones (#3088).
 
         Fires an ``OVERSEER_ALERT`` at ``_SYNC_ALERT_THRESHOLD`` consecutive
-        failures, then re-fires every 50th so a long outage stays visible
-        without per-attempt spam.  The #3088 incident ran 8 days / hundreds
-        of failed pushes with only per-attempt WARNINGs.
+        failures, then re-fires every ``_SYNC_ALERT_RESPAM_PERIOD`` failures
+        thereafter so a long outage stays visible without per-attempt spam.
+        The #3088 incident ran 8 days / hundreds of failed pushes with only
+        per-attempt WARNINGs.
+
+        Counter state is keyed per-repo at module scope rather than per
+        instance: route handlers re-create their ``StateStore`` on each
+        call, and a per-instance counter would fragment such that no
+        individual store ever crossed the threshold even when the repo's
+        underlying remote was repeatedly failing.
         """
+        with _sync_failure_state_lock:
+            failures, _ = _sync_failure_state.get(self.repo_path, (0, None))
+            if ok:
+                if failures >= self._SYNC_ALERT_THRESHOLD:
+                    recovered_from = failures
+                    log_recovery = True
+                else:
+                    log_recovery = False
+                _sync_failure_state.pop(self.repo_path, None)
+                n = 0
+            else:
+                n = failures + 1
+                _sync_failure_state[self.repo_path] = (n, detail)
+                log_recovery = False
+                recovered_from = 0
+
         if ok:
-            if self._sync_consecutive_failures >= self._SYNC_ALERT_THRESHOLD:
+            if log_recovery:
                 logger.info(
                     "State-branch remote sync recovered after %d consecutive failures (repo=%s)",
-                    self._sync_consecutive_failures,
+                    recovered_from,
                     self.repo_path,
                 )
-            self._sync_consecutive_failures = 0
-            self._sync_last_error = None
             return
 
-        self._sync_consecutive_failures += 1
-        self._sync_last_error = detail
-        n = self._sync_consecutive_failures
-        if n == self._SYNC_ALERT_THRESHOLD or n % 50 == 0:
+        # Fire at the threshold; thereafter re-fire every Nth additional
+        # failure.  The ``n > _SYNC_ALERT_THRESHOLD`` guard keeps the
+        # re-fire branch from triggering before the initial alert in the
+        # event the respam period is set smaller than the threshold (or
+        # the threshold is bumped above the respam period).
+        if n == self._SYNC_ALERT_THRESHOLD or (
+            n > self._SYNC_ALERT_THRESHOLD and n % self._SYNC_ALERT_RESPAM_PERIOD == 0
+        ):
             logger.error(
                 "OVERSEER_ALERT state_sync_push_failing: %d consecutive state-branch "
                 "push failures (repo=%s last_error=%s) — the remote durability "

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -1281,6 +1281,32 @@ class TestPushWorktreeBranch:
             assert len(push_calls) == 1
             push_data = push_calls[0].kwargs["data"]
             assert push_data["force"] is False
+            assert push_data["force_with_lease"] is False
+
+    def test_push_worktree_branch_force_with_lease_propagates(
+        self, gateway_client, mock_gateway_server
+    ):
+        """``force_with_lease=True`` must reach the ``/api/v1/git/push`` body.
+
+        The state-branch divergence reconciler (#3088) relies on this —
+        without it, the gateway never sees ``--force-with-lease`` and the
+        heal push hits the same non-fast-forward rejection it is healing.
+        """
+        with patch.object(
+            gateway_client, "_make_request", wraps=gateway_client._make_request
+        ) as mock_req:
+            gateway_client.push_worktree_branch(
+                pipeline_id="state-sync",
+                repo_path="/some/path",
+                branch="egg/pipeline-state",
+                ref="egg/pipeline-state",
+                force_with_lease=True,
+            )
+            push_calls = [c for c in mock_req.call_args_list if c.args[0] == "/api/v1/git/push"]
+            assert len(push_calls) == 1
+            push_data = push_calls[0].kwargs["data"]
+            assert push_data["force_with_lease"] is True
+            assert push_data["force"] is False
 
 
 class TestDeleteRemoteBranch:

--- a/orchestrator/tests/test_state_store.py
+++ b/orchestrator/tests/test_state_store.py
@@ -1412,6 +1412,40 @@ class TestRemoteSync:
         assert result is False
         assert mock_client.push_worktree_branch.call_count == 1
 
+    def test_reconcile_aborts_when_rev_parse_fails(self, state_store, caplog):
+        """Reconcile cannot classify divergence without both tips — no force.
+
+        Guards against a regression that mangles either rev-parse call (e.g.
+        wrong refname): the merge-base branch must not run against a junk
+        sha, and the force-with-lease push must not fire.
+        """
+        mock_client = MagicMock()
+        mock_client.push_worktree_branch.return_value = PushResult(
+            ok=False, category="non_fast_forward", detail="! [rejected]"
+        )
+        mock_client.fetch_branch.return_value = True
+
+        def fake_run_git(*args, cwd=None, check=True):
+            if args[0] == "rev-parse" and args[1].startswith("refs/heads/"):
+                return MagicMock(returncode=0, stdout="aaa111\n")
+            if args[0] == "rev-parse" and args[1].startswith("refs/remotes/"):
+                # Simulate the tracking ref disappearing between fetch and
+                # rev-parse (e.g. concurrent prune, malformed refname).
+                return MagicMock(returncode=128, stdout="", stderr="fatal: bad revision\n")
+            raise AssertionError(f"unexpected git call: {args}")
+
+        with (
+            patch("gateway_client.get_gateway_client", return_value=mock_client),
+            patch.object(state_store, "_run_git", side_effect=fake_run_git),
+            caplog.at_level(logging.WARNING, logger="orchestrator.state_store"),
+        ):
+            result = state_store.sync_to_remote()
+
+        assert result is False
+        # No second push attempt: classification refused.
+        assert mock_client.push_worktree_branch.call_count == 1
+        assert "could not resolve tips" in caplog.text
+
     # -- persistent-failure escalation (#3088) -------------------------------
 
     def test_persistent_sync_failure_fires_overseer_alert(self, state_store, caplog):

--- a/orchestrator/tests/test_state_store.py
+++ b/orchestrator/tests/test_state_store.py
@@ -4,6 +4,7 @@ Tests for state store.
 Note: Git operations are mocked since git init is not available in the sandbox.
 """
 
+import logging
 import os
 import shutil
 import subprocess
@@ -1295,15 +1296,151 @@ class TestRemoteSync:
 
         assert result is False
 
+    # -- non-fast-forward reconcile (#3088) ---------------------------------
+
+    @staticmethod
+    def _reconcile_run_git(local_sha, remote_sha, merge_base_sha, merge_base_rc=0):
+        """Build a _run_git side_effect for the reconcile git calls."""
+
+        def fake_run_git(*args, cwd=None, check=True):
+            if args[0] == "rev-parse" and args[1].startswith("refs/heads/"):
+                return MagicMock(returncode=0, stdout=f"{local_sha}\n")
+            if args[0] == "rev-parse" and args[1].startswith("refs/remotes/"):
+                return MagicMock(returncode=0, stdout=f"{remote_sha}\n")
+            if args[0] == "merge-base":
+                return MagicMock(returncode=merge_base_rc, stdout=f"{merge_base_sha}\n")
+            raise AssertionError(f"unexpected git call: {args}")
+
+        return fake_run_git
+
+    def test_non_fast_forward_reconciles_with_force_with_lease(self, state_store):
+        """Diverged-with-shared-history overwrites the out-of-band remote write.
+
+        The state branch is single-writer; a merge-base that is neither tip
+        means an out-of-band write landed on the remote and local evolved
+        past it — local wins via force-with-lease (#3088).
+        """
+        mock_client = MagicMock()
+        mock_client.push_worktree_branch.side_effect = [
+            PushResult(ok=False, category="non_fast_forward", detail="! [rejected]"),
+            PushResult(ok=True),
+        ]
+        mock_client.fetch_branch.return_value = True
+
+        with (
+            patch("gateway_client.get_gateway_client", return_value=mock_client),
+            patch.object(
+                state_store,
+                "_run_git",
+                side_effect=self._reconcile_run_git("aaa111", "bbb222", "ccc000"),
+            ),
+        ):
+            result = state_store.sync_to_remote()
+
+        assert result is True
+        mock_client.fetch_branch.assert_called_once_with(
+            pipeline_id="state-sync",
+            repo_path=str(state_store.repo_path),
+            args=["+refs/heads/egg/pipeline-state:refs/remotes/origin/egg/pipeline-state"],
+            mode="public",
+        )
+        assert mock_client.push_worktree_branch.call_count == 2
+        retry_kwargs = mock_client.push_worktree_branch.call_args_list[1].kwargs
+        assert retry_kwargs["force_with_lease"] is True
+        assert retry_kwargs["ref"] == "egg/pipeline-state"
+        assert state_store._sync_consecutive_failures == 0
+
+    def test_reconcile_refuses_unrelated_histories(self, state_store, caplog):
+        """No merge-base = local-wipe signature (#3070): never force, escalate."""
+        mock_client = MagicMock()
+        mock_client.push_worktree_branch.return_value = PushResult(
+            ok=False, category="non_fast_forward", detail="! [rejected]"
+        )
+        mock_client.fetch_branch.return_value = True
+
+        with (
+            patch("gateway_client.get_gateway_client", return_value=mock_client),
+            patch.object(
+                state_store,
+                "_run_git",
+                side_effect=self._reconcile_run_git("aaa111", "bbb222", "", merge_base_rc=1),
+            ),
+            caplog.at_level(logging.ERROR, logger="orchestrator.state_store"),
+        ):
+            result = state_store.sync_to_remote()
+
+        assert result is False
+        # No force push attempted — only the initial rejected push.
+        assert mock_client.push_worktree_branch.call_count == 1
+        assert "state_sync_unrelated_histories" in caplog.text
+
+    def test_reconcile_refuses_remote_strictly_ahead(self, state_store, caplog):
+        """Remote superset of local = local rollback: never force, escalate."""
+        mock_client = MagicMock()
+        mock_client.push_worktree_branch.return_value = PushResult(
+            ok=False, category="non_fast_forward", detail="! [rejected]"
+        )
+        mock_client.fetch_branch.return_value = True
+
+        with (
+            patch("gateway_client.get_gateway_client", return_value=mock_client),
+            patch.object(
+                state_store,
+                "_run_git",
+                # merge-base == local tip → remote is strictly ahead
+                side_effect=self._reconcile_run_git("aaa111", "bbb222", "aaa111"),
+            ),
+            caplog.at_level(logging.ERROR, logger="orchestrator.state_store"),
+        ):
+            result = state_store.sync_to_remote()
+
+        assert result is False
+        assert mock_client.push_worktree_branch.call_count == 1
+        assert "state_sync_remote_ahead" in caplog.text
+
+    def test_reconcile_aborts_when_fetch_fails(self, state_store):
+        """Reconcile cannot verify divergence without the remote tip — no force."""
+        mock_client = MagicMock()
+        mock_client.push_worktree_branch.return_value = PushResult(
+            ok=False, category="non_fast_forward", detail="! [rejected]"
+        )
+        mock_client.fetch_branch.return_value = False
+
+        with patch("gateway_client.get_gateway_client", return_value=mock_client):
+            result = state_store.sync_to_remote()
+
+        assert result is False
+        assert mock_client.push_worktree_branch.call_count == 1
+
+    # -- persistent-failure escalation (#3088) -------------------------------
+
+    def test_persistent_sync_failure_fires_overseer_alert(self, state_store, caplog):
+        """The Nth consecutive failure escalates beyond per-attempt WARNINGs."""
+        with caplog.at_level(logging.ERROR, logger="orchestrator.state_store"):
+            for _ in range(StateStore._SYNC_ALERT_THRESHOLD - 1):
+                state_store._record_sync_outcome(ok=False, detail="auth_failed: nope")
+            assert "OVERSEER_ALERT state_sync_push_failing" not in caplog.text
+
+            state_store._record_sync_outcome(ok=False, detail="auth_failed: nope")
+            assert "OVERSEER_ALERT state_sync_push_failing" in caplog.text
+
+    def test_sync_success_resets_failure_counter(self, state_store, caplog):
+        """A successful push resets the streak and logs recovery."""
+        for _ in range(StateStore._SYNC_ALERT_THRESHOLD):
+            state_store._record_sync_outcome(ok=False, detail="boom")
+
+        with caplog.at_level(logging.INFO, logger="orchestrator.state_store"):
+            state_store._record_sync_outcome(ok=True)
+
+        assert state_store._sync_consecutive_failures == 0
+        assert state_store._sync_last_error is None
+        assert "recovered" in caplog.text
+
     def test_sync_to_remote_async_debounces_and_retries(self, state_store):
         """_sync_to_remote_async retries after in-flight push when pending flag is set."""
         import time
 
         call_count = 0
-        original_in_flight = StateStore._push_in_flight
-        original_pending = StateStore._push_pending
-        StateStore._push_in_flight = False
-        StateStore._push_pending = False
 
         def slow_sync():
             nonlocal call_count
@@ -1311,32 +1448,24 @@ class TestRemoteSync:
             time.sleep(0.1)
             return True
 
-        try:
-            with patch.object(state_store, "sync_to_remote", side_effect=slow_sync):
-                # First call starts the thread
-                state_store._sync_to_remote_async()
-                # Small delay to ensure thread starts and sets flag
-                time.sleep(0.02)
-                # Second call should set _push_pending (not start a new thread)
-                state_store._sync_to_remote_async()
-                # Wait for both pushes to complete (initial + retry)
-                time.sleep(0.4)
+        with patch.object(state_store, "sync_to_remote", side_effect=slow_sync):
+            # First call starts the thread
+            state_store._sync_to_remote_async()
+            # Small delay to ensure thread starts and sets flag
+            time.sleep(0.02)
+            # Second call should set _push_pending (not start a new thread)
+            state_store._sync_to_remote_async()
+            # Wait for both pushes to complete (initial + retry)
+            time.sleep(0.4)
 
-            # Two pushes: original + retry triggered by pending flag
-            assert call_count == 2
-        finally:
-            StateStore._push_in_flight = original_in_flight
-            StateStore._push_pending = original_pending
+        # Two pushes: original + retry triggered by pending flag
+        assert call_count == 2
 
     def test_sync_to_remote_async_no_retry_without_pending(self, state_store):
         """_sync_to_remote_async does not retry when no pending commits arrived."""
         import time
 
         call_count = 0
-        original_in_flight = StateStore._push_in_flight
-        original_pending = StateStore._push_pending
-        StateStore._push_in_flight = False
-        StateStore._push_pending = False
 
         def slow_sync():
             nonlocal call_count
@@ -1344,18 +1473,43 @@ class TestRemoteSync:
             time.sleep(0.05)
             return True
 
-        try:
-            with patch.object(state_store, "sync_to_remote", side_effect=slow_sync):
-                # Single call with no concurrent calls
-                state_store._sync_to_remote_async()
-                # Wait for push to complete
-                time.sleep(0.2)
+        with patch.object(state_store, "sync_to_remote", side_effect=slow_sync):
+            # Single call with no concurrent calls
+            state_store._sync_to_remote_async()
+            # Wait for push to complete
+            time.sleep(0.2)
 
-            # Only one push — no pending flag was set
-            assert call_count == 1
-        finally:
-            StateStore._push_in_flight = original_in_flight
-            StateStore._push_pending = original_pending
+        # Only one push — no pending flag was set
+        assert call_count == 1
+
+    def test_push_debounce_is_per_instance(self, state_store, tmp_path):
+        """One repo's in-flight push must not swallow another repo's sync (#3088).
+
+        With the pre-#3088 ClassVar flags, repo B's push arriving while
+        repo A's was in flight collapsed into A's pending flag and the
+        retry re-pushed A — B's sync was silently dropped.
+        """
+        import time
+
+        other_repo = tmp_path / "other-repo"
+        other_repo.mkdir()
+        other_store = StateStore(other_repo, worktree_dir=other_repo)
+        other_store._worktree = other_repo
+
+        # Simulate repo A's push being in flight.
+        state_store._push_in_flight = True
+
+        called = threading.Event()
+        with patch.object(other_store, "sync_to_remote", side_effect=lambda: called.set()):
+            other_store._sync_to_remote_async()
+            assert called.wait(timeout=2), (
+                "repo B's push never ran — debounce state leaked across instances"
+            )
+        time.sleep(0.05)  # let the worker thread clear its own flags
+
+        # And repo A's flags are untouched by repo B's push.
+        assert state_store._push_in_flight is True
+        assert other_store._push_in_flight is False
 
     def test_restore_from_remote_when_branch_exists(self, state_store):
         """_restore_from_remote fetches when remote branch exists."""
@@ -1464,31 +1618,23 @@ class TestRemoteSync:
         import time
 
         call_count = 0
-        original_in_flight = StateStore._push_in_flight
-        original_pending = StateStore._push_pending
-        StateStore._push_in_flight = False
-        StateStore._push_pending = False
 
         def slow_sync():
             nonlocal call_count
             call_count += 1
             time.sleep(0.05)
             # Simulate another commit arriving during every push
-            with StateStore._push_lock:
-                StateStore._push_pending = True
+            with state_store._push_lock:
+                state_store._push_pending = True
             return True
 
-        try:
-            with patch.object(state_store, "sync_to_remote", side_effect=slow_sync):
-                state_store._sync_to_remote_async()
-                # Wait for the full retry chain to complete
-                time.sleep(0.5)
+        with patch.object(state_store, "sync_to_remote", side_effect=slow_sync):
+            state_store._sync_to_remote_async()
+            # Wait for the full retry chain to complete
+            time.sleep(0.5)
 
-            # Should be capped at _MAX_PUSH_RETRIES (3): initial + 2 retries
-            assert call_count == StateStore._MAX_PUSH_RETRIES
-        finally:
-            StateStore._push_in_flight = original_in_flight
-            StateStore._push_pending = original_pending
+        # Should be capped at _MAX_PUSH_RETRIES (3): initial + 2 retries
+        assert call_count == StateStore._MAX_PUSH_RETRIES
 
     def test_delete_pipeline_triggers_remote_sync(self, state_store, mock_git):
         """delete_pipeline syncs to remote after committing deletion."""

--- a/orchestrator/tests/test_state_store.py
+++ b/orchestrator/tests/test_state_store.py
@@ -1254,6 +1254,22 @@ class TestRunGitLocking:
 class TestRemoteSync:
     """Tests for remote sync (push/restore) of the state branch."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_sync_failure_state(self):
+        """Reset the module-global per-repo failure counter between tests.
+
+        ``_sync_failure_state`` is keyed on ``repo_path``; each test's
+        ``state_store`` fixture uses a fresh ``tmp_path`` so collisions
+        are unlikely today, but a future fixture that reuses paths
+        (session-scoped stores, parametrised cases) would inherit prior
+        counter state.  Clearing on teardown is cheap insurance.
+        """
+        import state_store as _state_store_mod
+
+        _state_store_mod._sync_failure_state.clear()
+        yield
+        _state_store_mod._sync_failure_state.clear()
+
     def test_sync_to_remote_calls_gateway_client(self, state_store):
         """sync_to_remote calls push_worktree_branch on the gateway client.
 
@@ -1469,6 +1485,28 @@ class TestRemoteSync:
         assert state_store._sync_consecutive_failures == 0
         assert state_store._sync_last_error is None
         assert "recovered" in caplog.text
+
+    def test_persistent_sync_failure_respams_on_period(self, state_store, caplog):
+        """Re-fire branch: alert again every ``_SYNC_ALERT_RESPAM_PERIOD``.
+
+        Guards the ``n > _SYNC_ALERT_THRESHOLD and n % _RESPAM_PERIOD == 0``
+        branch the PR specifically added a constant for.  A regression that
+        swaps the operator (``or`` for ``and``) or strips the ``n > THRESHOLD``
+        guard would slip through the threshold-only test.
+        """
+        threshold = StateStore._SYNC_ALERT_THRESHOLD
+        period = StateStore._SYNC_ALERT_RESPAM_PERIOD
+        with caplog.at_level(logging.ERROR, logger="orchestrator.state_store"):
+            for _ in range(threshold + period):
+                state_store._record_sync_outcome(ok=False, detail="still dead")
+
+        alert_count = caplog.text.count("OVERSEER_ALERT state_sync_push_failing")
+        # Initial fire at THRESHOLD plus one re-fire at the next RESPAM_PERIOD
+        # boundary above THRESHOLD.
+        assert alert_count == 2, (
+            f"expected 2 alerts (initial + 1 respam), got {alert_count} "
+            f"after {threshold + period} failures"
+        )
 
     def test_sync_to_remote_async_debounces_and_retries(self, state_store):
         """_sync_to_remote_async retries after in-flight push when pending flag is set."""

--- a/orchestrator/tests/test_state_store.py
+++ b/orchestrator/tests/test_state_store.py
@@ -1489,10 +1489,15 @@ class TestRemoteSync:
     def test_persistent_sync_failure_respams_on_period(self, state_store, caplog):
         """Re-fire branch: alert again every ``_SYNC_ALERT_RESPAM_PERIOD``.
 
-        Guards the ``n > _SYNC_ALERT_THRESHOLD and n % _RESPAM_PERIOD == 0``
-        branch the PR specifically added a constant for.  A regression that
-        swaps the operator (``or`` for ``and``) or strips the ``n > THRESHOLD``
-        guard would slip through the threshold-only test.
+        Guards the ``n % _RESPAM_PERIOD == 0`` re-fire branch the PR
+        specifically added a constant for — the threshold-only test
+        doesn't exercise it.  A regression that swaps the operator
+        (``or`` for ``and``) would either over- or under-fire and break
+        the count.  (Stripping the ``n > _SYNC_ALERT_THRESHOLD`` guard
+        would slip through with the current constants since
+        ``THRESHOLD < PERIOD``; that guard's purpose is robustness if
+        ``THRESHOLD`` is ever bumped past ``PERIOD``, which this test
+        does not parametrise.)
         """
         threshold = StateStore._SYNC_ALERT_THRESHOLD
         period = StateStore._SYNC_ALERT_RESPAM_PERIOD

--- a/scripts/file-size-allowlist.yaml
+++ b/scripts/file-size-allowlist.yaml
@@ -22,6 +22,8 @@ caps:
 files:
   orchestrator/routes/pipelines.py:
     issue: "2248"
+  orchestrator/state_store.py:
+    issue: "2248"
   gateway/gateway.py:
     issue: "2248"
   sandbox/egg_lib/orch_cli.py:


### PR DESCRIPTION
## Problem

#3088 investigation (full diagnosis in the issue) found the `egg/pipeline-state` remote backstop dies silently in two independent ways:

1. **Non-fast-forward wedge.** `sync_to_remote` pushes `force=False` with no reconcile path, so a single out-of-band write to the remote state branch permanently kills the backstop. Live incident: manual plan-surgery commits pushed to the remote on 06-02 wedged `jwbron/egg`'s sync for 8 days — 88 rejected pushes on 06-10 alone, all WARNING-level only. (Unwedged manually with a one-time `--force-with-lease` push; this PR makes that self-healing.)
2. **Cross-repo debounce bug.** `_push_in_flight` / `_push_pending` / `_push_lock` were `ClassVar`s shared across all `StateStore` instances. Repo B's push arriving while repo A's was in flight collapsed into A's pending flag — and the retry closure re-pushed **A**, silently dropping B's sync. With the egg store committing ~55×/day and its pushes failing slowly, other repos' syncs could be starved indefinitely.

And per the issue's escalation ask: persistent failure was invisible (per-attempt WARNINGs only).

## Fix

- **`_reconcile_diverged_remote` (state_store.py):** on a `non_fast_forward` rejection, fetch the remote tip with an explicit tracking refspec (#3072 lesson — bare-name fetches leave tracking refs stale) and merge-base the tips:
  - **Shared history** → the state branch is single-writer by design, so the local line is authoritative over an out-of-band remote write: push `--force-with-lease` (lease taken against the just-fetched tracking ref).
  - **Unrelated histories** (local-wipe signature, #3070 — remote may be the only surviving backup) and **remote strictly ahead** (local rollback — forcing would delete records) are never forced; both fire `OVERSEER_ALERT`s instead.
- **`_record_sync_outcome`:** per-repo consecutive-failure counter; `OVERSEER_ALERT state_sync_push_failing` at 5 consecutive failures, re-fired every 50th so a long outage stays visible without spam; recovery logged on success.
- **Debounce flags → instance attributes** (per repo), eliminating the cross-repo collapse.
- **`gateway_client.push_worktree_branch`:** new `force_with_lease` pass-through. The gateway `/api/v1/git/push` endpoint has supported it since #2137; it just wasn't reachable from this client path. Lease pushes skip the rebase-reconcile like `force` does.

`state_store.py` crossed the 1,500-line hard cap and joins the file-size allowlist under the #2248 decomposition umbrella.

## Out of scope (per #3088 diagnosis)

- per-repo `auth_mode: user` entries and PAT coverage for the cred-less external repos — host-side config decisions.
- Boot-time restore-probe noise for repos with no credentials.

## Testing

- New: reconcile force-with-lease happy path, unrelated-histories refusal, remote-ahead refusal, fetch-failure abort, alert threshold + reset, per-instance debounce isolation, lease-flag propagation.
- `orchestrator/tests/test_state_store.py` + `test_gateway_client.py`: 255 passed; `test_state_store_probe.py` + `test_commit_authorship_store.py` green.
- Pre-existing (unrelated) failure: `test_state_store_wedge_propagation.py::TestHealthEndpointReflectsStateStoreFailure::test_probe_skipped_when_request_context_missing` fails identically on a clean tree.

Issue: #3088
