### PR TITLE
fix(simplifier): de-role the producer + move companion gate into the verdict rubric (#3381)

### DIFF
--- a/orchestrator/action_guards.py
+++ b/orchestrator/action_guards.py
@@ -424,13 +424,20 @@ def check_confirm_guard(
 
     # --- Reviewer confirmation guards ---
     if is_reviewer:
-        # Exclude two classes of producer from the four reviewer guards
+        # Exclude three classes of producer from the four reviewer guards
         # below (has-reviewed / zero-proposal / stale-ACK / stale-NACK /
         # unresolved-NACK):
         #
         #   * Generic no-op producers (#3027): the producer declared it has
         #     no work, so there is nothing for the reviewer to review and it
         #     must not block the reviewer's confirm.
+        #   * Wake-only producers (#3381 / #3382-review): the de-roled
+        #     simplifier carries an advisory edge over the upstream producer
+        #     PURELY as the event-pump wake-wire and casts no verdict, so it
+        #     can never satisfy a has-reviewed guard on that edge. Excluding
+        #     it here lets the simplifier confirm its companion without a
+        #     verdict it will never cast — matching the pre-PR timing where
+        #     its (now-removed) advisory ACK cleared the guard.
         #   * Already-CONFIRMED producers (#3043): a producer only reaches
         #     the confirmed set after its CRITICAL reviewers have ACKed it,
         #     so its work is settled. A reviewer still carrying a missing
@@ -447,10 +454,11 @@ def check_confirm_guard(
         #     advance_phase(force=true) tripping #2806) are tracked
         #     separately in #3051; this filter is the tactical root-cause
         #     fix only and intentionally does not patch the recovery path.
+        wake_only = graph.wake_only_producers_for(agent_role)
         producers = [
             p
             for p in graph.producers_for(agent_role)
-            if not matrix.is_no_changes_proposal(p) and p not in confirmed
+            if not matrix.is_no_changes_proposal(p) and p not in confirmed and p not in wake_only
         ]
 
         # Guard 1: Must have reviewed all producers

--- a/orchestrator/review_graph.py
+++ b/orchestrator/review_graph.py
@@ -26,12 +26,26 @@ class ReviewEdge:
     reviewer_role: str
     producer_role: str
     criticality: ReviewCriticality = ReviewCriticality.CRITICAL
+    # A "wake-only" edge exists PURELY to drive the event-pump wake-wire:
+    # it re-invokes the reviewer when the producer proposes, but the
+    # reviewer casts NO verdict on it. This models the de-roled simplifier
+    # (#3381): it is a producer of the human-focused companion and carries
+    # an advisory edge over the upstream producer only so the ``ack`` arm
+    # re-invokes it on that producer's PROPOSE. Because the agent no longer
+    # issues an ACK/NACK, the edge must impose NO review obligation — it is
+    # excluded from pending-review derivation (so a de-roled reviewer is
+    # never assigned a spawn-able ``ack`` it cannot satisfy) and from the
+    # reviewer confirm guards (so it can confirm without a verdict it will
+    # never cast). A wake-only edge is always ADVISORY; wake_only is the
+    # stronger statement that even the agent-side verdict is gone.
+    wake_only: bool = False
 
-    def to_dict(self) -> dict[str, str]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "reviewer_role": self.reviewer_role,
             "producer_role": self.producer_role,
             "criticality": self.criticality.value,
+            "wake_only": self.wake_only,
         }
 
 
@@ -97,6 +111,19 @@ class ReviewGraph:
             for e in self._edges
             if e.producer_role == producer and e.criticality == ReviewCriticality.ADVISORY
         ]
+
+    def wake_only_producers_for(self, reviewer: str) -> set[str]:
+        """Producers a reviewer reaches via a wake-only edge.
+
+        A wake-only edge drives the event-pump wake-wire but carries no
+        review obligation — the reviewer never casts a verdict on it
+        (#3381, the de-roled simplifier). These producers must be excluded
+        from pending-review derivation and from the reviewer confirm guards
+        so the de-roled reviewer is never assigned an ``ack`` it can no
+        longer satisfy, and can confirm without a verdict it will never
+        cast.
+        """
+        return {e.producer_role for e in self._edges if e.reviewer_role == reviewer and e.wake_only}
 
     def get_edge(self, reviewer: str, producer: str) -> ReviewEdge | None:
         """Get a specific review edge."""
@@ -179,6 +206,7 @@ class ReviewGraph:
                 reviewer_role=e["reviewer_role"],
                 producer_role=e["producer_role"],
                 criticality=ReviewCriticality(e.get("criticality", "critical")),
+                wake_only=bool(e.get("wake_only", False)),
             )
             for e in data.get("edges", [])
         ]
@@ -203,14 +231,17 @@ def get_default_refine_graph() -> ReviewGraph:
             ReviewEdge("reviewer_agent_design", "refiner", ReviewCriticality.CRITICAL),
             # The simplifier produces the human-focused analysis companion
             # (faithful + jargon-free), gated CRITICAL by reviewer_refine.
-            # It is DUAL-ROLE — like the implement-phase tester — and carries
-            # an ADVISORY review edge over the refiner so the BRC ``ack`` arm
-            # re-invokes it when the refiner proposes (the proven wake-up the
-            # spawn-dedupe key relies on; a pure producer's first-propose key
-            # is constant and would never re-spawn). Advisory => the
-            # simplifier's verdict never blocks the refiner's consensus.
+            # It carries a WAKE-ONLY edge over the refiner so the BRC ``ack``
+            # arm re-invokes it when the refiner proposes (the proven wake-up
+            # the spawn-dedupe key relies on; a pure producer's first-propose
+            # key is constant and would never re-spawn). It is a PRODUCER
+            # ONLY (#3381): it casts no verdict, so the edge must impose no
+            # review obligation — wake_only excludes it from pending-review
+            # derivation and the confirm guards (otherwise the simplifier is
+            # derived a spawn-able ``ack`` for the whole window the refiner is
+            # PROPOSED, re-invoking an agent that can no longer satisfy it).
             ReviewEdge("reviewer_refine", "simplifier", ReviewCriticality.CRITICAL),
-            ReviewEdge("simplifier", "refiner", ReviewCriticality.ADVISORY),
+            ReviewEdge("simplifier", "refiner", ReviewCriticality.ADVISORY, wake_only=True),
         ]
     )
 
@@ -253,12 +284,14 @@ def get_default_plan_graph() -> ReviewGraph:
             # risk_analyst reviews task_planner (critical — risk lens, #2809)
             ReviewEdge("risk_analyst", "task_planner", ReviewCriticality.CRITICAL),
             # The simplifier produces the human-focused plan companion,
-            # gated CRITICAL by reviewer_plan. Dual-role like the refine-phase
-            # simplifier: an ADVISORY edge over task_planner re-invokes it via
-            # the ``ack`` arm when task_planner proposes (the tester wake-up
-            # pattern). Advisory => it never blocks task_planner's consensus.
+            # gated CRITICAL by reviewer_plan. Wake-only like the refine-phase
+            # simplifier: an edge over task_planner re-invokes it via the
+            # ``ack`` arm when task_planner proposes (the tester wake-up
+            # pattern). It is a PRODUCER ONLY (#3381) — it casts no verdict,
+            # so wake_only excludes the edge from pending-review derivation
+            # and the confirm guards (see the refine graph above).
             ReviewEdge("reviewer_plan", "simplifier", ReviewCriticality.CRITICAL),
-            ReviewEdge("simplifier", "task_planner", ReviewCriticality.ADVISORY),
+            ReviewEdge("simplifier", "task_planner", ReviewCriticality.ADVISORY, wake_only=True),
         ]
     )
 

