### PR TITLE
feat(#3278): persist Claude session per (pipeline,slice,role) across event pods (re-land of orphaned #3286)

### DIFF
--- a/docs/architecture/context-discipline.md
+++ b/docs/architecture/context-discipline.md
@@ -182,6 +182,37 @@ JSON file and reads it back:
   (temp file + `os.replace`) and equally defensive: a persistence failure
   returns `False` and never crashes the run it is bookkeeping for.
 
+### Cross-pod persistence ([#3278](https://github.com/jwbron/egg/issues/3278))
+
+The pointer file above is *pod-local*, but under the orchestrator-owned event
+loop ([#3164](https://github.com/jwbron/egg/issues/3164)) **every BRC event is a
+fresh one-shot pod** — so the pointer dies with the pod, and, crucially, so does
+the Claude Code **session transcript** (`$CLAUDE_CONFIG_DIR/projects/<cwd-slug>/<session_id>.jsonl`)
+that `claude --resume` reads back. Persisting the pointer alone is necessary but
+not sufficient: `--resume <session_id>` against a pod whose transcript is gone
+silently cold-starts, so the gate would record `below_threshold` "resume"
+decisions while every event actually reseeds. The substrate must carry the
+**transcript** across pods, not just the pointer.
+
+Because the sandbox has no direct write access to host state, the durable copy is
+**orchestrator-owned** and reached only over the controlled API:
+
+- **Durable store** — `orchestrator/session_state_store.py` keeps one Redis record
+  per `(pipeline, slice, role)` holding the pointer **and** the transcript
+  together (one key, no split-brain), under a TTL that reaps abandoned state.
+  Only the orchestrator writes it; the sandbox reaches it through
+  `POST/GET /api/v1/pipelines/<pid>/session-state`.
+- **Live store stays ephemeral** — the agent's `$CLAUDE_CONFIG_DIR` is the pod's
+  own filesystem (no host mount), so Claude Code writes the transcript locally
+  during the run exactly as before.
+- **Round-trip in the wrapper** — `egg-orch session-state pull` (before the agent)
+  re-materialises the prior transcript + pointer into this pod so `--resume`
+  finds a real session; `egg-orch session-state push` (after) ships the updated
+  session back. Both are best-effort (`|| true`, `timeout`-bounded) and gated on
+  warm resume being enabled, so a failed sync degrades to a cold reseed and the
+  default path is byte-identical. The agent's own return code is preserved across
+  the push.
+
 Mid-phase restarts additionally need the BRC *message record* to survive so a
 reseeded session can re-pull it and re-derive the #3189 anchors
 ([#3200](https://github.com/jwbron/egg/issues/3200)). `_write_brc_history`
@@ -197,7 +228,8 @@ switches, each read in exactly one place:
 |---------|---------|--------|
 | `EGG_CONTEXT_DISCIPLINE` | `egg_agent.context_discipline.context_discipline_enabled` | **Master switch** for the whole discipline (protected-root / queryable-environment split + JIT pull + threshold reseed). ON → every event-pump role takes the new path and `session_resume_enabled` is forced ON; OFF (default) → today's full-context inline path, byte-for-byte unchanged. Subsumes the narrower `EGG_SESSION_RESUME` knob (see below). |
 | `EGG_SESSION_RESUME` | `egg_agent.session.session_resume_enabled` | Narrower opt-in for warm resume. OFF (default) → a passed-in `session_id` is ignored and the agent cold-starts; the substrate is inert and the agent path is byte-for-byte the legacy cold-start. The master flag above subsumes this: `session_resume_enabled` returns `True` for `EGG_SESSION_RESUME` **or** `context_discipline_enabled()`. |
-| `EGG_SESSION_STATE_FILE` | `egg_agent.session.resolve_session_state_path` | Location of the cross-invocation session-state file. Unset → the round-trip is a no-op (substrate stays inert). |
+| `EGG_SESSION_STATE_FILE` | `egg_agent.session.resolve_session_state_path` | Location of the (pod-local) cross-invocation pointer file. The orchestrator injects an ephemeral pod path (`/tmp/egg-session-state.json`) into event pods **only when warm resume is enabled** (#3278); unset → the round-trip is a no-op (substrate stays inert). Its presence in the pod also gates the wrapper's `egg-orch session-state pull/push`. |
+| `CLAUDE_CONFIG_DIR` | Claude Code (+ `egg_lib.session_state_sync`) | Pins the Claude session-store root (`/home/egg/.claude`) so the wrapper's pull/push and the agent agree on the transcript path regardless of HOME resolution. Injected into event pods alongside `EGG_SESSION_STATE_FILE` when warm resume is enabled (#3278). |
 | `EGG_RESEED_THRESHOLD` | `egg_agent.reseed.resolve_reseed_threshold` | Cross-boundary integer override of the reseed threshold. The sandbox runs with `orchestrator` off `PYTHONPATH`, so the orchestrator **always** computes `reseed_threshold(model)` and exports the integer here via `_ExecutorEventSpawner.spawn_event` ([#3284](https://github.com/jwbron/egg/issues/3284)); the gate's `None` fallback branch is inert on the production event-pump path. In dev/CI (where `orchestrator` is on `PYTHONPATH`) the gate also imports the helper directly. |
 | `EGG_CONTEXT_MEASUREMENT` | `egg_agent.measurement.measurement_enabled` | Opt-in for the emit-only per-event measurement surfaces (#3249). ON (and `EGG_PIPELINE_ID` set) → after each BRC event the agent emits the six context-discipline metrics through the progress + heartbeat surfaces; OFF (default) → the legacy path is byte-identical (no measurement emit). |
 | `EGG_REAL_BACKEND_WINDOW` | `egg_agent.measurement._resolve_real_window` | Cross-boundary integer override of the model's real backend window, mirroring `EGG_RESEED_THRESHOLD`. Because `orchestrator` is off `PYTHONPATH` in-pod, this is the channel that populates the window-relative metrics (`real_backend_window` / `window_utilization`) in production; the orchestrator import is a dev/CI-only fallback, and both metrics degrade to `None` when neither yields a value. |

--- a/orchestrator/api.py
+++ b/orchestrator/api.py
@@ -51,6 +51,7 @@ try:
     from routes.phases import phases_bp
     from routes.pipelines import pipelines_bp
     from routes.progress import progress_bp
+    from routes.session_state import session_state_bp
     from routes.signals import signals_bp
     from webhooks import webhooks_bp
 
@@ -71,6 +72,7 @@ try:
     app.register_blueprint(commit_authorship_bp)
     app.register_blueprint(consensus_bp)
     app.register_blueprint(artifacts_bp)
+    app.register_blueprint(session_state_bp)
 
     # Emit the EGG_MESSAGE_POLL_MAX_WAIT startup log line. RISK-4 (issue
     # #1897): if the cap exceeds 90s we log a WARNING naming the gateway
@@ -101,6 +103,7 @@ except ImportError:
     from .routes.phases import phases_bp  # type: ignore[no-redef]
     from .routes.pipelines import pipelines_bp  # type: ignore[no-redef]
     from .routes.progress import progress_bp  # type: ignore[no-redef]
+    from .routes.session_state import session_state_bp  # type: ignore[no-redef]
     from .routes.signals import signals_bp  # type: ignore[no-redef]
     from .webhooks import webhooks_bp  # type: ignore[no-redef]
 
@@ -121,6 +124,7 @@ except ImportError:
     app.register_blueprint(commit_authorship_bp)
     app.register_blueprint(consensus_bp)
     app.register_blueprint(artifacts_bp)
+    app.register_blueprint(session_state_bp)
 
     try:
         from .routes.messages import log_poll_max_wait_startup  # type: ignore[no-redef]

--- a/orchestrator/concurrent_executor.py
+++ b/orchestrator/concurrent_executor.py
@@ -41,6 +41,19 @@ from agent_model_resolution import (
     resolve_agent_model,
 )
 from consensus_wrapper import build_consensus_wrapped_command
+
+try:
+    # Orchestrator-side check of the forwarded warm-resume flags
+    # (``EGG_SESSION_RESUME`` / ``EGG_CONTEXT_DISCIPLINE`` on the orchestrator's
+    # own env, which ``_forwarded_discipline_env`` propagates to the pod). Used to
+    # gate the #3278 session-store env so default pods stay byte-identical.
+    from egg_agent.session import session_resume_enabled
+except ImportError:  # pragma: no cover - egg_agent always on PYTHONPATH in prod/tests
+
+    def session_resume_enabled() -> bool:  # type: ignore[misc]
+        return False
+
+
 from events import EventType, emit_event
 from message_store import Message, MessageType, get_message_store
 from models import (
@@ -66,6 +79,15 @@ SpawnFn = Callable[..., Any]
 
 # Failure detection window: multiple failures within this window trigger abort
 MULTI_FAILURE_WINDOW_SECONDS = 60
+
+# Warm-resume session-store substrate (#3278). The agent's Claude session store
+# lives at ``$CLAUDE_CONFIG_DIR`` (default ``~/.claude`` = ``/home/egg/.claude``);
+# we pin it explicitly so the wrapper's pull/push and the agent agree on the path
+# regardless of HOME resolution. The pointer file is a pod-ephemeral local path
+# the gate round-trips (the durable copy is orchestrator-owned in Redis). Both are
+# injected only when warm resume is enabled, so default pods are byte-identical.
+_POD_CLAUDE_CONFIG_DIR = "/home/egg/.claude"
+_POD_SESSION_STATE_FILE = "/tmp/egg-session-state.json"  # noqa: S108 — pod-ephemeral, agent-local
 
 
 # Substrings (case-insensitive) indicating a spawn failure is worth retrying at
@@ -163,6 +185,15 @@ class _ExecutorEventSpawner:
         # branch). Inert unless a discipline/resume/measurement flag is on in the
         # pod — the only consumers read it (#3279); a plain default pod ignores it.
         env["EGG_RESEED_THRESHOLD"] = str(threshold)
+        # Warm-resume session-store substrate (#3278): pin the Claude session-store
+        # location and the local pointer file the slice-8 gate round-trips, so the
+        # wrapper's `egg-orch session-state pull|push` re-materialises the prior
+        # transcript and `--resume` finds it. Gated on resume being enabled so a
+        # default pod gets neither (byte-identical legacy path); the wrapper's
+        # pull/push run under the same flag.
+        if session_resume_enabled():
+            env["CLAUDE_CONFIG_DIR"] = _POD_CLAUDE_CONFIG_DIR
+            env["EGG_SESSION_STATE_FILE"] = _POD_SESSION_STATE_FILE
         return self._ex.spawn_fn(
             role=agent_role,
             branch=branch,

--- a/orchestrator/consensus_wrapper.py
+++ b/orchestrator/consensus_wrapper.py
@@ -247,7 +247,25 @@ invoke_agent_for_event() {{
         prompt="${{SYNC_FAILURE_BANNERS}}${{prompt}}"
         SYNC_FAILURE_BANNERS=""
     fi
+    # Warm-resume session-store sync (#3278). The orchestrator sets
+    # ``EGG_SESSION_STATE_FILE`` only when warm resume is enabled, so its
+    # presence gates the round-trip. ``pull`` re-materialises the prior
+    # event's transcript + pointer into this pod's ephemeral Claude store so
+    # ``--resume`` (the slice-8 gate's resume branch) finds a real session;
+    # ``push`` ships the updated session back after the agent exits. Both are
+    # best-effort (``|| true``, bounded by ``timeout``) — a failed sync
+    # degrades to a safe cold reseed and never wedges the event. The agent's
+    # own return code is preserved as this function's rc (the one-shot
+    # handler exits with it), so the post-agent push can't mask it.
+    if [ -n "${{EGG_SESSION_STATE_FILE:-}}" ]; then
+        timeout 60 egg-orch session-state pull 2>&1 | sed 's/^/[session-state] /' >&2 || true
+    fi
     {agent_command_prefix} "$prompt"
+    local _agent_rc=$?
+    if [ -n "${{EGG_SESSION_STATE_FILE:-}}" ]; then
+        timeout 60 egg-orch session-state push 2>&1 | sed 's/^/[session-state] /' >&2 || true
+    fi
+    return "$_agent_rc"
 }}
 
 # Sync-to-proposal (#3076 / #3077 clause 2): before a review invocation

--- a/orchestrator/routes/session_state.py
+++ b/orchestrator/routes/session_state.py
@@ -1,0 +1,139 @@
+"""Cross-pod warm-resume session-state endpoints (#3278).
+
+The orchestrator owns the durable, off-pod copy of each role's Claude Code
+session (pointer + transcript) keyed ``(pipeline, slice, role)`` — see
+``orchestrator/session_state_store.py``. The sandbox has no direct write access
+to that store; it reaches it only through these routes (``egg-orch
+session-state pull|push`` → ``orchestrator_request``), so the orchestrator stays
+the single writer.
+
+- ``POST /<pid>/session-state`` — an event pod, on exit, *pushes* its updated
+  session (``session_id`` + ``window_occupancy`` + the JSONL ``transcript``).
+- ``GET  /<pid>/session-state`` — the next event pod for the same ``(slice,
+  role)``, on startup, *pulls* the prior session so it can re-materialise the
+  transcript and warm-resume.
+
+Both are best-effort by contract: a miss / failure degrades to a safe cold
+reseed in the agent, so a GET miss returns ``200`` with ``found: false`` rather
+than ``404`` (the caller treats "nothing to resume" and "store unavailable"
+identically — it cold-starts).
+"""
+
+import sys
+from pathlib import Path
+from typing import Any
+
+from flask import Blueprint, Response, jsonify, request
+
+_parent_path = Path(__file__).parent.parent
+if str(_parent_path) not in sys.path:
+    sys.path.insert(0, str(_parent_path))
+
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+try:
+    from egg_logging import get_logger
+except ImportError:
+    import logging
+
+    def get_logger(name: str, **kwargs) -> logging.Logger:  # type: ignore[misc]
+        return logging.getLogger(name)
+
+
+from session_state_store import get_session_state_store
+
+logger = get_logger("orchestrator.session_state")
+
+session_state_bp = Blueprint("session_state", __name__, url_prefix="/api/v1/pipelines")
+
+
+def _make_error(message: str, status_code: int = 400) -> tuple[Response, int]:
+    return jsonify({"success": False, "message": message}), status_code
+
+
+@session_state_bp.route("/<pipeline_id>/session-state", methods=["POST"])
+def push_session_state(pipeline_id: str) -> tuple[Response, int]:
+    """Persist (overwrite) a role's warm-resume record.
+
+    Request body::
+
+        {
+            "role": "coder",
+            "slice_id": "slice-3",            # optional; null/absent → pipeline-level
+            "session_id": "uuid",
+            "window_occupancy": 123456,        # optional
+            "transcript": "<jsonl text>"       # optional (pointer-only when absent)
+        }
+    """
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return _make_error("Request body must be a JSON object")
+
+    role = body.get("role")
+    if not role or not isinstance(role, str):
+        return _make_error("Missing required field: role")
+
+    session_id = body.get("session_id")
+    if not session_id or not isinstance(session_id, str):
+        return _make_error("Missing required field: session_id")
+
+    slice_id = body.get("slice_id")
+    if slice_id is not None and not isinstance(slice_id, str):
+        return _make_error("slice_id must be a string or null")
+
+    occupancy = body.get("window_occupancy")
+    if occupancy is not None and (isinstance(occupancy, bool) or not isinstance(occupancy, int)):
+        return _make_error("window_occupancy must be an integer or null")
+
+    transcript = body.get("transcript")
+    if transcript is not None and not isinstance(transcript, str):
+        return _make_error("transcript must be a string or null")
+
+    stored = get_session_state_store().put(
+        pipeline_id,
+        slice_id,
+        role,
+        session_id=session_id,
+        window_occupancy=occupancy,
+        transcript=transcript,
+    )
+    logger.info(
+        "session-state push",
+        event_type="system",
+        event_subtype="session_state_push",
+        pipeline_id=pipeline_id,
+        slice_id=slice_id,
+        role=role,
+        stored=stored,
+        has_transcript=transcript is not None,
+    )
+    # ``stored=False`` is not an error: an empty session_id or oversized transcript
+    # simply degrades to a cold reseed next event. Report it so the caller can log.
+    return jsonify({"success": True, "stored": stored}), 200
+
+
+@session_state_bp.route("/<pipeline_id>/session-state", methods=["GET"])
+def pull_session_state(pipeline_id: str) -> tuple[Response, int]:
+    """Return a role's warm-resume record, or ``found: false`` on any miss.
+
+    Query params: ``role`` (required), ``slice_id`` (optional).
+    """
+    role = request.args.get("role")
+    if not role:
+        return _make_error("Missing required query param: role")
+    slice_id = request.args.get("slice_id") or None
+
+    record = get_session_state_store().get(pipeline_id, slice_id, role)
+    if record is None:
+        # Benign "nothing to resume" and "store unavailable" are intentionally
+        # indistinguishable here — the agent cold-starts either way.
+        return jsonify({"success": True, "found": False}), 200
+
+    data: dict[str, Any] = {
+        "session_id": record.session_id,
+        "window_occupancy": record.window_occupancy,
+        "transcript": record.transcript,
+    }
+    return jsonify({"success": True, "found": True, "data": data}), 200

--- a/orchestrator/session_state_store.py
+++ b/orchestrator/session_state_store.py
@@ -1,0 +1,244 @@
+"""Redis-backed cross-pod session-state store for the BRC warm-resume substrate (#3278).
+
+Under the orchestrator-owned event loop (#3164) each BRC event is a fresh one-shot
+pod, so the Claude Code session a role accumulates — its ``session_id`` + cumulative
+``window_occupancy`` (the slice-8 gate input) AND the **session transcript** that
+``claude --resume`` reads back — must survive pod death and be readable by the next
+event pod for the same ``(pipeline, slice, role)``. ``shared/egg_agent/session.py``
+already persists the small pointer to a *local* file; that file dies with the pod.
+This module is the durable, off-pod home keyed ``(pipeline, slice, role)``.
+
+**Why Redis, and why the orchestrator owns it.** The durable copy must be written
+by the orchestrator/gateway, never the sandbox (the sandbox has no direct write
+access to host state — it reaches this store only through the orchestrator route
+that wraps this module). Session state is inherently transient and TTL-shaped, so
+Redis — the orchestrator's existing ephemeral store — fits: a single key holds the
+pointer **and** the transcript together (no split-brain between a pointer and a
+separately-stored transcript), and the TTL reaps abandoned state automatically
+rather than leaking disk per ``(pipeline, slice, role)``.
+
+**Bias to reseed on any failure.** Every read/write failure (Redis down, oversized
+transcript, malformed payload) collapses to ``None`` / ``False`` rather than
+raising, so a lost record degrades to a safe cold reseed — exactly the
+``egg_agent.session`` substrate's existing contract. A transcript larger than
+:data:`MAX_TRANSCRIPT_BYTES` is dropped (not stored), so a pathological session can
+never wedge Redis; the next event simply reseeds.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger("orchestrator.session_state_store")
+
+__all__ = [
+    "MAX_TRANSCRIPT_BYTES",
+    "SESSION_STATE_TTL_SECONDS",
+    "SessionStateRecord",
+    "SessionStateStore",
+    "get_session_state_store",
+    "reset_session_state_store",
+    "set_session_state_store",
+]
+
+# Key prefix for the per-(pipeline, slice, role) record. The slice segment is
+# ``none`` for pipeline-level (non-sliced) spawns so the key shape is uniform.
+_KEY_PREFIX = "session-state"
+
+# TTL on each record. Session state is live only for the duration of a slice's
+# BRC cycle; a generous ceiling reaps abandoned state (cancelled pipeline, crashed
+# slice) without a separate sweeper, while comfortably outlasting any real cycle.
+SESSION_STATE_TTL_SECONDS = 6 * 60 * 60  # 6 hours
+
+# Hard cap on a stored transcript. A reseed bounds occupancy below ~400K tokens
+# (a few MB of JSONL), so a record far above that is anomalous; rather than push
+# an unbounded blob into Redis we drop it and let the next event reseed. Chosen
+# well above the expected ceiling so it only ever trips on pathological input.
+MAX_TRANSCRIPT_BYTES = 32 * 1024 * 1024  # 32 MiB
+
+
+class SessionStateRecord:
+    """A durable warm-resume record: pointer (``session_id`` + ``occupancy``)
+    plus the Claude Code session ``transcript`` (the JSONL ``--resume`` reads).
+
+    ``transcript`` may be ``None`` — a pointer-only record still lets the slice-8
+    gate read occupancy, but resume only actually re-enters the session when the
+    transcript is present to be re-materialised into the next pod.
+    """
+
+    __slots__ = ("session_id", "window_occupancy", "transcript")
+
+    def __init__(
+        self,
+        session_id: str,
+        window_occupancy: int | None = None,
+        transcript: str | None = None,
+    ) -> None:
+        self.session_id = session_id
+        self.window_occupancy = window_occupancy
+        self.transcript = transcript
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "window_occupancy": self.window_occupancy,
+            "transcript": self.transcript,
+        }
+
+
+def _coerce_occupancy(value: Any) -> int | None:
+    """Return ``value`` as an occupancy int, or ``None`` (bools are not ints here)."""
+    if isinstance(value, bool):
+        return None
+    return value if isinstance(value, int) else None
+
+
+class SessionStateStore:
+    """Redis-backed CRUD over per-(pipeline, slice, role) warm-resume records.
+
+    Constructed with an injected redis client (real in production via
+    :func:`get_session_state_store`, ``fakeredis.FakeRedis()`` in tests). Stores
+    bytes (``decode_responses=False``) and owns its own JSON (de)serialisation.
+    Every method is best-effort: a Redis/serialisation failure logs and returns
+    the cold-start sentinel (``None`` / ``False``) — it never raises into the
+    caller's request path.
+    """
+
+    def __init__(self, redis_client: Any) -> None:
+        self._redis = redis_client
+
+    @staticmethod
+    def _key(pipeline_id: str, slice_id: str | None, role: str) -> str:
+        return f"{_KEY_PREFIX}:{pipeline_id}:{slice_id or 'none'}:{role}"
+
+    def put(
+        self,
+        pipeline_id: str,
+        slice_id: str | None,
+        role: str,
+        *,
+        session_id: str | None,
+        window_occupancy: int | None = None,
+        transcript: str | None = None,
+    ) -> bool:
+        """Persist (overwrite) the record under a fresh TTL; return whether it stored.
+
+        Returns ``False`` (storing nothing) when ``session_id`` is empty or the
+        transcript exceeds :data:`MAX_TRANSCRIPT_BYTES` — both degrade safely to a
+        cold reseed on the next event.
+        """
+        sid = (session_id or "").strip()
+        if not sid:
+            return False
+        if transcript is not None and len(transcript.encode("utf-8")) > MAX_TRANSCRIPT_BYTES:
+            logger.warning(
+                "Session-state transcript exceeds %d bytes; not persisting "
+                "(pipeline=%s slice=%s role=%s) — next event reseeds",
+                MAX_TRANSCRIPT_BYTES,
+                pipeline_id,
+                slice_id,
+                role,
+            )
+            transcript = None
+            # A pointer-only record is still useful (occupancy for the gate), so
+            # fall through and store it without the oversized transcript.
+        record = SessionStateRecord(sid, _coerce_occupancy(window_occupancy), transcript)
+        try:
+            payload = json.dumps(record.to_dict()).encode("utf-8")
+            self._redis.setex(
+                self._key(pipeline_id, slice_id, role),
+                SESSION_STATE_TTL_SECONDS,
+                payload,
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001 — best-effort; never raise into the route
+            logger.warning(
+                "Failed to persist session state (pipeline=%s slice=%s role=%s): %s",
+                pipeline_id,
+                slice_id,
+                role,
+                exc,
+            )
+            return False
+
+    def get(self, pipeline_id: str, slice_id: str | None, role: str) -> SessionStateRecord | None:
+        """Read the record, or ``None`` — never raising.
+
+        ``None`` covers every benign and anomalous miss alike (no record, Redis
+        unreachable, malformed payload, no usable ``session_id``), so the caller's
+        decision collapses to a safe cold reseed.
+        """
+        try:
+            raw = self._redis.get(self._key(pipeline_id, slice_id, role))
+        except Exception as exc:  # noqa: BLE001 — best-effort read
+            logger.warning(
+                "Failed to read session state (pipeline=%s slice=%s role=%s): %s",
+                pipeline_id,
+                slice_id,
+                role,
+                exc,
+            )
+            return None
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+        except ValueError, TypeError:
+            logger.warning(
+                "Malformed session-state payload (pipeline=%s slice=%s role=%s); ignoring",
+                pipeline_id,
+                slice_id,
+                role,
+            )
+            return None
+        if not isinstance(data, dict):
+            return None
+        sid = data.get("session_id")
+        if not isinstance(sid, str) or not sid.strip():
+            return None
+        transcript = data.get("transcript")
+        if transcript is not None and not isinstance(transcript, str):
+            transcript = None
+        return SessionStateRecord(
+            sid.strip(),
+            _coerce_occupancy(data.get("window_occupancy")),
+            transcript,
+        )
+
+
+_store: SessionStateStore | None = None
+
+
+def get_session_state_store() -> SessionStateStore:
+    """Return the process-wide store, building a Redis client on first use.
+
+    Reads ``REDIS_HOST`` / ``REDIS_PORT`` / ``REDIS_DB`` exactly like
+    ``message_store.get_message_store`` so the session-state store lands on the
+    same Redis the rest of the orchestrator uses. ``decode_responses=False`` —
+    this module owns its bytes↔JSON handling.
+    """
+    global _store
+    if _store is None:
+        import redis
+
+        host = os.environ.get("REDIS_HOST", "localhost")
+        port = int(os.environ.get("REDIS_PORT", "6379"))
+        db = int(os.environ.get("REDIS_DB", "0"))
+        client = redis.Redis(host=host, port=port, db=db, decode_responses=False)
+        _store = SessionStateStore(client)
+    return _store
+
+
+def reset_session_state_store() -> None:
+    """Reset the process-wide store (tests inject a fakeredis-backed store)."""
+    global _store
+    _store = None
+
+
+def set_session_state_store(store: SessionStateStore | None) -> None:
+    """Install a store instance (tests inject ``SessionStateStore(fakeredis.FakeRedis())``)."""
+    global _store
+    _store = store

--- a/orchestrator/tests/golden/event_pump_wrapper.sh.golden
+++ b/orchestrator/tests/golden/event_pump_wrapper.sh.golden
@@ -177,7 +177,25 @@ invoke_agent_for_event() {
         prompt="${SYNC_FAILURE_BANNERS}${prompt}"
         SYNC_FAILURE_BANNERS=""
     fi
+    # Warm-resume session-store sync (#3278). The orchestrator sets
+    # ``EGG_SESSION_STATE_FILE`` only when warm resume is enabled, so its
+    # presence gates the round-trip. ``pull`` re-materialises the prior
+    # event's transcript + pointer into this pod's ephemeral Claude store so
+    # ``--resume`` (the slice-8 gate's resume branch) finds a real session;
+    # ``push`` ships the updated session back after the agent exits. Both are
+    # best-effort (``|| true``, bounded by ``timeout``) — a failed sync
+    # degrades to a safe cold reseed and never wedges the event. The agent's
+    # own return code is preserved as this function's rc (the one-shot
+    # handler exits with it), so the post-agent push can't mask it.
+    if [ -n "${EGG_SESSION_STATE_FILE:-}" ]; then
+        timeout 60 egg-orch session-state pull 2>&1 | sed 's/^/[session-state] /' >&2 || true
+    fi
     python3 -m egg_agent --model opus --max-turns 1000 "$prompt"
+    local _agent_rc=$?
+    if [ -n "${EGG_SESSION_STATE_FILE:-}" ]; then
+        timeout 60 egg-orch session-state push 2>&1 | sed 's/^/[session-state] /' >&2 || true
+    fi
+    return "$_agent_rc"
 }
 
 # Sync-to-proposal (#3076 / #3077 clause 2): before a review invocation

--- a/orchestrator/tests/test_concurrent_executor.py
+++ b/orchestrator/tests/test_concurrent_executor.py
@@ -1723,3 +1723,42 @@ class TestEventSpawnReseedThreshold:
 
         env = mock_spawn.call_args.kwargs["extra_env"]
         assert env["EGG_RESEED_THRESHOLD"] == "160000"
+
+
+class TestEventSpawnSessionStoreEnv:
+    """#3278: the warm-resume session-store env (CLAUDE_CONFIG_DIR + the pointer
+    file the slice-8 gate round-trips) is injected into event pods only when warm
+    resume is enabled, so a default pod stays byte-identical to the legacy path.
+    """
+
+    def _event_spawner(self, pipeline, mock_spawn):
+        from concurrent_executor import ConcurrentPhaseExecutor, _ExecutorEventSpawner
+        from egg_orchestrator.types import AgentRole
+
+        executor = ConcurrentPhaseExecutor(pipeline, spawn_fn=mock_spawn)
+        return _ExecutorEventSpawner(executor=executor, roles=[AgentRole.CODER], slice_id=None)
+
+    def _spawn_env(self, monkeypatch, *, discipline):
+        # session_resume_enabled() reads these off the orchestrator's env.
+        monkeypatch.delenv("EGG_SESSION_RESUME", raising=False)
+        if discipline:
+            monkeypatch.setenv("EGG_CONTEXT_DISCIPLINE", "true")
+        else:
+            monkeypatch.delenv("EGG_CONTEXT_DISCIPLINE", raising=False)
+        pipeline = _make_pipeline()
+        mock_spawn = MagicMock(return_value=_kubernetes_spawn_result())
+        spawner = self._event_spawner(pipeline, mock_spawn)
+        spawner.spawn_event(role="coder", action="propose", dedupe_key="k1")
+        return mock_spawn.call_args.kwargs["extra_env"]
+
+    def test_injected_when_resume_enabled(self, monkeypatch):
+        env = self._spawn_env(monkeypatch, discipline=True)
+        assert env["CLAUDE_CONFIG_DIR"] == "/home/egg/.claude"
+        assert env["EGG_SESSION_STATE_FILE"] == "/tmp/egg-session-state.json"  # noqa: S108
+
+    def test_omitted_when_resume_disabled(self, monkeypatch):
+        env = self._spawn_env(monkeypatch, discipline=False)
+        assert "CLAUDE_CONFIG_DIR" not in env
+        assert "EGG_SESSION_STATE_FILE" not in env
+        # The threshold rides regardless (#3279) — it's inert data, not substrate env.
+        assert env["EGG_RESEED_THRESHOLD"] == "400000"

--- a/orchestrator/tests/test_session_state_routes.py
+++ b/orchestrator/tests/test_session_state_routes.py
@@ -1,0 +1,107 @@
+"""Tests for the session-state push/pull endpoints (#3278)."""
+
+import sys
+from pathlib import Path
+
+import fakeredis
+import pytest
+from flask import Flask
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+import session_state_store
+from routes.session_state import session_state_bp
+from session_state_store import SessionStateStore
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.register_blueprint(session_state_bp)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def _fakeredis_store():
+    session_state_store.set_session_state_store(SessionStateStore(fakeredis.FakeRedis()))
+    yield
+    session_state_store.reset_session_state_store()
+
+
+_URL = "/api/v1/pipelines/issue-1/session-state"
+
+
+class TestPushPullRoundTrip:
+    def test_push_then_pull(self, client):
+        push = client.post(
+            _URL,
+            json={
+                "role": "coder",
+                "slice_id": "slice-3",
+                "session_id": "sid-abc",
+                "window_occupancy": 99,
+                "transcript": '{"l": 1}\n',
+            },
+        )
+        assert push.status_code == 200
+        assert push.get_json()["stored"] is True
+
+        pull = client.get(_URL, query_string={"role": "coder", "slice_id": "slice-3"})
+        assert pull.status_code == 200
+        body = pull.get_json()
+        assert body["found"] is True
+        assert body["data"]["session_id"] == "sid-abc"
+        assert body["data"]["window_occupancy"] == 99
+        assert body["data"]["transcript"] == '{"l": 1}\n'
+
+    def test_pull_miss_returns_found_false_not_404(self, client):
+        pull = client.get(_URL, query_string={"role": "coder", "slice_id": "slice-9"})
+        assert pull.status_code == 200
+        assert pull.get_json()["found"] is False
+
+    def test_pull_scopes_by_slice_and_role(self, client):
+        client.post(_URL, json={"role": "coder", "slice_id": "slice-3", "session_id": "a"})
+        # Wrong slice / role → miss.
+        assert (
+            client.get(_URL, query_string={"role": "coder", "slice_id": "slice-4"}).get_json()[
+                "found"
+            ]
+            is False
+        )
+        assert (
+            client.get(
+                _URL, query_string={"role": "reviewer_code", "slice_id": "slice-3"}
+            ).get_json()["found"]
+            is False
+        )
+
+    def test_pipeline_level_pull_omits_slice(self, client):
+        client.post(_URL, json={"role": "coder", "session_id": "pl"})
+        body = client.get(_URL, query_string={"role": "coder"}).get_json()
+        assert body["found"] is True
+        assert body["data"]["session_id"] == "pl"
+
+
+class TestValidation:
+    def test_push_requires_role(self, client):
+        r = client.post(_URL, json={"session_id": "a"})
+        assert r.status_code == 400
+
+    def test_push_requires_session_id(self, client):
+        r = client.post(_URL, json={"role": "coder"})
+        assert r.status_code == 400
+
+    def test_push_rejects_non_object_body(self, client):
+        r = client.post(_URL, json=["not", "an", "object"])
+        assert r.status_code == 400
+
+    def test_push_rejects_bad_occupancy(self, client):
+        r = client.post(_URL, json={"role": "coder", "session_id": "a", "window_occupancy": "big"})
+        assert r.status_code == 400
+
+    def test_pull_requires_role(self, client):
+        r = client.get(_URL)
+        assert r.status_code == 400

--- a/orchestrator/tests/test_session_state_store.py
+++ b/orchestrator/tests/test_session_state_store.py
@@ -1,0 +1,116 @@
+"""Tests for the Redis-backed cross-pod session-state store (#3278)."""
+
+import sys
+from pathlib import Path
+
+import fakeredis
+import pytest
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+from session_state_store import (
+    MAX_TRANSCRIPT_BYTES,
+    SESSION_STATE_TTL_SECONDS,
+    SessionStateStore,
+)
+
+
+@pytest.fixture
+def store():
+    return SessionStateStore(fakeredis.FakeRedis())
+
+
+class TestRoundTrip:
+    def test_put_then_get_returns_record(self, store):
+        store.put(
+            "issue-1",
+            "slice-3",
+            "coder",
+            session_id="sid-abc",
+            window_occupancy=123456,
+            transcript='{"line": 1}\n',
+        )
+        rec = store.get("issue-1", "slice-3", "coder")
+        assert rec is not None
+        assert rec.session_id == "sid-abc"
+        assert rec.window_occupancy == 123456
+        assert rec.transcript == '{"line": 1}\n'
+
+    def test_get_missing_returns_none(self, store):
+        assert store.get("issue-1", "slice-3", "coder") is None
+
+    def test_key_is_scoped_by_pipeline_slice_role(self, store):
+        store.put("issue-1", "slice-3", "coder", session_id="a")
+        # Any of pipeline / slice / role differing is a distinct record.
+        assert store.get("issue-2", "slice-3", "coder") is None
+        assert store.get("issue-1", "slice-4", "coder") is None
+        assert store.get("issue-1", "slice-3", "reviewer_code") is None
+        assert store.get("issue-1", "slice-3", "coder").session_id == "a"
+
+    def test_none_slice_is_pipeline_level_and_distinct(self, store):
+        store.put("issue-1", None, "coder", session_id="pipeline-level")
+        store.put("issue-1", "slice-3", "coder", session_id="sliced")
+        assert store.get("issue-1", None, "coder").session_id == "pipeline-level"
+        assert store.get("issue-1", "slice-3", "coder").session_id == "sliced"
+
+    def test_put_overwrites(self, store):
+        store.put("issue-1", "slice-3", "coder", session_id="old", window_occupancy=1)
+        store.put("issue-1", "slice-3", "coder", session_id="new", window_occupancy=2)
+        rec = store.get("issue-1", "slice-3", "coder")
+        assert rec.session_id == "new"
+        assert rec.window_occupancy == 2
+
+
+class TestTtl:
+    def test_put_sets_ttl(self, store):
+        store.put("issue-1", "slice-3", "coder", session_id="a")
+        # fakeredis honours TTL; assert a positive ttl near the configured value.
+        ttl = store._redis.ttl(SessionStateStore._key("issue-1", "slice-3", "coder"))
+        assert 0 < ttl <= SESSION_STATE_TTL_SECONDS
+
+
+class TestDefensiveContract:
+    def test_empty_session_id_not_stored(self, store):
+        assert store.put("issue-1", "slice-3", "coder", session_id="") is False
+        assert store.get("issue-1", "slice-3", "coder") is None
+
+    def test_pointer_only_record_round_trips(self, store):
+        assert store.put("issue-1", "slice-3", "coder", session_id="a") is True
+        rec = store.get("issue-1", "slice-3", "coder")
+        assert rec.session_id == "a"
+        assert rec.transcript is None
+        assert rec.window_occupancy is None
+
+    def test_oversized_transcript_dropped_but_pointer_kept(self, store):
+        big = "x" * (MAX_TRANSCRIPT_BYTES + 1)
+        assert store.put("issue-1", "slice-3", "coder", session_id="a", transcript=big) is True
+        rec = store.get("issue-1", "slice-3", "coder")
+        # Pointer survives; the oversized transcript is dropped (→ reseed).
+        assert rec.session_id == "a"
+        assert rec.transcript is None
+
+    def test_malformed_payload_returns_none(self, store):
+        store._redis.set(SessionStateStore._key("issue-1", "slice-3", "coder"), b"not json")
+        assert store.get("issue-1", "slice-3", "coder") is None
+
+    def test_occupancy_bool_coerced_to_none(self, store):
+        store.put("issue-1", "slice-3", "coder", session_id="a", window_occupancy=True)
+        assert store.get("issue-1", "slice-3", "coder").window_occupancy is None
+
+    def test_read_failure_returns_none(self):
+        class _Boom:
+            def get(self, *_a, **_k):
+                raise RuntimeError("redis down")
+
+        store = SessionStateStore(_Boom())
+        assert store.get("issue-1", "slice-3", "coder") is None
+
+    def test_write_failure_returns_false(self):
+        class _Boom:
+            def setex(self, *_a, **_k):
+                raise RuntimeError("redis down")
+
+        store = SessionStateStore(_Boom())
+        assert store.put("issue-1", "slice-3", "coder", session_id="a") is False

--- a/sandbox/egg_lib/cli_session_state.py
+++ b/sandbox/egg_lib/cli_session_state.py
@@ -1,0 +1,189 @@
+"""``egg-orch session-state pull|push`` — cross-pod warm-resume sync (#3278).
+
+Thin CLI layer over :mod:`egg_lib.session_state_sync`: resolves the
+``(pipeline, slice, role)`` identity from env, talks to the orchestrator's
+``/session-state`` route, and round-trips the transcript + pointer through the
+pod's ephemeral Claude session store. The event-pump wrapper calls ``pull``
+before invoking the agent and ``push`` after.
+
+Best-effort by contract: every failure (no orchestrator, miss, bad payload, I/O
+error) prints a diagnostic and exits ``0`` so the wrapper's flow continues — a
+failed sync degrades to a safe cold reseed, never a wedged event.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from urllib.parse import urlencode
+
+from egg_lib import session_state_sync
+
+# The transcript can be up to ``MAX_TRANSCRIPT_BYTES`` (32 MiB). ``orch_request``
+# defaults to a 15s HTTP timeout, which a large transcript on a slow link can
+# blow past — silently degrading to a reseed every event with no signal. Give the
+# transcript round-trip a budget that fits the payload class while staying under
+# the wrapper's outer ``timeout 60`` process bound (so the HTTP layer, not the
+# kill, is what bounds a genuinely stuck call).
+_SESSION_STATE_HTTP_TIMEOUT = 45
+
+
+def _identity() -> tuple[str, str, str | None] | None:
+    """Resolve ``(pipeline_id, role, slice_id)`` from env, or ``None`` if incomplete."""
+    pipeline_id = os.environ.get("EGG_PIPELINE_ID")
+    role = os.environ.get("EGG_AGENT_ROLE")
+    if not pipeline_id or not role:
+        print(
+            "session-state: EGG_PIPELINE_ID and EGG_AGENT_ROLE required; skipping",
+            file=sys.stderr,
+        )
+        return None
+    slice_id = os.environ.get("EGG_SLICE_ID") or None
+    return pipeline_id, role, slice_id
+
+
+def _session_state_file(args: argparse.Namespace) -> str | None:
+    return getattr(args, "session_state_file", None) or os.environ.get("EGG_SESSION_STATE_FILE")
+
+
+def cmd_session_state_pull(args: argparse.Namespace) -> int:
+    """Fetch the prior session for this (pipeline, slice, role) and stage a resume."""
+    ident = _identity()
+    if ident is None:
+        return 0
+    pipeline_id, role, slice_id = ident
+    ssf = _session_state_file(args)
+    if not ssf:
+        print(
+            "session-state pull: no --session-state-file / EGG_SESSION_STATE_FILE; skipping",
+            file=sys.stderr,
+        )
+        return 0
+    repo_path = session_state_sync.resolve_repo_path(getattr(args, "repo_path", None))
+    config_dir = session_state_sync.resolve_config_dir(getattr(args, "config_dir", None))
+
+    params = {"role": role}
+    if slice_id:
+        params["slice_id"] = slice_id
+    endpoint = f"/api/v1/pipelines/{pipeline_id}/session-state?{urlencode(params)}"
+
+    try:
+        from egg_lib.orch_cli import orch_request
+
+        result = orch_request(endpoint, method="GET", timeout=_SESSION_STATE_HTTP_TIMEOUT)
+    except (Exception, SystemExit) as exc:  # noqa: BLE001 — best-effort; never wedge the wrapper
+        print(
+            f"session-state pull: orchestrator request failed ({exc}); cold-starting",
+            file=sys.stderr,
+        )
+        return 0
+
+    if not isinstance(result, dict) or not result.get("found"):
+        print("session-state pull: no prior session; cold-starting", file=sys.stderr)
+        return 0
+
+    record = result.get("data") or {}
+    resumed = session_state_sync.write_pulled_state(
+        record,
+        repo_path=repo_path,
+        config_dir=config_dir,
+        session_state_file=ssf,
+    )
+    print(
+        f"session-state pull: {'staged resume' if resumed else 'pointer only (cold-start)'} "
+        f"for {role} slice={slice_id or 'none'}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def cmd_session_state_push(args: argparse.Namespace) -> int:
+    """Persist this pod's post-run session (pointer + transcript) to the orchestrator."""
+    ident = _identity()
+    if ident is None:
+        return 0
+    pipeline_id, role, slice_id = ident
+    ssf = _session_state_file(args)
+    if not ssf:
+        print(
+            "session-state push: no --session-state-file / EGG_SESSION_STATE_FILE; skipping",
+            file=sys.stderr,
+        )
+        return 0
+    repo_path = session_state_sync.resolve_repo_path(getattr(args, "repo_path", None))
+    config_dir = session_state_sync.resolve_config_dir(getattr(args, "config_dir", None))
+
+    body = session_state_sync.read_state_for_push(
+        repo_path=repo_path,
+        config_dir=config_dir,
+        session_state_file=ssf,
+    )
+    if body is None:
+        print("session-state push: no session to persist; skipping", file=sys.stderr)
+        return 0
+    body["role"] = role
+    body["slice_id"] = slice_id
+
+    try:
+        from egg_lib.orch_cli import orch_request
+
+        orch_request(
+            f"/api/v1/pipelines/{pipeline_id}/session-state",
+            method="POST",
+            data=body,
+            timeout=_SESSION_STATE_HTTP_TIMEOUT,
+        )
+    except (Exception, SystemExit) as exc:  # noqa: BLE001 — best-effort; never wedge the wrapper
+        print(
+            f"session-state push: orchestrator request failed ({exc}); state not persisted",
+            file=sys.stderr,
+        )
+        return 0
+    print(
+        f"session-state push: persisted {role} slice={slice_id or 'none'} "
+        f"(transcript={'yes' if body.get('transcript') else 'no'})",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def register_session_state_subcommand(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Register the ``session-state`` subcommand group on the given subparsers."""
+    ss_parser = subparsers.add_parser(
+        "session-state",
+        help="Cross-pod warm-resume session sync (#3278).",
+    )
+    ss_sub = ss_parser.add_subparsers(dest="session_state_command")
+
+    def _add_common(p: argparse.ArgumentParser) -> None:
+        p.add_argument(
+            "--session-state-file",
+            dest="session_state_file",
+            default=None,
+            help="Pointer file path (default: $EGG_SESSION_STATE_FILE).",
+        )
+        p.add_argument(
+            "--repo-path",
+            dest="repo_path",
+            default=None,
+            help="Agent cwd for the Claude project slug (default: $EGG_REPO_PATH or cwd).",
+        )
+        p.add_argument(
+            "--config-dir",
+            dest="config_dir",
+            default=None,
+            help="Claude config dir (default: $CLAUDE_CONFIG_DIR or ~/.claude).",
+        )
+
+    pull_parser = ss_sub.add_parser("pull", help="Fetch prior session and stage a resume.")
+    _add_common(pull_parser)
+    pull_parser.set_defaults(func=cmd_session_state_pull)
+
+    push_parser = ss_sub.add_parser("push", help="Persist this pod's session.")
+    _add_common(push_parser)
+    push_parser.set_defaults(func=cmd_session_state_push)
+
+    ss_parser.set_defaults(func=cmd_session_state_pull)

--- a/sandbox/egg_lib/orch_cli.py
+++ b/sandbox/egg_lib/orch_cli.py
@@ -4978,6 +4978,11 @@ def create_parser() -> argparse.ArgumentParser:
 
     register_push_subcommand(subparsers)
 
+    # --- session-state (cross-pod warm-resume sync, #3278) ---
+    from egg_lib.cli_session_state import register_session_state_subcommand
+
+    register_session_state_subcommand(subparsers)
+
     return parser
 
 

--- a/sandbox/egg_lib/session_state_sync.py
+++ b/sandbox/egg_lib/session_state_sync.py
@@ -1,0 +1,185 @@
+"""Cross-pod warm-resume session sync for the BRC event pump (#3278).
+
+Each BRC event is a one-shot pod whose Claude Code session store
+(``$CLAUDE_CONFIG_DIR/projects/<cwd-slug>/<session_id>.jsonl`` — the transcript
+``claude --resume`` reads) lives on the pod's ephemeral filesystem and dies with
+the pod. The durable copy is orchestrator-owned (Redis, keyed
+``(pipeline, slice, role)``); the sandbox reaches it only through the orchestrator
+route — it never writes host state. This module is the sandbox side of that
+round-trip, invoked by ``egg-orch session-state pull|push`` around the agent:
+
+- **pull** (before the agent runs): fetch the prior session and re-materialise the
+  transcript into this pod's ephemeral store + write the pointer file the slice-8
+  gate reads, so ``--resume`` finds a real transcript.
+- **push** (after the agent runs): ship the updated transcript + pointer back.
+
+The network calls live in ``orch_cli``; the slug math + file I/O here are pure and
+unit-tested. Everything is best-effort: a miss or failure degrades to a cold
+reseed (the ``egg_agent.session`` substrate's existing contract).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "claude_project_slug",
+    "is_safe_session_id",
+    "read_state_for_push",
+    "resolve_config_dir",
+    "resolve_repo_path",
+    "transcript_path",
+    "write_pulled_state",
+]
+
+# Claude Code derives a session's project directory from the absolute cwd by
+# replacing every non-alphanumeric character with ``-`` (so ``/``, ``.`` and
+# ``_`` all map to ``-``; letters/digits/existing ``-`` are preserved). Verified
+# empirically against the installed build, e.g.
+# ``/home/egg/repos/My_Repo.v2`` -> ``-home-egg-repos-My-Repo-v2``.
+_SLUG_NON_ALNUM = re.compile(r"[^a-zA-Z0-9]")
+
+# A Claude session id is a UUID (the SDK mints it), so it can only contain
+# hex/dash. We never interpolate anything outside this class into a filesystem
+# path: a ``../``-bearing, slash-bearing, or empty-after-strip value would
+# escape ``…/projects/<slug>/`` when joined. Guarding the path build is cheap
+# defense-in-depth and hardens the Redis→pull direction (where the value
+# originates off-pod) without coupling to the exact UUID layout.
+_SAFE_SESSION_ID = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9_-]*\Z")
+
+
+def is_safe_session_id(session_id: str) -> bool:
+    """Return whether *session_id* is safe to interpolate into a filesystem path.
+
+    Rejects empty / path-traversal (``..``) / separator-bearing values; accepts
+    the UUID/token shape the Claude SDK actually produces.
+    """
+    return bool(_SAFE_SESSION_ID.fullmatch(session_id))
+
+
+def claude_project_slug(repo_path: str | os.PathLike[str]) -> str:
+    """Return the Claude Code projects-dir slug for *repo_path* (the agent's cwd)."""
+    return _SLUG_NON_ALNUM.sub("-", os.path.abspath(str(repo_path)))
+
+
+def resolve_config_dir(explicit: str | None = None) -> Path:
+    """Resolve the Claude config dir: explicit arg, else ``$CLAUDE_CONFIG_DIR``, else ``~/.claude``."""
+    raw = (explicit or os.environ.get("CLAUDE_CONFIG_DIR") or "").strip()
+    if raw:
+        return Path(raw)
+    return Path.home() / ".claude"
+
+
+def resolve_repo_path(explicit: str | None = None) -> str:
+    """Resolve the agent cwd: explicit arg, else ``$EGG_REPO_PATH``, else the process cwd."""
+    raw = (explicit or os.environ.get("EGG_REPO_PATH") or "").strip()
+    return raw or os.getcwd()
+
+
+def transcript_path(
+    config_dir: str | os.PathLike[str],
+    repo_path: str | os.PathLike[str],
+    session_id: str,
+) -> Path:
+    """Return ``<config_dir>/projects/<cwd-slug>/<session_id>.jsonl``.
+
+    Raises ``ValueError`` if *session_id* is not path-safe (see
+    :func:`is_safe_session_id`) so a malformed value can never escape the
+    project dir; callers treat the raise as "nothing to resume" and reseed.
+    """
+    if not is_safe_session_id(session_id):
+        raise ValueError(f"unsafe session_id for transcript path: {session_id!r}")
+    slug = claude_project_slug(repo_path)
+    return Path(config_dir) / "projects" / slug / f"{session_id}.jsonl"
+
+
+def write_pulled_state(
+    record: dict[str, Any],
+    *,
+    repo_path: str,
+    config_dir: str | os.PathLike[str],
+    session_state_file: str,
+) -> bool:
+    """Materialise a pulled record into this pod; return whether resume is set up.
+
+    Writes the pointer file (``session_id`` + ``window_occupancy``, the format
+    ``egg_agent.session.read_session_state`` expects) and, when present, the
+    transcript JSONL at the path ``--resume`` will look for. Returns ``True`` only
+    when both the pointer and a transcript landed (a warm resume is actually
+    possible); a pointer-only record returns ``False`` (the gate can still read
+    occupancy, but there is nothing to resume — the agent cold-starts).
+
+    Best-effort: any I/O failure returns ``False`` rather than raising.
+    """
+    session_id = str(record.get("session_id") or "").strip()
+    if not session_id or not is_safe_session_id(session_id):
+        return False
+    occupancy = record.get("window_occupancy")
+    if isinstance(occupancy, bool) or not isinstance(occupancy, int):
+        occupancy = None
+    transcript = record.get("transcript")
+    if not isinstance(transcript, str):
+        transcript = None
+
+    try:
+        # Pointer file (consumed by decide_resume_session in the agent).
+        pointer = Path(session_state_file)
+        pointer.parent.mkdir(parents=True, exist_ok=True)
+        pointer.write_text(
+            json.dumps({"session_id": session_id, "window_occupancy": occupancy}),
+            encoding="utf-8",
+        )
+        if transcript is None:
+            return False
+        # Transcript file at the exact path --resume reads.
+        tpath = transcript_path(config_dir, repo_path, session_id)
+        tpath.parent.mkdir(parents=True, exist_ok=True)
+        tpath.write_text(transcript, encoding="utf-8")
+        return True
+    except OSError:
+        return False
+
+
+def read_state_for_push(
+    *,
+    repo_path: str,
+    config_dir: str | os.PathLike[str],
+    session_state_file: str,
+) -> dict[str, Any] | None:
+    """Build the push body from this pod's post-run state, or ``None`` if nothing to push.
+
+    Reads the pointer file the agent wrote (``write_session_state``) to learn the
+    current ``session_id`` + ``window_occupancy``, then reads the matching
+    transcript JSONL. Returns ``None`` when there is no usable session_id (the
+    agent produced no session — nothing to persist). A missing transcript still
+    yields a pointer-only body (occupancy survives for the next gate even if the
+    transcript could not be read).
+
+    Best-effort: any read failure collapses to ``None`` / a pointer-only body.
+    """
+    try:
+        raw = Path(session_state_file).read_text(encoding="utf-8")
+        pointer = json.loads(raw)
+    except OSError, ValueError, TypeError:
+        return None
+    if not isinstance(pointer, dict):
+        return None
+    session_id = str(pointer.get("session_id") or "").strip()
+    if not session_id or not is_safe_session_id(session_id):
+        return None
+    occupancy = pointer.get("window_occupancy")
+    if isinstance(occupancy, bool) or not isinstance(occupancy, int):
+        occupancy = None
+
+    body: dict[str, Any] = {"session_id": session_id, "window_occupancy": occupancy}
+    try:
+        body["transcript"] = transcript_path(config_dir, repo_path, session_id).read_text(
+            encoding="utf-8"
+        )
+    except OSError:
+        body["transcript"] = None
+    return body

--- a/sandbox/tests/test_cli_session_state.py
+++ b/sandbox/tests/test_cli_session_state.py
@@ -1,0 +1,107 @@
+"""Tests for the ``egg-orch session-state pull|push`` CLI (#3278).
+
+Focus on the best-effort contract (never wedge the wrapper) and the
+orchestrator round-trip; the slug/file logic is covered in
+``test_session_state_sync.py``.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_sandbox_path = Path(__file__).parent.parent
+if str(_sandbox_path) not in sys.path:
+    sys.path.insert(0, str(_sandbox_path))
+
+from egg_lib import cli_session_state as cli
+from egg_lib import orch_cli, session_state_sync
+
+
+def _args(**kw: object) -> argparse.Namespace:
+    ns = argparse.Namespace(session_state_file=None, repo_path=None, config_dir=None)
+    for k, v in kw.items():
+        setattr(ns, k, v)
+    return ns
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch, tmp_path):
+    monkeypatch.setenv("EGG_PIPELINE_ID", "issue-1")
+    monkeypatch.setenv("EGG_AGENT_ROLE", "coder")
+    monkeypatch.setenv("EGG_SLICE_ID", "slice-3")
+    monkeypatch.setenv("EGG_REPO_PATH", str(tmp_path / "repo"))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfg"))
+    monkeypatch.setenv("EGG_SESSION_STATE_FILE", str(tmp_path / "state.json"))
+    yield
+
+
+class TestBestEffort:
+    def test_pull_skips_without_identity(self, monkeypatch):
+        monkeypatch.delenv("EGG_PIPELINE_ID", raising=False)
+        assert cli.cmd_session_state_pull(_args()) == 0
+
+    def test_pull_swallows_orchestrator_failure(self, monkeypatch):
+        def _boom(*_a, **_k):
+            raise RuntimeError("orchestrator down")
+
+        monkeypatch.setattr(orch_cli, "orch_request", _boom)
+        assert cli.cmd_session_state_pull(_args()) == 0
+
+    def test_pull_miss_is_clean(self, monkeypatch):
+        monkeypatch.setattr(orch_cli, "orch_request", lambda *a, **k: {"found": False})
+        assert cli.cmd_session_state_pull(_args()) == 0
+
+    def test_push_skips_when_no_session(self, monkeypatch):
+        # No pointer file written → nothing to push.
+        called = []
+        monkeypatch.setattr(orch_cli, "orch_request", lambda *a, **k: called.append(1))
+        assert cli.cmd_session_state_push(_args()) == 0
+        assert called == []
+
+
+class TestRoundTrip:
+    def test_pull_writes_state_and_push_sends_it(self, monkeypatch, tmp_path):
+        repo = str(tmp_path / "repo")
+        cfg = str(tmp_path / "cfg")
+        ssf = str(tmp_path / "state.json")
+
+        # --- pull: orchestrator returns a stored session ---
+        get_result = {
+            "found": True,
+            "data": {
+                "session_id": "sid-1",
+                "window_occupancy": 42,
+                "transcript": '{"l":1}\n',
+            },
+        }
+        monkeypatch.setattr(orch_cli, "orch_request", lambda *a, **k: get_result)
+        assert cli.cmd_session_state_pull(_args()) == 0
+
+        # Pointer + transcript materialised where --resume reads.
+        assert json.loads(Path(ssf).read_text())["session_id"] == "sid-1"
+        tpath = session_state_sync.transcript_path(cfg, repo, "sid-1")
+        assert tpath.read_text() == '{"l":1}\n'
+
+        # --- push: ships the (unchanged) state back, scoped to slice+role ---
+        sent = {}
+
+        def _capture(endpoint, method="GET", data=None, timeout=None):
+            sent["endpoint"] = endpoint
+            sent["method"] = method
+            sent["data"] = data
+            sent["timeout"] = timeout
+            return {"success": True, "stored": True}
+
+        monkeypatch.setattr(orch_cli, "orch_request", _capture)
+        assert cli.cmd_session_state_push(_args()) == 0
+        assert sent["method"] == "POST"
+        assert sent["endpoint"] == "/api/v1/pipelines/issue-1/session-state"
+        assert sent["data"]["session_id"] == "sid-1"
+        assert sent["data"]["role"] == "coder"
+        assert sent["data"]["slice_id"] == "slice-3"
+        assert sent["data"]["transcript"] == '{"l":1}\n'
+        # Transcript round-trip gets a payload-sized HTTP timeout, not the 15s default.
+        assert sent["timeout"] == cli._SESSION_STATE_HTTP_TIMEOUT

--- a/sandbox/tests/test_session_state_sync.py
+++ b/sandbox/tests/test_session_state_sync.py
@@ -1,0 +1,200 @@
+"""Tests for the cross-pod warm-resume session sync logic (#3278)."""
+
+import json
+import sys
+from pathlib import Path
+
+_sandbox_path = Path(__file__).parent.parent
+if str(_sandbox_path) not in sys.path:
+    sys.path.insert(0, str(_sandbox_path))
+
+from egg_lib import session_state_sync as sync
+
+
+class TestSlug:
+    def test_matches_claude_code_algorithm(self):
+        # Verified empirically against the installed build:
+        # every non-alphanumeric char -> '-' (uppercase + '-' preserved).
+        assert (
+            sync.claude_project_slug("/home/egg/repos/My_Repo.v2-Test")
+            == "-home-egg-repos-My-Repo-v2-Test"
+        )
+
+    def test_is_absolute(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # A relative path is resolved to absolute before slugging.
+        assert sync.claude_project_slug("sub/dir").startswith("-")
+
+    def test_transcript_path_shape(self):
+        p = sync.transcript_path("/cfg", "/home/egg/repos/webapp", "sid-1")
+        assert p == Path("/cfg/projects/-home-egg-repos-webapp/sid-1.jsonl")
+
+
+class TestSafeSessionId:
+    def test_accepts_uuid_and_token_shapes(self):
+        assert sync.is_safe_session_id("550e8400-e29b-41d4-a716-446655440000")
+        assert sync.is_safe_session_id("sid_1")
+
+    def test_rejects_traversal_and_separators(self):
+        assert not sync.is_safe_session_id("")
+        assert not sync.is_safe_session_id("..")
+        assert not sync.is_safe_session_id("../../etc/passwd")
+        assert not sync.is_safe_session_id("a/b")
+        assert not sync.is_safe_session_id(".hidden")
+
+    def test_transcript_path_raises_on_unsafe_id(self):
+        import pytest
+
+        with pytest.raises(ValueError):
+            sync.transcript_path("/cfg", "/repo", "../escape")
+
+    def test_pull_rejects_unsafe_id_without_escaping(self, tmp_path):
+        cfg = tmp_path / "cfg"
+        ssf = tmp_path / "state.json"
+        # A traversal-bearing session_id must not write anything (no escape).
+        assert (
+            sync.write_pulled_state(
+                {"session_id": "../evil", "transcript": "x"},
+                repo_path="/repo",
+                config_dir=cfg,
+                session_state_file=str(ssf),
+            )
+            is False
+        )
+        assert not ssf.exists()
+        assert not (cfg / "projects").exists()
+
+    def test_push_rejects_unsafe_id(self, tmp_path):
+        ssf = tmp_path / "state.json"
+        ssf.write_text(json.dumps({"session_id": "../evil", "window_occupancy": 7}))
+        assert (
+            sync.read_state_for_push(
+                repo_path="/repo", config_dir=tmp_path / "cfg", session_state_file=str(ssf)
+            )
+            is None
+        )
+
+
+class TestResolvers:
+    def test_config_dir_explicit_wins(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/env")
+        assert sync.resolve_config_dir("/explicit") == Path("/explicit")
+
+    def test_config_dir_env_then_default(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/env")
+        assert sync.resolve_config_dir() == Path("/env")
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR")
+        assert sync.resolve_config_dir() == Path.home() / ".claude"
+
+    def test_repo_path_env_then_cwd(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("EGG_REPO_PATH", "/repo")
+        assert sync.resolve_repo_path() == "/repo"
+        monkeypatch.delenv("EGG_REPO_PATH")
+        monkeypatch.chdir(tmp_path)
+        assert sync.resolve_repo_path() == str(tmp_path)
+
+
+class TestPullWrite:
+    def test_writes_pointer_and_transcript(self, tmp_path):
+        cfg = tmp_path / "cfg"
+        ssf = tmp_path / "state.json"
+        repo = "/home/egg/repos/webapp"
+        resumed = sync.write_pulled_state(
+            {"session_id": "sid-1", "window_occupancy": 42, "transcript": '{"l":1}\n'},
+            repo_path=repo,
+            config_dir=cfg,
+            session_state_file=str(ssf),
+        )
+        assert resumed is True
+        # Pointer matches the egg_agent.session format.
+        pointer = json.loads(ssf.read_text())
+        assert pointer == {"session_id": "sid-1", "window_occupancy": 42}
+        # Transcript at the exact path --resume reads.
+        tpath = sync.transcript_path(cfg, repo, "sid-1")
+        assert tpath.read_text() == '{"l":1}\n'
+
+    def test_pointer_only_returns_false_no_transcript_file(self, tmp_path):
+        cfg = tmp_path / "cfg"
+        ssf = tmp_path / "state.json"
+        resumed = sync.write_pulled_state(
+            {"session_id": "sid-1", "window_occupancy": 42, "transcript": None},
+            repo_path="/repo",
+            config_dir=cfg,
+            session_state_file=str(ssf),
+        )
+        assert resumed is False
+        assert json.loads(ssf.read_text())["session_id"] == "sid-1"
+        assert not (cfg / "projects").exists()
+
+    def test_no_session_id_writes_nothing(self, tmp_path):
+        ssf = tmp_path / "state.json"
+        assert (
+            sync.write_pulled_state(
+                {"session_id": "", "transcript": "x"},
+                repo_path="/repo",
+                config_dir=tmp_path / "cfg",
+                session_state_file=str(ssf),
+            )
+            is False
+        )
+        assert not ssf.exists()
+
+
+class TestPushRead:
+    def test_reads_pointer_and_transcript(self, tmp_path):
+        cfg = tmp_path / "cfg"
+        ssf = tmp_path / "state.json"
+        repo = "/home/egg/repos/webapp"
+        ssf.write_text(json.dumps({"session_id": "sid-1", "window_occupancy": 7}))
+        tpath = sync.transcript_path(cfg, repo, "sid-1")
+        tpath.parent.mkdir(parents=True)
+        tpath.write_text('{"l":1}\n')
+
+        body = sync.read_state_for_push(repo_path=repo, config_dir=cfg, session_state_file=str(ssf))
+        assert body == {
+            "session_id": "sid-1",
+            "window_occupancy": 7,
+            "transcript": '{"l":1}\n',
+        }
+
+    def test_missing_transcript_yields_pointer_only_body(self, tmp_path):
+        ssf = tmp_path / "state.json"
+        ssf.write_text(json.dumps({"session_id": "sid-1", "window_occupancy": 7}))
+        body = sync.read_state_for_push(
+            repo_path="/repo", config_dir=tmp_path / "cfg", session_state_file=str(ssf)
+        )
+        assert body is not None
+        assert body["session_id"] == "sid-1"
+        assert body["transcript"] is None
+
+    def test_no_pointer_file_returns_none(self, tmp_path):
+        assert (
+            sync.read_state_for_push(
+                repo_path="/repo",
+                config_dir=tmp_path / "cfg",
+                session_state_file=str(tmp_path / "missing.json"),
+            )
+            is None
+        )
+
+    def test_pointer_without_session_id_returns_none(self, tmp_path):
+        ssf = tmp_path / "state.json"
+        ssf.write_text(json.dumps({"window_occupancy": 7}))
+        assert (
+            sync.read_state_for_push(
+                repo_path="/repo", config_dir=tmp_path / "cfg", session_state_file=str(ssf)
+            )
+            is None
+        )
+
+
+class TestRoundTrip:
+    def test_pull_then_push_is_stable(self, tmp_path):
+        """A pulled record read back for push reproduces the same body."""
+        cfg = tmp_path / "cfg"
+        ssf = tmp_path / "state.json"
+        repo = "/home/egg/repos/webapp"
+        record = {"session_id": "sid-1", "window_occupancy": 42, "transcript": '{"l":1}\n'}
+        sync.write_pulled_state(record, repo_path=repo, config_dir=cfg, session_state_file=str(ssf))
+        body = sync.read_state_for_push(repo_path=repo, config_dir=cfg, session_state_file=str(ssf))
+        assert body == record


### PR DESCRIPTION
## Why this PR exists (re-land)

#3278 was marked done but its code never reached `main`. PR #3286 ("Closes #3278", **MERGED**) was a stacked PR whose **base was `egg/3279-reseed-threshold-injection`, not `main`**. #3279 (PR #3284) merged to main at 05:25; #3286 then merged at 07:32 **into the already-merged #3279 branch**, which was a dead branch — so #3286's commits never propagated to main. All four of #3278's new files are absent from `main` today, while #3279's threshold injection is present. GitHub still shows #3286 as MERGED / Closes #3278, hence the issue looked done.

This re-applies the **#3278-only diff** (everything #3286 added on top of the #3279 branch tip) onto current `main`. The #3279 content is already on main and is excluded. Sole rebase conflict was the env-var table in `docs/architecture/context-discipline.md`, resolved to keep main's (#3284) `EGG_RESEED_THRESHOLD` row alongside #3278's new `EGG_SESSION_STATE_FILE` / `CLAUDE_CONFIG_DIR` rows.

## What

Make BRC warm resume (#3200) actually fire by persisting the Claude Code session **per `(pipeline, slice, role)` across the one-shot event pods** — the durable copy is orchestrator-owned and reached only over the controlled API, so the sandbox never writes host state.

`claude --resume <session_id>` re-enters a session by reading its **local transcript** (`$CLAUDE_CONFIG_DIR/projects/<cwd-slug>/<session_id>.jsonl`). Under the orchestrator-owned event loop (#3164) every BRC event is a fresh pod, so that transcript dies with the pod. Persisting only the `session_id`+`occupancy` pointer (the original #3276 scope) would let the gate record `below_threshold` "resume" decisions while every event silently cold-starts. The transcript itself has to cross pods.

## Design (constraint: sandbox never writes host state)

- **Live store stays ephemeral** — the agent's `$CLAUDE_CONFIG_DIR` is the pod's own filesystem (no host mount); Claude Code writes the transcript locally during the run, unchanged.
- **Durable copy is orchestrator-owned in Redis** — `session_state_store.py` keeps one TTL'd key per `(pipeline, slice, role)` holding the pointer **and** transcript together (no split-brain; TTL reaps abandoned state). Only the orchestrator writes it.
- **Round-trip over the controlled API** — `egg-orch session-state pull` (before the agent) re-materialises the prior transcript + pointer into the pod so `--resume` finds a real session; `egg-orch session-state push` (after) ships the updated session back. Both best-effort and `timeout`-bounded; a failed sync degrades to a safe cold reseed.

The existing `egg_agent` substrate (`session.py` / `reseed.py` / `__main__.py`) is **untouched**.

## Changes

- `orchestrator/session_state_store.py` — Redis store (TTL, size-guarded, best-effort).
- `orchestrator/routes/session_state.py` — `GET/POST /api/v1/pipelines/<pid>/session-state` (registered in `api.py`).
- `sandbox/egg_lib/session_state_sync.py` — slug + transcript/pointer file I/O (pure).
- `sandbox/egg_lib/cli_session_state.py` — `egg-orch session-state pull|push` (best-effort); verb wired in `orch_cli.py`.
- `orchestrator/concurrent_executor.py` — inject `CLAUDE_CONFIG_DIR` + `EGG_SESSION_STATE_FILE` into event pods, gated on `session_resume_enabled()` (default pods byte-identical).
- `orchestrator/consensus_wrapper.py` — pull before / push after the agent, preserving exit code; golden regenerated.
- `docs/architecture/context-discipline.md` — documents the cross-pod persistence layer.

## Tests

The original #3278 test suite comes along (store, route, sync, CLI, env-injection gating, wrapper golden). Per request, the suite was **not** re-run locally in this re-land session — relying on CI.

## Verification still owed in-cluster

`--resume` end-to-end across two real event pods (the spike confirmed file mechanics + relocation locally; the resume call itself needs in-cluster gateway/API-key auth). Also worth measuring transcript transfer cost per resumed event.

## Related

- #3286 (orphaned, merged into a dead stacked branch) — this re-lands its content.
- #3279 / #3284 — the per-model reseed threshold; already on main.
- #3200 / #3249 / #3271 — the gate + measurement that verify resume fires.
- #3164 / #3005 — why state must cross pods / the emptyDir-wipe hazard.

Closes #3278
