### PR TITLE
Expose live agent_models swap: update_pipeline_config MCP tool + resolved-model visibility (#3174)

### DIFF
--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -170,6 +170,85 @@ path — and `register_session` drops `None` values from the
 session-create request body, so the wire shape stays byte-identical
 to today.
 
+## Changing models on a live pipeline (#3174)
+
+`agent_models` is not submit-time-only: it can be changed on a
+**running** pipeline, and the change is honored at the next agent
+spawn. The operator surface is the `update_pipeline_config` MCP tool;
+the motivating scenario is "the current model is failing or
+rate-limited (e.g. an Anthropic session-limit outage) — swap every
+role to an open model and restart the phase."
+
+### The swap-and-restart procedure
+
+1. **Update the override map.** Per-role merge semantics: roles you
+   don't name keep their current override, a string sets the role's
+   model, an explicit `null` clears it (the role falls back to the
+   repo default / built-in tiers).
+
+   ```json
+   // update_pipeline_config MCP-tool arguments
+   {
+     "task_id": "issue-3064",
+     "agent_models": {
+       "coder": "deepseek-v4-pro",
+       "tester": "deepseek-v4-pro",
+       "reviewer_code": "deepseek-v4-pro"
+     }
+   }
+   ```
+
+   Role keys are validated against `MODEL_OVERRIDE_ROLES` (same
+   validator as submit time). Model *values* are not checked against a
+   registry — any non-Claude string routes to LiteLLM, so a typo
+   surfaces as a model-not-found error at spawn, not at update time.
+
+2. **Restart to apply.** Currently running agents keep the model they
+   were spawned with; the new map only affects future spawns. Use
+   `restart_phase` (whole phase on the new models) or `restart_agent`
+   (surgical: one agent, worktree preserved) to respawn now. Skipping
+   the restart is also valid — the next natural spawn (next review
+   cycle, next slice team) picks the new map up on its own.
+
+3. **Confirm.** Every spawn records the resolved alias on the agent's
+   execution record (`AgentExecution.resolved_model`). Check the
+   `resolved_model` field on `get_status`'s `running_agents` entries or
+   on `list_containers` rows — no need to grep pod logs for the
+   session-init line.
+
+### Why this is honored — the fresh-reload guarantee
+
+Two structural properties make the live swap safe, rather than
+accidental:
+
+- **The run loop never trusts a stale in-memory pipeline.** Both
+  `_run_pipeline`'s per-cycle loop and the `restart_phase` /
+  `restart_agent` handlers reload the pipeline from the state store
+  before resolving models for a spawn, and `resolve_agent_model` is a
+  pure function over that freshly-loaded config. There is no cached
+  decision to invalidate.
+- **Completed slices are not redone.** On a multi-slice implement
+  phase, `restart_phase`'s respawned scheduler bootstraps from the
+  contract's recorded `SliceStatus.COMPLETE` markers, so a mid-phase
+  model swap resumes at the current slice instead of re-running
+  finished ones (this is how the #3064 swap restarted at slice 3 of 6
+  with slices 1–2 skipped).
+
+Under the hood the tool is `PATCH
+/api/v1/pipelines/<id>/config` (lifecycle-secret-authenticated), a
+deliberately narrow wrapper over the state store's nested-update path.
+The generic `PATCH /pipelines/<id>` dotted-key form
+(`{"config.agent_models": {...}}`) still works but replaces the whole
+map instead of merging, validates only via the wrapped Pydantic error,
+and shouldn't be needed now that the scoped surface exists.
+
+> **Scope.** Only `agent_models` is mutable through this endpoint.
+> Most of `PipelineConfig` is consumed at submit time or mid-phase in
+> ways a partial update could corrupt; `agent_models` is safe
+> precisely because of the fresh-reload guarantee above. Widening the
+> allowlist (`_MUTABLE_CONFIG_KEYS` in `orchestrator/routes/pipelines.py`)
+> requires verifying the same guarantee for the new key.
+
 ## Gateway-side body handling
 
 For LiteLLM-bound requests the gateway forwards the body **unchanged**.

--- a/docs/index.md
+++ b/docs/index.md
@@ -153,6 +153,7 @@ Each major component has detailed documentation:
 | **Pipeline health monitoring** | [Pipeline Health Monitoring](guides/pipeline-health-monitoring.md) | [Health Checks README](../orchestrator/health_checks/README.md), [Agent Roles](reference/agent-roles.md), [Orchestrator Architecture](architecture/orchestrator.md) |
 | **Generating repository documentation** | [GitHub Automation: Documentation Onboarding](guides/github-automation.md#documentation-onboarding) | [Onboarding prompt](../shared/prompts/onboarding-docs-prompt.md), `egg-onboarding-docs` CLI |
 | **Running a single agent on a non-Claude model** | [Per-Agent Models](guides/per-agent-models.md) | [Upstream Routing](architecture/upstream-routing.md), [Agent Roles](reference/agent-roles.md), `orchestrator/agent_model_resolution.py` |
+| **Changing models on a live pipeline (swap + restart)** | [Per-Agent Models § Changing models on a live pipeline](guides/per-agent-models.md#changing-models-on-a-live-pipeline-3174) | `update_pipeline_config` MCP tool, `orchestrator/routes/pipelines.py` (`update_pipeline_config`), [#3174](https://github.com/jwbron/egg/issues/3174) |
 
 ## Quick Navigation
 

--- a/integration_tests/test_orchestrator_mcp_contract.py
+++ b/integration_tests/test_orchestrator_mcp_contract.py
@@ -171,11 +171,12 @@ class TestMCPDiscovery:
     def test_supporting_tools_advertised(self, orchestrator_mcp_url: str) -> None:
         # ``get_status`` and ``validate_config`` round out the contract
         # that the three target verbs depend on (polling + dry-run
-        # config validation).  Asserted separately so a regression in
-        # the supporting surface stays distinguishable from a regression
-        # in the headline tools.
+        # config validation); ``update_pipeline_config`` is the live
+        # agent_models swap surface (#3174).  Asserted separately so a
+        # regression in the supporting surface stays distinguishable
+        # from a regression in the headline tools.
         names = _list_tool_names(orchestrator_mcp_url)
-        for tool in ("get_status", "validate_config"):
+        for tool in ("get_status", "validate_config", "update_pipeline_config"):
             assert tool in names, f"{tool!r} not advertised. Advertised: {sorted(names)}"
 
 

--- a/orchestrator/concurrent_executor.py
+++ b/orchestrator/concurrent_executor.py
@@ -500,6 +500,7 @@ class ConcurrentPhaseExecutor:
             container_info=result.container_info,
             started_at=datetime.now(UTC),
             slice_id=self._slice_id,
+            resolved_model=decision.claude_code_alias,
         )
 
     def handle_agent_failure(self, role: str, error: str) -> dict[str, Any]:

--- a/orchestrator/mcp_tools.py
+++ b/orchestrator/mcp_tools.py
@@ -493,6 +493,47 @@ PIPELINE_TOOLS = [
         },
     },
     {
+        "name": "update_pipeline_config",
+        "description": (
+            "Update the safely-mutable subset of a live pipeline's config — "
+            "currently per-role model overrides (agent_models) only. "
+            "Per-role merge semantics: roles absent from the request keep "
+            "their current override, a string value sets the role's model, "
+            "an explicit null clears it (falling back to the repo default / "
+            "built-in model). Takes effect at the next agent spawn; "
+            "currently running agents keep the model they started with, so "
+            "pair with restart_phase / restart_agent to apply the change to "
+            "a running phase (the dominant use: the current model is "
+            "failing or rate-limited, swap and restart — #3174). Confirm "
+            "the swap via the resolved_model field on get_status agents / "
+            "list_containers entries."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "Pipeline/task ID",
+                },
+                "agent_models": {
+                    "type": "object",
+                    "description": (
+                        "Role -> model map to merge into the pipeline's "
+                        "agent_models override, e.g. "
+                        '{"coder": "deepseek-v4-pro", "tester": null}. '
+                        "Keys must be SDLC phase producer/reviewer roles "
+                        "(MODEL_OVERRIDE_ROLES). Values: a Claude alias "
+                        "(opus / sonnet / haiku / fable, optionally with "
+                        "[1m]) routes to Anthropic; any other string routes "
+                        "through the in-cluster LiteLLM proxy; null clears "
+                        "the role's override."
+                    ),
+                },
+            },
+            "required": ["task_id", "agent_models"],
+        },
+    },
+    {
         "name": "restart_agent",
         "description": (
             "Restart a single agent in a pipeline. Stops the existing container, "
@@ -1163,6 +1204,7 @@ class PipelineToolHandler:
             "get_pipeline_snapshot": self._handle_get_pipeline_snapshot,
             "get_contract": self._handle_get_contract,
             "validate_config": self._handle_validate_config,
+            "update_pipeline_config": self._handle_update_pipeline_config,
             "restart_agent": self._handle_restart_agent,
             "restart_phase": self._handle_restart_phase,
             "list_agent_local_commits": self._handle_list_agent_local_commits,
@@ -1419,6 +1461,66 @@ class PipelineToolHandler:
                     for err in e.errors()
                 ],
             }
