### PR TITLE
Per-slice green gate: execute repo checks at the slice tip before opening the slice PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,18 @@ sync-venv-if-uv:
 # `uv sync` fails when the hatchling build backend tries to package the
 # project. Dev tools (ruff, pytest, mypy, etc.) install fine without the
 # project itself. Issue #2087.
+#
+# The venv is created --relocatable because this .venv is persisted to
+# /opt/prebuilt-deps at image build (build context /tmp/repo-deps/<repo>/)
+# and restored into a different path (the pod's mounted worktree) at
+# runtime. A default uv venv writes absolute shebangs into console
+# scripts (pytest, mypy, ...), which dangle after the move; relocatable
+# venvs use self-resolving `#!/bin/sh` trampolines instead. uv records
+# `relocatable = true` in pyvenv.cfg, so the subsequent `uv sync` into
+# the venv keeps installing relocatable entry points. See #3398.
 sandbox-deps:
-	@echo "==> Syncing dev dependencies (no project install)..."
+	@echo "==> Syncing dev dependencies (no project install, relocatable venv)..."
+	@uv venv --relocatable
 	@uv sync --extra dev --no-install-project
 
 # Install all linting tools

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -18938,6 +18938,35 @@ def _run_implement_phase_slices(
                         scheduler.record_failure(slice_id)
                         return 1, evidence_failure
 
+                # #3398 — per-slice green gate: execute the repo's
+                # configured checks (repositories.yaml, via
+                # get_repo_checks) against the integration-branch tip
+                # in a sandboxed one-shot runner, and refuse to open
+                # the slice PR while any check is red. Closes the
+                # trust-vs-verify gap in the propose-time
+                # checks_passed self-report. Same posture as the
+                # evidence gate above: fail-open on infra errors,
+                # fail-closed only on a definitive red verdict;
+                # EGG_SLICE_GREEN_GATE is the operator switch
+                # (off during rollout / log / on).
+                if pipeline.repo:
+                    try:
+                        import slice_green_gate as _green_gate
+                    except ImportError:
+                        from .. import slice_green_gate as _green_gate  # type: ignore[no-redef]
+
+                    green_gate_failure = _green_gate.run_slice_green_gate(
+                        pipeline_id,
+                        spawner,
+                        slice_id,
+                        integration_branch,
+                        pipeline.repo,
+                        gateway_mode=gateway_mode,  # type: ignore[arg-type]
+                    )
+                    if green_gate_failure is not None:
+                        scheduler.record_failure(slice_id)
+                        return 1, green_gate_failure
+
                 # Snapshot the slice's PR data from the same loaded
                 # contract — no second lock acquire, no second file
                 # read.

--- a/orchestrator/slice_green_gate.py
+++ b/orchestrator/slice_green_gate.py
@@ -38,6 +38,18 @@ Mechanics mirror the two established precedents:
   failed). The caller records the slice failure, which routes through
   the existing cascade + ``OVERSEER_ALERT`` machinery.
 
