### PR TITLE
Gate sync_to_proposals merge to execution-needing reviewers (#3216 WS1·1a)

### DIFF
--- a/orchestrator/consensus_wrapper.py
+++ b/orchestrator/consensus_wrapper.py
@@ -70,6 +70,16 @@ SUPERVISION_BACKOFF_CAP_SECONDS = _supervision_policy.SUPERVISION_BACKOFF_CAP_SE
 SUPERVISION_FAILURE_STREAK_WARN = _supervision_policy.SUPERVISION_FAILURE_STREAK_WARN
 SUPERVISION_FAILURE_STREAK_ALERT = _supervision_policy.SUPERVISION_FAILURE_STREAK_ALERT
 
+from egg_contracts.agent_roles import REVIEWER_CHECKOUT_ROLE_VALUES
+
+# Space-separated role values for which ``sync_to_proposals`` performs a
+# working-tree merge (#3216, WS1 of #3209). Rendered into the wrapper
+# template as the ``checkout_roles`` field; the bash gate skips the merge
+# for any role not in this list. Sorted for a deterministic, golden-stable
+# render. The policy itself lives in ``egg_contracts.agent_roles`` so role
+# semantics stay in one place.
+EVENT_PUMP_CHECKOUT_ROLES = " ".join(sorted(str(r) for r in REVIEWER_CHECKOUT_ROLE_VALUES))
+
 
 def _event_loop_owner() -> str:
     """Return the BRC event-loop ownership mode (``pod`` | ``orchestrator``).
@@ -555,6 +565,26 @@ invoke_agent_for_event() {{
 SYNC_FAILURE_BANNERS=""
 
 sync_to_proposals() {{
+    # #3216 (WS1 of #3209): only reviewers that EXECUTE the proposal (run
+    # the test suite / build against the merged tree) need a working-tree
+    # merge. Every other reviewer reads peer artifacts via this prompt's
+    # ``git show`` / ``egg-artifact`` served reads, so merging the peer's
+    # *whole* tree into their worktree buys nothing and risks the dual-role
+    # criss-cross propagation that corrupts shared drafts (#3208: a reviewer
+    # arm merges a peer's plan.md, a later producer turn commits on top, and
+    # the cross-merged lineages spawn spurious conflicts / a rebase-mangled
+    # yaml fence / a "File modified since read" livelock). Allowed roles are
+    # rendered from ``REVIEWER_CHECKOUT_ROLE_VALUES``; default-deny so an
+    # unset/unknown role reads via git-show (the safe, non-replicating side).
+    local _role="${{EGG_AGENT_ROLE:-}}"
+    case " {checkout_roles} " in
+        *" $_role "*) : ;;  # role runs the proposal; a real merged checkout is required
+        *)
+            SYNC_FAILURE_BANNERS=""
+            cw_log "sync-to-proposal: role=$_role reads peer artifacts via git-show/egg-artifact; skipping working-tree merge (#3216)."
+            return 0
+            ;;
+    esac
     local event_payload="$1"
     local repo="${{EGG_REPO_PATH:-$PWD}}"
     local shas sha
@@ -1159,6 +1189,7 @@ def build_event_pump_wrapped_command(
         spvr_backoff_cap=SUPERVISION_BACKOFF_CAP_SECONDS,
         spvr_failure_streak_warn=SUPERVISION_FAILURE_STREAK_WARN,
         spvr_failure_streak_alert=SUPERVISION_FAILURE_STREAK_ALERT,
+        checkout_roles=EVENT_PUMP_CHECKOUT_ROLES,
     )
     # The triple-quoted template opens with a newline (so the source reads
     # cleanly); strip it so ``#!/bin/bash`` lands on line 1. The script is run

--- a/orchestrator/tests/golden/event_pump_wrapper_pod_default.sh.golden
+++ b/orchestrator/tests/golden/event_pump_wrapper_pod_default.sh.golden
@@ -406,6 +406,26 @@ invoke_agent_for_event() {
 SYNC_FAILURE_BANNERS=""
 
 sync_to_proposals() {
+    # #3216 (WS1 of #3209): only reviewers that EXECUTE the proposal (run
+    # the test suite / build against the merged tree) need a working-tree
+    # merge. Every other reviewer reads peer artifacts via this prompt's
+    # ``git show`` / ``egg-artifact`` served reads, so merging the peer's
+    # *whole* tree into their worktree buys nothing and risks the dual-role
+    # criss-cross propagation that corrupts shared drafts (#3208: a reviewer
+    # arm merges a peer's plan.md, a later producer turn commits on top, and
+    # the cross-merged lineages spawn spurious conflicts / a rebase-mangled
+    # yaml fence / a "File modified since read" livelock). Allowed roles are
+    # rendered from ``REVIEWER_CHECKOUT_ROLE_VALUES``; default-deny so an
+    # unset/unknown role reads via git-show (the safe, non-replicating side).
+    local _role="${EGG_AGENT_ROLE:-}"
+    case " tester " in
+        *" $_role "*) : ;;  # role runs the proposal; a real merged checkout is required
+        *)
+            SYNC_FAILURE_BANNERS=""
+            cw_log "sync-to-proposal: role=$_role reads peer artifacts via git-show/egg-artifact; skipping working-tree merge (#3216)."
+            return 0
+            ;;
+    esac
     local event_payload="$1"
     local repo="${EGG_REPO_PATH:-$PWD}"
     local shas sha

--- a/orchestrator/tests/test_consensus_wrapper.py
+++ b/orchestrator/tests/test_consensus_wrapper.py
@@ -1598,6 +1598,12 @@ class TestSyncToProposals:
         return (
             "#!/bin/bash\nset -uo pipefail\n"
             f"EGG_REPO_PATH={shlex.quote(repo)}\n"
+            # #3216 gates the working-tree merge to execution-needing
+            # reviewers; the merge-behavior assertions below run as the
+            # tester (the role that executes the proposal). The role-skip
+            # path has its own coverage in
+            # test_sync_to_proposals_role_gate.py.
+            "EGG_AGENT_ROLE=tester\n"
             + cw_match.group(0)
             + "\n"
             + sync_match.group(0)

--- a/orchestrator/tests/test_sync_to_proposals_role_gate.py
+++ b/orchestrator/tests/test_sync_to_proposals_role_gate.py
@@ -1,0 +1,212 @@
+"""Role gate on the wrapper's ``sync_to_proposals`` merge (#3216, WS1 of #3209).
+
+``sync_to_proposals`` runs ``git merge --no-edit <peer_proposal_sha>`` to
+give a reviewer a real checkout of the proposal under review. Pre-#3216 it
+ran on *every* reviewer ``ack``/``nack`` arm, ungated by role — which
+merged the peer's whole tree into the reviewer's worktree and, for
+dual-role agents, cross-pollinated concurrent producer lineages into the
+criss-cross merge topology that corrupts shared drafts (#3208).
+
+#3216 gates the merge to reviewers that must EXECUTE the proposal (only
+the ``tester`` runs the proposed tree). Every other reviewer reads peer
+artifacts via the per-event-prompt ``git show`` / ``egg-artifact`` served
+reads, so it skips the merge entirely. The policy set lives in
+``egg_contracts.agent_roles.REVIEWER_CHECKOUT_ROLE_VALUES`` and is rendered
+into the wrapper template as the ``checkout_roles`` field.
+
+These tests render the real wrapper, extract the ``sync_to_proposals``
+shell function, and run it against a throwaway git repo to assert the
+merge actually happens for ``tester`` and is actually skipped for a
+read-only reviewer role.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from consensus_wrapper import (  # noqa: E402
+    EVENT_PUMP_CHECKOUT_ROLES,
+    build_consensus_wrapped_command,
+)
+from egg_contracts.agent_roles import (  # noqa: E402
+    REVIEWER_CHECKOUT_ROLE_VALUES,
+)
+
+# A reviewer role that only reads diffs and must therefore be gated OUT of
+# the working-tree merge. Used both as a negative for the policy assertion
+# and as the skip case in the behavioral test.
+_READ_ONLY_REVIEWER_ROLE = "reviewer_code"
+
+
+def _rendered_script() -> str:
+    return build_consensus_wrapped_command("Prompt")[2]
+
+
+def _extract_sync_function(script: str) -> str:
+    """Return the ``sync_to_proposals`` shell function text.
+
+    The wrapper renders each function's closing brace as ``}`` at column 0,
+    so capture from the definition to the first column-0 ``}``.
+    """
+    match = re.search(
+        r"^sync_to_proposals\(\) \{.*?^\}",
+        script,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert match, "sync_to_proposals function not found in rendered wrapper"
+    body = match.group(0)
+    # Sanity: we captured the whole function, not a truncated prefix.
+    assert "esac" in body and "return 0" in body and body.rstrip().endswith("}")
+    return body
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_repo_with_peer_proposal(repo: Path) -> str:
+    """Create a repo whose HEAD is the review base and return a peer
+    proposal SHA that is NOT yet in HEAD's ancestry."""
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@e",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@e",
+    }
+
+    def git(*args: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        ).stdout.strip()
+
+    git("init", "-q", "-b", "main")
+    (repo / "base.txt").write_text("base\n")
+    git("add", ".")
+    git("commit", "-q", "-m", "base")
+    base_sha = git("rev-parse", "HEAD")
+
+    # Peer's proposal: a commit adding a distinct file, on its own branch,
+    # so it is not reachable from the reviewer's HEAD (still at base).
+    git("checkout", "-q", "-b", "peer")
+    (repo / "peer.txt").write_text("peer proposal\n")
+    git("add", ".")
+    git("commit", "-q", "-m", "peer proposal")
+    peer_sha = git("rev-parse", "HEAD")
+
+    # Put the reviewer worktree back on the review base.
+    git("checkout", "-q", "main")
+    assert git("rev-parse", "HEAD") == base_sha
+    return peer_sha
+
+
+def _run_sync(repo: Path, role: str, peer_sha: str) -> None:
+    """Source the extracted function and invoke it with a one-proposal
+    payload, as the given ``EGG_AGENT_ROLE``."""
+    fn = _extract_sync_function(_rendered_script())
+    harness = (
+        "set -uo pipefail\n"
+        "cw_log() { :; }\n"  # stub the wrapper logger
+        'SYNC_FAILURE_BANNERS=""\n'
+        f"{fn}\n"
+        'sync_to_proposals "$1"\n'
+    )
+    payload = f'{{"pending_reviews":[{{"proposal_commit_sha":"{peer_sha}"}}]}}'
+    subprocess.run(
+        ["bash", "-c", harness, "bash", payload],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "EGG_REPO_PATH": str(repo), "EGG_AGENT_ROLE": role},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Policy wiring
+# ---------------------------------------------------------------------------
+
+
+def test_checkout_roles_render_from_policy_set() -> None:
+    """The rendered ``checkout_roles`` list is exactly the policy set's
+    values — so editing ``REVIEWER_CHECKOUT_ROLE_VALUES`` changes the gate,
+    and no role is hard-coded in the bash."""
+    expected = {str(r) for r in REVIEWER_CHECKOUT_ROLE_VALUES}
+    assert set(EVENT_PUMP_CHECKOUT_ROLES.split()) == expected
+    # tester is the execution reviewer; a read-only reviewer is excluded.
+    assert "tester" in expected
+    assert _READ_ONLY_REVIEWER_ROLE not in expected
+
+
+def test_gate_is_rendered_into_the_wrapper() -> None:
+    script = _rendered_script()
+    assert f'case " {EVENT_PUMP_CHECKOUT_ROLES} " in' in script
+    assert "skipping working-tree merge (#3216)" in script
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: merge happens for tester, is skipped for a read-only reviewer
+# ---------------------------------------------------------------------------
+
+
+def test_tester_merges_peer_proposal(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    peer_sha = _init_repo_with_peer_proposal(repo)
+
+    _run_sync(repo, "tester", peer_sha)
+
+    # The merge ran: the peer proposal is now in HEAD's ancestry and its
+    # file is present in the reviewer's worktree.
+    ancestor_rc = subprocess.run(
+        ["git", "-C", str(repo), "merge-base", "--is-ancestor", peer_sha, "HEAD"],
+    ).returncode
+    assert ancestor_rc == 0, "tester worktree was not synced to the peer proposal"
+    assert (repo / "peer.txt").exists()
+
+
+def test_read_only_reviewer_skips_merge(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    peer_sha = _init_repo_with_peer_proposal(repo)
+    head_before = _git(repo, "rev-parse", "HEAD")
+
+    _run_sync(repo, _READ_ONLY_REVIEWER_ROLE, peer_sha)
+
+    # The merge was skipped: HEAD is unchanged and the peer's file never
+    # landed in this reviewer's worktree.
+    assert _git(repo, "rev-parse", "HEAD") == head_before
+    assert not (repo / "peer.txt").exists()
+    ancestor_rc = subprocess.run(
+        ["git", "-C", str(repo), "merge-base", "--is-ancestor", peer_sha, "HEAD"],
+    ).returncode
+    assert ancestor_rc != 0, "read-only reviewer should not contain the peer proposal"
+
+
+@pytest.mark.parametrize("role", ["", "unknown_role"])
+def test_unknown_or_unset_role_defaults_to_skip(tmp_path: Path, role: str) -> None:
+    """Default-deny: an unset or unrecognized role reads via git-show, so it
+    must not merge the peer tree."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    peer_sha = _init_repo_with_peer_proposal(repo)
+
+    _run_sync(repo, role, peer_sha)
+
+    assert not (repo / "peer.txt").exists()

--- a/shared/egg_contracts/agent_roles.py
+++ b/shared/egg_contracts/agent_roles.py
@@ -944,6 +944,20 @@ AGENT_ROLES: dict[AgentRole, AgentRoleDefinition] = {
 EXECUTION_ROLE_VALUES = frozenset({AgentRole.CODER, AgentRole.TESTER, AgentRole.DOCUMENTER})
 
 
+# Reviewer roles that must have the peer's proposal *merged into their
+# working tree* to do their job — i.e. they EXECUTE the proposal (run
+# the test suite / build against the merged tree) rather than only
+# reading its diff. The BRC event-pump wrapper's ``sync_to_proposals``
+# gate (#3216, WS1 of #3209) runs ``git merge`` only for these roles on
+# a review (``ack``/``nack``) arm; every other reviewer reads peer
+# artifacts via the per-event-prompt ``git show`` / ``egg-artifact``
+# served reads, so merging the peer's whole tree into their worktree
+# only risks the dual-role criss-cross propagation that corrupts shared
+# drafts (#3208). The ``tester`` is the only reviewer that runs the
+# proposed tree; reviewer_code and the refine/plan reviewers read diffs.
+REVIEWER_CHECKOUT_ROLE_VALUES = frozenset({AgentRole.TESTER})
+
+
 # Maps the fine-grained ``AgentRole`` shipped in agent sessions to the
 # coarse-grained ``Role`` enum used for contract field-ownership checks.
 # The gateway's contract and phase APIs consult this to authorize an

--- a/shared/egg_contracts/agent_roles.py
+++ b/shared/egg_contracts/agent_roles.py
@@ -955,6 +955,16 @@ EXECUTION_ROLE_VALUES = frozenset({AgentRole.CODER, AgentRole.TESTER, AgentRole.
 # only risks the dual-role criss-cross propagation that corrupts shared
 # drafts (#3208). The ``tester`` is the only reviewer that runs the
 # proposed tree; reviewer_code and the refine/plan reviewers read diffs.
+#
+# Residual: the ``tester`` is itself a dual-role agent (producer of test
+# code + reviewer) and must keep merging to execute ``make test`` against
+# the proposed tree, so the #3208 merge-then-commit-on-top criss-cross
+# shape stays *reachable via tester* in the implement phase. This gate
+# therefore does NOT fully close #3208 — it removes the shape for every
+# read-only reviewer (the plan-phase ``risk_analyst`` / ``plan.md``
+# corruption that motivated #3216). The remaining tester surface is an
+# accepted residual of WS1·1a, tracked under the parent #3209 (which
+# supersedes #3208); do not assume #3208 is closed by this set alone.
 REVIEWER_CHECKOUT_ROLE_VALUES = frozenset({AgentRole.TESTER})
 
 


### PR DESCRIPTION
## What

WS1 of #3209, part 1 (the merge-gate). Stops the live data-corruption mechanism diagnosed in #3208 (closed, superseded by #3209).

The BRC event-pump wrapper's `sync_to_proposals` ran `git merge --no-edit <peer_proposal_sha>` on **every** reviewer `ack`/`nack` arm (`consensus_wrapper.py`), ungated by role — merging the peer's *whole tree* into the reviewer's worktree (HEAD never reset). For dual-role agents (in the plan phase `risk_analyst` is producer + reviewer) this cross-pollinated concurrent producer lineages into a criss-cross merge topology that corrupted the shared `plan.md` draft: the rebase-mangled `yaml-tasks` fence and the `task_planner` "File modified since read" livelock from the `issue-3200` run.

## How

Gate the merge by role:
- `REVIEWER_CHECKOUT_ROLE_VALUES` (`egg_contracts.agent_roles`) names the reviewer roles that *execute* the proposal — currently just `tester` (it runs `make test` against the merged tree). Every other reviewer reads peer artifacts via served reads and gains nothing from the merge.
- `consensus_wrapper` renders the set into the template as `checkout_roles` and gates the top of `sync_to_proposals()`, covering both call sites (main loop + one-shot arm). Default-deny: an unset/unknown role reads via git-show (the non-replicating side).

## Tests

- New `test_sync_to_proposals_role_gate.py`: renders the real wrapper, extracts the function, runs it against a throwaway git repo — `tester` merges the peer proposal; a read-only reviewer and unset/unknown roles skip it. Policy-derived rendering asserted (editing the set changes the gate; no role hard-coded in bash).
- Golden snapshot regenerated (diff is only the gate block); behavioral `TestSyncToProposals` harness now runs as `tester`.
- Rendered wrapper passes `bash -n` and `shellcheck -S error`.
- Full suite: zero failures in the canonical CI test paths; pre-existing/infra failures verified present on `main`.

Part of #3209 · stacked PR for the read-by-name half (1b) follows.