+
+    def _handle_update_pipeline_config(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Update a live pipeline's agent_models override (#3174)."""
+        import json
+        from urllib.error import HTTPError
+
+        task_id = quote(args["task_id"], safe="")
+        agent_models = args.get("agent_models")
+        # Mirror validate_config / submit_task: tolerate a JSON-encoded
+        # string from MCP clients that double-serialize object args.
+        if isinstance(agent_models, str):
+            try:
+                agent_models = json.loads(agent_models)
+            except json.JSONDecodeError as e:
+                return {"error": f"agent_models is not valid JSON: {e}"}
+        if not isinstance(agent_models, dict) or not agent_models:
+            return {
+                "error": (
+                    "agent_models must be a non-empty object mapping role -> "
+                    'model, e.g. {"coder": "deepseek-v4-pro"} (null clears a '
+                    "role's override)"
+                )
+            }
+
+        try:
+            result = self._make_request(
+                f"/api/v1/pipelines/{task_id}/config",
+                method="PATCH",
+                data={"agent_models": agent_models},
+            )
+        except HTTPError as exc:
+            # Surface the orchestrator's structured error body (role-key
+            # validation, unknown pipeline) instead of urllib's bare
+            # "HTTP Error N: <reason>".
+            detail = ""
+            try:
+                raw = exc.read()
+                body = json.loads(raw.decode()) if raw else {}
+                detail = body.get("message") or ""
+            except Exception:
+                detail = ""
+            if detail:
+                return {"error": f"update_pipeline_config failed (HTTP {exc.code}): {detail}"}
+            return {"error": f"update_pipeline_config failed: {exc}"}
+        except Exception as exc:
+            return {"error": f"update_pipeline_config failed: {exc}"}
+
+        data = result.get("data", {})
+        return {
+            "updated": True,
+            "pipeline_id": data.get("pipeline_id", args["task_id"]),
+            "agent_models": data.get("agent_models", {}),
+            "updated_roles": data.get("updated_roles", {}),
+            "cleared_roles": data.get("cleared_roles", []),
+            "note": (
+                "Applies at the next agent spawn. Use restart_phase or "
+                "restart_agent to apply to currently running agents; confirm "
+                "via resolved_model in get_status / list_containers."
+            ),
+        }
 
     def _handle_get_status(self, args: dict[str, Any]) -> dict[str, Any]:
         """Get enriched pipeline status.

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -58,6 +58,16 @@ class PipelineStatus(StrEnum):
     FAILED = "failed"
     CANCELLED = "cancelled"
 
+    @classmethod
+    def terminal(cls) -> frozenset[PipelineStatus]:
+        """Statuses indicating the pipeline has reached a terminal state.
+
+        A terminal pipeline spawns no further agents and transitions to no
+        other status. Centralized here so callers share one definition
+        rather than redefining the set and drifting (#3174 review).
+        """
+        return frozenset({cls.COMPLETE, cls.FAILED, cls.CANCELLED})
+
 
 class PipelineMode(StrEnum):
     """Pipeline execution mode."""

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -263,6 +263,18 @@ class AgentExecution(BaseModel):
 
     started_at: datetime | None = Field(default=None, description="When started")
     completed_at: datetime | None = Field(default=None, description="When completed")
+    resolved_model: str | None = Field(
+        default=None,
+        description=(
+            "The Claude-Code-facing model alias the agent was spawned "
+            "with (``AgentModelDecision.claude_code_alias``, e.g. "
+            "``opus`` or ``deepseek-v4-pro[1m]``). Recorded at spawn / "
+            "restart time so operators can confirm a live "
+            "``agent_models`` swap took effect from ``get_status`` / "
+            "``list_containers`` instead of grepping pod logs (#3174). "
+            "``None`` on records persisted before the field existed."
+        ),
+    )
     commit: str | None = Field(default=None, description="Commit SHA if changes made")
     outputs: dict[str, Any] = Field(
         default_factory=dict, description="Handoff data for dependent agents"

--- a/orchestrator/overseer/monitor.py
+++ b/orchestrator/overseer/monitor.py
@@ -20,6 +20,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from models import PipelineStatus
 from overseer.classifier import (
     check_alignment,
     check_decision_consistency,
@@ -46,6 +47,11 @@ logger = logging.getLogger(__name__)
 # indicating human intervention is needed.
 _HUMAN_WORDS = ("human", "manual", "operator")
 _ACTION_WORDS = ("intervention", "attention", "review", "required", "needed", "escalat")
+
+# Pipeline status string values that indicate a terminal state. Derived from
+# the canonical PipelineStatus.terminal() set so the overseer shares one
+# definition with sse.py / state_store.py / routes (#3174 review).
+_TERMINAL_STATUSES = {status.value for status in PipelineStatus.terminal()}
 
 
 def _accepts_kwarg(func: Any, name: str) -> bool:
@@ -475,7 +481,7 @@ class OverseerMonitor:
                 )
 
             # 8. Check pipeline status for terminal state
-            if status in ("complete", "failed", "cancelled"):
+            if status in _TERMINAL_STATUSES:
                 # NOTE: the legacy ``_check_pr_phase_outcome`` safety-net
                 # was removed in #2777 (cq-4); see the docstring on the
                 # removed helper for why the condition is unreachable
@@ -490,7 +496,7 @@ class OverseerMonitor:
                 self.write_health_summary()
 
             # 9. Cross-phase consistency (LLM-based, only on phase transitions)
-            if status not in ("complete", "failed", "cancelled"):
+            if status not in _TERMINAL_STATUSES:
                 await self._check_cross_phase_consistency(
                     current_phase, decisions, contract_data=None
                 )

--- a/orchestrator/routes/containers.py
+++ b/orchestrator/routes/containers.py
@@ -195,6 +195,46 @@ def spawn_container(pipeline_id: str) -> tuple[Response, int]:
         return make_error_response(f"Backend error: {e}", status_code=500)
 
 
+def _resolved_models_by_container(pipeline_id: str) -> dict[str, str]:
+    """Best-effort map of container_id -> resolved model alias (#3174).
+
+    Containers come from the live backend, but the model an agent was
+    spawned with is recorded on the persisted ``AgentExecution`` at
+    spawn/restart time. Join the two here so ``list_containers`` shows
+    what each agent is actually running — the operator's confirmation
+    channel after a live ``agent_models`` swap, replacing grepping pod
+    logs for the session-init line. Any failure (pipeline state missing,
+    store contention, pre-#3174 records without the field) degrades to
+    an empty/partial map: listing containers must not depend on
+    state-store health.
+    """
+    mapping: dict[str, str] = {}
+    try:
+        from routes import get_repo_path
+        from state_store import discover_repo_paths, get_state_store
+
+        pipeline = None
+        for repo_path in discover_repo_paths(get_repo_path()):
+            try:
+                pipeline = get_state_store(repo_path).load_pipeline(pipeline_id)
+                break
+            except Exception:
+                continue
+        if pipeline is None:
+            return mapping
+        for phase_exec in pipeline.phases.values():
+            for agent in phase_exec.agents:
+                if agent.container_id and agent.resolved_model:
+                    mapping[agent.container_id] = agent.resolved_model
+    except Exception as e:
+        logger.debug(
+            "Could not join resolved models onto container list",
+            pipeline_id=pipeline_id,
+            error=str(e),
+        )
+    return mapping
+
+
 @containers_bp.route("/<pipeline_id>/containers", methods=["GET"])
 def list_pipeline_containers(pipeline_id: str) -> tuple[Response, int]:
     """
@@ -214,7 +254,8 @@ def list_pipeline_containers(pipeline_id: str) -> tuple[Response, int]:
                     {
                         "container_id": "abc123...",
                         "status": "running",
-                        "agent_role": "coder"
+                        "agent_role": "coder",
+                        "resolved_model": "opus"
                     }
                 ]
             }
@@ -229,6 +270,8 @@ def list_pipeline_containers(pipeline_id: str) -> tuple[Response, int]:
             labels={"egg.pipeline.id": pipeline_id},
         )
 
+        resolved_models = _resolved_models_by_container(pipeline_id)
+
         container_data = [
             {
                 "container_id": c.container_id,
@@ -240,6 +283,7 @@ def list_pipeline_containers(pipeline_id: str) -> tuple[Response, int]:
                 "exit_code": c.exit_code,
                 "pod_name": getattr(c, "pod_name", None),
                 "job_name": getattr(c, "job_name", None),
+                "resolved_model": resolved_models.get(c.container_id),
             }
             for c in containers
         ]

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2224,6 +2224,165 @@ def update_pipeline(pipeline_id: str) -> tuple[Response, int]:
         )
 
 
