### PR TITLE
Multi-repo pipelines: per-slice repo targeting + plan repo: key (#3393)

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -11343,6 +11343,51 @@ def _is_slice_dag_mode(contract) -> bool:
     return len(slices) > 1
 
 
+class SliceRepoContext(NamedTuple):
+    """Resolved repo + orchestrator worktree path for a slice (#3393).
+
+    ``repo`` is the slice's effective target repo (``slice.repo`` or the
+    pipeline primary). ``worktree_path`` is the orchestrator-accessible
+    git worktree for that repo — the *primary* worktree for primary-repo
+    slices, or the sibling repo dir under the same container worktree
+    root for a provisioned secondary repo. ``is_secondary`` is True only
+    when the slice targets a non-primary repo. ``provisioned`` is False
+    when a secondary repo has no worktree yet (e.g. an agent named a repo
+    that was never attached to the pipeline) — the caller must fail the
+    slice loudly rather than silently open its PR against the primary.
+    """
+
+    repo: str | None
+    worktree_path: Path | None
+    is_secondary: bool
+    provisioned: bool
+
+
+def _resolve_slice_repo_context(
+    pipeline,
+    slice_obj,
+    worktree_repo_path: Path,
+    repo_volumes: dict[str, str],
+) -> SliceRepoContext:
+    """Resolve where a slice's branch / PR / git ops should land (#3393).
+
+    Primary-repo (or unset) slices resolve to the primary worktree
+    unchanged, so the single-repo flow is byte-for-byte untouched. A
+    slice scoped to a secondary repo resolves to that repo's sibling
+    worktree (``<container-root>/<repo-name>``) when it was provisioned;
+    otherwise ``provisioned=False`` so the caller can fail the slice.
+    """
+    primary = pipeline.repo
+    repo = slice_obj.resolve_repo(primary) if slice_obj is not None else primary
+    if not repo or repo == primary:
+        return SliceRepoContext(repo or primary, worktree_repo_path, False, True)
+    short = repo.split("/")[-1]
+    candidate = worktree_repo_path.parent / short
+    if short in repo_volumes and candidate.exists():
+        return SliceRepoContext(repo, candidate, True, True)
+    return SliceRepoContext(repo, None, True, False)
+
+
 def _resolve_slice_base_branch(
     contract,
     slice_id: str,
@@ -18433,6 +18478,36 @@ def _run_implement_phase_slices(
                 slice_id: str,
                 parent_slice_id: str | None,  # noqa: ARG001 — kept for caller compat; resolver reads contract
             ) -> tuple[int, str]:
+                # #3393 multi-repo: resolve which repo (and orchestrator
+                # worktree) this slice's branch/PR/git ops target BEFORE
+                # any branch work. Primary-repo slices resolve to the
+                # primary worktree, so the single-repo flow is unchanged.
+                _slice_ctx_obj = next((s for s in contract.slices if s.id == slice_id), None)
+                slice_repo_ctx = _resolve_slice_repo_context(
+                    pipeline, _slice_ctx_obj, worktree_repo_path, repo_volumes
+                )
+                if slice_repo_ctx.is_secondary and not slice_repo_ctx.provisioned:
+                    # An agent scoped the slice to a repo the pipeline never
+                    # attached/provisioned. Fail loudly rather than silently
+                    # open the PR against the primary repo.
+                    logger.error(
+                        "Slice targets an unprovisioned repo; failing slice (#3393)",
+                        pipeline_id=pipeline_id,
+                        slice_id=slice_id,
+                        slice_repo=slice_repo_ctx.repo,
+                    )
+                    scheduler.record_failure(slice_id)
+                    return 1, (
+                        f"slice {slice_id}: target repo {slice_repo_ctx.repo!r} "
+                        "is not attached to this pipeline (no worktree provisioned)"
+                    )
+                slice_repo = slice_repo_ctx.repo
+                # Git ops for this slice (branch create, ls-remote, diff,
+                # BRC commit, PR) run against the slice's repo worktree;
+                # the CONTRACT lives only in the primary worktree, so
+                # contract load/save below stay on ``worktree_repo_path``.
+                slice_worktree_path = slice_repo_ctx.worktree_path or worktree_repo_path
+
                 # Resolve parent branch for stacking via
                 # :func:`_resolve_slice_base_branch` (#2777, cq-2 / cq-4 /
                 # cq-9 / cq-10). The helper handles both:
@@ -18479,18 +18554,31 @@ def _run_implement_phase_slices(
                         return True
                     return spawner.gateway.ls_remote_branch_strict(
                         pipeline_id,
-                        str(worktree_repo_path),
+                        str(slice_worktree_path),
                         f"refs/heads/{parent_branch}",
                         mode=gateway_mode,  # type: ignore[arg-type]
                     )
 
-                parent_branch = _resolve_slice_base_branch(
-                    contract,
-                    slice_id,
-                    pipeline_id=pipeline_id,
-                    pipeline_branch=pipeline_branch,
-                    parent_branch_exists=_probe_parent_branch_exists,
-                )
+                if slice_repo_ctx.is_secondary:
+                    # #3393: a secondary-repo slice has no context PR / work
+                    # branch in its repo and the stacked-PR model is
+                    # primary-repo-centric, so it bases its integration
+                    # branch + standalone PR on its OWN repo's base branch
+                    # (the per-repo base if configured, else that repo's
+                    # default branch). Cross-repo dependencies still
+                    # sequence execution via the scheduler; they do not
+                    # stack branches across repos.
+                    parent_branch = pipeline.base_branch_for(slice_repo) or _detect_default_branch(
+                        slice_worktree_path
+                    )
+                else:
+                    parent_branch = _resolve_slice_base_branch(
+                        contract,
+                        slice_id,
+                        pipeline_id=pipeline_id,
+                        pipeline_branch=pipeline_branch,
+                        parent_branch_exists=_probe_parent_branch_exists,
+                    )
                 integration_branch = f"{issue_branch}/{slice_id}"
 
                 # Persist the parent-branch reference on the contract
@@ -18554,7 +18642,7 @@ def _run_implement_phase_slices(
                     try:
                         already_merged = spawner.gateway.is_slice_branch_merged_into_parent(
                             pipeline_id,
-                            str(worktree_repo_path),
+                            str(slice_worktree_path),
                             integration_branch=integration_branch,
                             parent_branch=parent_branch,
                             integration_base_sha=recorded_base_sha,
@@ -18640,7 +18728,7 @@ def _run_implement_phase_slices(
                         # restart.
                         created_base_sha = spawner.gateway.create_slice_integration_branch(
                             pipeline_id,
-                            str(worktree_repo_path),
+                            str(slice_worktree_path),
                             integration_branch=integration_branch,
                             parent_branch=parent_branch,
                             # #2947 — hand the slice's recorded fork
@@ -18810,7 +18898,7 @@ def _run_implement_phase_slices(
                     evidence_failure = _check_slice_evidence_reachability(
                         pipeline_id,
                         spawner,
-                        worktree_repo_path,
+                        slice_worktree_path,
                         slice_id,
                         integration_branch,
                         gateway_mode=gateway_mode,  # type: ignore[arg-type]
@@ -18948,7 +19036,7 @@ def _run_implement_phase_slices(
                         _commit_slice_brc_history_to_integration_branch(
                             pipeline,
                             spawner,
-                            worktree_repo_path,
+                            slice_worktree_path,
                             slice_id,
                             integration_branch,
                             gateway_mode=gateway_mode,  # type: ignore[arg-type]
@@ -18979,7 +19067,7 @@ def _run_implement_phase_slices(
                     commit_subjects, diffstat = _build_slice_diff_summary(
                         pipeline,
                         spawner,
-                        worktree_repo_path,
+                        slice_worktree_path,
                         integration_branch,
                         parent_branch,
                         gateway_mode=gateway_mode,  # type: ignore[arg-type]
@@ -18987,7 +19075,7 @@ def _run_implement_phase_slices(
                     try:
                         slice_pr_url = spawner.gateway.create_slice_pr(
                             pipeline_id=pipeline_id,
-                            repo=pipeline.repo,
+                            repo=slice_repo,
                             slice_id=slice_id,
                             slice_name=slice_pr_data["slice_name"],
                             slice_tasks=slice_pr_data["slice_tasks"],

--- a/orchestrator/stacked_pr_reconciler.py
+++ b/orchestrator/stacked_pr_reconciler.py
@@ -216,7 +216,14 @@ def find_orphaned_child_prs(
         slice_branch = f"{slice_namespace_root}/{slice_.id}"
         pr = pr_by_head.get(slice_branch)
         if pr is None:
-            continue  # slice's PR hasn't been opened yet (or is closed)
+            # Slice's PR hasn't been opened yet (or is closed). This is
+            # also where #3393 secondary-repo slices fall out: ``open_prs``
+            # is scoped to the pipeline's primary repo, and a secondary
+            # slice's PR lives in a different repo, so its branch is never
+            # in ``pr_by_head``. Secondary slices base on their own repo's
+            # branch (no cross-repo stacking), so they have no stacked-PR
+            # orphan to reconcile here.
+            continue
         deleted_base = pr.get("base_ref") or pr.get("base")
         if not isinstance(deleted_base, str) or deleted_base in extant_branches:
             continue  # base still alive — GitHub auto-retarget did its job

--- a/orchestrator/tests/test_slice_repo_context.py
+++ b/orchestrator/tests/test_slice_repo_context.py
@@ -1,0 +1,86 @@
+"""Tests for ``_resolve_slice_repo_context`` (#3393 multi-repo pipelines).
+
+The helper decides, for one slice, which repo its branch / PR / git ops
+target and which orchestrator worktree to run them against. Primary-repo
+(or unset) slices must resolve to the primary worktree unchanged so the
+single-repo flow is byte-for-byte untouched; secondary-repo slices
+resolve to their sibling worktree when provisioned and signal
+``provisioned=False`` otherwise so the caller can fail loudly.
+"""
+
+from __future__ import annotations
+
+from egg_contracts.models import Slice
+from models import AdditionalRepo, Pipeline
+from routes.pipelines import _resolve_slice_repo_context
+
+
+def _worktrees(tmp_path, *repo_names):
+    """Create a container worktree root with one dir per repo name.
+
+    Returns (primary_worktree_path, repo_volumes) where repo_volumes maps
+    repo name → path, mirroring ``WorktreeResult.worktrees``.
+    """
+    root = tmp_path / "container"
+    root.mkdir()
+    volumes = {}
+    for name in repo_names:
+        d = root / name
+        d.mkdir()
+        volumes[name] = str(d)
+    return root / repo_names[0], volumes
+
+
+def test_primary_slice_resolves_to_primary_worktree(tmp_path):
+    primary_wt, volumes = _worktrees(tmp_path, "primary")
+    pipeline = Pipeline(id="issue-1", repo="owner/primary")
+    slice_obj = Slice(id="slice-1", name="x")  # repo unset → primary
+    ctx = _resolve_slice_repo_context(pipeline, slice_obj, primary_wt, volumes)
+    assert ctx.repo == "owner/primary"
+    assert ctx.worktree_path == primary_wt
+    assert ctx.is_secondary is False
+    assert ctx.provisioned is True
+
+
+def test_slice_repo_equal_to_primary_is_not_secondary(tmp_path):
+    primary_wt, volumes = _worktrees(tmp_path, "primary")
+    pipeline = Pipeline(id="issue-1", repo="owner/primary")
+    slice_obj = Slice(id="slice-1", name="x", repo="owner/primary")
+    ctx = _resolve_slice_repo_context(pipeline, slice_obj, primary_wt, volumes)
+    assert ctx.is_secondary is False
+    assert ctx.worktree_path == primary_wt
+
+
+def test_provisioned_secondary_slice_resolves_to_sibling_worktree(tmp_path):
+    primary_wt, volumes = _worktrees(tmp_path, "primary", "schema")
+    pipeline = Pipeline(
+        id="issue-1",
+        repo="owner/primary",
+        additional_repos=[AdditionalRepo(repo="owner/schema")],
+    )
+    slice_obj = Slice(id="slice-2", name="schema bump", repo="owner/schema")
+    ctx = _resolve_slice_repo_context(pipeline, slice_obj, primary_wt, volumes)
+    assert ctx.repo == "owner/schema"
+    assert ctx.worktree_path == primary_wt.parent / "schema"
+    assert ctx.is_secondary is True
+    assert ctx.provisioned is True
+
+
+def test_unprovisioned_secondary_slice_flags_not_provisioned(tmp_path):
+    # repo_volumes lacks 'schema' → the secondary repo was never provisioned.
+    primary_wt, volumes = _worktrees(tmp_path, "primary")
+    pipeline = Pipeline(id="issue-1", repo="owner/primary")
+    slice_obj = Slice(id="slice-2", name="x", repo="owner/schema")
+    ctx = _resolve_slice_repo_context(pipeline, slice_obj, primary_wt, volumes)
+    assert ctx.repo == "owner/schema"
+    assert ctx.is_secondary is True
+    assert ctx.provisioned is False
+    assert ctx.worktree_path is None
+
+
+def test_none_slice_obj_resolves_to_primary(tmp_path):
+    primary_wt, volumes = _worktrees(tmp_path, "primary")
+    pipeline = Pipeline(id="issue-1", repo="owner/primary")
+    ctx = _resolve_slice_repo_context(pipeline, None, primary_wt, volumes)
+    assert ctx.repo == "owner/primary"
+    assert ctx.is_secondary is False

--- a/shared/egg_contracts/plan_parser/_models.py
+++ b/shared/egg_contracts/plan_parser/_models.py
@@ -108,6 +108,7 @@ _KNOWN_SLICE_KEYS = frozenset(
         "id",
         "name",
         "goal",
+        "repo",
         "dependencies",
         "depends_on",
         "serialized_chain_order",
@@ -168,6 +169,9 @@ class ParsedPhase:
     dependencies: str = ""
     exit_criteria: str = ""
     serialized_chain_order: list[str] = field(default_factory=list)
+    # #3393 multi-repo: optional ``owner/name`` repo this slice targets.
+    # ``None`` (the default) means the pipeline's primary repo.
+    repo: str | None = None
 
     def to_contract_phase(self) -> Slice:
         """Convert to a contract Slice model (legacy alias name)."""
@@ -250,6 +254,9 @@ class ParsedPhase:
             tasks=[task.to_contract_task() for task in self.tasks],
             dependencies=normalized_deps,
             serialized_chain_order=normalised_chain,
+            # #3393 — carry the planner's per-slice repo onto the contract
+            # slice. A blank/whitespace value normalises to None (primary).
+            repo=(self.repo or "").strip() or None,
         )
 
 

--- a/shared/egg_contracts/plan_parser/_yaml_parse.py
+++ b/shared/egg_contracts/plan_parser/_yaml_parse.py
@@ -458,6 +458,9 @@ def parse_phases_from_yaml(
 
         phase_name = phase_data.get("name", f"Slice {phase_num}")
         phase_goal = phase_data.get("goal", "")
+        # #3393 multi-repo: optional per-slice target repo (owner/name).
+        # Absent → None → the pipeline's primary repo.
+        phase_repo = phase_data.get("repo")
         # #2743 — accept ``depends_on`` as an alias for ``dependencies``.
         # Pipeline-8b81ed32 produced a plan that used ``depends_on: <int>``
         # on every phase and the contract came back with empty deps because
@@ -651,6 +654,7 @@ def parse_phases_from_yaml(
                 dependencies=phase_dependencies,
                 exit_criteria=phase_exit_criteria,
                 serialized_chain_order=phase_serialized_chain_order,
+                repo=phase_repo,
             )
         )
 

--- a/shared/egg_contracts/tests/test_plan_parser_dependencies.py
+++ b/shared/egg_contracts/tests/test_plan_parser_dependencies.py
@@ -177,3 +177,53 @@ class TestLegacyToContractPhaseAlias:
         # Same shape, same canonical ids, same migrated deps.
         assert legacy.id == canonical.id == "slice-2"
         assert legacy.dependencies == canonical.dependencies == ["slice-1"]
+
+
+class TestSliceRepoParsing:
+    """#3393: per-slice ``repo`` key flows plan → ParsedPhase → Slice."""
+
+    def test_repo_propagates_to_contract_slice(self):
+        phase = ParsedPhase(number=1, name="s", goal="g", repo="owner/schema")
+        assert phase.to_contract_slice().repo == "owner/schema"
+
+    def test_blank_repo_normalises_to_none(self):
+        assert ParsedPhase(number=1, name="s", goal="g", repo="  ").to_contract_slice().repo is None
+
+    def test_absent_repo_defaults_to_none(self):
+        assert ParsedPhase(number=1, name="s", goal="g").to_contract_slice().repo is None
+
+    def test_repo_key_parsed_from_yaml_tasks_fence(self):
+        from egg_contracts.plan_parser import parse_plan
+
+        plan = (
+            "# Plan\n\n"
+            "```yaml\n"
+            "# yaml-tasks\n"
+            "slices:\n"
+            "  - id: slice-1\n"
+            "    name: schema bump\n"
+            "    goal: add v2 schema\n"
+            "    repo: owner/schema\n"
+            "    tasks:\n"
+            "      - id: task-1-1\n"
+            "        description: add schema\n"
+            "        acceptance_criteria: it exists\n"
+            "        role: coder\n"
+            "  - id: slice-2\n"
+            "    name: migrate consumer\n"
+            "    goal: cut over\n"
+            "    dependencies: slice-1\n"
+            "    tasks:\n"
+            "      - id: task-2-1\n"
+            "        description: migrate\n"
+            "        acceptance_criteria: done\n"
+            "        role: coder\n"
+            "```\n"
+        )
+        result = parse_plan(plan)
+        assert result.success, result.error
+        by_id = {s.id: s for s in result.to_contract_slices()}
+        assert by_id["slice-1"].repo == "owner/schema"
+        assert by_id["slice-2"].repo is None
+        # `repo` is a recognised key — no unknown-key warning.
+        assert not any("repo" in w.message.lower() for w in result.warnings)


### PR DESCRIPTION
## Summary

Stacked on #3403. Makes **submit-time multi-repo pipelines functional end-to-end**: a plan can scope a slice to a secondary repo and the pipeline creates that slice's integration branch and opens its PR **in that repo**, off that repo's own base branch.

Single-repo pipelines are unchanged — a slice with no `repo:` resolves to the primary worktree on the existing code path.

> Base this PR's review on the diff against `egg/multi-repo-pipelines-3403`'s branch (#3403), which it stacks on.

## What's included

**Plan dimension (`shared/egg_contracts/plan_parser/`):**
- The planner declares a slice's target repo with a per-slice `repo:` key (parallel to `goal:`). It's a recognised yaml-tasks key (no unknown-key warning), flows `ParsedPhase.repo` → `Slice.repo` via `to_contract_slice`, and a blank value normalises to `None` (primary).

**Per-slice branch/PR/worktree targeting (`_run_implement_phase_slices`):**
- New `_resolve_slice_repo_context()` resolves, per slice, the target repo + its orchestrator worktree (primary worktree for primary slices; the sibling repo worktree for a provisioned secondary repo). A slice scoped to a repo the pipeline never provisioned **fails loudly** rather than silently opening its PR against the primary.
- The slice's git ops — integration-branch create, merged-check, ls-remote probe, evidence-reachability check, BRC-history commit, diff summary, and `create_slice_pr(repo=…)` — run against the slice's repo worktree. **Contract load/save stay on the primary worktree** (the contract lives only there).
- Secondary-repo slices base their integration branch + **standalone** PR on their own repo's base branch (per-repo base if configured, else that repo's default). The primary-repo stacked-PR model is untouched; cross-repo dependencies sequence execution via the scheduler but don't stack branches across repos.

**Reconciler:**
- The stacked-PR reconciler is primary-repo-scoped (`open_prs` come from the primary `pr_repo`), so secondary-repo slice branches are naturally skipped — documented at the skip site.

## Deferred to a follow-up

The agent-proposed **brand-new-repo HITL flow** (detect new repos at `populate_contract`, surface in the phase gate, validate against network mode + attach on approval). Until then a plan may only target repos attached at submit time via `additional_repos`.

## Testing

- Plan `repo:` key parsing (`ParsedPhase` + full `parse_plan`, incl. no-spurious-warning).
- `_resolve_slice_repo_context` across primary / equal-to-primary / provisioned-secondary / unprovisioned-secondary / None-slice.
- Regression: slice-restart-hardening + full `shared/egg_contracts` suites green (236 passing). Full `make test` running.