### PR TITLE
fix(implement): reject false-complete slices that never ran (#3214)

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -16729,6 +16729,16 @@ def _run_implement_phase_slices(
     # On an invalid record, alert and decline to trust it — route the
     # slice through Layer-B/C so it is re-evaluated and (re-)run rather
     # than silently skipped.
+    #
+    # Note: a COMPLETE slice that recorded *no* durable evidence (no
+    # pr_number, no integration_base_sha — e.g. a legacy pre-#2871
+    # contract from before integration_base_sha existed) is distrusted
+    # here on every restart, even when it was genuinely merged. That is
+    # intentional, not a bug: such a slice falls through to Layer-B,
+    # where origin-side merge detection re-confirms it and re-marks it
+    # COMPLETE. The outcome stays correct; the only cost is one extra
+    # GitHub round-trip per restart. Any slice that forked under current
+    # code records integration_base_sha and is trusted here directly.
     layer_b_candidates = []
     for s in slices:
         if s.status == SliceStatus.COMPLETE:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -16737,8 +16737,13 @@ def _run_implement_phase_slices(
     # intentional, not a bug: such a slice falls through to Layer-B,
     # where origin-side merge detection re-confirms it and re-marks it
     # COMPLETE. The outcome stays correct; the only cost is one extra
-    # GitHub round-trip per restart. Any slice that forked under current
-    # code records integration_base_sha and is trusted here directly.
+    # GitHub round-trip per restart. A slice that forked under current
+    # code *usually* records integration_base_sha and is trusted here
+    # directly — but that write is best-effort (the get_remote_branch_sha
+    # call at slice spawn swallows failures and degrades to ancestor-only
+    # detection), so a current-code slice whose base-SHA write failed also
+    # falls through to Layer-B and self-corrects identically to the legacy
+    # case above.
     layer_b_candidates = []
     for s in slices:
         if s.status == SliceStatus.COMPLETE:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -173,6 +173,85 @@ class ForestValidationError(Exception):
         return ({"error": self.reason, "errors": self.errors}, 422)
 
 
+class SliceCompletionInvariantError(RuntimeError):
+    """Raised when a slice would be persisted ``COMPLETE`` without a valid
+    completion basis (#3214).
+
+    The #3214 wedge traced to an interior forest node (``slice-3`` on
+    pipeline ``issue-3200``) persisted as ``SliceStatus.COMPLETE`` while
+    its only task was still ``pending``, it had no integration branch, and
+    it carried its *parent's* commit SHA. ``_persist_slice_status_complete``
+    wrote that contradictory state with no validation, so the slice-DAG
+    driver skipped real work and the chain wedged with no successor — and
+    it hung ~9h silently because nothing failed loud at the moment of the
+    bad write.
+
+    A slice has a valid completion basis when ANY of these execution
+    signals is present:
+
+    * a slice PR is recorded / supplied (``pr_number``); or
+    * the caller declares a verified ``basis`` — ``"merged"`` (the
+      integration branch was ancestry-verified merged into its parent) or
+      ``"consensus_complete"`` (BRC consensus reached, PR not yet opened
+      or its URL unparseable); or
+    * the slice forked an integration branch (``integration_base_sha`` is
+      set — #2871); or
+    * every task is ``TaskStatus.COMPLETE``.
+
+    The predicate accepts any one signal so it can only flag the slice-3
+    state where *all* are absent — a slice marked COMPLETE with zero
+    evidence it ran. We raise here so that corrupt write fails loud at its
+    source instead of wedging the forest a phase later.
+    """
+
+
+# Completion bases a caller may declare when it has positive, verified
+# evidence a slice finished even though not every task is marked COMPLETE
+# on the contract (the crash-recovery / merged-skip paths). See
+# :class:`SliceCompletionInvariantError`.
+_VERIFIED_SLICE_COMPLETION_BASES = frozenset({"merged", "consensus_complete"})
+
+
+def _validate_slice_completion_basis(
+    slice_obj: Any,
+    *,
+    pr_number: int | None = None,
+    basis: str | None = None,
+) -> str | None:
+    """Return ``None`` when ``slice_obj`` may legitimately be marked
+    ``SliceStatus.COMPLETE``, else a human-readable reason it may not.
+
+    Shared by the write chokepoint (``_persist_slice_status_complete``,
+    which raises :class:`SliceCompletionInvariantError` on a reason) and
+    the Layer-A bootstrap read-trust point (which alerts and declines to
+    trust a contradictory contract-recorded COMPLETE rather than
+    propagating it into the scheduler). See
+    :class:`SliceCompletionInvariantError` for the basis rules (#3214).
+    """
+    has_pr = pr_number is not None or getattr(slice_obj, "pr_number", None) is not None
+    verified_basis = basis in _VERIFIED_SLICE_COMPLETION_BASES
+    # A slice that actually forked its integration branch recorded a base
+    # SHA (#2871). Its absence — together with no PR, no verified basis,
+    # and no completed tasks — is the slice-3 false-complete signature: a
+    # slice marked COMPLETE with zero evidence it ever ran. The predicate
+    # accepts ANY single execution signal so it can only flag that
+    # genuinely-contradictory state, never a legitimately-completed slice
+    # whose other signals happen to be absent (e.g. an unparseable PR URL
+    # leaves ``pr_number`` None but the slice still forked and reached
+    # consensus). ``tasks_all_complete`` is the canonical model-side
+    # predicate so this can't drift from the contract's own notion of
+    # "work finished".
+    forked = getattr(slice_obj, "integration_base_sha", None) is not None
+    if has_pr or verified_basis or forked or slice_obj.tasks_all_complete:
+        return None
+    return (
+        f"slice {getattr(slice_obj, 'id', '?')} would be marked COMPLETE with no "
+        f"evidence it ran: no slice PR, no verified merge/consensus basis "
+        f"(basis={basis!r}), no integration-branch fork base, and tasks not all "
+        f"complete"
+    )
+
+
 # Add shared directory to path for egg_logging
 _shared_path = Path(__file__).parent.parent.parent / "shared"
 if _shared_path.exists() and str(_shared_path) not in sys.path:
@@ -16502,6 +16581,7 @@ def _run_implement_phase_slices(
         *,
         pr_number: int | None = None,
         pr_url: str | None = None,
+        basis: str | None = None,
         commit_to_branch: bool = True,
     ) -> None:
         """Mark ``slice_id`` as ``SliceStatus.COMPLETE`` on the contract.
@@ -16530,6 +16610,16 @@ def _run_implement_phase_slices(
         successful slice's commit (the pipeline-scoped glob picks them
         up) or the phase-boundary commit, whichever fires first.
 
+        ``basis`` lets a caller declare *why* the slice is complete when
+        not every task is marked COMPLETE on the contract: ``"merged"``
+        (integration branch ancestry-verified merged into its parent) or
+        ``"consensus_complete"`` (BRC consensus reached pre-restart, PR
+        not yet opened). The PR-open caller passes ``pr_number`` instead.
+        Absent any of these — and with tasks still pending — the write is
+        a #3214 false-complete and :func:`_validate_slice_completion_basis`
+        raises :class:`SliceCompletionInvariantError` rather than persist
+        a slice as done that never ran.
+
         When the caller just opened the slice's PR it passes
         ``pr_number`` / ``pr_url`` so the linkage lands in the same
         contract write (#3122) — the context-PR body refresh and any
@@ -16552,13 +16642,49 @@ def _run_implement_phase_slices(
                 contract_local = load_contract(pipeline_id, worktree_repo_path)
                 for s in contract_local.slices:
                     if s.id == slice_id:
+                        # #3214 — refuse to persist a contradictory COMPLETE.
+                        # An interior forest node marked COMPLETE without a
+                        # valid basis (tasks pending, no PR, no verified
+                        # merge/consensus) skips a slice that never ran and
+                        # wedges the chain a phase later. Fail loud here, at
+                        # the source of the bad write, instead.
+                        invalid = _validate_slice_completion_basis(
+                            s, pr_number=pr_number, basis=basis
+                        )
+                        if invalid is not None:
+                            logger.error(
+                                "Refusing to persist slice.status=COMPLETE — "
+                                "invalid completion basis (#3214)",
+                                pipeline_id=pipeline_id,
+                                slice_id=slice_id,
+                                reason=invalid,
+                            )
+                            raise SliceCompletionInvariantError(invalid)
                         s.status = SliceStatus.COMPLETE
                         if pr_number is not None:
                             s.pr_number = pr_number
                         if pr_url is not None:
                             s.pr_url = pr_url
+                        logger.info(
+                            "Slice marked COMPLETE",
+                            pipeline_id=pipeline_id,
+                            slice_id=slice_id,
+                            basis=(
+                                basis
+                                or (
+                                    "pr"
+                                    if (pr_number is not None or s.pr_number is not None)
+                                    else "tasks_complete"
+                                )
+                            ),
+                            pr_number=pr_number if pr_number is not None else s.pr_number,
+                        )
                         break
                 save_contract(contract_local, worktree_repo_path)
+        except SliceCompletionInvariantError:
+            # Fail loud — never swallow the completion invariant into the
+            # best-effort save handler below (#3214).
+            raise
         except Exception as save_err:  # noqa: BLE001
             # Contract load/save under per-pipeline state lock.
             # Catches loader validation errors, atomic-rename / fdopen
@@ -16595,10 +16721,28 @@ def _run_implement_phase_slices(
     bootstrap_complete: list[str] = []
     bootstrap_merged: list[str] = []
 
-    # Layer (A): cheap, no I/O. Trust contract-recorded COMPLETE status.
+    # Layer (A): cheap, no I/O. Trust contract-recorded COMPLETE status —
+    # but verify the recorded COMPLETE is not itself a #3214 false-complete
+    # (an interior forest node persisted COMPLETE with pending tasks, no
+    # PR, no merge). Blindly trusting a corrupt contract here is how the
+    # false-complete propagated into the scheduler and wedged the chain.
+    # On an invalid record, alert and decline to trust it — route the
+    # slice through Layer-B/C so it is re-evaluated and (re-)run rather
+    # than silently skipped.
     layer_b_candidates = []
     for s in slices:
         if s.status == SliceStatus.COMPLETE:
+            invalid = _validate_slice_completion_basis(s, pr_number=s.pr_number)
+            if invalid is not None:
+                logger.error(
+                    "Contract records slice COMPLETE but the completion basis is "
+                    "invalid — NOT trusting it; re-evaluating the slice (#3214)",
+                    pipeline_id=pipeline_id,
+                    slice_id=s.id,
+                    reason=invalid,
+                )
+                layer_b_candidates.append(s)
+                continue
             scheduler.record_complete(s.id)
             bootstrap_complete.append(s.id)
             continue
@@ -16668,7 +16812,7 @@ def _run_implement_phase_slices(
         for slice_id, already_merged in results:
             if already_merged:
                 scheduler.record_complete(slice_id)
-                _persist_slice_status_complete(slice_id, commit_to_branch=False)
+                _persist_slice_status_complete(slice_id, basis="merged", commit_to_branch=False)
                 bootstrap_merged.append(slice_id)
 
     # Layer (C): non-COMPLETE slice classification (slice-4 TASK-4-4).
@@ -16732,7 +16876,7 @@ def _run_implement_phase_slices(
                 slice_id=s.id,
             )
             scheduler.record_complete(s.id)
-            _persist_slice_status_complete(s.id, commit_to_branch=False)
+            _persist_slice_status_complete(s.id, basis="consensus_complete", commit_to_branch=False)
             bootstrap_consensus_complete.append(s.id)
             continue
         if classification == "resume":
@@ -17061,7 +17205,7 @@ def _run_implement_phase_slices(
                             parent_branch=parent_branch,
                         )
                         scheduler.record_complete(slice_id)
-                        _persist_slice_status_complete(slice_id)
+                        _persist_slice_status_complete(slice_id, basis="merged")
                         try:
                             remove_peer_consensus_tracker(pipeline_id, slice_id)
                         except Exception:  # noqa: BLE001
@@ -17507,10 +17651,18 @@ def _run_implement_phase_slices(
                 # rather than racing them.
                 with get_pipeline_state_lock(pipeline_id):
                     scheduler.record_complete(slice_id)
+                    # Reaching here means ``_run_concurrent_phase`` returned
+                    # success (BRC consensus) AND ``pr_created`` gated above —
+                    # a verified completion independent of whether the PR URL
+                    # parsed to a number (#3122 stub URLs leave
+                    # ``slice_pr_number`` None). Declare the consensus basis so
+                    # the #3214 invariant accepts it; ``pr_number`` is still
+                    # passed for the slice-table linkage.
                     _persist_slice_status_complete(
                         slice_id,
                         pr_number=slice_pr_number,
                         pr_url=slice_pr_url if slice_pr_number else None,
+                        basis="consensus_complete",
                     )
 
                     # Refresh the context PR body so its slice table

--- a/orchestrator/tests/test_slice_completion_invariant.py
+++ b/orchestrator/tests/test_slice_completion_invariant.py
@@ -1,0 +1,210 @@
+"""Slice-completion validity invariant (#3214).
+
+Regression coverage for the false-complete class that wedged pipeline
+``issue-3200``: an interior forest node (``slice-3``) was persisted as
+``SliceStatus.COMPLETE`` while its only task was still ``pending``, it had
+no integration branch, no recorded fork base, and it carried its parent's
+commit SHA. ``_persist_slice_status_complete`` wrote that contradictory
+state with no validation, so the slice-DAG driver skipped a slice that
+never ran and the chain wedged with no successor — silently, for ~9h,
+because nothing failed loud at the moment of the bad write.
+
+The fix is a single completion-validity predicate
+(``_validate_slice_completion_basis``) enforced at both the write
+chokepoint (raise :class:`SliceCompletionInvariantError`) and the Layer-A
+bootstrap read-trust point (alert + decline to trust). Its canonical
+"work finished" half lives on the model as ``Slice.tasks_all_complete``
+so it can't drift across the orchestrator. These tests lock the predicate
+and the model property; the exact ``slice-3`` state is reproduced below as
+the concrete anchor.
+"""
+
+from __future__ import annotations
+
+from egg_contracts.models import Slice, SliceStatus, Task, TaskStatus
+from routes.pipelines import (
+    SliceCompletionInvariantError,
+    _validate_slice_completion_basis,
+)
+
+
+def _slice(
+    slice_id: str = "slice-3",
+    *,
+    task_statuses: list[TaskStatus] | None = None,
+    status: SliceStatus = SliceStatus.PENDING,
+    pr_number: int | None = None,
+    integration_base_sha: str | None = None,
+    parent_branch_at_creation: str | None = None,
+    commit: str | None = None,
+) -> Slice:
+    """Build a Slice with one task per entry in ``task_statuses``."""
+    statuses = task_statuses if task_statuses is not None else [TaskStatus.PENDING]
+    return Slice(
+        id=slice_id,
+        name=f"Slice {slice_id}",
+        status=status,
+        pr_number=pr_number,
+        integration_base_sha=integration_base_sha,
+        parent_branch_at_creation=parent_branch_at_creation,
+        commit=commit,
+        tasks=[
+            Task(id=f"task-3-{i + 1}", description="t", status=st, files_affected=[])
+            for i, st in enumerate(statuses)
+        ],
+    )
+
+
+# --------------------------------------------------------------------------
+# Slice.tasks_all_complete — the canonical model-side predicate
+# --------------------------------------------------------------------------
+
+
+class TestTasksAllComplete:
+    def test_all_complete(self) -> None:
+        assert _slice(task_statuses=[TaskStatus.COMPLETE]).tasks_all_complete is True
+
+    def test_multiple_all_complete(self) -> None:
+        assert (
+            _slice(task_statuses=[TaskStatus.COMPLETE, TaskStatus.COMPLETE]).tasks_all_complete
+            is True
+        )
+
+    def test_one_pending(self) -> None:
+        assert _slice(task_statuses=[TaskStatus.PENDING]).tasks_all_complete is False
+
+    def test_mixed(self) -> None:
+        assert (
+            _slice(task_statuses=[TaskStatus.COMPLETE, TaskStatus.PENDING]).tasks_all_complete
+            is False
+        )
+
+    def test_blocked_is_not_complete(self) -> None:
+        assert _slice(task_statuses=[TaskStatus.BLOCKED]).tasks_all_complete is False
+
+    def test_empty_task_list_is_not_complete(self) -> None:
+        # A slice with nothing to do is a degenerate state a caller must
+        # justify with a merged PR / verified consensus, not silently
+        # treat as done.
+        assert _slice(task_statuses=[]).tasks_all_complete is False
+
+
+# --------------------------------------------------------------------------
+# _validate_slice_completion_basis — accepts every legitimate basis
+# --------------------------------------------------------------------------
+
+
+class TestValidBases:
+    def test_all_tasks_complete(self) -> None:
+        assert _validate_slice_completion_basis(_slice(task_statuses=[TaskStatus.COMPLETE])) is None
+
+    def test_pr_number_argument(self) -> None:
+        # The run-loop PR-open caller passes pr_number; tasks may not all
+        # be flipped yet on the in-memory contract.
+        assert (
+            _validate_slice_completion_basis(
+                _slice(task_statuses=[TaskStatus.PENDING]), pr_number=3213
+            )
+            is None
+        )
+
+    def test_pr_number_on_model(self) -> None:
+        assert (
+            _validate_slice_completion_basis(
+                _slice(task_statuses=[TaskStatus.PENDING], pr_number=3213)
+            )
+            is None
+        )
+
+    def test_basis_merged(self) -> None:
+        # Layer-B bootstrap / run-loop merged-skip: ancestry-verified.
+        assert (
+            _validate_slice_completion_basis(
+                _slice(task_statuses=[TaskStatus.PENDING]), basis="merged"
+            )
+            is None
+        )
+
+    def test_basis_consensus_complete(self) -> None:
+        # Layer-C case 3 / run-loop success: consensus reached (PR not yet
+        # opened, or its URL unparseable so pr_number is None).
+        assert (
+            _validate_slice_completion_basis(
+                _slice(task_statuses=[TaskStatus.PENDING]), basis="consensus_complete"
+            )
+            is None
+        )
+
+    def test_forked_integration_branch(self) -> None:
+        # A slice that recorded a fork base actually ran its integration
+        # branch (#2871) — valid even with tasks still pending on the
+        # in-memory contract and an unparseable (None) PR number.
+        assert (
+            _validate_slice_completion_basis(
+                _slice(
+                    task_statuses=[TaskStatus.PENDING],
+                    integration_base_sha="a" * 40,
+                )
+            )
+            is None
+        )
+
+
+# --------------------------------------------------------------------------
+# _validate_slice_completion_basis — rejects the false-complete class
+# --------------------------------------------------------------------------
+
+
+class TestInvalidBases:
+    def test_pending_task_no_pr_no_basis_no_fork_is_rejected(self) -> None:
+        reason = _validate_slice_completion_basis(_slice(task_statuses=[TaskStatus.PENDING]))
+        assert reason is not None
+        assert "slice-3" in reason
+
+    def test_unknown_basis_does_not_pass(self) -> None:
+        # A caller-declared basis only counts if it is a recognised,
+        # verified basis — a typo / novel string must not slip through.
+        reason = _validate_slice_completion_basis(
+            _slice(task_statuses=[TaskStatus.PENDING]), basis="bogus"
+        )
+        assert reason is not None
+
+    def test_empty_tasks_no_pr_no_basis_no_fork_is_rejected(self) -> None:
+        reason = _validate_slice_completion_basis(_slice(task_statuses=[]))
+        assert reason is not None
+
+    def test_mixed_tasks_no_pr_no_basis_no_fork_is_rejected(self) -> None:
+        reason = _validate_slice_completion_basis(
+            _slice(task_statuses=[TaskStatus.COMPLETE, TaskStatus.PENDING])
+        )
+        assert reason is not None
+
+    def test_exact_slice3_production_state_is_flagged(self) -> None:
+        """The literal state read off pipeline ``issue-3200`` contract:
+        an interior node persisted COMPLETE with a pending task, no PR,
+        no fork base, no parent branch, carrying its parent's commit SHA.
+        The predicate must flag it — this is the wedge's root state.
+        """
+        slice3 = _slice(
+            slice_id="slice-3",
+            task_statuses=[TaskStatus.PENDING],
+            status=SliceStatus.COMPLETE,  # the corrupt on-disk status
+            pr_number=None,
+            integration_base_sha=None,
+            parent_branch_at_creation=None,
+            commit="9e3eea6197755372f57efa50a66178bd4a5a6c16",  # parent's commit
+        )
+        reason = _validate_slice_completion_basis(slice3, pr_number=slice3.pr_number)
+        assert reason is not None, "the slice-3 false-complete signature must be rejected"
+
+
+# --------------------------------------------------------------------------
+# SliceCompletionInvariantError contract
+# --------------------------------------------------------------------------
+
+
+class TestInvariantError:
+    def test_is_runtime_error(self) -> None:
+        # Propagates as a hard failure, not swallowed into a best-effort
+        # save handler.
+        assert issubclass(SliceCompletionInvariantError, RuntimeError)

--- a/orchestrator/tests/test_slice_run_loop_integration.py
+++ b/orchestrator/tests/test_slice_run_loop_integration.py
@@ -1184,6 +1184,10 @@ class TestSliceMergedDetection:
         pipeline = _make_pipeline()
         slice1 = _make_slice("slice-1", tasks=[_make_task("task-1-1")])
         slice1.status = SliceStatus.COMPLETE  # prior run wrote this on success
+        # A genuinely prior-completed slice recorded its integration-branch
+        # fork base — the #3214 evidence-of-running that lets Layer-A trust
+        # the COMPLETE status instead of distrusting a never-ran slice.
+        slice1.integration_base_sha = "a" * 40
         slice2 = _make_slice("slice-2", deps=["slice-1"], tasks=[_make_task("task-2-1")])
         contract = _make_contract(slices=[slice1, slice2])
 
@@ -1231,6 +1235,54 @@ class TestSliceMergedDetection:
         assert merged_calls_for_slice1 == [], (
             "step (A) must skip the GitHub-side merged-detection when contract "
             "already records COMPLETE"
+        )
+
+    def test_bootstrap_distrusts_false_complete_slice(self) -> None:
+        """#3214 — a slice recorded COMPLETE with no evidence it ran
+        (no PR, no fork base, tasks pending — the ``slice-3`` wedge
+        signature) must NOT be trusted at step (A). It is routed back
+        through merged-detection / re-run instead of being silently
+        skipped, so a corrupt contract can't false-complete the chain."""
+        pipeline = _make_pipeline()
+        slice1 = _make_slice("slice-1", tasks=[_make_task("task-1-1")])
+        slice1.status = SliceStatus.COMPLETE  # corrupt: COMPLETE but never ran
+        # No integration_base_sha, no pr_number, task still PENDING.
+        contract = _make_contract(slices=[slice1])
+
+        with (
+            patch("egg_contracts.loader.load_contract", return_value=contract),
+            patch("egg_contracts.loader.save_contract"),
+            patch("routes.pipelines._start_stacked_pr_reconciler") as mock_start_recon,
+            patch("routes.pipelines._run_concurrent_phase", return_value=(0, "ok")),
+            patch("orchestrator.peer_consensus.remove_peer_consensus_tracker"),
+        ):
+            mock_start_recon.return_value = (MagicMock(), threading.Event())
+            spawner = self._make_spawner()  # is_slice_branch_merged → False
+            exit_code, _ = _run_implement_phase_slices(
+                pipeline_id=pipeline.id,
+                pipeline=pipeline,
+                spawner=spawner,
+                repo_volumes={},
+                gateway_mode="public",
+                repos=["owner/repo"],
+                sandbox_env={},
+                store=MagicMock(),
+                certs_volume=None,
+                worktree_repo_path=Path("/tmp/x"),
+            )
+        assert exit_code == 0
+        # The false-complete slice was NOT trusted: step (A) declined it,
+        # so the GitHub-side merged-detection it would otherwise skip is
+        # invoked for slice-1 (proof the slice is re-evaluated, not
+        # silently skipped).
+        merged_calls_for_slice1 = [
+            c
+            for c in spawner.gateway.is_slice_branch_merged_into_parent.call_args_list
+            if c.kwargs.get("integration_branch", "").endswith("/slice-1")
+        ]
+        assert merged_calls_for_slice1 != [], (
+            "a COMPLETE slice with no evidence it ran must be re-evaluated, "
+            "not trusted at step (A) (#3214)"
         )
 
     def test_bootstrap_detects_merged_slice_on_origin(self) -> None:
@@ -1310,6 +1362,9 @@ class TestSliceMergedDetection:
         # remote to query.
         slice1 = _make_slice("slice-1", tasks=[_make_task("task-1-1")])
         slice1.status = SliceStatus.COMPLETE
+        # Evidence the slice actually ran (#3214) — without it Layer-A
+        # would distrust a COMPLETE slice that shows no sign of execution.
+        slice1.integration_base_sha = "a" * 40
         slice2 = _make_slice("slice-2", deps=["slice-1"], tasks=[_make_task("task-2-1")])
         contract = _make_contract(slices=[slice1, slice2])
 

--- a/shared/egg_contracts/models.py
+++ b/shared/egg_contracts/models.py
@@ -441,6 +441,19 @@ class Slice(EggContractBaseModel):
     def validate_commit(cls, v: Any) -> str | None:
         return _normalize_commit(v)
 
+    @property
+    def tasks_all_complete(self) -> bool:
+        """True iff this slice has tasks and every one is ``COMPLETE``.
+
+        Canonical "the slice's declared work finished" predicate, kept on
+        the model so completion checks don't drift across the orchestrator
+        (the slice-DAG completion invariant, overseer, health checks). An
+        empty task list is **not** complete — a slice with nothing to do is
+        a degenerate state a caller must justify some other way (a merged
+        PR / verified consensus), not silently treat as done. See #3214.
+        """
+        return bool(self.tasks) and all(t.status == TaskStatus.COMPLETE for t in self.tasks)
+
 
 # Backward-compat alias — see ``Slice`` docstring. ``Phase`` was the
 # original name pre-#2137; new code should reference ``Slice`` directly.


### PR DESCRIPTION
## Problem (#3214)

The slice-DAG **implement** phase on pipeline `issue-3200` wedged after slice-1 and hung silently for ~9h (`wedged_no_successor`), with slices 2–5 orphaned and no auto-recovery.

Pulling the live contract pinned the root state: **`slice-3` was persisted `status=complete` while it never ran** — its only task was `pending`, it had no integration branch, no `integration_base_sha`, no `parent_branch_at_creation`, and it carried its **parent's** commit SHA (`9e3eea6197…`). An interior forest node marked done with no real work skips a slice *and* breaks the chain (dependents fork off a branch that's empty or absent).

The enabling defect: `_persist_slice_status_complete` — the single chokepoint every completion path funnels through — set `s.status = SliceStatus.COMPLETE` with **zero validation**. It never checked that the slice's work happened; it trusted the caller. And the Layer-A bootstrap reconciliation blindly **trusts** any contract-recorded `COMPLETE`, so a corrupt record propagates straight into the scheduler. Nothing failed loud at the bad write, so a code bug became a 9h blind hang.

> The exact historical writer/timestamp could not be recovered (orchestrator logs rotated on pod restart; the contract was mutated over the ~9h before inspection). What live state *did* give us is the corruption signature and the unvalidated write path — which is what this fix closes.

## Fix

One completion-validity predicate enforced at both the write and the read-trust sides — the #3211/#3217 "one shared validator, multiple enforcement points" pattern:

- **`Slice.tasks_all_complete`** (new model property) — the canonical "the slice's declared work finished" check, kept on the model so completion logic can't drift across the orchestrator.
- **`_validate_slice_completion_basis(slice, *, pr_number, basis)`** — a slice may be `COMPLETE` only with **evidence it ran**, satisfying *any one* of: a slice PR (`pr_number`); a caller-declared verified `basis` (`"merged"` = ancestry-verified merged into parent; `"consensus_complete"` = BRC consensus reached, PR not yet opened or its URL unparseable); an `integration_base_sha` fork base (set when the slice forks its integration branch, #2871); or all tasks `COMPLETE`. Accepting any single signal means it flags **only** the slice-3 state where *all* are absent — and crucially does **not** false-positive on a slice that did fork + reach consensus but whose PR URL didn't parse to a number (a real path, per `test_unparseable_slice_pr_url_skips_linkage_and_refresh`).
- **Write chokepoint** (`_persist_slice_status_complete`): on an invalid basis, **raise `SliceCompletionInvariantError`** (fail loud at the source) instead of persisting a contradictory `COMPLETE`. A targeted `except` ensures it's never swallowed by the best-effort save handler.
- **Layer-A read-trust** (bootstrap): a contract-recorded `COMPLETE` lacking any run evidence is **no longer trusted** — it's logged and routed back through Layer-B/C so the slice is re-evaluated and (re-)run rather than silently skipped. An already-corrupt contract self-heals.
- The four legitimate callers declare their basis (`merged` / `consensus_complete` / `pr_number`); the run-loop success path declares `consensus_complete` since reaching it is gated on consensus **and** `pr_created`.

Net effect: the slice-3 false-complete class can no longer be *committed*, and if a contract is already corrupt the bootstrap **re-runs** the slice instead of wedging the chain. A silent multi-slice wedge becomes an immediate, attributable failure.

## Tests

- `orchestrator/tests/test_slice_completion_invariant.py` (18 cases): the `tasks_all_complete` model property; every legitimate basis (all-tasks-complete / pr arg / pr on model / merged / consensus_complete / **fork base**) passes; the false-complete class (no-evidence / unknown basis / empty / mixed) is rejected; and the **exact `slice-3` production state** reproduced from the `issue-3200` contract is flagged.
- `test_slice_run_loop_integration.py`: a new Layer-A integration test asserts a never-ran `COMPLETE` slice is **re-evaluated**, not trusted; two existing trust-test fixtures updated to model a *realistically* completed slice (records a fork base) — they had asserted the old blind-trust behavior this fix corrects.
- Verified green: `test_slice_completion_invariant` + `test_slice_run_loop_integration` + `test_slice_4_restart_hardening` + `test_short_flow_contract_population` + `test_restart_agent` (227 tests). Full `make test-all` run for final confirmation.

## Scope notes

- Independent of the in-flight #3209 workstreams (#3216/#3217/#3218 — plan-phase coordination + propose-time artifact validation) and the already-shipped #3211 (PR #3215). This is an implement-phase completion-state invariant; different phase, different files.
- Out of scope (belongs with watchdog issues #3210/#3212): post-hoc auto-recovery of an already-wedged phase. With this invariant the corruption isn't persisted, so there's nothing to recover from. A durable completion-decision audit trail (the observability gap that cost us the exact-writer attribution) is a worthwhile follow-up.

Closes #3214.
