### PR TITLE
chore(resolver): move glm to the 1M [1m] path for glm-5.2

### DIFF
--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -126,7 +126,7 @@ The resolver's classifier divides model strings into two camps:
 | `opus`, `opus[1m]`, `sonnet`, `sonnet[1m]`, `haiku`, `fable`, `fable[1m]` | `"anthropic"` | the model string verbatim | `None` |
 | `claude-*` (e.g. `claude-3-5-sonnet-20241022`) | `"anthropic"` | the model string verbatim | `None` |
 | Everything else with a real window ≥1M (e.g. `qwen3.7-max`, `deepseek-v4-*`) | `"litellm"` | `<model>[1m]` (the bare upstream name plus the 1M-context opt-in suffix) | the bare upstream name |
-| Sub-1M-window models (`_SUB_1M_CONTEXT_MODELS`: `kimi-k2.7-code` 256K, `glm-5.1` 202K) | `"litellm"` | `<model>` — bare, **no** `[1m]` (takes Claude Code's 200K default) | the bare upstream name |
+| Sub-1M-window models (`_SUB_1M_CONTEXT_MODELS`: `kimi-k2.7-code` 256K) | `"litellm"` | `<model>` — bare, **no** `[1m]` (takes Claude Code's 200K default) | the bare upstream name |
 
 Two consequences:
 
@@ -292,7 +292,7 @@ two env vars (plus one egg-side auth marker):
 - `ANTHROPIC_CUSTOM_MODEL_OPTION=<upstream>[1m]` — registers the
   custom model ID and tells Claude Code to use 1M-context
   compaction math. For models in `_SUB_1M_CONTEXT_MODELS` (Kimi
-  K2.7-Code, GLM-5.1) this is set to the **bare** `<upstream>` without
+  K2.7-Code) this is set to the **bare** `<upstream>` without
   the `[1m]` suffix; see the *Sub-1M-window upstreams (#2987)*
   callout below.
 - `ANTHROPIC_CUSTOM_MODEL_OPTION_NAME=<upstream>` — the bare
@@ -402,7 +402,7 @@ accident. See `context_guardrail_env()` in
 > `DISABLE_COMPACT` (which egg never sets). So the resolver appends
 > `[1m]` only for genuine ≥1M upstreams and **withholds it** for
 > models whose real window is below 1M — `_SUB_1M_CONTEXT_MODELS` in
-> `agent_model_resolution.py` (Kimi K2.7-Code 256K, GLM-5.1 202K). Those
+> `agent_model_resolution.py` (Kimi K2.7-Code 256K). Those
 > take Claude Code's 200K default, which auto-compacts safely below
 > their real limit instead of deferring compaction toward 1M and
 > overflowing the upstream mid-turn. The cost is the unused headroom

--- a/orchestrator/agent_model_resolution.py
+++ b/orchestrator/agent_model_resolution.py
@@ -27,7 +27,7 @@ the agent is spawned with ``--model <upstream>[1m]`` and the
 ``ANTHROPIC_CUSTOM_MODEL_OPTION`` / ``…_OPTION_NAME`` env vars set so
 Claude Code registers the custom model with a 1M-context-window
 compaction profile. Models whose real context window is below 1M
-(``_SUB_1M_CONTEXT_MODELS`` — e.g. Kimi 256K, GLM 202K) are the
+(``_SUB_1M_CONTEXT_MODELS`` — e.g. Kimi 256K) are the
 exception: they get the bare ``<upstream>`` alias so Claude Code uses
 its 200K default and compacts before their true limit, since Claude
 Code has no sub-1M custom-model profile (#2987). The gateway no longer
@@ -120,7 +120,6 @@ _CONTEXT_1M_SUFFIX = "[1m]"
 # window is <1M. See #2987.
 _SUB_1M_CONTEXT_MODELS: dict[str, int] = {
     "kimi-k2.7-code": 262_144,
-    "glm-5.1": 202_752,
 }
 
 # Recognised Claude aliases that route through the Anthropic upstream.

--- a/orchestrator/tests/test_agent_model_resolution.py
+++ b/orchestrator/tests/test_agent_model_resolution.py
@@ -475,7 +475,7 @@ class TestSubOneMContextModels:
     safely below their window. See #2987.
     """
 
-    @pytest.mark.parametrize("model", ["kimi-k2.7-code", "glm-5.1"])
+    @pytest.mark.parametrize("model", ["kimi-k2.7-code"])
     def test_sub_1m_model_drops_1m_suffix(self, model):
         resolve_agent_model = _resolver()
         AgentRole = _agent_role()
@@ -492,7 +492,7 @@ class TestSubOneMContextModels:
             f"model's real limit; got {d.claude_code_alias!r}"
         )
 
-    @pytest.mark.parametrize("model", ["kimi-k2.7-code", "glm-5.1"])
+    @pytest.mark.parametrize("model", ["kimi-k2.7-code"])
     def test_pre_suffixed_sub_1m_model_normalized_to_bare(self, model):
         """A stray operator ``[1m]`` on a sub-1M model is overridden — the
         registry is authoritative, so the alias is still bare.
@@ -507,14 +507,13 @@ class TestSubOneMContextModels:
         assert d.upstream_model == model
         assert d.claude_code_alias == model
 
-    @pytest.mark.parametrize("model", ["kimi-k2.7-code", "glm-5.1"])
+    @pytest.mark.parametrize("model", ["kimi-k2.7-code"])
     def test_sub_1m_env_vars_carry_bare_name(self, model, monkeypatch):
         """Every custom-model env var for a sub-1M model carries the bare
         name — none may leak the ``[1m]`` suffix (which would re-trigger the
-        1M profile for the main agent or its Task-tool subagents). Parametrized
-        over both registry entries so a future drift that only broke ``glm-5.1``
-        (e.g. a ``.lower()`` or escape that special-cased the hyphen-period in
-        ``k2.7``) is caught here, not in the field.
+        1M profile for the main agent or its Task-tool subagents). Guards the
+        full env-var fan-out so a drift that special-cased the hyphen-period in
+        ``k2.7`` (e.g. a ``.lower()`` or escape) is caught here, not in the field.
         """
         _clear_guardrail_overrides(monkeypatch)
         resolve_agent_model = _resolver()
@@ -534,10 +533,14 @@ class TestSubOneMContextModels:
             **_LITELLM_GUARDRAIL_DEFAULTS,
         }
 
-    @pytest.mark.parametrize("model", ["deepseek-v4-flash", "deepseek-v4-pro", "qwen3.7-max"])
+    @pytest.mark.parametrize(
+        "model", ["deepseek-v4-flash", "deepseek-v4-pro", "qwen3.7-max", "glm-5.2"]
+    )
     def test_one_m_models_still_carry_1m_suffix(self, model):
         """Regression guard: genuine >=1M cost-center models are unaffected —
-        they still get ``[1m]`` so they use their full 1M window.
+        they still get ``[1m]`` so they use their full 1M window. ``glm-5.2``
+        is the 1M successor to the sub-1M ``glm-5.1`` (removed from
+        ``_SUB_1M_CONTEXT_MODELS``), so it now takes the ``[1m]`` path.
         """
         resolve_agent_model = _resolver()
         AgentRole = _agent_role()


### PR DESCRIPTION
## What

GLM-5.2 ships a **true 1M context window** (5.1 was 202K), so it should take the resolver's `[1m]` compaction profile like the other ≥1M cost-center models (qwen, deepseek-v4-*) rather than the bare-alias sub-1M exception path.

- Remove `glm-5.1` from `_SUB_1M_CONTEXT_MODELS` in `orchestrator/agent_model_resolution.py`. With no glm entry, the resolver emits `glm-5.2[1m]`, which matches the `glm-5.2` + `glm-5.2[1m]` entries now in the egg-litellm `model_list` (`~/.config/egg/litellm-models.yaml`). Kimi K2.7-Code remains the only sub-1M entry.
- Update the module/guide docstrings that cited "GLM 202K" as a sub-1M example.

## Why this is the paired change

The host-side LiteLLM config (`config/litellm` parity) was bumped `glm-5.1 → glm-5.2` with a `[1m]` alias added. Without this resolver change, an agent role pinned to `glm-5.2` would still be withheld the suffix (had glm stayed in the sub-1M set) — under-using the new 1M window. The model id only changes routing data; nothing in the relitellm cache patches references glm, so no image patch is needed.

## Provider note (config side, not in this PR)

GLM-5.2 serves the full 1M only on a subset of providers; the model_list pin drops Together/Parasail (256K on GLM-5.2) so a `[1m]` fallback can't overrun the real window. That's in the dotfiles/egg yaml, not this repo.

## Tests

- Drop `glm-5.1` from the three `_SUB_1M_CONTEXT_MODELS` parametrize sets (Kimi remains).
- Add `glm-5.2` to `test_one_m_models_still_carry_1m_suffix` — positive coverage that it now gets `[1m]`.
- `test_registry_entries_all_below_1m` still passes (kimi-only dict).

`pytest orchestrator/tests/test_agent_model_resolution.py` → **71 passed**. `ruff check` clean.