### PR TITLE
fix(orchestrator): autostash + surface stderr in rebase_onto reconciler (#3245)

### DIFF
--- a/gateway/git_client.py
+++ b/gateway/git_client.py
@@ -652,6 +652,7 @@ GIT_ALLOWED_COMMANDS: dict[str, dict[str, list[str]]] = {
     "rebase": {
         "allowed_flags": [
             "--onto",
+            "--autostash",
             "--abort",
             "--continue",
             "--skip",
@@ -2376,10 +2377,16 @@ def build_rebase_onto_args(
                 f"{label} must look like a git ref (alnum + . _ / + -); got {v!r}",
             )
 
-    # Construct the canonical shape. We do NOT accept any extra flags
-    # — callers that need ``--abort`` / ``--continue`` go through the
-    # regular agent-driven path.
-    args = ["--onto", new_base, old_base, branch]
+    # Construct the canonical shape. ``--autostash`` is prepended so the
+    # rebase proceeds against a worktree carrying uncommitted
+    # ``.egg-state/agent-outputs/`` residue (BRC memory writes left
+    # uncommitted because post-agent auto-commit is disabled). Without
+    # it ``git rebase`` refuses with ``cannot rebase: You have unstaged
+    # changes`` even on conflict-free content (#3245) — the same refusal
+    # #2714 fixed on the push-reconcile rebase path. We do NOT accept any
+    # other extra flags — callers that need ``--abort`` / ``--continue``
+    # go through the regular agent-driven path.
+    args = ["--autostash", "--onto", new_base, old_base, branch]
     ok, err, _ = validate_git_args("rebase", args)
     if not ok:
         return [], False, err

--- a/gateway/tests/test_build_rebase_onto_args.py
+++ b/gateway/tests/test_build_rebase_onto_args.py
@@ -13,8 +13,9 @@ the request reaches the gateway's ``/git`` endpoint.
 Coverage:
 
 * Happy path: well-formed branch / new_base / old_base produce the
-  canonical ``["--onto", new_base, old_base, branch]`` shape and
-  ``ok=True``.
+  canonical ``["--autostash", "--onto", new_base, old_base, branch]``
+  shape and ``ok=True`` (``--autostash`` added in #3245 so the rebase
+  survives uncommitted ``.egg-state/agent-outputs/`` residue).
 * Empty / non-string inputs are rejected with ``ok=False`` and a
   ``branch / new_base / old_base must be a non-empty string`` error.
 * Whitespace-only inputs are rejected (``"   "`` is treated the same
@@ -55,9 +56,12 @@ class TestHappyPath:
         )
         assert ok is True
         assert err == ""
-        # The shape MUST be exactly --onto NEW OLD BRANCH so the
-        # gateway's allowlist sees positional refs only.
+        # The shape MUST be exactly --autostash --onto NEW OLD BRANCH so
+        # the gateway's allowlist sees positional refs only. --autostash
+        # (#3245) lets the rebase proceed against a worktree carrying
+        # uncommitted .egg-state/agent-outputs/ residue.
         assert args == [
+            "--autostash",
             "--onto",
             "egg/issue-2137",
             "egg/issue-2137/slice-1",
@@ -72,7 +76,7 @@ class TestHappyPath:
         )
         assert ok is True
         assert err == ""
-        assert args == ["--onto", "main", "develop", "feature"]
+        assert args == ["--autostash", "--onto", "main", "develop", "feature"]
 
     def test_returns_three_tuple_on_success(self) -> None:
         result = build_rebase_onto_args("a", "b", "c")
@@ -158,19 +162,20 @@ class TestNoFlagLeakage:
     """The helper does not allow flag injection via input strings."""
 
     def test_no_extra_flags_added_to_argv(self) -> None:
-        """The argv must contain ONLY ``--onto`` plus the three refs."""
+        """The argv contains ONLY ``--autostash`` / ``--onto`` plus the three refs."""
         args, ok, _ = build_rebase_onto_args("feature", "main", "develop")
         assert ok is True
-        # No ``--strategy-option`` / ``-X`` / ``--exec`` style flags.
+        # No ``--strategy-option`` / ``-X`` / ``--exec`` style flags — only
+        # the two canonical flags (#3245 added ``--autostash``).
         flag_args = [a for a in args if a.startswith("-")]
-        assert flag_args == ["--onto"]
+        assert flag_args == ["--autostash", "--onto"]
 
     def test_input_strings_travel_as_positional_refs(self) -> None:
         """Even if a ref name resembles a flag, the argv shape is fixed.
 
         The allowlist validator runs on the constructed argv. The refs
-        appear in fixed positions (slots 1, 2, 3 after ``--onto``); they
-        are not re-parsed as flags.
+        appear in fixed positions (slots 2, 3, 4 after ``--autostash
+        --onto``); they are not re-parsed as flags.
         """
         args, ok, _ = build_rebase_onto_args(
             branch="branch",
@@ -178,10 +183,11 @@ class TestNoFlagLeakage:
             old_base="old",
         )
         assert ok is True
-        assert args[0] == "--onto"
-        assert args[1] == "new"
-        assert args[2] == "old"
-        assert args[3] == "branch"
+        assert args[0] == "--autostash"
+        assert args[1] == "--onto"
+        assert args[2] == "new"
+        assert args[3] == "old"
+        assert args[4] == "branch"
 
     def test_validate_git_args_invoked(self) -> None:
         """validate_git_args is called and its verdict drives the return.
@@ -195,7 +201,7 @@ class TestNoFlagLeakage:
         # Sanity check: the canonical shape passes the real validator.
         args, ok, err = build_rebase_onto_args("a", "b", "c")
         assert ok is True
-        assert args == ["--onto", "b", "c", "a"]
+        assert args == ["--autostash", "--onto", "b", "c", "a"]
         assert err == ""
 
 

--- a/integration_tests/test_slice_pipeline_e2e.py
+++ b/integration_tests/test_slice_pipeline_e2e.py
@@ -326,9 +326,12 @@ class TestEndToEndOrphanHeal:
 
         rebase_payload, push_payload, edit_payload = payloads
 
-        # Step 1: canonical rebase argv.
+        # Step 1: canonical rebase argv. ``--autostash`` (#3245) is
+        # prepended so the rebase survives uncommitted
+        # ``.egg-state/agent-outputs/`` residue on the worktree.
         assert rebase_payload["operation"] == "rebase"
         assert rebase_payload["args"] == [
+            "--autostash",
             "--onto",
             "egg/issue-2137",
             "egg/issue-2137/slice-1",

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -129,7 +129,22 @@ def _build_rebase_onto_args(
                 f"{label} must look like a git ref (alnum + . _ / + -); got {v!r}",
             )
 
-    return ["--onto", new_base.strip(), old_base.strip(), branch.strip()], True, ""
+    # ``--autostash`` is prepended so the rebase proceeds against a
+    # worktree carrying uncommitted ``.egg-state/agent-outputs/`` residue
+    # (BRC memory writes left uncommitted because post-agent auto-commit
+    # is disabled). Without it ``git rebase`` refuses with ``cannot
+    # rebase: You have unstaged changes`` even on conflict-free content,
+    # surfacing as the opaque ``"git rebase failed"`` (#3245) — the same
+    # refusal #2714 fixed on the push-reconcile rebase path. The gateway
+    # ``rebase`` allowlist permits ``--autostash`` (gateway/git_client.py),
+    # and the base-branch rebase guard (gateway.py) ignores it (it is
+    # neither a positional nor an ``--onto`` value), so the protected-ref
+    # check on ``new_base`` is unaffected.
+    return (
+        ["--autostash", "--onto", new_base.strip(), old_base.strip(), branch.strip()],
+        True,
+        "",
+    )
 
 
 @dataclass
@@ -2226,11 +2241,23 @@ class GatewayClient:
             )
             return True
         except Exception as exc:  # noqa: BLE001
+            # ``str(exc)`` is the gateway's flattened message (e.g. the
+            # opaque ``"git rebase failed"`` for a non-zero git exit).
+            # The real git stderr — which distinguishes a dirty-worktree
+            # refusal from a genuine content conflict from a transport
+            # error — rides in ``GatewayError.details`` (the gateway puts
+            # ``{stdout, stderr, returncode}`` there). Surface it so an
+            # operator can tell a recoverable mechanism failure apart from
+            # a real conflict without spelunking the gateway pod (#3245).
+            raw_details = getattr(exc, "details", None)
+            details = raw_details if isinstance(raw_details, dict) else {}
             logger.warning(
                 "rebase_onto: gateway request failed",
                 pipeline_id=pipeline_id,
                 branch=branch,
                 error=str(exc),
+                git_stderr=(details.get("stderr") or "").strip() or None,
+                git_returncode=details.get("returncode"),
             )
             return False
         finally:

--- a/orchestrator/tests/test_gateway_client_rebase_onto.py
+++ b/orchestrator/tests/test_gateway_client_rebase_onto.py
@@ -46,7 +46,7 @@ for _p in (_orchestrator_path, _shared_path, _project_root):
         sys.path.insert(0, str(_p))
 
 import pytest  # noqa: E402
-from gateway_client import GatewayClient  # noqa: E402
+from gateway_client import GatewayClient, GatewayError  # noqa: E402
 
 
 @pytest.fixture
@@ -138,8 +138,11 @@ class TestHappyPath:
         payload = kwargs["data"]
         assert payload["operation"] == "rebase"
         assert payload["repo_path"] == "/repo"
-        # canonical shape: --onto NEW OLD BRANCH
+        # canonical shape: --autostash --onto NEW OLD BRANCH (#3245 —
+        # --autostash lets the rebase proceed against a worktree carrying
+        # uncommitted .egg-state/agent-outputs/ residue).
         assert payload["args"] == [
+            "--autostash",
             "--onto",
             "egg/issue-2137",
             "egg/issue-2137/slice-1",
@@ -220,6 +223,47 @@ class TestErrorPaths:
             )
         assert ok is False
         delete.assert_called_once_with("tok-rebase")
+
+    def test_gateway_error_surfaces_real_git_stderr(self, client: GatewayClient) -> None:
+        """A failed rebase logs the real git stderr from ``exc.details``,
+        not just the flattened ``"git rebase failed"`` message (#3245).
+
+        The gateway returns ``message="git rebase failed"`` with the true
+        stderr under ``details`` (e.g. the dirty-worktree refusal). The
+        handler must surface that so an operator can tell a recoverable
+        mechanism failure apart from a real content conflict.
+        """
+        gw_err = GatewayError(
+            "git rebase failed",
+            status_code=500,
+            details={
+                "stderr": "error: cannot rebase: You have unstaged changes.",
+                "returncode": 128,
+            },
+        )
+        with (
+            patch.object(client, "register_session", return_value=_fake_session()),
+            patch.object(client, "_make_request", side_effect=gw_err),
+            patch.object(client, "delete_session", return_value=True),
+            patch.object(GatewayClient, "self_ip", new="127.0.0.1"),
+            patch("gateway_client.logger") as mock_logger,
+        ):
+            ok = client.rebase_onto(
+                "issue-3245",
+                "/repo",
+                branch="egg/issue-3245/slice-2",
+                new_base="egg/issue-3245/slice-1",
+                old_base="egg/issue-3245/slice-0",
+            )
+        assert ok is False
+        # The warning carries the real git stderr + returncode.
+        warn_kwargs = next(
+            call.kwargs
+            for call in mock_logger.warning.call_args_list
+            if call.args and call.args[0] == "rebase_onto: gateway request failed"
+        )
+        assert warn_kwargs["git_stderr"] == "error: cannot rebase: You have unstaged changes."
+        assert warn_kwargs["git_returncode"] == 128
 
     def test_register_failure_returns_false(self, client: GatewayClient) -> None:
         with (
@@ -343,10 +387,11 @@ class TestEndToEndOrphanHeal:
             "/api/v1/gh/pr/edit",
         ]
 
-        # Step 1: local rebase shape unchanged.
+        # Step 1: local rebase shape — --autostash --onto NEW OLD BRANCH (#3245).
         rebase_payload = make_request.call_args_list[0].kwargs["data"]
         assert rebase_payload["operation"] == "rebase"
         assert rebase_payload["args"] == [
+            "--autostash",
             "--onto",
             "egg/issue-2137",
             "egg/issue-2137/slice-1",
@@ -526,8 +571,10 @@ class TestNoGatewayPackageDependency:
             )
 
         assert ok is True
-        # Canonical argv was built by the local helper.
+        # Canonical argv was built by the local helper (#3245 — --autostash
+        # prepended).
         assert make_request.call_args.kwargs["data"]["args"] == [
+            "--autostash",
             "--onto",
             "egg/issue-2535",
             "egg/issue-2535/slice-1",


### PR DESCRIPTION
## What

The orthogonal **reconciler-hygiene fix** from the re-scoped #3245.

The stacked-PR reconciler's `GatewayClient.rebase_onto` ran a bare `git rebase --onto <new_base> <old_base> <branch>`. `git rebase` refuses (`error: cannot rebase: You have unstaged changes`) whenever the worktree carries uncommitted `.egg-state/agent-outputs/` residue — BRC memory writes left uncommitted because post-agent auto-commit is disabled — **even on conflict-free content**. The failure surfaced only as the opaque `"git rebase failed"` log, with the real git stderr discarded into `GatewayError.details` and never logged.

## Changes

- **`--autostash`** prepended to the canonical `rebase --onto` argv in both:
  - `orchestrator/gateway_client.py::_build_rebase_onto_args` — the argv actually submitted at runtime, and
  - `gateway/git_client.py::build_rebase_onto_args` — the documented mirror.
  
  This matches the precedent **#2714** set on the push-reconcile rebase path (`_build_rebase_cmd`).
- **Gateway `rebase` allowlist** now permits `--autostash` so the submitted argv passes `validate_git_args`. The base-branch rebase guard in `gateway.py` is unaffected — it inspects `--onto` values / positionals, not `--autostash`, so the protected-ref check on `new_base` still blocks `--onto origin/main …`.
- **Real stderr surfaced**: the failure log now includes `git_stderr` / `git_returncode` from `GatewayError.details`, so a dirty-worktree refusal is distinguishable from a genuine content conflict or transport error without spelunking the gateway pod.

## Scope / what this is NOT

Per the re-scoped issue, this is **not** the cause of the slice-7 phase failure. The `rebase_onto` path is a stacked-PR reconciler side thread that counts a failure as `rebases_failed` and retries on the next tick — it never calls `record_failure` and cannot fail a slice or the phase. The primary bug (slice-7 failing post-consensus / pre-PR in `create_slice_pr` or a raised worker) has an **unconfirmed cause** because the run's logs rotated; capturing it requires re-running `issue-3200` with this error-surfacing patch in place (issue step 2). This PR ships the real, independently-correct hygiene fix and makes that next occurrence diagnosable.

## Test plan

- `gateway/tests/test_build_rebase_onto_args.py` + `orchestrator/tests/test_gateway_client_rebase_onto.py` — argv-shape assertions updated to the `--autostash --onto NEW OLD BRANCH` shape; **added** a test asserting the real git stderr/returncode is surfaced on failure. 37 pass.
- Gateway rebase-guard / pipeline-enforcement tests pass (the allowlist change doesn't relax the protected-ref guard).
- `ruff check` clean on all changed files.

Part of #3245 — ships the hygiene fix only; the primary slice-7 cause stays open pending the re-run (issue step 2). Intentionally does **not** auto-close the issue.

