### PR TITLE
feat(#3341): in-tool-loop WORKING heartbeat so busy producers stay visibly alive

### DIFF
--- a/docs/reference/agent-wait-patterns.md
+++ b/docs/reference/agent-wait-patterns.md
@@ -276,13 +276,19 @@ To keep the liveness signal alive during the turn, the SDK driver
 hook backed by `shared/egg_agent/working_heartbeat.py`: at most once per
 `EGG_WORKING_HEARTBEAT_INTERVAL_SECS` (default 120 s) it re-emits the
 same `WORKING` heartbeat the wrapper does (`egg-orch message heartbeat`,
-the per-role-deduped rate-limited `/heartbeat` endpoint, #1897) — exactly
-the signal `check_heartbeats` consumes. The interval sits well under the
-300 s Tier-1 and 600 s implement-phase silence windows (several ticks land
-before any tripwire could fire) and far under the 20/min
-`EGG_HEARTBEAT_RATE_LIMIT` cap. It is event-driven on tool calls, not a
-background timer, so it honours the wrapper's "no background emitter"
-stance — a heartbeat fires only when the agent is doing tool work.
+the rate-limited `/heartbeat` endpoint, #1897) — exactly the signal
+`check_heartbeats` consumes. `WORKING` is dedup-exempt at the route
+(`_DEDUP_EXEMPT_HEARTBEAT_STATES`, the same treatment as
+`WAITING_FOR_EVENT`): the wrapper records a `WORKING` beat before handing
+off, so without the exemption every in-tool-loop re-emit would dedup
+against that recorded state, emit no `MESSAGE_SENT` event, and never
+refresh `last_heartbeat` — the feature would silently no-op. The interval
+sits well under the 300 s Tier-1 and 600 s implement-phase silence windows
+(several ticks land — and refresh `last_heartbeat` — before any tripwire
+could fire) and far under the 20/min `EGG_HEARTBEAT_RATE_LIMIT` cap. It is
+event-driven on tool calls, not a background timer, so it honours the
+wrapper's "no background emitter" stance — a heartbeat fires only when the
+agent is doing tool work.
 
 Limitation: PostToolUse fires *after* a tool call returns, so a single
 uninterrupted tool call longer than the interval (e.g. one 10-minute

--- a/docs/reference/agent-wait-patterns.md
+++ b/docs/reference/agent-wait-patterns.md
@@ -258,6 +258,41 @@ unreachable, malformed JSON, unwritable cursor) degrades to "no
 injection", never an agent failure. `EGG_MIDTURN_MESSAGES=false`
 disables the hook entirely.
 
+### In-tool-loop WORKING heartbeat (#3341)
+
+The consensus wrapper emits exactly one `WORKING` heartbeat **before**
+handing control to the agent, then no further bus traffic until the
+(30+ minute) invocation returns — the deliberate "no background emitter"
+design. So a genuinely-busy producer making continuous tool calls looks
+bus-silent for the whole turn, and any single step past the
+heartbeat-silence threshold (`orchestrator_implement_heartbeat_timeout_seconds`,
+600 s) trips the health monitor's `check_heartbeats` tripwire regardless
+of how busy the pod is. Acting on that false stall by restarting can
+orphan in-flight commits and cascade-fail a multi-slice run (#3339), so
+the false positive has a real, expensive failure mode.
+
+To keep the liveness signal alive during the turn, the SDK driver
+(`shared/egg_agent/client.py`) installs a second throttled PostToolUse
+hook backed by `shared/egg_agent/working_heartbeat.py`: at most once per
+`EGG_WORKING_HEARTBEAT_INTERVAL_SECS` (default 120 s) it re-emits the
+same `WORKING` heartbeat the wrapper does (`egg-orch message heartbeat`,
+the per-role-deduped rate-limited `/heartbeat` endpoint, #1897) — exactly
+the signal `check_heartbeats` consumes. The interval sits well under the
+300 s Tier-1 and 600 s implement-phase silence windows (several ticks land
+before any tripwire could fire) and far under the 20/min
+`EGG_HEARTBEAT_RATE_LIMIT` cap. It is event-driven on tool calls, not a
+background timer, so it honours the wrapper's "no background emitter"
+stance — a heartbeat fires only when the agent is doing tool work.
+
+Limitation: PostToolUse fires *after* a tool call returns, so a single
+uninterrupted tool call longer than the interval (e.g. one 10-minute
+`make test-all` Bash call) still does not tick mid-call; the dominant
+repro (dozens of edits/tests/commits across a long turn) is covered.
+Every failure mode (missing `egg-orch`, orchestrator unreachable, 429
+rate-limit, subprocess timeout) degrades to "no heartbeat this tick",
+never an agent failure. Gated on `EGG_PIPELINE_ID` + `EGG_AGENT_ROLE`;
+`EGG_WORKING_HEARTBEAT=false` disables the hook entirely.
+
 ### Multi-reviewer NACK aggregation barrier (#2142)
 
 When two or more reviewers have NACKed the producer's current version,

--- a/orchestrator/routes/messages.py
+++ b/orchestrator/routes/messages.py
@@ -135,8 +135,18 @@ def _track_long_poll_end() -> None:
 # liveness keep-alive emitted by ``mcp__brc__wait_loop`` while it's
 # blocked — periodic identical beats are exactly the signal the
 # overseer's stall detector consumes, so dedup must not collapse them.
-# Rate-limit (20/min per slice+role; #2471) still applies.
-_DEDUP_EXEMPT_HEARTBEAT_STATES: frozenset[str] = frozenset({"WAITING_FOR_EVENT"})
+#
+# ``WORKING`` (issue #3341) is exempt for the same reason: the consensus
+# wrapper records one ``WORKING`` beat before handing off to the agent,
+# then the in-tool-loop ``WorkingHeartbeatEmitter`` re-emits ``WORKING``
+# during the turn to keep a busy producer visibly alive. Those periodic
+# identical beats are exactly what ``check_heartbeats`` consumes — without
+# this exemption every in-tool-loop beat dedups against the wrapper's
+# recorded ``WORKING`` state, emits no ``MESSAGE_SENT`` event, never
+# refreshes ``last_heartbeat``, and the feature silently no-ops.
+# Rate-limit (20/min per slice+role; #2471) still applies — the emitter's
+# 120s interval is 0.5/min, far under the cap.
+_DEDUP_EXEMPT_HEARTBEAT_STATES: frozenset[str] = frozenset({"WAITING_FOR_EVENT", "WORKING"})
 
 
 messages_bp = Blueprint("messages", __name__, url_prefix="/api/v1/pipelines")

--- a/orchestrator/tests/test_messages.py
+++ b/orchestrator/tests/test_messages.py
@@ -2583,7 +2583,12 @@ class TestHeartbeatRoute:
                 assert data["data"]["deduped"] is False
 
     def test_heartbeat_route_dedups_repeat_state(self, client, app):
-        """Plan TASK-3-2: repeated (state, waiting_on) tuples dedupe."""
+        """Plan TASK-3-2: repeated (state, waiting_on) tuples dedupe.
+
+        Uses ``IDLE`` — a non-exempt state. ``WORKING`` is no longer a
+        valid subject here: it joined ``_DEDUP_EXEMPT_HEARTBEAT_STATES``
+        in #3341 (see ``test_heartbeat_route_does_not_dedupe_working``).
+        """
         with app.test_request_context():
             with patch(
                 "routes.messages.get_state_store_for_pipeline"
@@ -2596,7 +2601,7 @@ class TestHeartbeatRoute:
                 role = "heartbeat-route-role-b"
                 resp1 = client.post(
                     "/api/v1/pipelines/test-pipeline/heartbeat",
-                    json={"from_role": role, "state": "WORKING"},
+                    json={"from_role": role, "state": "IDLE"},
                 )
                 assert resp1.status_code == 200
                 assert json.loads(resp1.data)["data"]["deduped"] is False
@@ -2604,7 +2609,7 @@ class TestHeartbeatRoute:
                 # Second identical call MUST dedupe.
                 resp2 = client.post(
                     "/api/v1/pipelines/test-pipeline/heartbeat",
-                    json={"from_role": role, "state": "WORKING"},
+                    json={"from_role": role, "state": "IDLE"},
                 )
                 assert resp2.status_code == 200
                 assert json.loads(resp2.data)["data"]["deduped"] is True
@@ -2639,6 +2644,106 @@ class TestHeartbeatRoute:
                     )
                     assert resp.status_code == 200
                     assert json.loads(resp.data)["data"]["deduped"] is False
+
+    def test_heartbeat_route_does_not_dedupe_working(self, client, app):
+        """Issue #3341: ``WORKING`` is a liveness keep-alive too.
+
+        The consensus wrapper records one ``WORKING`` beat before handing
+        off to the agent, then the in-tool-loop ``WorkingHeartbeatEmitter``
+        re-emits ``WORKING`` during the turn to keep a busy producer
+        visibly alive. Those periodic identical beats are exactly what
+        ``check_heartbeats`` consumes, so ``WORKING`` MUST skip the
+        ``(state, waiting_on)`` dedup filter even when consecutive posts
+        are byte-for-byte identical.
+
+        If a future refactor re-enables dedup for this state, every
+        in-tool-loop beat would dedup against the wrapper's recorded
+        ``WORKING`` state, emit no ``MESSAGE_SENT`` event, never refresh
+        ``last_heartbeat``, and the #3341 feature would silently no-op —
+        the exact regression this test guards against.
+        """
+        with app.test_request_context():
+            with patch(
+                "routes.messages.get_state_store_for_pipeline"
+            ) as mock_get_store_for_pipeline:
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+                role = "in-tool-loop-working-role"
+                for _ in range(3):
+                    resp = client.post(
+                        "/api/v1/pipelines/test-pipeline/heartbeat",
+                        json={"from_role": role, "state": "WORKING"},
+                    )
+                    assert resp.status_code == 200
+                    assert json.loads(resp.data)["data"]["deduped"] is False
+
+    def test_working_heartbeat_refreshes_health_monitor_last_heartbeat(
+        self, client, app, monkeypatch
+    ):
+        """#3341 cross-module regression: a repeated ``WORKING`` beat must
+        travel route → ``MESSAGE_SENT`` event → ``HealthMonitor`` and
+        refresh ``last_heartbeat``.
+
+        This is the gap the reviewer flagged: the per-emitter unit tests
+        stop at the subprocess boundary, so the silent dedup drop in the
+        ``/heartbeat`` route was invisible to them. The blocking bug was
+        that the route deduped the in-tool-loop emitter's ``WORKING`` beat
+        (identical to the wrapper's recorded state), emitted no
+        ``MESSAGE_SENT`` event, and so ``HealthMonitor._on_message_sent``
+        never bumped ``last_heartbeat`` — leaving ``check_heartbeats`` to
+        trip the false stall the feature was built to prevent. We drive a
+        real ``HealthMonitor`` off the same (synchronous) event bus the
+        route emits into and assert the second beat advances the clock.
+        """
+        import events as events_mod
+        from events import EventBus
+        from health_monitor import HealthMonitor
+        from models import PipelineConfig
+
+        # Synchronous bus so the route's emit_event delivers inline. Swap
+        # the module singleton so routes.messages.emit_event -> get_event_bus
+        # resolves to the same bus the HealthMonitor subscribes to.
+        bus = EventBus(async_delivery=False)
+        monkeypatch.setattr(events_mod, "_event_bus", bus)
+
+        role = "in-tool-loop-xmod-role"
+        monitor = HealthMonitor(bus, "test-pipeline", PipelineConfig())
+        monitor.set_active_roles({role})
+
+        with app.test_request_context():
+            with patch(
+                "routes.messages.get_state_store_for_pipeline"
+            ) as mock_get_store_for_pipeline:
+                mock_get_store_for_pipeline.return_value = (
+                    MagicMock(),
+                    _make_pipeline_mock(),
+                )
+
+                # 1) Wrapper-style first WORKING beat — records state and
+                #    refreshes last_heartbeat.
+                resp1 = client.post(
+                    "/api/v1/pipelines/test-pipeline/heartbeat",
+                    json={"from_role": role, "state": "WORKING"},
+                )
+                assert json.loads(resp1.data)["data"]["deduped"] is False
+                first_seen = monitor._last_heartbeat[role]
+
+                # 2) In-tool-loop re-emit — byte-identical WORKING, later in
+                #    wall-clock. Pre-#3341 this deduped and last_heartbeat
+                #    went stale; now it must pass through and advance.
+                with patch("health_monitor.time") as mock_time:
+                    later = first_seen + 200
+                    mock_time.time.return_value = later
+                    resp2 = client.post(
+                        "/api/v1/pipelines/test-pipeline/heartbeat",
+                        json={"from_role": role, "state": "WORKING"},
+                    )
+
+                assert json.loads(resp2.data)["data"]["deduped"] is False
+                assert monitor._last_heartbeat[role] == later
+                assert monitor._last_heartbeat[role] > first_seen
 
     def test_heartbeat_route_requires_from_role(self, client, app):
         """Missing from_role -> 400."""

--- a/shared/egg_agent/client.py
+++ b/shared/egg_agent/client.py
@@ -690,6 +690,47 @@ async def run_agent_async(
         post_tool_use.append(HookMatcher(matcher=None, hooks=[_inject_midturn_messages]))
         options.hooks = {**existing_hooks, "PostToolUse": post_tool_use}
 
+    # --- In-tool-loop WORKING heartbeat (#3341) ---
+    # The consensus wrapper emits one WORKING heartbeat before handing off to
+    # the agent, then nothing until the (30+ minute) invocation returns — the
+    # "no background emitter" design. So a genuinely-busy producer looks
+    # bus-silent for the whole turn, and any single step past the
+    # heartbeat-silence threshold (implement phase: 600s) trips the health
+    # monitor's check_heartbeats tripwire even though the pod is making
+    # continuous tool calls. Acting on that false stall by restarting can
+    # orphan in-flight commits and cascade-fail a multi-slice run (#3339).
+    # A throttled PostToolUse hook re-emits a WORKING heartbeat during the
+    # turn — the exact signal check_heartbeats consumes — so a busy agent
+    # stays visibly alive and the tripwire only fires on genuine silence.
+    # Same gating/escape-hatch shape as the mid-turn poller above;
+    # EGG_WORKING_HEARTBEAT=false is the rollback hatch.
+    from egg_agent.working_heartbeat import (
+        WorkingHeartbeatEmitter,
+        is_working_heartbeat_disabled,
+    )
+
+    if not is_working_heartbeat_disabled() and midturn_pipeline_id and midturn_role:
+        heartbeat_emitter = WorkingHeartbeatEmitter(midturn_pipeline_id, midturn_role)
+
+        async def _emit_working_heartbeat(
+            input_data: HookInput, tool_use_id: str | None, context: HookContext
+        ) -> HookJSONOutput:
+            # Fast-path: skip the thread boundary entirely when the interval
+            # gate is clearly closed (the matcher is None so this fires on
+            # every tool call). The lockless predicate may produce false
+            # positives under concurrent calls; emit() re-checks atomically.
+            if not heartbeat_emitter.is_due_to_emit():
+                return {}
+            # emit() runs an egg-orch subprocess when the interval has
+            # elapsed; keep it off the event loop. It never raises.
+            await asyncio.to_thread(heartbeat_emitter.emit)
+            return {}
+
+        existing_hooks = getattr(options, "hooks", None) or {}
+        post_tool_use = list(existing_hooks.get("PostToolUse", []))
+        post_tool_use.append(HookMatcher(matcher=None, hooks=[_emit_working_heartbeat]))
+        options.hooks = {**existing_hooks, "PostToolUse": post_tool_use}
+
     stdout_parts: list[str] = []
     actual_model: str | None = None
     result_meta: dict[str, Any] = {}

--- a/shared/egg_agent/tests/test_working_heartbeat.py
+++ b/shared/egg_agent/tests/test_working_heartbeat.py
@@ -1,0 +1,244 @@
+"""In-tool-loop WORKING heartbeat emitter (#3341).
+
+The consensus wrapper emits one WORKING heartbeat per one-shot event, then nothing
+until the (30+ minute) invocation returns — so a genuinely-busy producer looks
+bus-silent for the whole turn and trips the health monitor's heartbeat-silence
+tripwire (false stall → false restart → orphaned commit cascade, #3339). The
+PostToolUse-driven :class:`WorkingHeartbeatEmitter` re-emits the WORKING heartbeat
+during the turn, throttled by a monotonic interval gate so a chatty tool storm
+stays cheap.
+
+This module pins the contract:
+
+* the throttle gate (first emit due; suppressed within the interval; due again
+  after it elapses) and the atomic check-and-set;
+* the throttle window advancing on *attempt* (failed sends do not become a
+  per-tool-call subprocess storm);
+* fail-soft ``_send`` (missing binary / non-zero rc / timeout → ``False``, never
+  raises) and the exact ``egg-orch message heartbeat`` command shape; and
+* the ``EGG_WORKING_HEARTBEAT`` / ``EGG_WORKING_HEARTBEAT_INTERVAL_SECS`` env knobs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — make ``shared/`` importable so ``egg_agent.working_heartbeat``
+# resolves against the local tree (mirrors test_midturn_messages.py).
+# ---------------------------------------------------------------------------
+
+_shared_dir = Path(__file__).resolve().parents[2]
+if str(_shared_dir) not in sys.path:
+    sys.path.insert(0, str(_shared_dir))
+
+from egg_agent.working_heartbeat import (  # noqa: E402
+    DEFAULT_HEARTBEAT_INTERVAL_SECS,
+    WorkingHeartbeatEmitter,
+    _interval_secs,
+    is_working_heartbeat_disabled,
+)
+
+
+class _Clock:
+    """Controllable monotonic clock."""
+
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, secs: float) -> None:
+        self.t += secs
+
+
+def _make_emitter(interval_secs: float = 120.0):
+    clock = _Clock()
+    emitter = WorkingHeartbeatEmitter(
+        "issue-3341",
+        "coder",
+        interval_secs=interval_secs,
+        now=clock,
+    )
+    return emitter, clock
+
+
+# ---------------------------------------------------------------------------
+# Throttle gate
+# ---------------------------------------------------------------------------
+
+
+def test_first_emit_is_due_and_sends(monkeypatch) -> None:
+    emitter, _clock = _make_emitter()
+    sent: list[bool] = []
+    monkeypatch.setattr(emitter, "_send", lambda: sent.append(True) or True)
+
+    assert emitter.is_due_to_emit() is True
+    assert emitter.emit() is True
+    assert sent == [True]
+
+
+def test_within_interval_is_throttled(monkeypatch) -> None:
+    emitter, clock = _make_emitter(interval_secs=120.0)
+    calls: list[int] = []
+    monkeypatch.setattr(emitter, "_send", lambda: calls.append(1) or True)
+
+    assert emitter.emit() is True  # first emit fires
+    clock.advance(60.0)  # still inside the 120s window
+
+    assert emitter.is_due_to_emit() is False
+    assert emitter.emit() is False  # throttled — no second send
+    assert calls == [1]
+
+
+def test_due_again_after_interval_elapses(monkeypatch) -> None:
+    emitter, clock = _make_emitter(interval_secs=120.0)
+    calls: list[int] = []
+    monkeypatch.setattr(emitter, "_send", lambda: calls.append(1) or True)
+
+    assert emitter.emit() is True
+    clock.advance(120.0)  # window fully elapsed
+
+    assert emitter.is_due_to_emit() is True
+    assert emitter.emit() is True
+    assert calls == [1, 1]
+
+
+def test_failed_send_still_advances_throttle(monkeypatch) -> None:
+    """A transiently-unreachable orchestrator must not turn the hook into a
+    per-tool-call subprocess storm: the window advances on every attempt."""
+    emitter, clock = _make_emitter(interval_secs=120.0)
+    calls: list[int] = []
+
+    def _failing_send() -> bool:
+        calls.append(1)
+        return False
+
+    monkeypatch.setattr(emitter, "_send", _failing_send)
+
+    assert emitter.emit() is False  # attempted, send failed
+    assert calls == [1]
+
+    # Immediately retrying inside the window does NOT re-spawn the subprocess.
+    assert emitter.emit() is False
+    assert calls == [1]
+
+    clock.advance(120.0)
+    assert emitter.emit() is False  # window elapsed → attempts again
+    assert calls == [1, 1]
+
+
+# ---------------------------------------------------------------------------
+# _send fail-soft + command shape
+# ---------------------------------------------------------------------------
+
+
+def test_send_returns_false_when_binary_missing(monkeypatch) -> None:
+    emitter, _clock = _make_emitter()
+    monkeypatch.setattr("egg_agent.working_heartbeat.shutil.which", lambda _b: None)
+    assert emitter._send() is False
+
+
+def test_send_builds_expected_command_with_slice_tag(monkeypatch) -> None:
+    emitter, _clock = _make_emitter()
+    monkeypatch.setattr("egg_agent.working_heartbeat.shutil.which", lambda _b: "/usr/bin/egg-orch")
+    monkeypatch.setenv("EGG_SLICE_ID", "slice-3")
+    captured: dict[str, object] = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["timeout"] = kwargs.get("timeout")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("egg_agent.working_heartbeat.subprocess.run", _fake_run)
+
+    assert emitter._send() is True
+    assert captured["cmd"] == [
+        "/usr/bin/egg-orch",
+        "message",
+        "heartbeat",
+        "--state",
+        "WORKING",
+        "--body",
+        "in-tool-loop liveness (slice=slice-3)",
+    ]
+    assert captured["timeout"] == 5
+
+
+def test_send_defaults_slice_tag_to_none(monkeypatch) -> None:
+    emitter, _clock = _make_emitter()
+    monkeypatch.setattr("egg_agent.working_heartbeat.shutil.which", lambda _b: "/usr/bin/egg-orch")
+    monkeypatch.delenv("EGG_SLICE_ID", raising=False)
+    captured: dict[str, object] = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("egg_agent.working_heartbeat.subprocess.run", _fake_run)
+    emitter._send()
+    assert captured["cmd"][-1] == "in-tool-loop liveness (slice=none)"
+
+
+def test_send_non_zero_rc_is_false(monkeypatch) -> None:
+    """A 429 rate-limit surfaces as rc=3 — treated as a soft miss, not a raise."""
+    emitter, _clock = _make_emitter()
+    monkeypatch.setattr("egg_agent.working_heartbeat.shutil.which", lambda _b: "/usr/bin/egg-orch")
+
+    def _fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 3, stdout="", stderr="rate limited")
+
+    monkeypatch.setattr("egg_agent.working_heartbeat.subprocess.run", _fake_run)
+    assert emitter._send() is False
+
+
+def test_send_timeout_is_fail_soft(monkeypatch) -> None:
+    emitter, _clock = _make_emitter()
+    monkeypatch.setattr("egg_agent.working_heartbeat.shutil.which", lambda _b: "/usr/bin/egg-orch")
+
+    def _raise_timeout(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, 5)
+
+    monkeypatch.setattr("egg_agent.working_heartbeat.subprocess.run", _raise_timeout)
+    assert emitter._send() is False
+
+
+# ---------------------------------------------------------------------------
+# Env knobs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["false", "0", "off", "disabled", "FALSE", " Off "])
+def test_disabled_env_hatch(monkeypatch, value) -> None:
+    monkeypatch.setenv("EGG_WORKING_HEARTBEAT", value)
+    assert is_working_heartbeat_disabled() is True
+
+
+@pytest.mark.parametrize("value", ["", "true", "1", "on", "enabled"])
+def test_enabled_by_default(monkeypatch, value) -> None:
+    if value:
+        monkeypatch.setenv("EGG_WORKING_HEARTBEAT", value)
+    else:
+        monkeypatch.delenv("EGG_WORKING_HEARTBEAT", raising=False)
+    assert is_working_heartbeat_disabled() is False
+
+
+def test_interval_default(monkeypatch) -> None:
+    monkeypatch.delenv("EGG_WORKING_HEARTBEAT_INTERVAL_SECS", raising=False)
+    assert _interval_secs() == DEFAULT_HEARTBEAT_INTERVAL_SECS
+
+
+def test_interval_override(monkeypatch) -> None:
+    monkeypatch.setenv("EGG_WORKING_HEARTBEAT_INTERVAL_SECS", "45")
+    assert _interval_secs() == 45.0
+
+
+@pytest.mark.parametrize("value", ["notanumber", "0", "-5"])
+def test_interval_invalid_falls_back_to_default(monkeypatch, value) -> None:
+    monkeypatch.setenv("EGG_WORKING_HEARTBEAT_INTERVAL_SECS", value)
+    assert _interval_secs() == DEFAULT_HEARTBEAT_INTERVAL_SECS

--- a/shared/egg_agent/working_heartbeat.py
+++ b/shared/egg_agent/working_heartbeat.py
@@ -1,0 +1,204 @@
+"""In-tool-loop WORKING heartbeat emission (#3341).
+
+One ``propose`` invocation under the BRC event-pump can run 30+ minutes (a
+slice coder implements its whole task list in a single turn). The
+consensus wrapper emits exactly one ``WORKING`` heartbeat *before* handing
+control to the agent, then there is no further bus traffic until the
+invocation returns — the "no background emitter" design (see
+``orchestrator/consensus_wrapper.py``). So a genuinely-busy agent making
+continuous tool calls looks bus-silent for the whole turn, and any single
+step longer than the heartbeat-silence threshold
+(``orchestrator_implement_heartbeat_timeout_seconds``, 600s) trips the
+health monitor's ``check_heartbeats`` tripwire regardless of how busy the
+pod is. Acting on that false stall by restarting can orphan in-flight
+commits and cascade-fail a multi-slice run (#3339), so the false positive
+has a real, expensive failure mode.
+
+This module restores the missing liveness signal at its source: a
+throttled emitter that ``client.py`` wires into the SDK session as a
+PostToolUse hook. Every tool call gives it a chance to fire; a monotonic
+interval gate keeps the actual emission cheap (one ``egg-orch message
+heartbeat`` subprocess per ``EGG_WORKING_HEARTBEAT_INTERVAL_SECS``), so a
+busy agent stays visibly alive on the bus and the heartbeat tripwire only
+fires on genuine silence.
+
+It is the exact sibling of :class:`midturn_messages.MidturnMessagePoller`
+(#3123): same 30+-minute-turn problem, same hook shape (lockless fast-path
+predicate → ``asyncio.to_thread`` → fail-soft subprocess), and it reuses
+the same ``WORKING`` heartbeat the wrapper already emits — the
+schema-validated, per-role-deduped, rate-limited ``/heartbeat`` endpoint
+(#1897), which is exactly the signal ``check_heartbeats`` consumes.
+
+Design notes:
+
+* Event-driven, not a background timer: the heartbeat fires only when the
+  agent is doing tool work, which *is* the liveness semantics we want, and
+  it honours the wrapper's deliberate "no background emitter" stance.
+* The interval (default 120s) sits well under the 300s Tier-1 and 600s
+  implement-phase silence thresholds, so several ticks land before any
+  tripwire could fire, and well under the 20/min ``EGG_HEARTBEAT_RATE_LIMIT``
+  cap.
+* Limitation: PostToolUse fires *after* a tool call returns, so a single
+  uninterrupted tool call longer than the interval (e.g. one 10-minute
+  ``make test-all`` Bash call) still does not tick mid-call. The dominant
+  repro — dozens of edits/tests/commits across a long turn — is covered.
+* Fail-soft everywhere: a missing ``egg-orch`` binary, an unreachable
+  orchestrator, a 429 rate-limit, or a subprocess timeout all mean "no
+  heartbeat this tick" — never an agent failure.
+* Gated on pipeline context (``EGG_PIPELINE_ID`` + ``EGG_AGENT_ROLE``, read
+  from the pod env by the CLI handler) so non-pipeline ``egg_agent``
+  callers are untouched; ``EGG_WORKING_HEARTBEAT=false`` is the rollback
+  escape hatch.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import threading
+import time
+from collections.abc import Callable
+
+# Default seconds between heartbeat emissions. Tool calls arrive much more
+# often than this; the interval gate makes the hook effectively free
+# between emissions. 120s leaves ≥2 ticks before the 300s Tier-1 stall
+# window and ~5 before the 600s implement-phase window, while staying far
+# under the 20/min heartbeat rate-limit cap.
+DEFAULT_HEARTBEAT_INTERVAL_SECS = 120.0
+
+# Subprocess budget for one emission. Mirrors the consensus wrapper's
+# ``timeout 5 egg-orch message heartbeat`` — the heartbeat is best-effort
+# liveness, not something worth blocking the tool loop on.
+_EMIT_SUBPROCESS_TIMEOUT_SECS = 5
+
+# Body text echoed into the heartbeat so a snapshot/log reader can tell an
+# in-tool-loop liveness ping apart from the wrapper's once-per-event ping.
+_HEARTBEAT_BODY = "in-tool-loop liveness"
+
+
+def is_working_heartbeat_disabled() -> bool:
+    """Check the ``EGG_WORKING_HEARTBEAT`` escape hatch (default: enabled)."""
+    return (os.environ.get("EGG_WORKING_HEARTBEAT") or "").strip().lower() in (
+        "false",
+        "0",
+        "off",
+        "disabled",
+    )
+
+
+def _interval_secs() -> float:
+    raw = (os.environ.get("EGG_WORKING_HEARTBEAT_INTERVAL_SECS") or "").strip()
+    if raw:
+        try:
+            value = float(raw)
+            if value > 0:
+                return value
+        except ValueError:
+            pass
+    return DEFAULT_HEARTBEAT_INTERVAL_SECS
+
+
+class WorkingHeartbeatEmitter:
+    """Throttled in-tool-loop ``WORKING`` heartbeat emitter.
+
+    One instance per SDK session; :meth:`emit` is called from the
+    PostToolUse hook (via ``asyncio.to_thread`` — it runs a subprocess)
+    and returns ``True`` when it actually emitted, ``False`` otherwise.
+    """
+
+    def __init__(
+        self,
+        pipeline_id: str,
+        role: str,
+        *,
+        interval_secs: float | None = None,
+        now: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.pipeline_id = pipeline_id
+        self.role = role
+        self.interval_secs = interval_secs if interval_secs is not None else _interval_secs()
+        self._now = now
+        self._last_emit: float | None = None
+        # Guards the throttle check-and-set so two concurrent PostToolUse
+        # callbacks (today serial, but the SDK may move to concurrent
+        # delivery) cannot both observe a stale ``_last_emit`` and both
+        # spawn a heartbeat subprocess. ``is_due_to_emit`` outside the lock
+        # is intentionally lockless — a fast-path hint for hook callers;
+        # the authoritative gate is in ``emit`` under this lock.
+        self._emit_lock = threading.Lock()
+
+    # -- bus access -------------------------------------------------------
+
+    def _send(self) -> bool:
+        """Run one ``egg-orch message heartbeat`` subprocess (fail-soft).
+
+        ``pipeline_id`` / ``role`` are read from the pod env
+        (``EGG_PIPELINE_ID`` / ``EGG_AGENT_ROLE``) by the CLI handler, the
+        same way the consensus wrapper's ``emit_heartbeat`` invokes it.
+        Returns ``True`` on a clean exit, ``False`` on any failure (binary
+        missing, non-zero rc — including a 429 rate-limit surfaced as
+        rc=3 — timeout, or OS error).
+        """
+        binary = shutil.which("egg-orch")
+        if not binary:
+            return False
+        slice_tag = (os.environ.get("EGG_SLICE_ID") or "none").strip() or "none"
+        cmd = [
+            binary,
+            "message",
+            "heartbeat",
+            "--state",
+            "WORKING",
+            "--body",
+            f"{_HEARTBEAT_BODY} (slice={slice_tag})",
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=_EMIT_SUBPROCESS_TIMEOUT_SECS,
+                check=False,
+            )
+        except subprocess.SubprocessError, OSError:
+            return False
+        return proc.returncode == 0
+
+    # -- public API -------------------------------------------------------
+
+    def is_due_to_emit(self) -> bool:
+        """Lockless predicate — does the throttle window allow an emit now?
+
+        Intended as a fast-path hint for hook callers that want to avoid
+        crossing the ``asyncio.to_thread`` boundary on every tool call
+        when the emit is clearly throttled. False positives are possible
+        under concurrent calls (two callers can both observe the same
+        stale ``_last_emit``) — the authoritative gate is in :meth:`emit`
+        under ``_emit_lock``, which re-checks atomically and ensures only
+        one subprocess runs per interval.
+        """
+        last = self._last_emit
+        if last is None:
+            return True
+        return (self._now() - last) >= self.interval_secs
+
+    def emit(self) -> bool:
+        """Emit a ``WORKING`` heartbeat if the interval has elapsed.
+
+        Returns ``True`` when a heartbeat was actually sent, ``False`` when
+        throttled or on any send failure. The throttle window advances on
+        every *attempt* (not just clean sends) so a transiently-unreachable
+        orchestrator does not turn the hook into a per-tool-call subprocess
+        storm.
+        """
+        # Atomic check-and-set: closes the race where two concurrent
+        # callers both observe a stale ``_last_emit`` and both pass the
+        # gate, spawning duplicate subprocesses.
+        with self._emit_lock:
+            now = self._now()
+            if self._last_emit is not None and (now - self._last_emit) < self.interval_secs:
+                return False
+            self._last_emit = now
+
+        return self._send()

--- a/shared/egg_agent/working_heartbeat.py
+++ b/shared/egg_agent/working_heartbeat.py
@@ -26,8 +26,15 @@ It is the exact sibling of :class:`midturn_messages.MidturnMessagePoller`
 (#3123): same 30+-minute-turn problem, same hook shape (lockless fast-path
 predicate → ``asyncio.to_thread`` → fail-soft subprocess), and it reuses
 the same ``WORKING`` heartbeat the wrapper already emits — the
-schema-validated, per-role-deduped, rate-limited ``/heartbeat`` endpoint
-(#1897), which is exactly the signal ``check_heartbeats`` consumes.
+schema-validated, rate-limited ``/heartbeat`` endpoint (#1897), which is
+exactly the signal ``check_heartbeats`` consumes.
+
+``WORKING`` is in the route's ``_DEDUP_EXEMPT_HEARTBEAT_STATES``
+(``orchestrator/routes/messages.py``): the wrapper records one ``WORKING``
+beat before handing off, so without that exemption every in-tool-loop
+re-emit would dedup against the recorded state, emit no ``MESSAGE_SENT``
+event, and never refresh ``last_heartbeat`` — the feature would silently
+no-op. The exemption is what lets these ticks actually land.
 
 Design notes:
 
@@ -35,9 +42,9 @@ Design notes:
   agent is doing tool work, which *is* the liveness semantics we want, and
   it honours the wrapper's deliberate "no background emitter" stance.
 * The interval (default 120s) sits well under the 300s Tier-1 and 600s
-  implement-phase silence thresholds, so several ticks land before any
-  tripwire could fire, and well under the 20/min ``EGG_HEARTBEAT_RATE_LIMIT``
-  cap.
+  implement-phase silence thresholds, so several ticks land (and refresh
+  ``last_heartbeat``) before any tripwire could fire, and well under the
+  20/min ``EGG_HEARTBEAT_RATE_LIMIT`` cap.
 * Limitation: PostToolUse fires *after* a tool call returns, so a single
   uninterrupted tool call longer than the interval (e.g. one 10-minute
   ``make test-all`` Bash call) still does not tick mid-call. The dominant
@@ -115,6 +122,12 @@ class WorkingHeartbeatEmitter:
         interval_secs: float | None = None,
         now: Callable[[], float] = time.monotonic,
     ) -> None:
+        # ``pipeline_id`` / ``role`` are retained for identity/logging only —
+        # they intentionally do NOT scope the emission. ``_send`` shells out to
+        # ``egg-orch message heartbeat``, whose CLI handler reads the live
+        # ``EGG_PIPELINE_ID`` / ``EGG_AGENT_ROLE`` pod env (the same path the
+        # consensus wrapper's ``emit_heartbeat`` takes), so the heartbeat
+        # identity always comes from the env, not these fields.
         self.pipeline_id = pipeline_id
         self.role = role
         self.interval_secs = interval_secs if interval_secs is not None else _interval_secs()
@@ -161,6 +174,13 @@ class WorkingHeartbeatEmitter:
                 timeout=_EMIT_SUBPROCESS_TIMEOUT_SECS,
                 check=False,
             )
+        # NOTE: this is a PEP 758 multi-exception clause (Python 3.14+), NOT
+        # a Python-2 ``except E, name:`` capture — it catches both
+        # ``subprocess.SubprocessError`` and ``OSError``. ``ruff format``
+        # (target-version = py314) normalises the parenthesized
+        # ``except (A, B):`` to exactly this unparenthesized form, so the
+        # parens cannot be kept for readability without failing the format
+        # check; the comment carries that clarity instead.
         except subprocess.SubprocessError, OSError:
             return False
         return proc.returncode == 0

--- a/tests/shared/egg_agent/test_client.py
+++ b/tests/shared/egg_agent/test_client.py
@@ -1516,6 +1516,120 @@ class TestMidturnMessageHook:
         assert self._post_tool_use_hooks(mock_query) == []
 
 
+class TestWorkingHeartbeatHook:
+    """Issue #3341: pipeline sessions get a PostToolUse hook that re-emits a
+    WORKING heartbeat mid-turn, so a genuinely-busy producer stays visibly
+    alive and the health monitor's check_heartbeats tripwire only fires on
+    real silence. Gated on pipeline context (EGG_PIPELINE_ID + EGG_AGENT_ROLE)
+    with the EGG_WORKING_HEARTBEAT=false escape hatch.
+
+    The sibling mid-turn message poller (#3123) registers its own PostToolUse
+    hook under the same gate, so these tests disable it (EGG_MIDTURN_MESSAGES
+    =false) to isolate the heartbeat registration — except the explicit
+    "grows by one" test below, which keeps the poller on and asserts the
+    heartbeat hook is added *on top of* it. This positive coverage backs the
+    wiring that a prior revision of this PR shipped as a silent no-op.
+    """
+
+    @staticmethod
+    def _post_tool_use_hooks(mock_query):
+        opts = mock_query.call_args.kwargs["options"]
+        hooks = getattr(opts, "hooks", None) or {}
+        return hooks.get("PostToolUse", [])
+
+    @patch.dict(
+        os.environ,
+        {
+            "EGG_PIPELINE_ID": "pipeline-test",
+            "EGG_AGENT_ROLE": "coder",
+            "EGG_MCP_TOOLS": "false",
+            # Isolate the heartbeat hook from the sibling mid-turn poller
+            # (#3123), which also registers a PostToolUse hook here.
+            "EGG_MIDTURN_MESSAGES": "false",
+            # Default-enabled: assert the hook lands when the escape hatch is
+            # *unset*, so a future default flip can't silently drop it.
+            "EGG_WORKING_HEARTBEAT": "",
+        },
+    )
+    @patch("claude_agent_sdk.query", side_effect=_mock_query_success)
+    def test_hook_registered_in_pipeline_session(self, mock_query):
+        result = _run_async(run_agent_async("test prompt"))
+        assert result.success is True
+        post_hooks = self._post_tool_use_hooks(mock_query)
+        assert len(post_hooks) == 1
+        # No matcher → fires on every tool call (the emitter's interval gate
+        # makes that effectively free between actual heartbeat emits).
+        assert post_hooks[0].matcher is None
+        assert len(post_hooks[0].hooks) == 1
+
+    @patch("claude_agent_sdk.query", side_effect=_mock_query_success)
+    def test_hook_grows_post_tool_use_list_by_one(self, mock_query):
+        # Baseline: pipeline context with the heartbeat hatch closed leaves
+        # only the mid-turn poller's PostToolUse hook.
+        baseline_env = os.environ.copy()
+        baseline_env.update(
+            {
+                "EGG_PIPELINE_ID": "pipeline-test",
+                "EGG_AGENT_ROLE": "coder",
+                "EGG_MCP_TOOLS": "false",
+                "EGG_WORKING_HEARTBEAT": "false",
+            }
+        )
+        baseline_env.pop("EGG_MIDTURN_MESSAGES", None)
+        with patch.dict(os.environ, baseline_env, clear=True):
+            assert _run_async(run_agent_async("test prompt")).success is True
+        baseline = len(self._post_tool_use_hooks(mock_query))
+
+        # Enabling the heartbeat (hatch unset) adds exactly one PostToolUse
+        # hook on top of the poller — it composes, it doesn't replace.
+        enabled_env = os.environ.copy()
+        enabled_env.update(
+            {
+                "EGG_PIPELINE_ID": "pipeline-test",
+                "EGG_AGENT_ROLE": "coder",
+                "EGG_MCP_TOOLS": "false",
+            }
+        )
+        enabled_env.pop("EGG_MIDTURN_MESSAGES", None)
+        enabled_env.pop("EGG_WORKING_HEARTBEAT", None)
+        with patch.dict(os.environ, enabled_env, clear=True):
+            assert _run_async(run_agent_async("test prompt")).success is True
+        enabled = len(self._post_tool_use_hooks(mock_query))
+
+        assert enabled == baseline + 1
+
+    @patch("claude_agent_sdk.query", side_effect=_mock_query_success)
+    def test_hook_not_registered_outside_pipeline(self, mock_query):
+        env = os.environ.copy()
+        env.pop("EGG_PIPELINE_ID", None)
+        env.pop("EGG_AGENT_ROLE", None)
+        env.pop("EGG_WORKING_HEARTBEAT", None)
+        env["EGG_MCP_TOOLS"] = "false"
+        with patch.dict(os.environ, env, clear=True):
+            result = _run_async(run_agent_async("test prompt"))
+        assert result.success is True
+        assert self._post_tool_use_hooks(mock_query) == []
+
+    @patch.dict(
+        os.environ,
+        {
+            "EGG_PIPELINE_ID": "pipeline-test",
+            "EGG_AGENT_ROLE": "coder",
+            "EGG_MCP_TOOLS": "false",
+            # Disable the sibling mid-turn poller too, so this asserts the
+            # heartbeat escape hatch leaves *no* PostToolUse hook rather than
+            # colliding with the poller registration.
+            "EGG_MIDTURN_MESSAGES": "false",
+            "EGG_WORKING_HEARTBEAT": "false",
+        },
+    )
+    @patch("claude_agent_sdk.query", side_effect=_mock_query_success)
+    def test_escape_hatch_disables_hook(self, mock_query):
+        result = _run_async(run_agent_async("test prompt"))
+        assert result.success is True
+        assert self._post_tool_use_hooks(mock_query) == []
+
+
 class TestExitCodeSurfaceExcludesExTempfail:
     """Back the consensus-wrapper one-shot arm's exit-75 reservation.
 

--- a/tests/shared/egg_agent/test_client.py
+++ b/tests/shared/egg_agent/test_client.py
@@ -1468,6 +1468,10 @@ class TestMidturnMessageHook:
             "EGG_PIPELINE_ID": "pipeline-test",
             "EGG_AGENT_ROLE": "coder",
             "EGG_MCP_TOOLS": "false",
+            # Isolate this mid-turn-hook assertion from the sibling
+            # in-tool-loop WORKING heartbeat hook (#3341), which also
+            # registers a PostToolUse hook under pipeline context.
+            "EGG_WORKING_HEARTBEAT": "false",
         },
     )
     @patch("claude_agent_sdk.query", side_effect=_mock_query_success)
@@ -1499,6 +1503,10 @@ class TestMidturnMessageHook:
             "EGG_AGENT_ROLE": "coder",
             "EGG_MIDTURN_MESSAGES": "false",
             "EGG_MCP_TOOLS": "false",
+            # Disable the sibling WORKING heartbeat hook (#3341) too, so
+            # this asserts the mid-turn escape hatch leaves *no* PostToolUse
+            # hook rather than colliding with the heartbeat registration.
+            "EGG_WORKING_HEARTBEAT": "false",
         },
     )
     @patch("claude_agent_sdk.query", side_effect=_mock_query_success)


### PR DESCRIPTION
Fixes #3341.

## Problem

The overseer's heartbeat-silence detector repeatedly escalates a **healthy, actively-working producer** as "stalled" because the only liveness signal it has — the BRC message-bus heartbeat — goes silent during a long single-task turn.

Root cause is upstream of every detector. The consensus wrapper emits exactly **one** `WORKING` heartbeat *before* handing control to the agent (`orchestrator/consensus_wrapper.py`, deliberate "no background emitter" design), then there is no further bus traffic until the (30+ minute) one-shot invocation returns. So a producer making continuous tool calls looks bus-silent for the whole turn, and any single step past `orchestrator_implement_heartbeat_timeout_seconds` (600s) trips `health_monitor.check_heartbeats` regardless of how busy the pod is. The existing #2190 activity gate doesn't save it: `CONTAINER_ACTIVITY` is published only on git-commit registration, so a long `make test-all` between commits goes stale.

Why it matters: the remediation for a "stalled" agent is restart, and a `restart_phase` re-fork can orphan an in-flight commit and **cascade-fail an entire multi-slice run** (#3339). A false positive here has a real, expensive failure mode.

## Fix

Restore the missing signal at its source rather than patch the detectors. A throttled `WorkingHeartbeatEmitter` is wired into the SDK session as a second PostToolUse hook — the exact sibling of the #3123 `MidturnMessagePoller` (same 30+-minute-turn problem, same hook shape: lockless fast-path predicate → `asyncio.to_thread` → fail-soft subprocess). It re-emits the same `WORKING` heartbeat the wrapper does (`egg-orch message heartbeat`, the per-role-deduped rate-limited `/heartbeat` endpoint, #1897) — exactly the signal `check_heartbeats` consumes.

Because it restores the truthful liveness signal, **every** consumer is fixed at once — `check_heartbeats` (the path that fired the false escalations), the Tier-1 `detect_heartbeat_stall` detector, and the overseer — with no detector-logic changes.

- **Event-driven on tool calls, not a background timer** — honours the wrapper's "no background emitter" stance; a heartbeat fires only when the agent is doing tool work.
- **Throttled** to `EGG_WORKING_HEARTBEAT_INTERVAL_SECS` (default 120s): several ticks land before the 300s Tier-1 / 600s implement windows, and well under the 20/min `EGG_HEARTBEAT_RATE_LIMIT` cap.
- **Fail-soft everywhere** (missing `egg-orch`, unreachable orchestrator, 429, subprocess timeout → no tick, never an agent failure); gated on `EGG_PIPELINE_ID` + `EGG_AGENT_ROLE`; `EGG_WORKING_HEARTBEAT=false` rollback hatch.

### Known limitation

PostToolUse fires *after* a tool call returns, so a single uninterrupted tool call longer than the interval (e.g. one 10-minute `make test-all` Bash call) still won't tick mid-call. The dominant repro — dozens of edits/tests/commits across a long turn (exactly the issue-3312 evidence) — is covered.

## Out of scope (follow-ups)

- **Overseer "verify pod liveness before restart" gate** (issue Direction 2) — a *backstop* for the single-giant-call edge, not the root fix.
- **Latent bug:** Tier-1 `detect_heartbeat_stall` is effectively **dead code** today — `snapshot_from_health_context()` (detection_plane.py) never populates `last_tool_call_age_s`, so the detector always `continue`s. Worth its own issue.

## Testing

- 25 new unit tests in `shared/egg_agent/tests/test_working_heartbeat.py` (throttle gate, attempt-advances-window anti-storm, fail-soft `_send`, exact command shape incl. slice tag, env knobs).
- Full `shared/egg_agent` subset (37 tests, exercises the `client.py` hook wiring) green; `ruff check`/`format` clean; pre-commit clean. CI `test-all` is the ground truth.