### PR TITLE
Swap kimi-k2.6 for kimi-k2.7-code in the sub-1M model registry

### DIFF
--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -134,7 +134,7 @@ The resolver's classifier divides model strings into two camps:
 | `opus`, `opus[1m]`, `sonnet`, `sonnet[1m]`, `haiku`, `fable`, `fable[1m]` | `"anthropic"` | the model string verbatim | `None` |
 | `claude-*` (e.g. `claude-3-5-sonnet-20241022`) | `"anthropic"` | the model string verbatim | `None` |
 | Everything else with a real window ≥1M (e.g. `qwen3.7-max`, `deepseek-v4-*`) | `"litellm"` | `<model>[1m]` (the bare upstream name plus the 1M-context opt-in suffix) | the bare upstream name |
-| Sub-1M-window models (`_SUB_1M_CONTEXT_MODELS`: `kimi-k2.6` 256K, `glm-5.1` 202K) | `"litellm"` | `<model>` — bare, **no** `[1m]` (takes Claude Code's 200K default) | the bare upstream name |
+| Sub-1M-window models (`_SUB_1M_CONTEXT_MODELS`: `kimi-k2.7-code` 256K, `glm-5.1` 202K) | `"litellm"` | `<model>` — bare, **no** `[1m]` (takes Claude Code's 200K default) | the bare upstream name |
 
 Two consequences:
 
@@ -221,7 +221,7 @@ two env vars (plus one egg-side auth marker):
 - `ANTHROPIC_CUSTOM_MODEL_OPTION=<upstream>[1m]` — registers the
   custom model ID and tells Claude Code to use 1M-context
   compaction math. For models in `_SUB_1M_CONTEXT_MODELS` (Kimi
-  K2.6, GLM-5.1) this is set to the **bare** `<upstream>` without
+  K2.7-Code, GLM-5.1) this is set to the **bare** `<upstream>` without
   the `[1m]` suffix; see the *Sub-1M-window upstreams (#2987)*
   callout below.
 - `ANTHROPIC_CUSTOM_MODEL_OPTION_NAME=<upstream>` — the bare
@@ -288,7 +288,7 @@ registration.
 > `DISABLE_COMPACT` (which egg never sets). So the resolver appends
 > `[1m]` only for genuine ≥1M upstreams and **withholds it** for
 > models whose real window is below 1M — `_SUB_1M_CONTEXT_MODELS` in
-> `agent_model_resolution.py` (Kimi K2.6 256K, GLM-5.1 202K). Those
+> `agent_model_resolution.py` (Kimi K2.7-Code 256K, GLM-5.1 202K). Those
 > take Claude Code's 200K default, which auto-compacts safely below
 > their real limit instead of deferring compaction toward 1M and
 > overflowing the upstream mid-turn. The cost is the unused headroom

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -292,7 +292,7 @@ registration.
 > take Claude Code's 200K default, which auto-compacts safely below
 > their real limit instead of deferring compaction toward 1M and
 > overflowing the upstream mid-turn. The cost is the unused headroom
-> above 200K (e.g. ~56K for Kimi); Claude Code offers no in-between
+> above 200K (e.g. ~62K for Kimi, 262,144 − 200K); Claude Code offers no in-between
 > profile. Add a model to the set when its real window is <1M.
 
 ### Web tool availability on the LiteLLM path (#2856)

--- a/orchestrator/agent_model_resolution.py
+++ b/orchestrator/agent_model_resolution.py
@@ -117,7 +117,7 @@ _CONTEXT_1M_SUFFIX = "[1m]"
 # documents the real window (only membership is used). Add a model here when its
 # window is <1M. See #2987.
 _SUB_1M_CONTEXT_MODELS: dict[str, int] = {
-    "kimi-k2.6": 256_000,
+    "kimi-k2.7-code": 262_144,
     "glm-5.1": 202_752,
 }
 
@@ -264,8 +264,8 @@ def classify_model(model: str) -> AgentModelDecision:
     # real window is below 1M (``_SUB_1M_CONTEXT_MODELS``): those take the bare
     # name so Claude Code uses its 200K default and compacts before their true
     # limit instead of overflowing it. A pre-suffixed sub-1M model (e.g.
-    # ``kimi-k2.6[1m]``) is normalised back to bare here — the registry is
-    # authoritative over an operator's stray suffix.
+    # ``kimi-k2.7-code[1m]``) is normalised back to bare here — the registry
+    # is authoritative over an operator's stray suffix.
     if bare in _SUB_1M_CONTEXT_MODELS:
         claude_code_alias = bare
         if had_suffix:

--- a/orchestrator/tests/test_agent_model_resolution.py
+++ b/orchestrator/tests/test_agent_model_resolution.py
@@ -433,7 +433,7 @@ class TestSubOneMContextModels:
     safely below their window. See #2987.
     """
 
-    @pytest.mark.parametrize("model", ["kimi-k2.6", "glm-5.1"])
+    @pytest.mark.parametrize("model", ["kimi-k2.7-code", "glm-5.1"])
     def test_sub_1m_model_drops_1m_suffix(self, model):
         resolve_agent_model = _resolver()
         AgentRole = _agent_role()
@@ -450,7 +450,7 @@ class TestSubOneMContextModels:
             f"model's real limit; got {d.claude_code_alias!r}"
         )
 
-    @pytest.mark.parametrize("model", ["kimi-k2.6", "glm-5.1"])
+    @pytest.mark.parametrize("model", ["kimi-k2.7-code", "glm-5.1"])
     def test_pre_suffixed_sub_1m_model_normalized_to_bare(self, model):
         """A stray operator ``[1m]`` on a sub-1M model is overridden — the
         registry is authoritative, so the alias is still bare.
@@ -465,14 +465,14 @@ class TestSubOneMContextModels:
         assert d.upstream_model == model
         assert d.claude_code_alias == model
 
-    @pytest.mark.parametrize("model", ["kimi-k2.6", "glm-5.1"])
+    @pytest.mark.parametrize("model", ["kimi-k2.7-code", "glm-5.1"])
     def test_sub_1m_env_vars_carry_bare_name(self, model):
         """Every custom-model env var for a sub-1M model carries the bare
         name — none may leak the ``[1m]`` suffix (which would re-trigger the
         1M profile for the main agent or its Task-tool subagents). Parametrized
         over both registry entries so a future drift that only broke ``glm-5.1``
         (e.g. a ``.lower()`` or escape that special-cased the hyphen-period in
-        ``k2.6``) is caught here, not in the field.
+        ``k2.7``) is caught here, not in the field.
         """
         resolve_agent_model = _resolver()
         AgentRole = _agent_role()
@@ -524,7 +524,7 @@ class TestSubOneMContextModels:
             )
 
     def test_pre_suffixed_sub_1m_emits_override_warning(self, caplog):
-        """When an operator passes ``kimi-k2.6[1m]`` (sub-1M model with a
+        """When an operator passes ``kimi-k2.7-code[1m]`` (sub-1M model with a
         stray [1m] suffix), the resolver overrides the suffix and emits a
         warning — silent overrides leave operators chasing why their
         requested 1M profile isn't being applied.
@@ -534,24 +534,24 @@ class TestSubOneMContextModels:
         from agent_model_resolution import classify_model
 
         with caplog.at_level(logging.WARNING, logger="agent_model_resolution"):
-            d = classify_model("kimi-k2.6[1m]")
+            d = classify_model("kimi-k2.7-code[1m]")
 
-        assert d.claude_code_alias == "kimi-k2.6"
+        assert d.claude_code_alias == "kimi-k2.7-code"
         # The warning's %r formatting puts repr quotes around the input alias and
         # the normalised bare name; assert both quoted forms appear so a future
         # drift that swapped the format args (e.g. logged ``bare`` twice instead
         # of ``model, bare``) would still fail this test rather than passing on
         # the substring ``"[1m]"`` in the static format string alone.
         assert any(
-            "'kimi-k2.6[1m]'" in record.message and "'kimi-k2.6'" in record.message
+            "'kimi-k2.7-code[1m]'" in record.message and "'kimi-k2.7-code'" in record.message
             for record in caplog.records
         ), (
-            f"expected override warning naming both 'kimi-k2.6[1m]' and 'kimi-k2.6'; "
+            f"expected override warning naming both 'kimi-k2.7-code[1m]' and 'kimi-k2.7-code'; "
             f"got {[r.message for r in caplog.records]!r}"
         )
 
     def test_bare_sub_1m_emits_no_warning(self, caplog):
-        """The common case (operator passes the bare ``kimi-k2.6`` name)
+        """The common case (operator passes the bare ``kimi-k2.7-code`` name)
         must NOT emit the override warning — the warning is reserved for
         the actual override.
         """
@@ -560,7 +560,7 @@ class TestSubOneMContextModels:
         from agent_model_resolution import classify_model
 
         with caplog.at_level(logging.WARNING, logger="agent_model_resolution"):
-            classify_model("kimi-k2.6")
+            classify_model("kimi-k2.7-code")
 
         assert not caplog.records, (
             f"bare sub-1M model must not warn; got {[r.message for r in caplog.records]!r}"


### PR DESCRIPTION
## Summary

Replaces `kimi-k2.6` with `kimi-k2.7-code` (Moonshot's coding-focused successor, released 2026-06-12) as the routable Kimi model:

- `_SUB_1M_CONTEXT_MODELS` now registers `kimi-k2.7-code` at its real window of 262,144 tokens — same 256K class as K2.6, so it takes the same bare-alias path (no `[1m]`; Claude Code's 200K default compacts safely below the window).
- Tests and `docs/guides/per-agent-models.md` updated to match; K2.6 is removed rather than kept alongside.

## Cluster-side counterpart (not in-repo)

`~/.config/egg/litellm-models.yaml` (the LiteLLM ConfigMap overlay applied by `make litellm-config`) now registers `kimi-k2.7-code` → `openrouter/moonshotai/kimi-k2.7-code`. Launch-day provider landscape is only Moonshot AI (SG-hosted first party, excluded by the pin) and Novita (US: SF-HQ, AWS-hosted, SOC 2 Type II). The provider `order` leads with the vetted US privacy set as a forward pin — non-serving providers are skipped, so routing upgrades to DeepInfra-first as they onboard — with Novita appended as the only US host serving it today. `data_collection: deny` stays fail-closed. The host-side `~/.config/litellm/config.yaml` got the matching change (dotfiles).