### PR TITLE
fix(hitl): dedupe contract cq-N decisions + surface them in get_status

### DIFF
--- a/docs/hitl-decisions.md
+++ b/docs/hitl-decisions.md
@@ -183,11 +183,29 @@ router. Like `feedback-N`, those decisions are bridged into the orchestrator
 queue only *after* the phase gate is approved. An agent blocked on such a
 question before proposing never reaches the gate, so:
 
-- the decision does not appear in `get_status(...).pending_decisions`;
+- the decision does not appear in `get_status(...).pending_decisions` (which
+  lists only orchestrator-queue decisions);
 - calling `provide_input(decision_id="cq-N", ...)` previously returned
   **HTTP 404** (not in the queue), leaving the operator with no resolution
   channel and the pipeline deadlocking (#3071, observed on
   pipeline-c2faf164).
+
+**Surfacing (#3374).** Unresolved `cq-N` HITL decisions that are not yet
+bridged into the queue are surfaced in their own `get_status(...)` field,
+`pending_contract_decisions` — each entry carries `id`, `question`, `phase`,
+`options`, and `scope: "contract"`. It is kept distinct from
+`pending_decisions` so the two-wave resolve flow is unaffected; an operator
+driving via `get_status` no longer has to call `get_contract` out of band to
+discover them. Already-bridged questions are filtered out of this field so a
+mirrored `cq-N` is not listed twice.
+
+**Deduplication (#3374).** A later phase (or a re-run agent) that re-asks a
+question already registered and unresolved adopts the existing `cq-N` rather
+than minting a duplicate: `register_open_question` and the impasse-escalation
+router both dedupe on the normalized question text + phase via
+`egg_contracts.decisions.find_duplicate_open_question`. The registration is
+idempotent — the response carries `deduped: true` and no second contract
+write occurs.
 
 `provide_input` now falls back to the contract when the id is not found in
 the queue. It writes the resolution fields straight onto the contract
@@ -320,6 +338,8 @@ Two complementary bridges ensure contract-scoped decisions created by agents via
 **Server-side bridge (all modes):** After a phase gate is approved, `_queue_and_await_contract_decisions()` in `orchestrator/routes/pipelines.py` promotes any unresolved contract HITL decisions and feedback into the orchestrator's decision queue. HTTP/MCP callers (e.g., the `/sdlc` skill's Phase 4 handler) receive them as individual `choice` or `feedback` decisions. Once resolved, answers are written back to the contract so implement-phase agents see the human's choices. Without this bridge, contract questions registered via `egg-contract` would be silently dropped when a phase gate was approved, leaving the next phase's agents without the answers they need.
 
 **Client-side bridge (prompt-driven mode only):** In prompt-driven mode, the phase gate menu displays a `[q] Answer open questions` option when unanswered decisions exist in the contract JSON, letting humans respond from the terminal before approving. Approving a phase gate with unanswered questions triggers a warning prompt.
+
+**Gate-approval guard (#3374):** The bridge only promotes the *current* phase's `cq-N`; questions tagged for a later phase remain unanswered and otherwise invisible until that phase's gate. To avoid narrating an approval as "nothing else pending" while such questions sit outstanding, the `provide_input` response for a resolved `phase_gate` includes an `outstanding_contract_decisions` list of those later-phase unresolved `cq-N` (`id` / `question` / `phase`). They also remain visible in every `get_status` snapshot under `pending_contract_decisions`.
 
 ### Draft Document Display
 

--- a/docs/hitl-decisions.md
+++ b/docs/hitl-decisions.md
@@ -193,17 +193,28 @@ question before proposing never reaches the gate, so:
 **Surfacing (#3374).** Unresolved `cq-N` HITL decisions that are not yet
 bridged into the queue are surfaced in their own `get_status(...)` field,
 `pending_contract_decisions` — each entry carries `id`, `question`, `phase`,
-`options`, and `scope: "contract"`. It is kept distinct from
-`pending_decisions` so the two-wave resolve flow is unaffected; an operator
-driving via `get_status` no longer has to call `get_contract` out of band to
-discover them. Already-bridged questions are filtered out of this field so a
-mirrored `cq-N` is not listed twice.
+`options`, and `scope: "contract"`, plus `type: "hitl"` (mirroring the
+queue-decision shape) and a `note` string pointing the operator at the
+`provide_input` resolution flow. It is kept distinct from `pending_decisions`
+so the two-wave resolve flow is unaffected; an operator driving via
+`get_status` no longer has to call `get_contract` out of band to discover them.
+Already-bridged questions are filtered out of this field so a mirrored `cq-N`
+is not listed twice.
 
-**Deduplication (#3374).** A later phase (or a re-run agent) that re-asks a
-question already registered and unresolved adopts the existing `cq-N` rather
-than minting a duplicate: `register_open_question` and the impasse-escalation
-router both dedupe on the normalized question text + phase via
-`egg_contracts.decisions.find_duplicate_open_question`. The registration is
+**Deduplication (#3374).** A re-registration of a question already open and
+unresolved *under the same phase* adopts the existing `cq-N` rather than
+minting a duplicate: `register_open_question` and the impasse-escalation
+router both dedupe on the normalized question text **keyed by phase** via
+`egg_contracts.decisions.find_duplicate_open_question`. This covers the
+observed repro — a re-run agent, or a re-escalated impasse, re-asking within a
+single phase — and any re-ask explicitly tagged for that same phase. A genuine
+*cross-phase* re-ask (a different phase tag) is treated as a distinct question
+and mints a fresh `cq-N` by design, because its decision context differs: in
+the agent path the phase defaults to the contract's `current_phase`, so a
+question first posed in `refine` and re-posed in `plan` does **not** dedupe.
+The dedup key is (question, phase) only — the option set is not part of it, so
+a re-registration carrying a *different* option set adopts the stored options
+and logs a warning (the new options are not merged). The registration is
 idempotent — the response carries `deduped: true` and no second contract
 write occurs.
 

--- a/orchestrator/impasse_routing.py
+++ b/orchestrator/impasse_routing.py
@@ -535,11 +535,18 @@ def _record_escalate(
     # current decisions for an equivalent open question.
     duplicate = find_duplicate_open_question(contract.decisions, decision.question, decision.phase)
     if duplicate is not None:
+        # The dedup key is (normalized question, phase); the option set is
+        # not. If the re-escalation produced a different option set, the
+        # operator only ever sees the stored options — log it so the loss
+        # is not invisible (#3374 review).
+        new_labels = [getattr(o, "label", None) for o in (decision.options or [])]
+        existing_labels = [getattr(o, "label", None) for o in (duplicate.options or [])]
         logger.info(
             "Impasse escalation deduped onto existing HITL decision",
             slice_id=slice_obj.id if slice_obj else None,
             task_id=task.id if task else impasse.task_id,
             decision_id=duplicate.id,
+            options_differ=new_labels != existing_labels,
         )
         return RoutingDecision(
             action=ImpasseAction.ESCALATE,

--- a/orchestrator/impasse_routing.py
+++ b/orchestrator/impasse_routing.py
@@ -37,7 +37,7 @@ if _shared_path.exists() and str(_shared_path) not in sys.path:
     sys.path.insert(0, str(_shared_path))
 
 from egg_contracts.agent_roles import AgentRole as ContractAgentRole
-from egg_contracts.decisions import next_cq_id
+from egg_contracts.decisions import find_duplicate_open_question, next_cq_id
 from egg_contracts.impasse import Impasse, ImpasseCategory
 from egg_contracts.loader import load_contract, save_contract
 from egg_contracts.models import (
@@ -527,6 +527,30 @@ def _record_escalate(
     field_path, decision = _build_hitl_decision(
         contract, slice_obj, task, impasse, impassed_role, reason
     )
+
+    # Dedupe: a re-escalation of an impasse whose HITL question is already
+    # open and unanswered should adopt the existing ``cq-N`` rather than
+    # append an identical one (parity with ``register_open_question``).
+    # ``_build_hitl_decision`` did not mutate the contract, so scan the
+    # current decisions for an equivalent open question.
+    duplicate = find_duplicate_open_question(contract.decisions, decision.question, decision.phase)
+    if duplicate is not None:
+        logger.info(
+            "Impasse escalation deduped onto existing HITL decision",
+            slice_id=slice_obj.id if slice_obj else None,
+            task_id=task.id if task else impasse.task_id,
+            decision_id=duplicate.id,
+        )
+        return RoutingDecision(
+            action=ImpasseAction.ESCALATE,
+            impasse=impasse,
+            role=impassed_role,
+            task_id=task.id if task else impasse.task_id,
+            new_role=None,
+            reason=reason,
+            hitl_decision_id=duplicate.id,
+        )
+
     # decisions.* is owned by IMPLEMENTER per FIELD_OWNERSHIP — mirror
     # the existing ``register_open_question`` MCP tool's role choice.
     # The audit log records the orchestrator-side actor so it stays

--- a/orchestrator/mcp_tools/__init__.py
+++ b/orchestrator/mcp_tools/__init__.py
@@ -149,6 +149,7 @@ class PipelineToolHandler:
     _handle_get_status = _status._handle_get_status
     _live_running_agents_fallback = _status._live_running_agents_fallback
     _build_status_snapshot = _status._build_status_snapshot
+    _pending_contract_decisions = _status._pending_contract_decisions
     _enrich_pending_decisions = _status._enrich_pending_decisions
     _read_reviewer_feedback = _status._read_reviewer_feedback
     _handle_get_phase = _status._handle_get_phase

--- a/orchestrator/mcp_tools/_status.py
+++ b/orchestrator/mcp_tools/_status.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
+from egg_contracts.decisions import truncate_question
 from mcp_tools import logger
 
 
@@ -234,9 +235,6 @@ def _build_status_snapshot(self, raw_task_id: str) -> dict[str, Any]:
     return status
 
 
-_CONTRACT_QUESTION_MAX_CHARS = 4_000
-
-
 def _pending_contract_decisions(
     self,
     task_id: str,
@@ -291,8 +289,8 @@ def _pending_contract_decisions(
         if decision_id in bridged_ids:
             continue
         question = d.get("question") or ""
-        if isinstance(question, str) and len(question) > _CONTRACT_QUESTION_MAX_CHARS:
-            question = question[:_CONTRACT_QUESTION_MAX_CHARS] + "… (truncated)"
+        if isinstance(question, str):
+            question = truncate_question(question)
         surfaced.append(
             {
                 "id": decision_id,

--- a/orchestrator/mcp_tools/_status.py
+++ b/orchestrator/mcp_tools/_status.py
@@ -216,7 +216,103 @@ def _build_status_snapshot(self, raw_task_id: str) -> dict[str, Any]:
     # Enrichment: attach draft content to pending decisions (optional)
     self._enrich_pending_decisions(status, raw_task_id, pipeline_data)
 
+    # Surface contract-resident HITL decisions (``cq-N``) that the
+    # orchestrator queue does not yet know about. Agents register these
+    # via ``register_open_question``; they live on the SDLC contract and
+    # only reach ``pending_decisions`` (above) once the post-gate bridge
+    # promotes them. Until then they gate upcoming work but are invisible
+    # to an operator driving via ``get_status`` / ``wait-status`` — they
+    # had to call ``get_contract`` out of band to find them. Expose them
+    # as a sibling field (kept distinct from the queue so the documented
+    # two-wave resolve flow is unaffected). Issued last and best-effort:
+    # any failure leaves the field absent rather than breaking the
+    # snapshot. ``task_id`` is already URL-quoted above.
+    contract_pending = self._pending_contract_decisions(task_id, status["pending_decisions"])
+    if contract_pending:
+        status["pending_contract_decisions"] = contract_pending
+
     return status
+
+
+_CONTRACT_QUESTION_MAX_CHARS = 4_000
+
+
+def _pending_contract_decisions(
+    self,
+    task_id: str,
+    queue_pending: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return unresolved contract-resident HITL (``cq-N``) decisions.
+
+    ``task_id`` must already be URL-quoted (the caller quotes it once).
+    Reads the SDLC contract via the orchestrator's ``/api/v1/contracts``
+    endpoint and returns the unresolved ``type == "hitl"`` decisions that
+    are *not already mirrored* into the orchestrator queue — the post-gate
+    bridge mirrors a ``cq-N`` into a fresh ``decision-M`` whose context is
+    ``"Open contract question {cq-id}, ..."`` and the contract entry stays
+    unresolved until that queue decision is answered and written back, so
+    without this filter a bridged question would appear twice.
+
+    Best-effort: returns ``[]`` on any failure (missing contract, request
+    error) so a status snapshot is never broken by this enrichment.
+    """
+    try:
+        result = self._make_request(f"/api/v1/contracts/{task_id}?pipeline_id={task_id}")
+    except Exception as e:
+        logger.debug(
+            "Contract fetch for pending-decision surfacing failed",
+            task_id=task_id,
+            error=str(e),
+        )
+        return []
+
+    contract = result.get("data") if isinstance(result.get("data"), dict) else result
+    if not isinstance(contract, dict):
+        return []
+    decisions = contract.get("decisions") or []
+
+    # Ids already bridged into the queue (so we don't double-list them).
+    bridged_ids: set[str] = set()
+    for q in queue_pending:
+        context = q.get("context") or ""
+        match = re.match(r"Open contract question (cq-\d+),", context)
+        if match:
+            bridged_ids.add(match.group(1))
+
+    surfaced: list[dict[str, Any]] = []
+    for d in decisions:
+        if not isinstance(d, dict):
+            continue
+        if d.get("type") != "hitl" or d.get("resolved"):
+            continue
+        decision_id = d.get("id", "")
+        if not isinstance(decision_id, str) or not decision_id.startswith("cq-"):
+            continue
+        if decision_id in bridged_ids:
+            continue
+        question = d.get("question") or ""
+        if isinstance(question, str) and len(question) > _CONTRACT_QUESTION_MAX_CHARS:
+            question = question[:_CONTRACT_QUESTION_MAX_CHARS] + "… (truncated)"
+        surfaced.append(
+            {
+                "id": decision_id,
+                "question": question,
+                "phase": d.get("phase"),
+                "type": "hitl",
+                "options": [
+                    opt.get("label", "")
+                    for opt in (d.get("options") or [])
+                    if isinstance(opt, dict)
+                ],
+                "scope": "contract",
+                "note": (
+                    "Agent-registered contract question, not yet bridged into the "
+                    "decision queue. Resolve with the same decision-resolve flow "
+                    "(provide_input) using this id."
+                ),
+            }
+        )
+    return surfaced
 
 
 def _enrich_pending_decisions(

--- a/orchestrator/mcp_tools/_tool_defs.py
+++ b/orchestrator/mcp_tools/_tool_defs.py
@@ -90,7 +90,11 @@ PIPELINE_TOOLS = [
             "Get the current status of a pipeline task. "
             "Returns pipeline state (current_phase, status, agents, decisions), "
             "pipeline details (id, repo, issue_number, created_at, mode), "
-            "and recent_messages (from_role, type, subject, timestamp)."
+            "and recent_messages (from_role, type, subject, timestamp). "
+            "Also surfaces pending_contract_decisions: agent-registered "
+            "contract-resident HITL questions (`cq-N`) that are unresolved and "
+            "not yet bridged into the decision queue — these gate upcoming "
+            "work and are resolved via the same provide_input flow."
         ),
         "inputSchema": {
             "type": "object",

--- a/orchestrator/routes/decisions/__init__.py
+++ b/orchestrator/routes/decisions/__init__.py
@@ -90,7 +90,10 @@ from ._handlers import (  # noqa: E402,F401
     _maybe_complete_task_from_resolution,
     _normalize_choice_resolution,
 )
-from ._resolve import _resolve_contract_decision  # noqa: E402,F401
+from ._resolve import (  # noqa: E402,F401
+    _outstanding_contract_hitl,
+    _resolve_contract_decision,
+)
 from ._responses import (  # noqa: E402,F401
     make_error_response,
     make_success_response,

--- a/orchestrator/routes/decisions/_resolve.py
+++ b/orchestrator/routes/decisions/_resolve.py
@@ -182,6 +182,7 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
         # treats the absent resolution as approval and marks the current
         # phase complete. Only a phase_gate resolution is meant to drive the
         # phase forward, so only it triggers the revival.
+        outstanding_contract_decisions: list[dict[str, Any]] = []
         if decision.decision_type == "phase_gate":
             try:
                 from routes.pipelines import maybe_revive_orphaned_awaiting_human_driver
@@ -196,6 +197,14 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
                     exc_info=True,
                 )
 
+            # Gate-approval guard: report contract-resident HITL questions
+            # (``cq-N``) that this gate resolution leaves outstanding, so the
+            # operator is not told "proceeding" while agent-registered HITL
+            # questions sit unanswered. The post-gate bridge promotes the
+            # current phase's ``cq-N`` into the queue; questions tagged for a
+            # later phase remain outstanding and are the ones worth flagging.
+            outstanding_contract_decisions = _outstanding_contract_hitl(pipeline_id, _pipeline)
+
         return make_success_response(
             "Decision resolved",
             data={
@@ -209,6 +218,11 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
                     "scope": "queue",
                 },
                 **({"executed_action": executed_action} if executed_action else {}),
+                **(
+                    {"outstanding_contract_decisions": outstanding_contract_decisions}
+                    if outstanding_contract_decisions
+                    else {}
+                ),
             },
         )
 
@@ -233,6 +247,54 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
         )
     except DecisionAlreadyResolvedError as e:
         return make_error_response(str(e), status_code=409)
+
+
+def _outstanding_contract_hitl(pipeline_id: str, pipeline: Any) -> list[dict[str, Any]]:
+    """Return unresolved contract HITL (``cq-N``) decisions a gate leaves open.
+
+    Best-effort summary attached to a phase_gate resolve response (#3374):
+    contract-resident HITL questions that are *not* the current phase (so
+    the post-gate bridge will not promote them into the queue) and remain
+    unanswered. Reports ``id`` / ``question`` (truncated) / ``phase`` so the
+    operator gets explicit signal instead of a silent "proceeding". Any
+    failure yields ``[]`` — this guard must never block a resolution.
+    """
+    try:
+        import contract_store
+        from egg_contracts import load_contract
+        from routes.pipelines import _pipeline_identifier
+
+        worktree = contract_store.resolve_pipeline_worktree(pipeline_id)
+        if worktree is None:
+            return []
+        identifier = _pipeline_identifier(getattr(pipeline, "issue_number", None), pipeline_id)
+        contract = load_contract(identifier, worktree)
+    except Exception:
+        logger.debug(
+            "Outstanding-contract-decision scan failed after gate resolve",
+            pipeline_id=pipeline_id,
+            exc_info=True,
+        )
+        return []
+
+    current_phase = getattr(contract, "current_phase", None)
+    current_phase_val = getattr(current_phase, "value", current_phase)
+
+    outstanding: list[dict[str, Any]] = []
+    for d in contract.decisions or []:
+        if d.resolved or getattr(d.type, "value", d.type) != "hitl":
+            continue
+        d_phase = getattr(d.phase, "value", d.phase)
+        # The bridge promotes the current phase (and phase-less) questions
+        # into the queue on approval; only later-phase questions are left
+        # genuinely outstanding and invisible.
+        if d_phase is None or d_phase == current_phase_val:
+            continue
+        question = d.question or ""
+        if len(question) > 2_000:
+            question = question[:2_000] + "… (truncated)"
+        outstanding.append({"id": d.id, "question": question, "phase": d_phase})
+    return outstanding
 
 
 def _resolve_contract_decision(

--- a/orchestrator/routes/decisions/_resolve.py
+++ b/orchestrator/routes/decisions/_resolve.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import routes.decisions as _pkg
 from decision_queue import DecisionAlreadyResolvedError, DecisionNotFoundError
+from egg_contracts.decisions import truncate_question
 from events import EventType
 from flask import Response, request
 from state_store import InvalidPipelineIdError, PipelineNotFoundError
@@ -290,9 +291,7 @@ def _outstanding_contract_hitl(pipeline_id: str, pipeline: Any) -> list[dict[str
         # genuinely outstanding and invisible.
         if d_phase is None or d_phase == current_phase_val:
             continue
-        question = d.question or ""
-        if len(question) > 2_000:
-            question = question[:2_000] + "… (truncated)"
+        question = truncate_question(d.question or "")
         outstanding.append({"id": d.id, "question": question, "phase": d_phase})
     return outstanding
 

--- a/orchestrator/tests/test_impasse_routing.py
+++ b/orchestrator/tests/test_impasse_routing.py
@@ -230,6 +230,41 @@ class TestRouteImpassesEscalate:
         assert "external_blocker" in decision.question
         assert "upstream PR not merged" in decision.question
 
+    def test_repeated_escalation_dedupes_onto_existing_decision(self, tmp_path):
+        """Re-escalating the same impasse adopts the open ``cq-N`` rather
+        than appending an identical duplicate (#3374)."""
+        pid = _seed_contract(tmp_path)
+        contract = load_contract(pid, tmp_path)
+        contract.slices[0].tasks[0].delegation_attempts = DELEGATION_LIMIT
+        save_contract(contract, tmp_path)
+
+        imp = Impasse(
+            category=ImpasseCategory.PLAN_BUG,
+            reason="acceptance criteria contradict each other",
+            task_id="task-1-1",
+        )
+
+        def _escalate_once():
+            return route_impasses(
+                repo_path=tmp_path,
+                pipeline_id=pid,
+                contract_identifier=pid,
+                impasses=[(ContractAgentRole.CODER, imp)],
+                slice_id="slice-1",
+            )
+
+        first = _escalate_once()
+        second = _escalate_once()
+
+        assert first[0].action == ImpasseAction.ESCALATE
+        assert second[0].action == ImpasseAction.ESCALATE
+        # Both routing decisions point at the same HITL id...
+        assert first[0].hitl_decision_id == second[0].hitl_decision_id
+        # ...and only one decision was ever written to the contract.
+        contract = load_contract(pid, tmp_path)
+        hitl_ids = [d.id for d in contract.decisions if d.id.startswith("cq-")]
+        assert hitl_ids == [first[0].hitl_decision_id]
+
     def test_self_delegation_escalates(self, tmp_path):
         # Even though report_impasse rejects suggested_role==role at the
         # handler boundary, defense-in-depth: if a malformed payload

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -1617,16 +1617,25 @@ class TestGetStatusSyncHandler:
     def test_running_agents_no_fallback_when_persisted_present(self, handler):
         """Persisted running agents short-circuit the /status fallback (#3230).
 
-        Only two requests (pipeline + messages) are issued — no /status call —
-        when the persisted list already has a running agent.
+        No ``/status`` call is issued when the persisted list already has a
+        running agent. (A trailing contract fetch for ``cq-N`` surfacing
+        also runs — #3374 — so we assert on the absence of ``/status``
+        rather than a raw request count.)
         """
-        mock_make = MagicMock(side_effect=[self._pipeline_response(), self._messages_response()])
+        mock_make = MagicMock(
+            side_effect=[
+                self._pipeline_response(),
+                self._messages_response(),
+                {"data": {"decisions": []}},  # contract fetch (#3374)
+            ]
+        )
         with patch.object(handler, "_make_request", mock_make):
             result = handler.handle_tool_call("get_status", {"task_id": "issue-42"})
 
         assert [a["role"] for a in result["running_agents"]] == ["coder"]
-        # No /status request was made — exactly pipeline + messages.
-        assert mock_make.call_count == 2
+        # No /status request was made — the live-cohort fallback never fired.
+        requested = [call.args[0] for call in mock_make.call_args_list]
+        assert not any("/status" in endpoint for endpoint in requested)
 
     def test_running_agents_empty_when_no_live_pods(self, handler):
         """Quiescence (no live pods) stays empty — not misreported (#3230).

--- a/orchestrator/tests/test_mcp_tools_enrichment.py
+++ b/orchestrator/tests/test_mcp_tools_enrichment.py
@@ -200,3 +200,63 @@ class TestEnrichPendingDecisions:
         mock_repo_resolve.assert_not_called()
         mock_resolve.assert_not_called()
         assert "draft_content" not in status["pending_decisions"][0]
+
+
+def _contract_payload(decisions: list[dict]) -> dict:
+    return {"success": True, "data": {"decisions": decisions}}
+
+
+class TestPendingContractDecisions:
+    """Surface unresolved contract-resident HITL (``cq-N``) decisions (#3374)."""
+
+    def test_surfaces_unresolved_hitl(self, handler):
+        contract = _contract_payload(
+            [
+                {
+                    "id": "cq-1",
+                    "type": "hitl",
+                    "question": "Drop the slider?",
+                    "phase": "plan",
+                    "resolved": False,
+                    "options": [{"label": "Yes"}, {"label": "No"}],
+                }
+            ]
+        )
+        with patch.object(handler, "_make_request", return_value=contract):
+            out = handler._pending_contract_decisions("pipeline-1", queue_pending=[])
+
+        assert len(out) == 1
+        assert out[0]["id"] == "cq-1"
+        assert out[0]["scope"] == "contract"
+        assert out[0]["options"] == ["Yes", "No"]
+
+    def test_excludes_resolved_and_non_hitl(self, handler):
+        contract = _contract_payload(
+            [
+                {"id": "cq-1", "type": "hitl", "question": "a", "resolved": True},
+                {"id": "decision-1", "type": "phase_gate", "question": "b", "resolved": False},
+                {"id": "cq-2", "type": "hitl", "question": "c", "resolved": False},
+            ]
+        )
+        with patch.object(handler, "_make_request", return_value=contract):
+            out = handler._pending_contract_decisions("pipeline-1", queue_pending=[])
+
+        assert [d["id"] for d in out] == ["cq-2"]
+
+    def test_excludes_already_bridged(self, handler):
+        contract = _contract_payload(
+            [{"id": "cq-1", "type": "hitl", "question": "a", "resolved": False}]
+        )
+        # cq-1 already mirrored into the queue by the post-gate bridge.
+        queue_pending = [
+            {"id": "decision-9", "context": "Open contract question cq-1, registered by an agent."}
+        ]
+        with patch.object(handler, "_make_request", return_value=contract):
+            out = handler._pending_contract_decisions("pipeline-1", queue_pending=queue_pending)
+
+        assert out == []
+
+    def test_request_failure_returns_empty(self, handler):
+        with patch.object(handler, "_make_request", side_effect=RuntimeError("boom")):
+            out = handler._pending_contract_decisions("pipeline-1", queue_pending=[])
+        assert out == []

--- a/orchestrator/tests/test_resolve_contract_decision_route.py
+++ b/orchestrator/tests/test_resolve_contract_decision_route.py
@@ -406,5 +406,62 @@ def test_requires_lifecycle_secret(client, tmp_path):
     assert resp.status_code == 401
 
 
+class TestOutstandingContractHitl:
+    """The gate-approval guard summary attached to phase_gate resolutions (#3374)."""
+
+    def _save_mixed_contract(self, worktree: Path):
+        from egg_contracts import Contract, save_contract
+        from egg_contracts.models import Decision, DecisionType, PipelinePhase
+
+        contract = Contract(pipeline_id=PIPELINE_ID, current_phase=PipelinePhase.REFINE)
+        contract.decisions = [
+            # Later-phase, unresolved → outstanding (the bridge won't promote
+            # it at the refine gate).
+            Decision(
+                id="cq-1",
+                question="Drop the slider in the plan phase?",
+                type=DecisionType.HITL,
+                phase=PipelinePhase.PLAN,
+                resolved=False,
+            ),
+            # Current-phase question → the bridge promotes it; not flagged.
+            Decision(
+                id="cq-2",
+                question="Refine-scoped question?",
+                type=DecisionType.HITL,
+                phase=PipelinePhase.REFINE,
+                resolved=False,
+            ),
+            # Resolved later-phase question → not outstanding.
+            Decision(
+                id="cq-3",
+                question="Already answered?",
+                type=DecisionType.HITL,
+                phase=PipelinePhase.PLAN,
+                resolved=True,
+            ),
+        ]
+        save_contract(contract, worktree)
+
+    def test_reports_only_unresolved_later_phase_questions(self, tmp_path):
+        from routes.decisions import _outstanding_contract_hitl
+
+        self._save_mixed_contract(tmp_path)
+        pipeline_mock = MagicMock(issue_number=None)
+
+        with patch("contract_store.resolve_pipeline_worktree", return_value=tmp_path):
+            out = _outstanding_contract_hitl(PIPELINE_ID, pipeline_mock)
+
+        assert [d["id"] for d in out] == ["cq-1"]
+        assert out[0]["phase"] == "plan"
+
+    def test_no_worktree_returns_empty(self, tmp_path):
+        from routes.decisions import _outstanding_contract_hitl
+
+        pipeline_mock = MagicMock(issue_number=None)
+        with patch("contract_store.resolve_pipeline_worktree", return_value=None):
+            assert _outstanding_contract_hitl(PIPELINE_ID, pipeline_mock) == []
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/sandbox/egg_agent_tools/handlers/sdlc.py
+++ b/sandbox/egg_agent_tools/handlers/sdlc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from egg_contracts.decisions import find_duplicate_open_question, next_cq_id
@@ -13,6 +14,8 @@ from egg_agent_tools.handlers._gateway import (
     get_repo_path,
 )
 from egg_agent_tools.handlers.errors import GatewayError, HandlerError
+
+_logger = logging.getLogger(__name__)
 
 _VALID_PHASES = {"refine", "plan", "implement", "pr"}
 
@@ -109,6 +112,24 @@ def register_open_question(req: dict[str, Any]) -> dict[str, Any]:
         # Idempotent: no contract write, return the prior decision.
         duplicate = find_duplicate_open_question(decisions, question, decision_phase)
         if duplicate is not None:
+            # The dedup key is (normalized question, phase) — the option set
+            # is *not* part of it. If the re-registration carries a different
+            # option set, the operator only ever sees the stored options; the
+            # new ones are silently discarded. Log it so that loss is not
+            # invisible (#3374 review).
+            new_labels = [o["label"] for o in opt_objs]
+            existing_labels = [
+                o.get("label") for o in (duplicate.get("options") or []) if isinstance(o, dict)
+            ]
+            if new_labels != existing_labels:
+                _logger.warning(
+                    "register_open_question deduped onto %s but the re-registration's "
+                    "options differ from the stored ones; keeping the stored set "
+                    "(new=%r, stored=%r)",
+                    duplicate.get("id"),
+                    new_labels,
+                    existing_labels,
+                )
             return {
                 "ok": True,
                 "id": duplicate.get("id"),

--- a/sandbox/egg_agent_tools/handlers/sdlc.py
+++ b/sandbox/egg_agent_tools/handlers/sdlc.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from egg_contracts.decisions import next_cq_id
+from egg_contracts.decisions import find_duplicate_open_question, next_cq_id
 
 from egg_agent_tools.handlers._gateway import (
     container_id_field,
@@ -101,6 +101,20 @@ def register_open_question(req: dict[str, Any]) -> dict[str, Any]:
         decisions = contract.get("decisions", []) or []
         next_idx = len(decisions)
         decision_phase = phase or contract.get("current_phase")
+
+        # Dedupe: a later phase (or a re-run agent) that re-asks a
+        # question already registered and unanswered should adopt the
+        # existing ``cq-N`` rather than mint a duplicate — otherwise the
+        # operator who answers ``cq-1`` still faces an identical ``cq-4``.
+        # Idempotent: no contract write, return the prior decision.
+        duplicate = find_duplicate_open_question(decisions, question, decision_phase)
+        if duplicate is not None:
+            return {
+                "ok": True,
+                "id": duplicate.get("id"),
+                "decision": duplicate,
+                "deduped": True,
+            }
 
         # Agent-registered contract questions allocate ``cq-N`` from a
         # counter that ignores ``decision-N`` entries (written by the

--- a/sandbox/egg_agent_tools/handlers/sdlc.py
+++ b/sandbox/egg_agent_tools/handlers/sdlc.py
@@ -70,6 +70,10 @@ def register_open_question(req: dict[str, Any]) -> dict[str, Any]:
 
     Response:
         { ok: True, decision: {...}, id: "cq-N" }
+
+        On a dedup hit (the same normalized question already registered and
+        unanswered in the same phase), the existing decision is returned
+        verbatim with an extra ``deduped: True`` and no contract write.
     """
     question = req.get("question")
     if not question or not isinstance(question, str):

--- a/shared/egg_contracts/__init__.py
+++ b/shared/egg_contracts/__init__.py
@@ -86,7 +86,9 @@ from .audit import (
 )
 from .decisions import (
     CQ_ID_PATTERN,
+    find_duplicate_open_question,
     next_cq_id,
+    normalize_question,
 )
 from .dependency_graph import (
     DependencyGraph,
@@ -298,8 +300,10 @@ __all__ = [
     "list_contracts",
     "load_contract",
     "load_contract_from_branch",
+    "find_duplicate_open_question",
     "next_cq_id",
     "normalize_path",
+    "normalize_question",
     "save_contract",
     "validate_mutation",
     "validate_phase_mutation",

--- a/shared/egg_contracts/__init__.py
+++ b/shared/egg_contracts/__init__.py
@@ -85,10 +85,13 @@ from .audit import (
     format_audit_log,
 )
 from .decisions import (
+    CONTRACT_QUESTION_MAX_CHARS,
+    CONTRACT_QUESTION_TRUNCATION_SUFFIX,
     CQ_ID_PATTERN,
     find_duplicate_open_question,
     next_cq_id,
     normalize_question,
+    truncate_question,
 )
 from .dependency_graph import (
     DependencyGraph,
@@ -301,9 +304,12 @@ __all__ = [
     "load_contract",
     "load_contract_from_branch",
     "find_duplicate_open_question",
+    "CONTRACT_QUESTION_MAX_CHARS",
+    "CONTRACT_QUESTION_TRUNCATION_SUFFIX",
     "next_cq_id",
     "normalize_path",
     "normalize_question",
+    "truncate_question",
     "save_contract",
     "validate_mutation",
     "validate_phase_mutation",

--- a/shared/egg_contracts/decisions.py
+++ b/shared/egg_contracts/decisions.py
@@ -28,6 +28,27 @@ from typing import Any
 # stable as legacy ``decision-N`` entries come and go.
 CQ_ID_PATTERN = re.compile(r"^cq-([0-9]+)$")
 
+# Single source of truth for how long a HITL question may be before a
+# status/gate surface truncates it. Shared by the ``get_status``
+# surfacing (``_pending_contract_decisions``) and the phase_gate guard
+# (``_outstanding_contract_hitl``) so the same ``cq-N`` renders at one
+# consistent length on both surfaces (#3374 review).
+CONTRACT_QUESTION_MAX_CHARS = 4_000
+CONTRACT_QUESTION_TRUNCATION_SUFFIX = "… (truncated)"
+
+
+def truncate_question(question: str, max_chars: int = CONTRACT_QUESTION_MAX_CHARS) -> str:
+    """Return ``question`` truncated to ``max_chars`` with a suffix marker.
+
+    Single source of truth for the length cap applied when a HITL
+    question is echoed onto a status/gate surface, so both surfaces
+    truncate identically.
+    """
+    if len(question) > max_chars:
+        return question[:max_chars] + CONTRACT_QUESTION_TRUNCATION_SUFFIX
+    return question
+
+
 # Collapse runs of whitespace so trivially-reformatted re-registrations
 # of the same question (extra spaces, a wrapped newline) normalize to the
 # same key.

--- a/shared/egg_contracts/decisions.py
+++ b/shared/egg_contracts/decisions.py
@@ -28,6 +28,76 @@ from typing import Any
 # stable as legacy ``decision-N`` entries come and go.
 CQ_ID_PATTERN = re.compile(r"^cq-([0-9]+)$")
 
+# Collapse runs of whitespace so trivially-reformatted re-registrations
+# of the same question (extra spaces, a wrapped newline) normalize to the
+# same key.
+_WHITESPACE_RUN = re.compile(r"\s+")
+
+
+def normalize_question(question: Any) -> str:
+    """Return the dedupe-normalized form of a decision question.
+
+    Lower-cased, leading/trailing-stripped, and internal whitespace runs
+    collapsed to a single space. Non-string input normalizes to ``""``.
+    This is the single source of truth for the equivalence used by
+    :func:`find_duplicate_open_question`.
+    """
+    if not isinstance(question, str):
+        return ""
+    return _WHITESPACE_RUN.sub(" ", question).strip().lower()
+
+
+def _field(d: Any, name: str) -> Any:
+    """Read ``name`` from a Decision instance or a plain contract dict."""
+    if isinstance(d, dict):
+        return d.get(name)
+    return getattr(d, name, None)
+
+
+def find_duplicate_open_question(
+    existing: Iterable[Any],
+    question: str,
+    phase: Any,
+) -> Any | None:
+    """Return an existing unresolved HITL decision equivalent to ``question``.
+
+    A later phase or a re-run agent that registers a question already
+    posed (and not yet answered) should adopt the prior ``cq-N`` rather
+    than mint a duplicate (the operator who answers ``cq-1`` should not
+    then face an identical ``cq-4``). This scans ``existing`` for the
+    first decision that is
+
+    - a HITL decision (``type == "hitl"``),
+    - unresolved (``resolved`` is falsy), and
+    - whose :func:`normalize_question` form equals that of ``question``
+      under the same ``phase``.
+
+    ``existing`` may hold :class:`Decision` instances or plain dicts
+    (the gateway's JSON contract payload), mirroring :func:`next_cq_id`.
+    ``phase`` is compared on its string value so a ``PipelinePhase`` enum,
+    its ``.value``, or ``None`` all match consistently. Returns the
+    matching entry (so callers can reuse its id) or ``None``.
+    """
+    target = normalize_question(question)
+    if not target:
+        return None
+    target_phase = getattr(phase, "value", phase)
+
+    for d in existing:
+        d_type = _field(d, "type")
+        d_type = getattr(d_type, "value", d_type)
+        if d_type != "hitl":
+            continue
+        if _field(d, "resolved"):
+            continue
+        d_phase = _field(d, "phase")
+        d_phase = getattr(d_phase, "value", d_phase)
+        if d_phase != target_phase:
+            continue
+        if normalize_question(_field(d, "question")) == target:
+            return d
+    return None
+
 
 def next_cq_id(existing: Iterable[Any]) -> str:
     """Return the next ``cq-N`` id, ignoring non-``cq-`` ids in ``existing``.

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -515,15 +515,18 @@ decision directly.
 
 **Detection.** As of #3374, `get_status` surfaces these directly: unresolved `cq-N` HITL
 decisions that the queue does not yet know about appear in a sibling `pending_contract_decisions`
-list (each entry carries `id`, `question`, `phase`, `options`, and `scope: "contract"`). Check it
-on every snapshot — do not rely on `pending_decisions` alone, which only lists queue decisions.
-As a fallback (or to see resolved history), call `get_contract(task_id)` and inspect the
-`decisions` array; any entry with `resolved: false` is awaiting the operator.
+list (each entry carries `id`, `question`, `phase`, `options`, and `scope: "contract"`, plus
+`type: "hitl"` and a `note` pointing at the `provide_input` flow). Check it on every snapshot — do
+not rely on `pending_decisions` alone, which only lists queue decisions. As a fallback (or to see
+resolved history), call `get_contract(task_id)` and inspect the `decisions` array; any entry with
+`resolved: false` is awaiting the operator.
 
-> **Duplicates.** A question already registered and unresolved is no longer re-minted as a new
-> `cq-N` by a later phase or a re-run agent — `register_open_question` (and the impasse router)
-> dedupe on the normalized question + phase and adopt the existing decision (#3374). You should
-> not see two `cq-N` for the same question; if you do, it predates the fix.
+> **Duplicates.** A question already open and unresolved *under the same phase* is no longer
+> re-minted as a new `cq-N` by a re-run agent or a re-escalated impasse — `register_open_question`
+> (and the impasse router) dedupe on the normalized question keyed by phase and adopt the existing
+> decision (#3374). The dedup is phase-scoped: a genuine cross-phase re-ask (a different phase tag)
+> is a distinct question and *does* get a fresh `cq-N` by design. Within one phase you should not
+> see two `cq-N` for the same question; if you do, it predates the fix.
 
 **Answer it via `provide_input`:**
 

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -513,9 +513,17 @@ approved; an agent blocked pre-proposal never reaches the gate.
 deadlocked. **As of #3071**, the `provide_input` tool falls back to the contract and resolves the
 decision directly.
 
-**Detection.** When a `stuck-phase-transition` alert fires (or a pipeline sits blocked with an
-empty `pending_decisions`), call `get_contract(task_id)` and inspect the `decisions` array. If
-any entry has `resolved: false`, its `id`, `question`, and `options` are awaiting the operator.
+**Detection.** As of #3374, `get_status` surfaces these directly: unresolved `cq-N` HITL
+decisions that the queue does not yet know about appear in a sibling `pending_contract_decisions`
+list (each entry carries `id`, `question`, `phase`, `options`, and `scope: "contract"`). Check it
+on every snapshot — do not rely on `pending_decisions` alone, which only lists queue decisions.
+As a fallback (or to see resolved history), call `get_contract(task_id)` and inspect the
+`decisions` array; any entry with `resolved: false` is awaiting the operator.
+
+> **Duplicates.** A question already registered and unresolved is no longer re-minted as a new
+> `cq-N` by a later phase or a re-run agent — `register_open_question` (and the impasse router)
+> dedupe on the normalized question + phase and adopt the existing decision (#3374). You should
+> not see two `cq-N` for the same question; if you do, it predates the fix.
 
 **Answer it via `provide_input`:**
 
@@ -795,6 +803,8 @@ A phase that registers agent-level `choice` / `feedback` decisions (via `registe
 2. **Wave 2 — deferred decisions.** On `approve`, the pipeline **stays in `awaiting_human`** and the orchestrator moves the deferred choice/feedback decisions into `pending_decisions`. They wake the next `wait-status` Monitor invocation via `decision.created`. The next phase does not start until all of them are resolved. On `request_changes` / `change_approach`, the deferred decisions are discarded with the phase reset — no Wave 2.
 
 **Operator messaging implications** — when narrating a `phase_gate` approval to the user, do not say "approves and moves to the next phase". The accurate framing is: "approves the draft; if the phase registered deferred decisions, they will surface next for you to resolve before `<next phase>` starts." When the draft lists open questions that are not in the current `pending_decisions` snapshot, frame them as "these will surface as `<phase>`-phase decisions once the gate is approved", not "these will come up in the `<next phase>` phase".
+
+**Gate-approval guard (#3374)** — the `provide_input` response for a `phase_gate` includes an `outstanding_contract_decisions` list when the approval leaves *later-phase* `cq-N` HITL questions unanswered (current-phase ones are promoted by Wave 2; only questions tagged for a future phase remain genuinely outstanding). Surface these to the user so an approval is never narrated as "nothing else pending" while HITL questions sit unanswered downstream. They also appear in every `get_status` snapshot under `pending_contract_decisions` until resolved.
 
 **Handling rules by `decision_type`**:
 

--- a/tests/sandbox/egg_agent_tools/test_handlers_sdlc.py
+++ b/tests/sandbox/egg_agent_tools/test_handlers_sdlc.py
@@ -220,6 +220,68 @@ class TestRegisterOpenQuestion:
         # Exactly two calls — read + mutate; no retry.
         assert gr.call_count == 2
 
+    def test_dedupes_onto_existing_unresolved_question(self):
+        """A question already registered and unanswered for the same phase
+        is returned idempotently — no second ``cq-N`` is minted and no
+        contract mutate is issued (#3374)."""
+        existing = _fake_contract(
+            current_phase="plan",
+            decisions=[
+                {
+                    "id": "cq-1",
+                    "question": "Drop the slider?",
+                    "type": "hitl",
+                    "phase": "plan",
+                    "resolved": False,
+                }
+            ],
+        )
+        with (
+            patch(
+                "egg_agent_tools.handlers.sdlc.gateway_request",
+                side_effect=lambda *a, **kw: {"success": True, "data": existing},
+            ) as gr,
+            patch("egg_agent_tools.handlers.sdlc.get_contract_identifier", return_value=42),
+        ):
+            resp = sdlc.register_open_question({"question": "drop the   slider?"})
+
+        assert resp["id"] == "cq-1"
+        assert resp["deduped"] is True
+        # Only the contract read happened — no mutate write.
+        assert gr.call_count == 1
+
+    def test_resolved_duplicate_does_not_block_new_registration(self):
+        """An already-*resolved* identical question must not suppress a
+        fresh registration — only open questions dedupe (#3374)."""
+        existing = _fake_contract(
+            current_phase="plan",
+            decisions=[
+                {
+                    "id": "cq-1",
+                    "question": "Drop the slider?",
+                    "type": "hitl",
+                    "phase": "plan",
+                    "resolved": True,
+                }
+            ],
+        )
+        responses = [
+            {"success": True, "data": existing},
+            {"success": True, "data": {}},
+        ]
+        with (
+            patch(
+                "egg_agent_tools.handlers.sdlc.gateway_request",
+                side_effect=lambda *a, **kw: responses.pop(0),
+            ) as gr,
+            patch("egg_agent_tools.handlers.sdlc.get_contract_identifier", return_value=42),
+        ):
+            resp = sdlc.register_open_question({"question": "Drop the slider?"})
+
+        assert resp["id"] == "cq-2"
+        assert "deduped" not in resp
+        assert gr.call_count == 2
+
 
 class TestFetchContractNullData:
     """_fetch_contract must return {} when the gateway response has

--- a/tests/shared/egg_contracts/test_decisions.py
+++ b/tests/shared/egg_contracts/test_decisions.py
@@ -10,12 +10,36 @@ side still allocates ``decision-N``; the helper here is what both
 from __future__ import annotations
 
 from egg_contracts.decisions import (
+    CONTRACT_QUESTION_MAX_CHARS,
+    CONTRACT_QUESTION_TRUNCATION_SUFFIX,
     CQ_ID_PATTERN,
     find_duplicate_open_question,
     next_cq_id,
     normalize_question,
+    truncate_question,
 )
 from egg_contracts.models import Decision, DecisionType, PipelinePhase
+
+
+class TestTruncateQuestion:
+    """Single source of truth for the status/gate surface length cap (#3374 review)."""
+
+    def test_short_question_unchanged(self):
+        assert truncate_question("short") == "short"
+
+    def test_question_at_cap_unchanged(self):
+        q = "x" * CONTRACT_QUESTION_MAX_CHARS
+        assert truncate_question(q) == q
+
+    def test_overlong_question_truncated_with_suffix(self):
+        q = "x" * (CONTRACT_QUESTION_MAX_CHARS + 50)
+        out = truncate_question(q)
+        assert out == "x" * CONTRACT_QUESTION_MAX_CHARS + CONTRACT_QUESTION_TRUNCATION_SUFFIX
+
+    def test_respects_explicit_max_chars(self):
+        assert (
+            truncate_question("abcdef", max_chars=3) == "abc" + CONTRACT_QUESTION_TRUNCATION_SUFFIX
+        )
 
 
 class TestNextCqId:

--- a/tests/shared/egg_contracts/test_decisions.py
+++ b/tests/shared/egg_contracts/test_decisions.py
@@ -9,8 +9,13 @@ side still allocates ``decision-N``; the helper here is what both
 
 from __future__ import annotations
 
-from egg_contracts.decisions import CQ_ID_PATTERN, next_cq_id
-from egg_contracts.models import Decision, DecisionType
+from egg_contracts.decisions import (
+    CQ_ID_PATTERN,
+    find_duplicate_open_question,
+    next_cq_id,
+    normalize_question,
+)
+from egg_contracts.models import Decision, DecisionType, PipelinePhase
 
 
 class TestNextCqId:
@@ -58,3 +63,91 @@ class TestNextCqId:
         assert CQ_ID_PATTERN.match("decision-1") is None
         assert CQ_ID_PATTERN.match("cq-") is None
         assert CQ_ID_PATTERN.match("cq-1a") is None
+
+
+class TestNormalizeQuestion:
+    def test_lowercases_strips_and_collapses_whitespace(self):
+        assert normalize_question("  Drop the   Slider?\n") == "drop the slider?"
+
+    def test_non_string_normalizes_to_empty(self):
+        assert normalize_question(None) == ""
+        assert normalize_question(42) == ""
+
+    def test_equivalent_reformattings_match(self):
+        assert normalize_question("Drop the slider?") == normalize_question("drop   the\tslider?")
+
+
+class TestFindDuplicateOpenQuestion:
+    def test_returns_none_for_empty_question(self):
+        existing = [{"id": "cq-1", "type": "hitl", "question": "x", "resolved": False}]
+        assert find_duplicate_open_question(existing, "", None) is None
+
+    def test_matches_equivalent_unresolved_hitl_in_same_phase(self):
+        existing = [
+            {
+                "id": "cq-1",
+                "type": "hitl",
+                "question": "Drop the slider?",
+                "phase": "plan",
+                "resolved": False,
+            }
+        ]
+        hit = find_duplicate_open_question(existing, "drop the   slider?", "plan")
+        assert hit is not None
+        assert hit["id"] == "cq-1"
+
+    def test_no_match_when_phase_differs(self):
+        existing = [
+            {
+                "id": "cq-1",
+                "type": "hitl",
+                "question": "Drop the slider?",
+                "phase": "plan",
+                "resolved": False,
+            }
+        ]
+        assert find_duplicate_open_question(existing, "Drop the slider?", "refine") is None
+
+    def test_skips_resolved_decisions(self):
+        existing = [
+            {
+                "id": "cq-1",
+                "type": "hitl",
+                "question": "Drop the slider?",
+                "phase": "plan",
+                "resolved": True,
+            }
+        ]
+        assert find_duplicate_open_question(existing, "Drop the slider?", "plan") is None
+
+    def test_skips_non_hitl_decisions(self):
+        existing = [
+            {
+                "id": "decision-1",
+                "type": "phase_gate",
+                "question": "Drop the slider?",
+                "phase": "plan",
+                "resolved": False,
+            }
+        ]
+        assert find_duplicate_open_question(existing, "Drop the slider?", "plan") is None
+
+    def test_matches_pydantic_decisions_with_enum_phase(self):
+        existing = [
+            Decision(
+                id="cq-7",
+                question="Need a V2 schema?",
+                type=DecisionType.HITL,
+                phase=PipelinePhase.PLAN,
+            )
+        ]
+        hit = find_duplicate_open_question(existing, "need a v2 schema?", PipelinePhase.PLAN)
+        assert hit is not None
+        assert hit.id == "cq-7"
+
+    def test_phaseless_questions_match_on_none(self):
+        existing = [
+            {"id": "cq-1", "type": "hitl", "question": "Q?", "phase": None, "resolved": False}
+        ]
+        hit = find_duplicate_open_question(existing, "q?", None)
+        assert hit is not None and hit["id"] == "cq-1"


### PR DESCRIPTION
## Problem

Contract-resident `cq-N` HITL decisions — registered by agents via `register_open_question` or the impasse-escalation router — exhibited two distinct defects:

1. **Duplicate registration.** The same underlying question registered by successive phases (or a re-run agent) minted distinct `cq-N` ids with no dedupe. An operator who answered `cq-1` still faced an identical `cq-4`. `next_cq_id` only guarantees unique sequential ids; nothing checked question content.

2. **Never surfaced on the status surface.** `cq-N` live on the SDLC contract (`.egg-state/contracts/{id}.json`), not the orchestrator decision queue. `get_status.pending_decisions` is built solely from the queue, so unresolved `cq-N` were invisible there. They only enter the queue via the post-gate bridge (`_queue_and_await_contract_decisions`), which promotes *current-phase* decisions after a phase_gate approval. Questions tagged for a later phase (e.g. registered during refine but tagged `plan`) sat unbridged and invisible — an operator driving via `get_status` / `wait-status` got zero signal that HITL questions were pending, and a gate approval read as "nothing else pending" while questions were outstanding. Discovering them required an out-of-band `get_contract`.

## Changes

- **Dedupe at registration.** New `egg_contracts.decisions.find_duplicate_open_question(decisions, question, phase)` normalizes the question (lower/strip/whitespace-collapse) and matches an existing *unresolved* `hitl` decision in the same phase. `register_open_question` (and the impasse-escalation router) adopt the existing `cq-N` idempotently — no second contract write — instead of minting a duplicate. The MCP/CLI registration response carries `deduped: true` on a hit.

- **Surface in `get_status`.** A new sibling field `pending_contract_decisions` lists unresolved, not-yet-bridged `cq-N` (each with `id` / `question` / `phase` / `options` / `scope: "contract"`). Kept distinct from `pending_decisions` so the documented two-wave resolve flow is unaffected; already-bridged `cq-N` (mirrored into the queue) are filtered out so nothing is double-listed. Best-effort and issued last — never breaks the snapshot.

- **Gate-approval guard.** The `phase_gate` resolve response now includes `outstanding_contract_decisions`: the later-phase unresolved `cq-N` that the approval leaves open (current-phase ones are promoted by the bridge, so only future-phase questions are genuinely outstanding). The operator is no longer told "proceeding" while HITL questions sit unanswered downstream.

- **Docs:** `docs/hitl-decisions.md` and the SDLC `SKILL.md` document the new field, the dedupe/idempotency behavior, and the gate-approval guard.

## Tests

- `tests/shared/egg_contracts/test_decisions.py` — `normalize_question` + `find_duplicate_open_question` (dict & pydantic inputs, phase/resolved/type filtering).
- `tests/sandbox/egg_agent_tools/test_handlers_sdlc.py` — idempotent re-register (no second mutate); resolved duplicate does not suppress a fresh registration.
- `orchestrator/tests/test_mcp_tools_enrichment.py` — `_pending_contract_decisions` (surfacing, resolved/non-hitl exclusion, already-bridged filtering, request-failure fail-open).
- `orchestrator/tests/test_impasse_routing.py` — repeated escalation dedupes onto the existing decision.
- `orchestrator/tests/test_resolve_contract_decision_route.py` — `_outstanding_contract_hitl` reports only unresolved later-phase questions; empty when no worktree.

Full suite green (19,929 passed; the 2 `reap-stale-egg-images` failures are pre-existing host-env noise unrelated to this diff).