### PR TITLE
fix(orchestrator): adopt resumable slice fork via runtime merge-base re-derivation (#3245)

### DIFF
--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -2954,12 +2954,25 @@ class GatewayClient:
                 # destroyed.
                 #
                 # Gating on the slice's *own* recorded base (not a generic
-                # merge-base of the two tips) is what keeps this safe: a
-                # genuinely unrelated stale branch would not descend from
-                # this slice's recorded base, so it still falls through to
-                # the push and surfaces the rejection (preserving the
+                # merge-base of the two tips) is what keeps this *fast-path*
+                # safe: a genuinely unrelated stale branch would not descend
+                # from this slice's recorded base, so it still falls through
+                # to the push and surfaces the rejection (preserving the
                 # #2512/#2549 "don't silently overwrite unknown work"
-                # instinct). A true history rewrite of the parent (rebase)
+                # instinct). NOTE (#3245): the recorded-base invariant
+                # described here governs *this* check only. The #3245
+                # fall-through immediately below deliberately relaxes it —
+                # when the recorded base is untrusted/absent it re-derives a
+                # *generic* merge-base of the two tips and adopts on that.
+                # That widens adoption to the parent-rewrite class and any
+                # branch sharing some ancestor with the parent; it is safe
+                # because the slice branch name is slice-specific and
+                # gateway-restricted, adoption stays non-destructive, and a
+                # genuinely-unexpected branch surfaces as a CONFLICTING slice
+                # PR for a human rather than cascade-failing the phase. Do
+                # not read the "we gate on our own base" claim above as a
+                # whole-function invariant — see the #3245 block below.
+                # A true history rewrite of the parent (rebase)
                 # drops the base out of the parent's ancestry, so the
                 # second check fails and we likewise fall through — that
                 # harder class is deliberately left to the operator. The
@@ -3037,7 +3050,23 @@ class GatewayClient:
                 # never reset or force-push, so no committed work is
                 # destroyed. The re-derivation is idempotent, so a contract
                 # still carrying the corrupted base self-heals on every
-                # subsequent resume without a write-back here.
+                # subsequent resume.
+                #
+                # Return value: ``fork_base`` (the re-derived true base), not
+                # ``parent_sha``. When the recorded base was *corrupted* the
+                # caller's ``recorded_base_sha is None`` write-back guard is
+                # already satisfied (a stored — if wrong — base exists) and
+                # skips the write, so the return value is inert there. But
+                # this path *also* fires when ``integration_base_sha`` was
+                # absent (the #2947 ``integration_base_sha and …`` short-
+                # circuit drops through to here): then ``recorded_base_sha is
+                # None`` and the caller *does* persist whatever we return. We
+                # return the true ``fork_base`` so it records the real base
+                # rather than the advanced parent tip — which would itself be
+                # exactly the corruption shape this path exists to tolerate,
+                # and would pin the slice on the slower re-derivation route
+                # forever. Recording ``fork_base`` instead lets the cheaper
+                # #2947 fast-path fire on the next resume.
                 #
                 # Safety: ``fork_base is None`` (no shared history at all —
                 # an unrelated/orphan branch sitting at this name) and
@@ -3069,7 +3098,7 @@ class GatewayClient:
                         fork_base=fork_base,
                         recorded_integration_base_sha=integration_base_sha,
                     )
-                    return parent_sha
+                    return fork_base
 
                 # Could not verify ancestry: parent_sha is either not
                 # reachable from the existing tip (genuinely diverged

