### PR TITLE
fix(simplifier): make human companion a broad-audience summary, not a review

### DIFF
--- a/docs/reference/agent-roles.md
+++ b/docs/reference/agent-roles.md
@@ -83,7 +83,7 @@ All agents within a phase run concurrently via BRC consensus. Concurrency is ena
 
 ### `simplifier`
 
-**Purpose**: Produce a **human-focused companion** to the agent draft — a simplified, higher-level, jargon-free summary for a technical human reviewer outside the pipeline. Runs in **both** the refine and plan phases. The agent-focused drafts (`-analysis.md` / `-plan.md`) are unchanged; the companion is an additional, mandatory artifact.
+**Purpose**: Produce a **human-focused companion** to the agent draft — a plain-language summary for a **broad audience (engineers, PMs, and managers)**, readable by a non-engineer, free of egg-internal jargon and implementation minutiae (no `file:line` refs or code identifiers). It **summarises** the draft — it does not review or critique it (no ACK/NACK or constraint-list framing in the companion). Runs in **both** the refine and plan phases. The agent-focused drafts (`-analysis.md` / `-plan.md`) are unchanged; the companion is an additional, mandatory artifact.
 
 **Dual-role**: like the implement-phase `tester`, the simplifier is a producer whose work depends on an upstream producer's draft. It carries an **advisory** review edge over the upstream producer (`refiner` in refine, `task_planner` in plan) purely so the BRC `ack` arm re-invokes it when that producer proposes — its verdict never blocks the upstream's consensus. It then reads the proposed draft, writes the companion, and proposes it. The companion is reviewed CRITICAL by `reviewer_refine` (refine) / `reviewer_plan` (plan).
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -13206,7 +13206,42 @@ def _build_brc_preamble(
     # harden; (b) subsequent re-proposes and peer-producer proposals
     # (after the tester has proposed) likewise re-invoke the tester to
     # handle the Reviewer Lifecycle for those events.
-    if is_dual_role:
+    if is_dual_role and role_value == "simplifier":
+        # The simplifier is dual-role but ASYMMETRIC: its primary job is the
+        # producer one (the human-focused companion); the reviewer edge is
+        # advisory-only (the event-pump wake-up arm). It must NOT inherit the
+        # tester's review-and-harden banner below, which primes an ACK/NACK
+        # mental model and leads the companion to come out as a critique of
+        # the upstream draft instead of a plain-language summary.
+        lines.append(
+            "### Dual-Role Execution Order (READ FIRST — simplifier)\n\n"
+            "You are dual-role, but the two roles are **not symmetric**. Your "
+            "PRIMARY job is the PRODUCER one: writing a plain-language, "
+            "human-focused companion to the upstream producer's draft. Your "
+            "reviewer edge is **advisory only** — it exists so the event pump "
+            "re-invokes you when the upstream producer proposes, and your "
+            "verdict never blocks consensus.\n\n"
+            "**Execute in this order:**\n\n"
+            "1. **Producer ORIENT (FIRST).** Read the contract and orient. "
+            "Your producer WORK depends on the upstream producer's draft "
+            "existing, so you begin writing only once that producer issues "
+            "`CONSENSUS_PROPOSE` — the event-pump wrapper re-invokes you "
+            "carrying that proposal. Do not race ahead before the draft "
+            "exists.\n"
+            "2. **On the upstream producer's PROPOSE**, the wrapper re-invokes "
+            "you with the proposal in your event payload. SYNC the worktree, "
+            "read the draft, then write and PROPOSE the human-focused "
+            "companion (see Producer role below).\n"
+            "3. **Issue your advisory verdict in the same pass.** ACK the "
+            "upstream producer (you read its draft to summarise it); NACK "
+            "only if the draft is too incoherent or incomplete to summarise "
+            "faithfully. **Any critique you have belongs in this verdict and "
+            "its message — NEVER in the companion document.** The companion "
+            "is a simplified summary written *for humans to read*, not a "
+            "review of the draft, not a list of constraints the draft should "
+            "satisfy, and not an ACK/NACK rationale.\n"
+        )
+    elif is_dual_role:
         lines.append(
             "### Dual-Role Execution Order (READ FIRST — #2749, updated for "
             "coder-owns-tests)\n\n"
@@ -13406,6 +13441,17 @@ def _build_brc_preamble(
                 "step 3 (SYNC) with the proposal already in context."
                 + (
                     "\n\n   **Dual-role agents (you)** — per the "
+                    "*Dual-Role Execution Order* banner above (simplifier): "
+                    "your first invocation does ORIENT/PREPARE only. On the "
+                    "upstream producer's `CONSENSUS_PROPOSE` the wrapper "
+                    "re-invokes you with the proposal in your event payload; "
+                    "SYNC, write and PROPOSE your human-focused companion, "
+                    "then issue your ADVISORY ACK/NACK on the upstream "
+                    "producer in the same invocation. Your verdict is "
+                    "advisory and never blocks consensus — keep any critique "
+                    "in that verdict, never in the companion document."
+                    if role_value == "simplifier"
+                    else "\n\n   **Dual-role agents (you)** — per the "
                     "*Dual-Role Execution Order* banner above (updated "
                     "for coder-owns-tests): your first invocation does "
                     "ORIENT/PREPARE only. On the coder's "
@@ -13835,15 +13881,23 @@ def _build_reviewer_preparation(
                 "\n\n"
                 "**Human-focused plan companion (the simplifier's "
                 "``*-plan-human.md``):** the simplifier produces a simplified, "
-                "jargon-free companion to the plan for a technical human "
-                "reviewer outside the pipeline. You review it (CRITICAL). ACK "
-                "only when it faithfully captures the plan's essence, stays "
-                "high-level and digestible, and is free of egg-internal jargon "
-                "(no BRC/consensus/slice-DAG/contract/role terms). NACK the "
+                "plain-language companion to the plan for a **broad audience — "
+                "engineers, PMs, and managers**. You review it (CRITICAL). "
+                "**Read it side-by-side with the full plan** and ACK only when "
+                "it (a) faithfully captures the plan's essence, (b) is "
+                "materially lighter and more digestible than the full plan — "
+                "not a near-copy, (c) is readable by a non-engineer, and (d) "
+                "is free of egg-internal jargon (no "
+                "BRC/consensus/slice-DAG/contract/role terms). NACK the "
                 "**simplifier** (not the task_planner) if it misrepresents the "
-                "plan, leaks pipeline jargon, omits a material point, or merely "
-                "duplicates the full plan. A missing or empty companion is a "
-                "NACK — the companion is mandatory."
+                "plan, leaks pipeline jargon, omits a material point, merely "
+                "duplicates the full plan, or — critically — reads as a "
+                "**review/critique** of the plan rather than a summary of it "
+                '(ACK/NACK language, "should commit to", "anti-pattern to '
+                'reject", constraint lists) or buries the reader in '
+                "implementation detail (`file:line` refs, function/struct/field "
+                "names). A missing or empty companion is a NACK — the companion "
+                "is mandatory."
             )
     elif phase == "refine":
         if role_value in ("reviewer_refine", "reviewer_agent_design"):
@@ -13862,13 +13916,21 @@ def _build_reviewer_preparation(
                     "\n\n"
                     "**Human-focused analysis companion (the simplifier's "
                     "``*-analysis-human.md``):** the simplifier produces a "
-                    "simplified, jargon-free companion to the analysis for a "
-                    "technical human reviewer outside the pipeline. You review "
-                    "it (CRITICAL). ACK only when it faithfully captures the "
-                    "analysis's essence, stays high-level and digestible, and is "
-                    "free of egg-internal jargon. NACK the **simplifier** (not "
-                    "the refiner) if it misrepresents the analysis, leaks "
-                    "pipeline jargon, or merely duplicates the full draft. A "
+                    "simplified, plain-language companion to the analysis for a "
+                    "**broad audience — engineers, PMs, and managers**. You "
+                    "review it (CRITICAL). **Read it side-by-side with the full "
+                    "analysis** and ACK only when it (a) faithfully captures the "
+                    "analysis's essence, (b) is materially lighter and more "
+                    "digestible than the full draft — not a near-copy, (c) is "
+                    "readable by a non-engineer, and (d) is free of "
+                    "egg-internal jargon. NACK the **simplifier** (not the "
+                    "refiner) if it misrepresents the analysis, leaks pipeline "
+                    "jargon, omits a material point, merely duplicates the full "
+                    "draft, or — critically — reads as a **review/critique** of "
+                    "the analysis rather than a summary of it (ACK/NACK "
+                    'language, "should commit to", "anti-pattern to reject", '
+                    "constraint lists) or buries the reader in implementation "
+                    "detail (`file:line` refs, function/struct/field names). A "
                     "missing or empty companion is a NACK — it is mandatory."
                 )
             return base
@@ -14107,7 +14169,8 @@ def _build_producer_orientation(
             "proposal in your event payload. On that invocation: read the "
             "upstream draft, then write a simplified, higher-level companion "
             "that captures its essence in plain, jargon-free language for a "
-            "technical reader outside the pipeline, and PROPOSE it. In the same "
+            "broad audience (engineers, PMs, and managers) — a summary, NOT a "
+            "review of the draft — and PROPOSE it. In the same "
             f"pass, issue your ADVISORY review verdict on **{upstream}** — ACK "
             "(you read the draft to summarize it), or NACK only if the draft is "
             "too incoherent to faithfully summarize. Your verdict is advisory "
@@ -15342,22 +15405,33 @@ def _build_agent_prompt(
                 "",
                 f"1. Read **{_upstream}**'s draft of {_upstream_draft}.",
                 f"2. Write a HUMAN-FOCUSED companion to `{_human_path}`. This is a "
-                "simplified, higher-level summary for a **technical** human "
-                "reviewer who is NOT part of the pipeline. Capture the essence: "
-                f"{_essence}.",
+                "simplified, higher-level summary for a **broad audience — "
+                "engineers, PMs, and managers** — not a peer review. Capture the "
+                f"essence: {_essence}.",
                 "",
                 "   Rules:",
+                "   - **Broad, mixed audience.** Write so a non-engineer "
+                "(PM, manager) can follow *what is changing and why it matters*, "
+                "while staying accurate enough for an engineer. Explain any "
+                "unavoidable technical term in plain language.",
                 "   - **No egg-internal jargon.** Do not mention BRC, consensus, "
                 "propose/ACK/NACK, slices / slice-DAG, contracts, phases, "
                 "`serialized_chain_order`, Jaccard, or agent-role names. Describe "
                 "independently-shippable pieces in plain terms if you must "
                 "reference them at all.",
+                "   - **No implementation minutiae.** No `file:line` references, "
+                "no function / struct / field / type names or other code "
+                "identifiers, no per-field enumerations. Describe behaviour and "
+                "impact, not the code.",
+                "   - **This is NOT a review.** Do not critique, score, or gate "
+                'the upstream draft. No ACK/NACK language, no "the draft should '
+                'commit to …", no "anti-pattern to reject", no constraint '
+                "lists. Any critique you have goes in your advisory reviewer "
+                "verdict (below), never in this document.",
                 "   - **Much shorter and more digestible** than the upstream "
-                "draft — prose and short lists, not exhaustive enumeration.",
+                "draft — plain prose and short lists, not exhaustive enumeration.",
                 "   - **Faithful** — reflect the upstream draft accurately; "
                 "introduce no new scope, claims, or recommendations.",
-                "   - The audience is technical, so domain and code specifics are "
-                "fine; pipeline mechanics are not.",
                 "",
                 f"3. Commit and push `{_human_path}`, then PROPOSE it via "
                 "`egg-orch consensus propose`. The companion is **mandatory** — "

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -4542,6 +4542,106 @@ class TestProducerOrientation:
         assert "task_planner" in orient
         assert "CONSENSUS_PROPOSE" in orient
 
+    def test_simplifier_orientation_is_summary_not_review(self):
+        """Orientation frames the companion as a broad-audience summary, not
+        a review of the upstream draft (issue: human doc came out as a
+        critique/ACK-NACK constraint set rather than a simplification)."""
+        orient = _build_producer_orientation("simplifier", "refine", ["reviewer_refine"])
+        assert "broad audience" in orient.lower()
+        assert "NOT a review" in orient
+        # The legacy "technical reader outside the pipeline" narrowing must
+        # not creep back — that phrasing licensed the implementation jargon.
+        assert "technical reader outside the pipeline" not in orient
+
+
+class TestSimplifierHumanCompanionPrompt:
+    """The simplifier's human companion must be a plain-language summary for a
+    broad audience — NOT a review/critique of the upstream draft, and free of
+    implementation minutiae. Guards the prompt against the regression where the
+    ``*-human.md`` artifact came out as an ACK/NACK constraint set dense with
+    ``file:line`` / struct-field detail.
+    """
+
+    def test_simplifier_gets_own_banner_not_tester_banner(self):
+        """The dual-role simplifier must get its own producer-first banner, not
+        the tester's review-and-harden banner (which primed the ACK/NACK
+        mental model that turned the companion into a critique)."""
+        preamble = _build_brc_preamble(
+            "simplifier",
+            "refine",
+            repo="egg",
+            branch="egg/issue-1/work",
+            base_branch="main",
+        )
+        assert "Dual-Role Execution Order (READ FIRST — simplifier)" in preamble
+        # The tester-specific banner and its hardening language must be absent.
+        assert "coder-owns-tests" not in preamble
+        assert "hardening the coder's tests" not in preamble
+        # Critique belongs in the verdict, never in the companion document.
+        assert "NEVER in the companion document" in preamble
+
+    def test_tester_banner_unchanged_for_tester(self):
+        """The simplifier carve-out must not disturb the tester's banner."""
+        preamble = _build_brc_preamble(
+            "tester",
+            "implement",
+            repo="egg",
+            branch="egg/issue-1/work",
+            base_branch="main",
+        )
+        assert "coder-owns-tests" in preamble
+        assert "READ FIRST — simplifier" not in preamble
+
+    def test_simplifier_producer_rules_forbid_review_and_jargon(self):
+        """The producer rules must demand a broad-audience summary and forbid
+        review framing and implementation minutiae."""
+        result = _build_agent_prompt(
+            role_value="simplifier",
+            phase="refine",
+            pipeline_id="pid-1",
+            pipeline_mode="issue",
+            prompt="# Feature\n\nDetail.",
+            issue_number=1,
+        )
+        # Broad audience, not "technical reviewer outside the pipeline".
+        assert "engineers, PMs, and managers" in result
+        assert "technical** human" not in result
+        # Explicit "not a review" prohibition with the offending markers.
+        assert "This is NOT a review." in result
+        assert "anti-pattern to reject" in result
+        # No implementation minutiae.
+        assert "No implementation minutiae." in result
+        assert "file:line" in result
+
+    def test_simplifier_producer_rules_present_in_plan_phase(self):
+        """The same broad-audience / no-review rules apply in the plan phase."""
+        result = _build_agent_prompt(
+            role_value="simplifier",
+            phase="plan",
+            pipeline_id="pid-1",
+            pipeline_mode="issue",
+            prompt="# Feature\n\nDetail.",
+            issue_number=1,
+        )
+        assert "engineers, PMs, and managers" in result
+        assert "This is NOT a review." in result
+
+    def test_refine_reviewer_compares_companion_against_full_draft(self):
+        """The refine reviewer must read the companion side-by-side with the
+        full analysis and NACK a review-shaped or jargon-heavy companion."""
+        prep = _build_reviewer_preparation("reviewer_refine", "refine")
+        assert "side-by-side with the full analysis" in prep
+        assert "broad audience" in prep
+        assert "review/critique" in prep
+        assert "materially lighter" in prep
+
+    def test_plan_reviewer_compares_companion_against_full_draft(self):
+        """The plan reviewer carries the same side-by-side comparison gate."""
+        prep = _build_reviewer_preparation("reviewer_plan", "plan")
+        assert "side-by-side with the full plan" in prep
+        assert "broad audience" in prep
+        assert "review/critique" in prep
+
     def test_tester_orientation_contains_dual_mandate_pointer(self):
         """Tester orientation carries a brief dual-mandate pointer, NOT the
         full failing-test → NACK → HANDOFF instruction.

--- a/shared/egg_contracts/agent_roles.py
+++ b/shared/egg_contracts/agent_roles.py
@@ -548,15 +548,20 @@ SIMPLIFIER_ROLE = AgentRoleDefinition(
     role=AgentRole.SIMPLIFIER,
     description=(
         "Distills the producer's draft into a jargon-free, human-focused "
-        "companion summary in the refine and plan phases"
+        "companion summary for a broad audience (engineers, PMs, managers) "
+        "in the refine and plan phases"
     ),
     category=AgentCategory.ANALYSIS,
     responsibilities=[
         "Read the upstream producer's draft (refine analysis or plan)",
         "Write a simplified, higher-level companion that captures the essence",
-        "Keep it digestible for a technical reader outside the pipeline",
+        "Keep it digestible for a broad audience — engineers, PMs, and "
+        "managers — readable by a non-engineer",
         "Use no egg-internal jargon (no BRC, consensus, slice-DAG, contract, "
-        "propose/ACK/NACK, phase, or agent-role terms)",
+        "propose/ACK/NACK, phase, or agent-role terms) and no implementation "
+        "minutiae (no file:line refs or code identifiers)",
+        "Summarise the draft — do NOT review or critique it; no ACK/NACK or "
+        "constraint-list framing in the companion",
         "Faithfully reflect the upstream draft — introduce no new scope",
     ],
     dependencies=[],


### PR DESCRIPTION
## Problem

The simplifier's human-facing companion (`*-analysis-human.md` / `*-plan-human.md`) was being written as a **review/critique of the upstream draft** — an ACK/NACK constraint set, dense with `file:line` and struct/field-level detail — instead of the **jargon-free, human-centric summary** the artifact is meant to be. The role was producing reviewer output where it should produce an accessible plain-language document.

## Root cause

The producer prompt already asked for a "human-focused companion" with "no egg-internal jargon", but that signal was being drowned out:

1. **Inherited the tester's banner.** The simplifier is `is_dual_role`, so it received the tester's `### Dual-Role Execution Order (READ FIRST …)` banner — written entirely around "review and harden the coder's tests" and "ACK if coverage is sound, or NACK …". Marked **READ FIRST**, it primed an ACK/NACK mental model before the simplifier ever reached its own producer instructions.
2. **Licensed the jargon.** The producer prompt said *"The audience is technical, so domain and code specifics are fine"* and only forbade *pipeline* jargon (BRC/consensus/slices) — not *implementation* jargon or review framing. That's exactly the `file:line`/struct-field density observed.

## Changes

- **Simplifier-specific dual-role banner.** The simplifier now gets a producer-first banner: its primary job is the companion; the reviewer edge is advisory-only (the event-pump wake-up arm); any critique goes in the verdict, **never** in the companion. The tester's banner stays gated to the tester. The Reviewer-Lifecycle dual-role note is similarly branched.
- **Rewritten producer rules.** Target a **broad audience — engineers, PMs, and managers**; explicit prohibitions on (a) review / ACK-NACK / "should commit to" / "anti-pattern to reject" / constraint-list framing and (b) implementation minutiae (`file:line`, function/struct/field names, per-field enumerations). Keeps the faithful + much-lighter requirements.
- **Reviewer-side enforcement (no separate keyword gate).** The refine and plan reviewers now read the companion **side-by-side with the full draft** and NACK the simplifier when it is a near-copy, reads as a review/critique, or buries the reader in implementation detail. This keeps enforcement in the existing critical-review channel rather than adding a brittle keyword check.
- **Role definition** updated to mirror the broad-audience / no-review / no-minutiae intent.

## Tests

New `TestSimplifierHumanCompanionPrompt` covering the banner carve-out (simplifier gets its own banner; tester's is untouched), the producer rules (broad audience, "not a review", no minutiae), and the reviewer side-by-side comparison gate. Existing simplifier orientation, BRC-preamble, concurrent-executor, and BLE001 audit suites pass.
