### PR TITLE
Multi-repo pipelines: schema + env/worktree foundation (#3393)

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -7703,6 +7703,10 @@ def worktree_create() -> tuple[Response, int] | Response:
     container_id = data.get("container_id")
     repos = data.get("repos", [])
     base_branch = data.get("base_branch")  # None = resolve per-repo
+    # #3393 multi-repo: optional per-repo base-branch overrides
+    # (owner/name → branch). A repo absent here falls back to base_branch
+    # and then to the gateway-resolved default branch.
+    base_branches = data.get("base_branches") or {}
     assigned_branch = data.get("assigned_branch")  # None = skip upstream config
     # UID/GID for worktree ownership (default: 1000 for egg user)
     uid = data.get("uid")
@@ -7731,6 +7735,27 @@ def worktree_create() -> tuple[Response, int] | Response:
     if gid is not None and (not isinstance(gid, int) or gid < 0):
         return make_error("Invalid gid: must be a non-negative integer")
 
+    # Validate per-repo base_branches (#3393). Same defense-in-depth as the
+    # session-register endpoint: each override flows into git as positional
+    # argv, so reject non-strings and unsafe ref shapes (leading dash, ``..``,
+    # null bytes, ``//``) via validate_branch_ref before it touches git.
+    if base_branches:
+        if not isinstance(base_branches, dict):
+            return make_error("Invalid base_branches: must be an object mapping repo→branch")
+        for _repo_key, _branch_val in base_branches.items():
+            if not isinstance(_branch_val, str) or not _branch_val:
+                return make_error(
+                    f"Invalid base_branches[{_repo_key!r}]: must be a non-empty string"
+                )
+            if len(_branch_val) > 256:
+                return make_error(
+                    f"Invalid base_branches[{_repo_key!r}]: must be 256 characters or fewer"
+                )
+            try:
+                validate_branch_ref(_branch_val, "base_branch")
+            except ValueError as exc:
+                return make_error(str(exc))
+
     manager = get_worktree_manager()
     worktrees = {}
     errors = []
@@ -7748,12 +7773,17 @@ def worktree_create() -> tuple[Response, int] | Response:
         # feedback — previously hoisted out of the try, which let
         # resolve_default_branch failures bypass the per-repo errors[]
         # safety net entirely.
-        effective_branch = base_branch
+        # #3393: a per-repo override (keyed by the full owner/name slug, with
+        # a bare-name fallback) wins over the pipeline-wide base_branch.
+        repo_override = base_branches.get(repo) or base_branches.get(repo_name)
+        effective_branch = repo_override or base_branch
         try:
             # Resolve the default branch per-repo when no explicit base is given.
             # This ensures repos with non-standard default branches (e.g., master)
             # are handled correctly.  See #860.
-            effective_branch = base_branch or manager.resolve_default_branch(repo_name)
+            effective_branch = (
+                repo_override or base_branch or manager.resolve_default_branch(repo_name)
+            )
             info = manager.create_worktree(
                 repo_name=repo_name,
                 container_id=container_id,

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -5255,6 +5255,61 @@ class TestWorktreeCreateEndpointResolution:
             base = call_kwargs.kwargs.get("base_branch") or call_kwargs[1].get("base_branch")
             assert base == "origin/develop"
 
+    def test_worktree_create_per_repo_base_branches_override(self, client, launcher_auth_headers):
+        """#3393: base_branches[repo] wins over the pipeline-wide base_branch.
+
+        Repos absent from the override map fall back to the shared
+        base_branch (or the resolved default).
+        """
+        with patch.object(gateway, "get_worktree_manager") as mock_worktree:
+            mock_wt_manager = mock_worktree.return_value
+            mock_worktree_info = MagicMock()
+            mock_worktree_info.worktree_path = "/path/to/worktree"
+            mock_wt_manager.create_worktree.return_value = mock_worktree_info
+
+            response = client.post(
+                "/api/v1/worktree/create",
+                headers=launcher_auth_headers,
+                data=json.dumps(
+                    {
+                        "container_id": "test-container",
+                        "repos": ["owner/primary", "owner/schema"],
+                        "base_branch": "origin/main",
+                        "base_branches": {"owner/schema": "origin/develop"},
+                    }
+                ),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 200
+            # The overridden repo got develop; the other got the shared base.
+            bases = {
+                c.kwargs["repo_slug"]: c.kwargs["base_branch"]
+                for c in mock_wt_manager.create_worktree.call_args_list
+            }
+            assert bases["owner/primary"] == "origin/main"
+            assert bases["owner/schema"] == "origin/develop"
+            # resolve_default_branch is never needed — both had an explicit base.
+            mock_wt_manager.resolve_default_branch.assert_not_called()
+
+    def test_worktree_create_rejects_unsafe_base_branches_value(
+        self, client, launcher_auth_headers
+    ):
+        """A base_branches value with an unsafe ref shape is rejected."""
+        response = client.post(
+            "/api/v1/worktree/create",
+            headers=launcher_auth_headers,
+            data=json.dumps(
+                {
+                    "container_id": "test-container",
+                    "repos": ["owner/schema"],
+                    "base_branches": {"owner/schema": "--upload-pack=evil"},
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code != 200
+
 
 class TestWorktreeCreateFailureLogging:
     """Tests for worktree_create's failure-path observability and cleanup.

--- a/orchestrator/gateway_client/_worktree.py
+++ b/orchestrator/gateway_client/_worktree.py
@@ -17,6 +17,7 @@ def create_worktrees(
     uid: int | None = None,
     gid: int | None = None,
     base_branch: str | None = None,
+    base_branches: dict[str, str] | None = None,
     assigned_branch: str | None = None,
     timeout: int = 120,
 ) -> WorktreeResult:
@@ -33,6 +34,12 @@ def create_worktrees(
         gid: Group ID for worktree ownership
         base_branch: Branch to base worktrees on. When None, the gateway
             resolves the remote default branch per-repo (e.g., origin/main).
+            Applies to every repo without a ``base_branches`` override.
+        base_branches: Optional per-repo base-branch overrides
+            (owner/name → branch) for #3393 multi-repo pipelines, where a
+            schema repo and its consumer repo may track different default
+            branches. A repo absent from this map falls back to
+            ``base_branch`` and then to the gateway-resolved default.
         assigned_branch: Remote branch that pushes from the worktree
             should target.  When set, the gateway configures
             ``branch.<local>.merge`` so a naive ``git push`` from the
@@ -54,6 +61,8 @@ def create_worktrees(
     }
     if base_branch is not None:
         request_data["base_branch"] = base_branch
+    if base_branches:
+        request_data["base_branches"] = base_branches
     if assigned_branch is not None:
         request_data["assigned_branch"] = assigned_branch
     if uid is not None:

--- a/orchestrator/kubernetes_spawner/_spawn.py
+++ b/orchestrator/kubernetes_spawner/_spawn.py
@@ -520,31 +520,49 @@ def spawn_agent_job(
         if pipeline_repo:
             # owner/repo string used by the overseer auto-issue verb
             # (issue #1962) and the gateway's overseer guardrails.
+            # Stays the PRIMARY repo even for multi-repo pipelines.
             environment["EGG_PIPELINE_REPO"] = pipeline_repo
+            import json as _json
+
+            # #3393 multi-repo: expose the full repo set instead of
+            # collapsing to the primary. EGG_PIPELINE_REPOS is the JSON
+            # list of every owner/repo the pipeline operates on (primary
+            # first); EGG_REPO_VOLUMES_JSON maps each to its in-container
+            # worktree path (deterministic: /home/egg/repos/<name>) so an
+            # agent working a slice scoped to a secondary repo can cd into
+            # the right tree. Both omit-safe: single-repo pipelines still
+            # carry a one-element list / map.
+            environment["EGG_PIPELINE_REPOS"] = _json.dumps(repos)
+            environment["EGG_REPO_VOLUMES_JSON"] = _json.dumps(
+                {r: f"{repo_base}/{r.split('/')[-1]}" for r in repos}
+            )
+
             # #2528: sandbox containers don't have repositories.yaml
             # mounted, so the orchestrator pre-resolves the per-repo
             # role-pattern override here and passes it as a JSON
             # env var. ``shared.egg_restrictions.patterns`` checks
             # this env var first before attempting a filesystem
             # lookup. Failures are non-fatal — the lookup degrades
-            # to the global defaults.
+            # to the global defaults. #3393: resolve for EVERY repo,
+            # not just the primary, so per-repo restrictions apply when
+            # an agent touches a secondary repo.
             try:
-                import json as _json
-
                 from egg_restrictions.patterns import (
                     load_repo_pattern_override,
                 )
 
-                snapshot = load_repo_pattern_override(pipeline_repo)
-                if snapshot:
-                    environment["EGG_PIPELINE_REPO_PATTERNS_JSON"] = _json.dumps(
-                        {pipeline_repo: snapshot}
-                    )
+                overrides: dict[str, Any] = {}
+                for _repo in repos:
+                    snapshot = load_repo_pattern_override(_repo)
+                    if snapshot:
+                        overrides[_repo] = snapshot
+                if overrides:
+                    environment["EGG_PIPELINE_REPO_PATTERNS_JSON"] = _json.dumps(overrides)
             except Exception:
                 logger.exception(
-                    "Failed to pre-resolve role-pattern override for sandbox; "
+                    "Failed to pre-resolve role-pattern overrides for sandbox; "
                     "falling back to defaults",
-                    repo=pipeline_repo,
+                    repos=repos,
                 )
         if issue_number is not None:
             environment["EGG_ISSUE_NUMBER"] = str(issue_number)

--- a/orchestrator/mcp_tools/_submit.py
+++ b/orchestrator/mcp_tools/_submit.py
@@ -77,6 +77,27 @@ def _handle_submit_task(self, args: dict[str, Any]) -> dict[str, Any]:
         data["branch"] = args.get("branch") or f"egg/{base_id}"
     if args.get("repo"):
         data["repo"] = args["repo"]
+    # #3393 multi-repo: forward the optional secondary-repo list. Validate
+    # each entry's repo is owner/name up front so a malformed submission
+    # fails fast with a clear message rather than 500ing in the route.
+    if args.get("additional_repos"):
+        additional = args["additional_repos"]
+        if not isinstance(additional, list):
+            return {"error": "additional_repos must be a list of {repo, base_branch?} objects"}
+        normalized: list[dict[str, Any]] = []
+        for entry in additional:
+            if not isinstance(entry, dict) or not entry.get("repo"):
+                return {
+                    "error": "each additional_repos entry must be an object with a 'repo' field"
+                }
+            repo_val = str(entry["repo"]).strip()
+            if not re.fullmatch(r"[^/\s]+/[^/\s]+", repo_val):
+                return {"error": f"Invalid additional_repos repo '{repo_val}': expected owner/name"}
+            item: dict[str, Any] = {"repo": repo_val}
+            if entry.get("base_branch"):
+                item["base_branch"] = str(entry["base_branch"]).strip()
+            normalized.append(item)
+        data["additional_repos"] = normalized
     if args.get("config"):
         config = args["config"]
         if isinstance(config, str):

--- a/orchestrator/mcp_tools/_tool_defs.py
+++ b/orchestrator/mcp_tools/_tool_defs.py
@@ -32,6 +32,32 @@ PIPELINE_TOOLS = [
                     "type": "string",
                     "description": "Base branch for PR creation (optional). Defaults to the repo's default branch if not specified.",
                 },
+                "additional_repos": {
+                    "type": "array",
+                    "description": (
+                        "Secondary repos this pipeline should also operate on "
+                        "(#3393 multi-repo pipelines). The 'repo' arg is the "
+                        "primary repo; each entry here is an extra repo a slice "
+                        "may target. All repos must share the same auth mode "
+                        "(all public or all private). Omit for single-repo "
+                        "pipelines."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "repo": {
+                                "type": "string",
+                                "description": "Repository in owner/name format",
+                            },
+                            "base_branch": {
+                                "type": "string",
+                                "description": "Base branch for this repo (optional; "
+                                "defaults to the repo's default branch).",
+                            },
+                        },
+                        "required": ["repo"],
+                    },
+                },
                 "config": {
                     "type": "object",
                     "description": 'Optional pipeline configuration overrides (e.g. {"start_phase": "implement", "hitl_gates": false})',

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -1102,6 +1102,35 @@ class PipelineConfig(BaseModel):
         return v
 
 
+class AdditionalRepo(BaseModel):
+    """A secondary repo attached to a multi-repo pipeline (#3393).
+
+    The pipeline's primary repo stays on ``Pipeline.repo`` /
+    ``Pipeline.base_branch``; each *additional* repo a pipeline operates on
+    is one of these. ``base_branch`` is per-repo (a schema repo and its
+    consumer repo may track different default branches); ``None`` lets the
+    gateway resolve that repo's remote default branch, matching the
+    primary-repo behaviour.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    repo: str = Field(..., description="Repository in owner/name format")
+    base_branch: str | None = Field(
+        default=None,
+        description="Base branch for this repo's worktree/PRs. None → the "
+        "repo's remote default branch (resolved by the gateway).",
+    )
+
+    @field_validator("repo")
+    @classmethod
+    def _validate_repo(cls, v: str) -> str:
+        trimmed = (v or "").strip()
+        if not re.fullmatch(r"[^/\s]+/[^/\s]+", trimmed):
+            raise ValueError("repo must be in 'owner/name' format")
+        return trimmed
+
+
 class Pipeline(BaseModel):
     """Complete state of an SDLC pipeline execution.
 
@@ -1118,6 +1147,19 @@ class Pipeline(BaseModel):
     base_branch: str | None = Field(
         default=None,
         description="Base branch for PR creation. When None, auto-detected from repo's default branch.",
+    )
+    additional_repos: list[AdditionalRepo] = Field(
+        default_factory=list,
+        description=(
+            "Secondary repos this pipeline also operates on (#3393 "
+            "multi-repo pipelines). The primary repo stays on ``repo`` / "
+            "``base_branch``; these are the extra repos a slice may target "
+            "via ``Slice.repo``. Empty for single-repo pipelines and every "
+            "contract written before this field existed. Grown at submit "
+            "time (``additional_repos`` arg) or by HITL-approved agent "
+            "proposals at a phase gate. Use ``all_repos`` / "
+            "``base_branch_for`` rather than reading this directly."
+        ),
     )
     prompt: str | None = Field(default=None, description="User prompt for prompt-driven pipelines")
     status: PipelineStatus = Field(
@@ -1311,6 +1353,38 @@ class Pipeline(BaseModel):
         if phase.value not in self.phases:
             self.phases[phase.value] = PhaseExecution(phase=phase)
         return self.phases[phase.value]
+
+    @property
+    def all_repos(self) -> list[str]:
+        """Every repo this pipeline operates on, primary first (#3393).
+
+        The canonical accessor that replaces the historical
+        ``[pipeline.repo]`` collapse at the worktree / spawn / session call
+        sites. Returns the primary ``repo`` (when set) followed by each
+        ``additional_repos`` entry, de-duplicated while preserving order so
+        a repo accidentally listed as both primary and additional only
+        provisions once. Empty for local pipelines with no repo.
+        """
+        ordered: list[str] = []
+        for candidate in [self.repo, *(r.repo for r in self.additional_repos)]:
+            if candidate and candidate not in ordered:
+                ordered.append(candidate)
+        return ordered
+
+    def base_branch_for(self, repo: str) -> str | None:
+        """Base branch for ``repo`` — primary's or the additional entry's.
+
+        Returns ``self.base_branch`` for the primary repo and the matching
+        ``additional_repos`` entry's ``base_branch`` otherwise. ``None``
+        (the default) means "let the gateway resolve that repo's remote
+        default branch", identical to the single-repo behaviour.
+        """
+        if repo == self.repo:
+            return self.base_branch
+        for extra in self.additional_repos:
+            if extra.repo == repo:
+                return extra.base_branch
+        return None
 
     def get_pending_decisions(self) -> list[HITLDecision]:
         """Get all pending HITL decisions."""

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -2107,6 +2107,22 @@ def create_pipeline() -> tuple[Response, int]:
     repo = data.get("repo")
     branch = data.get("branch")
     base_branch = data.get("base_branch")
+    # #3393 multi-repo: secondary repos this pipeline also operates on.
+    # The MCP submit_task handler already normalised/validated each entry
+    # to {repo, base_branch?}; pydantic coerces into AdditionalRepo on the
+    # Pipeline model. Reject obviously-malformed direct-API payloads.
+    additional_repos = data.get("additional_repos")
+    if additional_repos is not None:
+        if not isinstance(additional_repos, list):
+            return make_error_response(
+                "additional_repos must be a list of {repo, base_branch?} objects"
+            )
+        for entry in additional_repos:
+            entry_repo = entry.get("repo") if isinstance(entry, dict) else None
+            if not entry_repo or not re.fullmatch(r"[^/\s]+/[^/\s]+", str(entry_repo).strip()):
+                return make_error_response(
+                    f"Invalid additional_repos entry {entry!r}: each needs a 'owner/name' repo"
+                )
     prompt = data.get("prompt")
     mode = data.get("mode", "issue")
     analysis = data.get("analysis")
@@ -2475,6 +2491,7 @@ def create_pipeline() -> tuple[Response, int]:
             repo=repo,
             branch=branch,
             base_branch=base_branch,
+            additional_repos=additional_repos,
             config=config,
             prompt=prompt,
             network_mode=network_mode,
@@ -24154,12 +24171,21 @@ def _run_pipeline(
         worktree_repo_path = repo_path  # default; overridden when worktrees exist
         host_uid = int(os.environ.get("HOST_UID", 1000))
         host_gid = int(os.environ.get("HOST_GID", 1000))
-        pipeline_repos = [pipeline.repo] if pipeline.repo else []
+        # #3393 multi-repo: provision a worktree for every repo the pipeline
+        # operates on (primary + additional), not just the primary.
+        pipeline_repos = pipeline.all_repos
 
         if host_repo_map:
             try:
                 # Request repos in owner/repo format if available, else bare names
                 wt_repos = pipeline_repos if pipeline_repos else list(host_repo_map.keys())
+                # Per-repo base branches (#3393): the primary uses
+                # pipeline.base_branch; each additional repo uses its own.
+                # Absent entries fall back to the repo's remote default
+                # branch (resolved by the gateway).
+                wt_base_branches = {
+                    r: pipeline.base_branch_for(r) for r in wt_repos if pipeline.base_branch_for(r)
+                }
                 # When the pipeline specifies a base_branch, pass it through
                 # so the worktree is branched from that ref instead of the
                 # repo's default branch.  Otherwise let the gateway resolve
@@ -24178,6 +24204,7 @@ def _run_pipeline(
                             uid=host_uid,
                             gid=host_gid,
                             base_branch=pipeline.base_branch,
+                            base_branches=wt_base_branches or None,
                         )
                         break  # Success — exit retry loop
                     except GatewayError as gw_err:
@@ -25172,11 +25199,13 @@ def _run_pipeline(
             if pipeline.prompt:
                 sandbox_env["EGG_PIPELINE_PROMPT"] = pipeline.prompt
 
+            # #3393 multi-repo: hand the spawn path every repo the pipeline
+            # operates on. EGG_REPO stays the primary for back-compat;
+            # _spawn.py exports the full set (EGG_PIPELINE_REPOS /
+            # EGG_REPO_VOLUMES_JSON) for agents that touch secondary repos.
+            repos = pipeline.all_repos
             if pipeline.repo:
-                repos = [pipeline.repo]
                 sandbox_env["EGG_REPO"] = pipeline.repo
-            else:
-                repos = []
 
             # Jira ticket advisory env vars (issue #1556).  These give sandbox
             # agents a stable handle for the ticket the pipeline is working

--- a/orchestrator/state_store/_crud.py
+++ b/orchestrator/state_store/_crud.py
@@ -162,6 +162,7 @@ def create_pipeline(
     repo: str | None = None,
     branch: str | None = None,
     base_branch: str | None = None,
+    additional_repos: list[dict[str, Any]] | None = None,
     config: dict[str, Any] | None = None,
     prompt: str | None = None,
     pipeline_id: str | None = None,
@@ -226,6 +227,9 @@ def create_pipeline(
             "repo": repo,
             "branch": branch,
             "base_branch": base_branch,
+            # #3393: pydantic coerces the list[dict] from the request body
+            # into list[AdditionalRepo]; empty/None stays a single-repo pipeline.
+            "additional_repos": additional_repos or [],
             "prompt": prompt,
             "network_mode": network_mode,
             # Contract is created separately — mark as unsynced until verified

--- a/orchestrator/tests/test_gateway_client.py
+++ b/orchestrator/tests/test_gateway_client.py
@@ -834,6 +834,36 @@ class TestWorktreeManagement:
         assert sent["assigned_branch"] == "egg/issue-1759-v3"
         assert sent["base_branch"] == "main"
 
+    def test_create_worktrees_forwards_base_branches_map(self, gateway_client):
+        """#3393: per-repo base_branches override map is forwarded."""
+        with patch.object(gateway_client, "_make_request") as mock_request:
+            mock_request.return_value = {
+                "success": True,
+                "data": {"worktrees": {"repo1": "/tmp/wt"}, "errors": []},
+            }
+            gateway_client.create_worktrees(
+                container_id="issue-1",
+                repos=["owner/primary", "owner/schema"],
+                base_branch="main",
+                base_branches={"owner/schema": "develop"},
+            )
+        sent = mock_request.call_args.kwargs["data"]
+        assert sent["base_branch"] == "main"
+        assert sent["base_branches"] == {"owner/schema": "develop"}
+
+    def test_create_worktrees_omits_base_branches_when_empty(self, gateway_client):
+        """An empty/omitted base_branches map leaves the key off the wire."""
+        with patch.object(gateway_client, "_make_request") as mock_request:
+            mock_request.return_value = {
+                "success": True,
+                "data": {"worktrees": {"repo1": "/tmp/wt"}, "errors": []},
+            }
+            gateway_client.create_worktrees(
+                container_id="issue-1",
+                repos=["owner/primary"],
+            )
+        assert "base_branches" not in mock_request.call_args.kwargs["data"]
+
     def test_create_worktrees_omits_assigned_branch_when_none(self, gateway_client):
         """When assigned_branch is None, the key is omitted from the request."""
         with patch.object(gateway_client, "_make_request") as mock_request:

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -322,6 +322,53 @@ class TestSpawnAgentJob:
         assert "GATEWAY_URL" in env
         assert "EGG_ORCHESTRATOR_URL" in env
 
+    def test_spawn_single_repo_env_carries_one_element_repo_set(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """#3393: single-repo spawn still exports the repo-set env vars."""
+        import json
+
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-1repo",
+            agent_role=AgentRole.TESTER,
+            repos=["owner/repo"],
+        )
+        env = result.environment
+        # Primary stays on EGG_PIPELINE_REPO for back-compat.
+        assert env["EGG_PIPELINE_REPO"] == "owner/repo"
+        assert json.loads(env["EGG_PIPELINE_REPOS"]) == ["owner/repo"]
+        assert json.loads(env["EGG_REPO_VOLUMES_JSON"]) == {"owner/repo": "/home/egg/repos/repo"}
+
+    def test_spawn_multi_repo_env_exposes_full_repo_set(
+        self, spawner, mock_k8s_client, mock_gateway
+    ):
+        """#3393: the spawn env no longer collapses to repos[0].
+
+        EGG_PIPELINE_REPO is the primary, but EGG_PIPELINE_REPOS and
+        EGG_REPO_VOLUMES_JSON carry every repo so an agent on a slice
+        scoped to a secondary repo can locate its worktree.
+        """
+        import json
+
+        result = spawner.spawn_agent_job(
+            pipeline_id="pipe-multi",
+            agent_role=AgentRole.CODER,
+            repos=["owner/primary", "owner/schema"],
+        )
+        env = result.environment
+        assert env["EGG_PIPELINE_REPO"] == "owner/primary"
+        assert json.loads(env["EGG_PIPELINE_REPOS"]) == [
+            "owner/primary",
+            "owner/schema",
+        ]
+        assert json.loads(env["EGG_REPO_VOLUMES_JSON"]) == {
+            "owner/primary": "/home/egg/repos/primary",
+            "owner/schema": "/home/egg/repos/schema",
+        }
+        # The full set is also handed to the gateway session.
+        reg_kwargs = mock_gateway.register_session.call_args.kwargs
+        assert reg_kwargs["repos"] == ["owner/primary", "owner/schema"]
+
     def test_spawn_injects_oauth_placeholder_on_anthropic_path(
         self, spawner, mock_k8s_client, mock_gateway
     ):

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -3248,3 +3248,73 @@ class TestUpdatePipelineConfig:
         required = tool["inputSchema"]["required"]
         assert "task_id" in required
         assert "agent_models" in required
+
+
+class TestSubmitTaskAdditionalRepos:
+    """#3393: submit_task accepts/validates the additional_repos list."""
+
+    def test_additional_repos_forwarded(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {"pipeline_id": "issue-1", "status": "pending"}
+            handler.handle_tool_call(
+                "submit_task",
+                {
+                    "description": "cross-repo change",
+                    "repo": "owner/primary",
+                    "issue_number": 1,
+                    "additional_repos": [
+                        {"repo": "owner/schema", "base_branch": "develop"},
+                        {"repo": "owner/client"},
+                    ],
+                },
+            )
+        sent = mock_req.call_args.kwargs["data"]
+        assert sent["repo"] == "owner/primary"
+        assert sent["additional_repos"] == [
+            {"repo": "owner/schema", "base_branch": "develop"},
+            {"repo": "owner/client"},
+        ]
+
+    def test_additional_repos_rejects_bad_repo(self, handler):
+        result = handler.handle_tool_call(
+            "submit_task",
+            {
+                "description": "x",
+                "repo": "owner/primary",
+                "issue_number": 1,
+                "additional_repos": [{"repo": "not-a-slug"}],
+            },
+        )
+        assert "error" in result
+        assert "owner/name" in result["error"]
+
+    def test_additional_repos_rejects_missing_repo_field(self, handler):
+        result = handler.handle_tool_call(
+            "submit_task",
+            {
+                "description": "x",
+                "repo": "owner/primary",
+                "issue_number": 1,
+                "additional_repos": [{"base_branch": "main"}],
+            },
+        )
+        assert "error" in result
+
+    def test_omitted_additional_repos_not_forwarded(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {"pipeline_id": "issue-1", "status": "pending"}
+            handler.handle_tool_call(
+                "submit_task",
+                {"description": "x", "repo": "owner/primary", "issue_number": 1},
+            )
+        assert "additional_repos" not in mock_req.call_args.kwargs["data"]
+
+    def test_schema_advertises_additional_repos(self):
+        from mcp_tools import PIPELINE_TOOLS
+
+        tool = next(t for t in PIPELINE_TOOLS if t["name"] == "submit_task")
+        props = tool["inputSchema"]["properties"]
+        assert "additional_repos" in props
+        assert props["additional_repos"]["type"] == "array"
+        item_props = props["additional_repos"]["items"]["properties"]
+        assert "repo" in item_props and "base_branch" in item_props

--- a/orchestrator/tests/test_models.py
+++ b/orchestrator/tests/test_models.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import pytest
 from models import (
     PHASE_CONSENSUS_TIMEOUT_DEFAULTS_MIN,
+    AdditionalRepo,
     AgentExecution,
     AgentExecutionStatus,
     AgentExitInfo,
@@ -1206,3 +1207,46 @@ class TestPipelinePhase:
         assert PipelinePhase.APPLY == "apply"
         # StrEnum: value-equal to string for serialisation symmetry.
         assert PipelinePhase("apply") == PipelinePhase.APPLY
+
+
+class TestMultiRepoPipeline:
+    """#3393: Pipeline repo-set accessors and back-compat."""
+
+    def test_additional_repo_owner_name_validation(self):
+        """AdditionalRepo.repo must be 'owner/name'; trims whitespace."""
+        assert AdditionalRepo(repo="  owner/name  ").repo == "owner/name"
+        for bad in ("bad", "a/b/c", "owner/", "/name", "owner name"):
+            with pytest.raises(ValueError):
+                AdditionalRepo(repo=bad)
+
+    def test_all_repos_primary_only(self):
+        """Single-repo pipeline reports just its primary repo."""
+        p = Pipeline(id="issue-1", repo="o/primary", base_branch="main")
+        assert p.all_repos == ["o/primary"]
+        assert p.base_branch_for("o/primary") == "main"
+
+    def test_all_repos_primary_first_then_additional(self):
+        """Primary leads; additional follow; duplicates collapse once."""
+        p = Pipeline(
+            id="issue-2",
+            repo="o/primary",
+            additional_repos=[
+                AdditionalRepo(repo="o/secondary", base_branch="dev"),
+                # a redundant restatement of the primary must not double-provision
+                AdditionalRepo(repo="o/primary"),
+            ],
+        )
+        assert p.all_repos == ["o/primary", "o/secondary"]
+        assert p.base_branch_for("o/secondary") == "dev"
+        # unknown / unset repos fall back to None (gateway resolves default)
+        assert p.base_branch_for("o/unknown") is None
+
+    def test_all_repos_empty_when_no_repo(self):
+        """Local pipelines with no repo report an empty repo set."""
+        assert Pipeline(id="local-1").all_repos == []
+
+    def test_back_compat_pre_3393_pipeline_json(self):
+        """Contracts written before #3393 (no additional_repos) still load."""
+        p = Pipeline.model_validate({"id": "issue-3", "repo": "o/p"})
+        assert p.additional_repos == []
+        assert p.all_repos == ["o/p"]

--- a/orchestrator/tests/test_state_store.py
+++ b/orchestrator/tests/test_state_store.py
@@ -112,6 +112,30 @@ class TestPipelineCreation:
         loaded = state_store.load_pipeline("issue-496")
         assert loaded.issue_number == 496
 
+    def test_create_pipeline_with_additional_repos(self, state_store):
+        """#3393: additional_repos round-trips through create + reload."""
+        state_store.create_pipeline(
+            issue_number=496,
+            repo="owner/primary",
+            branch="egg/issue-496",
+            additional_repos=[
+                {"repo": "owner/schema", "base_branch": "develop"},
+                {"repo": "owner/client"},
+            ],
+        )
+        loaded = state_store.load_pipeline("issue-496")
+        assert loaded.all_repos == ["owner/primary", "owner/schema", "owner/client"]
+        assert loaded.base_branch_for("owner/schema") == "develop"
+        assert loaded.base_branch_for("owner/client") is None
+
+    def test_create_pipeline_without_additional_repos_is_single_repo(self, state_store):
+        """Omitting additional_repos yields a plain single-repo pipeline."""
+        pipeline = state_store.create_pipeline(
+            issue_number=496, repo="owner/primary", branch="egg/issue-496"
+        )
+        assert pipeline.additional_repos == []
+        assert pipeline.all_repos == ["owner/primary"]
+
     def test_create_pipeline_with_config(self, state_store):
         """Test creating pipeline with custom config."""
         pipeline = state_store.create_pipeline(

--- a/shared/egg_contracts/models.py
+++ b/shared/egg_contracts/models.py
@@ -353,6 +353,19 @@ class Slice(EggContractBaseModel):
             "body then falls back to the program-description blurb)."
         ),
     )
+    repo: str | None = Field(
+        default=None,
+        description=(
+            "Target repository for this slice in ``owner/name`` format "
+            "(#3393 multi-repo pipelines). ``None`` — the default and the "
+            "value for every contract written before this field existed — "
+            "means the slice targets the pipeline's primary repo. A value "
+            "naming a repo not yet attached to the pipeline is treated by "
+            "``populate_contract`` as a *proposed* new repo requiring HITL "
+            "approval at the phase gate. Resolve with ``resolve_repo`` "
+            "rather than reading this field directly."
+        ),
+    )
     status: SliceStatus = Field(default=SliceStatus.PENDING, description="Slice status")
     review_cycles: int = Field(default=0, ge=0, description="Number of review cycles")
     max_cycles: int = Field(default=3, ge=1, description="Max cycles before escalation")
@@ -443,6 +456,19 @@ class Slice(EggContractBaseModel):
     @classmethod
     def validate_commit(cls, v: Any) -> str | None:
         return _normalize_commit(v)
+
+    def resolve_repo(self, primary: str | None) -> str | None:
+        """Repo this slice targets, falling back to the pipeline primary.
+
+        The canonical accessor for a slice's repo (#3393 multi-repo
+        pipelines): returns ``self.repo`` when the planner scoped the
+        slice to a specific repo, else the pipeline's ``primary`` repo.
+        Every slice-PR / worktree / review-graph call site should resolve
+        through this rather than reading ``self.repo`` so the
+        "unset means primary" default lives in one place and pre-#3393
+        contracts keep working.
+        """
+        return self.repo or primary
 
     @property
     def tasks_all_complete(self) -> bool:

--- a/shared/egg_contracts/tests/test_slice_migration.py
+++ b/shared/egg_contracts/tests/test_slice_migration.py
@@ -258,3 +258,27 @@ class TestContractIssueOrPipelineIdRequirement:
     def test_pipeline_id_only_loads(self) -> None:
         contract = Contract.model_validate({"slices": [], "pipeline_id": "issue-2137"})
         assert contract.pipeline_id == "issue-2137"
+
+
+class TestSliceRepoDimension:
+    """#3393: per-slice ``repo`` pointer and ``resolve_repo`` fallback."""
+
+    def test_repo_defaults_to_none(self) -> None:
+        """Unset on construction and on pre-#3393 payloads."""
+        assert Slice(id="slice-1", name="x").repo is None
+        loaded = Slice.model_validate({"id": "slice-1", "name": "x"})
+        assert loaded.repo is None
+
+    def test_resolve_repo_falls_back_to_primary(self) -> None:
+        """Unscoped slice resolves to the pipeline primary repo."""
+        assert Slice(id="slice-1", name="x").resolve_repo("o/primary") == "o/primary"
+
+    def test_resolve_repo_prefers_slice_repo(self) -> None:
+        """A scoped slice resolves to its own repo, not the primary."""
+        s = Slice(id="slice-1", name="x", repo="o/secondary")
+        assert s.resolve_repo("o/primary") == "o/secondary"
+
+    def test_repo_round_trips_through_dump(self) -> None:
+        """``repo`` serialises and reloads unchanged."""
+        s = Slice(id="slice-1", name="x", repo="o/secondary")
+        assert Slice.model_validate(s.model_dump()).repo == "o/secondary"


### PR DESCRIPTION
## Summary

Foundation for **multi-repo pipelines** (#3393) — letting one pipeline operate across more than one repository. This PR is the **additive, behavior-preserving** first slice: single-repo pipelines are unaffected (no `slice.repo` setter yet, so `all_repos == [repo]` and `additional_repos` defaults empty; old `.egg-state` contracts load and behave identically).

The infra was closer than it looked — the gateway already took a repo *list*. The concentrated gaps this PR closes are the **schema's missing repo dimension** and the **`repos[0]` / `pipeline.repo` collapse** in the agent env.

## What's included

**Schema (all new fields optional → back-compat):**
- `Slice.repo` + `Slice.resolve_repo(primary)` — per-slice repo pointer, defaults to the pipeline primary.
- `Pipeline.additional_repos` (`list[AdditionalRepo]`) + `all_repos` / `base_branch_for()` accessors. The single-repo collapse now lives behind these accessors.

**Submission:**
- `submit_task` accepts `additional_repos: [{repo, base_branch?}]`, validated in the MCP handler + create-pipeline route, persisted via `StateStore.create_pipeline`.

**Stop the collapse (the issue's headline gap):**
- `_spawn.py` keeps `EGG_PIPELINE_REPO`=primary but adds `EGG_PIPELINE_REPOS` + `EGG_REPO_VOLUMES_JSON`, and resolves per-repo role-pattern overrides for *every* repo. Worktree / env / session assembly uses `pipeline.all_repos`.

**Per-repo base branches:**
- `create_worktrees` (gateway client + endpoint) gains a `base_branches` map so additional repos fork from their own base; absent entries fall back to `base_branch` then the resolved default. Endpoint validates each override via `validate_branch_ref` (defense-in-depth).

## Deferred to a follow-up

Per-slice PR targeting, the plan-parser `repo:` key, and the agent-proposed-repo HITL flow. These move together because they touch the delicate stacked-PR / integration-branch subsystem (`create_slice_integration_branch`, ls-remote probes, cross-repo base resolution). Until then, a multi-repo submit provisions all worktrees / sessions / env (agents *can* operate across repos), but per-slice PR automation isn't wired.

Per the approved design: **arbitrary-N repos, no cross-repo merge-sequencing gate** (ordering via existing slice dependencies; humans merge in order), **uniform auth mode** across repos.

## Testing

Added coverage across 6 test files: schema round-trip / back-compat / accessors, submit validation, `create_pipeline` persistence, multi-repo spawn env, and per-repo `base_branches` on both the gateway client and endpoint. Targeted runs green (778 in the changed-file set). Full-suite failures observed were pre-existing ordering/pollution flakiness + known btrfs env noise — all pass in isolation and per-file; none trace to these changes.