### PR TITLE
fix(orchestrator): record slice fork base from create call, no round-trip (#3185)

### DIFF
--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -2714,8 +2714,23 @@ class GatewayClient:
         integration_base_sha: str | None = None,
         agent_role: str = "coder",
         mode: Literal["public", "private"] = "public",
-    ) -> bool:
+    ) -> str | None:
         """Create the slice integration branch on origin from ``parent_branch``.
+
+        On success returns the fork-base SHA the integration branch was
+        pushed at (the resolved ``parent_sha``) — exactly the value the
+        caller records as :attr:`Slice.integration_base_sha` (#2871).
+        Returning it here lets the caller persist the fork base from the
+        same gateway call that created the branch, with no extra
+        ``get_remote_branch_sha`` round-trip whose best-effort failure
+        previously left ``integration_base_sha`` unset and armed the
+        #3185 empty-branch trap (an un-started branch later misclassified
+        as merged by ancestor-only detection). ``None`` on any failure
+        (the caller logs and surfaces a clear error to the run loop). The
+        #2512 / #2947 recovery short-circuits also return ``parent_sha``:
+        they only fire when the branch already exists, which means a
+        prior run already recorded its base, so the caller's
+        "record only when unset" guard ignores the returned value there.
 
         Pushes ``<parent_sha>:refs/heads/<integration_branch>`` via a
         synthetic, launcher-authenticated session through
@@ -2748,14 +2763,20 @@ class GatewayClient:
         or whose base was never recorded) degrades to the prior
         behaviour — the rejection surfaces.
 
-        Returns ``True`` on success, ``False`` on any error (the
-        caller logs and surfaces a clear error to the run loop).
+        Returns the fork-base SHA (``parent_sha``) on success, ``None``
+        on any error (the caller logs and surfaces a clear error to the
+        run loop).
         """
         if not integration_branch or not parent_branch:
-            return False
+            return None
         if integration_branch == parent_branch:
             # No-op: integration branch already exists at parent's tip.
-            return True
+            # ``parent_sha`` is not resolved on this no-op path (no
+            # round-trip has happened yet), so return an empty string
+            # rather than a misleading None — the caller's "record only
+            # when unset" guard skips recording here anyway because the
+            # branch already existing means a prior run recorded its base.
+            return ""
 
         # Register one synthetic session up front and share it across
         # the fetch, ls-remote, and push (#2398).  The session is
@@ -2818,7 +2839,7 @@ class GatewayClient:
                     integration_branch=integration_branch,
                     parent_branch=parent_branch,
                 )
-                return False
+                return None
 
             # #2512 — restart_phase recovery: if the slice integration
             # branch already exists on origin with commits descended
@@ -2881,7 +2902,15 @@ class GatewayClient:
                         parent_sha=parent_sha,
                         existing_sha=existing_sha,
                     )
-                    return True
+                    # The branch already existed with commits descended from
+                    # ``parent_sha``, so ``parent_sha`` *is* the fork
+                    # base (the branch was created at it and advanced).
+                    # For post-#2871 contracts a prior run already
+                    # recorded it, so the caller's "record only when
+                    # unset" guard no-ops; for a pre-#2871 contract
+                    # this return value backfills the field correctly.
+                    # Either way ``parent_sha`` is the right value.
+                    return parent_sha
                 # #2947 — crash / restart mid-slice resume-in-place. The
                 # existing tip is NOT a descendant of the (advanced)
                 # parent, so the #2512 fast-path above did not fire — but
@@ -2963,7 +2992,12 @@ class GatewayClient:
                         existing_sha=existing_sha,
                         integration_base_sha=integration_base_sha,
                     )
-                    return True
+                    # This path is gated on ``integration_base_sha`` being
+                    # supplied, so the caller already has the recorded
+                    # base (``recorded_base_sha`` is not None) and skips
+                    # recording this return value. Return ``parent_sha``
+                    # so the caller treats the call as success.
+                    return parent_sha
                 # Could not verify ancestry: parent_sha is either not
                 # reachable from the existing tip (genuinely diverged
                 # history) or the merge-base call itself failed
@@ -3008,7 +3042,12 @@ class GatewayClient:
                 parent_branch=parent_branch,
                 parent_sha=parent_sha,
             )
