### PR TITLE
Route-conditional prompt guidance: fewer turns, leaner context on LiteLLM routes (#3175)

### DIFF
--- a/docs/development/STRUCTURE.md
+++ b/docs/development/STRUCTURE.md
@@ -285,7 +285,8 @@ shared/
 │   ├── result.py           # AgentResult dataclass
 │   ├── tool_interceptor.py # Pre-execution file write checks (Write/Edit/NotebookEdit) against role restrictions
 │   ├── tool_output_cap.py  # Predictive PreToolUse cap for built-in CC tools (Read/Grep): denies calls whose model-bound result is likely to be excessive (cost/context discipline, NOT the buffer-crash fix — that's the raised reader buffer in client.py, #2884); tunable via EGG_TOOL_OUTPUT_CAP / EGG_READ_CAP_BYTES (#2876)
-│   └── midturn_messages.py # Throttled PostToolUse hook that polls the message bus mid-turn and injects new operator-authored messages as additionalContext; backed by EGG_MIDTURN_MESSAGES_INTERVAL_SECS (default 60 s) and EGG_MIDTURN_MESSAGES=false escape hatch (#3123)
+│   ├── midturn_messages.py # Throttled PostToolUse hook that polls the message bus mid-turn and injects new operator-authored messages as additionalContext; backed by EGG_MIDTURN_MESSAGES_INTERVAL_SECS (default 60 s) and EGG_MIDTURN_MESSAGES=false escape hatch (#3123)
+│   └── route_guidance.py   # Advisory system-prompt addendum appended only on LiteLLM (non-Claude) routes: steers toward batched tool calls, filtered output, and subagent-isolated bulk reads to cut turns × context cost; gated on ANTHROPIC_CUSTOM_MODEL_OPTION, kill switch EGG_ROUTE_PROMPT_GUIDANCE=false (#3175)
 ├── egg_anchor/             # Agent anchor mechanism for post-compaction state recovery
 │   ├── __init__.py         # Public API exports
 │   ├── models.py           # Pydantic models (AgentAnchor, AnchorMeta, ProgressItem, Decision, BRCState)

--- a/shared/egg_agent/client.py
+++ b/shared/egg_agent/client.py
@@ -22,6 +22,10 @@ if TYPE_CHECKING:
     # these are never evaluated at runtime, so they don't belong in the
     # runtime import below — only HookMatcher is constructed at runtime.
     from claude_agent_sdk import HookContext, HookInput, HookJSONOutput
+    from claude_agent_sdk.types import SystemPromptFile, SystemPromptPreset
+
+    # The declared type of ``ClaudeAgentOptions.system_prompt``.
+    SystemPrompt = str | SystemPromptPreset | SystemPromptFile | None
 
 # Maximum length for tool input/output in log events to avoid bloating logs
 _MAX_TOOL_CONTENT_LOG_LEN = 2000
@@ -155,6 +159,32 @@ def _sdk_max_buffer_bytes() -> int:
         )
         return _MAX_SDK_MAX_BUFFER_BYTES
     return value
