### PR TITLE
fix(ci): skip implementation verification on the work->main context PR (#3254)

### DIFF
--- a/.github/workflows/on-pull-request-contract-verify.yml
+++ b/.github/workflows/on-pull-request-contract-verify.yml
@@ -51,6 +51,35 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Count the implementation slices in a pipeline's contract on a given
+          # ref. Mirrors the orchestrator's _is_slice_dag_mode discriminator
+          # (len(slices) > 1) so the work->main gate below can tell a multi-slice
+          # context roll-up apart from a single-slice/monolithic implementation
+          # PR (#3254 review). The contract is fetched by the pipeline's OWN key
+          # (egg/<id>/work -> id -> id.json, with a legacy bare-number fallback
+          # for pre-unification issue contracts) — never the whole contracts/
+          # dir, which inherits historical multi-slice contracts from main and
+          # would cause a false skip. Echoes the slice count; 0 on any
+          # fetch/parse failure so the caller fails open (review runs).
+          __egg_work_slice_count() {
+            local pid="$1" ref="$2" b64 count cf candidates
+            candidates="${pid}.json"
+            if [[ "$pid" == issue-* ]]; then
+              candidates="${candidates} ${pid#issue-}.json"
+            fi
+            for cf in $candidates; do
+              b64=$(gh api "repos/${{ github.repository }}/contents/.egg-state/contracts/${cf}?ref=${ref}" \
+                --jq '.content // ""' 2>/dev/null || echo "")
+              if [[ -n "$b64" ]]; then
+                count=$(printf '%s' "$b64" | base64 -d 2>/dev/null \
+                  | jq '((.slices // .phases) // []) | length' 2>/dev/null || echo 0)
+                echo "${count:-0}"
+                return 0
+              fi
+            done
+            echo 0
+          }
+
           # Fetch PR metadata (labels, head + base branch, body) in a single API call
           pr_data=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '{labels: [.labels[].name], branch: .head.ref, base: .base.ref, body: .body}')
           branch_name=$(echo "$pr_data" | jq -r '.branch')
@@ -101,19 +130,39 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
-            # Context/state PR (egg/<id>/work -> main) carries ONLY .egg-state/
-            # orchestration artifacts (contract, BRC history, drafts,
-            # agent-outputs) and never implementation code — that is delivered
-            # incrementally through the stacked slice PRs. Running
-            # implementation verification here is a false positive by
-            # construction (#3254), so skip deterministically on the head/base
-            # topology BEFORE the sdlc:pr / added-contract triggers can fire
-            # (the work->main diff *adds* the contract relative to main, which
-            # would otherwise trip the added-contract trigger below).
-            if [[ "$branch_name" =~ ^egg/.+/work$ && ( "$base_name" == "main" || "$base_name" == "master" ) ]]; then
-              echo "Context PR ${branch_name} -> ${base_name}: only .egg-state/ artifacts, skipping contract verification"
-              echo "run=false" >> "$GITHUB_OUTPUT"
-              exit 0
+            # The work->main PR (egg/<id>/work -> main) shares ONE head/base
+            # topology across two very different cases, and topology ALONE
+            # cannot tell them apart (#3254 review):
+            #
+            #   * Multi-slice pipeline — implementation is delivered through
+            #     stacked slice PRs (egg/<id>/slice-N -> egg/<id>/work), each
+            #     verified on its own (see the slice trigger below). The
+            #     work->main PR is then a pure context/state roll-up carrying
+            #     only .egg-state/ artifacts, so verifying it is a false
+            #     positive by construction. SKIP.
+            #   * Single-slice / monolithic pipeline — no slice PR is ever
+            #     opened (the orchestrator routes the implement phase through
+            #     the slice loop only when the contract has >1 slice; see
+            #     _is_slice_dag_mode). Implementation is committed directly onto
+            #     egg/<id>/work, so work->main IS the implementation PR and is
+            #     the ONLY GitHub-level verification it gets. DO NOT SKIP.
+            #
+            # Discriminate on the same key the orchestrator uses: the slice
+            # count in the contract on the work branch (len(slices) > 1). This
+            # must run BEFORE the sdlc:pr / added-contract triggers, since the
+            # work->main diff *adds* the contract relative to main and would
+            # otherwise trip the added-contract trigger below for the multi-slice
+            # roll-up too. A failed contract fetch yields 0 -> falls through to
+            # normal gating (fail-open — the safe direction).
+            if [[ "$branch_name" =~ ^egg/(.+)/work$ && ( "$base_name" == "main" || "$base_name" == "master" ) ]]; then
+              pipeline_id="${BASH_REMATCH[1]}"
+              slice_count=$(__egg_work_slice_count "$pipeline_id" "$branch_name")
+              if [[ "${slice_count:-0}" -gt 1 ]]; then
+                echo "Context PR ${branch_name} -> ${base_name}: multi-slice contract (${slice_count} slices) — implementation delivered via slice PRs, skipping contract verification (#3254)"
+                echo "run=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              echo "PR ${branch_name} -> ${base_name}: ${slice_count} slice(s) — single-slice/monolithic implementation PR, not a context roll-up; continuing to normal gating (#3254)"
             fi
 
             # Check if PR has sdlc:pr label

--- a/.github/workflows/on-pull-request-contract-verify.yml
+++ b/.github/workflows/on-pull-request-contract-verify.yml
@@ -51,9 +51,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Fetch PR metadata (labels, branch name, body) in a single API call
-          pr_data=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '{labels: [.labels[].name], branch: .head.ref, body: .body}')
+          # Fetch PR metadata (labels, head + base branch, body) in a single API call
+          pr_data=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '{labels: [.labels[].name], branch: .head.ref, base: .base.ref, body: .body}')
           branch_name=$(echo "$pr_data" | jq -r '.branch')
