### PR TITLE
Fix #3124: reopen confirmed producers on task reassignment + operator complete-task path

### DIFF
--- a/orchestrator/events.py
+++ b/orchestrator/events.py
@@ -84,6 +84,12 @@ class EventType(StrEnum):
     CONSENSUS_OBLIGATION_RESOLVED = "consensus.obligation_resolved"
     # A CONFIRMED producer's consensus participation was reopened after a
     # contract task was reassigned to it post-confirm (#3124).
+    # Intentionally has no subscriber today — emitted by
+    # ``peer_consensus.reopen_producer`` as a forward-compat hook for
+    # future SSE filters / metrics that want to count reopens (e.g.
+    # to alert when a slice churns post-confirm). The reopen itself is
+    # driven by the persisted ``CONSENSUS_REOPENED`` bus message, not
+    # by this event.
     CONSENSUS_PRODUCER_REOPENED = "consensus.producer_reopened"
 
     # HITL events

--- a/orchestrator/events.py
+++ b/orchestrator/events.py
@@ -82,6 +82,9 @@ class EventType(StrEnum):
     CONSENSUS_WITHDRAW_RECEIVED = "consensus.withdraw_received"
     CONSENSUS_FAILURE = "consensus.failure"
     CONSENSUS_OBLIGATION_RESOLVED = "consensus.obligation_resolved"
+    # A CONFIRMED producer's consensus participation was reopened after a
+    # contract task was reassigned to it post-confirm (#3124).
+    CONSENSUS_PRODUCER_REOPENED = "consensus.producer_reopened"
 
     # HITL events
     DECISION_CREATED = "decision.created"

--- a/orchestrator/impasse_routing.py
+++ b/orchestrator/impasse_routing.py
@@ -293,6 +293,24 @@ def _build_hitl_decision(
             label="Resolve the underlying blocker manually, then resume",
         )
     )