-            return True
+            # #3185 — return the fork base the branch was pushed at so
+            # the caller records ``integration_base_sha`` from this call
+            # with no extra round-trip. The previous best-effort re-fetch
+            # could silently fail (no ``retry_transient``) and leave the
+            # field unset, arming the empty-branch trap.
+            return parent_sha
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "Failed to create slice integration branch",
@@ -3018,7 +3057,7 @@ class GatewayClient:
                 parent_sha=parent_sha,
                 error=str(exc),
             )
-            return False
+            return None
         finally:
             if session_token:
                 try:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -17247,35 +17247,43 @@ def _run_implement_phase_slices(
                 # agents that would push to a missing parent.
                 if pipeline.repo:
                     try:
-                        branch_ok = bool(
-                            spawner.gateway.create_slice_integration_branch(
-                                pipeline_id,
-                                str(worktree_repo_path),
-                                integration_branch=integration_branch,
-                                parent_branch=parent_branch,
-                                # #2947 — hand the slice's recorded fork
-                                # base to the gateway so a crash/restart
-                                # over a branch that already carries this
-                                # slice's commits (with an additively
-                                # advanced parent) resumes in place
-                                # instead of non-fast-forward-failing.
-                                integration_base_sha=recorded_base_sha,
-                                # Orchestrator pre-creates the slice
-                                # integration branch on a synthetic session
-                                # before agents spawn; attribute to the
-                                # orchestrator, not a phantom coder (#2919).
-                                # The push rides the slice-integration
-                                # exemption (synthetic + branch shape), not a
-                                # role gate.
-                                agent_role="orchestrator",
-                                mode=gateway_mode,  # type: ignore[arg-type]
-                            )
+                        # #3185 — the helper now returns the fork-base
+                        # SHA it pushed the integration branch at (the
+                        # parent tip resolved inside the call), or None
+                        # on failure. Recording that SHA directly here
+                        # replaces a prior best-effort
+                        # ``get_remote_branch_sha`` re-fetch that could
+                        # silently fail (no ``retry_transient``) and
+                        # leave ``integration_base_sha`` unset — arming
+                        # the empty-pre-created-branch trap on the next
+                        # restart.
+                        created_base_sha = spawner.gateway.create_slice_integration_branch(
+                            pipeline_id,
+                            str(worktree_repo_path),
+                            integration_branch=integration_branch,
+                            parent_branch=parent_branch,
+                            # #2947 — hand the slice's recorded fork
+                            # base to the gateway so a crash/restart
+                            # over a branch that already carries this
+                            # slice's commits (with an additively
+                            # advanced parent) resumes in place
+                            # instead of non-fast-forward-failing.
+                            integration_base_sha=recorded_base_sha,
+                            # Orchestrator pre-creates the slice
+                            # integration branch on a synthetic session
+                            # before agents spawn; attribute to the
+                            # orchestrator, not a phantom coder (#2919).
+                            # The push rides the slice-integration
+                            # exemption (synthetic + branch shape), not a
+                            # role gate.
+                            agent_role="orchestrator",
+                            mode=gateway_mode,  # type: ignore[arg-type]
                         )
                     except Exception as branch_err:  # noqa: BLE001
                         # Gateway `create_slice_integration_branch`
                         # call. Catches GatewayError (HTTP/timeout)
-                        # and OSError (DNS / socket). Mark branch_ok
-                        # False so the cascade machinery surfaces a
+                        # and OSError (DNS / socket). Treat as failure
+                        # so the cascade machinery surfaces a
                         # missing-parent error.
                         logger.error(
                             "Slice integration branch creation raised",
@@ -17283,8 +17291,8 @@ def _run_implement_phase_slices(
                             slice_id=slice_id,
                             error=str(branch_err),
                         )
-                        branch_ok = False
-                    if not branch_ok:
+                        created_base_sha = None
+                    if created_base_sha is None:
                         logger.error(
                             "Slice integration branch creation failed; "
                             "marking slice failed (agents not spawned)",
@@ -17300,9 +17308,9 @@ def _run_implement_phase_slices(
                             f"{parent_branch}"
                         )
 
-                    # #2871 — record the integration branch's fork base
-                    # exactly once, on first creation. The branch was just
-                    # pushed at the parent's tip and no agent has been
+                    # #2871 / #3185 — record the integration branch's fork
+                    # base exactly once, on first creation. The branch was
+                    # just pushed at the parent's tip and no agent has been
                     # spawned yet, so its origin tip still equals its base.
                     # Persisting it now lets a later restart's bootstrap
                     # reconciliation (and the race check above) tell an
@@ -17312,33 +17320,35 @@ def _run_implement_phase_slices(
                     # only write it when unset so a restart over a branch
                     # that already carries slice commits (#2512 recovery)
                     # keeps its original base rather than the advanced tip.
-                    if recorded_base_sha is None:
+                    # ``created_base_sha`` is the SHA the create call
+                    # returned (no extra round-trip); it is an empty string
+                    # on the unreachable no-op path
+                    # (``integration_branch == parent_branch``), which we
+                    # skip here.
+                    if recorded_base_sha is None and created_base_sha:
                         try:
-                            base_sha = spawner.gateway.get_remote_branch_sha(
-                                pipeline_id,
-                                str(worktree_repo_path),
-                                f"refs/heads/{integration_branch}",
-                                mode=gateway_mode,  # type: ignore[arg-type]
-                            )
-                            if base_sha:
-                                with get_pipeline_state_lock(pipeline_id):
-                                    contract_local = load_contract(pipeline_id, worktree_repo_path)
-                                    for s in contract_local.slices:
-                                        if s.id == slice_id:
-                                            s.integration_base_sha = base_sha
-                                            break
-                                    save_contract(contract_local, worktree_repo_path)
-                                recorded_base_sha = base_sha
+                            with get_pipeline_state_lock(pipeline_id):
+                                contract_local = load_contract(pipeline_id, worktree_repo_path)
+                                for s in contract_local.slices:
+                                    if s.id == slice_id:
+                                        s.integration_base_sha = created_base_sha
+                                        break
+                                save_contract(contract_local, worktree_repo_path)
+                            recorded_base_sha = created_base_sha
                         except Exception as base_err:  # noqa: BLE001
-                            # Gateway `get_remote_branch_sha` +
-                            # contract load/save. Catches GatewayError,
-                            # OSError, and the loader/save exception
-                            # surface. Best-effort: empty-branch
-                            # detection degrades to ancestor-only.
+                            # Contract load/save under per-pipeline state
+                            # lock. Catches loader validation, atomic-
+                            # rename I/O, and pydantic re-serialisation
+                            # errors. Best-effort: the fork base is no
+                            # longer a round-trip failure (the SHA came
+                            # from the create call itself), so this now
+                            # only fires on a contract-write failure — a
+                            # transient the next run repairs on the same
+                            # create path.
                             logger.warning(
-                                "Failed to record slice integration_base_sha "
-                                "(#2871); empty-branch detection degrades to "
-                                "ancestor-only on a future restart",
+                                "Failed to persist slice integration_base_sha "
+                                "(#2871); a future restart re-records it on the "
+                                "create path",
                                 pipeline_id=pipeline_id,
                                 slice_id=slice_id,
                                 integration_branch=integration_branch,

--- a/orchestrator/tests/test_create_slice_integration_branch.py
+++ b/orchestrator/tests/test_create_slice_integration_branch.py
@@ -243,7 +243,7 @@ class TestCreateSliceIntegrationBranchFailures:
         assert push_invoked == [True]
 
     def test_push_failure_returns_false_and_cleans_up_session(self, gateway_client):
-        """If the push request raises, the function must return False
+        """If the push request raises, the function must return None
         and still delete the synthetic session (no gateway-side leak)."""
         delete_calls: list[str] = []
 
@@ -462,9 +462,9 @@ class TestCreateSliceIntegrationBranchRestartRecovery:
         """Issue #2512 reproduction: slice-1 branch on origin contains
         coder/tester commits descended from parent (cancel_task with
         cleanup=false followed by restart_phase).  ``create_slice_
-        integration_branch`` must detect this and return True without
-        pushing — the prior commits are exactly what restart_phase
-        promises to preserve."""
+        integration_branch`` must detect this and return the fork-base
+        SHA without pushing — the prior commits are exactly what
+        restart_phase promises to preserve."""
         parent_sha = "8a76c30d" * 5  # parent-branch tip
         existing_sha = "0c5c6697" * 5  # slice-1 tip from prior run
 
@@ -625,7 +625,7 @@ class TestCreateSliceIntegrationBranchRestartRecovery:
 
         assert ok is None, (
             "non-fast-forward rejection on diverged history must surface as "
-            "ok=False — that's the user-visible signal the operator needs"
+            "ok=None — that's the user-visible signal the operator needs"
         )
         assert delete_spy.call_args_list == [call("diverged-tok")], (
             "synthetic session must still be cleaned up in the rejection path"
@@ -844,7 +844,7 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
         """The incident itself: slice has its own commits built on the
         recorded base, parent advanced additively (base ancestor of both,
         neither tip an ancestor of the other). Must preserve the branch
-        and return True WITHOUT pushing."""
+        and return the fork-base SHA WITHOUT pushing."""
         base_sha = "b0b0b0b0" * 5  # slice-2 tip when slice-3 was created
         existing_sha = "e1e1e1e1" * 5  # slice-3 tip (documenter commits)
         parent_sha = "a2a2a2a2" * 5  # slice-2 tip, advanced additively
@@ -879,7 +879,7 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
             [base_sha, parent_sha],
         ]
         # Symmetric coverage for ``test_push_failure_returns_false_and_cleans
-        # _up_session``: the new ``return True`` lives inside the outer
+        # _up_session``: the new ``return parent_sha`` lives inside the outer
         # ``try``, so ``delete_session`` must still fire from the ``finally``
         # on this success path. Pinning it here freezes that — a future
         # refactor that moved the early-return outside the try (or skipped
@@ -888,7 +888,7 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
         assert delete_calls == ["tok-resume-incident"], (
             "synthetic session must be deleted on the resume-in-place "
             "success path (the ``finally`` must still fire despite the "
-            "early ``return True``)"
+            "early ``return parent_sha``)"
         )
 
     def test_parent_rebase_falls_through_to_push(self, gateway_client):

--- a/orchestrator/tests/test_create_slice_integration_branch.py
+++ b/orchestrator/tests/test_create_slice_integration_branch.py
@@ -95,7 +95,16 @@ class TestCreateSliceIntegrationBranchSuccess:
                 parent_branch="egg/issue-2393",
             )
 
-        assert ok is True
+        assert ok
+        # #3185 — the helper returns the fork-base SHA it pushed at, so
+        # the caller records ``integration_base_sha`` from this call with
+        # no extra ``get_remote_branch_sha`` round-trip (whose best-effort
+        # failure previously left the field unset and armed the
+        # empty-branch trap). The returned SHA is the resolved parent tip.
+        assert ok == parent_sha, (
+            "create_slice_integration_branch must return the fork-base SHA "
+            f"(parent tip), got {ok!r}"
+        )
         assert len(push_payloads) == 1
         push = push_payloads[0]
         assert push["refspec"] == f"{parent_sha}:refs/heads/egg/issue-2393/slice-1", (
@@ -153,7 +162,7 @@ class TestCreateSliceIntegrationBranchSuccess:
                 parent_branch="egg/issue-2393",
             )
 
-        assert ok is True
+        assert ok
         assert order == [
             "fetch",
             "ls-remote:refs/heads/egg/issue-2393",
@@ -189,7 +198,7 @@ class TestCreateSliceIntegrationBranchFailures:
                 parent_branch="egg/issue-2393",
             )
 
-        assert ok is False
+        assert ok is None
         assert push_invoked == [], "push must not be issued when parent is not on origin"
 
     def test_fetch_returning_false_does_not_short_circuit(self, gateway_client):
@@ -230,7 +239,7 @@ class TestCreateSliceIntegrationBranchFailures:
                 parent_branch="egg/issue-2393",
             )
 
-        assert ok is True
+        assert ok
         assert push_invoked == [True]
 
     def test_push_failure_returns_false_and_cleans_up_session(self, gateway_client):
@@ -267,7 +276,7 @@ class TestCreateSliceIntegrationBranchFailures:
                 parent_branch="egg/issue-2393",
             )
 
-        assert ok is False
+        assert ok is None
         assert delete_calls == ["tok-push"]
 
 
@@ -285,7 +294,7 @@ class TestCreateSliceIntegrationBranchShortCircuits:
                     integration_branch="",
                     parent_branch="egg/issue-2393",
                 )
-                is False
+                is None
             )
             assert (
                 gateway_client.create_slice_integration_branch(
@@ -294,7 +303,7 @@ class TestCreateSliceIntegrationBranchShortCircuits:
                     integration_branch="egg/issue-2393/slice-1",
                     parent_branch="",
                 )
-                is False
+                is None
             )
             mock_req.assert_not_called()
             mock_fetch.assert_not_called()
@@ -314,7 +323,9 @@ class TestCreateSliceIntegrationBranchShortCircuits:
                 integration_branch="egg/issue-2393",
                 parent_branch="egg/issue-2393",
             )
-        assert ok is True
+        # No-op path returns a non-None sentinel (the fork base is not
+        # resolved here — no round-trip — so the caller skips recording).
+        assert ok is not None
         mock_req.assert_not_called()
         mock_fetch.assert_not_called()
         mock_ls.assert_not_called()
@@ -352,7 +363,7 @@ class TestCreateSliceIntegrationBranchSession:
                 mode="private",
             )
 
-        assert ok is True
+        assert ok
         register_spy.assert_called_once()
         kwargs = register_spy.call_args.kwargs
         assert kwargs["synthetic"] is True
@@ -393,7 +404,7 @@ class TestCreateSliceIntegrationBranchSession:
                 parent_branch="egg/issue-2393",
             )
 
-        assert ok is True
+        assert ok
         assert register_spy.call_count == 1, "session must be registered exactly once"
         assert delete_spy.call_args_list == [call("shared-tok")], (
             "session must be deleted exactly once with the shared token"
@@ -427,7 +438,7 @@ class TestCreateSliceIntegrationBranchSession:
                 parent_branch="egg/issue-2393",
             )
 
-        assert ok is False
+        assert ok is None
         assert register_spy.call_count == 1
         assert delete_spy.call_args_list == [call("orphan-tok")]
 
@@ -495,7 +506,7 @@ class TestCreateSliceIntegrationBranchRestartRecovery:
                 parent_branch="egg/issue-2474",
             )
 
-        assert ok is True, "must short-circuit success when prior work descends from parent"
+        assert ok, "must short-circuit success when prior work descends from parent"
         assert push_invoked == [], (
             "must NOT push when integration branch already descends from "
             "parent — that push would be rejected as non-fast-forward"
@@ -552,14 +563,14 @@ class TestCreateSliceIntegrationBranchRestartRecovery:
                 parent_branch="egg/issue-1",
             )
 
-        assert ok is True, "diverged history → push proceeds and (here) succeeds"
+        assert ok, "diverged history → push proceeds and (here) succeeds"
         assert len(push_invoked) == 1, "must attempt the push when histories diverge"
         assert push_invoked[0]["refspec"] == (f"{parent_sha}:refs/heads/egg/issue-1/slice-1")
 
     def test_diverged_history_push_rejection_surfaces_as_failure(self, gateway_client):
         """The whole point of falling through to the push on diverged
         history is that origin's non-fast-forward rejection surfaces
-        as a clear ``ok is False`` signal (rather than silently
+        as a clear ``ok is None`` failure signal (rather than silently
         overwriting unknown work).  Pin that the rejection actually
         propagates and that the synthetic session is still cleaned up
         in the failure path."""
@@ -612,7 +623,7 @@ class TestCreateSliceIntegrationBranchRestartRecovery:
                 parent_branch="egg/issue-1",
             )
 
-        assert ok is False, (
+        assert ok is None, (
             "non-fast-forward rejection on diverged history must surface as "
             "ok=False — that's the user-visible signal the operator needs"
         )
@@ -650,7 +661,7 @@ class TestCreateSliceIntegrationBranchRestartRecovery:
                 parent_branch="egg/issue-1",
             )
 
-        assert ok is True
+        assert ok
         assert push_invoked == [True], "push still runs (it's a fast-forward no-op)"
         assert merge_base_calls == [], (
             "must not run merge-base when existing tip is already at parent_sha"
@@ -708,7 +719,7 @@ class TestCreateSliceIntegrationBranchRestartRecovery:
                 parent_branch="egg/issue-1",
             )
 
-        assert ok is True
+        assert ok
         assert push_invoked == [True], "push must run on the first-run / branch-absent path"
         assert merge_base_calls == [], (
             "must not run merge-base when integration branch doesn't exist on origin"
@@ -856,7 +867,7 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
             session_token="tok-resume-incident",
         )
 
-        assert ok is True, "additive-advance + own commits must resume in place"
+        assert ok, "additive-advance + own commits must resume in place"
         assert push_invoked == [], (
             "must NOT push — a parent-tip push here is non-fast-forward and "
             "would discard / fail the slice's committed work"
@@ -904,7 +915,7 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
             base_sha=base_sha,
         )
 
-        assert ok is True, "diverged push (here) succeeds in the stub"
+        assert ok, "diverged push (here) succeeds in the stub"
         assert len(push_invoked) == 1, "rebase class must fall through to the push"
         assert push_invoked[0]["refspec"] == f"{parent_sha}:refs/heads/{self._INT}"
         assert [a[1:] for a in merge_base_args] == [
@@ -996,7 +1007,7 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
             base_sha=base_sha,
         )
 
-        assert ok is True
+        assert ok
         assert len(push_invoked) == 1, "un-started branch must fast-forward to parent"
         assert push_invoked[0]["refspec"] == f"{parent_sha}:refs/heads/{self._INT}"
         # Only the #2512 probe runs; the resume-in-place probes are gated
@@ -1342,7 +1353,7 @@ class TestShaIsAncestor:
             ok = gateway_client._sha_is_ancestor(
                 "pipe-1", "/repo", "aaaa", "bbbb", bearer_token="tok"
             )
-        assert ok is True
+        assert ok
         call_data = mock_req.call_args.kwargs["data"]
         assert call_data["operation"] == "merge-base"
         assert call_data["args"] == ["--is-ancestor", "aaaa", "bbbb"]

--- a/orchestrator/tests/test_create_slice_integration_branch.py
+++ b/orchestrator/tests/test_create_slice_integration_branch.py
@@ -172,7 +172,7 @@ class TestCreateSliceIntegrationBranchSuccess:
 
 
 class TestCreateSliceIntegrationBranchFailures:
-    def test_returns_false_when_parent_missing_on_origin(self, gateway_client):
+    def test_returns_none_when_parent_missing_on_origin(self, gateway_client):
         """If ``ls-remote`` returns no SHA (parent doesn't exist on
         origin), fail fast — don't issue a push that would emit git's
         confusing ``src refspec X does not match any``."""
@@ -242,7 +242,7 @@ class TestCreateSliceIntegrationBranchFailures:
         assert ok
         assert push_invoked == [True]
 
-    def test_push_failure_returns_false_and_cleans_up_session(self, gateway_client):
+    def test_push_failure_returns_none_and_cleans_up_session(self, gateway_client):
         """If the push request raises, the function must return None
         and still delete the synthetic session (no gateway-side leak)."""
         delete_calls: list[str] = []
@@ -281,7 +281,7 @@ class TestCreateSliceIntegrationBranchFailures:
 
 
 class TestCreateSliceIntegrationBranchShortCircuits:
-    def test_empty_branch_returns_false_without_calls(self, gateway_client):
+    def test_empty_branch_returns_none_without_calls(self, gateway_client):
         with (
             patch.object(gateway_client, "_make_request") as mock_req,
             patch.object(gateway_client, "fetch_branch") as mock_fetch,
@@ -878,7 +878,7 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
             [base_sha, existing_sha],
             [base_sha, parent_sha],
         ]
-        # Symmetric coverage for ``test_push_failure_returns_false_and_cleans
+        # Symmetric coverage for ``test_push_failure_returns_none_and_cleans
         # _up_session``: the new ``return parent_sha`` lives inside the outer
         # ``try``, so ``delete_session`` must still fire from the ``finally``
         # on this success path. Pinning it here freezes that — a future

--- a/orchestrator/tests/test_gateway_transient_retry.py
+++ b/orchestrator/tests/test_gateway_transient_retry.py
@@ -233,12 +233,12 @@ class TestCreateSliceIntegrationBranchRetry:
                 parent_branch="egg/issue-2869/work",
             )
 
-        assert ok is True
+        assert ok  # #3185 — returns the fork-base SHA on success
         assert push_attempts["n"] == 2, "push should retry once after the transient blip"
 
     def test_permanent_push_rejection_still_fails_without_retry(self, gateway_client):
         """A non-fast-forward rejection (permanent 5xx) is not retried —
-        it surfaces as ``ok is False`` on the first attempt."""
+        it surfaces as ``ok is None`` on the first attempt."""
         push_attempts = {"n": 0}
 
         def fake_make_request(endpoint, method=None, data=None, **kwargs):
@@ -265,5 +265,5 @@ class TestCreateSliceIntegrationBranchRetry:
                 parent_branch="egg/issue-2869/work",
             )
 
-        assert ok is False
+        assert ok is None  # #3185 — failure returns None
         assert push_attempts["n"] == 1, "permanent rejection must not be retried"

--- a/orchestrator/tests/test_slice_run_loop_integration.py
+++ b/orchestrator/tests/test_slice_run_loop_integration.py
@@ -1905,9 +1905,11 @@ class TestCoderFixesForHolisticReview:
 
         call_order: list[str] = []
 
-        def _track_create_branch(*args: Any, **kwargs: Any) -> bool:
+        def _track_create_branch(*args: Any, **kwargs: Any) -> str:
             call_order.append("create_slice_integration_branch")
-            return True
+            # #3185 — the helper now returns the fork-base SHA it
+            # pushed at, not a bare bool.
+            return "a" * 40
 
         def _track_create_pr(*args: Any, **kwargs: Any) -> str:
             call_order.append("create_slice_pr")
@@ -2414,7 +2416,7 @@ class TestGlobalSliceAdmit:
             mock_start_recon.return_value = (MagicMock(), threading.Event())
             spawner = MagicMock()
             spawner.gateway = MagicMock()
-            spawner.gateway.create_slice_integration_branch.return_value = False
+            spawner.gateway.create_slice_integration_branch.return_value = None
             _run_implement_phase_slices(
                 pipeline_id=pipeline.id,
                 pipeline=pipeline,
@@ -2461,9 +2463,11 @@ class TestSliceIntegrationBranchPrecedesAgentSpawn:
 
         call_order: list[str] = []
 
-        def _track_create_branch(*args: Any, **kwargs: Any) -> bool:
+        def _track_create_branch(*args: Any, **kwargs: Any) -> str:
             call_order.append("create_slice_integration_branch")
-            return True
+            # #3185 — the helper now returns the fork-base SHA it
+            # pushed at, not a bare bool.
+            return "a" * 40
 
         def _track_run_phase(*args: Any, **kwargs: Any) -> tuple[int, str]:
             call_order.append("_run_concurrent_phase")
@@ -2511,6 +2515,55 @@ class TestSliceIntegrationBranchPrecedesAgentSpawn:
             "ref must exist on origin first"
         )
 
+    def test_fork_base_recorded_from_create_return_no_extra_round_trip(self) -> None:
+        """#3185 — the run loop records ``integration_base_sha`` from the
+        SHA ``create_slice_integration_branch`` returns, with no separate
+        ``get_remote_branch_sha`` round-trip. The prior best-effort
+        re-fetch could silently fail (no ``retry_transient``) and leave
+        the field unset, arming the empty-pre-created-branch trap on the
+        next restart (an un-started branch misclassified as merged by
+        ancestor-only detection in ``is_slice_branch_merged_into_parent``).
+        """
+        pipeline = _make_pipeline()
+        slice_obj = _make_slice("slice-1", tasks=[_make_task("task-1-1")])
+        contract = _make_contract(slices=[slice_obj])
+        fork_base = "b" * 40
+
+        with (
+            patch("egg_contracts.loader.load_contract", return_value=contract),
+            patch("egg_contracts.loader.save_contract"),
+            patch("routes.pipelines._start_stacked_pr_reconciler") as mock_start_recon,
+            patch(
+                "routes.pipelines._run_concurrent_phase", return_value=(0, "ok")
+            ) as mock_run_phase,
+            patch("orchestrator.peer_consensus.remove_peer_consensus_tracker"),
+        ):
+            mock_start_recon.return_value = (MagicMock(), threading.Event())
+            spawner = MagicMock()
+            spawner.gateway = MagicMock()
+            spawner.gateway.create_slice_integration_branch.return_value = fork_base
+            spawner.gateway.create_slice_pr.return_value = "https://example/pr/1"
+            spawner.gateway.is_slice_branch_merged_into_parent.return_value = False
+            _run_implement_phase_slices(
+                pipeline_id=pipeline.id,
+                pipeline=pipeline,
+                spawner=spawner,
+                repo_volumes={},
+                gateway_mode="public",
+                repos=["owner/repo"],
+                sandbox_env={},
+                store=MagicMock(),
+                certs_volume=None,
+                worktree_repo_path=Path("/tmp/x"),
+            )
+        # The fork base returned by the create call landed on the slice.
+        assert slice_obj.integration_base_sha == fork_base, (
+            f"integration_base_sha must be recorded from the create call's "
+            f"return value, not a separate best-effort re-fetch; got "
+            f"{slice_obj.integration_base_sha!r}"
+        )
+        assert mock_run_phase.call_count == 1
+
     def test_concurrent_phase_not_invoked_when_integration_branch_creation_fails(
         self,
     ) -> None:
@@ -2538,7 +2591,7 @@ class TestSliceIntegrationBranchPrecedesAgentSpawn:
             mock_start_recon.return_value = (MagicMock(), threading.Event())
             spawner = MagicMock()
             spawner.gateway = MagicMock()
-            spawner.gateway.create_slice_integration_branch.return_value = False
+            spawner.gateway.create_slice_integration_branch.return_value = None
 
             _run_implement_phase_slices(
                 pipeline_id=pipeline.id,
@@ -2583,10 +2636,11 @@ class TestSliceIntegrationBranchQualifierPreserved:
 
         captured: dict[str, Any] = {}
 
-        def _capture(*args: Any, **kwargs: Any) -> bool:
+        def _capture(*args: Any, **kwargs: Any) -> str:
             captured["parent_branch"] = kwargs.get("parent_branch")
             captured["integration_branch"] = kwargs.get("integration_branch")
-            return True
+            # #3185 — the helper returns the fork-base SHA, not a bool.
+            return "a" * 40
 
         with (
             patch("egg_contracts.loader.load_contract", return_value=contract),

--- a/shared/egg_contracts/models.py
+++ b/shared/egg_contracts/models.py
@@ -397,14 +397,17 @@ class Slice(EggContractBaseModel):
         description=(
             "Origin SHA the slice's integration branch was forked at "
             "when first created (#2871). Recorded once, right after "
-            "``create_slice_integration_branch`` succeeds and before any "
-            "agent is spawned, so the branch tip still equals its base. "
-            "Lets ``is_slice_branch_merged_into_parent`` distinguish an "
+            "``create_slice_integration_branch`` succeeds — the helper "
+            "returns the SHA it pushed at, so the caller records it with "
+            "no extra round-trip (#3185) — and before any agent is "
+            "spawned, so the branch tip still equals its base. Lets "
+            "``is_slice_branch_merged_into_parent`` distinguish an "
             "*empty, un-started* slice branch (tip still == this base, so "
             "trivially an ancestor of an advanced parent) from a genuinely "
-            "*merged* one (tip moved past the base). ``None`` for slices "
-            "provisioned before this field existed — the merged-check then "
-            "falls back to its prior ancestor-only behaviour."
+            "*merged* one (tip moved past the base). ``None`` only for "
+            "slices provisioned before this field existed — the "
+            "merged-check then falls back to its prior ancestor-only "
+            "behaviour."
         ),
     )
     commit: str | None = Field(


### PR DESCRIPTION
## What

Resolves the residual #3185 scenario: an empty, pre-created slice integration branch misclassified as "merged" by bootstrap Layer-B when `integration_base_sha` was never recorded.

## Root cause

`is_slice_branch_merged_into_parent` marks a slice COMPLETE when its integration branch is ancestor-reachable from its parent's tip. The #2871 guard prevents this for an empty branch — but only when `integration_base_sha` is recorded. That recording was **best-effort**: the run loop issued a *separate* `get_remote_branch_sha` round-trip after `create_slice_integration_branch` succeeded, and it didn't even pass `retry_transient`. A transient gateway blip left the field unset; on the next restart Layer-B fell back to ancestor-only detection and silently skipped a slice that never ran (observed live on issue-3064 slice-4).

The fork-base SHA was being thrown away: `create_slice_integration_branch` already resolves `parent_sha` (the exact fork point) internally to build the push refspec — it just returned a bare bool instead of the SHA it pushed at.

## Fix

`create_slice_integration_branch` now returns the fork-base SHA (`parent_sha`) on success and `None` on failure. The caller records `integration_base_sha` directly from that return value, deleting the separate best-effort re-fetch entirely. Zero extra round-trips; the field the merged-detection keys on is now populated reliably on the same call that created the branch.

## Why no behavior change to merged detection itself

Once a slice PR merges, its commits become reachable from the parent tip — indistinguishable from an empty branch by ancestry alone. The recorded `integration_base_sha` is the *only* signal that distinguishes "empty, tip == fork" from "merged, tip advanced past fork", so reliable recording is the correct fix rather than a fallback heuristic (which would re-run genuinely-merged slices — an untested behavior change).

The #2512 / #2947 recovery short-circuits also return `parent_sha`:
- **#2512** fires only when the branch descends from `parent_sha`, so `parent_sha` *is* the fork base — correct, and a useful backfill for pre-#2871 contracts.
- **#2947** is gated on `integration_base_sha` being supplied, so the caller already has the base and skips recording the return value.

The narrow `integration_branch == parent_branch` no-op path (unreachable for real slices) returns an empty-string sentinel; the caller's "record only when unset and truthy" guard skips it.

## Tests

- Updated unit + integration suites that bound the helper's return contract (`ok is True/False` → truthy SHA / `is None`).
- Added a regression asserting the helper returns the fork base (`ok == parent_sha`).
- Added a run-loop test asserting the fork base is recorded from the create return with no separate round-trip.
- 173 directly-affected tests pass; 747 adjacent slice/pipeline suites pass (920 total).

Refs #3185