### PR TITLE
fix(#3312): repair dangling sandbox/bin/egg-contract symlink (egg-review CI fix)

### DIFF
--- a/sandbox/bin/egg-contract
+++ b/sandbox/bin/egg-contract
@@ -1,1 +1,1 @@
-../egg_lib/contract_cli.py
+../egg_lib/contract_cli/__main__.py

--- a/sandbox/egg_lib/contract_cli/__main__.py
+++ b/sandbox/egg_lib/contract_cli/__main__.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Entry point so ``egg-contract`` can be invoked as a path-style script.
+
+``sandbox/bin/egg-contract`` symlinks to this file. When Python executes a
+script by path, it puts the script's own directory
+(``…/egg_lib/contract_cli/``) on ``sys.path[0]`` — that is not enough to
+import the package as ``egg_lib.contract_cli`` (the barrel uses relative
+imports). This thin wrapper prepends the sandbox root (two directories up
+from this file: ``…/sandbox``) to ``sys.path`` and resolves ``main`` through
+the package's re-export barrel, mirroring ``orch_cli/__main__.py`` and
+``scripts/select_tests/__main__.py``.
+
+Keeping the entry-point/path-fixup logic isolated here means the package
+itself (``__init__.py`` + ``_*.py`` submodules) is consumed uniformly via
+``import egg_lib.contract_cli`` and does not have to reason about
+path-vs-package invocation forms.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Prepend the sandbox root (parent of ``egg_lib``) so ``egg_lib.contract_cli``
+# resolves when this file is run directly via the ``egg-contract`` symlink.
+# Path: …/sandbox/egg_lib/contract_cli/__main__.py -> parents[2] == …/sandbox
+_SANDBOX_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+if _SANDBOX_ROOT not in sys.path:
+    sys.path.insert(0, _SANDBOX_ROOT)
+
+from egg_lib.contract_cli import main  # noqa: E402 — sys.path setup must precede import
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Slice-1 decomposed `sandbox/egg_lib/contract_cli.py` into the `contract_cli/` sub-package, leaving `sandbox/bin/egg-contract` (`-> ../egg_lib/contract_cli.py`) a **dangling symlink**. This broke:
- the **`egg-review` CI actions** (Agent-Mode Design, Contract Verification) — their staging step fails `Could not find file .../sandbox/bin/egg-contract`;
- any path-style invocation of `egg-contract`.

Discovered merging the #3312 stack: slices 1–17 were admin-merged without checks; the `egg-review` bot failures on slice-17 (#3365) traced to this dangling symlink.

## Fix

Mirror the `orch_cli` pattern (slice-17): add `contract_cli/__main__.py`, a thin path-fixup shim that prepends the sandbox root to `sys.path` and resolves `main` through the package's re-export barrel, then repoint the symlink at it.

```
sandbox/bin/egg-contract -> ../egg_lib/contract_cli/__main__.py   (was: ../egg_lib/contract_cli.py — dangling)
```

Verified: `python sandbox/bin/egg-contract --help` runs (rc=0, full argparse help). The barrel uses relative imports (`from . import …`), so it can't be run as a bare script — the `__main__.py` shim is required, same as `orch_cli`.

## Why this wasn't caught at slice-1

Slice-1's R3 Dockerfile-COPY mitigation covered the container-image COPY path but not the `sandbox/bin` symlink — the symlink ships via the whole-repo `COPY . /opt/egg-runtime/` (Dockerfile:360) and `chmod +x sandbox/bin/*` (line 362), which silently skips a broken symlink. The failure only surfaced when the `egg-review` action tried to *resolve* it. Worth a follow-up: the lint should detect dangling `sandbox/bin` symlinks when a barrel-eligible file decomposes.

## Test plan
- [x] `python sandbox/bin/egg-contract --help` → rc=0, full help
- [ ] `egg-review` CI actions pass on this PR (staging now resolves)
- [ ] `make lint` / `make test-all` unaffected (symlink + new `__main__.py` only)

Related: #3312 (decomposition), slice-1 (`contract_cli`), slice-17 (`orch_cli` `__main__.py` template).