+    if task is not None:
+        # Executable option (#3124): the resolve route's dispatch hook
+        # (``routes.decisions._maybe_complete_task_from_resolution``)
+        # recognizes the ``Mark task <id> complete`` shape and performs
+        # the audited operator completion — no pod-exec impersonation.
+        options.append(
+            DecisionOption(
+                id=f"opt-{len(options) + 1}",
+                label=f"Mark task {task.id} complete",
+                description=(
+                    "Operator attests the deliverable already exists. "
+                    "Resolving with this option EXECUTES the completion "
+                    "(status=complete) as an audited operator action; "
+                    "reply free-form with 'Mark task "
+                    f"{task.id} complete, commit <sha>' to link evidence."
+                ),
+            )
+        )
     options.append(
         DecisionOption(
             id=f"opt-{len(options) + 1}",

--- a/orchestrator/message_store.py
+++ b/orchestrator/message_store.py
@@ -74,6 +74,14 @@ class MessageType:
     # re-emerges from replay and the HITL gate asks the operator about
     # work that was already done.
     CONSENSUS_OBLIGATION_RESOLVED = "CONSENSUS_OBLIGATION_RESOLVED"
+    # Confirmed-producer reopen (#3124): a contract task was reassigned to
+    # a producer after it CONFIRMED, so the orchestrator reopened its
+    # consensus participation (CONFIRMED → WORKING). Persisted so
+    # ``reconstruct_tracker_from_messages`` can replay the transition —
+    # without it, replay would reject the producer's post-reopen proposal
+    # (the propose guard requires WORKING) and a restart would resurrect
+    # the deadlock the reopen resolved. ``to_role`` carries the producer.
+    CONSENSUS_REOPENED = "CONSENSUS_REOPENED"
     # Overseer anomaly broadcasts (issue #1413)
     OVERSEER_ALERT = "OVERSEER_ALERT"
     # Tier 1 health monitor nudge messages (issue #1428)

--- a/orchestrator/operator_actions.py
+++ b/orchestrator/operator_actions.py
@@ -1,0 +1,214 @@
+"""Operator-grade contract task mutations (#3124).
+
+Before this module, an operator facing a contract task that no live
+agent was permitted to satisfy (e.g. a task reassigned to a producer
+that had already CONFIRMED — see #3124) had no in-band remediation:
+task ``status`` is owned by implementer/reviewer
+(``egg_contracts.roles.FIELD_OWNERSHIP``), the overseer's mutations get
+403, and the documented workaround was to ``kubectl exec`` into an
+agent pod and impersonate its role. This module is the sanctioned
+path: it applies the mutation as ``Role.HUMAN`` (the operator), audited
+with the operator actor string, and is exposed through
+lifecycle-secret-guarded surfaces only (the orchestrator REST route in
+``routes/contracts.py`` and the HITL decision-resolution dispatch in
+``routes/decisions.py``) — sandbox agents cannot reach it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+_parent_path = Path(__file__).parent
+if str(_parent_path) not in sys.path:
+    sys.path.insert(0, str(_parent_path))
+
+_shared_path = Path(__file__).parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+import contract_store  # noqa: E402
+from egg_contracts import Role, apply_mutation, load_contract, save_contract  # noqa: E402
+from egg_contracts.loader import ContractNotFoundError  # noqa: E402
+
+try:
+    from egg_logging import get_logger
+except ImportError:  # pragma: no cover — logging fallback
+    import logging
+
+    def get_logger(name: str, **kwargs: Any):  # type: ignore[misc]
+        return logging.getLogger(name)
+
+
+logger = get_logger("orchestrator.operator_actions")
+
+
+class OperatorActionError(Exception):
+    """Operator action failed; ``status_code`` maps to the HTTP response."""
+
+    def __init__(self, message: str, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+def complete_task_as_operator(
+    pipeline_id: str,
+    task_id: str,
+    *,
+    commit: str | None = None,
+    reason: str = "",
+    actor: str = "operator",
+    issue_number: int | None = None,
+) -> dict[str, Any]:
+    """Mark a contract task ``complete`` as an audited operator action.
+
+    Mirrors the agent-side ``mcp__task__complete`` handler (link the
+    commit first when provided, then flip ``status``) but runs as
+    ``Role.HUMAN`` so it is not subject to the implementer/reviewer
+    field-ownership restriction. Both mutations go through
+    ``apply_mutation`` so the contract audit log records the actor and
+    reason.
+
+    Callers MUST sit behind an operator-authenticated surface
+    (lifecycle secret); this function does no authentication itself.
+
+    Raises :class:`OperatorActionError` with an HTTP-ish status code on
+    any failure (worktree/contract/task not found, mutation rejected,
+    save failed).
+    """
+    worktree = contract_store.resolve_pipeline_worktree(pipeline_id)
+    if worktree is None:
+        raise OperatorActionError(
+            f"No pipeline worktree found for {pipeline_id} (pipeline not "
+            f"set up on this host, or already cleaned up)",
+            status_code=404,
+        )
+
+    # Contracts are keyed by pipeline id in the k8s flow and by issue
+    # number in older flows — same candidate order as the completeness
+    # gate's ``load_live_contract``.
+    identifiers: list[int | str] = [pipeline_id]
+    if issue_number:
+        identifiers.append(issue_number)
+
+    last_error: str = "contract not found"
+    for identifier in identifiers:
+        with contract_store.lock_for(identifier):
+            try:
+                contract = load_contract(identifier, worktree)
+            except ContractNotFoundError:
+                continue
+            except Exception as exc:
+                last_error = str(exc)
+                continue
+
+            return _complete_task_locked(
+                contract,
+                worktree,
+                identifier,
+                task_id,
+                commit=commit,
+                reason=reason,
+                actor=actor,
+            )
+
+    raise OperatorActionError(
+        f"Contract for {pipeline_id} not loadable ({last_error})",
+        status_code=404,
+    )
+
+
+def _complete_task_locked(
+    contract: Any,
+    worktree: Path,
+    identifier: int | str,
+    task_id: str,
+    *,
+    commit: str | None,
+    reason: str,
+    actor: str,
+) -> dict[str, Any]:
+    """Apply the completion mutations. Caller holds the contract lock."""
+    located: tuple[int, int, Any, Any] | None = None
+    for slice_idx, slice_obj in enumerate(contract.slices or []):
+        for task_idx, task in enumerate(slice_obj.tasks or []):
+            if task.id == task_id:
+                located = (slice_idx, task_idx, slice_obj, task)
+                break
+        if located:
+            break
+
+    if located is None:
+        raise OperatorActionError(
+            f"Task {task_id!r} not found on contract {identifier}",
+            status_code=404,
+        )
+
+    slice_idx, task_idx, slice_obj, task = located
+    prior_status = str(task.status)
+
+    audit_reason = "Operator task completion (#3124)"
+    if reason:
+        audit_reason = f"{audit_reason}: {reason}"
+
+    # Commit evidence first, then status — same order as the agent-side
+    # handler so a failure between the two leaves the safer state
+    # (commit linked, task still pending) rather than a completed task
+    # with no evidence.
+    if commit:
+        result = apply_mutation(
+            contract,
+            role=Role.HUMAN,
+            actor=actor,
+            field_path=f"phases.{slice_idx}.tasks.{task_idx}.commit",
+            new_value=commit,
+            reason=audit_reason,
+        )
+        if not result.success:
+            raise OperatorActionError(
+                f"Commit-link mutation rejected: {result.message}",
+                status_code=400,
+            )
+
+    result = apply_mutation(
+        contract,
+        role=Role.HUMAN,
+        actor=actor,
+        field_path=f"phases.{slice_idx}.tasks.{task_idx}.status",
+        new_value="complete",
+        reason=audit_reason,
+    )
+    if not result.success:
+        raise OperatorActionError(
+            f"Status mutation rejected: {result.message}",
+            status_code=400,
+        )
+
+    try:
+        save_contract(contract, worktree)
+    except Exception as exc:
+        raise OperatorActionError(
+            f"Failed to save contract: {exc}",
+            status_code=500,
+        ) from exc
+
+    logger.info(
+        "Operator marked contract task complete",
+        identifier=str(identifier),
+        task_id=task_id,
+        slice_id=getattr(slice_obj, "id", None),
+        prior_status=prior_status,
+        commit=commit,
+        actor=actor,
+    )
+
+    return {
+        "task_id": task_id,
+        "slice_id": getattr(slice_obj, "id", None),
+        "prior_status": prior_status,
+        "status": "complete",
+        "commit": commit or getattr(task, "commit", None) or None,
+        "actor": actor,
+    }

--- a/orchestrator/peer_consensus.py
+++ b/orchestrator/peer_consensus.py
@@ -1478,6 +1478,67 @@ class PeerConsensusTracker:
                 "affected_reviewers": reviewers,
             }
 
+    def reopen_producer(self, agent_role: str, reason: str = "") -> dict[str, Any]:
+        """Reopen a CONFIRMED producer's consensus participation (#3124).
+
+        A task reassignment (impasse delegation or a direct operator
+        mutation of ``phases.*.tasks.*.role``) can land on a producer
+        that has already CONFIRMED. Confirmation is otherwise a one-way
+        lock — ``check_propose_guard`` rejects proposals from the
+        CONFIRMED phase — so the contract would carry an incomplete
+        task row that no live agent is permitted to deliver, while the
+        #3114 completeness gate (correctly) refuses to close the slice
+        over it. Reopening flips the producer's FSM back to WORKING and
+        clears its confirmed status so the next ``next-action`` poll
+        derives ``propose``; from there the existing re-propose
+        machinery applies (#1411 stale-confirm discard on propose,
+        ``_un_confirm_stale_reviewers`` forcing re-review of the new
+        version).
+
+        Dual-role agents keep their reviewer-side FSM untouched — their
+        prior reviews of peers remain valid; only their own deliverable
+        is reopened. ``handle_confirmed`` already requires both FSMs to
+        be CONFIRMED before re-adding the role to the confirmed set.
+
+        Idempotent: returns ``{"status": "noop"}`` when the producer is
+        not confirmed (nothing to reopen), so message replay can apply
+        it blindly.
+
+        Raises ValueError if the role is not a producer in the graph.
+        """
+        with self._lock:
+            if not self.graph.is_producer(agent_role):
+                raise ValueError(
+                    f"Cannot reopen '{agent_role}': not a producer in the review graph"
+                )
+
+            was_confirmed = (
+                agent_role in self._confirmed
+                or self._producer_phases.get(agent_role) == ConsensusPhase.CONFIRMED
+            )
+            if not was_confirmed:
+                return {"status": "noop", "role": agent_role}
+
+            self._producer_phases[agent_role] = ConsensusPhase.WORKING
+            self._confirmed.discard(agent_role)
+
+            emit_event(
+                EventType.CONSENSUS_PRODUCER_REOPENED,
+                self.pipeline_id,
+                data={"role": agent_role, "reason": reason},
+            )
+
+            logger.info(
+                "Reopened confirmed producer",
+                producer=agent_role,
+                reason=reason,
+                pipeline_id=self.pipeline_id,
+            )
+
+            self._run_invariant_checks("reopen_producer")
+
+            return {"status": "reopened", "role": agent_role, "reason": reason}
+
     def is_timeout_handled(self) -> bool:
         """Check whether the BRC tracker has already handled the timeout."""
         with self._lock:
@@ -2041,6 +2102,12 @@ def reconstruct_tracker_from_messages(
         # this, a satisfied obligation re-emerges and the HITL gate
         # asks the operator about work that was already done.
         "CONSENSUS_OBLIGATION_RESOLVED",
+        # Confirmed-producer reopen after task reassignment (#3124).
+        # Replayed so the CONFIRMED→WORKING transition survives restarts —
+        # without it, replay would reject the producer's post-reopen
+        # proposal (the propose guard requires WORKING) and resurrect the
+        # deadlock the reopen resolved.
+        "CONSENSUS_REOPENED",
     }
     consensus_msgs = [m for m in messages if m.message_type in consensus_types]
 
@@ -2180,6 +2247,17 @@ def reconstruct_tracker_from_messages(
 
             elif msg.message_type == "CONSENSUS_CONFIRMED":
                 tracker.handle_confirmed(msg.from_role)
+
+            elif msg.message_type == "CONSENSUS_REOPENED":
+                # Emitted by the orchestrator (next-action route) when a
+                # contract task was reassigned to an already-confirmed
+                # producer (#3124). ``to_role`` carries the producer;
+                # ``from_role`` is the orchestrator and is deliberately
+                # not replayed as a participant. reopen_producer is
+                # idempotent, so a duplicate message is harmless.
+                reopened_producer = msg.to_role
+                if reopened_producer and reopened_producer != "all":
+                    tracker.reopen_producer(reopened_producer, reason="replay")
 
             elif msg.message_type == "CONSENSUS_OBLIGATION_RESOLVED":
                 # Metadata carries the participant roles plus optional

--- a/orchestrator/routes/consensus.py
+++ b/orchestrator/routes/consensus.py
@@ -53,6 +53,7 @@ from peer_consensus import (
     reconstruct_tracker_from_messages,
 )
 from slice_id_validation import extract_slice_id as _extract_slice_id
+from state_store import get_state_store
 
 logger = get_logger("orchestrator.consensus")
 
@@ -421,6 +422,177 @@ def _derive_next_action(
         return "wait", None, "role not in review graph"
 
 
+def _maybe_reopen_confirmed_producer(
+    tracker: PeerConsensusTracker,
+    pipeline_id: str,
+    slice_id: str | None,
+    role: str,
+) -> list[dict[str, Any]] | None:
+    """Reopen ``role``'s consensus participation when a contract task was
+    (re)assigned to it after it confirmed (#3124).
+
+    Task reassignment (impasse delegation, direct operator mutation of
+    ``phases.*.tasks.*.role``) does not consult consensus state, so it
+    can land on a producer that already CONFIRMED. Confirmation is
+    otherwise a one-way lock — ``_derive_next_action`` short-circuits a
+    confirmed role to ``wait`` and ``check_propose_guard`` rejects
+    proposals from CONFIRMED — while the #3114 completeness gate
+    (correctly) holds the slice open over the undelivered row. Without
+    a reopen, the slice deadlocks with no in-band remediation.
+
+    Detection is derived purely from persistent contract state (the
+    confirmed producer owns non-``complete`` task rows in scope), so
+    the check is naturally idempotent across polls, restarts, and
+    tracker reconstruction. A ``CONSENSUS_REOPENED`` message is written
+    to the bus *before* the tracker mutation so message replay performs
+    the same transition (see ``reconstruct_tracker_from_messages``).
+
+    Returns the incomplete task rows when a reopen happened (or was
+    already in effect for this poll), else ``None``. Failure posture
+    mirrors the #3114 gate: fail-open — an orchestrator-side read
+    failure skips the reopen (the role keeps waiting; the gate and the
+    operator path remain the backstop) rather than crashing the poll.
+    The ``EGG_CONTRACT_ACK_GATE`` kill switch disables this check along
+    with the rest of the completeness-gate family: with the gate off,
+    consensus can close over incomplete rows, so there is nothing to
+    reopen for.
+    """
+    if not tracker.graph.is_producer(role):
+        return None
+    # Cheap pre-check before any contract IO: only a confirmed producer
+    # (or one whose producer FSM is CONFIRMED — the dual-role
+    # intermediate state) can need reopening. Reading _producer_phases
+    # without the lock is a hint only; reopen_producer re-checks under
+    # the lock.
+    if role not in tracker.confirmed_roles and (
+        tracker._producer_phases.get(role) != ConsensusPhase.CONFIRMED
+    ):
+        return None
+
+    try:
+        import contract_completeness as cc
+    except ImportError:
+        from .. import contract_completeness as cc  # type: ignore[no-redef]
+
+    if not cc.gate_enabled():
+        return None
+
+    try:
+        from routes import (
+            get_repo_path,
+            resolve_repo_path_for_pipeline,
+            resolve_worktree_path,
+        )
+
+        repo_path = resolve_repo_path_for_pipeline(pipeline_id, get_repo_path())
+        pipeline_state = get_state_store(repo_path).load_pipeline(pipeline_id)
+        phase_attr = getattr(pipeline_state, "current_phase", None)
+        current_phase = phase_attr.value if phase_attr is not None else None
+        issue_number = getattr(pipeline_state, "issue_number", None)
+    except Exception as exc:
+        logger.warning(
+            "Confirmed-producer reopen check skipped: pipeline state unreadable",
+            pipeline_id=pipeline_id,
+            role=role,
+            error=str(exc),
+        )
+        return None
+
+    # Implement phase only — plan/refine consensus runs against contracts
+    # whose task rows are expected to be pending (#3114 scoping).
+    if current_phase != "implement":
+        return None
+
+    try:
+        worktree = resolve_worktree_path(pipeline_id, repo_path)
+    except Exception as exc:
+        logger.warning(
+            "Confirmed-producer reopen check skipped: worktree unresolvable",
+            pipeline_id=pipeline_id,
+            role=role,
+            error=str(exc),
+        )
+        return None
+
+    identifiers: list[int | str] = [pipeline_id]
+    if issue_number:
+        identifiers.append(issue_number)
+    contract = cc.load_live_contract(worktree, identifiers)
+    if contract is None:
+        return None
+
+    rows = cc.incomplete_tasks(contract, slice_id, role=role)
+    if not rows:
+        # Empty (everything delivered) or None (slice not found) — the
+        # confirmed state is consistent with the contract; nothing to do.
+        return None
+
+    reason = (
+        f"contract task(s) {[r['id'] for r in rows]} assigned to {role} after it confirmed (#3124)"
+    )
+
+    # Persist the reopen for replay BEFORE mutating the tracker: if the
+    # write succeeds but the orchestrator dies before the mutation, the
+    # idempotent replay arm applies it; if the write fails, the tracker
+    # stays confirmed and the next poll retries the whole sequence.
+    try:
+        from message_store import Message, MessageType, get_message_store
+
+        get_message_store().add_message(
+            Message(
+                pipeline_id=pipeline_id,
+                from_role="orchestrator",
+                to_role=role,
+                message_type=MessageType.CONSENSUS_REOPENED,
+                subject=f"Consensus reopened for {role}",
+                body=reason,
+                phase=current_phase,
+                metadata={
+                    "incomplete_tasks": rows,
+                    **({"slice_id": slice_id} if slice_id is not None else {}),
+                },
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "Confirmed-producer reopen skipped: could not persist CONSENSUS_REOPENED",
+            pipeline_id=pipeline_id,
+            role=role,
+            error=str(exc),
+        )
+        return None
+
+    try:
+        result = tracker.reopen_producer(role, reason=reason)
+    except ValueError as exc:
+        logger.warning(
+            "Confirmed-producer reopen failed",
+            pipeline_id=pipeline_id,
+            role=role,
+            error=str(exc),
+        )
+        return None
+
+    if result.get("status") == "reopened":
+        logger.info(
+            "Reopened confirmed producer after task reassignment",
+            pipeline_id=pipeline_id,
+            slice_id=slice_id,
+            role=role,
+            incomplete_tasks=[r["id"] for r in rows],
+        )
+        # The consensus-confirmed marker (#1473) asserts "BRC review
+        # complete" to the gateway's session-cleanup auto-commit; that
+        # is no longer true, so remove it (best-effort).
+        try:
+            marker = worktree / ".egg-state" / "agent-outputs" / "consensus-confirmed"
+            marker.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+    return rows
+
+
 @consensus_bp.route("/<pipeline_id>/consensus/next-action", methods=["POST"])
 def handle_next_action(pipeline_id: str) -> tuple[Response, int]:
     """Derive the next BRC action for the given role.
@@ -488,7 +660,20 @@ def handle_next_action(pipeline_id: str) -> tuple[Response, int]:
             status_code=400,
         )
 
+    # Confirmed-producer reopen (#3124): a task reassigned to this role
+    # after it confirmed flips it back to WORKING so the derivation
+    # below returns ``propose`` instead of locking it on ``wait``.
+    reopened_rows = _maybe_reopen_confirmed_producer(tracker, pipeline_id, slice_id, role)
+
     action, event_payload, reason = _derive_next_action(tracker, role)
+    if reopened_rows and action == "propose":
+        event_payload = dict(event_payload or {})
+        event_payload["reopened_after_confirm"] = True
+        event_payload["incomplete_tasks"] = reopened_rows
+        reason = (
+            "consensus reopened: contract task(s) were assigned to this role "
+            "after it confirmed — deliver them, mark them complete, and re-propose"
+        )
     if action not in _VALID_ACTIONS:  # pragma: no cover - defensive
         logger.error(
             "next-action produced invalid action; coercing to wait",

--- a/orchestrator/routes/consensus.py
+++ b/orchestrator/routes/consensus.py
@@ -464,6 +464,26 @@ def _maybe_reopen_confirmed_producer(
     # intermediate state) can need reopening. Reading _producer_phases
     # without the lock is a hint only; reopen_producer re-checks under
     # the lock.
+    #
+    # The OR-guard intentionally catches the dual-role intermediate
+    # window between ``handle_confirmed`` setting
+    # ``_producer_phases[role] = CONFIRMED`` and ``is_fully_confirmed``
+    # adding the role to ``_confirmed``. During that window
+    # ``role in tracker.confirmed_roles`` is False but
+    # ``_producer_phases.get(role) == CONFIRMED`` — both halves are
+    # load-bearing for dual-role correctness; do not simplify to a
+    # single-clause check.
+    #
+    # Concurrency note: two parallel next-action polls for the same
+    # role can both pass this lock-free pre-check, each persist a
+    # ``CONSENSUS_REOPENED`` bus message, and only the first will flip
+    # the FSM (the second's ``reopen_producer`` returns
+    # ``{"status": "noop"}`` because the lock-held re-check sees
+    # ``WORKING``). The tracker stays consistent and the contract IO
+    # is idempotent; the bus picks up a duplicate informational
+    # message. This is preferable to spanning a lock across contract
+    # IO — the duplicate is harmless and the replay arm is idempotent
+    # over repeated reopens.
     if role not in tracker.confirmed_roles and (
         tracker._producer_phases.get(role) != ConsensusPhase.CONFIRMED
     ):

--- a/orchestrator/routes/contracts.py
+++ b/orchestrator/routes/contracts.py
@@ -456,6 +456,16 @@ def _audit_confirmed_assignee_reassignment(
                     "field_path": field_path,
                     "new_assignee": new_value,
                     "actor": actor,
+                    # The reopen is contingent on the producer wrapper
+                    # still polling next-action. If the wrapper already
+                    # exited after CONFIRMED (the #3124 motivating
+                    # scenario for slices that closed before the
+                    # mutation landed), no poll will fire and the
+                    # operator-grade fallback
+                    # (POST /api/v1/contracts/<id>/tasks/<task>/complete
+                    # or the executable "Mark task <id> complete" HITL
+                    # option) is the only path forward.
+                    "reopen_requires_active_poll": True,
                 },
             )
     except Exception:  # pragma: no cover — observability must not break mutations
@@ -507,17 +517,35 @@ def operator_complete_task(identifier: str, task_id: str) -> tuple[Response, int
             status_code=400,
         )
 
+    # Scope the audit actor under the ``operator:`` namespace so a
+    # body-provided string can't be set to a sandbox-agent role like
+    # ``coder``/``reviewer`` and read in the audit log as an agent
+    # mutation. The route is lifecycle-secret guarded so this is
+    # belt-and-braces, but it keeps the audit trail honest if two
+    # different host-side tools call this endpoint with their own
+    # actor suffixes.
+    actor_suffix = body.get("actor")
+    actor = f"operator:{actor_suffix}" if actor_suffix else "operator"
+
     try:
         result = complete_task_as_operator(
             pipeline_id,
             task_id,
             commit=body.get("commit"),
             reason=body.get("reason", ""),
-            actor=body.get("actor", "operator"),
+            actor=actor,
             issue_number=ident if isinstance(ident, int) else None,
         )
     except OperatorActionError as exc:
         return _error(exc.message, status_code=exc.status_code)
+
+    logger.info(
+        "Operator marked task complete",
+        pipeline_id=pipeline_id,
+        task_id=task_id,
+        actor=actor,
+        source=getattr(request, "egg_source", "unknown"),
+    )
 
     return _success(f"Task {task_id} marked complete by operator", data=result)
 

--- a/orchestrator/routes/contracts.py
+++ b/orchestrator/routes/contracts.py
@@ -541,10 +541,12 @@ def operator_complete_task(identifier: str, task_id: str) -> tuple[Response, int
 
     logger.info(
         "Operator marked task complete",
-        pipeline_id=pipeline_id,
-        task_id=task_id,
-        actor=actor,
-        source=getattr(request, "egg_source", "unknown"),
+        extra={
+            "pipeline_id": pipeline_id,
+            "task_id": task_id,
+            "actor": actor,
+            "source": getattr(request, "egg_source", "unknown"),
+        },
     )
 
     return _success(f"Task {task_id} marked complete by operator", data=result)

--- a/orchestrator/routes/contracts.py
+++ b/orchestrator/routes/contracts.py
@@ -58,6 +58,7 @@ from egg_contracts import (  # noqa: E402
 from egg_contracts import (
     contract_exists as _contract_exists,
 )
+from lifecycle_auth import require_lifecycle_secret  # noqa: E402
 
 logger = logging.getLogger("orchestrator.contracts")
 
@@ -397,10 +398,128 @@ def mutate_contract(identifier: str) -> tuple[Response, int]:
         },
     )
 
+    _audit_confirmed_assignee_reassignment(result.contract, field_path, new_value, actor)
+
     return _success(
         "Mutation applied successfully",
         data={"contract": export_contract(result.contract, include_audit_log=False)},
     )
+
+
+_TASK_ROLE_PATH_RE = re.compile(r"^phases\.(\d+)\.tasks\.\d+\.role$")
+
+
+def _audit_confirmed_assignee_reassignment(
+    contract: Contract,
+    field_path: str,
+    new_value: Any,
+    actor: str,
+) -> None:
+    """Log when a ``tasks.*.role`` mutation targets a confirmed producer (#3124).
+
+    Reassigning a task to a producer that has already CONFIRMED its
+    slice consensus used to deadlock silently: the assignee could never
+    re-enter WORKING, and the #3114 completeness gate held the slice
+    open over the undelivered row. The next-action route now reopens
+    the producer's participation on its next poll
+    (``routes.consensus._maybe_reopen_confirmed_producer``), so this
+    hook is observability only — it makes the reassign-after-confirm
+    moment visible in the orchestrator log instead of leaving the
+    reopen to be discovered post-hoc. Best-effort: any failure here
+    must not affect the mutation that already succeeded.
+    """
+    try:
+        match = _TASK_ROLE_PATH_RE.match(field_path)
+        if not match or not isinstance(new_value, str):
+            return
+
+        pipeline_id, _repo_hint = _pipeline_context()
+        if not pipeline_id:
+            return
+
+        slice_idx = int(match.group(1))
+        slices = list(getattr(contract, "slices", None) or [])
+        slice_id = getattr(slices[slice_idx], "id", None) if slice_idx < len(slices) else None
+
+        from peer_consensus import get_peer_consensus_tracker
+
+        tracker = get_peer_consensus_tracker(pipeline_id, slice_id)
+        if tracker is None:
+            return
+        if new_value in tracker.confirmed_roles:
+            logger.warning(
+                "Task reassigned to an already-confirmed producer; its consensus "
+                "participation will reopen on its next next-action poll (#3124)",
+                extra={
+                    "pipeline_id": pipeline_id,
+                    "slice_id": slice_id,
+                    "field_path": field_path,
+                    "new_assignee": new_value,
+                    "actor": actor,
+                },
+            )
+    except Exception:  # pragma: no cover — observability must not break mutations
+        logger.debug("Confirmed-assignee reassignment audit skipped", exc_info=True)
+
+
+@contracts_bp.route("/<identifier>/tasks/<task_id>/complete", methods=["POST"])
+@require_lifecycle_secret
+def operator_complete_task(identifier: str, task_id: str) -> tuple[Response, int]:
+    """Mark a contract task complete as an audited operator action (#3124).
+
+    The in-band remediation for a task no live agent is permitted to
+    satisfy (e.g. reassigned to a producer that already CONFIRMED).
+    Replaces the ``kubectl exec`` + ``EGG_AGENT_ROLE=<role>
+    egg-contract complete-task`` impersonation workaround.
+
+    URL params:
+        identifier: Pipeline id (preferred) or issue number.
+        task_id: Contract task id (e.g. ``TASK-2-3``).
+
+    Request body (all optional)::
+
+        {"commit": "<sha evidence>",
+         "reason": "<why the operator is attesting completion>"}
+
+    Auth: lifecycle-secret guarded — operator/host surface only.
+    Sandbox agents keep using ``mcp__task__complete`` under their own
+    role; this route is not proxied by the gateway.
+    """
+    # Lazy import — operator_actions pulls in contract_store locking and
+    # egg_contracts; importing per-call mirrors the heavy-dependency
+    # seams used by routes/decisions.py.
+    from operator_actions import OperatorActionError, complete_task_as_operator
+
+    ident = _coerce_identifier(identifier)
+    validation_error = _validate_identifier(ident)
+    if validation_error:
+        return validation_error
+
+    body = request.get_json(silent=True) or {}
+    if not isinstance(body, dict):
+        return _error("Request body must be a JSON object")
+
+    pipeline_id = body.get("pipeline_id") or (str(ident) if not isinstance(ident, int) else None)
+    if not pipeline_id:
+        return _error(
+            "Cannot resolve pipeline worktree: pass the pipeline id as the "
+            "URL identifier or in the request body as 'pipeline_id'",
+            status_code=400,
+        )
+
+    try:
+        result = complete_task_as_operator(
+            pipeline_id,
+            task_id,
+            commit=body.get("commit"),
+            reason=body.get("reason", ""),
+            actor=body.get("actor", "operator"),
+            issue_number=ident if isinstance(ident, int) else None,
+        )
+    except OperatorActionError as exc:
+        return _error(exc.message, status_code=exc.status_code)
+
+    return _success(f"Task {task_id} marked complete by operator", data=result)
 
 
 @contract_mutations_bp.route("/validate", methods=["POST"])

--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -499,8 +499,16 @@ def _invalidate_conditional_acks(
 # completion option should emit a label of the form
 # ``Mark task <task-id> complete`` (backticks around the id tolerated);
 # free-form replies may append ``commit <sha>`` to link evidence.
+#
+# Pattern is anchored to the start of the resolution (optional leading
+# whitespace) and matched with ``re.match``: an unanchored ``re.search``
+# would fire on prose like "I do **not** want to mark task X complete",
+# triggering an audited, durable status mutation buried in a free-form
+# "Other (explain in reply)" reply. The documented free-form flow ("Mark
+# task <id> complete, commit <sha>") still matches; only buried
+# substrings are rejected.
 _COMPLETE_TASK_RESOLUTION_RE = re.compile(
-    r"Mark task\s+`{0,2}([A-Za-z0-9._\-]+)`{0,2}\s+complete",
+    r"\s*Mark task\s+`{0,2}([A-Za-z0-9._\-]+)`{0,2}\s+complete",
     re.IGNORECASE,
 )
 _COMMIT_EVIDENCE_RE = re.compile(r"\bcommit[\s:=]+([0-9a-fA-F]{7,40})\b")
@@ -523,7 +531,7 @@ def _maybe_complete_task_from_resolution(
     """
     if not resolution:
         return None
-    match = _COMPLETE_TASK_RESOLUTION_RE.search(resolution)
+    match = _COMPLETE_TASK_RESOLUTION_RE.match(resolution)
     if not match:
         return None
     task_id = match.group(1)

--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -491,6 +491,95 @@ def _invalidate_conditional_acks(
         )
 
 
+# Canonical executable task-completion resolution (#3124). Any decision
+# whose chosen option (or free-form reply) matches this shape EXECUTES
+# the completion when resolved — instead of recording a choice and
+# leaving the operator to ``kubectl exec`` into an agent pod and
+# impersonate its role. Decision creators that want an executable
+# completion option should emit a label of the form
+# ``Mark task <task-id> complete`` (backticks around the id tolerated);
+# free-form replies may append ``commit <sha>`` to link evidence.
+_COMPLETE_TASK_RESOLUTION_RE = re.compile(
+    r"Mark task\s+`{0,2}([A-Za-z0-9._\-]+)`{0,2}\s+complete",
+    re.IGNORECASE,
+)
+_COMMIT_EVIDENCE_RE = re.compile(r"\bcommit[\s:=]+([0-9a-fA-F]{7,40})\b")
+
+
+def _maybe_complete_task_from_resolution(
+    pipeline_id: str,
+    decision_id: str,
+    resolution: str | None,
+) -> dict[str, Any] | None:
+    """Execute an operator ``Mark task <id> complete`` resolution (#3124).
+
+    Returns the executed-action payload (merged into the resolve
+    response so the operator sees the completion happened), or ``None``
+    when the resolution is not a task-completion choice. Execution
+    failure is logged AND surfaced in the returned payload — the
+    decision is already marked resolved by the time dispatch runs, so a
+    silent failure here would recreate the records-a-choice-but-
+    executes-nothing gap this hook closes.
+    """
+    if not resolution:
+        return None
+    match = _COMPLETE_TASK_RESOLUTION_RE.search(resolution)
+    if not match:
+        return None
+    task_id = match.group(1)
+    commit_match = _COMMIT_EVIDENCE_RE.search(resolution)
+    commit = commit_match.group(1) if commit_match else None
+
+    from operator_actions import OperatorActionError, complete_task_as_operator
+
+    try:
+        result = complete_task_as_operator(
+            pipeline_id,
+            task_id,
+            commit=commit,
+            reason=f"HITL decision {decision_id} resolved with task-completion option",
+            actor=f"operator:decision:{decision_id}",
+        )
+    except OperatorActionError as exc:
+        logger.error(
+            "Task-completion resolution failed; task remains incomplete",
+            pipeline_id=pipeline_id,
+            decision_id=decision_id,
+            task_id=task_id,
+            error=exc.message,
+        )
+        return {
+            "action": "complete_task",
+            "task_id": task_id,
+            "success": False,
+            "error": exc.message,
+        }
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.error(
+            "Task-completion resolution raised unexpectedly",
+            pipeline_id=pipeline_id,
+            decision_id=decision_id,
+            task_id=task_id,
+            error=str(exc),
+            exc_info=True,
+        )
+        return {
+            "action": "complete_task",
+            "task_id": task_id,
+            "success": False,
+            "error": str(exc),
+        }
+
+    logger.info(
+        "Executed task completion from decision resolution",
+        pipeline_id=pipeline_id,
+        decision_id=decision_id,
+        task_id=task_id,
+        commit=commit,
+    )
+    return {"action": "complete_task", "success": True, **result}
+
+
 @decisions_bp.route("/<pipeline_id>/decisions", methods=["GET"])
 def list_decisions(pipeline_id: str) -> tuple[Response, int]:
     """
@@ -874,6 +963,13 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
         # required one was removed), so resolution just marks the decision
         # RESOLVED.
 
+        # Executable task-completion option (#3124): "Mark task <id>
+        # complete" performs the audited operator mutation instead of
+        # leaving the operator to impersonate an agent role via pod exec.
+        executed_action = _maybe_complete_task_from_resolution(
+            pipeline_id, decision_id, dispatch_resolution
+        )
+
         return make_success_response(
             "Decision resolved",
             data={
@@ -885,7 +981,8 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
                     if decision.resolved_at
                     else None,
                     "scope": "queue",
-                }
+                },
+                **({"executed_action": executed_action} if executed_action else {}),
             },
         )
 
@@ -1104,6 +1201,13 @@ def _resolve_contract_decision(
             exc_info=True,
         )
 
+    # Executable task-completion option (#3124) — same dispatch as the
+    # queue path, so a contract-resident (``cq-N``) decision resolved
+    # pre-bridge also executes instead of only recording the choice.
+    executed_action = _maybe_complete_task_from_resolution(
+        pipeline_id, decision_id, _normalize_choice_resolution(resolution)
+    )
+
     return make_success_response(
         "Decision resolved",
         data={
@@ -1113,7 +1217,8 @@ def _resolve_contract_decision(
                 "resolution": resolution,
                 "resolved_at": resolved_at.isoformat(),
                 "scope": "contract",
-            }
+            },
+            **({"executed_action": executed_action} if executed_action else {}),
         },
     )
 

--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -507,11 +507,20 @@ def _invalidate_conditional_acks(
 # "Other (explain in reply)" reply. The documented free-form flow ("Mark
 # task <id> complete, commit <sha>") still matches; only buried
 # substrings are rejected.
+#
+# Optional commit evidence is captured ONLY when it immediately follows
+# the completion clause, separated by whitespace or punctuation with no
+# intervening prose. This prevents replies like "Mark task X complete;
+# the prior commit abc1234 was wrong" from attaching ``abc1234`` as
+# evidence when the operator was referring to an unrelated commit. The
+# documented forms ("Mark task X complete, commit <sha>" / "Mark task X
+# complete commit <sha>") still capture; only commits gated behind
+# intervening words are rejected.
 _COMPLETE_TASK_RESOLUTION_RE = re.compile(
-    r"\s*Mark task\s+`{0,2}([A-Za-z0-9._\-]+)`{0,2}\s+complete",
+    r"\s*Mark task\s+`{0,2}([A-Za-z0-9._\-]+)`{0,2}\s+complete"
+    r"(?:[\s,;:.]+\bcommit[\s:=]+([0-9a-fA-F]{7,40})\b)?",
     re.IGNORECASE,
 )
-_COMMIT_EVIDENCE_RE = re.compile(r"\bcommit[\s:=]+([0-9a-fA-F]{7,40})\b")
 
 
 def _maybe_complete_task_from_resolution(
@@ -535,8 +544,7 @@ def _maybe_complete_task_from_resolution(
     if not match:
         return None
     task_id = match.group(1)
-    commit_match = _COMMIT_EVIDENCE_RE.search(resolution)
-    commit = commit_match.group(1) if commit_match else None
+    commit = match.group(2)
 
     from operator_actions import OperatorActionError, complete_task_as_operator
 

--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -2516,6 +2516,29 @@ def _existing_confirmed_for_role(
     except Exception:
         return (False, False)
 
+    # Confirmed-producer reopen awareness (#3124): a CONSENSUS_REOPENED
+    # targeting this role invalidates any *earlier* CONFIRMED message —
+    # the role re-entered WORKING, so its eventual re-confirm must write
+    # a fresh CONFIRMED message. Without this, the dedupe below would
+    # swallow the re-confirm and message replay (which processes the
+    # post-reopen re-propose *after* the stale CONFIRMED) would leave
+    # the role unconfirmed forever after an orchestrator restart.
+    latest_reopen_ts = None
+    for m in messages:
+        if str(getattr(m, "message_type", "")) != "CONSENSUS_REOPENED":
+            continue
+        if getattr(m, "to_role", None) != agent_role:
+            continue
+        msg_phase = getattr(m, "phase", None)
+        if phase is not None and msg_phase is not None and msg_phase != phase:
+            continue
+        metadata = getattr(m, "metadata", None) or {}
+        if metadata.get("slice_id") != slice_id:
+            continue
+        ts = getattr(m, "timestamp", None)
+        if ts is not None and (latest_reopen_ts is None or ts > latest_reopen_ts):
+            latest_reopen_ts = ts
+
     has_final = False
     has_pending = False
     for m in messages:
@@ -2537,6 +2560,13 @@ def _existing_confirmed_for_role(
         # confirms.
         if metadata.get("slice_id") != slice_id:
             continue
+        # Stale: confirmed before the latest reopen (#3124). A missing
+        # timestamp counts as stale — the safe failure direction here is
+        # a duplicate CONFIRMED write, not a lost re-confirm.
+        if latest_reopen_ts is not None:
+            ts = getattr(m, "timestamp", None)
+            if ts is None or ts <= latest_reopen_ts:
+                continue
         if metadata.get("pending_acks"):
             has_pending = True
         else:

--- a/orchestrator/tests/test_confirmed_producer_reopen.py
+++ b/orchestrator/tests/test_confirmed_producer_reopen.py
@@ -368,17 +368,20 @@ class TestNextActionReopen:
         assert sent.message_type == "CONSENSUS_REOPENED"
         assert sent.to_role == "coder"
 
-    def test_confirmed_producer_with_no_incomplete_tasks_stays_wait(self, client):
+    def test_no_incomplete_rows_does_not_reopen(self, client):
+        # The invariants under test are: (1) no reopen — coder stays
+        # confirmed — and (2) no CONSENSUS_REOPENED message hits the
+        # bus. The reported action is incidental (consensus is globally
+        # complete here, so the confirmed short-circuit reports
+        # "complete"); the name used to suggest "stays wait", which the
+        # behaviour contradicts.
         tracker = _tracker()
         _confirm_all(tracker)
 
         resp, msg_store = _next_action_with_reopen_env(client, tracker, rows=[])
 
         action, _ = _action(resp)
-        # Consensus is globally complete here, so the confirmed
-        # short-circuit reports completion — the point is it does NOT
-        # reopen or propose.
-        assert action in ("wait", "complete")
+        assert action != "propose"
         assert "coder" in tracker.confirmed_roles
         msg_store.add_message.assert_not_called()
 
@@ -605,6 +608,31 @@ class TestOperatorCompleteTaskRoute:
         assert data["data"]["status"] == "complete"
         assert data["data"]["task_id"] == "task-1-1"
 
+    def test_route_scopes_body_actor_under_operator_namespace(self, route_client):
+        # A body-provided ``actor`` must be prefixed with ``operator:``
+        # so it can't be set to an agent role and read in the audit log
+        # as an agent mutation.
+        with patch("operator_actions.complete_task_as_operator") as complete_mock:
+            complete_mock.return_value = {"task_id": "task-1-1", "status": "complete"}
+            route_client.post(
+                "/api/v1/contracts/pid-3124/tasks/task-1-1/complete",
+                headers={"Authorization": "Bearer test-secret"},
+                data=json.dumps({"actor": "coder"}),
+                content_type="application/json",
+            )
+        assert complete_mock.call_args[1]["actor"] == "operator:coder"
+
+    def test_route_default_actor_is_operator(self, route_client):
+        with patch("operator_actions.complete_task_as_operator") as complete_mock:
+            complete_mock.return_value = {"task_id": "task-1-1", "status": "complete"}
+            route_client.post(
+                "/api/v1/contracts/pid-3124/tasks/task-1-1/complete",
+                headers={"Authorization": "Bearer test-secret"},
+                data=json.dumps({}),
+                content_type="application/json",
+            )
+        assert complete_mock.call_args[1]["actor"] == "operator"
+
 
 # ---------------------------------------------------------------------------
 # decisions: executable "Mark task <id> complete" resolution
@@ -651,6 +679,28 @@ class TestDecisionResolutionDispatch:
         )
         assert result["success"] is False
         assert "contract gone" in result["error"]
+
+    def test_buried_prose_does_not_execute_completion(self):
+        # An operator who chooses "Other (explain in reply)" and writes
+        # a free-form reply that happens to quote the option label
+        # ("...do not want to mark task X complete...") must not trigger
+        # the audited status mutation. The pattern is anchored to the
+        # start of the resolution; only the documented free-form flow
+        # ("Mark task <id> complete[, commit <sha>]") executes.
+        result, complete_mock = self._dispatch(
+            "I do not want to mark task TASK-2-3 complete; "
+            "the producer should fix the failing test instead.",
+        )
+        assert result is None
+        complete_mock.assert_not_called()
+
+    def test_leading_whitespace_still_matches(self):
+        result, complete_mock = self._dispatch(
+            "   Mark task TASK-2-3 complete",
+            return_value={"task_id": "TASK-2-3", "status": "complete"},
+        )
+        assert result["success"] is True
+        complete_mock.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_confirmed_producer_reopen.py
+++ b/orchestrator/tests/test_confirmed_producer_reopen.py
@@ -1,0 +1,702 @@
+"""Tests for the confirmed-producer reopen + operator remediation (#3124).
+
+Covers:
+
+* ``PeerConsensusTracker.reopen_producer`` — CONFIRMED→WORKING reopen,
+  idempotent no-op, non-producer rejection, and the downstream
+  re-propose cascade (#1411 stale-confirm discard,
+  ``_un_confirm_stale_reviewers``).
+* ``reconstruct_tracker_from_messages`` — the ``CONSENSUS_REOPENED``
+  replay arm: without it, replaying the post-reopen proposal would be
+  rejected (propose guard requires WORKING) and a restart would
+  resurrect the deadlock.
+* ``routes.consensus._maybe_reopen_confirmed_producer`` via the
+  next-action route — a confirmed producer that owns incomplete
+  contract rows is flipped back to ``propose``; kill switch and
+  no-incomplete-rows cases stay ``wait``.
+* ``routes.signals._existing_confirmed_for_role`` — a CONFIRMED that
+  predates the latest CONSENSUS_REOPENED no longer dedupes the
+  re-confirm message write.
+* ``operator_actions.complete_task_as_operator`` + the lifecycle-
+  guarded REST route — the in-band operator path that replaces
+  pod-exec role impersonation.
+* ``routes.decisions._maybe_complete_task_from_resolution`` — the
+  executable ``Mark task <id> complete`` resolution.
+* ``impasse_routing._build_hitl_decision`` — escalations expose the
+  executable completion option.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+# Mock docker before importing route modules that depend on it.
+sys.modules.setdefault("docker", MagicMock())
+sys.modules.setdefault("docker.errors", MagicMock())
+sys.modules.setdefault("docker.types", MagicMock())
+
+from egg_orchestrator.types import ConsensusPhase  # noqa: E402
+from peer_consensus import (  # noqa: E402
+    PeerConsensusTracker,
+    _trackers,
+    _trackers_lock,
+    reconstruct_tracker_from_messages,
+)
+from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph  # noqa: E402
+
+PIPELINE_ID = "pipeline-3124-reopen"
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _graph() -> ReviewGraph:
+    return ReviewGraph(
+        [
+            ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL),
+        ]
+    )
+
+
+def _tracker(pipeline_id: str = PIPELINE_ID) -> PeerConsensusTracker:
+    t = PeerConsensusTracker(pipeline_id, _graph(), cooldown_seconds=0)
+    t.register_agent("coder")
+    t.register_agent("reviewer_code")
+    return t
+
+
+def _propose(tracker: PeerConsensusTracker, role: str = "coder") -> None:
+    tracker.handle_propose(
+        role,
+        {
+            "summary": (
+                "Proposal with substantive content describing the work, "
+                "tests run, and tasks satisfied for review."
+            ),
+            "artifacts": ["a.py"],
+            "commit_sha": "abc1234",
+        },
+    )
+
+
+def _ack(tracker: PeerConsensusTracker, reviewer: str, producer: str, *, version: int = 1) -> None:
+    tracker.handle_ack(
+        reviewer,
+        producer,
+        {
+            "artifact_references": ["a.py"],
+            "reason": (
+                "Substantive review verdict satisfying the ≥50 char content "
+                "gate enforced by _validate_brc_content."
+            ),
+            "ack_version": version,
+        },
+    )
+
+
+def _confirm_all(tracker: PeerConsensusTracker) -> None:
+    """coder proposes, reviewer ACKs, both confirm."""
+    _propose(tracker)
+    _ack(tracker, "reviewer_code", "coder")
+    tracker.handle_confirmed("coder")
+    tracker.handle_confirmed("reviewer_code")
+
+
+# ---------------------------------------------------------------------------
+# Tracker unit: reopen_producer
+# ---------------------------------------------------------------------------
+
+
+class TestReopenProducer:
+    def test_reopen_confirmed_producer_returns_to_working(self):
+        tracker = _tracker()
+        _confirm_all(tracker)
+        assert "coder" in tracker.confirmed_roles
+
+        result = tracker.reopen_producer("coder", reason="task reassigned")
+
+        assert result["status"] == "reopened"
+        assert "coder" not in tracker.confirmed_roles
+        assert tracker._producer_phases["coder"] == ConsensusPhase.WORKING
+
+    def test_reopened_producer_can_repropose_and_cascade_unconfirms_reviewer(self):
+        """The re-propose path after a reopen is the existing machinery:
+        the new version invalidates the reviewer's stale confirm
+        (``_un_confirm_stale_reviewers``) so the slice re-converges on
+        the new deliverable instead of closing over the old one.
+        """
+        tracker = _tracker()
+        _confirm_all(tracker)
+        tracker.reopen_producer("coder", reason="task reassigned")
+
+        _propose(tracker)  # v2 — must not raise (WORKING again)
+
+        assert tracker.matrix.get_proposal_version("coder") == 2
+        assert "reviewer_code" not in tracker.confirmed_roles  # stale confirm cleared
+
+        # Full re-convergence works end to end.
+        _ack(tracker, "reviewer_code", "coder", version=2)
+        tracker.handle_confirmed("coder")
+        tracker.handle_confirmed("reviewer_code")
+        assert tracker.evaluate()["is_complete"]
+
+    def test_reopen_unconfirmed_producer_is_noop(self):
+        tracker = _tracker()
+        _propose(tracker)
+        result = tracker.reopen_producer("coder")
+        assert result["status"] == "noop"
+        assert tracker._producer_phases["coder"] == ConsensusPhase.PROPOSED
+
+    def test_reopen_non_producer_raises(self):
+        tracker = _tracker()
+        with pytest.raises(ValueError, match="not a producer"):
+            tracker.reopen_producer("reviewer_code")
+
+
+# ---------------------------------------------------------------------------
+# Reconstruction: CONSENSUS_REOPENED replay arm
+# ---------------------------------------------------------------------------
+
+
+class _FakeMessage:
+    def __init__(
+        self,
+        message_type: str,
+        from_role: str,
+        to_role: str = "all",
+        metadata: dict | None = None,
+        timestamp: datetime | None = None,
+        msg_id: str = "",
+    ) -> None:
+        self.id = msg_id or f"msg-{message_type.lower()}-{from_role}"
+        self.message_type = message_type
+        self.from_role = from_role
+        self.to_role = to_role
+        self.body = ""
+        self.phase = "implement"
+        self.metadata = metadata or {}
+        self.timestamp = timestamp or datetime.now(UTC)
+
+
+class _FakeMessageStore:
+    def __init__(self, messages: list[_FakeMessage]) -> None:
+        self._messages = list(messages)
+
+    def get_messages(self, pipeline_id: str, *, limit: int = 100) -> list[_FakeMessage]:
+        return list(self._messages)
+
+
+class TestReconstructionReplaysReopen:
+    def test_post_reopen_proposal_survives_replay(self):
+        pid = "pipeline-3124-reconstruct"
+        t0 = datetime.now(UTC)
+        propose_payload = {
+            "payload": {
+                "summary": (
+                    "Proposal with substantive content describing the work, "
+                    "tests run, and tasks satisfied for review."
+                ),
+                "artifacts": ["a.py"],
+                "commit_sha": "abc1234",
+            }
+        }
+        ack_payload = {
+            "payload": {
+                "artifact_references": ["a.py"],
+                "reason": (
+                    "Substantive review verdict satisfying the ≥50 char "
+                    "content gate enforced by _validate_brc_content."
+                ),
+                "ack_version": 1,
+            }
+        }
+        messages = [
+            _FakeMessage(
+                "CONSENSUS_PROPOSE", "coder", metadata=propose_payload, timestamp=t0, msg_id="m1"
+            ),
+            _FakeMessage(
+                "CONSENSUS_ACK",
+                "reviewer_code",
+                to_role="coder",
+                metadata=ack_payload,
+                timestamp=t0 + timedelta(seconds=1),
+                msg_id="m2",
+            ),
+            _FakeMessage(
+                "CONSENSUS_CONFIRMED",
+                "coder",
+                timestamp=t0 + timedelta(seconds=2),
+                msg_id="m3",
+            ),
+            _FakeMessage(
+                "CONSENSUS_CONFIRMED",
+                "reviewer_code",
+                timestamp=t0 + timedelta(seconds=3),
+                msg_id="m4",
+            ),
+            # Task reassigned post-confirm → orchestrator reopened coder.
+            _FakeMessage(
+                "CONSENSUS_REOPENED",
+                "orchestrator",
+                to_role="coder",
+                timestamp=t0 + timedelta(seconds=4),
+                msg_id="m5",
+            ),
+            # coder's post-reopen proposal — without the replay arm the
+            # propose guard rejects this (phase CONFIRMED, not WORKING).
+            _FakeMessage(
+                "CONSENSUS_PROPOSE",
+                "coder",
+                metadata=propose_payload,
+                timestamp=t0 + timedelta(seconds=5),
+                msg_id="m6",
+            ),
+        ]
+
+        try:
+            tracker = reconstruct_tracker_from_messages(
+                pid, _graph(), message_store=_FakeMessageStore(messages)
+            )
+            assert tracker is not None
+            # The v2 proposal replayed — version advanced past the reopen.
+            assert tracker.matrix.get_proposal_version("coder") == 2
+            assert "coder" not in tracker.confirmed_roles
+            assert tracker._producer_phases["coder"] == ConsensusPhase.PROPOSED
+        finally:
+            with _trackers_lock:
+                _trackers.pop(pid, None)
+
+
+# ---------------------------------------------------------------------------
+# Route: next-action reopen
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client():
+    from flask import Flask
+    from routes.consensus import consensus_bp
+
+    app = Flask(__name__)
+    app.register_blueprint(consensus_bp)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def _incomplete_row(task_id: str = "task-2-2") -> dict:
+    return {"id": task_id, "role": "coder", "status": "pending", "commit": None}
+
+
+def _next_action_with_reopen_env(
+    client,
+    tracker,
+    *,
+    rows,
+    gate_enabled: bool = True,
+    role: str = "coder",
+):
+    """POST next-action with the contract/state plumbing patched so the
+    reopen helper sees an implement-phase pipeline whose contract has
+    ``rows`` incomplete for ``role``."""
+    pipeline_state = SimpleNamespace(
+        current_phase=SimpleNamespace(value="implement"),
+        issue_number=None,
+    )
+    state_store = MagicMock()
+    state_store.load_pipeline.return_value = pipeline_state
+    msg_store = MagicMock()
+
+    with (
+        patch("routes.consensus.get_peer_consensus_tracker", return_value=tracker),
+        patch("routes.consensus.get_state_store", return_value=state_store),
+        patch("routes.get_repo_path", return_value=Path("/tmp/unused")),
+        patch("routes.resolve_repo_path_for_pipeline", side_effect=lambda pid, p: p),
+        patch("routes.resolve_worktree_path", return_value=Path("/tmp/unused-worktree")),
+        patch("contract_completeness.gate_enabled", return_value=gate_enabled),
+        patch("contract_completeness.load_live_contract", return_value=object()),
+        patch("contract_completeness.incomplete_tasks", return_value=rows),
+        patch("message_store.get_message_store", return_value=msg_store),
+    ):
+        resp = client.post(
+            f"/api/v1/pipelines/{PIPELINE_ID}/consensus/next-action",
+            data=json.dumps({"role": role}),
+            content_type="application/json",
+        )
+    return resp, msg_store
+
+
+def _action(resp) -> tuple[str, dict]:
+    assert resp.status_code == 200, resp.data
+    data = json.loads(resp.data)
+    payload = data.get("data", data)
+    return payload["action"], payload
+
+
+class TestNextActionReopen:
+    def test_confirmed_producer_with_incomplete_task_gets_propose(self, client):
+        tracker = _tracker()
+        _confirm_all(tracker)
+
+        resp, msg_store = _next_action_with_reopen_env(client, tracker, rows=[_incomplete_row()])
+
+        action, payload = _action(resp)
+        assert action == "propose"
+        assert payload["event_payload"]["reopened_after_confirm"] is True
+        assert payload["event_payload"]["incomplete_tasks"] == [_incomplete_row()]
+        # Tracker state actually flipped.
+        assert "coder" not in tracker.confirmed_roles
+        assert tracker._producer_phases["coder"] == ConsensusPhase.WORKING
+        # The reopen was persisted for replay.
+        sent = msg_store.add_message.call_args[0][0]
+        assert sent.message_type == "CONSENSUS_REOPENED"
+        assert sent.to_role == "coder"
+
+    def test_confirmed_producer_with_no_incomplete_tasks_stays_wait(self, client):
+        tracker = _tracker()
+        _confirm_all(tracker)
+
+        resp, msg_store = _next_action_with_reopen_env(client, tracker, rows=[])
+
+        action, _ = _action(resp)
+        # Consensus is globally complete here, so the confirmed
+        # short-circuit reports completion — the point is it does NOT
+        # reopen or propose.
+        assert action in ("wait", "complete")
+        assert "coder" in tracker.confirmed_roles
+        msg_store.add_message.assert_not_called()
+
+    def test_kill_switch_disables_reopen(self, client):
+        tracker = _tracker()
+        _confirm_all(tracker)
+
+        resp, msg_store = _next_action_with_reopen_env(
+            client, tracker, rows=[_incomplete_row()], gate_enabled=False
+        )
+
+        action, _ = _action(resp)
+        assert action in ("wait", "complete")
+        assert "coder" in tracker.confirmed_roles
+        msg_store.add_message.assert_not_called()
+
+    def test_unconfirmed_producer_skips_contract_read(self, client):
+        """The cheap pre-check must keep contract IO off the hot path."""
+        tracker = _tracker()
+        _propose(tracker)  # PROPOSED, not confirmed
+
+        with (
+            patch("routes.consensus.get_peer_consensus_tracker", return_value=tracker),
+            patch("contract_completeness.load_live_contract") as load_mock,
+        ):
+            resp = client.post(
+                f"/api/v1/pipelines/{PIPELINE_ID}/consensus/next-action",
+                data=json.dumps({"role": "coder"}),
+                content_type="application/json",
+            )
+        action, _ = _action(resp)
+        assert action == "wait"
+        load_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# signals: _existing_confirmed_for_role reopen-awareness
+# ---------------------------------------------------------------------------
+
+
+def _confirmed_msg(role: str, ts: datetime, *, pending: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        from_role=role,
+        to_role="all",
+        message_type="CONSENSUS_CONFIRMED",
+        phase="implement",
+        metadata={"pending_acks": True} if pending else {"consensus_reached": True},
+        timestamp=ts,
+    )
+
+
+def _reopened_msg(role: str, ts: datetime) -> SimpleNamespace:
+    return SimpleNamespace(
+        from_role="orchestrator",
+        to_role=role,
+        message_type="CONSENSUS_REOPENED",
+        phase="implement",
+        metadata={},
+        timestamp=ts,
+    )
+
+
+class TestExistingConfirmedReopenAware:
+    def _probe(self, messages):
+        from routes.signals import _existing_confirmed_for_role
+
+        store = MagicMock()
+        store.get_messages.return_value = messages
+        with patch("message_store.get_message_store", return_value=store):
+            return _existing_confirmed_for_role("pid", "coder", "implement")
+
+    def test_confirmed_before_reopen_is_stale(self):
+        t0 = datetime.now(UTC)
+        has_final, has_pending = self._probe(
+            [
+                _confirmed_msg("coder", t0),
+                _reopened_msg("coder", t0 + timedelta(seconds=10)),
+            ]
+        )
+        assert has_final is False
+        assert has_pending is False
+
+    def test_reconfirm_after_reopen_counts(self):
+        t0 = datetime.now(UTC)
+        has_final, _ = self._probe(
+            [
+                _confirmed_msg("coder", t0),
+                _reopened_msg("coder", t0 + timedelta(seconds=10)),
+                _confirmed_msg("coder", t0 + timedelta(seconds=20)),
+            ]
+        )
+        assert has_final is True
+
+    def test_reopen_for_other_role_does_not_invalidate(self):
+        t0 = datetime.now(UTC)
+        has_final, _ = self._probe(
+            [
+                _confirmed_msg("coder", t0),
+                _reopened_msg("tester", t0 + timedelta(seconds=10)),
+            ]
+        )
+        assert has_final is True
+
+    def test_no_reopen_behaves_as_before(self):
+        t0 = datetime.now(UTC)
+        has_final, has_pending = self._probe(
+            [
+                _confirmed_msg("coder", t0),
+                _confirmed_msg("coder", t0 + timedelta(seconds=1), pending=True),
+            ]
+        )
+        assert has_final is True
+        assert has_pending is True
+
+
+# ---------------------------------------------------------------------------
+# operator_actions.complete_task_as_operator
+# ---------------------------------------------------------------------------
+
+
+def _contract_dict() -> dict:
+    return {
+        "schemaVersion": "1.0",
+        "pipeline_id": "pid-3124",
+        "issue": {"number": 42, "title": "reopen test", "url": "http://example"},
+        "phases": [
+            {
+                "id": "slice-1",
+                "name": "only",
+                "tasks": [
+                    {
+                        "id": "task-1-1",
+                        "description": "pending coder work",
+                        "role": "coder",
+                        "status": "pending",
+                    },
+                ],
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def contract_worktree(tmp_path: Path) -> Path:
+    contracts_dir = tmp_path / ".egg-state" / "contracts"
+    contracts_dir.mkdir(parents=True)
+    (contracts_dir / "pid-3124.json").write_text(json.dumps(_contract_dict()))
+    return tmp_path
+
+
+class TestOperatorCompleteTask:
+    def test_completes_task_with_commit_evidence(self, contract_worktree: Path):
+        from egg_contracts import load_contract
+        from operator_actions import complete_task_as_operator
+
+        with patch("contract_store.resolve_pipeline_worktree", return_value=contract_worktree):
+            result = complete_task_as_operator(
+                "pid-3124",
+                "task-1-1",
+                commit="c0ffee123",
+                reason="confirmed-producer deadlock remediation",
+                actor="operator:test",
+            )
+
+        assert result["status"] == "complete"
+        assert result["prior_status"] == "pending"
+        assert result["commit"] == "c0ffee123"
+
+        contract = load_contract("pid-3124", contract_worktree)
+        task = contract.slices[0].tasks[0]
+        assert str(task.status) == "complete"
+        assert task.commit == "c0ffee123"
+        # Audited as the operator, not an agent role.
+        audit_actors = {e.actor for e in contract.audit_log}
+        assert "operator:test" in audit_actors
+
+    def test_unknown_task_raises_404(self, contract_worktree: Path):
+        from operator_actions import OperatorActionError, complete_task_as_operator
+
+        with (
+            patch("contract_store.resolve_pipeline_worktree", return_value=contract_worktree),
+            pytest.raises(OperatorActionError) as exc_info,
+        ):
+            complete_task_as_operator("pid-3124", "task-9-9")
+        assert exc_info.value.status_code == 404
+
+    def test_missing_worktree_raises_404(self):
+        from operator_actions import OperatorActionError, complete_task_as_operator
+
+        with (
+            patch("contract_store.resolve_pipeline_worktree", return_value=None),
+            pytest.raises(OperatorActionError) as exc_info,
+        ):
+            complete_task_as_operator("pid-gone", "task-1-1")
+        assert exc_info.value.status_code == 404
+
+
+class TestOperatorCompleteTaskRoute:
+    @pytest.fixture
+    def route_client(self, monkeypatch):
+        from flask import Flask
+        from routes.contracts import contracts_bp
+
+        monkeypatch.setenv("EGG_LIFECYCLE_SECRET", "test-secret")
+        app = Flask(__name__)
+        app.register_blueprint(contracts_bp)
+        app.config["TESTING"] = True
+        return app.test_client()
+
+    def test_route_requires_lifecycle_secret(self, route_client):
+        resp = route_client.post("/api/v1/contracts/pid-3124/tasks/task-1-1/complete")
+        assert resp.status_code == 401
+
+    def test_route_executes_operator_completion(self, route_client, contract_worktree):
+        with patch("contract_store.resolve_pipeline_worktree", return_value=contract_worktree):
+            resp = route_client.post(
+                "/api/v1/contracts/pid-3124/tasks/task-1-1/complete",
+                headers={"Authorization": "Bearer test-secret"},
+                data=json.dumps({"commit": "c0ffee123", "reason": "operator attests"}),
+                content_type="application/json",
+            )
+        assert resp.status_code == 200, resp.data
+        data = json.loads(resp.data)
+        assert data["data"]["status"] == "complete"
+        assert data["data"]["task_id"] == "task-1-1"
+
+
+# ---------------------------------------------------------------------------
+# decisions: executable "Mark task <id> complete" resolution
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionResolutionDispatch:
+    def _dispatch(self, resolution, **patch_kwargs):
+        from routes.decisions import _maybe_complete_task_from_resolution
+
+        with patch("operator_actions.complete_task_as_operator", **patch_kwargs) as complete_mock:
+            result = _maybe_complete_task_from_resolution("pid", "cq-3", resolution)
+        return result, complete_mock
+
+    def test_non_matching_resolution_is_ignored(self):
+        result, complete_mock = self._dispatch("Cancel the slice and re-plan")
+        assert result is None
+        complete_mock.assert_not_called()
+
+    def test_matching_resolution_executes_completion(self):
+        result, complete_mock = self._dispatch(
+            "Mark task TASK-2-3 complete",
+            return_value={"task_id": "TASK-2-3", "status": "complete"},
+        )
+        assert result["success"] is True
+        complete_mock.assert_called_once()
+        assert complete_mock.call_args[0] == ("pid", "TASK-2-3")
+        assert complete_mock.call_args[1]["commit"] is None
+
+    def test_backticks_and_commit_evidence_parse(self):
+        result, complete_mock = self._dispatch(
+            "Mark task ``TASK-2-3`` complete, commit abc1234def",
+            return_value={"task_id": "TASK-2-3", "status": "complete"},
+        )
+        assert result["success"] is True
+        assert complete_mock.call_args[1]["commit"] == "abc1234def"
+
+    def test_execution_failure_is_surfaced_not_silent(self):
+        from operator_actions import OperatorActionError
+
+        result, _ = self._dispatch(
+            "Mark task TASK-2-3 complete",
+            side_effect=OperatorActionError("contract gone", status_code=404),
+        )
+        assert result["success"] is False
+        assert "contract gone" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# impasse escalation exposes the executable option
+# ---------------------------------------------------------------------------
+
+
+class TestImpasseEscalationOption:
+    def test_escalation_with_task_offers_executable_completion(self):
+        from egg_contracts.impasse import Impasse, ImpasseCategory
+        from egg_contracts.models import Contract
+        from impasse_routing import _build_hitl_decision
+
+        contract = Contract.model_validate(_contract_dict())
+        slice_obj = contract.slices[0]
+        task = slice_obj.tasks[0]
+        impasse = Impasse(
+            category=ImpasseCategory.WRONG_ROLE,
+            reason="deliverable path is coder-owned per the file-restriction model",
+            task_id=task.id,
+            suggested_role="coder",
+        )
+
+        _field_path, decision = _build_hitl_decision(
+            contract, slice_obj, task, impasse, "documenter", "delegation limit reached"
+        )
+
+        labels = [o.label for o in decision.options]
+        assert f"Mark task {task.id} complete" in labels
+        # The executable option precedes the catch-all "Other".
+        assert labels[-1] == "Other (explain in reply)"
+
+    def test_escalation_without_task_omits_completion_option(self):
+        from egg_contracts.impasse import Impasse, ImpasseCategory
+        from egg_contracts.models import Contract
+        from impasse_routing import _build_hitl_decision
+
+        contract = Contract.model_validate(_contract_dict())
+        impasse = Impasse(
+            category=ImpasseCategory.WRONG_ROLE,
+            reason="could not resolve the task from the contract state",
+        )
+
+        _field_path, decision = _build_hitl_decision(
+            contract, None, None, impasse, "documenter", "could not resolve task_id"
+        )
+
+        labels = [o.label for o in decision.options]
+        assert not any(label.startswith("Mark task") for label in labels)

--- a/orchestrator/tests/test_confirmed_producer_reopen.py
+++ b/orchestrator/tests/test_confirmed_producer_reopen.py
@@ -702,6 +702,35 @@ class TestDecisionResolutionDispatch:
         assert result["success"] is True
         complete_mock.assert_called_once()
 
+    def test_unrelated_commit_after_prose_is_not_attached(self):
+        # Commit evidence must immediately follow the completion clause
+        # (separated only by whitespace/punctuation, never prose). A
+        # free-form reply like "Mark task X complete; the prior commit
+        # abc1234 was wrong" must not attach abc1234 as evidence when
+        # the operator was referring to an unrelated commit.
+        result, complete_mock = self._dispatch(
+            "Mark task TASK-2-3 complete; the prior commit abc1234def was wrong",
+            return_value={"task_id": "TASK-2-3", "status": "complete"},
+        )
+        assert result["success"] is True
+        complete_mock.assert_called_once()
+        assert complete_mock.call_args[1]["commit"] is None
+
+    def test_commit_evidence_after_punctuation_separator_attaches(self):
+        # The documented free-form flow allows any of comma, semicolon,
+        # colon, period, or whitespace as the separator between the
+        # completion clause and the commit evidence — all four must
+        # still capture the commit.
+        for separator in (",", ";", ":", "."):
+            result, complete_mock = self._dispatch(
+                f"Mark task TASK-2-3 complete{separator} commit abc1234def",
+                return_value={"task_id": "TASK-2-3", "status": "complete"},
+            )
+            assert result["success"] is True, f"separator {separator!r} failed"
+            assert complete_mock.call_args[1]["commit"] == "abc1234def", (
+                f"separator {separator!r} did not capture commit"
+            )
+
 
 # ---------------------------------------------------------------------------
 # impasse escalation exposes the executable option

--- a/scripts/file-size-allowlist.yaml
+++ b/scripts/file-size-allowlist.yaml
@@ -71,3 +71,9 @@ files:
   # Decompose in a follow-up PR.
   sandbox/egg_lib/contract_cli.py:
     issue: "3033"
+  # #3124 added the operator complete-task route, executable decision
+  # resolution dispatch, and impasse-escalation option, pushing the file
+  # from ~1,490 lines to 1,512 lines (12 over the 1,500-line hard cap).
+  # Decompose in a follow-up PR.
+  orchestrator/routes/decisions.py:
+    issue: "3124"

--- a/scripts/file-size-allowlist.yaml
+++ b/scripts/file-size-allowlist.yaml
@@ -73,7 +73,7 @@ files:
     issue: "3033"
   # #3124 added the operator complete-task route, executable decision
   # resolution dispatch, and impasse-escalation option, pushing the file
-  # from ~1,490 lines to 1,512 lines (12 over the 1,500-line hard cap).
+  # from ~1,490 lines to ~1,520 lines (20 over the 1,500-line hard cap).
   # Decompose in a follow-up PR.
   orchestrator/routes/decisions.py:
     issue: "3124"


### PR DESCRIPTION
Fixes #3124.

## Problem

Reassigning a contract task to a producer that has already CONFIRMED creates a contract state no live agent is permitted to satisfy. Confirmation is a one-way lock (`check_propose_guard` rejects proposals from CONFIRMED; `_derive_next_action` short-circuits confirmed roles to `wait`), the #3114 completeness gate correctly holds the slice open over the undelivered row, and every remaining actor is disqualified (overseer 403, producer locked, `restart_agent` = producer-permanent-death per #2806, decision resolution executed nothing). The only remediation was `kubectl exec` + `EGG_AGENT_ROLE=<role>` impersonation.

## Part A — self-healing reopen (live cycles)

- **`PeerConsensusTracker.reopen_producer()`** — flips the producer FSM CONFIRMED → WORKING and discards confirmed status. Idempotent. From there the *existing* re-propose machinery takes over: the #1411 stale-confirm discard and `_un_confirm_stale_reviewers` force re-review of the new version, so the slice re-converges on the actual deliverable.
- **next-action route** — before deriving the action, a confirmed producer that owns incomplete contract rows (the #3114 `contract_completeness` helpers; implement phase only; same fail-open posture and `EGG_CONTRACT_ACK_GATE` kill switch) is reopened and told to `propose` with the row list in the payload. Detection derives purely from persistent contract state, so it is idempotent across polls, restarts, and reconstruction. The live event-pump wrapper already loops on next-action post-confirm, so no sandbox change is needed.
- **`CONSENSUS_REOPENED` message** — written to the bus *before* the tracker mutation and replayed by `reconstruct_tracker_from_messages`. Without this, replay would reject the post-reopen proposal (propose guard requires WORKING) and an orchestrator restart would resurrect the deadlock.
- **`_existing_confirmed_for_role()`** — a CONFIRMED that predates the latest reopen no longer counts for dedupe, so the producer's re-confirm writes a fresh message and replay ordering stays correct.
- **contracts mutate route** — structured audit log when a `tasks.*.role` mutation lands on a currently-confirmed assignee (observability for the reopen that will follow).

## Part B — operator-grade remediation (backstop for dead cycles)

When the producer's wrapper is already gone (or consensus fully closed before the mutation landed), Part A can't fire — the gate escalates and the operator needs an in-band channel:

- **`operator_actions.complete_task_as_operator()`** — marks a task complete with optional commit evidence as `Role.HUMAN` via `apply_mutation`, so it bypasses the implementer/reviewer field-ownership 403 *honestly* and lands in the contract audit log as an operator action.
- **`POST /api/v1/contracts/<id>/tasks/<task_id>/complete`** — lifecycle-secret-guarded REST route; host/operator surface only, never proxied to sandbox agents.
- **Executable decision resolution** — resolving a decision with `Mark task <id> complete` (optionally `… commit <sha>`) now executes the completion on both the queue path and the contract-resident `cq-N` fallback path, with the execution outcome surfaced in the resolve response (a failed execution is visible, not silent). Impasse-escalation decisions now offer this option when a task is resolved.

## Tests

`orchestrator/tests/test_confirmed_producer_reopen.py` (24 tests): tracker reopen + re-propose cascade + full re-convergence, reconstruction replay of the reopen (the v2 proposal survives), route-level reopen (flip to propose, kill switch, no-incomplete-rows, no contract IO for unconfirmed roles), reopen-aware confirm dedupe, operator completion (mutation + audit actor + 404s + route auth), decision-resolution dispatch (regex, commit evidence, surfaced failure), impasse option presence.

Targeted runs green: the new file plus `test_consensus_next_action*`, `test_consensus_confirmed_idempotent`, `test_contract_completeness_gate`, `test_contracts_routes`, `test_decisions_routes`, `test_impasse_routing`, `test_conditional_ack`, `test_consensus`, `test_signals`, `test_slice_4_restart_hardening`, `test_brc_phase_propagation`, `test_check_consensus_slice_isolation` — 460 passed.

## Relation to existing issues

- #2806 (producer restart = permanent death) is unchanged; this provides the recovery path it forecloses.
- #3114's gate behavior is unchanged; the reopen reuses its helpers, scoping, and kill switch so the two controls move together.