### PR TITLE
feat: human-focused companion drafts for refine and plan phases

### DIFF
--- a/docs/guides/concurrent-execution.md
+++ b/docs/guides/concurrent-execution.md
@@ -48,8 +48,8 @@ When concurrent execution starts, the `ConcurrentPhaseExecutor` (in `orchestrato
 
 | Phase | Spawned roles |
 |-------|--------------|
-| `refine` | `refiner`, `reviewer_refine`, `reviewer_agent_design` (egg repo only) |
-| `plan` | `architect`, `task_planner`, `risk_analyst`, `reviewer_plan` |
+| `refine` | `refiner`, `simplifier`, `reviewer_refine`, `reviewer_agent_design` (egg repo only) |
+| `plan` | `architect`, `task_planner`, `risk_analyst`, `simplifier`, `reviewer_plan` |
 | `implement` | `coder`, `tester`, `documenter`, `reviewer_code`, `reviewer_code_holistic`, `reviewer_contract`, `reviewer_security`, `reviewer_concurrency` |
 
 **Branch model**: For **refine** and **plan**, all agents operate on the pipeline's shared branch (e.g., `egg/issue-123/work`) and coordinate commits via the message bus to sequence their work and avoid conflicts. For **implement**, each slice runs on its own integration branch (`egg/issue-N/slice-M`); the shared-branch coordination described below applies *within* a slice's agent team — see [Slice-DAG Implement Phase](../architecture/slice-dag.md).

--- a/docs/reference/agent-roles.md
+++ b/docs/reference/agent-roles.md
@@ -99,6 +99,8 @@ All agents within a phase run concurrently via BRC consensus. Concurrency is ena
 
 **Reviewed by**: `reviewer_refine` (refine, CRITICAL) / `reviewer_plan` (plan, CRITICAL).
 
+**Failure surface & operator recovery**: because the companion is a mandatory, CRITICAL-reviewed producer artifact, a simplifier crash or a persistent reviewer NACK on the (cosmetic) summary stalls the refine/plan phase gate — a failure surface neither phase had before this role existed. There is intentionally **no automatic degraded fallback** (the gate does not silently proceed on the agent draft alone), so a missing companion is always surfaced rather than swallowed. To recover, the operator can either re-run the stalled phase so the simplifier re-attempts the companion, or — if the simplifier is repeatedly unable to land it — unblock the gate manually: the HITL gate comment falls back to the full agent draft inline whenever the companion is absent (see `_read_human_phase_draft` / the gate composition in `orchestrator/routes/pipelines.py`), so the operator still has the substantive draft in hand to approve against. The mandatory-producer coupling is a deliberate choice that keeps the human-readable summary from silently disappearing; the cost is that a summarization failure blocks substantive progress until the operator intervenes.
+
 ## Plan Phase
 
 ### `architect`

--- a/docs/reference/agent-roles.md
+++ b/docs/reference/agent-roles.md
@@ -9,7 +9,7 @@ Every agent role belongs to one of five categories. Categories enable dynamic te
 | Category | Purpose | Roles |
 |----------|---------|-------|
 | **EXECUTION** | Produce artifacts (code, tests, docs, Jira mutations) | `coder`, `tester`, `documenter`, `applier` |
-| **ANALYSIS** | Analyze tasks and plan work | `refiner`, `architect`, `task_planner`, `risk_analyst` |
+| **ANALYSIS** | Analyze tasks and plan work | `refiner`, `architect`, `task_planner`, `risk_analyst`, `simplifier` |
 | **REVIEW** | Validate quality and correctness | `reviewer_code`, `reviewer_code_holistic`, `reviewer_contract`, `reviewer_refine`, `reviewer_plan`, `reviewer_agent_design`, `reviewer_security`, `reviewer_concurrency` |
 | **UTILITY** | Cross-cutting support tasks | `autofixer`, `conflict_resolver` |
 | **INTERFACE** | Pipeline health and monitoring | `overseer` |
@@ -21,12 +21,13 @@ Use `get_roles_by_category(AgentCategory.REVIEW)` to dynamically query roles by 
 | Role | Category | Phase | Parallel? | Depends On |
 |------|----------|-------|-----------|------------|
 | `refiner` | Analysis | Refine | No | — |
-| `reviewer_refine` | Review | Refine | Yes (with `reviewer_agent_design`) | refiner |
+| `simplifier` | Analysis (dual-role: advisory reviewer of the upstream producer) | Refine + Plan | Yes | refiner (refine) / task_planner (plan), advisory |
+| `reviewer_refine` | Review | Refine | Yes (with `reviewer_agent_design`) | refiner, simplifier |
 | `reviewer_agent_design` | Review | Refine (egg repo only) | Yes (with `reviewer_refine`) | refiner |
 | `architect` | Analysis | Plan | No | — |
 | `task_planner` | Analysis | Plan | Yes (with `risk_analyst`) | architect |
 | `risk_analyst` | Analysis (dual-role: also reviews `architect` + `task_planner`) | Plan | Yes (with `task_planner`) | architect |
-| `reviewer_plan` | Review | Plan | No | architect, task_planner, risk_analyst |
+| `reviewer_plan` | Review | Plan | No | architect, task_planner, risk_analyst, simplifier |
 | `applier` | Execution | Apply (epic-mode only) | No | — |
 | `coder` | Execution | Implement | No | — |
 | `tester` | Execution | Implement | Yes (with `documenter`) | coder |
@@ -79,6 +80,24 @@ All agents within a phase run concurrently via BRC consensus. Concurrency is ena
 
 **Outputs**:
 - `.egg-state/reviews/{identifier}-refine-agent-design-review.json` — Verdict file
+
+### `simplifier`
+
+**Purpose**: Produce a **human-focused companion** to the agent draft — a simplified, higher-level, jargon-free summary for a technical human reviewer outside the pipeline. Runs in **both** the refine and plan phases. The agent-focused drafts (`-analysis.md` / `-plan.md`) are unchanged; the companion is an additional, mandatory artifact.
+
+**Dual-role**: like the implement-phase `tester`, the simplifier is a producer whose work depends on an upstream producer's draft. It carries an **advisory** review edge over the upstream producer (`refiner` in refine, `task_planner` in plan) purely so the BRC `ack` arm re-invokes it when that producer proposes — its verdict never blocks the upstream's consensus. It then reads the proposed draft, writes the companion, and proposes it. The companion is reviewed CRITICAL by `reviewer_refine` (refine) / `reviewer_plan` (plan).
+
+**File access**:
+- Allowed writes: `.egg-state/drafts/`, `.egg-state/agent-outputs/`
+- Blocked: All source code, `.egg-state/contracts/`
+
+**Outputs**:
+- `.egg-state/drafts/{identifier}-analysis-human.md` — Human companion to the refine analysis
+- `.egg-state/drafts/{identifier}-plan-human.md` — Human companion to the implementation plan
+
+**Surfacing**: the companion leads the refine/plan HITL gate comment (with a link to the full agent draft), and is linked from the context PR body. Registered in `shared/egg_contracts/artifact_spec.py` as `analysis-draft-human` / `plan-draft-human`, so its presence is enforced at propose time (existence-only — no parse check).
+
+**Reviewed by**: `reviewer_refine` (refine, CRITICAL) / `reviewer_plan` (plan, CRITICAL).
 
 ## Plan Phase
 

--- a/orchestrator/review_graph.py
+++ b/orchestrator/review_graph.py
@@ -201,6 +201,16 @@ def get_default_refine_graph() -> ReviewGraph:
             ReviewEdge("reviewer_refine", "refiner", ReviewCriticality.CRITICAL),
             # reviewer_agent_design reviews refiner (critical)
             ReviewEdge("reviewer_agent_design", "refiner", ReviewCriticality.CRITICAL),
+            # The simplifier produces the human-focused analysis companion
+            # (faithful + jargon-free), gated CRITICAL by reviewer_refine.
+            # It is DUAL-ROLE — like the implement-phase tester — and carries
+            # an ADVISORY review edge over the refiner so the BRC ``ack`` arm
+            # re-invokes it when the refiner proposes (the proven wake-up the
+            # spawn-dedupe key relies on; a pure producer's first-propose key
+            # is constant and would never re-spawn). Advisory => the
+            # simplifier's verdict never blocks the refiner's consensus.
+            ReviewEdge("reviewer_refine", "simplifier", ReviewCriticality.CRITICAL),
+            ReviewEdge("simplifier", "refiner", ReviewCriticality.ADVISORY),
         ]
     )
 
@@ -242,6 +252,13 @@ def get_default_plan_graph() -> ReviewGraph:
             ReviewEdge("risk_analyst", "architect", ReviewCriticality.CRITICAL),
             # risk_analyst reviews task_planner (critical — risk lens, #2809)
             ReviewEdge("risk_analyst", "task_planner", ReviewCriticality.CRITICAL),
+            # The simplifier produces the human-focused plan companion,
+            # gated CRITICAL by reviewer_plan. Dual-role like the refine-phase
+            # simplifier: an ADVISORY edge over task_planner re-invokes it via
+            # the ``ack`` arm when task_planner proposes (the tester wake-up
+            # pattern). Advisory => it never blocks task_planner's consensus.
+            ReviewEdge("reviewer_plan", "simplifier", ReviewCriticality.CRITICAL),
+            ReviewEdge("simplifier", "task_planner", ReviewCriticality.ADVISORY),
         ]
     )
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -24672,6 +24672,20 @@ def _run_pipeline(
 
                     # Detect whether the gate content changed compared to the
                     # previous phase_gate decision for this phase (if any).
+                    #
+                    # NB: this compares ``gate_context``, which leads with the
+                    # simplifier's human-focused summary when a companion
+                    # exists. That summary is intentionally high-level and
+                    # lossy, so a re-refinement that materially changes the
+                    # detailed agent draft *without* altering the summary will
+                    # report ``content_changed=False``. The flag only feeds the
+                    # overseer's no-op-rerun health heuristic
+                    # (``overseer/monitor.py`` ``_check_rerun_anomaly``) — it
+                    # never gates re-prompting — so a missed change here is at
+                    # worst a suppressed advisory alert, not a correctness
+                    # issue. We compare the gate content (not the full draft)
+                    # deliberately so the heuristic tracks what the operator
+                    # actually sees at the gate.
                     _content_changed: bool | None = None
                     _prev_gate = next(
                         (

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5525,6 +5525,34 @@ def _get_draft_path(
     return f".egg-state/drafts/{prefix}-{filename}"
 
 
+# Human-focused companion drafts (mandatory, produced by the simplifier).
+# Resolved through the same artifact-spec registry as the agent drafts so
+# the path knowledge lives in exactly one place. Kept separate from
+# ``_get_draft_path`` (which is pinned byte-for-byte by a consistency test
+# and switches on the real phase value) rather than overloading its phase
+# argument with a synthetic ``refine-human`` key.
+_HUMAN_SPEC_BY_PHASE = {"refine": "analysis-draft-human", "plan": "plan-draft-human"}
+
+
+def _get_human_draft_path(
+    phase: str,
+    issue_number: int | None = None,
+    pipeline_id: str | None = None,
+) -> str | None:
+    """Return the relative path to the human-focused companion draft.
+
+    Returns ``None`` for phases without a registered human companion
+    (currently only ``refine`` and ``plan`` have one).
+    """
+    spec_name = _HUMAN_SPEC_BY_PHASE.get(phase)
+    if spec_name is None:
+        return None
+    from egg_contracts.artifact_spec import resolve_artifact_path
+
+    identifier = _pipeline_identifier(issue_number, pipeline_id or "unknown")
+    return resolve_artifact_path(spec_name, identifier)
+
+
 def _cleanup_stale_generic_drafts(worktree_path: Path) -> bool:
     """Remove unprefixed generic draft files from a worktree.
 
@@ -6121,6 +6149,49 @@ def _read_phase_draft(
         if content is not None:
             logger.info(
                 "Read draft from remote tracking ref (local copy missing)",
+                phase=phase,
+                branch=branch,
+            )
+            return _truncate(content)
+
+    return None
+
+
+def _read_human_phase_draft(
+    repo_path: Path,
+    phase: str,
+    issue_number: int | None = None,
+    pipeline_id: str | None = None,
+    max_chars: int = 32000,
+    branch: str | None = None,
+) -> str | None:
+    """Read the human-focused companion draft for a phase.
+
+    Mirrors :func:`_read_phase_draft` (disk first, then the
+    ``git show origin/{branch}`` fallback for a copy that only landed on
+    the remote branch), but resolves the path via
+    :func:`_get_human_draft_path` and has no generic-path variant — the
+    companion is always pipeline-identified. Returns ``None`` when the
+    companion is absent (so the gate falls back to the agent draft).
+    """
+    human_rel = _get_human_draft_path(phase, issue_number=issue_number, pipeline_id=pipeline_id)
+    if not human_rel:
+        return None
+
+    def _truncate(content: str) -> str:
+        if len(content) > max_chars:
+            return content[:max_chars] + f"\n\n... (truncated, {len(content)} chars total)"
+        return content
+
+    human_path = repo_path / human_rel
+    if human_path.exists():
+        return _truncate(human_path.read_text(encoding="utf-8"))
+
+    if branch:
+        content = _git_show_draft(repo_path, branch, human_rel)
+        if content is not None:
+            logger.info(
+                "Read human companion draft from remote tracking ref (local copy missing)",
                 phase=phase,
                 branch=branch,
             )
@@ -9830,6 +9901,12 @@ def _compose_context_pr_body(
             )
             if rel_path and (worktree_repo_path / rel_path).is_file():
                 doc_links.append(f"[{label}]({link_base}/{rel_path})")
+            # Human-focused companion (the simplifier's ``*-human.md``), when present.
+            human_rel = _get_human_draft_path(
+                phase, issue_number=pipeline.issue_number, pipeline_id=pipeline.id
+            )
+            if human_rel and (worktree_repo_path / human_rel).is_file():
+                doc_links.append(f"[{label} (human summary)]({link_base}/{human_rel})")
         if doc_links:
             body_lines.append(f"- Docs: {', '.join(doc_links)}")
             has_meaningful_content = True
@@ -12632,6 +12709,7 @@ def _build_brc_preamble(
             "architect",
             "task_planner",
             "risk_analyst",
+            "simplifier",
         )
         is_reviewer = role_value in (
             "reviewer_code",
@@ -12641,6 +12719,10 @@ def _build_brc_preamble(
             "reviewer_refine",
             "reviewer_agent_design",
             "reviewer_plan",
+            # simplifier is dual-role: advisory reviewer of the upstream
+            # refine/plan producer (its wake-up arm), plus producer of the
+            # human-focused companion draft.
+            "simplifier",
         )
         reviewers = []
         producers = []
@@ -13159,6 +13241,11 @@ _ROLE_DESCRIPTIONS: dict[str, tuple[str, str]] = {
         "Reviews plan phase outputs",
         "ACK/NACK on architecture, tasks, and risk assessment",
     ),
+    "simplifier": (
+        "Distills the producer's draft into a jargon-free, human-focused "
+        "companion summary (depends on the producer's pushed draft)",
+        "a simplified `*-human.md` companion to the analysis/plan",
+    ),
 }
 
 
@@ -13316,10 +13403,22 @@ def _build_reviewer_preparation(
                 "task groups with no internal dependency. Name the seam in "
                 "your NACK so the architect's re-propose is actionable. "
                 "See criteria §11 for the full rubric and examples."
+                "\n\n"
+                "**Human-focused plan companion (the simplifier's "
+                "``*-plan-human.md``):** the simplifier produces a simplified, "
+                "jargon-free companion to the plan for a technical human "
+                "reviewer outside the pipeline. You review it (CRITICAL). ACK "
+                "only when it faithfully captures the plan's essence, stays "
+                "high-level and digestible, and is free of egg-internal jargon "
+                "(no BRC/consensus/slice-DAG/contract/role terms). NACK the "
+                "**simplifier** (not the task_planner) if it misrepresents the "
+                "plan, leaks pipeline jargon, omits a material point, or merely "
+                "duplicates the full plan. A missing or empty companion is a "
+                "NACK — the companion is mandatory."
             )
     elif phase == "refine":
         if role_value in ("reviewer_refine", "reviewer_agent_design"):
-            return (
+            base = (
                 "While waiting for the refiner's proposal, prepare by: "
                 "(a) reading the prior review feedback that triggered this "
                 "refinement cycle, "
@@ -13329,6 +13428,21 @@ def _build_reviewer_preparation(
                 "When the proposal arrives, focus on whether the specific "
                 "feedback items were addressed."
             )
+            if role_value == "reviewer_refine":
+                base += (
+                    "\n\n"
+                    "**Human-focused analysis companion (the simplifier's "
+                    "``*-analysis-human.md``):** the simplifier produces a "
+                    "simplified, jargon-free companion to the analysis for a "
+                    "technical human reviewer outside the pipeline. You review "
+                    "it (CRITICAL). ACK only when it faithfully captures the "
+                    "analysis's essence, stays high-level and digestible, and is "
+                    "free of egg-internal jargon. NACK the **simplifier** (not "
+                    "the refiner) if it misrepresents the analysis, leaks "
+                    "pipeline jargon, or merely duplicates the full draft. A "
+                    "missing or empty companion is a NACK — it is mandatory."
+                )
+            return base
 
     # Generic fallback
     return (
@@ -13535,6 +13649,40 @@ def _build_producer_orientation(
         reviewer_awareness = (
             f" Your work will be reviewed by **{reviewer_names}** — "
             "keep their review criteria in mind as you work."
+        )
+
+    # The simplifier runs in both the refine and plan phases and is
+    # DUAL-ROLE (advisory reviewer of the upstream producer + producer of
+    # the human-focused companion). Its producer WORK depends on the
+    # upstream producer's draft existing, so — like the implement-phase
+    # tester — it orients up-front and starts producing only once the
+    # upstream proposes (the event pump re-invokes it on that PROPOSE via
+    # its advisory review arm).
+    if role_value == "simplifier":
+        if phase == "plan":
+            upstream, draft_desc = "task_planner", "the implementation plan"
+        else:  # refine
+            upstream, draft_desc = "refiner", "the refine analysis"
+        sync_note = ""
+        if branch:
+            sync_note = (
+                f" When re-invoked on the PROPOSE, sync your worktree first: "
+                f"`git fetch origin && git merge origin/{branch} --no-edit`."
+            )
+        return (
+            f"your producer WORK depends on **{upstream}**'s draft of {draft_desc} "
+            "existing — do NOT write your companion before it is pushed. ORIENT "
+            "now (read the contract and the issue/task description so you "
+            "understand the subject), then exit; the event pump re-invokes you "
+            f"when **{upstream}** issues `CONSENSUS_PROPOSE`, carrying that "
+            "proposal in your event payload. On that invocation: read the "
+            "upstream draft, then write a simplified, higher-level companion "
+            "that captures its essence in plain, jargon-free language for a "
+            "technical reader outside the pipeline, and PROPOSE it. In the same "
+            f"pass, issue your ADVISORY review verdict on **{upstream}** — ACK "
+            "(you read the draft to summarize it), or NACK only if the draft is "
+            "too incoherent to faithfully summarize. Your verdict is advisory "
+            f"and never blocks **{upstream}**'s consensus." + sync_note + reviewer_awareness
         )
 
     if phase == "implement":
@@ -13924,6 +14072,9 @@ def _build_agent_prompt(
     _architect_output_path = _resolve_artifact_path("architect-output", _identifier)
     _architect_slices_path = _resolve_artifact_path("architect-slices", _identifier)
     _risk_analyst_output_path = _resolve_artifact_path("risk-analyst-output", _identifier)
+    # Human-focused companion drafts the simplifier produces (one per phase).
+    _analysis_human_path = _resolve_artifact_path("analysis-draft-human", _identifier)
+    _plan_human_path = _resolve_artifact_path("plan-draft-human", _identifier)
 
     # Role-specific instructions
     lines.append("## Your Task\n")
@@ -14713,6 +14864,73 @@ def _build_agent_prompt(
                 "notes. Be specific in ``feedback`` — name the file, "
                 "the slice, the missing mitigation — so the upstream "
                 "producer's re-propose is actionable.",
+                "",
+                *_EXPLORATION_SUBAGENT_GUIDANCE,
+            ]
+        )
+    elif role_value == "simplifier":
+        if phase == "plan":
+            _upstream = "task_planner"
+            _upstream_draft = "the implementation plan"
+            _human_path = _plan_human_path
+            _essence = (
+                "what will be built, the major steps/phases, the test strategy "
+                "in brief, and the key risks"
+            )
+        else:  # refine
+            _upstream = "refiner"
+            _upstream_draft = "the refine analysis"
+            _human_path = _analysis_human_path
+            _essence = "the problem, the recommended approach, and the key trade-offs"
+        lines.extend(
+            [
+                "**You are dual-role (producer AND advisory reviewer) in this "
+                "phase.** You produce a human-focused companion to "
+                f"{_upstream_draft}, and you carry an ADVISORY review edge over "
+                f"**{_upstream}** purely so the event pump re-invokes you when it "
+                "proposes — your verdict never blocks its consensus. The "
+                "*Dual-Role Execution Order* banner in your BRC preamble is the "
+                "authoritative ordering — read it first.",
+                "",
+                "## Producer role (human-focused companion)",
+                "",
+                f"Your WORK depends on **{_upstream}**'s draft existing. ORIENT "
+                f"now, then start producing only once **{_upstream}** issues "
+                "`CONSENSUS_PROPOSE` (the event pump re-invokes you carrying that "
+                "proposal). On that invocation:",
+                "",
+                f"1. Read **{_upstream}**'s draft of {_upstream_draft}.",
+                f"2. Write a HUMAN-FOCUSED companion to `{_human_path}`. This is a "
+                "simplified, higher-level summary for a **technical** human "
+                "reviewer who is NOT part of the pipeline. Capture the essence: "
+                f"{_essence}.",
+                "",
+                "   Rules:",
+                "   - **No egg-internal jargon.** Do not mention BRC, consensus, "
+                "propose/ACK/NACK, slices / slice-DAG, contracts, phases, "
+                "`serialized_chain_order`, Jaccard, or agent-role names. Describe "
+                "independently-shippable pieces in plain terms if you must "
+                "reference them at all.",
+                "   - **Much shorter and more digestible** than the upstream "
+                "draft — prose and short lists, not exhaustive enumeration.",
+                "   - **Faithful** — reflect the upstream draft accurately; "
+                "introduce no new scope, claims, or recommendations.",
+                "   - The audience is technical, so domain and code specifics are "
+                "fine; pipeline mechanics are not.",
+                "",
+                f"3. Commit and push `{_human_path}`, then PROPOSE it via "
+                "`egg-orch consensus propose`. The companion is **mandatory** — "
+                "always write at least a one-paragraph summary; do NOT take the "
+                "no-op propose path.",
+                "",
+                f"## Reviewer role (advisory, on {_upstream})",
+                "",
+                f"When **{_upstream}** proposes, emit an ADVISORY verdict in the "
+                "same pass: `egg-orch consensus ack` (you read the draft to "
+                "summarize it), or `egg-orch consensus nack` **only** if the "
+                "draft is too incoherent or incomplete to summarize faithfully. "
+                "Advisory means your verdict is recorded but never blocks "
+                f"**{_upstream}**'s consensus.",
                 "",
                 *_EXPLORATION_SUBAGENT_GUIDANCE,
             ]
@@ -24424,7 +24642,35 @@ def _run_pipeline(
                         f"or provide feedback to request changes."
                     )
 
-                    # Detect whether the draft changed compared to the
+                    # Lead the gate comment with the simplifier's human-focused
+                    # companion (simplified, jargon-free) when present, and link
+                    # the full agent draft for depth. Falls back to the full
+                    # draft inline when no companion exists (older pipelines,
+                    # or the companion failed to land).
+                    human_content = _read_human_phase_draft(
+                        worktree_repo_path,
+                        current_phase.value,
+                        issue_number=pipeline.issue_number,
+                        pipeline_id=pipeline_id,
+                        branch=pipeline.branch,
+                    )
+                    gate_context = draft_content
+                    if human_content:
+                        full_draft_link = ""
+                        draft_rel = _get_draft_path(
+                            current_phase.value,
+                            issue_number=pipeline.issue_number,
+                            pipeline_id=pipeline_id,
+                        )
+                        if pipeline.repo and pipeline.branch and draft_rel:
+                            blob = f"https://github.com/{pipeline.repo}/blob/{pipeline.branch}"
+                            full_draft_link = (
+                                f"\n\n[View the full detailed {phase_label} draft]"
+                                f"({blob}/{draft_rel})"
+                            )
+                        gate_context = f"{human_content}{full_draft_link}"
+
+                    # Detect whether the gate content changed compared to the
                     # previous phase_gate decision for this phase (if any).
                     _content_changed: bool | None = None
                     _prev_gate = next(
@@ -24438,12 +24684,12 @@ def _run_pipeline(
                         None,
                     )
                     if _prev_gate is not None:
-                        _content_changed = draft_content != _prev_gate.context
+                        _content_changed = gate_context != _prev_gate.context
 
                     dq = get_decision_queue(pipeline_id, repo_path)
                     decision = dq.queue_decision(
                         question=question,
-                        context=draft_content,
+                        context=gate_context,
                         options=["approve", "request changes"],
                         decision_type="phase_gate",
                         phase=current_phase,

--- a/orchestrator/routes/signals.py
+++ b/orchestrator/routes/signals.py
@@ -1242,7 +1242,9 @@ def _validate_plan_extensions(
 
 _ARTIFACT_HUMAN_LABEL: dict[str, str] = {
     "analysis-draft": "analysis draft",
+    "analysis-draft-human": "human-focused analysis summary",
     "plan-draft": "plan draft",
+    "plan-draft-human": "human-focused plan summary",
     "architect-output": "architect-output artifact",
     "architect-slices": "architect-slices scaffold",
     "risk-analyst-output": "risk-analyst-output artifact",

--- a/orchestrator/tests/test_ble001_narrowing_audit.py
+++ b/orchestrator/tests/test_ble001_narrowing_audit.py
@@ -120,11 +120,12 @@ def test_audit_window_retains_documented_ble001_population() -> None:
     [15131, 16105] to [15700, 16850] after slice-4 (#2548) inserted
     ~775 lines earlier in the file (eager-persist of
     ``parent_branch_at_creation``, merge-base fallback in
-    ``_resolve_slice_base_branch``, Layer-C bootstrap). The shifted
-    window captures the same audited handlers plus 3 additional
-    noqa sites added by slice-4 inside the same region (each
-    following the documented variable-name + inline-comment
-    pattern).
+    ``_resolve_slice_base_branch``, Layer-C bootstrap), then to
+    [15923, 17073] after the human-focused draft companion work
+    inserted ~223 lines earlier in the file (the ``simplifier``
+    role's orientation + task prompt, ``_get_human_draft_path`` /
+    ``_read_human_phase_draft`` helpers, reviewer-prep additions).
+    The shifted window captures the same audited handlers.
 
     We pin the population count loosely (>=10 sites in window — the
     audit allowed narrowing 4 of the original 20) rather than the
@@ -139,7 +140,7 @@ def test_audit_window_retains_documented_ble001_population() -> None:
     after the handler, others via a preceding block comment).
     """
     lines = _PIPELINES_SRC.splitlines()
-    audit_window = range(15700 - 1, 16850 + 1)  # zero-indexed slice
+    audit_window = range(15923 - 1, 17073 + 1)  # zero-indexed slice
     noqa_lines = [i for i, line in enumerate(lines) if "noqa: BLE001" in line and i in audit_window]
     assert len(noqa_lines) >= 10, (
         f"Expected at least 10 ``# noqa: BLE001`` swallow sites inside the "

--- a/orchestrator/tests/test_concurrent_executor.py
+++ b/orchestrator/tests/test_concurrent_executor.py
@@ -465,6 +465,23 @@ class TestReviewGraphIntegration:
         assert "reviewer_refine" in graph.critical_reviewers_for("refiner")
         assert "reviewer_agent_design" in graph.critical_reviewers_for("refiner")
 
+        # The simplifier produces the human-focused companion and is
+        # dual-role: CRITICAL-reviewed by reviewer_refine, and carrying an
+        # ADVISORY edge over the refiner so the BRC ``ack`` arm re-invokes
+        # it when the refiner proposes. These four properties are
+        # load-bearing — a regression that dropped the advisory edge or
+        # flipped its criticality would silently break the wake-up.
+        assert graph.is_producer("simplifier")
+        assert graph.is_reviewer("simplifier")
+        assert graph.is_dual_role("simplifier")
+        # reviewer_refine CRITICAL-reviews the simplifier's companion
+        assert "reviewer_refine" in graph.reviewers_for("simplifier")
+        assert "reviewer_refine" in graph.critical_reviewers_for("simplifier")
+        # simplifier reviews refiner ADVISORY (wake-up edge, never blocks)
+        assert "simplifier" in graph.reviewers_for("refiner")
+        assert "simplifier" in graph.advisory_reviewers_for("refiner")
+        assert "simplifier" not in graph.critical_reviewers_for("refiner")
+
         # Phase lookup returns same structure
         phase_graph = get_review_graph_for_phase("refine")
         assert len(phase_graph.edges) == len(graph.edges)
@@ -496,6 +513,24 @@ class TestReviewGraphIntegration:
         assert "risk_analyst" in graph.reviewers_for("task_planner")
         assert "risk_analyst" in graph.critical_reviewers_for("architect")
         assert "risk_analyst" in graph.critical_reviewers_for("task_planner")
+
+        # The simplifier produces the human-focused plan companion and is
+        # dual-role like the refine-phase simplifier: CRITICAL-reviewed by
+        # reviewer_plan, with an ADVISORY edge over task_planner so the BRC
+        # ``ack`` arm re-invokes it when task_planner proposes. These four
+        # properties are load-bearing — a regression that dropped the
+        # advisory edge or flipped its criticality would silently break the
+        # wake-up.
+        assert graph.is_producer("simplifier")
+        assert graph.is_reviewer("simplifier")
+        assert graph.is_dual_role("simplifier")
+        # reviewer_plan CRITICAL-reviews the simplifier's companion
+        assert "reviewer_plan" in graph.reviewers_for("simplifier")
+        assert "reviewer_plan" in graph.critical_reviewers_for("simplifier")
+        # simplifier reviews task_planner ADVISORY (wake-up edge, never blocks)
+        assert "simplifier" in graph.reviewers_for("task_planner")
+        assert "simplifier" in graph.advisory_reviewers_for("task_planner")
+        assert "simplifier" not in graph.critical_reviewers_for("task_planner")
 
         # Phase lookup returns same structure
         phase_graph = get_review_graph_for_phase("plan")

--- a/orchestrator/tests/test_models.py
+++ b/orchestrator/tests/test_models.py
@@ -1101,6 +1101,7 @@ class TestAgentRole:
         assert AgentRole.TASK_PLANNER in roles
         assert AgentRole.RISK_ANALYST in roles
         assert AgentRole.REFINER in roles
+        assert AgentRole.SIMPLIFIER in roles
         assert AgentRole.REVIEWER_CODE in roles
         assert AgentRole.REVIEWER_CODE_HOLISTIC in roles
         assert AgentRole.REVIEWER_CONTRACT in roles
@@ -1115,9 +1116,10 @@ class TestAgentRole:
         # Registry-size pin. Count grew from the original 18 → 19 with
         # APPLIER (#1557) → 20 with ORCHESTRATOR (#2893) → back to 19 when
         # ORCHESTRATOR was removed (#2925: the orchestrator is the control
-        # plane, not an agent role). Bump this and add the matching
+        # plane, not an agent role) → 20 with SIMPLIFIER (human-focused
+        # draft companions). Bump this and add the matching
         # `assert AgentRole.X in roles` above whenever a new role lands.
-        assert len(roles) == 19
+        assert len(roles) == 20
 
 
 class TestBackwardCompatibility:

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -4514,6 +4514,23 @@ class TestProducerOrientation:
         assert "tasks[].files" in orient
         assert "acceptance criteria" in orient.lower()
 
+    def test_simplifier_orientation_gates_on_upstream_propose(self):
+        """The refine-phase simplifier orientation tells it its work depends
+        on the refiner's CONSENSUS_PROPOSE and is re-invoked by the event
+        pump — the proven tester-style dependency wake-up."""
+        orient = _build_producer_orientation("simplifier", "refine", ["reviewer_refine"])
+        assert "refiner" in orient
+        assert "CONSENSUS_PROPOSE" in orient
+        assert "event pump" in orient.lower()
+        assert "jargon-free" in orient.lower()
+
+    def test_simplifier_orientation_plan_phase_targets_task_planner(self):
+        """The plan-phase simplifier orientation targets the task_planner's
+        plan as its upstream draft."""
+        orient = _build_producer_orientation("simplifier", "plan", ["reviewer_plan"])
+        assert "task_planner" in orient
+        assert "CONSENSUS_PROPOSE" in orient
+
     def test_tester_orientation_contains_dual_mandate_pointer(self):
         """Tester orientation carries a brief dual-mandate pointer, NOT the
         full failing-test → NACK → HANDOFF instruction.

--- a/orchestrator/tests/test_read_phase_draft.py
+++ b/orchestrator/tests/test_read_phase_draft.py
@@ -14,7 +14,9 @@ from routes.pipelines import (
     _cleanup_stale_generic_drafts,
     _draft_filename,
     _get_generic_draft_path,
+    _get_human_draft_path,
     _git_show_draft,
+    _read_human_phase_draft,
     _read_phase_draft,
 )
 
@@ -627,3 +629,180 @@ class TestReadPhaseDraftGitShowFallback:
         # Should have an info log about reading from remote ref
         info_calls = mock_logger.info.call_args_list
         assert any("remote tracking ref" in call[0][0] for call in info_calls)
+
+
+class TestGetHumanDraftPath:
+    """Tests for _get_human_draft_path."""
+
+    def test_refine_returns_analysis_human_md(self):
+        """Refine phase maps to the issue-prefixed -analysis-human.md path."""
+        result = _get_human_draft_path("refine", issue_number=42)
+        assert result == ".egg-state/drafts/42-analysis-human.md"
+
+    def test_plan_returns_plan_human_md(self):
+        """Plan phase maps to the issue-prefixed -plan-human.md path."""
+        result = _get_human_draft_path("plan", issue_number=7)
+        assert result == ".egg-state/drafts/7-plan-human.md"
+
+    def test_pipeline_id_used_when_no_issue(self):
+        """Pipeline ID is used as prefix when no issue_number is provided."""
+        result = _get_human_draft_path("refine", pipeline_id="pid123")
+        assert result == ".egg-state/drafts/pid123-analysis-human.md"
+
+    def test_implement_phase_returns_none(self):
+        """Phases without a registered human companion return None."""
+        assert _get_human_draft_path("implement", issue_number=42) is None
+
+    def test_unknown_phase_returns_none(self):
+        """Arbitrary phases have no human companion; returns None."""
+        assert _get_human_draft_path("review", issue_number=42) is None
+
+    def test_human_suffix_disjoint_from_agent_draft(self):
+        """The companion suffix must not collide with the agent draft path."""
+        from routes.pipelines import _get_draft_path
+
+        human = _get_human_draft_path("refine", issue_number=42)
+        agent = _get_draft_path("refine", issue_number=42)
+        assert human != agent
+        assert human == ".egg-state/drafts/42-analysis-human.md"
+        assert agent == ".egg-state/drafts/42-analysis.md"
+
+
+class TestReadHumanPhaseDraft:
+    """Tests for _read_human_phase_draft (the human companion reader)."""
+
+    def test_returns_full_content_within_limit(self, tmp_path: Path):
+        """Content shorter than max_chars is returned in full."""
+        drafts = tmp_path / ".egg-state" / "drafts"
+        drafts.mkdir(parents=True)
+        (drafts / "42-analysis-human.md").write_text("human summary", encoding="utf-8")
+
+        result = _read_human_phase_draft(tmp_path, "refine", issue_number=42)
+        assert result == "human summary"
+
+    def test_truncates_content_exceeding_limit(self, tmp_path: Path):
+        """Content longer than max_chars is truncated with a suffix."""
+        drafts = tmp_path / ".egg-state" / "drafts"
+        drafts.mkdir(parents=True)
+        content = "x" * 200
+        (drafts / "42-analysis-human.md").write_text(content, encoding="utf-8")
+
+        result = _read_human_phase_draft(tmp_path, "refine", issue_number=42, max_chars=100)
+        assert result.startswith("x" * 100)
+        assert "... (truncated, 200 chars total)" in result
+
+    def test_plan_phase_reads_plan_human(self, tmp_path: Path):
+        """Plan phase reads the -plan-human.md companion."""
+        drafts = tmp_path / ".egg-state" / "drafts"
+        drafts.mkdir(parents=True)
+        (drafts / "7-plan-human.md").write_text("plan summary", encoding="utf-8")
+
+        result = _read_human_phase_draft(tmp_path, "plan", issue_number=7)
+        assert result == "plan summary"
+
+    def test_pipeline_id_used_when_no_issue(self, tmp_path: Path):
+        """Pipeline ID is used as prefix when no issue_number is provided."""
+        drafts = tmp_path / ".egg-state" / "drafts"
+        drafts.mkdir(parents=True)
+        (drafts / "pid123-analysis-human.md").write_text("human", encoding="utf-8")
+
+        result = _read_human_phase_draft(tmp_path, "refine", pipeline_id="pid123")
+        assert result == "human"
+
+    def test_missing_companion_returns_none(self, tmp_path: Path):
+        """Returns None when the companion file does not exist (gate falls back)."""
+        drafts = tmp_path / ".egg-state" / "drafts"
+        drafts.mkdir(parents=True)
+
+        result = _read_human_phase_draft(tmp_path, "refine", issue_number=42)
+        assert result is None
+
+    def test_no_companion_for_implement_phase(self, tmp_path: Path):
+        """Implement phase has no human companion; returns None."""
+        result = _read_human_phase_draft(tmp_path, "implement", issue_number=42)
+        assert result is None
+
+    def test_no_generic_fallback(self, tmp_path: Path):
+        """Unlike the agent reader, the companion has no generic-path variant.
+
+        An unprefixed analysis-human.md must NOT satisfy a pipeline-identified
+        read — the companion is always pipeline-identified.
+        """
+        drafts = tmp_path / ".egg-state" / "drafts"
+        drafts.mkdir(parents=True)
+        (drafts / "analysis-human.md").write_text("generic should be ignored", encoding="utf-8")
+
+        result = _read_human_phase_draft(tmp_path, "refine", issue_number=42)
+        assert result is None
+
+    def test_git_show_fallback_when_disk_missing(self, tmp_path: Path, monkeypatch):
+        """Falls back to git show when the disk copy only landed on the remote."""
+        import routes.pipelines as mod
+
+        drafts = tmp_path / ".egg-state" / "drafts"
+        drafts.mkdir(parents=True)
+
+        captured: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "human draft from remote"
+            return result
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+        result = _read_human_phase_draft(
+            tmp_path, "refine", pipeline_id="pid123", branch="egg/pid123/work"
+        )
+        assert result == "human draft from remote"
+        # The ref:path must target the human companion path
+        assert any("pid123-analysis-human.md" in c[-1] for c in captured)
+
+    def test_git_show_not_attempted_without_branch(self, tmp_path: Path, monkeypatch):
+        """Git show is not attempted when branch is None."""
+        import routes.pipelines as mod
+
+        drafts = tmp_path / ".egg-state" / "drafts"
+        drafts.mkdir(parents=True)
+
+        call_log: list = []
+
+        def fake_run(cmd, **kwargs):
+            call_log.append(cmd)
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "should not be read"
+            return result
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+        result = _read_human_phase_draft(tmp_path, "refine", pipeline_id="pid123")
+        assert result is None
+        assert len(call_log) == 0
+
+    def test_disk_preferred_over_git_show(self, tmp_path: Path, monkeypatch):
+        """Disk copy is preferred over git show even when branch is provided."""
+        import routes.pipelines as mod
+
+        drafts = tmp_path / ".egg-state" / "drafts"
+        drafts.mkdir(parents=True)
+        (drafts / "pid123-analysis-human.md").write_text("disk human", encoding="utf-8")
+
+        call_log: list = []
+
+        def fake_run(cmd, **kwargs):
+            call_log.append(cmd)
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "remote human"
+            return result
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+        result = _read_human_phase_draft(
+            tmp_path, "refine", pipeline_id="pid123", branch="egg/pid123/work"
+        )
+        assert result == "disk human"
+        assert len(call_log) == 0

--- a/shared/egg_contracts/agent_roles.py
+++ b/shared/egg_contracts/agent_roles.py
@@ -53,7 +53,7 @@ class AgentRole(StrEnum):
     The orchestrator uses these roles to parallelize work where dependencies allow.
 
     Execution roles: CODER, TESTER, DOCUMENTER
-    Analysis roles: ARCHITECT, TASK_PLANNER, RISK_ANALYST, REFINER
+    Analysis roles: ARCHITECT, TASK_PLANNER, RISK_ANALYST, REFINER, SIMPLIFIER
     Review roles: REVIEWER_CODE, REVIEWER_CODE_HOLISTIC,
                   REVIEWER_CONTRACT, REVIEWER_AGENT_DESIGN,
                   REVIEWER_REFINE, REVIEWER_PLAN,
@@ -77,6 +77,11 @@ class AgentRole(StrEnum):
     TASK_PLANNER = "task_planner"
     RISK_ANALYST = "risk_analyst"
     REFINER = "refiner"
+    # Distills a producer's draft (refine analysis / plan) into a
+    # human-focused, jargon-free companion copy. Runs in the refine and
+    # plan phases as a producer gated on the upstream producer's
+    # CONSENSUS_PROPOSE (the coder→tester dependency pattern).
+    SIMPLIFIER = "simplifier"
     # Review roles
     REVIEWER_CODE = "reviewer_code"
     REVIEWER_CODE_HOLISTIC = "reviewer_code_holistic"
@@ -524,6 +529,54 @@ REFINER_ROLE = AgentRoleDefinition(
     requires_inputs=[],
 )
 
+# Simplifier role (human-focused draft companions). Runs in BOTH the
+# refine and plan phases as a producer of the ``*-human.md`` companion
+# copy. It does NOT review the upstream producer — its work simply
+# depends on the producer's pushed draft, so it is sequenced via the
+# BRC dependency prompt (the coder→tester convention), not a review
+# edge. ``dependencies`` is left empty: that field feeds the
+# write-overlap / dependency-graph wave analysis (which runs per-phase
+# against the phase's role set), and this single role-def spans two
+# phases with two different upstreams, so coupling it to one producer
+# here would be wrong. File access mirrors the refiner: drafts and
+# agent-outputs only.
+SIMPLIFIER_ROLE = AgentRoleDefinition(
+    role=AgentRole.SIMPLIFIER,
+    description=(
+        "Distills the producer's draft into a jargon-free, human-focused "
+        "companion summary in the refine and plan phases"
+    ),
+    category=AgentCategory.ANALYSIS,
+    responsibilities=[
+        "Read the upstream producer's draft (refine analysis or plan)",
+        "Write a simplified, higher-level companion that captures the essence",
+        "Keep it digestible for a technical reader outside the pipeline",
+        "Use no egg-internal jargon (no BRC, consensus, slice-DAG, contract, "
+        "propose/ACK/NACK, phase, or agent-role terms)",
+        "Faithfully reflect the upstream draft — introduce no new scope",
+    ],
+    dependencies=[],
+    file_access=FileAccessPattern(
+        allowed_read=[],  # Can read all files
+        allowed_write=[
+            ".egg-state/drafts/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=[
+            "**/*.py",
+            "**/*.ts",
+            "**/*.tsx",
+            "**/*.js",
+            "**/*.jsx",
+            "**/*.go",
+            "**/*.java",
+            ".egg-state/contracts/",
+        ],
+    ),
+    produces_outputs=["analysis_draft_human", "plan_draft_human"],
+    requires_inputs=["analysis_draft", "task_breakdown"],
+)
+
 # Reviewer agent role definitions
 # Reviewers can only write to reviews/ and agent-outputs/ directories.
 # Use directory-based blocks instead of "**/*" which breaks can_write()
@@ -922,6 +975,7 @@ AGENT_ROLES: dict[AgentRole, AgentRoleDefinition] = {
     AgentRole.TASK_PLANNER: TASK_PLANNER_ROLE,
     AgentRole.RISK_ANALYST: RISK_ANALYST_ROLE,
     AgentRole.REFINER: REFINER_ROLE,
+    AgentRole.SIMPLIFIER: SIMPLIFIER_ROLE,
     # Review roles
     AgentRole.REVIEWER_CODE: REVIEWER_CODE_ROLE,
     AgentRole.REVIEWER_CODE_HOLISTIC: REVIEWER_CODE_HOLISTIC_ROLE,
@@ -988,6 +1042,10 @@ AGENT_ROLE_TO_CONTRACT_ROLE: dict[AgentRole, Role] = {
     AgentRole.TASK_PLANNER: Role.IMPLEMENTER,
     AgentRole.RISK_ANALYST: Role.IMPLEMENTER,
     AgentRole.REFINER: Role.IMPLEMENTER,
+    # Simplifier: produces the human-focused companion draft; writes the
+    # same draft/agent-output contract fields as the other analysis
+    # producers.
+    AgentRole.SIMPLIFIER: Role.IMPLEMENTER,
     # Review: verdicts and phase-status/current_phase mutations
     AgentRole.REVIEWER_CODE: Role.REVIEWER,
     AgentRole.REVIEWER_CODE_HOLISTIC: Role.REVIEWER,
@@ -1153,8 +1211,13 @@ class AgentExecution:
 
 _PHASE_ROLES: dict[str, list[AgentRole]] = {
     "implement": [AgentRole.CODER, AgentRole.TESTER, AgentRole.DOCUMENTER],
-    "plan": [AgentRole.ARCHITECT, AgentRole.TASK_PLANNER, AgentRole.RISK_ANALYST],
-    "refine": [AgentRole.REFINER],
+    "plan": [
+        AgentRole.ARCHITECT,
+        AgentRole.TASK_PLANNER,
+        AgentRole.RISK_ANALYST,
+        AgentRole.SIMPLIFIER,
+    ],
+    "refine": [AgentRole.REFINER, AgentRole.SIMPLIFIER],
     # Apply phase (issue #1557): single producer (APPLIER) reviewed by
     # REVIEWER_CONTRACT on contract-state convergence. Inserted between
     # PLAN and IMPLEMENT only for epic pipelines — the orchestrator

--- a/shared/egg_contracts/artifact_spec.py
+++ b/shared/egg_contracts/artifact_spec.py
@@ -134,6 +134,17 @@ _SPECS: tuple[ArtifactSpec, ...] = (
             "risk_analyst",
         ),
     ),
+    # Human-focused companion to the refine analysis (mandatory). Produced
+    # by the simplifier after the refiner proposes; the refine reviewer
+    # gates it on "faithful + jargon-free". Existence-only at propose time
+    # (no parse check — that is keyed on "plan-draft" alone in signals.py).
+    ArtifactSpec(
+        name="analysis-draft-human",
+        path_template=".egg-state/drafts/{identifier}-analysis-human.md",
+        phase="refine",
+        producer_role="simplifier",
+        consumer_roles=("reviewer_refine",),
+    ),
     ArtifactSpec(
         name="plan-draft",
         path_template=".egg-state/drafts/{identifier}-plan.md",
@@ -146,6 +157,16 @@ _SPECS: tuple[ArtifactSpec, ...] = (
             "tester",
             "documenter",
         ),
+    ),
+    # Human-focused companion to the implementation plan (mandatory).
+    # Produced by the simplifier after the task_planner proposes; the plan
+    # reviewer gates it. Existence-only at propose time.
+    ArtifactSpec(
+        name="plan-draft-human",
+        path_template=".egg-state/drafts/{identifier}-plan-human.md",
+        phase="plan",
+        producer_role="simplifier",
+        consumer_roles=("reviewer_plan",),
     ),
     ArtifactSpec(
         name="architect-output",

--- a/shared/egg_contracts/tests/test_artifact_spec.py
+++ b/shared/egg_contracts/tests/test_artifact_spec.py
@@ -50,7 +50,7 @@ from pathlib import Path
 import phase_filter
 import pytest
 from egg_restrictions.phase_patterns import phase_file_verdict
-from routes.pipelines import _get_draft_path
+from routes.pipelines import _get_draft_path, _get_human_draft_path
 
 # The spec module is the unit under test. ``all_specs`` is aliased on
 # import to avoid colliding with the pytest fixture of the same name —
@@ -168,7 +168,9 @@ class TestRegistryShape:
         # weakening every per-row test into a no-op iteration.
         expected = {
             "analysis-draft",
+            "analysis-draft-human",
             "plan-draft",
+            "plan-draft-human",
             "architect-output",
             "architect-slices",
             "risk-analyst-output",
@@ -226,6 +228,23 @@ class TestResolutionRoundTrip:
         rows = tuple(specs_for("plan", "task_planner"))
         assert len(rows) == 1
         assert rows[0].name == "plan-draft"
+
+    def test_human_companion_concrete_paths(self) -> None:
+        assert (
+            resolve_artifact_path("plan-draft-human", "3077")
+            == ".egg-state/drafts/3077-plan-human.md"
+        )
+        assert (
+            resolve_artifact_path("analysis-draft-human", "3077")
+            == ".egg-state/drafts/3077-analysis-human.md"
+        )
+
+    def test_specs_for_simplifier_is_per_phase_singleton(self) -> None:
+        # The simplifier produces exactly the human companion in each phase.
+        refine_rows = tuple(specs_for("refine", "simplifier"))
+        assert [r.name for r in refine_rows] == ["analysis-draft-human"]
+        plan_rows = tuple(specs_for("plan", "simplifier"))
+        assert [r.name for r in plan_rows] == ["plan-draft-human"]
 
     def test_specs_for_artifactless_role_returns_empty(self) -> None:
         # Roles that have no registered artifact must return an empty
@@ -333,6 +352,31 @@ class TestConsistencyB_GetDraftPathEquality:
             f"{spec_name}: _get_draft_path({phase!r}) → {legacy!r} but "
             f"spec resolved to {spec_resolved!r} (identifier={identifier!r})"
         )
+
+    @pytest.mark.parametrize(
+        "phase_to_spec",
+        [("refine", "analysis-draft-human"), ("plan", "plan-draft-human")],
+        ids=("refine", "plan"),
+    )
+    @pytest.mark.parametrize("identifier", _IDENTIFIERS, ids=("int", "str"))
+    def test_get_human_draft_path_equals_spec_resolution(
+        self,
+        phase_to_spec: tuple[str, str],
+        identifier: int | str,
+    ) -> None:
+        # The human-companion path helper routes through the same registry
+        # as ``_get_draft_path`` so the path knowledge stays single-sourced.
+        phase, spec_name = phase_to_spec
+        issue_number, pipeline_id = self._identifier_from(identifier)
+        human = _get_human_draft_path(phase, issue_number=issue_number, pipeline_id=pipeline_id)
+        spec_resolved = resolve_artifact_path(spec_name, identifier)
+        assert human == spec_resolved, (
+            f"{spec_name}: _get_human_draft_path({phase!r}) → {human!r} but "
+            f"spec resolved to {spec_resolved!r} (identifier={identifier!r})"
+        )
+
+    def test_get_human_draft_path_none_for_unregistered_phase(self) -> None:
+        assert _get_human_draft_path("implement", issue_number=3077) is None
 
 
 # ---------------------------------------------------------------------------
@@ -626,6 +670,11 @@ class TestNameForPath:
     def test_known_concrete_paths(self) -> None:
         assert name_for_path(".egg-state/drafts/3200-plan.md") == "plan-draft"
         assert name_for_path(".egg-state/drafts/3200-analysis.md") == "analysis-draft"
+        # Human companions reverse-resolve distinctly; the ``-human.md``
+        # suffix is disjoint from the plain ``-plan.md`` / ``-analysis.md``
+        # prefixes, so neither shadows the other (regression guard).
+        assert name_for_path(".egg-state/drafts/3200-plan-human.md") == "plan-draft-human"
+        assert name_for_path(".egg-state/drafts/3200-analysis-human.md") == "analysis-draft-human"
         assert (
             name_for_path(".egg-state/agent-outputs/3200-architect-output.json")
             == "architect-output"

--- a/shared/egg_restrictions/patterns.py
+++ b/shared/egg_restrictions/patterns.py
@@ -525,6 +525,27 @@ REFINER_PATTERNS = AgentFilePattern(
     ],
 )
 
+# Simplifier writes the human-focused draft companions; same write
+# surface as the refiner (drafts + agent-outputs, never code/contracts).
+SIMPLIFIER_PATTERNS = AgentFilePattern(
+    role=AgentRole.SIMPLIFIER,
+    description="drafts and agent-outputs only",
+    allowed_patterns=[
+        ".egg-state/drafts/",
+        ".egg-state/agent-outputs/",
+    ],
+    blocked_patterns=[
+        "**/*.py",
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx",
+        "**/*.go",
+        "**/*.java",
+        ".egg-state/contracts/",
+    ],
+)
+
 REVIEWER_REFINE_PATTERNS = AgentFilePattern(
     role=AgentRole.REVIEWER_REFINE,
     description="reviews and agent-outputs only",
@@ -728,6 +749,7 @@ AGENT_PATTERNS: dict[str, AgentFilePattern] = {
     AgentRole.REVIEWER_CONTRACT: REVIEWER_CONTRACT_PATTERNS,
     AgentRole.REVIEWER_AGENT_DESIGN: REVIEWER_AGENT_DESIGN_PATTERNS,
     AgentRole.REFINER: REFINER_PATTERNS,
+    AgentRole.SIMPLIFIER: SIMPLIFIER_PATTERNS,
     AgentRole.REVIEWER_REFINE: REVIEWER_REFINE_PATTERNS,
     AgentRole.REVIEWER_PLAN: REVIEWER_PLAN_PATTERNS,
     AgentRole.REVIEWER_SECURITY: REVIEWER_SECURITY_PATTERNS,
@@ -830,6 +852,7 @@ def build_agent_patterns(
         AgentRole.REVIEWER_CONTRACT: REVIEWER_CONTRACT_PATTERNS,
         AgentRole.REVIEWER_AGENT_DESIGN: REVIEWER_AGENT_DESIGN_PATTERNS,
         AgentRole.REFINER: REFINER_PATTERNS,
+        AgentRole.SIMPLIFIER: SIMPLIFIER_PATTERNS,
         AgentRole.REVIEWER_REFINE: REVIEWER_REFINE_PATTERNS,
         AgentRole.REVIEWER_PLAN: REVIEWER_PLAN_PATTERNS,
         AgentRole.REVIEWER_SECURITY: REVIEWER_SECURITY_PATTERNS,

--- a/shared/tests/test_egg_restrictions.py
+++ b/shared/tests/test_egg_restrictions.py
@@ -75,13 +75,14 @@ class TestAgentRole:
 
 
 class TestAgentPatterns:
-    def test_registry_has_all_19_roles(self):
+    def test_registry_has_all_20_roles(self):
         # Issue #1557 — APPLIER joined the registry (Jira-epic SDLC
         # support); the count grew from 19 to 20. Issue #2925 — ORCHESTRATOR
         # was removed (the orchestrator is the control plane, not an agent
         # role; its gh pre-flights now run on launcher-authed control-plane
-        # routes), dropping the count back to 19.
-        assert len(AGENT_PATTERNS) == 19
+        # routes), dropping the count back to 19. SIMPLIFIER (human-focused
+        # draft companions) brings it to 20.
+        assert len(AGENT_PATTERNS) == 20
 
     def test_registry_keys_match_role_constants(self):
         expected_roles = {
@@ -94,6 +95,8 @@ class TestAgentPatterns:
             AgentRole.TASK_PLANNER,
             AgentRole.RISK_ANALYST,
             AgentRole.REFINER,
+            # Human-focused draft companions (refine + plan).
+            AgentRole.SIMPLIFIER,
             AgentRole.REVIEWER_CODE,
             AgentRole.REVIEWER_CODE_HOLISTIC,
             AgentRole.REVIEWER_CONTRACT,

--- a/tests/shared/egg_contracts/test_agent_roles.py
+++ b/tests/shared/egg_contracts/test_agent_roles.py
@@ -79,6 +79,7 @@ class TestAgentRole:
         "task_planner",
         "risk_analyst",
         "refiner",
+        "simplifier",
         "applier",
         "reviewer_code",
         "reviewer_code_holistic",
@@ -94,7 +95,7 @@ class TestAgentRole:
     }
 
     def test_all_expected_roles_exist(self):
-        """All 19 expected roles should be present in the enum."""
+        """All 20 expected roles should be present in the enum."""
         actual = {r.value for r in AgentRole}
         assert self.EXPECTED_ROLES == actual, (
             f"Missing roles: {self.EXPECTED_ROLES - actual}, "
@@ -102,8 +103,8 @@ class TestAgentRole:
         )
 
     def test_role_count(self):
-        """Should have exactly 19 canonical roles."""
-        assert len(AgentRole) == 19
+        """Should have exactly 20 canonical roles."""
+        assert len(AgentRole) == 20
 
     def test_execution_roles(self):
         assert AgentRole.CODER == "coder"


### PR DESCRIPTION
## Summary

Adds a **human-focused companion** to the refine and plan phase drafts. The existing agent-focused drafts (`-analysis.md` / `-plan.md`) are unchanged; each now gains a parallel `-human.md` copy that is simplified, higher-level, and free of egg-internal jargon — digestible for a technical reader who is not a pipeline operator.

A new dedicated **`simplifier`** agent produces the companions. It runs in both the refine and plan phases.

## Design

The `simplifier` is a **dual-role** agent following the proven implement-phase `tester` pattern:

- It is a **producer** of the `-human.md` companion, reviewed CRITICAL by `reviewer_refine` (refine) / `reviewer_plan` (plan).
- It carries an **advisory** review edge over the upstream producer (`refiner` / `task_planner`) purely so the BRC `ack` arm re-invokes it when that producer proposes. Its verdict never blocks the upstream's consensus.

Why dual-role rather than a pure producer: a pure producer's first-`propose` spawn-dedupe key is constant (`event_loop.event_identity` collapses it to `"v|"`), so a producer that orients-and-exits before the upstream draft exists would be marked done on that key and never re-spawned — a deadlock. The advisory review edge gives the simplifier a fresh, sha-keyed `ack` wake-up on the upstream's propose, exactly as the tester gets woken by the coder.

## Enforcement & surfacing

- **Mandatory**: registered in `artifact_spec.py` as `analysis-draft-human` / `plan-draft-human`, so the existing propose-time presence check NACKs the simplifier if the companion is missing. Existence-only — the plan-draft parse check is keyed on `plan-draft` alone, so the companions are not parse-checked.
- **HITL gate**: the companion now **leads** the refine/plan gate comment, with a link to the full agent draft for depth.
- **Context PR body**: links both the agent draft and the human companion.

## Changes

- `shared/egg_contracts/agent_roles.py` — new `SIMPLIFIER` role (enum, definition, `AGENT_ROLES`, `_PHASE_ROLES` for refine+plan, contract-role map).
- `shared/egg_contracts/artifact_spec.py` — two mandatory human-companion specs.
- `shared/egg_restrictions/patterns.py` — `simplifier` write pattern (drafts + agent-outputs only).
- `orchestrator/review_graph.py` — `reviewer_* → simplifier` (CRITICAL) + `simplifier → upstream` (advisory) edges.
- `orchestrator/routes/pipelines.py` — `_get_human_draft_path` helper, simplifier orientation + task prompt, reviewer-prep additions, `_read_human_phase_draft`, gate-comment composition, context-PR links, role description, BRC-preamble fallback classification.
- `orchestrator/routes/signals.py` — artifact labels for clean NACK messages.
- Docs: `agent-roles.md`, `concurrent-execution.md`.
- Tests: artifact-spec (rows, concrete paths, name_for_path, human-path consistency), agent-roles (count, expected set), prompt orientation.

## Test plan

- `make test-all` green.
- Manual: submit a small pipeline; confirm `-analysis-human.md` / `-plan-human.md` land on the work branch, the HITL gate leads with the human summary + full-draft link, the context PR links both, and consensus closes without stalling.
