### PR TITLE
fix(ci): stop conflict bot polluting slice-PR history; serve canonical contract (#3255)

### DIFF
--- a/.github/workflows/on-merge-conflict.yml
+++ b/.github/workflows/on-merge-conflict.yml
@@ -69,7 +69,7 @@ jobs:
           # Note: mergeable_state is only available after GitHub computes it,
           # which happens asynchronously. PRs with "UNKNOWN" state are skipped.
           prs=$(gh api repos/${{ github.repository }}/pulls --paginate \
-            -q '[.[] | select(.state == "open") | {number: .number, title: .title, head_repo: .head.repo.full_name}]')
+            -q '[.[] | select(.state == "open") | {number: .number, title: .title, head_repo: .head.repo.full_name, head_ref: .head.ref}]')
 
           conflicting=()
           while IFS= read -r pr_json; do
@@ -77,10 +77,27 @@ jobs:
             pr_num=$(echo "$pr_json" | jq -r '.number')
             pr_title=$(echo "$pr_json" | jq -r '.title')
             head_repo=$(echo "$pr_json" | jq -r '.head_repo')
+            head_ref=$(echo "$pr_json" | jq -r '.head_ref')
 
             # Skip fork PRs — bot can't push to forks
             if [[ "$head_repo" != "${{ github.repository }}" ]]; then
               echo "PR #${pr_num} is from a fork ($head_repo), skipping — bot cannot push to forks"
+              continue
+            fi
+
+            # Skip egg slice PRs (#3255). A slice PR's head is egg/<id>/slice-<N>
+            # and its base is the advancing egg/<id>/work state-branch. Resolving
+            # such a PR by merging the base in (this bot's strategy) drags every
+            # later slice's "Persist contract after slice ... completion" commit —
+            # and re-stamped copies of the whole refine/plan prefix — into the
+            # early slice's history, even though the slice's file diff stays
+            # correct. Slice-stack reconciliation is owned by the orchestrator's
+            # stacked-PR reconciler, not this generic base-into-head merge bot, so
+            # leave slice PRs to it. The egg/<id>/work -> main context PR (whose
+            # head does NOT match this pattern) is deliberately still resolved
+            # here so the base PR keeps tracking main.
+            if [[ "$head_ref" =~ ^egg/.+/slice-[0-9]+$ ]]; then
+              echo "PR #${pr_num} is an egg slice PR ($head_ref), skipping — orchestrator owns slice-stack reconciliation (#3255)"
               continue
             fi
 

--- a/.github/workflows/reusable-conflict-resolve.yml
+++ b/.github/workflows/reusable-conflict-resolve.yml
@@ -121,9 +121,40 @@ jobs:
         if: steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip == 'true'
         run: echo "Skipping conflict resolution due to [skip-conflict-fix] marker"
 