--- a/orchestrator/review_graph.py
+++ b/orchestrator/review_graph.py
@@ -26,18 +26,26 @@ class ReviewEdge:
     reviewer_role: str
     producer_role: str
     criticality: ReviewCriticality = ReviewCriticality.CRITICAL
-    # A "wake-only" edge exists PURELY to drive the event-pump wake-wire:
-    # it re-invokes the reviewer when the producer proposes, but the
-    # reviewer casts NO verdict on it. This models the de-roled simplifier
-    # (#3381): it is a producer of the human-focused companion and carries
-    # an advisory edge over the upstream producer only so the ``ack`` arm
-    # re-invokes it on that producer's PROPOSE. Because the agent no longer
-    # issues an ACK/NACK, the edge must impose NO review obligation — it is
-    # excluded from pending-review derivation (so a de-roled reviewer is
-    # never assigned a spawn-able ``ack`` it cannot satisfy) and from the
+    # A "wake-only" edge is an advisory edge the reviewer NEVER votes on.
+    # It models the de-roled simplifier (#3381): a producer of the
+    # human-focused companion that retains an advisory edge over the
+    # upstream refine/plan producer but issues no ACK/NACK on it.
+    #
+    # It does NOT drive the wake. The simplifier is woken to write its
+    # companion by the ordinary producer **propose-arm**: a WORKING
+    # producer re-derives ``propose`` on every event-loop poll, and a clean
+    # orient-and-exit is a *legitimate* outcome that frees the spawn-dedupe
+    # key, so the orchestrator re-spawns it until it proposes (see
+    # ``test_event_loop.py::test_stale_exit_is_a_non_trigger_through_loop``).
+    # The simplifier self-gates on the upstream draft existing, so it
+    # orients-and-exits until the draft is committed, then proposes.
+    #
+    # ``wake_only`` exists only to NEUTRALIZE the residual advisory edge so
+    # it carries no review obligation: it is excluded from pending-review
+    # derivation (so the de-roled reviewer is never assigned a spawn-able
+    # ``ack`` it cannot satisfy — the regression #3381 fixed) and from the
     # reviewer confirm guards (so it can confirm without a verdict it will
-    # never cast). A wake-only edge is always ADVISORY; wake_only is the
-    # stronger statement that even the agent-side verdict is gone.
+    # never cast). A wake-only edge is always ADVISORY.
     wake_only: bool = False
 
     def to_dict(self) -> dict[str, Any]:
@@ -231,15 +239,16 @@ def get_default_refine_graph() -> ReviewGraph:
             ReviewEdge("reviewer_agent_design", "refiner", ReviewCriticality.CRITICAL),
             # The simplifier produces the human-focused analysis companion
             # (faithful + jargon-free), gated CRITICAL by reviewer_refine.
-            # It carries a WAKE-ONLY edge over the refiner so the BRC ``ack``
-            # arm re-invokes it when the refiner proposes (the proven wake-up
-            # the spawn-dedupe key relies on; a pure producer's first-propose
-            # key is constant and would never re-spawn). It is a PRODUCER
-            # ONLY (#3381): it casts no verdict, so the edge must impose no
-            # review obligation — wake_only excludes it from pending-review
-            # derivation and the confirm guards (otherwise the simplifier is
-            # derived a spawn-able ``ack`` for the whole window the refiner is
-            # PROPOSED, re-invoking an agent that can no longer satisfy it).
+            # It is a PRODUCER ONLY (#3381): the propose-arm wakes it to
+            # write the companion (it self-gates on the refiner's draft
+            # existing), and it casts no verdict on anyone. It retains a
+            # WAKE-ONLY advisory edge over the refiner only as a structural
+            # marker; wake_only carries no review obligation — it excludes
+            # the edge from pending-review derivation and the confirm guards
+            # so the simplifier is never derived a spawn-able ``ack`` it
+            # cannot satisfy and can confirm its own companion without ever
+            # voting on the refiner. (See the ReviewEdge.wake_only docstring
+            # for why the propose-arm, not this edge, is the wake.)
             ReviewEdge("reviewer_refine", "simplifier", ReviewCriticality.CRITICAL),
             ReviewEdge("simplifier", "refiner", ReviewCriticality.ADVISORY, wake_only=True),
         ]
@@ -285,11 +294,12 @@ def get_default_plan_graph() -> ReviewGraph:
             ReviewEdge("risk_analyst", "task_planner", ReviewCriticality.CRITICAL),
             # The simplifier produces the human-focused plan companion,
             # gated CRITICAL by reviewer_plan. Wake-only like the refine-phase
-            # simplifier: an edge over task_planner re-invokes it via the
-            # ``ack`` arm when task_planner proposes (the tester wake-up
-            # pattern). It is a PRODUCER ONLY (#3381) — it casts no verdict,
-            # so wake_only excludes the edge from pending-review derivation
-            # and the confirm guards (see the refine graph above).
+            # simplifier: a PRODUCER ONLY (#3381) woken to write the companion
+            # by the propose-arm (self-gating on task_planner's draft), casting
+            # no verdict. It retains a WAKE-ONLY advisory edge over task_planner
+            # only as a structural marker; wake_only excludes it from
+            # pending-review derivation and the confirm guards (see the refine
+            # graph above and the ReviewEdge.wake_only docstring).
             ReviewEdge("reviewer_plan", "simplifier", ReviewCriticality.CRITICAL),
             ReviewEdge("simplifier", "task_planner", ReviewCriticality.ADVISORY, wake_only=True),
         ]

