### PR TITLE
fix(#3299): pin sandbox ruff to repo constraint

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -155,8 +155,11 @@ RUN pip3 install --no-cache-dir \
     requests \
     cryptography \
     PyJWT \
-    # Dev dependencies for linting and testing
-    ruff \
+    # Dev dependencies for linting and testing.
+    # ruff is pinned to the repo constraint (pyproject.toml) so the agent's
+    # `ruff format` output can't drift ahead of what CI's `ruff format --check`
+    # accepts and produce format diffs on PR open (#3299).
+    "ruff>=0.15.12,<0.16" \
     pytest \
     # Required by gateway (for running tests)
     flask \
@@ -172,8 +175,10 @@ RUN pip3 install --no-cache-dir \
     pyyaml toml python-dateutil orjson \
     # Testing frameworks
     pytest pytest-cov pytest-asyncio pytest-xdist hypothesis fakeredis \
-    # Code quality tools
-    black ruff mypy isort \
+    # Code quality tools.
+    # ruff is pinned to the repo constraint (pyproject.toml) to keep the
+    # agent's formatter output in lockstep with CI's `ruff format --check` (#3299).
+    black "ruff>=0.15.12,<0.16" mypy isort \
     # Type stubs
     types-requests types-PyYAML types-toml \
     # CLI and terminal


### PR DESCRIPTION
## Summary

Both `pip install` sites in `sandbox/Dockerfile` installed **unpinned `ruff`**, so the agent image could pick up a ruff newer than the repo pin (`ruff>=0.15.12,<0.16` in `pyproject.toml`). The agent's `ruff format` could then format code differently than CI's `ruff format --check` accepts, producing **format drift on PR open** — the "toolchain" half of failure class 1 in #3298.

## Change

- `sandbox/Dockerfile:162` (component deps) — pin `"ruff>=0.15.12,<0.16"`
- `sandbox/Dockerfile:181` (lockdown pre-install) — pin `"ruff>=0.15.12,<0.16"`

Both now match the `pyproject.toml` constraint, so the agent's formatter output stays in lockstep with CI.

## Scope

mypy/black/isort don't reformat agent-authored code in a CI-checked way, so **ruff is the only format-version-drift vector** here. The agent runs only in the sandbox image, so `gateway`/`orchestrator` Dockerfiles are out of scope (neither installs ruff).

## Why this alone isn't enough

Per #3299: pinning closes the *version*-drift vector, but nothing currently *runs* `ruff format` on the agent path before a PR opens (gateway disables git hooks). Pin here; gate there — this is the cheap, independently-shippable half.

Part of #3298. Closes #3299.