### PR TITLE
Exempt fixture/testdata trees from doc-path push guard (#3396)

### DIFF
--- a/docs/reference/agent-roles.md
+++ b/docs/reference/agent-roles.md
@@ -259,14 +259,29 @@ worktree branch.
   chokepoint, so credential-shim modifications are reviewed by
   `reviewer_security` rather than blocked at the role-pattern layer.
   See [security-review-criteria.md](../../shared/prompts/security-review-criteria.md).
-- Block exemptions (always writable, overriding the blocks above):
+- Block exemptions (writable, overriding the *soft* blocks above —
+  docs and the broad `.egg-state/` block):
   `.egg-state/agent-outputs/` (coder's handoff output),
   `.egg-state/agent-anchors/` (per-agent anchor state, scoped by
   `check_anchor_write_permission`),
   `skills/` (skill definitions are functional code),
   `sandbox/agent-config/rules/*.md` and
   `sandbox/agent-config/commands/*.md` (Claude Code agent config
-  represented as markdown — functional code, not documentation).
+  represented as markdown — functional code, not documentation),
+  `**/fixtures/` and `**/testdata/` (test-fixture / testdata trees are
+  test **inputs**, not documentation — fixtures deliberately imitate doc
+  files like `AGENTS.md` / `README.md` because the tools under test scan
+  doc files, so the `**/*.md` docs block would otherwise misclassify them
+  as documenter-owned; see
+  [#3396](https://github.com/jwbron/egg/issues/3396)).
+- Hard blocks (non-exemptible — no block exemption above can carve these
+  back, because exemptions are evaluated against the union of all blocks
+  and the broad `**/fixtures/` / `**/testdata/` carve-outs would
+  otherwise punch through): `.github/` (branch-protection invariant) and
+  the sensitive `.egg-state/` state subtrees `.egg-state/contracts/`,
+  `.egg-state/drafts/`, `.egg-state/pipelines/`, `.egg-state/reviews/`,
+  `.egg-state/oversight/`. See
+  [#3396](https://github.com/jwbron/egg/issues/3396).
 
 **Outputs**:
 - Commits on the worktree branch
@@ -308,17 +323,26 @@ tests, and its mandate is two-fold: **(1) comprehensive regression coverage** �
   `**/*_test.go`, `**/test_*.go`,
   `**/*.test.{ts,tsx,js,jsx}`, `**/*.spec.{ts,tsx,js,jsx}`;
   `**/conftest.py`; plus the tester-relevant pin files
-  `.python-version`, `**/*.lock`, `**/requirements*.txt`; and
+  `.python-version`, `**/*.lock`, `**/requirements*.txt`;
+  `**/fixtures/` and `**/testdata/` (fixture / testdata trees the tester
+  review-and-hardens alongside the coder — see
+  [#3396](https://github.com/jwbron/egg/issues/3396); note this widens
+  the tester allowlist beyond test files: **any** file under a
+  `fixtures/` / `testdata/` directory is tester-writable, including a
+  production module that happens to live under one — intended, as
+  fixtures are treated as test inputs the tester co-owns); and
   `.egg-state/agent-outputs/`.
-- Blocked: `docs/`, `**/README.md`, `**/*.md` (documenter's scope);
-  `.egg-state/contracts/` (pipeline state); and `.github/`
-  (branch-protection invariant — the tester's `allowed_patterns` does
-  not cover `.yml` / `.yaml` / `.json`, so the tester also has no write
-  access under `.github-staging/`. A CI fix or test-fixture change
-  uncovered during testing must be handed off to the coder via
-  `HANDOFF` rather than staged directly). Source code and config
-  files outside tests are out of scope by definition — the coder owns
-  them (everything not listed in this section or the documenter's).
+- Blocked: `docs/`, `**/README.md`, `**/*.md` (documenter's scope). The
+  `**/fixtures/` / `**/testdata/` carve-out clears this docs block for
+  fixture markdown, mirroring the coder.
+- Hard-blocked (non-exemptible — the fixture/testdata carve-out cannot
+  reach these): `.github/` (branch-protection invariant) and
+  `.egg-state/contracts/` (contracts flow through the contract API, not
+  git). A CI fix uncovered during testing must be handed off to the
+  coder via `HANDOFF` rather than staged directly. Source code and
+  config files outside tests/fixtures are out of scope by definition —
+  the coder owns them (everything not listed in this section or the
+  documenter's).
 
 **Outputs**:
 - Test file commits on the worktree branch
@@ -345,7 +369,10 @@ tests, and its mandate is two-fold: **(1) comprehensive regression coverage** �
   convention). Source-code markdown that is functional (e.g.
   `sandbox/agent-config/rules/*.md`, `sandbox/agent-config/commands/*.md`,
   `skills/**/*.md`) is owned by the coder via block exemptions, not the
-  documenter.
+  documenter. Likewise markdown under `**/fixtures/` / `**/testdata/`
+  trees is a test **input** the coder/tester co-own via block exemptions,
+  not documentation — see
+  [#3396](https://github.com/jwbron/egg/issues/3396).
 
 **Outputs**:
 - Documentation commits on the worktree branch

--- a/docs/reference/agent-roles.md
+++ b/docs/reference/agent-roles.md
@@ -245,25 +245,24 @@ worktree branch.
   extensionless scripts (e.g. `bin/egg`, `sandbox/egg`), **and test files**
   are all coder-writable by default — the coder authors its own tests
   (intentional overlap with the tester; see the phase preamble above).
-- Blocked: `docs/`, `**/README.md`, `**/*.md` (documenter's scope);
-  `.egg-state/` (pipeline state);
-  plus a block on `.github/` (CI workflows —
-  branch-protection invariant). To propose `.github/` changes,
-  write the end-state to `.github-staging/` mirroring the `.github/`
-  structure (e.g. stage `.github/workflows/ci.yml` as
-  `.github-staging/workflows/ci.yml`); the agent must call the staged
-  files out in its PR body so the human reviewer moves them into
-  `.github/` before merge
+- Blocked (*soft* — the docs scope, carved back for functional-code
+  markdown below): `docs/`, `**/README.md`, `**/*.md` (documenter's
+  scope). `.github/` and the whole `.egg-state/` tree are **hard**-blocked
+  (see below), not soft — to propose `.github/` changes, write the
+  end-state to `.github-staging/` mirroring the `.github/` structure (e.g.
+  stage `.github/workflows/ci.yml` as `.github-staging/workflows/ci.yml`);
+  the agent must call the staged files out in its PR body so the human
+  reviewer moves them into `.github/` before merge
   ([#2508](https://github.com/jwbron/egg/issues/2508)).
   `sandbox/scripts/` is **writable** — the gateway is the sole egress
   chokepoint, so credential-shim modifications are reviewed by
   `reviewer_security` rather than blocked at the role-pattern layer.
   See [security-review-criteria.md](../../shared/prompts/security-review-criteria.md).
-- Block exemptions (writable, overriding the *soft* blocks above —
-  docs and the broad `.egg-state/` block):
-  `.egg-state/agent-outputs/` (coder's handoff output),
-  `.egg-state/agent-anchors/` (per-agent anchor state, scoped by
-  `check_anchor_write_permission`),
+- Block exemptions (writable, overriding the *soft* docs block only —
+  these are markdown files that are functional code / test inputs, not
+  documentation, and can NEVER reach the hard blocks below):
+  `.egg-state/agent-outputs/` (coder's handoff output — clears the docs
+  block for `brc-memory.md` and other markdown handoffs),
   `skills/` (skill definitions are functional code),
   `sandbox/agent-config/rules/*.md` and
   `sandbox/agent-config/commands/*.md` (Claude Code agent config
@@ -274,13 +273,21 @@ worktree branch.
   doc files, so the `**/*.md` docs block would otherwise misclassify them
   as documenter-owned; see
   [#3396](https://github.com/jwbron/egg/issues/3396)).
-- Hard blocks (non-exemptible — no block exemption above can carve these
-  back, because exemptions are evaluated against the union of all blocks
-  and the broad `**/fixtures/` / `**/testdata/` carve-outs would
-  otherwise punch through): `.github/` (branch-protection invariant) and
-  the sensitive `.egg-state/` state subtrees `.egg-state/contracts/`,
-  `.egg-state/drafts/`, `.egg-state/pipelines/`, `.egg-state/reviews/`,
-  `.egg-state/oversight/`. See
+- Hard blocks (non-exemptible — the broad `**/fixtures/` / `**/testdata/`
+  block exemptions are evaluated against the union of all blocks, so
+  without this tier a fixtures/testdata path under any of these would
+  become writable): `.github/` (branch-protection invariant) and the
+  **whole `.egg-state/` tree**. Hard-blocking `.egg-state/` as a whole
+  (rather than enumerating sensitive subtrees) makes the "current and
+  future subdir" invariant hold without maintenance — no fixtures/testdata
+  exemption can reach `contracts/`, `drafts/`, `pipelines/`, `reviews/`,
+  `oversight/`, `brc-history/`, `checks/`, or any subdir added later.
+- Hard-block carve-backs (the *only* paths carved back out of the
+  `.egg-state/` hard block, via a narrow explicitly-anchored allowlist
+  that can never match `.github/` or a future `.egg-state/<newdir>/`):
+  `.egg-state/agent-outputs/` (coder's git-pushed handoff output) and
+  `.egg-state/agent-anchors/` (per-agent anchor state, scoped downstream
+  by `check_anchor_write_permission`). See
   [#3396](https://github.com/jwbron/egg/issues/3396).
 
 **Outputs**:
@@ -332,17 +339,26 @@ tests, and its mandate is two-fold: **(1) comprehensive regression coverage** �
   production module that happens to live under one — intended, as
   fixtures are treated as test inputs the tester co-owns); and
   `.egg-state/agent-outputs/`.
-- Blocked: `docs/`, `**/README.md`, `**/*.md` (documenter's scope). The
-  `**/fixtures/` / `**/testdata/` carve-out clears this docs block for
-  fixture markdown, mirroring the coder.
-- Hard-blocked (non-exemptible — the fixture/testdata carve-out cannot
-  reach these): `.github/` (branch-protection invariant) and
-  `.egg-state/contracts/` (contracts flow through the contract API, not
-  git). A CI fix uncovered during testing must be handed off to the
-  coder via `HANDOFF` rather than staged directly. Source code and
-  config files outside tests/fixtures are out of scope by definition —
-  the coder owns them (everything not listed in this section or the
-  documenter's).
+- Blocked (*soft* — docs scope): `docs/`, `**/README.md`, `**/*.md`
+  (documenter's scope). The `**/fixtures/` / `**/testdata/` carve-out
+  clears this docs block for fixture markdown, mirroring the coder.
+- Hard-blocked (non-exemptible — the fixture/testdata patterns appear in
+  BOTH the tester's allowlist and its docs-block exemption, so without
+  this tier a fixtures/testdata path under any of these would be
+  tester-writable): `.github/` (branch-protection invariant) and the
+  **whole `.egg-state/` tree** — contracts flow through the contract API,
+  not git, and `drafts/`/`pipelines/`/`reviews/`/`oversight/` (and any
+  future subdir) are owned by other roles. Hard-blocking the whole tree
+  (rather than only `.egg-state/contracts/`) closes the hole where
+  `**/fixtures/` made every other `.egg-state/` subdir tester-writable
+  ([#3396](https://github.com/jwbron/egg/issues/3396)). A CI fix uncovered
+  during testing must be handed off to the coder via `HANDOFF` rather than
+  staged directly. Source code and config files outside tests/fixtures are
+  out of scope by definition — the coder owns them (everything not listed
+  in this section or the documenter's).
+- Hard-block carve-back (the *only* `.egg-state/` subdir the tester can
+  write, via a narrow anchored allowlist): `.egg-state/agent-outputs/`
+  (the tester's handoff output).
 
 **Outputs**:
 - Test file commits on the worktree branch

--- a/gateway/phase_filter.py
+++ b/gateway/phase_filter.py
@@ -76,6 +76,7 @@ class FileRestriction:
     blocked_patterns: list[str] = field(default_factory=list)
     block_exempt_patterns: list[str] = field(default_factory=list)
     hard_blocked_patterns: list[str] = field(default_factory=list)
+    hard_block_exempt_patterns: list[str] = field(default_factory=list)
     blocked_reason: str = ""
 
     @classmethod
@@ -86,6 +87,7 @@ class FileRestriction:
             blocked_patterns=data.get("blocked_patterns", []),
             block_exempt_patterns=data.get("block_exempt_patterns", []),
             hard_blocked_patterns=data.get("hard_blocked_patterns", []),
+            hard_block_exempt_patterns=data.get("hard_block_exempt_patterns", []),
             blocked_reason=data.get("blocked_reason", ""),
         )
 
@@ -105,11 +107,14 @@ class FileRestriction:
             # Paths that escape the repository are always blocked
             return True
 
-        # Hard blocks cannot be carved back by block_exempt_patterns. This
-        # mirrors AgentFilePattern.can_write so the gateway early-reject
-        # agrees with per-commit attribution (#3396).
+        # Hard blocks cannot be carved back by the broad block_exempt_patterns —
+        # only by the narrow, explicitly-anchored hard_block_exempt_patterns
+        # (e.g. `.egg-state/agent-outputs/` under a whole-tree `.egg-state/`
+        # hard block). This mirrors AgentFilePattern.can_write so the gateway
+        # early-reject agrees with per-commit attribution (#3396).
         if any(match_pattern(normalized, p) for p in self.hard_blocked_patterns):
-            return True
+            if not any(match_pattern(normalized, p) for p in self.hard_block_exempt_patterns):
+                return True
 
         if not any(match_pattern(normalized, p) for p in self.blocked_patterns):
             return False
@@ -579,6 +584,7 @@ class PhaseFilter:
                     blocked_patterns=list(pattern.blocked_patterns),
                     block_exempt_patterns=list(pattern.block_exempt_patterns),
                     hard_blocked_patterns=list(pattern.hard_blocked_patterns),
+                    hard_block_exempt_patterns=list(pattern.hard_block_exempt_patterns),
                     blocked_reason=blocked_reason,
                 )
             )

--- a/gateway/phase_filter.py
+++ b/gateway/phase_filter.py
@@ -75,6 +75,7 @@ class FileRestriction:
     role: str
     blocked_patterns: list[str] = field(default_factory=list)
     block_exempt_patterns: list[str] = field(default_factory=list)
+    hard_blocked_patterns: list[str] = field(default_factory=list)
     blocked_reason: str = ""
 
     @classmethod
@@ -84,6 +85,7 @@ class FileRestriction:
             role=data["role"],
             blocked_patterns=data.get("blocked_patterns", []),
             block_exempt_patterns=data.get("block_exempt_patterns", []),
+            hard_blocked_patterns=data.get("hard_blocked_patterns", []),
             blocked_reason=data.get("blocked_reason", ""),
         )
 
@@ -101,6 +103,12 @@ class FileRestriction:
             normalized = self._normalize_path(file_path)
         except ValueError:
             # Paths that escape the repository are always blocked
+            return True
+
+        # Hard blocks cannot be carved back by block_exempt_patterns. This
+        # mirrors AgentFilePattern.can_write so the gateway early-reject
+        # agrees with per-commit attribution (#3396).
+        if any(match_pattern(normalized, p) for p in self.hard_blocked_patterns):
             return True
 
         if not any(match_pattern(normalized, p) for p in self.blocked_patterns):
@@ -553,7 +561,7 @@ class PhaseFilter:
         """
         restrictions: list[FileRestriction] = []
         for role, pattern in AGENT_PATTERNS.items():
-            if not pattern.blocked_patterns:
+            if not pattern.blocked_patterns and not pattern.hard_blocked_patterns:
                 continue
             if pattern.description:
                 blocked_reason = (
@@ -570,6 +578,7 @@ class PhaseFilter:
                     role=role,
                     blocked_patterns=list(pattern.blocked_patterns),
                     block_exempt_patterns=list(pattern.block_exempt_patterns),
+                    hard_blocked_patterns=list(pattern.hard_blocked_patterns),
                     blocked_reason=blocked_reason,
                 )
             )

--- a/gateway/tests/test_agent_restrictions_patterns.py
+++ b/gateway/tests/test_agent_restrictions_patterns.py
@@ -196,6 +196,22 @@ class TestCanWrite:
         # Exempt pattern should NOT let paths inside docs/ through
         assert pattern.can_write("docs/rules/evil.md") is False
 
+    def test_hard_block_cannot_be_exempted(self):
+        """hard_blocked_patterns are non-negotiable — no block_exempt
+        pattern can carve them back (#3396)."""
+        pattern = AgentFilePattern(
+            role="test",
+            allowed_patterns=["**", "**/fixtures/"],
+            blocked_patterns=["**/*.md"],
+            block_exempt_patterns=["**/fixtures/"],
+            hard_blocked_patterns=[".github/"],
+        )
+        # A fixtures path outside .github/ is exempted from the docs block.
+        assert pattern.can_write("pkg/fixtures/readme.md") is True
+        # But the same carve-out must NOT punch through the hard block.
+        assert pattern.can_write(".github/fixtures/readme.md") is False
+        assert pattern.can_write(".github/workflows/ci.yml") is False
+
 
 class TestCoderRole:
     """Verify coder agent can/cannot write expected files."""

--- a/gateway/tests/test_agent_restrictions_patterns.py
+++ b/gateway/tests/test_agent_restrictions_patterns.py
@@ -212,6 +212,26 @@ class TestCanWrite:
         assert pattern.can_write(".github/fixtures/readme.md") is False
         assert pattern.can_write(".github/workflows/ci.yml") is False
 
+    def test_hard_block_carved_back_only_by_hard_block_exempt(self):
+        """A hard block can be carved back ONLY by the narrow, anchored
+        hard_block_exempt_patterns — never by the broad block_exempt_patterns
+        (#3396). This is what lets a whole-tree `.egg-state/` hard block still
+        let `agent-outputs/` through while blocking every other subdir."""
+        pattern = AgentFilePattern(
+            role="test",
+            allowed_patterns=["**"],
+            blocked_patterns=["**/*.md"],
+            block_exempt_patterns=["**/fixtures/"],
+            hard_blocked_patterns=[".egg-state/"],
+            hard_block_exempt_patterns=[".egg-state/agent-outputs/"],
+        )
+        # The anchored carve-back resolves.
+        assert pattern.can_write(".egg-state/agent-outputs/handoff.json") is True
+        # The broad fixtures/ exemption cannot reach a hard-blocked subdir,
+        # current or future.
+        assert pattern.can_write(".egg-state/checks/fixtures/x.json") is False
+        assert pattern.can_write(".egg-state/some-new-dir/fixtures/x.json") is False
+
 
 class TestCoderRole:
     """Verify coder agent can/cannot write expected files."""

--- a/gateway/tests/test_phase_filter.py
+++ b/gateway/tests/test_phase_filter.py
@@ -571,8 +571,11 @@ class TestPhaseFilterFileRestrictions:
         assert "documenter" in roles
 
         coder = next(r for r in restrictions if r.role == "coder")
-        assert ".egg-state/" in coder.blocked_patterns
+        # The whole `.egg-state/` tree is a non-exemptible hard block (#3396);
+        # `.egg-state/agent-outputs/` is carved back via the two exempt tiers.
+        assert ".egg-state/" in coder.hard_blocked_patterns
         assert ".egg-state/agent-outputs/" in coder.block_exempt_patterns
+        assert ".egg-state/agent-outputs/" in coder.hard_block_exempt_patterns
 
     def test_legacy_file_restrictions_key_emits_deprecation(self, tmp_path: Path):
         """A stale config carrying ``file_restrictions`` warns but does not

--- a/gateway/tests/test_phase_filter_restrictions.py
+++ b/gateway/tests/test_phase_filter_restrictions.py
@@ -205,26 +205,61 @@ class TestFileRestriction:
         # But the exemption must NOT punch through the hard block.
         assert restriction.is_file_blocked(".github/fixtures/readme.md") is True
 
+    def test_hard_block_exempt_carves_back_only_anchored_paths(self):
+        """#3396: hard_block_exempt_patterns is the ONLY way to carve a path
+        back out of a hard block — and only the narrow, anchored paths in it,
+        never the broad block_exempt_patterns."""
+        restriction = FileRestriction(
+            role="coder",
+            blocked_patterns=["**/*.md"],
+            block_exempt_patterns=["**/fixtures/"],
+            hard_blocked_patterns=[".egg-state/"],
+            hard_block_exempt_patterns=[".egg-state/agent-outputs/"],
+        )
+        # The anchored carve-back resolves under the whole-tree hard block.
+        assert restriction.is_file_blocked(".egg-state/agent-outputs/handoff.json") is False
+        # But the broad fixtures/ exemption cannot reach a hard-blocked subdir,
+        # including one not enumerated anywhere (future-subdir invariant).
+        assert restriction.is_file_blocked(".egg-state/checks/fixtures/x.json") is True
+        assert restriction.is_file_blocked(".egg-state/some-new-dir/fixtures/x.json") is True
+
     def test_from_dict_hard_blocked_patterns(self):
         restriction = FileRestriction.from_dict(
             {
                 "role": "coder",
                 "blocked_patterns": ["**/*.md"],
-                "hard_blocked_patterns": [".github/"],
+                "hard_blocked_patterns": [".github/", ".egg-state/"],
+                "hard_block_exempt_patterns": [".egg-state/agent-outputs/"],
             }
         )
-        assert restriction.hard_blocked_patterns == [".github/"]
+        assert restriction.hard_blocked_patterns == [".github/", ".egg-state/"]
+        assert restriction.hard_block_exempt_patterns == [".egg-state/agent-outputs/"]
 
     def test_default_restrictions_project_hard_blocks(self):
         """The projection from AGENT_PATTERNS must carry hard_blocked_patterns
-        so the gateway early-reject enforces the non-exemptible tier (#3396)."""
+        AND hard_block_exempt_patterns so the gateway early-reject enforces the
+        non-exemptible tier with its carve-backs (#3396)."""
         pf = PhaseFilter()
         restrictions = {r.role: r for r in pf._get_default_file_restrictions()}
         coder = restrictions[AgentRole.CODER]
         assert ".github/" in coder.hard_blocked_patterns
-        # The fixture carve-out must not open .github/ for the coder.
+        assert ".egg-state/" in coder.hard_blocked_patterns
+        assert ".egg-state/agent-outputs/" in coder.hard_block_exempt_patterns
+        # The fixture carve-out must not open .github/ or any .egg-state/ subdir
+        # for the coder — including subdirs not hand-listed anywhere.
         assert coder.is_file_blocked(".github/fixtures/x.md") is True
         assert coder.is_file_blocked(".egg-state/contracts/fixtures/x.json") is True
+        assert coder.is_file_blocked(".egg-state/brc-history/fixtures/x.json") is True
+        assert coder.is_file_blocked(".egg-state/some-new-dir/fixtures/x.json") is True
+        # ...but the coder's own handoff carve-backs still resolve.
+        assert coder.is_file_blocked(".egg-state/agent-outputs/handoff.json") is False
+        assert coder.is_file_blocked(".egg-state/agent-anchors/coder.json") is False
+        # The tester's whole-tree .egg-state/ block behaves the same way.
+        tester = restrictions[AgentRole.TESTER]
+        assert ".egg-state/" in tester.hard_blocked_patterns
+        assert tester.is_file_blocked(".egg-state/drafts/fixtures/x.json") is True
+        assert tester.is_file_blocked(".egg-state/some-new-dir/fixtures/x.json") is True
+        assert tester.is_file_blocked(".egg-state/agent-outputs/tester.json") is False
 
 
 class TestPhaseFilterDefaultPermissions:

--- a/gateway/tests/test_phase_filter_restrictions.py
+++ b/gateway/tests/test_phase_filter_restrictions.py
@@ -12,6 +12,7 @@ Covers:
 """
 
 import pytest
+from egg_restrictions import AgentRole
 from egg_restrictions.matchers import match_pattern
 from phase_filter import (
     FileRestriction,
@@ -189,6 +190,41 @@ class TestFileRestriction:
         assert restriction.role == "implementer"
         assert restriction.blocked_patterns == [".egg-state/contracts/"]
         assert restriction.blocked_reason == "Use contract API"
+
+    def test_hard_block_is_not_exemptible(self):
+        """#3396: hard_blocked_patterns cannot be carved back by
+        block_exempt_patterns, mirroring AgentFilePattern.can_write."""
+        restriction = FileRestriction(
+            role="coder",
+            blocked_patterns=["**/*.md"],
+            block_exempt_patterns=["**/fixtures/"],
+            hard_blocked_patterns=[".github/"],
+        )
+        # Exemption clears the docs block outside the hard-blocked tree.
+        assert restriction.is_file_blocked("pkg/fixtures/readme.md") is False
+        # But the exemption must NOT punch through the hard block.
+        assert restriction.is_file_blocked(".github/fixtures/readme.md") is True
+
+    def test_from_dict_hard_blocked_patterns(self):
+        restriction = FileRestriction.from_dict(
+            {
+                "role": "coder",
+                "blocked_patterns": ["**/*.md"],
+                "hard_blocked_patterns": [".github/"],
+            }
+        )
+        assert restriction.hard_blocked_patterns == [".github/"]
+
+    def test_default_restrictions_project_hard_blocks(self):
+        """The projection from AGENT_PATTERNS must carry hard_blocked_patterns
+        so the gateway early-reject enforces the non-exemptible tier (#3396)."""
+        pf = PhaseFilter()
+        restrictions = {r.role: r for r in pf._get_default_file_restrictions()}
+        coder = restrictions[AgentRole.CODER]
+        assert ".github/" in coder.hard_blocked_patterns
+        # The fixture carve-out must not open .github/ for the coder.
+        assert coder.is_file_blocked(".github/fixtures/x.md") is True
+        assert coder.is_file_blocked(".egg-state/contracts/fixtures/x.json") is True
 
 
 class TestPhaseFilterDefaultPermissions:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7245,6 +7245,17 @@ def _build_role_restrictions_section(repo: str | None = None) -> str:
             lines.append(f"- **Allowed**: {', '.join(f'`{p}`' for p in pattern.allowed_patterns)}")
         if pattern.blocked_patterns:
             lines.append(f"- **Blocked**: {', '.join(f'`{p}`' for p in pattern.blocked_patterns)}")
+        # Hard blocks are rejected even when they'd match the allow list or a
+        # fixture/docs exemption (#3396) — the planner must see them so it
+        # doesn't route a hard-blocked path (e.g. a fixture under `.github/`
+        # or any `.egg-state/` subdir) to this role.
+        if pattern.hard_blocked_patterns:
+            hard = f"- **Hard-blocked (never pushable)**: {', '.join(f'`{p}`' for p in pattern.hard_blocked_patterns)}"
+            if pattern.hard_block_exempt_patterns:
+                hard += (
+                    f" (except {', '.join(f'`{p}`' for p in pattern.hard_block_exempt_patterns)})"
+                )
+            lines.append(hard)
         lines.append("")
 
     lines.append(
@@ -14913,7 +14924,11 @@ def _build_file_boundary_section(role_value: str, repo: str | None = None) -> st
     if pattern is None:
         return ""
 
-    if not pattern.allowed_patterns and not pattern.blocked_patterns:
+    if (
+        not pattern.allowed_patterns
+        and not pattern.blocked_patterns
+        and not pattern.hard_blocked_patterns
+    ):
         return ""
 
     lines = [
@@ -14927,6 +14942,20 @@ def _build_file_boundary_section(role_value: str, repo: str | None = None) -> st
         lines.append("**Allowed:** " + ", ".join(f"`{p}`" for p in pattern.allowed_patterns))
     if pattern.blocked_patterns:
         lines.append("**Blocked:** " + ", ".join(f"`{p}`" for p in pattern.blocked_patterns))
+    # Hard blocks are a stricter tier: they are rejected even when they would
+    # otherwise match your allow list or a docs/fixture exemption (#3396). The
+    # agent must see them, or it will author a hard-blocked path (e.g.
+    # `.egg-state/contracts/fixtures/x.json`, `.github/actions/x/testdata/`),
+    # hit a gateway 403, and have no way to understand why.
+    if pattern.hard_blocked_patterns:
+        hard_line = "**Hard-blocked (never pushable, no exemption applies):** " + ", ".join(
+            f"`{p}`" for p in pattern.hard_blocked_patterns
+        )
+        if pattern.hard_block_exempt_patterns:
+            hard_line += " — except " + ", ".join(
+                f"`{p}`" for p in pattern.hard_block_exempt_patterns
+            )
+        lines.append(hard_line)
 
     # `.github/` staging-dir convention (issue #2508). Surfaced for the
     # coder role specifically because it's the producer that's expected

--- a/orchestrator/tests/test_pipeline_prompts.py
+++ b/orchestrator/tests/test_pipeline_prompts.py
@@ -4904,6 +4904,25 @@ class TestFileBoundarySection:
         section = _build_file_boundary_section("nonexistent_role")
         assert section == ""
 
+    def test_coder_renders_hard_blocked_tier(self):
+        """#3396: the non-exemptible hard-block tier must be visible in the
+        agent prompt — otherwise the agent authors a hard-blocked path, hits a
+        gateway 403, and can't understand why."""
+        section = _build_file_boundary_section("coder")
+        assert "Hard-blocked" in section
+        assert "`.github/`" in section
+        assert "`.egg-state/`" in section
+        # The carve-backs must be rendered so the agent knows they still resolve.
+        assert "`.egg-state/agent-outputs/`" in section
+
+    def test_tester_renders_hard_blocked_tier(self):
+        """#3396: the tester prompt previously listed only docs as blocked; it
+        must now surface the `.github/` + `.egg-state/` hard blocks."""
+        section = _build_file_boundary_section("tester")
+        assert "Hard-blocked" in section
+        assert "`.github/`" in section
+        assert "`.egg-state/`" in section
+
     def test_coder_prompt_includes_file_boundaries(self):
         """The coder agent prompt includes file boundary info."""
         result = _build_agent_prompt(
@@ -4956,6 +4975,15 @@ class TestBuildRoleRestrictionsSection:
         section = _build_role_restrictions_section()
         assert "**Allowed**" in section
         assert "**Blocked**" in section
+
+    def test_includes_hard_blocked_tier(self):
+        """#3396: the planner must see the non-exemptible hard-block tier so it
+        doesn't route a hard-blocked path (a fixture under `.github/` or any
+        `.egg-state/` subdir) to a producer role that can't push it."""
+        section = _build_role_restrictions_section()
+        assert "Hard-blocked" in section
+        # Rendered for both producer roles that carry hard blocks.
+        assert section.count("Hard-blocked") >= 2
 
     def test_includes_role_assignment_guidance(self):
         """Section includes guidance about when to assign each role."""

--- a/shared/egg_contracts/plan_parser/_validators.py
+++ b/shared/egg_contracts/plan_parser/_validators.py
@@ -282,9 +282,12 @@ def _is_file_blocked_for_role(role: str, file_path: str, repo: str | None = None
     if normalized.startswith("../") or normalized.startswith("/"):
         return True
 
-    # Hard blocks cannot be carved back by block_exempt_patterns (#3396).
+    # Hard blocks cannot be carved back by the broad block_exempt_patterns —
+    # only by the narrow, explicitly-anchored hard_block_exempt_patterns
+    # (#3396).
     if any(match_pattern(normalized, p) for p in pattern.hard_blocked_patterns):
-        return True
+        if not any(match_pattern(normalized, p) for p in pattern.hard_block_exempt_patterns):
+            return True
     if not any(match_pattern(normalized, p) for p in pattern.blocked_patterns):
         return False
     if any(match_pattern(normalized, p) for p in pattern.block_exempt_patterns):

--- a/shared/egg_contracts/plan_parser/_validators.py
+++ b/shared/egg_contracts/plan_parser/_validators.py
@@ -253,8 +253,10 @@ def _is_file_blocked_for_role(role: str, file_path: str, repo: str | None = None
 
     Mirrors ``gateway/phase_filter.py::FileRestriction.is_file_blocked``
     so plan-time validation matches push-time enforcement 1:1. The
-    gateway's check intentionally consults only blocked + block-exempt
-    patterns (not allowed_patterns), and so does this function.
+    gateway's check intentionally consults only hard-blocked + blocked +
+    block-exempt patterns (not allowed_patterns), and so does this
+    function. Hard blocks cannot be carved back by block-exempt patterns
+    (#3396).
 
     Per-repo overrides (#2528): when ``repo`` is supplied, the pattern
     used reflects ``role_patterns:`` in ``repositories.yaml`` for that
@@ -280,6 +282,9 @@ def _is_file_blocked_for_role(role: str, file_path: str, repo: str | None = None
     if normalized.startswith("../") or normalized.startswith("/"):
         return True
 
+    # Hard blocks cannot be carved back by block_exempt_patterns (#3396).
+    if any(match_pattern(normalized, p) for p in pattern.hard_blocked_patterns):
+        return True
     if not any(match_pattern(normalized, p) for p in pattern.blocked_patterns):
         return False
     if any(match_pattern(normalized, p) for p in pattern.block_exempt_patterns):

--- a/shared/egg_restrictions/patterns.py
+++ b/shared/egg_restrictions/patterns.py
@@ -258,6 +258,19 @@ def _build_coder_pattern(
             "sandbox/agent-config/commands/*.md",
             # Top-level skills directory (skill definitions are functional code)
             "skills/",
+            # Test-fixture / testdata trees are test INPUTS, not documentation.
+            # Fixtures deliberately imitate doc files (AGENTS.md, README.md,
+            # .cursor/rules.md, ...) because the tools under test scan doc
+            # files; the `**/*.md` docs block would otherwise misclassify them
+            # as documenter-owned and 403 the coder that ships them alongside
+            # the test. Same "functional code, not docs" rationale as the
+            # agent-config carve-outs above. The `**/<dir>/` directory form is
+            # the reliably-matched shape (the matcher's multi-`**` handling is
+            # fnmatch-loose and misses direct children); it correctly leaves
+            # genuine docs (`docs/`, `README.md`, nested `README.md`)
+            # documenter-owned. See #3396.
+            "**/fixtures/",
+            "**/testdata/",
         ],
     )
 
@@ -292,6 +305,12 @@ def _build_tester_pattern(
             # Dependency files (test dependency management)
             "**/*.lock",
             "**/requirements*.txt",
+            # Test-fixture / testdata trees are test inputs the tester
+            # review-and-hardens alongside the coder. They are not in
+            # ``tests_globs`` unless nested under a ``tests/`` dir, so they
+            # must be allowed explicitly here (see #3396).
+            "**/fixtures/",
+            "**/testdata/",
             # Handoff output
             ".egg-state/agent-outputs/",
         ],
@@ -302,6 +321,14 @@ def _build_tester_pattern(
             ".egg-state/contracts/",
             # Issue #2521: parity with TESTER_ROLE.blocked_write — see CODER_PATTERNS for rationale.
             ".github/",
+        ],
+        block_exempt_patterns=[
+            # Fixture markdown (AGENTS.md, README.md, ...) is a test input,
+            # not documentation — clear the `**/*.md` docs block for the
+            # fixture/testdata trees the tester co-owns. Mirrors the coder
+            # carve-out. See #3396.
+            "**/fixtures/",
+            "**/testdata/",
         ],
     )
 

--- a/shared/egg_restrictions/patterns.py
+++ b/shared/egg_restrictions/patterns.py
@@ -53,6 +53,7 @@ class AgentFilePattern:
     blocked_patterns: list[str] = field(default_factory=list)
     block_exempt_patterns: list[str] = field(default_factory=list)
     hard_blocked_patterns: list[str] = field(default_factory=list)
+    hard_block_exempt_patterns: list[str] = field(default_factory=list)
     description: str = ""
 
     def can_write(self, file_path: str) -> bool:
@@ -83,11 +84,23 @@ class AgentFilePattern:
             all blocked patterns, so a broad, un-anchored exemption (e.g.
             ``**/fixtures/``, added to clear the docs block for fixture
             markdown) would otherwise also punch through the ``.github/``
-            branch-protection block and the sensitive ``.egg-state/`` state
-            blocks for any path carrying a ``fixtures/``/``testdata/``
+            branch-protection block and the ``.egg-state/`` pipeline-state
+            block for any path carrying a ``fixtures/``/``testdata/``
             segment. Security-critical blocks that must survive every
-            exemption live here and are checked before anything else.
-            See #3396.
+            broad exemption live here and are checked before anything else.
+
+            ``hard_block_exempt_patterns`` is the *only* way to carve a
+            path back out of a hard block. It is deliberately kept to a
+            tiny, explicitly-anchored allowlist (e.g.
+            ``.egg-state/agent-outputs/``) so that hard-blocking a whole
+            tree like ``.egg-state/`` still lets the handful of subdirs a
+            role legitimately owns resolve — without reopening the tree to
+            the broad ``fixtures/``/``testdata/`` exemption or to any
+            future ``.egg-state/`` subdir. Because these carve-backs are
+            anchored to specific paths (never ``**/fixtures/``), they can
+            neither match a ``.github/`` path nor a ``.egg-state/<newdir>/``
+            path, so the "current and future subdir" invariant holds
+            without hand-listing subtrees. See #3396.
         """
         normalized = self._normalize_path(file_path)
 
@@ -95,10 +108,13 @@ class AgentFilePattern:
         if normalized == "__INVALID_PATH_TRAVERSAL__":
             return False
 
-        # Hard blocks are non-negotiable: no block_exempt pattern can carve
-        # them back. Checked before the soft block/exempt pair below.
+        # Hard blocks are non-negotiable: the broad block_exempt_patterns
+        # can never carve them back. Only the narrow, explicitly-anchored
+        # hard_block_exempt_patterns can. Checked before the soft
+        # block/exempt pair below.
         if any(match_pattern(normalized, p) for p in self.hard_blocked_patterns):
-            return False
+            if not any(match_pattern(normalized, p) for p in self.hard_block_exempt_patterns):
+                return False
 
         # Check blocked patterns FIRST - security takes precedence
         # BUT skip the block if the path matches a block-exemption pattern.
@@ -235,37 +251,30 @@ def _build_coder_pattern(
         # allowlist to be edited.  See #1901.
         allowed_patterns=["**"],
         blocked_patterns=[
-            # Pipeline state (catch-all for every current and future subdir;
-            # .egg-state/agent-outputs/ is carved back via block_exempt_patterns)
-            ".egg-state/",
             # Documenter scope
             *docs_globs,
             # NOTE: tester's test scope is intentionally NOT blocked — the
             # coder authors its own tests (overlap with the tester). See the
             # docstring above.
-            # NOTE: `.github/` and the sensitive `.egg-state/` state subtrees
+            # NOTE: `.github/` and the whole `.egg-state/` pipeline-state tree
             # are enforced via `hard_blocked_patterns` below (not here) so the
             # `**/fixtures/` / `**/testdata/` block-exempt carve-outs cannot
-            # punch through them. See #3396.
+            # punch through them. The `.egg-state/` subdirs the coder legitimately
+            # owns are carved back via `hard_block_exempt_patterns`. See #3396.
         ],
         block_exempt_patterns=[
-            # Coder's handoff directory — the only .egg-state/ subdir the coder
-            # owns.
+            # These exemptions clear the *docs* (`**/*.md`) soft block only —
+            # they are markdown files that are functional code / test inputs,
+            # not documentation. They do NOT reach the hard blocks below.
+            #
+            # Coder's handoff directory — brc-memory.md and other markdown
+            # handoffs live under it, so it must clear the docs block. (The
+            # directory itself is carved back out of the `.egg-state/` hard
+            # block via `hard_block_exempt_patterns`.)
             ".egg-state/agent-outputs/",
-            # Per-agent anchor files. The gateway's `check_anchor_write_permission`
-            # (gateway/phase_filter.py::check_anchor_write_permission) enforces
-            # per-agent scoping — an agent may only write its own
-            # `.egg-state/agent-anchors/<AGENT_ANCHOR_ID>.json`. That downstream
-            # guard can only run if the role-level check lets the path through,
-            # so this exemption restores the pre-#1901 behavior where the legacy
-            # `**/*.json` allowlist matched anchor files. The contract task
-            # TASK-1-1 for #1901 did not enumerate this exemption — the gap was
-            # surfaced by tester's pre-existing test_push_*_anchor_write tests
-            # against the new blocklist-complement. See #1901 NACK discussion.
-            ".egg-state/agent-anchors/",
             # Agent config .md files are functional code (rules, skills, commands),
             # not documentation. See #1537. Paths are specific to avoid bypassing
-            # other blocked patterns (docs/, tests/, .egg-state/contracts/).
+            # other blocked patterns (docs/, tests/).
             "sandbox/agent-config/rules/*.md",
             "sandbox/agent-config/commands/*.md",
             # Top-level skills directory (skill definitions are functional code)
@@ -280,18 +289,21 @@ def _build_coder_pattern(
             # the reliably-matched shape (the matcher's multi-`**` handling is
             # fnmatch-loose and misses direct children); it correctly leaves
             # genuine docs (`docs/`, `README.md`, nested `README.md`)
-            # documenter-owned. See #3396.
+            # documenter-owned. Because this is a *soft* block exemption, it
+            # can never reach the `.github/` / `.egg-state/` hard blocks — a
+            # fixtures/testdata path under either stays blocked. See #3396.
             "**/fixtures/",
             "**/testdata/",
         ],
         hard_blocked_patterns=[
             # Non-exemptible blocks. `block_exempt_patterns` (which is
             # evaluated against the union of all blocked patterns) can never
-            # carve these back — see the AgentFilePattern.can_write docstring
-            # and #3396. Without this tier the `**/fixtures/` / `**/testdata/`
+            # carve these back — only the narrow `hard_block_exempt_patterns`
+            # below can. See the AgentFilePattern.can_write docstring and
+            # #3396. Without this tier the `**/fixtures/` / `**/testdata/`
             # carve-outs would exempt any path with a fixtures/testdata
             # segment from these blocks too (e.g. `.github/actions/x/testdata/`
-            # or `.egg-state/contracts/fixtures/`).
+            # or `.egg-state/checks/fixtures/`).
             #
             # Branch-protection invariant: CI workflows and CODEOWNERS. Agents
             # that need to propose `.github/` changes write the proposed
@@ -299,19 +311,34 @@ def _build_coder_pattern(
             # allowlist) and flag it in the PR body so a human moves it into
             # `.github/` before merge (issue #2508).
             ".github/",
-            # Sensitive pipeline-state subtrees the coder must never write via
-            # git (contracts flow through the contract API, not git — #2979;
-            # drafts/pipelines/reviews/oversight are owned by the plan/review/
-            # overseer roles). The broad `.egg-state/` block above is a *soft*
-            # block so the coder's own carve-backs (agent-outputs/,
-            # agent-anchors/) still work; these specific subtrees are
-            # hard-blocked so no `**/fixtures/`/`**/testdata/` exemption
-            # reaches them.
-            ".egg-state/contracts/",
-            ".egg-state/drafts/",
-            ".egg-state/pipelines/",
-            ".egg-state/reviews/",
-            ".egg-state/oversight/",
+            # Whole pipeline-state tree. Contracts flow through the contract
+            # API, not git (#2979); drafts/pipelines/reviews/oversight are
+            # owned by the plan/review/overseer roles; brc-history/checks and
+            # any *future* `.egg-state/` subdir are likewise not coder-owned.
+            # Hard-blocking the tree as a whole (rather than enumerating
+            # sensitive subtrees) makes the "current and future subdir"
+            # invariant hold without maintenance: no `**/fixtures/` /
+            # `**/testdata/` exemption can reach any `.egg-state/` subdir. The
+            # two subdirs the coder legitimately owns are carved back via
+            # `hard_block_exempt_patterns` below.
+            ".egg-state/",
+        ],
+        hard_block_exempt_patterns=[
+            # The ONLY carve-backs from the `.egg-state/` hard block. Kept to
+            # a tiny, explicitly-anchored allowlist so they can never match a
+            # `.github/` path or a future `.egg-state/<newdir>/` path.
+            #
+            # Coder's handoff directory — the only .egg-state/ subdir the coder
+            # owns for git-pushed output.
+            ".egg-state/agent-outputs/",
+            # Per-agent anchor files. The gateway's `check_anchor_write_permission`
+            # (gateway/phase_filter.py::check_anchor_write_permission) enforces
+            # per-agent scoping — an agent may only write its own
+            # `.egg-state/agent-anchors/<AGENT_ANCHOR_ID>.json`. That downstream
+            # guard can only run if the role-level check lets the path through,
+            # so this carve-back restores the pre-#1901 behavior where the legacy
+            # `**/*.json` allowlist matched anchor files. See #1901 NACK discussion.
+            ".egg-state/agent-anchors/",
         ],
     )
 
@@ -363,17 +390,19 @@ def _build_tester_pattern(
         blocked_patterns=[
             # Documentation (Documenter handles)
             *docs_globs,
-            # NOTE: `.egg-state/contracts/` and `.github/` are enforced via
+            # NOTE: the whole `.egg-state/` tree and `.github/` are enforced via
             # `hard_blocked_patterns` below (not here) so the `**/fixtures/` /
-            # `**/testdata/` block-exempt carve-outs — and the same patterns
-            # in `allowed_patterns` above — cannot punch through them. See
-            # #3396.
+            # `**/testdata/` patterns — present in BOTH `allowed_patterns` and
+            # `block_exempt_patterns` above — cannot punch through them. The
+            # only `.egg-state/` subdir the tester owns (`agent-outputs/`) is
+            # carved back via `hard_block_exempt_patterns`. See #3396.
         ],
         block_exempt_patterns=[
             # Fixture markdown (AGENTS.md, README.md, ...) is a test input,
             # not documentation — clear the `**/*.md` docs block for the
             # fixture/testdata trees the tester co-owns. Mirrors the coder
-            # carve-out. See #3396.
+            # carve-out. This is a *soft* block exemption; it can never reach
+            # the `.github/` / `.egg-state/` hard blocks. See #3396.
             "**/fixtures/",
             "**/testdata/",
         ],
@@ -381,13 +410,26 @@ def _build_tester_pattern(
             # Non-exemptible blocks (see AgentFilePattern.can_write docstring
             # and #3396). The tester allowlist and block-exempt list both
             # match `**/fixtures/` / `**/testdata/`, so without this tier a
-            # fixture/testdata path under `.github/` or `.egg-state/contracts/`
-            # would be tester-writable.
-            # Contracts flow through the contract API, not git (#2979).
-            ".egg-state/contracts/",
+            # fixture/testdata path under `.github/` or *any* `.egg-state/`
+            # subdir would be tester-writable.
+            #
+            # Whole pipeline-state tree — contracts flow through the contract
+            # API, not git (#2979), and drafts/pipelines/reviews/oversight (and
+            # any future subdir) are owned by other roles. Hard-blocking the
+            # tree as a whole (rather than only `.egg-state/contracts/`) closes
+            # the hole where `**/fixtures/` made every other `.egg-state/`
+            # subdir tester-writable. The tester's own handoff dir is carved
+            # back via `hard_block_exempt_patterns`.
+            ".egg-state/",
             # Issue #2521: parity with TESTER_ROLE.blocked_write — see
             # CODER_PATTERNS for the branch-protection rationale.
             ".github/",
+        ],
+        hard_block_exempt_patterns=[
+            # The ONLY carve-back from the `.egg-state/` hard block: the
+            # tester's handoff output directory. Explicitly anchored so it can
+            # never match a `.github/` or future `.egg-state/<newdir>/` path.
+            ".egg-state/agent-outputs/",
         ],
     )
 

--- a/shared/egg_restrictions/patterns.py
+++ b/shared/egg_restrictions/patterns.py
@@ -52,6 +52,7 @@ class AgentFilePattern:
     allowed_patterns: list[str] = field(default_factory=list)
     blocked_patterns: list[str] = field(default_factory=list)
     block_exempt_patterns: list[str] = field(default_factory=list)
+    hard_blocked_patterns: list[str] = field(default_factory=list)
     description: str = ""
 
     def can_write(self, file_path: str) -> bool:
@@ -75,11 +76,28 @@ class AgentFilePattern:
             coders (documentation), but ``.md`` files in agent-config
             directories (rules, skills, commands) are functional code and
             are exempted via block_exempt_patterns.
+
+            ``hard_blocked_patterns`` is a stricter tier that
+            ``block_exempt_patterns`` can NEVER override. It exists because
+            ``block_exempt_patterns`` is evaluated against the *union* of
+            all blocked patterns, so a broad, un-anchored exemption (e.g.
+            ``**/fixtures/``, added to clear the docs block for fixture
+            markdown) would otherwise also punch through the ``.github/``
+            branch-protection block and the sensitive ``.egg-state/`` state
+            blocks for any path carrying a ``fixtures/``/``testdata/``
+            segment. Security-critical blocks that must survive every
+            exemption live here and are checked before anything else.
+            See #3396.
         """
         normalized = self._normalize_path(file_path)
 
         # Reject invalid paths (e.g., path traversal attempts)
         if normalized == "__INVALID_PATH_TRAVERSAL__":
+            return False
+
+        # Hard blocks are non-negotiable: no block_exempt pattern can carve
+        # them back. Checked before the soft block/exempt pair below.
+        if any(match_pattern(normalized, p) for p in self.hard_blocked_patterns):
             return False
 
         # Check blocked patterns FIRST - security takes precedence
@@ -225,16 +243,10 @@ def _build_coder_pattern(
             # NOTE: tester's test scope is intentionally NOT blocked — the
             # coder authors its own tests (overlap with the tester). See the
             # docstring above.
-            # Defense-in-depth: CI workflows and CODEOWNERS — preserves the
-            # branch-protection invariant. Agents that need to propose
-            # `.github/` changes (CI workflow edits, CODEOWNERS rotation)
-            # write the proposed end-state to top-level `.github-staging/`
-            # mirroring the `.github/` structure; the prefix-match below
-            # leaves `.github-staging/` allowed via the `**` allowlist.
-            # The agent flags the staged files in its PR body so the
-            # human reviewer moves them into `.github/` before merge
-            # (issue #2508).
-            ".github/",
+            # NOTE: `.github/` and the sensitive `.egg-state/` state subtrees
+            # are enforced via `hard_blocked_patterns` below (not here) so the
+            # `**/fixtures/` / `**/testdata/` block-exempt carve-outs cannot
+            # punch through them. See #3396.
         ],
         block_exempt_patterns=[
             # Coder's handoff directory — the only .egg-state/ subdir the coder
@@ -272,6 +284,35 @@ def _build_coder_pattern(
             "**/fixtures/",
             "**/testdata/",
         ],
+        hard_blocked_patterns=[
+            # Non-exemptible blocks. `block_exempt_patterns` (which is
+            # evaluated against the union of all blocked patterns) can never
+            # carve these back — see the AgentFilePattern.can_write docstring
+            # and #3396. Without this tier the `**/fixtures/` / `**/testdata/`
+            # carve-outs would exempt any path with a fixtures/testdata
+            # segment from these blocks too (e.g. `.github/actions/x/testdata/`
+            # or `.egg-state/contracts/fixtures/`).
+            #
+            # Branch-protection invariant: CI workflows and CODEOWNERS. Agents
+            # that need to propose `.github/` changes write the proposed
+            # end-state to top-level `.github-staging/` (allowed via the `**`
+            # allowlist) and flag it in the PR body so a human moves it into
+            # `.github/` before merge (issue #2508).
+            ".github/",
+            # Sensitive pipeline-state subtrees the coder must never write via
+            # git (contracts flow through the contract API, not git — #2979;
+            # drafts/pipelines/reviews/oversight are owned by the plan/review/
+            # overseer roles). The broad `.egg-state/` block above is a *soft*
+            # block so the coder's own carve-backs (agent-outputs/,
+            # agent-anchors/) still work; these specific subtrees are
+            # hard-blocked so no `**/fixtures/`/`**/testdata/` exemption
+            # reaches them.
+            ".egg-state/contracts/",
+            ".egg-state/drafts/",
+            ".egg-state/pipelines/",
+            ".egg-state/reviews/",
+            ".egg-state/oversight/",
+        ],
     )
 
 
@@ -308,7 +349,12 @@ def _build_tester_pattern(
             # Test-fixture / testdata trees are test inputs the tester
             # review-and-hardens alongside the coder. They are not in
             # ``tests_globs`` unless nested under a ``tests/`` dir, so they
-            # must be allowed explicitly here (see #3396).
+            # must be allowed explicitly here (see #3396). NOTE: this widens
+            # the tester allowlist beyond test files — any file under a
+            # ``fixtures/``/``testdata/`` directory becomes tester-writable,
+            # including a production module that happens to live under one
+            # (e.g. ``app/fixtures/loader.py``). That is intended: fixtures
+            # are treated as test inputs the tester co-owns.
             "**/fixtures/",
             "**/testdata/",
             # Handoff output
@@ -317,10 +363,11 @@ def _build_tester_pattern(
         blocked_patterns=[
             # Documentation (Documenter handles)
             *docs_globs,
-            # Contracts
-            ".egg-state/contracts/",
-            # Issue #2521: parity with TESTER_ROLE.blocked_write — see CODER_PATTERNS for rationale.
-            ".github/",
+            # NOTE: `.egg-state/contracts/` and `.github/` are enforced via
+            # `hard_blocked_patterns` below (not here) so the `**/fixtures/` /
+            # `**/testdata/` block-exempt carve-outs — and the same patterns
+            # in `allowed_patterns` above — cannot punch through them. See
+            # #3396.
         ],
         block_exempt_patterns=[
             # Fixture markdown (AGENTS.md, README.md, ...) is a test input,
@@ -329,6 +376,18 @@ def _build_tester_pattern(
             # carve-out. See #3396.
             "**/fixtures/",
             "**/testdata/",
+        ],
+        hard_blocked_patterns=[
+            # Non-exemptible blocks (see AgentFilePattern.can_write docstring
+            # and #3396). The tester allowlist and block-exempt list both
+            # match `**/fixtures/` / `**/testdata/`, so without this tier a
+            # fixture/testdata path under `.github/` or `.egg-state/contracts/`
+            # would be tester-writable.
+            # Contracts flow through the contract API, not git (#2979).
+            ".egg-state/contracts/",
+            # Issue #2521: parity with TESTER_ROLE.blocked_write — see
+            # CODER_PATTERNS for the branch-protection rationale.
+            ".github/",
         ],
     )
 

--- a/shared/tests/test_egg_restrictions.py
+++ b/shared/tests/test_egg_restrictions.py
@@ -379,6 +379,44 @@ class TestFixtureTreeCarveOut:
         assert not CODER_PATTERNS.can_write(".github/workflows/ci.yml")
         assert not TESTER_PATTERNS.can_write(".egg-state/contracts/spec.json")
 
+    def test_carveout_does_not_punch_through_github_block(self):
+        # #3396 regression: the ``**/fixtures/`` / ``**/testdata/``
+        # block-exempt carve-outs are evaluated against the union of all
+        # blocked patterns, so a fixture/testdata segment under ``.github/``
+        # must NOT become writable. ``.github/`` is a hard block that no
+        # exemption can override.
+        github_fixture_paths = [
+            ".github/fixtures/x.yml",
+            ".github/fixtures/x.md",
+            ".github/actions/foo/testdata/case.yml",
+            ".github/testdata/readme.md",
+        ]
+        for path in github_fixture_paths:
+            assert not CODER_PATTERNS.can_write(path), path
+            assert not TESTER_PATTERNS.can_write(path), path
+
+    def test_carveout_does_not_punch_through_egg_state_blocks(self):
+        # #3396 regression: a fixture/testdata segment under a sensitive
+        # ``.egg-state/`` subtree must stay blocked — the exemption must not
+        # reach contracts/drafts/pipelines/reviews/oversight.
+        egg_state_fixture_paths = [
+            ".egg-state/contracts/fixtures/z.json",
+            ".egg-state/drafts/fixtures/a.json",
+            ".egg-state/pipelines/testdata/b.json",
+            ".egg-state/reviews/testdata/c.json",
+            ".egg-state/oversight/fixtures/d.json",
+        ]
+        for path in egg_state_fixture_paths:
+            assert not CODER_PATTERNS.can_write(path), path
+        # Tester's contract hard-block is likewise non-exemptible.
+        assert not TESTER_PATTERNS.can_write(".egg-state/contracts/fixtures/z.json")
+
+    def test_coder_egg_state_carvebacks_still_writable(self):
+        # The `.egg-state/` block stays *soft* so the coder's own handoff
+        # carve-backs keep working after the hard-block tier was added.
+        assert CODER_PATTERNS.can_write(".egg-state/agent-outputs/handoff.json")
+        assert CODER_PATTERNS.can_write(".egg-state/agent-anchors/anchor.json")
+
 
 class TestTesterPatterns:
     def test_allows_test_dirs(self):

--- a/shared/tests/test_egg_restrictions.py
+++ b/shared/tests/test_egg_restrictions.py
@@ -331,6 +331,55 @@ class TestCoderBlocklistComplement:
         assert not CODER_PATTERNS.can_write("../../etc/passwd")
 
 
+class TestFixtureTreeCarveOut:
+    """#3396: test-fixture / testdata trees are test inputs, not docs.
+
+    Fixtures deliberately imitate doc files (``AGENTS.md``, ``README.md``,
+    ``.cursor/rules.md``, ...) because the tools under test scan doc
+    files. Without a carve-out the ``**/*.md`` docs block misclassifies
+    them as documenter-owned and 403s the coder/tester that ship them
+    alongside the test. These are the exact paths from the #3396 denial.
+    """
+
+    FIXTURE_PATHS = [
+        ".agents/tools/agents_tools/harness/fixtures/excluded-siblings/.cursor/rules.md",
+        ".agents/tools/agents_tools/harness/fixtures/excluded-siblings/.github/instructions/copilot.md",
+        ".agents/tools/agents_tools/harness/fixtures/excluded-siblings/.pi/prompts.md",
+        ".agents/tools/agents_tools/harness/fixtures/staled/AGENTS.md",
+        ".agents/tools/agents_tools/harness/fixtures/unresolvable-citation/AGENTS.md",
+        ".agents/tools/testdata/README.md",
+        ".agents/tools/testdata/mini_repo/AGENTS.md",
+    ]
+
+    def test_coder_can_write_fixture_markdown(self):
+        for path in self.FIXTURE_PATHS:
+            assert CODER_PATTERNS.can_write(path), path
+
+    def test_tester_can_write_fixture_markdown(self):
+        # The tester review-and-hardens fixtures alongside the coder.
+        for path in self.FIXTURE_PATHS:
+            assert TESTER_PATTERNS.can_write(path), path
+
+    def test_carveout_covers_non_md_fixture_files(self):
+        # The directory-form carve-out is extension-agnostic: any file
+        # under a fixtures/testdata tree is a test input.
+        assert CODER_PATTERNS.can_write("pkg/fixtures/data/sample.json")
+        assert CODER_PATTERNS.can_write("pkg/testdata/golden.txt")
+
+    def test_real_docs_stay_documenter_owned(self):
+        # Negative control: genuine documentation must NOT be swept in.
+        for path in ["docs/guides/testing.md", "README.md", "shared/README.md", "docs/index.md"]:
+            assert not CODER_PATTERNS.can_write(path), path
+            assert not TESTER_PATTERNS.can_write(path), path
+            assert DOCUMENTER_PATTERNS.can_write(path), path
+
+    def test_hard_blocks_unaffected(self):
+        # The carve-out must not open a hole in the security blocks.
+        assert not CODER_PATTERNS.can_write(".egg-state/contracts/spec.json")
+        assert not CODER_PATTERNS.can_write(".github/workflows/ci.yml")
+        assert not TESTER_PATTERNS.can_write(".egg-state/contracts/spec.json")
+
+
 class TestTesterPatterns:
     def test_allows_test_dirs(self):
         assert TESTER_PATTERNS.can_write("tests/test_foo.py")

--- a/shared/tests/test_egg_restrictions.py
+++ b/shared/tests/test_egg_restrictions.py
@@ -396,26 +396,49 @@ class TestFixtureTreeCarveOut:
             assert not TESTER_PATTERNS.can_write(path), path
 
     def test_carveout_does_not_punch_through_egg_state_blocks(self):
-        # #3396 regression: a fixture/testdata segment under a sensitive
-        # ``.egg-state/`` subtree must stay blocked — the exemption must not
-        # reach contracts/drafts/pipelines/reviews/oversight.
+        # #3396 regression: a fixture/testdata segment under ANY ``.egg-state/``
+        # subtree must stay blocked for BOTH roles. The whole ``.egg-state/``
+        # tree is hard-blocked (only agent-outputs/agent-anchors carved back),
+        # so no ``**/fixtures/`` / ``**/testdata/`` exemption can reach it.
+        #
+        # These include the subtrees the previous (enumeration-based) fix
+        # missed — ``brc-history`` and ``checks`` are present and git-tracked
+        # in the repo today — plus contracts/drafts/pipelines/reviews/oversight.
         egg_state_fixture_paths = [
             ".egg-state/contracts/fixtures/z.json",
             ".egg-state/drafts/fixtures/a.json",
             ".egg-state/pipelines/testdata/b.json",
             ".egg-state/reviews/testdata/c.json",
             ".egg-state/oversight/fixtures/d.json",
+            ".egg-state/brc-history/fixtures/x.json",
+            ".egg-state/checks/fixtures/x.json",
+            ".egg-state/checkpoints/fixtures/y.json",
         ]
         for path in egg_state_fixture_paths:
-            assert not CODER_PATTERNS.can_write(path), path
-        # Tester's contract hard-block is likewise non-exemptible.
-        assert not TESTER_PATTERNS.can_write(".egg-state/contracts/fixtures/z.json")
+            assert not CODER_PATTERNS.can_write(path), f"coder {path}"
+            assert not TESTER_PATTERNS.can_write(path), f"tester {path}"
 
-    def test_coder_egg_state_carvebacks_still_writable(self):
-        # The `.egg-state/` block stays *soft* so the coder's own handoff
-        # carve-backs keep working after the hard-block tier was added.
+    def test_carveout_does_not_punch_through_future_egg_state_subdir(self):
+        # The invariant must hold for subdirs that don't exist yet — the
+        # whole-tree hard block is what makes this true without editing the
+        # pattern list when a new ``.egg-state/`` subdir is added.
+        for role_pattern in (CODER_PATTERNS, TESTER_PATTERNS):
+            assert not role_pattern.can_write(".egg-state/some-new-dir/fixtures/x.json"), (
+                role_pattern.role
+            )
+            assert not role_pattern.can_write(".egg-state/another-future-dir/testdata/y.json"), (
+                role_pattern.role
+            )
+
+    def test_egg_state_carvebacks_still_writable(self):
+        # The whole ``.egg-state/`` tree is hard-blocked, but the handoff
+        # carve-backs (agent-outputs/, and for the coder agent-anchors/) are
+        # restored via ``hard_block_exempt_patterns`` so they keep working.
         assert CODER_PATTERNS.can_write(".egg-state/agent-outputs/handoff.json")
         assert CODER_PATTERNS.can_write(".egg-state/agent-anchors/anchor.json")
+        # Markdown handoffs (brc-memory.md) must clear the docs block too.
+        assert CODER_PATTERNS.can_write(".egg-state/agent-outputs/coder/brc-memory.md")
+        assert TESTER_PATTERNS.can_write(".egg-state/agent-outputs/tester.json")
 
 
 class TestTesterPatterns:


### PR DESCRIPTION
Fixes #3396.

## Problem

A coder's slice propose was 403'd with `restricted_path_modified` on test-fixture markdown files. All 7 blocked paths were `.md` files under a fixture tree:

- `.../harness/fixtures/staled/AGENTS.md`
- `.../fixtures/excluded-siblings/.cursor/rules.md`
- `.../testdata/README.md`
- ... etc.

**Root cause:** the coder's docs blocklist (`DEFAULT_DOCS_GLOBS` = `docs/`, `**/*.md`, `**/README.md`) matches markdown at *any depth*. Fixtures that deliberately imitate doc files — because the tools under test scan doc files — get classified as documentation, so they become documenter-owned and the coder/tester that ship them alongside the test can't push them.

(The `.github`/`.cursor`/`.pi` framing in the issue is a partial red herring: the matcher only prefix-matches `.github/` at the repo root, so nested `.github/` under a fixture tree is never caught by the `.github/` block. Every one of the 7 denials is purely the `**/*.md` glob.)

## Fix

Option 2 from the issue: exempt recognized fixture/testdata trees. This reuses the existing `block_exempt_patterns` mechanism — the same "these `.md` are functional code, not documentation" carve-out already used for `sandbox/agent-config/rules/*.md` and `skills/`.

- **Coder** (`_build_coder_pattern`): add `**/fixtures/` and `**/testdata/` to `block_exempt_patterns`.
- **Tester** (`_build_tester_pattern`): add the same trees to `allowed_patterns` (tester uses an allowlist, not catch-all) and a matching `block_exempt_patterns`, so review-and-harden of fixtures works too.

The directory-form `**/<dir>/` pattern is the reliably-matched shape (the matcher's multi-`**` handling is fnmatch-loose and misses direct children like `testdata/README.md`).

**Rejected alternatives:** anchoring doc patterns to the repo root (issue option 1) would gut the documenter's legitimate ownership of nested `docs/`/`README.md`; per-slice role-aware ownership (option 3) is a large architectural change and the guard is authorship-based, not contract-file-list-based.

## Verification

- New `TestFixtureTreeCarveOut` asserts coder + tester can write the exact 7 paths from the denial, that non-`.md` fixture files are also covered, and — as negative controls — that genuine docs (`docs/*.md`, `README.md`, nested `README.md`) stay documenter-owned and the `.egg-state/` / `.github/` hard blocks are unaffected.
- Full changeset-aware `make test` green (20083 passed; the only 2 failures are the pre-existing `reap-stale-egg-images` btrfs-host environment noise, unrelated to this change).