+          base_name=$(echo "$pr_data" | jq -r '.base')
           labels=$(echo "$pr_data" | jq -r '.labels[]')
           pr_body=$(echo "$pr_data" | jq -r '.body // ""')
 
@@ -100,6 +101,21 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
+            # Context/state PR (egg/<id>/work -> main) carries ONLY .egg-state/
+            # orchestration artifacts (contract, BRC history, drafts,
+            # agent-outputs) and never implementation code — that is delivered
+            # incrementally through the stacked slice PRs. Running
+            # implementation verification here is a false positive by
+            # construction (#3254), so skip deterministically on the head/base
+            # topology BEFORE the sdlc:pr / added-contract triggers can fire
+            # (the work->main diff *adds* the contract relative to main, which
+            # would otherwise trip the added-contract trigger below).
+            if [[ "$branch_name" =~ ^egg/.+/work$ && ( "$base_name" == "main" || "$base_name" == "master" ) ]]; then
+              echo "Context PR ${branch_name} -> ${base_name}: only .egg-state/ artifacts, skipping contract verification"
+              echo "run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
             # Check if PR has sdlc:pr label
             if echo "$labels" | grep -q "^sdlc:pr$"; then
               echo "PR has sdlc:pr label, running contract verification"

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -85,15 +85,22 @@ jobs:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
-      - name: Get PR HEAD SHA
+      - name: Get PR HEAD SHA and branch topology
         id: pr-head
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
         run: |
-          head_sha=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '.head.sha')
-          echo "sha=${head_sha}" >> "$GITHUB_OUTPUT"
-          echo "PR HEAD SHA: ${head_sha}"
+          pr_json=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}")
+          head_sha=$(echo "$pr_json" | jq -r '.head.sha')
+          head_ref=$(echo "$pr_json" | jq -r '.head.ref')
+          base_ref=$(echo "$pr_json" | jq -r '.base.ref')
+          {
+            echo "sha=${head_sha}"
+            echo "head-ref=${head_ref}"
+            echo "base-ref=${base_ref}"
+          } >> "$GITHUB_OUTPUT"
+          echo "PR HEAD SHA: ${head_sha} (${head_ref} -> ${base_ref})"
 
       # NOTE: This step duplicates marker detection logic from the "Find last bot review
       # commit for re-review context" step in the review job (lines 306-388). This is
@@ -160,10 +167,25 @@ jobs:
           PR_TITLE: ${{ inputs.pr_title }}
           ALREADY_REVIEWED: ${{ steps.already-reviewed.outputs.already-reviewed }}
           HEAD_SHA: ${{ steps.pr-head.outputs.sha }}
