### PR TITLE
fix(#3315): reset BRC consensus-timeout timer on restart_phase

### DIFF
--- a/orchestrator/approval_matrix.py
+++ b/orchestrator/approval_matrix.py
@@ -107,13 +107,34 @@ class ApprovalMatrix:
         self._revision_counts: dict[tuple[str, str], int] = {}
 
         # Initialize entries from graph edges
-        for edge in graph.edges:
+        self._seed_entries_from_graph()
+
+    def _seed_entries_from_graph(self) -> None:
+        """(Re)initialize every edge to a fresh PENDING entry from the graph."""
+        for edge in self._graph.edges:
             key = (edge.reviewer_role, edge.producer_role)
             self._entries[key] = ApprovalEntry(
                 reviewer_role=edge.reviewer_role,
                 producer_role=edge.producer_role,
             )
             self._revision_counts[key] = 0
+
+    def reset(self) -> None:
+        """Clear all ACK/NACK state back to a fresh, never-reviewed matrix.
+
+        Re-seeds every graph edge to a PENDING :class:`ApprovalEntry` (so
+        ``timestamp`` is ``None`` again) and drops proposal versions, no-op
+        flags, and revision counts. Used by :meth:`PeerConsensus.clear` on a
+        ``restart_phase`` / ``restart_agent`` so a stale ACK/NACK timestamp
+        cannot survive the restart and make ``get_latest_entry_timestamp``
+        (and thus the convergence-stall / consensus-timeout clocks) read time
+        from the pre-restart phase (#3315).
+        """
+        self._entries.clear()
+        self._proposal_versions.clear()
+        self._proposal_no_changes.clear()
+        self._revision_counts.clear()
+        self._seed_entries_from_graph()
 
     def record_proposal(self, producer: str, no_changes: bool = False) -> int:
         """Record a new proposal from a producer. Returns the version number.

--- a/orchestrator/peer_consensus/_state.py
+++ b/orchestrator/peer_consensus/_state.py
@@ -180,6 +180,12 @@ def clear(self) -> None:
         self._last_auto_repropose_timestamp.clear()
         self._auto_repropose_counts.clear()
         self._last_explicit_propose_timestamp.clear()
+        # Reset the approval matrix too — otherwise stale ACK/NACK
+        # entry timestamps survive a restart and ``get_latest_progress_
+        # timestamp`` keeps reporting bus activity from the pre-restart
+        # phase, tripping the convergence-stall / consensus-timeout clocks
+        # on the freshly-restarted phase (#3315).
+        self.matrix.reset()
 
 
 def _un_confirm_stale_reviewers(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -15614,7 +15614,7 @@ def _persist_hitl_decision(
 
 
 def _cancel_consensus_timeout_decisions(pipeline: Pipeline) -> int:
-    """Cancel any pending consensus-timeout HITL on ``pipeline`` (#3315 facet b).
+    """Cancel any pending consensus-timeout HITL on ``pipeline`` (#3315 facet c).
 
     Pure mutator (no lock / load / save): marks every pending
     ``consensus_timeout_incomplete`` decision ``CANCELLED`` with an
@@ -15664,7 +15664,7 @@ _DIVERGENCE_RECONCILE_HITL_CONTEXT = "divergence_reconcile_unacked"
 # Retry/Accept/Abort decision).  The convergence-success path uses this to
 # auto-withdraw the decision once the phase reaches genuine consensus, so an
 # operator is never left disposing of a decision the system already obsoleted
-# (#3315 facet b — happens when a superseded thread opens the decision and a
+# (#3315 facet c — happens when a superseded thread opens the decision and a
 # restarted thread then converges).
 _CONSENSUS_TIMEOUT_HITL_CONTEXT = "consensus_timeout_incomplete"
 
@@ -18746,6 +18746,31 @@ def _clear_stale_impasses_for_producers(
         )
 
 
+def _pipeline_superseded_by_restart(store, pipeline_id: str, run_epoch: datetime | None) -> bool:
+    """True if a newer ``run_epoch`` means another thread now owns this pipeline.
+
+    Reloads pipeline state and compares its ``run_epoch`` against the epoch the
+    caller runs under (#3315 facet a). Best-effort: a missing epoch or a load
+    failure returns ``False`` so a transient store hiccup never tears down a
+    legitimately-running phase. Shared by the ``_run_concurrent_phase`` poll
+    loop and the slice-path impasse-retry wrapper so the "no escalation when
+    superseded" property holds on both routes.
+    """
+    if store is None or run_epoch is None:
+        return False
+    try:
+        _epoch_pip = store.load_pipeline(pipeline_id)
+    except Exception as _epoch_err:  # noqa: BLE001 — never wedge the caller
+        logger.debug(
+            "Epoch supersession check failed; continuing",
+            pipeline_id=pipeline_id,
+            error=str(_epoch_err),
+        )
+        return False
+    current_epoch = _epoch_pip.run_epoch or _epoch_pip.created_at
+    return current_epoch != run_epoch
+
+
 def _run_concurrent_phase_with_impasse_retry(
     pipeline_id: str,
     pipeline: Pipeline,
@@ -18863,6 +18888,24 @@ def _run_concurrent_phase_with_impasse_retry(
             return last_exit, last_logs
 
         if not impasses:
+            return last_exit, last_logs
+
+        # Defense-in-depth (#3315 facet a, slice path): if a restart bumped
+        # ``run_epoch`` while this thread was running, a stale producer-written
+        # impasse file could otherwise drive ``route_impasses`` into a HITL
+        # against the freshly-restarted phase. The poll loop in
+        # ``_run_concurrent_phase`` already bails on supersession before any
+        # escalation; mirror that here so the "no escalation when superseded"
+        # property holds on the slice path too — return the (superseded) result
+        # without routing.
+        if _pipeline_superseded_by_restart(store, pipeline_id, run_epoch):
+            logger.info(
+                "Restart superseded this thread before impasse routing; "
+                "skipping route_impasses to avoid escalating against a "
+                "freshly-restarted phase",
+                pipeline_id=pipeline_id,
+                slice_id=slice_id,
+            )
             return last_exit, last_logs
 
         try:
@@ -19366,19 +19409,7 @@ def _run_concurrent_phase(
         failure returns ``False`` so a transient store hiccup never tears
         down a legitimately-running phase.
         """
-        if store is None or run_epoch is None:
-            return False
-        try:
-            _epoch_pip = store.load_pipeline(pipeline_id)
-        except Exception as _epoch_err:  # noqa: BLE001 — never wedge the loop
-            logger.debug(
-                "Epoch supersession check failed; continuing",
-                pipeline_id=pipeline_id,
-                error=str(_epoch_err),
-            )
-            return False
-        current_epoch = _epoch_pip.run_epoch or _epoch_pip.created_at
-        return current_epoch != run_epoch
+        return _pipeline_superseded_by_restart(store, pipeline_id, run_epoch)
 
     # Track which containers have exited and their results.
     exited_containers: dict[str, ContainerInfo] = {}
@@ -19577,7 +19608,7 @@ def _run_concurrent_phase(
                         ci.exited_at = datetime.now(UTC)
 
                 # Auto-withdraw any stale consensus-timeout HITL a superseded
-                # thread opened before this phase converged (#3315 facet b).
+                # thread opened before this phase converged (#3315 facet c).
                 # Folded into this already-locked load→save so it costs no
                 # extra lock and rides every consensus-success path.
                 _withdrawn = _cancel_consensus_timeout_decisions(pip)

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -15613,6 +15613,29 @@ def _persist_hitl_decision(
         return None
 
 
+def _cancel_consensus_timeout_decisions(pipeline: Pipeline) -> int:
+    """Cancel any pending consensus-timeout HITL on ``pipeline`` (#3315 facet b).
+
+    Pure mutator (no lock / load / save): marks every pending
+    ``consensus_timeout_incomplete`` decision ``CANCELLED`` with an
+    auto-withdrawal note and returns how many it cancelled.  Called from the
+    consensus-success path (under the pipeline state lock, on the freshly
+    loaded pipeline that is about to be saved) so a stale forced-choice a
+    *superseded* thread opened before the phase converged is withdrawn in the
+    same write that marks the agents COMPLETE — the operator is never left
+    disposing of a decision the system already obsoleted by converging.
+    """
+    withdrawn = 0
+    for decision in pipeline.get_pending_decisions():
+        if decision.context != _CONSENSUS_TIMEOUT_HITL_CONTEXT:
+            continue
+        decision.status = DecisionStatus.CANCELLED
+        decision.resolution = "auto-withdrawn: consensus subsequently converged"
+        decision.resolved_at = datetime.now(UTC)
+        withdrawn += 1
+    return withdrawn
+
+
 # Bound on how many times the worktree-divergence reconcile will pause
 # for the operator before giving up and failing the pipeline (#2979).
 # A small budget guards against an operator repeatedly choosing
@@ -15634,6 +15657,16 @@ _DIVERGENCE_RECONCILE_HITL_OPTIONS = [
 # route surfaces the existing pending decision rather than appending a fresh
 # one.
 _DIVERGENCE_RECONCILE_HITL_CONTEXT = "divergence_reconcile_unacked"
+
+# Stable string discriminator set on the consensus-timeout / incomplete-
+# consensus HITL the orchestrator opens when a phase times out without
+# converging (the "Consensus timed out; consensus incomplete …"
+# Retry/Accept/Abort decision).  The convergence-success path uses this to
+# auto-withdraw the decision once the phase reaches genuine consensus, so an
+# operator is never left disposing of a decision the system already obsoleted
+# (#3315 facet b — happens when a superseded thread opens the decision and a
+# restarted thread then converges).
+_CONSENSUS_TIMEOUT_HITL_CONTEXT = "consensus_timeout_incomplete"
 
 
 def _find_pending_divergence_reconcile_decision(pipeline: Pipeline):
@@ -17090,6 +17123,7 @@ def _run_implement_phase_slices(
     store,
     certs_volume: str | None,
     worktree_repo_path: Path,
+    run_epoch: datetime | None = None,
 ) -> tuple[int, str]:
     """Drive the implement phase as a DAG of independent slices (#2137).
 
@@ -18174,6 +18208,7 @@ def _run_implement_phase_slices(
                     certs_volume=certs_volume,
                     worktree_repo_path=worktree_repo_path,
                     slice_id=slice_id,
+                    run_epoch=run_epoch,
                 )
 
                 if exit_code_inner != 0:
@@ -18727,6 +18762,7 @@ def _run_concurrent_phase_with_impasse_retry(
     slice_id: str | None = None,
     operator_directives: list[OperatorDirective] | None = None,
     iteration_history: list[IterationSummary] | None = None,
+    run_epoch: datetime | None = None,
 ) -> tuple[int, str]:
     """Run a concurrent phase, auto-delegating impasses once before HITL.
 
@@ -18808,6 +18844,7 @@ def _run_concurrent_phase_with_impasse_retry(
             slice_id=slice_id,
             operator_directives=operator_directives,
             iteration_history=iteration_history,
+            run_epoch=run_epoch,
         )
 
         try:
@@ -18912,6 +18949,7 @@ def _run_concurrent_phase(
     slice_id: str | None = None,
     operator_directives: list[OperatorDirective] | None = None,
     iteration_history: list[IterationSummary] | None = None,
+    run_epoch: datetime | None = None,
 ) -> tuple[int, str]:
     """Run a phase using concurrent all-agents-at-once execution.
 
@@ -19305,6 +19343,43 @@ def _run_concurrent_phase(
     start_time = time.monotonic()
     objection_decision_created = False
 
+    # ``run_epoch`` is the authoritative epoch the owning ``_run_pipeline``
+    # thread captured at start (#1638). The poll loop uses it to detect a
+    # ``restart_phase`` (or any restart that bumps ``run_epoch``) that
+    # superseded this thread (#3315). ``start_time`` is a fresh monotonic
+    # clock per call, but a parked-then-restarted phase leaves the *old*
+    # ``_run_concurrent_phase`` thread alive in its poll loop with a
+    # ``start_time`` from the original phase start; once its ``elapsed``
+    # crosses ``consensus_timeout`` it would fire a spurious consensus-timeout
+    # OVERSEER_ALERT + HITL decision against the freshly-restarted phase. The
+    # new ``_run_pipeline`` thread owns the pipeline now, so this stale thread
+    # must bail before escalating. When ``run_epoch`` is not supplied (legacy
+    # / direct-call callers) the guard is dormant — behaviour is unchanged.
+
+    def _superseded_by_restart() -> bool:
+        """True if a newer run_epoch means another thread owns this pipeline.
+
+        Reloads pipeline state and compares its ``run_epoch`` against the
+        epoch this thread runs under. Mirrors the post-return epoch check
+        (#1638) but runs *inside* the poll loop so a superseded thread stops
+        polling before it can fire stale escalations. Best-effort: a load
+        failure returns ``False`` so a transient store hiccup never tears
+        down a legitimately-running phase.
+        """
+        if store is None or run_epoch is None:
+            return False
+        try:
+            _epoch_pip = store.load_pipeline(pipeline_id)
+        except Exception as _epoch_err:  # noqa: BLE001 — never wedge the loop
+            logger.debug(
+                "Epoch supersession check failed; continuing",
+                pipeline_id=pipeline_id,
+                error=str(_epoch_err),
+            )
+            return False
+        current_epoch = _epoch_pip.run_epoch or _epoch_pip.created_at
+        return current_epoch != run_epoch
+
     # Track which containers have exited and their results.
     exited_containers: dict[str, ContainerInfo] = {}
 
@@ -19500,6 +19575,20 @@ def _run_concurrent_phase(
                         # reflects successful consensus completion.
                         ci.exit_code = 0
                         ci.exited_at = datetime.now(UTC)
+
+                # Auto-withdraw any stale consensus-timeout HITL a superseded
+                # thread opened before this phase converged (#3315 facet b).
+                # Folded into this already-locked load→save so it costs no
+                # extra lock and rides every consensus-success path.
+                _withdrawn = _cancel_consensus_timeout_decisions(pip)
+                if _withdrawn:
+                    logger.info(
+                        "Auto-withdrew stale consensus-timeout HITL decision(s) on convergence",
+                        pipeline_id=pipeline_id,
+                        phase=phase_str,
+                        withdrawn=_withdrawn,
+                    )
+
                 store.save_pipeline(pip)
         except Exception as track_err:
             logger.warning(
@@ -19517,6 +19606,27 @@ def _run_concurrent_phase(
 
     while True:
         elapsed = time.monotonic() - start_time
+
+        # 0. Bail if a restart superseded this thread (#3315). A parked phase
+        #    that is restarted after the consensus-timeout budget elapsed
+        #    leaves this old thread polling with a stale ``start_time``; the
+        #    new ``_run_pipeline`` thread already owns the pipeline. Exit
+        #    cleanly — stop this executor's event loop so it stops requesting
+        #    one-shot spawns — WITHOUT firing the timeout escalation. Return a
+        #    NON-zero exit so the caller never mistakes this for success and
+        #    advances the phase; the post-return epoch check (#1638) at the
+        #    call site re-confirms the restart and exits the old thread without
+        #    marking the phase FAILED.
+        if _superseded_by_restart():
+            logger.info(
+                "Phase superseded by restart (run_epoch changed) — exiting stale "
+                "_run_concurrent_phase thread without escalation",
+                pipeline_id=pipeline_id,
+                phase=phase,
+                slice_id=slice_id,
+            )
+            executor.stop_event_loop()
+            return 1, "Phase superseded by restart; stale monitor thread exited."
 
         # 1. Check consensus
         try:
@@ -20405,6 +20515,7 @@ def _run_concurrent_phase(
                     question=question,
                     options=["Retry phase", "Accept current state", "Abort phase"],
                     phase=pipeline.current_phase,
+                    context=_CONSENSUS_TIMEOUT_HITL_CONTEXT,
                 )
                 combined_logs += log_suffix
                 return 1, combined_logs
@@ -24804,6 +24915,7 @@ def _run_pipeline(
                                 store=store,
                                 certs_volume=certs_volume,
                                 worktree_repo_path=worktree_repo_path,
+                                run_epoch=run_epoch,
                             )
                         else:
                             # Pre-#2137 monolithic-implement fallback. The
@@ -24830,6 +24942,7 @@ def _run_pipeline(
                                 worktree_repo_path=worktree_repo_path,
                                 operator_directives=_phase_operator_directives,
                                 iteration_history=_phase_iteration_history,
+                                run_epoch=run_epoch,
                             )
                     except (ContainerSpawnError, KubernetesSpawnError) as e:
                         with get_pipeline_state_lock(pipeline_id):

--- a/orchestrator/tests/test_peer_consensus_integration.py
+++ b/orchestrator/tests/test_peer_consensus_integration.py
@@ -331,6 +331,31 @@ class TestProgressTimestamps:
         assert progress_ts is not None
         assert progress_ts > proposal_ts
 
+    def test_clear_resets_matrix_progress_timestamp(self, tracker):
+        """``clear()`` must drop the approval-matrix ACK/NACK timestamp (#3315).
+
+        ``restart_phase`` calls ``clear()`` to reset consensus state. Before
+        the fix, ``clear()`` left ``self.matrix`` populated, so a stale ACK/
+        NACK timestamp survived the restart and ``get_latest_progress_
+        timestamp`` kept reporting bus activity from the pre-restart phase —
+        tripping the convergence-stall / consensus-timeout clocks on the
+        freshly-restarted phase. A full clear must zero both signals.
+        """
+        tracker.handle_propose(
+            "coder", {"summary": "v1", "artifacts": ["a.py"], "commit_sha": "abc1234"}
+        )
+        tracker.handle_ack("reviewer_code", "coder", {"artifact_references": ["a.py"]})
+        # Both the proposal and the matrix ACK now carry timestamps.
+        assert tracker.get_latest_progress_timestamp() is not None
+        assert tracker.matrix.get_latest_entry_timestamp() is not None
+
+        tracker.clear()
+
+        # After a full clear, neither the proposal nor the matrix should
+        # report any bus activity — the restart starts the clock fresh.
+        assert tracker.get_latest_progress_timestamp() is None
+        assert tracker.matrix.get_latest_entry_timestamp() is None
+
 
 class TestAgentCrash:
     """Test agent crash handling."""

--- a/orchestrator/tests/test_restart_phase_consensus_timer.py
+++ b/orchestrator/tests/test_restart_phase_consensus_timer.py
@@ -1,0 +1,253 @@
+"""Tests for restart_phase ↔ consensus-timeout-timer reset (issue #3315).
+
+A phase that is parked past the consensus-timeout budget and then restarted
+used to fire a spurious consensus-timeout OVERSEER_ALERT + HITL decision
+against the freshly-restarted phase, because the *old* ``_run_concurrent_phase``
+thread kept polling with a stale ``start_time`` (its poll loop had no
+``run_epoch`` check) and, separately, the decision it opened was never
+withdrawn once consensus subsequently converged.
+
+These tests cover:
+- facet (a): the poll loop bails (non-zero, no escalation) when ``run_epoch``
+  changes mid-flight, so a superseded thread cannot escalate.
+- facet (b): ``_withdraw_consensus_timeout_decisions`` cancels a pending
+  ``consensus_timeout_incomplete`` HITL once the phase converges.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from models import (
+    AgentExecution,
+    AgentExecutionStatus,
+    AgentRole,
+    DecisionStatus,
+    PhaseExecution,
+    Pipeline,
+    PipelineConfig,
+    PipelinePhase,
+    PipelineStatus,
+)
+from routes.pipelines import (
+    _CONSENSUS_TIMEOUT_HITL_CONTEXT,
+    _cancel_consensus_timeout_decisions,
+    _run_concurrent_phase,
+)
+
+_CALL_ARGS = {
+    "repo_volumes": {},
+    "gateway_mode": "public",
+    "repos": ["owner/repo"],
+    "sandbox_env": {},
+    "certs_volume": None,
+    "worktree_repo_path": Path("/tmp/test-repo"),
+}
+
+
+def _make_pipeline(pipeline_id: str = "issue-3315") -> Pipeline:
+    config = PipelineConfig()
+    for key, val in {
+        "concurrent_execution": True,
+        "max_concurrent_agents": 5,
+        "consensus_timeout_minutes": 30,
+    }.items():
+        try:
+            setattr(config, key, val)
+        except AttributeError, ValueError:
+            config.__dict__[key] = val
+    return Pipeline(
+        id=pipeline_id,
+        issue_number=3315,
+        repo="owner/repo",
+        branch="egg/issue-3315",
+        status=PipelineStatus.RUNNING,
+        current_phase=PipelinePhase.REFINE,
+        config=config,
+        run_epoch=datetime(2020, 1, 1, tzinfo=UTC),
+    )
+
+
+def _make_real_store(pipeline: Pipeline) -> MagicMock:
+    """MagicMock store that round-trips a real Pipeline through load/save."""
+    holder = {"json": pipeline.model_dump_json()}
+    store = MagicMock()
+    store.load_pipeline.side_effect = lambda _pid: Pipeline.model_validate_json(holder["json"])
+    store.save_pipeline.side_effect = lambda p: holder.__setitem__("json", p.model_dump_json())
+    return store
+
+
+class TestEpochGuardBailsWithoutEscalation:
+    """facet (a): a restart-superseded thread exits without escalating."""
+
+    @patch("routes.pipelines.time.sleep")
+    @patch("routes.pipelines.time.monotonic")
+    @patch("routes.pipelines._emit_event")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
+    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
+    def test_superseded_thread_exits_without_timeout_escalation(
+        self, MockExecutor, mock_prompt, mock_lock, mock_emit, mock_monotonic, mock_sleep
+    ):
+        # Monotonic clock already past the 30-min budget — without the epoch
+        # guard this thread would hit the consensus-timeout branch on its
+        # first poll and fire the spurious alert + HITL decision.
+        mock_monotonic.return_value = 100_000.0
+
+        pipeline = _make_pipeline()
+        phase_exec = PhaseExecution(phase=PipelinePhase.REFINE, status=PipelineStatus.RUNNING)
+
+        # The reloaded pipeline carries a NEWER run_epoch — i.e. restart_phase
+        # bumped it and a new _run_pipeline thread now owns the pipeline.
+        mock_store = MagicMock()
+        reloaded = MagicMock()
+        reloaded.get_phase_execution.return_value = phase_exec
+        reloaded.status = PipelineStatus.RUNNING
+        reloaded.run_epoch = datetime(2030, 1, 1, tzinfo=UTC)
+        reloaded.created_at = datetime(2030, 1, 1, tzinfo=UTC)
+        mock_store.load_pipeline.return_value = reloaded
+
+        executions = [
+            AgentExecution(
+                role=AgentRole.REFINER,
+                status=AgentExecutionStatus.RUNNING,
+                container_id="refiner-1",
+                started_at=datetime.now(UTC),
+            ),
+        ]
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        MockExecutor.return_value = mock_executor_instance
+
+        mock_spawner = MagicMock()
+        mock_spawner.create_concurrent_spawn_fn.return_value = MagicMock()
+
+        mock_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("routes.pipelines._handle_brc_consensus_timeout") as mock_timeout,
+            patch("routes.pipelines._persist_hitl_decision") as mock_hitl,
+        ):
+            exit_code, logs = _run_concurrent_phase(
+                pipeline_id="issue-3315",
+                pipeline=pipeline,
+                phase="refine",
+                spawner=mock_spawner,
+                store=mock_store,
+                run_epoch=pipeline.run_epoch,
+                **_CALL_ARGS,
+            )
+
+        # Bails non-zero (never treated as success → never advances the phase).
+        assert exit_code == 1
+        assert "superseded" in logs.lower()
+        # The epoch check is step 0 — before consensus is ever evaluated.
+        assert mock_executor_instance.check_consensus.call_count == 0
+        # No consensus-timeout escalation of any kind fired.
+        mock_timeout.assert_not_called()
+        mock_hitl.assert_not_called()
+        # The stale event loop was torn down so it stops requesting spawns.
+        assert mock_executor_instance.stop_event_loop.called
+
+
+class TestAutoWithdrawConsensusTimeoutDecision:
+    """facet (b): convergence withdraws a stale consensus-timeout HITL."""
+
+    def test_pending_timeout_decision_is_cancelled(self):
+        pipeline = _make_pipeline()
+        decision = pipeline.add_decision(
+            question="Consensus timed out; consensus incomplete; agents never confirmed: refiner.",
+            options=["Retry phase", "Accept current state", "Abort phase"],
+            phase=PipelinePhase.REFINE,
+        )
+        decision.context = _CONSENSUS_TIMEOUT_HITL_CONTEXT
+
+        withdrawn = _cancel_consensus_timeout_decisions(pipeline)
+
+        assert withdrawn == 1
+        assert decision.status == DecisionStatus.CANCELLED
+        assert decision.resolution is not None
+        assert "converged" in decision.resolution
+        assert decision.resolved_at is not None
+        assert pipeline.get_pending_decisions() == []
+
+    def test_unrelated_pending_decision_is_left_alone(self):
+        pipeline = _make_pipeline()
+        # A different pending decision (e.g. an objection HITL) must survive.
+        other = pipeline.add_decision(
+            question="Agent(s) objecting to phase completion. How to proceed?",
+            options=["Override objections", "Wait for resolution", "Abort phase"],
+            phase=PipelinePhase.REFINE,
+        )
+
+        withdrawn = _cancel_consensus_timeout_decisions(pipeline)
+
+        assert withdrawn == 0
+        assert other.status == DecisionStatus.PENDING
+
+    @patch("routes.pipelines.time.sleep")
+    @patch("routes.pipelines.time.monotonic")
+    @patch("routes.pipelines._emit_event")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
+    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
+    def test_convergence_withdraws_stale_decision_end_to_end(
+        self, MockExecutor, mock_prompt, mock_lock, mock_emit, mock_monotonic, mock_sleep
+    ):
+        """A stale consensus-timeout HITL on disk is cancelled when the phase
+        converges — proving the wiring into ``_update_agents_complete``."""
+        mock_monotonic.return_value = 10.0
+
+        # Disk pipeline carries a pending consensus-timeout decision opened by
+        # a (now superseded) thread before this phase converged.
+        disk_pipeline = _make_pipeline()
+        stale = disk_pipeline.add_decision(
+            question="Consensus timed out; consensus incomplete; agents never confirmed: refiner.",
+            options=["Retry phase", "Accept current state", "Abort phase"],
+            phase=PipelinePhase.REFINE,
+        )
+        stale.context = _CONSENSUS_TIMEOUT_HITL_CONTEXT
+        mock_store = _make_real_store(disk_pipeline)
+
+        executions = [
+            AgentExecution(
+                role=AgentRole.REFINER,
+                status=AgentExecutionStatus.RUNNING,
+                container_id="refiner-1",
+                started_at=datetime.now(UTC),
+            ),
+        ]
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        mock_executor_instance.check_consensus.return_value = {
+            "is_complete": True,
+            "has_objections": False,
+            "blocking_agents": [],
+        }
+        MockExecutor.return_value = mock_executor_instance
+
+        mock_spawner = MagicMock()
+        mock_spawner.create_concurrent_spawn_fn.return_value = MagicMock()
+
+        mock_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        exit_code, _logs = _run_concurrent_phase(
+            pipeline_id="issue-3315",
+            pipeline=_make_pipeline(),
+            phase="refine",
+            spawner=mock_spawner,
+            store=mock_store,
+            **_CALL_ARGS,
+        )
+
+        assert exit_code == 0
+        # The decision was withdrawn in the same write that marked agents
+        # COMPLETE — reload from the store and confirm it is no longer pending.
+        persisted = mock_store.load_pipeline("issue-3315")
+        assert persisted.get_pending_decisions() == []
+        cancelled = next(d for d in persisted.decisions if d.id == stale.id)
+        assert cancelled.status == DecisionStatus.CANCELLED
+        assert cancelled.resolution is not None
+        assert "converged" in cancelled.resolution

--- a/orchestrator/tests/test_restart_phase_consensus_timer.py
+++ b/orchestrator/tests/test_restart_phase_consensus_timer.py
@@ -10,7 +10,7 @@ withdrawn once consensus subsequently converged.
 These tests cover:
 - facet (a): the poll loop bails (non-zero, no escalation) when ``run_epoch``
   changes mid-flight, so a superseded thread cannot escalate.
-- facet (b): ``_cancel_consensus_timeout_decisions`` cancels a pending
+- facet (c): ``_cancel_consensus_timeout_decisions`` cancels a pending
   ``consensus_timeout_incomplete`` HITL once the phase converges.
 """
 
@@ -159,7 +159,7 @@ class TestEpochGuardBailsWithoutEscalation:
 
 
 class TestAutoWithdrawConsensusTimeoutDecision:
-    """facet (b): convergence withdraws a stale consensus-timeout HITL."""
+    """facet (c): convergence withdraws a stale consensus-timeout HITL."""
 
     def test_pending_timeout_decision_is_cancelled(self):
         pipeline = _make_pipeline()

--- a/orchestrator/tests/test_restart_phase_consensus_timer.py
+++ b/orchestrator/tests/test_restart_phase_consensus_timer.py
@@ -10,7 +10,7 @@ withdrawn once consensus subsequently converged.
 These tests cover:
 - facet (a): the poll loop bails (non-zero, no escalation) when ``run_epoch``
   changes mid-flight, so a superseded thread cannot escalate.
-- facet (b): ``_withdraw_consensus_timeout_decisions`` cancels a pending
+- facet (b): ``_cancel_consensus_timeout_decisions`` cancels a pending
   ``consensus_timeout_incomplete`` HITL once the phase converges.
 """
 
@@ -32,7 +32,9 @@ from models import (
 from routes.pipelines import (
     _CONSENSUS_TIMEOUT_HITL_CONTEXT,
     _cancel_consensus_timeout_decisions,
+    _pipeline_superseded_by_restart,
     _run_concurrent_phase,
+    _run_concurrent_phase_with_impasse_retry,
 )
 
 _CALL_ARGS = {
@@ -89,9 +91,14 @@ class TestEpochGuardBailsWithoutEscalation:
     def test_superseded_thread_exits_without_timeout_escalation(
         self, MockExecutor, mock_prompt, mock_lock, mock_emit, mock_monotonic, mock_sleep
     ):
-        # Monotonic clock already past the 30-min budget — without the epoch
-        # guard this thread would hit the consensus-timeout branch on its
-        # first poll and fire the spurious alert + HITL decision.
+        # A stable monotonic clock (constant ⇒ ``elapsed == 0``). The point of
+        # this test is *not* to drive elapsed past the timeout budget — it's
+        # that the epoch guard short-circuits at step 0 of the poll loop,
+        # before ``check_consensus`` and long before any elapsed/timeout
+        # arithmetic, so a superseded thread can never reach the escalation
+        # branch regardless of how much wall-clock has accrued. We assert
+        # exactly that below (``check_consensus.call_count == 0`` + no
+        # escalation), so the constant clock is sufficient.
         mock_monotonic.return_value = 100_000.0
 
         pipeline = _make_pipeline()
@@ -251,3 +258,109 @@ class TestAutoWithdrawConsensusTimeoutDecision:
         assert cancelled.status == DecisionStatus.CANCELLED
         assert cancelled.resolution is not None
         assert "converged" in cancelled.resolution
+
+
+class TestPipelineSupersededHelper:
+    """The shared epoch-supersession predicate (facet a)."""
+
+    def test_none_run_epoch_is_never_superseded(self):
+        # Direct-call paths that don't thread an epoch must opt out entirely —
+        # the helper must not even touch the store.
+        store = MagicMock()
+        assert _pipeline_superseded_by_restart(store, "issue-3315", None) is False
+        store.load_pipeline.assert_not_called()
+
+    def test_newer_on_disk_epoch_means_superseded(self):
+        reloaded = MagicMock()
+        reloaded.run_epoch = datetime(2030, 1, 1, tzinfo=UTC)
+        reloaded.created_at = datetime(2030, 1, 1, tzinfo=UTC)
+        store = MagicMock()
+        store.load_pipeline.return_value = reloaded
+        assert (
+            _pipeline_superseded_by_restart(store, "issue-3315", datetime(2020, 1, 1, tzinfo=UTC))
+            is True
+        )
+
+    def test_matching_epoch_is_not_superseded(self):
+        epoch = datetime(2025, 6, 1, tzinfo=UTC)
+        reloaded = MagicMock()
+        reloaded.run_epoch = epoch
+        reloaded.created_at = epoch
+        store = MagicMock()
+        store.load_pipeline.return_value = reloaded
+        assert _pipeline_superseded_by_restart(store, "issue-3315", epoch) is False
+
+    def test_load_failure_returns_false(self):
+        # A transient store hiccup must never tear down a running phase.
+        store = MagicMock()
+        store.load_pipeline.side_effect = RuntimeError("git read failed")
+        assert (
+            _pipeline_superseded_by_restart(store, "issue-3315", datetime(2020, 1, 1, tzinfo=UTC))
+            is False
+        )
+
+
+class TestImpasseRetrySkipsRoutingWhenSuperseded:
+    """facet (a), slice path: a superseded thread does not route impasses.
+
+    A stale producer-written impasse file must not drive ``route_impasses``
+    into a HITL against a freshly-restarted phase.
+    """
+
+    @patch("orchestrator.impasse_routing.route_impasses")
+    @patch("orchestrator.impasse_routing.collect_impasses")
+    @patch("routes.pipelines._run_concurrent_phase")
+    def test_superseded_thread_skips_route_impasses(self, mock_run, mock_collect, mock_route):
+        mock_run.return_value = (0, "phase logs")
+        # Non-empty impasse scan — without the guard this would route to HITL.
+        mock_collect.return_value = [MagicMock()]
+
+        # On-disk pipeline carries a NEWER epoch — a restart superseded us.
+        reloaded = MagicMock()
+        reloaded.run_epoch = datetime(2030, 1, 1, tzinfo=UTC)
+        reloaded.created_at = datetime(2030, 1, 1, tzinfo=UTC)
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = reloaded
+
+        exit_code, logs = _run_concurrent_phase_with_impasse_retry(
+            pipeline_id="issue-3315",
+            pipeline=_make_pipeline(),
+            phase="implement",
+            spawner=MagicMock(),
+            store=mock_store,
+            run_epoch=datetime(2020, 1, 1, tzinfo=UTC),
+            **_CALL_ARGS,
+        )
+
+        # Returned the (superseded) phase result untouched, and never routed.
+        assert exit_code == 0
+        assert logs == "phase logs"
+        mock_route.assert_not_called()
+
+    @patch("orchestrator.impasse_routing.route_impasses")
+    @patch("orchestrator.impasse_routing.collect_impasses")
+    @patch("routes.pipelines._run_concurrent_phase")
+    def test_live_thread_still_routes_impasses(self, mock_run, mock_collect, mock_route):
+        # Same setup but the on-disk epoch matches — routing must still happen.
+        mock_run.return_value = (0, "phase logs")
+        mock_collect.return_value = [MagicMock()]
+        mock_route.return_value = []
+
+        epoch = datetime(2025, 6, 1, tzinfo=UTC)
+        reloaded = MagicMock()
+        reloaded.run_epoch = epoch
+        reloaded.created_at = epoch
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = reloaded
+
+        _run_concurrent_phase_with_impasse_retry(
+            pipeline_id="issue-3315",
+            pipeline=_make_pipeline(),
+            phase="implement",
+            spawner=MagicMock(),
+            store=mock_store,
+            run_epoch=epoch,
+            **_CALL_ARGS,
+        )
+
+        mock_route.assert_called()


### PR DESCRIPTION
Closes #3315.

## Problem

A refine/plan/implement phase that was parked past its consensus-timeout budget and then resumed with `restart_phase` fired a spurious `consensus-timeout: <role> [high]` `OVERSEER_ALERT` plus a forced-choice `Retry phase / Accept current state / Abort phase` HITL decision against the freshly-restarted, healthy phase — within ~160s of respawn, before the new agents had a chance to propose. The decision is actively dangerous (every option tears down in-flight work) and it survived even after the phase later reached genuine consensus.

## Root cause — three "a clock that survives restart" defects

**(a) The old `_run_concurrent_phase` thread is never interrupted.** `restart_phase` bumps `run_epoch` and spawns a new `_run_pipeline` thread, but the old `_run_concurrent_phase` poll loop has **no epoch check** — the only one runs *after* it returns (`pipelines.py` #1638). So the superseded thread keeps polling with a stale monotonic `start_time` from the original phase start; once `elapsed` crosses `consensus_timeout` (~the residual of a 27-min park against a 30-min budget) it fires `_handle_brc_consensus_timeout` (the alert) and the orchestrator-mode incomplete-consensus HITL, *then* exits. This is the observed path (the alert subject + decision text are unique to it).

**(b) `PeerConsensus.clear()` never reset the approval matrix.** It cleared proposal timestamps but left `self.matrix` populated, so `get_latest_progress_timestamp()` kept returning the pre-restart ACK/NACK timestamp — which the event-loop convergence-stall check reads. Latent on the *new* event loop after restart (nearly fired in the same run; saved only by a just-in-time propose).

**(c) The stale decision was never withdrawn on later convergence.** Nothing retracted a consensus-timeout HITL once the phase converged, leaving the operator to dispose of a decision the system had already obsoleted.

## Fix

- **(a)** Thread the authoritative `run_epoch` from `_run_pipeline` through `_run_implement_phase_slices` → `_run_concurrent_phase_with_impasse_retry` → `_run_concurrent_phase`, and bail at the **top of the poll loop** when a restart superseded the thread: stop this executor's event loop and return non-zero with no escalation (the post-return #1638 epoch check then swallows it without marking the phase FAILED). Guard is **dormant when `run_epoch` is not supplied**, so existing direct-call paths/tests are unchanged.
- **(b)** Add `ApprovalMatrix.reset()` (re-seed every edge to PENDING, `timestamp=None`; drop version/no-op/revision maps) and call it from `PeerConsensus.clear()`.
- **(c)** Tag the orchestrator-mode timeout decision with a stable `consensus_timeout_incomplete` context, and auto-cancel any pending decision carrying it inside `_update_agents_complete` — the already-locked load→save that runs on **every** consensus-success path, so it costs no extra lock and rides all convergence routes.

## Tests

New `orchestrator/tests/test_restart_phase_consensus_timer.py`:
- superseded thread bails non-zero, stops its event loop, and fires **no** `_handle_brc_consensus_timeout` / `_persist_hitl_decision`;
- pure-mutator cancels tagged decisions and leaves unrelated ones pending;
- end-to-end: a stale tagged decision on disk is CANCELLED when `_run_concurrent_phase` converges.

Plus `test_peer_consensus_integration.py`: `clear()` zeroes both the proposal and approval-matrix progress timestamps.

Targeted suites green (375 passed across the consensus/restart/event-loop tests). The only `make test` failures are pre-existing and unrelated (docs `#2548` cross-ref; the known `reap-stale-egg-images` btrfs env noise).