--- a/orchestrator/routes/consensus.py
+++ b/orchestrator/routes/consensus.py
@@ -170,12 +170,25 @@ def _has_pending_peer_proposals(
     producers = tracker.graph.producers_for(reviewer)
     if not producers:
         return False, []
+    wake_only = tracker.graph.wake_only_producers_for(reviewer)
     pending: list[dict[str, Any]] = []
     for producer in producers:
         # Skip self-reviews (a dual-role agent reviewing its own producer
         # role); BRC does not require self-review and including it would
         # let a dual-role agent block on itself.
         if producer == reviewer:
+            continue
+        # Skip wake-only edges (#3381 / #3382-review): the de-roled
+        # simplifier carries an advisory edge over the upstream producer
+        # PURELY as the event-pump wake-wire and casts no verdict. Treating
+        # it as a pending review would derive a spawn-able ``ack`` for the
+        # entire window the upstream is PROPOSED, re-invoking an agent that
+        # can no longer satisfy the event (and risks re-PROPOSING the
+        # companion, invalidating the companion reviewer's ACK). The edge
+        # wakes the simplifier on the upstream's PROPOSE; it never obliges a
+        # review. This restores the pre-PR self-terminating wake-wire
+        # without reintroducing a verdict.
+        if producer in wake_only:
             continue
         # Skip a generic no-op proposal (#3027): the producer declared it
         # has no work in this slice, so there is nothing to review and the

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -13459,17 +13459,22 @@ def _build_brc_preamble(
                     " (or a `CONSENSUS_PROPOSE` for a re-propose — "
                     "version > 1, after you NACKed a prior version; "
                     "dual-role agents handle both — see Reviewer "
-                    "Lifecycle step 8 for the adversarial re-review "
+                    "Lifecycle step 7 for the adversarial re-review "
                     "framing)"
-                    if is_dual_role
+                    if is_dual_role and casts_real_verdicts
                     else ""
                 )
                 + ", act on it — failure to respond stalls the pipeline. "
-                "If you are a reviewer of the re-proposing producer, "
-                "re-review and ACK/NACK the new proposal (dual-role agents: "
-                "see Reviewer Lifecycle step 8 below for the adversarial "
-                "re-review framing that applies to this case). Otherwise, "
-                "re-confirm via `egg-orch consensus confirmed`.",
+                + (
+                    "If you are a reviewer of the re-proposing producer, "
+                    "re-review and ACK/NACK the new proposal (dual-role "
+                    "agents: see Reviewer Lifecycle step 7 below for the "
+                    "adversarial re-review framing that applies to this "
+                    "case). Otherwise, re-confirm via "
+                    "`egg-orch consensus confirmed`."
+                    if casts_real_verdicts
+                    else "Re-confirm via `egg-orch consensus confirmed`."
+                ),
                 "7. **RESOLVE OBLIGATIONS YOU SATISFY (#2338)**: If you "
                 "land a commit that satisfies a *different* producer's "
                 "conditional-ACK obligation in-cycle — typical pattern: "

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -13190,6 +13190,7 @@ def _build_brc_preamble(
         producers = graph.producers_for(role_value) if is_reviewer else []
         wake_only_producers = graph.wake_only_producers_for(role_value)
         all_roles = sorted(graph.all_roles())
+        graph_available = True
     except Exception:
         is_producer = role_value in (
             "coder",
@@ -13221,6 +13222,7 @@ def _build_brc_preamble(
         producers = []
         wake_only_producers = set()
         all_roles = []
+        graph_available = False
 
     lines: list[str] = [
         "\n\n## CRITICAL: BRC Consensus Protocol\n",
@@ -13239,7 +13241,20 @@ def _build_brc_preamble(
     # exclude wake_only producers, so the preamble does not contradict the
     # producer-only execution banner the simplifier receives.
     real_producers = [p for p in producers if p not in wake_only_producers]
-    casts_real_verdicts = bool(real_producers)
+    if graph_available:
+        casts_real_verdicts = bool(real_producers)
+    else:
+        # Degraded path: the graph load failed, so ``producers == []`` for every
+        # role and we cannot distinguish wake_only edges from real ones. Fall
+        # back to raw ``is_reviewer`` so we don't silently strip the Reviewer
+        # Lifecycle / "As a reviewer" coordination block from a *genuine*
+        # reviewer (reviewer_code/refine/plan) when the graph is unavailable —
+        # pre-#3381 this path gated those blocks on raw ``is_reviewer``. The
+        # simplifier — the only wake_only role — stays producer-only: it is
+        # excluded here, and is independently rendered producer-only by the
+        # ``is_dual_role and role_value == "simplifier"`` banner dispatch, which
+        # still fires in the fallback.
+        casts_real_verdicts = is_reviewer and role_value != "simplifier"
 
     if is_producer and casts_real_verdicts:
         role_type_desc = "PRODUCER and REVIEWER (dual role)"

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -13188,6 +13188,7 @@ def _build_brc_preamble(
         is_reviewer = graph.is_reviewer(role_value)
         reviewers = graph.reviewers_for(role_value) if is_producer else []
         producers = graph.producers_for(role_value) if is_reviewer else []
+        wake_only_producers = graph.wake_only_producers_for(role_value)
         all_roles = sorted(graph.all_roles())
     except Exception:
         is_producer = role_value in (
@@ -13208,13 +13209,17 @@ def _build_brc_preamble(
             "reviewer_refine",
             "reviewer_agent_design",
             "reviewer_plan",
-            # simplifier is dual-role: advisory reviewer of the upstream
-            # refine/plan producer (its wake-up arm), plus producer of the
-            # human-focused companion draft.
+            # simplifier retains a wake_only advisory edge over the upstream
+            # refine/plan producer, so the graph reports it as a reviewer —
+            # but it casts no verdict (#3381) and is rendered PRODUCER-ONLY
+            # below (the wake_only edge is excluded from the real-reviewer
+            # determination). Listed here so the degraded fallback path still
+            # recognizes it; producer-only rendering is handled uniformly.
             "simplifier",
         )
         reviewers = []
         producers = []
+        wake_only_producers = set()
         all_roles = []
 
     lines: list[str] = [
@@ -13225,11 +13230,22 @@ def _build_brc_preamble(
     ]
 
     is_dual_role = is_producer and is_reviewer
-    if is_dual_role:
+
+    # A role whose only reviewed producers are reached via wake_only edges
+    # (the de-roled simplifier, #3381) casts no verdict on anyone, so it is a
+    # PRODUCER in every behavioural sense — render it as one. We keep the
+    # graph-level ``is_dual_role`` flag intact for the banner dispatch below;
+    # only the rendered role-type label and the "assigned producers" line
+    # exclude wake_only producers, so the preamble does not contradict the
+    # producer-only execution banner the simplifier receives.
+    real_producers = [p for p in producers if p not in wake_only_producers]
+    casts_real_verdicts = bool(real_producers)
+
+    if is_producer and casts_real_verdicts:
         role_type_desc = "PRODUCER and REVIEWER (dual role)"
     elif is_producer:
         role_type_desc = "PRODUCER"
-    elif is_reviewer:
+    elif casts_real_verdicts:
         role_type_desc = "REVIEWER"
     else:
         role_type_desc = "PARTICIPANT"
@@ -13237,8 +13253,8 @@ def _build_brc_preamble(
     lines.append(f"Your role type: **{role_type_desc}**")
     if reviewers:
         lines.append(f"Your reviewers: {', '.join(reviewers)}")
-    if producers:
-        lines.append(f"Your assigned producers: {', '.join(producers)}")
+    if real_producers:
+        lines.append(f"Your assigned producers: {', '.join(real_producers)}")
     lines.append("")
 
     # Agent roster: show all active agents and what they do
@@ -13267,14 +13283,16 @@ def _build_brc_preamble(
     # (after the tester has proposed) likewise re-invoke the tester to
     # handle the Reviewer Lifecycle for those events.
     if is_dual_role and role_value == "simplifier":
-        # The simplifier carries an advisory review edge over the upstream
-        # producer PURELY as the event-pump wake-wire — it is what re-invokes
-        # the simplifier when the upstream proposes. It is NOT a reviewer in
-        # any behavioural sense: it issues no verdict, casts no ACK/NACK, and
-        # never critiques the draft (#3381). Treating it as a reviewer is what
-        # made the companion come out as a review/critique memo instead of a
-        # plain-language summary. So it gets a PRODUCER-ONLY banner here and
-        # must NOT inherit the tester's review-and-harden banner below.
+        # The simplifier is a PRODUCER ONLY (#3381). It is woken to write the
+        # companion by the ordinary producer propose-arm (it self-gates on the
+        # upstream draft existing), NOT by its advisory edge over the upstream
+        # — that edge is wake_only and casts no verdict, so it is inert in
+        # consensus derivation (see review_graph.ReviewEdge.wake_only). It is
+        # NOT a reviewer in any behavioural sense: it issues no verdict, casts
+        # no ACK/NACK, and never critiques the draft. Treating it as a reviewer
+        # is what made the companion come out as a review/critique memo instead
+        # of a plain-language summary. So it gets a PRODUCER-ONLY banner here
+        # and must NOT inherit the tester's review-and-harden banner below.
         lines.append(
             "### Execution Order (READ FIRST — simplifier)\n\n"
             "You are a **producer only**: your single job is to write a "

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -13210,6 +13210,15 @@ def _build_brc_preamble(
             "reviewer_refine",
             "reviewer_agent_design",
             "reviewer_plan",
+            # risk_analyst is a genuine dual-role reviewer in the plan graph
+            # (CRITICAL reviewer of architect + task_planner, #2809) as well as
+            # a producer of the risk register. Listed here so the degraded
+            # fallback path keeps its Reviewer Lifecycle / "As a reviewer"
+            # block instead of stripping it to producer-only — mirroring the
+            # live plan graph. Unlike the simplifier its edges are real
+            # verdicts, so ``casts_real_verdicts`` (raw ``is_reviewer`` in the
+            # degraded path) correctly stays True for it.
+            "risk_analyst",
             # simplifier retains a wake_only advisory edge over the upstream
             # refine/plan producer, so the graph reports it as a reviewer —
             # but it casts no verdict (#3381) and is rendered PRODUCER-ONLY

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -13496,7 +13496,17 @@ def _build_brc_preamble(
         )
         lines.extend(producer_lifecycle)
 
-    if is_reviewer:
+    # Gate the Reviewer Lifecycle on ``casts_real_verdicts``, not raw
+    # ``is_reviewer`` (#3381). A role whose only reviewed producers are
+    # reached via ``wake_only`` edges (the de-roled simplifier) issues no
+    # ACK/NACK and must NOT receive the reviewer playbook — REVIEW, ACK/NACK,
+    # CONFIRM, adversarial re-review — which would directly contradict its
+    # producer-only execution banner. This mirrors the producer-only invariant
+    # already asserted for the coder (``test_producer_only_no_sync_step``): a
+    # producer-only role gets no ``### Reviewer Lifecycle`` at all. A pure
+    # reviewer (``reviewer_refine``) and the dual-role tester both cast real
+    # verdicts, so they keep it.
+    if is_reviewer and casts_real_verdicts:
         lines.extend(
             [
                 "### Reviewer Lifecycle",
@@ -13515,16 +13525,7 @@ def _build_brc_preamble(
                 "invocation; subsequent invocations land you directly at "
                 "step 3 (SYNC) with the proposal already in context."
                 + (
-                    "\n\n   **You (simplifier) are a producer only** — per the "
-                    "*Execution Order* banner above: your first invocation does "
-                    "ORIENT/PREPARE only. On the upstream producer's "
-                    "`CONSENSUS_PROPOSE` the wrapper re-invokes you with the "
-                    "proposal in your event payload; SYNC, then write and "
-                    "PROPOSE your human-focused companion. That is the whole "
-                    "job — you do not review the draft, and you issue no "
-                    "ACK/NACK on it."
-                    if role_value == "simplifier"
-                    else "\n\n   **Dual-role agents (you)** — per the "
+                    "\n\n   **Dual-role agents (you)** — per the "
                     "*Dual-Role Execution Order* banner above (updated "
                     "for coder-owns-tests): your first invocation does "
                     "ORIENT/PREPARE only. On the coder's "
@@ -13695,7 +13696,10 @@ def _build_brc_preamble(
             ]
         )
 
-    if is_reviewer:
+    # Same gate as the Reviewer Lifecycle above (#3381): a wake-only,
+    # verdict-free role (de-roled simplifier) gets no reviewer-coordination
+    # guidance, since it never ACK/NACKs.
+    if is_reviewer and casts_real_verdicts:
         lines.extend(
             [
                 "**As a reviewer**, when you need clarification before "

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5387,7 +5387,62 @@ def _get_refine_review_criteria() -> str:
         "the agent must re-run `egg-contract add-decision` or "
         "`egg-contract add-feedback` for each question.\n"
         "- If there are zero open questions, verify that the requirements are "
-        "genuinely unambiguous and no assumptions were made silently.\n"
+        "genuinely unambiguous and no assumptions were made silently.\n\n"
+        + _human_companion_review_criteria(
+            companion="`*-analysis-human.md`",
+            parent="the refine analysis",
+            producer="refiner",
+        )
+    )
+
+
+def _human_companion_review_criteria(*, companion: str, parent: str, producer: str) -> str:
+    """Forcing checklist for verifying the simplifier's human companion.
+
+    Shared by the refine and plan reviewer rubrics so the companion is
+    judged at VERDICT time (#3381), not merely mentioned in the reviewer's
+    "while waiting" preparation text. The simplifier is a producer-only role
+    whose companion is gated CRITICAL by this reviewer; the companion is the
+    only artifact with no automated content check, so this reviewer is the
+    sole gate on its format. Walk every item before ACKing the **simplifier**
+    (this section governs the simplifier's proposal, never the {producer}'s).
+    """
+    return (
+        f"### Human-Focused Companion ({companion} — the simplifier's "
+        "proposal)\n"
+        f"The simplifier produces {companion}, a plain-language companion to "
+        f"{parent} for a **broad audience — engineers, PMs, and managers**. "
+        "It is gated CRITICAL by you and has no automated content check, so "
+        "you are the only gate on its format. **You must walk this checklist "
+        "and answer every item before you ACK the simplifier** (this is a "
+        f"separate verdict from your review of the {producer}; NACK the "
+        "**simplifier**, never the "
+        f"{producer}, for companion defects):\n"
+        f"1. **Is it a summary, not a review?** Open {companion} and the full "
+        f"{parent} side-by-side. NACK if the companion reads as a "
+        "review/critique of the draft rather than a summary of it — any "
+        'verdict/scoring framing ("verdict", "what I verified", "I '
+        'affirm", "sound", ACK/NACK language), any directives aimed at a '
+        'later phase ("the plan should commit to", "don\'t let the plan '
+        'inflate", "guardrails", "anti-pattern to reject"), or any '
+        "constraint lists. The companion explains the change to a human; it "
+        "does not judge it.\n"
+        "2. **Is it free of implementation minutiae?** NACK if it contains "
+        "`file:line` references (e.g. `foo.go::Bar` / `L209`), function / "
+        "struct / field / type names or other code identifiers, or per-field "
+        "enumerations. It should describe behaviour and user-visible impact, "
+        "not the code.\n"
+        "3. **Is it materially lighter than the parent?** NACK if it is a "
+        "near-copy or as long/dense as the full draft. It must be "
+        "substantially shorter and more digestible — plain prose and short "
+        "lists.\n"
+        "4. **Is it readable by a non-engineer?** NACK if a PM or manager "
+        "could not follow *what is changing and why it matters*, or if it "
+        "leaks egg-internal jargon (BRC, consensus, slice-DAG, contract, "
+        "phase, agent-role terms).\n"
+        f"5. **Is it faithful?** NACK if it misrepresents {parent}, omits a "
+        "material point, or introduces new scope/claims.\n"
+        "A missing or empty companion is a NACK — it is mandatory.\n"
     )
 
 
@@ -5623,7 +5678,12 @@ def _get_plan_review_criteria() -> str:
         "Belt-and-suspenders self-check: "
         '`python3 -c "from egg_contracts.plan_parser import parse_plan_file, '
         "validate_slice_file_overlap as v; r = parse_plan_file('<plan-path>'); "
-        "print('\\n'.join(v(r.to_contract_slices())))\"`.\n"
+        "print('\\n'.join(v(r.to_contract_slices())))\"`.\n\n"
+        + _human_companion_review_criteria(
+            companion="`*-plan-human.md`",
+            parent="the implementation plan",
+            producer="task_planner",
+        )
     )
 
 
@@ -13207,39 +13267,36 @@ def _build_brc_preamble(
     # (after the tester has proposed) likewise re-invoke the tester to
     # handle the Reviewer Lifecycle for those events.
     if is_dual_role and role_value == "simplifier":
-        # The simplifier is dual-role but ASYMMETRIC: its primary job is the
-        # producer one (the human-focused companion); the reviewer edge is
-        # advisory-only (the event-pump wake-up arm). It must NOT inherit the
-        # tester's review-and-harden banner below, which primes an ACK/NACK
-        # mental model and leads the companion to come out as a critique of
-        # the upstream draft instead of a plain-language summary.
+        # The simplifier carries an advisory review edge over the upstream
+        # producer PURELY as the event-pump wake-wire — it is what re-invokes
+        # the simplifier when the upstream proposes. It is NOT a reviewer in
+        # any behavioural sense: it issues no verdict, casts no ACK/NACK, and
+        # never critiques the draft (#3381). Treating it as a reviewer is what
+        # made the companion come out as a review/critique memo instead of a
+        # plain-language summary. So it gets a PRODUCER-ONLY banner here and
+        # must NOT inherit the tester's review-and-harden banner below.
         lines.append(
-            "### Dual-Role Execution Order (READ FIRST — simplifier)\n\n"
-            "You are dual-role, but the two roles are **not symmetric**. Your "
-            "PRIMARY job is the PRODUCER one: writing a plain-language, "
-            "human-focused companion to the upstream producer's draft. Your "
-            "reviewer edge is **advisory only** — it exists so the event pump "
-            "re-invokes you when the upstream producer proposes, and your "
-            "verdict never blocks consensus.\n\n"
+            "### Execution Order (READ FIRST — simplifier)\n\n"
+            "You are a **producer only**: your single job is to write a "
+            "plain-language, human-focused companion to the upstream "
+            "producer's draft. You do **not** review, critique, score, or "
+            "vote on that draft — you never issue an ACK or a NACK. (An "
+            "internal wake-wire re-invokes you when the upstream proposes so "
+            "you know its draft is ready; consensus never waits on a verdict "
+            "from you, so there is nothing to respond to.)\n\n"
             "**Execute in this order:**\n\n"
-            "1. **Producer ORIENT (FIRST).** Read the contract and orient. "
-            "Your producer WORK depends on the upstream producer's draft "
-            "existing, so you begin writing only once that producer issues "
-            "`CONSENSUS_PROPOSE` — the event-pump wrapper re-invokes you "
-            "carrying that proposal. Do not race ahead before the draft "
-            "exists.\n"
+            "1. **ORIENT (FIRST).** Read the contract and orient. Your work "
+            "depends on the upstream producer's draft existing, so you begin "
+            "writing only once that producer issues `CONSENSUS_PROPOSE` — the "
+            "event-pump wrapper re-invokes you carrying that proposal. Do not "
+            "race ahead before the draft exists.\n"
             "2. **On the upstream producer's PROPOSE**, the wrapper re-invokes "
             "you with the proposal in your event payload. SYNC the worktree, "
             "read the draft, then write and PROPOSE the human-focused "
-            "companion (see Producer role below).\n"
-            "3. **Issue your advisory verdict in the same pass.** ACK the "
-            "upstream producer (you read its draft to summarise it); NACK "
-            "only if the draft is too incoherent or incomplete to summarise "
-            "faithfully. **Any critique you have belongs in this verdict and "
-            "its message — NEVER in the companion document.** The companion "
-            "is a simplified summary written *for humans to read*, not a "
-            "review of the draft, not a list of constraints the draft should "
-            "satisfy, and not an ACK/NACK rationale.\n"
+            "companion (see Producer role below). That is the whole job — "
+            "the companion is a simplified summary written *for humans to "
+            "read*, never a review of the draft, a list of constraints the "
+            "draft should satisfy, or an ACK/NACK rationale.\n"
         )
     elif is_dual_role:
         lines.append(
@@ -13440,16 +13497,14 @@ def _build_brc_preamble(
                 "invocation; subsequent invocations land you directly at "
                 "step 3 (SYNC) with the proposal already in context."
                 + (
-                    "\n\n   **Dual-role agents (you)** — per the "
-                    "*Dual-Role Execution Order* banner above (simplifier): "
-                    "your first invocation does ORIENT/PREPARE only. On the "
-                    "upstream producer's `CONSENSUS_PROPOSE` the wrapper "
-                    "re-invokes you with the proposal in your event payload; "
-                    "SYNC, write and PROPOSE your human-focused companion, "
-                    "then issue your ADVISORY ACK/NACK on the upstream "
-                    "producer in the same invocation. Your verdict is "
-                    "advisory and never blocks consensus — keep any critique "
-                    "in that verdict, never in the companion document."
+                    "\n\n   **You (simplifier) are a producer only** — per the "
+                    "*Execution Order* banner above: your first invocation does "
+                    "ORIENT/PREPARE only. On the upstream producer's "
+                    "`CONSENSUS_PROPOSE` the wrapper re-invokes you with the "
+                    "proposal in your event payload; SYNC, then write and "
+                    "PROPOSE your human-focused companion. That is the whole "
+                    "job — you do not review the draft, and you issue no "
+                    "ACK/NACK on it."
                     if role_value == "simplifier"
                     else "\n\n   **Dual-role agents (you)** — per the "
                     "*Dual-Role Execution Order* banner above (updated "
@@ -14142,13 +14197,13 @@ def _build_producer_orientation(
             "keep their review criteria in mind as you work."
         )
 
-    # The simplifier runs in both the refine and plan phases and is
-    # DUAL-ROLE (advisory reviewer of the upstream producer + producer of
-    # the human-focused companion). Its producer WORK depends on the
-    # upstream producer's draft existing, so — like the implement-phase
-    # tester — it orients up-front and starts producing only once the
-    # upstream proposes (the event pump re-invokes it on that PROPOSE via
-    # its advisory review arm).
+    # The simplifier runs in both the refine and plan phases as a PRODUCER
+    # ONLY (the human-focused companion). It carries an advisory review edge
+    # over the upstream producer purely as the event-pump wake-wire — that is
+    # what re-invokes it on the upstream's PROPOSE — but it issues no verdict
+    # and never reviews the draft (#3381). Its work depends on the upstream
+    # producer's draft existing, so — like the implement-phase tester — it
+    # orients up-front and starts producing only once the upstream proposes.
     if role_value == "simplifier":
         if phase == "plan":
             upstream, draft_desc = "task_planner", "the implementation plan"
@@ -14161,7 +14216,7 @@ def _build_producer_orientation(
                 f"`git fetch origin && git merge origin/{branch} --no-edit`."
             )
         return (
-            f"your producer WORK depends on **{upstream}**'s draft of {draft_desc} "
+            f"your WORK depends on **{upstream}**'s draft of {draft_desc} "
             "existing — do NOT write your companion before it is pushed. ORIENT "
             "now (read the contract and the issue/task description so you "
             "understand the subject), then exit; the event pump re-invokes you "
@@ -14170,11 +14225,9 @@ def _build_producer_orientation(
             "upstream draft, then write a simplified, higher-level companion "
             "that captures its essence in plain, jargon-free language for a "
             "broad audience (engineers, PMs, and managers) — a summary, NOT a "
-            "review of the draft — and PROPOSE it. In the same "
-            f"pass, issue your ADVISORY review verdict on **{upstream}** — ACK "
-            "(you read the draft to summarize it), or NACK only if the draft is "
-            "too incoherent to faithfully summarize. Your verdict is advisory "
-            f"and never blocks **{upstream}**'s consensus." + sync_note + reviewer_awareness
+            "review of the draft — and PROPOSE it. That is the whole job: you "
+            f"do NOT review **{upstream}**'s draft and you issue no ACK or NACK "
+            "on it." + sync_note + reviewer_awareness
         )
 
     if phase == "implement":
@@ -15388,13 +15441,13 @@ def _build_agent_prompt(
             _essence = "the problem, the recommended approach, and the key trade-offs"
         lines.extend(
             [
-                "**You are dual-role (producer AND advisory reviewer) in this "
-                "phase.** You produce a human-focused companion to "
-                f"{_upstream_draft}, and you carry an ADVISORY review edge over "
-                f"**{_upstream}** purely so the event pump re-invokes you when it "
-                "proposes — your verdict never blocks its consensus. The "
-                "*Dual-Role Execution Order* banner in your BRC preamble is the "
-                "authoritative ordering — read it first.",
+                "**You are a producer only in this phase.** You produce a "
+                f"human-focused companion to {_upstream_draft}. You do NOT "
+                f"review **{_upstream}**'s draft, and you issue no ACK or NACK "
+                "on it: an internal wake-wire re-invokes you when it proposes "
+                "so you know its draft is ready, and consensus never waits on a "
+                "verdict from you. The *Execution Order* banner in your BRC "
+                "preamble is the authoritative ordering — read it first.",
                 "",
                 "## Producer role (human-focused companion)",
                 "",
@@ -15426,8 +15479,8 @@ def _build_agent_prompt(
                 "   - **This is NOT a review.** Do not critique, score, or gate "
                 'the upstream draft. No ACK/NACK language, no "the draft should '
                 'commit to …", no "anti-pattern to reject", no constraint '
-                "lists. Any critique you have goes in your advisory reviewer "
-                "verdict (below), never in this document.",
+                "lists. You have no critique to record anywhere — your only "
+                "output is this plain-language summary.",
                 "   - **Much shorter and more digestible** than the upstream "
                 "draft — plain prose and short lists, not exhaustive enumeration.",
                 "   - **Faithful** — reflect the upstream draft accurately; "
@@ -15436,16 +15489,7 @@ def _build_agent_prompt(
                 f"3. Commit and push `{_human_path}`, then PROPOSE it via "
                 "`egg-orch consensus propose`. The companion is **mandatory** — "
                 "always write at least a one-paragraph summary; do NOT take the "
-                "no-op propose path.",
-                "",
-                f"## Reviewer role (advisory, on {_upstream})",
-                "",
-                f"When **{_upstream}** proposes, emit an ADVISORY verdict in the "
-                "same pass: `egg-orch consensus ack` (you read the draft to "
-                "summarize it), or `egg-orch consensus nack` **only** if the "
-                "draft is too incoherent or incomplete to summarize faithfully. "
-                "Advisory means your verdict is recorded but never blocks "
-                f"**{_upstream}**'s consensus.",
+                "no-op propose path. That completes your work for this phase.",
                 "",
                 *_EXPLORATION_SUBAGENT_GUIDANCE,
             ]

--- a/orchestrator/tests/test_consensus_next_action.py
+++ b/orchestrator/tests/test_consensus_next_action.py
@@ -593,6 +593,94 @@ def test_advisory_reviewer_can_confirm_after_producer_confirmed(client, advisory
 
 
 # ---------------------------------------------------------------------------
+# Wake-only edge (#3381 / #3382-review): the de-roled simplifier carries an
+# ADVISORY wake_only edge over the upstream producer PURELY as the
+# event-pump wake-wire. It casts no verdict, so that edge must impose NO
+# review obligation — never a spawn-able ``ack`` and never a confirm block.
+# These are BEHAVIORAL guards over the next-action derivation (the prompt
+# de-roling is covered separately in test_pipeline_prompts.py).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def simplifier_refine_tracker():
+    """The real refine-phase graph: refiner (producer) + its two CRITICAL
+    reviewers + the simplifier, which is a PRODUCER of the human companion
+    and carries a WAKE-ONLY advisory edge over the refiner.
+    """
+    from review_graph import get_default_refine_graph
+
+    t = PeerConsensusTracker(PIPELINE_ID, get_default_refine_graph(), cooldown_seconds=0)
+    for role in ("refiner", "reviewer_refine", "reviewer_agent_design", "simplifier"):
+        t.register_agent(role)
+    return t
+
+
+def test_wake_only_simplifier_never_routed_to_ack(client, simplifier_refine_tracker):
+    """Blocking #3382 finding: for the whole window the refiner is PROPOSED,
+    the de-roled simplifier must derive a quiet ``wait`` — never a spawn-able
+    ``ack``.
+
+    Pre-fix, ``_has_pending_peer_proposals`` did not skip the advisory
+    wake-only edge, so the simplifier (which now casts no verdict) was
+    derived ``ack`` for the entire span ``[refiner proposes → refiner
+    confirms]`` and got re-spawned on every 5s poll — invoking an agent that
+    could no longer satisfy the event, and risking a companion re-PROPOSE
+    that invalidates reviewer_refine's ACK. The wake_only flag restores the
+    self-terminating wake-wire without reintroducing a verdict.
+    """
+    t = simplifier_refine_tracker
+    _propose(t, "refiner")
+    _propose(t, "simplifier")  # the human-focused companion
+
+    # Refiner is PROPOSED and the simplifier has not (and never will) cast a
+    # verdict on it. Repeated derivations must stay ``wait``, not ``ack``.
+    for _ in range(3):
+        resp = _post_next_action(client, "simplifier", tracker=t)
+        _assert_action(resp, "wait")
+
+    # Even once the refiner is fully ACKed by its CRITICAL reviewers (the
+    # full pre-fix re-spawn window), the simplifier still owes it no verdict.
+    _ack(t, "reviewer_refine", "refiner", version=1)
+    _ack(t, "reviewer_agent_design", "refiner", version=1)
+    resp = _post_next_action(client, "simplifier", tracker=t)
+    _assert_action(resp, "wait")
+
+
+def test_wake_only_simplifier_confirms_without_verdict(client, simplifier_refine_tracker):
+    """The phase must CONVERGE: the simplifier confirms its companion once
+    reviewer_refine ACKs it, WITHOUT ever casting a verdict on the refiner,
+    and global consensus completes.
+    """
+    t = simplifier_refine_tracker
+    _propose(t, "refiner")
+    _propose(t, "simplifier")
+    # Refiner's CRITICAL reviewers ACK it; the simplifier never does.
+    _ack(t, "reviewer_refine", "refiner", version=1)
+    _ack(t, "reviewer_agent_design", "refiner", version=1)
+    # reviewer_refine ACKs the companion (the simplifier's only CRITICAL reviewer).
+    _ack(t, "reviewer_refine", "simplifier", version=1)
+
+    # The wake-only edge over the refiner imposes no review obligation, so
+    # the simplifier is now eligible to confirm.
+    resp = _post_next_action(client, "simplifier", tracker=t)
+    _assert_action(resp, "confirm")
+
+    # Drive everyone to CONFIRMED — consensus completes with no simplifier verdict.
+    t.handle_confirmed("refiner")
+    t.handle_confirmed("simplifier")
+    t.handle_confirmed("reviewer_refine")
+    t.handle_confirmed("reviewer_agent_design")
+    assert t.evaluate()["is_complete"] is True
+    # The simplifier never cast a verdict on the refiner — its wake-only
+    # matrix entry stays at the registration-time PENDING (never ACK/NACK).
+    from approval_matrix import ApprovalState
+
+    entry = t.matrix.get_entry("simplifier", "refiner")
+    assert entry is None or entry.state == ApprovalState.PENDING
+
+
+# ---------------------------------------------------------------------------
 # Edge cases — these are NOT in the 9-case list but cover regressions
 # the route would otherwise allow.
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_consensus_next_action.py
+++ b/orchestrator/tests/test_consensus_next_action.py
@@ -680,6 +680,35 @@ def test_wake_only_simplifier_confirms_without_verdict(client, simplifier_refine
     assert entry is None or entry.state == ApprovalState.PENDING
 
 
+def test_wake_only_simplifier_woken_to_propose_by_propose_arm(client, simplifier_refine_tracker):
+    """#3382 non-blocking-3: the simplifier's wake-to-propose is the producer
+    ``propose`` arm, NOT its wake-only advisory edge.
+
+    The two tests above ``_propose(t, "simplifier")`` first, driving the FSM
+    straight to PROPOSED and skipping the WORKING-state wake. This test covers
+    the actual wake mechanism the corrected comments point at: a WORKING
+    producer re-derives ``propose`` on every poll (the event loop's re-spawn
+    of a legitimate orient-and-exit is what wakes it — see
+    ``test_event_loop.py::test_stale_exit_is_a_non_trigger_through_loop``).
+    The wake-only edge over the refiner contributes nothing here: the
+    simplifier derives ``propose`` regardless of whether the refiner has
+    proposed, so it is never gated on (and never ``ack``s) the advisory edge.
+    """
+    t = simplifier_refine_tracker
+
+    # WORKING simplifier, refiner has NOT yet proposed: the simplifier is woken
+    # to propose its companion by the propose arm, not by any upstream event.
+    for _ in range(3):
+        resp = _post_next_action(client, "simplifier", tracker=t)
+        _assert_action(resp, "propose")
+
+    # The refiner proposing does not change the simplifier's own wake-to-propose
+    # (it is not routed to ``ack`` for the wake-only edge).
+    _propose(t, "refiner")
+    resp = _post_next_action(client, "simplifier", tracker=t)
+    _assert_action(resp, "propose")
+
+
 # ---------------------------------------------------------------------------
 # Edge cases — these are NOT in the 9-case list but cover regressions
 # the route would otherwise allow.

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -6347,6 +6347,43 @@ class TestDualRoleExecutionOrdering:
         )
         assert "### Dual-Role Execution Order" not in coder_preamble
 
+    def test_genuine_reviewer_keeps_lifecycle_in_review_graph_fallback(self, monkeypatch):
+        """The ``casts_real_verdicts`` gate (#3381) must NOT silently strip the
+        Reviewer Lifecycle from a *genuine* reviewer when the ``review_graph``
+        load fails. In the fallback ``producers == []`` for every role, so a
+        naive ``bool(real_producers)`` gate would degrade every reviewer to
+        PARTICIPANT; the fallback instead reverts to raw ``is_reviewer``. The
+        simplifier — the only wake_only role — must still be producer-only."""
+        import review_graph
+
+        def _raise(*_args, **_kwargs):
+            raise RuntimeError("simulated review_graph failure")
+
+        monkeypatch.setattr(review_graph, "get_review_graph_for_phase", _raise)
+
+        # Genuine pure reviewers retain the full reviewer playbook even in the
+        # degraded path (the fallback is the last line of defense, not a
+        # degraded mode that strips real reviewers).
+        for role, phase in (
+            ("reviewer_code", "implement"),
+            ("reviewer_refine", "refine"),
+            ("reviewer_plan", "plan"),
+        ):
+            preamble = _build_brc_preamble(role, phase)
+            assert "### Reviewer Lifecycle" in preamble, (
+                f"Genuine reviewer {role!r} must keep its Reviewer Lifecycle "
+                "in the review_graph fallback — the casts_real_verdicts gate "
+                "must revert to raw is_reviewer when the graph is unavailable."
+            )
+            assert "Your role type: **REVIEWER**" in preamble
+
+        # The de-roled simplifier stays producer-only in the fallback: no
+        # Reviewer Lifecycle, no ACK/NACK template.
+        for phase in ("refine", "plan"):
+            simplifier_preamble = _build_brc_preamble("simplifier", phase)
+            assert "### Reviewer Lifecycle" not in simplifier_preamble
+            assert "egg-orch consensus nack <role>" not in simplifier_preamble
+
 
 # ---------------------------------------------------------------------------
 # #2527 — plan reviewer's task role↔files alignment check

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -4599,6 +4599,28 @@ class TestSimplifierHumanCompanionPrompt:
         # The banner explicitly tells it it issues no ACK/NACK.
         assert "you never issue an ack or a nack" in lowered
 
+    def test_simplifier_preamble_has_no_reviewer_lifecycle(self):
+        """#3381: the de-roled simplifier is a producer only, so by the
+        project's own invariant (see ``test_producer_only_no_sync_step`` for
+        the coder) it must NOT receive the Reviewer Lifecycle or the
+        ``As a reviewer`` coordination block. Gating those blocks on
+        ``casts_real_verdicts`` rather than raw ``is_reviewer`` keeps the
+        wake-only advisory edge from leaking a full ACK/NACK + adversarial
+        re-review playbook that contradicts the producer-only banner."""
+        for phase in ("refine", "plan"):
+            preamble = _build_brc_preamble(
+                "simplifier",
+                phase,
+                repo="egg",
+                branch="egg/issue-1/work",
+                base_branch="main",
+            )
+            assert "### Reviewer Lifecycle" not in preamble, phase
+            assert "egg-orch consensus nack <role>" not in preamble, phase
+            assert "**As a reviewer**" not in preamble, phase
+            # No adversarial re-review mandate either.
+            assert "NACK without hesitance" not in preamble, phase
+
     def test_simplifier_agent_prompt_has_no_reviewer_section(self):
         """#3381: the simplifier agent prompt must not carry a reviewer-role
         section instructing an advisory ACK/NACK on the upstream."""

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -4620,6 +4620,13 @@ class TestSimplifierHumanCompanionPrompt:
             assert "**As a reviewer**" not in preamble, phase
             # No adversarial re-review mandate either.
             assert "NACK without hesitance" not in preamble, phase
+            # Producer Lifecycle step 6 must not leak dual-role reviewer
+            # framing to the producer-only simplifier, nor a dangling
+            # cross-reference to a Reviewer Lifecycle section it no longer
+            # receives.
+            assert "re-review and ACK/NACK the new proposal" not in preamble, phase
+            assert "dual-role agents handle both" not in preamble, phase
+            assert "Reviewer Lifecycle step" not in preamble, phase
 
     def test_simplifier_agent_prompt_has_no_reviewer_section(self):
         """#3381: the simplifier agent prompt must not carry a reviewer-role

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -4562,10 +4562,11 @@ class TestSimplifierHumanCompanionPrompt:
     ``file:line`` / struct-field detail.
     """
 
-    def test_simplifier_gets_own_banner_not_tester_banner(self):
-        """The dual-role simplifier must get its own producer-first banner, not
-        the tester's review-and-harden banner (which primed the ACK/NACK
-        mental model that turned the companion into a critique)."""
+    def test_simplifier_gets_producer_only_banner_not_tester_banner(self):
+        """The simplifier must get its own PRODUCER-ONLY banner, not the
+        tester's review-and-harden banner (which primed the ACK/NACK mental
+        model that turned the companion into a critique). Per #3381 the
+        simplifier issues no verdict at all."""
         preamble = _build_brc_preamble(
             "simplifier",
             "refine",
@@ -4573,12 +4574,45 @@ class TestSimplifierHumanCompanionPrompt:
             branch="egg/issue-1/work",
             base_branch="main",
         )
-        assert "Dual-Role Execution Order (READ FIRST — simplifier)" in preamble
+        assert "Execution Order (READ FIRST — simplifier)" in preamble
+        assert "producer only" in preamble
         # The tester-specific banner and its hardening language must be absent.
         assert "coder-owns-tests" not in preamble
         assert "hardening the coder's tests" not in preamble
-        # Critique belongs in the verdict, never in the companion document.
-        assert "NEVER in the companion document" in preamble
+
+    def test_simplifier_banner_issues_no_verdict(self):
+        """#3381: the simplifier must not be told to issue an ACK/NACK or
+        verdict on the upstream draft — being a reviewer is what made the
+        companion come out review-shaped. The advisory edge stays in the
+        review graph purely as the event-pump wake-wire."""
+        preamble = _build_brc_preamble(
+            "simplifier",
+            "refine",
+            repo="egg",
+            branch="egg/issue-1/work",
+            base_branch="main",
+        )
+        lowered = preamble.lower()
+        # No instruction to cast a verdict on the upstream draft.
+        assert "issue your advisory verdict" not in lowered
+        assert "advisory ack/nack" not in lowered
+        # The banner explicitly tells it it issues no ACK/NACK.
+        assert "you never issue an ack or a nack" in lowered
+
+    def test_simplifier_agent_prompt_has_no_reviewer_section(self):
+        """#3381: the simplifier agent prompt must not carry a reviewer-role
+        section instructing an advisory ACK/NACK on the upstream."""
+        result = _build_agent_prompt(
+            role_value="simplifier",
+            phase="refine",
+            pipeline_id="pid-1",
+            pipeline_mode="issue",
+            prompt="# Feature\n\nDetail.",
+            issue_number=1,
+        )
+        assert "## Reviewer role" not in result
+        assert "emit an ADVISORY verdict" not in result
+        assert "producer only" in result
 
     def test_tester_banner_unchanged_for_tester(self):
         """The simplifier carve-out must not disturb the tester's banner."""
@@ -4641,6 +4675,31 @@ class TestSimplifierHumanCompanionPrompt:
         assert "side-by-side with the full plan" in prep
         assert "broad audience" in prep
         assert "review/critique" in prep
+
+    def test_refine_verdict_rubric_includes_companion_checklist(self):
+        """#3381 (gate side): the companion checklist must live in the refine
+        reviewer's VERDICT rubric, not just its 'while waiting' prep text —
+        the prep text is not the rubric the reviewer runs at ACK/NACK time, so
+        the gate had no companion criteria and ACKed a review-shaped doc."""
+        criteria = _get_refine_review_criteria()
+        assert "Human-Focused Companion" in criteria
+        assert "*-analysis-human.md" in criteria
+        # Forcing language + the specific defects it must NACK on.
+        assert "before you ACK the simplifier" in criteria
+        assert "summary, not a review" in criteria
+        assert "file:line" in criteria
+        assert "materially lighter" in criteria
+        # NACK the simplifier, never the producer it summarises.
+        assert "NACK the **simplifier**, never the refiner" in criteria
+
+    def test_plan_verdict_rubric_includes_companion_checklist(self):
+        """The plan reviewer's verdict rubric carries the same forcing
+        companion checklist, scoped to the plan companion + task_planner."""
+        criteria = _get_plan_review_criteria()
+        assert "Human-Focused Companion" in criteria
+        assert "*-plan-human.md" in criteria
+        assert "before you ACK the simplifier" in criteria
+        assert "NACK the **simplifier**, never the task_planner" in criteria
 
     def test_tester_orientation_contains_dual_mandate_pointer(self):
         """Tester orientation carries a brief dual-mandate pointer, NOT the

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -6377,6 +6377,20 @@ class TestDualRoleExecutionOrdering:
             )
             assert "Your role type: **REVIEWER**" in preamble
 
+        # risk_analyst is a genuine *dual-role* reviewer in the plan graph
+        # (CRITICAL reviewer of architect + task_planner, #2809) and a producer
+        # of the risk register. The fallback is_reviewer set must list it so the
+        # degraded path keeps its Reviewer Lifecycle instead of stripping it to
+        # producer-only — matching the live plan graph.
+        risk_analyst_preamble = _build_brc_preamble("risk_analyst", "plan")
+        assert "### Reviewer Lifecycle" in risk_analyst_preamble, (
+            "risk_analyst is a genuine plan-graph reviewer; the review_graph "
+            "fallback must keep its Reviewer Lifecycle rather than degrade it "
+            "to producer-only."
+        )
+        dual_role_label = "Your role type: **PRODUCER and REVIEWER (dual role)**"
+        assert dual_role_label in risk_analyst_preamble
+
         # The de-roled simplifier stays producer-only in the fallback: no
         # Reviewer Lifecycle, no ACK/NACK template.
         for phase in ("refine", "plan"):


### PR DESCRIPTION
Fixes #3381.

The simplifier's `*-analysis-human.md` / `*-plan-human.md` companion kept coming out as a review/verification memo (verdict framing, `file:line` detail, plan-phase directives) even after #3376/#3377. Per the issue there are **two independent failures**; this PR fixes each at its root. No automated keyword guard — the reviewer remains the content gate, as requested.

## Problem A — production side: the doc was the wrong format from the start

Even post-#3376 the simplifier was still *structurally a reviewer*: both prompt paths (`_build_producer_orientation` and the `_build_agent_prompt` "## Reviewer role" section) required it to emit an ADVISORY ACK/NACK verdict on the upstream draft in the same pass. So the agent entered every invocation wearing a reviewer hat and its output came out review-shaped. #3376 fenced the companion section ("not a review *here*") but left the role identity intact — fencing can't beat "you *are* the reviewer of this draft."

- Strip **all** reviewer/verdict semantics from the three simplifier prompt blocks (the dual-role banner, the dual-role-agents note, `_build_producer_orientation`, and the `_build_agent_prompt` reviewer-role section). The simplifier is now a **producer only**: the upstream's `CONSENSUS_PROPOSE` is purely its cue to read-and-summarize; it issues no ACK/NACK.
- The advisory review edge **stays** in `review_graph.py` as the pure event-pump **wake-wire** (it's what re-invokes the simplifier on the upstream's propose; removing it reintroduces the `"v|"` first-propose dedupe deadlock).
- **No consensus-engine change needed.** `is_fully_acked` counts only CRITICAL reviewers, and the #3043 confirm-guard exclusion already drops a never-voted advisory edge once the upstream producer confirms — so the simplifier confirms normally without ever casting a verdict.

## Problem B — gate side: reviewer_refine approved it anyway

The companion criteria #3376 added lived only in `_build_reviewer_preparation` — the "while waiting, prepare by…" prep text — **not** in the rubric the reviewer runs at verdict time. `_get_refine_review_criteria` / `_get_plan_review_criteria` were entirely about the refiner/planner draft (sections 1–N) with **zero** companion criteria, and `_get_review_criteria_for_type` is keyed by reviewer **type**, not by which producer is under review. So when `reviewer_refine` rendered its verdict on the *simplifier's* companion it applied the refiner-analysis rubric, which gave it no grounds to NACK — and it ACKed by default.

- Add a forcing `_human_companion_review_criteria` checklist into **both verdict rubrics**. The reviewer must walk it before ACKing the simplifier — summary-not-review, no `file:line`/symbol detail, materially lighter than the parent, readable by a non-engineer, faithful — and NACK the **simplifier** (not the producer it summarises) on any defect.

The two are complementary: A removes the source of the bad format; B is the defense-in-depth gate that should have caught it and didn't.

## Tests

- Regression guards for the de-roled simplifier: producer-only banner, no verdict/ACK-NACK instruction, no `## Reviewer role` section.
- Verdict-rubric companion-checklist guards for both refine and plan.
- Targeted suite (`test_pipeline_prompts.py` + `test_concurrent_executor.py`): **535 pass**; `ruff` clean. Full `make test`/`make test-all` not run.