### PR TITLE
egg-litellm: port reasoning streaming fixes from jwbron/litellm#4

### DIFF
--- a/config/litellm/Dockerfile
+++ b/config/litellm/Dockerfile
@@ -3,8 +3,8 @@
 # egg routes non-Claude agents (the cq-6 OpenRouter/Qwen pilot, #2799)
 # through this proxy: Claude Code -> gateway -> LiteLLM -> OpenRouter. The
 # stock image's Anthropic->OpenAI translation drops prompt-cache hits on
-# Qwen/DeepSeek, billing full input rate every turn. patch_litellm_cache.py
-# closes the three gaps at build time (see that script for the diagnosis);
+# Qwen/DeepSeek and mis-streams reasoning models. patch_litellm_cache.py
+# closes the five gaps at build time (see that script for the diagnosis);
 # cost_callback.py surfaces the resulting cost/cache stats into the pod log
 # stream. Both mirror the host-side dotfiles setup that took Qwen cache hit
 # rate from 0% to ~99.99%.

--- a/config/litellm/patch_litellm_cache.py
+++ b/config/litellm/patch_litellm_cache.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
-"""Apply egg's LiteLLM prompt-cache patches at image-build time.
+"""Apply egg's LiteLLM prompt-cache and reasoning-stream patches at image-build time.
 
 LiteLLM's stock Anthropic->OpenAI translation (the path Claude Code's
 ``/v1/messages`` requests take when routed at a non-Claude OpenRouter
-backend) drops prompt-cache hits for Qwen/DeepSeek. Three independent
-gaps cause it; this script closes all three by editing the installed
-``litellm`` package in place, then ``config/litellm/Dockerfile`` bakes
-the result into the ``egg-litellm`` image.
+backend) drops prompt-cache hits for Qwen/DeepSeek and mis-streams
+reasoning models. Five independent gaps cause it; this script closes all
+five by editing the installed ``litellm`` package in place, then
+``config/litellm/Dockerfile`` bakes the result into the ``egg-litellm``
+image.
 
-The patches mirror the host-side ``relitellm`` script (jwbron/dotfiles),
-which was validated empirically against ``litellm==1.86.2``: cache hit
-rate on Qwen via OpenRouter went 0% -> ~99.99%, ~10x input-cost cut on
-identical-prefix turns. The image pins that same version (see the
-Dockerfile ``FROM``), so the needles below are known to match.
+The cache patches mirror the host-side ``relitellm`` script
+(jwbron/dotfiles), which was validated empirically against
+``litellm==1.86.2``: cache hit rate on Qwen via OpenRouter went 0% ->
+~99.99%, ~10x input-cost cut on identical-prefix turns. The reasoning
+patches mirror jwbron/litellm#4, validated against Kimi K2.7-Code via
+OpenRouter. The image pins that same version (see the Dockerfile
+``FROM``), so the needles below are known to match.
 
   1. ``CacheControlSupportedModels`` (openrouter/chat/transformation.py)
      add QWEN + DEEPSEEK so ``cache_control`` survives the OpenRouter
@@ -38,11 +41,27 @@ Dockerfile ``FROM``), so the needles below are known to match.
      ``cache_read_input_tokens`` stays 0 forever. The sibling
      ``messages/transformation.py`` path already filters it via
      ``_filter_billing_headers_from_system``; the adapter path missed it.
+  4. ``_translate_streaming_openai_chunk_to_anthropic_content_block``
+     (anthropic adapter transformation.py) add a ``reasoning_content``
+     branch that opens a proper ``thinking`` content block. OpenRouter-style
+     reasoning models stream ``delta.reasoning_content`` rather than
+     Anthropic-native ``delta.thinking_blocks``; without this patch the
+     block start is typed ``text`` while the deltas are
+     ``thinking_delta`` — a malformed stream that clients (e.g. Claude
+     Code) render as visible assistant text and feed back as assistant
+     content on later turns.
+  5. ``AnthropicStreamWrapper`` block-transition requeue (anthropic adapter
+     streaming_iterator.py) preserve the trigger chunk's first delta on
+     text/thinking block transitions, not just on ``input_json_delta``
+     tool transitions. Without it the first reasoning token of every
+     thinking block and the first answer token after thinking are silently
+     dropped; a one-chunk answer can vanish entirely. Applied to both the
+     sync ``__next__`` and async ``__anext__`` paths.
 
 Idempotent: each patch detects whether it is already applied. Fails
 loudly (non-zero exit) if a needle is missing, so a LiteLLM version bump
 that moves the code surfaces at build time instead of silently shipping
