### PR TITLE
Add first_principles_reviewer with seed-redirect accept-path

### DIFF
--- a/docs/guides/concurrent-execution.md
+++ b/docs/guides/concurrent-execution.md
@@ -48,7 +48,7 @@ When concurrent execution starts, the `ConcurrentPhaseExecutor` (in `orchestrato
 
 | Phase | Spawned roles |
 |-------|--------------|
-| `refine` | `refiner`, `simplifier`, `reviewer_refine`, `reviewer_agent_design` (egg repo only) |
+| `refine` | `refiner`, `simplifier`, `reviewer_refine`, `first_principles_reviewer`, `reviewer_agent_design` (egg repo only) |
 | `plan` | `architect`, `task_planner`, `risk_analyst`, `simplifier`, `reviewer_plan` |
 | `implement` | `coder`, `tester`, `documenter`, `reviewer_code`, `reviewer_code_holistic`, `reviewer_contract`, `reviewer_security`, `reviewer_concurrency` |
 

--- a/docs/guides/sdlc-pipeline.md
+++ b/docs/guides/sdlc-pipeline.md
@@ -257,7 +257,7 @@ The orchestrator runs multiple specialized reviewers in parallel, with phase-spe
 
 | Phase | Reviewers | Focus |
 |-------|-----------|-------|
-| **Refine** | Refine, Agent-Design | Analysis quality, agent-mode alignment |
+| **Refine** | Refine, First-Principles, Agent-Design | Analysis quality, premise/direction (escalates redirects via HITL), agent-mode alignment |
 | **Plan** | Plan | Plan quality, task breakdown, alignment with analysis |
 | **Implement** | Contract, Code | Contract fulfillment, security, correctness |
 

--- a/docs/reference/agent-roles.md
+++ b/docs/reference/agent-roles.md
@@ -10,7 +10,7 @@ Every agent role belongs to one of five categories. Categories enable dynamic te
 |----------|---------|-------|
 | **EXECUTION** | Produce artifacts (code, tests, docs, Jira mutations) | `coder`, `tester`, `documenter`, `applier` |
 | **ANALYSIS** | Analyze tasks and plan work | `refiner`, `architect`, `task_planner`, `risk_analyst`, `simplifier` |
-| **REVIEW** | Validate quality and correctness | `reviewer_code`, `reviewer_code_holistic`, `reviewer_contract`, `reviewer_refine`, `reviewer_plan`, `reviewer_agent_design`, `reviewer_security`, `reviewer_concurrency` |
+| **REVIEW** | Validate quality and correctness | `reviewer_code`, `reviewer_code_holistic`, `reviewer_contract`, `reviewer_refine`, `first_principles_reviewer`, `reviewer_plan`, `reviewer_agent_design`, `reviewer_security`, `reviewer_concurrency` |
 | **UTILITY** | Cross-cutting support tasks | `autofixer`, `conflict_resolver` |
 | **INTERFACE** | Pipeline health and monitoring | `overseer` |
 
@@ -24,6 +24,7 @@ Use `get_roles_by_category(AgentCategory.REVIEW)` to dynamically query roles by 
 | `simplifier` | Analysis (dual-role: advisory reviewer of the upstream producer) | Refine + Plan | Yes | refiner (refine) / task_planner (plan), advisory |
 | `reviewer_refine` | Review | Refine | Yes (with `reviewer_agent_design`) | refiner, simplifier |
 | `reviewer_agent_design` | Review | Refine (egg repo only) | Yes (with `reviewer_refine`) | refiner |
+| `first_principles_reviewer` | Review | Refine | Yes (with `reviewer_refine`) | refiner (premise/direction; escalates via HITL, never NACKs) |
 | `architect` | Analysis | Plan | No | — |
 | `task_planner` | Analysis | Plan | Yes (with `risk_analyst`) | architect |
 | `risk_analyst` | Analysis (dual-role: also reviews `architect` + `task_planner`) | Plan | Yes (with `task_planner`) | architect |
@@ -80,6 +81,31 @@ All agents within a phase run concurrently via BRC consensus. Concurrency is ena
 
 **Outputs**:
 - `.egg-state/reviews/{identifier}-refine-agent-design-review.json` — Verdict file
+
+### `first_principles_reviewer`
+
+**Purpose**: Adversarially review the pipeline's *seed* (the operator's task statement) and the *direction* the refiner's analysis is taking — from first principles. It asks whether the premise is sound and the direction appropriate, not whether the analysis is well-written (that is `reviewer_refine`'s job). Spawned for all repos.
+
+**Escalation, not NACK**: a redirect of the seed is the operator's call, not the refiner's to fix — the seed is operator-owned and the refiner cannot rewrite it. So this role **never NACKs the refiner**. It surfaces significant redirects (a materially simpler path, a different approach, a scope change, or not building the work at all) as **phase-scoped HITL decisions** via `egg-contract add-decision --phase refine`, then ACKs the refiner. Its CRITICAL review edge guarantees it weighs in before consensus closes; an open redirect decision independently holds the refine→plan completion gate until the operator resolves it. It is fine for it to be relatively noisy, provided each redirect is concrete and evidence-backed.
+
+**Contract role**: `reviewer`. Reviewers may *create* HITL decisions (resolution stays human-only) — see `shared/egg_contracts/roles.py`.
+
+**File access**: Same as `reviewer_refine` (`.egg-state/reviews/`, `.egg-state/agent-outputs/`; no source/drafts/contracts).
+
+**Outputs**:
+- `.egg-state/reviews/{identifier}-refine-first-principles-reviewer-review.json` — Verdict file
+- `.egg-state/agent-outputs/{identifier}-first-principles.json` — proposed redirect (`proposed_task_description`), read by the accept-path on adopt
+- Phase-scoped HITL decisions on the contract (the redirects)
+
+**Accept-path**: the redirect decision carries three verbatim option labels. On the operator's choice the orchestrator acts:
+
+| Choice | Effect |
+|--------|--------|
+| Adopt the redirect | Rewrites the seed (`contract.task_description`, audited operator mutation) to the reviewer's `proposed_task_description`, commits+pushes it to the work branch, and re-runs the refine phase against it (`apply_first_principles_redirect` → `_restart_refine_phase`). |
+| Proceed as-is | No-op; the current direction stands and the decision is marked resolved. |
+| Don't build this | Cancels the pipeline. |
+
+The label↔hook match is a single source of truth (`FIRST_PRINCIPLES_*_OPTION` in `orchestrator/routes/decisions/_handlers.py`, interpolated into the reviewer prompt). Dispatch lives in `_maybe_apply_first_principles_redirect`, wired into both decision-resolve paths (the contract-fallback path is the primary trigger — the decision blocks the refine gate and is resolved pre-bridge).
 
 ### `simplifier`
 

--- a/docs/reference/agent-roles.md
+++ b/docs/reference/agent-roles.md
@@ -86,7 +86,7 @@ All agents within a phase run concurrently via BRC consensus. Concurrency is ena
 
 **Purpose**: Adversarially review the pipeline's *seed* (the operator's task statement) and the *direction* the refiner's analysis is taking — from first principles. It asks whether the premise is sound and the direction appropriate, not whether the analysis is well-written (that is `reviewer_refine`'s job). Spawned for all repos.
 
-**Escalation, not NACK**: a redirect of the seed is the operator's call, not the refiner's to fix — the seed is operator-owned and the refiner cannot rewrite it. So this role **never NACKs the refiner**. It surfaces significant redirects (a materially simpler path, a different approach, a scope change, or not building the work at all) as **phase-scoped HITL decisions** via `egg-contract add-decision --phase refine`, then ACKs the refiner. Its CRITICAL review edge guarantees it weighs in before consensus closes; an open redirect decision independently holds the refine→plan completion gate until the operator resolves it. It is fine for it to be relatively noisy, provided each redirect is concrete and evidence-backed.
+**Escalation, not NACK**: a redirect of the seed is the operator's call, not the refiner's to fix — the seed is operator-owned and the refiner cannot rewrite it. So this role **never NACKs the refiner**. It surfaces significant redirects (a materially simpler path, a different approach, a scope change, or not building the work at all) as **phase-scoped HITL decisions** via `mcp__sdlc__register_open_question` (`phase=refine`), then ACKs the refiner. Its CRITICAL review edge guarantees it weighs in before consensus closes; an open redirect decision independently holds the refine→plan completion gate until the operator resolves it. It is fine for it to be relatively noisy, provided each redirect is concrete and evidence-backed.
 
 **Contract role**: `reviewer`. Reviewers may *create* HITL decisions (resolution stays human-only) — see `shared/egg_contracts/roles.py`.
 
@@ -94,14 +94,13 @@ All agents within a phase run concurrently via BRC consensus. Concurrency is ena
 
 **Outputs**:
 - `.egg-state/reviews/{identifier}-refine-first-principles-reviewer-review.json` — Verdict file
-- `.egg-state/agent-outputs/{identifier}-first-principles.json` — proposed redirect (`proposed_task_description`), read by the accept-path on adopt
-- Phase-scoped HITL decisions on the contract (the redirects)
+- Phase-scoped HITL decisions on the contract (the redirects). When a redirect proposes a concrete new direction, the decision also carries the FULL proposed seed on its `redirect_seed` field — written through the same `register_open_question` RPC that creates the decision, so it reaches the shared pipeline worktree even though a BRC reviewer has no commit/push path of its own.
 
 **Accept-path**: the redirect decision carries three verbatim option labels. On the operator's choice the orchestrator acts:
 
 | Choice | Effect |
 |--------|--------|
-| Adopt the redirect | Rewrites the seed (`contract.task_description`, audited operator mutation) to the reviewer's `proposed_task_description`, commits+pushes it to the work branch, and re-runs the refine phase against it (`apply_first_principles_redirect` → `_restart_refine_phase`). |
+| Adopt the redirect | Rewrites the seed (`contract.task_description`, audited operator mutation) to the reviewer's `redirect_seed`, commits+pushes it to the work branch, and re-runs the refine phase against it (`apply_first_principles_redirect` → `_restart_refine_phase`). |
 | Proceed as-is | No-op; the current direction stands and the decision is marked resolved. |
 | Don't build this | Cancels the pipeline. |
 

--- a/orchestrator/kubernetes_spawner/__init__.py
+++ b/orchestrator/kubernetes_spawner/__init__.py
@@ -247,6 +247,7 @@ _ROLES_WITHOUT_WORKTREE: frozenset[AgentRole] = frozenset(
         AgentRole.REVIEWER_CONTRACT,
         AgentRole.REVIEWER_AGENT_DESIGN,
         AgentRole.REVIEWER_REFINE,
+        AgentRole.FIRST_PRINCIPLES_REVIEWER,
         AgentRole.REVIEWER_PLAN,
         AgentRole.REVIEWER_SECURITY,
         AgentRole.REVIEWER_CONCURRENCY,

--- a/orchestrator/operator_actions.py
+++ b/orchestrator/operator_actions.py
@@ -212,3 +212,98 @@ def _complete_task_locked(
         "commit": commit or getattr(task, "commit", None) or None,
         "actor": actor,
     }
+
+
+def rewrite_task_description_as_operator(
+    pipeline_id: str,
+    new_task_description: str,
+    *,
+    reason: str = "",
+    actor: str = "operator",
+    issue_number: int | None = None,
+) -> dict[str, Any]:
+    """Rewrite the pipeline's seed (``contract.task_description``) as an operator action.
+
+    The first-principles redirect accept-path calls this when an operator
+    adopts a redirect: the seed is rewritten to the proposed direction so the
+    re-run refine phase analyzes against it. Runs as ``Role.HUMAN`` — the seed
+    is otherwise immutable by agents (it is the operator-owned identity anchor),
+    which is exactly why a redirect must be a human's call. The mutation goes
+    through ``apply_mutation`` so the audit log records the actor and reason.
+
+    Returns ``{"worktree", "identifier", "prior", "new"}``. The caller is
+    responsible for durably committing+pushing the worktree to the work branch
+    so a subsequent refine restart's re-fork sees the rewrite. Raises
+    :class:`OperatorActionError` on failure.
+    """
+    new_seed = (new_task_description or "").strip()
+    if not new_seed:
+        raise OperatorActionError("new_task_description must be non-empty", status_code=400)
+
+    worktree = contract_store.resolve_pipeline_worktree(pipeline_id)
+    if worktree is None:
+        raise OperatorActionError(
+            f"No pipeline worktree found for {pipeline_id} (pipeline not "
+            f"set up on this host, or already cleaned up)",
+            status_code=404,
+        )
+
+    identifiers: list[int | str] = [pipeline_id]
+    if issue_number:
+        identifiers.append(issue_number)
+
+    audit_reason = "Operator first-principles redirect (seed rewrite)"
+    if reason:
+        audit_reason = f"{audit_reason}: {reason}"
+
+    last_error = "contract not found"
+    for identifier in identifiers:
+        with contract_store.lock_for(identifier):
+            try:
+                contract = load_contract(identifier, worktree)
+            except ContractNotFoundError:
+                continue
+            except Exception as exc:
+                last_error = str(exc)
+                continue
+
+            prior = getattr(contract, "task_description", None)
+            result = apply_mutation(
+                contract,
+                role=Role.HUMAN,
+                actor=actor,
+                field_path="task_description",
+                new_value=new_seed,
+                reason=audit_reason,
+            )
+            if not result.success:
+                raise OperatorActionError(
+                    f"task_description mutation rejected: {result.message}",
+                    status_code=400,
+                )
+
+            try:
+                save_contract(contract, worktree)
+            except Exception as exc:
+                raise OperatorActionError(
+                    f"Failed to save contract: {exc}",
+                    status_code=500,
+                ) from exc
+
+            logger.info(
+                "Operator rewrote seed for first-principles redirect",
+                identifier=str(identifier),
+                pipeline_id=pipeline_id,
+                actor=actor,
+            )
+            return {
+                "worktree": str(worktree),
+                "identifier": identifier,
+                "prior": prior,
+                "new": new_seed,
+            }
+
+    raise OperatorActionError(
+        f"Contract for {pipeline_id} not loadable ({last_error})",
+        status_code=404,
+    )

--- a/orchestrator/review_graph.py
+++ b/orchestrator/review_graph.py
@@ -227,9 +227,10 @@ def get_default_refine_graph() -> ReviewGraph:
     Review adjacency per the phase-role mappings:
     - reviewer_refine reviews refiner (critical)
     - reviewer_agent_design reviews refiner (critical)
+    - first_principles_reviewer reviews refiner (critical)
 
     Producers: refiner
-    Reviewers: reviewer_refine, reviewer_agent_design
+    Reviewers: reviewer_refine, reviewer_agent_design, first_principles_reviewer
     """
     return ReviewGraph(
         [
@@ -237,6 +238,15 @@ def get_default_refine_graph() -> ReviewGraph:
             ReviewEdge("reviewer_refine", "refiner", ReviewCriticality.CRITICAL),
             # reviewer_agent_design reviews refiner (critical)
             ReviewEdge("reviewer_agent_design", "refiner", ReviewCriticality.CRITICAL),
+            # first_principles_reviewer reviews refiner (critical). The CRITICAL
+            # edge is the "must weigh in" lever: refine consensus cannot close
+            # until this role has reviewed and ACKed the refiner. It does NOT
+            # NACK on first-principles grounds — premise/direction concerns are
+            # the operator's call, not the refiner's to fix (the seed is
+            # operator-owned), so it ACKs and raises any redirect as a
+            # phase-scoped HITL decision, which independently holds the
+            # refine→plan completion gate open until the operator resolves it.
+            ReviewEdge("first_principles_reviewer", "refiner", ReviewCriticality.CRITICAL),
             # The simplifier produces the human-focused analysis companion
             # (faithful + jargon-free), gated CRITICAL by reviewer_refine.
             # It is a PRODUCER ONLY (#3381): the propose-arm wakes it to

--- a/orchestrator/routes/decisions/__init__.py
+++ b/orchestrator/routes/decisions/__init__.py
@@ -85,10 +85,17 @@ from ._graph_mutations import (  # noqa: E402,F401
 )
 from ._handlers import (  # noqa: E402,F401
     _COMPLETE_TASK_RESOLUTION_RE,
+    FIRST_PRINCIPLES_ADOPT_OPTION,
+    FIRST_PRINCIPLES_CANCEL_OPTION,
+    FIRST_PRINCIPLES_OPTIONS,
+    FIRST_PRINCIPLES_PROCEED_OPTION,
+    _cancel_pipeline_in_process,
     _handle_conditional_ack_gate,
     _handle_restart_agent,
+    _maybe_apply_first_principles_redirect,
     _maybe_complete_task_from_resolution,
     _normalize_choice_resolution,
+    _read_first_principles_redirect,
 )
 from ._resolve import (  # noqa: E402,F401
     _outstanding_contract_hitl,

--- a/orchestrator/routes/decisions/_handlers.py
+++ b/orchestrator/routes/decisions/_handlers.py
@@ -310,3 +310,218 @@ def _maybe_complete_task_from_resolution(
         commit=commit,
     )
     return {"action": "complete_task", "success": True, **result}
+
+
+# ---------------------------------------------------------------------------
+# First-principles redirect accept-path
+# ---------------------------------------------------------------------------
+#
+# The ``first_principles_reviewer`` files a refine-phase HITL decision whose
+# options are EXACTLY these labels; the resolve hook below keys on the resolved
+# label. SINGLE SOURCE OF TRUTH — the reviewer criteria in
+# ``routes/pipelines.py`` interpolate these same strings into the agent's
+# prompt, so the label the agent writes and the label this hook matches can
+# never drift. The reviewer also commits the proposed new direction to
+# ``FIRST_PRINCIPLES_ARTIFACT_TEMPLATE``; ``adopt`` reads it back from there.
+FIRST_PRINCIPLES_ADOPT_OPTION = "Adopt the redirect (rewrite the seed and re-run the refine phase)"
+FIRST_PRINCIPLES_PROCEED_OPTION = "Proceed as-is (the current direction stands)"
+FIRST_PRINCIPLES_CANCEL_OPTION = "Don't build this (cancel the pipeline)"
+FIRST_PRINCIPLES_OPTIONS = (
+    FIRST_PRINCIPLES_ADOPT_OPTION,
+    FIRST_PRINCIPLES_PROCEED_OPTION,
+    FIRST_PRINCIPLES_CANCEL_OPTION,
+)
+FIRST_PRINCIPLES_ARTIFACT_TEMPLATE = ".egg-state/agent-outputs/{identifier}-first-principles.json"
+
+
+def _read_first_principles_redirect(pipeline_id: str, pipeline: Any) -> str | None:
+    """Read the reviewer's proposed redirect (the new seed) from its artifact.
+
+    The ``first_principles_reviewer`` commits its proposed redirect to
+    ``{identifier}-first-principles.json`` (``proposed_task_description``); the
+    ``adopt`` path reads it back here rather than relying on the lossy decision
+    bridge (the pipeline-queue ``HITLDecision.options`` is ``list[str]`` — bare
+    labels with no structured payload). Returns the stripped new seed, or
+    ``None`` when no artifact / payload is present.
+    """
+    import contract_store
+    from routes.pipelines import _pipeline_identifier
+
+    worktree = contract_store.resolve_pipeline_worktree(pipeline_id)
+    if worktree is None:
+        return None
+    identifier = _pipeline_identifier(getattr(pipeline, "issue_number", None), pipeline_id)
+    path = Path(worktree) / FIRST_PRINCIPLES_ARTIFACT_TEMPLATE.format(identifier=identifier)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError, json.JSONDecodeError:
+        logger.warning(
+            "First-principles artifact present but unreadable",
+            pipeline_id=pipeline_id,
+            path=str(path),
+        )
+        return None
+    proposed = data.get("proposed_task_description") if isinstance(data, dict) else None
+    if isinstance(proposed, str) and proposed.strip():
+        return proposed.strip()
+    return None
+
+
+def _cancel_pipeline_in_process(pipeline_id: str, *, reason: str) -> None:
+    """Cancel a pipeline from a resolution hook (status CANCELLED + cleanup).
+
+    Mirrors the inline cancel pattern used elsewhere: flip status under the
+    pipeline state lock, emit ``PIPELINE_CANCELLED``, and cancel pending
+    decisions so any ``wait_for_decision`` unblocks.
+    """
+    from models import PipelineStatus
+    from state_store import get_pipeline_state_lock
+
+    store, _ = _pkg.get_state_store_for_pipeline(pipeline_id)
+    lock = get_pipeline_state_lock(pipeline_id)
+    with lock:
+        pipeline = store.load_pipeline(pipeline_id)
+        pipeline.status = PipelineStatus.CANCELLED
+        pipeline.error = reason
+        store.update_pipeline(pipeline_id, pipeline.model_dump(mode="json"))
+
+    try:
+        _pkg.emit_event(
+            EventType.PIPELINE_CANCELLED,
+            pipeline_id=pipeline_id,
+            data={"reason": reason},
+        )
+    except Exception:
+        logger.warning(
+            "Failed to emit PIPELINE_CANCELLED event after first-principles cancel",
+            pipeline_id=pipeline_id,
+            exc_info=True,
+        )
+    try:
+        queue = _pkg.get_decision_queue(pipeline_id, store.repo_path)
+        for d in queue.get_pending_decisions():
+            queue.cancel_decision(d.id)
+    except Exception:
+        logger.warning(
+            "Failed to cancel pending decisions after first-principles cancel",
+            pipeline_id=pipeline_id,
+            exc_info=True,
+        )
+
+
+def _maybe_apply_first_principles_redirect(
+    pipeline_id: str,
+    decision: Any,
+    resolution_label: str,
+    pipeline: Any,
+) -> dict[str, Any] | None:
+    """Execute a first-principles redirect resolution — the accept-path.
+
+    Keys on the resolved option label (one of ``FIRST_PRINCIPLES_OPTIONS``):
+
+    - **Adopt** → rewrite the seed to the reviewer's proposed redirect and
+      re-run the refine phase against it.
+    - **Don't build** → cancel the pipeline.
+    - **Proceed** → no-op; the current direction stands and the decision is
+      simply marked resolved.
+
+    Returns an executed-action payload merged into the resolve response, or
+    ``None`` when the resolution is not a first-principles option. Failure is
+    logged AND surfaced in the payload — the decision is already resolved by
+    the time dispatch runs, so a silent failure would strand the operator's
+    intent.
+    """
+    label = resolution_label or ""
+    if label not in FIRST_PRINCIPLES_OPTIONS:
+        return None
+
+    # Guard: only act on refine-phase first-principles decisions. The labels
+    # are specific enough to be effectively unique, but the phase check keeps a
+    # coincidental match in another phase from triggering a seed rewrite.
+    phase = getattr(decision, "phase", None)
+    phase_val = getattr(phase, "value", phase)
+    if phase_val is not None and phase_val != "refine":
+        return None
+
+    decision_id = getattr(decision, "id", "?")
+
+    if label == FIRST_PRINCIPLES_PROCEED_OPTION:
+        logger.info(
+            "First-principles redirect: operator chose proceed-as-is",
+            pipeline_id=pipeline_id,
+            decision_id=decision_id,
+        )
+        return {"action": "first_principles_redirect", "outcome": "proceed", "success": True}
+
+    if label == FIRST_PRINCIPLES_CANCEL_OPTION:
+        try:
+            _cancel_pipeline_in_process(
+                pipeline_id,
+                reason=f"first-principles redirect: operator chose not to build (decision {decision_id})",
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "First-principles cancel failed; pipeline not cancelled",
+                pipeline_id=pipeline_id,
+                decision_id=decision_id,
+                error=str(exc),
+                exc_info=True,
+            )
+            return {
+                "action": "first_principles_redirect",
+                "outcome": "cancel",
+                "success": False,
+                "error": str(exc),
+            }
+        return {"action": "first_principles_redirect", "outcome": "cancelled", "success": True}
+
+    # Adopt: rewrite the seed and re-run refine.
+    new_seed = _read_first_principles_redirect(pipeline_id, pipeline)
+    if not new_seed:
+        logger.error(
+            "First-principles adopt: no proposed redirect found in the "
+            "first-principles artifact; cannot rewrite the seed",
+            pipeline_id=pipeline_id,
+            decision_id=decision_id,
+        )
+        return {
+            "action": "first_principles_redirect",
+            "outcome": "adopt",
+            "success": False,
+            "error": "no proposed redirect found in the first-principles artifact",
+        }
+    try:
+        from routes.pipelines import apply_first_principles_redirect
+
+        agents = apply_first_principles_redirect(
+            pipeline_id, new_seed, reason=f"decision {decision_id} adopted"
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "First-principles adopt failed; seed/refine state may be partially "
+            "updated (the decision is still resolved)",
+            pipeline_id=pipeline_id,
+            decision_id=decision_id,
+            error=str(exc),
+            exc_info=True,
+        )
+        return {
+            "action": "first_principles_redirect",
+            "outcome": "adopt",
+            "success": False,
+            "error": str(exc),
+        }
+    logger.info(
+        "First-principles redirect adopted: seed rewritten, refine re-run",
+        pipeline_id=pipeline_id,
+        decision_id=decision_id,
+        agents_restarted=agents,
+    )
+    return {
+        "action": "first_principles_redirect",
+        "outcome": "adopted",
+        "success": True,
+        "agents_restarted": agents,
+    }

--- a/orchestrator/routes/decisions/_handlers.py
+++ b/orchestrator/routes/decisions/_handlers.py
@@ -393,15 +393,31 @@ def _read_redirect_seed_from_contract(pipeline_id: str, decision_id: Any) -> str
         return None
 
     decisions = getattr(contract, "decisions", None) or []
-    fallback: str | None = None
+    seed_carriers: list[tuple[Any, str]] = []
     for d in decisions:
         seed = getattr(d, "redirect_seed", None)
         if not (isinstance(seed, str) and seed.strip()):
             continue
-        if getattr(d, "id", None) == decision_id:
+        did = getattr(d, "id", None)
+        if did == decision_id:
             return seed.strip()
-        fallback = seed.strip()
-    return fallback
+        seed_carriers.append((did, seed.strip()))
+
+    if not seed_carriers:
+        return None
+    # Id miss: fall back to the sole redirect-carrying decision. With more than
+    # one candidate the choice is order-dependent (no id matched), so warn —
+    # in normal operation the reviewer files exactly one such decision.
+    if len(seed_carriers) > 1:
+        logger.warning(
+            "Ambiguous first-principles redirect fallback: %d decisions carry a "
+            "redirect_seed but none match the resolved id; using the last",
+            len(seed_carriers),
+            pipeline_id=pipeline_id,
+            decision_id=decision_id,
+            candidate_ids=[did for did, _ in seed_carriers],
+        )
+    return seed_carriers[-1][1]
 
 
 def _cancel_pipeline_in_process(pipeline_id: str, *, reason: str) -> None:

--- a/orchestrator/routes/decisions/_handlers.py
+++ b/orchestrator/routes/decisions/_handlers.py
@@ -321,8 +321,10 @@ def _maybe_complete_task_from_resolution(
 # label. SINGLE SOURCE OF TRUTH — the reviewer criteria in
 # ``routes/pipelines.py`` interpolate these same strings into the agent's
 # prompt, so the label the agent writes and the label this hook matches can
-# never drift. The reviewer also commits the proposed new direction to
-# ``FIRST_PRINCIPLES_ARTIFACT_TEMPLATE``; ``adopt`` reads it back from there.
+# never drift. The reviewer also carries the proposed new direction on the
+# decision's ``redirect_seed`` field (written through the same contract-mutate
+# RPC that creates the decision — the one channel proven to reach the shared
+# pipeline worktree); ``adopt`` reads it back from there.
 FIRST_PRINCIPLES_ADOPT_OPTION = "Adopt the redirect (rewrite the seed and re-run the refine phase)"
 FIRST_PRINCIPLES_PROCEED_OPTION = "Proceed as-is (the current direction stands)"
 FIRST_PRINCIPLES_CANCEL_OPTION = "Don't build this (cancel the pipeline)"
@@ -331,42 +333,75 @@ FIRST_PRINCIPLES_OPTIONS = (
     FIRST_PRINCIPLES_PROCEED_OPTION,
     FIRST_PRINCIPLES_CANCEL_OPTION,
 )
-FIRST_PRINCIPLES_ARTIFACT_TEMPLATE = ".egg-state/agent-outputs/{identifier}-first-principles.json"
 
 
-def _read_first_principles_redirect(pipeline_id: str, pipeline: Any) -> str | None:
-    """Read the reviewer's proposed redirect (the new seed) from its artifact.
+def _read_first_principles_redirect(pipeline_id: str, decision: Any) -> str | None:
+    """Recover the reviewer's proposed redirect (the new seed) for ``adopt``.
 
-    The ``first_principles_reviewer`` commits its proposed redirect to
-    ``{identifier}-first-principles.json`` (``proposed_task_description``); the
-    ``adopt`` path reads it back here rather than relying on the lossy decision
-    bridge (the pipeline-queue ``HITLDecision.options`` is ``list[str]`` — bare
-    labels with no structured payload). Returns the stripped new seed, or
-    ``None`` when no artifact / payload is present.
+    The ``first_principles_reviewer`` carries its proposed redirect on the
+    decision's ``redirect_seed`` field, written through the same
+    ``register_open_question`` → contract-mutate RPC that creates the decision.
+    That RPC writes **directly into the shared pipeline worktree**, so unlike a
+    free-standing file in the reviewer's per-agent worktree (which has no
+    commit/push path off it under BRC isolation) the payload actually reaches
+    the orchestrator.
+
+    The primary resolve path hands us the contract ``Decision`` itself, so the
+    field is read straight off ``decision``. The bridged queue path hands us a
+    pipeline ``HITLDecision`` (a ``list[str]`` of bare option labels with no
+    structured payload), so we fall back to reloading the contract and reading
+    ``redirect_seed`` off the matching ``cq-N`` decision. Returns the stripped
+    new seed, or ``None`` when no payload is present.
+    """
+    seed = getattr(decision, "redirect_seed", None)
+    if isinstance(seed, str) and seed.strip():
+        return seed.strip()
+    # Fallback (bridged queue path): the pipeline HITLDecision doesn't carry
+    # ``redirect_seed``; recover it from the contract decision of the same id.
+    return _read_redirect_seed_from_contract(pipeline_id, getattr(decision, "id", None))
+
+
+def _read_redirect_seed_from_contract(pipeline_id: str, decision_id: Any) -> str | None:
+    """Read ``redirect_seed`` off the contract decision ``decision_id``.
+
+    Best-effort: returns ``None`` (and logs) when the worktree/contract can't
+    be loaded or the decision carries no redirect payload. When ``decision_id``
+    doesn't resolve to a contract decision, scans for the single first-
+    principles decision carrying a ``redirect_seed`` (the reviewer is the only
+    producer of that field, so the match is unambiguous).
     """
     import contract_store
-    from routes.pipelines import _pipeline_identifier
 
-    worktree = contract_store.resolve_pipeline_worktree(pipeline_id)
-    if worktree is None:
-        return None
-    identifier = _pipeline_identifier(getattr(pipeline, "issue_number", None), pipeline_id)
-    path = Path(worktree) / FIRST_PRINCIPLES_ARTIFACT_TEMPLATE.format(identifier=identifier)
-    if not path.exists():
-        return None
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except OSError, json.JSONDecodeError:
+        from egg_contracts import load_contract
+        from routes.pipelines import _pipeline_identifier
+
+        store, _ = _pkg.get_state_store_for_pipeline(pipeline_id)
+        pipeline = store.load_pipeline(pipeline_id)
+        worktree = contract_store.resolve_pipeline_worktree(pipeline_id)
+        if worktree is None:
+            return None
+        identifier = _pipeline_identifier(getattr(pipeline, "issue_number", None), pipeline_id)
+        contract = load_contract(identifier, worktree)
+    except Exception:  # noqa: BLE001
         logger.warning(
-            "First-principles artifact present but unreadable",
+            "Could not load contract to recover first-principles redirect seed",
             pipeline_id=pipeline_id,
-            path=str(path),
+            decision_id=decision_id,
+            exc_info=True,
         )
         return None
-    proposed = data.get("proposed_task_description") if isinstance(data, dict) else None
-    if isinstance(proposed, str) and proposed.strip():
-        return proposed.strip()
-    return None
+
+    decisions = getattr(contract, "decisions", None) or []
+    fallback: str | None = None
+    for d in decisions:
+        seed = getattr(d, "redirect_seed", None)
+        if not (isinstance(seed, str) and seed.strip()):
+            continue
+        if getattr(d, "id", None) == decision_id:
+            return seed.strip()
+        fallback = seed.strip()
+    return fallback
 
 
 def _cancel_pipeline_in_process(pipeline_id: str, *, reason: str) -> None:
@@ -439,10 +474,15 @@ def _maybe_apply_first_principles_redirect(
 
     # Guard: only act on refine-phase first-principles decisions. The labels
     # are specific enough to be effectively unique, but the phase check keeps a
-    # coincidental match in another phase from triggering a seed rewrite.
+    # coincidental match outside refine from triggering a seed rewrite. The
+    # phase is always populated on both resolve paths (the contract Decision is
+    # filed with ``--phase refine``; the bridged HITLDecision auto-infers it
+    # from the pipeline's current phase, which is refine while this gate is
+    # open), so require an exact match rather than letting ``phase=None``
+    # through.
     phase = getattr(decision, "phase", None)
     phase_val = getattr(phase, "value", phase)
-    if phase_val is not None and phase_val != "refine":
+    if phase_val != "refine":
         return None
 
     decision_id = getattr(decision, "id", "?")
@@ -478,11 +518,11 @@ def _maybe_apply_first_principles_redirect(
         return {"action": "first_principles_redirect", "outcome": "cancelled", "success": True}
 
     # Adopt: rewrite the seed and re-run refine.
-    new_seed = _read_first_principles_redirect(pipeline_id, pipeline)
+    new_seed = _read_first_principles_redirect(pipeline_id, decision)
     if not new_seed:
         logger.error(
-            "First-principles adopt: no proposed redirect found in the "
-            "first-principles artifact; cannot rewrite the seed",
+            "First-principles adopt: no proposed redirect found on the "
+            "decision's redirect_seed; cannot rewrite the seed",
             pipeline_id=pipeline_id,
             decision_id=decision_id,
         )
@@ -490,7 +530,7 @@ def _maybe_apply_first_principles_redirect(
             "action": "first_principles_redirect",
             "outcome": "adopt",
             "success": False,
-            "error": "no proposed redirect found in the first-principles artifact",
+            "error": "no proposed redirect found on the decision's redirect_seed",
         }
     try:
         from routes.pipelines import apply_first_principles_redirect

--- a/orchestrator/routes/decisions/_resolve.py
+++ b/orchestrator/routes/decisions/_resolve.py
@@ -156,10 +156,21 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
         # required one was removed), so resolution just marks the decision
         # RESOLVED.
 
+        # First-principles redirect accept-path: when the operator resolves a
+        # refine-phase first-principles decision, "adopt" rewrites the seed and
+        # re-runs refine, "don't build" cancels, "proceed" is a no-op. Keyed on
+        # the resolved option label. (Primary trigger is the contract-fallback
+        # path below — these decisions block the refine gate and are resolved
+        # pre-bridge — but it is wired here too as a safety net for the bridged
+        # case.)
+        first_principles_action = _pkg._maybe_apply_first_principles_redirect(
+            pipeline_id, decision, dispatch_resolution, _pipeline
+        )
+
         # Executable task-completion option (#3124): "Mark task <id>
         # complete" performs the audited operator mutation instead of
         # leaving the operator to impersonate an agent role via pod exec.
-        executed_action = _pkg._maybe_complete_task_from_resolution(
+        executed_action = first_principles_action or _pkg._maybe_complete_task_from_resolution(
             pipeline_id, decision_id, dispatch_resolution
         )
 
@@ -488,11 +499,21 @@ def _resolve_contract_decision(
             exc_info=True,
         )
 
+    # First-principles redirect accept-path — same dispatch as the queue path.
+    # This is the PRIMARY trigger: a first_principles_reviewer redirect decision
+    # is phase-scoped to refine and blocks the refine gate, so the operator
+    # resolves it here (pre-bridge) — "adopt" rewrites the seed and re-runs
+    # refine, "don't build" cancels, "proceed" is a no-op.
+    normalized_resolution = _pkg._normalize_choice_resolution(resolution)
+    first_principles_action = _pkg._maybe_apply_first_principles_redirect(
+        pipeline_id, decision, normalized_resolution, pipeline
+    )
+
     # Executable task-completion option (#3124) — same dispatch as the
     # queue path, so a contract-resident (``cq-N``) decision resolved
     # pre-bridge also executes instead of only recording the choice.
-    executed_action = _pkg._maybe_complete_task_from_resolution(
-        pipeline_id, decision_id, _pkg._normalize_choice_resolution(resolution)
+    executed_action = first_principles_action or _pkg._maybe_complete_task_from_resolution(
+        pipeline_id, decision_id, normalized_resolution
     )
 
     return make_success_response(

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -4231,6 +4231,237 @@ def restart_phase(pipeline_id: str, phase: str) -> tuple[Response, int]:
     )
 
 
+def apply_first_principles_redirect(
+    pipeline_id: str,
+    new_task_description: str,
+    *,
+    reason: str,
+) -> list[str]:
+    """Adopt a first-principles redirect: rewrite the seed and re-run refine.
+
+    Called in-process from the decision-resolve hook when an operator adopts a
+    redirect raised by the ``first_principles_reviewer``. Two durable steps:
+
+    1. **Rewrite the seed** via the operator-grade
+       ``rewrite_task_description_as_operator`` (audited, ``Role.HUMAN``), then
+       commit+push the worktree to the work branch so the refine restart's
+       re-fork (which forks fresh worktrees from ``origin/<branch>``) sees the
+       rewritten ``task_description`` rather than the old one.
+    2. **Re-run refine** via :func:`_restart_refine_phase`.
+
+    Returns the role values respawned. Raises on failure; the caller logs and
+    leaves the decision resolved (the operator's intent is recorded regardless).
+    """
+    from operator_actions import rewrite_task_description_as_operator
+
+    repo_path = get_repo_path()
+    store, pipeline = _resolve_pipeline(pipeline_id, repo_path)
+    issue_number = getattr(pipeline, "issue_number", None)
+    gateway_mode, _ = _compute_gateway_mode(pipeline)
+    spawner = _get_spawner()
+
+    rewrite = rewrite_task_description_as_operator(
+        pipeline_id,
+        new_task_description,
+        reason=reason,
+        actor="operator:first-principles-redirect",
+        issue_number=issue_number,
+    )
+
+    # Durably land the rewritten seed on the work branch. The refine restart
+    # below deletes per-agent worktrees and re-forks fresh ones from
+    # ``origin/<branch>``; without this push the re-fork would re-materialise
+    # the OLD seed and the redirect would be silently lost (#3080 re-fork
+    # semantics).
+    worktree = Path(rewrite["worktree"])
+    identifier = _pipeline_identifier(issue_number, pipeline_id)
+    try:
+        committed = _commit_statefiles_to_worktree(
+            worktree,
+            f"first-principles redirect: rewrite seed — {reason}"[:200],
+            identifier,
+            pipeline_id=pipeline_id,
+        )
+        if committed and pipeline.branch:
+            spawner.gateway.push_worktree_branch(
+                pipeline_id=pipeline_id,
+                repo_path=str(worktree),
+                branch=pipeline.branch,
+                mode=gateway_mode,
+                base_branch=pipeline.base_branch,
+            )
+    except Exception as exc:  # noqa: BLE001 — best-effort; restart still proceeds
+        logger.warning(
+            "Failed to push rewritten seed to work branch; refine restart may "
+            "re-fork the prior seed (first-principles redirect)",
+            pipeline_id=pipeline_id,
+            error=str(exc),
+        )
+
+    return _restart_refine_phase(
+        pipeline_id, store, reason=reason, spawner=spawner, gateway_mode=gateway_mode
+    )
+
+
+def _restart_refine_phase(
+    pipeline_id: str,
+    store: Any,
+    *,
+    reason: str,
+    spawner: Any,
+    gateway_mode: str,
+) -> list[str]:
+    """Re-run the refine phase in-process (non-route sibling of ``restart_phase``).
+
+    Mirrors ``restart_phase``'s essential steps for the refine phase so the
+    first-principles accept-path can re-run refine from the decision-resolve
+    hook (no Flask request). Refine has no slices, so the per-slice tracker
+    loop in ``restart_phase`` is intentionally omitted. Raises ``ValueError``
+    if the pipeline is not currently parked at the refine phase.
+    """
+    phase = PipelinePhase.REFINE.value
+    lock = get_pipeline_state_lock(pipeline_id)
+    with lock:
+        pipeline = store.load_pipeline(pipeline_id)
+        if pipeline.current_phase.value != phase:
+            raise ValueError(
+                f"_restart_refine_phase: pipeline {pipeline_id} is not at the "
+                f"refine phase (current: {pipeline.current_phase.value})"
+            )
+        phase_exec = pipeline.phases.get(phase)
+        if phase_exec is None:
+            raise ValueError(f"Refine phase not found in pipeline {pipeline_id}")
+
+        agent_roles: list[AgentRole] = []
+        for agent in phase_exec.agents:
+            if hasattr(agent, "role"):
+                role = agent.role if isinstance(agent.role, AgentRole) else AgentRole(agent.role)
+                agent_roles.append(role)
+        if not agent_roles:
+            from egg_contracts.agent_roles import get_roles_for_phase as _grfp
+
+            for r in _grfp(
+                phase,
+                include_reviewers=True,
+                repo=pipeline.repo,
+                has_contract=getattr(pipeline, "has_contract", True),
+            ):
+                try:
+                    agent_roles.append(AgentRole(r.value))
+                except ValueError:
+                    continue
+
+        old_container_ids = [c.container_id for c in phase_exec.containers]
+        phase_exec.containers = []
+        phase_exec.agents = []
+        phase_exec.review_cycles = 0
+        phase_exec.hitl_review_cycles = 0
+        phase_exec.status = PipelineStatus.PENDING
+        phase_exec.started_at = None
+        phase_exec.work_started_at = None
+        phase_exec.completed_at = None
+        phase_exec.error = None
+        phase_exec.cycle_timings = []
+        pipeline.status = PipelineStatus.RUNNING
+        pipeline.error = None
+        pipeline.run_epoch = datetime.now(UTC)
+        store.update_pipeline(pipeline_id, pipeline.model_dump(mode="json"))
+
+    # --- Outside the lock: slow, idempotent, best-effort teardown ---
+    for container_id in old_container_ids:
+        try:
+            spawner.stop_agent_container(container_id, cleanup_session=True)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "Failed to stop container during refine redirect restart",
+                container_id=container_id[:12] if container_id else "?",
+                error=str(e),
+            )
+        try:
+            spawner.remove_agent_container(container_id, force=True, cleanup_session=False)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "Failed to remove container during refine redirect restart",
+                container_id=container_id[:12] if container_id else "?",
+                error=str(e),
+            )
+
+    restart_role_values = {role.value for role in agent_roles}
+    try:
+        all_worktrees = agent_salvage.enumerate_agent_worktrees(pipeline_id, validate_git=False)
+    except (OSError, ImportError, RuntimeError) as e:
+        logger.warning(
+            "Failed to enumerate per-agent worktrees during refine redirect restart",
+            pipeline_id=pipeline_id,
+            error=str(e),
+        )
+        all_worktrees = []
+    worktrees_to_delete = [wt for wt in all_worktrees if wt.agent_role in restart_role_values]
+    if worktrees_to_delete:
+        try:
+            agent_salvage.auto_salvage_pipeline(
+                spawner.gateway,
+                pipeline_id,
+                worktree_filter={wt.worktree_id for wt in worktrees_to_delete},
+                mode=gateway_mode,
+                base_branch=pipeline.base_branch,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "Auto-salvage failed during refine redirect restart; proceeding",
+                pipeline_id=pipeline_id,
+                error=str(e),
+            )
+    for wt in worktrees_to_delete:
+        try:
+            spawner.gateway.delete_worktrees(container_id=wt.worktree_id, force=True)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "Failed to delete per-agent worktree during refine redirect restart",
+                agent_worktree_id=wt.worktree_id,
+                pipeline_id=pipeline_id,
+                error=str(e),
+            )
+
+    try:
+        from peer_consensus import get_peer_consensus_tracker
+
+        tracker = get_peer_consensus_tracker(pipeline_id)
+        if tracker:
+            tracker.clear()
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Failed to clear peer consensus during refine redirect restart",
+            pipeline_id=pipeline_id,
+            error=str(e),
+        )
+
+    spawner.reset_restart_counts(pipeline_id)
+    try:
+        from health_monitor import get_health_monitor
+
+        _hm = get_health_monitor()
+        if _hm is not None:
+            for role in agent_roles:
+                _hm.reset_agent(role.value)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Failed to reset health-monitor state during refine redirect restart",
+            pipeline_id=pipeline_id,
+            error=str(e),
+        )
+
+    _spawn_pipeline_run_thread(pipeline_id, store.repo_path, pipeline.run_epoch)
+    agents_to_restart = [role.value for role in agent_roles]
+    logger.info(
+        "Refine phase re-run for first-principles redirect",
+        pipeline_id=pipeline_id,
+        reason=reason,
+        agents_to_restart=agents_to_restart,
+    )
+    return agents_to_restart
+
+
 def _filter_salvage_worktrees(
     worktrees: list[Any],
     *,
@@ -5446,6 +5677,100 @@ def _human_companion_review_criteria(*, companion: str, parent: str, producer: s
     )
 
 
+def _get_first_principles_review_criteria() -> str:
+    """Return review criteria for the adversarial first-principles reviewer.
+
+    The escalation instructions interpolate the accept-path's sentinel option
+    labels + artifact path from ``routes.decisions`` so the labels the agent
+    writes (here) and the labels the resolve hook matches stay a single source
+    of truth — they cannot drift. Lazy import avoids a module-load cycle.
+    """
+    from routes.decisions import (
+        FIRST_PRINCIPLES_ADOPT_OPTION,
+        FIRST_PRINCIPLES_CANCEL_OPTION,
+        FIRST_PRINCIPLES_PROCEED_OPTION,
+    )
+    from routes.decisions._handlers import FIRST_PRINCIPLES_ARTIFACT_TEMPLATE
+
+    artifact_path = FIRST_PRINCIPLES_ARTIFACT_TEMPLATE.format(identifier="<identifier>")
+    return (
+        "You are the **first-principles reviewer**. Your subject is the "
+        "pipeline's **seed** — the operator's task statement (run "
+        "`egg-contract show` and read `task_description`, plus the linked "
+        "issue) — and the **direction** the refiner's analysis is taking. You "
+        "judge whether the *premise is sound and the direction is "
+        "appropriate*, NOT the quality of the analysis — that is "
+        "`reviewer_refine`'s job, so do not duplicate it.\n\n"
+        "### 1. Interrogate the premise\n"
+        "- Is the stated problem real, and is solving it worth the work?\n"
+        "- Is the premise contradicted by what's actually in the codebase — "
+        "the thing it proposes to build already exists, or the problem is "
+        "already handled?\n"
+        "- Will the stated direction actually achieve the stated goal, or does "
+        "it solve something adjacent?\n\n"
+        "### 2. Surface significant redirects (where warranted)\n"
+        "Raise a redirect only when you can name a concrete, evidence-backed "
+        "alternative — never a vague 'have you considered'. Valid redirects:\n"
+        "- A **materially simpler path** that achieves the same goal.\n"
+        "- A **fundamentally different approach** that is better on the "
+        "merits.\n"
+        "- A **scope change** — widen it if the seed under-reaches the real "
+        "goal, narrow it if it over-reaches.\n"
+        "- **Don't build it** — the work is unnecessary, already solved, or "
+        "solves a non-problem.\n"
+        "Back each redirect with evidence: a codebase fact (`file:line`), the "
+        "seed's own stated goal, or a specific contradiction. Raising more "
+        "than one is fine — it is acceptable to be relatively noisy — but "
+        "consolidate related concerns and hold every one to the "
+        "concrete-and-evidenced bar.\n\n"
+        "### 3. What NOT to raise (stay in your lane)\n"
+        "- Analysis-quality issues (research depth, option trade-offs, "
+        "completeness) — `reviewer_refine` owns those.\n"
+        "- Work decomposition, slice-DAG shape, PR packaging, or "
+        "implementation strategy (API shape, migration approach) — those "
+        "belong to the plan phase and the planner.\n"
+        "- Taste, stylistic preference, or 'did you consider X' with no "
+        "concrete better alternative.\n"
+        "If the premise and direction are sound, say so briefly and ACK — a "
+        "clean pass is a common and correct outcome. Do not manufacture an "
+        "objection to look diligent.\n\n"
+        "### 4. How to act — escalate, never NACK\n"
+        "- **Never NACK the refiner on first-principles grounds.** A NACK only "
+        "re-runs the refiner, which cannot change the operator-owned seed; "
+        "premise and direction are the operator's call, not the refiner's to "
+        "fix.\n"
+        "- When you have a redirect, do BOTH of the following so the operator "
+        "can act on it with one click (the **accept-path**):\n"
+        f"  1. **Write your proposed redirect to `{artifact_path}`** (replace "
+        "`<identifier>` with this pipeline's identifier — the same one used "
+        "for your other agent-output files). It must be a JSON object with a "
+        "`proposed_task_description` field holding the FULL rewritten seed — "
+        "the complete task statement as it should read if the operator adopts "
+        "your redirect (not a diff, not just the objection). Include a short "
+        "`concern` field too. Example: "
+        '`{"concern": "...", "proposed_task_description": "..."}`.\n'
+        "  2. **File the phase-scoped HITL decision** with these EXACT option "
+        "labels (do not paraphrase — the orchestrator matches them verbatim to "
+        "drive the accept-path):\n"
+        "     `egg-contract add-decision --phase refine --question "
+        '"<state the concern, then the concrete redirect and why>" '
+        f'--options "{FIRST_PRINCIPLES_ADOPT_OPTION}" '
+        f'"{FIRST_PRINCIPLES_PROCEED_OPTION}" '
+        f'"{FIRST_PRINCIPLES_CANCEL_OPTION}"`\n'
+        "     On the operator's choice the orchestrator will: **adopt** → "
+        "rewrite the seed to your `proposed_task_description` and re-run the "
+        "refine phase against it; **proceed** → leave the direction unchanged; "
+        "**don't build** → cancel the pipeline. If you have only an objection "
+        "with no concrete alternative direction, you do not have a redirect — "
+        "do not file the decision.\n"
+        "- Then **ACK the refiner**: your first-principles pass is done and "
+        "any concerns are filed for the operator. Your ACK does not endorse "
+        "the direction — it records that you reviewed it; the open decision "
+        "independently holds the refine→plan gate until the operator resolves "
+        "it.\n"
+    )
+
+
 def _get_plan_review_criteria() -> str:
     """Return review criteria for the dedicated plan reviewer."""
     return (
@@ -5800,6 +6125,8 @@ def _get_review_criteria_for_type(
         return _get_contract_review_criteria(repo_path=repo_path)
     elif reviewer_type == "refine":
         return _get_refine_review_criteria()
+    elif reviewer_type == "first-principles-reviewer":
+        return _get_first_principles_review_criteria()
     elif reviewer_type == "plan":
         return _get_plan_review_criteria()
     elif reviewer_type == "security":
@@ -5877,6 +6204,17 @@ def _get_reviewer_scope_preamble(reviewer_type: str, phase: str) -> str:
             "approach. Agent-mode design alignment is handled by another reviewer.\n\n"
             "**Analysis format:** Provide section-by-section evaluation of the refine "
             "output — assess each major section for depth, accuracy, and completeness."
+        )
+    elif reviewer_type == "first-principles-reviewer":
+        return (
+            "This is an adversarial **first-principles review**. Focus ONLY on "
+            "whether the premise is sound and the direction appropriate — the "
+            "seed and where the refiner's analysis is heading. Do NOT review "
+            "analysis quality, code, or implementation detail; other agents "
+            "own those.\n\n"
+            "You escalate by surfacing HITL decisions for the operator, not by "
+            "NACKing the refiner. If the direction is sound, a brief approval "
+            "and ACK is the right outcome — do not manufacture an objection."
         )
     elif reviewer_type == "plan":
         return (
@@ -13209,6 +13547,13 @@ def _build_brc_preamble(
             "tester",
             "reviewer_refine",
             "reviewer_agent_design",
+            # first_principles_reviewer is a genuine refine-phase reviewer: it
+            # casts a real ACK verdict on the refiner (CRITICAL edge), so the
+            # degraded fallback keeps its Reviewer Lifecycle block. It never
+            # NACKs (redirects go to the operator as HITL decisions), but it
+            # DOES vote, so — unlike the simplifier — it is a real verdict and
+            # ``casts_real_verdicts`` (raw ``is_reviewer`` here) stays True.
+            "first_principles_reviewer",
             "reviewer_plan",
             # risk_analyst is a genuine dual-role reviewer in the plan graph
             # (CRITICAL reviewer of architect + task_planner, #2809) as well as
@@ -13814,6 +14159,12 @@ _ROLE_DESCRIPTIONS: dict[str, tuple[str, str]] = {
         "Reviews refinement changes",
         "ACK/NACK on refined implementation",
     ),
+    "first_principles_reviewer": (
+        "Adversarially reviews the seed and the refiner's direction from "
+        "first principles; surfaces significant redirects to the operator as "
+        "HITL decisions and never NACKs the refiner",
+        "an ACK on the refiner plus any HITL redirect decisions",
+    ),
     "reviewer_agent_design": (
         "Reviews agent design and architecture decisions",
         "ACK/NACK on design choices",
@@ -14040,6 +14391,21 @@ def _build_reviewer_preparation(
                     "missing or empty companion is a NACK — it is mandatory."
                 )
             return base
+        if role_value == "first_principles_reviewer":
+            return (
+                "While waiting for the refiner's proposal, prepare your "
+                "first-principles pass: (a) read the seed — `egg-contract "
+                "show` and the linked issue — and restate, in your own words, "
+                "the problem it claims to solve and why; (b) explore the "
+                "codebase to test that premise against reality (does the thing "
+                "already exist? is the problem already handled? is there a far "
+                "simpler path?); (c) form your own view of whether this is the "
+                "right direction and what a materially better one would be. "
+                "When the refiner proposes, you are checking the *premise and "
+                "direction*, not the analysis quality — surface any concrete "
+                "redirect as a phase-scoped HITL decision for the operator and "
+                "ACK the refiner. Never NACK on first-principles grounds."
+            )
 
     # Generic fallback
     return (

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5681,18 +5681,16 @@ def _get_first_principles_review_criteria() -> str:
     """Return review criteria for the adversarial first-principles reviewer.
 
     The escalation instructions interpolate the accept-path's sentinel option
-    labels + artifact path from ``routes.decisions`` so the labels the agent
-    writes (here) and the labels the resolve hook matches stay a single source
-    of truth — they cannot drift. Lazy import avoids a module-load cycle.
+    labels from ``routes.decisions`` so the labels the agent writes (here) and
+    the labels the resolve hook matches stay a single source of truth — they
+    cannot drift. Lazy import avoids a module-load cycle.
     """
     from routes.decisions import (
         FIRST_PRINCIPLES_ADOPT_OPTION,
         FIRST_PRINCIPLES_CANCEL_OPTION,
         FIRST_PRINCIPLES_PROCEED_OPTION,
     )
-    from routes.decisions._handlers import FIRST_PRINCIPLES_ARTIFACT_TEMPLATE
 
-    artifact_path = FIRST_PRINCIPLES_ARTIFACT_TEMPLATE.format(identifier="<identifier>")
     return (
         "You are the **first-principles reviewer**. Your subject is the "
         "pipeline's **seed** — the operator's task statement (run "
@@ -5739,30 +5737,29 @@ def _get_first_principles_review_criteria() -> str:
         "re-runs the refiner, which cannot change the operator-owned seed; "
         "premise and direction are the operator's call, not the refiner's to "
         "fix.\n"
-        "- When you have a redirect, do BOTH of the following so the operator "
-        "can act on it with one click (the **accept-path**):\n"
-        f"  1. **Write your proposed redirect to `{artifact_path}`** (replace "
-        "`<identifier>` with this pipeline's identifier — the same one used "
-        "for your other agent-output files). It must be a JSON object with a "
-        "`proposed_task_description` field holding the FULL rewritten seed — "
-        "the complete task statement as it should read if the operator adopts "
-        "your redirect (not a diff, not just the objection). Include a short "
-        "`concern` field too. Example: "
-        '`{"concern": "...", "proposed_task_description": "..."}`.\n'
-        "  2. **File the phase-scoped HITL decision** with these EXACT option "
-        "labels (do not paraphrase — the orchestrator matches them verbatim to "
-        "drive the accept-path):\n"
-        "     `egg-contract add-decision --phase refine --question "
-        '"<state the concern, then the concrete redirect and why>" '
-        f'--options "{FIRST_PRINCIPLES_ADOPT_OPTION}" '
-        f'"{FIRST_PRINCIPLES_PROCEED_OPTION}" '
-        f'"{FIRST_PRINCIPLES_CANCEL_OPTION}"`\n'
-        "     On the operator's choice the orchestrator will: **adopt** → "
-        "rewrite the seed to your `proposed_task_description` and re-run the "
-        "refine phase against it; **proceed** → leave the direction unchanged; "
-        "**don't build** → cancel the pipeline. If you have only an objection "
-        "with no concrete alternative direction, you do not have a redirect — "
-        "do not file the decision.\n"
+        "- When you have a redirect, **file one phase-scoped HITL decision** "
+        "via the `mcp__sdlc__register_open_question` tool so the operator can "
+        "act on it with one click (the **accept-path**). Pass these args:\n"
+        '  - `phase`: `"refine"`.\n'
+        "  - `question`: state the concern, then the concrete redirect and "
+        "why (operator-facing prose).\n"
+        "  - `options`: these EXACT labels, in this order — do NOT paraphrase, "
+        "the orchestrator matches them verbatim to drive the accept-path: "
+        f'`["{FIRST_PRINCIPLES_ADOPT_OPTION}", '
+        f'"{FIRST_PRINCIPLES_PROCEED_OPTION}", '
+        f'"{FIRST_PRINCIPLES_CANCEL_OPTION}"]`.\n'
+        "  - `redirect_seed`: the FULL rewritten seed — the complete "
+        "`task_description` as it should read if the operator adopts your "
+        "redirect (not a diff, not just the objection). This rides the same "
+        "RPC that files the decision, so the orchestrator can read it back "
+        "directly; do NOT write it to a free-standing file (a reviewer "
+        "worktree has no path to carry one to the orchestrator).\n"
+        "  On the operator's choice the orchestrator will: **adopt** → rewrite "
+        "the seed to your `redirect_seed` and re-run the refine phase against "
+        "it; **proceed** → leave the direction unchanged; **don't build** → "
+        "cancel the pipeline. If you have only an objection with no concrete "
+        "alternative direction, you do not have a redirect — do not file the "
+        "decision (omit `redirect_seed`).\n"
         "- Then **ACK the refiner**: your first-principles pass is done and "
         "any concerns are filed for the operator. Your ACK does not endorse "
         "the direction — it records that you reviewed it; the open decision "

--- a/orchestrator/tests/test_consensus_next_action.py
+++ b/orchestrator/tests/test_consensus_next_action.py
@@ -604,14 +604,21 @@ def test_advisory_reviewer_can_confirm_after_producer_confirmed(client, advisory
 
 @pytest.fixture
 def simplifier_refine_tracker():
-    """The real refine-phase graph: refiner (producer) + its two CRITICAL
-    reviewers + the simplifier, which is a PRODUCER of the human companion
-    and carries a WAKE-ONLY advisory edge over the refiner.
+    """The real refine-phase graph: refiner (producer) + its three CRITICAL
+    reviewers (reviewer_refine, reviewer_agent_design, first_principles_reviewer)
+    + the simplifier, which is a PRODUCER of the human companion and carries a
+    WAKE-ONLY advisory edge over the refiner.
     """
     from review_graph import get_default_refine_graph
 
     t = PeerConsensusTracker(PIPELINE_ID, get_default_refine_graph(), cooldown_seconds=0)
-    for role in ("refiner", "reviewer_refine", "reviewer_agent_design", "simplifier"):
+    for role in (
+        "refiner",
+        "reviewer_refine",
+        "reviewer_agent_design",
+        "first_principles_reviewer",
+        "simplifier",
+    ):
         t.register_agent(role)
     return t
 
@@ -658,6 +665,10 @@ def test_wake_only_simplifier_confirms_without_verdict(client, simplifier_refine
     # Refiner's CRITICAL reviewers ACK it; the simplifier never does.
     _ack(t, "reviewer_refine", "refiner", version=1)
     _ack(t, "reviewer_agent_design", "refiner", version=1)
+    # first_principles_reviewer is also a CRITICAL reviewer of the refiner: it
+    # ACKs (it escalates redirects via HITL, never via NACK), so consensus on
+    # the refiner now requires its ACK too.
+    _ack(t, "first_principles_reviewer", "refiner", version=1)
     # reviewer_refine ACKs the companion (the simplifier's only CRITICAL reviewer).
     _ack(t, "reviewer_refine", "simplifier", version=1)
 
@@ -671,6 +682,7 @@ def test_wake_only_simplifier_confirms_without_verdict(client, simplifier_refine
     t.handle_confirmed("simplifier")
     t.handle_confirmed("reviewer_refine")
     t.handle_confirmed("reviewer_agent_design")
+    t.handle_confirmed("first_principles_reviewer")
     assert t.evaluate()["is_complete"] is True
     # The simplifier never cast a verdict on the refiner — its wake-only
     # matrix entry stays at the registration-time PENDING (never ACK/NACK).

--- a/orchestrator/tests/test_first_principles_reviewer.py
+++ b/orchestrator/tests/test_first_principles_reviewer.py
@@ -3,7 +3,9 @@
 Covers the additive wiring (role registry, refine review graph, gateway
 patterns, the broadened ``decisions.*`` capability), the prompt single-source
 invariant (the criteria interpolate the exact accept-path option labels), and
-the resolution-hook dispatch logic (proceed / phase-guard / adopt-no-artifact).
+the resolution-hook dispatch logic (proceed / phase-guard / adopt — reading the
+proposed seed off the decision's ``redirect_seed`` field, the channel that
+actually propagates from a BRC reviewer to the orchestrator).
 
 The integration the hook drives end-to-end — the durable seed rewrite and the
 refine re-run — is validated by a live proving run, not here; these tests pin
@@ -97,7 +99,10 @@ class TestPromptSingleSource:
         assert FIRST_PRINCIPLES_ADOPT_OPTION in criteria
         assert FIRST_PRINCIPLES_PROCEED_OPTION in criteria
         assert FIRST_PRINCIPLES_CANCEL_OPTION in criteria
-        assert "-first-principles.json" in criteria
+        # The proposed seed travels on the decision's redirect_seed field via
+        # register_open_question — NOT a free-standing worktree file.
+        assert "redirect_seed" in criteria
+        assert "register_open_question" in criteria
         assert "Never NACK" in criteria
 
     def test_reviewer_type_dispatch(self) -> None:
@@ -154,16 +159,19 @@ class TestAcceptPathHookDispatch:
         )
         assert out is None
 
-    def test_adopt_without_artifact_fails_loudly(self, tmp_path) -> None:
+    def test_adopt_without_redirect_seed_fails_loudly(self) -> None:
         from routes.decisions import (
             FIRST_PRINCIPLES_ADOPT_OPTION,
             _maybe_apply_first_principles_redirect,
         )
 
-        # No first-principles artifact on the (empty) worktree → adopt cannot
-        # recover the proposed seed and must surface a failure, never silently
-        # succeed.
-        with patch("contract_store.resolve_pipeline_worktree", return_value=tmp_path):
+        # The decision carries no redirect_seed and the contract fallback finds
+        # none → adopt cannot recover the proposed seed and must surface a
+        # failure, never silently succeed.
+        with patch(
+            "routes.decisions._handlers._read_redirect_seed_from_contract",
+            return_value=None,
+        ):
             out = _maybe_apply_first_principles_redirect(
                 "p1",
                 self._decision(),
@@ -175,37 +183,66 @@ class TestAcceptPathHookDispatch:
         assert out["success"] is False
         assert "no proposed redirect" in out["error"]
 
-    def test_adopt_reads_artifact_and_calls_redirect(self, tmp_path) -> None:
-        import json
-
+    def test_adopt_reads_redirect_seed_off_decision(self) -> None:
         from routes.decisions import (
             FIRST_PRINCIPLES_ADOPT_OPTION,
             _maybe_apply_first_principles_redirect,
         )
 
-        outputs = tmp_path / ".egg-state" / "agent-outputs"
-        outputs.mkdir(parents=True)
-        (outputs / "7-first-principles.json").write_text(
-            json.dumps({"concern": "c", "proposed_task_description": "Do the simpler thing"})
-        )
+        # Primary resolve path: the contract Decision is handed in directly and
+        # carries the proposed seed on ``redirect_seed`` — read it straight off,
+        # no worktree file involved.
+        decision = self._decision()
+        decision.redirect_seed = "Do the simpler thing"
 
-        with (
-            patch("contract_store.resolve_pipeline_worktree", return_value=tmp_path),
-            patch("routes.pipelines._pipeline_identifier", return_value=7),
-            patch(
-                "routes.pipelines.apply_first_principles_redirect",
-                return_value=["refiner", "reviewer_refine"],
-            ) as mock_redirect,
-        ):
+        with patch(
+            "routes.pipelines.apply_first_principles_redirect",
+            return_value=["refiner", "reviewer_refine"],
+        ) as mock_redirect:
             out = _maybe_apply_first_principles_redirect(
                 "p1",
-                self._decision(),
+                decision,
                 FIRST_PRINCIPLES_ADOPT_OPTION,
                 SimpleNamespace(issue_number=7),
             )
 
         mock_redirect.assert_called_once()
         assert mock_redirect.call_args.args[1] == "Do the simpler thing"
+        assert out["outcome"] == "adopted"
+        assert out["success"] is True
+
+    def test_adopt_recovers_redirect_seed_from_contract_on_queue_path(self) -> None:
+        from routes.decisions import (
+            FIRST_PRINCIPLES_ADOPT_OPTION,
+            _maybe_apply_first_principles_redirect,
+        )
+
+        # Bridged queue path: the pipeline HITLDecision has no redirect_seed, so
+        # the hook falls back to the contract decision of the same id, which the
+        # register_open_question RPC wrote into the shared worktree.
+        contract_decision = SimpleNamespace(id="cq-1", redirect_seed="Narrow the scope")
+        contract = SimpleNamespace(decisions=[contract_decision])
+        store = SimpleNamespace(load_pipeline=lambda _pid: SimpleNamespace(issue_number=7))
+
+        with (
+            patch("routes.decisions.get_state_store_for_pipeline", return_value=(store, None)),
+            patch("contract_store.resolve_pipeline_worktree", return_value="/tmp/wt"),
+            patch("routes.pipelines._pipeline_identifier", return_value=7),
+            patch("egg_contracts.load_contract", return_value=contract),
+            patch(
+                "routes.pipelines.apply_first_principles_redirect",
+                return_value=["refiner"],
+            ) as mock_redirect,
+        ):
+            out = _maybe_apply_first_principles_redirect(
+                "p1",
+                self._decision(decision_id="cq-1"),  # no redirect_seed on this object
+                FIRST_PRINCIPLES_ADOPT_OPTION,
+                SimpleNamespace(issue_number=7),
+            )
+
+        mock_redirect.assert_called_once()
+        assert mock_redirect.call_args.args[1] == "Narrow the scope"
         assert out["outcome"] == "adopted"
         assert out["success"] is True
 

--- a/orchestrator/tests/test_first_principles_reviewer.py
+++ b/orchestrator/tests/test_first_principles_reviewer.py
@@ -246,7 +246,7 @@ class TestAcceptPathHookDispatch:
         assert out["outcome"] == "adopted"
         assert out["success"] is True
 
-    def test_fallback_warns_when_multiple_seeds_and_id_misses(self, caplog) -> None:
+    def test_fallback_warns_when_multiple_seeds_and_id_misses(self) -> None:
         from routes.decisions._handlers import _read_redirect_seed_from_contract
 
         # Id miss with more than one redirect-carrying decision: the choice is
@@ -265,13 +265,17 @@ class TestAcceptPathHookDispatch:
             patch("contract_store.resolve_pipeline_worktree", return_value="/tmp/wt"),
             patch("routes.pipelines._pipeline_identifier", return_value=7),
             patch("egg_contracts.load_contract", return_value=contract),
-            caplog.at_level("WARNING"),
+            patch("routes.decisions._handlers.logger") as mock_logger,
         ):
             seed = _read_redirect_seed_from_contract("p1", "cq-99")
 
         assert seed == "second seed"
+        # egg's structured logger sets ``propagate=False``, so its records
+        # bypass pytest's caplog fixture; assert the warning call directly.
+        assert mock_logger.warning.called
         assert any(
-            "Ambiguous first-principles redirect fallback" in r.getMessage() for r in caplog.records
+            "Ambiguous first-principles redirect fallback" in str(call.args[0])
+            for call in mock_logger.warning.call_args_list
         )
 
 

--- a/orchestrator/tests/test_first_principles_reviewer.py
+++ b/orchestrator/tests/test_first_principles_reviewer.py
@@ -246,6 +246,34 @@ class TestAcceptPathHookDispatch:
         assert out["outcome"] == "adopted"
         assert out["success"] is True
 
+    def test_fallback_warns_when_multiple_seeds_and_id_misses(self, caplog) -> None:
+        from routes.decisions._handlers import _read_redirect_seed_from_contract
+
+        # Id miss with more than one redirect-carrying decision: the choice is
+        # order-dependent, so the scan warns and returns the last candidate
+        # rather than silently picking one (#3385 review).
+        contract = SimpleNamespace(
+            decisions=[
+                SimpleNamespace(id="cq-1", redirect_seed="first seed"),
+                SimpleNamespace(id="cq-2", redirect_seed="second seed"),
+            ]
+        )
+        store = SimpleNamespace(load_pipeline=lambda _pid: SimpleNamespace(issue_number=7))
+
+        with (
+            patch("routes.decisions.get_state_store_for_pipeline", return_value=(store, None)),
+            patch("contract_store.resolve_pipeline_worktree", return_value="/tmp/wt"),
+            patch("routes.pipelines._pipeline_identifier", return_value=7),
+            patch("egg_contracts.load_contract", return_value=contract),
+            caplog.at_level("WARNING"),
+        ):
+            seed = _read_redirect_seed_from_contract("p1", "cq-99")
+
+        assert seed == "second seed"
+        assert any(
+            "Ambiguous first-principles redirect fallback" in r.getMessage() for r in caplog.records
+        )
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/orchestrator/tests/test_first_principles_reviewer.py
+++ b/orchestrator/tests/test_first_principles_reviewer.py
@@ -1,0 +1,214 @@
+"""Tests for the ``first_principles_reviewer`` role and its accept-path.
+
+Covers the additive wiring (role registry, refine review graph, gateway
+patterns, the broadened ``decisions.*`` capability), the prompt single-source
+invariant (the criteria interpolate the exact accept-path option labels), and
+the resolution-hook dispatch logic (proceed / phase-guard / adopt-no-artifact).
+
+The integration the hook drives end-to-end — the durable seed rewrite and the
+refine re-run — is validated by a live proving run, not here; these tests pin
+the pure, unit-testable surface.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+class TestRoleWiring:
+    def test_role_in_refine_reviewers_all_repos(self) -> None:
+        from egg_contracts.agent_roles import AgentRole, get_roles_for_phase
+
+        egg = get_roles_for_phase("refine", repo="jwbron/egg")
+        other = get_roles_for_phase("refine", repo="acme/widgets")
+        assert AgentRole.FIRST_PRINCIPLES_REVIEWER in egg
+        # Not egg-only — questioning the premise is universal.
+        assert AgentRole.FIRST_PRINCIPLES_REVIEWER in other
+
+    def test_contract_role_is_reviewer(self) -> None:
+        from egg_contracts.agent_roles import AgentRole, get_contract_role
+        from egg_contracts.roles import Role
+
+        assert get_contract_role(AgentRole.FIRST_PRINCIPLES_REVIEWER) == Role.REVIEWER
+
+    def test_role_definition_is_review_no_source_writes(self) -> None:
+        from egg_contracts.agent_roles import AgentCategory, AgentRole, get_role_definition
+
+        defn = get_role_definition(AgentRole.FIRST_PRINCIPLES_REVIEWER)
+        assert defn.category == AgentCategory.REVIEW
+        assert ".egg-state/agent-outputs/" in defn.file_access.allowed_write
+        # It must never touch source or the contract directly.
+        assert not defn.file_access.can_write("orchestrator/foo.py")
+        assert not defn.file_access.can_write(".egg-state/contracts/x.json")
+
+    def test_gateway_patterns_registered(self) -> None:
+        from egg_contracts.agent_roles import AgentRole
+        from egg_restrictions.patterns import get_agent_patterns_for_repo
+
+        pats = get_agent_patterns_for_repo()
+        assert AgentRole.FIRST_PRINCIPLES_REVIEWER in pats
+
+
+class TestReviewGraph:
+    def test_critical_reviewer_of_refiner(self) -> None:
+        from review_graph import get_review_graph_for_phase
+
+        g = get_review_graph_for_phase("refine", repo="jwbron/egg")
+        assert "first_principles_reviewer" in g.critical_reviewers_for("refiner")
+        # It reviews; it does not produce.
+        assert g.is_reviewer("first_principles_reviewer")
+        assert not g.is_producer("first_principles_reviewer")
+
+    def test_present_for_non_egg_repos(self) -> None:
+        from review_graph import get_review_graph_for_phase
+
+        g = get_review_graph_for_phase("refine", repo="acme/widgets")
+        assert "first_principles_reviewer" in g.critical_reviewers_for("refiner")
+
+
+class TestDecisionCreateCapability:
+    """The (B) capability grant: reviewers may CREATE decisions, not resolve."""
+
+    def test_reviewer_can_create_but_not_resolve_decisions(self) -> None:
+        from egg_contracts.roles import Role, can_modify
+
+        assert can_modify(Role.REVIEWER, "decisions.0") is True
+        assert can_modify(Role.REVIEWER, "decisions.0.resolved") is False
+        assert can_modify(Role.REVIEWER, "decisions.0.resolution") is False
+        # Implementer create-access is unaffected.
+        assert can_modify(Role.IMPLEMENTER, "decisions.0") is True
+
+
+class TestPromptSingleSource:
+    """The criteria must interpolate the EXACT accept-path option labels."""
+
+    def test_criteria_interpolate_the_sentinel_labels(self) -> None:
+        from routes.decisions import (
+            FIRST_PRINCIPLES_ADOPT_OPTION,
+            FIRST_PRINCIPLES_CANCEL_OPTION,
+            FIRST_PRINCIPLES_PROCEED_OPTION,
+        )
+        from routes.pipelines import _get_first_principles_review_criteria
+
+        criteria = _get_first_principles_review_criteria()
+        # Drift between the label the agent writes and the label the hook
+        # matches would silently break the accept-path — pin them together.
+        assert FIRST_PRINCIPLES_ADOPT_OPTION in criteria
+        assert FIRST_PRINCIPLES_PROCEED_OPTION in criteria
+        assert FIRST_PRINCIPLES_CANCEL_OPTION in criteria
+        assert "-first-principles.json" in criteria
+        assert "Never NACK" in criteria
+
+    def test_reviewer_type_dispatch(self) -> None:
+        from routes.pipelines import _get_review_criteria_for_type
+
+        # The role-name → reviewer-type one-liner yields this verbatim.
+        rt = "first_principles_reviewer".replace("reviewer_", "", 1).replace("_", "-")
+        assert rt == "first-principles-reviewer"
+        assert "first-principles" in _get_review_criteria_for_type(rt, "refine")
+
+
+class TestAcceptPathHookDispatch:
+    def _decision(self, phase_value: str | None = "refine", decision_id: str = "cq-1"):
+        phase = SimpleNamespace(value=phase_value) if phase_value is not None else None
+        return SimpleNamespace(id=decision_id, phase=phase)
+
+    def test_non_matching_label_returns_none(self) -> None:
+        from routes.decisions import _maybe_apply_first_principles_redirect
+
+        out = _maybe_apply_first_principles_redirect(
+            "p1", self._decision(), "Some unrelated resolution", SimpleNamespace(issue_number=1)
+        )
+        assert out is None
+
+    def test_proceed_is_a_noop_action(self) -> None:
+        from routes.decisions import (
+            FIRST_PRINCIPLES_PROCEED_OPTION,
+            _maybe_apply_first_principles_redirect,
+        )
+
+        out = _maybe_apply_first_principles_redirect(
+            "p1",
+            self._decision(),
+            FIRST_PRINCIPLES_PROCEED_OPTION,
+            SimpleNamespace(issue_number=1),
+        )
+        assert out == {
+            "action": "first_principles_redirect",
+            "outcome": "proceed",
+            "success": True,
+        }
+
+    def test_phase_guard_skips_non_refine(self) -> None:
+        from routes.decisions import (
+            FIRST_PRINCIPLES_ADOPT_OPTION,
+            _maybe_apply_first_principles_redirect,
+        )
+
+        out = _maybe_apply_first_principles_redirect(
+            "p1",
+            self._decision(phase_value="plan"),
+            FIRST_PRINCIPLES_ADOPT_OPTION,
+            SimpleNamespace(issue_number=1),
+        )
+        assert out is None
+
+    def test_adopt_without_artifact_fails_loudly(self, tmp_path) -> None:
+        from routes.decisions import (
+            FIRST_PRINCIPLES_ADOPT_OPTION,
+            _maybe_apply_first_principles_redirect,
+        )
+
+        # No first-principles artifact on the (empty) worktree → adopt cannot
+        # recover the proposed seed and must surface a failure, never silently
+        # succeed.
+        with patch("contract_store.resolve_pipeline_worktree", return_value=tmp_path):
+            out = _maybe_apply_first_principles_redirect(
+                "p1",
+                self._decision(),
+                FIRST_PRINCIPLES_ADOPT_OPTION,
+                SimpleNamespace(issue_number=1),
+            )
+        assert out is not None
+        assert out["outcome"] == "adopt"
+        assert out["success"] is False
+        assert "no proposed redirect" in out["error"]
+
+    def test_adopt_reads_artifact_and_calls_redirect(self, tmp_path) -> None:
+        import json
+
+        from routes.decisions import (
+            FIRST_PRINCIPLES_ADOPT_OPTION,
+            _maybe_apply_first_principles_redirect,
+        )
+
+        outputs = tmp_path / ".egg-state" / "agent-outputs"
+        outputs.mkdir(parents=True)
+        (outputs / "7-first-principles.json").write_text(
+            json.dumps({"concern": "c", "proposed_task_description": "Do the simpler thing"})
+        )
+
+        with (
+            patch("contract_store.resolve_pipeline_worktree", return_value=tmp_path),
+            patch("routes.pipelines._pipeline_identifier", return_value=7),
+            patch(
+                "routes.pipelines.apply_first_principles_redirect",
+                return_value=["refiner", "reviewer_refine"],
+            ) as mock_redirect,
+        ):
+            out = _maybe_apply_first_principles_redirect(
+                "p1",
+                self._decision(),
+                FIRST_PRINCIPLES_ADOPT_OPTION,
+                SimpleNamespace(issue_number=7),
+            )
+
+        mock_redirect.assert_called_once()
+        assert mock_redirect.call_args.args[1] == "Do the simpler thing"
+        assert out["outcome"] == "adopted"
+        assert out["success"] is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/orchestrator/tests/test_models.py
+++ b/orchestrator/tests/test_models.py
@@ -1107,6 +1107,7 @@ class TestAgentRole:
         assert AgentRole.REVIEWER_CONTRACT in roles
         assert AgentRole.REVIEWER_AGENT_DESIGN in roles
         assert AgentRole.REVIEWER_REFINE in roles
+        assert AgentRole.FIRST_PRINCIPLES_REVIEWER in roles
         assert AgentRole.REVIEWER_PLAN in roles
         assert AgentRole.REVIEWER_SECURITY in roles
         assert AgentRole.REVIEWER_CONCURRENCY in roles
@@ -1117,9 +1118,11 @@ class TestAgentRole:
         # APPLIER (#1557) → 20 with ORCHESTRATOR (#2893) → back to 19 when
         # ORCHESTRATOR was removed (#2925: the orchestrator is the control
         # plane, not an agent role) → 20 with SIMPLIFIER (human-focused
-        # draft companions). Bump this and add the matching
-        # `assert AgentRole.X in roles` above whenever a new role lands.
-        assert len(roles) == 20
+        # draft companions) → 21 with FIRST_PRINCIPLES_REVIEWER (adversarial
+        # premise/direction reviewer in the refine phase). Bump this and add
+        # the matching `assert AgentRole.X in roles` above whenever a new role
+        # lands.
+        assert len(roles) == 21
 
 
 class TestBackwardCompatibility:

--- a/orchestrator/tests/test_pipeline_role_to_reviewer_type_mapping.py
+++ b/orchestrator/tests/test_pipeline_role_to_reviewer_type_mapping.py
@@ -61,6 +61,11 @@ class TestRoleValueToReviewerTypeMappingInvariant:
             ("reviewer_contract", "contract"),
             ("reviewer_agent_design", "agent-design"),
             ("reviewer_refine", "refine"),
+            # Mandate-first name (no ``reviewer_`` prefix): the one-liner
+            # leaves it intact and only swaps underscores, yielding the
+            # slightly redundant but correct ``first-principles-reviewer``
+            # type the criteria dispatch keys on.
+            ("first_principles_reviewer", "first-principles-reviewer"),
             ("reviewer_plan", "plan"),
             # The two new lens reviewers — pitfall-1 guard. The current
             # one-liner already produces the right reviewer_type for

--- a/sandbox/egg_agent_tools/handlers/sdlc.py
+++ b/sandbox/egg_agent_tools/handlers/sdlc.py
@@ -126,11 +126,12 @@ def register_open_question(req: dict[str, Any]) -> dict[str, Any]:
         # Idempotent: no contract write, return the prior decision.
         duplicate = find_duplicate_open_question(decisions, question, decision_phase)
         if duplicate is not None:
-            # The dedup key is (normalized question, phase) — the option set
-            # is *not* part of it. If the re-registration carries a different
-            # option set, the operator only ever sees the stored options; the
-            # new ones are silently discarded. Log it so that loss is not
-            # invisible (#3374 review).
+            # The dedup key is (normalized question, phase) — neither the option
+            # set nor the redirect seed is part of it. If the re-registration
+            # carries a different option set or a different ``redirect_seed``,
+            # the operator only ever sees the stored values; the new ones are
+            # silently discarded. Log it so that loss is not invisible
+            # (#3374 review).
             new_labels = [o["label"] for o in opt_objs]
             existing_labels = [
                 o.get("label") for o in (duplicate.get("options") or []) if isinstance(o, dict)
@@ -143,6 +144,14 @@ def register_open_question(req: dict[str, Any]) -> dict[str, Any]:
                     duplicate.get("id"),
                     new_labels,
                     existing_labels,
+                )
+            existing_seed = duplicate.get("redirect_seed")
+            if redirect_seed is not None and redirect_seed != existing_seed:
+                _logger.warning(
+                    "register_open_question deduped onto %s but the re-registration's "
+                    "redirect_seed differs from the stored one; keeping the stored "
+                    "seed (the operator adopts the originally-registered redirect)",
+                    duplicate.get("id"),
                 )
             return {
                 "ok": True,

--- a/sandbox/egg_agent_tools/handlers/sdlc.py
+++ b/sandbox/egg_agent_tools/handlers/sdlc.py
@@ -65,6 +65,13 @@ def register_open_question(req: dict[str, Any]) -> dict[str, Any]:
             appended automatically for parity with the CLI.
         phase (str): optional override; defaults to the contract's
             ``current_phase``.
+        redirect_seed (str): optional. Machine-consumed payload for the
+            ``first_principles_reviewer`` seed-redirect accept-path — the FULL
+            proposed ``task_description`` the operator adopts when resolving
+            this decision. Stored on the decision itself (it rides the same
+            contract-mutate RPC that creates the decision), because a BRC
+            reviewer has no commit/push path to carry a free-standing
+            agent-worktree file into the shared pipeline worktree.
         repo_path (str): optional override for repo path.
         pipeline_id / issue: optional contract identifier.
 
@@ -82,6 +89,9 @@ def register_open_question(req: dict[str, Any]) -> dict[str, Any]:
     if phase is not None and phase not in _VALID_PHASES:
         raise HandlerError(f"'phase' must be one of {sorted(_VALID_PHASES)}; got {phase!r}")
     options = list(req.get("options") or [])
+    redirect_seed = req.get("redirect_seed")
+    if redirect_seed is not None and not isinstance(redirect_seed, str):
+        raise HandlerError("'redirect_seed' must be a string when provided")
     repo_path = req.get("repo_path") or get_repo_path()
 
     identifier = _resolve_identifier(req)
@@ -160,6 +170,8 @@ def register_open_question(req: dict[str, Any]) -> dict[str, Any]:
             "resolved_at": None,
             "debounce_until": None,
         }
+        if redirect_seed is not None:
+            new_decision["redirect_seed"] = redirect_seed
 
         reason = f"Created HITL decision: {question[:50]}" + ("..." if len(question) > 50 else "")
         result = gateway_request(

--- a/sandbox/egg_agent_tools/tools/sdlc.py
+++ b/sandbox/egg_agent_tools/tools/sdlc.py
@@ -25,6 +25,15 @@ _REGISTER_SCHEMA: dict[str, Any] = {
             "enum": ["refine", "plan", "implement", "pr"],
             "description": "Pipeline phase (defaults to contract's current_phase)",
         },
+        "redirect_seed": {
+            "type": "string",
+            "description": (
+                "first_principles_reviewer only: the FULL proposed "
+                "task_description the operator adopts via the seed-redirect "
+                "accept-path. Stored on the decision (rides this same RPC) so "
+                "the orchestrator can read it back without a worktree file."
+            ),
+        },
         "issue": {"type": "integer", "description": "Optional issue-number override"},
         "pipeline_id": {
             "type": "string",

--- a/shared/egg_contracts/agent_roles.py
+++ b/shared/egg_contracts/agent_roles.py
@@ -56,8 +56,8 @@ class AgentRole(StrEnum):
     Analysis roles: ARCHITECT, TASK_PLANNER, RISK_ANALYST, REFINER, SIMPLIFIER
     Review roles: REVIEWER_CODE, REVIEWER_CODE_HOLISTIC,
                   REVIEWER_CONTRACT, REVIEWER_AGENT_DESIGN,
-                  REVIEWER_REFINE, REVIEWER_PLAN,
-                  REVIEWER_SECURITY, REVIEWER_CONCURRENCY
+                  REVIEWER_REFINE, FIRST_PRINCIPLES_REVIEWER,
+                  REVIEWER_PLAN, REVIEWER_SECURITY, REVIEWER_CONCURRENCY
     Utility roles: AUTOFIXER, CONFLICT_RESOLVER
     Interface roles: OVERSEER
     """
@@ -88,6 +88,16 @@ class AgentRole(StrEnum):
     REVIEWER_CONTRACT = "reviewer_contract"
     REVIEWER_AGENT_DESIGN = "reviewer_agent_design"
     REVIEWER_REFINE = "reviewer_refine"
+    # Adversarial first-principles reviewer of the refine phase. Reviews the
+    # pipeline's *seed* (the operator's task statement) and the direction the
+    # refiner's analysis is taking — questioning whether the premise is sound
+    # and the direction appropriate. It never NACKs the refiner (a NACK only
+    # re-runs the producer, which cannot change the operator-owned seed);
+    # instead it ACKs and, when warranted, surfaces a redirect as a
+    # phase-scoped HITL decision for the operator. Named mandate-first rather
+    # than ``reviewer_first_principles`` so the role reads as what it does in
+    # the escalations an operator sees.
+    FIRST_PRINCIPLES_REVIEWER = "first_principles_reviewer"
     REVIEWER_PLAN = "reviewer_plan"
     REVIEWER_SECURITY = "reviewer_security"
     REVIEWER_CONCURRENCY = "reviewer_concurrency"
@@ -737,6 +747,51 @@ REVIEWER_REFINE_ROLE = AgentRoleDefinition(
     requires_inputs=["analysis_draft"],
 )
 
+# Adversarial first-principles reviewer (refine phase). Unlike
+# ``reviewer_refine`` (which judges the *quality* of the analysis) this role
+# questions the *premise and direction*: is the seed's rationale sound, is the
+# stated direction the right one, or is there a materially simpler path / a
+# better approach / a scope change — or should the work not happen at all? Its
+# subject is the operator's seed (``contract.task_description``), read against
+# codebase reality, plus the direction the refiner's draft is taking. It does
+# NOT NACK the refiner (the refiner cannot rewrite the operator-owned seed, so
+# a NACK is the wrong channel); it ACKs and, when it finds a concern worth a
+# human's call, surfaces a redirect as a phase-scoped HITL decision. Mapped to
+# ``Role.REVIEWER``; reviewers gained decision-create access in roles.py so it
+# can raise that decision itself. File access mirrors the other refine
+# reviewers: it writes its assessment to ``.egg-state/agent-outputs/`` (the
+# accept-path reads the proposed redirect back from there) and its verdict to
+# ``.egg-state/reviews/`` — never source, drafts, or contracts.
+FIRST_PRINCIPLES_REVIEWER_ROLE = AgentRoleDefinition(
+    role=AgentRole.FIRST_PRINCIPLES_REVIEWER,
+    description=(
+        "Adversarially reviews the pipeline's seed and the refiner's direction "
+        "from first principles, surfacing significant redirects as HITL "
+        "decisions in the refine phase"
+    ),
+    category=AgentCategory.REVIEW,
+    responsibilities=[
+        "Read the seed (the operator's task statement) and the refiner's draft",
+        "Question the premise: is the rationale sound and the direction right?",
+        "Surface concrete redirects where warranted — a materially simpler "
+        "path, a different approach, a scope change, or not building it at all",
+        "Raise redirects as phase-scoped HITL decisions for the operator; "
+        "never NACK the refiner on first-principles grounds",
+        "ACK the refiner once the first-principles pass is done",
+    ],
+    dependencies=[AgentRole.REFINER],
+    file_access=FileAccessPattern(
+        allowed_read=[],
+        allowed_write=[
+            ".egg-state/reviews/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=_REVIEWER_BLOCKED_WRITE,
+    ),
+    produces_outputs=["review_verdict", "first_principles_assessment"],
+    requires_inputs=["analysis_draft"],
+)
+
 REVIEWER_PLAN_ROLE = AgentRoleDefinition(
     role=AgentRole.REVIEWER_PLAN,
     description="Reviews plan phase output quality and completeness",
@@ -991,6 +1046,7 @@ AGENT_ROLES: dict[AgentRole, AgentRoleDefinition] = {
     AgentRole.REVIEWER_CONTRACT: REVIEWER_CONTRACT_ROLE,
     AgentRole.REVIEWER_AGENT_DESIGN: REVIEWER_AGENT_DESIGN_ROLE,
     AgentRole.REVIEWER_REFINE: REVIEWER_REFINE_ROLE,
+    AgentRole.FIRST_PRINCIPLES_REVIEWER: FIRST_PRINCIPLES_REVIEWER_ROLE,
     AgentRole.REVIEWER_PLAN: REVIEWER_PLAN_ROLE,
     AgentRole.REVIEWER_SECURITY: REVIEWER_SECURITY_ROLE,
     AgentRole.REVIEWER_CONCURRENCY: REVIEWER_CONCURRENCY_ROLE,
@@ -1061,6 +1117,9 @@ AGENT_ROLE_TO_CONTRACT_ROLE: dict[AgentRole, Role] = {
     AgentRole.REVIEWER_CONTRACT: Role.REVIEWER,
     AgentRole.REVIEWER_AGENT_DESIGN: Role.REVIEWER,
     AgentRole.REVIEWER_REFINE: Role.REVIEWER,
+    # Pure reviewer; gains decision-create via the broadened decisions.*
+    # ownership in roles.py (it surfaces seed redirects as HITL decisions).
+    AgentRole.FIRST_PRINCIPLES_REVIEWER: Role.REVIEWER,
     AgentRole.REVIEWER_PLAN: Role.REVIEWER,
     AgentRole.REVIEWER_SECURITY: Role.REVIEWER,
     AgentRole.REVIEWER_CONCURRENCY: Role.REVIEWER,
@@ -1248,6 +1307,7 @@ _PHASE_REVIEWERS: dict[str, list[AgentRole]] = {
     "refine": [
         AgentRole.REVIEWER_REFINE,
         AgentRole.REVIEWER_AGENT_DESIGN,
+        AgentRole.FIRST_PRINCIPLES_REVIEWER,
     ],
     # Apply phase reviewer (issue #1557 — architect's slice-3 design +
     # risk_analyst R1 mitigation). REVIEWER_CONTRACT ACKs on

--- a/shared/egg_contracts/models.py
+++ b/shared/egg_contracts/models.py
@@ -501,6 +501,19 @@ class Decision(EggContractBaseModel):
     resolved_by: str | None = Field(default=None, description="Who resolved")
     resolved_at: datetime | None = Field(default=None, description="When resolved")
     debounce_until: datetime | None = Field(default=None, description="Debounce expiration")
+    redirect_seed: str | None = Field(
+        default=None,
+        description=(
+            "Machine-consumed payload for the first_principles_reviewer "
+            "seed-redirect accept-path: the FULL proposed task_description the "
+            "operator adopts when they resolve this decision with "
+            "``FIRST_PRINCIPLES_ADOPT_OPTION``. Carried on the decision itself "
+            "(written through the same contract-mutate RPC that creates the "
+            "decision) rather than a free-standing agent-worktree file, because "
+            "a BRC reviewer has no commit/push path to the shared pipeline "
+            "worktree. ``None`` for every other decision."
+        ),
+    )
 
 
 class DeferredAction(EggContractBaseModel):

--- a/shared/egg_contracts/roles.py
+++ b/shared/egg_contracts/roles.py
@@ -68,8 +68,14 @@ FIELD_OWNERSHIP: dict[str, FieldOwner] = {
     "acceptance_criteria.*.verified": Role.REVIEWER,
     # Pipeline phase transitions owned by reviewer (allows implement→pr advancement)
     "current_phase": Role.REVIEWER,
-    # Decisions: implementer can CREATE new decisions, but only human can RESOLVE them
-    "decisions.*": Role.IMPLEMENTER,
+    # Decisions: implementer AND reviewer can CREATE new decisions, but only
+    # human can RESOLVE them. Reviewer create-access (the frozenset) lets a
+    # review-phase agent surface a HITL decision of its own — e.g. the
+    # ``first_principles_reviewer`` raising a redirect of the pipeline's seed
+    # for an operator to decide — without being mapped to IMPLEMENTER just to
+    # borrow the write. Resolution stays HUMAN-only (the fields below), so the
+    # broadened create-access cannot let an agent self-resolve.
+    "decisions.*": frozenset({Role.IMPLEMENTER, Role.REVIEWER}),
     "decisions.*.resolved": Role.HUMAN,
     "decisions.*.resolution": Role.HUMAN,
     "decisions.*.resolved_by": Role.HUMAN,

--- a/shared/egg_restrictions/patterns.py
+++ b/shared/egg_restrictions/patterns.py
@@ -553,6 +553,18 @@ REVIEWER_REFINE_PATTERNS = AgentFilePattern(
     blocked_patterns=_REVIEWER_BLOCKED,
 )
 
+# First-principles reviewer: same reviewer write surface (reviews +
+# agent-outputs only, never source/drafts/contracts). It writes its
+# assessment under .egg-state/agent-outputs/ and its verdict under
+# .egg-state/reviews/; redirects go to the operator as HITL decisions, not
+# pushed files.
+FIRST_PRINCIPLES_REVIEWER_PATTERNS = AgentFilePattern(
+    role=AgentRole.FIRST_PRINCIPLES_REVIEWER,
+    description="reviews and agent-outputs only",
+    allowed_patterns=_REVIEWER_ALLOWED,
+    blocked_patterns=_REVIEWER_BLOCKED,
+)
+
 REVIEWER_PLAN_PATTERNS = AgentFilePattern(
     role=AgentRole.REVIEWER_PLAN,
     description="reviews and agent-outputs only",
@@ -751,6 +763,7 @@ AGENT_PATTERNS: dict[str, AgentFilePattern] = {
     AgentRole.REFINER: REFINER_PATTERNS,
     AgentRole.SIMPLIFIER: SIMPLIFIER_PATTERNS,
     AgentRole.REVIEWER_REFINE: REVIEWER_REFINE_PATTERNS,
+    AgentRole.FIRST_PRINCIPLES_REVIEWER: FIRST_PRINCIPLES_REVIEWER_PATTERNS,
     AgentRole.REVIEWER_PLAN: REVIEWER_PLAN_PATTERNS,
     AgentRole.REVIEWER_SECURITY: REVIEWER_SECURITY_PATTERNS,
     AgentRole.REVIEWER_CONCURRENCY: REVIEWER_CONCURRENCY_PATTERNS,
@@ -854,6 +867,7 @@ def build_agent_patterns(
         AgentRole.REFINER: REFINER_PATTERNS,
         AgentRole.SIMPLIFIER: SIMPLIFIER_PATTERNS,
         AgentRole.REVIEWER_REFINE: REVIEWER_REFINE_PATTERNS,
+        AgentRole.FIRST_PRINCIPLES_REVIEWER: FIRST_PRINCIPLES_REVIEWER_PATTERNS,
         AgentRole.REVIEWER_PLAN: REVIEWER_PLAN_PATTERNS,
         AgentRole.REVIEWER_SECURITY: REVIEWER_SECURITY_PATTERNS,
         AgentRole.REVIEWER_CONCURRENCY: REVIEWER_CONCURRENCY_PATTERNS,

--- a/shared/tests/test_egg_restrictions.py
+++ b/shared/tests/test_egg_restrictions.py
@@ -75,14 +75,15 @@ class TestAgentRole:
 
 
 class TestAgentPatterns:
-    def test_registry_has_all_20_roles(self):
+    def test_registry_has_all_roles(self):
         # Issue #1557 — APPLIER joined the registry (Jira-epic SDLC
         # support); the count grew from 19 to 20. Issue #2925 — ORCHESTRATOR
         # was removed (the orchestrator is the control plane, not an agent
         # role; its gh pre-flights now run on launcher-authed control-plane
         # routes), dropping the count back to 19. SIMPLIFIER (human-focused
-        # draft companions) brings it to 20.
-        assert len(AGENT_PATTERNS) == 20
+        # draft companions) brings it to 20. FIRST_PRINCIPLES_REVIEWER
+        # (adversarial premise/direction reviewer, refine phase) brings it to 21.
+        assert len(AGENT_PATTERNS) == 21
 
     def test_registry_keys_match_role_constants(self):
         expected_roles = {
@@ -102,6 +103,8 @@ class TestAgentPatterns:
             AgentRole.REVIEWER_CONTRACT,
             AgentRole.REVIEWER_AGENT_DESIGN,
             AgentRole.REVIEWER_REFINE,
+            # Adversarial premise/direction reviewer (refine phase).
+            AgentRole.FIRST_PRINCIPLES_REVIEWER,
             AgentRole.REVIEWER_PLAN,
             AgentRole.REVIEWER_SECURITY,
             AgentRole.REVIEWER_CONCURRENCY,

--- a/tests/sandbox/egg_agent_tools/test_handlers_sdlc.py
+++ b/tests/sandbox/egg_agent_tools/test_handlers_sdlc.py
@@ -298,6 +298,42 @@ class TestRegisterOpenQuestion:
         # Only the contract read happened — no mutate write.
         assert gr.call_count == 1
 
+    def test_dedup_warns_when_redirect_seed_differs(self, caplog):
+        """A re-registration that dedupes onto an existing open question but
+        carries a *different* ``redirect_seed`` keeps the stored seed and logs
+        the discard so the loss is not invisible (#3385 review)."""
+        existing = _fake_contract(
+            current_phase="refine",
+            decisions=[
+                {
+                    "id": "cq-1",
+                    "question": "Redirect the seed?",
+                    "type": "hitl",
+                    "phase": "refine",
+                    "resolved": False,
+                    "redirect_seed": "original proposed seed",
+                }
+            ],
+        )
+        with (
+            patch(
+                "egg_agent_tools.handlers.sdlc.gateway_request",
+                side_effect=lambda *a, **kw: {"success": True, "data": existing},
+            ) as gr,
+            patch("egg_agent_tools.handlers.sdlc.get_contract_identifier", return_value=42),
+            caplog.at_level("WARNING", logger="egg_agent_tools.handlers.sdlc"),
+        ):
+            resp = sdlc.register_open_question(
+                {"question": "Redirect the seed?", "redirect_seed": "a different seed"}
+            )
+
+        assert resp["id"] == "cq-1"
+        assert resp["deduped"] is True
+        # The stored seed wins; the new one is discarded but logged.
+        assert resp["decision"]["redirect_seed"] == "original proposed seed"
+        assert gr.call_count == 1
+        assert any("redirect_seed differs" in r.message for r in caplog.records)
+
     def test_resolved_duplicate_does_not_block_new_registration(self):
         """An already-*resolved* identical question must not suppress a
         fresh registration — only open questions dedupe (#3374)."""

--- a/tests/sandbox/egg_agent_tools/test_handlers_sdlc.py
+++ b/tests/sandbox/egg_agent_tools/test_handlers_sdlc.py
@@ -70,6 +70,54 @@ class TestRegisterOpenQuestion:
         assert data["new_value"]["phase"] == "plan"
         assert data["actor"] == "egg"
 
+    def test_redirect_seed_carried_on_decision(self):
+        # The first_principles_reviewer's proposed seed rides this same RPC so
+        # the orchestrator can read it back off the decision — no worktree file.
+        fake_contract = _fake_contract()
+        responses = [
+            {"success": True, "data": fake_contract},
+            {"success": True, "data": {}},
+        ]
+        with (
+            patch(
+                "egg_agent_tools.handlers.sdlc.gateway_request",
+                side_effect=lambda *a, **kw: responses.pop(0),
+            ) as gr,
+            patch("egg_agent_tools.handlers.sdlc.get_contract_identifier", return_value=42),
+        ):
+            resp = sdlc.register_open_question(
+                {"question": "redirect?", "redirect_seed": "Do the simpler thing"}
+            )
+
+        assert resp["decision"]["redirect_seed"] == "Do the simpler thing"
+        # And it reaches the gateway mutate payload verbatim.
+        data = gr.call_args_list[1].kwargs["data"]
+        assert data["new_value"]["redirect_seed"] == "Do the simpler thing"
+
+    def test_redirect_seed_omitted_when_absent(self):
+        # No redirect_seed key on a normal decision — the field stays off the
+        # payload so it defaults to None on the model.
+        fake_contract = _fake_contract()
+        responses = [
+            {"success": True, "data": fake_contract},
+            {"success": True, "data": {}},
+        ]
+        with (
+            patch(
+                "egg_agent_tools.handlers.sdlc.gateway_request",
+                side_effect=lambda *a, **kw: responses.pop(0),
+            ) as gr,
+            patch("egg_agent_tools.handlers.sdlc.get_contract_identifier", return_value=42),
+        ):
+            resp = sdlc.register_open_question({"question": "q?"})
+
+        assert "redirect_seed" not in resp["decision"]
+        assert "redirect_seed" not in gr.call_args_list[1].kwargs["data"]["new_value"]
+
+    def test_non_string_redirect_seed_rejected(self):
+        with pytest.raises(HandlerError):
+            sdlc.register_open_question({"question": "q?", "redirect_seed": 123})
+
     def test_no_options_keeps_list_empty(self):
         fake_contract = _fake_contract()
         responses = [

--- a/tests/shared/egg_contracts/test_agent_roles.py
+++ b/tests/shared/egg_contracts/test_agent_roles.py
@@ -88,6 +88,7 @@ class TestAgentRole:
         "reviewer_concurrency",
         "reviewer_agent_design",
         "reviewer_refine",
+        "first_principles_reviewer",
         "reviewer_plan",
         "overseer",
         "autofixer",
@@ -95,7 +96,7 @@ class TestAgentRole:
     }
 
     def test_all_expected_roles_exist(self):
-        """All 20 expected roles should be present in the enum."""
+        """All 21 expected roles should be present in the enum."""
         actual = {r.value for r in AgentRole}
         assert self.EXPECTED_ROLES == actual, (
             f"Missing roles: {self.EXPECTED_ROLES - actual}, "
@@ -103,8 +104,8 @@ class TestAgentRole:
         )
 
     def test_role_count(self):
-        """Should have exactly 20 canonical roles."""
-        assert len(AgentRole) == 20
+        """Should have exactly 21 canonical roles."""
+        assert len(AgentRole) == 21
 
     def test_execution_roles(self):
         assert AgentRole.CODER == "coder"
@@ -123,6 +124,7 @@ class TestAgentRole:
         assert AgentRole.REVIEWER_CONTRACT == "reviewer_contract"
         assert AgentRole.REVIEWER_AGENT_DESIGN == "reviewer_agent_design"
         assert AgentRole.REVIEWER_REFINE == "reviewer_refine"
+        assert AgentRole.FIRST_PRINCIPLES_REVIEWER == "first_principles_reviewer"
         assert AgentRole.REVIEWER_PLAN == "reviewer_plan"
 
     def test_utility_roles(self):
@@ -315,6 +317,7 @@ class TestAgentRolesRegistry:
             "reviewer_contract",
             "reviewer_agent_design",
             "reviewer_refine",
+            "first_principles_reviewer",
             "reviewer_plan",
         ]:
             role = AgentRole(role_name)
@@ -401,10 +404,11 @@ class TestGetRolesByCategory:
         assert "reviewer_contract" in role_values
         assert "reviewer_agent_design" in role_values
         assert "reviewer_refine" in role_values
+        assert "first_principles_reviewer" in role_values
         assert "reviewer_plan" in role_values
         assert "reviewer_security" in role_values
         assert "reviewer_concurrency" in role_values
-        assert len(roles) == 8
+        assert len(roles) == 9
 
     def test_utility_roles(self):
         from egg_contracts.agent_roles import get_roles_by_category


### PR DESCRIPTION
## Summary

Adds a `first_principles_reviewer` to the **refine** phase: an adversarial reviewer whose subject is the pipeline's **seed** (the operator's task statement) and the **direction** the refiner's analysis is taking — not the analysis quality (`reviewer_refine` owns that). It questions whether the premise is sound and the direction appropriate, and surfaces significant redirects to the **operator** as HITL decisions.

Because the seed is operator-owned and the refiner can't rewrite it, a premise objection is the operator's call, not the producer's to fix — so this role **never NACKs the refiner**. It ACKs and raises redirects as phase-scoped HITL decisions. Its CRITICAL review edge guarantees it weighs in before consensus closes; an open redirect decision independently holds the refine→plan gate until the operator resolves it.

It ships with the **accept-path**: resolving the redirect decision drives a real action.

| Operator choice | Effect |
|-----------------|--------|
| **Adopt the redirect** | Durably rewrites the seed (`contract.task_description`, audited `Role.HUMAN` mutation) to the reviewer's proposed direction, commits+pushes it to the work branch, and re-runs the refine phase against it. |
| **Proceed as-is** | No-op; the current direction stands. |
| **Don't build this** | Cancels the pipeline. |

## Design notes

- **Reviewer, not producer.** It's a genuine CRITICAL reviewer of the refiner (`is_reviewer`, not a producer), spawned for all repos. Its contract role stays `reviewer`; reviewers gained `decisions.*` **create** access (resolution stays human-only) so it can raise the HITL decision itself — `risk_analyst`-style precedent that a graph reviewer surfaces operator decisions.
- **Escalate, never NACK.** A NACK only re-runs the refiner, which can't change the seed. The reviewer prompt is explicit: file a redirect HITL decision and ACK.
- **Label↔hook single source of truth.** The three option labels live as `FIRST_PRINCIPLES_*_OPTION` constants in `routes/decisions/_handlers.py` and are interpolated into the reviewer prompt, so the label the agent writes and the label the resolve hook matches cannot drift. The proposed new seed travels via a committed artifact (`{id}-first-principles.json`) — the decision bridge drops structured option payloads, so the artifact is the robust channel.
- **Accept-path wired into both resolve paths.** The contract-fallback path is the primary trigger (the decision blocks the refine gate and is resolved pre-bridge); the queue path is a safety net.
- **Calibration.** It may be relatively noisy *provided each redirect is concrete and evidence-backed*; an explicit "what NOT to raise" list keeps it out of `reviewer_refine`'s and the planner's lanes, and a clean pass + ACK is the expected common outcome.

## Touchpoints

- `shared/egg_contracts/agent_roles.py` — role enum/definition/registry, contract-role map, `_PHASE_REVIEWERS["refine"]`
- `shared/egg_contracts/roles.py` — broaden `decisions.*` create-ownership to `{IMPLEMENTER, REVIEWER}`
- `shared/egg_restrictions/patterns.py` — gateway push patterns
- `orchestrator/review_graph.py` — CRITICAL `first_principles_reviewer → refiner` edge
- `orchestrator/routes/pipelines.py` — reviewer criteria/preamble/roster/prep + `apply_first_principles_redirect` / `_restart_refine_phase`
- `orchestrator/operator_actions.py` — `rewrite_task_description_as_operator`
- `orchestrator/routes/decisions/` — `_maybe_apply_first_principles_redirect` hook + constants, wired into both resolve paths
- docs + tests

## Validation

- `make lint` clean; new unit tests pass; changeset-aware `make test` green (see CI).
- **Needs a live proving run** for the accept-path integration specifically: the durable seed-rewrite surviving the refine restart's worktree re-fork, and the refine re-run itself. That's the next step — testing it on a live pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
