### PR TITLE
Inject context guardrails on agent spawns, tighter on LiteLLM routes (#3175 PR 2)

### DIFF
--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -270,37 +270,47 @@ agent's `--model` flag to `<upstream>[1m]` for the standard ≥1M case
 ``--model``-keyed pathway also routes through the custom-model
 registration.
 
-## Context guardrails on the LiteLLM path (#3175)
+## Context guardrails (#3175)
 
-On the LiteLLM path every SDK turn re-sends the whole conversation and
-cached tokens bill at a discounted-but-nonzero rate, so a single tool
-call that dumps tens of kilotokens (a verbose `pytest -v`, a
-whole-megafile Read, an unbounded MCP result) is re-billed on every
-subsequent turn for the life of the session. `env_vars()` therefore
-injects three size caps on LiteLLM decisions only — Claude-routed
-spawns carry none of them, so the Claude path's tool behavior is
-unchanged:
+Every SDK turn re-sends the whole conversation, and cached tokens bill
+at a discounted-but-nonzero rate on **every** route (~10% of input
+price on Anthropic; a comparable blended rate on LiteLLM upstreams) —
+so a single tool call that dumps tens of kilotokens (a verbose
+`pytest -v`, a whole-megafile Read, an unbounded MCP result) is
+re-billed on every subsequent turn for the life of the session.
+`env_vars()` therefore injects size caps on every decision; the
+LiteLLM path — where turn counts run 3–5× the Claude baseline,
+multiplying the re-bill — additionally gets a tighter Read cap:
 
-| Sandbox env var | Default | Unit | What it bounds |
-|---|---|---|---|
-| `BASH_MAX_OUTPUT_LENGTH` | `20000` | characters | Claude Code's built-in Bash-result truncation; oversized output is saved to a session file and the agent gets the path plus a preview |
-| `EGG_READ_CAP_BYTES` | `65536` | bytes | the predictive whole-file-Read deny in `shared/egg_agent/tool_output_cap.py` — a quarter of the 256 KiB Claude-route default, pushing big files toward `offset`/`limit` paging |
-| `MAX_MCP_OUTPUT_TOKENS` | `15000` | tokens | Claude Code's MCP-result cap (built-in default 25k); excess is persisted to disk and replaced with a file reference |
+| Sandbox env var | Default | Unit | Routes | What it bounds |
+|---|---|---|---|---|
+| `BASH_MAX_OUTPUT_LENGTH` | `20000` | characters | all | Claude Code's built-in Bash-result truncation; oversized output is saved to a session file and the agent gets the path plus a preview |
+| `MAX_MCP_OUTPUT_TOKENS` | `15000` | tokens | all | Claude Code's MCP-result cap (built-in default 25k); excess is persisted to disk and replaced with a file reference |
+| `EGG_READ_CAP_BYTES` | `65536` | bytes | LiteLLM only | the predictive whole-file-Read deny in `shared/egg_agent/tool_output_cap.py` — a quarter of its built-in 256 KiB default (which continues to guard the Claude route), pushing big files toward `offset`/`limit` paging |
 
 These are **guardrails, not constraints**: the thresholds are sized so
-normal work never hits them, and every cap carries its own remedy (the
-spill file for Bash/MCP, the paging remedy in the Read-cap deny
-message), so the agent always has a path to the same information.
+normal work never hits them, and every cap is overridable by the agent
+itself when it deliberately needs more:
 
-Operators override a value by setting the matching
-`EGG_LITELLM_`-prefixed variable on the **orchestrator**
-(`EGG_LITELLM_BASH_MAX_OUTPUT_LENGTH`, `EGG_LITELLM_READ_CAP_BYTES`,
-`EGG_LITELLM_MAX_MCP_OUTPUT_TOKENS`). Setting one to the empty string
+- **Bash / MCP** — the full output is spilled to a file whose path the
+  agent receives, so nothing is ever unreachable; the agent reads,
+  greps, or tails the spill file (or pipes the command to a file
+  itself).
+- **Read** — the deny message names an agent-writable override file
+  (`/tmp/egg-read-cap-bytes`): the agent writes the byte size it needs
+  and retries. The file is pod-local and outside the repo worktree, so
+  the override can never be committed and dies with the pod.
+- **Grep** — the content-mode deny only fires with no `head_limit` at
+  all; a deliberate large `head_limit` passes.
+
+Operators override the injected values on the **orchestrator** via
+`EGG_AGENT_BASH_MAX_OUTPUT_LENGTH`, `EGG_AGENT_MAX_MCP_OUTPUT_TOKENS`,
+and `EGG_LITELLM_READ_CAP_BYTES`. Setting one to the empty string
 omits that guardrail from the injection entirely; an unparseable or
 non-positive value logs a warning and falls back to the default. The
 override names are deliberately distinct from the sandbox-side names so
 a value in the orchestrator's own environment is never forwarded by
-accident. See `litellm_context_guardrail_env()` in
+accident. See `context_guardrail_env()` in
 `orchestrator/agent_model_resolution.py`.
 
 > **Capability env vars (`MAX_THINKING_TOKENS`,

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -270,6 +270,39 @@ agent's `--model` flag to `<upstream>[1m]` for the standard ≥1M case
 ``--model``-keyed pathway also routes through the custom-model
 registration.
 
+## Context guardrails on the LiteLLM path (#3175)
+
+On the LiteLLM path every SDK turn re-sends the whole conversation and
+cached tokens bill at a discounted-but-nonzero rate, so a single tool
+call that dumps tens of kilotokens (a verbose `pytest -v`, a
+whole-megafile Read, an unbounded MCP result) is re-billed on every
+subsequent turn for the life of the session. `env_vars()` therefore
+injects three size caps on LiteLLM decisions only — Claude-routed
+spawns carry none of them, so the Claude path's tool behavior is
+unchanged:
+
+| Sandbox env var | Default | Unit | What it bounds |
+|---|---|---|---|
+| `BASH_MAX_OUTPUT_LENGTH` | `20000` | characters | Claude Code's built-in Bash-result truncation; oversized output is saved to a session file and the agent gets the path plus a preview |
+| `EGG_READ_CAP_BYTES` | `65536` | bytes | the predictive whole-file-Read deny in `shared/egg_agent/tool_output_cap.py` — a quarter of the 256 KiB Claude-route default, pushing big files toward `offset`/`limit` paging |
+| `MAX_MCP_OUTPUT_TOKENS` | `15000` | tokens | Claude Code's MCP-result cap (built-in default 25k); excess is persisted to disk and replaced with a file reference |
+
+These are **guardrails, not constraints**: the thresholds are sized so
+normal work never hits them, and every cap carries its own remedy (the
+spill file for Bash/MCP, the paging remedy in the Read-cap deny
+message), so the agent always has a path to the same information.
+
+Operators override a value by setting the matching
+`EGG_LITELLM_`-prefixed variable on the **orchestrator**
+(`EGG_LITELLM_BASH_MAX_OUTPUT_LENGTH`, `EGG_LITELLM_READ_CAP_BYTES`,
+`EGG_LITELLM_MAX_MCP_OUTPUT_TOKENS`). Setting one to the empty string
+omits that guardrail from the injection entirely; an unparseable or
+non-positive value logs a warning and falls back to the default. The
+override names are deliberately distinct from the sandbox-side names so
+a value in the orchestrator's own environment is never forwarded by
+accident. See `litellm_context_guardrail_env()` in
+`orchestrator/agent_model_resolution.py`.
+
 > **Capability env vars (`MAX_THINKING_TOKENS`,
 > `ANTHROPIC_CUSTOM_MODEL_OPTION_SUPPORTED_CAPABILITIES`).** Not set
 > by default — clamping them to zero/empty maximises cost savings

--- a/orchestrator/agent_model_resolution.py
+++ b/orchestrator/agent_model_resolution.py
@@ -41,6 +41,7 @@ test paths without further plumbing.
 from __future__ import annotations
 
 import logging
+import os
 import re
 from dataclasses import dataclass
 
@@ -137,6 +138,82 @@ _CLAUDE_EXACT_ALIASES = frozenset(
 )
 _CLAUDE_VERSIONED_RE = re.compile(r"^claude-")
 
+# Context guardrails for LiteLLM-routed agents (#3175). On the LiteLLM
+# path every SDK turn re-sends the whole conversation and cached tokens
+# bill at a discounted-but-nonzero rate, so one careless tool call that
+# dumps tens of kilotokens (verbose ``pytest -v``, a whole-megafile
+# Read, an unbounded MCP result) is re-billed on every subsequent turn
+# for the life of the session. These caps bound the size a single tool
+# result can park in the conversation. They are guardrails, not
+# constraints: thresholds are sized so normal work never hits them, and
+# every cap carries its own remedy — Claude Code spills oversized Bash
+# and MCP results to a file the agent can Read/grep, and the Read cap's
+# deny message points at ``offset``/``limit`` paging
+# (``shared/egg_agent/tool_output_cap.py``).
+#
+# Tuple shape: (sandbox env var, orchestrator-side override env var,
+# default). Operators override a value by setting the
+# ``EGG_LITELLM_``-prefixed variable on the orchestrator; setting it to
+# the empty string omits that guardrail from the injection entirely.
+# The override names are deliberately distinct from the sandbox-side
+# names so a value in the orchestrator's own environment (e.g. a dev
+# running it under Claude Code) is never forwarded by accident.
+#
+# Defaults:
+# - ``BASH_MAX_OUTPUT_LENGTH`` (characters): Claude Code's built-in
+#   post-hoc Bash truncation — oversized output is saved to a session
+#   file and the agent gets the path plus a preview. 20k chars ≈ 5k
+#   tokens per result.
+# - ``EGG_READ_CAP_BYTES`` (bytes): predictive whole-file-Read deny in
+#   ``tool_output_cap.py``; 64 KiB ≈ 16k tokens, a quarter of the
+#   256 KiB Claude-route default, pushing big files toward paging.
+# - ``MAX_MCP_OUTPUT_TOKENS`` (tokens): Claude Code's MCP result cap
+#   (built-in default 25k); excess is persisted to disk and replaced
+#   with a file reference.
+_LITELLM_CONTEXT_GUARDRAILS: tuple[tuple[str, str, str], ...] = (
+    ("BASH_MAX_OUTPUT_LENGTH", "EGG_LITELLM_BASH_MAX_OUTPUT_LENGTH", "20000"),
+    ("EGG_READ_CAP_BYTES", "EGG_LITELLM_READ_CAP_BYTES", str(64 * 1024)),
+    ("MAX_MCP_OUTPUT_TOKENS", "EGG_LITELLM_MAX_MCP_OUTPUT_TOKENS", "15000"),
+)
+
+
+def litellm_context_guardrail_env() -> dict[str, str]:
+    """Context-guardrail env vars for a LiteLLM-routed agent (#3175).
+
+    Reads the operator overrides from the orchestrator's environment on
+    every call (spawn-frequency, so no caching) and validates each as a
+    positive integer — an unparseable or non-positive override logs a
+    warning and falls back to the built-in default rather than
+    forwarding garbage the sandbox would misread. An empty-string
+    override opts that guardrail out entirely.
+    """
+    env: dict[str, str] = {}
+    for target, override, default in _LITELLM_CONTEXT_GUARDRAILS:
+        raw = os.environ.get(override)
+        if raw is None:
+            env[target] = default
+            continue
+        value = raw.strip()
+        if not value:
+            # Explicit per-guardrail opt-out: don't inject the var, so the
+            # sandbox keeps Claude Code's (or tool_output_cap's) own default.
+            continue
+        try:
+            if int(value) <= 0:
+                raise ValueError(value)
+        except ValueError:
+            logger.warning(
+                "Ignoring %s=%r: expected a positive integer (or empty to "
+                "opt out); falling back to the default %s=%s. See #3175.",
+                override,
+                raw,
+                target,
+                default,
+            )
+            value = default
+        env[target] = value
+    return env
+
 
 @dataclass(frozen=True)
 class AgentModelDecision:
@@ -213,6 +290,15 @@ class AgentModelDecision:
           rather than the ``[1m]`` alias: these vars are documented to
           take a model name and the ``[1m]`` suffix is read per-variable,
           and small/fast helper calls don't need the 1M window.
+
+        LiteLLM-routed agents additionally get the context guardrails
+        from :func:`litellm_context_guardrail_env` (#3175) — per-turn
+        re-billing of the full conversation makes a single oversized
+        tool result disproportionately expensive on this path, so
+        Bash/Read/MCP result sizes are bounded (with built-in remedies;
+        see the guardrail table's comment). Claude-routed spawns are
+        untouched: this method returns an empty dict there, so the
+        Claude wire shape and tool behavior stay identical to today.
         """
         if self.upstream == UPSTREAM_ANTHROPIC or self.upstream_model is None:
             return {}
@@ -223,6 +309,7 @@ class AgentModelDecision:
             "CLAUDE_CODE_SUBAGENT_MODEL": self.claude_code_alias,
             "ANTHROPIC_DEFAULT_HAIKU_MODEL": self.upstream_model,
             "ANTHROPIC_SMALL_FAST_MODEL": self.upstream_model,
+            **litellm_context_guardrail_env(),
         }
 
 
@@ -362,5 +449,6 @@ __all__ = [
     "UPSTREAM_ANTHROPIC",
     "UPSTREAM_LITELLM",
     "classify_model",
+    "litellm_context_guardrail_env",
     "resolve_agent_model",
 ]

--- a/orchestrator/agent_model_resolution.py
+++ b/orchestrator/agent_model_resolution.py
@@ -138,57 +138,71 @@ _CLAUDE_EXACT_ALIASES = frozenset(
 )
 _CLAUDE_VERSIONED_RE = re.compile(r"^claude-")
 
-# Context guardrails for LiteLLM-routed agents (#3175). On the LiteLLM
-# path every SDK turn re-sends the whole conversation and cached tokens
-# bill at a discounted-but-nonzero rate, so one careless tool call that
-# dumps tens of kilotokens (verbose ``pytest -v``, a whole-megafile
-# Read, an unbounded MCP result) is re-billed on every subsequent turn
-# for the life of the session. These caps bound the size a single tool
-# result can park in the conversation. They are guardrails, not
-# constraints: thresholds are sized so normal work never hits them, and
-# every cap carries its own remedy — Claude Code spills oversized Bash
-# and MCP results to a file the agent can Read/grep, and the Read cap's
-# deny message points at ``offset``/``limit`` paging
+# Context guardrails for agent spawns (#3175). Every SDK turn re-sends
+# the whole conversation, and cached tokens bill at a
+# discounted-but-nonzero rate on every route (~10% of the input price
+# on Anthropic; a comparable blended rate on LiteLLM upstreams), so one
+# careless tool call that dumps tens of kilotokens (verbose ``pytest
+# -v``, a whole-megafile Read, an unbounded MCP result) is re-billed on
+# every subsequent turn for the life of the session. These caps bound
+# the size a single tool result can park in the conversation. They are
+# guardrails, not constraints: thresholds are sized so normal work
+# never hits them, and every cap carries its own remedy — Claude Code
+# spills oversized Bash and MCP results to a file the agent can
+# Read/grep, and the Read cap's deny message points at
+# ``offset``/``limit`` paging plus an agent-writable override file
 # (``shared/egg_agent/tool_output_cap.py``).
 #
 # Tuple shape: (sandbox env var, orchestrator-side override env var,
-# default). Operators override a value by setting the
-# ``EGG_LITELLM_``-prefixed variable on the orchestrator; setting it to
-# the empty string omits that guardrail from the injection entirely.
-# The override names are deliberately distinct from the sandbox-side
-# names so a value in the orchestrator's own environment (e.g. a dev
-# running it under Claude Code) is never forwarded by accident.
+# default). Operators override a value by setting the override variable
+# on the orchestrator; setting it to the empty string omits that
+# guardrail from the injection entirely. The override names are
+# deliberately distinct from the sandbox-side names so a value in the
+# orchestrator's own environment (e.g. a dev running it under Claude
+# Code) is never forwarded by accident.
 #
-# Defaults:
+# The Bash and MCP caps apply to EVERY route — the dump arithmetic is
+# route-independent; only the multiplier differs:
 # - ``BASH_MAX_OUTPUT_LENGTH`` (characters): Claude Code's built-in
 #   post-hoc Bash truncation — oversized output is saved to a session
 #   file and the agent gets the path plus a preview. 20k chars ≈ 5k
 #   tokens per result.
-# - ``EGG_READ_CAP_BYTES`` (bytes): predictive whole-file-Read deny in
-#   ``tool_output_cap.py``; 64 KiB ≈ 16k tokens, a quarter of the
-#   256 KiB Claude-route default, pushing big files toward paging.
 # - ``MAX_MCP_OUTPUT_TOKENS`` (tokens): Claude Code's MCP result cap
 #   (built-in default 25k); excess is persisted to disk and replaced
 #   with a file reference.
-_LITELLM_CONTEXT_GUARDRAILS: tuple[tuple[str, str, str], ...] = (
-    ("BASH_MAX_OUTPUT_LENGTH", "EGG_LITELLM_BASH_MAX_OUTPUT_LENGTH", "20000"),
+_CONTEXT_GUARDRAILS: tuple[tuple[str, str, str], ...] = (
+    ("BASH_MAX_OUTPUT_LENGTH", "EGG_AGENT_BASH_MAX_OUTPUT_LENGTH", "20000"),
+    ("MAX_MCP_OUTPUT_TOKENS", "EGG_AGENT_MAX_MCP_OUTPUT_TOKENS", "15000"),
+)
+
+# LiteLLM-only extra: a tighter Read cap. The predictive whole-file-Read
+# deny in ``tool_output_cap.py`` already guards every route at its
+# built-in 256 KiB default; on the LiteLLM path — where turn counts run
+# 3-5x the Claude baseline, multiplying the re-bill — this pushes big
+# files toward paging earlier (64 KiB ≈ 16k tokens). The Claude route
+# deliberately keeps the 256 KiB default rather than getting this var.
+_LITELLM_EXTRA_GUARDRAILS: tuple[tuple[str, str, str], ...] = (
     ("EGG_READ_CAP_BYTES", "EGG_LITELLM_READ_CAP_BYTES", str(64 * 1024)),
-    ("MAX_MCP_OUTPUT_TOKENS", "EGG_LITELLM_MAX_MCP_OUTPUT_TOKENS", "15000"),
 )
 
 
-def litellm_context_guardrail_env() -> dict[str, str]:
-    """Context-guardrail env vars for a LiteLLM-routed agent (#3175).
+def context_guardrail_env(upstream: str) -> dict[str, str]:
+    """Context-guardrail env vars for an agent spawn (#3175).
 
-    Reads the operator overrides from the orchestrator's environment on
-    every call (spawn-frequency, so no caching) and validates each as a
-    positive integer — an unparseable or non-positive override logs a
-    warning and falls back to the built-in default rather than
-    forwarding garbage the sandbox would misread. An empty-string
-    override opts that guardrail out entirely.
+    Returns the route-independent Bash/MCP caps for every *upstream*,
+    plus the tighter Read cap on the LiteLLM path. Reads the operator
+    overrides from the orchestrator's environment on every call
+    (spawn-frequency, so no caching) and validates each as a positive
+    integer — an unparseable or non-positive override logs a warning
+    and falls back to the built-in default rather than forwarding
+    garbage the sandbox would misread. An empty-string override opts
+    that guardrail out entirely.
     """
+    guardrails = _CONTEXT_GUARDRAILS
+    if upstream == UPSTREAM_LITELLM:
+        guardrails = guardrails + _LITELLM_EXTRA_GUARDRAILS
     env: dict[str, str] = {}
-    for target, override, default in _LITELLM_CONTEXT_GUARDRAILS:
+    for target, override, default in guardrails:
         raw = os.environ.get(override)
         if raw is None:
             env[target] = default
@@ -262,8 +276,8 @@ class AgentModelDecision:
         ``ANTHROPIC_CUSTOM_MODEL_OPTION``, not this var. LiteLLM-routed
         agents talk to the gateway, not anthropic.com, and the gateway
         injects its own credentials at proxy time. The Anthropic path
-        returns an empty dict so default-Claude spawns carry no extra
-        env (the existing pre-#2832 wire shape).
+        carries none of these registration vars, so default-Claude
+        spawns keep the pre-#2832 wire shape.
 
         We also redirect the other two resolution paths that would
         otherwise emit a Claude model name the LiteLLM proxy can't
@@ -291,17 +305,19 @@ class AgentModelDecision:
           take a model name and the ``[1m]`` suffix is read per-variable,
           and small/fast helper calls don't need the 1M window.
 
-        LiteLLM-routed agents additionally get the context guardrails
-        from :func:`litellm_context_guardrail_env` (#3175) — per-turn
-        re-billing of the full conversation makes a single oversized
-        tool result disproportionately expensive on this path, so
-        Bash/Read/MCP result sizes are bounded (with built-in remedies;
-        see the guardrail table's comment). Claude-routed spawns are
-        untouched: this method returns an empty dict there, so the
-        Claude wire shape and tool behavior stay identical to today.
+        Every route additionally gets the context guardrails from
+        :func:`context_guardrail_env` (#3175) — per-turn re-billing of
+        the full conversation makes a single oversized tool result
+        disproportionately expensive on any route, so Bash/MCP result
+        sizes are bounded everywhere (with built-in remedies; see the
+        guardrail table's comment), and the LiteLLM path adds a tighter
+        Read cap on top. The Anthropic path therefore no longer returns
+        an empty dict (the pre-#3175 shape): it carries exactly the
+        Bash/MCP guardrails and none of the custom-model registration,
+        so the Claude *wire* shape is unchanged.
         """
         if self.upstream == UPSTREAM_ANTHROPIC or self.upstream_model is None:
-            return {}
+            return context_guardrail_env(self.upstream)
         return {
             "ANTHROPIC_CUSTOM_MODEL_OPTION": self.claude_code_alias,
             "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME": self.upstream_model,
@@ -309,7 +325,7 @@ class AgentModelDecision:
             "CLAUDE_CODE_SUBAGENT_MODEL": self.claude_code_alias,
             "ANTHROPIC_DEFAULT_HAIKU_MODEL": self.upstream_model,
             "ANTHROPIC_SMALL_FAST_MODEL": self.upstream_model,
-            **litellm_context_guardrail_env(),
+            **context_guardrail_env(self.upstream),
         }
 
 
@@ -449,6 +465,6 @@ __all__ = [
     "UPSTREAM_ANTHROPIC",
     "UPSTREAM_LITELLM",
     "classify_model",
-    "litellm_context_guardrail_env",
+    "context_guardrail_env",
     "resolve_agent_model",
 ]

--- a/orchestrator/concurrent_executor.py
+++ b/orchestrator/concurrent_executor.py
@@ -468,9 +468,10 @@ class ConcurrentPhaseExecutor:
             )
 
         # On the LiteLLM path Claude Code needs the ANTHROPIC_CUSTOM_MODEL_OPTION
-        # env vars to opt into 1M-context compaction math (#2832). The decision's
-        # ``env_vars()`` is empty on the Anthropic path, so default-Claude spawns
-        # carry no extra env — the pre-#2832 wire shape.
+        # env vars to opt into 1M-context compaction math (#2832). Every route
+        # also picks up the context-guardrail caps (#3175); the Anthropic path
+        # carries only those — no custom-model registration — so the Claude
+        # wire shape is unchanged.
         env = {**env, **decision.env_vars()}
 
         # Forward the upstream/upstream_model kwargs to the spawner only

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2974,12 +2974,13 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
         restart_upstream_kwargs["upstream"] = _model_decision.upstream
         restart_upstream_kwargs["upstream_model"] = _model_decision.upstream_model
 
-    # Merge ANTHROPIC_CUSTOM_MODEL_OPTION env vars on the LiteLLM path (#2832)
-    # so the restarted agent registers the custom model exactly like the
-    # initial spawn did. Empty on the Anthropic path.
-    decision_env = _model_decision.env_vars()
-    if decision_env:
-        extra_env = {**extra_env, **decision_env}
+    # Merge the model-decision env vars so the restarted agent matches the
+    # initial spawn. On the LiteLLM path these include the
+    # ANTHROPIC_CUSTOM_MODEL_OPTION vars (#2832) for custom-model registration;
+    # every route also picks up the context-guardrail caps (#3175), so this is
+    # non-empty on the Anthropic path too — restarted Anthropic agents inherit
+    # the same guardrails as the initial spawn (matches concurrent_executor).
+    extra_env = {**extra_env, **_model_decision.env_vars()}
 
     try:
         spawned = spawner.restart_agent_container(

--- a/orchestrator/tests/test_agent_model_resolution.py
+++ b/orchestrator/tests/test_agent_model_resolution.py
@@ -92,22 +92,27 @@ def _pipeline_config(**overrides):
     return PipelineConfig(**overrides)
 
 
-# Built-in defaults of the LiteLLM-path context guardrails (#3175),
-# mirrored from ``_LITELLM_CONTEXT_GUARDRAILS``. Every LiteLLM decision's
-# ``env_vars()`` carries these alongside the custom-model registration.
+# Built-in defaults of the context guardrails (#3175), mirrored from
+# ``_CONTEXT_GUARDRAILS`` / ``_LITELLM_EXTRA_GUARDRAILS``. The Bash/MCP
+# caps ride on EVERY decision's ``env_vars()`` (the dump arithmetic is
+# route-independent); the tighter Read cap is LiteLLM-only (the Claude
+# route keeps tool_output_cap's built-in 256 KiB default).
 _GUARDRAIL_DEFAULTS = {
     "BASH_MAX_OUTPUT_LENGTH": "20000",
-    "EGG_READ_CAP_BYTES": "65536",
     "MAX_MCP_OUTPUT_TOKENS": "15000",
+}
+_LITELLM_GUARDRAIL_DEFAULTS = {
+    **_GUARDRAIL_DEFAULTS,
+    "EGG_READ_CAP_BYTES": "65536",
 }
 
 # Orchestrator-side override knobs for the guardrails — cleared in tests
 # that assert exact env shapes so a value in the developer's own
 # environment can't skew the expectation.
 _GUARDRAIL_OVERRIDE_VARS = (
-    "EGG_LITELLM_BASH_MAX_OUTPUT_LENGTH",
+    "EGG_AGENT_BASH_MAX_OUTPUT_LENGTH",
+    "EGG_AGENT_MAX_MCP_OUTPUT_TOKENS",
     "EGG_LITELLM_READ_CAP_BYTES",
-    "EGG_LITELLM_MAX_MCP_OUTPUT_TOKENS",
 )
 
 
@@ -420,10 +425,10 @@ class TestLiteLLMClassification:
         need the 1M window).
 
         Since #3175 the LiteLLM env also carries the context guardrails
-        (``BASH_MAX_OUTPUT_LENGTH`` / ``EGG_READ_CAP_BYTES`` /
-        ``MAX_MCP_OUTPUT_TOKENS``) — per-turn re-billing of the full
-        conversation makes a single oversized tool result
-        disproportionately expensive on this path.
+        (``BASH_MAX_OUTPUT_LENGTH`` / ``MAX_MCP_OUTPUT_TOKENS`` plus the
+        LiteLLM-only ``EGG_READ_CAP_BYTES`` tightening) — per-turn
+        re-billing of the full conversation makes a single oversized
+        tool result disproportionately expensive.
         """
         _clear_guardrail_overrides(monkeypatch)
         resolve_agent_model = _resolver()
@@ -440,13 +445,17 @@ class TestLiteLLMClassification:
             "CLAUDE_CODE_SUBAGENT_MODEL": "qwen3-coder-30b[1m]",
             "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3-coder-30b",
             "ANTHROPIC_SMALL_FAST_MODEL": "qwen3-coder-30b",
-            **_GUARDRAIL_DEFAULTS,
+            **_LITELLM_GUARDRAIL_DEFAULTS,
         }
 
-    def test_anthropic_env_vars_empty(self):
-        """Default Anthropic path MUST inject no extra env so today's
-        spawn shape stays byte-identical to the pre-#2832 wire.
+    def test_anthropic_env_vars_carry_only_guardrails(self, monkeypatch):
+        """The default Anthropic path carries exactly the route-independent
+        Bash/MCP context guardrails (#3175) and none of the custom-model
+        registration vars — so the Claude *wire* shape stays identical to
+        the pre-#2832 spawn, and the Read cap keeps tool_output_cap's
+        built-in 256 KiB default (no ``EGG_READ_CAP_BYTES``).
         """
+        _clear_guardrail_overrides(monkeypatch)
         resolve_agent_model = _resolver()
         AgentRole = _agent_role()
         config = _pipeline_config()
@@ -454,7 +463,7 @@ class TestLiteLLMClassification:
         with patch("config.repo_config.get_default_agent_model", return_value=None):
             d = resolve_agent_model(AgentRole.CODER, config, None)
 
-        assert d.env_vars() == {}
+        assert d.env_vars() == _GUARDRAIL_DEFAULTS
 
 
 class TestSubOneMContextModels:
@@ -521,7 +530,7 @@ class TestSubOneMContextModels:
             "CLAUDE_CODE_SUBAGENT_MODEL": model,
             "ANTHROPIC_DEFAULT_HAIKU_MODEL": model,
             "ANTHROPIC_SMALL_FAST_MODEL": model,
-            **_GUARDRAIL_DEFAULTS,
+            **_LITELLM_GUARDRAIL_DEFAULTS,
         }
 
     @pytest.mark.parametrize("model", ["deepseek-v4-flash", "deepseek-v4-pro", "qwen3.7-max"])
@@ -602,20 +611,21 @@ class TestSubOneMContextModels:
 
 
 # =============================================================================
-# LiteLLM-path context guardrails (#3175)
+# Context guardrails (#3175)
 # =============================================================================
 
 
-class TestLiteLLMContextGuardrails:
-    """Route-aware context guardrails (#3175 PR 2).
+class TestContextGuardrails:
+    """Context guardrails on agent spawns (#3175 PR 2).
 
-    On the LiteLLM path every turn re-bills the whole conversation at
-    the cached rate, so a single oversized tool result (verbose
-    ``pytest -v``, whole-megafile Read, unbounded MCP result) keeps
-    costing for the life of the session. ``env_vars()`` therefore
-    injects ``BASH_MAX_OUTPUT_LENGTH`` / ``EGG_READ_CAP_BYTES`` /
-    ``MAX_MCP_OUTPUT_TOKENS`` on LiteLLM decisions only —
-    Claude-routed spawns must stay byte-identical to today.
+    Every turn re-bills the whole conversation at the cached rate — on
+    every route; Anthropic cache reads are ~10% of input price — so a
+    single oversized tool result (verbose ``pytest -v``, whole-megafile
+    Read, unbounded MCP result) keeps costing for the life of the
+    session. ``env_vars()`` injects ``BASH_MAX_OUTPUT_LENGTH`` /
+    ``MAX_MCP_OUTPUT_TOKENS`` on every decision; the LiteLLM path adds
+    a tighter ``EGG_READ_CAP_BYTES`` (the Claude route keeps
+    tool_output_cap's built-in 256 KiB default).
     """
 
     @pytest.fixture(autouse=True)
@@ -628,19 +638,30 @@ class TestLiteLLMContextGuardrails:
 
         return classify_model("deepseek-v4-pro")
 
-    def test_litellm_decision_carries_guardrail_defaults(self):
+    def _anthropic_decision(self):
+        from agent_model_resolution import classify_model
+
+        return classify_model("opus")
+
+    def test_litellm_decision_carries_all_guardrail_defaults(self):
         env = self._litellm_decision().env_vars()
+        for var, default in _LITELLM_GUARDRAIL_DEFAULTS.items():
+            assert env.get(var) == default
+
+    def test_anthropic_decision_carries_bash_and_mcp_caps(self):
+        env = self._anthropic_decision().env_vars()
         for var, default in _GUARDRAIL_DEFAULTS.items():
             assert env.get(var) == default
 
-    def test_anthropic_decision_carries_no_guardrails(self):
-        """Claude-route spawns are explicitly out of scope for #3175 —
-        their env must stay empty even with operator overrides set.
+    def test_anthropic_decision_skips_read_cap_tightening(self):
+        """The Read tightening is deliberately LiteLLM-only: the Claude
+        route already runs tool_output_cap's predictive Read cap at its
+        built-in 256 KiB default, and injecting the 64 KiB value would
+        tighten production-route behavior 4x — even an operator override
+        of the LiteLLM knob must not leak across routes.
         """
-        from agent_model_resolution import classify_model
-
         self.monkeypatch.setenv("EGG_LITELLM_READ_CAP_BYTES", "1024")
-        assert classify_model("opus").env_vars() == {}
+        assert "EGG_READ_CAP_BYTES" not in self._anthropic_decision().env_vars()
 
     def test_operator_override_respected(self):
         self.monkeypatch.setenv("EGG_LITELLM_READ_CAP_BYTES", "131072")
@@ -650,16 +671,21 @@ class TestLiteLLMContextGuardrails:
         assert env["BASH_MAX_OUTPUT_LENGTH"] == _GUARDRAIL_DEFAULTS["BASH_MAX_OUTPUT_LENGTH"]
         assert env["MAX_MCP_OUTPUT_TOKENS"] == _GUARDRAIL_DEFAULTS["MAX_MCP_OUTPUT_TOKENS"]
 
+    def test_bash_mcp_overrides_apply_to_both_routes(self):
+        self.monkeypatch.setenv("EGG_AGENT_BASH_MAX_OUTPUT_LENGTH", "30000")
+        for decision in (self._litellm_decision(), self._anthropic_decision()):
+            assert decision.env_vars()["BASH_MAX_OUTPUT_LENGTH"] == "30000"
+
     def test_empty_override_opts_guardrail_out(self):
-        """An empty-string override omits that var entirely, so the
-        sandbox falls back to Claude Code's (or tool_output_cap's) own
-        default — the per-guardrail kill switch.
+        """An empty-string override omits that var entirely — on both
+        routes — so the sandbox falls back to Claude Code's (or
+        tool_output_cap's) own default; the per-guardrail kill switch.
         """
-        self.monkeypatch.setenv("EGG_LITELLM_BASH_MAX_OUTPUT_LENGTH", "")
-        env = self._litellm_decision().env_vars()
-        assert "BASH_MAX_OUTPUT_LENGTH" not in env
-        assert env["EGG_READ_CAP_BYTES"] == _GUARDRAIL_DEFAULTS["EGG_READ_CAP_BYTES"]
-        assert env["MAX_MCP_OUTPUT_TOKENS"] == _GUARDRAIL_DEFAULTS["MAX_MCP_OUTPUT_TOKENS"]
+        self.monkeypatch.setenv("EGG_AGENT_BASH_MAX_OUTPUT_LENGTH", "")
+        for decision in (self._litellm_decision(), self._anthropic_decision()):
+            env = decision.env_vars()
+            assert "BASH_MAX_OUTPUT_LENGTH" not in env
+            assert env["MAX_MCP_OUTPUT_TOKENS"] == _GUARDRAIL_DEFAULTS["MAX_MCP_OUTPUT_TOKENS"]
 
     @pytest.mark.parametrize("bad", ["not-a-number", "64kb", "0", "-5"])
     def test_invalid_override_warns_and_falls_back(self, bad, caplog):
@@ -670,13 +696,13 @@ class TestLiteLLMContextGuardrails:
         """
         import logging
 
-        self.monkeypatch.setenv("EGG_LITELLM_MAX_MCP_OUTPUT_TOKENS", bad)
+        self.monkeypatch.setenv("EGG_AGENT_MAX_MCP_OUTPUT_TOKENS", bad)
         with caplog.at_level(logging.WARNING, logger="agent_model_resolution"):
             env = self._litellm_decision().env_vars()
 
         assert env["MAX_MCP_OUTPUT_TOKENS"] == _GUARDRAIL_DEFAULTS["MAX_MCP_OUTPUT_TOKENS"]
         assert any(
-            "EGG_LITELLM_MAX_MCP_OUTPUT_TOKENS" in record.message and repr(bad) in record.message
+            "EGG_AGENT_MAX_MCP_OUTPUT_TOKENS" in record.message and repr(bad) in record.message
             for record in caplog.records
         ), (
             f"expected fallback warning naming the override; got {[r.message for r in caplog.records]!r}"

--- a/orchestrator/tests/test_agent_model_resolution.py
+++ b/orchestrator/tests/test_agent_model_resolution.py
@@ -92,6 +92,30 @@ def _pipeline_config(**overrides):
     return PipelineConfig(**overrides)
 
 
+# Built-in defaults of the LiteLLM-path context guardrails (#3175),
+# mirrored from ``_LITELLM_CONTEXT_GUARDRAILS``. Every LiteLLM decision's
+# ``env_vars()`` carries these alongside the custom-model registration.
+_GUARDRAIL_DEFAULTS = {
+    "BASH_MAX_OUTPUT_LENGTH": "20000",
+    "EGG_READ_CAP_BYTES": "65536",
+    "MAX_MCP_OUTPUT_TOKENS": "15000",
+}
+
+# Orchestrator-side override knobs for the guardrails — cleared in tests
+# that assert exact env shapes so a value in the developer's own
+# environment can't skew the expectation.
+_GUARDRAIL_OVERRIDE_VARS = (
+    "EGG_LITELLM_BASH_MAX_OUTPUT_LENGTH",
+    "EGG_LITELLM_READ_CAP_BYTES",
+    "EGG_LITELLM_MAX_MCP_OUTPUT_TOKENS",
+)
+
+
+def _clear_guardrail_overrides(monkeypatch):
+    for var in _GUARDRAIL_OVERRIDE_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
 # =============================================================================
 # AgentModelDecision dataclass shape
 # =============================================================================
@@ -379,7 +403,7 @@ class TestLiteLLMClassification:
         assert d.upstream_model == "qwen3-coder-30b"
         assert d.claude_code_alias == "qwen3-coder-30b[1m]"
 
-    def test_litellm_env_vars_register_custom_model(self):
+    def test_litellm_env_vars_register_custom_model(self, monkeypatch):
         """``AgentModelDecision.env_vars()`` returns the
         ``ANTHROPIC_CUSTOM_MODEL_OPTION`` pair that Claude Code reads at
         startup to opt the custom model into 1M compaction math (#2832),
@@ -394,7 +418,14 @@ class TestLiteLLMClassification:
         ``[1m]`` alias; the haiku vars carry the bare upstream name
         (the suffix is read per-variable and small/fast calls don't
         need the 1M window).
+
+        Since #3175 the LiteLLM env also carries the context guardrails
+        (``BASH_MAX_OUTPUT_LENGTH`` / ``EGG_READ_CAP_BYTES`` /
+        ``MAX_MCP_OUTPUT_TOKENS``) — per-turn re-billing of the full
+        conversation makes a single oversized tool result
+        disproportionately expensive on this path.
         """
+        _clear_guardrail_overrides(monkeypatch)
         resolve_agent_model = _resolver()
         AgentRole = _agent_role()
         config = _pipeline_config(agent_models={"coder": "qwen3-coder-30b"})
@@ -409,6 +440,7 @@ class TestLiteLLMClassification:
             "CLAUDE_CODE_SUBAGENT_MODEL": "qwen3-coder-30b[1m]",
             "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3-coder-30b",
             "ANTHROPIC_SMALL_FAST_MODEL": "qwen3-coder-30b",
+            **_GUARDRAIL_DEFAULTS,
         }
 
     def test_anthropic_env_vars_empty(self):
@@ -466,7 +498,7 @@ class TestSubOneMContextModels:
         assert d.claude_code_alias == model
 
     @pytest.mark.parametrize("model", ["kimi-k2.7-code", "glm-5.1"])
-    def test_sub_1m_env_vars_carry_bare_name(self, model):
+    def test_sub_1m_env_vars_carry_bare_name(self, model, monkeypatch):
         """Every custom-model env var for a sub-1M model carries the bare
         name — none may leak the ``[1m]`` suffix (which would re-trigger the
         1M profile for the main agent or its Task-tool subagents). Parametrized
@@ -474,6 +506,7 @@ class TestSubOneMContextModels:
         (e.g. a ``.lower()`` or escape that special-cased the hyphen-period in
         ``k2.7``) is caught here, not in the field.
         """
+        _clear_guardrail_overrides(monkeypatch)
         resolve_agent_model = _resolver()
         AgentRole = _agent_role()
         config = _pipeline_config(agent_models={"coder": model})
@@ -488,6 +521,7 @@ class TestSubOneMContextModels:
             "CLAUDE_CODE_SUBAGENT_MODEL": model,
             "ANTHROPIC_DEFAULT_HAIKU_MODEL": model,
             "ANTHROPIC_SMALL_FAST_MODEL": model,
+            **_GUARDRAIL_DEFAULTS,
         }
 
     @pytest.mark.parametrize("model", ["deepseek-v4-flash", "deepseek-v4-pro", "qwen3.7-max"])
@@ -564,6 +598,88 @@ class TestSubOneMContextModels:
 
         assert not caplog.records, (
             f"bare sub-1M model must not warn; got {[r.message for r in caplog.records]!r}"
+        )
+
+
+# =============================================================================
+# LiteLLM-path context guardrails (#3175)
+# =============================================================================
+
+
+class TestLiteLLMContextGuardrails:
+    """Route-aware context guardrails (#3175 PR 2).
+
+    On the LiteLLM path every turn re-bills the whole conversation at
+    the cached rate, so a single oversized tool result (verbose
+    ``pytest -v``, whole-megafile Read, unbounded MCP result) keeps
+    costing for the life of the session. ``env_vars()`` therefore
+    injects ``BASH_MAX_OUTPUT_LENGTH`` / ``EGG_READ_CAP_BYTES`` /
+    ``MAX_MCP_OUTPUT_TOKENS`` on LiteLLM decisions only —
+    Claude-routed spawns must stay byte-identical to today.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_overrides(self, monkeypatch):
+        _clear_guardrail_overrides(monkeypatch)
+        self.monkeypatch = monkeypatch
+
+    def _litellm_decision(self):
+        from agent_model_resolution import classify_model
+
+        return classify_model("deepseek-v4-pro")
+
+    def test_litellm_decision_carries_guardrail_defaults(self):
+        env = self._litellm_decision().env_vars()
+        for var, default in _GUARDRAIL_DEFAULTS.items():
+            assert env.get(var) == default
+
+    def test_anthropic_decision_carries_no_guardrails(self):
+        """Claude-route spawns are explicitly out of scope for #3175 —
+        their env must stay empty even with operator overrides set.
+        """
+        from agent_model_resolution import classify_model
+
+        self.monkeypatch.setenv("EGG_LITELLM_READ_CAP_BYTES", "1024")
+        assert classify_model("opus").env_vars() == {}
+
+    def test_operator_override_respected(self):
+        self.monkeypatch.setenv("EGG_LITELLM_READ_CAP_BYTES", "131072")
+        env = self._litellm_decision().env_vars()
+        assert env["EGG_READ_CAP_BYTES"] == "131072"
+        # The other two guardrails keep their defaults.
+        assert env["BASH_MAX_OUTPUT_LENGTH"] == _GUARDRAIL_DEFAULTS["BASH_MAX_OUTPUT_LENGTH"]
+        assert env["MAX_MCP_OUTPUT_TOKENS"] == _GUARDRAIL_DEFAULTS["MAX_MCP_OUTPUT_TOKENS"]
+
+    def test_empty_override_opts_guardrail_out(self):
+        """An empty-string override omits that var entirely, so the
+        sandbox falls back to Claude Code's (or tool_output_cap's) own
+        default — the per-guardrail kill switch.
+        """
+        self.monkeypatch.setenv("EGG_LITELLM_BASH_MAX_OUTPUT_LENGTH", "")
+        env = self._litellm_decision().env_vars()
+        assert "BASH_MAX_OUTPUT_LENGTH" not in env
+        assert env["EGG_READ_CAP_BYTES"] == _GUARDRAIL_DEFAULTS["EGG_READ_CAP_BYTES"]
+        assert env["MAX_MCP_OUTPUT_TOKENS"] == _GUARDRAIL_DEFAULTS["MAX_MCP_OUTPUT_TOKENS"]
+
+    @pytest.mark.parametrize("bad", ["not-a-number", "64kb", "0", "-5"])
+    def test_invalid_override_warns_and_falls_back(self, bad, caplog):
+        """Garbage overrides must not be forwarded into the sandbox —
+        ``tool_output_cap`` would warn-and-default per call and Claude
+        Code's handling is undefined. Warn once at resolution time and
+        inject the built-in default instead.
+        """
+        import logging
+
+        self.monkeypatch.setenv("EGG_LITELLM_MAX_MCP_OUTPUT_TOKENS", bad)
+        with caplog.at_level(logging.WARNING, logger="agent_model_resolution"):
+            env = self._litellm_decision().env_vars()
+
+        assert env["MAX_MCP_OUTPUT_TOKENS"] == _GUARDRAIL_DEFAULTS["MAX_MCP_OUTPUT_TOKENS"]
+        assert any(
+            "EGG_LITELLM_MAX_MCP_OUTPUT_TOKENS" in record.message and repr(bad) in record.message
+            for record in caplog.records
+        ), (
+            f"expected fallback warning naming the override; got {[r.message for r in caplog.records]!r}"
         )
 
 

--- a/shared/egg_agent/tool_output_cap.py
+++ b/shared/egg_agent/tool_output_cap.py
@@ -66,8 +66,20 @@ _NON_PAGEABLE_BINARY_EXTENSIONS = frozenset(
     {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tiff", ".tif", ".ico", _NOTEBOOK_EXTENSION}
 )
 
-# Raw EGG_READ_CAP_BYTES values we've already warned about, so a misconfigured
-# knob logs once per distinct value rather than on every Read in the session.
+# Agent-writable override for the Read byte cap (#3175). The predictive cap
+# is a guardrail against *accidental* whole-file dumps, not a hard
+# constraint — an agent that deliberately needs an oversized read in a
+# single result raises its own session's cap by writing the byte size it
+# needs to this file (the deny message says exactly how). It lives in /tmp:
+# pod-local and outside the repo worktree, so the override can never be
+# committed, and it dies with the pod. Re-read on every Read alongside the
+# env knob, so it takes effect on the immediate retry; when both are set
+# the file wins — it is the more deliberate, more recent signal.
+_READ_CAP_OVERRIDE_FILE = Path("/tmp/egg-read-cap-bytes")
+
+# Raw cap values we've already warned about (keyed by source+value), so a
+# misconfigured knob logs once per distinct value rather than on every Read
+# in the session.
 _warned_cap_values: set[str] = set()
 
 
@@ -86,42 +98,60 @@ def is_output_cap_disabled() -> bool:
 
 
 def _read_cap_bytes() -> int:
-    """Resolve the Read byte cap from env, falling back to the default.
+    """Resolve the Read byte cap: agent override file, then env, then default.
 
-    ``EGG_READ_CAP_BYTES`` is an operator tuning knob, so a *set-but-invalid*
-    value is logged loudly before falling back — an operator who typoed the
-    value or used an unsupported suffix (``2mb``, ``0``, a negative) would
-    otherwise silently get the default and a different false-positive rate
-    than they intended. The unset case stays silent (the default is expected).
+    The override file (``_READ_CAP_OVERRIDE_FILE``) is the agent's own
+    deliberate escape hatch and wins when present and valid. The
+    ``EGG_READ_CAP_BYTES`` env var is the operator tuning knob. Both are
+    *set-but-invalid* loudly: a typoed value or unsupported suffix
+    (``2mb``, ``0``, a negative) would otherwise silently fall back and
+    produce a different false-positive rate than intended. The unset
+    cases stay silent (the default is expected).
     """
+    try:
+        raw_override = _READ_CAP_OVERRIDE_FILE.read_text().strip()
+    except OSError:
+        raw_override = ""
+    if raw_override:
+        value = _parse_cap(raw_override, source=str(_READ_CAP_OVERRIDE_FILE))
+        if value is not None:
+            return value
+
     raw = os.environ.get("EGG_READ_CAP_BYTES", "").strip()
     if not raw:
         return _DEFAULT_READ_CAP_BYTES
+    value = _parse_cap(raw, source="EGG_READ_CAP_BYTES")
+    return value if value is not None else _DEFAULT_READ_CAP_BYTES
+
+
+def _parse_cap(raw: str, source: str) -> int | None:
+    """Parse a cap value, warning (once per source+value) when invalid."""
     try:
         value = int(raw)
     except ValueError:
-        _warn_invalid_cap(raw, "is not an integer")
-        return _DEFAULT_READ_CAP_BYTES
+        _warn_invalid_cap(raw, source, "is not an integer")
+        return None
     if value <= 0:
-        _warn_invalid_cap(raw, "must be a positive integer")
-        return _DEFAULT_READ_CAP_BYTES
+        _warn_invalid_cap(raw, source, "must be a positive integer")
+        return None
     return value
 
 
-def _warn_invalid_cap(raw: str, problem: str) -> None:
-    """Warn that an invalid EGG_READ_CAP_BYTES is being ignored, once per value.
+def _warn_invalid_cap(raw: str, source: str, problem: str) -> None:
+    """Warn that an invalid cap value is being ignored, once per source+value.
 
     The cap is resolved on every ``Read``, so warning unconditionally would emit
     hundreds of identical lines for one misconfiguration. Track the raw values
     already warned about so a fixed-then-re-broken knob still warns on the new
     bad value, but a steady bad value warns only once.
     """
-    if raw in _warned_cap_values:
+    key = f"{source}={raw}"
+    if key in _warned_cap_values:
         return
-    _warned_cap_values.add(raw)
+    _warned_cap_values.add(key)
     logger.warning(
-        f"EGG_READ_CAP_BYTES={raw!r} {problem}; ignoring it and using the "
-        f"default {_DEFAULT_READ_CAP_BYTES} bytes"
+        f"{source}={raw!r} {problem}; ignoring it and falling back "
+        f"(default {_DEFAULT_READ_CAP_BYTES} bytes)"
     )
 
 
@@ -226,11 +256,18 @@ def check_read_output_risk(tool_input: dict[str, Any], cwd: str | None) -> str |
     # Source code is roughly ~4 B/token, so this rough KB→token estimate is
     # accurate enough to motivate paging without overstating precision.
     approx_tokens_k = max(1, approx_kb // 4)
+    # Suggest a cap that admits this exact read (next KiB above the file
+    # size), so the deliberate-override path is a single copy-pastable
+    # command rather than arithmetic.
+    override_cap = ((size // 1024) + 1) * 1024
     return (
         f"Read denied: '{file_path}' is ~{approx_kb} KB, large enough that "
         f"reading it whole would dump ~{approx_tokens_k}k tokens to the model "
         f"in a single tool result — wasteful of context budget when the call "
-        f"can be narrowed. {_read_remedy(suffix, cap)}"
+        f"can be narrowed. {_read_remedy(suffix, cap)} If you have weighed the "
+        f"cost and deliberately need this result whole in one call, raise this "
+        f"session's cap and retry (Bash: echo {override_cap} > "
+        f"{_READ_CAP_OVERRIDE_FILE})."
     )
 
 

--- a/shared/egg_agent/tool_output_cap.py
+++ b/shared/egg_agent/tool_output_cap.py
@@ -150,8 +150,10 @@ def _warn_invalid_cap(raw: str, source: str, problem: str) -> None:
         return
     _warned_cap_values.add(key)
     logger.warning(
-        f"{source}={raw!r} {problem}; ignoring it and falling back "
-        f"(default {_DEFAULT_READ_CAP_BYTES} bytes)"
+        f"{source}={raw!r} {problem}; ignoring it and falling back to the next "
+        f"configured source in precedence order (override file, then the "
+        f"EGG_READ_CAP_BYTES env var, then the {_DEFAULT_READ_CAP_BYTES}-byte "
+        f"default)"
     )
 
 

--- a/tests/shared/egg_agent/test_tool_output_cap.py
+++ b/tests/shared/egg_agent/test_tool_output_cap.py
@@ -22,6 +22,16 @@ def _reset_cap_warning_cache():
     tool_output_cap._warned_cap_values.clear()
 
 
+@pytest.fixture(autouse=True)
+def _isolated_override_file(tmp_path, monkeypatch):
+    # Point the agent-writable override file (#3175) into the test's tmp dir so
+    # a stray /tmp/egg-read-cap-bytes on the host can't skew any test, and so
+    # override tests can write it without touching the real path.
+    override = tmp_path / "egg-read-cap-bytes"
+    monkeypatch.setattr(tool_output_cap, "_READ_CAP_OVERRIDE_FILE", override)
+    return override
+
+
 def _write(tmp_path, name, size):
     p = tmp_path / name
     p.write_bytes(b"x" * size)
@@ -179,6 +189,74 @@ class TestReadCap:
         assert (
             check_read_output_risk({"file_path": str(png), "limit": 10}, str(tmp_path)) is not None
         )
+
+
+class TestReadCapOverrideFile:
+    """Agent-side deliberate override of the Read cap (#3175).
+
+    The predictive cap is a guardrail against accidental dumps, not a hard
+    constraint: the deny message tells the agent it can write the byte size
+    it needs to the override file and retry. The file is re-read on every
+    Read and wins over the env knob when present and valid.
+    """
+
+    def test_deny_message_advertises_override_path(self, tmp_path, _isolated_override_file):
+        big = _write(tmp_path, "big.py", 300 * 1024)
+        reason = check_read_output_risk({"file_path": str(big)}, str(tmp_path))
+        assert reason is not None
+        assert str(_isolated_override_file) in reason
+        assert "echo" in reason
+
+    def test_override_file_raises_cap(self, tmp_path, _isolated_override_file):
+        big = _write(tmp_path, "big.py", 300 * 1024)
+        _isolated_override_file.write_text("1048576\n")
+        assert check_read_output_risk({"file_path": str(big)}, str(tmp_path)) is None
+
+    def test_suggested_override_admits_the_denied_read(self, tmp_path, _isolated_override_file):
+        # End-to-end remedy loop: the deny message suggests a concrete value;
+        # writing exactly that value must make the retry succeed.
+        import re
+
+        big = _write(tmp_path, "big.py", 300 * 1024)
+        reason = check_read_output_risk({"file_path": str(big)}, str(tmp_path))
+        match = re.search(r"echo (\d+) >", reason)
+        assert match, f"deny message must carry a copy-pastable override value; got {reason!r}"
+        _isolated_override_file.write_text(match.group(1))
+        assert check_read_output_risk({"file_path": str(big)}, str(tmp_path)) is None
+
+    @patch.dict(os.environ, {"EGG_READ_CAP_BYTES": "1024"})
+    def test_override_file_wins_over_env(self, tmp_path, _isolated_override_file):
+        big = _write(tmp_path, "big.py", 300 * 1024)
+        _isolated_override_file.write_text("1048576")
+        assert check_read_output_risk({"file_path": str(big)}, str(tmp_path)) is None
+
+    def test_override_file_can_tighten(self, tmp_path, _isolated_override_file):
+        # The file is taken as-is, not max()-ed with the default — an agent
+        # (or a test harness) writing a smaller value gets a smaller cap.
+        mid = _write(tmp_path, "mid.py", 2048)
+        _isolated_override_file.write_text("1024")
+        assert check_read_output_risk({"file_path": str(mid)}, str(tmp_path)) is not None
+
+    @patch("egg_agent.tool_output_cap.logger")
+    def test_invalid_override_warns_once_and_falls_back(
+        self, mock_logger, tmp_path, _isolated_override_file
+    ):
+        # Garbage in the override file must be loud (once) and leave the
+        # default cap in force: the small file stays allowed, the big one
+        # stays denied.
+        _isolated_override_file.write_text("all-of-it")
+        small = _write(tmp_path, "small.py", 2048)
+        big = _write(tmp_path, "big.py", 300 * 1024)
+        for _ in range(3):
+            assert check_read_output_risk({"file_path": str(small)}, str(tmp_path)) is None
+        assert check_read_output_risk({"file_path": str(big)}, str(tmp_path)) is not None
+        assert mock_logger.warning.call_count == 1
+
+    @patch("egg_agent.tool_output_cap.logger")
+    def test_absent_override_file_is_silent(self, mock_logger, tmp_path):
+        small = _write(tmp_path, "small.py", 1024)
+        check_read_output_risk({"file_path": str(small)}, str(tmp_path))
+        mock_logger.warning.assert_not_called()
 
 
 class TestGrepCap:


### PR DESCRIPTION
PR 2 of the #3175 plan (guardrails against accidental context dumps — see https://github.com/jwbron/egg/issues/3175#issuecomment-4695658536, extended to all routes per review discussion).

## Problem

Every SDK turn re-sends the whole conversation, and cached tokens bill at a discounted-but-nonzero rate on every route (~10% of input price on Anthropic; comparable blended rate on LiteLLM upstreams). A single careless tool call that parks tens of kilotokens in the conversation (verbose `pytest -v`, a whole-megafile Read, an unbounded MCP result) is therefore re-billed on every subsequent turn for the life of the session. On the LiteLLM route — where turn counts run 3–5× the Claude baseline — this is the dominant cost driver (#3175 measurements), but the arithmetic is route-independent.

## Change

`AgentModelDecision.env_vars()` (`orchestrator/agent_model_resolution.py`) now injects size caps on **every** decision, with one LiteLLM-only extra:

| Sandbox env var | Default | Routes | What it bounds |
|---|---|---|---|
| `BASH_MAX_OUTPUT_LENGTH` | `20000` chars | all | Claude Code's built-in Bash truncation; oversized output is saved to a session file the agent can Read/grep |
| `MAX_MCP_OUTPUT_TOKENS` | `15000` | all | Claude Code's MCP-result cap (built-in default 25k); excess is persisted to disk with a file reference |
| `EGG_READ_CAP_BYTES` | `65536` | LiteLLM only | the predictive whole-file-Read deny in `shared/egg_agent/tool_output_cap.py` (#2876) — a quarter of its built-in 256 KiB default, which continues to guard the Claude route |

The Anthropic path carries exactly the two universal caps and none of the custom-model registration vars, so the Claude **wire** shape is unchanged.

**Guardrails, not constraints — every cap is agent-overridable when the need is deliberate:**

- **Bash / MCP**: full output spills to a file whose path the agent receives — nothing is ever unreachable.
- **Read**: the deny message carries a copy-pastable command (`echo <bytes> > /tmp/egg-read-cap-bytes`) sized to admit the exact denied read; `tool_output_cap.py` re-reads the override file on every Read and it wins over the env knob. Pod-local and outside the worktree, so it can't be committed and dies with the pod.
- **Grep**: the content-mode deny only fires with no `head_limit` at all; an explicit large `head_limit` passes.

**Operator overrides** (orchestrator env): `EGG_AGENT_BASH_MAX_OUTPUT_LENGTH`, `EGG_AGENT_MAX_MCP_OUTPUT_TOKENS`, `EGG_LITELLM_READ_CAP_BYTES`. Empty string opts a guardrail out entirely; an unparseable or non-positive value warns and falls back to the default. Names are deliberately distinct from the sandbox-side vars so a value in the orchestrator's own environment is never forwarded by accident.

Placing the injection in `env_vars()` (rather than the k8s spawner) covers both spawn sites — `concurrent_executor._spawn_agent` and the restart path in `routes/pipelines.py` — and any future spawner, since all merge `decision.env_vars()` into `extra_env`.

## Verification

- `orchestrator/tests/test_agent_model_resolution.py`: `TestContextGuardrails` (all-route Bash/MCP defaults, LiteLLM-only Read tightening that doesn't leak across routes even when overridden, override/opt-out/invalid-fallback behavior); exact-shape `env_vars()` tests updated for both paths.
- `tests/shared/egg_agent/test_tool_output_cap.py`: `TestReadCapOverrideFile` (override raises the cap, suggested value from the deny message admits the denied read end-to-end, file wins over env, invalid content warns once and falls back, absent file silent); autouse fixture isolates all tests from a stray host-side override file.
- Downstream consumers green: `test_concurrent_executor.py`, `test_kubernetes_spawner.py`, `test_overseer_spawn.py`, `test_deployment_routes.py`, `test_removal_validation_1165.py`, `test_client.py` (675 tests across affected suites).
- The token reduction itself needs no field measurement — it follows from the arithmetic, and a never-firing guardrail is an acceptable no-op. What's worth watching is the opposite direction: caps biting legitimate work, visible as discrete events (Read-cap denials, spill-file references) in agent transcripts — and agents now have a documented self-service escape hatch when the need is real.

Part of #3175.