--- a/orchestrator/gateway_client.py
+++ b/orchestrator/gateway_client.py
@@ -2760,8 +2760,18 @@ class GatewayClient:
         (rather than non-fast-forward-rejected) by checking that the
         recorded base is still an ancestor of both the existing tip and
         the advanced parent. ``None`` (slices provisioned before #2871,
-        or whose base was never recorded) degrades to the prior
-        behaviour — the rejection surfaces.
+        or whose base was never recorded) does not gate this fast-path.
+
+        When that recorded-base fast-path does not fire — base absent, or
+        an out-of-band actor (restart/salvage/manual edit) rewrote it so
+        it no longer descends to the slice tip (#3245) — the method falls
+        back to re-deriving the fork point from git (``merge-base`` of the
+        existing tip and the advanced parent). A genuine shared fork point
+        that is strictly behind the existing tip means the branch is a
+        resumable additive fork: it is adopted in place rather than
+        non-fast-forward-rejected. Only a branch with no shared history,
+        or one sitting at/behind the fork with no own commits, still falls
+        through to the push (surfacing the rejection / fast-forwarding).
 
         Returns the fork-base SHA (``parent_sha``) on success, ``None``
         on any error (the caller logs and surfaces a clear error to the
@@ -2998,6 +3008,69 @@ class GatewayClient:
                     # recording this return value. Return ``parent_sha``
                     # so the caller treats the call as success.
                     return parent_sha
+                # #3245 — durable resume-in-place when the *recorded* base
+                # cannot be trusted. The #2947 fast-path above gates
+                # resume-in-place on ``integration_base_sha``, but that
+                # stored SHA is mutable by out-of-band actors: a
+                # ``restart_phase`` slice copy, a ``salvage_agent_commits``
+                # run, or a manual contract edit can rewrite it — in the
+                # observed incident (issue-3200 slice-7) it was overwritten
+                # to the *advanced parent tip*. A base that no longer is an
+                # ancestor of the slice's own tip fails the #2947 check, and
+                # we would otherwise fall through to a ``parent_sha`` push
+                # that is non-fast-forward → FAILS the slice → cascades the
+                # whole phase, even though the branch is a perfectly
+                # resumable additive fork whose committed work is intact.
+                #
+                # Re-derive the fork point straight from git instead of
+                # trusting the stored SHA: the merge-base of the existing
+                # tip and the advanced parent. We reach here only when the
+                # parent is NOT an ancestor of the existing tip (the #2512
+                # fast-forward path already returned above), so a real
+                # shared merge-base that is *strictly behind* the existing
+                # tip means the two have DIVERGED from a common fork point
+                # — i.e. the slice forked from the parent's lineage and
+                # carries its own commits while the parent advanced. Adopt
+                # the branch as-is and resume in place; the parent's new
+                # commits reconcile at slice-PR / merge time exactly as for
+                # a slice whose parent advanced while it ran normally. We
+                # never reset or force-push, so no committed work is
+                # destroyed. The re-derivation is idempotent, so a contract
+                # still carrying the corrupted base self-heals on every
+                # subsequent resume without a write-back here.
+                #
+                # Safety: ``fork_base is None`` (no shared history at all —
+                # an unrelated/orphan branch sitting at this name) and
+                # ``fork_base == existing_sha`` (the branch is *behind* the
+                # parent with no unique commits — an un-started branch that
+                # should fast-forward, not resume) both fall through to the
+                # push below, preserving the "don't adopt unknown work /
+                # do fast-forward an empty branch" instincts of #2512/#2947.
+                fork_base = self.merge_base(
+                    pipeline_id,
+                    repo_path,
+                    existing_sha,
+                    parent_sha,
+                    bearer_token=session_token,
+                    mode=mode,
+                )
+                if fork_base and fork_base != existing_sha:
+                    logger.info(
+                        "Slice integration branch shares a fork point with "
+                        "the advanced parent and carries its own commits — "
+                        "adopting it and resuming in place via runtime "
+                        "merge-base re-derivation (#3245; recorded base "
+                        "untrusted/stale)",
+                        pipeline_id=pipeline_id,
+                        integration_branch=integration_branch,
+                        parent_branch=parent_branch,
+                        parent_sha=parent_sha,
+                        existing_sha=existing_sha,
+                        fork_base=fork_base,
+                        recorded_integration_base_sha=integration_base_sha,
+                    )
+                    return parent_sha
+
                 # Could not verify ancestry: parent_sha is either not
                 # reachable from the existing tip (genuinely diverged
                 # history) or the merge-base call itself failed

--- a/orchestrator/tests/test_create_slice_integration_branch.py
+++ b/orchestrator/tests/test_create_slice_integration_branch.py
@@ -945,7 +945,10 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
             base_sha=base_sha,
         )
 
-        assert ok == parent_sha, "rewrite class now resumes in place (#3245)"
+        assert ok == fork_sha, (
+            "#3245 returns the re-derived true fork base, not the advanced "
+            "parent tip, so the caller records the real base"
+        )
         assert push_invoked == [], (
             "must NOT push — the branch is adopted in place; a parent-tip "
             "push here is non-fast-forward and would fail the slice"
@@ -1025,7 +1028,12 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
             base_sha=base_sha,
         )
 
-        assert ok == parent_sha, "corrupted-base slice must resume in place via #3245 re-derivation"
+        assert ok == real_fork, (
+            "corrupted-base slice must resume in place via #3245 "
+            "re-derivation, returning the re-derived true fork base "
+            "(not the corrupt parent tip) so the caller persists the real "
+            "base and the next resume hits the cheaper #2947 fast-path"
+        )
         assert push_invoked == [], (
             "must NOT push — adopting the existing fork in place preserves "
             "the slice's consensus-approved commits"

--- a/orchestrator/tests/test_create_slice_integration_branch.py
+++ b/orchestrator/tests/test_create_slice_integration_branch.py
@@ -742,6 +742,7 @@ def _ancestry_make_request(
     *,
     push_invoked: list[dict],
     merge_base_args: list[list[str]],
+    merge_bases: dict[tuple[str, str], str] | None = None,
 ):
     """Build a ``_make_request`` side effect that answers
     ``merge-base --is-ancestor`` from an ``(ancestor, descendant) -> bool``
@@ -751,6 +752,15 @@ def _ancestry_make_request(
     missing) mapping raises the ``returncode=1`` ``GatewayError`` that
     ``_sha_is_ancestor`` interprets as "not an ancestor" — exactly how the
     real gateway surfaces ``git merge-base --is-ancestor``'s non-zero exit.
+
+    ``merge_bases`` answers the bare ``git merge-base <ref_a> <ref_b>``
+    probe (the #3245 runtime fork-point re-derivation) from a
+    ``(ref_a, ref_b) -> fork_base_sha`` map. A missing entry surfaces the
+    same ``returncode=1`` ``GatewayError`` that ``merge_base`` maps to
+    ``None`` ("no shared history"). Only the ``--is-ancestor`` probes are
+    appended to ``merge_base_args`` so existing sequence assertions stay
+    pinned to the ancestry checks; the bare merge-base probe is asserted
+    via its own ``merge_bases`` wiring.
     """
 
     def fake_make_request(endpoint, method=None, data=None, **kwargs):
@@ -759,10 +769,21 @@ def _ancestry_make_request(
             return {"success": True, "data": {}}
         if endpoint == "/api/v1/git/execute":
             args = list((data or {}).get("args", []))
-            merge_base_args.append(args)
-            ancestor, descendant = args[1], args[2]
-            if ancestry.get((ancestor, descendant), False):
-                return {"success": True, "data": {"returncode": 0}}
+            if args and args[0] == "--is-ancestor":
+                merge_base_args.append(args)
+                ancestor, descendant = args[1], args[2]
+                if ancestry.get((ancestor, descendant), False):
+                    return {"success": True, "data": {"returncode": 0}}
+                raise GatewayError(
+                    "git merge-base failed",
+                    status_code=500,
+                    details={"returncode": 1, "stdout": "", "stderr": ""},
+                )
+            # Bare ``git merge-base <ref_a> <ref_b>`` — the #3245 fork-point
+            # re-derivation. args == [ref_a, ref_b].
+            fork = (merge_bases or {}).get((args[0], args[1])) if len(args) >= 2 else None
+            if fork:
+                return {"success": True, "data": {"stdout": fork + "\n", "returncode": 0}}
             raise GatewayError(
                 "git merge-base failed",
                 status_code=500,
@@ -891,14 +912,20 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
             "early ``return parent_sha``)"
         )
 
-    def test_parent_rebase_falls_through_to_push(self, gateway_client):
-        """If the parent was *rewritten* (rebase) rather than advanced
-        additively, the recorded base is no longer an ancestor of the
-        parent tip. The harder rewrite class is out of scope — fall
-        through to the push so the rejection surfaces."""
+    def test_parent_rewrite_resumes_in_place_via_rederivation(self, gateway_client):
+        """If the parent was *rewritten* (rebase) so the recorded base is
+        no longer an ancestor of the parent tip, the #2947 fast-path does
+        not fire. Pre-#3245 this fell through to a non-fast-forward push
+        that FAILED the slice and cascaded the phase. Now the #3245 runtime
+        re-derivation finds the genuine shared fork point (a rewrite still
+        leaves a common ancestor) and adopts the branch in place — the
+        committed work is preserved and the parent's commits reconcile at
+        slice-PR / merge time (surfacing as a CONFLICTING PR for human
+        review), which is strictly better than failing the whole phase."""
         base_sha = "b0b0b0b0" * 5
         existing_sha = "e1e1e1e1" * 5
         parent_sha = "a2a2a2a2" * 5
+        fork_sha = "c0c0c0c0" * 5  # real shared ancestor before the rewrite
         push_invoked: list[dict] = []
         merge_base_args: list[list[str]] = []
         ancestry = {
@@ -909,19 +936,106 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
         ok = self._create(
             gateway_client,
             _ancestry_make_request(
-                ancestry, push_invoked=push_invoked, merge_base_args=merge_base_args
+                ancestry,
+                push_invoked=push_invoked,
+                merge_base_args=merge_base_args,
+                merge_bases={(existing_sha, parent_sha): fork_sha},
             ),
             self._remotes(parent_sha, existing_sha),
             base_sha=base_sha,
         )
 
-        assert ok, "diverged push (here) succeeds in the stub"
-        assert len(push_invoked) == 1, "rebase class must fall through to the push"
-        assert push_invoked[0]["refspec"] == f"{parent_sha}:refs/heads/{self._INT}"
+        assert ok == parent_sha, "rewrite class now resumes in place (#3245)"
+        assert push_invoked == [], (
+            "must NOT push — the branch is adopted in place; a parent-tip "
+            "push here is non-fast-forward and would fail the slice"
+        )
+        # The 3 is-ancestor probes still run (#2512, then #2947's two
+        # checks); the bare merge-base re-derivation then adopts.
         assert [a[1:] for a in merge_base_args] == [
             [parent_sha, existing_sha],
             [base_sha, existing_sha],
             [base_sha, parent_sha],
+        ]
+
+    def test_no_shared_history_falls_through_to_push(self, gateway_client):
+        """An existing branch that shares NO history with the parent (a
+        genuine orphan/unrelated branch sitting at this name) has no
+        merge-base, so #3245 re-derivation returns None and we fall
+        through to the push — preserving the "don't adopt unknown work"
+        instinct."""
+        base_sha = "b0b0b0b0" * 5
+        existing_sha = "e1e1e1e1" * 5
+        parent_sha = "a2a2a2a2" * 5
+        push_invoked: list[dict] = []
+        merge_base_args: list[list[str]] = []
+        ancestry = {
+            (parent_sha, existing_sha): False,
+            (base_sha, existing_sha): True,
+            (base_sha, parent_sha): False,
+        }
+        ok = self._create(
+            gateway_client,
+            _ancestry_make_request(
+                ancestry,
+                push_invoked=push_invoked,
+                merge_base_args=merge_base_args,
+                merge_bases={},  # no shared fork point
+            ),
+            self._remotes(parent_sha, existing_sha),
+            base_sha=base_sha,
+        )
+
+        assert ok, "no-shared-history push (here) succeeds in the stub"
+        assert len(push_invoked) == 1, "no shared fork point must fall through to the push"
+        assert push_invoked[0]["refspec"] == f"{parent_sha}:refs/heads/{self._INT}"
+
+    def test_corrupted_base_overwritten_to_parent_tip_resumes_in_place(self, gateway_client):
+        """Regression for the issue-3200 slice-7 incident (#3245): an
+        out-of-band actor (restart/salvage/manual edit) overwrote the
+        recorded ``integration_base_sha`` to the *advanced parent tip*.
+        That base then fails its own ancestor-of-slice-tip check, so the
+        #2947 fast-path can't fire — but the branch is a perfectly
+        resumable additive fork. The #3245 runtime re-derivation must
+        find the real fork point and adopt it in place rather than
+        non-fast-forward-failing the slice (which cascaded the phase)."""
+        # The corruption: recorded base == the current parent tip.
+        parent_sha = "a2a2a2a2" * 5
+        base_sha = parent_sha  # overwritten to parent tip by the restart actor
+        existing_sha = "e1e1e1e1" * 5  # slice tip, forked from the *real* base
+        real_fork = "8913746b" + "0" * 32  # the genuine fork point
+        push_invoked: list[dict] = []
+        merge_base_args: list[list[str]] = []
+        ancestry = {
+            # #2512: parent is NOT an ancestor of the slice tip.
+            (parent_sha, existing_sha): False,
+            # #2947: base==parent_sha is NOT an ancestor of the slice tip
+            # (this is the exact check the corruption defeats).
+            (base_sha, existing_sha): False,
+        }
+        ok = self._create(
+            gateway_client,
+            _ancestry_make_request(
+                ancestry,
+                push_invoked=push_invoked,
+                merge_base_args=merge_base_args,
+                merge_bases={(existing_sha, parent_sha): real_fork},
+            ),
+            self._remotes(parent_sha, existing_sha),
+            base_sha=base_sha,
+        )
+
+        assert ok == parent_sha, "corrupted-base slice must resume in place via #3245 re-derivation"
+        assert push_invoked == [], (
+            "must NOT push — adopting the existing fork in place preserves "
+            "the slice's consensus-approved commits"
+        )
+        # #2512 (parent->existing) runs; #2947 short-circuits at its first
+        # ancestor check (base->existing False), so only two is-ancestor
+        # probes precede the merge-base re-derivation.
+        assert [a[1:] for a in merge_base_args] == [
+            [parent_sha, existing_sha],
+            [base_sha, existing_sha],
         ]
 
     def test_branch_not_descended_from_recorded_base_falls_through(self, gateway_client):
@@ -991,7 +1105,12 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
         (no slice commits yet) must take the fast-forward push path that
         advances it to the new parent tip — NOT resume-in-place, which
         would pin it to the stale base. The ``existing_sha != base`` guard
-        is what keeps it off the resume path."""
+        keeps it off the #2947 fast-path; and because the branch carries no
+        commits beyond the fork, the #3245 re-derivation's
+        ``fork_base != existing_sha`` guard also declines to adopt it (the
+        merge-base of an un-started branch and its advanced parent is the
+        branch tip itself), so it correctly falls through to the
+        fast-forward push."""
         base_sha = "b0b0b0b0" * 5
         existing_sha = base_sha  # un-started: tip still at the creation base
         parent_sha = "a2a2a2a2" * 5
@@ -1001,7 +1120,13 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
         ok = self._create(
             gateway_client,
             _ancestry_make_request(
-                ancestry, push_invoked=push_invoked, merge_base_args=merge_base_args
+                ancestry,
+                push_invoked=push_invoked,
+                merge_base_args=merge_base_args,
+                # Realistic: an un-started branch sits at the fork, so
+                # merge-base(existing, parent) == existing — the #3245
+                # guard must NOT adopt it.
+                merge_bases={(existing_sha, parent_sha): existing_sha},
             ),
             self._remotes(parent_sha, existing_sha),
             base_sha=base_sha,
@@ -1010,8 +1135,9 @@ class TestCreateSliceIntegrationBranchResumeInPlace:
         assert ok
         assert len(push_invoked) == 1, "un-started branch must fast-forward to parent"
         assert push_invoked[0]["refspec"] == f"{parent_sha}:refs/heads/{self._INT}"
-        # Only the #2512 probe runs; the resume-in-place probes are gated
-        # off by ``existing_sha != integration_base_sha``.
+        # Only the #2512 is-ancestor probe runs; the resume-in-place
+        # is-ancestor probes are gated off by
+        # ``existing_sha != integration_base_sha``.
         assert [a[1:] for a in merge_base_args] == [[parent_sha, existing_sha]]
 
 


### PR DESCRIPTION
## What

The **primary-bug fix** for the re-scoped #3245: a slice-DAG implement phase failed at integration because, on resume, a pre-existing slice integration branch carrying consensus-approved work was rejected with a non-fast-forward push, failing the slice and cascading the whole phase.

## Root cause (confirmed against live `issue-3200` state)

`create_slice_integration_branch` gated its resume-in-place recovery (#2512 / #2947) on the **recorded** `integration_base_sha`. That stored SHA is mutable by out-of-band actors — a `restart_phase` slice copy, a `salvage_agent_commits` run, or a manual contract edit. In the slice-7 incident it was overwritten to the **advanced parent tip** (`8913746b0` → `11606eb5`), so it was no longer an ancestor of the slice's own tip. The #2947 check therefore failed and the method fell through to a `parent_sha:refs/heads/<slice>` push that is non-fast-forward → `record_failure` → phase cascade.

This happened even though slice-7 was a perfectly resumable **additive fork**: `merge-base(slice-7, slice-6) == 8913746b0`, the real fork point, still on the parent's history (slice-6 only advanced additively — no rewrite). The issue's earlier "force-update the branch to the parent tip" suggestion would have **discarded** slice-7's 7 commits; this fix is non-destructive.

## Fix

When the recorded-base fast-path doesn't fire (base absent or untrustworthy), **re-derive the fork point from git** — `merge-base(existing_tip, parent)` — instead of trusting the stored SHA. We only reach this point when the parent is not already an ancestor of the existing tip (#2512 handled that), so a real shared merge-base strictly behind the existing tip means the branch is a diverged additive fork: **adopt it in place** and let the parent's commits reconcile at slice-PR / merge time, exactly as for a slice whose parent advanced while it ran normally.

- Never resets or force-pushes — **no committed work is destroyed**.
- Idempotent — a contract still carrying the corrupted base **self-heals** on every subsequent resume (no write-back needed).

### Safety preserved
- **No shared history** (orphan/unrelated branch at this name) → no merge-base → falls through to the push (surfaces the rejection; doesn't adopt unknown work).
- **Un-started branch at the fork** (no own commits) → `fork_base == existing_tip` → falls through to the fast-forward push (advances it to the new parent), not adopted at the stale base.
- A genuine parent **history rewrite** is also adopted-in-place and surfaces as a CONFLICTING slice PR for human review — strictly better than failing the whole phase before any agent spawns.

## Test plan

`orchestrator/tests/test_create_slice_integration_branch.py` (33 pass):
- New regression `test_corrupted_base_overwritten_to_parent_tip_resumes_in_place` — the exact slice-7 incident.
- New `test_no_shared_history_falls_through_to_push` — orphan branch still falls through.
- Updated `test_parent_rewrite_resumes_in_place_via_rederivation` (was `…falls_through_to_push`) — rewrite class now resumes in place via re-derivation.
- Updated `test_unstarted_branch_at_base_still_fast_forwards` — now models the realistic merge-base to pin the `fork_base != existing_tip` guard.
- Test harness `_ancestry_make_request` extended to answer bare `git merge-base` probes.

Also green: `test_slice_4_restart_hardening`, `test_slice_run_loop_integration`, `test_gateway_transient_retry`, `gateway/tests/test_pipeline_push_block` (160 pass total); `ruff check` clean.

Part of #3245 (primary cause). The orthogonal `rebase_onto` reconciler hygiene is PR #3246. Intentionally does **not** auto-close the issue.