### PR TITLE
Per-role cost attribution + estimated cost for LiteLLM routes (#3175)

### DIFF
--- a/config/litellm/cost_callback.py
+++ b/config/litellm/cost_callback.py
@@ -269,9 +269,19 @@ def _extract_estimated_cost(mcd):
     It is an estimate, not a bill: the pricing map may lag the provider's
     rates or lack cache-discount entries for a model. Returns None — never
     0.0 — when LiteLLM couldn't price the call (model absent from the map),
-    mirroring the billed-cost "unknown ≠ free" discipline."""
+    mirroring the billed-cost "unknown ≠ free" discipline.
+
+    Reads the top-level ``response_cost`` first, then falls back to
+    ``standard_logging_object.response_cost`` — the latter is LiteLLM's
+    aggregated/finalized metrics object, preferred for streaming, so the
+    fallback hardens against a LiteLLM version where the top-level key is
+    absent on the streaming path."""
     try:
-        rc = (mcd or {}).get("response_cost")
+        mcd = mcd or {}
+        rc = mcd.get("response_cost")
+        if not isinstance(rc, (int, float)):
+            slo = mcd.get("standard_logging_object")
+            rc = slo.get("response_cost") if isinstance(slo, dict) else None
         if isinstance(rc, (int, float)) and rc > 0:
             return float(rc)
         return None

--- a/config/litellm/cost_callback.py
+++ b/config/litellm/cost_callback.py
@@ -35,6 +35,20 @@ cache-hit-rate metric (the primary cq-6 signal) is unaffected. Real cost is
 still captured on the non-streaming path, where ``original_response``
 carries the raw provider JSON with ``usage.cost``.
 
+Because the billed cost is therefore unknown on essentially every agent
+call, each line also carries ``cost_estimated``: LiteLLM's own
+``response_cost``, computed at logging time from the assembled usage and
+its pricing map, which survives streaming (issue #3175). It is kept
+strictly separate from ``cost`` — an estimate from a possibly-stale rate
+card must never be mistaken for a bill — and follows the same null-not-zero
+rule when LiteLLM cannot price the model.
+
+Each line additionally carries ``pipeline_id`` / ``agent_role`` / ``phase``
+read from the gateway-stamped ``x-egg-*`` request headers (issue #3175),
+so per-role spend is a log query instead of a hand cross-reference against
+agent completion logs. The fields are None for traffic that didn't come
+through an attribution-aware gateway hop.
+
 Unlike the host-side ``cost_callback.py`` this is derived from, egg agents
 are headless: there is no statusline to read a per-session JSON file, and
 the container runs read-only. So we log to stdout (captured by egg's log
@@ -192,24 +206,75 @@ def _extract_cache_stats(usage):
     return prompt, cached, cache_write, reasoning
 
 
-def _extract_session_id(mcd):
-    """``x-claude-code-session-id`` is sent by Claude Code on every request.
+def _proxy_request_headers(mcd):
+    """Return the proxy request headers from ``model_call_details``, lowercased.
 
-    In ``model_call_details`` it lands under
+    In ``model_call_details`` the request lands under
     ``litellm_params.proxy_server_request`` (``get_litellm_params`` packs it
     there); check the top level too in case a future path surfaces it there.
     Lowercase header keys defensively — ``clean_headers`` preserves the wire
     casing of header keys, so a non-lowercase hop (gateway, HTTP/1.1 client)
-    would otherwise collapse every call to ``_no_session`` and silently blend
-    the per-session hit rate into a global one."""
+    would otherwise make every header lookup miss silently."""
     try:
         mcd = mcd or {}
         psr = mcd.get("proxy_server_request")
         if not isinstance(psr, dict):
             psr = (mcd.get("litellm_params") or {}).get("proxy_server_request")
         headers = (psr or {}).get("headers") or {}
-        headers = {k.lower(): v for k, v in headers.items() if isinstance(k, str)}
-        return headers.get("x-claude-code-session-id") or None
+        return {k.lower(): v for k, v in headers.items() if isinstance(k, str)}
+    except Exception:
+        return {}
+
+
+def _extract_session_id(mcd):
+    """``x-claude-code-session-id`` is sent by Claude Code on every request.
+
+    A lookup miss would collapse every call to ``_no_session`` and silently
+    blend the per-session hit rate into a global one."""
+    return _proxy_request_headers(mcd).get("x-claude-code-session-id") or None
+
+
+# Gateway-stamped attribution headers (issue #3175). The gateway resolves the
+# agent's Session on every proxied ``/v1/messages`` call and stamps these on
+# non-Anthropic hops (it strips any agent-supplied ``x-egg-*`` first, so the
+# values are gateway-authoritative). They map a session's spend to a pipeline
+# and role directly in the log line — no hand cross-referencing of agent
+# completion logs.
+_ATTRIBUTION_HEADERS = (
+    ("pipeline_id", "x-egg-pipeline-id"),
+    ("agent_role", "x-egg-agent-role"),
+    ("phase", "x-egg-phase"),
+)
+
+
+def _extract_attribution(mcd):
+    """Return ``{pipeline_id, agent_role, phase}`` from the gateway's
+    attribution headers; each value is None when absent (pre-#3175 gateway,
+    non-agent probe, or a direct non-gateway client)."""
+    headers = _proxy_request_headers(mcd)
+    out = {}
+    for field, header in _ATTRIBUTION_HEADERS:
+        value = headers.get(header)
+        out[field] = value if isinstance(value, str) and value else None
+    return out
+
+
+def _extract_estimated_cost(mcd):
+    """LiteLLM's own computed cost for the call, as an *estimate*.
+
+    Unlike the upstream-billed ``cost`` (dropped by stream-chunk reassembly —
+    see the module docstring), ``response_cost`` is computed by LiteLLM's
+    logging layer from the assembled usage and its model pricing map, so it
+    survives the streaming path that carries essentially all agent traffic.
+    It is an estimate, not a bill: the pricing map may lag the provider's
+    rates or lack cache-discount entries for a model. Returns None — never
+    0.0 — when LiteLLM couldn't price the call (model absent from the map),
+    mirroring the billed-cost "unknown ≠ free" discipline."""
+    try:
+        rc = (mcd or {}).get("response_cost")
+        if isinstance(rc, (int, float)) and rc > 0:
+            return float(rc)
+        return None
     except Exception:
         return None
 
@@ -260,6 +325,7 @@ class LiteLLMCostLogger(CustomLogger):
             # back to the assembled response object's usage.
             usage = _raw_upstream_usage(mcd) or _usage_from_response_obj(response_obj)
             cost = _extract_cost(usage)
+            cost_estimated = _extract_estimated_cost(mcd)
             prompt, cached, cache_write, reasoning = _extract_cache_stats(usage)
             if cost is None and prompt == 0 and cached == 0:
                 return
@@ -267,15 +333,20 @@ class LiteLLMCostLogger(CustomLogger):
             # (the streaming path — see module docstring). We accumulate only
             # known costs and count how many calls contributed one, so a
             # session that never saw a real cost reports ``cost: null`` rather
-            # than a misleading ``0.0``.
+            # than a misleading ``0.0``. ``cost_estimated`` (LiteLLM's own
+            # pricing-map figure, which DOES survive streaming) follows the
+            # same discipline under its own counters.
             sid = _extract_session_id(mcd) or "_no_session"
             model = _extract_model(mcd)
+            attribution = _extract_attribution(mcd)
             with _lock:
                 agg = _session_totals.get(sid)
                 if agg is None:
                     agg = {
                         "cost": 0.0,
                         "cost_known_calls": 0.0,
+                        "cost_estimated": 0.0,
+                        "cost_estimated_known_calls": 0.0,
                         "calls": 0.0,
                         "prompt_tokens": 0.0,
                         "cached_tokens": 0.0,
@@ -285,6 +356,9 @@ class LiteLLMCostLogger(CustomLogger):
                 if cost is not None:
                     agg["cost"] += cost
                     agg["cost_known_calls"] += 1
+                if cost_estimated is not None:
+                    agg["cost_estimated"] += cost_estimated
+                    agg["cost_estimated_known_calls"] += 1
                 agg["calls"] += 1
                 agg["prompt_tokens"] += prompt
                 agg["cached_tokens"] += cached
@@ -316,6 +390,10 @@ class LiteLLMCostLogger(CustomLogger):
             session = {
                 "cost": totals["cost"] if totals["cost_known_calls"] > 0 else None,
                 "cost_known_calls": int(totals["cost_known_calls"]),
+                "cost_estimated": (
+                    totals["cost_estimated"] if totals["cost_estimated_known_calls"] > 0 else None
+                ),
+                "cost_estimated_known_calls": int(totals["cost_estimated_known_calls"]),
                 "calls": int(totals["calls"]),
                 "prompt_tokens": int(totals["prompt_tokens"]),
                 "cached_tokens": int(totals["cached_tokens"]),
@@ -326,8 +404,14 @@ class LiteLLMCostLogger(CustomLogger):
                 {
                     "session_id": sid,
                     "model": model,
+                    # Gateway-stamped attribution (#3175); None values mean the
+                    # request did not come through an attribution-aware gateway
+                    # hop. Session-stable, but emitted per line so every log
+                    # line is independently queryable by role/pipeline.
+                    **attribution,
                     "call": {
                         "cost": cost,
+                        "cost_estimated": cost_estimated,
                         "prompt_tokens": int(prompt),
                         "cached_tokens": int(cached),
                         "cache_write_tokens": int(cache_write),

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -9351,7 +9351,11 @@ def _with_attribution_headers(headers: dict[str, str], session: Any) -> dict[str
         ("x-egg-phase", session.phase),
     ):
         if value:
-            headers[header] = _sanitize_attribution_value(str(value))
+            sanitized = _sanitize_attribution_value(str(value))
+            # A value of only control chars sanitizes to "" — don't stamp an
+            # empty-valued header (the callback would coerce it to None anyway).
+            if sanitized:
+                headers[header] = sanitized
     return headers
 
 

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -9315,16 +9315,59 @@ class _HopPrepError(Exception):
         self.response = response
 
 
+def _sanitize_attribution_value(value: str) -> str:
+    """Constrain a session field to a safe HTTP header value.
+
+    The values are orchestrator-authoritative (set via the launcher-secret
+    ``register_session``), so this is belt-and-braces: drop anything outside
+    printable ASCII (CR/LF would otherwise allow header injection) and cap
+    the length so a pathological value cannot bloat every upstream request.
+    """
+    return "".join(ch for ch in value if 32 <= ord(ch) < 127)[:256]
+
+
+def _with_attribution_headers(headers: dict[str, str], session: Any) -> dict[str, str]:
+    """Stamp gateway-authoritative ``x-egg-*`` attribution onto a non-Anthropic hop.
+
+    The egg-litellm ``cost_callback`` keys its per-session cost/cache log
+    lines on ``x-claude-code-session-id``, which maps to a role only by hand
+    cross-referencing agent completion logs (issue #3175). The gateway
+    resolves the full ``Session`` — ``pipeline_id`` / ``agent_role`` /
+    ``phase`` — on every ``/v1/messages`` call anyway, so it stamps them here
+    and the callback logs spend per role directly.
+
+    Any client-supplied ``x-egg-*`` header is dropped first: the sandbox
+    controls its own request headers (e.g. via ``ANTHROPIC_CUSTOM_HEADERS``),
+    so agent-supplied values are untrusted and must never masquerade as
+    attribution. Applied only to non-Anthropic hops — the Claude path stays
+    byte-identical.
+    """
+    headers = {k: v for k, v in headers.items() if not k.lower().startswith("x-egg-")}
+    if session is None:
+        return headers
+    for header, value in (
+        ("x-egg-pipeline-id", session.pipeline_id),
+        ("x-egg-agent-role", session.agent_role),
+        ("x-egg-phase", session.phase),
+    ):
+        if value:
+            headers[header] = _sanitize_attribution_value(str(value))
+    return headers
+
+
 def _prepare_hop(
     hop: RouteHop,
     request_headers: Any,
     request_body: bytes,
+    session: Any = None,
 ) -> _PreparedHop:
     """Build the (client, headers, body) for one hop.
 
     Headers are rebuilt with ``_get_forwarded_headers`` from the *original*
     request headers on every call, then this hop's credential is injected —
     so a fallback hop never inherits the previous upstream's auth header.
+    Non-Anthropic hops additionally carry ``x-egg-*`` attribution headers
+    derived from ``session`` (issue #3175); see ``_with_attribution_headers``.
     Raises ``_HopPrepError`` (carrying the error response) on a credential or
     unknown-upstream failure for this hop; the caller decides whether to
     advance to a fallback or surface it.
@@ -9333,6 +9376,8 @@ def _prepare_hop(
     headers, cred_error = _inject_upstream_credentials(headers, upstream=hop.upstream)
     if cred_error:
         raise _HopPrepError(cred_error)
+    if hop.upstream != "anthropic":
+        headers = _with_attribution_headers(headers, session)
 
     if hop.upstream == "anthropic":
         client = get_anthropic_client()
@@ -9700,7 +9745,7 @@ def proxy_anthropic_messages() -> tuple[Response, int] | Response:
                 is_last_hop = hop_idx == len(chain) - 1
                 serving_upstream = hop.upstream
                 try:
-                    prepared = _prepare_hop(hop, request.headers, request_body)
+                    prepared = _prepare_hop(hop, request.headers, request_body, session=session)
                 except _HopPrepError as prep_err:
                     if is_last_hop:
                         return prep_err.response
@@ -9812,7 +9857,7 @@ def proxy_anthropic_messages() -> tuple[Response, int] | Response:
                 is_last_hop = hop_idx == len(chain) - 1
                 serving_upstream = hop.upstream
                 try:
-                    prepared = _prepare_hop(hop, request.headers, request_body)
+                    prepared = _prepare_hop(hop, request.headers, request_body, session=session)
                 except _HopPrepError as prep_err:
                     if is_last_hop:
                         return prep_err.response
@@ -9911,7 +9956,7 @@ def proxy_count_tokens() -> tuple[Response, int] | Response:
     initial_hop = chain[0]
     serving_upstream = initial_hop.upstream
     try:
-        prepared = _prepare_hop(initial_hop, request.headers, count_tokens_body)
+        prepared = _prepare_hop(initial_hop, request.headers, count_tokens_body, session=session)
     except _HopPrepError as prep_err:
         return prep_err.response
 

--- a/gateway/tests/test_upstream_routing.py
+++ b/gateway/tests/test_upstream_routing.py
@@ -359,13 +359,18 @@ def client():
         yield c
 
 
-def _register_session(upstream: str = "anthropic", mode: str = "public") -> str:
-    """Register a session and return the placeholder-wrapped auth value."""
+def _register_session(upstream: str = "anthropic", mode: str = "public", **session_fields) -> str:
+    """Register a session and return the placeholder-wrapped auth value.
+
+    ``session_fields`` passes through to ``register_session`` (e.g.
+    ``pipeline_id`` / ``agent_role`` / ``phase`` for the attribution tests).
+    """
     sm = gateway.get_session_manager()
     token, _session = sm.register_session(
         container_id=f"c-routing-{upstream}-{os.urandom(4).hex()}",
         upstream=upstream,
         mode=mode,
+        **session_fields,
     )
     return to_placeholder(token)
 
@@ -472,6 +477,118 @@ class TestFallbackOnQuota:
         assert litellm.idx == 1
         assert anthropic.idx == 1
         assert "x-api-key" not in anthropic.last_headers
+
+
+class TestAttributionHeaders:
+    """Gateway-authoritative ``x-egg-*`` attribution on non-Anthropic hops (#3175).
+
+    The litellm hop must carry the session's pipeline/role/phase so the
+    egg-litellm cost callback can attribute spend per role; the Anthropic
+    path must stay byte-identical (no stamped headers); and agent-supplied
+    ``x-egg-*`` headers must never survive onto a non-Anthropic hop.
+    """
+
+    _SESSION_FIELDS = {
+        "pipeline_id": "pipeline-20260612-abc",
+        "agent_role": "reviewer_code",
+        "phase": "implement",
+    }
+
+    def test_litellm_hop_carries_attribution(self, client) -> None:
+        auth = _register_session(upstream="litellm", **self._SESSION_FIELDS)
+        with _routed(EMPTY_POLICY) as (_anthropic, litellm):
+            resp = client.post(
+                "/v1/messages",
+                data=_messages_body("deepseek-v4-flash", stream=True),
+                headers={"x-api-key": auth, "content-type": "application/json"},
+            )
+        assert resp.status_code == 200
+        assert litellm.last_headers.get("x-egg-pipeline-id") == "pipeline-20260612-abc"
+        assert litellm.last_headers.get("x-egg-agent-role") == "reviewer_code"
+        assert litellm.last_headers.get("x-egg-phase") == "implement"
+
+    def test_count_tokens_hop_carries_attribution(self, client) -> None:
+        auth = _register_session(upstream="litellm", **self._SESSION_FIELDS)
+        with _routed(EMPTY_POLICY) as (_anthropic, litellm):
+            client.post(
+                "/v1/messages/count_tokens",
+                data=_messages_body("deepseek-v4-flash", stream=False),
+                headers={"x-api-key": auth, "content-type": "application/json"},
+            )
+        assert litellm.last_headers.get("x-egg-agent-role") == "reviewer_code"
+
+    def test_unset_session_fields_emit_no_headers(self, client) -> None:
+        # A session with only a role: no empty-valued pipeline/phase headers.
+        auth = _register_session(upstream="litellm", agent_role="coder")
+        with _routed(EMPTY_POLICY) as (_anthropic, litellm):
+            client.post(
+                "/v1/messages",
+                data=_messages_body("deepseek-v4-flash", stream=True),
+                headers={"x-api-key": auth, "content-type": "application/json"},
+            )
+        assert litellm.last_headers.get("x-egg-agent-role") == "coder"
+        assert "x-egg-pipeline-id" not in litellm.last_headers
+        assert "x-egg-phase" not in litellm.last_headers
+
+    def test_agent_supplied_x_egg_headers_are_stripped(self, client) -> None:
+        # The sandbox controls its own request headers; a forged x-egg-*
+        # value must never masquerade as gateway attribution on the litellm
+        # hop — neither overriding a real field nor smuggling a novel key.
+        auth = _register_session(upstream="litellm", **self._SESSION_FIELDS)
+        with _routed(EMPTY_POLICY) as (_anthropic, litellm):
+            client.post(
+                "/v1/messages",
+                data=_messages_body("deepseek-v4-flash", stream=True),
+                headers={
+                    "x-api-key": auth,
+                    "content-type": "application/json",
+                    "x-egg-agent-role": "trusted_user",
+                    "x-egg-forged": "1",
+                },
+            )
+        assert litellm.last_headers.get("x-egg-agent-role") == "reviewer_code"
+        assert "x-egg-forged" not in litellm.last_headers
+
+    def test_anthropic_hop_is_not_stamped(self, client) -> None:
+        # No-op invariant: the Claude path carries no attribution headers.
+        auth = _register_session(upstream="anthropic", **self._SESSION_FIELDS)
+        with _routed(EMPTY_POLICY) as (anthropic, _litellm):
+            client.post(
+                "/v1/messages",
+                data=_messages_body("claude-opus-4-8", stream=True),
+                headers={"x-api-key": auth, "content-type": "application/json"},
+            )
+        assert not [k for k in anthropic.last_headers if k.lower().startswith("x-egg-")]
+
+    def test_fallback_to_anthropic_drops_attribution(self, client) -> None:
+        # litellm 429 → anthropic fallback: the litellm hop is stamped, the
+        # anthropic hop is not (scoping mirrors the credential-bleed guard).
+        auth = _register_session(upstream="litellm", **self._SESSION_FIELDS)
+        policy = parse_routing_policy(
+            {
+                "fallbacks": {
+                    "deepseek-v4-flash": [{"upstream": "anthropic", "model": "claude-opus-4-8"}],
+                }
+            }
+        )
+        with _routed(
+            policy,
+            anthropic_script=[_FakeStreamResponse(200)],
+            litellm_script=[_FakeStreamResponse(429, chunks=(b'{"error":"rate"}',))],
+        ) as (anthropic, litellm):
+            client.post(
+                "/v1/messages",
+                data=_messages_body("deepseek-v4-flash", stream=True),
+                headers={"x-api-key": auth, "content-type": "application/json"},
+            )
+        assert litellm.last_headers.get("x-egg-agent-role") == "reviewer_code"
+        assert not [k for k in anthropic.last_headers if k.lower().startswith("x-egg-")]
+
+    def test_header_values_are_sanitized(self) -> None:
+        # CR/LF (header injection) and control chars dropped; length capped.
+        assert gateway._sanitize_attribution_value("a\r\nx-evil: 1") == "ax-evil: 1"
+        assert gateway._sanitize_attribution_value("rôle") == "rle"
+        assert len(gateway._sanitize_attribution_value("x" * 1000)) == 256
 
 
 class TestTransientFivexx:

--- a/gateway/tests/test_upstream_routing.py
+++ b/gateway/tests/test_upstream_routing.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import os
+import types
 from collections.abc import Iterator
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
@@ -544,9 +545,13 @@ class TestAttributionHeaders:
                     "content-type": "application/json",
                     "x-egg-agent-role": "trusted_user",
                     "x-egg-forged": "1",
+                    # Mixed-case forgery: the strip lowercases the key, so an
+                    # X-Egg-... header must be dropped too, not slip through.
+                    "X-Egg-Pipeline-Id": "forged-pipeline",
                 },
             )
         assert litellm.last_headers.get("x-egg-agent-role") == "reviewer_code"
+        assert litellm.last_headers.get("x-egg-pipeline-id") == "pipeline-20260612-abc"
         assert "x-egg-forged" not in litellm.last_headers
 
     def test_anthropic_hop_is_not_stamped(self, client) -> None:
@@ -589,6 +594,14 @@ class TestAttributionHeaders:
         assert gateway._sanitize_attribution_value("a\r\nx-evil: 1") == "ax-evil: 1"
         assert gateway._sanitize_attribution_value("rôle") == "rle"
         assert len(gateway._sanitize_attribution_value("x" * 1000)) == 256
+
+    def test_control_only_value_emits_no_header(self) -> None:
+        # A field of only control chars sanitizes to "" — no empty-valued
+        # header should be stamped at all.
+        session = types.SimpleNamespace(pipeline_id="\r\n", agent_role="coder", phase=None)
+        out = gateway._with_attribution_headers({}, session)
+        assert "x-egg-pipeline-id" not in out
+        assert out["x-egg-agent-role"] == "coder"
 
 
 class TestTransientFivexx:

--- a/tests/config/test_cost_callback.py
+++ b/tests/config/test_cost_callback.py
@@ -234,6 +234,22 @@ class TestEstimatedCost:
         assert cc._extract_estimated_cost({}) is None
         assert cc._extract_estimated_cost(None) is None
 
+    def test_falls_back_to_standard_logging_object(self):
+        # A LiteLLM version that omits the top-level key but populates the
+        # finalized metrics object must still yield the estimate.
+        assert (
+            cc._extract_estimated_cost({"standard_logging_object": {"response_cost": 0.05}}) == 0.05
+        )
+        # Top-level takes precedence when present.
+        assert (
+            cc._extract_estimated_cost(
+                {"response_cost": 0.02, "standard_logging_object": {"response_cost": 0.05}}
+            )
+            == 0.02
+        )
+        # A non-dict standard_logging_object is ignored, not raised on.
+        assert cc._extract_estimated_cost({"standard_logging_object": "nope"}) is None
+
 
 class TestAttribution:
     """Gateway-stamped ``x-egg-*`` headers land as per-line attribution

--- a/tests/config/test_cost_callback.py
+++ b/tests/config/test_cost_callback.py
@@ -81,15 +81,31 @@ def _nonstreaming_usage() -> dict:
     }
 
 
-def _mcd(session_id: str, *, raw_usage: dict | None = None) -> dict:
+def _mcd(
+    session_id: str,
+    *,
+    raw_usage: dict | None = None,
+    extra_headers: dict | None = None,
+    response_cost: float | None = None,
+) -> dict:
     """Build a ``model_call_details`` dict the callback understands."""
+    headers = {"x-claude-code-session-id": session_id, **(extra_headers or {})}
     mcd: dict = {
         "model": "openrouter/qwen/qwen3-max",
-        "proxy_server_request": {"headers": {"x-claude-code-session-id": session_id}},
+        "proxy_server_request": {"headers": headers},
     }
     if raw_usage is not None:
         mcd["original_response"] = json.dumps({"usage": raw_usage})
+    if response_cost is not None:
+        mcd["response_cost"] = response_cost
     return mcd
+
+
+_ATTRIBUTION_HEADERS = {
+    "x-egg-pipeline-id": "pipeline-20260612-abc",
+    "x-egg-agent-role": "reviewer_code",
+    "x-egg-phase": "implement",
+}
 
 
 class TestExtractCost:
@@ -157,3 +173,104 @@ class TestRecordCostReporting:
         assert session["cost_known_calls"] == 1
         # Only the known cost is summed; the unknown turn contributes nothing.
         assert session["cost"] == 0.0123
+
+
+class TestEstimatedCost:
+    """LiteLLM's pricing-map ``response_cost`` survives streaming and is
+    surfaced as ``cost_estimated``, strictly separate from the billed
+    ``cost`` and under the same null-not-zero discipline (#3175)."""
+
+    def setup_method(self):
+        cc._session_totals.clear()
+
+    def _capture(self, monkeypatch) -> list[dict]:
+        emitted: list[dict] = []
+        monkeypatch.setattr(cc, "_emit", lambda payload: emitted.append(payload))
+        return emitted
+
+    def test_streaming_call_carries_estimate_while_cost_stays_null(self, monkeypatch):
+        emitted = self._capture(monkeypatch)
+        cc.LiteLLMCostLogger()._record(
+            _mcd("e1", response_cost=0.021),
+            types.SimpleNamespace(usage=_streaming_usage()),
+        )
+        payload = emitted[0]
+        # The billed cost is still unrecoverable on streaming — must stay null.
+        assert payload["call"]["cost"] is None
+        assert payload["call"]["cost_estimated"] == 0.021
+        assert payload["session"]["cost"] is None
+        assert payload["session"]["cost_estimated"] == 0.021
+        assert payload["session"]["cost_estimated_known_calls"] == 1
+
+    def test_unpriceable_model_reports_null_estimate(self, monkeypatch):
+        # No response_cost (model absent from LiteLLM's pricing map) must
+        # read as "unknown", never "$0".
+        emitted = self._capture(monkeypatch)
+        cc.LiteLLMCostLogger()._record(_mcd("e2"), types.SimpleNamespace(usage=_streaming_usage()))
+        payload = emitted[0]
+        assert payload["call"]["cost_estimated"] is None
+        assert payload["session"]["cost_estimated"] is None
+        assert payload["session"]["cost_estimated_known_calls"] == 0
+
+    def test_estimate_accumulates_only_known_calls(self, monkeypatch):
+        emitted = self._capture(monkeypatch)
+        logger = cc.LiteLLMCostLogger()
+        logger._record(
+            _mcd("e3", response_cost=0.01), types.SimpleNamespace(usage=_streaming_usage())
+        )
+        logger._record(_mcd("e3"), types.SimpleNamespace(usage=_streaming_usage()))
+        logger._record(
+            _mcd("e3", response_cost=0.02), types.SimpleNamespace(usage=_streaming_usage())
+        )
+        session = emitted[-1]["session"]
+        assert session["calls"] == 3
+        assert session["cost_estimated_known_calls"] == 2
+        assert round(session["cost_estimated"], 6) == 0.03
+
+    def test_non_positive_or_garbage_estimates_are_unknown(self):
+        assert cc._extract_estimated_cost({"response_cost": 0}) is None
+        assert cc._extract_estimated_cost({"response_cost": -0.1}) is None
+        assert cc._extract_estimated_cost({"response_cost": "0.01"}) is None
+        assert cc._extract_estimated_cost({}) is None
+        assert cc._extract_estimated_cost(None) is None
+
+
+class TestAttribution:
+    """Gateway-stamped ``x-egg-*`` headers land as per-line attribution
+    fields; absence (pre-#3175 gateway, non-gateway client) reads as None."""
+
+    def setup_method(self):
+        cc._session_totals.clear()
+
+    def _capture(self, monkeypatch) -> list[dict]:
+        emitted: list[dict] = []
+        monkeypatch.setattr(cc, "_emit", lambda payload: emitted.append(payload))
+        return emitted
+
+    def test_attribution_headers_are_emitted(self, monkeypatch):
+        emitted = self._capture(monkeypatch)
+        cc.LiteLLMCostLogger()._record(
+            _mcd("a1", extra_headers=_ATTRIBUTION_HEADERS),
+            types.SimpleNamespace(usage=_streaming_usage()),
+        )
+        payload = emitted[0]
+        assert payload["pipeline_id"] == "pipeline-20260612-abc"
+        assert payload["agent_role"] == "reviewer_code"
+        assert payload["phase"] == "implement"
+
+    def test_missing_attribution_reads_as_none(self, monkeypatch):
+        emitted = self._capture(monkeypatch)
+        cc.LiteLLMCostLogger()._record(_mcd("a2"), types.SimpleNamespace(usage=_streaming_usage()))
+        payload = emitted[0]
+        assert payload["pipeline_id"] is None
+        assert payload["agent_role"] is None
+        assert payload["phase"] is None
+
+    def test_header_casing_is_normalized(self, monkeypatch):
+        # A non-lowercase hop must not blind the attribution lookup.
+        emitted = self._capture(monkeypatch)
+        cc.LiteLLMCostLogger()._record(
+            _mcd("a3", extra_headers={"X-Egg-Agent-Role": "coder"}),
+            types.SimpleNamespace(usage=_streaming_usage()),
+        )
+        assert emitted[0]["agent_role"] == "coder"


### PR DESCRIPTION
PR 1 of the #3175 plan ([scoping comment](https://github.com/jwbron/egg/issues/3175#issuecomment-4695657105)): make per-role spend on the LiteLLM route a log query instead of a hand cross-reference. Zero agent-visible behavior change; the Anthropic path is untouched.

## Gateway — attribution headers on non-Anthropic hops

`_prepare_hop` now takes the already-resolved `Session` and stamps `x-egg-pipeline-id` / `x-egg-agent-role` / `x-egg-phase` onto non-Anthropic hops. The gateway resolves the session on every proxied `/v1/messages` (and `count_tokens`) call anyway, so this is pure wiring — no orchestrator or sandbox changes.

Security posture:
- **Gateway-authoritative**: any client-supplied `x-egg-*` header is stripped before stamping. The sandbox controls its own request headers (e.g. `ANTHROPIC_CUSTOM_HEADERS`), so agent-supplied values must never masquerade as attribution.
- Values are sanitized to printable ASCII (CR/LF would allow header injection) and length-capped — belt-and-braces, since they're orchestrator-set via the launcher-authenticated `register_session`.
- Scoped to non-Anthropic hops only, mirroring the credential-bleed guard: a litellm→anthropic fallback hop carries no `x-egg-*` headers, and the Claude path stays byte-identical.

## cost_callback — attribution fields + `cost_estimated`

- Every log line now carries `pipeline_id` / `agent_role` / `phase` read from the gateway-stamped headers (None for traffic that didn't come through an attribution-aware hop — predictable schema for queries).
- New `cost_estimated` per call and per session: LiteLLM's own pricing-map `response_cost`, which — unlike the upstream-billed `cost` — survives stream-chunk reassembly. This is the root cause of the issue's `cost_known_calls: 2 of 127`: Claude Code always streams, and reassembly drops the provider's cost field, so the billed figure is structurally absent on agent traffic.
- `cost_estimated` is kept strictly separate from `cost` (an estimate from a possibly-stale rate card must never read as a bill) and follows the same null-not-zero discipline under its own `cost_estimated_known_calls` counter.

## Tests

- `gateway/tests/test_upstream_routing.py`: litellm hop carries attribution; `count_tokens` parity; unset session fields emit no headers; forged `x-egg-*` stripped; Anthropic hop never stamped (no-op invariant); fallback hop drops attribution; sanitizer behavior.
- `tests/config/test_cost_callback.py`: attribution emitted / None when absent / casing-normalized; estimate present while billed cost stays null on streaming; estimate accumulates only known calls; non-positive/garbage estimates read as unknown.

Unblocks (no code): the lever-3 audit — identifying the 127-call flat-context session's role on the next LiteLLM run.

Closes nothing; part of #3175.