### PR TITLE
Serve reviewer reads by artifact name, retire git show <sha>:<path> (#3216 WS1·1b)

### DIFF
--- a/orchestrator/routes/event_prompt.py
+++ b/orchestrator/routes/event_prompt.py
@@ -939,21 +939,37 @@ def _build_delta_entries(
         artifacts = [a.replace("`", "") for a in artifacts]
         refs_text = "\n".join(f"- `{a}`" for a in artifacts)
         if proposal_sha:
-            # First review with a known proposal SHA: render concrete,
-            # working read commands instead of the directionless "fetch
-            # and read the diffs yourself" (#3076 — reviewers NACKed
-            # plans they could not find because nothing said WHERE the
-            # producer's work lives; their worktree does not contain
-            # it, but the shared object store resolves the SHA).
-            show_cmds = "\n".join(f"- `git show {proposal_sha}:{a}`" for a in artifacts)
+            # First review with a known proposal SHA. The producer's work
+            # is NOT in this reviewer's worktree — per-role worktrees are
+            # isolated, and #3216 (WS1 of #3209) stops syncing peer trees
+            # into read-only reviewers — so render served reads keyed by
+            # artifact NAME rather than path-bearing `git show <sha>:<path>`
+            # commands. `egg-artifact` resolves the repo path server-side
+            # from the spec registry and streams the committed bytes at
+            # <sha>, regardless of whether the commit resolves in this
+            # worktree's object store (the #3002 split-store case the old
+            # `git show` channel breaks on). Registered coordination
+            # artifacts get a per-name read; anything unregistered is
+            # covered by the full proposed-change delta below.
+            from egg_contracts.artifact_spec import name_for_path
+
+            read_names: list[str] = []
+            for a in artifacts:
+                name = name_for_path(a)
+                if name and name not in read_names:
+                    read_names.append(name)
+            read_cmds = "\n".join(
+                f"- `egg-artifact get {name} --ref {proposal_sha}`" for name in read_names
+            )
             fallback_delta = (
                 "(No `last_reviewed_commit_sha` recorded yet for this "
                 "producer — this is your FIRST review of this proposal. "
-                "The producer's work is NOT in your working tree; per-"
-                "role worktrees are isolated. Read it via the proposed "
-                f"commit `{proposal_sha}`, which resolves from your "
-                "worktree through the shared object store:)\n\n"
-                + (f"Proposed artifacts:\n{show_cmds}\n\n" if artifacts else "")
+                "The producer's work is NOT in your working tree; per-role "
+                "worktrees are isolated. Read each registered coordination "
+                f"artifact at the proposed commit `{proposal_sha}` via the "
+                "served read — it resolves the artifact server-side from "
+                "its spec-registered name, no local checkout required:)\n\n"
+                + (f"Proposed artifacts:\n{read_cmds}\n\n" if read_cmds else "")
                 + "Full proposed change:\n"
                 f"- `git log {proposal_sha} --not origin/{base_branch} -p`\n\n"
                 "Do NOT NACK for a missing file before reading it via "

--- a/orchestrator/tests/test_compose_event_prompt.py
+++ b/orchestrator/tests/test_compose_event_prompt.py
@@ -869,10 +869,14 @@ def test_build_delta_entries_legacy_payload_keeps_head_endpoint() -> None:
     assert mock_log.call_args.kwargs.get("end_ref") == "HEAD"
 
 
-def test_build_delta_entries_first_review_renders_git_show_commands() -> None:
-    """First review (no stored SHA) with a proposal SHA renders concrete,
-    working read commands — the producer's work is not in the reviewer's
-    working tree, and a plain Read of the path is expected to fail."""
+def test_build_delta_entries_first_review_renders_served_read_commands() -> None:
+    """First review (no stored SHA) with a proposal SHA renders served
+    reads keyed by artifact NAME (#3216, WS1 of #3209): a registered
+    coordination artifact path reverse-resolves to its spec name and the
+    reviewer is handed ``egg-artifact get <name> --ref <sha>`` rather than
+    a path-bearing ``git show``. The producer's work is not in the
+    reviewer's working tree, and a plain Read of the path is expected to
+    fail."""
     from pathlib import Path
 
     from orchestrator.routes.event_prompt import _build_delta_entries
@@ -888,6 +892,8 @@ def test_build_delta_entries_first_review_renders_git_show_commands() -> None:
                 {
                     "producer": "architect",
                     "current_version": 1,
+                    # .egg-state/drafts/p-plan.md reverse-resolves to the
+                    # registered ``plan-draft`` artifact.
                     "artifact_refs": [".egg-state/drafts/p-plan.md"],
                     "proposal_commit_sha": "b521d7d",
                 }
@@ -898,11 +904,13 @@ def test_build_delta_entries_first_review_renders_git_show_commands() -> None:
     entry = entries[0]
     assert entry["proposal_commit_sha"] == "b521d7d"
     delta = entry["delta"]
-    assert "git show b521d7d:.egg-state/drafts/p-plan.md" in delta
+    assert "egg-artifact get plan-draft --ref b521d7d" in delta
     assert "git log b521d7d --not origin/main -p" in delta
     assert "NOT in your working tree" in delta
     # The anti-phantom-NACK instruction is the point of the render.
     assert "Do NOT NACK" in delta
+    # Strict read-by-name: no path-bearing git-show coordination command.
+    assert "git show" not in delta
 
     # A 40-char SHA must render identically — guards against the
     # SHA-validation regex regressing to a fixed ``{7,7}`` width and
@@ -928,17 +936,19 @@ def test_build_delta_entries_first_review_renders_git_show_commands() -> None:
     )
     assert len(entries_full) == 1
     delta_full = entries_full[0]["delta"]
-    assert f"git show {full_sha}:.egg-state/drafts/p-plan.md" in delta_full
+    assert f"egg-artifact get plan-draft --ref {full_sha}" in delta_full
     assert f"git log {full_sha} --not origin/main -p" in delta_full
 
 
-def test_build_delta_entries_first_review_strips_backticks_from_artifact_paths() -> None:
-    """Producer-supplied artifact paths containing a backtick would otherwise
-    break the markdown code span the agent renders. The first-review
-    fallback strips backticks before interpolation; ``proposal_sha`` is
-    hex-validated upstream so it is not the attack surface. Belt-and-
-    braces only -- the agent (not bash) is the consumer, so this is not
-    a shell-injection vector."""
+def test_build_delta_entries_first_review_unregistered_paths_get_no_per_artifact_read() -> None:
+    """Strict read-by-name (#3216, WS1 of #3209): the first-review fallback
+    renders ``egg-artifact get <name>`` ONLY for paths that reverse-resolve
+    to a registered coordination artifact. Implement-phase code files
+    (``src/*.py``) are not registered, so they get no per-artifact read
+    command — the full ``git log -p`` delta covers them. Because the
+    rendered name comes from the spec registry (not producer input), the
+    old backtick-injection-via-path vector is structurally gone: no
+    producer-supplied path string reaches a rendered command at all."""
     from pathlib import Path
 
     from orchestrator.routes.event_prompt import _build_delta_entries
@@ -962,12 +972,15 @@ def test_build_delta_entries_first_review_strips_backticks_from_artifact_paths()
     )
     assert len(entries) == 1
     delta = entries[0]["delta"]
-    # The stripped path is what gets interpolated; no raw backtick from
-    # the artifact value reaches the rendered ``git show`` command, which
-    # would otherwise terminate the surrounding markdown code span.
-    assert "git show abc1234:src/evil.py" in delta
-    assert "git show abc1234:src/ok.py" in delta
+    # No per-artifact read command for unregistered code paths …
+    assert "egg-artifact get" not in delta
+    assert "git show" not in delta
+    # … and no producer-supplied path (let alone its backtick) is interpolated.
+    assert "src/" not in delta
     assert "`evil`" not in delta
+    # The full proposed-change delta is the review surface for code files.
+    assert "git log abc1234 --not origin/main -p" in delta
+    assert "Do NOT NACK" in delta
 
 
 def test_build_delta_entries_first_review_no_sha_strips_backticks_from_refs_text() -> None:

--- a/orchestrator/tests/test_prompt_sync_ratchet.py
+++ b/orchestrator/tests/test_prompt_sync_ratchet.py
@@ -126,7 +126,7 @@ _ALLOWLIST: tuple[tuple[str, str, int], ...] = (
     # prompt-constructing string — agents never see it. Reworking the
     # comment to drop the literal token would strip the pointer
     # reviewers depend on to navigate the deletion.
-    ("event_prompt.py", "git fetch", 970),
+    ("event_prompt.py", "git fetch", 986),
 )
 
 

--- a/sandbox/bin/egg-artifact
+++ b/sandbox/bin/egg-artifact
@@ -1,0 +1,1 @@
+../scripts/egg-artifact

--- a/sandbox/tests/test_bin_wrappers_on_path.py
+++ b/sandbox/tests/test_bin_wrappers_on_path.py
@@ -29,6 +29,12 @@ _PATH_DIR_ON_IMAGE = "/opt/egg-runtime/sandbox/bin"
 # Bare wrapper commands the orchestrator renders into reviewer prompts. Each
 # must be resolvable on PATH, i.e. present in sandbox/bin and pointing at an
 # existing executable.
+#
+# MAINTENANCE: this set is coupled to the renderer (event_prompt.py) only via
+# the shared command string — there is no derivation, so if the renderer starts
+# emitting a *different* bare command this guard stays green while silently
+# diverging. When you add a bare command to the reviewer fallback prompt, add it
+# here too (and pin its rendered string in test_compose_event_prompt.py).
 _REVIEWER_BARE_COMMANDS = ("egg-artifact",)
 
 

--- a/sandbox/tests/test_bin_wrappers_on_path.py
+++ b/sandbox/tests/test_bin_wrappers_on_path.py
@@ -1,0 +1,56 @@
+"""Guard that reviewer-facing wrapper CLIs are reachable on the sandbox PATH.
+
+The event-pump's first-review fallback hands reviewers a bare ``egg-artifact
+get <name> --ref <sha>`` command (orchestrator/routes/event_prompt.py). The
+reviewer runs that through the Bash tool, so ``egg-artifact`` must resolve as a
+bare command in the sandbox image. It ships as ``sandbox/scripts/egg-artifact``,
+but ``sandbox/scripts/`` is *not* on PATH — only ``sandbox/bin`` is (the
+Dockerfile's image-level ``ENV PATH``). The two surfaces drifted in #3221: the
+renderer depended on ``egg-artifact`` before anything installed it on PATH, so a
+reviewer following the prompt got ``command not found`` while every unit test
+(which only assert the rendered *string*) stayed green.
+
+These tests pin the install surface to the rendered command so they cannot
+silently drift apart again.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SANDBOX = _REPO_ROOT / "sandbox"
+_DOCKERFILE = _SANDBOX / "Dockerfile"
+
+# Directory the Dockerfile prepends to PATH at the image level (issue #1799).
+_PATH_DIR_ON_IMAGE = "/opt/egg-runtime/sandbox/bin"
+
+# Bare wrapper commands the orchestrator renders into reviewer prompts. Each
+# must be resolvable on PATH, i.e. present in sandbox/bin and pointing at an
+# existing executable.
+_REVIEWER_BARE_COMMANDS = ("egg-artifact",)
+
+
+def test_dockerfile_puts_sandbox_bin_on_path() -> None:
+    """The PATH dir these wrappers live in must actually be on PATH."""
+    dockerfile = _DOCKERFILE.read_text()
+    assert _PATH_DIR_ON_IMAGE in dockerfile, (
+        f"Dockerfile no longer puts {_PATH_DIR_ON_IMAGE} on PATH; update this guard."
+    )
+
+
+def test_reviewer_wrappers_are_installed_on_path() -> None:
+    """Each bare command rendered into reviewer prompts resolves on PATH."""
+    bin_dir = _SANDBOX / "bin"
+    for cmd in _REVIEWER_BARE_COMMANDS:
+        wrapper = bin_dir / cmd
+        assert wrapper.is_symlink() or wrapper.is_file(), (
+            f"{cmd!r} is rendered as a bare command in reviewer prompts but is "
+            f"not installed in sandbox/bin (which is on PATH). Add it so the "
+            f"rendered command resolves."
+        )
+        # Resolve through symlinks and confirm the target exists and is runnable.
+        target = wrapper.resolve()
+        assert target.is_file(), f"{cmd!r} -> {target} does not resolve to a file."
+        assert os.access(target, os.X_OK), f"{cmd!r} -> {target} is not executable."

--- a/shared/egg_contracts/artifact_spec.py
+++ b/shared/egg_contracts/artifact_spec.py
@@ -185,6 +185,21 @@ _SPECS: tuple[ArtifactSpec, ...] = (
 # ``dict``) for the annotation so callers can't rely on mutation.
 _BY_NAME: Mapping[str, ArtifactSpec] = {spec.name: spec for spec in _SPECS}
 
+# Path -> name reverse-resolution patterns, compiled once at import time.
+# The specs are frozen, so the ``prefix``/``suffix`` split and the anchored
+# single-segment pattern never change between calls; precompiling here keeps
+# ``name_for_path`` off the per-call ``re.compile`` cost (one pattern per
+# spec, per render).  ``[^/]+`` matches the single non-empty, slash-free
+# ``{identifier}`` segment; ``fullmatch`` anchors both ends.
+_PATH_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = tuple(
+    (
+        re.compile(re.escape(prefix) + "[^/]+" + re.escape(suffix)),
+        spec.name,
+    )
+    for spec in _SPECS
+    for prefix, _, suffix in (spec.path_template.partition("{identifier}"),)
+)
+
 
 def all_specs() -> tuple[ArtifactSpec, ...]:
     """Return every registered spec as an immutable tuple.
@@ -260,11 +275,9 @@ def name_for_path(path: str) -> str | None:
     matches; the first match wins.
     """
     candidate = path.strip()
-    for spec in _SPECS:
-        prefix, _, suffix = spec.path_template.partition("{identifier}")
-        pattern = re.compile(f"{re.escape(prefix)}[^/]+{re.escape(suffix)}")
+    for pattern, name in _PATH_PATTERNS:
         if pattern.fullmatch(candidate):
-            return spec.name
+            return name
     return None
 
 

--- a/shared/egg_contracts/artifact_spec.py
+++ b/shared/egg_contracts/artifact_spec.py
@@ -34,6 +34,7 @@ rather than re-introducing a parser.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 
@@ -238,9 +239,39 @@ def resolve_artifact_path(name: str, identifier: str | int) -> str:
     return spec_by_name(name).resolve_path(identifier)
 
 
+def name_for_path(path: str) -> str | None:
+    """Reverse-resolve a concrete repo-relative ``path`` to its registered
+    artifact name, or ``None`` when no spec matches.
+
+    This is the inverse of :meth:`ArtifactSpec.resolve_path`: the
+    served-read consumers (the event-prompt first-review renderer in
+    ``orchestrator/routes/event_prompt.py``, #3216 WS1 of #3209) know a
+    producer's *changed paths* but the served-read endpoint and the
+    ``egg-artifact`` verb address artifacts by *name*. This maps the path
+    back so reviewers are handed ``egg-artifact get <name> --ref <sha>``
+    instead of a path-bearing ``git show <sha>:<path>``.
+
+    Each ``path_template`` has exactly one ``{identifier}`` placeholder
+    (enforced at construction), so it reduces to a ``prefix`` /
+    ``suffix`` pair around a single path segment. The identifier never
+    contains a ``/`` (it is an issue number or a hyphenated pipeline id),
+    so the placeholder matches one non-empty, slash-free run. The
+    templates have disjoint prefix+suffix shapes, so at most one spec
+    matches; the first match wins.
+    """
+    candidate = path.strip()
+    for spec in _SPECS:
+        prefix, _, suffix = spec.path_template.partition("{identifier}")
+        pattern = re.compile(f"{re.escape(prefix)}[^/]+{re.escape(suffix)}")
+        if pattern.fullmatch(candidate):
+            return spec.name
+    return None
+
+
 __all__ = [
     "ArtifactSpec",
     "all_specs",
+    "name_for_path",
     "resolve_artifact_path",
     "spec_by_name",
     "specs_for",

--- a/shared/egg_contracts/tests/test_artifact_spec.py
+++ b/shared/egg_contracts/tests/test_artifact_spec.py
@@ -59,6 +59,7 @@ from routes.pipelines import _get_draft_path
 # module function.
 from egg_contracts.artifact_spec import (
     ArtifactSpec,
+    name_for_path,
     resolve_artifact_path,
     spec_by_name,
     specs_for,
@@ -606,4 +607,49 @@ def test_module_exports_are_callable() -> None:
     # at every consumer call site.
     assert callable(resolve_artifact_path)
     assert callable(specs_for)
+    assert callable(name_for_path)
+
+
+class TestNameForPath:
+    """``name_for_path`` reverse-resolves a concrete path back to its
+    registered artifact name — the inverse of ``resolve_path`` used by the
+    event-prompt served-read renderer (#3216, WS1 of #3209)."""
+
+    @pytest.mark.parametrize("identifier", ["3200", 3200, "issue-3077-replan"])
+    def test_round_trips_every_registered_spec(self, identifier) -> None:
+        # resolve_path -> name_for_path is identity on the name for every
+        # row, for both issue-number and hyphenated-pipeline identifiers.
+        for spec in registered_specs():
+            path = spec.resolve_path(identifier)
+            assert name_for_path(path) == spec.name
+
+    def test_known_concrete_paths(self) -> None:
+        assert name_for_path(".egg-state/drafts/3200-plan.md") == "plan-draft"
+        assert name_for_path(".egg-state/drafts/3200-analysis.md") == "analysis-draft"
+        assert (
+            name_for_path(".egg-state/agent-outputs/3200-architect-output.json")
+            == "architect-output"
+        )
+        assert (
+            name_for_path(".egg-state/agent-outputs/3200-architect-slices.yaml")
+            == "architect-slices"
+        )
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        assert name_for_path("  .egg-state/drafts/3200-plan.md\n") == "plan-draft"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "",
+            "README.md",
+            ".egg-state/drafts/3200-plan.txt",  # wrong suffix
+            ".egg-state/other/3200-plan.md",  # wrong prefix
+            ".egg-state/drafts/3200-plan.md.bak",  # trailing junk
+            ".egg-state/drafts/a/b-plan.md",  # identifier must be one segment
+        ],
+    )
+    def test_unregistered_paths_return_none(self, path: str) -> None:
+        assert name_for_path(path) is None
+
     assert callable(spec_by_name)


### PR DESCRIPTION
## What

WS1 of #3209, part 2 (strict read-by-name). **Stacked on #3220** (1a, the merge-gate) — review/merge that first.

The event-pump's first-review fallback handed reviewers literal `git show <sha>:<path>` commands per changed artifact, anchored on the shared host object store resolving the SHA. That is the implicit replicated channel #3209 retires: it breaks on a split object store (#3002/GKE) and keeps the path-guessing coupling the artifact spec exists to remove. The name-resolving served-read endpoint + `egg-artifact` helper already shipped in #3077 slice-4 but were **orphaned** — nothing referenced them.

## How (strict, per the #3209 HITL decision)

Reviewers now read each registered coordination artifact via `egg-artifact get <name> --ref <sha>`, which resolves the repo path server-side from the spec registry and streams the committed bytes regardless of whether the commit resolves in the reviewer's worktree.

- `artifact_spec.name_for_path()` — reverse-resolves a concrete path to its registered artifact name (inverse of `resolve_path`), matching each `path_template`'s single `{identifier}` placeholder as one slash-free segment.
- `event_prompt` first-review fallback renders `egg-artifact get <name> --ref <sha>` for paths that resolve to a registered artifact, **drops** the path-bearing `git show`, and keeps the full `git log <sha> --not origin/<base> -p` delta (the review surface for unregistered files, e.g. implement-phase code). Prose drops the "shared object store" framing.

Side effect: producer-supplied paths no longer reach any rendered command — only spec-registered names do — so the prior backtick-injection-via-path concern is structurally eliminated.

## Tests

- `name_for_path` round-trips every registered spec (issue-number and hyphenated-pipeline identifiers) and rejects unregistered paths.
- Event-prompt tests: served-read-by-name rendering for registered artifacts; no per-artifact read (and no path interpolated) for unregistered code paths; full delta still present.
- Ratchet allowlist line updated for the event_prompt edit; `test_event_prompt_has_no_sync_mechanics` still green.

Part of #3209.