+# Config keys the live config-update route accepts. Deliberately a tight
+# allowlist (#3174): most of PipelineConfig is consumed at submit time or
+# mid-phase in ways a partial update could corrupt, whereas
+# ``agent_models`` is re-resolved from a fresh store load before every
+# spawn (the run loop reloads the pipeline at the top of each cycle, and
+# the restart_agent / restart_phase paths load fresh state), so mutating
+# it on a live pipeline is honored by construction. Widen only after
+# verifying the same fresh-reload guarantee holds for the new key.
+_MUTABLE_CONFIG_KEYS = frozenset({"agent_models"})
+
+
+@pipelines_bp.route("/<pipeline_id>/config", methods=["PATCH"])
+@require_lifecycle_secret
+def update_pipeline_config(pipeline_id: str) -> tuple[Response, int]:
+    """Update the safely-mutable subset of a live pipeline's config (#3174).
+
+    Currently that subset is ``agent_models`` only. Semantics are a
+    per-role merge with the pipeline's existing override map: roles
+    absent from the request keep their current value, a string value
+    sets that role's override, and an explicit ``null`` clears it (the
+    role falls back to the repository default / built-in tiers).
+
+    The updated config takes effect at the next agent spawn — currently
+    running agents keep the model they were started with. Pair with
+    ``restart_phase`` / ``restart_agent`` to apply the change to a
+    running phase. Model *values* are not validated against a registry
+    here (any non-Claude string routes to LiteLLM, mirroring submit-time
+    behavior); a typo surfaces as a model-not-found error at spawn.
+
+    URL params:
+        pipeline_id: Pipeline ID
+
+    Request body:
+        {
+            "agent_models": {
+                "coder": "deepseek-v4-pro",
+                "tester": null
+            }
+        }
+
+    Response:
+        {
+            "success": true,
+            "data": {
+                "pipeline_id": "issue-123",
+                "agent_models": {...},      # effective map after the merge
+                "updated_roles": {...},     # roles set by this request
+                "cleared_roles": [...]      # roles cleared by this request
+            }
+        }
+    """
+    data = request.get_json()
+    if data is None:
+        return make_error_response("Missing request body")
+    if not isinstance(data, dict):
+        return make_error_response("Request body must be a JSON object")
+
+    unsupported = sorted(set(data) - _MUTABLE_CONFIG_KEYS)
+    if unsupported:
+        return make_error_response(
+            f"Unsupported config keys: {unsupported}. This endpoint updates "
+            f"only the safely-mutable config subset: {sorted(_MUTABLE_CONFIG_KEYS)}",
+            status_code=400,
+        )
+
+    agent_models = data.get("agent_models")
+    if not isinstance(agent_models, dict) or not agent_models:
+        return make_error_response(
+            "agent_models must be a non-empty object mapping role -> model "
+            "(use null as the model to clear a role's override)",
+            status_code=400,
+        )
+
+    # Pre-validate role keys against MODEL_OVERRIDE_ROLES so the operator
+    # gets the same actionable message as PipelineConfig's field validator
+    # instead of a wrapped pydantic StateValidationError. Lazy import
+    # mirrors models._validate_agent_models_roles.
+    from egg_contracts.agent_roles import MODEL_OVERRIDE_ROLES
+
+    valid_roles = {role.value for role in MODEL_OVERRIDE_ROLES}
+    invalid_roles = sorted(role for role in agent_models if role not in valid_roles)
+    if invalid_roles:
+        return make_error_response(
+            f"Invalid agent_models role keys: {invalid_roles}. agent_models "
+            f"is honored only for SDLC phase producer and reviewer roles: "
+            f"{sorted(valid_roles)}",
+            status_code=400,
+        )
+    invalid_values = sorted(
+        role
+        for role, model in agent_models.items()
+        if model is not None and (not isinstance(model, str) or not model.strip())
+    )
+    if invalid_values:
+        return make_error_response(
+            f"Invalid agent_models values for roles {invalid_values}: each "
+            f"value must be a non-empty model string, or null to clear the "
+            f"role's override",
+            status_code=400,
+        )
+
+    repo_path = get_repo_path()
+
+    try:
+        store, _pipeline = _resolve_pipeline(pipeline_id, repo_path)
+
+        # Merge under the pipeline state lock so a concurrent writer
+        # (another config update, the run loop persisting state) can't
+        # interleave between our load and the store's load-modify-save.
+        # The per-pipeline lock is an RLock, so update_pipeline's own
+        # acquisition nests cleanly.
+        with get_pipeline_state_lock(pipeline_id):
+            current = store.load_pipeline(pipeline_id)
+            merged = dict(current.config.agent_models)
+            updated_roles: dict[str, str] = {}
+            cleared_roles: list[str] = []
+            for role_key, model in agent_models.items():
+                if model is None:
+                    if merged.pop(role_key, None) is not None:
+                        cleared_roles.append(role_key)
+                else:
+                    merged[role_key] = model.strip()
+                    updated_roles[role_key] = model.strip()
+            pipeline = store.update_pipeline(pipeline_id, {"config.agent_models": merged})
+
+        logger.info(
+            "Pipeline agent_models updated",
+            pipeline_id=pipeline_id,
+            updated_roles=updated_roles,
+            cleared_roles=cleared_roles,
+        )
+
+        return make_success_response(
+            "Pipeline config updated",
+            data={
+                "pipeline_id": pipeline.id,
+                "agent_models": pipeline.config.agent_models,
+                "updated_roles": updated_roles,
+                "cleared_roles": cleared_roles,
+            },
+        )
+
+    except InvalidPipelineIdError:
+        return make_error_response(
+            f"Invalid pipeline ID format: {pipeline_id}",
+            status_code=400,
+        )
+    except PipelineNotFoundError:
+        return make_error_response(
+            f"Pipeline {pipeline_id} not found",
+            status_code=404,
+        )
+    except StateValidationError as e:
+        return make_error_response(
+            f"Invalid update: {e}",
+            status_code=400,
+        )
+
+
 def _compute_gateway_mode(
     pipeline: Pipeline,
 ) -> tuple[Literal["public", "private"], str | None]:
