### PR TITLE
fix(orchestrator): don't false-complete a never-implemented slice as basis=merged (#3253)

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -202,6 +202,15 @@ class SliceCompletionInvariantError(RuntimeError):
     state where *all* are absent — a slice marked COMPLETE with zero
     evidence it ran. We raise here so that corrupt write fails loud at its
     source instead of wedging the forest a phase later.
+
+    #3253 refinement: ``basis="merged"`` is no longer an unconditional
+    pass. A merged slice went through a PR and left commits its producers
+    recorded; a ``basis="merged"`` write with **no PR and no produced task
+    commit** is an empty / never-implemented branch that origin ancestry
+    mis-detected as merged (the slice-10 case — producers exhausted before
+    committing, so the integration branch's tip is still its fork base and
+    is trivially an ancestor of the advanced parent). Such a write is
+    rejected so the slice is re-run rather than false-completed.
     """
 
 
@@ -210,6 +219,28 @@ class SliceCompletionInvariantError(RuntimeError):
 # on the contract (the crash-recovery / merged-skip paths). See
 # :class:`SliceCompletionInvariantError`.
 _VERIFIED_SLICE_COMPLETION_BASES = frozenset({"merged", "consensus_complete"})
+
+
+def _slice_produced_commits(slice_obj: Any) -> bool:
+    """Return True iff any of the slice's tasks recorded a commit SHA.
+
+    This is the base-SHA-independent "a producer actually committed work"
+    signal (#3253). It reads *task* commits only — a slice whose producers
+    all failed before committing has every ``task.commit`` ``None`` (the
+    AC-4 measurement in the issue-3200 slice-10 incident). It deliberately
+    ignores ``Slice.commit``: that field can carry the *parent's* SHA on a
+    false-complete (the #3214 slice-3 carryover), so it is not trustworthy
+    evidence the slice itself produced anything.
+
+    An empty integration branch (tip still at its fork base, so trivially
+    an ancestor of an advanced parent) is indistinguishable from a merged
+    one by origin ancestry alone once the recorded fork base is missing or
+    stale (#3245). The contract's task-commit record is the durable signal
+    that survives that ambiguity: no task commit + no slice PR ⇒ the slice
+    never ran and must be re-run, not completed.
+    """
+    tasks = getattr(slice_obj, "tasks", None) or []
+    return any(getattr(t, "commit", None) for t in tasks)
 
 
 def _validate_slice_completion_basis(
@@ -229,6 +260,21 @@ def _validate_slice_completion_basis(
     :class:`SliceCompletionInvariantError` for the basis rules (#3214).
     """
     has_pr = pr_number is not None or getattr(slice_obj, "pr_number", None) is not None
+    # #3253 — a ``basis="merged"`` slice with no PR and no produced task
+    # commits is not a merged slice; it is an empty / never-implemented
+    # integration branch (tip still at its fork base) that origin ancestry
+    # mis-detected as merged. A genuine merge went through a PR and left
+    # commits the producers recorded. Reject so the restart re-runs the
+    # slice instead of false-completing the pipeline with its work missing.
+    # This guard fires *before* the verified-basis / forked free-passes
+    # below so a recorded (possibly stale) fork base cannot rescue it.
+    if basis == "merged" and not has_pr and not _slice_produced_commits(slice_obj):
+        return (
+            f"slice {getattr(slice_obj, 'id', '?')} would be marked COMPLETE "
+            f"basis='merged' with no slice PR and no produced task commits — an "
+            f"empty / never-implemented integration branch is not a merged one "
+            f"(#3253)"
+        )
     verified_basis = basis in _VERIFIED_SLICE_COMPLETION_BASES
     # A slice that actually forked its integration branch recorded a base
     # SHA (#2871). Its absence — together with no PR, no verified basis,
@@ -16589,6 +16635,32 @@ def _run_implement_phase_slices(
                     error=str(detect_err),
                 )
                 return slice_obj.id, False
+            # #3253 — guard against a false-positive merged result. A slice
+            # whose producers never committed (no produced task commit) and
+            # that has no slice PR has an empty integration branch: its tip
+            # is still the fork base, so it is trivially an ancestor of an
+            # advanced parent and the origin ancestry check reports it
+            # merged. Marking it COMPLETE basis=merged silently drops the
+            # slice and lets the pipeline complete with its work missing —
+            # the restart-to-retry failure mode (#3138 producer exhaustion →
+            # operator restart → false-complete). Override to not-merged so
+            # the slice falls through to Layer-C and re-runs. A genuine merge
+            # has produced commits or a recorded PR, so this never overrides
+            # a real merge.
+            if (
+                merged
+                and not _slice_produced_commits(slice_obj)
+                and getattr(slice_obj, "pr_number", None) is None
+            ):
+                logger.warning(
+                    "Bootstrap merged-detection overridden: origin ancestry "
+                    "reports merged but the slice has no produced task commit "
+                    "and no PR — empty/un-started branch, re-running rather than "
+                    "false-completing as merged (#3253)",
+                    pipeline_id=pipeline_id,
+                    slice_id=slice_obj.id,
+                )
+                return slice_obj.id, False
             return slice_obj.id, bool(merged)
 
         max_workers = min(len(layer_b_candidates), 8)
@@ -16920,6 +16992,11 @@ def _run_implement_phase_slices(
                 # one. It is ``None`` on a slice's first run (recorded
                 # only after the branch is created, just below).
                 recorded_base_sha: str | None = None
+                # #3253 — capture whether the slice has any produced task
+                # commit / PR while we hold the contract, so the race-merged
+                # skip below cannot mistake an empty / un-started branch for
+                # a merged one (see the merged-acceptance guard below).
+                slice_produced_work = False
                 try:
                     with get_pipeline_state_lock(pipeline_id):
                         contract_local = load_contract(pipeline_id, worktree_repo_path)
@@ -16941,6 +17018,9 @@ def _run_implement_phase_slices(
                                 if s.status == SliceStatus.PENDING:
                                     s.status = SliceStatus.IN_PROGRESS
                                 recorded_base_sha = s.integration_base_sha
+                                slice_produced_work = (
+                                    _slice_produced_commits(s) or s.pr_number is not None
+                                )
                                 break
                         save_contract(contract_local, worktree_repo_path)
                 except Exception as save_err:  # noqa: BLE001
@@ -16983,6 +17063,22 @@ def _run_implement_phase_slices(
                             pipeline_id=pipeline_id,
                             slice_id=slice_id,
                             error=str(detect_err),
+                        )
+                        already_merged = False
+                    # #3253 — a slice with no produced task commit and no PR
+                    # has an empty integration branch (tip still at the fork
+                    # base); origin ancestry reports it merged because that
+                    # base is trivially an ancestor of an advanced parent.
+                    # Don't skip it as merged — spawn so it actually runs.
+                    if already_merged and not slice_produced_work:
+                        logger.info(
+                            "Slice merged-detection ignored: no produced task commit "
+                            "and no PR — empty/un-started branch, spawning instead of "
+                            "skipping as merged (#3253)",
+                            pipeline_id=pipeline_id,
+                            slice_id=slice_id,
+                            integration_branch=integration_branch,
+                            parent_branch=parent_branch,
                         )
                         already_merged = False
                     if already_merged:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -238,6 +238,13 @@ def _slice_produced_commits(slice_obj: Any) -> bool:
     stale (#3245). The contract's task-commit record is the durable signal
     that survives that ambiguity: no task commit + no slice PR ⇒ the slice
     never ran and must be re-run, not completed.
+
+    A slice with *no tasks* returns ``False`` here (``any([])``). Paired with
+    "origin-detected merged, no PR" that would force such a slice to re-run
+    indefinitely — but a zero-task slice is unreachable in practice:
+    plan-derived slices always carry at least one task. The safe direction is
+    re-run over silently-dropped work, so the edge needs no special-casing
+    (#3253).
     """
     tasks = getattr(slice_obj, "tasks", None) or []
     return any(getattr(t, "commit", None) for t in tasks)
@@ -16564,6 +16571,21 @@ def _run_implement_phase_slices(
     # detection), so a current-code slice whose base-SHA write failed also
     # falls through to Layer-B and self-corrects identically to the legacy
     # case above.
+    #
+    # Known limitation (#3253): a slice that pre-fix code *already* persisted
+    # COMPLETE basis="merged" with a stale ``integration_base_sha`` and no
+    # produced commits / PR is still trusted here — Layer-A validates with no
+    # ``basis`` (the #3253 merged-empty guard keys on ``basis == "merged"``,
+    # which Layer-A never supplies), so the ``forked`` free-pass below accepts
+    # the stale fork base. This is deliberately *not* fixed by broadening the
+    # guard to the basis-less path: a legitimate ``basis="consensus_complete"``
+    # slice can also have no PR and no recorded task commit (best-effort agent
+    # recording + ``pr_number`` None on an unparseable PR URL, #3122), so
+    # re-running on "no commit + no PR" alone here would re-run genuinely
+    # completed work. The #3253 fix prevents the corrupt write going forward;
+    # a pipeline already wedged by this exact bug *before* the upgrade needs a
+    # manual contract touch-up (clear the slice's COMPLETE status) rather than
+    # self-healing on restart.
     layer_b_candidates = []
     for s in slices:
         if s.status == SliceStatus.COMPLETE:

--- a/orchestrator/tests/test_slice_completion_invariant.py
+++ b/orchestrator/tests/test_slice_completion_invariant.py
@@ -32,14 +32,22 @@ def _slice(
     slice_id: str = "slice-3",
     *,
     task_statuses: list[TaskStatus] | None = None,
+    task_commits: list[str | None] | None = None,
     status: SliceStatus = SliceStatus.PENDING,
     pr_number: int | None = None,
     integration_base_sha: str | None = None,
     parent_branch_at_creation: str | None = None,
     commit: str | None = None,
 ) -> Slice:
-    """Build a Slice with one task per entry in ``task_statuses``."""
+    """Build a Slice with one task per entry in ``task_statuses``.
+
+    ``task_commits`` (when given) supplies a per-task commit SHA aligned
+    with ``task_statuses`` — used to model whether the slice's producers
+    actually committed work (#3253). ``None`` entries leave that task's
+    commit unset.
+    """
     statuses = task_statuses if task_statuses is not None else [TaskStatus.PENDING]
+    commits = task_commits if task_commits is not None else [None] * len(statuses)
     return Slice(
         id=slice_id,
         name=f"Slice {slice_id}",
@@ -49,7 +57,13 @@ def _slice(
         parent_branch_at_creation=parent_branch_at_creation,
         commit=commit,
         tasks=[
-            Task(id=f"task-3-{i + 1}", description="t", status=st, files_affected=[])
+            Task(
+                id=f"task-3-{i + 1}",
+                description="t",
+                status=st,
+                files_affected=[],
+                commit=commits[i] if i < len(commits) else None,
+            )
             for i, st in enumerate(statuses)
         ],
     )
@@ -116,11 +130,27 @@ class TestValidBases:
             is None
         )
 
-    def test_basis_merged(self) -> None:
-        # Layer-B bootstrap / run-loop merged-skip: ancestry-verified.
+    def test_basis_merged_with_produced_commit(self) -> None:
+        # Layer-B bootstrap / run-loop merged-skip: ancestry-verified AND
+        # the slice's producers actually committed work (#3253). A real
+        # merge always leaves recorded task commits, so basis="merged" is
+        # trusted here even with the task status not yet flipped COMPLETE
+        # on the in-memory contract.
         assert (
             _validate_slice_completion_basis(
-                _slice(task_statuses=[TaskStatus.PENDING]), basis="merged"
+                _slice(task_statuses=[TaskStatus.PENDING], task_commits=["a" * 40]),
+                basis="merged",
+            )
+            is None
+        )
+
+    def test_basis_merged_with_pr(self) -> None:
+        # A recorded slice PR is itself sufficient evidence of a real
+        # merge even if the task-commit record is absent (#3253).
+        assert (
+            _validate_slice_completion_basis(
+                _slice(task_statuses=[TaskStatus.PENDING], pr_number=3213),
+                basis="merged",
             )
             is None
         )
@@ -178,6 +208,37 @@ class TestInvalidBases:
             _slice(task_statuses=[TaskStatus.COMPLETE, TaskStatus.PENDING])
         )
         assert reason is not None
+
+    def test_basis_merged_no_pr_no_commit_is_rejected(self) -> None:
+        # #3253 — the slice-10 signature: basis="merged" detected on
+        # origin (empty/ancestor integration branch) but the slice never
+        # ran (no PR, every task.commit None). A merge with no PR and no
+        # produced commit is not a valid completion basis; reject it so
+        # the restart re-runs the slice instead of false-completing.
+        slice10 = _slice(
+            slice_id="slice-10",
+            task_statuses=[TaskStatus.PENDING, TaskStatus.PENDING],
+            task_commits=[None, None],
+            pr_number=None,
+        )
+        reason = _validate_slice_completion_basis(slice10, basis="merged")
+        assert reason is not None, "basis=merged with no PR + no commit must be rejected"
+        assert "slice-10" in reason
+        assert "3253" in reason
+
+    def test_basis_merged_no_pr_no_commit_rejected_despite_fork_base(self) -> None:
+        # The #3253 guard must fire even when a (stale, #3245) fork base is
+        # recorded — the recorded integration_base_sha would otherwise pass
+        # the #2871 "forked" free-pass and let the empty branch through.
+        slice10 = _slice(
+            slice_id="slice-10",
+            task_statuses=[TaskStatus.PENDING],
+            task_commits=[None],
+            pr_number=None,
+            integration_base_sha="b" * 40,
+        )
+        reason = _validate_slice_completion_basis(slice10, basis="merged")
+        assert reason is not None, "a recorded fork base must not rescue an empty merged slice"
 
     def test_exact_slice3_production_state_is_flagged(self) -> None:
         """The literal state read off pipeline ``issue-3200`` contract:

--- a/orchestrator/tests/test_slice_run_loop_integration.py
+++ b/orchestrator/tests/test_slice_run_loop_integration.py
@@ -140,12 +140,13 @@ def _make_slice(
     )
 
 
-def _make_task(task_id: str, description: str = "") -> Task:
+def _make_task(task_id: str, description: str = "", *, commit: str | None = None) -> Task:
     return Task(
         id=task_id,
         description=description or f"Task {task_id}",
         status=TaskStatus.PENDING,
         files_affected=[],
+        commit=commit,
     )
 
 
@@ -1292,7 +1293,11 @@ class TestSliceMergedDetection:
         complete, persists ``status=COMPLETE``, and the run loop
         proceeds with slice-2 alone."""
         pipeline = _make_pipeline()
-        slice1 = _make_slice("slice-1", tasks=[_make_task("task-1-1")])
+        # slice-1 is genuinely merged — its producer recorded a commit
+        # (#3253: a real merge leaves produced task commits, which is what
+        # distinguishes it from an empty/never-implemented branch that
+        # origin ancestry would also report as merged).
+        slice1 = _make_slice("slice-1", tasks=[_make_task("task-1-1", commit="a" * 40)])
         slice2 = _make_slice("slice-2", deps=["slice-1"], tasks=[_make_task("task-2-1")])
         contract = _make_contract(slices=[slice1, slice2])
 
@@ -1346,6 +1351,82 @@ class TestSliceMergedDetection:
         assert slice1.status == SliceStatus.COMPLETE, (
             "step (B) must persist slice.status=COMPLETE so subsequent restarts "
             "skip the GitHub round-trip"
+        )
+
+    def test_bootstrap_never_completes_never_implemented_slice_as_merged(self) -> None:
+        """#3253 — a slice whose producers never committed (no produced
+        task commit, no PR, tasks ``commit=None``) has an empty
+        integration branch whose tip is still its fork base, so origin
+        ancestry trivially reports it ``merged``. The bootstrap must NOT
+        mark it COMPLETE basis=merged (which would silently drop the
+        slice and let the pipeline complete with its work missing — the
+        slice-10 incident). It must re-run instead.
+
+        This is the restart-to-retry path: a producer fails (e.g. #3138
+        model-quota exhaustion), the operator restarts, and the empty
+        branch must be re-run, not false-completed.
+        """
+        pipeline = _make_pipeline()
+        # slice-1 completed normally; slice-2 is the never-implemented one:
+        # IN_PROGRESS with an empty integration branch (it was created — its
+        # branch exists on origin — but no producer ever committed, so every
+        # task.commit is None), mirroring the slice-10 incident.
+        slice1 = _make_slice("slice-1", tasks=[_make_task("task-1-1", commit="a" * 40)])
+        slice2 = _make_slice(
+            "slice-2",
+            deps=["slice-1"],
+            tasks=[_make_task("task-2-1")],  # commit=None
+        )
+        slice2.status = SliceStatus.IN_PROGRESS
+        contract = _make_contract(slices=[slice1, slice2])
+
+        # Origin ancestry reports BOTH slices merged — but slice-2's
+        # "merged" is the empty/ancestor false positive.
+        with (
+            patch("egg_contracts.loader.load_contract", return_value=contract),
+            patch("egg_contracts.loader.save_contract"),
+            patch("routes.pipelines._start_stacked_pr_reconciler") as mock_start_recon,
+            patch(
+                "routes.pipelines._run_concurrent_phase", return_value=(0, "ok")
+            ) as mock_run_phase,
+            patch("orchestrator.peer_consensus.remove_peer_consensus_tracker"),
+        ):
+            mock_start_recon.return_value = (MagicMock(), threading.Event())
+            spawner = self._make_spawner()
+            spawner.gateway.is_slice_branch_merged_into_parent.return_value = True
+            # slice-2's integration branch exists on origin (forked but
+            # empty) — Layer-C sees a non-None tip…
+            spawner.gateway.get_remote_branch_sha.return_value = "c" * 40
+            # …but no live agents (the failed producers exited), so the
+            # #2914 resume-guard reclassifies it fresh and it re-runs.
+            spawner.backend = MagicMock()
+            spawner.backend.list_containers.return_value = []
+            exit_code, _ = _run_implement_phase_slices(
+                pipeline_id=pipeline.id,
+                pipeline=pipeline,
+                spawner=spawner,
+                repo_volumes={},
+                gateway_mode="public",
+                repos=["owner/repo"],
+                sandbox_env={},
+                store=MagicMock(),
+                certs_volume=None,
+                worktree_repo_path=Path("/tmp/x"),
+            )
+        assert exit_code == 0
+        # The discrimination: slice-1 (real produced commit) is accepted as
+        # merged and skipped; slice-2 (never implemented) is NOT skipped as
+        # merged — it is re-run via _run_concurrent_phase. (It then legitimately
+        # completes off the back of that successful re-run — that's the
+        # correct outcome, distinct from the bug, which false-completed it at
+        # bootstrap basis=merged without ever running it.)
+        invoked = {c.kwargs["slice_id"] for c in mock_run_phase.call_args_list}
+        assert "slice-2" in invoked, (
+            "a never-implemented slice that origin reports merged must be re-run, "
+            "not false-completed as merged at bootstrap (#3253)"
+        )
+        assert "slice-1" not in invoked, (
+            "a genuinely-merged slice (produced commit) is still skipped as merged"
         )
 
     def test_bootstrap_does_nothing_when_pipeline_repo_unset(self) -> None:
@@ -1408,7 +1489,10 @@ class TestSliceMergedDetection:
         re-check before push and skip cleanly — no agent spawn, no
         slice-PR creation, no integration-branch push."""
         pipeline = _make_pipeline()
-        slice1 = _make_slice("slice-1", tasks=[_make_task("task-1-1")])
+        # slice-1 produced a commit — required for the merged-skip paths to
+        # engage at all (#3253: a slice with no produced commit and no PR is
+        # treated as never-implemented and is never skipped as merged).
+        slice1 = _make_slice("slice-1", tasks=[_make_task("task-1-1", commit="a" * 40)])
         contract = _make_contract(slices=[slice1])
 
         # First call (bootstrap): not merged. Second call (race
@@ -1700,8 +1784,11 @@ class TestSliceBoundaryStatefileCommit:
         produce ONE batched commit, not one per slice — and no
         per-slice-close commits (nothing ran)."""
         pipeline = _make_pipeline()
-        slice1 = _make_slice("slice-1", tasks=[_make_task("task-1-1")])
-        slice2 = _make_slice("slice-2", tasks=[_make_task("task-2-1")])
+        # Both slices are genuinely merged — each producer recorded a commit
+        # (#3253: the produced-commit record is what lets the merged-detection
+        # mark them COMPLETE rather than treating them as never-implemented).
+        slice1 = _make_slice("slice-1", tasks=[_make_task("task-1-1", commit="a" * 40)])
+        slice2 = _make_slice("slice-2", tasks=[_make_task("task-2-1", commit="b" * 40)])
         contract = _make_contract(slices=[slice1, slice2])
         commit_mock = MagicMock(return_value=True)
         spawner = self._make_spawner()


### PR DESCRIPTION
Fixes #3253.

## Problem

On `restart_phase` (and any bootstrap-reconciliation re-entry of a slice-DAG implement phase), a slice that was **never implemented** — its producers never committed, so its integration branch has zero unique commits vs its parent and no PR — was mis-classified **COMPLETE with `basis=merged`** and skipped. The phase then completed and the pipeline reported `complete` with that slice's work missing.

Live repro: issue-3200 slice-10. Its three producers all exhausted their `propose` invocations (#3138) because the Claude subscription quota ran out — an external cause, so none committed. The operator switched keys and `restart_phase(implement)` was issued to re-run slice-10; instead the post-restart bootstrap false-completed it (`basis=merged`, `pr_number=None`, tasks `commit=null`).

## Root cause

The origin ancestry check (`is_slice_branch_merged_into_parent`) can't tell an **empty/ancestor** branch (tip still at its fork base → trivially an ancestor of an advanced parent) from a **genuinely-merged** one once the recorded fork base is missing or stale (#3245). The `#2871` base-SHA guard didn't fire, and `_validate_slice_completion_basis` accepted `basis=merged` unconditionally despite `pr_number=None` and zero produced commits.

## Fix

The base-SHA-independent signal is the contract's **task-commit record**: no produced task commit + no slice PR ⇒ the slice never ran. Defense-in-depth on that signal:

- **Bootstrap Layer-B** — override a `merged=True` detection to not-merged when the slice has no produced task commit and no PR. It falls through to Layer-C and re-runs (the `#2914` resume-guard reclassifies it fresh when no live agents remain).
- **Run-loop race-merged skip** — same guard before skipping a spawn.
- **`_validate_slice_completion_basis`** — reject `basis=merged` with no PR and no produced task commit (a merge with neither is not a valid completion basis). A backstop at the write chokepoint.

A genuine merge has produced commits or a recorded PR, so none of these override a real merge. New `_slice_produced_commits()` reads **task** commits only — `Slice.commit` can carry the parent's SHA on a false-complete (#3214), so it's not trustworthy.

Note: Layer-C already re-runs such a slice via the `#2914` agents-alive guard once Layer-B stops marking it merged — no Layer-C change was needed.

## Tests

- New end-to-end regression (`test_bootstrap_never_completes_never_implemented_slice_as_merged`) reproduces the slice-10 scenario: a slice origin reports merged but never ran is re-run, while a genuinely-merged sibling is still skipped.
- New validator rejection tests for the `basis=merged` + no-PR + no-commit signature (incl. with a stale recorded fork base).
- Updated existing merged-detection tests to give genuinely-merged slices a produced task commit (the `#3253`-correct representation of merged work).

`make test` green (18046 passed; the 2 failures are the pre-existing reap-script `127` env failures on this host, root-caused in #3222, unrelated to this change).

## Out of scope

The issue notes a diagnosability gap (#3138 surfaced producer exhaustion only as "10 consecutive failures" without the underlying quota/auth error). That's a separate concern; not bundled here.