### PR TITLE
fix(brc): push operator directives to agents + mid-turn operator message delivery (#3123)

### DIFF
--- a/docs/architecture/orchestrator.md
+++ b/docs/architecture/orchestrator.md
@@ -1027,14 +1027,16 @@ section is the wait-side companion to this architecture description.
 ### Per-event prompt composer (`compose_event_prompt`)
 
 `compose_event_prompt(role, event_payload, memory_excerpt, nacks,
-git_log_delta, base_branch) -> str` builds the one-shot user prompt the
-wrapper invokes the agent with at each `case action.kind == INVOKE`
+git_log_delta, base_branch, *, task_description="") -> str` builds the
+one-shot user prompt the wrapper invokes the agent with at each
+`case action.kind == INVOKE`
 branch of the deterministic loop (see [Deterministic loop structure](#deterministic-loop-structure)
 above). It assembles, in order:
 
 | Position | Section | Source | Bound |
 |----------|---------|--------|-------|
 | Top | Role banner + one-line event description | `role` + `event_payload.kind` | A few hundred bytes; identifies the producer/reviewer side of the dispatch. |
+| Top | Task & operator directives (#3123) | The contract's `task_description`, read from the worktree contract file via the pod-inherited `EGG_PIPELINE_ID` / `EGG_ISSUE_NUMBER`; omitted when empty (GitHub-issue pipelines) | ≤ 4 KB (`TASK_DESCRIPTION_MAX_CHARS`), truncated with a pointer to `mcp__sdlc__show_contract`. Pushes the operator's submit-time directives into every invocation instead of relying on the agent pulling them per the rules file. |
 | Middle | NACK payload (per-reviewer NACK with `reason` + `artifact_refs`) | `orchestrator/peer_consensus.py` `_open_nacks_barrier_response.nacks[]` (line numbers come from the slice-3 contract spec and are drift-prone — prefer the function-name reference; the function span is around lines 949–1046 in practice) — the same envelope the producer sees on the aggregated-NACK 409 (see [§10.6](../reference/agent-wait-patterns.md#106-409-stale_version--aggregated-nack-are-event-pump-signals-not-transient-errors)). | One section per reviewer that NACKed the current version; rendered with reason text + artifact references. |
 | Middle | Single expected action | `event_payload.kind` | A few hundred bytes; states whether the agent should review, fix, confirm, etc. |
 | Tail | Per-producer git-log delta | `git log {last_reviewed_commit_sha}..HEAD --not origin/{base_branch} -p` ← `last_reviewed_commit_sha` from the [BRC memory file](brc-memory.md) | Scaled by actual change size; **NOT** counted against the 10 KB envelope. |

--- a/docs/reference/agent-wait-patterns.md
+++ b/docs/reference/agent-wait-patterns.md
@@ -172,6 +172,33 @@ the wrapper back off (≤ 2 s in test mode, exponential in production) and
 retry. A permanent error (exit 3 — 4xx, bad pipeline id, argparse misuse)
 makes the wrapper exit 1 so the agent fails fast.
 
+### Mid-turn operator message delivery (#3123)
+
+Wait-loop and the event-pump deliver messages **between** agent
+invocations, but one producer invocation can legitimately run 30+
+minutes (a slice coder implements its whole task list in a single
+`propose` turn). To keep operator corrections from landing only after
+the contradicting work is done, the SDK driver
+(`shared/egg_agent/client.py`) installs a throttled PostToolUse hook
+backed by `shared/egg_agent/midturn_messages.py`: at most once per
+`EGG_MIDTURN_MESSAGES_INTERVAL_SECS` (default 60 s) it runs
+`egg-orch message poll` against the bus and injects any **new
+operator-authored** messages (`from_role` ∈ overseer/human/operator/
+user) into the running session as additional context. Peer-agent and
+protocol traffic (`CONSENSUS_*`, heartbeats) is never injected — it
+stays on the between-invocation path the wrapper sequences.
+
+The poll cursor persists in `EGG_WAIT_CURSOR_DIR` across one-shot
+invocations (same back-channel pattern as the wait-loop cursor above),
+so a message landing between invocations is injected at the start of
+the next one and nothing is double-delivered. The first poll of a
+fresh pipeline seeds the cursor at the stream tip without injecting —
+the hook is for corrections that arrive after work started, not for
+replaying history. Every failure mode (missing `egg-orch`, orchestrator
+unreachable, malformed JSON, unwritable cursor) degrades to "no
+injection", never an agent failure. `EGG_MIDTURN_MESSAGES=false`
+disables the hook entirely.
+
 ### Multi-reviewer NACK aggregation barrier (#2142)
 
 When two or more reviewers have NACKed the producer's current version,
@@ -1503,13 +1530,15 @@ reverse-merge order; see
 #### 10.9.1 What shows up in the per-event prompt
 
 `compose_event_prompt(role, event_payload, memory_excerpt, nacks,
-git_log_delta, base_branch) -> str` (slice-3, `orchestrator/routes/pipelines.py`)
+git_log_delta, base_branch, *, task_description="") -> str` (slice-3,
+`orchestrator/routes/pipelines.py`)
 assembles the single user prompt the wrapper dispatches at each
 `INVOKE` branch of the §10.1 deterministic loop. The shape:
 
 | Position | Section | Where it comes from | Bound |
 |----------|---------|---------------------|-------|
 | Top | Role banner + one-line event description | `role` + `event_payload.kind` | A few hundred bytes per case. |
