### PR TITLE
Validate slice DAG is a forest at plan propose time (#3211)

### DIFF
--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -1104,6 +1104,8 @@ def _validate_plan_extensions(
     try:
         from egg_contracts.plan_parser import (
             parse_plan,
+            validate_forest,
+            validate_slice_file_overlap,
             validate_task_role_alignment,
         )
     except ImportError:
@@ -1154,7 +1156,61 @@ def _validate_plan_extensions(
         )
         return
 
-    # (2) Role↔files alignment (#2527). #2528: pass the pipeline's repo so
+    # (2) Slice-DAG shape — forest (#2137) and file-overlap ordering
+    # (#3046). Both validators run at *populate* time today (the contract
+    # populator in ``routes/pipelines.py::_populate_contract_from_plan``),
+    # where a violation stashes ``plan_review_feedback`` and fails the whole
+    # pipeline ~24 min after consensus — the #3211 anti-pattern. Running the
+    # SAME validators here NACKs the producer while it is still alive in BRC
+    # (the #3016 pattern), so it re-emits a forest *before* consensus rather
+    # than a phase later. Reusing the populator's exact validators means the
+    # propose-time check and the populate check cannot diverge. Same
+    # non-blocking posture as the wraps above: a validator that *raises*
+    # (e.g. a future ``Slice`` field tightening) degrades to skip; only
+    # returned errors NACK.
+    try:
+        forest_errors = validate_forest(slices)
+        overlap_errors = validate_slice_file_overlap(slices)
+    except Exception as exc:
+        logger.warning(
+            "plan DAG-shape validation: validator raised (non-blocking)",
+            pipeline_id=pipeline_id,
+            commit_sha=commit_sha,
+            error=str(exc),
+        )
+        forest_errors = []
+        overlap_errors = []
+
+    if forest_errors:
+        bullets = "\n".join(f"  - {e}" for e in forest_errors)
+        raise ValueError(
+            "Plan proposal rejected: the slice DAG is not a forest.\n"
+            "Each slice must have at most one DAG parent — the implement "
+            "phase ships every slice as a stacked PR with exactly one base "
+            "branch, so multi-parent slices break the stacking invariant "
+            "and are hard-rejected at plan ingestion. Serialise the "
+            "upstream cluster into a linear ``dependencies`` chain and "
+            "record the chosen order on the downstream slice's "
+            "``serialized_chain_order`` field (see issue #2137 plan "
+            "TASK-2-3), then re-propose:\n" + bullets
+        )
+
+    if overlap_errors:
+        bullets = "\n".join(f"  - {e}" for e in overlap_errors)
+        raise ValueError(
+            "Plan proposal rejected: slices touch overlapping files "
+            "without a dependency ordering.\n"
+            "The implement phase cuts each slice's branch off its "
+            "dependency parent (roots off ``work``); two slices that touch "
+            "the same file must be ordered along ONE dependency chain or "
+            "their branches fork independently off the shared base and "
+            "collide at integration (a guaranteed modify/delete conflict). "
+            "Serialise the overlapping cluster into one linear "
+            "``dependencies`` chain — or merge the slices — then "
+            "re-propose:\n" + bullets
+        )
+
+    # (3) Role↔files alignment (#2527). #2528: pass the pipeline's repo so
     # per-repo ``role_patterns`` from repositories.yaml are honoured — plan-time
     # validation must mirror push-time enforcement, which also reads the per-repo
     # overrides (gateway/agent_restrictions.py).

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -2299,6 +2299,182 @@ class TestPlanProposalValidation:
         "in prose here rather than in a structured appendix.\n"
     )
 
+    # #3211 incident fixture: a legitimately diamond-shaped slice DAG —
+    # slice-5 (integration) naturally depends on BOTH slice-2 (resume) and
+    # slice-4 (enrichment). The implement phase ships each slice as a stacked
+    # PR off exactly one base, so the DAG must be a forest (≤1 parent). Today
+    # this only blows up at post-consensus contract population
+    # (``forest_violation``); the propose-time validator must NACK it now,
+    # while the producer is still alive in BRC, with the
+    # ``serialized_chain_order`` remediation.
+    _PLAN_WITH_NON_FOREST_DAG = (
+        "# Plan\n"
+        "\n"
+        "```yaml\n"
+        "# yaml-tasks\n"
+        "slices:\n"
+        "  - id: 1\n"
+        "    name: Restart fix\n"
+        "    goal: root\n"
+        "    tasks:\n"
+        "      - id: TASK-1-1\n"
+        "        description: a\n"
+        "        acceptance: a\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - orchestrator/a.py\n"
+        "  - id: 2\n"
+        "    name: Session resume\n"
+        "    goal: resume\n"
+        "    dependencies: slice-1\n"
+        "    tasks:\n"
+        "      - id: TASK-2-1\n"
+        "        description: b\n"
+        "        acceptance: b\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - orchestrator/b.py\n"
+        "  - id: 3\n"
+        "    name: Deterministic seed\n"
+        "    goal: seed\n"
+        "    dependencies: slice-1\n"
+        "    tasks:\n"
+        "      - id: TASK-3-1\n"
+        "        description: c\n"
+        "        acceptance: c\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - orchestrator/c.py\n"
+        "  - id: 4\n"
+        "    name: Enrichment\n"
+        "    goal: enrich\n"
+        "    dependencies: slice-3\n"
+        "    tasks:\n"
+        "      - id: TASK-4-1\n"
+        "        description: d\n"
+        "        acceptance: d\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - orchestrator/d.py\n"
+        "  - id: 5\n"
+        "    name: Integration\n"
+        "    goal: integrate\n"
+        "    dependencies: slice-2, slice-4\n"
+        "    tasks:\n"
+        "      - id: TASK-5-1\n"
+        "        description: e\n"
+        "        acceptance: e\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - orchestrator/e.py\n"
+        "```\n"
+    )
+
+    # #3211 companion: a valid forest serialised per the #2137 rule —
+    # slice-5 depends on slice-4 ALONE, with ``serialized_chain_order``
+    # recording the deliberate slice-2 → slice-4 ordering. All file sets are
+    # disjoint, so neither the forest nor the overlap validator fires. This
+    # is the shape the planner should have emitted for issue-3200.
+    _PLAN_WITH_SERIALIZED_FOREST = (
+        "# Plan\n"
+        "\n"
+        "```yaml\n"
+        "# yaml-tasks\n"
+        "slices:\n"
+        "  - id: 1\n"
+        "    name: Restart fix\n"
+        "    goal: root\n"
+        "    tasks:\n"
+        "      - id: TASK-1-1\n"
+        "        description: a\n"
+        "        acceptance: a\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - orchestrator/a.py\n"
+        "  - id: 2\n"
+        "    name: Session resume\n"
+        "    goal: resume\n"
+        "    dependencies: slice-1\n"
+        "    tasks:\n"
+        "      - id: TASK-2-1\n"
+        "        description: b\n"
+        "        acceptance: b\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - orchestrator/b.py\n"
+        "  - id: 3\n"
+        "    name: Deterministic seed\n"
+        "    goal: seed\n"
+        "    dependencies: slice-1\n"
+        "    tasks:\n"
+        "      - id: TASK-3-1\n"
+        "        description: c\n"
+        "        acceptance: c\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - orchestrator/c.py\n"
+        "  - id: 4\n"
+        "    name: Enrichment\n"
+        "    goal: enrich\n"
+        "    dependencies: slice-3\n"
+        "    tasks:\n"
+        "      - id: TASK-4-1\n"
+        "        description: d\n"
+        "        acceptance: d\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - orchestrator/d.py\n"
+        "  - id: 5\n"
+        "    name: Integration\n"
+        "    goal: integrate\n"
+        "    dependencies: slice-4\n"
+        "    serialized_chain_order:\n"
+        "      - slice-2\n"
+        "      - slice-4\n"
+        "    tasks:\n"
+        "      - id: TASK-5-1\n"
+        "        description: e\n"
+        "        acceptance: e\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - orchestrator/e.py\n"
+        "```\n"
+    )
+
+    # #3046/#3211 companion: two parallel ROOT slices (neither depends on the
+    # other) whose tasks touch the SAME file. This is a valid forest (each has
+    # ≤1 parent) so it slips past ``validate_forest``, but ``validate_slice_
+    # file_overlap`` must reject it — the branches fork independently off the
+    # shared base and collide at integration.
+    _PLAN_WITH_OVERLAPPING_SLICES = (
+        "# Plan\n"
+        "\n"
+        "```yaml\n"
+        "# yaml-tasks\n"
+        "slices:\n"
+        "  - id: 1\n"
+        "    name: First\n"
+        "    goal: edit shared\n"
+        "    tasks:\n"
+        "      - id: TASK-1-1\n"
+        "        description: a\n"
+        "        acceptance: a\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - orchestrator/shared_module.py\n"
+        "  - id: 2\n"
+        "    name: Second\n"
+        "    goal: also edit shared\n"
+        "    tasks:\n"
+        "      - id: TASK-2-1\n"
+        "        description: b\n"
+        "        acceptance: b\n"
+        "        role: coder\n"
+        "        files:\n"
+        "          - orchestrator/shared_module.py\n"
+        "```\n"
+    )
+
     @staticmethod
     def _patched_store(issue_number: int | None = 2527, branch: str = "egg/issue-2527"):
         mock_pipeline = MagicMock()
@@ -2371,6 +2547,58 @@ class TestPlanProposalValidation:
             payload = {"commit_sha": "abc1234"}
             with pytest.raises(ValueError, match="does not parse into any tasks"):
                 _validate_plan_proposal("issue-2527", payload, Path("/tmp/repo"))
+
+    def test_rejects_non_forest_slice_dag_at_propose_time(self):
+        """#3211 regression: a diamond-shaped slice DAG (slice-5 depends on
+        both slice-2 and slice-4) is NACKed at propose-time with the
+        ``serialized_chain_order`` remediation — instead of passing BRC
+        consensus and failing the whole pipeline at ``populate_contract``
+        (``forest_violation``) ~24 min later, while the producer is dead.
+        """
+        from routes.signals import _validate_plan_proposal
+
+        with (
+            self._patched_store(),
+            self._patched_worktree(),
+            self._patched_subprocess(self._PLAN_WITH_NON_FOREST_DAG),
+        ):
+            payload = {"commit_sha": "abc1234"}
+            with pytest.raises(ValueError, match="the slice DAG is not a forest"):
+                _validate_plan_proposal("issue-2527", payload, Path("/tmp/repo"))
+
+    def test_rejects_overlapping_unordered_slices_at_propose_time(self):
+        """#3046/#3211 regression: two parallel root slices touching the same
+        file (a valid forest, but unordered overlap) are NACKed at propose-time
+        with the serialise-the-cluster remediation — instead of failing at
+        ``populate_contract`` (``slice_overlap_violation``) post-consensus.
+        """
+        from routes.signals import _validate_plan_proposal
+
+        with (
+            self._patched_store(),
+            self._patched_worktree(),
+            self._patched_subprocess(self._PLAN_WITH_OVERLAPPING_SLICES),
+        ):
+            payload = {"commit_sha": "abc1234"}
+            with pytest.raises(ValueError, match="slices touch overlapping files"):
+                _validate_plan_proposal("issue-2527", payload, Path("/tmp/repo"))
+
+    def test_accepts_serialized_forest_plan(self):
+        """#3211: the would-be diamond serialised per the #2137 rule (slice-5
+        depends on slice-4 alone, ``serialized_chain_order`` records the
+        slice-2 → slice-4 order, file sets disjoint) passes propose-time
+        validation — no raise.
+        """
+        from routes.signals import _validate_plan_proposal
+
+        with (
+            self._patched_store(),
+            self._patched_worktree(),
+            self._patched_subprocess(self._PLAN_WITH_SERIALIZED_FOREST),
+        ):
+            payload = {"commit_sha": "abc1234"}
+            # Should not raise.
+            _validate_plan_proposal("issue-2527", payload, Path("/tmp/repo"))
 
     def test_rejects_when_plan_draft_absent(self):
         """``git show`` non-zero exit (plan absent at commit) → presence raise


### PR DESCRIPTION
## Problem

On pipeline `issue-3200` the plan phase reached **full BRC consensus** (all 4 agents CONFIRMED, `phase.completed` fired), and *then* contract population **failed**: the plan producer had emitted a legitimately diamond-shaped slice DAG (`slice-5` depended on both `slice-2` and `slice-4`), which is not a forest. `contract.slices` came back empty → pipeline `failed` → operator HITL. ~24 min of plan work plus 4 agents' confirmations wasted before the failure surfaced — with the producer already dead.

Forest (#2137) and file-overlap (#3046) validation only ran in the **post-consensus** contract populator (`_populate_contract_from_plan`). This is the same "validate too late" anti-pattern #3016 fixed for canonical draft paths.

## Fix

Run the populator's exact validators — `validate_forest` and `validate_slice_file_overlap` — at **propose time** inside `_validate_plan_extensions` (the plan-draft propose validator in `routes/signals.py`), right after `to_contract_slices()`. A non-forest or unordered-overlap proposal is now NACKed **while the producer is still alive in BRC**, with the `serialized_chain_order` remediation, so it re-emits a forest before consensus instead of a phase later.

- Reusing the populator's exact validators keeps the propose-time and populate-time checks from diverging (same rationale already documented for the #3026 parseability check).
- Same non-blocking posture as the sibling parseability/role-alignment checks: a validator that *raises* (e.g. a future `Slice` field tightening) degrades to skip; only returned errors NACK.

## On the issue's second ask

The issue also asked to "ensure the planner is prompted" with the forest constraint. It already is — both the refine path (`pipelines.py:~12237`) and the concurrent plan path (`pipelines.py:~14525`) carry the HARD forest constraint, the `serialized_chain_order` auto-serialization rule, the #3046 file-overlap rule, and a worked YAML example. The planner knew the rule and still emitted a diamond, so the durable fix is the deterministic propose-time gate — not more prompt prose. No prompt change in this PR.

## Tests

`orchestrator/tests/test_pipeline_prompts.py` (the existing home of plan-proposal-validation tests):
- `test_rejects_non_forest_slice_dag_at_propose_time` — the issue-3200 diamond is NACKed at propose time.
- `test_rejects_overlapping_unordered_slices_at_propose_time` — two parallel root slices sharing a file (a valid forest, unordered overlap) NACKed.
- `test_accepts_serialized_forest_plan` — the would-be diamond serialised per #2137 (slice-5 → slice-4 alone, `serialized_chain_order: [slice-2, slice-4]`, disjoint files) passes.

The underlying validators stay covered by `test_validate_forest.py` / `test_validate_slice_file_overlap.py`. All 472 in the touched suites pass.

Closes #3211.

## Relationship to sibling issues from the same incident
- **#3208** (producers collide on the shared `*-plan.md` draft path) and **#3209** (BRC artifact-spec Phase 2) were spawned from the same `issue-3200` plan phase. This PR is independent of #3208 (distinct root cause: concurrency on a shared file).
- #3209 plans to eventually replace this bespoke propose validator with spec-derived validation; these forest/overlap extensions live in `_validate_plan_extensions` and would fold into that table-driven check when #3209 lands. Additive, no conflict.