@@ -3110,6 +3269,7 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
                     agent.container_id = spawned.container_info.container_id
                     agent.status = AgentExecutionStatus.RUNNING
                     agent.started_at = respawn_started_at
+                    agent.resolved_model = _model_decision.claude_code_alias
                     found = True
                     break
                 if not found:
@@ -3120,6 +3280,7 @@ def restart_agent(pipeline_id: str, agent_role: str) -> tuple[Response, int]:
                             status=AgentExecutionStatus.RUNNING,
                             started_at=respawn_started_at,
                             slice_id=slice_id,
+                            resolved_model=_model_decision.claude_code_alias,
                         )
                     )
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2337,6 +2337,26 @@ def update_pipeline_config(pipeline_id: str) -> tuple[Response, int]:
         # acquisition nests cleanly.
         with get_pipeline_state_lock(pipeline_id):
             current = store.load_pipeline(pipeline_id)
+
+            # Reject mutations on terminal pipelines (#3174 review). No future
+            # spawn consumes ``agent_models`` once a pipeline is COMPLETE /
+            # FAILED / CANCELLED, so the merge would be a silent no-op; a 409
+            # gives the operator a clear signal and matches restart_phase's
+            # terminal-state precondition style. Checked under the lock against
+            # freshly-loaded state so a concurrent terminal transition can't
+            # slip a mutation through.
+            if current.status in (
+                PipelineStatus.COMPLETE,
+                PipelineStatus.FAILED,
+                PipelineStatus.CANCELLED,
+            ):
+                return make_error_response(
+                    f"Pipeline {pipeline_id} is in terminal state "
+                    f"{current.status.value}; agent_models cannot be updated "
+                    "(no future spawn would consume the change).",
+                    status_code=409,
+                )
+
             merged = dict(current.config.agent_models)
             updated_roles: dict[str, str] = {}
             cleared_roles: list[str] = []
@@ -18206,6 +18226,16 @@ def _run_concurrent_phase(
                         container_id=exec_info.container_id,
                         started_at=datetime.now(UTC),
                         slice_id=slice_id,
+                        # Carry the per-agent resolved model through the
+                        # reconstruction (#3174). ``_spawn_agent`` stamps this on
+                        # the in-memory execution, but the persisted record is
+                        # rebuilt from scratch here — without this copy the field
+                        # dead-ends at None and both operator confirmation
+                        # channels (get_status, list_containers), which read from
+                        # persisted state, surface ``resolved_model: null`` for
+                        # every concurrent-phase agent (initial spawn and
+                        # restart_phase respawn alike).
+                        resolved_model=exec_info.resolved_model,
                     )
                     phase_execution.agents.append(agent_state)
                 store.save_pipeline(pip)
