### PR TITLE
Escalate deterministic fast-fail streaks on the event-pump agent arm

### DIFF
--- a/orchestrator/consensus_wrapper.py
+++ b/orchestrator/consensus_wrapper.py
@@ -673,13 +673,19 @@ raise_agent_fail_alert() {{
     local last_rc="$2"
     local last_secs="$3"
     local action="$4"
-    # Duration-aware classification (#3138): a sub-second failure means
-    # the invocation died before/at SDK init -- unknown model alias,
-    # auth misconfiguration, prompt-rendering crash -- i.e. a permanent
+    # Duration-aware classification (#3138): a fast failure means the
+    # invocation died before/at SDK init -- unknown model alias, auth
+    # misconfiguration, prompt-rendering crash -- i.e. a permanent
     # configuration-class failure, not a transient. Name that in the
     # alert so the operator doesn't have to infer it from cadence. The
     # wrapper still never self-FAILs (post-#2908 design): the kill
     # decision stays with the operator.
+    #
+    # The ``-le 2`` threshold (not ``< 1``) is deliberate: ``$SECONDS``
+    # has whole-second granularity and ``invoke_agent_for_event`` includes
+    # prompt-composer overhead, so a genuine pre-SDK-init crash routinely
+    # measures 1-2s. Do not tighten this to ``< 1`` -- it would misclassify
+    # those crashes as transient.
     local classification="repeated agent-invocation failure; attempts are taking ${{last_secs}}s so this may be transient (API/quota/transport)"
     if [ "$last_secs" -le 2 ]; then
         classification="attempts are fast-failing (${{last_secs}}s, before/at SDK init) -- likely a permanent configuration-class failure (unknown model alias, auth misconfiguration, prompt-rendering crash)"
@@ -868,7 +874,10 @@ while true; do
                 AGENT_FAIL_STREAK=$(( AGENT_FAIL_STREAK + 1 ))
                 cw_log "agent invocation failed (action=$ACTION, rc=$agent_rc, streak=$AGENT_FAIL_STREAK, duration=${{agent_invoke_secs}}s). Idle counter continues to accrue."
                 if [ "$AGENT_FAIL_STREAK" -ge 5 ] && [ "$AGENT_FAIL_ALERTED_5" != "true" ]; then
-                    cw_log "agent invocation has failed ${{AGENT_FAIL_STREAK}} times in a row (action=$ACTION) -- this is likely a permanent failure (unknown model alias, auth misconfiguration, prompt-rendering crash), not a transient. Idle budget continues to accrue."
+                    # The per-failure line above already printed the streak
+                    # count this iteration; this escalation line adds the
+                    # diagnosis (likely permanent), not the count.
+                    cw_log "agent invocation streak crossed 5 (action=$ACTION) -- this is likely a permanent failure (unknown model alias, auth misconfiguration, prompt-rendering crash), not a transient. Idle budget continues to accrue."
                     AGENT_FAIL_ALERTED_5=true
                 fi
                 if [ "$AGENT_FAIL_STREAK" -ge 10 ] && [ "$AGENT_FAIL_ALERTED_10" != "true" ]; then

--- a/orchestrator/consensus_wrapper.py
+++ b/orchestrator/consensus_wrapper.py
@@ -22,6 +22,14 @@ event. A deterministic bash loop drives the lifecycle:
   default 30 min, architect od-4); priority climbs to ``high`` on the
   2× boundary; the loop keeps blocking rather than exiting 1 →
   FAILED.
+* escalate a consecutive agent-invocation failure streak (#3138):
+  linear backoff on the ``propose|ack|nack`` arm (streak × 2 s,
+  capped 30 s, parity with the ``confirm`` arm), a sticky log warning
+  at streak 5, and a sticky ``OVERSEER_ALERT`` (anomaly
+  ``agent-invocation-fail-streak``) at streak 10 whose detail
+  classifies sub-second failures as configuration-class (unknown
+  model alias, auth, prompt-rendering crash). The loop still never
+  self-FAILs.
 
 Slice-4 history
 ~~~~~~~~~~~~~~~
@@ -596,6 +604,18 @@ ALERTED_AT_DOUBLE=false
 # after the role briefly transitioned through ``wait`` / ``propose``.
 CONFIRM_FAIL_STREAK=0
 AGENT_FAIL_STREAK=0
+# Sticky latches for the agent-invocation fail streak (#3138). Like the
+# ``NEXT_ACTION_ALERTED_*`` latches below they are wrapper-lifetime
+# sticky (the streak counter itself resets via the arm-cluster dispatch
+# at the top of the loop, but a re-fired warning after a brief recovery
+# is noise, not signal). The 10-streak latch escalates to a real
+# overseer alert -- a streak of fast-failing invocations is a strong
+# permanent/configuration-class signal (unknown model alias, auth
+# misconfiguration, prompt-rendering crash) that the operator should
+# hear about from the wrapper itself, not minutes later via the
+# overseer's generic heartbeat-silence anomaly.
+AGENT_FAIL_ALERTED_5=false
+AGENT_FAIL_ALERTED_10=false
 # Consecutive failures from ``fetch_next_action`` (reviewer §3): used
 # to surface a distinguishable "many consecutive 5xx/transport failures"
 # log line so an unhealthy orchestrator is differentiable from a benign
@@ -645,6 +665,31 @@ print(f\"role={{role}} producer_phase={{my.get('producer_phase','?')}} reviewer_
         --priority "$priority" \
         --summary "BRC event-pump idle for ${{idle}}s$summary_extra" \
         --detail "Event-pump for role=${{EGG_AGENT_ROLE:-agent}} slice=${{EGG_SLICE_ID:-none}} has seen no actionable BRC event for ${{idle}}s (configured budget ${{IDLE_BUDGET_SECS}}s). The loop continues blocking; no FAILED transition is forced. BRC state: $brc_snapshot" \
+        >/dev/null 2>&1 || true
+}}
+
+raise_agent_fail_alert() {{
+    local streak="$1"
+    local last_rc="$2"
+    local last_secs="$3"
+    local action="$4"
+    # Duration-aware classification (#3138): a sub-second failure means
+    # the invocation died before/at SDK init -- unknown model alias,
+    # auth misconfiguration, prompt-rendering crash -- i.e. a permanent
+    # configuration-class failure, not a transient. Name that in the
+    # alert so the operator doesn't have to infer it from cadence. The
+    # wrapper still never self-FAILs (post-#2908 design): the kill
+    # decision stays with the operator.
+    local classification="repeated agent-invocation failure; attempts are taking ${{last_secs}}s so this may be transient (API/quota/transport)"
+    if [ "$last_secs" -le 2 ]; then
+        classification="attempts are fast-failing (${{last_secs}}s, before/at SDK init) -- likely a permanent configuration-class failure (unknown model alias, auth misconfiguration, prompt-rendering crash)"
+    fi
+    timeout 5 egg-orch overseer alert "${{EGG_PIPELINE_ID:-unknown}}" \
+        --role "${{EGG_AGENT_ROLE:-agent}}" \
+        --anomaly agent-invocation-fail-streak \
+        --priority high \
+        --summary "agent invocation failing repeatedly (action=${{action}}, streak=${{streak}})" \
+        --detail "Event-pump for role=${{EGG_AGENT_ROLE:-agent}} slice=${{EGG_SLICE_ID:-none}} has had ${{streak}} consecutive agent-invocation failures on action=${{action}} (last rc=${{last_rc}}): ${{classification}}. The loop keeps retrying with linear backoff (capped 30s); no FAILED transition is forced. Idle budget continues to accrue." \
         >/dev/null 2>&1 || true
 }}
 
@@ -812,21 +857,39 @@ while true; do
             if [ "$ACTION" = "ack" ] || [ "$ACTION" = "nack" ]; then
                 sync_to_proposals "$EVENT_PAYLOAD"
             fi
+            agent_invoke_start=$SECONDS
             invoke_agent_for_event "$ACTION" "$EVENT_PAYLOAD"
             agent_rc=$?
+            agent_invoke_secs=$(( SECONDS - agent_invoke_start ))
             if [ "$agent_rc" -eq 0 ]; then
                 note_progress
                 AGENT_FAIL_STREAK=0
             else
                 AGENT_FAIL_STREAK=$(( AGENT_FAIL_STREAK + 1 ))
-                cw_log "agent invocation failed (action=$ACTION, rc=$agent_rc, streak=$AGENT_FAIL_STREAK). Idle counter continues to accrue."
-                # Agent startup typically gives a natural floor of
-                # seconds-to-tens-of-seconds, so no explicit backoff is
-                # required here -- but if the failure was sub-second (e.g.
-                # a prompt-rendering crash before SDK init), add a small
-                # floor so the orchestrator's next-action route isn't
-                # hammered.
-                sleep 1
+                cw_log "agent invocation failed (action=$ACTION, rc=$agent_rc, streak=$AGENT_FAIL_STREAK, duration=${{agent_invoke_secs}}s). Idle counter continues to accrue."
+                if [ "$AGENT_FAIL_STREAK" -ge 5 ] && [ "$AGENT_FAIL_ALERTED_5" != "true" ]; then
+                    cw_log "agent invocation has failed ${{AGENT_FAIL_STREAK}} times in a row (action=$ACTION) -- this is likely a permanent failure (unknown model alias, auth misconfiguration, prompt-rendering crash), not a transient. Idle budget continues to accrue."
+                    AGENT_FAIL_ALERTED_5=true
+                fi
+                if [ "$AGENT_FAIL_STREAK" -ge 10 ] && [ "$AGENT_FAIL_ALERTED_10" != "true" ]; then
+                    raise_agent_fail_alert "$AGENT_FAIL_STREAK" "$agent_rc" "$agent_invoke_secs" "$ACTION"
+                    AGENT_FAIL_ALERTED_10=true
+                fi
+                # #3138: the old flat ``sleep 1`` here assumed agent
+                # startup gives a natural seconds-to-tens-of-seconds
+                # floor, but a pre-SDK-init failure (unknown model
+                # alias, prompt-rendering crash) fails in <1 s and was
+                # retried at the floor indefinitely (160+ consecutive
+                # retries on the first issue-3077 run). Backoff parity
+                # with the ``confirm`` arm above: linear in the streak,
+                # capped at 30 s, so a deterministic fast-fail loop
+                # stops hammering the orchestrator while a one-off
+                # transient still retries promptly.
+                agent_backoff_secs=$(( AGENT_FAIL_STREAK * 2 ))
+                if [ "$agent_backoff_secs" -gt 30 ]; then
+                    agent_backoff_secs=30
+                fi
+                sleep "$agent_backoff_secs"
             fi
             ;;
         *)

