### PR TITLE
fix(#3339): scope slice evidence-reachability gate to role-bound tasks

### DIFF
--- a/orchestrator/contract_completeness.py
+++ b/orchestrator/contract_completeness.py
@@ -255,7 +255,11 @@ def evidence_commits(
 
 
 def format_evidence_rows(rows: list[dict[str, Any]]) -> str:
-    """One-line-per-row summary for evidence-reachability messages."""
+    """One-line-per-row summary for evidence-reachability messages.
+
+    Every row from ``evidence_commits`` is role-bound (``task.role`` is
+    truthy), so ``role`` is always a concrete producer role here.
+    """
     return "; ".join(
-        f"{r['id']} (role={r['role'] or 'unassigned'}, commit={r['commit']})" for r in rows
+        f"{r['id']} (role={r['role']}, commit={r['commit']})" for r in rows
     )

--- a/orchestrator/contract_completeness.py
+++ b/orchestrator/contract_completeness.py
@@ -215,9 +215,28 @@ def evidence_commits(
     before flipping status), and a cited-but-unreachable commit is a
     gap worth failing on either way.
 
-    Returns one dict per row (``id`` / ``role`` / ``commit``), empty
-    list when no row cites a commit, or ``None`` when ``slice_id`` was
-    given but no such slice exists (caller skips the gate).
+    **Role-less rows are excluded (#3339).** The gate exists to protect
+    the producer-scoped #3124 flow: a *confirmed producer* records a
+    post-confirmation commit that lives only on its local worktree
+    branch, so the deliverable would be lost on close. That producer
+    always owns a role. A task with ``role=None`` (planner left it
+    unassigned) has no producer obligated to push its commit through
+    ``consensus_push``, so a SHA it cites is bookkeeping — not a gated
+    deliverable. Yet a stray ``add-commit`` / ``complete-task --commit``
+    on such a row (and ``_merge_preserved_slice_runtime`` re-attaching
+    it across a ``restart_phase`` re-fork) made the gate fire on an
+    orphan commit ``role=unassigned`` for a slice that had *already
+    reached full BRC consensus* — every reviewer approved the diff that
+    is on the integration branch — and that single bookkeeping mismatch
+    failed the slice and cascaded the whole phase. Scoping the gate to
+    role-bound rows keeps its full protection for real producer commits
+    while no longer nuking a consensus-reached slice on an unassigned
+    orphan.
+
+    Returns one dict per role-bound row (``id`` / ``role`` /
+    ``commit``), empty list when no such row cites a commit, or ``None``
+    when ``slice_id`` was given but no such slice exists (caller skips
+    the gate).
 
     Row ordering is intentional: slice-declaration order outermost,
     task-declaration order within each slice. Callers (the close-merge
@@ -231,7 +250,7 @@ def evidence_commits(
         {"id": task.id, "role": task.role, "commit": task.commit}
         for sl in slices
         for task in sl.tasks or []
-        if task.commit
+        if task.commit and task.role
     ]
 
 

--- a/orchestrator/contract_completeness.py
+++ b/orchestrator/contract_completeness.py
@@ -260,6 +260,4 @@ def format_evidence_rows(rows: list[dict[str, Any]]) -> str:
     Every row from ``evidence_commits`` is role-bound (``task.role`` is
     truthy), so ``role`` is always a concrete producer role here.
     """
-    return "; ".join(
-        f"{r['id']} (role={r['role']}, commit={r['commit']})" for r in rows
-    )
+    return "; ".join(f"{r['id']} (role={r['role']}, commit={r['commit']})" for r in rows)

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -11596,6 +11596,11 @@ def _check_slice_evidence_reachability(
     through the existing cascade + HITL escalation machinery instead of
     closing silently.
 
+    Only role-bound task rows are gated (#3339): the check exists for
+    the producer-scoped #3124 flow, so a ``role=unassigned`` row's
+    orphan commit is bookkeeping, not a gated deliverable, and must not
+    fail a consensus-reached slice. See ``cc.evidence_commits``.
+
     Failure posture mirrors the other completeness checks (#3081 /
     #3114): the gate degrades to ``None`` (close proceeds, warning
     logged) when the contract cannot be read, the slice id does not

--- a/orchestrator/tests/test_evidence_reachability_gate.py
+++ b/orchestrator/tests/test_evidence_reachability_gate.py
@@ -172,6 +172,29 @@ class TestEvidenceCommits:
         assert rows is not None
         assert rows[1] == {"id": "task-2-2", "role": "documenter", "commit": LATE_SHA}
 
+    def test_roleless_row_with_orphan_commit_excluded(self, tmp_path: Path) -> None:
+        # #3339: a task the planner left unassigned (role=None) can still
+        # acquire a commit (a stray add-commit, or _merge_preserved_slice_
+        # runtime re-attaching one across a restart_phase re-fork). That SHA
+        # is bookkeeping, not a producer deliverable, so the gate must not
+        # see it — otherwise an orphan role=unassigned commit fails a
+        # consensus-reached slice and cascades the whole phase.
+        contract = _contract_dict()
+        slice2 = contract["phases"][1]
+        roleless = slice2["tasks"][3]
+        assert roleless["id"] == "task-2-4"
+        assert "role" not in roleless  # planner left it unassigned
+        roleless["commit"] = "e" * 40  # the orphan SHA from #3339
+        contracts_dir = tmp_path / ".egg-state" / "contracts"
+        contracts_dir.mkdir(parents=True, exist_ok=True)
+        (contracts_dir / f"{PIPELINE_ID}.json").write_text(json.dumps(contract))
+
+        rows = cc.evidence_commits(_load(tmp_path), "slice-2")
+        assert rows is not None
+        ids = [r["id"] for r in rows]
+        assert "task-2-4" not in ids
+        assert ids == ["task-2-1", "task-2-2", "task-2-3"]
+
     def test_format_evidence_rows(self) -> None:
         text = cc.format_evidence_rows(
             [
@@ -482,6 +505,28 @@ class TestCheckSliceEvidenceReachability:
         assert LATE_SHA in result
         assert INTEGRATION_BRANCH in result
         assert cc.EVIDENCE_GATE_ENV_VAR in result
+
+    def test_roleless_orphan_commit_does_not_fail_slice(self, tmp_path: Path, gate_env) -> None:
+        # #3339 regression: a slice whose only commit-bearing task is a
+        # role=unassigned orphan must close cleanly. The gateway reports
+        # the orphan SHA unreachable, but the roleless row is never put to
+        # the probe, so the gate returns None instead of failing the
+        # consensus-reached slice and cascading the phase.
+        contract = _contract_dict()
+        slice2 = contract["phases"][1]
+        for task in slice2["tasks"]:
+            task.pop("commit", None)  # drop the producer rows' commits
+        slice2["tasks"][3]["commit"] = "e" * 40  # task-2-4, roleless orphan
+        contracts_dir = tmp_path / ".egg-state" / "contracts"
+        contracts_dir.mkdir(parents=True, exist_ok=True)
+        (contracts_dir / f"{PIPELINE_ID}.json").write_text(json.dumps(contract))
+
+        spawner = _spawner(["e" * 40])  # gateway would flag it unreachable
+        result = _check_slice_evidence_reachability(
+            PIPELINE_ID, spawner, tmp_path, "slice-2", INTEGRATION_BRANCH
+        )
+        assert result is None
+        spawner.gateway.find_unreachable_evidence_commits.assert_not_called()
 
     def test_pre_loaded_contract_skips_internal_load(self, tmp_path: Path, gate_env) -> None:
         """When the caller pre-loads the contract (the close-path

--- a/orchestrator/tests/test_evidence_reachability_gate.py
+++ b/orchestrator/tests/test_evidence_reachability_gate.py
@@ -196,14 +196,16 @@ class TestEvidenceCommits:
         assert ids == ["task-2-1", "task-2-2", "task-2-3"]
 
     def test_format_evidence_rows(self) -> None:
+        # #3339: evidence_commits only ever emits role-bound rows, so the
+        # formatter always sees a concrete producer role.
         text = cc.format_evidence_rows(
             [
                 {"id": "task-2-2", "role": "documenter", "commit": "abc1234"},
-                {"id": "task-2-4", "role": None, "commit": "def5678"},
+                {"id": "task-2-4", "role": "coder", "commit": "def5678"},
             ]
         )
         assert "task-2-2 (role=documenter, commit=abc1234)" in text
-        assert "task-2-4 (role=unassigned, commit=def5678)" in text
+        assert "task-2-4 (role=coder, commit=def5678)" in text
 
 
 class TestEvidenceGateEnabled:


### PR DESCRIPTION
Fixes #3339.

## Problem

The #3125 evidence-reachability gate fails a slice close when a contract task record cites a commit SHA not reachable from the slice's integration branch. On `issue-3312` (19-slice sequential chain) it fired **deterministically, ~1 slice per `restart_phase`**, on a task attributed to `role=unassigned` — even though the slice had already reached **full BRC consensus** (all 8 agents confirmed). One bookkeeping mismatch failed the slice and cascaded the whole phase, making the chain effectively unrunnable.

## Root cause

The gate was built for the **producer-scoped #3124 flow**: a *confirmed producer* records a post-confirmation `complete-task --commit` whose commit lives only on its local worktree branch, so the deliverable would be lost on close. That producer always owns a role.

But `evidence_commits` enforced on **every** task with a commit — including `role=unassigned` planner-leftover rows. A roleless task has no producer obligated to push its commit through `consensus_push`, so a SHA it cites is bookkeeping, not a gated deliverable. A stray `add-commit`/`complete-task --commit` on such a row — and `_merge_preserved_slice_runtime` re-attaching it across a `restart_phase` re-fork — made the gate fire on an orphan `role=unassigned` commit for a slice whose actual, reviewer-approved diff is already on the integration branch.

## Fix

Scope `evidence_commits` to role-bound rows (`task.commit and task.role`). This is **direction 2(b)** from the issue ("distinguish `role=unassigned` orphans from genuine lost work") and keeps the gate's full protection for real producer commits. The `EGG_EVIDENCE_REACHABILITY_GATE` kill switch is unchanged.

## Changes

- `contract_completeness.evidence_commits`: skip role-less rows, with the #3339 rationale documented
- `routes/pipelines._check_slice_evidence_reachability`: docstring note on the role-bound scoping
- `test_evidence_reachability_gate`: unit + gate-level regressions that a roleless orphan commit is excluded from the row set and never put to the gateway probe

## Testing

- `pytest orchestrator/tests/test_evidence_reachability_gate.py` — 33 passed (2 new)
- `pytest -k "completeness or evidence"` — 89 passed, 3 skipped
- `pytest orchestrator/tests/test_slice_run_loop_integration.py` — 53 passed
- ruff check + format clean