@@ -19384,6 +19414,13 @@ def _spawn_and_wait(
     """
     from models import ContainerInfo, ContainerStatus, PipelinePhase
 
+    try:
+        from agent_model_resolution import DEFAULT_AGENT_MODEL
+    except ImportError:
+        from ..agent_model_resolution import (  # type: ignore[import-not-found, no-redef]
+            DEFAULT_AGENT_MODEL,
+        )
+
     retry_kwargs: dict = {}
     if spawn_max_retries is not None:
         retry_kwargs["spawn_max_retries"] = spawn_max_retries
@@ -19445,12 +19482,19 @@ def _spawn_and_wait(
                 # ``slice_id`` through here — otherwise the new
                 # ``(role, slice_id)`` walks added in #2422 will not see
                 # the record. See PR #2435 review thread.
+                # This helper hard-codes the default Anthropic auth path (see
+                # the NOTE above ``spawn_agent_job``), so the resolved model is
+                # always the built-in default alias. Stamp it for parity with
+                # ``_run_concurrent_phase`` / ``restart_agent`` (#3174) — if this
+                # test-only path is ever resurrected for production it will not
+                # silently regress resolved-model visibility.
                 agent_execution = AgentExecution(
                     role=agent_role,
                     status=AgentExecutionStatus.RUNNING,
                     container_id=spawned.container_info.container_id,
                     slice_id=None,
                     started_at=datetime.now(UTC),
+                    resolved_model=DEFAULT_AGENT_MODEL,
                 )
                 phase_execution.agents.append(agent_execution)
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2345,11 +2345,7 @@ def update_pipeline_config(pipeline_id: str) -> tuple[Response, int]:
             # terminal-state precondition style. Checked under the lock against
             # freshly-loaded state so a concurrent terminal transition can't
             # slip a mutation through.
-            if current.status in (
-                PipelineStatus.COMPLETE,
-                PipelineStatus.FAILED,
-                PipelineStatus.CANCELLED,
-            ):
+            if current.status in PipelineStatus.terminal():
                 return make_error_response(
                     f"Pipeline {pipeline_id} is in terminal state "
                     f"{current.status.value}; agent_models cannot be updated "

--- a/orchestrator/sse.py
+++ b/orchestrator/sse.py
@@ -33,6 +33,7 @@ except ImportError:
 
 from dag_visualizer import generate_status_report, render_pipeline_dag
 from events import Event, EventBus, EventType, get_event_bus
+from models import PipelineStatus
 from state_store import PipelineNotFoundError, get_state_store
 
 logger = get_logger("orchestrator.sse")
@@ -53,8 +54,10 @@ TERMINAL_EVENT_TYPES = {
     EventType.PIPELINE_CANCELLED,
 }
 
-# Pipeline status values that indicate a terminal state
-TERMINAL_STATUSES = {"complete", "failed", "cancelled"}
+# Pipeline status values that indicate a terminal state. Derived from the
+# canonical PipelineStatus.terminal() set so the SSE stream and the rest of
+# the orchestrator share one definition (#3174 review).
+TERMINAL_STATUSES = {status.value for status in PipelineStatus.terminal()}
 
 
 def format_sse_event(

--- a/orchestrator/state_store.py
+++ b/orchestrator/state_store.py
@@ -1271,12 +1271,7 @@ class StateStore:
         with get_pipeline_state_lock(pipeline_id):
             if self.pipeline_exists(pipeline_id):
                 existing = self.load_pipeline(pipeline_id)
-                terminal = {
-                    PipelineStatus.CANCELLED,
-                    PipelineStatus.FAILED,
-                    PipelineStatus.COMPLETE,
-                }
-                if existing.status in terminal:
+                if existing.status in PipelineStatus.terminal():
                     logger.info(
                         "Replacing terminal pipeline %s (status=%s)",
                         pipeline_id,
@@ -1400,11 +1395,7 @@ class StateStore:
         Returns:
             List of active pipelines
         """
-        terminal_statuses = {
-            PipelineStatus.COMPLETE,
-            PipelineStatus.FAILED,
-            PipelineStatus.CANCELLED,
-        }
+        terminal_statuses = PipelineStatus.terminal()
 
         pipelines = []
         for pipeline_id in self.list_pipelines():

--- a/orchestrator/tests/test_concurrent_executor.py
+++ b/orchestrator/tests/test_concurrent_executor.py
@@ -1458,3 +1458,37 @@ class TestResolverMissingRepoConfigDoesNotCrash:
             executor._spawn_agent(AgentRole.CODER, prompt_text="run task")
 
         assert mock_spawn.call_count == 1
+
+
+class TestSpawnRecordsResolvedModel:
+    """#3174: every spawn records the resolved Claude-Code-facing alias
+    on the ``AgentExecution`` so operators can confirm a live
+    ``agent_models`` swap from ``get_status`` / ``list_containers``
+    instead of grepping pod logs for the session-init line."""
+
+    def test_override_recorded_on_execution(self):
+        from concurrent_executor import ConcurrentPhaseExecutor
+        from egg_orchestrator.types import AgentRole
+
+        pipeline = _make_pipeline()
+        pipeline.config.agent_models = {"coder": "deepseek-v4-pro"}
+        mock_spawn = MagicMock(return_value=_kubernetes_spawn_result())
+        executor = ConcurrentPhaseExecutor(pipeline, spawn_fn=mock_spawn)
+
+        execution = executor._spawn_agent(AgentRole.CODER)
+
+        # LiteLLM-routed: the recorded alias carries the [1m] suffix,
+        # matching the --model flag and the session-init log line.
+        assert execution.resolved_model == "deepseek-v4-pro[1m]"
+
+    def test_default_recorded_on_execution(self):
+        from concurrent_executor import ConcurrentPhaseExecutor
+        from egg_orchestrator.types import AgentRole
+
+        pipeline = _make_pipeline()
+        mock_spawn = MagicMock(return_value=_kubernetes_spawn_result())
+        executor = ConcurrentPhaseExecutor(pipeline, spawn_fn=mock_spawn)
+
+        execution = executor._spawn_agent(AgentRole.CODER)
+
+        assert execution.resolved_model == "opus"

--- a/orchestrator/tests/test_concurrent_wait.py
+++ b/orchestrator/tests/test_concurrent_wait.py
@@ -52,13 +52,19 @@ def _make_concurrent_pipeline(pipeline_id: str = "issue-999") -> Pipeline:
     )
 
 
-def _make_execution(role: AgentRole, container_id: str, status=AgentExecutionStatus.RUNNING):
+def _make_execution(
+    role: AgentRole,
+    container_id: str,
+    status=AgentExecutionStatus.RUNNING,
+    resolved_model: str | None = None,
+):
     """Create an AgentExecution with the given role and container."""
     return AgentExecution(
         role=role,
         status=status,
         container_id=container_id,
         started_at=datetime.now(UTC),
+        resolved_model=resolved_model,
     )
 
 
@@ -330,6 +336,62 @@ class TestRunConcurrentPhaseWait:
         # store.save_pipeline called at least twice: once after spawn recording,
         # once after wait/status update
         assert mock_store.save_pipeline.call_count >= 2
+
+    @patch("routes.pipelines.time.sleep")
+    @patch("routes.pipelines.time.monotonic")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
+    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
+    def test_persisted_agent_carries_resolved_model(
+        self, MockExecutor, mock_build_prompt, mock_state_lock, mock_monotonic, mock_sleep
+    ):
+        """The per-agent resolved_model survives the spawn->persist reconstruction.
+
+        Regression for #3174: ``_spawn_agent`` stamps ``resolved_model`` on the
+        in-memory AgentExecution, but ``_run_concurrent_phase`` rebuilds a fresh
+        StateAgentExecution before saving. The earlier code dropped the field,
+        so the persisted record — the one both operator confirmation channels
+        (get_status, list_containers) read from — reported ``resolved_model:
+        null`` for every concurrent-phase agent. Assert the persisted record (on
+        the phase execution that gets saved) carries it through.
+        """
+        mock_monotonic.return_value = 0.0
+
+        executions = [
+            _make_execution(AgentRole.CODER, "coder-abc", resolved_model="qwen3-max[1m]"),
+            _make_execution(AgentRole.TESTER, "tester-abc", resolved_model="opus"),
+        ]
+
+        pipeline, mock_store, mock_spawner, mock_docker, phase_exec = self._make_mocks(executions)
+
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        mock_executor_instance.check_consensus.return_value = _NO_CONSENSUS
+        MockExecutor.return_value = mock_executor_instance
+
+        mock_state_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_state_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        _run_concurrent_phase(
+            pipeline_id="issue-999",
+            pipeline=pipeline,
+            phase="implement",
+            spawner=mock_spawner,
+            repo_volumes={},
+            gateway_mode="public",
+            repos=["owner/repo"],
+            sandbox_env={},
+            store=mock_store,
+            certs_volume=None,
+            worktree_repo_path=Path("/tmp/test-repo"),
+        )
+
+        # The persisted records live on the phase execution that was saved.
+        recorded = {a.role: a.resolved_model for a in phase_exec.agents}
+        assert recorded.get(AgentRole.CODER) == "qwen3-max[1m]"
+        assert recorded.get(AgentRole.TESTER) == "opus"
+        # None of the spawned agents should dead-end at a null model.
+        assert all(model is not None for model in recorded.values())
 
     @patch("routes.pipelines.time.sleep")
     @patch("routes.pipelines.time.monotonic")

--- a/orchestrator/tests/test_containers_routes.py
+++ b/orchestrator/tests/test_containers_routes.py
@@ -116,3 +116,94 @@ class TestNonObjectJsonBodyReturns400:
         assert body["success"] is False
         assert "json object" in body["message"].lower(), body
         mock_get_backend.assert_not_called()
