### PR TITLE
fix(orchestrator): revive restart-orphaned AWAITING_HUMAN driver on decision resolve (#3233)

### DIFF
--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -993,18 +993,32 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
         # the driver via start_pipeline's AWAITING_HUMAN recovery once the
         # queue has no remaining pending decisions. No-ops when a live driver
         # is already polling (the normal in-process path consumes it).
-        try:
-            from routes.pipelines import maybe_revive_orphaned_awaiting_human_driver
+        #
+        # Gate strictly on the *resolved decision* being a phase_gate.
+        # start_pipeline's AWAITING_HUMAN recovery assumes the park is a
+        # phase gate (it advances/resets the phase from the latest resolved
+        # phase_gate resolution); AWAITING_HUMAN is *not* synonymous with
+        # "parked at a phase gate". Other driverless AWAITING_HUMAN parks —
+        # the worktree-divergence reconcile HITL (#2979), which parks with a
+        # deliberately inert ``choice`` decision the operator resolves before
+        # re-running populate_contract — would otherwise be force-advanced
+        # spuriously: with no fresh phase_gate resolution, _parse_resolution
+        # treats the absent resolution as approval and marks the current
+        # phase complete. Only a phase_gate resolution is meant to drive the
+        # phase forward, so only it triggers the revival.
+        if decision.decision_type == "phase_gate":
+            try:
+                from routes.pipelines import maybe_revive_orphaned_awaiting_human_driver
 
-            maybe_revive_orphaned_awaiting_human_driver(pipeline_id, store.repo_path)
-        except Exception:
-            logger.warning(
-                "Orphaned-driver revival check failed after decision resolve "
-                "(decision is still resolved) (#3233)",
-                pipeline_id=pipeline_id,
-                decision_id=decision_id,
-                exc_info=True,
-            )
+                maybe_revive_orphaned_awaiting_human_driver(pipeline_id, store.repo_path)
+            except Exception:
+                logger.warning(
+                    "Orphaned-driver revival check failed after decision resolve "
+                    "(decision is still resolved) (#3233)",
+                    pipeline_id=pipeline_id,
+                    decision_id=decision_id,
+                    exc_info=True,
+                )
 
         return make_success_response(
             "Decision resolved",

--- a/orchestrator/routes/decisions.py
+++ b/orchestrator/routes/decisions.py
@@ -986,6 +986,26 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
             pipeline_id, decision_id, dispatch_resolution
         )
 
+        # #3233: if the orchestrator restarted while this pipeline was parked
+        # AWAITING_HUMAN, the in-memory _run_pipeline driver that polls
+        # wait_for_decision is gone — this resolution would otherwise be
+        # recorded with no consumer and the pipeline hangs silently. Revive
+        # the driver via start_pipeline's AWAITING_HUMAN recovery once the
+        # queue has no remaining pending decisions. No-ops when a live driver
+        # is already polling (the normal in-process path consumes it).
+        try:
+            from routes.pipelines import maybe_revive_orphaned_awaiting_human_driver
+
+            maybe_revive_orphaned_awaiting_human_driver(pipeline_id, store.repo_path)
+        except Exception:
+            logger.warning(
+                "Orphaned-driver revival check failed after decision resolve "
+                "(decision is still resolved) (#3233)",
+                pipeline_id=pipeline_id,
+                decision_id=decision_id,
+                exc_info=True,
+            )
+
         return make_success_response(
             "Decision resolved",
             data={

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -22191,6 +22191,148 @@ def _spawn_pipeline_run_thread(
     return thread
 
 
+def has_live_pipeline_driver(pipeline_id: str) -> bool:
+    """Return True if a live ``_run_pipeline`` driver thread owns this pipeline.
+
+    Driver threads are named ``pipeline-{id}`` (``start_pipeline``'s initial
+    and AWAITING_HUMAN-recovery spawns), ``pipeline-{id}-{epoch}``
+    (``_spawn_pipeline_run_thread``), or ``pipeline-{id}-respawn-...`` (the
+    spurious-PNFE recovery).  Every variant is either exactly ``pipeline-{id}``
+    or carries a ``pipeline-{id}-`` prefix, so the literal-hyphen boundary
+    keeps a pipeline whose id is a prefix of another (``issue-3`` vs
+    ``issue-32``) from matching.
+
+    After an orchestrator restart the process holds no driver threads, which
+    is precisely the orphaned-parked condition behind #3233: a pipeline left
+    AWAITING_HUMAN with a pending decision has no thread polling
+    ``wait_for_decision``, so a later resolution is recorded with no consumer
+    and the pipeline hangs silently.
+    """
+    exact = f"pipeline-{pipeline_id}"
+    prefix = exact + "-"
+    for t in threading.enumerate():
+        if not t.is_alive():
+            continue
+        if t.name == exact or t.name.startswith(prefix):
+            return True
+    return False
+
+
+def _broadcast_orphaned_driver_alert(pipeline_id: str, pipeline: Pipeline) -> None:
+    """Surface an orphaned-driver revival as an overseer alert (#3233).
+
+    A resolved decision on a driver-less pipeline used to return ``success``
+    and hang invisibly.  Emit an OVERSEER_ALERT alongside the WARNING log so
+    the recovery is visible on the bus, not just in orchestrator logs.
+    Best-effort: a broadcast failure never blocks the revival itself.
+    """
+    try:
+        from message_store import Message, MessageType
+
+        store_fn = _get_message_store()
+        if store_fn is None:
+            return
+        msg_store = store_fn()
+        phase = pipeline.current_phase.value if pipeline.current_phase else None
+        msg_store.add_message(
+            Message(
+                pipeline_id=pipeline_id,
+                from_role="orchestrator",
+                to_role="all",
+                message_type=MessageType.OVERSEER_ALERT,
+                subject="orphaned_driver_revived: orchestrator [info]",
+                body=(
+                    "A HITL decision was resolved on a pipeline whose "
+                    "_run_pipeline driver thread did not survive an "
+                    "orchestrator restart. The driver is being re-launched so "
+                    "the resolution is acted on (no manual start_pipeline "
+                    "needed). See #3233."
+                ),
+                metadata={"reason": "restart_orphaned_awaiting_human"},
+                phase=phase,
+            )
+        )
+    except Exception as alert_err:  # noqa: BLE001
+        logger.warning(
+            "Failed to broadcast orphaned-driver revival alert (non-fatal)",
+            pipeline_id=pipeline_id,
+            error=str(alert_err),
+        )
+
+
+def maybe_revive_orphaned_awaiting_human_driver(pipeline_id: str, repo_path: Path) -> bool:
+    """Re-launch the driver for an AWAITING_HUMAN pipeline orphaned by a restart.
+
+    Called from the decision-resolve path (#3233).  When the orchestrator
+    restarts while a pipeline is parked AWAITING_HUMAN at a phase gate, the
+    in-memory ``_run_pipeline`` driver blocked on ``wait_for_decision`` is
+    gone and startup reconciliation deliberately leaves the still-pending
+    decision as-is (``startup_reconciliation.py``).  Resolving the decision
+    then flips it to RESOLVED with no consumer and the pipeline hangs
+    silently — the operator sees ``success`` and nothing happens.
+
+    This detects that no live driver owns the pipeline and, once the queue
+    has no remaining pending decisions, routes through ``start_pipeline``'s
+    proven AWAITING_HUMAN recovery branch (advance-or-rerun + driver respawn)
+    so the resolution self-heals without a manual ``start_pipeline``.
+
+    No-ops (returns ``False``) when a live driver is already polling — the
+    normal in-process path consumes the resolution — or when the pipeline
+    isn't in the orphaned-parked state.  Must be called from a Flask request
+    context (it reuses the lifecycle-secret-guarded ``start_pipeline`` route),
+    which the resolve-decision handler satisfies.
+    """
+    store = get_state_store(repo_path)
+    try:
+        pipeline = store.load_pipeline(pipeline_id)
+    except Exception:
+        return False
+
+    if pipeline.status != PipelineStatus.AWAITING_HUMAN:
+        return False
+    # A multi-decision batch (e.g. the contract-decision bridge) is only
+    # ready to resume once every decision is resolved; leave it parked while
+    # siblings are still pending.
+    if pipeline.get_pending_decisions():
+        return False
+    if has_live_pipeline_driver(pipeline_id):
+        return False
+
+    logger.warning(
+        "Decision resolved on AWAITING_HUMAN pipeline with no live driver "
+        "thread (orphaned by an orchestrator restart); reviving via "
+        "start_pipeline recovery so the resolution is acted on (#3233)",
+        pipeline_id=pipeline_id,
+        current_phase=pipeline.current_phase.value if pipeline.current_phase else None,
+    )
+    _broadcast_orphaned_driver_alert(pipeline_id, pipeline)
+
+    try:
+        _resp, status_code = start_pipeline(pipeline_id)
+    except Exception as revive_err:  # noqa: BLE001
+        logger.warning(
+            "Orphaned-driver revival raised (decision is still resolved; an "
+            "operator can recover manually via start_pipeline) (#3233)",
+            pipeline_id=pipeline_id,
+            error=str(revive_err),
+        )
+        return False
+
+    if status_code != 200:
+        logger.warning(
+            "Orphaned-driver revival did not start the pipeline (#3233)",
+            pipeline_id=pipeline_id,
+            status_code=status_code,
+        )
+        return False
+
+    logger.info(
+        "Orphaned AWAITING_HUMAN pipeline revived after decision resolution (#3233)",
+        pipeline_id=pipeline_id,
+    )
+    return True
+
+
 # Tunables for the spurious-PipelineNotFoundError recovery path in
 # ``_run_pipeline``.  The verify retry covers the empty-file race window
 # during a ``git commit`` truncate-and-rewrite on the state worktree

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -22240,7 +22240,7 @@ def _broadcast_orphaned_driver_alert(pipeline_id: str, pipeline: Pipeline) -> No
                 from_role="orchestrator",
                 to_role="all",
                 message_type=MessageType.OVERSEER_ALERT,
-                subject="orphaned_driver_revived: orchestrator [info]",
+                subject="orphaned_driver_revived: orchestrator [medium]",
                 body=(
                     "A HITL decision was resolved on a pipeline whose "
                     "_run_pipeline driver thread did not survive an "

--- a/orchestrator/tests/test_orphaned_driver_revival.py
+++ b/orchestrator/tests/test_orphaned_driver_revival.py
@@ -197,3 +197,69 @@ class TestResolveRouteTriggersRevival:
         assert resp.status_code == 200
         mock_revive.assert_called_once()
         assert mock_revive.call_args[0][0] == "issue-3200"
+
+    @patch("routes.pipelines.maybe_revive_orphaned_awaiting_human_driver")
+    @patch("routes.decisions.get_state_store_for_pipeline")
+    @patch("routes.decisions.get_decision_queue")
+    def test_resolve_skips_revival_for_non_phase_gate_decision(
+        self, mock_get_queue, mock_get_store, mock_revive, client, tmp_path
+    ):
+        """A resolved non-phase-gate decision (e.g. the worktree-reconcile
+        ``choice`` HITL, #2979) must NOT trigger the AWAITING_HUMAN revival.
+
+        ``start_pipeline``'s recovery assumes a phase-gate park and would
+        spuriously force-advance the phase; only a phase_gate resolution is
+        meant to drive the phase forward (#3233 review fix).
+        """
+        from models import DecisionStatus, HITLDecision
+
+        mock_get_store.return_value = (MagicMock(repo_path=tmp_path), MagicMock())
+        queue = MagicMock()
+        queue.resolve_decision.return_value = HITLDecision(
+            id="decision-9",
+            question="Reconcile the worktree, then re-run populate_contract",
+            decision_type="choice",
+            status=DecisionStatus.RESOLVED,
+            resolution="Acknowledged",
+        )
+        mock_get_queue.return_value = queue
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-3200/decisions/decision-9/resolve",
+            json={"resolution": "Acknowledged"},
+        )
+
+        assert resp.status_code == 200
+        mock_revive.assert_not_called()
+
+
+class TestBroadcastOrphanedDriverAlert:
+    """``_broadcast_orphaned_driver_alert`` constructs and sends a real
+    OVERSEER_ALERT (#3233 review: close the untested-broadcast gap)."""
+
+    @patch("routes.pipelines._get_message_store")
+    def test_emits_overseer_alert_with_expected_fields(self, mock_get_store_fn):
+        from message_store import MessageType
+        from routes.pipelines import _broadcast_orphaned_driver_alert
+
+        msg_store = MagicMock()
+        mock_get_store_fn.return_value = lambda: msg_store
+
+        pipeline = _pipeline()
+        _broadcast_orphaned_driver_alert("issue-3200", pipeline)
+
+        msg_store.add_message.assert_called_once()
+        sent = msg_store.add_message.call_args[0][0]
+        assert sent.pipeline_id == "issue-3200"
+        assert sent.from_role == "orchestrator"
+        assert sent.to_role == "all"
+        assert sent.message_type == MessageType.OVERSEER_ALERT
+        assert "[medium]" in sent.subject
+        assert sent.metadata == {"reason": "restart_orphaned_awaiting_human"}
+
+    @patch("routes.pipelines._get_message_store", return_value=None)
+    def test_no_message_store_is_a_noop(self, _mock_get_store_fn):
+        from routes.pipelines import _broadcast_orphaned_driver_alert
+
+        # Must not raise when the message store factory is unavailable.
+        _broadcast_orphaned_driver_alert("issue-3200", _pipeline())

--- a/orchestrator/tests/test_orphaned_driver_revival.py
+++ b/orchestrator/tests/test_orphaned_driver_revival.py
@@ -1,0 +1,199 @@
+"""Regression tests for restart-orphaned AWAITING_HUMAN driver revival (#3233).
+
+When the orchestrator restarts while a pipeline is parked AWAITING_HUMAN at a
+phase gate, the in-memory ``_run_pipeline`` driver that polls
+``wait_for_decision`` is gone.  Startup reconciliation deliberately leaves a
+still-pending decision as-is, so resolving it afterwards records the
+resolution with no consumer and the pipeline hangs silently.  The
+decision-resolve path now revives the driver via ``start_pipeline``'s proven
+AWAITING_HUMAN recovery once the queue drains, so the resolution self-heals.
+"""
+
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+from models import Pipeline, PipelineStatus  # noqa: E402
+
+
+def _pipeline(pipeline_id="issue-3200", status=PipelineStatus.AWAITING_HUMAN, decisions=None):
+    p = Pipeline(id=pipeline_id, issue_number=3200, repo="owner/repo", branch="egg/test")
+    p.status = status
+    if decisions:
+        p.decisions = decisions
+    return p
+
+
+class TestHasLivePipelineDriver:
+    """Thread-name detection underpinning the orphaned-driver check."""
+
+    def test_detects_exact_and_suffixed_names(self):
+        from routes.pipelines import has_live_pipeline_driver
+
+        pid = "issue-9999-driver-test"
+        for name in (f"pipeline-{pid}", f"pipeline-{pid}-1700000000"):
+            stop = threading.Event()
+            t = threading.Thread(target=stop.wait, name=name, daemon=True)
+            t.start()
+            try:
+                assert has_live_pipeline_driver(pid) is True
+            finally:
+                stop.set()
+                t.join(timeout=2)
+
+    def test_no_thread_returns_false(self):
+        from routes.pipelines import has_live_pipeline_driver
+
+        # No driver thread exists for this id — the post-restart condition.
+        assert has_live_pipeline_driver("issue-no-such-driver-3233") is False
+
+    def test_prefix_collision_is_safe(self):
+        """A driver for ``issue-32`` must not satisfy the check for ``issue-3``."""
+        from routes.pipelines import has_live_pipeline_driver
+
+        stop = threading.Event()
+        t = threading.Thread(target=stop.wait, name="pipeline-issue-32", daemon=True)
+        t.start()
+        try:
+            assert has_live_pipeline_driver("issue-32") is True
+            assert has_live_pipeline_driver("issue-3") is False
+        finally:
+            stop.set()
+            t.join(timeout=2)
+
+
+class TestMaybeReviveOrphanedDriver:
+    """``maybe_revive_orphaned_awaiting_human_driver`` decision logic."""
+
+    @patch("routes.pipelines.start_pipeline")
+    @patch("routes.pipelines._broadcast_orphaned_driver_alert")
+    @patch("routes.pipelines.has_live_pipeline_driver", return_value=False)
+    @patch("routes.pipelines.get_state_store")
+    def test_revives_when_orphaned_and_resolved(
+        self, mock_get_store, _mock_has_driver, _mock_alert, mock_start, tmp_path
+    ):
+        from routes.pipelines import maybe_revive_orphaned_awaiting_human_driver
+
+        store = MagicMock()
+        store.load_pipeline.return_value = _pipeline()  # AWAITING_HUMAN, 0 pending
+        mock_get_store.return_value = store
+        mock_start.return_value = (MagicMock(), 200)
+
+        assert maybe_revive_orphaned_awaiting_human_driver("issue-3200", tmp_path) is True
+        mock_start.assert_called_once_with("issue-3200")
+
+    @patch("routes.pipelines.start_pipeline")
+    @patch("routes.pipelines.has_live_pipeline_driver", return_value=True)
+    @patch("routes.pipelines.get_state_store")
+    def test_skips_when_live_driver_present(
+        self, mock_get_store, _mock_has_driver, mock_start, tmp_path
+    ):
+        from routes.pipelines import maybe_revive_orphaned_awaiting_human_driver
+
+        store = MagicMock()
+        store.load_pipeline.return_value = _pipeline()
+        mock_get_store.return_value = store
+
+        assert maybe_revive_orphaned_awaiting_human_driver("issue-3200", tmp_path) is False
+        mock_start.assert_not_called()
+
+    @patch("routes.pipelines.start_pipeline")
+    @patch("routes.pipelines.has_live_pipeline_driver", return_value=False)
+    @patch("routes.pipelines.get_state_store")
+    def test_skips_when_decisions_still_pending(
+        self, mock_get_store, _mock_has_driver, mock_start, tmp_path
+    ):
+        from models import DecisionStatus, HITLDecision
+        from routes.pipelines import maybe_revive_orphaned_awaiting_human_driver
+
+        pending = HITLDecision(id="decision-4", question="q?", status=DecisionStatus.PENDING)
+        store = MagicMock()
+        store.load_pipeline.return_value = _pipeline(decisions=[pending])
+        mock_get_store.return_value = store
+
+        assert maybe_revive_orphaned_awaiting_human_driver("issue-3200", tmp_path) is False
+        mock_start.assert_not_called()
+
+    @patch("routes.pipelines.start_pipeline")
+    @patch("routes.pipelines.has_live_pipeline_driver", return_value=False)
+    @patch("routes.pipelines.get_state_store")
+    def test_skips_when_not_awaiting_human(
+        self, mock_get_store, _mock_has_driver, mock_start, tmp_path
+    ):
+        from routes.pipelines import maybe_revive_orphaned_awaiting_human_driver
+
+        store = MagicMock()
+        store.load_pipeline.return_value = _pipeline(status=PipelineStatus.RUNNING)
+        mock_get_store.return_value = store
+
+        assert maybe_revive_orphaned_awaiting_human_driver("issue-3200", tmp_path) is False
+        mock_start.assert_not_called()
+
+    @patch("routes.pipelines.start_pipeline")
+    @patch("routes.pipelines._broadcast_orphaned_driver_alert")
+    @patch("routes.pipelines.has_live_pipeline_driver", return_value=False)
+    @patch("routes.pipelines.get_state_store")
+    def test_returns_false_when_start_pipeline_errors(
+        self, mock_get_store, _mock_has_driver, _mock_alert, mock_start, tmp_path
+    ):
+        from routes.pipelines import maybe_revive_orphaned_awaiting_human_driver
+
+        store = MagicMock()
+        store.load_pipeline.return_value = _pipeline()
+        mock_get_store.return_value = store
+        mock_start.return_value = (MagicMock(), 409)
+
+        assert maybe_revive_orphaned_awaiting_human_driver("issue-3200", tmp_path) is False
+
+
+class TestResolveRouteTriggersRevival:
+    """The resolve-decision route wires the revival into the queue path."""
+
+    @pytest.fixture
+    def client(self):
+        from flask import Flask
+        from routes.decisions import decisions_bp
+
+        app = Flask(__name__)
+        app.register_blueprint(decisions_bp)
+        app.config["TESTING"] = True
+        return app.test_client()
+
+    @patch("routes.pipelines.maybe_revive_orphaned_awaiting_human_driver")
+    @patch("routes.decisions.get_state_store_for_pipeline")
+    @patch("routes.decisions.get_decision_queue")
+    def test_resolve_invokes_revival(
+        self, mock_get_queue, mock_get_store, mock_revive, client, tmp_path
+    ):
+        from models import DecisionStatus, HITLDecision
+
+        mock_get_store.return_value = (MagicMock(repo_path=tmp_path), MagicMock())
+        queue = MagicMock()
+        queue.resolve_decision.return_value = HITLDecision(
+            id="decision-3",
+            question="q?",
+            decision_type="phase_gate",
+            status=DecisionStatus.RESOLVED,
+            resolution='{"action": "request_changes", "feedback": "redo"}',
+        )
+        mock_get_queue.return_value = queue
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-3200/decisions/decision-3/resolve",
+            json={"resolution": '{"action": "request_changes", "feedback": "redo"}'},
+        )
+
+        assert resp.status_code == 200
+        mock_revive.assert_called_once()
+        assert mock_revive.call_args[0][0] == "issue-3200"


### PR DESCRIPTION
Closes #3233.

## Problem

When the orchestrator restarts (redeploy / pod recycle) while a pipeline is parked **`AWAITING_HUMAN`** at a phase gate, the in-memory `_run_pipeline` driver that was blocked on `wait_for_decision` does not survive the process restart. Startup reconciliation (#2411) only handles the *0-pending* case (marks `FAILED`); for a pipeline with a **pending** decision it deliberately "leaves as-is", assuming a driver is polling. None is.

So a later `provide_input` → `resolve_decision` flips the decision to `RESOLVED` with **no consumer**: `provide_input` returns `success: true`, but the phase never resets/advances, no agents spawn, and the pipeline hangs **silently** (no `FAILED`, no alert). The only recovery was a manual `start_pipeline` — exactly the live repro on `issue-3200` (2026-06-25).

## Why not just re-launch the driver at startup

Resuming `_run_pipeline` raw on an `AWAITING_HUMAN` phase is unsafe: the `PENDING` guard is skipped but the unconditional spawn loop (`_run_concurrent_phase`) still runs, so it would **re-spawn the already-completed phase's agents**. `start_pipeline`'s recovery avoids this by first transitioning the phase *out* of `AWAITING_HUMAN` (advance or reset) before spawning — which needs the resolution in hand. So the fix hinges on the resolution moment.

## Fix (Approach B from the issue — revive on resolve)

`resolve_decision` now, after recording the resolution, checks whether a live driver owns the pipeline; if not and the queue has drained, it routes through `start_pipeline`'s proven `AWAITING_HUMAN` recovery so the resolution self-heals — no manual `start_pipeline`.

- **`has_live_pipeline_driver()`** — scans `threading.enumerate()` for the driver thread (`pipeline-{id}` / `pipeline-{id}-{suffix}`). The literal-hyphen boundary is collision-safe (`issue-3` vs `issue-32`). Post-restart no such thread exists; during normal operation the driver is alive and polling, so this is a no-op.
- **`maybe_revive_orphaned_awaiting_human_driver()`** — no-ops when a live driver is polling, when decisions remain pending (multi-decision batch), or when the pipeline isn't `AWAITING_HUMAN`. Otherwise it **WARNs + emits an `OVERSEER_ALERT`** (the silent hang is itself a bug — now surfaced) and reuses `start_pipeline`.

Startup reconciliation is unchanged — its "leave pending>0 as-is" is correct; this closes the *consumer* gap.

## Scope

Covers the **phase-gate** gate (the reported + dominant path). The contract-decision *bridge* (`_queue_and_await_contract_decisions`) has the same driver-less-after-restart shape via a separate multi-wait loop; left as a follow-up rather than bundled.

## Tests

`orchestrator/tests/test_orphaned_driver_revival.py`:
- thread detection incl. prefix-collision safety,
- the revive/skip decision matrix (orphaned→revive; live driver / pending / not-awaiting / start_pipeline-non-200 → skip),
- `resolve_decision` invokes the revival on the queue success path.

Existing `test_decisions_routes`, `test_start_pipeline`, `test_startup_reconciliation` (155 tests) still pass; lint clean.