### PR TITLE
feat(#3300): block pipeline finalize on unresolved contract gaps

### DIFF
--- a/orchestrator/routes/phases.py
+++ b/orchestrator/routes/phases.py
@@ -1035,6 +1035,65 @@ def _collect_unresolved_phase_decisions(
     return unresolved
 
 
+def _collect_unresolved_contract_gaps(
+    pipeline: Pipeline,
+    store_repo_path: Path,
+) -> list[str]:
+    """Return ``"<task>/<gap>"`` ids for every unresolved ``TaskGap``.
+
+    A tester→coder :class:`TaskGap` left ``resolved == False`` ships into
+    the committed contract snapshot and fails ``test_models_gaps.py`` red
+    in CI on the already-open PR (#3298 class 4). This scans the contract
+    so :func:`complete_phase` can block finalize on open gaps — the same
+    way it blocks on unresolved HITL decisions — instead of discovering
+    them reactively in CI. See #3300.
+
+    Gaps are not phase-scoped: at finalize every gap should be resolved,
+    so the scan spans all tasks (unlike the phase-filtered decision
+    scan). Returns an empty list for clean contracts and when the
+    contract is absent/unloadable (the gate fails open, mirroring the
+    decision scan — a load failure must never strand the pipeline).
+    """
+    if not pipeline.has_contract:
+        return []
+
+    try:
+        from egg_contracts.loader import (
+            ContractNotFoundError,
+            ContractValidationError,
+            load_contract,
+        )
+    except ImportError:
+        logger.warning(
+            "Failed to scan contract for unresolved gaps",
+            pipeline_id=pipeline.id,
+            exc_info=True,
+        )
+        return []
+
+    try:
+        from routes import resolve_worktree_path
+        from routes.pipelines import _pipeline_identifier
+
+        worktree_path = resolve_worktree_path(pipeline.id, store_repo_path)
+        contract_id = _pipeline_identifier(pipeline.issue_number, pipeline.id)
+        try:
+            contract = load_contract(contract_id, worktree_path)
+        except ContractNotFoundError:
+            return []
+        return [f"{task_id}/{gap.id}" for task_id, gap in contract.unresolved_gaps()]
+    except OSError, ValueError, ContractValidationError:
+        # Mirror _collect_unresolved_phase_decisions: filesystem /
+        # serialization / validation failures fail open and log; only
+        # programming errors are left to propagate.
+        logger.warning(
+            "Failed to scan contract for unresolved gaps",
+            pipeline_id=pipeline.id,
+            exc_info=True,
+        )
+        return []
+
+
 @phases_bp.route("/<pipeline_id>/phase/complete", methods=["POST"])
 @require_lifecycle_secret
 def complete_phase(pipeline_id: str) -> tuple[Response, int]:
@@ -1149,6 +1208,30 @@ def complete_phase(pipeline_id: str) -> tuple[Response, int]:
                 reason="unresolved_hitl_decisions",
             )
 
+        # Block finalize while the contract carries unresolved TaskGaps.
+        # A tester→coder gap left open ships into the committed contract
+        # and fails test_models_gaps.py red in CI on the already-open PR
+        # (#3298 class 4). Mirror the unresolved-HITL guard above so the
+        # failure is symmetric and surfaced early; force=true abandons.
+        # See #3300.
+        unresolved_gap_ids = _collect_unresolved_contract_gaps(pipeline, store.repo_path)
+        if unresolved_gap_ids and not force:
+            return make_error_response(
+                (
+                    f"Phase '{pipeline.current_phase.value}' has "
+                    f"{len(unresolved_gap_ids)} unresolved contract gap"
+                    f"{'s' if len(unresolved_gap_ids) != 1 else ''}. "
+                    "Resolve them (set the gap's resolved=true) or pass "
+                    "force=true to ship with the gap open."
+                ),
+                status_code=409,
+                details={
+                    "phase": pipeline.current_phase.value,
+                    "unresolved_gap_ids": unresolved_gap_ids,
+                },
+                reason="unresolved_contract_gaps",
+            )
+
         phase_execution = pipeline.get_phase_execution(pipeline.current_phase)
         phase_execution.status = PipelineStatus.COMPLETE
         phase_execution.completed_at = datetime.now(UTC)
@@ -1161,17 +1244,21 @@ def complete_phase(pipeline_id: str) -> tuple[Response, int]:
         # so the abandoned decisions remain on the frozen phase history for
         # audit, even though they were never resolved. Values must be
         # strings (PhaseExecution.artifacts is dict[str, str]).
-        if force and unresolved_ids:
+        if force and (unresolved_ids or unresolved_gap_ids):
             merged = dict(phase_execution.artifacts)
-            merged["force_completed_decisions"] = json.dumps(unresolved_ids)
+            if unresolved_ids:
+                merged["force_completed_decisions"] = json.dumps(unresolved_ids)
+            if unresolved_gap_ids:
+                merged["force_completed_gaps"] = json.dumps(unresolved_gap_ids)
             if force_reason:
                 merged["force_reason"] = force_reason
             phase_execution.artifacts = merged
             logger.warning(
-                "Phase force-completed with unresolved HITL decisions",
+                "Phase force-completed with unresolved HITL decisions / contract gaps",
                 pipeline_id=pipeline_id,
                 phase=pipeline.current_phase.value,
                 unresolved_decision_ids=unresolved_ids,
+                unresolved_gap_ids=unresolved_gap_ids,
                 force_reason=force_reason,
             )
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -21985,6 +21985,7 @@ def _await_unresolved_gap_gate(
     worktree_repo_path: Path,
     pipeline_identifier: int | str,
     phase: PipelinePhase,
+    hitl_gates: bool = True,
 ) -> bool:
     """Block phase finalize while the contract carries unresolved TaskGaps.
 
@@ -21995,17 +21996,25 @@ def _await_unresolved_gap_gate(
     otherwise mark it complete and finalize with the gap open and no
     human in the loop. This surfaces a blocking ``phase_gate`` HITL
     decision listing the open gaps and waits — mirroring the
-    unresolved-HITL guard in ``complete_phase`` (#1788) and honoring the
-    "always surface HITL, never auto-resolve" rule (so it fires
-    regardless of ``config.hitl_gates``). See #3300.
+    unresolved-HITL guard in ``complete_phase`` (#1788). See #3300.
 
     The operator resolves the gap (set the gap's ``resolved=true`` via
     the contract-mutate path, e.g. by re-running/kicking the coder) and
     approves, or picks the override option to ship with the gap open. The
     contract is re-read after each approval so a stale ``approve`` cannot
     advance with a gap still open. Returns ``True`` when a gate was
-    surfaced (resolved or overridden), ``False`` when the contract was
-    already clean (the common path, no gate shown).
+    surfaced and the contract may have changed (resolved or overridden),
+    ``False`` when the contract was already clean (the common path) or
+    the escalation could only be logged (autonomous run, below).
+
+    **Autonomous runs.** ``wait_for_decision`` polls indefinitely and
+    both options require a human, so a fully-autonomous pipeline
+    (``hitl_gates is False``) has no path forward — blocking here would
+    convert a red-but-progressing PR into an indefinite stall (the
+    health monitor would eventually tear it down). When ``hitl_gates is
+    False`` we therefore *surface* the escalation (event + warning) but
+    do **not** block: the reactive ``test_models_gaps.py`` CI check
+    remains the backstop, exactly as it was before this gate existed.
 
     A best-effort scan: contract load failures fail open (log + return)
     so a transient read error can never strand the pipeline.
@@ -22034,6 +22043,39 @@ def _await_unresolved_gap_gate(
     open_gaps = _load_open_gaps()
     if not open_gaps:
         return False
+
+    if not hitl_gates:
+        # No human in the loop — do not block forever. Both options need a
+        # human, so blocking would convert a red-but-progressing PR into an
+        # indefinite stall. Surface the escalation (so observers still see
+        # it) + log loudly, and let the reactive CI backstop catch the open
+        # gap on the PR, exactly as before this gate existed.
+        report_pipeline_status(
+            store.load_pipeline(pipeline_id),
+            event_type="phase.gap_gate",
+            message=f"{phase.value} phase has unresolved coverage gaps",
+        )
+        logger.warning(
+            "Unresolved-gap gate: open gaps on an autonomous pipeline "
+            "(hitl_gates=False); surfacing but not blocking",
+            pipeline_id=pipeline_id,
+            phase=phase.value,
+            open_gap_ids=[f"{t}/{g.id}" for t, g in open_gaps],
+        )
+        return False
+
+    def _set_status(status: PipelineStatus) -> Pipeline:
+        # Mirror the phase_gate block: drive both pipeline and the phase
+        # box so the DAG visualization renders the gate on the right
+        # phase, and the operator's wait-status monitor wakes.
+        with get_pipeline_state_lock(pipeline_id):
+            pipeline = store.load_pipeline(pipeline_id)
+            pipeline.status = status
+            phase_execution = pipeline.get_phase_execution(phase)
+            if phase_execution is not None:
+                phase_execution.status = status
+            store.save_pipeline(pipeline)
+        return pipeline
 
     dq = get_decision_queue(pipeline_id, repo_path)
     gated = False
@@ -22067,10 +22109,7 @@ def _await_unresolved_gap_gate(
 
         # Mark AWAITING_HUMAN + surface to event watchers, mirroring the
         # phase_gate block so the operator's wait-status monitor wakes.
-        with get_pipeline_state_lock(pipeline_id):
-            pipeline = store.load_pipeline(pipeline_id)
-            pipeline.status = PipelineStatus.AWAITING_HUMAN
-            store.save_pipeline(pipeline)
+        pipeline = _set_status(PipelineStatus.AWAITING_HUMAN)
         report_pipeline_status(
             pipeline,
             event_type="phase.gap_gate",
@@ -22086,10 +22125,7 @@ def _await_unresolved_gap_gate(
         resolved = dq.wait_for_decision(decision.id)
         # Restore RUNNING now the gate cleared (re-set to AWAITING_HUMAN
         # above on the next loop if gaps remain).
-        with get_pipeline_state_lock(pipeline_id):
-            pipeline = store.load_pipeline(pipeline_id)
-            pipeline.status = PipelineStatus.RUNNING
-            store.save_pipeline(pipeline)
+        _set_status(PipelineStatus.RUNNING)
 
         if resolved.status != DecisionStatus.RESOLVED:
             # Cancelled / abandoned — don't spin; let the loop proceed so
@@ -22110,6 +22146,21 @@ def _await_unresolved_gap_gate(
                 phase=phase.value,
                 open_gap_ids=[f"{t}/{g.id}" for t, g in open_gaps],
             )
+            # Record the override on the frozen phase artifacts for audit
+            # parity with the complete_phase endpoint's ``force`` path
+            # (otherwise the load-bearing run-loop override left only a
+            # transient log line). Values must be strings —
+            # PhaseExecution.artifacts is dict[str, str].
+            with get_pipeline_state_lock(pipeline_id):
+                pipeline = store.load_pipeline(pipeline_id)
+                phase_execution = pipeline.get_phase_execution(phase)
+                if phase_execution is not None:
+                    merged = dict(phase_execution.artifacts)
+                    merged["force_completed_gaps"] = json.dumps(
+                        [f"{t}/{g.id}" for t, g in open_gaps]
+                    )
+                    phase_execution.artifacts = merged
+                    store.save_pipeline(pipeline)
             return gated
 
         # Approval path: re-read the contract. If the operator actually
@@ -24741,20 +24792,62 @@ def _run_pipeline(
             # ship into the committed contract (which would fail
             # test_models_gaps.py red in CI on the already-open PR —
             # #3298 class 4). Scoped to IMPLEMENT, where gaps are written;
-            # no-ops on a clean contract. Fires regardless of
-            # config.hitl_gates: an open gap is an escalation, not a
-            # routine phase approval.
+            # no-ops on a clean contract. On a fully-autonomous pipeline
+            # (hitl_gates=False) the gate surfaces the escalation but does
+            # not block — both options need a human, so blocking would
+            # stall the pipeline indefinitely; the reactive CI check stays
+            # the backstop there.
             if current_phase == PipelinePhase.IMPLEMENT:
                 try:
-                    _await_unresolved_gap_gate(
+                    gap_gated = _await_unresolved_gap_gate(
                         store,
                         pipeline_id,
                         repo_path,
                         worktree_repo_path,
                         _pipeline_identifier(pipeline.issue_number, pipeline_id),
                         current_phase,
+                        pipeline.config.hitl_gates,
                     )
                     pipeline = store.load_pipeline(pipeline_id)
+                    # The gate ran before the statefile commit+push above,
+                    # so when it changed the contract (operator resolved a
+                    # gap, or the override audit landed) the resolution is
+                    # still uncommitted in the worktree. Re-commit + push so
+                    # the work branch tree CI sees reflects the post-gate
+                    # contract, not the open-gap snapshot pushed earlier.
+                    if gap_gated:
+                        try:
+                            _commit_statefiles_to_worktree(
+                                worktree_repo_path,
+                                f"Persist contract after {current_phase.value} gap gate",
+                                pipeline_identifier=_pipeline_identifier(
+                                    pipeline.issue_number, pipeline_id
+                                ),
+                                pipeline_id=pipeline_id,
+                            )
+                        except Exception as git_err:
+                            logger.warning(
+                                "Failed to commit statefiles after gap gate (continuing)",
+                                pipeline_id=pipeline_id,
+                                phase=current_phase.value,
+                                error=str(git_err),
+                            )
+                        if pipeline.branch and worktree_repo_path != repo_path:
+                            try:
+                                spawner.gateway.push_worktree_branch(
+                                    pipeline_id=pipeline_id,
+                                    repo_path=str(worktree_repo_path),
+                                    branch=pipeline.branch,
+                                    mode=gateway_mode,
+                                    base_branch=pipeline.base_branch,
+                                )
+                            except Exception as push_err:
+                                logger.warning(
+                                    "Failed to push statefiles after gap gate (continuing)",
+                                    pipeline_id=pipeline_id,
+                                    phase=current_phase.value,
+                                    error=str(push_err),
+                                )
                 except Exception as gap_gate_err:  # noqa: BLE001
                     # Never let a gate bug strand the pipeline — the
                     # reactive test_models_gaps.py CI check remains the

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -24809,15 +24809,16 @@ def _run_pipeline(
                         pipeline.config.hitl_gates,
                     )
                     pipeline = store.load_pipeline(pipeline_id)
-                    # The gate ran before the statefile commit+push above,
-                    # so when it changed the contract (operator resolved a
-                    # gap, or the override audit landed) the resolution is
-                    # still uncommitted in the worktree. Re-commit + push so
-                    # the work branch tree CI sees reflects the post-gate
+                    # The gate ran after the statefile commit+push above, so
+                    # when it changed the contract (operator resolved a gap,
+                    # or the override audit landed) the resolution is still
+                    # uncommitted in the worktree. Re-commit + push so the
+                    # work branch tree CI sees reflects the post-gate
                     # contract, not the open-gap snapshot pushed earlier.
                     if gap_gated:
+                        gate_committed = False
                         try:
-                            _commit_statefiles_to_worktree(
+                            gate_committed = _commit_statefiles_to_worktree(
                                 worktree_repo_path,
                                 f"Persist contract after {current_phase.value} gap gate",
                                 pipeline_identifier=_pipeline_identifier(
@@ -24832,7 +24833,11 @@ def _run_pipeline(
                                 phase=current_phase.value,
                                 error=str(git_err),
                             )
-                        if pipeline.branch and worktree_repo_path != repo_path:
+                        # Skip the follow-up push when nothing was committed
+                        # (e.g. the override path leaves the contract
+                        # unchanged) — it would be a no-op fast-forward
+                        # (#2548).
+                        if gate_committed and pipeline.branch and worktree_repo_path != repo_path:
                             try:
                                 spawner.gateway.push_worktree_branch(
                                     pipeline_id=pipeline_id,

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -21978,6 +21978,158 @@ def _queue_and_await_contract_decisions(
             _save_contract_update(_apply_fb)
 
 
+def _await_unresolved_gap_gate(
+    store: Any,
+    pipeline_id: str,
+    repo_path: Path,
+    worktree_repo_path: Path,
+    pipeline_identifier: int | str,
+    phase: PipelinePhase,
+) -> bool:
+    """Block phase finalize while the contract carries unresolved TaskGaps.
+
+    A tester→coder :class:`TaskGap` left ``resolved == False`` ships into
+    the committed contract snapshot and fails ``test_models_gaps.py`` red
+    in CI on the already-open PR (#3298 class 4). The implement phase is
+    **not** in ``_HITL_GATE_PHASES``, so the autonomous run loop would
+    otherwise mark it complete and finalize with the gap open and no
+    human in the loop. This surfaces a blocking ``phase_gate`` HITL
+    decision listing the open gaps and waits — mirroring the
+    unresolved-HITL guard in ``complete_phase`` (#1788) and honoring the
+    "always surface HITL, never auto-resolve" rule (so it fires
+    regardless of ``config.hitl_gates``). See #3300.
+
+    The operator resolves the gap (set the gap's ``resolved=true`` via
+    the contract-mutate path, e.g. by re-running/kicking the coder) and
+    approves, or picks the override option to ship with the gap open. The
+    contract is re-read after each approval so a stale ``approve`` cannot
+    advance with a gap still open. Returns ``True`` when a gate was
+    surfaced (resolved or overridden), ``False`` when the contract was
+    already clean (the common path, no gate shown).
+
+    A best-effort scan: contract load failures fail open (log + return)
+    so a transient read error can never strand the pipeline.
+    """
+    try:
+        from egg_contracts.loader import load_contract
+    except ImportError:
+        logger.warning(
+            "egg_contracts not available, skipping unresolved-gap gate",
+            pipeline_id=pipeline_id,
+        )
+        return False
+
+    def _load_open_gaps() -> list[tuple[str, Any]] | None:
+        try:
+            contract = load_contract(pipeline_identifier, worktree_repo_path)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "Could not load contract for unresolved-gap gate (skipping)",
+                pipeline_id=pipeline_id,
+                error=str(e),
+            )
+            return None
+        return contract.unresolved_gaps()
+
+    open_gaps = _load_open_gaps()
+    if not open_gaps:
+        return False
+
+    dq = get_decision_queue(pipeline_id, repo_path)
+    gated = False
+
+    while open_gaps:
+        gated = True
+        gap_lines = "\n".join(
+            f"- `{task_id}` / `{gap.id}` ({gap.from_role}→{gap.to_role}): {gap.description}"
+            for task_id, gap in open_gaps
+        )
+        question = (
+            f"The {phase.value} phase has {len(open_gaps)} unresolved coverage "
+            f"gap{'s' if len(open_gaps) != 1 else ''}. Resolve "
+            f"{'them' if len(open_gaps) != 1 else 'it'} (mark the gap resolved "
+            "via the contract) and approve, or choose 'override' to finalize "
+            "with the gap open."
+        )
+        context = (
+            "These tester→coder coverage gaps are still open on the contract. "
+            "Finalizing with an open gap ships it into the committed contract "
+            "and fails CI (test_models_gaps.py) red on the PR.\n\n"
+            f"{gap_lines}"
+        )
+        decision = dq.queue_decision(
+            question=question,
+            context=context,
+            options=["approve", "override"],
+            decision_type="phase_gate",
+            phase=phase,
+        )
+
+        # Mark AWAITING_HUMAN + surface to event watchers, mirroring the
+        # phase_gate block so the operator's wait-status monitor wakes.
+        with get_pipeline_state_lock(pipeline_id):
+            pipeline = store.load_pipeline(pipeline_id)
+            pipeline.status = PipelineStatus.AWAITING_HUMAN
+            store.save_pipeline(pipeline)
+        report_pipeline_status(
+            pipeline,
+            event_type="phase.gap_gate",
+            message=f"{phase.value} phase has unresolved coverage gaps",
+        )
+        if _emit_event is not None:
+            _emit_event(
+                EventType.DECISION_CREATED,
+                pipeline_id,
+                data={"phase": phase.value},
+            )
+
+        resolved = dq.wait_for_decision(decision.id)
+        # Restore RUNNING now the gate cleared (re-set to AWAITING_HUMAN
+        # above on the next loop if gaps remain).
+        with get_pipeline_state_lock(pipeline_id):
+            pipeline = store.load_pipeline(pipeline_id)
+            pipeline.status = PipelineStatus.RUNNING
+            store.save_pipeline(pipeline)
+
+        if resolved.status != DecisionStatus.RESOLVED:
+            # Cancelled / abandoned — don't spin; let the loop proceed so
+            # a cancel can tear the pipeline down.
+            logger.warning(
+                "Unresolved-gap gate ended without resolution; proceeding",
+                pipeline_id=pipeline_id,
+                phase=phase.value,
+                decision_status=getattr(resolved.status, "value", resolved.status),
+            )
+            return gated
+
+        resolution = (resolved.resolution or "").strip().lower()
+        if "override" in resolution:
+            logger.warning(
+                "Unresolved-gap gate overridden — finalizing with open gaps",
+                pipeline_id=pipeline_id,
+                phase=phase.value,
+                open_gap_ids=[f"{t}/{g.id}" for t, g in open_gaps],
+            )
+            return gated
+
+        # Approval path: re-read the contract. If the operator actually
+        # marked the gaps resolved, the gate clears; otherwise re-surface.
+        reloaded = _load_open_gaps()
+        if reloaded is None:
+            # Load failed — fail open rather than strand the pipeline.
+            return gated
+        open_gaps = reloaded
+        if open_gaps:
+            logger.info(
+                "Unresolved-gap gate approved but gaps still open; re-surfacing",
+                pipeline_id=pipeline_id,
+                phase=phase.value,
+                remaining=len(open_gaps),
+            )
+
+    return gated
+
+
 # ---------------------------------------------------------------------------
 # Jira-epic SDLC scheduling helpers (issue #1557 — task-1-4 / task-2-7)
 # ---------------------------------------------------------------------------
@@ -24579,6 +24731,39 @@ def _run_pipeline(
                         pipeline_id=pipeline_id,
                         phase=current_phase,
                         error=str(push_err),
+                    )
+
+            # --- Unresolved-gap gate (#3300) ---
+            # Block finalize while the contract carries an unresolved
+            # tester→coder TaskGap. Runs after the worktree sync above so
+            # the contract reflects the agents' final writes, and BEFORE
+            # the phase_gate / advance / finalize below so the gap can't
+            # ship into the committed contract (which would fail
+            # test_models_gaps.py red in CI on the already-open PR —
+            # #3298 class 4). Scoped to IMPLEMENT, where gaps are written;
+            # no-ops on a clean contract. Fires regardless of
+            # config.hitl_gates: an open gap is an escalation, not a
+            # routine phase approval.
+            if current_phase == PipelinePhase.IMPLEMENT:
+                try:
+                    _await_unresolved_gap_gate(
+                        store,
+                        pipeline_id,
+                        repo_path,
+                        worktree_repo_path,
+                        _pipeline_identifier(pipeline.issue_number, pipeline_id),
+                        current_phase,
+                    )
+                    pipeline = store.load_pipeline(pipeline_id)
+                except Exception as gap_gate_err:  # noqa: BLE001
+                    # Never let a gate bug strand the pipeline — the
+                    # reactive test_models_gaps.py CI check remains the
+                    # backstop if this fails open.
+                    logger.warning(
+                        "Unresolved-gap gate raised (continuing)",
+                        pipeline_id=pipeline_id,
+                        phase=current_phase.value,
+                        error=str(gap_gate_err),
                     )
 
             # --- HITL gate: pause for human approval ---

--- a/orchestrator/tests/test_advance_phase_thread.py
+++ b/orchestrator/tests/test_advance_phase_thread.py
@@ -490,14 +490,16 @@ class TestPostBrcBandSwallowsErrors:
         # the broader handler.  Find every call to the helper and assert
         # the immediately-following ``except`` clause is ``Exception``.
         call_sites = list(re.finditer(r"_commit_statefiles_to_worktree\(", source))
-        # Four known call sites in ``_run_pipeline``: initial statefile
-        # commit, pre-sync commit (#2488), post-phase commit, and
-        # post-HITL-resolution commit.  The former pre-PR commit was
-        # removed in #2777 (slice-2) along with the PR phase.  Pin the
-        # count so a future move/delete is caught rather than silently
-        # degrading coverage.
-        assert len(call_sites) == 4, (
-            f"Expected 4 _commit_statefiles_to_worktree call sites in "
+        # Five known call sites in ``_run_pipeline``: initial statefile
+        # commit, pre-sync commit (#2488), post-phase commit,
+        # post-HITL-resolution commit, and post-gap-gate commit (#3300,
+        # re-persists the contract after the unresolved-gap gate resolves
+        # so the work branch CI sees the post-gate tree).  The former
+        # pre-PR commit was removed in #2777 (slice-2) along with the PR
+        # phase.  Pin the count so a future move/delete is caught rather
+        # than silently degrading coverage.
+        assert len(call_sites) == 5, (
+            f"Expected 5 _commit_statefiles_to_worktree call sites in "
             f"_run_pipeline, found {len(call_sites)}.  If a call was "
             f"intentionally added/removed, update this count and the "
             f"comment above."

--- a/orchestrator/tests/test_complete_phase_endpoint.py
+++ b/orchestrator/tests/test_complete_phase_endpoint.py
@@ -621,3 +621,125 @@ class TestCompletePhasePendingDecisions:
             resp = client.post("/api/v1/pipelines/issue-42/phase/complete")
 
         assert resp.status_code == 200
+
+    # ------------------------------------------------------------------
+    # #3300 — unresolved contract gaps block finalize
+    # ------------------------------------------------------------------
+
+    def _contract_with_gap(self, *, resolved: bool):
+        from egg_contracts.models import Contract
+
+        return Contract(
+            pipeline_id="issue-42",
+            slices=[
+                {
+                    "id": "slice-1",
+                    "name": "n",
+                    "tasks": [
+                        {
+                            "id": "task-1-2",
+                            "description": "d",
+                            "gaps": [
+                                {
+                                    "id": "gap-1",
+                                    "from_role": "tester",
+                                    "to_role": "coder",
+                                    "description": "no error-path test",
+                                    "resolved": resolved,
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        )
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_unresolved_gap_blocks_finalize(self, mock_get_store, _mock_clear, client):
+        """An open tester→coder TaskGap must 409 the phase-complete with
+        reason=unresolved_contract_gaps (#3300, #3298 class 4)."""
+        pipeline = Pipeline(
+            id="issue-42",
+            issue_number=42,
+            repo="owner/repo",
+            branch="egg/issue-42",
+        )
+        pipeline.current_phase = PipelinePhase.IMPLEMENT
+        mock_store = MagicMock()
+        mock_get_store.return_value = (mock_store, pipeline)
+
+        with (
+            patch("routes.pipelines._pipeline_identifier", return_value=42),
+            patch("routes.resolve_worktree_path", side_effect=lambda _pid, rp: rp),
+            patch(
+                "egg_contracts.loader.load_contract",
+                return_value=self._contract_with_gap(resolved=False),
+            ),
+        ):
+            resp = client.post("/api/v1/pipelines/issue-42/phase/complete")
+
+        assert resp.status_code == 409
+        body = json.loads(resp.data)
+        assert body["reason"] == "unresolved_contract_gaps"
+        assert body["details"]["unresolved_gap_ids"] == ["task-1-2/gap-1"]
+        mock_store.save_pipeline.assert_not_called()
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_resolved_gap_does_not_block(self, mock_get_store, _mock_clear, client):
+        pipeline = Pipeline(
+            id="issue-42",
+            issue_number=42,
+            repo="owner/repo",
+            branch="egg/issue-42",
+        )
+        pipeline.current_phase = PipelinePhase.IMPLEMENT
+        mock_store = MagicMock()
+        mock_get_store.return_value = (mock_store, pipeline)
+
+        with (
+            patch("routes.pipelines._pipeline_identifier", return_value=42),
+            patch("routes.resolve_worktree_path", side_effect=lambda _pid, rp: rp),
+            patch(
+                "egg_contracts.loader.load_contract",
+                return_value=self._contract_with_gap(resolved=True),
+            ),
+        ):
+            resp = client.post("/api/v1/pipelines/issue-42/phase/complete")
+
+        assert resp.status_code == 200
+
+    @patch("routes.phases._clear_concurrent_state")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_force_overrides_gap_and_audits(self, mock_get_store, _mock_clear, client):
+        """force=true ships past an open gap and records the override on the
+        frozen phase artifacts for audit."""
+        pipeline = Pipeline(
+            id="issue-42",
+            issue_number=42,
+            repo="owner/repo",
+            branch="egg/issue-42",
+        )
+        pipeline.current_phase = PipelinePhase.IMPLEMENT
+        mock_store = MagicMock()
+        mock_get_store.return_value = (mock_store, pipeline)
+
+        with (
+            patch("routes.pipelines._pipeline_identifier", return_value=42),
+            patch("routes.resolve_worktree_path", side_effect=lambda _pid, rp: rp),
+            patch("routes.pipelines._persist_phase_brc_history"),
+            patch(
+                "egg_contracts.loader.load_contract",
+                return_value=self._contract_with_gap(resolved=False),
+            ),
+        ):
+            resp = client.post(
+                "/api/v1/pipelines/issue-42/phase/complete",
+                json={"force": True, "force_reason": "shipping with known gap"},
+            )
+
+        assert resp.status_code == 200
+        phase_exec = pipeline.get_phase_execution(PipelinePhase.IMPLEMENT)
+        assert phase_exec.artifacts["force_completed_gaps"] == json.dumps(["task-1-2/gap-1"])
+        assert phase_exec.artifacts["force_reason"] == "shipping with known gap"

--- a/orchestrator/tests/test_unresolved_gap_gate.py
+++ b/orchestrator/tests/test_unresolved_gap_gate.py
@@ -101,8 +101,13 @@ def _run_gate(
     load_side_effect: list[Any],
     *,
     hitl_gates: bool = True,
-) -> tuple[bool, Pipeline]:
-    """Invoke the gate with the queue + a scripted load_contract sequence."""
+) -> tuple[bool, Pipeline, MagicMock]:
+    """Invoke the gate with the queue + a scripted load_contract sequence.
+
+    Returns ``(gated, pipeline, report_mock)`` — ``report_mock`` is the
+    patched ``report_pipeline_status`` so callers can assert the
+    escalation was surfaced.
+    """
     from routes.pipelines import _await_unresolved_gap_gate
 
     pipeline = Pipeline(
@@ -118,7 +123,7 @@ def _run_gate(
     with (
         patch("routes.pipelines.get_decision_queue", return_value=dq),
         patch("routes.pipelines.get_pipeline_state_lock", return_value=nullcontext()),
-        patch("routes.pipelines.report_pipeline_status"),
+        patch("routes.pipelines.report_pipeline_status") as report_mock,
         patch("routes.pipelines._emit_event", None),
         patch("egg_contracts.loader.load_contract", side_effect=load_side_effect),
     ):
@@ -131,13 +136,13 @@ def _run_gate(
             PipelinePhase.IMPLEMENT,
             hitl_gates,
         )
-    return gated, pipeline
+    return gated, pipeline, report_mock
 
 
 def test_clean_contract_no_gate() -> None:
     """A resolved gap (or no gap) must not surface a decision."""
     dq = _FakeQueue(resolutions=[])
-    gated, _ = _run_gate(dq, load_side_effect=[_contract(resolved=True)])
+    gated, _, _ = _run_gate(dq, load_side_effect=[_contract(resolved=True)])
     assert gated is False
     assert dq.queued == []
 
@@ -147,7 +152,7 @@ def test_open_gap_override_finalizes() -> None:
     records the override on the frozen phase artifacts for audit parity
     with the complete_phase endpoint's force path (#3300 review)."""
     dq = _FakeQueue(resolutions=["override"])
-    gated, pipeline = _run_gate(dq, load_side_effect=[_contract(resolved=False)])
+    gated, pipeline, _ = _run_gate(dq, load_side_effect=[_contract(resolved=False)])
     assert gated is True
     assert len(dq.queued) == 1
     assert dq.queued[0].decision_type == "phase_gate"
@@ -218,7 +223,7 @@ def test_autonomous_open_gap_surfaces_but_does_not_block() -> None:
     would stall forever. The reactive CI check stays the backstop (#3300
     review). The escalation is still surfaced (report_pipeline_status)."""
     dq = _FakeQueue(resolutions=[])
-    gated, pipeline = _run_gate(
+    gated, pipeline, report_mock = _run_gate(
         dq,
         load_side_effect=[_contract(resolved=False)],
         hitl_gates=False,
@@ -227,13 +232,15 @@ def test_autonomous_open_gap_surfaces_but_does_not_block() -> None:
     assert dq.queued == []
     # Never parked in AWAITING_HUMAN — the loop proceeds to finalize.
     assert pipeline.status != PipelineStatus.AWAITING_HUMAN
+    # The escalation is still surfaced even though the gate doesn't block.
+    assert report_mock.called
 
 
 def test_open_gap_approve_then_clear() -> None:
     """Approval after the operator resolves the gap clears the gate with a
     single prompt (re-read finds the contract clean)."""
     dq = _FakeQueue(resolutions=["approve"])
-    gated, _ = _run_gate(
+    gated, _, _ = _run_gate(
         dq,
         load_side_effect=[_contract(resolved=False), _contract(resolved=True)],
     )
@@ -245,7 +252,7 @@ def test_open_gap_approve_without_resolving_resurfaces() -> None:
     """A stale 'approve' while the gap is still open must NOT advance — the
     gate re-surfaces until resolved or overridden."""
     dq = _FakeQueue(resolutions=["approve", "override"])
-    gated, _ = _run_gate(
+    gated, _, _ = _run_gate(
         dq,
         load_side_effect=[_contract(resolved=False), _contract(resolved=False)],
     )
@@ -257,6 +264,6 @@ def test_open_gap_approve_without_resolving_resurfaces() -> None:
 def test_unresolved_decision_does_not_spin() -> None:
     """A cancelled/abandoned gate (non-RESOLVED) returns instead of looping."""
     dq = _FakeQueue(resolutions=[None])
-    gated, _ = _run_gate(dq, load_side_effect=[_contract(resolved=False)])
+    gated, _, _ = _run_gate(dq, load_side_effect=[_contract(resolved=False)])
     assert gated is True
     assert len(dq.queued) == 1

--- a/orchestrator/tests/test_unresolved_gap_gate.py
+++ b/orchestrator/tests/test_unresolved_gap_gate.py
@@ -96,7 +96,12 @@ class _FakeQueue:
         raise AssertionError(f"decision {decision_id} not queued")
 
 
-def _run_gate(dq: _FakeQueue, load_side_effect: list[Any]) -> tuple[bool, Pipeline]:
+def _run_gate(
+    dq: _FakeQueue,
+    load_side_effect: list[Any],
+    *,
+    hitl_gates: bool = True,
+) -> tuple[bool, Pipeline]:
     """Invoke the gate with the queue + a scripted load_contract sequence."""
     from routes.pipelines import _await_unresolved_gap_gate
 
@@ -124,6 +129,7 @@ def _run_gate(dq: _FakeQueue, load_side_effect: list[Any]) -> tuple[bool, Pipeli
             Path("/worktree"),
             42,
             PipelinePhase.IMPLEMENT,
+            hitl_gates,
         )
     return gated, pipeline
 
@@ -137,7 +143,9 @@ def test_clean_contract_no_gate() -> None:
 
 
 def test_open_gap_override_finalizes() -> None:
-    """An open gap surfaces a phase_gate decision; 'override' ships it."""
+    """An open gap surfaces a phase_gate decision; 'override' ships it and
+    records the override on the frozen phase artifacts for audit parity
+    with the complete_phase endpoint's force path (#3300 review)."""
     dq = _FakeQueue(resolutions=["override"])
     gated, pipeline = _run_gate(dq, load_side_effect=[_contract(resolved=False)])
     assert gated is True
@@ -147,6 +155,78 @@ def test_open_gap_override_finalizes() -> None:
     assert "task-1-2" in dq.queued[0].context
     # Status restored to RUNNING after the gate clears.
     assert pipeline.status == PipelineStatus.RUNNING
+    # Durable override audit on the phase box, not just a log line.
+    import json
+
+    phase_exec = pipeline.get_phase_execution(PipelinePhase.IMPLEMENT)
+    assert phase_exec.artifacts["force_completed_gaps"] == json.dumps(["task-1-2/gap-1"])
+
+
+def test_open_gap_marks_phase_box_awaiting_human() -> None:
+    """While blocking, both the pipeline and the implement phase box must
+    read AWAITING_HUMAN so the DAG renders the gate on the right phase
+    (#3300 review). A FakeQueue captures status at queue time."""
+    captured: dict[str, Any] = {}
+
+    class _CapturingQueue(_FakeQueue):
+        def __init__(self, pipeline_ref: list[Pipeline], resolutions):
+            super().__init__(resolutions)
+            self._pipeline_ref = pipeline_ref
+
+        def wait_for_decision(self, decision_id: str):
+            # Status is set to AWAITING_HUMAN just before the wait.
+            pl = self._pipeline_ref[0]
+            captured["pipeline"] = pl.status
+            captured["phase"] = pl.get_phase_execution(PipelinePhase.IMPLEMENT).status
+            return super().wait_for_decision(decision_id)
+
+    pipeline_ref: list[Pipeline] = []
+    dq = _CapturingQueue(pipeline_ref, resolutions=["override"])
+
+    from routes.pipelines import _await_unresolved_gap_gate
+
+    pipeline = Pipeline(id="issue-42", issue_number=42, repo="owner/repo", branch="egg/issue-42")
+    pipeline.current_phase = PipelinePhase.IMPLEMENT
+    pipeline_ref.append(pipeline)
+    store = MagicMock()
+    store.load_pipeline.return_value = pipeline
+
+    with (
+        patch("routes.pipelines.get_decision_queue", return_value=dq),
+        patch("routes.pipelines.get_pipeline_state_lock", return_value=nullcontext()),
+        patch("routes.pipelines.report_pipeline_status"),
+        patch("routes.pipelines._emit_event", None),
+        patch("egg_contracts.loader.load_contract", side_effect=[_contract(resolved=False)]),
+    ):
+        _await_unresolved_gap_gate(
+            store,
+            "issue-42",
+            Path("/repo"),
+            Path("/worktree"),
+            42,
+            PipelinePhase.IMPLEMENT,
+            True,
+        )
+
+    assert captured["pipeline"] == PipelineStatus.AWAITING_HUMAN
+    assert captured["phase"] == PipelineStatus.AWAITING_HUMAN
+
+
+def test_autonomous_open_gap_surfaces_but_does_not_block() -> None:
+    """On a fully-autonomous pipeline (hitl_gates=False) an open gap must
+    NOT queue a blocking decision — both options need a human, so blocking
+    would stall forever. The reactive CI check stays the backstop (#3300
+    review). The escalation is still surfaced (report_pipeline_status)."""
+    dq = _FakeQueue(resolutions=[])
+    gated, pipeline = _run_gate(
+        dq,
+        load_side_effect=[_contract(resolved=False)],
+        hitl_gates=False,
+    )
+    assert gated is False
+    assert dq.queued == []
+    # Never parked in AWAITING_HUMAN — the loop proceeds to finalize.
+    assert pipeline.status != PipelineStatus.AWAITING_HUMAN
 
 
 def test_open_gap_approve_then_clear() -> None:

--- a/orchestrator/tests/test_unresolved_gap_gate.py
+++ b/orchestrator/tests/test_unresolved_gap_gate.py
@@ -1,0 +1,182 @@
+"""Tests for the run-loop unresolved-gap finalize gate (#3300).
+
+The implement phase is not in ``_HITL_GATE_PHASES``, so the autonomous
+run loop would mark it complete and finalize with an open tester→coder
+``TaskGap`` still on the contract — shipping it into the committed
+contract and failing ``test_models_gaps.py`` red in CI on the
+already-open PR (#3298 class 4). ``_await_unresolved_gap_gate`` surfaces
+a blocking ``phase_gate`` decision and waits for the operator to resolve
+the gap or explicitly override.
+
+See: https://github.com/jwbron/egg/issues/3300
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from models import DecisionStatus, HITLDecision, Pipeline, PipelinePhase, PipelineStatus
+
+
+def _contract(*, resolved: bool):
+    """Build a Contract carrying a single tester→coder gap."""
+    from egg_contracts.models import Contract
+
+    return Contract(
+        pipeline_id="issue-42",
+        slices=[
+            {
+                "id": "slice-1",
+                "name": "n",
+                "tasks": [
+                    {
+                        "id": "task-1-2",
+                        "description": "d",
+                        "gaps": [
+                            {
+                                "id": "gap-1",
+                                "from_role": "tester",
+                                "to_role": "coder",
+                                "description": "no error-path test",
+                                "resolved": resolved,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    )
+
+
+class _FakeQueue:
+    """Resolves each queued decision with the next caller-provided value.
+
+    A ``None`` resolution entry yields a still-PENDING decision (models a
+    cancelled / abandoned gate).
+    """
+
+    def __init__(self, resolutions: list[str | None]) -> None:
+        self._resolutions = list(resolutions)
+        self.queued: list[HITLDecision] = []
+        self._counter = 0
+
+    def queue_decision(
+        self,
+        question: str,
+        context: str = "",
+        options: list[str] | None = None,
+        decision_type: str = "choice",
+        questions: list[dict[str, str]] | None = None,
+        phase: PipelinePhase | None = None,
+        content_changed: bool | None = None,
+    ) -> HITLDecision:
+        self._counter += 1
+        res = self._resolutions.pop(0) if self._resolutions else ""
+        decision = HITLDecision(
+            id=f"orch-{self._counter}",
+            question=question,
+            context=context,
+            options=options or [],
+            decision_type=decision_type,  # type: ignore[arg-type]
+            questions=questions or [],
+            phase=phase,
+            status=DecisionStatus.PENDING if res is None else DecisionStatus.RESOLVED,
+            resolution=None if res is None else res,
+        )
+        self.queued.append(decision)
+        return decision
+
+    def wait_for_decision(self, decision_id: str) -> HITLDecision:
+        for d in self.queued:
+            if d.id == decision_id:
+                return d
+        raise AssertionError(f"decision {decision_id} not queued")
+
+
+def _run_gate(dq: _FakeQueue, load_side_effect: list[Any]) -> tuple[bool, Pipeline]:
+    """Invoke the gate with the queue + a scripted load_contract sequence."""
+    from routes.pipelines import _await_unresolved_gap_gate
+
+    pipeline = Pipeline(
+        id="issue-42",
+        issue_number=42,
+        repo="owner/repo",
+        branch="egg/issue-42",
+    )
+    pipeline.current_phase = PipelinePhase.IMPLEMENT
+    store = MagicMock()
+    store.load_pipeline.return_value = pipeline
+
+    with (
+        patch("routes.pipelines.get_decision_queue", return_value=dq),
+        patch("routes.pipelines.get_pipeline_state_lock", return_value=nullcontext()),
+        patch("routes.pipelines.report_pipeline_status"),
+        patch("routes.pipelines._emit_event", None),
+        patch("egg_contracts.loader.load_contract", side_effect=load_side_effect),
+    ):
+        gated = _await_unresolved_gap_gate(
+            store,
+            "issue-42",
+            Path("/repo"),
+            Path("/worktree"),
+            42,
+            PipelinePhase.IMPLEMENT,
+        )
+    return gated, pipeline
+
+
+def test_clean_contract_no_gate() -> None:
+    """A resolved gap (or no gap) must not surface a decision."""
+    dq = _FakeQueue(resolutions=[])
+    gated, _ = _run_gate(dq, load_side_effect=[_contract(resolved=True)])
+    assert gated is False
+    assert dq.queued == []
+
+
+def test_open_gap_override_finalizes() -> None:
+    """An open gap surfaces a phase_gate decision; 'override' ships it."""
+    dq = _FakeQueue(resolutions=["override"])
+    gated, pipeline = _run_gate(dq, load_side_effect=[_contract(resolved=False)])
+    assert gated is True
+    assert len(dq.queued) == 1
+    assert dq.queued[0].decision_type == "phase_gate"
+    assert dq.queued[0].options == ["approve", "override"]
+    assert "task-1-2" in dq.queued[0].context
+    # Status restored to RUNNING after the gate clears.
+    assert pipeline.status == PipelineStatus.RUNNING
+
+
+def test_open_gap_approve_then_clear() -> None:
+    """Approval after the operator resolves the gap clears the gate with a
+    single prompt (re-read finds the contract clean)."""
+    dq = _FakeQueue(resolutions=["approve"])
+    gated, _ = _run_gate(
+        dq,
+        load_side_effect=[_contract(resolved=False), _contract(resolved=True)],
+    )
+    assert gated is True
+    assert len(dq.queued) == 1
+
+
+def test_open_gap_approve_without_resolving_resurfaces() -> None:
+    """A stale 'approve' while the gap is still open must NOT advance — the
+    gate re-surfaces until resolved or overridden."""
+    dq = _FakeQueue(resolutions=["approve", "override"])
+    gated, _ = _run_gate(
+        dq,
+        load_side_effect=[_contract(resolved=False), _contract(resolved=False)],
+    )
+    assert gated is True
+    # Two prompts: the ignored approve, then the override that ships it.
+    assert len(dq.queued) == 2
+
+
+def test_unresolved_decision_does_not_spin() -> None:
+    """A cancelled/abandoned gate (non-RESOLVED) returns instead of looping."""
+    dq = _FakeQueue(resolutions=[None])
+    gated, _ = _run_gate(dq, load_side_effect=[_contract(resolved=False)])
+    assert gated is True
+    assert len(dq.queued) == 1

--- a/shared/egg_contracts/models.py
+++ b/shared/egg_contracts/models.py
@@ -1191,6 +1191,30 @@ class Contract(EggContractBaseModel):
                 return decision
         return None
 
+    def unresolved_gaps(self) -> list[tuple[str, TaskGap]]:
+        """Return ``(task_id, gap)`` pairs for every unresolved ``TaskGap``.
+
+        A :class:`TaskGap` is a tester→coder coverage-gap handoff with a
+        ``resolved`` flag.  An unresolved gap left on the contract at
+        finalize ships into the committed contract snapshot and fails
+        ``test_models_gaps.py`` red in CI on the already-open PR (#3298
+        class 4).  This walks every task across every slice and surfaces
+        the open gaps so the finalize/PR-open gate (#3300) can block
+        before the contract is committed, rather than discovering it
+        reactively in CI.
+
+        Gaps are not phase-scoped: at finalize *every* gap should be
+        resolved, so the scan spans all tasks.  Returns an empty list
+        when the contract is clean (the common case).
+        """
+        open_gaps: list[tuple[str, TaskGap]] = []
+        for slice_ in self.slices:
+            for task in slice_.tasks:
+                for gap in task.gaps:
+                    if not gap.resolved:
+                        open_gaps.append((task.id, gap))
+        return open_gaps
+
     def get_agent_execution(self, role: AgentRoleType | str) -> AgentExecutionModel | None:
         """Get the execution state for an agent role.
 

--- a/tests/shared/egg_contracts/test_models_gaps.py
+++ b/tests/shared/egg_contracts/test_models_gaps.py
@@ -188,14 +188,31 @@ class TestTaskGapsRoundTrip:
 
 class TestBackCompatWithExistingContracts:
     """Old on-disk contracts MUST continue to load cleanly post-iter-2,
-    and the parsed task objects must expose ``gaps`` as an empty list
-    (NOT an absent key) so the rendered MCP response shape stays stable.
+    and the parsed task objects must expose ``gaps`` as a list (NOT an
+    absent key) so the rendered MCP response shape stays stable.
+
+    A committed contract must carry **no unresolved gaps** — a tester→
+    coder :class:`TaskGap` left ``resolved == False`` is the #3298 class-4
+    failure the finalize gate (#3300) blocks.  A *resolved* gap is the
+    intended terminal state: ``TaskGap.resolved`` is an audit flag (set
+    via the contract-mutate path; there is no removal path), so a gap that
+    has been addressed legitimately stays on the contract as a record.
+    This invariant — ``not gap.resolved`` for every gap — is exactly what
+    ``Contract.unresolved_gaps()`` and the finalize gate enforce, so the
+    proactive gate and this reactive backstop cannot drift.
     """
 
     @pytest.mark.parametrize("fixture", CONTRACT_FIXTURES, ids=lambda p: p.name)
     def test_existing_contract_parses(self, fixture: Path):
-        """A pre-iter-2 contract must load post-iter-2 and report
-        ``gaps=[]`` on every task.
+        """A pre-iter-2 contract must load post-iter-2 and report no
+        *unresolved* gaps on any task.
+
+        Legacy fixtures predate gaps entirely, so they trivially satisfy
+        the invariant (``gaps == []``).  The assertion is deliberately
+        ``not gap.resolved`` rather than ``gaps == []`` so it matches the
+        finalize gate's clearing criterion (``Contract.unresolved_gaps()``):
+        a contract whose gaps the operator resolved before finalize must
+        pass *both* gates, not clear the gate yet fail this test red.
 
         Some legacy fixtures have unrelated schema drift (e.g., old
         agent role enums); those predate the gaps migration and are
@@ -222,12 +239,19 @@ class TestBackCompatWithExistingContracts:
                 f"Legacy fixture {fixture.name} has unrelated schema drift "
                 f"(not about gaps): {str(exc).splitlines()[0]}"
             )
-        # Every task, in every phase, must report gaps as a list.
+        # Every task, in every phase, must report gaps as a list with no
+        # *unresolved* gap left open (resolved gaps are a kept audit trail).
         for phase in contract.phases:
             for task in phase.tasks:
-                assert task.gaps == [], (
+                assert isinstance(task.gaps, list), (
                     f"{fixture.name}: task {task.id} in phase {phase.id} "
-                    f"has non-empty gaps before iter-2 writes landed"
+                    f"does not expose gaps as a list"
+                )
+                unresolved = [g.id for g in task.gaps if not g.resolved]
+                assert unresolved == [], (
+                    f"{fixture.name}: task {task.id} in phase {phase.id} "
+                    f"committed with unresolved gaps {unresolved} "
+                    f"(#3298 class 4 — the finalize gate must block these)"
                 )
 
     def test_at_least_one_fixture_back_compat_tested(self):
@@ -395,6 +419,42 @@ class TestContractUnresolvedGaps:
         )
         ids = sorted(f"{t}/{g.id}" for t, g in contract.unresolved_gaps())
         assert ids == ["task-1-1/gap-1", "task-1-2/gap-3"]
+
+    def test_resolved_contract_passes_both_gates(self):
+        """Cross-check that the gate and the reactive backstop agree.
+
+        The finalize gate (#3300) clears when ``unresolved_gaps() == []``;
+        the resolution path it advertises sets ``resolved=true`` (there is
+        no gap-removal path).  A contract that took that path therefore
+        carries a *resolved* gap.  This pins the invariant that such a
+        contract clears the gate **and** satisfies the reactive
+        ``test_existing_contract_parses`` check (no unresolved gaps),
+        so resolving a gap can never produce the red PR the gate exists to
+        prevent.  If the two criteria ever diverge again, this fails.
+        """
+        contract = self._contract_with_gaps(
+            [
+                (
+                    "task-1-1",
+                    [
+                        {
+                            "id": "gap-1",
+                            "from_role": "tester",
+                            "to_role": "coder",
+                            "description": "addressed by the coder",
+                            "resolved": True,
+                        }
+                    ],
+                )
+            ]
+        )
+        # Gate criterion: cleared.
+        assert contract.unresolved_gaps() == []
+        # Reactive-backstop criterion (test_existing_contract_parses):
+        # no *unresolved* gap on any committed task.
+        for phase in contract.phases:
+            for task in phase.tasks:
+                assert [g.id for g in task.gaps if not g.resolved] == []
 
 
 class TestGapsMutationAuthorization:

--- a/tests/shared/egg_contracts/test_models_gaps.py
+++ b/tests/shared/egg_contracts/test_models_gaps.py
@@ -292,6 +292,111 @@ class TestContractJsonSchema:
 # --------------------------------------------------------------------
 
 
+class TestContractUnresolvedGaps:
+    """``Contract.unresolved_gaps()`` powers the finalize/PR-open gate
+    (#3300): it must surface every open gap across all slices so the
+    pipeline can block before committing a contract that would fail
+    ``test_models_gaps.py`` red in CI."""
+
+    def _contract_with_gaps(self, gaps_by_task):
+        return Contract(
+            pipeline_id="issue-3300",
+            slices=[
+                {
+                    "id": "slice-1",
+                    "name": "n",
+                    "tasks": [
+                        {"id": task_id, "description": "d", "gaps": gaps}
+                        for task_id, gaps in gaps_by_task
+                    ],
+                }
+            ],
+        )
+
+    def test_clean_contract_returns_empty(self):
+        contract = self._contract_with_gaps([("task-1-1", [])])
+        assert contract.unresolved_gaps() == []
+
+    def test_resolved_gaps_excluded(self):
+        contract = self._contract_with_gaps(
+            [
+                (
+                    "task-1-1",
+                    [
+                        {
+                            "id": "gap-1",
+                            "from_role": "tester",
+                            "to_role": "coder",
+                            "description": "d",
+                            "resolved": True,
+                        }
+                    ],
+                )
+            ]
+        )
+        assert contract.unresolved_gaps() == []
+
+    def test_open_gap_surfaced_with_task_id(self):
+        contract = self._contract_with_gaps(
+            [
+                (
+                    "task-1-2",
+                    [
+                        {
+                            "id": "gap-3",
+                            "from_role": "tester",
+                            "to_role": "coder",
+                            "description": "no error-path test",
+                        }
+                    ],
+                )
+            ]
+        )
+        open_gaps = contract.unresolved_gaps()
+        assert len(open_gaps) == 1
+        task_id, gap = open_gaps[0]
+        assert task_id == "task-1-2"
+        assert gap.id == "gap-3"
+        assert gap.resolved is False
+
+    def test_mixed_resolved_and_open_across_tasks(self):
+        contract = self._contract_with_gaps(
+            [
+                (
+                    "task-1-1",
+                    [
+                        {
+                            "id": "gap-1",
+                            "from_role": "tester",
+                            "to_role": "coder",
+                            "description": "open",
+                        },
+                        {
+                            "id": "gap-2",
+                            "from_role": "tester",
+                            "to_role": "coder",
+                            "description": "closed",
+                            "resolved": True,
+                        },
+                    ],
+                ),
+                (
+                    "task-1-2",
+                    [
+                        {
+                            "id": "gap-3",
+                            "from_role": "reviewer_code",
+                            "to_role": "coder",
+                            "description": "also open",
+                        }
+                    ],
+                ),
+            ]
+        )
+        ids = sorted(f"{t}/{g.id}" for t, g in contract.unresolved_gaps())
+        assert ids == ["task-1-1/gap-1", "task-1-2/gap-3"]
+
+
 class TestGapsMutationAuthorization:
     """The tester role hits the gateway as IMPLEMENTER; the reviewer
     roles hit as REVIEWER.  Both must be allowed to write gaps."""


### PR DESCRIPTION
Closes #3300. Part of #3298 (failure class 4).

## Problem

An unresolved tester→coder `TaskGap` could flow straight through to a committed contract and an open PR. `tests/shared/egg_contracts/test_models_gaps.py` only catches this **reactively in CI** (it globs committed contracts and asserts `gaps == []`), so by the time it fires the PR is already open and red — exactly how the context PR #3280 opened red in the #3298 stack.

## Root cause

There was no proactive gate. The issue text says "mirror the check in `complete_phase`," but `complete_phase` (the HTTP endpoint) is only called by operators/tests — the real pipeline runs the autonomous `_run_pipeline` loop, which marks the implement phase `COMPLETE` directly. And `_HITL_GATE_PHASES = {"refine", "plan"}` — **implement has no HITL gate**, so a dangling gap finalizes with no human in the loop. Gating only the endpoint would be a no-op for real runs.

## Fix

A proactive finalize gate at two chokepoints:

- **Run loop (load-bearing):** `_await_unresolved_gap_gate` runs at implement-complete (after the worktree sync, before advance/finalize). On an open gap it surfaces a blocking `phase_gate` HITL decision listing the gaps and waits for the operator to resolve them (set `resolved=true`) or pick `override`. It re-reads the contract after each approval so a stale `approve` can't advance with a gap still open. Fires regardless of `config.hitl_gates` (an open gap is an escalation, not a routine phase approval) and fails open on contract-load errors so a gate bug can never strand the pipeline.
- **`complete_phase` endpoint:** mirrors the existing unresolved-HITL-decision guard — `409` with `reason=unresolved_contract_gaps` unless `force=true` (which now also records `force_completed_gaps` for audit).

New `Contract.unresolved_gaps()` surfaces open gaps across all slices (gaps aren't phase-scoped — at finalize every gap should be resolved).

This complements, not replaces, the reactive `test_models_gaps.py` backstop.

## Scope boundary (re #3298)

This gates finalize/`complete_phase` on unresolved gaps. It does **not** guarantee a *freshly-opened* slice PR is gap-free (#3298 criterion c) — gaps are written by the tester mid-implement, often after the coder's slice PR is already open. That stricter property isn't cleanly achievable without serializing tester-after-coder per slice (which fights the streaming-PR model), so it's deliberately out of #3300. Posting a note on #3298 to keep criterion (c) honest.

## Tests

- `Contract.unresolved_gaps()` — clean / resolved-excluded / open-surfaced-with-task-id / mixed-across-tasks.
- `complete_phase` — open gap 409s with `unresolved_contract_gaps`; resolved gap passes; `force=true` ships + audits `force_completed_gaps`.
- Run-loop gate — clean no-op; override finalizes; approve-after-resolve clears in one prompt; stale approve re-surfaces; cancelled gate doesn't spin.

All targeted suites green; `make lint` clean (ruff + mypy).