+
+
+def _append_system_prompt_addendum(
+    existing_prompt: SystemPrompt, addendum: str
+) -> tuple[SystemPrompt, bool]:
+    """Append ``addendum`` to a plain-str system prompt, preserving other forms.
+
+    ``options.system_prompt`` is typed ``str | SystemPromptPreset |
+    SystemPromptFile | None``. We only know how to extend the plain-str case:
+    we append after a blank line (rstrip first so the join is stable). For a
+    ``None`` prompt the addendum becomes the whole prompt. For the
+    preset / file forms append semantics are undefined, so the caller's prompt
+    is returned unchanged and ``appended=False`` signals the caller to log the
+    skip rather than silently drop either the caller's prompt or the addendum.
+
+    Returns ``(new_prompt, appended)``. This is the shared shape behind both
+    the MCP-tool ``SYSTEM_PROMPT_NUDGE`` append and the LiteLLM-route guidance
+    append (#3175 review) — keeping the data-loss-avoidance contract in one
+    tested place.
+    """
+    if isinstance(existing_prompt, str) and existing_prompt:
+        return existing_prompt.rstrip() + "\n\n" + addendum, True
+    if existing_prompt:
+        # SystemPromptPreset / SystemPromptFile — cannot append; preserve.
+        return existing_prompt, False
+    return addendum, True
 
 
 async def run_agent_async(
@@ -352,9 +382,10 @@ async def run_agent_async(
             # plumbing but SystemPromptPreset / SystemPromptFile
             # append semantics are not defined).
             existing_prompt = options.system_prompt
-            if isinstance(existing_prompt, str) and existing_prompt:
-                options.system_prompt = existing_prompt.rstrip() + "\n\n" + SYSTEM_PROMPT_NUDGE
-            elif existing_prompt:
+            options.system_prompt, appended = _append_system_prompt_addendum(
+                existing_prompt, SYSTEM_PROMPT_NUDGE
+            )
+            if not appended:
                 # SystemPromptPreset / SystemPromptFile — we cannot
                 # append to these forms.  Preserve the caller's prompt
                 # and skip the nudge to avoid silent data loss.
@@ -364,8 +395,6 @@ async def run_agent_async(
                     event_type="system",
                     event_subtype="mcp_nudge_skipped",
                 )
-            else:
-                options.system_prompt = SYSTEM_PROMPT_NUDGE
             logger.info(
                 "Registered egg MCP tools",
                 event_type="system",
@@ -508,9 +537,10 @@ async def run_agent_async(
     route_addendum = route_guidance_addendum()
     if route_addendum:
         existing_prompt = options.system_prompt
-        if isinstance(existing_prompt, str) and existing_prompt:
-            options.system_prompt = existing_prompt.rstrip() + "\n\n" + route_addendum
-        elif existing_prompt:
+        options.system_prompt, appended = _append_system_prompt_addendum(
+            existing_prompt, route_addendum
+        )
+        if not appended:
             # SystemPromptPreset / SystemPromptFile — append semantics are
             # not defined for these forms (same constraint as the MCP
             # nudge above); preserve the caller's prompt and skip.
@@ -520,8 +550,6 @@ async def run_agent_async(
                 event_type="system",
                 event_subtype="route_guidance_skipped",
             )
-        else:
-            options.system_prompt = route_addendum
         if isinstance(options.system_prompt, str) and route_addendum in options.system_prompt:
             logger.info(
                 "Appended LiteLLM-route working-style guidance to system prompt",

--- a/shared/egg_agent/client.py
+++ b/shared/egg_agent/client.py
@@ -492,6 +492,43 @@ async def run_agent_async(
             event_subtype="ddg_mcp_enabled",
         )
 
+    # --- Route-conditional working-style guidance for the LiteLLM path (#3175) ---
+    # On non-Claude routes every turn re-bills the whole conversation at the
+    # cached-token rate, and open models take 3-5x more, smaller steps than the
+    # Claude baseline — turns × context-size dominates cost. Append an advisory
+    # system-prompt addendum steering toward batched tool calls, filtered
+    # output, and subagent-isolated bulk reads. The addendum is a constant
+    # gated only on pod-lifetime env (ANTHROPIC_CUSTOM_MODEL_OPTION, the same
+    # route signal as the DDG fallback above), so the rendered system prompt
+    # stays per-session stable and the cacheable prefix is unaffected. Same
+    # plain-str append semantics as SYSTEM_PROMPT_NUDGE above;
+    # EGG_ROUTE_PROMPT_GUIDANCE=false is the rollback escape hatch.
+    from egg_agent.route_guidance import route_guidance_addendum
+
+    route_addendum = route_guidance_addendum()
+    if route_addendum:
+        existing_prompt = options.system_prompt
+        if isinstance(existing_prompt, str) and existing_prompt:
+            options.system_prompt = existing_prompt.rstrip() + "\n\n" + route_addendum
+        elif existing_prompt:
+            # SystemPromptPreset / SystemPromptFile — append semantics are
+            # not defined for these forms (same constraint as the MCP
+            # nudge above); preserve the caller's prompt and skip.
+            logger.warning(
+                "Cannot append route guidance to non-string system_prompt "
+                f"(type={type(existing_prompt).__name__}); guidance omitted",
+                event_type="system",
+                event_subtype="route_guidance_skipped",
+            )
+        else:
+            options.system_prompt = route_addendum
+        if isinstance(options.system_prompt, str) and route_addendum in options.system_prompt:
+            logger.info(
+                "Appended LiteLLM-route working-style guidance to system prompt",
+                event_type="system",
+                event_subtype="route_guidance_enabled",
+            )
+
     # --- Mid-turn operator message delivery (#3123) ---
     # One propose invocation under the BRC event-pump can run 30+ minutes
     # (a slice coder implements its whole task list in one turn), and the

--- a/shared/egg_agent/client.py
+++ b/shared/egg_agent/client.py
@@ -374,13 +374,11 @@ async def run_agent_async(
             existing_servers = getattr(options, "mcp_servers", None) or {}
             options.mcp_servers = {**existing_servers, **mcp_servers}
             # Preserve any caller-supplied system_prompt; append the
-            # nudge.  ``options.system_prompt`` is typed
-            # ``str | SystemPromptPreset | SystemPromptFile | None`` —
-            # we only know how to extend the plain-str case; for preset
-            # / file forms the nudge is set as the full prompt (the
-            # caller's preset/file remains accessible via the SDK's own
-            # plumbing but SystemPromptPreset / SystemPromptFile
-            # append semantics are not defined).
+            # nudge via the shared helper.  It extends the plain-str
+            # case (and None) and, for the preset / file forms whose
+            # append semantics are undefined, returns the caller's
+            # prompt unchanged with ``appended=False`` so we skip the
+            # nudge rather than dropping the caller's prompt.
             existing_prompt = options.system_prompt
             options.system_prompt, appended = _append_system_prompt_addendum(
                 existing_prompt, SYSTEM_PROMPT_NUDGE

--- a/shared/egg_agent/client.py
+++ b/shared/egg_agent/client.py
@@ -13,7 +13,7 @@ import logging
 import os
 from collections.abc import AsyncIterator, Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, Any
 
 from egg_agent.result import AgentResult
 
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from claude_agent_sdk.types import SystemPromptFile, SystemPromptPreset
 
     # The declared type of ``ClaudeAgentOptions.system_prompt``.
-    SystemPrompt: TypeAlias = str | SystemPromptPreset | SystemPromptFile | None
+    type SystemPrompt = str | SystemPromptPreset | SystemPromptFile | None
 
 # Maximum length for tool input/output in log events to avoid bloating logs
 _MAX_TOOL_CONTENT_LOG_LEN = 2000

--- a/shared/egg_agent/client.py
+++ b/shared/egg_agent/client.py
@@ -13,7 +13,7 @@ import logging
 import os
 from collections.abc import AsyncIterator, Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from egg_agent.result import AgentResult
 
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from claude_agent_sdk.types import SystemPromptFile, SystemPromptPreset
 
     # The declared type of ``ClaudeAgentOptions.system_prompt``.
-    SystemPrompt = str | SystemPromptPreset | SystemPromptFile | None
+    SystemPrompt: TypeAlias = str | SystemPromptPreset | SystemPromptFile | None
 
 # Maximum length for tool input/output in log events to avoid bloating logs
 _MAX_TOOL_CONTENT_LOG_LEN = 2000

--- a/shared/egg_agent/route_guidance.py
+++ b/shared/egg_agent/route_guidance.py
@@ -1,0 +1,86 @@
+"""Route-conditional working-style guidance for non-Claude model routes (#3175).
+
+On the LiteLLM route the dominant cost driver is per-turn re-billing of
+large agentic contexts: every SDK turn re-sends the whole conversation,
+and prompt-cached tokens are discounted, not free — so cost scales with
+turns × context-size. Measured against the Claude baseline, open models
+also take 3–5× more, smaller steps for comparable events (#3175), which
+multiplies the turn factor.
+
+This module renders an advisory system-prompt addendum that
+``egg_agent.client.run_agent_async`` appends only when the session is
+routed through LiteLLM — signalled by ``ANTHROPIC_CUSTOM_MODEL_OPTION``,
+the same route detection the DDG web-tool fallback uses (#2856). The env
+var is fixed for the pod's lifetime and the addendum is a pure constant,
+so the rendered system prompt is stable per session and cannot break the
+cacheable prompt prefix. Claude-route sessions are untouched.
+
+The guidance is working-style steering, not budgets: it removes wasted
+round trips (one tool call per turn, unfiltered output dumps, bulk reads
+held in the parent session) without truncating reviews or skipping
+verification steps. ``EGG_ROUTE_PROMPT_GUIDANCE=false`` is the rollback
+escape hatch.
+"""
+
+from __future__ import annotations
+
+import os
+
+# The addendum appended to the system prompt on LiteLLM routes. Keep it
+# a pure constant (no interpolation) — per-session stability is what
+# keeps the cacheable prefix intact across the session's turns. Names
+# only the ``general-purpose`` subagent: the sandbox runtime registers
+# no other AgentDefinition (no ``agents=`` on ClaudeAgentOptions, no
+# ``.claude/agents/*.md``), and naming an unknown type burns a turn on
+# the retry (see ``_EXPLORATION_SUBAGENT_GUIDANCE`` in
+# ``orchestrator/routes/pipelines.py``).
+LITELLM_ROUTE_GUIDANCE: str = """\
+## Working style on this model route (advisory)
+
+This session is routed to a model whose billing re-sends the whole
+conversation every turn — cached tokens are discounted, not free — so
+cost scales with turns × context size. Do the same work in fewer, denser
+steps. None of this changes WHAT you must do, only how many round trips
+it takes:
+
+1. **Batch independent tool calls in one turn.** When several
+   reads/greps/commands do not depend on each other's results, issue
+   them together instead of one per turn.
+2. **Filter command output instead of dumping it.** Pipe long output
+   through `grep`/`head`/`tail` (e.g. `... 2>&1 | tail -50` for a test
+   run), page large files with `offset`/`limit`, and bound searches with
+   `head_limit`. Anything pasted into the conversation is re-billed on
+   every later turn.
+3. **Delegate bulk exploration to a subagent.** For wide file surveys or
+   deep multi-file investigation, use the Agent tool
+   (`subagent_type: general-purpose`) and ask for a focused summary with
+   `file:line` citations — the read bulk stays out of this session's
+   per-turn cost.
+
+These are working-style preferences, not budgets: never skip
+verification, shorten a review, or drop required steps to save turns.
+"""
+
+# Values that disable the addendum, mirroring the EGG_MCP_TOOLS /
+# EGG_TOOL_OUTPUT_CAP kill-switch parsing.
+_DISABLED_VALUES = ("false", "0", "no", "off")
+
+
+def is_route_guidance_disabled() -> bool:
+    """True when the operator disabled the addendum via env."""
+    return os.environ.get("EGG_ROUTE_PROMPT_GUIDANCE", "").strip().lower() in _DISABLED_VALUES
+
+
+def route_guidance_addendum() -> str | None:
+    """Return the addendum for this session's route, or ``None``.
+
+    Non-``None`` only when the pod env signals the LiteLLM route
+    (``ANTHROPIC_CUSTOM_MODEL_OPTION`` set — exported by
+    ``orchestrator.agent_model_resolution.AgentModelDecision.env_vars``)
+    and the operator has not set the kill switch.
+    """
+    if is_route_guidance_disabled():
+        return None
+    if not os.environ.get("ANTHROPIC_CUSTOM_MODEL_OPTION", "").strip():
+        return None
+    return LITELLM_ROUTE_GUIDANCE

--- a/shared/tests/test_client_system_prompt.py
+++ b/shared/tests/test_client_system_prompt.py
@@ -1,0 +1,51 @@
+"""Tests for the shared system-prompt addendum append helper (#3175 review).
+
+``egg_agent.client._append_system_prompt_addendum`` is the single shape
+behind both the MCP-tool ``SYSTEM_PROMPT_NUDGE`` append and the
+LiteLLM-route guidance append. These pin the data-loss-avoidance contract:
+a plain-str prompt is extended, a ``None`` prompt becomes the addendum, and
+the non-string preset / file forms (which have no defined append semantics)
+are preserved unchanged with ``appended=False`` so the caller logs a skip
+rather than silently dropping either the caller's prompt or the addendum.
+"""
+
+from egg_agent.client import _append_system_prompt_addendum
+
+
+class _FakePreset:
+    """Stand-in for SystemPromptPreset / SystemPromptFile (truthy, non-str)."""
+
+
+class TestAppendSystemPromptAddendum:
+    def test_str_prompt_is_extended_after_blank_line(self):
+        new_prompt, appended = _append_system_prompt_addendum("base prompt", "ADD")
+        assert appended is True
+        assert new_prompt == "base prompt\n\nADD"
+
+    def test_trailing_whitespace_stripped_before_join(self):
+        # rstrip keeps the join stable regardless of the caller's trailing
+        # newlines — the cacheable prefix must not wobble on whitespace.
+        new_prompt, appended = _append_system_prompt_addendum("base prompt\n\n  ", "ADD")
+        assert appended is True
+        assert new_prompt == "base prompt\n\nADD"
+
+    def test_none_prompt_becomes_addendum(self):
+        new_prompt, appended = _append_system_prompt_addendum(None, "ADD")
+        assert appended is True
+        assert new_prompt == "ADD"
+
+    def test_empty_str_prompt_becomes_addendum(self):
+        # Empty string is falsy — falls through to the addendum-only branch,
+        # mirroring the inline logic both call sites had before extraction.
+        new_prompt, appended = _append_system_prompt_addendum("", "ADD")
+        assert appended is True
+        assert new_prompt == "ADD"
+
+    def test_preset_prompt_is_preserved_and_skipped(self):
+        # The data-loss-avoidance contract: a preset / file prompt cannot be
+        # appended to, so it is returned unchanged and appended=False signals
+        # the caller (run_agent_async) to log the skip warning.
+        preset = _FakePreset()
+        new_prompt, appended = _append_system_prompt_addendum(preset, "ADD")
+        assert appended is False
+        assert new_prompt is preset

--- a/shared/tests/test_route_guidance.py
+++ b/shared/tests/test_route_guidance.py
@@ -1,0 +1,84 @@
+"""Tests for the LiteLLM-route system-prompt addendum (#3175).
+
+The addendum is appended by ``egg_agent.client.run_agent_async`` only on
+non-Claude routes; these tests pin the env gate and the properties the
+caching design depends on (pure constant, bounded size, names only the
+``general-purpose`` subagent).
+"""
+
+import pytest
+from egg_agent.route_guidance import (
+    LITELLM_ROUTE_GUIDANCE,
+    is_route_guidance_disabled,
+    route_guidance_addendum,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_CUSTOM_MODEL_OPTION", raising=False)
+    monkeypatch.delenv("EGG_ROUTE_PROMPT_GUIDANCE", raising=False)
+
+
+class TestRouteGate:
+    def test_claude_route_gets_no_addendum(self):
+        # ANTHROPIC_CUSTOM_MODEL_OPTION unset = first-party Anthropic route.
+        assert route_guidance_addendum() is None
+
+    def test_blank_route_var_gets_no_addendum(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_CUSTOM_MODEL_OPTION", "   ")
+        assert route_guidance_addendum() is None
+
+    def test_litellm_route_gets_addendum(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_CUSTOM_MODEL_OPTION", "deepseek-v4-pro[1m]")
+        assert route_guidance_addendum() == LITELLM_ROUTE_GUIDANCE
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", "off", "FALSE", " Off "])
+    def test_kill_switch_disables(self, monkeypatch, value):
+        monkeypatch.setenv("ANTHROPIC_CUSTOM_MODEL_OPTION", "deepseek-v4-pro[1m]")
+        monkeypatch.setenv("EGG_ROUTE_PROMPT_GUIDANCE", value)
+        assert is_route_guidance_disabled()
+        assert route_guidance_addendum() is None
+
+    @pytest.mark.parametrize("value", ["", "true", "1", "on", "garbage"])
+    def test_non_disabling_values_keep_addendum(self, monkeypatch, value):
+        monkeypatch.setenv("ANTHROPIC_CUSTOM_MODEL_OPTION", "qwen3-max[1m]")
+        monkeypatch.setenv("EGG_ROUTE_PROMPT_GUIDANCE", value)
+        assert not is_route_guidance_disabled()
+        assert route_guidance_addendum() == LITELLM_ROUTE_GUIDANCE
+
+
+class TestAddendumContent:
+    def test_deterministic(self, monkeypatch):
+        # Per-session stability is the cache-prefix contract: two renders
+        # in the same env must be byte-identical.
+        monkeypatch.setenv("ANTHROPIC_CUSTOM_MODEL_OPTION", "deepseek-v4-pro[1m]")
+        assert route_guidance_addendum() == route_guidance_addendum()
+
+    def test_bounded_size(self):
+        # The addendum rides in the system prompt of every LiteLLM-routed
+        # session; keep it well under the per-event envelope scale so it
+        # never becomes its own context-cost problem.
+        assert len(LITELLM_ROUTE_GUIDANCE.encode("utf-8")) < 2048
+
+    def test_names_only_registered_subagent(self):
+        # The sandbox runtime registers no AgentDefinition beyond the SDK's
+        # built-in general-purpose; naming an unregistered type (e.g.
+        # Explore) burns a turn on the unknown-subagent retry — the exact
+        # waste this addendum exists to remove. Mirrors the constraint on
+        # _EXPLORATION_SUBAGENT_GUIDANCE in orchestrator/routes/pipelines.py.
+        assert "general-purpose" in LITELLM_ROUTE_GUIDANCE
+        assert "Explore" not in LITELLM_ROUTE_GUIDANCE
+
+    def test_core_levers_present(self):
+        # Levers 2 + 4 from #3175 PR 3: batching, output filtering,
+        # subagent-isolated bulk reads.
+        assert "Batch independent tool calls" in LITELLM_ROUTE_GUIDANCE
+        assert "Filter command output" in LITELLM_ROUTE_GUIDANCE
+        assert "subagent" in LITELLM_ROUTE_GUIDANCE
+
+    def test_advisory_not_budget(self):
+        # The guidance must steer working style without licensing skipped
+        # verification — pin the explicit disclaimer.
+        assert "not budgets" in LITELLM_ROUTE_GUIDANCE
+        assert "never skip" in LITELLM_ROUTE_GUIDANCE


### PR DESCRIPTION
PR 3 of the [#3175 plan](https://github.com/jwbron/egg/issues/3175#issuecomment-4695659911) (levers 2 + 4). PR 1 (attribution) and PR 2 (guardrails) are in progress separately.

## What

On non-Claude routes, cost scales with turns × context-size: every SDK turn re-bills the whole conversation at the cached-token rate, and deepseek sessions run 3–5× the Fable turn count for comparable events. This PR appends an **advisory working-style addendum to the system prompt** only when the session is on the LiteLLM route:

1. **Batch independent tool calls** in one turn — divides the turns × context product directly.
2. **Filter, don't dump** — `grep`/`head`/`tail`, `offset`/`limit` paging, `head_limit` — complements PR 2's truncation guardrails by avoiding the dump in the first place.
3. **Delegate bulk exploration to a subagent** (`subagent_type: general-purpose`) so the read bulk never enters the parent session's per-turn re-bill.

Explicitly framed as preferences, not budgets — never skip verification or shorten a review to save turns.

## How

- New `shared/egg_agent/route_guidance.py`: the addendum as a **pure constant** plus an env-gated helper. Route detection is `ANTHROPIC_CUSTOM_MODEL_OPTION` — the same signal the DDG web-tool fallback uses (#2856), exported by `AgentModelDecision.env_vars()` on LiteLLM routes only.
- `shared/egg_agent/client.py` appends it to `options.system_prompt` with the same plain-str semantics as `SYSTEM_PROMPT_NUDGE`.
- Kill switch: `EGG_ROUTE_PROMPT_GUIDANCE=false`.

### Why the SDK client, not the role-prompt builders or the entrypoint

- **Coverage**: the event-pump architecture means most agent turns come from per-event one-shot prompts (`event_prompt.py`), not the spawn-time role prompts — a role-prompt-builder addendum would miss them. `run_agent_async` is the one choke point every invocation passes through.
- k8s pods bypass `sandbox/entrypoint.py` (override the image ENTRYPOINT), so entrypoint-side injection wouldn't fire where the cost is.
- **Cache safety**: the addendum is a constant gated only on pod-lifetime env, so the rendered system prompt is byte-stable per session — the cacheable prefix is unaffected. Claude-route sessions are untouched.
- The guidance names only `general-purpose` — the sandbox registers no other AgentDefinition, and naming an unregistered type (e.g. `Explore`) burns a turn on the unknown-subagent retry (mirrors `_EXPLORATION_SUBAGENT_GUIDANCE` in `pipelines.py`).

## Targeting note

The issue sequenced this after PR 1's attribution data identifies which roles dominate spend. This applies the addendum uniformly to all roles on LiteLLM routes — it's advisory and role-neutral, so uniform application is the safe default; per-role targeting (or exclusion, if the audit shows event-pump re-invocation overhead rather than agent behavior) can ride on top once the PR 1 logs are in.

## Verification

- 19 unit tests in `shared/tests/test_route_guidance.py`: env gate (route signal, kill-switch parsing), determinism, ≤2 KiB size bound, no-`Explore` constraint, advisory-not-budget disclaimer.
- Live verification uses PR 1's logs: per-role turn counts and cumulative prompt tokens on LiteLLM routes should drop vs. the #3064 slice-3 baseline with unchanged review/consensus outcomes.

Closes nothing on its own — third leg of #3175.