### PR TITLE
Enforce one simplifier draft per phase at propose time

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -15895,6 +15895,13 @@ def _build_agent_prompt(
                 'commit to …", no "anti-pattern to reject", no constraint '
                 "lists. You have no critique to record anywhere — your only "
                 "output is this plain-language summary.",
+                f"   - **Exactly one file.** Commit ONLY `{_human_path}`. Do "
+                "NOT create any other `.egg-state/drafts/` file — no separate "
+                "`*-simplifier-*.md` constraints/guardrails/verification "
+                "companion. Any review reasoning goes in the BRC channel "
+                "(your verdict), never a second persisted document. A "
+                "proposal that introduces a second draft is rejected at "
+                "propose time.",
                 "   - **Much shorter and more digestible** than the upstream "
                 "draft — plain prose and short lists, not exhaustive enumeration.",
                 "   - **Faithful** — reflect the upstream draft accurately; "

--- a/orchestrator/routes/signals/__init__.py
+++ b/orchestrator/routes/signals/__init__.py
@@ -147,6 +147,7 @@ from ._validation import (  # noqa: E402,F401
     _BRC_CONDITION_MIN_LEN,
     _BRC_MIN_CONTENT_LEN,
     _artifact_human_label,
+    _reject_extra_simplifier_drafts,
     _require_route_version,
     _validate_brc_content,
     _validate_plan_extensions,

--- a/orchestrator/routes/signals/_validation.py
+++ b/orchestrator/routes/signals/_validation.py
@@ -575,6 +575,111 @@ def _validate_producer_artifacts(
             f"re-propose."
         )
 
+    # The simplifier persists exactly ONE artifact per phase — the registered
+    # human-focused companion. Its review reasoning and simplification
+    # constraints belong in the BRC channel (its ACK/NACK and review verdict),
+    # not a second persisted document. The presence loop above only confirms
+    # the human companion *exists*; it never catches an *extra* draft the agent
+    # freelanced alongside it (e.g. a "*-simplifier-*.md" guardrails/constraints
+    # companion). The producer prompt and reviewer rubric forbid that in prose,
+    # but those are soft gates — this makes "one simplifier draft, no more" a
+    # structural invariant at propose time. Deliberately scoped to the
+    # simplifier: other producers' extra-draft policy is out of scope here.
+    if agent_role == "simplifier":
+        _pkg._reject_extra_simplifier_drafts(
+            pipeline_id=pipeline_id,
+            worktree_path=worktree_path,
+            commit_sha=commit_sha,
+            identifier=identifier,
+            allowed_rel_paths={spec.resolve_path(identifier) for spec in specs},
+            phase=phase,
+        )
+
+
+def _reject_extra_simplifier_drafts(
+    *,
+    pipeline_id: str,
+    worktree_path: Path,
+    commit_sha: str,
+    identifier: str | int,
+    allowed_rel_paths: set[str],
+    phase: str,
+) -> None:
+    """Reject a simplifier proposal that persists any draft beyond its one
+    registered human companion.
+
+    The simplifier is a producer-only role whose sole output is the
+    human-focused ``*-human.md`` summary. A second persisted document (the
+    historically-observed ``*-simplifier-*.md`` constraints/guardrails
+    companion) is redundant with the architect/planner's authoritative draft
+    and the BRC review, and is an extra surface to drift out of sync with
+    operator decisions. The review reasoning the companion tried to carry
+    belongs in the BRC channel instead.
+
+    This inspects only the files the *proposed commit* introduced under
+    ``.egg-state/drafts/{identifier}-`` (so upstream producers' drafts, which
+    that commit does not touch, are never implicated) and raises if any of them
+    is not in ``allowed_rel_paths`` (the registered human-companion path).
+
+    Graceful degradation mirrors the surrounding validator: a git failure or a
+    non-zero ``git show`` (we cannot list the commit's files) returns silently
+    rather than blaming the producer. The raise fires only when we can
+    positively name an extra draft the commit added.
+    """
+    drafts_prefix = f".egg-state/drafts/{identifier}-"
+    try:
+        result = _pkg.subprocess.run(
+            [
+                "git",
+                "-C",
+                str(worktree_path),
+                "show",
+                "--name-only",
+                "--pretty=format:",
+                commit_sha,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except Exception as exc:
+        _pkg.logger.warning(
+            "simplifier extra-draft check: git show failed (non-blocking)",
+            pipeline_id=pipeline_id,
+            phase=phase,
+            commit_sha=commit_sha,
+            error=str(exc),
+        )
+        return
+
+    if result.returncode != 0:
+        # Could not enumerate the commit's files (e.g. commit not resolvable
+        # locally). Treat as inconclusive and degrade gracefully — the presence
+        # check already gates the human companion itself.
+        return
+
+    extras = sorted(
+        path
+        for line in result.stdout.splitlines()
+        for path in (line.strip(),)
+        if path.startswith(drafts_prefix) and path not in allowed_rel_paths
+    )
+    if not extras:
+        return
+
+    allowed_display = ", ".join(f"`{p}`" for p in sorted(allowed_rel_paths))
+    extras_display = ", ".join(f"`{p}`" for p in extras)
+    raise ValueError(
+        f"simplifier proposal rejected: the proposed commit ({commit_sha[:8]}) "
+        f"introduces draft file(s) {extras_display} beyond your one registered "
+        f"human-focused companion ({allowed_display}). The simplifier persists "
+        f"exactly one artifact per phase — the plain-language summary. Your "
+        f"review reasoning and any simplification constraints belong in the BRC "
+        f"channel (your ACK/NACK and review verdict), not a second persisted "
+        f"document. Remove the extra draft file(s), commit, and re-propose."
+    )
+
 
 def _validate_plan_proposal(
     pipeline_id: str,

--- a/orchestrator/tests/test_signals.py
+++ b/orchestrator/tests/test_signals.py
@@ -3312,3 +3312,164 @@ class TestSpecDerivedProposeValidation:
         message = response.get_json().get("message", "")
         assert "role↔files alignment violations" in message, message
         mock_tracker.handle_propose.assert_not_called()
+
+
+class TestSimplifierSingleArtifactEnforcement:
+    """Propose-time enforcement that the simplifier persists exactly ONE draft.
+
+    The simplifier is a producer-only role whose sole output is the registered
+    human-focused companion (``*-analysis-human.md`` / ``*-plan-human.md``). Its
+    review reasoning belongs in the BRC channel (its verdict), not a second
+    persisted document. Prompt + reviewer-rubric prose forbid a freelanced
+    ``*-simplifier-*.md`` constraints/guardrails companion, but those are soft
+    gates; this hard gate in ``_validate_producer_artifacts`` makes "one
+    simplifier draft, no more" a structural invariant at propose time.
+
+    The check inspects only the files the *proposed commit* introduced under
+    ``.egg-state/drafts/{identifier}-`` — so the upstream producer's draft
+    (which the simplifier's commit never touches) is never implicated — and
+    rejects any draft that is not the registered human companion.
+    """
+
+    _PLAN_HUMAN_PATH = ".egg-state/drafts/42-plan-human.md"
+    _ANALYSIS_HUMAN_PATH = ".egg-state/drafts/42-analysis-human.md"
+    _EXTRA_PLAN_COMPANION = ".egg-state/drafts/42-simplifier-plan.md"
+    _EXTRA_ANALYSIS_COMPANION = ".egg-state/drafts/42-simplifier-analysis.md"
+
+    @staticmethod
+    def _router(name_only_stdout: str, *, name_only_returncode: int = 0):
+        """Route the two ``git show`` shapes this validator emits: the
+        per-spec presence ``git show <sha>:<path>`` (always present here) and
+        the new ``git show --name-only --pretty=format: <sha>`` enumerating the
+        commit's files.
+        """
+
+        def _run(cmd, *_args, **_kwargs):
+            cmd_str = " ".join(str(p) for p in cmd)
+            if "--name-only" in cmd_str:
+                return _make_subprocess_result(
+                    stdout=name_only_stdout, returncode=name_only_returncode
+                )
+            if "show" in cmd_str:
+                # Per-spec presence check — the human companion exists.
+                return _make_subprocess_result(stdout="present\n")
+            return _make_subprocess_result()
+
+        return _run
+
+    def _validate(self, *, agent_role="simplifier", phase="plan", router):
+        from routes.signals import _validate_producer_artifacts
+
+        pipeline = _pipeline_with_phase(phase)
+        with patch("routes.signals.subprocess.run", side_effect=router):
+            _validate_producer_artifacts(
+                "issue-42",
+                {"commit_sha": "abc1234"},
+                Path("/tmp/repo"),
+                agent_role=agent_role,
+                phase=phase,
+                pipeline_state=pipeline,
+                worktree_path=Path("/tmp/wt"),
+                branch_verified=True,
+            )
+
+    def test_accepts_when_only_human_companion_committed(self):
+        """Plan simplifier whose commit introduces only the human companion ⇒
+        no raise.
+        """
+        self._validate(router=self._router(f"\n{self._PLAN_HUMAN_PATH}\n"))
+
+    def test_rejects_extra_simplifier_plan_companion(self):
+        """The historically-observed failure: the plan simplifier commits the
+        human doc AND a second ``*-simplifier-plan.md`` guardrails companion ⇒
+        rejected, naming the extra file.
+        """
+        router = self._router(f"\n{self._PLAN_HUMAN_PATH}\n{self._EXTRA_PLAN_COMPANION}\n")
+        with pytest.raises(ValueError, match="beyond your one registered"):
+            self._validate(router=router)
+
+    def test_rejects_extra_simplifier_analysis_companion_in_refine(self):
+        """Structural, not plan-specific: the refine simplifier is gated the
+        same way for a ``*-simplifier-analysis.md`` companion.
+        """
+        router = self._router(f"\n{self._ANALYSIS_HUMAN_PATH}\n{self._EXTRA_ANALYSIS_COMPANION}\n")
+        with pytest.raises(ValueError, match="exactly one artifact per phase"):
+            self._validate(phase="refine", router=router)
+
+    def test_ignores_non_draft_and_upstream_files(self):
+        """The gate is scoped to ``.egg-state/drafts/{id}-`` files the commit
+        introduced. A stray non-draft path (or an agent-output) in the commit's
+        file list is not a second *draft*, so it does not trip the gate.
+        """
+        router = self._router(
+            f"\n{self._PLAN_HUMAN_PATH}\n"
+            "src/incidental.py\n"
+            ".egg-state/agent-outputs/42-architect-output.json\n"
+        )
+        self._validate(router=router)
+
+    def test_non_simplifier_producer_not_subject_to_gate(self):
+        """The task_planner legitimately commits ``42-plan.md`` (its registered
+        draft); the simplifier-only gate must never fire for it even though that
+        path matches the drafts prefix.
+        """
+
+        # task_planner's presence spec is plan-draft; the router returns a
+        # parseable plan so the presence/extension checks pass, and the
+        # --name-only branch is never consulted for a non-simplifier role.
+        def _run(cmd, *_args, **_kwargs):
+            cmd_str = " ".join(str(p) for p in cmd)
+            if "--name-only" in cmd_str:
+                raise AssertionError("simplifier gate ran for task_planner")
+            if "show" in cmd_str:
+                return _make_subprocess_result(
+                    stdout=(
+                        "# Plan\n\n```yaml\n# yaml-tasks\nslices:\n"
+                        "  - id: 1\n    name: S\n    goal: g\n    tasks:\n"
+                        "      - id: TASK-1-1\n        description: d\n"
+                        "        acceptance: a\n        role: tester\n"
+                        "        files:\n          - integration_tests/conftest.py\n```\n"
+                    )
+                )
+            return _make_subprocess_result()
+
+        self._validate(agent_role="task_planner", phase="plan", router=_run)
+
+    # -- graceful degradation on the helper itself --------------------------
+
+    def test_helper_skips_when_git_show_errors(self):
+        """A non-zero ``git show --name-only`` (commit not enumerable) ⇒ skip,
+        never blame the producer.
+        """
+        from routes.signals import _reject_extra_simplifier_drafts
+
+        with patch(
+            "routes.signals.subprocess.run",
+            return_value=_make_subprocess_result(returncode=128),
+        ):
+            # Should not raise even though we cannot list the commit's files.
+            _reject_extra_simplifier_drafts(
+                pipeline_id="issue-42",
+                worktree_path=Path("/tmp/wt"),
+                commit_sha="abc1234",
+                identifier=42,
+                allowed_rel_paths={self._PLAN_HUMAN_PATH},
+                phase="plan",
+            )
+
+    def test_helper_skips_on_subprocess_exception(self):
+        """An infra failure (timeout) on the enumerate call degrades gracefully."""
+        from routes.signals import _reject_extra_simplifier_drafts
+
+        with patch(
+            "routes.signals.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="git", timeout=15),
+        ):
+            _reject_extra_simplifier_drafts(
+                pipeline_id="issue-42",
+                worktree_path=Path("/tmp/wt"),
+                commit_sha="abc1234",
+                identifier=42,
+                allowed_rel_paths={self._PLAN_HUMAN_PATH},
+                phase="plan",
+            )


### PR DESCRIPTION
Closes #3399.

## Problem

The simplifier is a producer-only role whose sole output should be the registered human-focused companion (`*-analysis-human.md` / `*-plan-human.md`). Its review reasoning and simplification constraints belong in the **BRC channel** (its ACK/NACK and review verdict), not a second persisted document.

The producer prompt and the reviewer rubric already say this in prose, but those are **soft** gates. Propose-time validation (`_validate_producer_artifacts`) only checks the registered artifact is *present* — it never caught an *extra* draft the agent freelanced. So nothing structurally stopped the simplifier from also dropping a `.egg-state/drafts/*-simplifier-*.md` constraints/guardrails companion alongside the compliant human doc, which is redundant with the architect/planner's authoritative draft and the BRC review, and an extra surface to drift out of sync with operator decisions.

## Change

A hard propose-time gate: a simplifier proposal is rejected if its proposed commit introduces any `.egg-state/drafts/{id}-` file other than the registered human companion.

- **`orchestrator/routes/signals/_validation.py`** — new `_reject_extra_simplifier_drafts`, called from `_validate_producer_artifacts` for the simplifier after the presence loop. It inspects only the files the *proposed commit* introduced under `.egg-state/drafts/{id}-` (so the upstream producer's draft, which the simplifier's commit never touches, is never implicated) and raises only when it can positively name an extra draft. Any git failure or non-zero `git show` degrades gracefully — it never blames the producer for an infra hiccup, matching the surrounding validator.
- **`orchestrator/routes/signals/__init__.py`** — re-export the helper through the barrel so its patch seam resolves (per the `routes/signals/` decomposition convention).
- **`orchestrator/routes/pipelines.py`** — one prompt bullet in the simplifier producer block telling it to commit only the human companion (no second draft), matching what the gate enforces.

Deliberately scoped to the simplifier; other producers' extra-draft policy is out of scope.

## Tests

`TestSimplifierSingleArtifactEnforcement` in `orchestrator/tests/test_signals.py`:
- accepts a commit that introduces only the human companion
- rejects an extra `*-simplifier-plan.md` (plan) and `*-simplifier-analysis.md` (refine) companion
- ignores non-draft / agent-output / upstream paths (the gate is scoped to drafts the commit introduced)
- leaves non-simplifier producers (e.g. `task_planner` committing its own `*-plan.md`) untouched
- degrades gracefully on a non-zero `git show` and on a subprocess exception

`make lint-python` clean; targeted suites (`test_signals.py`, `test_pipeline_prompts.py` — 566 tests) green.