+      # Skip egg slice PRs (#3255). A slice PR's head is egg/<id>/slice-<N> and
+      # its base is the advancing egg/<id>/work state-branch. Resolving such a PR
+      # by merging the base in (this bot's strategy) drags every later slice's
+      # contract-persist commit — and re-stamped copies of the whole refine/plan
+      # prefix — into the early slice's history. Slice-stack reconciliation is
+      # owned by the orchestrator's stacked-PR reconciler, not this generic
+      # base-into-head merge bot. The push/schedule entry point already skips
+      # these in on-merge-conflict.yml's `find` step; this guard makes the
+      # invariant airtight for the manual-dispatch (workflow_dispatch) entry
+      # point, which calls this reusable workflow directly and would otherwise
+      # re-introduce exactly the pollution #3255 removes. The egg/<id>/work ->
+      # main context PR (whose head does NOT match this pattern) is deliberately
+      # still resolved here so the base PR keeps tracking main.
+      - name: Check for egg slice PR
+        if: steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true'
+        id: slice-check
+        env:
+          HEAD_REF: ${{ steps.pr-meta.outputs.head-ref }}
+        run: |
+          set -euo pipefail
+          if [[ "$HEAD_REF" =~ ^egg/.+/slice-[0-9]+$ ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "PR head $HEAD_REF is an egg slice PR, skipping — orchestrator owns slice-stack reconciliation (#3255)"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Early exit if slice PR
+        if: steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true' && steps.slice-check.outputs.skip == 'true'
+        run: echo "Skipping conflict resolution for egg slice PR — orchestrator owns slice-stack reconciliation (#3255)"
+
       # Minimize previous conflict resolution comments (status comments marked with semantic marker)
       - name: Minimize previous conflict comments
-        if: steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true'
+        if: steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true' && steps.slice-check.outputs.skip != 'true'
         run: |
           set -euo pipefail
           gh api "repos/${{ github.repository }}/issues/${{ env.PR_NUMBER }}/comments" \
@@ -142,7 +173,7 @@ jobs:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
 
       - name: Post starting comment
-        if: steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true'
+        if: steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true' && steps.slice-check.outputs.skip != 'true'
         run: |
           set -euo pipefail
           BODY="<!-- egg-status-comment -->
@@ -156,14 +187,14 @@ jobs:
 
       # SECURITY: Build the conflict prompt from a trusted checkout (main).
       - name: Checkout main (trusted)
-        if: steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true'
+        if: steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true' && steps.slice-check.outputs.skip != 'true'
         uses: actions/checkout@v4
         with:
           ref: main
           persist-credentials: false
 
       - name: Build conflict prompt
-        if: steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true'
+        if: steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true' && steps.slice-check.outputs.skip != 'true'
         id: prompt
         run: bash ${{ inputs.prompt_script }}
         env:
@@ -172,7 +203,7 @@ jobs:
           BASE_REF: ${{ inputs.base_ref || steps.pr-meta.outputs.base-ref }}
 
       - name: Checkout PR branch
-        if: steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true'
+        if: steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true' && steps.slice-check.outputs.skip != 'true'
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.pr-meta.outputs.head-repo }}
@@ -181,7 +212,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run egg conflict resolution
-        if: steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true'
+        if: steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true' && steps.slice-check.outputs.skip != 'true'
         id: egg
         uses: jwbron/egg/action@main
         with:
@@ -196,7 +227,7 @@ jobs:
           timeout: ${{ inputs.timeout }}
 
       - name: Post result comment
-        if: always() && !cancelled() && steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true'
+        if: always() && !cancelled() && steps.fork-check.outputs.skip != 'true' && steps.skip-check.outputs.skip != 'true' && steps.slice-check.outputs.skip != 'true'
         run: |
           set -euo pipefail
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -538,7 +538,17 @@ jobs:
               echo "::warning::Empty content for ${name} on ${work_branch} (too large for contents API?); keeping PR-branch copy"
               continue
             fi
-            echo "$content" | base64 -d > ".egg-state/contracts/${name}"
+            # Decode to a temp file and promote only on success. A raw
+            # `base64 -d > dest` under `set -euo pipefail` would hard-fail the
+            # whole review job if the payload ever fails to decode; this step is
+            # best-effort, so a bad decode must degrade to "keep the PR-branch
+            # copy", not abort the review (#3255 review note).
+            if ! echo "$content" | base64 -d > ".egg-state/contracts/${name}.tmp" 2>/dev/null; then
+              echo "::warning::Failed to base64-decode ${name} from ${work_branch}; keeping PR-branch copy"
+              rm -f ".egg-state/contracts/${name}.tmp"
+              continue
+            fi
+            mv ".egg-state/contracts/${name}.tmp" ".egg-state/contracts/${name}"
             echo "Overlaid canonical .egg-state/contracts/${name} from ${work_branch}"
           done <<< "$names"
 

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -502,6 +502,46 @@ jobs:
           ref: ${{ steps.pr-meta.outputs.head-sha }}
           persist-credentials: false
 