+
+
+class TestListContainersResolvedModel:
+    """#3174: ``list_containers`` joins the per-spawn ``resolved_model``
+    from persisted pipeline state onto the live container rows."""
+
+    def _container(self, container_id: str):
+        from models import AgentRole, ContainerInfo, ContainerStatus
+
+        return ContainerInfo(
+            container_id=container_id,
+            container_name=f"egg-test-{container_id}",
+            status=ContainerStatus.RUNNING,
+            agent_role=AgentRole.CODER,
+        )
+
+    def test_resolved_model_joined_onto_rows(self, client):
+        from unittest.mock import MagicMock
+
+        backend = MagicMock()
+        backend.list_containers.return_value = [
+            self._container("container-aaa"),
+            self._container("container-bbb"),
+        ]
+        with (
+            patch("routes.containers._get_backend", return_value=backend),
+            patch(
+                "routes.containers._resolved_models_by_container",
+                return_value={"container-aaa": "deepseek-v4-pro[1m]"},
+            ),
+        ):
+            response = client.get("/api/v1/pipelines/issue-77/containers")
+
+        assert response.status_code == 200, response.data
+        rows = {c["container_id"]: c for c in response.get_json()["data"]["containers"]}
+        assert rows["container-aaa"]["resolved_model"] == "deepseek-v4-pro[1m]"
+        # Pre-#3174 records (no persisted decision) degrade to null.
+        assert rows["container-bbb"]["resolved_model"] is None
+
+    def test_join_helper_reads_pipeline_state(self):
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from models import (
+            AgentExecution,
+            AgentRole,
+            PhaseExecution,
+            Pipeline,
+            PipelinePhase,
+        )
+        from routes.containers import _resolved_models_by_container
+
+        pipeline = Pipeline(
+            id="issue-77",
+            issue_number=77,
+            repo="test/repo",
+            branch="egg/issue-77",
+        )
+        pipeline.phases = {
+            "implement": PhaseExecution(
+                phase=PipelinePhase.IMPLEMENT,
+                agents=[
+                    AgentExecution(
+                        role=AgentRole.CODER,
+                        container_id="container-aaa",
+                        resolved_model="qwen3-max[1m]",
+                    ),
+                    # No recorded decision — must be absent from the map,
+                    # not present as None.
+                    AgentExecution(role=AgentRole.TESTER, container_id="container-bbb"),
+                ],
+            ),
+        }
+        store = MagicMock()
+        store.load_pipeline.return_value = pipeline
+
+        with (
+            patch("routes.get_repo_path", return_value=Path("/repos")),
+            patch("state_store.discover_repo_paths", return_value=[Path("/repos/test")]),
+            patch("state_store.get_state_store", return_value=store),
+        ):
+            mapping = _resolved_models_by_container("issue-77")
+
+        assert mapping == {"container-aaa": "qwen3-max[1m]"}
+
+    def test_join_helper_degrades_to_empty_on_failure(self):
+        """Listing containers must not depend on state-store health."""
+        from routes.containers import _resolved_models_by_container
+
+        with patch("routes.get_repo_path", side_effect=RuntimeError("no repo path")):
+            assert _resolved_models_by_container("issue-77") == {}

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -952,6 +952,8 @@ class TestToolRouting:
             "get_pipeline_snapshot",
             "get_contract",
             "validate_config",
+            # Live agent_models swap (#3174)
+            "update_pipeline_config",
             "restart_agent",
             "restart_phase",
             "advance_phase",
@@ -3056,3 +3058,100 @@ class TestAnswerFeedback:
         required = tool["inputSchema"]["required"]
         assert "task_id" in required
         assert "answers" in required