+          HEAD_REF: ${{ steps.pr-head.outputs.head-ref }}
+          BASE_REF: ${{ steps.pr-head.outputs.base-ref }}
         run: |
           # For workflow_dispatch, always run
           if [[ "${{ inputs.event_name }}" == "workflow_dispatch" ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Context/state PR (egg/<id>/work -> main) carries ONLY .egg-state/
+          # orchestration artifacts and never implementation code — that lands
+          # incrementally through the stacked slice PRs. Implementation-style
+          # review here is a false positive by construction (#3254), so skip
+          # deterministically on the head/base topology. Slice PRs
+          # (egg/<id>/slice-N -> egg/<id>/work) are unaffected and reviewed as
+          # before.
+          if [[ "$HEAD_REF" =~ ^egg/.+/work$ && ( "$BASE_REF" == "main" || "$BASE_REF" == "master" ) ]]; then
+            echo "::notice::Skipping review: context PR ${HEAD_REF} -> ${BASE_REF} holds only .egg-state/ artifacts"
+            echo "run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -91,16 +91,56 @@ jobs:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
         run: |
+          set -euo pipefail
           pr_json=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}")
           head_sha=$(echo "$pr_json" | jq -r '.head.sha')
           head_ref=$(echo "$pr_json" | jq -r '.head.ref')
           base_ref=$(echo "$pr_json" | jq -r '.base.ref')
+
+          # Decide whether this is a multi-slice *context roll-up* work->main PR
+          # (egg/<id>/work -> main carrying only .egg-state/ artifacts), as
+          # opposed to a single-slice/monolithic implementation PR that happens
+          # to share the same topology. Topology ALONE is too coarse (#3254
+          # review): the orchestrator opens slice PRs — and thus turns work->main
+          # into a pure roll-up — only when the contract has more than one slice
+          # (_is_slice_dag_mode: len(slices) > 1). A single-slice/monolithic
+          # pipeline commits implementation directly onto egg/<id>/work, so its
+          # work->main PR IS the implementation PR and is the ONLY GitHub-level
+          # review it gets. So gate the skip on the slice count in the contract
+          # on the work branch, fetched by the pipeline's OWN key (never the
+          # whole contracts/ dir, which inherits historical multi-slice
+          # contracts from main). Fetch/parse failures leave context-pr=false
+          # (fail-open -> review runs, the safe direction).
+          context_pr=false
+          if [[ "$head_ref" =~ ^egg/(.+)/work$ && ( "$base_ref" == "main" || "$base_ref" == "master" ) ]]; then
+            pipeline_id="${BASH_REMATCH[1]}"
+            slice_count=0
+            candidates="${pipeline_id}.json"
+            if [[ "$pipeline_id" == issue-* ]]; then
+              candidates="${candidates} ${pipeline_id#issue-}.json"
+            fi
+            for cf in $candidates; do
+              b64=$(gh api "repos/${{ github.repository }}/contents/.egg-state/contracts/${cf}?ref=${head_ref}" \
+                --jq '.content // ""' 2>/dev/null || echo "")
+              if [[ -n "$b64" ]]; then
+                slice_count=$(printf '%s' "$b64" | base64 -d 2>/dev/null \
+                  | jq '((.slices // .phases) // []) | length' 2>/dev/null || echo 0)
+                break
+              fi
+            done
+            if [[ "${slice_count:-0}" -gt 1 ]]; then
+              context_pr=true
+            fi
+            echo "work->main PR ${head_ref}: ${slice_count} slice(s) -> context-pr=${context_pr}"
+          fi
+
           {
             echo "sha=${head_sha}"
             echo "head-ref=${head_ref}"
             echo "base-ref=${base_ref}"
+            echo "context-pr=${context_pr}"
           } >> "$GITHUB_OUTPUT"
-          echo "PR HEAD SHA: ${head_sha} (${head_ref} -> ${base_ref})"
+          echo "PR HEAD SHA: ${head_sha} (${head_ref} -> ${base_ref}, context-pr=${context_pr})"
 
       # NOTE: This step duplicates marker detection logic from the "Find last bot review
       # commit for re-review context" step in the review job (lines 306-388). This is
@@ -169,6 +209,7 @@ jobs:
           HEAD_SHA: ${{ steps.pr-head.outputs.sha }}
           HEAD_REF: ${{ steps.pr-head.outputs.head-ref }}
           BASE_REF: ${{ steps.pr-head.outputs.base-ref }}
+          CONTEXT_PR: ${{ steps.pr-head.outputs.context-pr }}
         run: |
           # For workflow_dispatch, always run
           if [[ "${{ inputs.event_name }}" == "workflow_dispatch" ]]; then
@@ -176,15 +217,23 @@ jobs:
             exit 0
           fi
 
-          # Context/state PR (egg/<id>/work -> main) carries ONLY .egg-state/
-          # orchestration artifacts and never implementation code — that lands
-          # incrementally through the stacked slice PRs. Implementation-style
-          # review here is a false positive by construction (#3254), so skip
-          # deterministically on the head/base topology. Slice PRs
-          # (egg/<id>/slice-N -> egg/<id>/work) are unaffected and reviewed as
-          # before.
-          if [[ "$HEAD_REF" =~ ^egg/.+/work$ && ( "$BASE_REF" == "main" || "$BASE_REF" == "master" ) ]]; then
-            echo "::notice::Skipping review: context PR ${HEAD_REF} -> ${BASE_REF} holds only .egg-state/ artifacts"
+          # Multi-slice context/state PR (egg/<id>/work -> main): the pr-head
+          # step already confirmed, via the contract slice count, that
+          # implementation is delivered through reviewed slice PRs, so this
+          # work->main PR is a pure .egg-state/ roll-up and implementation-style
+          # review is a false positive by construction (#3254). A
+          # single-slice/monolithic work->main PR is NOT flagged (context-pr
+          # stays false) and is reviewed normally — it is the only GitHub-level
+          # review the implementation gets. Topology alone is too coarse to make
+          # this call, which is why the discriminator lives in pr-head.
+          #
+          # NOTE: the contract-verification caller
+          # (on-pull-request-contract-verify.yml) already short-circuits this
+          # same context PR in its OWN should-run gate before it ever reaches
+          # reusable-review.yml, so this skip is effectively only exercised by
+          # the egg-reviewer caller (on-pull-request.yml).
+          if [[ "$CONTEXT_PR" == "true" ]]; then
+            echo "::notice::Skipping review: multi-slice context PR ${HEAD_REF} -> ${BASE_REF} holds only .egg-state/ artifacts"
             echo "run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/tests/config/test_contract_verify_workflow.py
+++ b/tests/config/test_contract_verify_workflow.py
@@ -17,6 +17,15 @@ verification runs for a given PR. That gate is a proven regression magnet:
 These assertions lock in all three trigger conditions so a future "cleanup"
 cannot silently drop the slice trigger (or reintroduce the #1134 over-fire) without
 the suite going red.
+
+* #3254: the work->main *context/state* PR (`egg/<id>/work -> main`) holds only
+  `.egg-state/` orchestration artifacts — never implementation code — so
+  running implementation verification on it is a false positive by
+  construction. A deterministic head/base topology gate short-circuits it to
+  `run=false` *before* the added-contract trigger (condition 2) can fire on the
+  contract the work->main diff necessarily adds. The assertions below lock that
+  ordering in so the skip cannot be reordered after — or removed by — a future
+  edit.
 """
 
 from __future__ import annotations
@@ -28,6 +37,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "on-pull-request-contract-verify.yml"
+REUSABLE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "reusable-review.yml"
 
 
 @pytest.fixture
@@ -39,6 +49,21 @@ def check_script() -> str:
     jobs = data.get("jobs", {})
     should_run = jobs.get("should-run")
     assert should_run is not None, "missing `should-run` job in contract-verify workflow"
+    steps = should_run.get("steps", [])
+    check_steps = [s for s in steps if isinstance(s, dict) and s.get("id") == "check"]
+    assert check_steps, "missing `check` step (id: check) in the should-run job"
+    return check_steps[0].get("run", "")
+
+
+@pytest.fixture
+def reusable_check_script() -> str:
+    """Return the bash body of reusable-review.yml's `should-run` `check` step."""
+    if not REUSABLE_WORKFLOW.exists():
+        pytest.skip(f"{REUSABLE_WORKFLOW} not found — repo is in an unexpected state")
+    data = yaml.safe_load(REUSABLE_WORKFLOW.read_text(encoding="utf-8"))
+    jobs = data.get("jobs", {})
+    should_run = jobs.get("should-run")
+    assert should_run is not None, "missing `should-run` job in reusable-review workflow"
     steps = should_run.get("steps", [])
     check_steps = [s for s in steps if isinstance(s, dict) and s.get("id") == "check"]
     assert check_steps, "missing `check` step (id: check) in the should-run job"
@@ -137,4 +162,71 @@ def test_slice_trigger_is_topology_keyed_not_bare_existence(check_script: str) -
         "`if [[ ... slice-[0-9]+$ ... ]]; then ... fi` block — this risks "
         "reintroducing the #1134 over-fire on PRs that merely inherit the "
         "default branch's contracts"
+    )
+
+
+def test_context_pr_skip_present(check_script: str) -> None:
+    """#3254: the work->main context PR is deterministically skipped.
+
+    The context/state PR (`egg/<id>/work -> main`) holds only `.egg-state/`
+    artifacts, so the gate must short-circuit it to `run=false` on the
+    head/base topology rather than letting implementation verification run.
+    """
+    assert "^egg/.+/work$" in check_script, (
+        "should-run gate has no context-PR head match — the work->main "
+        "context PR will fall through and run implementation verification (#3254)"
+    )
+    # The skip must actually disable the run, not merely match the branch.
+    skip_idx = next(
+        (i for i, line in enumerate(check_script.splitlines()) if "^egg/.+/work$" in line),
+        None,
+    )
+    assert skip_idx is not None
+    tail = "\n".join(check_script.splitlines()[skip_idx : skip_idx + 5])
+    assert "run=false" in tail, (
+        "the context-PR head match does not set run=false on the next lines — "
+        "the skip is inert (#3254)"
+    )
+
+
+def test_context_pr_skip_precedes_other_triggers(check_script: str) -> None:
+    """The context-PR skip must fire BEFORE the sdlc:pr / added-contract triggers.
+
+    The work->main diff necessarily *adds* the contract relative to main, which
+    would trip the added-contract trigger (condition 2); the context PR also
+    carries the `sdlc:pr` label. So the deterministic skip only wins if it is
+    evaluated first. Lock that ordering in.
+    """
+    lines = check_script.splitlines()
+    work_idx = next((i for i, ln in enumerate(lines) if "^egg/.+/work$" in ln), None)
+    label_idx = next((i for i, ln in enumerate(lines) if 'grep -q "^sdlc:pr$"' in ln), None)
+    added_idx = next((i for i, ln in enumerate(lines) if 'status == "added"' in ln), None)
+    assert work_idx is not None, "context-PR skip missing (#3254)"
+    assert label_idx is not None and added_idx is not None
+    assert work_idx < label_idx, (
+        "context-PR skip is evaluated after the sdlc:pr label trigger — the "
+        "label would win and verification would run on the context PR (#3254)"
+    )
+    assert work_idx < added_idx, (
+        "context-PR skip is evaluated after the added-contract trigger — the "
+        "work->main contract add would win and verification would run (#3254)"
+    )
+
+
+def test_reusable_review_skips_context_pr(reusable_check_script: str) -> None:
+    """#3254: the shared review gate (egg-reviewer + contract-verification) also
+    skips the work->main context PR deterministically on head/base topology."""
+    assert "^egg/.+/work$" in reusable_check_script, (
+        "reusable-review should-run gate has no context-PR head match — the "
+        "egg-reviewer will run implementation-style review on the work->main "
+        "context PR (#3254)"
+    )
+    skip_idx = next(
+        (i for i, line in enumerate(reusable_check_script.splitlines()) if "^egg/.+/work$" in line),
+        None,
+    )
+    assert skip_idx is not None
+    tail = "\n".join(reusable_check_script.splitlines()[skip_idx : skip_idx + 5])
+    assert "run=false" in tail, (
+        "the reusable-review context-PR match does not set run=false — the skip is inert (#3254)"
     )

--- a/tests/config/test_contract_verify_workflow.py
+++ b/tests/config/test_contract_verify_workflow.py
@@ -19,13 +19,20 @@ cannot silently drop the slice trigger (or reintroduce the #1134 over-fire) with
 the suite going red.
 
 * #3254: the work->main *context/state* PR (`egg/<id>/work -> main`) holds only
-  `.egg-state/` orchestration artifacts — never implementation code — so
-  running implementation verification on it is a false positive by
-  construction. A deterministic head/base topology gate short-circuits it to
-  `run=false` *before* the added-contract trigger (condition 2) can fire on the
-  contract the work->main diff necessarily adds. The assertions below lock that
-  ordering in so the skip cannot be reordered after — or removed by — a future
-  edit.
+  `.egg-state/` orchestration artifacts when the pipeline is *multi-slice* —
+  implementation is then delivered through the stacked slice PRs — so running
+  implementation verification on it is a false positive by construction. But a
+  single-slice / monolithic pipeline commits implementation directly onto the
+  work branch, so *its* work->main PR IS the implementation PR and must still be
+  verified. The two share an identical head/base topology, so the gate keys the
+  skip on the contract slice count on the work branch (`len(slices) > 1`,
+  mirroring the orchestrator's `_is_slice_dag_mode`) rather than topology alone,
+  and short-circuits the multi-slice roll-up to `run=false` *before* the
+  added-contract trigger (condition 2) can fire on the contract the work->main
+  diff necessarily adds. The assertions below lock in both the slice-count
+  gating (so a single-slice/monolithic implementation PR is never silently
+  skipped) and the ordering (so the skip cannot be reordered after — or removed
+  by — a future edit).
 """
 
 from __future__ import annotations
@@ -68,6 +75,27 @@ def reusable_check_script() -> str:
     check_steps = [s for s in steps if isinstance(s, dict) and s.get("id") == "check"]
     assert check_steps, "missing `check` step (id: check) in the should-run job"
     return check_steps[0].get("run", "")
+
+
+@pytest.fixture
+def reusable_pr_head_script() -> str:
+    """Return the bash body of reusable-review.yml's `should-run` `pr-head` step.
+
+    The #3254 slice-count discriminator lives here (not in the `check` step)
+    because this step holds the `GH_TOKEN`; it fetches the contract on the work
+    branch, counts slices, and emits the `context-pr` output the `check` step
+    gates on.
+    """
+    if not REUSABLE_WORKFLOW.exists():
+        pytest.skip(f"{REUSABLE_WORKFLOW} not found — repo is in an unexpected state")
+    data = yaml.safe_load(REUSABLE_WORKFLOW.read_text(encoding="utf-8"))
+    jobs = data.get("jobs", {})
+    should_run = jobs.get("should-run")
+    assert should_run is not None, "missing `should-run` job in reusable-review workflow"
+    steps = should_run.get("steps", [])
+    pr_head_steps = [s for s in steps if isinstance(s, dict) and s.get("id") == "pr-head"]
+    assert pr_head_steps, "missing `pr-head` step (id: pr-head) in the should-run job"
+    return pr_head_steps[0].get("run", "")
 
 
 def test_label_trigger_present(check_script: str) -> None:
@@ -166,67 +194,124 @@ def test_slice_trigger_is_topology_keyed_not_bare_existence(check_script: str) -
 
 
 def test_context_pr_skip_present(check_script: str) -> None:
-    """#3254: the work->main context PR is deterministically skipped.
+    """#3254: the multi-slice work->main context PR is deterministically skipped.
 
-    The context/state PR (`egg/<id>/work -> main`) holds only `.egg-state/`
-    artifacts, so the gate must short-circuit it to `run=false` on the
-    head/base topology rather than letting implementation verification run.
+    The multi-slice context/state PR (`egg/<id>/work -> main`) holds only
+    `.egg-state/` artifacts, so the gate must short-circuit it to `run=false`
+    rather than letting implementation verification run.
     """
-    assert "^egg/.+/work$" in check_script, (
-        "should-run gate has no context-PR head match — the work->main "
+    assert "^egg/(.+)/work$" in check_script, (
+        "should-run gate has no work-branch head match — the work->main "
         "context PR will fall through and run implementation verification (#3254)"
     )
-    # The skip must actually disable the run, not merely match the branch.
-    skip_idx = next(
-        (i for i, line in enumerate(check_script.splitlines()) if "^egg/.+/work$" in line),
-        None,
+    # The skip must actually disable the run.
+    assert 'echo "run=false"' in check_script, (
+        "the work->main gate does not set run=false anywhere — the skip is inert (#3254)"
     )
-    assert skip_idx is not None
-    tail = "\n".join(check_script.splitlines()[skip_idx : skip_idx + 5])
-    assert "run=false" in tail, (
-        "the context-PR head match does not set run=false on the next lines — "
-        "the skip is inert (#3254)"
+
+
+def test_context_pr_skip_is_slice_count_gated(check_script: str) -> None:
+    """#3254 review (BLOCKING fix): the work->main skip must NOT fire on topology
+    alone — only on a multi-slice contract.
+
+    A single-slice / monolithic pipeline commits implementation directly onto
+    `egg/<id>/work`, so its `egg/<id>/work -> main` PR IS the implementation PR
+    and is the *only* GitHub-level verification it gets. A skip keyed on bare
+    head/base topology would suppress that review (the regression flagged on the
+    PR). The skip must instead be gated on the contract slice count
+    (`len(slices) > 1`, mirroring the orchestrator's `_is_slice_dag_mode`), so a
+    monolithic/single-slice work->main PR falls through to normal gating.
+    """
+    # The discriminator must consult the contract slice count, not just topology.
+    assert "slice_count" in check_script and "-gt 1" in check_script, (
+        "work->main skip is not gated on the contract slice count (`-gt 1`) — "
+        "it would suppress review of single-slice/monolithic implementation "
+        "PRs, the only GitHub-level review they get (#3254 review)"
+    )
+    # The slice count must come from the contract on the work branch, fetched
+    # by the pipeline's own key — not the whole contracts/ dir (which inherits
+    # historical multi-slice contracts from main and would false-skip).
+    assert "contents/.egg-state/contracts/" in check_script, (
+        "the slice count is not read from the pipeline's contract on the work "
+        "branch — the discriminator has no source of truth (#3254 review)"
+    )
+    # The slices field (canonical) or its legacy `phases` alias must be counted.
+    assert ".slices" in check_script, (
+        "the slice count does not reference the contract `slices` field "
+        "(_is_slice_dag_mode parity) (#3254 review)"
     )
 
 
 def test_context_pr_skip_precedes_other_triggers(check_script: str) -> None:
-    """The context-PR skip must fire BEFORE the sdlc:pr / added-contract triggers.
+    """The work->main skip must be evaluated BEFORE the sdlc:pr / added-contract triggers.
 
     The work->main diff necessarily *adds* the contract relative to main, which
     would trip the added-contract trigger (condition 2); the context PR also
-    carries the `sdlc:pr` label. So the deterministic skip only wins if it is
-    evaluated first. Lock that ordering in.
+    carries the `sdlc:pr` label. So the deterministic slice-count skip only wins
+    for the multi-slice roll-up if it is evaluated first. Lock that ordering in.
     """
     lines = check_script.splitlines()
-    work_idx = next((i for i, ln in enumerate(lines) if "^egg/.+/work$" in ln), None)
+    work_idx = next((i for i, ln in enumerate(lines) if "^egg/(.+)/work$" in ln), None)
     label_idx = next((i for i, ln in enumerate(lines) if 'grep -q "^sdlc:pr$"' in ln), None)
     added_idx = next((i for i, ln in enumerate(lines) if 'status == "added"' in ln), None)
-    assert work_idx is not None, "context-PR skip missing (#3254)"
+    assert work_idx is not None, "work->main skip missing (#3254)"
     assert label_idx is not None and added_idx is not None
     assert work_idx < label_idx, (
-        "context-PR skip is evaluated after the sdlc:pr label trigger — the "
+        "work->main skip is evaluated after the sdlc:pr label trigger — the "
         "label would win and verification would run on the context PR (#3254)"
     )
     assert work_idx < added_idx, (
-        "context-PR skip is evaluated after the added-contract trigger — the "
+        "work->main skip is evaluated after the added-contract trigger — the "
         "work->main contract add would win and verification would run (#3254)"
     )
 
 
-def test_reusable_review_skips_context_pr(reusable_check_script: str) -> None:
-    """#3254: the shared review gate (egg-reviewer + contract-verification) also
-    skips the work->main context PR deterministically on head/base topology."""
-    assert "^egg/.+/work$" in reusable_check_script, (
-        "reusable-review should-run gate has no context-PR head match — the "
-        "egg-reviewer will run implementation-style review on the work->main "
-        "context PR (#3254)"
+def test_reusable_review_skips_context_pr(
+    reusable_check_script: str, reusable_pr_head_script: str
+) -> None:
+    """#3254: the shared review gate (egg-reviewer) skips the *multi-slice*
+    work->main context PR, and the decision is slice-count gated.
+
+    The slice-count discriminator lives in the `pr-head` step (which holds the
+    `GH_TOKEN`) and is surfaced to the `check` step as the `context-pr` output;
+    the `check` step skips iff `context-pr == true`. Assert both halves so the
+    egg-reviewer cannot regress to a bare-topology skip that suppresses review
+    of single-slice/monolithic implementation PRs (#3254 review).
+    """
+    # pr-head: slice-count gated on the work-branch contract.
+    assert "^egg/(.+)/work$" in reusable_pr_head_script, (
+        "reusable-review pr-head has no work-branch head match (#3254)"
+    )
+    assert "slice_count" in reusable_pr_head_script and "-gt 1" in reusable_pr_head_script, (
+        "reusable-review pr-head does not gate context-pr on the contract slice "
+        "count — egg-reviewer would skip single-slice/monolithic implementation "
+        "PRs (#3254 review)"
+    )
+    assert "contents/.egg-state/contracts/" in reusable_pr_head_script, (
+        "reusable-review pr-head does not read the contract on the work branch "
+        "to count slices (#3254 review)"
+    )
+    assert 'echo "context-pr=' in reusable_pr_head_script, (
+        "reusable-review pr-head does not emit the context-pr output the check "
+        "step gates on (#3254)"
+    )
+    # check: skip is driven by the context-pr output, not raw topology.
+    assert "CONTEXT_PR" in reusable_check_script, (
+        "reusable-review check step does not consult the context-pr output — "
+        "the slice-count decision is not wired into the skip (#3254 review)"
     )
     skip_idx = next(
-        (i for i, line in enumerate(reusable_check_script.splitlines()) if "^egg/.+/work$" in line),
+        (
+            i
+            for i, line in enumerate(reusable_check_script.splitlines())
+            if 'CONTEXT_PR" == "true"' in line
+        ),
         None,
     )
-    assert skip_idx is not None
+    assert skip_idx is not None, (
+        "reusable-review check step has no `CONTEXT_PR == true` skip branch (#3254)"
+    )
     tail = "\n".join(reusable_check_script.splitlines()[skip_idx : skip_idx + 5])
     assert "run=false" in tail, (
-        "the reusable-review context-PR match does not set run=false — the skip is inert (#3254)"
+        "the reusable-review context-PR branch does not set run=false — the skip is inert (#3254)"
     )


### PR DESCRIPTION
## Problem

The two automated PR reviewers — **contract-verification** (`james-in-a-box`) and **egg-reviewer** — ran their full implementation-verification standards against the **context/state PR** (`egg/<id>/work` → `main`), where they fail **by construction**. That PR contains only `.egg-state/` orchestration artifacts (contract, BRC history, drafts, agent-outputs) and never implementation code — implementation is delivered incrementally through the stacked slice PRs. So both bots issued spurious `REQUEST_CHANGES` (observed on #3234).

## Root cause

The PR topology (context/state vs slice) was not modeled at review **dispatch** time. The workflows detected *slice* PRs by head-branch pattern but had no corresponding detection for the context PR, and the base ref — which disambiguates — was either not fetched (`on-pull-request-contract-verify.yml`) or fetched but never consulted in the `should-run` decision (`reusable-review.yml`).

## Fix

Make context-PR detection deterministic at dispatch — head/base topology, not model judgment:

- **`on-pull-request-contract-verify.yml`**: fetch `base.ref` and short-circuit `run=false` when head matches `^egg/.+/work$` and base is `main`/`master`, **before** the `sdlc:pr` / added-contract triggers can fire (the work→main diff *adds* the contract relative to main, which would otherwise trip the added-contract trigger).
- **`reusable-review.yml`**: the shared `should-run` gate — which covers both the egg-reviewer (`on-pull-request.yml`) and the contract-verification caller — now captures head/base refs and applies the same skip.

Slice PRs (`egg/<id>/slice-N` → `egg/<id>/work`) are unaffected and reviewed exactly as before.

## Tests

Extends `tests/config/test_contract_verify_workflow.py` (the existing structural-gate regression suite):

- `test_context_pr_skip_present` — the context-PR head match exists and actually sets `run=false`.
- `test_context_pr_skip_precedes_other_triggers` — locks the skip *ahead* of the `sdlc:pr` and added-contract triggers (otherwise they'd win on the context PR).
- `test_reusable_review_skips_context_pr` — the shared egg-reviewer gate also skips deterministically.

`actionlint` clean; all 7 workflow-gate tests pass.

## Acceptance

- [x] A `egg/<id>/work` → `main` PR does not receive an implementation-verification `REQUEST_CHANGES` from either bot.
- [x] Slice PRs continue to be verified/reviewed as today (regression guard retained).
- [x] Detection is deterministic (branch-name + base-ref at dispatch), not model judgment.

Closes #3254