-an unpatched image that bills full input rate.
+an unpatched image that bills full input rate or drops reasoning tokens.
 """
 
 import importlib.util
@@ -99,6 +118,9 @@ def _apply(path: str, present: str, needle: str, replacement: str, label: str) -
 def _patch_root(root: str) -> None:
     f1 = os.path.join(root, "llms/openrouter/chat/transformation.py")
     f2 = os.path.join(root, "llms/anthropic/experimental_pass_through/adapters/transformation.py")
+    f3 = os.path.join(
+        root, "llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py"
+    )
     print(f"== patching {root}")
 
     # Patch 1 — CacheControlSupportedModels: add QWEN + DEEPSEEK.
@@ -117,7 +139,7 @@ def _patch_root(root: str) -> None:
             '    QWEN = "qwen"\n'
             '    DEEPSEEK = "deepseek"\n'
         ),
-        label="Patch 1/3 (CacheControlSupportedModels)",
+        label="Patch 1/5 (CacheControlSupportedModels)",
     )
 
     # Patch 2 — broaden ONLY the cache_control gate (not the shared
@@ -148,7 +170,7 @@ def _patch_root(root: str) -> None:
             "            )\n"
             "        ):\n"
         ),
-        label="Patch 2/3 (cache_control gate)",
+        label="Patch 2/5 (cache_control gate)",
     )
 
     # Patch 3 — drop x-anthropic-billing-header during Anthropic->OpenAI translation.
@@ -183,7 +205,236 @@ def _patch_root(root: str) -> None:
             '                        "text": text,\n'
             "                    }\n"
         ),
-        label="Patch 3/3 (x-anthropic-billing-header filter)",
+        label="Patch 3/5 (x-anthropic-billing-header filter)",
+    )
+
+    # Patch 4 — OpenRouter-style reasoning_content must open a thinking
+    # content block, not fall through to a text block.
+    _apply(
+        f2,
+        present="# egg reasoning patch: OpenRouter-style reasoning_content",
+        needle=(
+            "            elif isinstance(choice, StreamingChoices) and hasattr(\n"
+            '                choice.delta, "thinking_blocks"\n'
+            "            ):\n"
+        ),
+        replacement=(
+            "            elif isinstance(choice, StreamingChoices) and getattr(\n"
+            '                choice.delta, "reasoning_content", None\n'
+            "            ):\n"
+            "                # egg reasoning patch: OpenRouter-style reasoning_content\n"
+            "                # streams must open a thinking content block. Without\n"
+            "                # this, thinking_delta events are emitted inside a\n"
+            "                # text-typed block, which clients render as visible\n"
+            "                # assistant text and feed back as assistant content.\n"
+            '                return "thinking", ChatCompletionThinkingBlock(\n'
+            '                    type="thinking", thinking="", signature=""\n'
+            "                )\n"
+            "            elif isinstance(choice, StreamingChoices) and hasattr(\n"
+            '                choice.delta, "thinking_blocks"\n'
+            "            ):\n"
+        ),
+        label="Patch 4/5 (reasoning_content thinking block)",
+    )
+
+    # Patch 5a — sync __next__: don't drop the first delta on text or
+    # thinking block transitions.
+    _apply(
+        f3,
+        present="# egg reasoning patch (sync first-delta)",
+        needle=(
+            "                    # Queue the sequence: content_block_stop -> content_block_start\n"
+            "                    # For text blocks the trigger chunk is not emitted as a separate\n"
+            "                    # delta because content_block_start carries the information.\n"
+            "                    # For tool_use blocks we must also emit the trigger chunk's delta\n"
+            "                    # when it carries input_json_delta data, because some providers\n"
+            "                    # (e.g. xAI, Gemini) include tool arguments in the same streaming\n"
+            "                    # chunk as the function name/id.\n"
+            "\n"
+            "                    # 1. Stop current content block\n"
+            "                    self.chunk_queue.append(\n"
+            "                        {\n"
+            '                            "type": "content_block_stop",\n'
+            '                            "index": max(self.current_content_block_index - 1, 0),\n'
+            "                        }\n"
+            "                    )\n"
+            "\n"
+            "                    # 2. Start new content block\n"
+            "                    self.chunk_queue.append(\n"
+            "                        {\n"
+            '                            "type": "content_block_start",\n'
+            '                            "index": self.current_content_block_index,\n'
+            '                            "content_block": self.current_content_block_start,\n'
+            "                        }\n"
+            "                    )\n"
+            "\n"
+            "                    # 3. If the trigger chunk carries tool argument data, queue it\n"
+            "                    # so the input_json_delta is not silently dropped.\n"
+            "                    if (\n"
+            '                        processed_chunk.get("type") == "content_block_delta"\n'
+            '                        and isinstance(processed_chunk.get("delta"), dict)\n'
+            '                        and processed_chunk["delta"].get("type") == "input_json_delta"\n'
+            '                        and processed_chunk["delta"].get("partial_json")\n'
+            "                    ):\n"
+            "                        self.chunk_queue.append(processed_chunk)\n"
+        ),
+        replacement=(
+            "                    # Queue the sequence: content_block_stop -> content_block_start,\n"
+            "                    # then re-queue the trigger chunk's delta when it carries payload\n"
+            "                    # the new content_block_start doesn't already include (see step 3).\n"
+            "                    # egg reasoning patch (sync first-delta)\n"
+            "\n"
+            "                    # 1. Stop current content block\n"
+            "                    self.chunk_queue.append(\n"
+            "                        {\n"
+            '                            "type": "content_block_stop",\n'
+            '                            "index": max(self.current_content_block_index - 1, 0),\n'
+            "                        }\n"
+            "                    )\n"
+            "\n"
+            "                    # 2. Start new content block\n"
+            "                    self.chunk_queue.append(\n"
+            "                        {\n"
+            '                            "type": "content_block_start",\n'
+            '                            "index": self.current_content_block_index,\n'
+            '                            "content_block": self.current_content_block_start,\n'
+            "                        }\n"
+            "                    )\n"
+            "\n"
+            "                    # 3. If the trigger chunk itself carries delta payload not\n"
+            "                    # already embedded in the new content_block_start, queue it\n"
+            "                    # so the first delta of the block isn't silently dropped:\n"
+            "                    # - input_json_delta: some providers (e.g. xAI, Gemini)\n"
+            "                    #   include tool arguments in the same streaming chunk as\n"
+            "                    #   the function name/id.\n"
+            "                    # - text_delta: the text block start is always empty, so\n"
+            "                    #   the trigger chunk's text is the block's first token.\n"
+            "                    # - thinking_delta: same, but only when the block start\n"
+            "                    #   doesn't already embed the thinking content (it does\n"
+            "                    #   for providers that send Anthropic-native\n"
+            "                    #   thinking_blocks).\n"
+            '                    if processed_chunk.get("type") == "content_block_delta" and isinstance(\n'
+            '                        processed_chunk.get("delta"), dict\n'
+            "                    ):\n"
+            '                        trigger_delta = processed_chunk["delta"]\n'
+            '                        trigger_delta_type = trigger_delta.get("type")\n'
+            "                        if (\n"
+            "                            (\n"
+            '                                trigger_delta_type == "input_json_delta"\n'
+            '                                and trigger_delta.get("partial_json")\n'
+            "                            )\n"
+            "                            or (\n"
+            '                                trigger_delta_type == "text_delta"\n'
+            '                                and trigger_delta.get("text")\n'
+            "                            )\n"
+            "                            or (\n"
+            '                                trigger_delta_type == "thinking_delta"\n'
+            '                                and trigger_delta.get("thinking")\n'
+            '                                and not self.current_content_block_start.get("thinking")\n'
+            "                            )\n"
+            "                        ):\n"
+            "                            self.chunk_queue.append(processed_chunk)\n"
+        ),
+        label="Patch 5/5a (sync first-delta requeue)",
+    )
+
+    # Patch 5b — async __anext__: same first-delta preservation.
+    _apply(
+        f3,
+        present="# egg reasoning patch (async first-delta)",
+        needle=(
+            "                        # Queue the sequence: content_block_stop -> content_block_start\n"
+            "                        # For text blocks the trigger chunk is not emitted as a separate\n"
+            "                        # delta because content_block_start carries the information.\n"
+            "                        # For tool_use blocks we must also emit the trigger chunk's delta\n"
+            "                        # when it carries input_json_delta data, because some providers\n"
+            "                        # (e.g. xAI, Gemini) include tool arguments in the same streaming\n"
+            "                        # chunk as the function name/id.\n"
+            "\n"
+            "                        # 1. Stop current content block\n"
+            "                        self.chunk_queue.append(\n"
+            "                            {\n"
+            '                                "type": "content_block_stop",\n'
+            '                                "index": max(self.current_content_block_index - 1, 0),\n'
+            "                            }\n"
+            "                        )\n"
+            "                        self.chunk_queue.append(\n"
+            "                            {\n"
+            '                                "type": "content_block_start",\n'
+            '                                "index": self.current_content_block_index,\n'
+            '                                "content_block": self.current_content_block_start,\n'
+            "                            }\n"
+            "                        )\n"
+            "\n"
+            "                        # 3. If the trigger chunk carries tool argument data, queue it\n"
+            "                        # so the input_json_delta is not silently dropped.\n"
+            "                        if (\n"
+            '                            processed_chunk.get("type") == "content_block_delta"\n'
+            '                            and isinstance(processed_chunk.get("delta"), dict)\n'
+            '                            and processed_chunk["delta"].get("type")\n'
+            '                            == "input_json_delta"\n'
+            '                            and processed_chunk["delta"].get("partial_json")\n'
+            "                        ):\n"
+            "                            self.chunk_queue.append(processed_chunk)\n"
+        ),
+        replacement=(
+            "                        # Queue the sequence: content_block_stop -> content_block_start,\n"
+            "                        # then re-queue the trigger chunk's delta when it carries payload\n"
+            "                        # the new content_block_start doesn't already include (see step 3).\n"
+            "                        # egg reasoning patch (async first-delta)\n"
+            "\n"
+            "                        # 1. Stop current content block\n"
+            "                        self.chunk_queue.append(\n"
+            "                            {\n"
+            '                                "type": "content_block_stop",\n'
+            '                                "index": max(self.current_content_block_index - 1, 0),\n'
+            "                            }\n"
+            "                        )\n"
+            "                        self.chunk_queue.append(\n"
+            "                            {\n"
+            '                                "type": "content_block_start",\n'
+            '                                "index": self.current_content_block_index,\n'
+            '                                "content_block": self.current_content_block_start,\n'
+            "                            }\n"
+            "                        )\n"
+            "\n"
+            "                        # 3. If the trigger chunk itself carries delta payload\n"
+            "                        # not already embedded in the new content_block_start,\n"
+            "                        # queue it so the first delta of the block isn't\n"
+            "                        # silently dropped:\n"
+            "                        # - input_json_delta: some providers (e.g. xAI, Gemini)\n"
+            "                        #   include tool arguments in the same streaming chunk\n"
+            "                        #   as the function name/id.\n"
+            "                        # - text_delta: the text block start is always empty,\n"
+            "                        #   so the trigger chunk's text is the block's first\n"
+            "                        #   token.\n"
+            "                        # - thinking_delta: same, but only when the block start\n"
+            "                        #   doesn't already embed the thinking content (it does\n"
+            "                        #   for providers that send Anthropic-native\n"
+            "                        #   thinking_blocks).\n"
+            '                        if processed_chunk.get("type") == "content_block_delta" and isinstance(\n'
+            '                            processed_chunk.get("delta"), dict\n'
+            "                        ):\n"
+            '                            trigger_delta = processed_chunk["delta"]\n'
+            '                            trigger_delta_type = trigger_delta.get("type")\n'
+            "                            if (\n"
+            "                                (\n"
+            '                                    trigger_delta_type == "input_json_delta"\n'
+            '                                    and trigger_delta.get("partial_json")\n'
+            "                                )\n"
+            "                                or (\n"
+            '                                    trigger_delta_type == "text_delta"\n'
+            '                                    and trigger_delta.get("text")\n'
+            "                                )\n"
+            "                                or (\n"
+            '                                    trigger_delta_type == "thinking_delta"\n'
+            '                                    and trigger_delta.get("thinking")\n'
+            '                                    and not self.current_content_block_start.get("thinking")\n'
+            "                                )\n"
+            "                            ):\n"
+            "                                self.chunk_queue.append(processed_chunk)\n"
+        ),
+        label="Patch 5/5b (async first-delta requeue)",
     )
 
 

--- a/config/litellm/patch_litellm_cache.py
+++ b/config/litellm/patch_litellm_cache.py
@@ -115,23 +115,24 @@ def _apply(path: str, present: str, needle: str, replacement: str, label: str) -
     print(f"{label}: applied")
 
 
-def _patch_root(root: str) -> None:
-    f1 = os.path.join(root, "llms/openrouter/chat/transformation.py")
-    f2 = os.path.join(root, "llms/anthropic/experimental_pass_through/adapters/transformation.py")
-    f3 = os.path.join(
-        root, "llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py"
-    )
-    print(f"== patching {root}")
+F1 = "llms/openrouter/chat/transformation.py"
+F2 = "llms/anthropic/experimental_pass_through/adapters/transformation.py"
+F3 = "llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py"
 
+# Every patch as a self-contained spec: (file, present marker, needle,
+# replacement, label). Module-level so tests can apply them to a checked-in
+# fixture and assert the resulting source without re-declaring the needles
+# (no fixture/needle drift). ``_patch_root`` just walks this list.
+PATCHES: list[dict[str, str]] = [
     # Patch 1 — CacheControlSupportedModels: add QWEN + DEEPSEEK.
     # Idempotency marker is the egg-specific comment, not ``QWEN = "qwen"``:
     # if a future LiteLLM adds QWEN natively but not DEEPSEEK, a generic marker
     # would see it "already applied" and silently ship without DEEPSEEK.
-    _apply(
-        f1,
-        present="# egg cache patch. OpenRouter natively supports cache_control",
-        needle='    ZAI = "z-ai"\n',
-        replacement=(
+    {
+        "file": F1,
+        "present": "# egg cache patch. OpenRouter natively supports cache_control",
+        "needle": '    ZAI = "z-ai"\n',
+        "replacement": (
             '    ZAI = "z-ai"\n'
             "    # egg cache patch. OpenRouter natively supports cache_control\n"
             "    # for these providers — see\n"
@@ -139,18 +140,17 @@ def _patch_root(root: str) -> None:
             '    QWEN = "qwen"\n'
             '    DEEPSEEK = "deepseek"\n'
         ),
-        label="Patch 1/5 (CacheControlSupportedModels)",
-    )
-
+        "label": "Patch 1/5 (CacheControlSupportedModels)",
+    },
     # Patch 2 — broaden ONLY the cache_control gate (not the shared
     # is_anthropic_claude_model predicate, which also gates thinking
     # translation — see module docstring). Touches the single call site in
     # _add_cache_control_to_target.
-    _apply(
-        f2,
-        present="# egg cache patch. Broaden ONLY the cache_control gate",
-        needle="        if cache_control and model and self.is_anthropic_claude_model(model):\n",
-        replacement=(
+    {
+        "file": F2,
+        "present": "# egg cache patch. Broaden ONLY the cache_control gate",
+        "needle": "        if cache_control and model and self.is_anthropic_claude_model(model):\n",
+        "replacement": (
             "        # egg cache patch. Broaden ONLY the cache_control gate to\n"
             "        # cover the OpenRouter qwen/deepseek routes. Do NOT widen\n"
             "        # is_anthropic_claude_model itself: it also gates the\n"
@@ -170,14 +170,13 @@ def _patch_root(root: str) -> None:
             "            )\n"
             "        ):\n"
         ),
-        label="Patch 2/5 (cache_control gate)",
-    )
-
+        "label": "Patch 2/5 (cache_control gate)",
+    },
     # Patch 3 — drop x-anthropic-billing-header during Anthropic->OpenAI translation.
-    _apply(
-        f2,
-        present='"x-anthropic-billing-header:" filter (egg cache patch)',
-        needle=(
+    {
+        "file": F2,
+        "present": '"x-anthropic-billing-header:" filter (egg cache patch)',
+        "needle": (
             "            for block in system_content:\n"
             '                if isinstance(block, dict) and block.get("type") == "text":\n'
             "                    text_block: Dict[str, Any] = {\n"
@@ -185,7 +184,7 @@ def _patch_root(root: str) -> None:
             '                        "text": block.get("text", ""),\n'
             "                    }\n"
         ),
-        replacement=(
+        "replacement": (
             "            for block in system_content:\n"
             '                if isinstance(block, dict) and block.get("type") == "text":\n'
             '                    text = block.get("text", "")\n'
@@ -205,20 +204,29 @@ def _patch_root(root: str) -> None:
             '                        "text": text,\n'
             "                    }\n"
         ),
-        label="Patch 3/5 (x-anthropic-billing-header filter)",
-    )
-
+        "label": "Patch 3/5 (x-anthropic-billing-header filter)",
+    },
     # Patch 4 — OpenRouter-style reasoning_content must open a thinking
-    # content block, not fall through to a text block.
-    _apply(
-        f2,
-        present="# egg reasoning patch: OpenRouter-style reasoning_content",
-        needle=(
+    # content block, not fall through to a text block. The bare
+    # ``thinking_blocks`` elif appears in two sibling functions; we anchor the
+    # needle on the preceding text-block elif (``choice.delta.content is not
+    # None ...``), which is unique to
+    # _translate_streaming_openai_chunk_to_anthropic_content_block — the other
+    # function's preceding branch is the ``tool_calls`` block. Without this
+    # anchor, an upstream reorder could silently retarget the str.replace.
+    {
+        "file": F2,
+        "present": "# egg reasoning patch: OpenRouter-style reasoning_content",
+        "needle": (
+            "            elif choice.delta.content is not None and len(choice.delta.content) > 0:\n"
+            '                return "text", TextBlock(type="text", text="")\n'
             "            elif isinstance(choice, StreamingChoices) and hasattr(\n"
             '                choice.delta, "thinking_blocks"\n'
             "            ):\n"
         ),
-        replacement=(
+        "replacement": (
+            "            elif choice.delta.content is not None and len(choice.delta.content) > 0:\n"
+            '                return "text", TextBlock(type="text", text="")\n'
             "            elif isinstance(choice, StreamingChoices) and getattr(\n"
             '                choice.delta, "reasoning_content", None\n'
             "            ):\n"
@@ -234,15 +242,14 @@ def _patch_root(root: str) -> None:
             '                choice.delta, "thinking_blocks"\n'
             "            ):\n"
         ),
-        label="Patch 4/5 (reasoning_content thinking block)",
-    )
-
+        "label": "Patch 4/5 (reasoning_content thinking block)",
+    },
     # Patch 5a — sync __next__: don't drop the first delta on text or
     # thinking block transitions.
-    _apply(
-        f3,
-        present="# egg reasoning patch (sync first-delta)",
-        needle=(
+    {
+        "file": F3,
+        "present": "# egg reasoning patch (sync first-delta)",
+        "needle": (
             "                    # Queue the sequence: content_block_stop -> content_block_start\n"
             "                    # For text blocks the trigger chunk is not emitted as a separate\n"
             "                    # delta because content_block_start carries the information.\n"
@@ -278,7 +285,7 @@ def _patch_root(root: str) -> None:
             "                    ):\n"
             "                        self.chunk_queue.append(processed_chunk)\n"
         ),
-        replacement=(
+        "replacement": (
             "                    # Queue the sequence: content_block_stop -> content_block_start,\n"
             "                    # then re-queue the trigger chunk's delta when it carries payload\n"
             "                    # the new content_block_start doesn't already include (see step 3).\n"
@@ -335,14 +342,13 @@ def _patch_root(root: str) -> None:
             "                        ):\n"
             "                            self.chunk_queue.append(processed_chunk)\n"
         ),
-        label="Patch 5/5a (sync first-delta requeue)",
-    )
-
+        "label": "Patch 5/5a (sync first-delta requeue)",
+    },
     # Patch 5b — async __anext__: same first-delta preservation.
-    _apply(
-        f3,
-        present="# egg reasoning patch (async first-delta)",
-        needle=(
+    {
+        "file": F3,
+        "present": "# egg reasoning patch (async first-delta)",
+        "needle": (
             "                        # Queue the sequence: content_block_stop -> content_block_start\n"
             "                        # For text blocks the trigger chunk is not emitted as a separate\n"
             "                        # delta because content_block_start carries the information.\n"
@@ -377,7 +383,7 @@ def _patch_root(root: str) -> None:
             "                        ):\n"
             "                            self.chunk_queue.append(processed_chunk)\n"
         ),
-        replacement=(
+        "replacement": (
             "                        # Queue the sequence: content_block_stop -> content_block_start,\n"
             "                        # then re-queue the trigger chunk's delta when it carries payload\n"
             "                        # the new content_block_start doesn't already include (see step 3).\n"
@@ -434,8 +440,21 @@ def _patch_root(root: str) -> None:
             "                            ):\n"
             "                                self.chunk_queue.append(processed_chunk)\n"
         ),
-        label="Patch 5/5b (async first-delta requeue)",
-    )
+        "label": "Patch 5/5b (async first-delta requeue)",
+    },
+]
+
+
+def _patch_root(root: str) -> None:
+    print(f"== patching {root}")
+    for spec in PATCHES:
+        _apply(
+            os.path.join(root, spec["file"]),
+            present=spec["present"],
+            needle=spec["needle"],
+            replacement=spec["replacement"],
+            label=spec["label"],
+        )
 
 
 def main() -> None:

--- a/tests/config/test_patch_litellm_cache.py
+++ b/tests/config/test_patch_litellm_cache.py
@@ -1,0 +1,157 @@
+"""Unit tests for the egg-litellm build-time patch script.
+
+``config/litellm/patch_litellm_cache.py`` edits the installed ``litellm``
+package in place at image-build time (see PR #3190 / #3199). The real
+``litellm==1.86.2`` is not a project dependency — and cannot run on the
+repo's Python — so we exercise the patch *mechanics* against fixtures that
+embed the exact needles the script targets, then assert the resulting
+source. This is the patch-script regression the CI image build doesn't give
+us: the build catches version drift via the fail-loud needle check, but
+nothing else exercises idempotency, the replacement payload, or the Patch 4
+needle-uniqueness anchor.
+
+The fixtures are derived from ``PATCHES`` itself (the module-level spec
+list), so there is no fixture/needle drift: a needle change automatically
+flows into the fixture the test patches.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+CONFIG_DIR = Path(__file__).resolve().parent.parent.parent / "config" / "litellm"
+
+
+def _load_patch_module():
+    """Load ``patch_litellm_cache`` from disk (it isn't an importable package)."""
+    path = CONFIG_DIR / "patch_litellm_cache.py"
+    spec = importlib.util.spec_from_file_location("patch_litellm_cache", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["patch_litellm_cache"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+plc = _load_patch_module()
+
+
+def _build_fixture_root(root: Path) -> None:
+    """Write one fixture file per patched ``litellm`` path, each containing
+    every needle that targets that path concatenated verbatim."""
+    by_file: dict[str, list[str]] = {}
+    for spec in plc.PATCHES:
+        by_file.setdefault(spec["file"], []).append(spec["needle"])
+    for rel, needles in by_file.items():
+        fpath = root / rel
+        fpath.parent.mkdir(parents=True, exist_ok=True)
+        fpath.write_text("# fixture head\n\n" + "\n\n".join(needles) + "\n\n# fixture tail\n")
+
+
+def test_each_needle_occurs_once_in_its_fixture(tmp_path):
+    """Sanity: the needles are distinct, so the fixture contains each exactly
+    once. If this fails the other assertions can't be trusted."""
+    _build_fixture_root(tmp_path)
+    for spec in plc.PATCHES:
+        src = (tmp_path / spec["file"]).read_text()
+        assert src.count(spec["needle"]) == 1, spec["label"]
+
+
+def test_patch_applies_all_markers(tmp_path):
+    """After ``_patch_root`` every patch's present-marker is in its file and
+    the raw needle has been rewritten away."""
+    _build_fixture_root(tmp_path)
+    plc._patch_root(str(tmp_path))
+
+    for spec in plc.PATCHES:
+        src = (tmp_path / spec["file"]).read_text()
+        assert spec["present"] in src, f"{spec['label']}: marker missing after patch"
+        # The replacement is now present; raw needle should be gone unless the
+        # needle is (intentionally) a substring of the replacement.
+        assert spec["replacement"] in src, f"{spec['label']}: replacement missing"
+
+
+def test_patch_is_idempotent(tmp_path):
+    """Re-running over already-patched source is a no-op (no error, no double
+    application) — each ``_apply`` short-circuits on its present-marker."""
+    _build_fixture_root(tmp_path)
+    plc._patch_root(str(tmp_path))
+    first = {spec["file"]: (tmp_path / spec["file"]).read_text() for spec in plc.PATCHES}
+
+    plc._patch_root(str(tmp_path))  # second pass must change nothing
+    for rel, content in first.items():
+        assert (tmp_path / rel).read_text() == content, f"{rel}: not idempotent"
+        # Marker count unchanged → no double-apply.
+    for spec in plc.PATCHES:
+        src = (tmp_path / spec["file"]).read_text()
+        assert src.count(spec["present"]) == 1, f"{spec['label']}: applied twice"
+
+
+def test_missing_needle_fails_loud(tmp_path):
+    """A drifted source (needle absent, marker absent) must raise SystemExit
+    rather than silently shipping an unpatched image."""
+    _build_fixture_root(tmp_path)
+    # Corrupt one fixture so a needle no longer matches.
+    target = plc.PATCHES[0]
+    fpath = tmp_path / target["file"]
+    fpath.write_text("# drifted source with no matching needle\n")
+
+    with pytest.raises(SystemExit):
+        plc._patch_root(str(tmp_path))
+
+
+def test_missing_file_fails_loud(tmp_path):
+    """A missing target file must raise SystemExit, not pass silently."""
+    # Empty root — none of the litellm paths exist.
+    with pytest.raises(SystemExit):
+        plc._patch_root(str(tmp_path))
+
+
+def test_patch4_needle_anchors_on_content_block_function(tmp_path):
+    """Regression for the Patch 4 needle-uniqueness fix (#3199 review).
+
+    The bare ``thinking_blocks`` elif appears in two sibling functions. The
+    Patch 4 needle anchors on the preceding text-block elif
+    (``choice.delta.content is not None ...``), which is unique to
+    ``_translate_streaming_openai_chunk_to_anthropic_content_block``. A
+    fixture containing a *second* (sibling-function-style) bare
+    ``thinking_blocks`` elif — preceded by a ``tool_calls`` block, not the
+    text elif — must be left untouched."""
+    patch4 = next(p for p in plc.PATCHES if p["label"].startswith("Patch 4/5"))
+
+    # Sibling function: bare thinking_blocks elif preceded by a tool_calls
+    # branch (mirrors _translate_streaming_openai_chunk_to_anthropic). It must
+    # NOT match the Patch 4 needle.
+    sibling = (
+        "SENTINEL_SIBLING_BEGIN\n"
+        "            if choice.delta.tool_calls is not None:\n"
+        "                partial_json = ''\n"
+        "            elif isinstance(choice, StreamingChoices) and hasattr(\n"
+        '                choice.delta, "thinking_blocks"\n'
+        "            ):\n"
+        "                pass\n"
+        "SENTINEL_SIBLING_END\n"
+    )
+    fixture = sibling + "\n" + patch4["needle"]
+
+    f2 = tmp_path / patch4["file"]
+    f2.parent.mkdir(parents=True, exist_ok=True)
+    f2.write_text(fixture)
+
+    plc._apply(
+        str(f2),
+        present=patch4["present"],
+        needle=patch4["needle"],
+        replacement=patch4["replacement"],
+        label=patch4["label"],
+    )
+    result = f2.read_text()
+
+    # The intended branch was rewritten exactly once.
+    assert result.count(patch4["present"]) == 1
+    # The sibling block is byte-for-byte unchanged.
+    start = result.index("SENTINEL_SIBLING_BEGIN")
+    end = result.index("SENTINEL_SIBLING_END") + len("SENTINEL_SIBLING_END\n")
+    assert result[start:end] == sibling


### PR DESCRIPTION
Fixes #3190.

Ports the two reasoning-stream patches from jwbron/litellm#4 into the egg-litellm build-time patch script:

- **Patch 4 (transformation.py):** OpenRouter-style `delta.reasoning_content` now opens a proper Anthropic `thinking` content block, so reasoning no longer renders as visible assistant text or leaks back into the conversation history.
- **Patch 5 (streaming_iterator.py):** block-type transitions now re-queue the trigger chunk's first `text_delta` / `thinking_delta`, not just `input_json_delta`. This preserves the first reasoning token and the first answer token after thinking; native `thinking_blocks` providers are guarded against duplication. Applied to both sync `__next__` and async `__anext__`.

Also updates the Dockerfile comment and patch labels/docstring to reflect five total patches.

Validated against a clean `litellm==1.86.2` install: all five patches apply cleanly, are idempotent on re-run, and a mocked reasoning stream reassembles to `thinking: 'We think.'` / `text: 'The answer.'` with first tokens intact.