### PR TITLE
Skip code-review + autofix bots on SDLC pipeline PRs

### DIFF
--- a/.github/workflows/on-check-failure.yml
+++ b/.github/workflows/on-check-failure.yml
@@ -50,6 +50,7 @@ jobs:
           WORKFLOW_EVENT: ${{ github.event.workflow_run.event }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
@@ -62,12 +63,24 @@ jobs:
           elif [[ "$WORKFLOW_CONCLUSION" == "failure" && \
                   "$WORKFLOW_EVENT" == "pull_request" && \
                   -n "$PR_NUMBER" && "$PR_NUMBER" != "null" && "$PR_NUMBER" != "" ]]; then
-            {
-              echo "run=true"
-              echo "pr_number=${PR_NUMBER}"
-              echo "failed_workflow=${WORKFLOW_NAME}"
-              echo "failed_run_id=${WORKFLOW_RUN_ID}"
-            } >> "$GITHUB_OUTPUT"
+            # Skip SDLC pipeline-produced PRs. The egg orchestrator opens exactly
+            # two branch shapes — egg/<id>/slice-<N> and egg/<id>/work — and the
+            # pipeline fixes its own checks in-band; an external autofixer just
+            # pushes commits that pollute slice history (#3255). Human PRs
+            # (egg/<topic>) and the doc-updater (egg/doc-update-*) do not match
+            # and are autofixed normally. workflow_dispatch above still forces a
+            # manual autofix run when one is explicitly requested.
+            if [[ "$HEAD_BRANCH" =~ ^egg/.+/slice-[0-9]+$ || "$HEAD_BRANCH" =~ ^egg/.+/work$ ]]; then
+              echo "Skipping autofix: SDLC pipeline PR branch ${HEAD_BRANCH} is fixed in-band by the pipeline"
+              echo "run=false" >> "$GITHUB_OUTPUT"
+            else
+              {
+                echo "run=true"
+                echo "pr_number=${PR_NUMBER}"
+                echo "failed_workflow=${WORKFLOW_NAME}"
+                echo "failed_run_id=${WORKFLOW_RUN_ID}"
+              } >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -25,9 +25,45 @@ jobs:
           fi
           echo "All required repository variables are configured"
 
+  # Skip the GitHub-level code reviewer on SDLC pipeline-produced PRs. The egg
+  # orchestrator opens exactly two branch shapes — egg/<id>/slice-<N> and
+  # egg/<id>/work — and both are already reviewed in-band by the pipeline's own
+  # BRC consensus, so this reviewer is redundant; worse, it pushes commits and
+  # so pollutes slice history (#3255). Human PRs (egg/<topic>) and the
+  # doc-updater bot (egg/doc-update-*) do NOT match and are reviewed normally.
+  # The gate lives here (the egg-reviewer caller) rather than in the shared
+  # reusable-review.yml because the contract-verification caller
+  # (on-pull-request-contract-verify.yml) also calls reusable-review.yml and
+  # MUST keep verifying slice PRs (#3040).
+  should-run:
+    name: Check if code review should run
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Check branch topology
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          # Manual dispatch always runs — explicit override of the skip below.
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$HEAD_REF" =~ ^egg/.+/slice-[0-9]+$ || "$HEAD_REF" =~ ^egg/.+/work$ ]]; then
+            echo "::notice::Skipping code review: SDLC pipeline PR branch ${HEAD_REF} is reviewed in-band by the pipeline"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "run=true" >> "$GITHUB_OUTPUT"
+
   review:
     name: egg-review / Code
-    needs: [validate-config]
+    needs: [validate-config, should-run]
+    if: needs.should-run.outputs.run == 'true'
     permissions:
       contents: read
       pull-requests: write

--- a/docs/guides/github-automation.md
+++ b/docs/guides/github-automation.md
@@ -291,6 +291,15 @@ Only runs on PRs that modify agent-related files:
 - `docs/guides/sdlc-pipeline.md` — SDLC pipeline operational guide
 - `docs/architecture/**` — Architecture documentation
 
+> **Note — pipeline PRs are not skipped here.** Unlike the code reviewer and autofixer
+> (which skip `egg/<id>/slice-<N>` and `egg/<id>/work` PRs), this design reviewer still
+> runs on pipeline PRs that touch the paths above. That is intentional: it pushes **no**
+> commits (its only output is a PR comment), so it does not pollute slice history — the
+> #3255 driver behind those skips does not apply. The in-band BRC agent-mode-design review
+> already covers pipeline PRs, so the GitHub-level run here is redundant but harmless; a
+> matching head-ref gate on this caller is an easy follow-on if the redundant comment noise
+> becomes unwanted.
+
 ### What It Reviews
 
 This is a **specialized** review, not a general code review. The base AI Code Review

--- a/docs/guides/github-automation.md
+++ b/docs/guides/github-automation.md
@@ -49,9 +49,17 @@ and via `workflow_dispatch` with a PR number.
 1. **Skip checks** — Skips draft PRs, PRs with `[skip-review]` in the title, and PRs where
    the current HEAD commit has already been reviewed by the same bot — this prevents redundant
    reviews when a draft PR is marked as ready for review without new commits. It also skips
-   multi-slice work→main context PRs (`egg/<id>/work -> main` with more than one contract slice —
-   implementation is delivered through reviewed slice PRs, so this PR carries only `.egg-state/`
-   artifacts); single-slice/monolithic work→main PRs are not skipped.
+   **all SDLC pipeline-produced PRs** — both slice PRs (`egg/<id>/slice-<N>`) and work→main PRs
+   (`egg/<id>/work`). These are reviewed in-band by the pipeline's own BRC consensus, so the
+   GitHub-level reviewer is redundant and (because it pushes commits) pollutes slice history
+   (#3255). This skip is gated in `on-pull-request.yml`'s `should-run` job (the egg-reviewer
+   caller) by head-branch shape, **not** in the shared `reusable-review.yml`, because the
+   contract-verification caller (`on-pull-request-contract-verify.yml`) also calls
+   `reusable-review.yml` and must keep verifying slice PRs (#3040). Human PRs (`egg/<topic>`)
+   and the doc-updater bot (`egg/doc-update-*`) do not match and are reviewed normally;
+   `workflow_dispatch` forces a review regardless. (`reusable-review.yml` retains its own
+   narrower multi-slice context-PR skip for any other caller, but for the egg-reviewer path the
+   `on-pull-request.yml` gate supersedes it.)
 2. **Wait for CI checks** — Waits for all non-review checks (e.g., lint, tests) to complete
    before starting the review. Skips checks matching `egg-review /` (the standard reviewer
    job prefix), `egg-reviewer-` (nested reviewer jobs), `SDLC Pipeline`, or `SDLC HITL` to
@@ -362,6 +370,12 @@ Uses a per-check fixer loop where CI validates after each fix attempt.
 
 ### How It Works
 
+0. **SDLC pipeline-PR skip** — The `should-run` gate skips autofix on SDLC pipeline-produced
+   PRs — both slice PRs (`egg/<id>/slice-<N>`) and work→main PRs (`egg/<id>/work`), matched on
+   the triggering run's `head_branch`. These PRs fix their own checks in-band through the
+   pipeline; an external autofixer just pushes commits that pollute slice history (#3255). Human
+   PRs (`egg/<topic>`) and the doc-updater (`egg/doc-update-*`) do not match and are autofixed
+   normally; `workflow_dispatch` forces an autofix run regardless.
 1. **Skip check** — Skips PRs with `[skip-autofix]` in the title.
 2. **Identify failed jobs** — Queries the GitHub API for which specific jobs failed
    in the triggering workflow run (e.g., Python, Shell within Lint).

--- a/tests/config/test_sdlc_pr_bot_skip.py
+++ b/tests/config/test_sdlc_pr_bot_skip.py
@@ -170,6 +170,18 @@ def _extract_branch_regexes(job: dict, step_id: str) -> list[str]:
         f"no bash `=~` regex operands found in step (id: {step_id}) — the "
         "branch-topology check is not gating on the head ref at all"
     )
+    # Pin the helper to "exactly the two gate regexes", not "whatever `=~`
+    # operands happen to be here". The scan is greedy over the whole `run:`
+    # script, so a future maintainer adding an unrelated `[[ … =~ … ]]` to the
+    # same step would otherwise OR a stray operand into `_is_skipped` and flip
+    # table cases. Asserting the count makes that break loud and self-pointing
+    # at the new operand rather than silently mutating the behavioral table.
+    assert len(operands) == 2, (
+        f"expected exactly 2 bash `=~` regex operands in step (id: {step_id}), "
+        f"found {len(operands)}: {operands!r} — the branch-topology gate should "
+        "embed only the slice and work head-ref shapes; an extra operand here "
+        "would be OR'd into the skip decision and change which refs are skipped"
+    )
     return operands
 
 

--- a/tests/config/test_sdlc_pr_bot_skip.py
+++ b/tests/config/test_sdlc_pr_bot_skip.py
@@ -1,0 +1,133 @@
+"""SDLC pipeline-produced PRs must skip the GitHub-level code reviewer and the
+check autofixer.
+
+The egg orchestrator opens exactly two branch shapes — ``egg/<id>/slice-<N>``
+and ``egg/<id>/work`` — and both are already reviewed (and check-fixed) in-band
+by the pipeline itself. Re-running the GitHub-level egg-reviewer and autofixer
+on them is redundant and, because both push commits, pollutes slice history
+(#3255). These tests pin the skip gates so a refactor can't silently re-enable
+the bots on pipeline PRs.
+
+Crucially, the code-review skip must live in ``on-pull-request.yml`` (the
+egg-reviewer caller), NOT in the shared ``reusable-review.yml`` — the
+contract-verification caller (``on-pull-request-contract-verify.yml``) also
+calls ``reusable-review.yml`` and MUST keep verifying slice PRs (#3040).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+REVIEW_CALLER = WORKFLOWS / "on-pull-request.yml"
+AUTOFIX_CALLER = WORKFLOWS / "on-check-failure.yml"
+REUSABLE_REVIEW = WORKFLOWS / "reusable-review.yml"
+
+# The two pipeline branch shapes, as bash regexes. Both gates must match both.
+SLICE_RE = "^egg/.+/slice-[0-9]+$"
+WORK_RE = "^egg/.+/work$"
+
+
+def _job(workflow: Path, job_id: str) -> dict:
+    if not workflow.exists():
+        pytest.skip(f"{workflow} not found — repo is in an unexpected state")
+    data = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+    job = data.get("jobs", {}).get(job_id)
+    assert job is not None, f"missing `{job_id}` job in {workflow.name}"
+    return job
+
+
+def _step_run(job: dict, step_id: str) -> str:
+    steps = job.get("steps", [])
+    matches = [s for s in steps if isinstance(s, dict) and s.get("id") == step_id]
+    assert matches, f"missing step (id: {step_id})"
+    return matches[0].get("run", "")
+
+
+# --------------------------------------------------------------------------- #
+# Code review (on-pull-request.yml)
+# --------------------------------------------------------------------------- #
+
+
+def test_review_gate_skips_both_pipeline_shapes() -> None:
+    """The egg-reviewer should-run gate skips slice AND work branches."""
+    script = _step_run(_job(REVIEW_CALLER, "should-run"), "check")
+    assert SLICE_RE in script, (
+        "on-pull-request.yml should-run does not skip slice PRs "
+        f"({SLICE_RE}) — the code reviewer will run on pipeline slice PRs"
+    )
+    assert WORK_RE in script, (
+        "on-pull-request.yml should-run does not skip work→main PRs "
+        f"({WORK_RE}) — the code reviewer will run on pipeline work PRs"
+    )
+    assert "run=false" in script, "the skip branch does not set run=false (inert skip)"
+
+
+def test_review_gate_allows_manual_dispatch() -> None:
+    """workflow_dispatch is an explicit override and must always run."""
+    script = _step_run(_job(REVIEW_CALLER, "should-run"), "check")
+    assert "workflow_dispatch" in script and "run=true" in script, (
+        "on-pull-request.yml should-run does not force a run on workflow_dispatch — "
+        "the manual escape hatch is gone"
+    )
+
+
+def test_review_job_is_gated_on_should_run() -> None:
+    """The review job must actually consume the gate, not just define it."""
+    review = _job(REVIEW_CALLER, "review")
+    needs = review.get("needs", [])
+    assert "should-run" in needs, (
+        "review job does not `needs: should-run` — the skip gate is not wired in"
+    )
+    cond = review.get("if", "")
+    assert "should-run" in cond and "run" in cond, (
+        "review job has no `if: needs.should-run.outputs.run == 'true'` — "
+        "the gate output is not consulted"
+    )
+
+
+def test_review_skip_lives_in_caller_not_shared_workflow() -> None:
+    """The broad pipeline-PR skip must NOT be in reusable-review.yml, which the
+    contract-verification caller shares and which must keep verifying slice PRs
+    (#3040). reusable-review keeps only its narrower multi-slice context skip.
+    """
+    reusable_check = _step_run(_job(REUSABLE_REVIEW, "should-run"), "check")
+    assert SLICE_RE not in reusable_check, (
+        "reusable-review.yml should-run skips slice PRs — this would also "
+        "suppress contract verification on every slice PR (#3040)"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Check autofixer (on-check-failure.yml)
+# --------------------------------------------------------------------------- #
+
+
+def test_autofix_gate_skips_both_pipeline_shapes() -> None:
+    """The autofix should-run gate skips slice AND work branches."""
+    script = _step_run(_job(AUTOFIX_CALLER, "should-run"), "check")
+    assert SLICE_RE in script, (
+        "on-check-failure.yml should-run does not skip slice PRs "
+        f"({SLICE_RE}) — the autofixer will push commits onto pipeline slice PRs"
+    )
+    assert WORK_RE in script, (
+        "on-check-failure.yml should-run does not skip work→main PRs "
+        f"({WORK_RE}) — the autofixer will run on pipeline work PRs"
+    )
+    assert "head_branch" in script.lower(), (
+        "on-check-failure.yml should-run does not read the triggering run's "
+        "head_branch — it has no branch to gate on"
+    )
+
+
+def test_autofix_gate_allows_manual_dispatch() -> None:
+    """workflow_dispatch is an explicit override and must always run."""
+    script = _step_run(_job(AUTOFIX_CALLER, "should-run"), "check")
+    assert "workflow_dispatch" in script and "run=true" in script, (
+        "on-check-failure.yml should-run does not force a run on workflow_dispatch — "
+        "the manual escape hatch is gone"
+    )

--- a/tests/config/test_sdlc_pr_bot_skip.py
+++ b/tests/config/test_sdlc_pr_bot_skip.py
@@ -16,6 +16,7 @@ calls ``reusable-review.yml`` and MUST keep verifying slice PRs (#3040).
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -130,4 +131,66 @@ def test_autofix_gate_allows_manual_dispatch() -> None:
     assert "workflow_dispatch" in script and "run=true" in script, (
         "on-check-failure.yml should-run does not force a run on workflow_dispatch — "
         "the manual escape hatch is gone"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Behavioral coverage of the skip patterns
+# --------------------------------------------------------------------------- #
+#
+# The tests above pin the literal regex strings into the workflow scripts, which
+# catches accidental deletion of a gate. They do NOT, however, catch a regex that
+# still contains the pinned substring but is subtly broken (a dropped anchor, a
+# stray character). The table below feeds representative branch refs through the
+# SAME patterns the workflows embed — combined with the bash `||` the gates use —
+# so the actual match/no-match behavior is locked in, not just the spelling.
+#
+# Both gates skip when the head ref matches SLICE_RE *or* WORK_RE. We compile the
+# pinned constants (which `test_*_skips_both_pipeline_shapes` proves are the ones
+# actually present in the scripts) and assert the resulting decision per ref.
+
+
+def _is_skipped(ref: str) -> bool:
+    """True when a head ref matches either pipeline shape — i.e. the bot skips it.
+
+    Mirrors the workflows' ``[[ "$REF" =~ SLICE_RE || "$REF" =~ WORK_RE ]]``.
+    """
+    return bool(re.search(SLICE_RE, ref)) or bool(re.search(WORK_RE, ref))
+
+
+# (ref, should_be_skipped). Comments note why, including the deliberate
+# over-matches on multi-segment refs (acceptable: CLAUDE.md mandates
+# single-segment human branches `egg/<topic>`).
+_REF_CASES = [
+    # Pipeline shapes — MUST skip.
+    ("egg/issue-5/slice-2", True),
+    ("egg/123/slice-0", True),
+    ("egg/abc/slice-10", True),
+    ("egg/issue-5/work", True),
+    ("egg/123/work", True),
+    # Human / doc-updater single-segment branches — MUST run (not skipped).
+    ("egg/topic", False),
+    ("egg/doc-update-1", False),
+    ("egg/feature", False),
+    ("main", False),
+    # Anchor regressions the spelling-only tests would miss — MUST run.
+    ("egg/issue-5/slice-2x", False),  # trailing char defeats `[0-9]+$`
+    ("egg/issue-5/slice-", False),  # no digit
+    ("egg/issue-5/work-extra", False),  # trailing chars defeat `work$`
+    ("xegg/issue-5/work", False),  # leading char defeats `^egg/`
+    ("egg/slice-2", False),  # needs an intermediate `<id>/` segment
+    # Multi-segment refs DO match — documents the known over-match (a deliberate
+    # trade-off; human branches are single-segment by convention).
+    ("egg/feature/work", True),
+    ("egg/foo/slice-1", True),
+]
+
+
+@pytest.mark.parametrize(("ref", "skipped"), _REF_CASES)
+def test_skip_patterns_match_expected_refs(ref: str, skipped: bool) -> None:
+    """The pinned regexes skip exactly the pipeline branch shapes (and the
+    documented multi-segment over-match), and let everything else through."""
+    assert _is_skipped(ref) is skipped, (
+        f"ref {ref!r}: expected skipped={skipped}, got {_is_skipped(ref)} — "
+        f"SLICE_RE={SLICE_RE!r} WORK_RE={WORK_RE!r}"
     )

--- a/tests/config/test_sdlc_pr_bot_skip.py
+++ b/tests/config/test_sdlc_pr_bot_skip.py
@@ -145,17 +145,48 @@ def test_autofix_gate_allows_manual_dispatch() -> None:
 # SAME patterns the workflows embed — combined with the bash `||` the gates use —
 # so the actual match/no-match behavior is locked in, not just the spelling.
 #
-# Both gates skip when the head ref matches SLICE_RE *or* WORK_RE. We compile the
-# pinned constants (which `test_*_skips_both_pipeline_shapes` proves are the ones
-# actually present in the scripts) and assert the resulting decision per ref.
+# Crucially, the table runs against the regexes *extracted from the YAML run:
+# script*, not the SLICE_RE/WORK_RE constants. A substring pin (`SLICE_RE in
+# script`) would accept a typo'd workflow regex with a stray trailing character
+# (e.g. `^egg/.+/slice-[0-9]+$X`) — that string contains SLICE_RE as a substring,
+# so the pin passes, yet it matches different refs in bash. Parsing the actual
+# `=~` operands out of the script and feeding *those* through the table closes
+# that gap: a trailing-char regression changes the operand and trips a case here.
 
 
-def _is_skipped(ref: str) -> bool:
-    """True when a head ref matches either pipeline shape — i.e. the bot skips it.
+def _extract_branch_regexes(job: dict, step_id: str) -> list[str]:
+    """Recover the bash ``=~`` regex operands from a should-run check script.
 
-    Mirrors the workflows' ``[[ "$REF" =~ SLICE_RE || "$REF" =~ WORK_RE ]]``.
+    Both gates embed ``[[ "$REF" =~ <slice-re> || "$REF" =~ <work-re> ]]``. The
+    operands are unquoted (bash requires this for ``=~`` to treat the RHS as a
+    regex rather than a literal) and are therefore whitespace-terminated, so a
+    simple ``=~ <non-space-run>`` scan recovers the exact regexes the workflow
+    applies at runtime — including any stray trailing character a typo would
+    introduce, which a substring pin against the constants would silently accept.
     """
-    return bool(re.search(SLICE_RE, ref)) or bool(re.search(WORK_RE, ref))
+    script = _step_run(job, step_id)
+    operands = re.findall(r"=~\s+(\S+)", script)
+    assert operands, (
+        f"no bash `=~` regex operands found in step (id: {step_id}) — the "
+        "branch-topology check is not gating on the head ref at all"
+    )
+    return operands
+
+
+# The two pipeline-PR gates whose embedded regexes drive the behavioral table.
+_BEHAVIORAL_GATES = [
+    pytest.param(REVIEW_CALLER, "should-run", "check", id="review-caller"),
+    pytest.param(AUTOFIX_CALLER, "should-run", "check", id="autofix-caller"),
+]
+
+
+def _is_skipped(ref: str, patterns: list[str]) -> bool:
+    """True when a head ref matches any pipeline shape — i.e. the bot skips it.
+
+    Mirrors the workflows' ``[[ "$REF" =~ <re1> || "$REF" =~ <re2> ]]`` over the
+    regexes actually extracted from the gate's ``run:`` script.
+    """
+    return any(re.search(pattern, ref) for pattern in patterns)
 
 
 # (ref, should_be_skipped). Comments note why, including the deliberate
@@ -186,11 +217,19 @@ _REF_CASES = [
 ]
 
 
+@pytest.mark.parametrize(("workflow", "job_id", "step_id"), _BEHAVIORAL_GATES)
 @pytest.mark.parametrize(("ref", "skipped"), _REF_CASES)
-def test_skip_patterns_match_expected_refs(ref: str, skipped: bool) -> None:
-    """The pinned regexes skip exactly the pipeline branch shapes (and the
-    documented multi-segment over-match), and let everything else through."""
-    assert _is_skipped(ref) is skipped, (
-        f"ref {ref!r}: expected skipped={skipped}, got {_is_skipped(ref)} — "
-        f"SLICE_RE={SLICE_RE!r} WORK_RE={WORK_RE!r}"
+def test_skip_patterns_match_expected_refs(
+    workflow: Path, job_id: str, step_id: str, ref: str, skipped: bool
+) -> None:
+    """Each gate's *embedded* regexes skip exactly the pipeline branch shapes
+    (and the documented multi-segment over-match), and let everything else
+    through. Runs against the operands parsed out of the YAML run: script, so a
+    trailing-char anchor regression that survives the substring pins is caught.
+    """
+    patterns = _extract_branch_regexes(_job(workflow, job_id), step_id)
+    decision = _is_skipped(ref, patterns)
+    assert decision is skipped, (
+        f"{workflow.name} ref {ref!r}: expected skipped={skipped}, got "
+        f"{decision} — extracted patterns={patterns!r}"
     )


### PR DESCRIPTION
## What

The GitHub-level **egg-reviewer** (code review) and **check autofixer** now skip all SDLC pipeline-produced PRs — both slice PRs (\`egg/<id>/slice-<N>\`) and work→main PRs (\`egg/<id>/work\`), e.g. #3248.

## Why

Pipeline PRs are already reviewed and check-fixed in-band by the pipeline's own BRC consensus, so these GitHub-level bots are redundant. Worse, both push commits onto slice branches and pollute slice history (the #3255 problem).

## How

- **\`on-pull-request.yml\`** (code reviewer) — new \`should-run\` gate skips both pipeline branch shapes by head-ref; the \`review\` job is gated on it.
- **\`on-check-failure.yml\`** (autofixer) — its \`should-run\` skips the same shapes via the triggering run's \`head_branch\`.

### Key design decision

The code-review skip lives in the **\`on-pull-request.yml\` caller**, *not* the shared \`reusable-review.yml\`. The **contract-verification** bot (\`on-pull-request-contract-verify.yml\`) also calls \`reusable-review.yml\` and **must keep verifying slice PRs** (#3040) — a blanket skip in the shared file would have silently killed that. \`reusable-review.yml\` is unchanged.

## Preserved

- \`workflow_dispatch\` still forces a manual run of either bot on any PR (escape hatch).
- Human PRs (\`egg/<topic>\`) and the doc-updater (\`egg/doc-update-*\`) don't match the pattern — reviewed/autofixed as before.
- Contract verification untouched; Address Review Feedback untouched (a human can still \`@mention\` the bot on a pipeline PR).

## Tests

- New \`tests/config/test_sdlc_pr_bot_skip.py\` (6 tests) pins both gates and asserts the skip is **not** in \`reusable-review.yml\`.
- Existing \`tests/config/test_contract_verify_workflow.py\` (8 tests) stays green, confirming \`reusable-review.yml\` behavior is preserved.
- \`make lint\` clean.

## Out of scope

The **contract-verification** bot still runs on slice PRs (only the reviewer + autofixer were requested). Easy to add a matching gate to its caller if wanted.