+      # #3255: a slice PR's .egg-state/contracts/ copy is frozen at the branch's
+      # fork point — the orchestrator is the sole contract writer and persists it
+      # to egg/<id>/work, never to slice branches (gateway phase_filter #2979).
+      # Now that the conflict bot no longer merges work into slice branches (so
+      # the slice's commit list stays clean), give contract verification the
+      # canonical, live contract by overlaying it from egg/<id>/work into the
+      # review checkout. Best-effort and working-tree only — never staged,
+      # committed, or pushed, so slice history is untouched. Uses the contents
+      # API rather than a git fetch+checkout so no PR-supplied .gitattributes
+      # smudge filter can execute against the bot token.
+      - name: Overlay canonical contract from work branch (slice PRs)
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+          HEAD_REF: ${{ steps.pr-meta.outputs.head-ref }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$HEAD_REF" =~ ^egg/(.+)/slice-[0-9]+$ ]]; then
+            echo "PR head $HEAD_REF is not a slice branch; using the PR's own contract"
+            exit 0
+          fi
+          work_branch="egg/${BASH_REMATCH[1]}/work"
+          names=$(gh api "repos/${GITHUB_REPOSITORY}/contents/.egg-state/contracts?ref=${work_branch}" \
+            --jq '.[] | select(.name | endswith(".json")) | .name' 2>/dev/null || echo "")
+          if [[ -z "$names" ]]; then
+            echo "::warning::No contract found on ${work_branch}; leaving the PR branch contract in place (#3255)"
+            exit 0
+          fi
+          mkdir -p .egg-state/contracts
+          while IFS= read -r name; do
+            [[ -z "$name" ]] && continue
+            content=$(gh api "repos/${GITHUB_REPOSITORY}/contents/.egg-state/contracts/${name}?ref=${work_branch}" \
+              --jq '.content' 2>/dev/null || echo "")
+            if [[ -z "$content" ]]; then
+              echo "::warning::Empty content for ${name} on ${work_branch} (too large for contents API?); keeping PR-branch copy"
+              continue
+            fi
+            echo "$content" | base64 -d > ".egg-state/contracts/${name}"
+            echo "Overlaid canonical .egg-state/contracts/${name} from ${work_branch}"
+          done <<< "$names"
+
       - name: Run egg to review and post feedback
         id: egg
         uses: jwbron/egg/action@main

--- a/tests/config/test_slice_pr_history_hygiene.py
+++ b/tests/config/test_slice_pr_history_hygiene.py
@@ -36,6 +36,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 CONFLICT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "on-merge-conflict.yml"
+REUSABLE_CONFLICT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "reusable-conflict-resolve.yml"
 REVIEW_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "reusable-review.yml"
 
 SLICE_HEAD_REGEX = "^egg/.+/slice-[0-9]+$"
@@ -118,6 +119,44 @@ def test_conflict_bot_does_not_skip_the_context_pr(find_script: str) -> None:
         "the conflict bot appears to skip the work/context PR too — it must keep "
         "resolving egg/<id>/work -> main so the base PR stays up to date (#3255)"
     )
+
+
+def test_reusable_conflict_resolve_skips_slice_prs() -> None:
+    """Defense-in-depth: the reusable workflow must also skip slice PRs.
+
+    The ``find`` step only guards the push/schedule entry point. The
+    ``workflow_dispatch`` (manual) entry point calls
+    ``reusable-conflict-resolve.yml`` directly with an operator-supplied
+    ``pr_number`` and would otherwise re-introduce exactly the history pollution
+    #3255 removes. The slice skip therefore also lives in the reusable workflow,
+    where both entry points converge.
+    """
+    slice_check = _step_run(REUSABLE_CONFLICT_WORKFLOW, "resolve", step_id="slice-check")
+    assert SLICE_HEAD_REGEX in slice_check, (
+        "the reusable conflict-resolve workflow no longer matches the slice-PR "
+        "head pattern — manual dispatch could re-pollute slice history (#3255)"
+    )
+    assert "skip=true" in slice_check, (
+        "the reusable conflict-resolve slice-check sets no skip output (#3255)"
+    )
+
+    # Every step that performs the actual conflict resolution must be gated on
+    # the slice-check skip, or the guard is inert.
+    data = yaml.safe_load(REUSABLE_CONFLICT_WORKFLOW.read_text(encoding="utf-8"))
+    gated = {
+        "Checkout PR branch",
+        "Run egg conflict resolution",
+    }
+    seen = set()
+    for step in data["jobs"]["resolve"].get("steps", []):
+        if not isinstance(step, dict) or step.get("name") not in gated:
+            continue
+        seen.add(step["name"])
+        assert "steps.slice-check.outputs.skip != 'true'" in step.get("if", ""), (
+            f"step {step['name']!r} is not gated on the slice-check skip — a "
+            f"manually dispatched slice PR would still be resolved (#3255)"
+        )
+    assert seen == gated, f"expected gated steps {gated} not all present, saw {seen}"
 
 
 def test_review_overlays_canonical_contract_for_slice_prs() -> None:

--- a/tests/config/test_slice_pr_history_hygiene.py
+++ b/tests/config/test_slice_pr_history_hygiene.py
@@ -1,0 +1,161 @@
+"""Structural guards for slice-PR commit-history hygiene (#3255).
+
+Slice PRs (`egg/<id>/slice-N -> egg/<id>/work`) used to accumulate large
+numbers of unrelated commits — every later slice's
+``Persist contract after slice ... completion`` commit plus re-stamped copies
+of the whole refine/plan prefix (observed 9x on PR #3236). The file *diffs*
+stayed correct, but the commit list was heavily polluted, confusing human and
+bot reviewers (companion to #3254).
+
+Root cause, confirmed against the live issue-3200 branches: the generic
+``on-merge-conflict.yml`` bot resolves a conflicting PR by merging its *base*
+into its head. For a slice PR the base is the advancing ``egg/<id>/work``
+state-branch, so each merge dragged work's entire lineage into the early
+slice's history. ``egg/<id>/work`` itself is clean and append-only — the
+pollution lived entirely on slice branches.
+
+The fix has two halves, both asserted here so a future "cleanup" cannot
+silently regress them:
+
+1. ``on-merge-conflict.yml`` skips slice PRs — slice-stack reconciliation is
+   owned by the orchestrator, not the generic base-into-head merge bot. The
+   ``egg/<id>/work -> main`` context PR is deliberately *not* skipped so the
+   base PR keeps tracking ``main``.
+2. ``reusable-review.yml`` overlays the canonical contract from
+   ``egg/<id>/work`` into a slice PR's review checkout (working-tree only),
+   so contract verification still reasons about the live contract even though
+   the conflict bot no longer merges work in.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+CONFLICT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "on-merge-conflict.yml"
+REVIEW_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "reusable-review.yml"
+
+SLICE_HEAD_REGEX = "^egg/.+/slice-[0-9]+$"
+
+
+def _step_run(
+    workflow: Path, job: str, *, step_id: str | None = None, step_name: str | None = None
+) -> str:
+    if not workflow.exists():
+        pytest.skip(f"{workflow} not found — repo is in an unexpected state")
+    data = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+    job_def = data.get("jobs", {}).get(job)
+    assert job_def is not None, f"missing `{job}` job in {workflow.name}"
+    for step in job_def.get("steps", []):
+        if not isinstance(step, dict):
+            continue
+        if step_id is not None and step.get("id") == step_id:
+            return step.get("run", "")
+        if step_name is not None and step.get("name") == step_name:
+            return step.get("run", "")
+    raise AssertionError(
+        f"step (id={step_id!r}, name={step_name!r}) not found in `{job}` of {workflow.name}"
+    )
+
+
+@pytest.fixture
+def find_script() -> str:
+    """The bash body of the conflict bot's `find` step (id: find)."""
+    return _step_run(CONFLICT_WORKFLOW, "find-conflicts", step_id="find")
+
+
+def test_conflict_bot_reads_head_ref(find_script: str) -> None:
+    """The PR projection must surface each PR's head ref so the skip can key on it.
+
+    Without ``head_ref`` in the projection there is nothing to match the slice
+    pattern against and the skip silently never fires.
+    """
+    assert "head_ref" in find_script, (
+        "the conflict bot's PR projection no longer exposes `head_ref` — the "
+        "slice-PR skip (#3255) has nothing to match on"
+    )
+
+
+def test_conflict_bot_skips_slice_prs(find_script: str) -> None:
+    """A slice PR head must be matched and skipped (not added to `conflicting`)."""
+    lines = find_script.splitlines()
+    slice_if_idx = next(
+        (
+            i
+            for i, line in enumerate(lines)
+            if line.lstrip().startswith("if [[") and SLICE_HEAD_REGEX in line
+        ),
+        None,
+    )
+    assert slice_if_idx is not None, (
+        "the conflict bot has no `if [[ ... ^egg/.+/slice-[0-9]+$ ... ]]` guard — "
+        "slice PRs will again be auto-resolved by merging work in, re-polluting "
+        "their commit history (#3255)"
+    )
+    # The guard must short-circuit (continue) rather than fall through into the
+    # conflicting+=("$pr_num") accumulation.
+    tail = "\n".join(lines[slice_if_idx : slice_if_idx + 4])
+    assert "continue" in tail, (
+        "the slice-PR guard does not `continue` — a slice PR could still be "
+        "queued for conflict resolution (#3255)"
+    )
+
+
+def test_conflict_bot_does_not_skip_the_context_pr(find_script: str) -> None:
+    """The skip must be keyed on slice topology, not all egg branches.
+
+    The ``egg/<id>/work -> main`` context PR must keep being conflict-resolved
+    so the base PR tracks ``main`` (an explicit requirement of #3255). A blanket
+    ``^egg/`` skip would silently stop updating it.
+    """
+    assert "/slice-" in SLICE_HEAD_REGEX  # guard against a typo in this test
+    assert SLICE_HEAD_REGEX in find_script, "slice-topology skip regex missing"
+    # No blanket egg-namespace skip that would also catch the work branch.
+    assert "^egg/.+/work" not in find_script and '"^egg/"' not in find_script, (
+        "the conflict bot appears to skip the work/context PR too — it must keep "
+        "resolving egg/<id>/work -> main so the base PR stays up to date (#3255)"
+    )
+
+
+def test_review_overlays_canonical_contract_for_slice_prs() -> None:
+    """The slice-PR review checkout must overlay the contract from work.
+
+    Once the conflict bot stops merging work into slice branches, a slice
+    branch's contract is frozen at its fork point. Contract verification must
+    instead read the live contract from ``egg/<id>/work`` (the orchestrator's
+    sole-writer branch — gateway phase_filter #2979).
+    """
+    overlay = _step_run(
+        REVIEW_WORKFLOW,
+        "review",
+        step_name="Overlay canonical contract from work branch (slice PRs)",
+    )
+    assert "slice-[0-9]+$" in overlay, (
+        "the overlay step no longer derives the work branch from a slice head match (#3255)"
+    )
+    assert "ref=${work_branch}" in overlay, (
+        "the overlay step no longer reads .egg-state/contracts from the canonical "
+        "work branch via the contents API (#3255)"
+    )
+
+
+def test_overlay_runs_after_pr_checkout_and_before_review() -> None:
+    """Ordering guard: overlay must land between the PR checkout and the review.
+
+    If the overlay ran before the PR checkout, the checkout would clobber it;
+    if it ran after the egg review step, the reviewer would never see it.
+    """
+    data = yaml.safe_load(REVIEW_WORKFLOW.read_text(encoding="utf-8"))
+    names = [s.get("name") for s in data["jobs"]["review"].get("steps", []) if isinstance(s, dict)]
+    checkout = "Checkout PR code for review"
+    overlay = "Overlay canonical contract from work branch (slice PRs)"
+    review = "Run egg to review and post feedback"
+    for name in (checkout, overlay, review):
+        assert name in names, f"review job missing expected step {name!r} (#3255)"
+    assert names.index(checkout) < names.index(overlay) < names.index(review), (
+        "the canonical-contract overlay is mis-ordered — it must run after the PR "
+        "checkout and before the egg review step (#3255)"
+    )