+| Top | Task & operator directives (#3123) | Contract `task_description` read from the worktree contract file (`EGG_PIPELINE_ID` / `EGG_ISSUE_NUMBER`); omitted for GitHub-issue pipelines | ≤ 4 KB, truncated with a `mcp__sdlc__show_contract` pointer. |
 | Middle | Per-reviewer NACK block (`reason` + `artifact_refs`) | `orchestrator/peer_consensus.py` `_open_nacks_barrier_response.nacks[]` (line numbers come from the slice-3 contract spec and are drift-prone — prefer the function-name reference; the function span is around lines 949–1046 in practice) — the same NACK envelope a producer sees in the aggregated-NACK 409 from §10.6 | One block per NACKing reviewer. |
 | Middle | The single expected action | `event_payload.kind` | A few hundred bytes. |
 | Tail | Git-log delta (full, per-producer — see §10.9.2) | `git log {last_reviewed_commit_sha}..HEAD --not origin/{base_branch} -p` with `last_reviewed_commit_sha` read from the slice-1 [BRC memory file](../architecture/brc-memory.md) | Scaled by change size; **NOT** counted against the 10 KB envelope. |

--- a/orchestrator/consensus_wrapper.py
+++ b/orchestrator/consensus_wrapper.py
@@ -380,7 +380,9 @@ wait_for_event() {{
 # ``compose_event_prompt`` payload: memory excerpt (when
 # ``EGG_BRC_MEMORY=full``) + per-producer
 # ``git log {{sha}}..HEAD --not origin/{{base}} -p`` delta + NACK
-# payload. The composer lives at
+# payload + the contract's ``task_description`` (#3123, read from the
+# worktree contract file via the pod-inherited ``EGG_PIPELINE_ID`` /
+# ``EGG_ISSUE_NUMBER``). The composer lives at
 # ``/opt/egg-runtime/orchestrator/routes/event_prompt.py`` -- the
 # wrapper invokes its ``if __name__ == '__main__'`` CLI directly so the
 # heavy ``orchestrator.routes`` package ``__init__.py`` (Flask import)

--- a/orchestrator/routes/event_prompt.py
+++ b/orchestrator/routes/event_prompt.py
@@ -86,6 +86,22 @@ _ENVELOPE_TRUNCATION_SENTINEL: str = (
     "blocker before re-proposing)\n"
 )
 
+# Cap on the inline copy of the contract's ``task_description`` (#3123).
+# The full text stays one tool call away (``mcp__sdlc__show_contract``);
+# this inline excerpt exists so the operator's task framing — including
+# binding directives like "adopt prior branch X, do not reimplement" —
+# is PUSHED into every one-shot invocation instead of relying on the
+# agent pulling it per the rules file. 4 KB inside the 10 KB envelope
+# leaves room for the event payload and the (separately truncatable)
+# NACKs section.
+TASK_DESCRIPTION_MAX_CHARS: int = 4000
+
+_TASK_TRUNCATION_SENTINEL: str = (
+    "\n…(task description truncated — read the full text with "
+    "``mcp__sdlc__show_contract`` before making scope or adopt-vs-"
+    "reimplement decisions)\n"
+)
+
 
 def _truncate(text: str, max_chars: int) -> str:
     """Trim ``text`` to ``max_chars`` characters with an ellipsis sentinel.
@@ -363,6 +379,89 @@ def _render_memory_section(memory_excerpt: str) -> str:
     )
 
 
+def _render_task_section(task_description: str) -> str:
+    """Render the contract's ``task_description`` as a pushed section (#3123).
+
+    The #3033/#3042 channel made the submit description reliably land in
+    ``contract.task_description``, but delivery stayed pull-based: nothing
+    in the per-event prompt or the role-scoped task views surfaced it, so
+    an agent could complete a whole slice without ever reading the
+    operator's directives (observed live: a slice coder reimplemented 12
+    completed tasks from scratch past a prominent "ADOPT, DO NOT
+    REIMPLEMENT" directive). This section closes the last hop by pushing
+    the text into every one-shot invocation.
+
+    Truncated at ``TASK_DESCRIPTION_MAX_CHARS`` with an explicit sentinel
+    — the full text is one ``mcp__sdlc__show_contract`` call away.
+    """
+    if not (task_description or "").strip():
+        return ""
+    body = (task_description or "").strip()
+    if len(body) > TASK_DESCRIPTION_MAX_CHARS:
+        body = body[:TASK_DESCRIPTION_MAX_CHARS] + _TASK_TRUNCATION_SENTINEL
+    return "\n".join(
+        [
+            "## Task & operator directives (contract ``task_description``)",
+            "",
+            "This is the operator's authoritative, submit-time task "
+            "statement for the whole pipeline. It is BINDING for every "
+            "event you handle: re-read it before structural decisions "
+            "(what to adopt vs. implement from scratch, scope "
+            "boundaries, hard requirements). If it conflicts with what "
+            "you were about to do, the directive wins — course-correct "
+            "or raise a HITL decision rather than proceeding.",
+            "",
+            body,
+            "",
+        ]
+    )
+
+
+def _read_task_description(repo_path: Path) -> str:
+    """Read ``task_description`` from the worktree contract file (#3123).
+
+    Resolves the contract identifier from ``EGG_PIPELINE_ID`` /
+    ``EGG_ISSUE_NUMBER`` (both exported into agent pods; the composer
+    subprocess inherits them) and reads
+    ``.egg-state/contracts/<key>.json`` directly — this script runs
+    standalone via the wrapper bash, so it cannot import
+    ``egg_contracts``. The contract file is committed and pushed to the
+    assigned branch before any agent spawns, so a fresh worktree always
+    carries it; ``task_description`` is written at contract creation and
+    never mutated mid-phase, so the worktree copy cannot go stale.
+
+    Fail-soft like the memory reader above: a missing file, malformed
+    JSON, or absent field yields ``""`` (section omitted) rather than
+    failing the composer — the wrapper would otherwise fall back to the
+    stub prompt and lose the delta/NACK sections too.
+    """
+    candidates: list[str] = []
+    pipeline_id = (os.environ.get("EGG_PIPELINE_ID") or "").strip()
+    if pipeline_id:
+        candidates.append(f"{pipeline_id}.json")
+    issue_number = (os.environ.get("EGG_ISSUE_NUMBER") or "").strip()
+    if issue_number:
+        # Mirrors egg_contracts.loader._canonical_key for int identifiers.
+        candidates.append(f"issue-{issue_number}.json")
+
+    contracts_dir = repo_path / ".egg-state" / "contracts"
+    for name in candidates:
+        try:
+            raw = (contracts_dir / name).read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(data, dict):
+            continue
+        task_description = data.get("task_description")
+        if isinstance(task_description, str) and task_description.strip():
+            return task_description.strip()
+    return ""
+
+
 def compose_event_prompt(
     role: str,
     event_payload: dict[str, Any] | None,
@@ -370,6 +469,8 @@ def compose_event_prompt(
     nacks: list[dict[str, Any]] | None,
     git_log_delta: list[dict[str, Any]] | None,
     base_branch: str,
+    *,
+    task_description: str = "",
 ) -> str:
     """Compose the per-event one-shot prompt the wrapper hands the agent.
 
@@ -377,7 +478,8 @@ def compose_event_prompt(
     (TASK-3-1): ``(role, event_payload, memory_excerpt, nacks,
     git_log_delta, base_branch) -> str``. The wrapper bash invokes this
     via ``python3 -c`` so changing the positional order would silently
-    break the call site; keep the order stable.
+    break the call site; keep the order stable. New inputs go after the
+    ``*`` as keyword-only with a safe default (see ``task_description``).
 
     Args:
         role: Agent role token (e.g. ``"coder"``, ``"reviewer_code"``).
@@ -403,6 +505,13 @@ def compose_event_prompt(
             surface).
         base_branch: Base branch the delta excludes (renders as
             ``--not origin/<base_branch>``). Usually ``main``.
+        task_description: The contract's ``task_description`` (#3123) —
+            the operator's submit-time task statement including any
+            binding directives. Rendered (capped at
+            ``TASK_DESCRIPTION_MAX_CHARS``) right after the event
+            section so every one-shot invocation carries the operator's
+            framing; pass ``""`` to omit (GitHub-issue pipelines, or a
+            worktree without the contract file).
 
     Returns:
         Rendered prompt string suitable for passing as the positional
@@ -419,6 +528,7 @@ def compose_event_prompt(
     base_branch = (base_branch or "main").strip() or "main"
 
     event_section = _render_event_section(role, event_payload)
+    task_section = _render_task_section(task_description)
     delta_section, _delta_bytes = _render_producer_delta_section(git_log_delta, base_branch)
     nacks_section = _render_nacks_section(nacks)
     memory_section = _render_memory_section(memory_excerpt)
@@ -443,13 +553,16 @@ def compose_event_prompt(
     # prompt envelope (excluding delta) ≤ 10 KB"). The envelope is the
     # sum of all sections EXCLUDING the rendered delta; if it would
     # overflow we truncate the NACKs section (the variable-size driver
-    # — event/contract are bounded and memory is already 2 KB capped)
+    # — event/contract are bounded, memory is already 2 KB capped, and
+    # the task section is pre-capped at TASK_DESCRIPTION_MAX_CHARS)
     # while preserving the architect's od-6 tail-position contract for
     # memory. The truncation is byte-exact with ``errors="replace"`` so
     # a UTF-8 multibyte sequence split at the boundary doesn't crash;
     # the sentinel's own byte length is subtracted from the per-section
     # budget so the post-truncation envelope honours the cap.
-    envelope_sections = [s for s in (event_section, nacks_section, contract, memory_section) if s]
+    envelope_sections = [
+        s for s in (event_section, task_section, nacks_section, contract, memory_section) if s
+    ]
     envelope_bytes = sum(len(s.encode("utf-8")) for s in envelope_sections) + max(
         0, len(envelope_sections) - 1
     )
@@ -465,6 +578,8 @@ def compose_event_prompt(
             )
 
     parts: list[str] = [event_section]
+    if task_section:
+        parts.append(task_section)
     if delta_section:
         parts.append(delta_section)
     if nacks_section:
@@ -1020,6 +1135,9 @@ def _cli(argv: list[str] | None = None) -> int:
       ``write-only`` to keep the writer warm without reading the
       excerpt, or ``off`` for the one-release rollback escape hatch
       (no writes, no reads).
+    * ``EGG_PIPELINE_ID`` / ``EGG_ISSUE_NUMBER`` (pod env, inherited —
+      not re-exported by the wrapper) — contract identifier for the
+      ``task_description`` section (#3123). Unset → section omitted.
     """
     parser = argparse.ArgumentParser(
         description="Render the per-event BRC event-pump prompt (slice-3).",
@@ -1093,6 +1211,14 @@ def _cli(argv: list[str] | None = None) -> int:
 
     nacks = _extract_nacks(event_payload)
 
+    # Contract task statement (#3123) — pushed into every per-event
+    # prompt so operator directives don't depend on the agent pulling
+    # ``task_description`` per the rules file. Identifier comes from
+    # ``EGG_PIPELINE_ID`` / ``EGG_ISSUE_NUMBER`` (pod env, inherited by
+    # this subprocess); empty on GitHub-issue pipelines or when the
+    # worktree lacks the contract file (fail-soft).
+    task_description = _read_task_description(repo_path)
+
     prompt = compose_event_prompt(
         role,
         event_payload if isinstance(event_payload, dict) else {"raw": event_payload},
@@ -1100,6 +1226,7 @@ def _cli(argv: list[str] | None = None) -> int:
         nacks,
         delta_entries,
         base_branch,
+        task_description=task_description,
     )
     sys.stdout.write(prompt)
     return 0

--- a/orchestrator/routes/messages.py
+++ b/orchestrator/routes/messages.py
@@ -303,7 +303,7 @@ def poll_messages(pipeline_id: str) -> tuple[Response, int]:
     since_id = request.args.get("since_id")
     try:
         limit = int(request.args.get("limit", "100"))
-    except ValueError, TypeError:
+    except (ValueError, TypeError):  # fmt: skip
         return _make_error("Invalid limit parameter: must be an integer")
 
     # Long-polling support. Cap is configurable via EGG_MESSAGE_POLL_MAX_WAIT
@@ -311,7 +311,7 @@ def poll_messages(pipeline_id: str) -> tuple[Response, int]:
     # requests will return 504; see docs/reference/agent-wait-patterns.md.
     try:
         wait = min(max(int(request.args.get("wait", "0")), 0), _get_poll_max_wait())
-    except ValueError, TypeError:
+    except (ValueError, TypeError):  # fmt: skip
         wait = 0
 
     message_store = get_message_store()
@@ -500,7 +500,7 @@ def get_brc_transcript(pipeline_id: str) -> tuple[Response, int]:
 
     try:
         limit = int(request.args.get("limit", str(_BRC_TRANSCRIPT_DEFAULT_LIMIT)))
-    except ValueError, TypeError:
+    except (ValueError, TypeError):  # fmt: skip
         return _make_error("Invalid limit parameter: must be an integer")
     if limit <= 0:
         return _make_error("Invalid limit parameter: must be > 0")
@@ -722,12 +722,12 @@ def wait_messages(pipeline_id: str) -> tuple[Response, int]:
     since_id = request.args.get("since_id")
     try:
         limit = int(request.args.get("limit", "100"))
-    except ValueError, TypeError:
+    except (ValueError, TypeError):  # fmt: skip
         return _make_error("Invalid limit parameter: must be an integer")
 
     try:
         timeout = min(max(int(request.args.get("timeout", "0")), 0), _get_poll_max_wait())
-    except ValueError, TypeError:
+    except (ValueError, TypeError):  # fmt: skip
         timeout = 0
 
     if timeout <= 0:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5661,7 +5661,13 @@ def _pull_contract_from_source_branch(
     put binding resume directives (e.g. "adopt prior branch X, do not
     reimplement" — #3123). When non-empty it replaces the pulled value;
     the source value stays recoverable from the source branch's git
-    history.
+    history. When ``None`` AND ``issue_number is not None`` the pulled
+    value is cleared (the live issue body is the authoritative task
+    statement and ``task_description`` should be ``None``, mirroring the
+    ``create_contract()`` shape on the call site's fallback path —
+    without this clear, forking a free-text pipeline into an issue
+    pipeline would leak the source pipeline's description into every
+    per-event prompt). Otherwise the pulled value is preserved.
 
     Returns True when a contract was successfully pulled, False otherwise.
     Best-effort: missing, invalid, or unreachable source contracts all yield
@@ -5760,8 +5766,27 @@ def _pull_contract_from_source_branch(
     # directives — never reaches any agent-visible surface, because the
     # caller skips create_contract() (the only other writer of
     # ``task_description``) whenever the pull succeeds.
-    if task_description and task_description.strip():
+    #
+    # Three cases:
+    #   1. Caller passed a non-blank prompt → replace (free-text resubmit
+    #      with the new directives).
+    #   2. Caller passed ``None`` and the pipeline has an ``issue_number``
+    #      → explicit clear. The create_contract() fallback at the call
+    #      site (pipelines.py::_run_pipeline) passes ``task_description=
+    #      None`` for issue pipelines because the live body is fetched
+    #      via ``gh issue view`` instead. Without the explicit clear,
+    #      forking a free-text pipeline into an issue pipeline (source
+    #      branch = egg/free-text-x, new issue_number = 42) would carry
+    #      the SOURCE pipeline's free-text description into the per-event
+    #      prompt of every issue-pipeline agent.
+    #   3. Caller passed ``None`` or blank and no ``issue_number`` (a
+    #      plain resume with no new prompt) → preserve the pulled value
+    #      so the source pipeline's task statement still drives the
+    #      resumed run.
+    if task_description is not None and task_description.strip():
         contract.task_description = task_description
+    elif task_description is None and issue_number is not None:
+        contract.task_description = None
     save_contract(contract, repo_path)
 
     logger.info(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5642,6 +5642,7 @@ def _pull_contract_from_source_branch(
     pipeline_id: str,
     spawner: Any | None = None,
     gateway_mode: str = "public",
+    task_description: str | None = None,
 ) -> bool:
     """Load a persisted contract from ``origin/<source_branch>`` into the worktree.
 
@@ -5653,6 +5654,14 @@ def _pull_contract_from_source_branch(
     reads the contract via ``git show``, rebinds its pipeline_id to the new
     pipeline, and writes it into the worktree so the caller can skip
     ``create_contract()`` and proceed to commit+push the pulled contract.
+
+    ``task_description`` is the NEW submit's prompt. The pulled contract
+    carries the SOURCE pipeline's ``task_description``, but the resubmit's
+    description is authoritative for THIS pipeline and is where operators
+    put binding resume directives (e.g. "adopt prior branch X, do not
+    reimplement" — #3123). When non-empty it replaces the pulled value;
+    the source value stays recoverable from the source branch's git
+    history.
 
     Returns True when a contract was successfully pulled, False otherwise.
     Best-effort: missing, invalid, or unreachable source contracts all yield
@@ -5746,6 +5755,13 @@ def _pull_contract_from_source_branch(
     # canonical key when the pipeline was forked with a qualifier
     # (e.g. source=issue-1965, new=issue-1965-v2).
     contract.pipeline_id = pipeline_id
+    # Refresh the task statement from the new submit (#3123): without
+    # this, the resubmit's prompt — including any operator resume
+    # directives — never reaches any agent-visible surface, because the
+    # caller skips create_contract() (the only other writer of
+    # ``task_description``) whenever the pull succeeds.
+    if task_description and task_description.strip():
+        contract.task_description = task_description
     save_contract(contract, repo_path)
 
     logger.info(
@@ -21349,6 +21365,14 @@ def _run_pipeline(
                             pipeline_id=pipeline.id,
                             spawner=spawner,
                             gateway_mode=gateway_mode,
+                            # Mirror the create_contract() fallback below:
+                            # ``task_description`` is populated only for
+                            # pipelines without a GitHub issue (#3042); for
+                            # issue pipelines agents fetch the live body
+                            # via ``gh issue view`` instead.
+                            task_description=(
+                                pipeline.prompt if pipeline.issue_number is None else None
+                            ),
                         )
                     except Exception:
                         logger.warning(

--- a/orchestrator/tests/test_compose_event_prompt.py
+++ b/orchestrator/tests/test_compose_event_prompt.py
@@ -2297,3 +2297,244 @@ def test_cli_empty_stdin_falls_back_to_action_only_payload(tmp_path) -> None:
     assert rc == 0
     out = out_buf.getvalue()
     assert "Action: **confirm**" in out
+
+
+# ---------------------------------------------------------------------------
+# Task & operator directives section (#3123)
+# ---------------------------------------------------------------------------
+
+
+def test_task_section_rendered_when_task_description_provided() -> None:
+    """The contract task statement is pushed into the per-event prompt."""
+    prompt = compose_event_prompt(
+        "coder",
+        {"action": "propose", "tasks": ["task-1-1"]},
+        "",
+        [],
+        [],
+        "main",
+        task_description=(
+            "## PRIOR SLICE-1 WORK: ADOPT, DO NOT REIMPLEMENT\n"
+            "Merge origin egg/prior/slice-1 @ cfdca2b; do not rewrite."
+        ),
+    )
+
+    assert "## Task & operator directives (contract ``task_description``)" in prompt
+    assert "ADOPT, DO NOT REIMPLEMENT" in prompt
+    # The directive framing makes bindingness explicit.
+    assert "BINDING" in prompt
+    # Placed right after the event section, before the role contract.
+    event_idx = prompt.index("## Event")
+    task_idx = prompt.index("## Task & operator directives")
+    contract_idx = prompt.index("## What to do")
+    assert event_idx < task_idx < contract_idx
+
+
+def test_task_section_omitted_when_empty_or_default() -> None:
+    """No task section without a task_description (GitHub-issue pipelines)."""
+    for kwargs in ({}, {"task_description": ""}, {"task_description": "   \n"}):
+        prompt = compose_event_prompt(
+            "coder",
+            {"action": "propose"},
+            "",
+            [],
+            [],
+            "main",
+            **kwargs,
+        )
+        assert "## Task & operator directives" not in prompt
+
+
+def test_task_section_truncates_at_cap_with_sentinel() -> None:
+    """Oversized descriptions are cut with an explicit pointer to the contract."""
+    from orchestrator.routes.event_prompt import TASK_DESCRIPTION_MAX_CHARS
+
+    oversized = "directive " * (TASK_DESCRIPTION_MAX_CHARS // 5)
+    prompt = compose_event_prompt(
+        "coder",
+        {"action": "propose"},
+        "",
+        [],
+        [],
+        "main",
+        task_description=oversized,
+    )
+
+    assert "task description truncated" in prompt
+    assert "mcp__sdlc__show_contract" in prompt
+    # The retained prefix is exactly the cap.
+    task_idx = prompt.index("## Task & operator directives")
+    assert "directive directive" in prompt[task_idx:]
+
+
+def test_task_section_counts_toward_envelope_cap() -> None:
+    """A capped task section + pathological NACKs still honour the 10 KB bound."""
+    from orchestrator.routes.event_prompt import TASK_DESCRIPTION_MAX_CHARS
+
+    nacks = [
+        {
+            "reviewer": f"reviewer_{i}",
+            "version": 3,
+            "reason": "blocker " * 600,
+            "artifact_refs": [],
+        }
+        for i in range(6)
+    ]
+    prompt = compose_event_prompt(
+        "coder",
+        {"action": "propose"},
+        "",
+        nacks,
+        [],
+        "main",
+        task_description="x" * TASK_DESCRIPTION_MAX_CHARS,
+    )
+
+    envelope = _strip_git_log_blocks(prompt)
+    assert len(envelope.encode("utf-8")) <= PROMPT_ENVELOPE_MAX_BYTES + 1024, (
+        "envelope must stay near the cap with the task section included"
+    )
+    # The NACKs section (the designated variable-size driver) was the
+    # part that got truncated — the task section survives whole.
+    assert "NACK list truncated" in prompt
+    assert "task description truncated" not in prompt
+
+
+def test_read_task_description_from_pipeline_id_contract(tmp_path) -> None:
+    """``EGG_PIPELINE_ID`` resolves the worktree contract file."""
+    import json as _json
+    import os
+
+    from orchestrator.routes.event_prompt import _read_task_description
+
+    contracts = tmp_path / ".egg-state" / "contracts"
+    contracts.mkdir(parents=True)
+    (contracts / "pipeline-abc123.json").write_text(
+        _json.dumps({"task_description": "Adopt the prior branch.  "}),
+        encoding="utf-8",
+    )
+
+    saved = {k: os.environ.get(k) for k in ("EGG_PIPELINE_ID", "EGG_ISSUE_NUMBER")}
+    try:
+        os.environ["EGG_PIPELINE_ID"] = "pipeline-abc123"
+        os.environ.pop("EGG_ISSUE_NUMBER", None)
+        assert _read_task_description(tmp_path) == "Adopt the prior branch."
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def test_read_task_description_issue_number_fallback(tmp_path) -> None:
+    """``EGG_ISSUE_NUMBER`` falls back to the ``issue-<N>.json`` key."""
+    import json as _json
+    import os
+
+    from orchestrator.routes.event_prompt import _read_task_description
+
+    contracts = tmp_path / ".egg-state" / "contracts"
+    contracts.mkdir(parents=True)
+    (contracts / "issue-42.json").write_text(
+        _json.dumps({"task_description": "from issue contract"}),
+        encoding="utf-8",
+    )
+
+    saved = {k: os.environ.get(k) for k in ("EGG_PIPELINE_ID", "EGG_ISSUE_NUMBER")}
+    try:
+        # Pipeline id points at a MISSING file; the issue key must win.
+        os.environ["EGG_PIPELINE_ID"] = "pipeline-missing"
+        os.environ["EGG_ISSUE_NUMBER"] = "42"
+        assert _read_task_description(tmp_path) == "from issue contract"
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def test_read_task_description_fail_soft(tmp_path) -> None:
+    """Missing dir, malformed JSON, absent/None field → '' (never raises)."""
+    import os
+
+    from orchestrator.routes.event_prompt import _read_task_description
+
+    saved = {k: os.environ.get(k) for k in ("EGG_PIPELINE_ID", "EGG_ISSUE_NUMBER")}
+    try:
+        os.environ["EGG_PIPELINE_ID"] = "pipeline-x"
+        os.environ.pop("EGG_ISSUE_NUMBER", None)
+
+        # No contracts dir at all.
+        assert _read_task_description(tmp_path) == ""
+
+        contracts = tmp_path / ".egg-state" / "contracts"
+        contracts.mkdir(parents=True)
+        target = contracts / "pipeline-x.json"
+
+        # Malformed JSON.
+        target.write_text("{not json", encoding="utf-8")
+        assert _read_task_description(tmp_path) == ""
+
+        # Valid JSON, field absent / null (GitHub-issue contracts).
+        target.write_text('{"pipeline_id": "pipeline-x"}', encoding="utf-8")
+        assert _read_task_description(tmp_path) == ""
+        target.write_text('{"task_description": null}', encoding="utf-8")
+        assert _read_task_description(tmp_path) == ""
+
+        # No identifier env at all.
+        os.environ.pop("EGG_PIPELINE_ID", None)
+        target.write_text('{"task_description": "text"}', encoding="utf-8")
+        assert _read_task_description(tmp_path) == ""
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def test_cli_renders_task_section_from_worktree_contract(tmp_path) -> None:
+    """End-to-end: the CLI reads the contract file and renders the section."""
+    import io
+    import json as _json
+    import os
+    import sys as _sys
+
+    from orchestrator.routes import event_prompt
+
+    contracts = tmp_path / ".egg-state" / "contracts"
+    contracts.mkdir(parents=True)
+    (contracts / "pipeline-e2e.json").write_text(
+        _json.dumps({"task_description": "PRIOR WORK: ADOPT, DO NOT REIMPLEMENT"}),
+        encoding="utf-8",
+    )
+
+    saved_env = {
+        k: os.environ.get(k)
+        for k in ("EGG_AGENT_ROLE", "EGG_REPO_PATH", "EGG_PIPELINE_ID", "EGG_ISSUE_NUMBER")
+    }
+    saved_stdin = _sys.stdin
+    saved_stdout = _sys.stdout
+    out_buf = io.StringIO()
+    try:
+        os.environ["EGG_AGENT_ROLE"] = "coder"
+        os.environ["EGG_REPO_PATH"] = str(tmp_path)
+        os.environ["EGG_PIPELINE_ID"] = "pipeline-e2e"
+        os.environ.pop("EGG_ISSUE_NUMBER", None)
+        _sys.stdin = io.StringIO('{"action": "propose"}')
+        _sys.stdout = out_buf
+        rc = event_prompt._cli(["propose"])
+    finally:
+        _sys.stdin = saved_stdin
+        _sys.stdout = saved_stdout
+        for k, v in saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+    assert rc == 0
+    out = out_buf.getvalue()
+    assert "## Task & operator directives" in out
+    assert "PRIOR WORK: ADOPT, DO NOT REIMPLEMENT" in out

--- a/orchestrator/tests/test_source_branch.py
+++ b/orchestrator/tests/test_source_branch.py
@@ -1637,3 +1637,72 @@ class TestPullContractFromSourceBranch:
 
         assert result is True
         assert saved["contract"].pipeline_id == "run-abc123"
+
+    def test_refreshes_task_description_from_new_submit(self, tmp_path):
+        """The resubmit's prompt replaces the pulled task_description (#3123).
+
+        The pulled contract carries the SOURCE pipeline's description;
+        without the refresh, the new submit's operator directives (e.g.
+        adopt-prior-work instructions) never reach any agent-visible
+        surface because the pull short-circuits create_contract().
+        """
+        from routes.pipelines import _pull_contract_from_source_branch
+
+        source_contract = self._make_contract(pipeline_id="run-abc123")
+        source_contract.task_description = "old v5 description"
+
+        saved = {}
+
+        with (
+            patch("subprocess.run") as mock_subprocess,
+            patch(
+                "egg_contracts.loader.load_contract_from_branch",
+                return_value=source_contract,
+            ),
+            patch("egg_contracts.loader.save_contract") as mock_save,
+        ):
+            mock_subprocess.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+            mock_save.side_effect = lambda c, r: saved.setdefault("contract", c)
+            result = _pull_contract_from_source_branch(
+                repo_path=tmp_path,
+                source_branch="egg/run-abc123",
+                issue_number=None,
+                pipeline_id="run-abc123-v2",
+                task_description="v6: PRIOR WORK: ADOPT, DO NOT REIMPLEMENT",
+            )
+
+        assert result is True
+        assert saved["contract"].task_description == ("v6: PRIOR WORK: ADOPT, DO NOT REIMPLEMENT")
+
+    def test_preserves_pulled_task_description_when_none_provided(self, tmp_path):
+        """No/blank new prompt keeps the pulled description (no regression)."""
+        from routes.pipelines import _pull_contract_from_source_branch
+
+        for new_description in (None, "", "   "):
+            source_contract = self._make_contract(pipeline_id="run-abc123")
+            source_contract.task_description = "original description"
+
+            saved = {}
+
+            with (
+                patch("subprocess.run") as mock_subprocess,
+                patch(
+                    "egg_contracts.loader.load_contract_from_branch",
+                    return_value=source_contract,
+                ),
+                patch("egg_contracts.loader.save_contract") as mock_save,
+            ):
+                mock_subprocess.return_value = subprocess.CompletedProcess(
+                    [], 0, stdout="", stderr=""
+                )
+                mock_save.side_effect = lambda c, r, _saved=saved: _saved.setdefault("contract", c)
+                result = _pull_contract_from_source_branch(
+                    repo_path=tmp_path,
+                    source_branch="egg/run-abc123",
+                    issue_number=None,
+                    pipeline_id="run-abc123",
+                    task_description=new_description,
+                )
+
+            assert result is True
+            assert saved["contract"].task_description == "original description"

--- a/orchestrator/tests/test_source_branch.py
+++ b/orchestrator/tests/test_source_branch.py
@@ -1706,3 +1706,42 @@ class TestPullContractFromSourceBranch:
 
             assert result is True
             assert saved["contract"].task_description == "original description"
+
+    def test_clears_pulled_task_description_when_forking_to_issue_pipeline(self, tmp_path):
+        """Forking a free-text pipeline into an issue pipeline clears the
+        pulled ``task_description`` (#3123 follow-up).
+
+        The caller passes ``task_description=None`` for issue-numbered
+        pipelines because agents fetch the live body via ``gh issue
+        view``. Without the explicit clear, the SOURCE pipeline's
+        free-text description survives and the directive-pushing reader
+        in ``compose_event_prompt`` renders it in every per-event prompt
+        of every agent on the new issue pipeline.
+        """
+        from routes.pipelines import _pull_contract_from_source_branch
+
+        source_contract = self._make_contract(pipeline_id="run-free-text")
+        source_contract.task_description = "free-text description from source pipeline"
+
+        saved = {}
+
+        with (
+            patch("subprocess.run") as mock_subprocess,
+            patch(
+                "egg_contracts.loader.load_contract_from_branch",
+                return_value=source_contract,
+            ),
+            patch("egg_contracts.loader.save_contract") as mock_save,
+        ):
+            mock_subprocess.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+            mock_save.side_effect = lambda c, r, _saved=saved: _saved.setdefault("contract", c)
+            result = _pull_contract_from_source_branch(
+                repo_path=tmp_path,
+                source_branch="egg/run-free-text",
+                issue_number=42,
+                pipeline_id="issue-42",
+                task_description=None,
+            )
+
+        assert result is True
+        assert saved["contract"].task_description is None

--- a/shared/egg_agent/client.py
+++ b/shared/egg_agent/client.py
@@ -501,6 +501,15 @@ async def run_agent_async(
         async def _inject_midturn_messages(
             input_data: HookInput, tool_use_id: str | None, context: HookContext
         ) -> HookJSONOutput:
+            # Fast-path: when the interval gate is clearly closed, skip
+            # the thread boundary entirely. The matcher is None so this
+            # hook fires on every tool call; under a chatty tool storm
+            # the per-call cost (thread creation + GIL handoff) is
+            # otherwise paid even when there is no work to do. The
+            # lockless predicate may produce false positives under
+            # concurrent calls; poll() re-checks atomically.
+            if not midturn_poller.is_due_to_poll():
+                return {}
             # poll() runs an egg-orch subprocess when the interval has
             # elapsed; keep it off the event loop. Between polls it is a
             # monotonic-clock comparison.

--- a/shared/egg_agent/client.py
+++ b/shared/egg_agent/client.py
@@ -478,6 +478,56 @@ async def run_agent_async(
             event_subtype="ddg_mcp_enabled",
         )
 
+    # --- Mid-turn operator message delivery (#3123) ---
+    # One propose invocation under the BRC event-pump can run 30+ minutes
+    # (a slice coder implements its whole task list in one turn), and the
+    # message bus is only consulted between invocations — so an operator
+    # correction sent via send_message lands after the contradicting work
+    # is done. A throttled PostToolUse hook polls the bus during the turn
+    # and surfaces new operator-authored messages as additionalContext.
+    # Gated on pipeline context (EGG_PIPELINE_ID + EGG_AGENT_ROLE) so
+    # non-pipeline egg_agent callers are untouched; EGG_MIDTURN_MESSAGES=
+    # false is the rollback escape hatch.
+    from egg_agent.midturn_messages import (
+        MidturnMessagePoller,
+        is_midturn_messages_disabled,
+    )
+
+    midturn_pipeline_id = (os.environ.get("EGG_PIPELINE_ID") or "").strip()
+    midturn_role = (os.environ.get("EGG_AGENT_ROLE") or "").strip()
+    if not is_midturn_messages_disabled() and midturn_pipeline_id and midturn_role:
+        midturn_poller = MidturnMessagePoller(midturn_pipeline_id, midturn_role)
+
+        async def _inject_midturn_messages(
+            input_data: HookInput, tool_use_id: str | None, context: HookContext
+        ) -> HookJSONOutput:
+            # poll() runs an egg-orch subprocess when the interval has
+            # elapsed; keep it off the event loop. Between polls it is a
+            # monotonic-clock comparison.
+            context_block = await asyncio.to_thread(midturn_poller.poll)
+            if not context_block:
+                return {}
+            logger.info(
+                "Injected mid-turn operator messages",
+                event_type="system",
+                event_subtype="midturn_message_injection",
+                tool_use_id=tool_use_id,
+                block_chars=len(context_block),
+            )
+            return {
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUse",
+                    "additionalContext": context_block,
+                }
+            }
+
+        existing_hooks = getattr(options, "hooks", None) or {}
+        # No matcher → fires for every tool; the poller's interval gate
+        # makes that effectively free between actual bus polls.
+        post_tool_use = list(existing_hooks.get("PostToolUse", []))
+        post_tool_use.append(HookMatcher(matcher=None, hooks=[_inject_midturn_messages]))
+        options.hooks = {**existing_hooks, "PostToolUse": post_tool_use}
+
     stdout_parts: list[str] = []
     actual_model: str | None = None
     result_meta: dict[str, Any] = {}

--- a/shared/egg_agent/midturn_messages.py
+++ b/shared/egg_agent/midturn_messages.py
@@ -44,6 +44,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import threading
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -59,11 +60,20 @@ DEFAULT_POLL_INTERVAL_SECS = 60.0
 # 15 s; one extra second of headroom avoids racing it.
 _POLL_SUBPROCESS_TIMEOUT_SECS = 16
 
-# ``from_role`` values whose messages are operator-authored course
-# corrections worth surfacing mid-turn. ``overseer`` covers both the
-# MCP ``send_message`` tool (sent as the overseer role) and overseer
-# monitor alerts; the rest cover direct human/operator senders.
-_INJECT_FROM_ROLES = frozenset({"overseer", "human", "operator", "user"})
+# ``from_role`` values whose messages are operator-authored or
+# orchestrator-issued course corrections worth surfacing mid-turn.
+# ``overseer`` covers both the MCP ``send_message`` tool (sent as the
+# overseer role) and overseer monitor alerts; ``orchestrator`` covers
+# deterministic nudges that originate in the orchestrator itself —
+# notably the ``brc_confirmation_timeout`` directed wake to a stuck
+# producer (``orchestrator/routes/pipelines.py::_send_brc_confirmation_nudge``)
+# and the overseer-respawn broadcast (same module, ``_handle_overseer_respawn``).
+# Without ``orchestrator`` in this set the brc-confirmation-timeout nudge
+# would be silently dropped — the producer's poll fetches it, advances
+# the cursor past it, and injects nothing, which is exactly the
+# silent-drop failure mode #3123 was meant to close. The remaining
+# entries cover direct human/operator senders.
+_INJECT_FROM_ROLES = frozenset({"overseer", "orchestrator", "human", "operator", "user"})
 
 # Cap on the rendered injection block. Operator messages are normally
 # short directives; a pathological body should not blow up the turn.
@@ -119,6 +129,13 @@ class MidturnMessagePoller:
         self.interval_secs = interval_secs if interval_secs is not None else _poll_interval_secs()
         self._now = now
         self._last_poll: float | None = None
+        # Guards the throttle check-and-set so two concurrent PostToolUse
+        # callbacks (today serial, but the SDK may move to concurrent
+        # delivery) cannot both observe a stale ``_last_poll`` and both
+        # spawn a poll subprocess. ``is_due_to_poll`` outside the lock is
+        # intentionally lockless — it is a fast-path hint for hook
+        # callers; the authoritative gate is in ``poll`` under this lock.
+        self._poll_lock = threading.Lock()
 
         base_dir = cursor_dir or os.environ.get("EGG_WAIT_CURSOR_DIR") or tempfile.gettempdir()
         # Hash the identifiers into the filename so arbitrary pipeline
@@ -178,7 +195,7 @@ class MidturnMessagePoller:
                 timeout=_POLL_SUBPROCESS_TIMEOUT_SECS,
                 check=False,
             )
-        except subprocess.SubprocessError, OSError:
+        except (subprocess.SubprocessError, OSError):  # fmt: skip
             return None
         if proc.returncode != 0:
             return None
@@ -199,6 +216,22 @@ class MidturnMessagePoller:
 
     # -- public API -------------------------------------------------------
 
+    def is_due_to_poll(self) -> bool:
+        """Lockless predicate — does the throttle window allow a poll now?
+
+        Intended as a fast-path hint for hook callers that want to avoid
+        crossing the ``asyncio.to_thread`` boundary on every tool call
+        when the poll is clearly throttled. False positives are
+        possible under concurrent calls (two callers can both observe
+        the same stale ``_last_poll``) — the authoritative gate is in
+        ``poll`` under ``_poll_lock``, which re-checks atomically and
+        ensures only one fetch runs per interval.
+        """
+        last = self._last_poll
+        if last is None:
+            return True
+        return (self._now() - last) >= self.interval_secs
+
     def poll(self) -> str | None:
         """Poll the bus if the interval has elapsed; return a block to inject.
 
@@ -206,10 +239,14 @@ class MidturnMessagePoller:
         new messages arrived, or when the new messages are all
         non-operator traffic (their ids still advance the cursor).
         """
-        now = self._now()
-        if self._last_poll is not None and (now - self._last_poll) < self.interval_secs:
-            return None
-        self._last_poll = now
+        # Atomic check-and-set: closes the race where two concurrent
+        # callers both observe a stale ``_last_poll`` and both pass the
+        # gate, spawning duplicate subprocesses.
+        with self._poll_lock:
+            now = self._now()
+            if self._last_poll is not None and (now - self._last_poll) < self.interval_secs:
+                return None
+            self._last_poll = now
 
         cursor = self._read_cursor()
         fetched = self._fetch(since_id=cursor)

--- a/shared/egg_agent/midturn_messages.py
+++ b/shared/egg_agent/midturn_messages.py
@@ -124,7 +124,9 @@ class MidturnMessagePoller:
         # Hash the identifiers into the filename so arbitrary pipeline
         # ids / roles can't produce path separators (same defensive
         # stance as the wait CLI's cursor path, #2323).
-        digest = hashlib.md5(f"{pipeline_id}\x00{role}".encode(), usedforsecurity=False).hexdigest()[:12]
+        digest = hashlib.md5(
+            f"{pipeline_id}\x00{role}".encode(), usedforsecurity=False
+        ).hexdigest()[:12]
         self._cursor_path = Path(base_dir) / f"egg-midturn-msg-cursor-{digest}"
 
     # -- cursor -----------------------------------------------------------

--- a/shared/egg_agent/midturn_messages.py
+++ b/shared/egg_agent/midturn_messages.py
@@ -124,7 +124,7 @@ class MidturnMessagePoller:
         # Hash the identifiers into the filename so arbitrary pipeline
         # ids / roles can't produce path separators (same defensive
         # stance as the wait CLI's cursor path, #2323).
-        digest = hashlib.md5(f"{pipeline_id}\x00{role}".encode()).hexdigest()[:12]
+        digest = hashlib.md5(f"{pipeline_id}\x00{role}".encode(), usedforsecurity=False).hexdigest()[:12]
         self._cursor_path = Path(base_dir) / f"egg-midturn-msg-cursor-{digest}"
 
     # -- cursor -----------------------------------------------------------

--- a/shared/egg_agent/midturn_messages.py
+++ b/shared/egg_agent/midturn_messages.py
@@ -1,0 +1,270 @@
+"""Mid-turn operator message delivery (#3123).
+
+A long producer turn under the BRC event-pump can run 30+ minutes (one
+``propose`` invocation implements a whole slice), and the message bus is
+only consulted between invocations — so an operator correction sent via
+``send_message`` lands after the contradicting work is already done, and
+the only remaining lever is a full review cycle. Restarting the agent is
+not a safe nudge either (#2806: the consensus wrapper treats producer
+restart as permanent death).
+
+This module provides a throttled poller that ``client.py`` wires into the
+SDK session as a PostToolUse hook: every tool call gives it a chance to
+fire, an interval gate keeps the actual polling cheap (one ``egg-orch
+message poll`` subprocess per ``EGG_MIDTURN_MESSAGES_INTERVAL_SECS``),
+and any *new* operator-authored messages are rendered as
+``additionalContext`` so the directive reaches the model mid-turn.
+
+Scope decisions:
+
+* Only operator-authored traffic is injected (``from_role`` in
+  ``_INJECT_FROM_ROLES``). Peer-agent and protocol messages
+  (``CONSENSUS_*``, heartbeats) stay on the between-invocation path —
+  injecting them would thrash producers with chatter the BRC wrapper
+  already sequences.
+* The cursor persists across one-shot invocations (file in
+  ``EGG_WAIT_CURSOR_DIR``, same back-channel pattern as the ``wait``
+  CLI's cursor file, #2323), so a message that lands *between*
+  invocations is injected at the start of the next one rather than
+  dropped, and nothing is double-delivered.
+* First poll ever (no cursor file) seeds the cursor at the stream tip
+  WITHOUT injecting: pre-existing history was already visible to the
+  agent through the normal channels; this hook is for corrections that
+  arrive after work started.
+* Fail-soft everywhere: a missing ``egg-orch`` binary, an unreachable
+  orchestrator, malformed JSON, or an unwritable cursor file mean "no
+  injection this turn" — never an agent failure.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+# Default seconds between actual bus polls. Tool calls arrive much more
+# often than this; the interval gate makes the hook effectively free
+# between polls. 60 s keeps worst-case correction latency around a
+# minute — versus the length of the whole remaining turn today.
+DEFAULT_POLL_INTERVAL_SECS = 60.0
+
+# Subprocess budget for one poll. The CLI's own non-waiting timeout is
+# 15 s; one extra second of headroom avoids racing it.
+_POLL_SUBPROCESS_TIMEOUT_SECS = 16
+
+# ``from_role`` values whose messages are operator-authored course
+# corrections worth surfacing mid-turn. ``overseer`` covers both the
+# MCP ``send_message`` tool (sent as the overseer role) and overseer
+# monitor alerts; the rest cover direct human/operator senders.
+_INJECT_FROM_ROLES = frozenset({"overseer", "human", "operator", "user"})
+
+# Cap on the rendered injection block. Operator messages are normally
+# short directives; a pathological body should not blow up the turn.
+_RENDERED_BLOCK_MAX_CHARS = 8000
+
+_BLOCK_TRUNCATION_SENTINEL = (
+    "\n…(messages truncated — run `egg-orch message poll` to read the "
+    "full backlog before continuing)\n"
+)
+
+
+def is_midturn_messages_disabled() -> bool:
+    """Check the ``EGG_MIDTURN_MESSAGES`` escape hatch (default: enabled)."""
+    return (os.environ.get("EGG_MIDTURN_MESSAGES") or "").strip().lower() in (
+        "false",
+        "0",
+        "off",
+        "disabled",
+    )
+
+
+def _poll_interval_secs() -> float:
+    raw = (os.environ.get("EGG_MIDTURN_MESSAGES_INTERVAL_SECS") or "").strip()
+    if raw:
+        try:
+            value = float(raw)
+            if value > 0:
+                return value
+        except ValueError:
+            pass
+    return DEFAULT_POLL_INTERVAL_SECS
+
+
+class MidturnMessagePoller:
+    """Throttled message-bus poller for mid-turn operator delivery.
+
+    One instance per SDK session; ``poll()`` is called from the
+    PostToolUse hook (via ``asyncio.to_thread`` — it runs a subprocess)
+    and returns either a rendered markdown block to inject or ``None``.
+    """
+
+    def __init__(
+        self,
+        pipeline_id: str,
+        role: str,
+        *,
+        interval_secs: float | None = None,
+        cursor_dir: str | None = None,
+        now: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.pipeline_id = pipeline_id
+        self.role = role
+        self.interval_secs = interval_secs if interval_secs is not None else _poll_interval_secs()
+        self._now = now
+        self._last_poll: float | None = None
+
+        base_dir = cursor_dir or os.environ.get("EGG_WAIT_CURSOR_DIR") or tempfile.gettempdir()
+        # Hash the identifiers into the filename so arbitrary pipeline
+        # ids / roles can't produce path separators (same defensive
+        # stance as the wait CLI's cursor path, #2323).
+        digest = hashlib.md5(f"{pipeline_id}\x00{role}".encode()).hexdigest()[:12]
+        self._cursor_path = Path(base_dir) / f"egg-midturn-msg-cursor-{digest}"
+
+    # -- cursor -----------------------------------------------------------
+
+    def _read_cursor(self) -> str | None:
+        try:
+            value = self._cursor_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+        return value or None
+
+    def _write_cursor(self, message_id: str) -> None:
+        try:
+            self._cursor_path.write_text(message_id, encoding="utf-8")
+        except OSError:
+            # Unwritable cursor degrades to "seed again next session" —
+            # worst case is a re-injection, not a failure.
+            pass
+
+    # -- bus access -------------------------------------------------------
+
+    def _fetch(self, since_id: str | None) -> tuple[list[dict[str, Any]], bool] | None:
+        """Run one ``egg-orch message poll`` subprocess.
+
+        Returns ``(messages, since_id_stale)`` or ``None`` on any
+        failure (binary missing, non-zero rc, timeout, bad JSON).
+        """
+        binary = shutil.which("egg-orch")
+        if not binary:
+            return None
+        cmd = [
+            binary,
+            "message",
+            "poll",
+            self.pipeline_id,
+            "--role",
+            self.role,
+            "--limit",
+            "100",
+            "--json",
+        ]
+        if since_id:
+            cmd += ["--since", since_id]
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=_POLL_SUBPROCESS_TIMEOUT_SECS,
+                check=False,
+            )
+        except subprocess.SubprocessError, OSError:
+            return None
+        if proc.returncode != 0:
+            return None
+        try:
+            result = json.loads(proc.stdout or "")
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(result, dict) or not result.get("success", False):
+            return None
+        data = result.get("data") or {}
+        if not isinstance(data, dict):
+            return None
+        raw_messages = data.get("messages")
+        if not isinstance(raw_messages, list):
+            raw_messages = []
+        messages = [m for m in raw_messages if isinstance(m, dict)]
+        return messages, bool(data.get("since_id_stale"))
+
+    # -- public API -------------------------------------------------------
+
+    def poll(self) -> str | None:
+        """Poll the bus if the interval has elapsed; return a block to inject.
+
+        Returns ``None`` when throttled, on any fetch failure, when no
+        new messages arrived, or when the new messages are all
+        non-operator traffic (their ids still advance the cursor).
+        """
+        now = self._now()
+        if self._last_poll is not None and (now - self._last_poll) < self.interval_secs:
+            return None
+        self._last_poll = now
+
+        cursor = self._read_cursor()
+        fetched = self._fetch(since_id=cursor)
+        if fetched is None:
+            return None
+        messages, since_id_stale = fetched
+
+        last_id = ""
+        for message in messages:
+            message_id = message.get("id")
+            if isinstance(message_id, str) and message_id:
+                last_id = message_id
+        if last_id:
+            self._write_cursor(last_id)
+
+        if cursor is None or since_id_stale:
+            # First poll (seed at tip) or store-side cursor invalidation
+            # (#2464: re-snap rather than replaying an unbounded
+            # backlog). Either way: advance, inject nothing.
+            return None
+
+        operator_messages = [
+            m
+            for m in messages
+            if str(m.get("from_role") or "").strip().lower() in _INJECT_FROM_ROLES
+        ]
+        if not operator_messages:
+            return None
+        return _render_block(operator_messages)
+
+
+def _render_block(messages: list[dict[str, Any]]) -> str:
+    """Render operator messages as the injected context block."""
+    lines: list[str] = [
+        "## Operator message(s) received mid-turn",
+        "",
+        "The operator sent the following while you were working. They are "
+        "BINDING course corrections — apply them to your remaining work "
+        "NOW. If a directive contradicts work you have already done this "
+        "turn, stop and reconcile (rework, drop, or adopt as directed) "
+        "before proposing; do not finish the contradicted approach first.",
+        "",
+    ]
+    for message in messages:
+        timestamp = str(message.get("timestamp") or "")[:19]
+        from_role = str(message.get("from_role") or "?")
+        message_type = str(message.get("message_type") or "?")
+        subject = str(message.get("subject") or "").strip()
+        header = f"### [{timestamp}] from {from_role} ({message_type})"
+        if subject:
+            header += f": {subject}"
+        lines.append(header)
+        lines.append("")
+        body = str(message.get("body") or "").strip()
+        lines.append(body if body else "(no body)")
+        lines.append("")
+    block = "\n".join(lines)
+    if len(block) > _RENDERED_BLOCK_MAX_CHARS:
+        block = block[:_RENDERED_BLOCK_MAX_CHARS] + _BLOCK_TRUNCATION_SENTINEL
+    return block

--- a/tests/shared/egg_agent/test_client.py
+++ b/tests/shared/egg_agent/test_client.py
@@ -1418,3 +1418,63 @@ class TestCanUseToolPassesMcpNames:
             assert isinstance(_run_async(_check(name, {}, object())), PermissionResultAllow), (
                 f"MCP tool denied: {name}"
             )
+
+
+class TestMidturnMessageHook:
+    """Issue #3123: pipeline sessions get a PostToolUse hook that polls the
+    message bus mid-turn and injects new operator messages, so a correction
+    can land inside a 30+ minute propose invocation instead of after it.
+    Gated on pipeline context (EGG_PIPELINE_ID + EGG_AGENT_ROLE) with the
+    EGG_MIDTURN_MESSAGES=false escape hatch.
+    """
+
+    @staticmethod
+    def _post_tool_use_hooks(mock_query):
+        opts = mock_query.call_args.kwargs["options"]
+        hooks = getattr(opts, "hooks", None) or {}
+        return hooks.get("PostToolUse", [])
+
+    @patch.dict(
+        os.environ,
+        {
+            "EGG_PIPELINE_ID": "pipeline-test",
+            "EGG_AGENT_ROLE": "coder",
+            "EGG_MCP_TOOLS": "false",
+        },
+    )
+    @patch("claude_agent_sdk.query", side_effect=_mock_query_success)
+    def test_hook_registered_in_pipeline_session(self, mock_query):
+        result = _run_async(run_agent_async("test prompt"))
+        assert result.success is True
+        post_hooks = self._post_tool_use_hooks(mock_query)
+        assert len(post_hooks) == 1
+        # No matcher → fires on every tool (the poller's interval gate
+        # makes that effectively free between actual bus polls).
+        assert post_hooks[0].matcher is None
+        assert len(post_hooks[0].hooks) == 1
+
+    @patch("claude_agent_sdk.query", side_effect=_mock_query_success)
+    def test_hook_not_registered_outside_pipeline(self, mock_query):
+        env = os.environ.copy()
+        env.pop("EGG_PIPELINE_ID", None)
+        env.pop("EGG_AGENT_ROLE", None)
+        env["EGG_MCP_TOOLS"] = "false"
+        with patch.dict(os.environ, env, clear=True):
+            result = _run_async(run_agent_async("test prompt"))
+        assert result.success is True
+        assert self._post_tool_use_hooks(mock_query) == []
+
+    @patch.dict(
+        os.environ,
+        {
+            "EGG_PIPELINE_ID": "pipeline-test",
+            "EGG_AGENT_ROLE": "coder",
+            "EGG_MIDTURN_MESSAGES": "false",
+            "EGG_MCP_TOOLS": "false",
+        },
+    )
+    @patch("claude_agent_sdk.query", side_effect=_mock_query_success)
+    def test_escape_hatch_disables_hook(self, mock_query):
+        result = _run_async(run_agent_async("test prompt"))
+        assert result.success is True
+        assert self._post_tool_use_hooks(mock_query) == []

--- a/tests/shared/egg_agent/test_midturn_messages.py
+++ b/tests/shared/egg_agent/test_midturn_messages.py
@@ -91,6 +91,65 @@ class TestFirstPollSeedsCursor:
         assert "pipeline-test" in cmd
         assert "--role" in cmd
 
+    def test_first_poll_with_overflow_history_snaps_to_tip(self, tmp_path):
+        """Pre-existing history past the bus limit doesn't re-inject as new.
+
+        ``message_store`` returns ``matches[-limit:]`` with no ``since_id``
+        — the LAST ``limit`` messages, not the oldest — so the seed-at-tip
+        guarantee in the docstring is load-bearing on that semantic.
+        This test pins the poller's behavior: when the store returns the
+        last ``limit`` messages and an operator-authored directive is
+        among them (i.e. could plausibly be \"new\"), the first poll
+        still treats the whole batch as history, advances the cursor to
+        the very tip, and injects nothing. A second poll with no further
+        messages then asserts the cursor stayed at the tip (no replay).
+        """
+        clock = _Clock()
+        poller = _make_poller(tmp_path, clock)
+
+        # Simulate the store returning the last 100 (tail of 110+ stream).
+        # Include an operator-authored message in the batch so we can
+        # confirm seed-at-tip suppresses it (a regression would render
+        # it because operator filtering would otherwise kick in).
+        tail_count = 100
+        tail = [
+            _message(
+                f"msg-{i}",
+                from_role=("overseer" if i == 50 else "coder"),
+                body=("historical operator directive" if i == 50 else "peer chatter"),
+            )
+            for i in range(11, 11 + tail_count)
+        ]
+
+        with (
+            patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"),
+            patch(
+                "egg_agent.midturn_messages.subprocess.run",
+                return_value=_completed(_poll_response(tail)),
+            ) as mock_run,
+        ):
+            assert poller.poll() is None  # seed-at-tip — historical operator msg suppressed
+
+        assert poller._cursor_path.read_text() == f"msg-{11 + tail_count - 1}"  # tip
+        cmd = mock_run.call_args.args[0]
+        assert "--since" not in cmd
+
+        # Second poll, interval elapsed, store returns nothing new.
+        clock.value += 61.0
+        with (
+            patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"),
+            patch(
+                "egg_agent.midturn_messages.subprocess.run",
+                return_value=_completed(_poll_response([])),
+            ) as mock_run,
+        ):
+            assert poller.poll() is None
+
+        # Cursor still at the tip; no historical operator message was injected.
+        assert poller._cursor_path.read_text() == f"msg-{11 + tail_count - 1}"
+        cmd = mock_run.call_args.args[0]
+        assert cmd[cmd.index("--since") + 1] == f"msg-{11 + tail_count - 1}"
+
     def test_second_poll_injects_new_operator_message(self, tmp_path):
         """A message arriving after the seed is rendered for injection."""
         clock = _Clock()
@@ -143,6 +202,94 @@ class TestThrottle:
             poller.poll()
 
         assert mock_run.call_count == 1
+
+    def test_concurrent_polls_share_the_throttle_slot(self, tmp_path):
+        """Two callers entering ``poll`` simultaneously fetch at most once.
+
+        ``poll()`` runs under ``asyncio.to_thread``; if PostToolUse ever
+        delivers callbacks concurrently, the throttle check-and-set must
+        be atomic — otherwise both callers observe a stale ``_last_poll``,
+        both pass the gate, and both spawn a subprocess (and risk a
+        duplicate-injection window). The lock around the check-and-set
+        in ``poll`` closes the race; here we drive two threads through
+        the gate simultaneously and assert only one fetch ran.
+        """
+        import threading as _threading
+
+        clock = _Clock()
+        poller = _make_poller(tmp_path, clock)
+        # Seed cursor so the first eligible poll is treated as new
+        # (covers both throttle paths: seed and steady-state).
+        poller._cursor_path.write_text("msg-0", encoding="utf-8")
+
+        gate = _threading.Event()
+        fetch_started = _threading.Event()
+
+        def slow_run(*_a, **_kw):
+            fetch_started.set()
+            gate.wait(timeout=2.0)
+            return _completed(_poll_response([_message("msg-1", body="op directive")]))
+
+        results: list[Any] = []
+        errors: list[BaseException] = []
+
+        def runner():
+            try:
+                results.append(poller.poll())
+            except BaseException as exc:  # pragma: no cover - propagate
+                errors.append(exc)
+
+        with (
+            patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"),
+            patch("egg_agent.midturn_messages.subprocess.run", side_effect=slow_run) as mock_run,
+        ):
+            t1 = _threading.Thread(target=runner)
+            t2 = _threading.Thread(target=runner)
+            t1.start()
+            # Wait until t1 is inside the fetch (so t2 hits the lock /
+            # post-set throttle and must see ``_last_poll`` advanced).
+            assert fetch_started.wait(timeout=2.0)
+            t2.start()
+            gate.set()
+            t1.join(timeout=3.0)
+            t2.join(timeout=3.0)
+
+        assert not errors, errors
+        assert mock_run.call_count == 1
+        # Exactly one caller gets the block; the other is throttled out.
+        assert sum(r is not None for r in results) == 1
+        assert sum(r is None for r in results) == 1
+
+    def test_is_due_to_poll_predicate(self, tmp_path):
+        """Lockless fast-path predicate exposes the throttle window.
+
+        Lets ``client.py``'s PostToolUse hook skip ``asyncio.to_thread``
+        on every tool call once the interval gate is closed. The
+        predicate is intentionally lockless; the authoritative gate is
+        in ``poll`` under ``_poll_lock`` (covered by
+        ``test_concurrent_polls_share_the_throttle_slot``).
+        """
+        clock = _Clock()
+        poller = _make_poller(tmp_path, clock)
+
+        # Never polled yet → due.
+        assert poller.is_due_to_poll() is True
+
+        with (
+            patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"),
+            patch(
+                "egg_agent.midturn_messages.subprocess.run",
+                return_value=_completed(_poll_response([])),
+            ),
+        ):
+            poller.poll()
+
+        # Just polled → not due.
+        assert poller.is_due_to_poll() is False
+        clock.value += 30.0
+        assert poller.is_due_to_poll() is False
+        clock.value += 31.0  # past 60s interval
+        assert poller.is_due_to_poll() is True
 
     def test_default_interval_from_env(self, monkeypatch):
         monkeypatch.setenv("EGG_MIDTURN_MESSAGES_INTERVAL_SECS", "120")
@@ -207,6 +354,37 @@ class TestFiltering:
         assert "operator directive" in block
         assert "human follow-up" in block
         assert "peer chatter" not in block
+
+    def test_orchestrator_role_is_injected(self, tmp_path):
+        """Orchestrator-issued nudges surface mid-turn (e.g. the
+        ``brc_confirmation_timeout`` directed wake from
+        ``orchestrator/routes/pipelines.py::_send_brc_confirmation_nudge``,
+        whose whole point is to nudge a producer that has stalled
+        post-ACK)."""
+        clock = _Clock()
+        poller = self._seeded_poller(tmp_path, clock)
+        batch = [
+            _message(
+                "msg-1",
+                from_role="orchestrator",
+                message_type="OVERSEER_ALERT",
+                subject="BRC confirmation timeout — call mcp__brc__confirm",
+                body="You are PROPOSED and fully ACKed but have not confirmed in 300s.",
+            )
+        ]
+
+        with (
+            patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"),
+            patch(
+                "egg_agent.midturn_messages.subprocess.run",
+                return_value=_completed(_poll_response(batch)),
+            ),
+        ):
+            block = poller.poll()
+
+        assert block is not None
+        assert "mcp__brc__confirm" in block
+        assert "from orchestrator" in block
 
     def test_since_id_stale_resnaps_without_injecting(self, tmp_path):
         """Store-side cursor invalidation (#2464) re-snaps to tip silently."""

--- a/tests/shared/egg_agent/test_midturn_messages.py
+++ b/tests/shared/egg_agent/test_midturn_messages.py
@@ -1,0 +1,325 @@
+"""Tests for mid-turn operator message delivery (#3123).
+
+The poller's contract: throttled bus polls via an ``egg-orch message
+poll`` subprocess, a cursor file that persists across one-shot
+invocations, seed-at-tip on first poll (no history flood), operator-only
+injection, and fail-soft on every failure mode.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+from unittest.mock import patch
+
+from egg_agent.midturn_messages import (
+    DEFAULT_POLL_INTERVAL_SECS,
+    MidturnMessagePoller,
+    is_midturn_messages_disabled,
+)
+
+
+def _poll_response(messages: list[dict[str, Any]], *, stale: bool = False) -> str:
+    data: dict[str, Any] = {"messages": messages, "count": len(messages)}
+    if stale:
+        data["since_id_stale"] = True
+    return json.dumps({"success": True, "data": data})
+
+
+def _completed(stdout: str, rc: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess([], rc, stdout=stdout, stderr="")
+
+
+def _message(
+    msg_id: str,
+    from_role: str = "overseer",
+    body: str = "Adopt the prior branch.",
+    **extra: Any,
+) -> dict[str, Any]:
+    return {
+        "id": msg_id,
+        "from_role": from_role,
+        "to_role": "coder",
+        "message_type": "GUIDANCE",
+        "subject": "course correction",
+        "timestamp": "2026-06-11T09:00:00",
+        "body": body,
+        **extra,
+    }
+
+
+class _Clock:
+    """Deterministic monotonic clock the tests advance by hand."""
+
+    def __init__(self) -> None:
+        self.value = 1000.0
+
+    def __call__(self) -> float:
+        return self.value
+
+
+def _make_poller(tmp_path, clock: _Clock | None = None) -> MidturnMessagePoller:
+    return MidturnMessagePoller(
+        "pipeline-test",
+        "coder",
+        interval_secs=60.0,
+        cursor_dir=str(tmp_path),
+        now=clock or _Clock(),
+    )
+
+
+class TestFirstPollSeedsCursor:
+    def test_first_poll_seeds_at_tip_without_injecting(self, tmp_path):
+        """No cursor file → record the tip, inject nothing (history is not new)."""
+        poller = _make_poller(tmp_path)
+        history = [_message("msg-1"), _message("msg-2", from_role="coder")]
+
+        with (
+            patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"),
+            patch(
+                "egg_agent.midturn_messages.subprocess.run",
+                return_value=_completed(_poll_response(history)),
+            ) as mock_run,
+        ):
+            assert poller.poll() is None
+
+        # Cursor seeded at the last message id; no --since on the seed poll.
+        assert poller._cursor_path.read_text() == "msg-2"
+        cmd = mock_run.call_args.args[0]
+        assert "--since" not in cmd
+        assert "pipeline-test" in cmd
+        assert "--role" in cmd
+
+    def test_second_poll_injects_new_operator_message(self, tmp_path):
+        """A message arriving after the seed is rendered for injection."""
+        clock = _Clock()
+        poller = _make_poller(tmp_path, clock)
+
+        with (
+            patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"),
+            patch(
+                "egg_agent.midturn_messages.subprocess.run",
+                return_value=_completed(_poll_response([_message("msg-1")])),
+            ),
+        ):
+            assert poller.poll() is None  # seed
+
+        clock.value += 61.0
+        new_message = _message("msg-2", body="ADOPT, DO NOT REIMPLEMENT")
+        with (
+            patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"),
+            patch(
+                "egg_agent.midturn_messages.subprocess.run",
+                return_value=_completed(_poll_response([new_message])),
+            ) as mock_run,
+        ):
+            block = poller.poll()
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[cmd.index("--since") + 1] == "msg-1"
+        assert block is not None
+        assert "ADOPT, DO NOT REIMPLEMENT" in block
+        assert "Operator message(s) received mid-turn" in block
+        assert "BINDING" in block
+        assert poller._cursor_path.read_text() == "msg-2"
+
+
+class TestThrottle:
+    def test_polls_are_interval_gated(self, tmp_path):
+        clock = _Clock()
+        poller = _make_poller(tmp_path, clock)
+
+        with (
+            patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"),
+            patch(
+                "egg_agent.midturn_messages.subprocess.run",
+                return_value=_completed(_poll_response([])),
+            ) as mock_run,
+        ):
+            poller.poll()
+            clock.value += 30.0  # under the 60s interval
+            poller.poll()
+            poller.poll()
+
+        assert mock_run.call_count == 1
+
+    def test_default_interval_from_env(self, monkeypatch):
+        monkeypatch.setenv("EGG_MIDTURN_MESSAGES_INTERVAL_SECS", "120")
+        poller = MidturnMessagePoller("p", "r")
+        assert poller.interval_secs == 120.0
+
+        monkeypatch.setenv("EGG_MIDTURN_MESSAGES_INTERVAL_SECS", "not-a-number")
+        poller = MidturnMessagePoller("p", "r")
+        assert poller.interval_secs == DEFAULT_POLL_INTERVAL_SECS
+
+        monkeypatch.setenv("EGG_MIDTURN_MESSAGES_INTERVAL_SECS", "-5")
+        poller = MidturnMessagePoller("p", "r")
+        assert poller.interval_secs == DEFAULT_POLL_INTERVAL_SECS
+
+
+class TestFiltering:
+    def _seeded_poller(self, tmp_path, clock: _Clock) -> MidturnMessagePoller:
+        poller = _make_poller(tmp_path, clock)
+        poller._cursor_path.write_text("msg-0", encoding="utf-8")
+        return poller
+
+    def test_peer_and_protocol_traffic_not_injected_but_advances_cursor(self, tmp_path):
+        """Non-operator messages stay on the between-invocation path."""
+        clock = _Clock()
+        poller = self._seeded_poller(tmp_path, clock)
+        peer_traffic = [
+            _message("msg-1", from_role="coder", message_type="CONSENSUS_PROPOSE"),
+            _message("msg-2", from_role="tester", message_type="STATUS"),
+        ]
+
+        with (
+            patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"),
+            patch(
+                "egg_agent.midturn_messages.subprocess.run",
+                return_value=_completed(_poll_response(peer_traffic)),
+            ),
+        ):
+            assert poller.poll() is None
+
+        # Cursor still advances so the chatter is not re-fetched forever.
+        assert poller._cursor_path.read_text() == "msg-2"
+
+    def test_mixed_batch_injects_only_operator_messages(self, tmp_path):
+        clock = _Clock()
+        poller = self._seeded_poller(tmp_path, clock)
+        batch = [
+            _message("msg-1", from_role="coder", body="peer chatter"),
+            _message("msg-2", from_role="overseer", body="operator directive"),
+            _message("msg-3", from_role="human", body="human follow-up"),
+        ]
+
+        with (
+            patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"),
+            patch(
+                "egg_agent.midturn_messages.subprocess.run",
+                return_value=_completed(_poll_response(batch)),
+            ),
+        ):
+            block = poller.poll()
+
+        assert block is not None
+        assert "operator directive" in block
+        assert "human follow-up" in block
+        assert "peer chatter" not in block
+
+    def test_since_id_stale_resnaps_without_injecting(self, tmp_path):
+        """Store-side cursor invalidation (#2464) re-snaps to tip silently."""
+        clock = _Clock()
+        poller = self._seeded_poller(tmp_path, clock)
+        replay = [_message("msg-7"), _message("msg-8")]
+
+        with (
+            patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"),
+            patch(
+                "egg_agent.midturn_messages.subprocess.run",
+                return_value=_completed(_poll_response(replay, stale=True)),
+            ),
+        ):
+            assert poller.poll() is None
+
+        assert poller._cursor_path.read_text() == "msg-8"
+
+
+class TestFailSoft:
+    def test_missing_binary_is_silent(self, tmp_path):
+        poller = _make_poller(tmp_path)
+        with patch("egg_agent.midturn_messages.shutil.which", return_value=None):
+            assert poller.poll() is None
+
+    def test_nonzero_rc_timeout_and_bad_json_are_silent(self, tmp_path):
+        clock = _Clock()
+        poller = _make_poller(tmp_path, clock)
+        failure_modes = [
+            _completed("", rc=1),
+            subprocess.TimeoutExpired(cmd="egg-orch", timeout=16),
+            _completed("not json"),
+            _completed(json.dumps({"success": False, "message": "boom"})),
+        ]
+        with patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"):
+            for mode in failure_modes:
+                clock.value += 61.0
+                kwargs = (
+                    {"side_effect": mode} if isinstance(mode, Exception) else {"return_value": mode}
+                )
+                with patch("egg_agent.midturn_messages.subprocess.run", **kwargs):
+                    assert poller.poll() is None
+        # No cursor was ever written on failures.
+        assert not poller._cursor_path.exists()
+
+    def test_failed_fetch_does_not_advance_cursor(self, tmp_path):
+        clock = _Clock()
+        poller = _make_poller(tmp_path, clock)
+        poller._cursor_path.write_text("msg-5", encoding="utf-8")
+
+        with (
+            patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"),
+            patch(
+                "egg_agent.midturn_messages.subprocess.run",
+                return_value=_completed("", rc=2),
+            ),
+        ):
+            assert poller.poll() is None
+
+        assert poller._cursor_path.read_text() == "msg-5"
+
+
+class TestRendering:
+    def test_block_truncated_at_cap(self, tmp_path):
+        from egg_agent.midturn_messages import _RENDERED_BLOCK_MAX_CHARS
+
+        clock = _Clock()
+        poller = _make_poller(tmp_path, clock)
+        poller._cursor_path.write_text("msg-0", encoding="utf-8")
+        huge = [_message("msg-1", body="directive " * 2000)]
+
+        with (
+            patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"),
+            patch(
+                "egg_agent.midturn_messages.subprocess.run",
+                return_value=_completed(_poll_response(huge)),
+            ),
+        ):
+            block = poller.poll()
+
+        assert block is not None
+        assert len(block) < _RENDERED_BLOCK_MAX_CHARS + 200
+        assert "messages truncated" in block
+
+    def test_empty_body_renders_placeholder(self, tmp_path):
+        clock = _Clock()
+        poller = _make_poller(tmp_path, clock)
+        poller._cursor_path.write_text("msg-0", encoding="utf-8")
+
+        with (
+            patch("egg_agent.midturn_messages.shutil.which", return_value="/usr/bin/egg-orch"),
+            patch(
+                "egg_agent.midturn_messages.subprocess.run",
+                return_value=_completed(_poll_response([_message("msg-1", body="")])),
+            ),
+        ):
+            block = poller.poll()
+
+        assert block is not None
+        assert "(no body)" in block
+
+
+class TestDisableSwitch:
+    def test_default_enabled(self, monkeypatch):
+        monkeypatch.delenv("EGG_MIDTURN_MESSAGES", raising=False)
+        assert is_midturn_messages_disabled() is False
+
+    def test_disabled_values(self, monkeypatch):
+        for value in ("false", "0", "off", "disabled", "FALSE", " Off "):
+            monkeypatch.setenv("EGG_MIDTURN_MESSAGES", value)
+            assert is_midturn_messages_disabled() is True
+
+    def test_enabled_values(self, monkeypatch):
+        for value in ("true", "1", "on", "anything-else"):
+            monkeypatch.setenv("EGG_MIDTURN_MESSAGES", value)
+            assert is_midturn_messages_disabled() is False


### PR DESCRIPTION
Closes #3123.

## Problem

Operator directives in the submit description reliably reach the contract's `task_description` (#3033/#3042), but delivery stops there — it is pull-based. Nothing in a slice agent's hot path surfaces it: the per-event prompt (`compose_event_prompt`) carries only event/NACKs/git-delta/BRC-memory, and the role-scoped task views (`get_assigned_tasks`) return tasks only. The single thread holding it together is a generic rules-file instruction, and on the incident run (`pipeline-13643fa6`) that thread broke: the slice-1 coder reimplemented 12 already-completed tasks from scratch past a prominent "PRIOR WORK: ADOPT, DO NOT REIMPLEMENT" directive that was sitting in its contract the whole time.

The correction channel is also structurally too slow: one `propose` invocation can run 30+ minutes (a slice coder implements its whole task list in one turn), and overseer `send_message` traffic is only consulted between invocations — with agent restart unsafe per #2806, there is no safe mid-turn nudge.

See the corrected diagnosis appended to #3123 for the full verification trail.

## Changes

**1. Push `task_description` into every per-event prompt** (`orchestrator/routes/event_prompt.py`)
- New "Task & operator directives" section rendered right after the event banner, capped at 4 KB (`TASK_DESCRIPTION_MAX_CHARS`) with an explicit truncation sentinel pointing at `mcp__sdlc__show_contract`.
- Read fail-soft from the worktree contract file (`.egg-state/contracts/<key>.json`) via the pod-inherited `EGG_PIPELINE_ID` / `EGG_ISSUE_NUMBER` — the contract is committed and pushed to the assigned branch before any agent spawns, and `task_description` never mutates mid-phase, so the worktree copy cannot go stale. Empty/missing (GitHub-issue pipelines) → section omitted.
- Counts toward the existing 10 KB envelope; NACKs remain the designated truncation target.
- `compose_event_prompt` keeps its fixed positional signature; the new input is keyword-only with a safe default.

**2. Mid-turn operator message delivery** (`shared/egg_agent/midturn_messages.py`, wired in `client.py`)
- A PostToolUse hook (no matcher → every tool call) backed by a throttled poller: at most once per `EGG_MIDTURN_MESSAGES_INTERVAL_SECS` (default 60 s) it runs `egg-orch message poll` and injects new **operator-authored** messages (`from_role` ∈ overseer/human/operator/user) as `additionalContext`. Peer/protocol traffic is never injected.
- Cursor file persists across one-shot invocations (`EGG_WAIT_CURSOR_DIR`, same back-channel pattern as the #2323 wait cursor): no double-delivery, and a message landing between invocations is injected at the start of the next one. First poll seeds at the stream tip without replaying history. Honours the store's `since_id_stale` re-snap signal (#2464).
- Fail-soft on every mode (missing binary, unreachable orchestrator, bad JSON, unwritable cursor) — degrades to "no injection", never an agent failure. `EGG_MIDTURN_MESSAGES=false` is the escape hatch. Gated on pipeline context so non-pipeline `egg_agent` callers are untouched.
- Worst-case correction latency drops from "length of the remaining turn" to ~1 minute.

**3. Refresh `task_description` on `source_branch` resubmits** (`orchestrator/routes/pipelines.py`)
- `_pull_contract_from_source_branch` rebinds `pipeline_id` but kept the SOURCE pipeline's `task_description`; since a successful pull skips `create_contract()` (the only other writer), a resume submit's directives were silently dropped on that path. The new submit's prompt now replaces the pulled value (mirroring the `create_contract` convention: only for pipelines without a GitHub issue). Didn't fire in the incident but is the same failure one path over.

Deferred (per the revised scope on the issue): first-class structural adoption (`adopt_branches`) — overlaps existing `source_branch` artifact/contract pull and #3073 fork-from-assigned, deserves its own design pass.

## Testing

Targeted suites, all green:
- `orchestrator/tests/test_compose_event_prompt.py` (85, incl. 8 new: section shape/placement, cap+sentinel, envelope interplay, contract-file reader incl. fail-soft, CLI end-to-end)
- `tests/shared/egg_agent/test_midturn_messages.py` (15 new: seed-at-tip, cursor threading, throttle, operator filtering, stale re-snap, fail-soft, render caps, escape hatch)
- `tests/shared/egg_agent/test_client.py` (70, incl. 3 new for hook wiring/gating)
- `orchestrator/tests/test_source_branch.py` (59, incl. 2 new for the refresh)
- `orchestrator/tests/test_consensus_wrapper.py` (42), `orchestrator/tests/test_brc_nack_iteration.py` (11)

Lint: ruff check + format clean on all changed files; file-size gate passes (event_prompt.py soft-cap warning pre-existed).