--- a/orchestrator/tests/test_consensus_wrapper.py
+++ b/orchestrator/tests/test_consensus_wrapper.py
@@ -1178,6 +1178,204 @@ class TestEventPumpConfirmFailureRaisesIdleAlert:
         )
 
 
+class TestEventPumpAgentFailStreakEscalation:
+    """(#3138) The ``propose|ack|nack`` arm must not retry a
+    deterministic fast failure indefinitely at a flat 1 s cadence.
+
+    Pre-fix bug shape (first issue-3077 run, 2026-06-11): the refiner's
+    agent invocation failed pre-SDK-init (unknown model alias, rc=1 in
+    <1 s) and the arm retried it 160+ consecutive times, one every
+    ~2-3 s, with no backoff growth and no escalation. ``AGENT_FAIL_STREAK``
+    was computed and logged but nothing acted on it; the only detection
+    was the overseer's generic heartbeat-silence anomaly ~8 minutes in.
+
+    Post-fix, the arm has parity with its two siblings:
+      - backoff parity with the ``confirm`` arm: linear in the streak
+        (streak x 2 s), capped at 30 s;
+      - escalation parity beyond the ``fetch_next_action`` latches: a
+        sticky log warning at streak 5 and a sticky OVERSEER_ALERT
+        (anomaly ``agent-invocation-fail-streak``) at streak 10 whose
+        detail classifies sub-second failures as configuration-class.
+    The wrapper still never self-FAILs (post-#2908 design).
+    """
+
+    def test_template_has_agent_arm_backoff_and_streak_latches(self, monkeypatch):
+        """Render-level lock-in: the agent arm computes a capped linear
+        backoff from ``AGENT_FAIL_STREAK``, defines both sticky latches,
+        raises the streak alert, and no longer contains the flat
+        ``sleep 1`` retry floor as executable bash."""
+        monkeypatch.setenv("EGG_BRC_EVENT_PUMP", "true")
+        script = build_consensus_wrapped_command("Prompt")[-1]
+
+        assert "agent_backoff_secs=$(( AGENT_FAIL_STREAK * 2 ))" in script, (
+            "agent arm must grow its retry sleep linearly with the "
+            "fail streak (parity with the confirm arm)"
+        )
+        assert 'sleep "$agent_backoff_secs"' in script
+        assert "AGENT_FAIL_ALERTED_5=false" in script
+        assert "AGENT_FAIL_ALERTED_10=false" in script
+        assert "raise_agent_fail_alert" in script
+        assert "agent-invocation-fail-streak" in script, (
+            "streak escalation must reach the overseer as a distinctly "
+            "named anomaly, not only a cw_log line"
+        )
+        # The pre-#3138 flat retry floor must not survive as executable
+        # bash (a backtick-quoted mention in a comment is fine).
+        executable_lines = [
+            line.strip() for line in script.splitlines() if not line.lstrip().startswith("#")
+        ]
+        assert "sleep 1" not in executable_lines, (
+            "#3138 regression: the agent arm's flat `sleep 1` retry "
+            "floor is back — a pre-SDK-init failure would again retry "
+            "indefinitely at the floor"
+        )
+
+    def test_persistent_agent_failure_backs_off_and_fires_streak_alert(self, tmp_path, monkeypatch):
+        """End-to-end behavioural test of the #3138 fix.
+
+        Drive the rendered event-pump bash against stubbed shims:
+          - ``brc get-state`` → role unconfirmed, consensus incomplete
+          - ``brc next-action`` → ``{"action":"propose"}`` every call
+          - ``python3 -m egg_agent ...`` → exit 1 immediately (the
+            pre-SDK-init fast-fail signature from #3136; inline
+            ``python3 -c`` JSON parsing forwards to the real
+            interpreter)
+          - ``overseer alert`` → record the call to a log file
+          - ``sleep`` → record the requested duration, then sleep a
+            scaled-down 0.05 s so the loop reaches a deep streak
+            within the test timeout without real waiting
+
+        Assertions:
+          - the recorded sleep durations are exactly the expected
+            capped-linear sequence (2, 4, 6, ... capped at 30) — i.e.
+            backoff grows with the streak and respects the cap;
+          - the streak reached at least 10 (so the escalation path ran);
+          - the ``agent-invocation-fail-streak`` overseer alert fired
+            EXACTLY once (sticky latch — pre-fix the signal never
+            fired; an unsticky latch would flood);
+          - the alert detail carries the sub-second
+            configuration-class classification.
+        """
+        monkeypatch.setenv("EGG_BRC_EVENT_PUMP", "true")
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        alert_log = tmp_path / "alert_calls.log"
+        sleep_log = tmp_path / "sleep_calls.log"
+        general_log = tmp_path / "egg_orch.log"
+
+        mock_orch = bin_dir / "egg-orch"
+        mock_orch.write_text(
+            "#!/bin/bash\n"
+            f'echo "$@" >> {shlex.quote(str(general_log))}\n'
+            'sub="$1 $2"\n'
+            'case "$sub" in\n'
+            '    "brc get-state")\n'
+            '        echo \'{"consensus":{"agents":{"coder":{"confirmed":false,'
+            '"producer_phase":"WAITING_FOR_REVIEW"}},"is_complete":false}}\'\n'
+            "        ;;\n"
+            '    "brc next-action")\n'
+            '        echo \'{"action":"propose"}\'\n'
+            "        ;;\n"
+            '    "overseer alert")\n'
+            f'        echo "alert: $*" >> {shlex.quote(str(alert_log))}\n'
+            "        ;;\n"
+            "    *)\n"
+            "        ;;\n"
+            "esac\n"
+            "exit 0\n"
+        )
+        os.chmod(str(mock_orch), 0o755)  # nosec B103
+
+        # Inline ``python3 -c`` / stdin parsing forwards to the real
+        # interpreter; the ``python3 -m egg_agent`` invocation path
+        # fast-fails like an unknown-model session-init crash (#3136).
+        real_python = sys.executable
+        mock_python = bin_dir / "python3"
+        mock_python.write_text(
+            "#!/bin/bash\n"
+            'if [ "$1" = "-c" ] || [ "$1" = "-" ]; then\n'
+            f'    exec {shlex.quote(real_python)} "$@"\n'
+            "fi\n"
+            "exit 1\n"
+        )
+        os.chmod(str(mock_python), 0o755)  # nosec B103
+
+        # Record requested sleep durations, then sleep a scaled-down
+        # constant so backoff growth is observable without real waiting.
+        # ``command -p`` resolves the real sleep from the default PATH
+        # (this stub shadows ``sleep`` on the test PATH, so a bare
+        # ``sleep`` here would recurse).
+        mock_sleep = bin_dir / "sleep"
+        mock_sleep.write_text(
+            "#!/bin/bash\n"
+            f'echo "$1" >> {shlex.quote(str(sleep_log))}\n'
+            "command -p sleep 0.05 2>/dev/null || exit 0\n"
+            "exit 0\n"
+        )
+        os.chmod(str(mock_sleep), 0o755)  # nosec B103
+
+        env = os.environ.copy()
+        env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+        env["EGG_BRC_EVENT_PUMP"] = "true"
+        # Leave the idle budget at its 30-min default: the streak alert
+        # must come from the agent arm, not the idle-budget safety net.
+        env.pop("EGG_BRC_IDLE_BUDGET_MIN", None)
+        env["EGG_AGENT_ROLE"] = "coder"
+        env["EGG_PIPELINE_ID"] = "test-pipeline"
+        env["EGG_CONCURRENT_MODE"] = "true"
+
+        cmd = build_consensus_wrapped_command("Prompt")
+        try:
+            subprocess.run(
+                cmd,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            pass  # expected — the wrapper loops; we bound it.
+
+        assert sleep_log.exists(), (
+            "agent arm never slept after a failed invocation -- the "
+            "event-pump loop may not have reached the propose arm. "
+            "egg-orch log:\n" + (general_log.read_text() if general_log.exists() else "(empty)")
+        )
+        observed = [int(line) for line in sleep_log.read_text().split() if line.isdigit()]
+        expected = [min(2 * (i + 1), 30) for i in range(len(observed))]
+        assert observed == expected, (
+            "#3138 regression: agent-arm retry sleeps must follow the "
+            "capped-linear backoff (streak x 2 s, capped 30 s, parity "
+            f"with the confirm arm). Observed {observed[:20]}, expected "
+            f"{expected[:20]}"
+        )
+        assert len(observed) >= 10, (
+            "test did not reach streak 10 within the timeout; the "
+            f"escalation path was not exercised (streak={len(observed)})"
+        )
+
+        assert alert_log.exists(), (
+            "#3138 regression: 10+ consecutive fast agent-invocation "
+            "failures did not raise an overseer alert from the wrapper. "
+            "Pre-fix, AGENT_FAIL_STREAK was computed and discarded; the "
+            "operator only heard about the loop ~8 minutes later via "
+            "the overseer's generic heartbeat-silence anomaly. egg-orch "
+            "log:\n" + general_log.read_text()
+        )
+        alert_text = alert_log.read_text()
+        alert_count = alert_text.count("agent-invocation-fail-streak")
+        assert alert_count == 1, (
+            "streak alert must fire exactly once per wrapper lifetime "
+            f"(sticky AGENT_FAIL_ALERTED_10 latch); got {alert_count}. "
+            f"Alert text:\n{alert_text}"
+        )
+        assert "configuration-class" in alert_text, (
+            "sub-second failures must be classified as configuration-"
+            "class (unknown model alias, auth, prompt-rendering crash) "
+            f"in the alert detail. Alert text:\n{alert_text}"
+        )
+
+
 class TestEventPumpInvokesComposer:
     """Pin the wrapper template's ``invoke_agent_for_event`` invocation
     shape (reviewer_contract NACK v1, plan TASK-3-2 acceptance "Wrapper

--- a/orchestrator/tests/test_consensus_wrapper.py
+++ b/orchestrator/tests/test_consensus_wrapper.py
@@ -1331,7 +1331,11 @@ class TestEventPumpAgentFailStreakEscalation:
                 env=env,
                 capture_output=True,
                 text=True,
-                timeout=10,
+                # Needs >=10 loop iterations, each spawning several
+                # egg-orch/python3 subprocesses, to exercise the streak-10
+                # escalation. 20s gives headroom on a loaded CI host so the
+                # ``len(observed) >= 10`` assertion below doesn't flake.
+                timeout=20,
             )
         except subprocess.TimeoutExpired:
             pass  # expected — the wrapper loops; we bound it.


### PR DESCRIPTION
Fixes #3138.

## Problem

On the first `issue-3077` run, the refiner's agent invocation failed deterministically at session init (unknown model alias, rc=1 in <1 s; #3136) and the event-pump's `propose|ack|nack` arm retried it **160+ consecutive times** at a flat `sleep 1` cadence with no backoff growth and no escalation. `AGENT_FAIL_STREAK` was computed and logged, but nothing acted on it — the only detection was the overseer's *generic* heartbeat-silence anomaly ~8 minutes in.

The arm's two siblings already had the missing shapes: the `confirm` arm has linear backoff (streak × 2 s, capped 30 s) and `fetch_next_action` has sticky streak latches.

## Change

All in the `propose|ack|nack` failure branch of the event-pump template (`orchestrator/consensus_wrapper.py`):

1. **Backoff parity with the `confirm` arm** — the flat `sleep 1` becomes `AGENT_FAIL_STREAK × 2 s`, capped at 30 s. A one-off transient still retries promptly; a deterministic fast-fail loop stops hammering the orchestrator. The existing arm-cluster streak reset at the top of the loop is unchanged.
2. **Real escalation, not just log parity** — sticky `cw_log` warning at streak 5, and at streak 10 a sticky one-shot `OVERSEER_ALERT` (anomaly `agent-invocation-fail-streak`, priority high) raised from the wrapper itself. With the backoff, that lands ~2 minutes into a fast-fail loop instead of ~8 minutes via the generic anomaly, and it names the actual problem.
3. **Duration-aware classification, no fail-fast** — per-invocation wall time is measured; sub-second failures are classified in the alert detail as configuration-class (unknown model alias, auth misconfiguration, prompt-rendering crash). The wrapper still never self-FAILs (post-#2908 design): the loop keeps blocking and the kill decision stays with the operator.

## Tests

`orchestrator/tests/test_consensus_wrapper.py`, new `TestEventPumpAgentFailStreakEscalation`:

- **Render-level lock-in**: the rendered bash contains the capped-linear backoff arithmetic, both sticky latches, the distinctly named anomaly, and no executable flat `sleep 1`.
- **Behavioral** (modeled on `TestEventPumpConfirmFailureRaisesIdleAlert`): drives the rendered bash against stubbed `egg-orch` / `python3` / `sleep` shims reproducing the #3136 fast-fail signature. Asserts the recorded sleep durations are exactly the capped-linear sequence (2, 4, 6, … capped at 30), the streak alert fires **exactly once** (sticky latch), and the alert carries the configuration-class classification.

`test_consensus_wrapper.py` suite: 51 passed. Adjacent wrapper-referencing suites (`test_concurrent_executor`, `test_concurrent_integration`, `test_prompt_sync_ratchet`, `test_slice_overlap_ingest`): 119 passed.