### PR DESCRIPTION
Fixes #3255.

## Problem
Slice PRs (`egg/<id>/slice-N → egg/<id>/work`) accumulate large numbers of **unrelated commits** — every later slice's `Persist contract after slice ... completion` commit plus re-stamped copies of the entire refine/plan prefix (9× on PR #3236; 3× `Initialize SDLC` / 16× `Persist` / 4 merge commits on the live `slice-1` branch). The file diffs stay correct, but the commit list is heavily polluted, confusing human and bot reviewers (companion to #3254).

## Root cause (confirmed against the live issue-3200 branches)
The generic **`on-merge-conflict.yml`** bot resolves a conflicting PR by merging its **base** into its head. For a slice PR the base is the advancing `egg/<id>/work` state-branch — the orchestrator commits a contract-persist commit there on **every** slice completion (#3117) — so each bot merge dragged `work`'s whole lineage into the early slice's history.

`egg/<id>/work` itself is **clean and append-only** (1× `Initialize SDLC`, 9× `Persist`, 0 merges; `main` is its ancestor). The pollution lived entirely on slice branches.

> Note: the issue's "the reconciler merges work in" framing is a mis-attribution. The orchestrator's stacked-PR reconciler never merges `work` into running slice branches — this **CI bot** does. The `Merge origin/.../work into slice-N: resolve conflict in .egg-state/contracts/...` commits are produced by `action/build-conflict-prompt.sh`.

## Fix (two halves)
1. **`on-merge-conflict.yml` skips slice PRs.** Slice-stack reconciliation is owned by the orchestrator (its stacked-PR reconciler retargets bases; producer agents resolve content conflicts in-pipeline via `git fetch && git merge`), not this generic base-into-head merge bot. The **`egg/<id>/work → main` context PR is deliberately NOT skipped**, so the base PR keeps tracking `main` and stays up to date.
2. **`reusable-review.yml` overlays the canonical contract** from `egg/<id>/work` into a slice PR's review checkout (working-tree only — never staged/committed/pushed). Once the bot stops merging `work` in, a slice branch's contract is frozen at its fork point; contract verification instead reads the **live** contract from `work` (the orchestrator's sole-writer branch — gateway `phase_filter` #2979). Uses the contents API, not a git fetch+checkout, so no PR-supplied `.gitattributes` smudge filter can run against the bot token.

## Acceptance criteria
- ✅ Early slice PRs no longer accumulate later slices' `Persist contract …` commits — the producer (work→slice bot merges) is removed.
- ✅ The refine/plan prefix can no longer be re-imported N× (same producer).
- ✅ Slice diffs unchanged — this only changes which branches the conflict bot touches and adds a working-tree-only contract overlay in CI.
- ✅ The base/context PR keeps being conflict-resolved (explicit non-skip).
- ✅ CI still reasons about a current contract for slice PRs (canonical-`work` overlay).

## Tests
`tests/config/test_slice_pr_history_hygiene.py` — structural guards locking in: the slice-PR skip + `continue`, the `head_ref` projection, the context-PR exemption (no blanket `^egg/` skip), the canonical-contract overlay reading from `ref=${work_branch}`, and its ordering between PR checkout and the egg review step. `actionlint` clean on both workflows.

## Scope / follow-ups
Mechanism-2 (re-stamped refine/plan prefix duplication) is fixed at the source here — without the work→slice merges the prefix cannot be re-imported. Any residual rebase-driven duplication is the orthogonal #3146/#3245/#3250 merge-base family and out of scope. Existing already-polluted slice branches are not rewritten (forward-looking fix). #3254 (reviewers running impl-verification on the context PR) is a separate, related issue — not bundled.