+
+
+class TestUpdatePipelineConfig:
+    """The update_pipeline_config tool (#3174) — live agent_models swap."""
+
+    def test_success_patches_config_endpoint(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {
+                "success": True,
+                "data": {
+                    "pipeline_id": "issue-77",
+                    "agent_models": {"coder": "deepseek-v4-pro"},
+                    "updated_roles": {"coder": "deepseek-v4-pro"},
+                    "cleared_roles": [],
+                },
+            }
+            result = handler.handle_tool_call(
+                "update_pipeline_config",
+                {"task_id": "issue-77", "agent_models": {"coder": "deepseek-v4-pro"}},
+            )
+
+        assert mock_req.call_args[0][0] == "/api/v1/pipelines/issue-77/config"
+        assert mock_req.call_args[1]["method"] == "PATCH"
+        assert mock_req.call_args[1]["data"] == {"agent_models": {"coder": "deepseek-v4-pro"}}
+        assert result["updated"] is True
+        assert result["pipeline_id"] == "issue-77"
+        assert result["agent_models"] == {"coder": "deepseek-v4-pro"}
+        assert result["updated_roles"] == {"coder": "deepseek-v4-pro"}
+        # The note steers the operator to the restart + confirmation flow.
+        assert "restart_phase" in result["note"]
+        assert "resolved_model" in result["note"]
+
+    def test_task_id_is_url_encoded(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {"success": True, "data": {}}
+            handler.handle_tool_call(
+                "update_pipeline_config",
+                {"task_id": "weird/id", "agent_models": {"coder": "opus"}},
+            )
+
+        assert mock_req.call_args[0][0] == "/api/v1/pipelines/weird%2Fid/config"
+
+    def test_json_string_agent_models_parsed(self, handler):
+        """MCP clients that double-serialize object args still work
+        (mirrors submit_task / validate_config tolerance)."""
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {"success": True, "data": {}}
+            handler.handle_tool_call(
+                "update_pipeline_config",
+                {"task_id": "issue-77", "agent_models": '{"coder": "opus"}'},
+            )
+
+        assert mock_req.call_args[1]["data"] == {"agent_models": {"coder": "opus"}}
+
+    @pytest.mark.parametrize("bad", [None, {}, [], "not json {", 42])
+    def test_invalid_agent_models_rejected_without_request(self, handler, bad):
+        with patch.object(handler, "_make_request") as mock_req:
+            result = handler.handle_tool_call(
+                "update_pipeline_config",
+                {"task_id": "issue-77", "agent_models": bad},
+            )
+
+        assert "error" in result
+        mock_req.assert_not_called()
+
+    def test_http_error_surfaces_route_message(self, handler):
+        """A 400 from the route (e.g. invalid role key) must surface the
+        route's structured message, not urllib's bare reason string."""
+        import io
+
+        body = json.dumps(
+            {"success": False, "message": "Invalid agent_models role keys: ['overseer']"}
+        ).encode()
+        err = HTTPError(
+            url="http://localhost:9849/api/v1/pipelines/issue-77/config",
+            code=400,
+            msg="BAD REQUEST",
+            hdrs=None,
+            fp=io.BytesIO(body),
+        )
+        with patch.object(handler, "_make_request", side_effect=err):
+            result = handler.handle_tool_call(
+                "update_pipeline_config",
+                {"task_id": "issue-77", "agent_models": {"overseer": "opus"}},
+            )
+
+        assert "error" in result
+        assert "HTTP 400" in result["error"]
+        assert "overseer" in result["error"]
+
+    def test_registered_in_pipeline_tools_schema(self):
+        from mcp_tools import PIPELINE_TOOLS
+
+        tool = next(t for t in PIPELINE_TOOLS if t["name"] == "update_pipeline_config")
+        required = tool["inputSchema"]["required"]
+        assert "task_id" in required
+        assert "agent_models" in required

--- a/orchestrator/tests/test_update_pipeline_config.py
+++ b/orchestrator/tests/test_update_pipeline_config.py
@@ -1,0 +1,223 @@
+"""Tests for the live pipeline config-update endpoint (#3174).
+
+``PATCH /api/v1/pipelines/<id>/config`` is the scoped operator surface
+for changing a running pipeline's ``agent_models`` override (wrapped by
+the ``update_pipeline_config`` MCP tool). Covers:
+
+- the key allowlist (``agent_models`` only),
+- per-role merge semantics (set / null-clears / absent-keeps),
+- role-key validation against ``MODEL_OVERRIDE_ROLES`` and value
+  validation (non-empty strings or null),
+- error mapping (404 unknown pipeline, 400 validation, 401 unauth).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+from models import Pipeline, PipelineConfig, PipelineStatus
+from routes.pipelines import pipelines_bp
+from state_store import PipelineNotFoundError
+
+
+@pytest.fixture
+def app():
+    """Create a test Flask app with the pipelines blueprint."""
+    app = Flask(__name__)
+    app.register_blueprint(pipelines_bp)
+    app.config["TESTING"] = True
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    """Create a test client. Lifecycle auth is injected by the
+    orchestrator-level ``_inject_lifecycle_auth`` autouse fixture."""
+    return app.test_client()
+
+
+def _make_pipeline(agent_models: dict[str, str] | None = None) -> Pipeline:
+    return Pipeline(
+        id="issue-77",
+        repo="test/repo",
+        issue_number=77,
+        branch="egg/issue-77",
+        status=PipelineStatus.RUNNING,
+        config=PipelineConfig(agent_models=agent_models or {}),
+    )
+
+
+def _mock_store(pipeline: Pipeline) -> MagicMock:
+    """Store whose ``update_pipeline`` reflects the merged map back,
+    mirroring the real load-modify-save behavior."""
+    store = MagicMock()
+    store.load_pipeline.return_value = pipeline
+
+    def _update(pipeline_id, updates):
+        assert set(updates) == {"config.agent_models"}, updates
+        return _make_pipeline(updates["config.agent_models"])
+
+    store.update_pipeline.side_effect = _update
+    return store
+
+
+@patch("routes.pipelines.get_repo_path")
+@patch("routes.pipelines._resolve_pipeline")
+class TestUpdatePipelineConfigMerge:
+    """Per-role merge semantics."""
+
+    def test_set_preserves_unnamed_roles(self, mock_resolve, mock_repo, client):
+        pipeline = _make_pipeline({"coder": "opus"})
+        store = _mock_store(pipeline)
+        mock_resolve.return_value = (store, pipeline)
+
+        response = client.patch(
+            "/api/v1/pipelines/issue-77/config",
+            json={"agent_models": {"tester": "deepseek-v4-pro"}},
+        )
+
+        assert response.status_code == 200, response.data
+        data = response.get_json()["data"]
+        # Unnamed role keeps its override; named role is set.
+        assert data["agent_models"] == {"coder": "opus", "tester": "deepseek-v4-pro"}
+        assert data["updated_roles"] == {"tester": "deepseek-v4-pro"}
+        assert data["cleared_roles"] == []
+        store.update_pipeline.assert_called_once_with(
+            "issue-77",
+            {"config.agent_models": {"coder": "opus", "tester": "deepseek-v4-pro"}},
+        )
+
+    def test_null_clears_role(self, mock_resolve, mock_repo, client):
+        pipeline = _make_pipeline({"coder": "opus", "tester": "qwen3-max"})
+        store = _mock_store(pipeline)
+        mock_resolve.return_value = (store, pipeline)
+
+        response = client.patch(
+            "/api/v1/pipelines/issue-77/config",
+            json={"agent_models": {"tester": None}},
+        )
+
+        assert response.status_code == 200, response.data
+        data = response.get_json()["data"]
+        assert data["agent_models"] == {"coder": "opus"}
+        assert data["updated_roles"] == {}
+        assert data["cleared_roles"] == ["tester"]
+
+    def test_clearing_absent_role_is_noop(self, mock_resolve, mock_repo, client):
+        pipeline = _make_pipeline({"coder": "opus"})
+        store = _mock_store(pipeline)
+        mock_resolve.return_value = (store, pipeline)
+
+        response = client.patch(
+            "/api/v1/pipelines/issue-77/config",
+            json={"agent_models": {"tester": None}},
+        )
+
+        assert response.status_code == 200, response.data
+        data = response.get_json()["data"]
+        assert data["agent_models"] == {"coder": "opus"}
+        # Not reported as cleared — there was nothing to clear.
+        assert data["cleared_roles"] == []
+
+    def test_model_value_whitespace_stripped(self, mock_resolve, mock_repo, client):
+        pipeline = _make_pipeline()
+        store = _mock_store(pipeline)
+        mock_resolve.return_value = (store, pipeline)
+
+        response = client.patch(
+            "/api/v1/pipelines/issue-77/config",
+            json={"agent_models": {"coder": "  deepseek-v4-pro  "}},
+        )
+
+        assert response.status_code == 200, response.data
+        data = response.get_json()["data"]
+        assert data["agent_models"] == {"coder": "deepseek-v4-pro"}
+
+
+@patch("routes.pipelines.get_repo_path")
+@patch("routes.pipelines._resolve_pipeline")
+class TestUpdatePipelineConfigValidation:
+    """Request validation runs before any store write."""
+
+    def _assert_no_write(self, mock_resolve):
+        if mock_resolve.return_value and isinstance(mock_resolve.return_value, tuple):
+            store = mock_resolve.return_value[0]
+            store.update_pipeline.assert_not_called()
+
+    def test_invalid_role_key_400(self, mock_resolve, mock_repo, client):
+        pipeline = _make_pipeline()
+        store = _mock_store(pipeline)
+        mock_resolve.return_value = (store, pipeline)
+
+        response = client.patch(
+            "/api/v1/pipelines/issue-77/config",
+            json={"agent_models": {"overseer": "opus"}},
+        )
+
+        assert response.status_code == 400, response.data
+        message = response.get_json()["message"]
+        # Actionable error: names the bad key and lists the honored roles.
+        assert "overseer" in message
+        assert "coder" in message
+        self._assert_no_write(mock_resolve)
+
+    @pytest.mark.parametrize("bad_value", ["", "   ", 42, ["opus"]])
+    def test_invalid_model_value_400(self, mock_resolve, mock_repo, client, bad_value):
+        pipeline = _make_pipeline()
+        store = _mock_store(pipeline)
+        mock_resolve.return_value = (store, pipeline)
+
+        response = client.patch(
+            "/api/v1/pipelines/issue-77/config",
+            json={"agent_models": {"coder": bad_value}},
+        )
+
+        assert response.status_code == 400, response.data
+        assert "coder" in response.get_json()["message"]
+        self._assert_no_write(mock_resolve)
+
+    def test_unsupported_config_key_400(self, mock_resolve, mock_repo, client):
+        response = client.patch(
+            "/api/v1/pipelines/issue-77/config",
+            json={"hitl_gates": False, "agent_models": {"coder": "opus"}},
+        )
+
+        assert response.status_code == 400, response.data
+        message = response.get_json()["message"]
+        assert "hitl_gates" in message
+        assert "agent_models" in message
+
+    @pytest.mark.parametrize("body", [{}, {"agent_models": {}}, {"agent_models": "coder=opus"}])
+    def test_missing_or_empty_agent_models_400(self, mock_resolve, mock_repo, client, body):
+        response = client.patch("/api/v1/pipelines/issue-77/config", json=body)
+        assert response.status_code == 400, response.data
+
+    def test_non_object_body_400(self, mock_resolve, mock_repo, client):
+        response = client.patch(
+            "/api/v1/pipelines/issue-77/config",
+            data="[1, 2]",
+            content_type="application/json",
+        )
+        assert response.status_code == 400, response.data
+
+
+class TestUpdatePipelineConfigErrors:
+    @patch("routes.pipelines.get_repo_path")
+    @patch("routes.pipelines._resolve_pipeline")
+    def test_pipeline_not_found_404(self, mock_resolve, mock_repo, client):
+        mock_resolve.side_effect = PipelineNotFoundError("issue-77")
+
+        response = client.patch(
+            "/api/v1/pipelines/issue-77/config",
+            json={"agent_models": {"coder": "opus"}},
+        )
+
+        assert response.status_code == 404, response.data
+
+    def test_requires_lifecycle_auth(self, client):
+        response = client.patch(
+            "/api/v1/pipelines/issue-77/config",
+            json={"agent_models": {"coder": "opus"}},
+            _lifecycle_auth=False,
+        )
+        assert response.status_code == 401, response.data

--- a/orchestrator/tests/test_update_pipeline_config.py
+++ b/orchestrator/tests/test_update_pipeline_config.py
@@ -8,7 +8,8 @@ the ``update_pipeline_config`` MCP tool). Covers:
 - per-role merge semantics (set / null-clears / absent-keeps),
 - role-key validation against ``MODEL_OVERRIDE_ROLES`` and value
   validation (non-empty strings or null),
-- error mapping (404 unknown pipeline, 400 validation, 401 unauth).
+- error mapping (404 unknown pipeline, 400 validation, 401 unauth,
+  409 terminal-state mutation).
 """
 
 from unittest.mock import MagicMock, patch
@@ -36,13 +37,16 @@ def client(app):
     return app.test_client()
 
 
-def _make_pipeline(agent_models: dict[str, str] | None = None) -> Pipeline:
+def _make_pipeline(
+    agent_models: dict[str, str] | None = None,
+    status: PipelineStatus = PipelineStatus.RUNNING,
+) -> Pipeline:
     return Pipeline(
         id="issue-77",
         repo="test/repo",
         issue_number=77,
         branch="egg/issue-77",
-        status=PipelineStatus.RUNNING,
+        status=status,
         config=PipelineConfig(agent_models=agent_models or {}),
     )
 
@@ -221,3 +225,32 @@ class TestUpdatePipelineConfigErrors:
             _lifecycle_auth=False,
         )
         assert response.status_code == 401, response.data
+
+
+@patch("routes.pipelines.get_repo_path")
+@patch("routes.pipelines._resolve_pipeline")
+class TestUpdatePipelineConfigTerminalState:
+    """Terminal pipelines reject config mutations with 409 (#3174 review).
+
+    Once a pipeline is COMPLETE / FAILED / CANCELLED no future spawn consumes
+    ``agent_models``, so the merge would be a silent no-op. A 409 gives the
+    operator a clear signal instead.
+    """
+
+    @pytest.mark.parametrize(
+        "status",
+        [PipelineStatus.COMPLETE, PipelineStatus.FAILED, PipelineStatus.CANCELLED],
+    )
+    def test_terminal_state_409_and_no_write(self, mock_resolve, mock_repo, client, status):
+        pipeline = _make_pipeline({"coder": "opus"}, status=status)
+        store = _mock_store(pipeline)
+        mock_resolve.return_value = (store, pipeline)
+
+        response = client.patch(
+            "/api/v1/pipelines/issue-77/config",
+            json={"agent_models": {"tester": "deepseek-v4-pro"}},
+        )
+
+        assert response.status_code == 409, response.data
+        assert status.value in response.get_json()["message"]
+        store.update_pipeline.assert_not_called()


### PR DESCRIPTION
Closes #3174.

## What

Makes the live per-pipeline model swap discoverable, documented, and confirmable. The mechanism already worked (generic `PATCH` + dotted-key `config.agent_models` update, honored because every spawn path re-resolves from a fresh store load) but had no operator surface — the #3064 outage swap required reading orchestrator source and hand-crafting an authenticated curl.

## Changes

**Scoped config-update surface**
- `PATCH /api/v1/pipelines/<id>/config` (lifecycle-secret-authenticated), allowlisted to `agent_models` only (`_MUTABLE_CONFIG_KEYS`). Per-role **merge** semantics: a string sets the role's override, an explicit `null` clears it, absent roles keep their value. Role keys are pre-validated against `MODEL_OVERRIDE_ROLES` with the same actionable message as the `PipelineConfig` validator; the merge runs under the per-pipeline state lock.
- New `update_pipeline_config` MCP tool wrapping the route (JSON-string arg tolerance, structured HTTP-error surfacing). The tool description and response `note` steer operators to the full flow: swap → `restart_phase` / `restart_agent` → confirm.

**Resolved-model visibility**
- `AgentExecution.resolved_model` records the resolved Claude-Code-facing alias (`AgentModelDecision.claude_code_alias`) at both spawn sites — `concurrent_executor._spawn_agent` and the `restart_agent` record update. `get_status`'s `running_agents` / `completed_agents` carry it implicitly (full record dumps); `list_containers` joins it onto live container rows best-effort (degrades to `null`, never blocks listing on state-store health).

**Docs**
- `per-agent-models.md` gains a *Changing models on a live pipeline* section: the swap-and-restart procedure, the fresh-reload guarantee that makes it honored by construction, the slice-bootstrap skip of completed slices, and confirmation via `resolved_model`. `docs/index.md` lookup row added.

## Design notes

- A standalone update tool was chosen over an `agent_models` param on `restart_phase` because it composes with **both** restart tools (whole-phase respawn, or surgical single-agent swap with worktree preserved) and with no restart at all (next review cycle / slice team picks it up).
- Model *values* are deliberately not validated against a registry — any non-Claude string routes to LiteLLM, mirroring submit-time behavior; a typo surfaces at spawn.

## Tests

- `orchestrator/tests/test_update_pipeline_config.py` (new): merge/clear semantics, role-key + value validation, allowlist, 404/401 mapping (16 tests).
- `test_mcp_tools.py`: handler routing, URL-encoding, JSON-string tolerance, pre-request rejection, HTTP-error message surfacing, schema registration; registry pin updated.
- `test_concurrent_executor.py`: `resolved_model` recorded for override (`deepseek-v4-pro[1m]`) and default (`opus`) paths.
- `test_containers_routes.py`: join onto container rows, helper state-read, fail-open degradation.
- `integration_tests/test_orchestrator_mcp_contract.py`: tool advertised over MCP.

`make lint` clean; touched-area suites (`test_mcp_tools`, `test_concurrent_executor`, `test_pipelines_api`, `test_restart_agent`, `test_restart_phase`, `test_agent_model_resolution`, `test_state_store`, `test_models`, `test_containers_routes`, new file) all pass — 720 tests.