+  The fail-open guarantee only covers infrastructure failures the
+  *orchestrator* observes before/around check execution. Once the runner
+  is executing the checks, an infrastructure fault *inside* that
+  execution — a transient gateway hiccup on a git call, a mid-run
+  session-token expiry, an OOM-killed test worker, disk pressure —
+  exits the check non-zero and surfaces as ``ok:false``, i.e. a
+  definitive red that ``on`` mode blocks on. This is inherent to
+  shelling out to checks (CI has the same property); the staged
+  ``off → log → on`` rollout de-risks it, but ``on`` mode does not
+  distinguish an infra-induced red inside a check from a genuine
+  check failure.
+
 Rollout is staged via ``EGG_SLICE_GREEN_GATE``: ``off`` (default) →
 ``log`` (run checks, log the verdict loudly, never block — the soak mode
 while #3301 contract-single-writer is still landing, since a stale
@@ -98,6 +110,17 @@ _DEFAULT_SKIP_CHECKS = "security"
 # wedging the slice close.
 GREEN_GATE_TIMEOUT_ENV_VAR = "EGG_SLICE_GREEN_GATE_TIMEOUT_SECONDS"
 _DEFAULT_TIMEOUT_SECONDS = 1800
+
+# Extra wall-clock the orchestrator's wait loop allows on top of the
+# in-pod check budget, to absorb pod scheduling + image-pull latency.
+# The wait clock starts at Job submit, before the pod is scheduled/pulled
+# — so on a cold node a long image pull would otherwise eat into the
+# check budget and trip a spurious fail-open timeout even when the checks
+# would have passed. The pod's own ``activeDeadlineSeconds`` (which the
+# kubelet counts from pod *start*, i.e. after scheduling) still caps the
+# actual check duration, so a genuinely hung check is killed by the pod
+# deadline rather than lingering for the full grace-padded wait.
+_POD_SCHEDULING_GRACE_SECONDS = 120
 
 # Per-check output tail retained in the verdict (runner side) and the
 # smaller slice carried into the failure string routed to the cascade /
@@ -279,7 +302,10 @@ def _gate_timeout_seconds() -> int:
     raw = os.environ.get(GREEN_GATE_TIMEOUT_ENV_VAR, "")
     try:
         value = int(raw)
-    except TypeError, ValueError:
+    except ValueError:
+        # ``raw`` is always a ``str`` (``os.environ.get(..., "")``), so
+        # ``int()`` can only raise ``ValueError`` here — ``TypeError`` is
+        # unreachable.
         return _DEFAULT_TIMEOUT_SECONDS
     return value if value > 0 else _DEFAULT_TIMEOUT_SECONDS
 
@@ -716,7 +742,12 @@ def run_slice_green_gate(
             mode=mode,
         )
 
-        pod = _wait_for_runner_pod(spawner.k8s, namespace, gate_id, timeout=timeout)
+        pod = _wait_for_runner_pod(
+            spawner.k8s,
+            namespace,
+            gate_id,
+            timeout=timeout + _POD_SCHEDULING_GRACE_SECONDS,
+        )
         if pod is None:
             logger.warning(
                 "Green gate skipped: runner pod did not reach a terminal state (#3398)",
@@ -724,6 +755,7 @@ def run_slice_green_gate(
                 slice_id=slice_id,
                 gate_id=gate_id,
                 timeout_seconds=timeout,
+                wait_budget_seconds=timeout + _POD_SCHEDULING_GRACE_SECONDS,
             )
             return None
 

--- a/orchestrator/slice_green_gate.py
+++ b/orchestrator/slice_green_gate.py
@@ -1,0 +1,798 @@
+"""Per-slice green gate — execute repo checks at the slice tip before PR-open (#3398).
+
+Every PR the ``issue-2270-overhaul`` pipeline opened was red: nothing on
+the slice-close path ever *ran* ``make lint`` / ``make test`` against the
+slice's integration-branch tip. The propose-time validator
+(``routes.signals._validation._validate_tester_check_coverage``) only
+compares the tester's self-reported ``checks_passed`` *names* against the
+configured checks — it never executes anything, so a tester whose claim
+does not match reality (scoped-down test run, unfinished format step)
+sails through and CI becomes the first honest verdict, after the PR is
+already open.
+
+This module closes that trust-vs-verify gap. At slice close — after BRC
+consensus, after the #3125 evidence-reachability gate, before any close
+side effect — the orchestrator spawns a sandboxed one-shot **check-runner
+Job** that checks out the integration-branch tip and executes the repo's
+configured checks (``config.repo_config.get_repo_checks``; never
+hardcoded commands). The runner prints a structured verdict to stdout;
+the orchestrator parses it and blocks the slice PR from opening while any
+check is red. The configured commands execute untrusted repo code
+(pytest/mypy import the tree), so they must never run in the orchestrator
+process — the runner pod is sandboxed exactly like an agent pod
+(default-deny egress except gateway/DNS; git routes through the gateway
+via a session token).
+
+Mechanics mirror the two established precedents:
+
+* Job lifecycle is modeled on the network-isolation probe
+  (``routes.deployment._network_probe``): one-shot Job (``backoffLimit``
+  0, ``restartPolicy`` Never), poll for a terminal pod phase, read the
+  log with ``_preload_content=False`` (the k8s client's default path
+  json.loads-then-str()s JSON-shaped bodies, corrupting them), parse the
+  sentinel verdict line, delete the Job in ``finally``.
+* Gate posture mirrors the #3125 evidence gate: **fail-open on
+  infrastructure errors** (worktree/session/spawn failure, pod timeout,
+  unparseable verdict — close proceeds with a warning), **fail-closed
+  only on a definitive red** (a parsed verdict reporting a check
+  failed). The caller records the slice failure, which routes through
+  the existing cascade + ``OVERSEER_ALERT`` machinery.
+
+Rollout is staged via ``EGG_SLICE_GREEN_GATE``: ``off`` (default) →
+``log`` (run checks, log the verdict loudly, never block — the soak mode
+while #3301 contract-single-writer is still landing, since a stale
+contract snapshot on the slice tip can red contract-hygiene tests for
+reasons unrelated to the slice's code) → ``on`` (block).
+
+The check toolchain is the **repo-defined** one, not the sandbox
+image's: ``repositories.yaml::build_commands`` builds the repo's pinned
+dev environment at image build (e.g. egg's ``make sandbox-deps`` →
+``uv sync --extra dev``) and persists the dirs it names (``.venv``) to
+``/opt/prebuilt-deps/<owner--repo>/``. The runner restores those into
+its worktree before executing checks, so the tools that run are exactly
+the versions the repo pins — toolchain-identical to CI by construction.
+(The restore requires the venv to be relocatable; ``make sandbox-deps``
+creates it so.) When the repo config declares ``persist_dirs`` but the
+image carries no prebuilt snapshot, the runner exits non-zero — an
+infrastructure failure that fails open, never a false red from
+missing tools. ``make test``'s changeset-aware narrowing derives its
+baseline via ``git merge-base HEAD origin/<default>`` inside the
+runner's fresh worktree — the *cumulative* slice diff, deliberately
+wider than the tester's own-files scope that let the #3398 class-3
+failures through.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from typing import TYPE_CHECKING, Any, Literal
+
+from egg_logging import get_logger
+
+if TYPE_CHECKING:
+    from kubernetes_spawner import KubernetesSpawner
+
+logger = get_logger("orchestrator.slice_green_gate")
+
+# Operator switch for the green gate. Three-state, default off during
+# rollout (#3398): "off"/unset → gate skipped entirely; "log" → checks
+# run and a red verdict is logged loudly but never blocks; "on" → a red
+# verdict blocks the slice PR from opening.
+GREEN_GATE_ENV_VAR = "EGG_SLICE_GREEN_GATE"
+
+_ENABLED_VALUES = frozenset({"on", "1", "true", "yes"})
+_LOG_ONLY_VALUES = frozenset({"log", "log-only", "log_only"})
+
+# Comma-separated check *names* (from repositories.yaml ``checks``) the
+# gate skips. Default skips ``security``: the full scan belongs on the
+# context PR / terminal verification, not on every slice close.
+GREEN_GATE_SKIP_CHECKS_ENV_VAR = "EGG_SLICE_GREEN_GATE_SKIP_CHECKS"
+_DEFAULT_SKIP_CHECKS = "security"
+
+# Wall-clock budget for the runner pod (spawn-to-terminal). A slice's
+# changeset-narrowed ``make test`` normally finishes well inside this;
+# the ceiling exists so a hung suite degrades to fail-open instead of
+# wedging the slice close.
+GREEN_GATE_TIMEOUT_ENV_VAR = "EGG_SLICE_GREEN_GATE_TIMEOUT_SECONDS"
+_DEFAULT_TIMEOUT_SECONDS = 1800
+
+# Per-check output tail retained in the verdict (runner side) and the
+# smaller slice carried into the failure string routed to the cascade /
+# OVERSEER_ALERT payload.
+_VERDICT_OUTPUT_TAIL_CHARS = 4000
+_FAILURE_MESSAGE_TAIL_CHARS = 1500
+
+# Sentinel prefixing the runner's single-line JSON verdict on stdout.
+# Parsed from the end of the pod log so check output that happens to be
+# JSON-shaped can never be mistaken for the verdict.
+VERDICT_SENTINEL = "EGG_GREEN_GATE_VERDICT:"
+
+# Label carrying the per-invocation gate id; the wait loop locates the
+# runner pod by this selector (mirrors ``egg.io/probe-id``).
+_GATE_ID_LABEL = "egg.io/green-gate-id"
+
+# The runner program, executed as ``python3 -c`` in the pod. Restores
+# the repo's prebuilt build_commands artifacts (its pinned ``.venv``)
+# into the worktree, then reads the check list (JSON) and repo dir from
+# env, runs each check sequentially with combined output capture, and
+# prints the sentinel verdict line. Always exits 0 when the harness
+# itself worked: the verdict — not the pod exit code — is the pass/fail
+# channel, so a non-zero pod exit unambiguously means runner
+# infrastructure failure (fail-open). Missing/failed prebuilt restore
+# when the repo config requires one is exactly such an infra failure —
+# proceeding would red every check with "command not found" and block
+# the slice for a toolchain-packaging problem that is not its fault.
+_RUNNER_PROGRAM = """
+import json, os, shutil, subprocess, sys, time
+
+checks = json.loads(os.environ["EGG_GREEN_GATE_CHECKS"])
+repo_dir = os.environ["EGG_GREEN_GATE_REPO_DIR"]
+tail = int(os.environ.get("EGG_GREEN_GATE_OUTPUT_TAIL", "4000"))
+
+
+def restore_prebuilt(target_dir):
+    # Mirror sandbox.entrypoint._worktrees.restore_prebuilt_deps: copy
+    # /opt/prebuilt-deps/<owner--repo>/* (the persist_dirs snapshot from
+    # the repo's build_commands, e.g. .venv) into the mounted worktree,
+    # skipping paths that already exist. No chown needed — this pod runs
+    # as the worktree's owning uid, unlike the root entrypoint.
+    base = os.environ.get("EGG_GREEN_GATE_PREBUILT_BASE", "/opt/prebuilt-deps")
+    name = os.path.basename(os.path.normpath(target_dir))
+    if not os.path.isdir(base):
+        return None
+
+    def copy_if_missing(src, dst, **kwargs):
+        if os.path.exists(dst) or os.path.islink(dst):
+            return
+        if os.path.islink(src):
+            os.symlink(os.readlink(src), dst)
+        else:
+            shutil.copy2(src, dst, **kwargs)
+
+    for entry in sorted(os.listdir(base)):
+        if entry == "__egg_system_dirs__" or not entry.endswith("--" + name):
+            continue
+        shutil.copytree(
+            os.path.join(base, entry),
+            target_dir,
+            copy_function=copy_if_missing,
+            dirs_exist_ok=True,
+            symlinks=False,
+        )
+        return entry
+    return None
+
+
+try:
+    restored = restore_prebuilt(repo_dir)
+except Exception as exc:
+    print(f"green-gate runner: prebuilt deps restore failed: {exc}", file=sys.stderr)
+    sys.exit(1)
+if os.environ.get("EGG_GREEN_GATE_REQUIRE_PREBUILT") == "1" and restored is None:
+    print(
+        "green-gate runner: repo config declares persist_dirs but no prebuilt "
+        "snapshot exists under /opt/prebuilt-deps — rebuild the sandbox image",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+results = []
+for check in checks:
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(
+            ["bash", "-c", check["command"]],
+            cwd=repo_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            errors="replace",
+        )
+        rc, out = proc.returncode, proc.stdout or ""
+    except Exception as exc:
+        rc, out = -1, f"runner failed to execute check: {exc}"
+    results.append(
+        {
+            "name": check["name"],
+            "ok": rc == 0,
+            "exit_code": rc,
+            "duration_seconds": round(time.monotonic() - started, 1),
+            "output_tail": out[-tail:],
+        }
+    )
+
+print("EGG_GREEN_GATE_VERDICT:" + json.dumps({"checks": results}), flush=True)
+"""
+
+
+def green_gate_mode() -> Literal["off", "log", "on"]:
+    """Resolve the operator switch to one of ``off`` / ``log`` / ``on``.
+
+    Unknown values resolve to ``off``: during rollout an operator typo
+    must degrade to "gate does nothing", never to "gate blocks slices".
+    """
+    raw = os.environ.get(GREEN_GATE_ENV_VAR, "off").strip().lower()
+    if raw in _ENABLED_VALUES:
+        return "on"
+    if raw in _LOG_ONLY_VALUES:
+        return "log"
+    return "off"
+
+
+def _gate_checks(repo: str) -> list[dict[str, str]]:
+    """Return the configured checks the gate runs for ``repo``.
+
+    Config-driven: exactly ``get_repo_checks(repo)`` minus the names in
+    the skip set (default ``security``). Returns ``[]`` — gate skips —
+    when the repo has no checks configured or config loading fails
+    (fail-open: a config problem must not block a consensus-reached
+    slice).
+    """
+    try:
+        from config.repo_config import get_repo_checks
+    except ImportError:
+        try:
+            from repo_config import get_repo_checks  # type: ignore[no-redef]
+        except ImportError:
+            return []
+
+    try:
+        configured = get_repo_checks(repo)
+    except Exception as exc:  # noqa: BLE001 — config load is best-effort
+        logger.warning(
+            "Green gate skipped: failed to load repo checks config (#3398)",
+            repo=repo,
+            error=str(exc),
+        )
+        return []
+
+    raw_skip = os.environ.get(GREEN_GATE_SKIP_CHECKS_ENV_VAR, _DEFAULT_SKIP_CHECKS)
+    skip = {name.strip().lower() for name in raw_skip.split(",") if name.strip()}
+    return [c for c in configured if c["name"].strip().lower() not in skip]
+
+
+def _repo_requires_prebuilt(repo: str) -> bool:
+    """True when ``repo``'s build_commands persist a toolchain snapshot.
+
+    A repo that declares ``persist_dirs`` (e.g. ``.venv``) defines its
+    check toolchain via ``build_commands`` — the runner must restore the
+    prebuilt snapshot or fail as infrastructure, never run checks
+    against whatever happens to be on the image PATH.
+    """
+    try:
+        from config.repo_config import get_repo_build_commands
+    except ImportError:
+        try:
+            from repo_config import get_repo_build_commands  # type: ignore[no-redef]
+        except ImportError:
+            return False
+    try:
+        return bool((get_repo_build_commands(repo) or {}).get("persist_dirs"))
+    except Exception:  # noqa: BLE001 — config load is best-effort
+        return False
+
+
+def _gate_timeout_seconds() -> int:
+    raw = os.environ.get(GREEN_GATE_TIMEOUT_ENV_VAR, "")
+    try:
+        value = int(raw)
+    except TypeError, ValueError:
+        return _DEFAULT_TIMEOUT_SECONDS
+    return value if value > 0 else _DEFAULT_TIMEOUT_SECONDS
+
+
+def _build_runner_job_manifest(
+    *,
+    gate_id: str,
+    pipeline_id: str,
+    slice_id: str,
+    image: str,
+    checks: list[dict[str, str]],
+    repo_mounts: dict[str, str],
+    repo_dir: str,
+    env: dict[str, str],
+    timeout_seconds: int,
+    host_uid: int,
+    host_gid: int,
+) -> dict[str, Any]:
+    """Construct the check-runner V1Job body as a plain dict.
+
+    Returning a dict keeps the builder unit-testable without the
+    kubernetes SDK (mirrors ``_build_probe_job_manifest``). Labels
+    deliberately carry ``app.kubernetes.io/component: agent`` — the
+    NetworkPolicies select on it, and without it default-deny-egress
+    blocks even DNS — but **not** the orchestrator/agent-role/slice
+    labels the monitor and running-agent views enumerate: the runner is
+    ephemeral infrastructure, not an agent, and must not surface in
+    supervision or trip heartbeat-silence tripwires.
+
+    ``repo_mounts`` maps container mount path → host worktree path.
+    """
+    full_env = dict(env)
+    full_env["EGG_GREEN_GATE_CHECKS"] = json.dumps(checks)
+    full_env["EGG_GREEN_GATE_REPO_DIR"] = repo_dir
+    full_env["EGG_GREEN_GATE_OUTPUT_TAIL"] = str(_VERDICT_OUTPUT_TAIL_CHARS)
+
+    volumes = []
+    volume_mounts = []
+    for i, (container_path, host_path) in enumerate(sorted(repo_mounts.items())):
+        volumes.append(
+            {
+                "name": f"repo-{i}",
+                "hostPath": {"path": host_path, "type": "Directory"},
+            }
+        )
+        volume_mounts.append({"name": f"repo-{i}", "mountPath": container_path})
+
+    return {
+        "apiVersion": "batch/v1",
+        "kind": "Job",
+        "metadata": {
+            "name": f"egg-greengate-{gate_id}",
+            "labels": {
+                "app.kubernetes.io/component": "agent",
+                "app.kubernetes.io/part-of": "egg",
+                "egg.green-gate": "true",
+                _GATE_ID_LABEL: gate_id,
+                "egg.pipeline.id": pipeline_id,
+                "egg.green-gate.slice": slice_id,
+            },
+        },
+        "spec": {
+            # Primary cleanup is the caller's finally-delete; the TTL
+            # only extends lifetime when the orchestrator crashed before
+            # reaching it (probe precedent).
+            "ttlSecondsAfterFinished": 300,
+            # Give the in-pod checks the full budget; the orchestrator's
+            # wait loop enforces the same ceiling, and the deadline
+            # guarantees a hung check terminates rather than lingering.
+            "activeDeadlineSeconds": timeout_seconds + 60,
+            "backoffLimit": 0,
+            "template": {
+                "metadata": {
+                    "labels": {
+                        "app.kubernetes.io/component": "agent",
+                        "egg.green-gate": "true",
+                        _GATE_ID_LABEL: gate_id,
+                    },
+                },
+                "spec": {
+                    "restartPolicy": "Never",
+                    "automountServiceAccountToken": False,
+                    # Match agent pods so the runner can write test/lint
+                    # caches and selection JSON into the worktree the
+                    # gateway just chowned to the host uid/gid.
+                    "securityContext": {
+                        "runAsUser": host_uid,
+                        "runAsGroup": host_gid,
+                        "fsGroup": host_gid,
+                    },
+                    "containers": [
+                        {
+                            "name": "green-gate",
+                            "image": image,
+                            "imagePullPolicy": "IfNotPresent",
+                            "command": ["python3", "-c", _RUNNER_PROGRAM],
+                            "env": [{"name": k, "value": v} for k, v in sorted(full_env.items())],
+                            "securityContext": {
+                                "allowPrivilegeEscalation": False,
+                                "capabilities": {"drop": ["ALL"]},
+                            },
+                            "volumeMounts": volume_mounts,
+                        }
+                    ],
+                    "volumes": volumes,
+                },
+            },
+        },
+    }
+
+
+def _submit_runner_job(k8s: Any, namespace: str, manifest: dict[str, Any]) -> None:
+    """Convert the manifest dict to V1 objects and create the Job."""
+    from kubernetes import client as k8s_client_pkg
+
+    container = manifest["spec"]["template"]["spec"]["containers"][0]
+    pod_spec = manifest["spec"]["template"]["spec"]
+    body = k8s_client_pkg.V1Job(
+        api_version=manifest["apiVersion"],
+        kind=manifest["kind"],
+        metadata=k8s_client_pkg.V1ObjectMeta(
+            name=manifest["metadata"]["name"],
+            labels=manifest["metadata"]["labels"],
+        ),
+        spec=k8s_client_pkg.V1JobSpec(
+            ttl_seconds_after_finished=manifest["spec"]["ttlSecondsAfterFinished"],
+            active_deadline_seconds=manifest["spec"]["activeDeadlineSeconds"],
+            backoff_limit=manifest["spec"]["backoffLimit"],
+            template=k8s_client_pkg.V1PodTemplateSpec(
+                metadata=k8s_client_pkg.V1ObjectMeta(
+                    labels=manifest["spec"]["template"]["metadata"]["labels"],
+                ),
+                spec=k8s_client_pkg.V1PodSpec(
+                    restart_policy=pod_spec["restartPolicy"],
+                    automount_service_account_token=False,
+                    security_context=k8s_client_pkg.V1PodSecurityContext(
+                        run_as_user=pod_spec["securityContext"]["runAsUser"],
+                        run_as_group=pod_spec["securityContext"]["runAsGroup"],
+                        fs_group=pod_spec["securityContext"]["fsGroup"],
+                    ),
+                    containers=[
+                        k8s_client_pkg.V1Container(
+                            name=container["name"],
+                            image=container["image"],
+                            image_pull_policy=container["imagePullPolicy"],
+                            command=container["command"],
+                            env=[
+                                k8s_client_pkg.V1EnvVar(name=e["name"], value=e["value"])
+                                for e in container["env"]
+                            ],
+                            security_context=k8s_client_pkg.V1SecurityContext(
+                                allow_privilege_escalation=False,
+                                capabilities=k8s_client_pkg.V1Capabilities(drop=["ALL"]),
+                            ),
+                            volume_mounts=[
+                                k8s_client_pkg.V1VolumeMount(
+                                    name=m["name"], mount_path=m["mountPath"]
+                                )
+                                for m in container["volumeMounts"]
+                            ],
+                        )
+                    ],
+                    volumes=[
+                        k8s_client_pkg.V1Volume(
+                            name=v["name"],
+                            host_path=k8s_client_pkg.V1HostPathVolumeSource(
+                                path=v["hostPath"]["path"],
+                                type=v["hostPath"]["type"],
+                            ),
+                        )
+                        for v in pod_spec["volumes"]
+                    ],
+                ),
+            ),
+        ),
+    )
+    k8s.batch_api.create_namespaced_job(namespace=namespace, body=body)
+
+
+def _wait_for_runner_pod(k8s: Any, namespace: str, gate_id: str, *, timeout: float) -> Any:
+    """Return the runner pod once Succeeded/Failed, or None on timeout."""
+    selector = f"{_GATE_ID_LABEL}={gate_id}"
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            pods = k8s.core_api.list_namespaced_pod(namespace=namespace, label_selector=selector)
+        except Exception:  # noqa: BLE001 — transient list errors are retried
+            time.sleep(5.0)
+            continue
+        for pod in getattr(pods, "items", []) or []:
+            phase = (getattr(pod, "status", None) and pod.status.phase) or ""
+            if phase in {"Succeeded", "Failed"}:
+                return pod
+        time.sleep(5.0)
+    return None
+
+
+def _read_runner_log(k8s: Any, namespace: str, pod_name: str) -> str:
+    """Read the runner pod's stdout as raw text.
+
+    ``_preload_content=False`` is load-bearing: the kubernetes client's
+    default path runs ``json.loads`` on JSON-shaped response bodies and
+    ``str()``s the dict back, corrupting the verdict line into a Python
+    dict repr (probe precedent, ``_read_probe_log``). The lazy ``.data``
+    read must stay inside the try — that is where the network I/O
+    actually happens.
+    """
+    try:
+        raw = k8s.core_api.read_namespaced_pod_log(
+            name=pod_name, namespace=namespace, _preload_content=False
+        )
+        if raw is None:
+            return ""
+        data = getattr(raw, "data", raw)
+    except Exception as exc:  # noqa: BLE001 — log read is best-effort
+        logger.warning("Green gate runner log read failed", pod=pod_name, error=str(exc))
+        return ""
+    if data is None:
+        return ""
+    if isinstance(data, bytes):
+        return data.decode("utf-8", errors="replace")
+    return str(data)
+
+
+def _delete_runner_job(k8s: Any, namespace: str, gate_id: str) -> None:
+    """Best-effort Job cleanup. Never raises."""
+    name = f"egg-greengate-{gate_id}"
+    try:
+        from kubernetes import client as k8s_client_pkg
+
+        k8s.batch_api.delete_namespaced_job(
+            name=name,
+            namespace=namespace,
+            body=k8s_client_pkg.V1DeleteOptions(
+                propagation_policy="Background", grace_period_seconds=0
+            ),
+        )
+    except Exception as exc:  # noqa: BLE001 — cleanup must never wedge the close
+        logger.info("Green gate job cleanup skipped", job=name, error=str(exc))
+
+
+def parse_verdict(raw_log: str) -> dict[str, Any] | None:
+    """Extract the sentinel-prefixed JSON verdict from the pod log.
+
+    Scans from the end so check output can never shadow the verdict.
+    Returns ``None`` when no parseable verdict line exists (an
+    infrastructure failure — the caller fails open).
+    """
+    if not raw_log:
+        return None
+    for line in reversed(raw_log.splitlines()):
+        line = line.strip()
+        if not line.startswith(VERDICT_SENTINEL):
+            continue
+        try:
+            parsed = json.loads(line[len(VERDICT_SENTINEL) :])
+        except json.JSONDecodeError:
+            return None
+        if isinstance(parsed, dict) and isinstance(parsed.get("checks"), list):
+            return parsed
+        return None
+    return None
+
+
+def _format_failed_checks(failed: list[dict[str, Any]]) -> str:
+    """Render failing checks + output tails into the failure string."""
+    parts = []
+    for check in failed:
+        tail = str(check.get("output_tail") or "")[-_FAILURE_MESSAGE_TAIL_CHARS:]
+        parts.append(f"[{check.get('name')}] exit {check.get('exit_code')}:\n{tail}".strip())
+    return "\n\n".join(parts)
+
+
+def run_slice_green_gate(
+    pipeline_id: str,
+    spawner: "KubernetesSpawner",  # noqa: UP037
+    slice_id: str,
+    integration_branch: str,
+    repo: str,
+    *,
+    gateway_mode: Literal["public", "private"] = "public",
+) -> str | None:
+    """Execute the repo's configured checks at the slice tip; gate PR-open (#3398).
+
+    Runs after slice consensus and the #3125 evidence gate, before any
+    close side effect. Returns ``None`` when the slice may close (checks
+    green, gate off/log-mode, or an infrastructure failure — fail-open),
+    or a human-readable failure string naming the red checks — the
+    caller records the slice failure with it, routing through the
+    existing cascade + OVERSEER_ALERT machinery instead of opening a
+    red PR.
+
+    The runner gets its own gateway worktree forked from
+    ``origin/<integration_branch>`` (both ``base_branch`` and
+    ``assigned_branch`` point at it so the assigned-branch fork-point
+    override, #3068, resolves to the same tip) and its own gateway
+    session so the sandbox git wrapper works — ``make test``'s selector
+    shells out to gateway-routed git for its merge-base/diff. The
+    session role is ``tester``: the runner does exactly the read-side
+    work a tester session is scoped for, and never pushes.
+    """
+    mode = green_gate_mode()
+    if mode == "off":
+        logger.info(
+            "Green gate disabled by kill switch (#3398)",
+            pipeline_id=pipeline_id,
+            slice_id=slice_id,
+        )
+        return None
+
+    checks = _gate_checks(repo)
+    if not checks:
+        logger.info(
+            "Green gate skipped: no configured checks for repo (#3398)",
+            pipeline_id=pipeline_id,
+            slice_id=slice_id,
+            repo=repo,
+        )
+        return None
+
+    namespace = os.environ.get("EGG_AGENTS_NAMESPACE", "egg-agents")
+    image = os.environ.get("EGG_SANDBOX_IMAGE", "egg:latest")
+    timeout = _gate_timeout_seconds()
+    host_uid = int(os.environ.get("HOST_UID", 1000))
+    host_gid = int(os.environ.get("HOST_GID", 1000))
+    gate_id = uuid.uuid4().hex[:12]
+    runner_id = f"egg-greengate-{gate_id}"
+
+    # --- materialize the slice tip: gateway worktree at the integration branch
+    try:
+        wt_result = spawner.gateway.create_worktrees(
+            container_id=runner_id,
+            repos=[repo],
+            uid=host_uid,
+            gid=host_gid,
+            base_branch=integration_branch,
+            assigned_branch=integration_branch,
+        )
+    except Exception as exc:  # noqa: BLE001 — infra failure fails open
+        logger.warning(
+            "Green gate skipped: runner worktree creation failed (#3398)",
+            pipeline_id=pipeline_id,
+            slice_id=slice_id,
+            error=str(exc),
+        )
+        return None
+    if not (wt_result and wt_result.success and wt_result.worktrees):
+        logger.warning(
+            "Green gate skipped: runner worktree creation returned no paths (#3398)",
+            pipeline_id=pipeline_id,
+            slice_id=slice_id,
+            errors=getattr(wt_result, "errors", None),
+        )
+        return None
+
+    session_token: str | None = None
+    job_submitted = False
+    try:
+        # --- gateway session so the sandbox git wrapper (test selector) works
+        try:
+            session_info = spawner.gateway.register_session(
+                container_id=runner_id,
+                mode=gateway_mode,
+                repos=[repo],
+                uid=host_uid,
+                gid=host_gid,
+                phase="implement",
+                pipeline_id=pipeline_id,
+                agent_role="tester",
+                branch=integration_branch,
+                base_branch=integration_branch,
+                retry_transient=True,
+            )
+            session_token = session_info.session_token
+        except Exception as exc:  # noqa: BLE001 — infra failure fails open
+            logger.warning(
+                "Green gate skipped: runner session registration failed (#3398)",
+                pipeline_id=pipeline_id,
+                slice_id=slice_id,
+                error=str(exc),
+            )
+            return None
+
+        repo_mounts: dict[str, str] = {}
+        repo_dir = ""
+        for host_path in wt_result.worktrees.values():
+            container_path = f"/home/egg/repos/{os.path.basename(host_path)}"
+            repo_mounts[container_path] = host_path
+            repo_dir = container_path
+
+        from kubernetes_spawner import GATEWAY_K8S_URL
+
+        env = {
+            "GATEWAY_URL": GATEWAY_K8S_URL,
+            "CONTAINER_ID": runner_id,
+            "EGG_SESSION_TOKEN": session_token,
+            "EGG_GREEN_GATE_REQUIRE_PREBUILT": ("1" if _repo_requires_prebuilt(repo) else "0"),
+        }
+
+        manifest = _build_runner_job_manifest(
+            gate_id=gate_id,
+            pipeline_id=pipeline_id,
+            slice_id=slice_id,
+            image=image,
+            checks=checks,
+            repo_mounts=repo_mounts,
+            repo_dir=repo_dir,
+            env=env,
+            timeout_seconds=timeout,
+            host_uid=host_uid,
+            host_gid=host_gid,
+        )
+
+        try:
+            _submit_runner_job(spawner.k8s, namespace, manifest)
+            job_submitted = True
+        except Exception as exc:  # noqa: BLE001 — infra failure fails open
+            logger.warning(
+                "Green gate skipped: runner job submit failed (#3398)",
+                pipeline_id=pipeline_id,
+                slice_id=slice_id,
+                error=str(exc),
+            )
+            return None
+
+        logger.info(
+            "Green gate runner spawned (#3398)",
+            pipeline_id=pipeline_id,
+            slice_id=slice_id,
+            gate_id=gate_id,
+            integration_branch=integration_branch,
+            checks=[c["name"] for c in checks],
+            timeout_seconds=timeout,
+            mode=mode,
+        )
+
+        pod = _wait_for_runner_pod(spawner.k8s, namespace, gate_id, timeout=timeout)
+        if pod is None:
+            logger.warning(
+                "Green gate skipped: runner pod did not reach a terminal state (#3398)",
+                pipeline_id=pipeline_id,
+                slice_id=slice_id,
+                gate_id=gate_id,
+                timeout_seconds=timeout,
+            )
+            return None
+
+        pod_name = (getattr(pod, "metadata", None) and pod.metadata.name) or ""
+        phase = (getattr(pod, "status", None) and pod.status.phase) or ""
+        raw_log = _read_runner_log(spawner.k8s, namespace, pod_name)
+        verdict = parse_verdict(raw_log)
+
+        if verdict is None:
+            # Covers pod Failed (runner harness crashed — the verdict is
+            # printed even when checks are red, so a missing verdict is
+            # never a check failure) and unparseable output.
+            logger.warning(
+                "Green gate skipped: no parseable verdict from runner (#3398)",
+                pipeline_id=pipeline_id,
+                slice_id=slice_id,
+                gate_id=gate_id,
+                pod_phase=phase,
+                log_tail=raw_log[-500:],
+            )
+            return None
+
+        failed = [c for c in verdict["checks"] if not c.get("ok")]
+        if not failed:
+            logger.info(
+                "Green gate passed: slice tip green on configured checks (#3398)",
+                pipeline_id=pipeline_id,
+                slice_id=slice_id,
+                gate_id=gate_id,
+                checks=[c.get("name") for c in verdict["checks"]],
+            )
+            return None
+
+        failed_names = ", ".join(str(c.get("name")) for c in failed)
+        logger.error(
+            "Green gate red: configured checks failed at the slice tip (#3398)",
+            pipeline_id=pipeline_id,
+            slice_id=slice_id,
+            gate_id=gate_id,
+            integration_branch=integration_branch,
+            failed_checks=failed_names,
+            mode=mode,
+        )
+        if mode == "log":
+            return None
+        return (
+            f"slice {slice_id}: green gate failed — configured checks are red "
+            f"at integration branch {integration_branch} tip: {failed_names}.\n\n"
+            f"{_format_failed_checks(failed)}\n\n"
+            f"Fix the failures on {integration_branch} and restart the slice; "
+            f"set {GREEN_GATE_ENV_VAR}=off to bypass."
+        )
+    finally:
+        if job_submitted:
+            _delete_runner_job(spawner.k8s, namespace, gate_id)
+        if session_token is not None:
+            try:
+                spawner.gateway.delete_session_by_container(runner_id)
+            except Exception as exc:  # noqa: BLE001 — cleanup is best-effort
+                logger.info(
+                    "Green gate session cleanup skipped",
+                    runner_id=runner_id,
+                    error=str(exc),
+                )
+        try:
+            spawner.gateway.delete_worktrees(runner_id, force=True)
+        except Exception as exc:  # noqa: BLE001 — cleanup is best-effort
+            logger.info(
+                "Green gate worktree cleanup skipped",
+                runner_id=runner_id,
+                error=str(exc),
+            )

--- a/orchestrator/tests/test_slice_green_gate.py
+++ b/orchestrator/tests/test_slice_green_gate.py
@@ -1,0 +1,665 @@
+"""Tests for the per-slice green gate (#3398).
+
+Covers:
+
+* ``green_gate_mode`` — the three-state operator switch (off default,
+  log soak mode, on; unknown values degrade to off).
+* ``_gate_checks`` / ``_repo_requires_prebuilt`` — config-driven check
+  selection (skip set, default ``security``) and the prebuilt-toolchain
+  requirement derived from ``build_commands.persist_dirs``.
+* ``parse_verdict`` — sentinel-line extraction from noisy pod logs.
+* ``_RUNNER_PROGRAM`` — executed for real in a subprocess: check
+  execution + verdict shape, output tails, the prebuilt-deps restore
+  (copy-if-missing), and the required-but-missing infra exit.
+* ``_build_runner_job_manifest`` — labels (NetworkPolicy component
+  label present; monitor/agent-supervision labels absent), env, mounts,
+  deadline.
+* ``run_slice_green_gate`` — gate wiring: kill switch, fail-open on
+  every infrastructure failure (worktree, session, submit, timeout,
+  unparseable verdict), fail-closed only on a definitive red verdict,
+  log-mode never blocking, and cleanup (job/session/worktree) on every
+  path that created the resource.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+_shared_path = _orchestrator_path.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+import slice_green_gate as sgg  # noqa: E402
+from gateway_client import SessionInfo, WorktreeResult  # noqa: E402
+
+PIPELINE_ID = "pipeline-green-gate-test"
+SLICE_ID = "slice-2"
+INTEGRATION_BRANCH = "egg/issue-3398/work/slice-2"
+REPO = "jwbron/egg"
+
+CHECKS = [
+    {"name": "lint", "command": "make lint"},
+    {"name": "test", "command": "make test"},
+]
+CHECKS_WITH_SECURITY = [*CHECKS, {"name": "security", "command": "make security"}]
+
+
+@pytest.fixture
+def gate_env(monkeypatch: pytest.MonkeyPatch) -> pytest.MonkeyPatch:
+    for var in (
+        sgg.GREEN_GATE_ENV_VAR,
+        sgg.GREEN_GATE_SKIP_CHECKS_ENV_VAR,
+        sgg.GREEN_GATE_TIMEOUT_ENV_VAR,
+    ):
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+# ----------------------------------------------------------------------
+# green_gate_mode
+# ----------------------------------------------------------------------
+
+
+class TestGreenGateMode:
+    def test_default_is_off(self, gate_env: pytest.MonkeyPatch) -> None:
+        assert sgg.green_gate_mode() == "off"
+
+    @pytest.mark.parametrize("value", ["on", "ON", " true ", "1", "yes"])
+    def test_enabled_values(self, gate_env: pytest.MonkeyPatch, value: str) -> None:
+        gate_env.setenv(sgg.GREEN_GATE_ENV_VAR, value)
+        assert sgg.green_gate_mode() == "on"
+
+    @pytest.mark.parametrize("value", ["log", "LOG", "log-only", "log_only"])
+    def test_log_values(self, gate_env: pytest.MonkeyPatch, value: str) -> None:
+        gate_env.setenv(sgg.GREEN_GATE_ENV_VAR, value)
+        assert sgg.green_gate_mode() == "log"
+
+    @pytest.mark.parametrize("value", ["off", "0", "false", "", "banana", "enabled"])
+    def test_everything_else_is_off(self, gate_env: pytest.MonkeyPatch, value: str) -> None:
+        gate_env.setenv(sgg.GREEN_GATE_ENV_VAR, value)
+        assert sgg.green_gate_mode() == "off"
+
+
+# ----------------------------------------------------------------------
+# _gate_checks / _repo_requires_prebuilt / _gate_timeout_seconds
+# ----------------------------------------------------------------------
+
+
+class TestGateChecks:
+    def test_default_skips_security(self, gate_env: pytest.MonkeyPatch) -> None:
+        with patch("config.repo_config.get_repo_checks", return_value=CHECKS_WITH_SECURITY):
+            assert sgg._gate_checks(REPO) == CHECKS
+
+    def test_custom_skip_set(self, gate_env: pytest.MonkeyPatch) -> None:
+        gate_env.setenv(sgg.GREEN_GATE_SKIP_CHECKS_ENV_VAR, "security, TEST")
+        with patch("config.repo_config.get_repo_checks", return_value=CHECKS_WITH_SECURITY):
+            assert sgg._gate_checks(REPO) == [{"name": "lint", "command": "make lint"}]
+
+    def test_empty_skip_env_runs_everything(self, gate_env: pytest.MonkeyPatch) -> None:
+        gate_env.setenv(sgg.GREEN_GATE_SKIP_CHECKS_ENV_VAR, "")
+        with patch("config.repo_config.get_repo_checks", return_value=CHECKS_WITH_SECURITY):
+            assert sgg._gate_checks(REPO) == CHECKS_WITH_SECURITY
+
+    def test_no_configured_checks(self, gate_env: pytest.MonkeyPatch) -> None:
+        with patch("config.repo_config.get_repo_checks", return_value=[]):
+            assert sgg._gate_checks(REPO) == []
+
+    def test_config_error_fails_open(self, gate_env: pytest.MonkeyPatch) -> None:
+        with patch("config.repo_config.get_repo_checks", side_effect=RuntimeError("boom")):
+            assert sgg._gate_checks(REPO) == []
+
+
+class TestRepoRequiresPrebuilt:
+    def test_persist_dirs_requires(self) -> None:
+        with patch(
+            "config.repo_config.get_repo_build_commands",
+            return_value={"persist_dirs": [".venv"]},
+        ):
+            assert sgg._repo_requires_prebuilt(REPO) is True
+
+    def test_no_build_commands(self) -> None:
+        with patch("config.repo_config.get_repo_build_commands", return_value={}):
+            assert sgg._repo_requires_prebuilt(REPO) is False
+
+    def test_empty_persist_dirs(self) -> None:
+        with patch(
+            "config.repo_config.get_repo_build_commands",
+            return_value={"persist_dirs": [], "commands": ["npm ci"]},
+        ):
+            assert sgg._repo_requires_prebuilt(REPO) is False
+
+    def test_config_error_fails_open(self) -> None:
+        with patch(
+            "config.repo_config.get_repo_build_commands",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert sgg._repo_requires_prebuilt(REPO) is False
+
+
+class TestGateTimeout:
+    def test_default(self, gate_env: pytest.MonkeyPatch) -> None:
+        assert sgg._gate_timeout_seconds() == sgg._DEFAULT_TIMEOUT_SECONDS
+
+    def test_override(self, gate_env: pytest.MonkeyPatch) -> None:
+        gate_env.setenv(sgg.GREEN_GATE_TIMEOUT_ENV_VAR, "600")
+        assert sgg._gate_timeout_seconds() == 600
+
+    @pytest.mark.parametrize("value", ["-5", "0", "soon", ""])
+    def test_invalid_falls_back(self, gate_env: pytest.MonkeyPatch, value: str) -> None:
+        gate_env.setenv(sgg.GREEN_GATE_TIMEOUT_ENV_VAR, value)
+        assert sgg._gate_timeout_seconds() == sgg._DEFAULT_TIMEOUT_SECONDS
+
+
+# ----------------------------------------------------------------------
+# parse_verdict
+# ----------------------------------------------------------------------
+
+
+def _verdict_line(checks: list[dict[str, Any]]) -> str:
+    return sgg.VERDICT_SENTINEL + json.dumps({"checks": checks})
+
+
+class TestParseVerdict:
+    def test_parses_sentinel_line(self) -> None:
+        log = "make output\nmore output\n" + _verdict_line([{"name": "lint", "ok": True}])
+        verdict = sgg.parse_verdict(log)
+        assert verdict is not None
+        assert verdict["checks"][0]["name"] == "lint"
+
+    def test_json_shaped_check_output_is_not_the_verdict(self) -> None:
+        log = (
+            _verdict_line([{"name": "lint", "ok": False}])
+            + "\n"
+            + json.dumps({"checks": [{"name": "lint", "ok": True}]})
+        )
+        verdict = sgg.parse_verdict(log)
+        assert verdict is not None
+        assert verdict["checks"][0]["ok"] is False
+
+    def test_empty_log(self) -> None:
+        assert sgg.parse_verdict("") is None
+
+    def test_no_sentinel(self) -> None:
+        assert sgg.parse_verdict("ruff.....ok\nall tests passed\n") is None
+
+    def test_malformed_json_after_sentinel(self) -> None:
+        assert sgg.parse_verdict(sgg.VERDICT_SENTINEL + "{not json") is None
+
+    def test_verdict_without_checks_list(self) -> None:
+        assert sgg.parse_verdict(sgg.VERDICT_SENTINEL + json.dumps({"ok": True})) is None
+
+
+# ----------------------------------------------------------------------
+# _RUNNER_PROGRAM — executed for real in a subprocess
+# ----------------------------------------------------------------------
+
+
+def _run_runner(
+    tmp_path: Path,
+    checks: list[dict[str, str]],
+    *,
+    require_prebuilt: str = "0",
+    prebuilt_base: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    repo_dir = tmp_path / "egg"
+    repo_dir.mkdir(exist_ok=True)
+    env = dict(os.environ)
+    env.update(
+        {
+            "EGG_GREEN_GATE_CHECKS": json.dumps(checks),
+            "EGG_GREEN_GATE_REPO_DIR": str(repo_dir),
+            "EGG_GREEN_GATE_OUTPUT_TAIL": "200",
+            "EGG_GREEN_GATE_REQUIRE_PREBUILT": require_prebuilt,
+            "EGG_GREEN_GATE_PREBUILT_BASE": str(
+                prebuilt_base if prebuilt_base is not None else tmp_path / "no-prebuilt"
+            ),
+        }
+    )
+    return subprocess.run(
+        [sys.executable, "-c", sgg._RUNNER_PROGRAM],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+
+class TestRunnerProgram:
+    def test_green_and_red_checks(self, tmp_path: Path) -> None:
+        proc = _run_runner(
+            tmp_path,
+            [
+                {"name": "ok-check", "command": "echo all good"},
+                {"name": "red-check", "command": "echo boom; exit 3"},
+            ],
+        )
+        assert proc.returncode == 0
+        verdict = sgg.parse_verdict(proc.stdout)
+        assert verdict is not None
+        by_name = {c["name"]: c for c in verdict["checks"]}
+        assert by_name["ok-check"]["ok"] is True
+        assert by_name["ok-check"]["exit_code"] == 0
+        assert "all good" in by_name["ok-check"]["output_tail"]
+        assert by_name["red-check"]["ok"] is False
+        assert by_name["red-check"]["exit_code"] == 3
+        assert "boom" in by_name["red-check"]["output_tail"]
+
+    def test_output_tail_is_capped(self, tmp_path: Path) -> None:
+        proc = _run_runner(
+            tmp_path,
+            [{"name": "noisy", "command": "yes filler | head -n 2000; true"}],
+        )
+        verdict = sgg.parse_verdict(proc.stdout)
+        assert verdict is not None
+        assert len(verdict["checks"][0]["output_tail"]) <= 200
+
+    def test_checks_run_in_repo_dir(self, tmp_path: Path) -> None:
+        (tmp_path / "egg").mkdir(exist_ok=True)
+        (tmp_path / "egg" / "marker.txt").write_text("present")
+        proc = _run_runner(tmp_path, [{"name": "cwd", "command": "cat marker.txt"}])
+        verdict = sgg.parse_verdict(proc.stdout)
+        assert verdict is not None
+        assert "present" in verdict["checks"][0]["output_tail"]
+
+    def test_prebuilt_restore_copy_if_missing(self, tmp_path: Path) -> None:
+        prebuilt = tmp_path / "prebuilt" / "jwbron--egg"
+        (prebuilt / ".venv" / "bin").mkdir(parents=True)
+        (prebuilt / ".venv" / "bin" / "tool").write_text("prebuilt tool")
+        (prebuilt / "existing.txt").write_text("prebuilt version")
+
+        repo_dir = tmp_path / "egg"
+        repo_dir.mkdir()
+        (repo_dir / "existing.txt").write_text("worktree version")
+
+        proc = _run_runner(
+            tmp_path,
+            [{"name": "check", "command": "cat .venv/bin/tool existing.txt"}],
+            require_prebuilt="1",
+            prebuilt_base=tmp_path / "prebuilt",
+        )
+        assert proc.returncode == 0
+        verdict = sgg.parse_verdict(proc.stdout)
+        assert verdict is not None
+        tail = verdict["checks"][0]["output_tail"]
+        assert "prebuilt tool" in tail
+        # copy-if-missing: worktree files are never clobbered.
+        assert "worktree version" in tail
+
+    def test_required_prebuilt_missing_is_infra_exit(self, tmp_path: Path) -> None:
+        proc = _run_runner(
+            tmp_path,
+            [{"name": "check", "command": "true"}],
+            require_prebuilt="1",
+        )
+        assert proc.returncode == 1
+        assert sgg.parse_verdict(proc.stdout) is None
+        assert "prebuilt" in proc.stderr
+
+    def test_optional_prebuilt_missing_proceeds(self, tmp_path: Path) -> None:
+        proc = _run_runner(
+            tmp_path,
+            [{"name": "check", "command": "true"}],
+            require_prebuilt="0",
+        )
+        assert proc.returncode == 0
+        verdict = sgg.parse_verdict(proc.stdout)
+        assert verdict is not None
+        assert verdict["checks"][0]["ok"] is True
+
+
+# ----------------------------------------------------------------------
+# _build_runner_job_manifest
+# ----------------------------------------------------------------------
+
+
+def _manifest(**overrides: Any) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "gate_id": "abc123def456",
+        "pipeline_id": PIPELINE_ID,
+        "slice_id": SLICE_ID,
+        "image": "egg:latest",
+        "checks": CHECKS,
+        "repo_mounts": {"/home/egg/repos/egg": "/home/host/.egg-worktrees/x/egg"},
+        "repo_dir": "/home/egg/repos/egg",
+        "env": {"GATEWAY_URL": "http://gw:9848", "EGG_GREEN_GATE_REQUIRE_PREBUILT": "1"},
+        "timeout_seconds": 1800,
+        "host_uid": 1000,
+        "host_gid": 1000,
+    }
+    kwargs.update(overrides)
+    return sgg._build_runner_job_manifest(**kwargs)
+
+
+class TestBuildRunnerJobManifest:
+    def test_network_policy_label_present(self) -> None:
+        manifest = _manifest()
+        for labels in (
+            manifest["metadata"]["labels"],
+            manifest["spec"]["template"]["metadata"]["labels"],
+        ):
+            assert labels["app.kubernetes.io/component"] == "agent"
+            assert labels[sgg._GATE_ID_LABEL] == "abc123def456"
+
+    def test_no_agent_supervision_labels(self) -> None:
+        # The runner is infrastructure, not an agent: it must not carry
+        # the labels the monitor / running-agent views / list_slice_jobs
+        # enumerate, or it would surface in supervision and trip
+        # heartbeat-silence tripwires.
+        manifest = _manifest()
+        all_labels = {
+            **manifest["metadata"]["labels"],
+            **manifest["spec"]["template"]["metadata"]["labels"],
+        }
+        for forbidden in ("egg.orchestrator", "egg.agent.role", "egg.slice.id"):
+            assert forbidden not in all_labels
+
+    def test_env_carries_checks_and_repo_dir(self) -> None:
+        manifest = _manifest()
+        env = {
+            e["name"]: e["value"]
+            for e in manifest["spec"]["template"]["spec"]["containers"][0]["env"]
+        }
+        assert json.loads(env["EGG_GREEN_GATE_CHECKS"]) == CHECKS
+        assert env["EGG_GREEN_GATE_REPO_DIR"] == "/home/egg/repos/egg"
+        assert env["EGG_GREEN_GATE_REQUIRE_PREBUILT"] == "1"
+        assert env["GATEWAY_URL"] == "http://gw:9848"
+
+    def test_worktree_mount(self) -> None:
+        manifest = _manifest()
+        pod = manifest["spec"]["template"]["spec"]
+        assert pod["volumes"][0]["hostPath"]["path"] == "/home/host/.egg-worktrees/x/egg"
+        mount = pod["containers"][0]["volumeMounts"][0]
+        assert mount["mountPath"] == "/home/egg/repos/egg"
+        assert mount["name"] == pod["volumes"][0]["name"]
+
+    def test_one_shot_job_shape(self) -> None:
+        manifest = _manifest(timeout_seconds=600)
+        assert manifest["spec"]["backoffLimit"] == 0
+        assert manifest["spec"]["activeDeadlineSeconds"] == 660
+        assert manifest["spec"]["template"]["spec"]["restartPolicy"] == "Never"
+        command = manifest["spec"]["template"]["spec"]["containers"][0]["command"]
+        assert command[:2] == ["python3", "-c"]
+
+    def test_runs_as_host_uid(self) -> None:
+        manifest = _manifest(host_uid=1234, host_gid=5678)
+        ctx = manifest["spec"]["template"]["spec"]["securityContext"]
+        assert ctx == {"runAsUser": 1234, "runAsGroup": 5678, "fsGroup": 5678}
+
+
+# ----------------------------------------------------------------------
+# run_slice_green_gate
+# ----------------------------------------------------------------------
+
+
+def _session_info() -> SessionInfo:
+    return SessionInfo(
+        session_token="tok-123",
+        container_id="egg-greengate-x",
+        container_ip=None,
+        mode="public",
+        created_at=datetime.now(),
+        expires_at=datetime.now() + timedelta(hours=24),
+    )
+
+
+def _spawner(
+    *,
+    worktrees: dict[str, str] | None = None,
+    worktree_exc: Exception | None = None,
+    session_exc: Exception | None = None,
+) -> MagicMock:
+    spawner = MagicMock()
+    if worktree_exc is not None:
+        spawner.gateway.create_worktrees.side_effect = worktree_exc
+    else:
+        spawner.gateway.create_worktrees.return_value = WorktreeResult(
+            success=True,
+            worktrees=(
+                worktrees
+                if worktrees is not None
+                else {REPO: "/home/host/.egg-worktrees/runner/egg"}
+            ),
+            errors=[],
+        )
+    if session_exc is not None:
+        spawner.gateway.register_session.side_effect = session_exc
+    else:
+        spawner.gateway.register_session.return_value = _session_info()
+    return spawner
+
+
+def _terminal_pod(phase: str = "Succeeded") -> SimpleNamespace:
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name="egg-greengate-pod"),
+        status=SimpleNamespace(phase=phase),
+    )
+
+
+def _run_gate(spawner: MagicMock) -> str | None:
+    return sgg.run_slice_green_gate(
+        PIPELINE_ID,
+        spawner,
+        SLICE_ID,
+        INTEGRATION_BRANCH,
+        REPO,
+        gateway_mode="public",
+    )
+
+
+@pytest.fixture
+def enabled_gate(gate_env: pytest.MonkeyPatch) -> pytest.MonkeyPatch:
+    gate_env.setenv(sgg.GREEN_GATE_ENV_VAR, "on")
+    return gate_env
+
+
+@pytest.fixture
+def configured_checks():
+    with (
+        patch("config.repo_config.get_repo_checks", return_value=CHECKS),
+        patch(
+            "config.repo_config.get_repo_build_commands",
+            return_value={"persist_dirs": [".venv"]},
+        ),
+    ):
+        yield
+
+
+class TestRunSliceGreenGate:
+    def test_kill_switch_off_skips_everything(
+        self, gate_env: pytest.MonkeyPatch, configured_checks: None
+    ) -> None:
+        spawner = _spawner()
+        assert _run_gate(spawner) is None
+        spawner.gateway.create_worktrees.assert_not_called()
+
+    def test_no_configured_checks_skips(self, enabled_gate: pytest.MonkeyPatch) -> None:
+        spawner = _spawner()
+        with patch("config.repo_config.get_repo_checks", return_value=[]):
+            assert _run_gate(spawner) is None
+        spawner.gateway.create_worktrees.assert_not_called()
+
+    def test_worktree_failure_fails_open(
+        self, enabled_gate: pytest.MonkeyPatch, configured_checks: None
+    ) -> None:
+        spawner = _spawner(worktree_exc=RuntimeError("gateway down"))
+        assert _run_gate(spawner) is None
+        spawner.gateway.register_session.assert_not_called()
+
+    def test_worktree_unsuccessful_fails_open(
+        self, enabled_gate: pytest.MonkeyPatch, configured_checks: None
+    ) -> None:
+        spawner = _spawner()
+        spawner.gateway.create_worktrees.return_value = WorktreeResult(
+            success=False, worktrees={}, errors=["no branch"]
+        )
+        assert _run_gate(spawner) is None
+        spawner.gateway.register_session.assert_not_called()
+
+    def test_session_failure_fails_open_and_cleans_worktree(
+        self, enabled_gate: pytest.MonkeyPatch, configured_checks: None
+    ) -> None:
+        spawner = _spawner(session_exc=RuntimeError("no session"))
+        assert _run_gate(spawner) is None
+        spawner.gateway.delete_worktrees.assert_called_once()
+        spawner.gateway.delete_session_by_container.assert_not_called()
+
+    def test_submit_failure_fails_open_and_cleans_up(
+        self, enabled_gate: pytest.MonkeyPatch, configured_checks: None
+    ) -> None:
+        spawner = _spawner()
+        with (
+            patch.object(sgg, "_submit_runner_job", side_effect=RuntimeError("api error")),
+            patch.object(sgg, "_delete_runner_job") as delete_job,
+        ):
+            assert _run_gate(spawner) is None
+        delete_job.assert_not_called()
+        runner_id = spawner.gateway.register_session.call_args.kwargs["container_id"]
+        spawner.gateway.delete_session_by_container.assert_called_once_with(runner_id)
+        spawner.gateway.delete_worktrees.assert_called_once()
+
+    def test_pod_timeout_fails_open_and_cleans_up(
+        self, enabled_gate: pytest.MonkeyPatch, configured_checks: None
+    ) -> None:
+        spawner = _spawner()
+        with (
+            patch.object(sgg, "_submit_runner_job") as submit,
+            patch.object(sgg, "_wait_for_runner_pod", return_value=None),
+            patch.object(sgg, "_delete_runner_job") as delete_job,
+        ):
+            assert _run_gate(spawner) is None
+        submit.assert_called_once()
+        delete_job.assert_called_once()
+        spawner.gateway.delete_session_by_container.assert_called_once()
+        spawner.gateway.delete_worktrees.assert_called_once()
+
+    def test_unparseable_verdict_fails_open(
+        self, enabled_gate: pytest.MonkeyPatch, configured_checks: None
+    ) -> None:
+        spawner = _spawner()
+        with (
+            patch.object(sgg, "_submit_runner_job"),
+            patch.object(sgg, "_wait_for_runner_pod", return_value=_terminal_pod("Failed")),
+            patch.object(sgg, "_read_runner_log", return_value="crash traceback"),
+            patch.object(sgg, "_delete_runner_job"),
+        ):
+            assert _run_gate(spawner) is None
+
+    def test_green_verdict_proceeds(
+        self, enabled_gate: pytest.MonkeyPatch, configured_checks: None
+    ) -> None:
+        spawner = _spawner()
+        log = _verdict_line([{"name": "lint", "ok": True}, {"name": "test", "ok": True}])
+        with (
+            patch.object(sgg, "_submit_runner_job"),
+            patch.object(sgg, "_wait_for_runner_pod", return_value=_terminal_pod()),
+            patch.object(sgg, "_read_runner_log", return_value=log),
+            patch.object(sgg, "_delete_runner_job") as delete_job,
+        ):
+            assert _run_gate(spawner) is None
+        delete_job.assert_called_once()
+        spawner.gateway.delete_session_by_container.assert_called_once()
+        spawner.gateway.delete_worktrees.assert_called_once()
+
+    def test_red_verdict_blocks_with_actionable_message(
+        self, enabled_gate: pytest.MonkeyPatch, configured_checks: None
+    ) -> None:
+        spawner = _spawner()
+        log = "make output\n" + _verdict_line(
+            [
+                {"name": "lint", "ok": True, "exit_code": 0, "output_tail": ""},
+                {
+                    "name": "test",
+                    "ok": False,
+                    "exit_code": 2,
+                    "output_tail": "FAILED orchestrator/tests/test_x.py::test_y",
+                },
+            ]
+        )
+        with (
+            patch.object(sgg, "_submit_runner_job"),
+            patch.object(sgg, "_wait_for_runner_pod", return_value=_terminal_pod()),
+            patch.object(sgg, "_read_runner_log", return_value=log),
+            patch.object(sgg, "_delete_runner_job") as delete_job,
+        ):
+            failure = _run_gate(spawner)
+        assert failure is not None
+        assert SLICE_ID in failure
+        assert INTEGRATION_BRANCH in failure
+        assert "test" in failure
+        assert "FAILED orchestrator/tests/test_x.py::test_y" in failure
+        assert sgg.GREEN_GATE_ENV_VAR in failure
+        assert "lint" not in failure.split("green gate failed")[1].split("\n")[0]
+        # Cleanup still runs on the blocking path.
+        delete_job.assert_called_once()
+        spawner.gateway.delete_session_by_container.assert_called_once()
+        spawner.gateway.delete_worktrees.assert_called_once()
+
+    def test_red_verdict_in_log_mode_does_not_block(
+        self, gate_env: pytest.MonkeyPatch, configured_checks: None
+    ) -> None:
+        gate_env.setenv(sgg.GREEN_GATE_ENV_VAR, "log")
+        spawner = _spawner()
+        log = _verdict_line([{"name": "test", "ok": False, "exit_code": 2, "output_tail": "x"}])
+        with (
+            patch.object(sgg, "_submit_runner_job") as submit,
+            patch.object(sgg, "_wait_for_runner_pod", return_value=_terminal_pod()),
+            patch.object(sgg, "_read_runner_log", return_value=log),
+            patch.object(sgg, "_delete_runner_job"),
+        ):
+            assert _run_gate(spawner) is None
+        # Log mode still runs the checks — it only skips the block.
+        submit.assert_called_once()
+
+    def test_worktree_forked_from_integration_branch(
+        self, enabled_gate: pytest.MonkeyPatch, configured_checks: None
+    ) -> None:
+        spawner = _spawner()
+        log = _verdict_line([{"name": "lint", "ok": True}])
+        with (
+            patch.object(sgg, "_submit_runner_job"),
+            patch.object(sgg, "_wait_for_runner_pod", return_value=_terminal_pod()),
+            patch.object(sgg, "_read_runner_log", return_value=log),
+            patch.object(sgg, "_delete_runner_job"),
+        ):
+            _run_gate(spawner)
+        wt_kwargs = spawner.gateway.create_worktrees.call_args.kwargs
+        assert wt_kwargs["base_branch"] == INTEGRATION_BRANCH
+        assert wt_kwargs["assigned_branch"] == INTEGRATION_BRANCH
+        assert wt_kwargs["repos"] == [REPO]
+        sess_kwargs = spawner.gateway.register_session.call_args.kwargs
+        assert sess_kwargs["agent_role"] == "tester"
+        assert sess_kwargs["pipeline_id"] == PIPELINE_ID
+
+    def test_manifest_env_marks_prebuilt_required(
+        self, enabled_gate: pytest.MonkeyPatch, configured_checks: None
+    ) -> None:
+        spawner = _spawner()
+        log = _verdict_line([{"name": "lint", "ok": True}])
+        with (
+            patch.object(sgg, "_submit_runner_job") as submit,
+            patch.object(sgg, "_wait_for_runner_pod", return_value=_terminal_pod()),
+            patch.object(sgg, "_read_runner_log", return_value=log),
+            patch.object(sgg, "_delete_runner_job"),
+        ):
+            _run_gate(spawner)
+        manifest = submit.call_args.args[2]
+        env = {
+            e["name"]: e["value"]
+            for e in manifest["spec"]["template"]["spec"]["containers"][0]["env"]
+        }
+        assert env["EGG_GREEN_GATE_REQUIRE_PREBUILT"] == "1"
+        assert env["EGG_SESSION_TOKEN"] == "tok-123"
+        assert json.loads(env["EGG_GREEN_GATE_CHECKS"]) == CHECKS

--- a/orchestrator/tests/test_slice_green_gate.py
+++ b/orchestrator/tests/test_slice_green_gate.py
@@ -540,11 +540,19 @@ class TestRunSliceGreenGate:
         spawner = _spawner()
         with (
             patch.object(sgg, "_submit_runner_job") as submit,
-            patch.object(sgg, "_wait_for_runner_pod", return_value=None),
+            patch.object(sgg, "_wait_for_runner_pod", return_value=None) as wait,
             patch.object(sgg, "_delete_runner_job") as delete_job,
         ):
             assert _run_gate(spawner) is None
         submit.assert_called_once()
+        # The orchestrator-side wait budget must include the scheduling grace so a
+        # cold-node image pull does not eat the check timeout and trip a spurious
+        # fail-open (#3398). Pin the caller-side wiring so a refactor that drops the
+        # grace can't stay green.
+        assert (
+            wait.call_args.kwargs["timeout"]
+            == sgg._DEFAULT_TIMEOUT_SECONDS + sgg._POD_SCHEDULING_GRACE_SECONDS
+        )
         delete_job.assert_called_once()
         spawner.gateway.delete_session_by_container.assert_called_once()
         spawner.gateway.delete_worktrees.assert_called_once()

--- a/orchestrator/tests/test_slice_green_gate.py
+++ b/orchestrator/tests/test_slice_green_gate.py
@@ -42,8 +42,8 @@ _shared_path = _orchestrator_path.parent / "shared"
 if _shared_path.exists() and str(_shared_path) not in sys.path:
     sys.path.insert(0, str(_shared_path))
 
-from egg_config.constants import TEST_GATEWAY_PORT  # noqa: E402
 import slice_green_gate as sgg  # noqa: E402
+from egg_config.constants import TEST_GATEWAY_PORT  # noqa: E402
 from gateway_client import SessionInfo, WorktreeResult  # noqa: E402
 
 PIPELINE_ID = "pipeline-green-gate-test"

--- a/orchestrator/tests/test_slice_green_gate.py
+++ b/orchestrator/tests/test_slice_green_gate.py
@@ -42,6 +42,7 @@ _shared_path = _orchestrator_path.parent / "shared"
 if _shared_path.exists() and str(_shared_path) not in sys.path:
     sys.path.insert(0, str(_shared_path))
 
+from egg_config.constants import TEST_GATEWAY_PORT  # noqa: E402
 import slice_green_gate as sgg  # noqa: E402
 from gateway_client import SessionInfo, WorktreeResult  # noqa: E402
 
@@ -334,7 +335,10 @@ def _manifest(**overrides: Any) -> dict[str, Any]:
         "checks": CHECKS,
         "repo_mounts": {"/home/egg/repos/egg": "/home/host/.egg-worktrees/x/egg"},
         "repo_dir": "/home/egg/repos/egg",
-        "env": {"GATEWAY_URL": "http://gw:9848", "EGG_GREEN_GATE_REQUIRE_PREBUILT": "1"},
+        "env": {
+            "GATEWAY_URL": f"http://gw:{TEST_GATEWAY_PORT}",
+            "EGG_GREEN_GATE_REQUIRE_PREBUILT": "1",
+        },
         "timeout_seconds": 1800,
         "host_uid": 1000,
         "host_gid": 1000,
@@ -375,7 +379,7 @@ class TestBuildRunnerJobManifest:
         assert json.loads(env["EGG_GREEN_GATE_CHECKS"]) == CHECKS
         assert env["EGG_GREEN_GATE_REPO_DIR"] == "/home/egg/repos/egg"
         assert env["EGG_GREEN_GATE_REQUIRE_PREBUILT"] == "1"
-        assert env["GATEWAY_URL"] == "http://gw:9848"
+        assert env["GATEWAY_URL"] == f"http://gw:{TEST_GATEWAY_PORT}"
 
     def test_worktree_mount(self) -> None:
         manifest = _manifest()


### PR DESCRIPTION
Closes #3398.

## What

Adds the Tier 1 **per-slice green gate**: before `create_slice_pr`, the orchestrator now *executes* the repo's configured checks (`repositories.yaml::checks` via `get_repo_checks`) against the slice's integration-branch tip in a sandboxed one-shot runner Job, and refuses to open the PR while any check is red.

This closes the trust-vs-verify gap that produced the all-red #3280 stack: the propose-time validator (`_validate_tester_check_coverage`) only compares the tester's self-reported `checks_passed` *names* against config — nothing ever ran the checks at the tip, so format drift (class 1), the lint-ordering-masked mypy failure (class 2), and slicing-order test failures (class 3) all sailed into open PRs.

## How

**Check-runner Job** (`orchestrator/slice_green_gate.py`, modeled on the `validate_network_isolation` probe):
- Gateway worktree forked from `origin/<integration-branch>` (both `base_branch` and `assigned_branch`, so the #3068 fork-point override resolves to the same tip), mounted hostPath into a one-shot pod on the sandbox image.
- Gateway session (role `tester`, read-side only — the runner never pushes) so the sandbox git wrapper works; `make test`'s selector needs gateway-routed `merge-base`/`diff`. The baseline it derives is the **cumulative** slice diff vs `origin/main` — deliberately wider than the tester's own-touched-files scope that let class 3 through.
- Runner restores the repo's **prebuilt `build_commands` toolchain** (`/opt/prebuilt-deps/<owner--repo>/.venv`) into the worktree before running checks, so the tools that run are exactly the versions the repo pins — toolchain-identical to CI by construction, no reliance on globally-installed sandbox tools. If the repo config declares `persist_dirs` but no snapshot exists, the runner exits non-zero (infra failure → fail-open), never a false red from missing tools.
- Verdict is a sentinel-prefixed single JSON line on stdout, read with `_preload_content=False` (probe precedent — the k8s client's default path corrupts JSON-shaped log bodies). Pod exit code is reserved for harness failure; the verdict is the pass/fail channel.
- Job carries the NetworkPolicy `component: agent` label but **none** of the monitor/running-agent-view labels — it must not surface in supervision or trip heartbeat-silence tripwires.

**Gate wiring** (`orchestrator/routes/pipelines.py`): slots immediately after the #3125 evidence gate with the identical shape — red verdict → `scheduler.record_failure(slice_id)` + fail the close, routing through the existing cascade + `OVERSEER_ALERT` machinery; **fail-open on every infrastructure error** (worktree/session/spawn failure, timeout, unparseable verdict), fail-closed only on a definitive red.

**Relocatable venv** (`Makefile`): `sandbox-deps` now runs `uv venv --relocatable` first. The persisted `.venv` is built under `/tmp/repo-deps/...` and restored into a different path at runtime; default uv venvs write absolute console-script shebangs that dangle after the move (`ruff` survives as an ELF binary, `pytest`/`mypy`/`yamllint` break). Relocatable venvs use self-resolving `#!/bin/sh` trampolines — verified to survive a directory move, and `uv` records `relocatable = true` in `pyvenv.cfg` so the subsequent `uv sync` keeps installing trampolined entry points.

## Config

| Env var | Default | Meaning |
|---|---|---|
| `EGG_SLICE_GREEN_GATE` | `off` | `off` → gate skipped; `log` → run checks, log verdict loudly, never block (soak mode); `on` → block on red |
| `EGG_SLICE_GREEN_GATE_SKIP_CHECKS` | `security` | check names the gate skips (full scan stays on the context PR) |
| `EGG_SLICE_GREEN_GATE_TIMEOUT_SECONDS` | `1800` | runner budget; timeout fails open |

Unknown `EGG_SLICE_GREEN_GATE` values degrade to `off` — an operator typo must never block slices.

## Rollout

1. Land this (gate default **off**).
2. Rebuild the sandbox image so the persisted `.venv` is relocatable (`make redeploy` covers it) — until then the restored venv's Python entry points would dangle, which the runner surfaces as red checks in `log` mode.
3. Soak in `log` mode on a live pipeline. Note: while #3301 (contract single-writer) is open, slice tips carry stale contract snapshots that can red contract-hygiene tests for reasons unrelated to the slice — `log` mode is the guard against false blocks until it lands.
4. Flip `on`.

## Behavior note

The gate runs synchronously inside the slice close, and `record_complete` (which unblocks dependent slices) only happens after PR-open — so dependents already wait for a green parent tip. That makes today's wiring effectively the *strict* mode from the design; #3410 tracks the throughput variant (async gate) if check latency on long chains warrants it. Expect the gate to loudly block slicing-order (class 3) failures until #3411 (architect co-location) cures them upstream — loud + blocked beats silent + red.

## Testing

- 62 new tests in `orchestrator/tests/test_slice_green_gate.py`: mode switch, config-driven check selection, verdict parsing, **the actual runner program executed in a subprocess** (check execution, output tails, prebuilt restore copy-if-missing semantics, required-but-missing infra exit), manifest shape (labels/env/mounts/deadline), and end-to-end gate wiring (every fail-open path, red-blocks, log-mode, cleanup on all paths).
- Seam-adjacent suites green: `test_evidence_reachability_gate` (33), `test_unresolved_gap_gate` + `test_slice_gate_recheck` (11), slice run-loop integration + BRC-commit suites (76).
- Relocatable-venv behavior verified by hand: absolute shebang confirmed on a default `uv sync` venv; `--relocatable` venv's `pytest` runs after `mv` of the venv dir.

## Follow-ups

- #3409 — Stage A: server-side format autofix at the gate (config-driven `fix` command)
- #3410 — throughput/strict mode split for long slice chains
- #3411 — architect slice co-location (upstream cure for class 3)