### PR TITLE
Fix re-review delta off-by-one deadlock and unchanged re-propose churn (#3395)

### DIFF
--- a/orchestrator/health_checks/tier1/incomplete_consensus_stall.py
+++ b/orchestrator/health_checks/tier1/incomplete_consensus_stall.py
@@ -81,6 +81,13 @@ class IncompleteConsensusStallCheck:
         self._consecutive_ticks: dict[str, int] = {}
         # Track proposal timestamps to detect new proposals (#1609)
         self._last_known_proposal_ts: dict[str, float] = {}
+        # Post-proposal grace scoping (#3395): the proposal-SHA fingerprint
+        # the grace was last granted for, and the timestamp of that
+        # commit-advancing proposal. An unchanged-tree re-propose refreshes
+        # the raw proposal timestamp but not the fingerprint, so it must
+        # neither reset stall tracking nor re-open the grace window.
+        self._graced_fingerprints: dict[str, tuple[tuple[str, str], ...]] = {}
+        self._graced_proposal_ts: dict[str, float] = {}
 
     def run(self, context: PipelineHealthContext) -> HealthResult:
         """Check for stuck incomplete consensus."""
@@ -111,24 +118,39 @@ class IncompleteConsensusStallCheck:
                     f"({self._grace_seconds}s); check skipped."
                 )
 
-        # Post-proposal grace: give reviewers time after CONSENSUS_PROPOSE (#1609)
+        # Post-proposal grace: give reviewers time after CONSENSUS_PROPOSE
+        # (#1609). Scoped to *commit-advancing* proposals (#3395): the grace
+        # window is keyed to the last proposal that changed the proposal-SHA
+        # fingerprint, so a NACK loop of unchanged-tree re-proposes spaced
+        # under the grace interval can no longer reset stall tracking and
+        # suppress this check forever. A ``None`` fingerprint (tracker
+        # unavailable) conservatively counts as advancing — pre-#3395
+        # behaviour.
         pipeline_id = pipeline.id
         post_proposal_grace = getattr(pipeline.config, "post_proposal_grace_seconds", 300)
         latest_proposal_ts = self._get_latest_proposal_timestamp(pipeline_id)
         if latest_proposal_ts is not None:
             prev_known = self._last_known_proposal_ts.get(pipeline_id, 0.0)
             if latest_proposal_ts > prev_known:
-                # New proposal arrived — reset stall tracking
                 self._last_known_proposal_ts[pipeline_id] = latest_proposal_ts
-                self._reset_tracking(pipeline_id)
+                fingerprint = self._get_proposal_sha_fingerprint(pipeline_id)
+                if fingerprint is None or fingerprint != self._graced_fingerprints.get(pipeline_id):
+                    # New commit-advancing proposal — reset stall tracking
+                    # and (re-)open the grace window.
+                    if fingerprint is not None:
+                        self._graced_fingerprints[pipeline_id] = fingerprint
+                    self._graced_proposal_ts[pipeline_id] = latest_proposal_ts
+                    self._reset_tracking(pipeline_id)
 
-            time_since_proposal = time.time() - latest_proposal_ts
-            if time_since_proposal < post_proposal_grace:
-                return self._healthy(
-                    f"CONSENSUS_PROPOSE received {time_since_proposal:.0f}s ago, "
-                    f"within post-proposal grace period ({post_proposal_grace}s); "
-                    f"check skipped."
-                )
+            graced_ts = self._graced_proposal_ts.get(pipeline_id)
+            if graced_ts is not None:
+                time_since_proposal = time.time() - graced_ts
+                if time_since_proposal < post_proposal_grace:
+                    return self._healthy(
+                        f"CONSENSUS_PROPOSE received {time_since_proposal:.0f}s ago, "
+                        f"within post-proposal grace period ({post_proposal_grace}s); "
+                        f"check skipped."
+                    )
 
         # Evaluate consensus state
         blocking_agents = self._get_blocking_agents(pipeline_id, pipeline)
@@ -289,6 +311,29 @@ class IncompleteConsensusStallCheck:
                 exc_info=True,
             )
 
+        return None
+
+    def _get_proposal_sha_fingerprint(self, pipeline_id: str) -> tuple[tuple[str, str], ...] | None:
+        """Return a hashable snapshot of every producer's proposal SHA, or None.
+
+        Lets the post-proposal grace distinguish a commit-advancing proposal
+        from an unchanged-tree re-propose (#3395): the latter refreshes the
+        proposal timestamp but not this fingerprint. ``None`` (tracker
+        unavailable / query failure) tells the caller to fall back to the
+        pre-#3395 timestamp-only behaviour.
+        """
+        try:
+            from peer_consensus import get_peer_consensus_tracker
+
+            tracker = get_peer_consensus_tracker(pipeline_id)
+            if tracker is not None:
+                return tuple(sorted(tracker.get_all_proposal_commit_shas().items()))
+        except Exception:
+            logger.debug(
+                "Proposal SHA fingerprint query failed",
+                pipeline_id=pipeline_id,
+                exc_info=True,
+            )
         return None
 
     def _has_recent_activity(

--- a/orchestrator/overseer/monitor/__init__.py
+++ b/orchestrator/overseer/monitor/__init__.py
@@ -148,6 +148,13 @@ class OverseerMonitor:
         self._incomplete_consensus_hitl_created = False
         # Track the absolute start time for activity deferral cap (#1609)
         self._incomplete_consensus_absolute_start: float | None = None
+        # Post-proposal grace scoping (#3395): the proposal-SHA fingerprint
+        # the grace window was last granted for, and when it changed. NOT
+        # cleared by _reset_incomplete_consensus_tracking — the grace path
+        # itself resets that state, and clearing the fingerprint there
+        # would re-grant grace to unchanged-tree re-proposes.
+        self._incomplete_consensus_graced_fingerprint: tuple[tuple[str, str], ...] | None = None
+        self._incomplete_consensus_graced_at: float | None = None
 
         # Re-run anomaly deduplication (decision IDs already flagged)
         self._rerun_anomaly_reported: set[str] = set()
@@ -243,6 +250,7 @@ class OverseerMonitor:
     _check_post_consensus_stall = _consensus_stall._check_post_consensus_stall
     _blocking_agents_are_active = _consensus_stall._blocking_agents_are_active
     _get_recent_proposal_age = _consensus_stall._get_recent_proposal_age
+    _get_proposal_sha_fingerprint = _consensus_stall._get_proposal_sha_fingerprint
     _check_incomplete_consensus_stall = _consensus_stall._check_incomplete_consensus_stall
     _reset_incomplete_consensus_tracking = _consensus_stall._reset_incomplete_consensus_tracking
 

--- a/orchestrator/overseer/monitor/_consensus_stall.py
+++ b/orchestrator/overseer/monitor/_consensus_stall.py
@@ -185,6 +185,28 @@ def _get_recent_proposal_age(self) -> float | None:
     return None
 
 
+def _get_proposal_sha_fingerprint(self) -> tuple[tuple[str, str], ...] | None:
+    """Return a hashable snapshot of every producer's proposal SHA, or None.
+
+    The incomplete-consensus grace window (#1609) must only be granted
+    for proposals that actually advance a commit SHA (#3395): an
+    unchanged-tree re-propose refreshes the proposal timestamp but not
+    this fingerprint, so back-to-back empty re-proposes spaced under the
+    grace interval can no longer reset the stall timer forever. ``None``
+    (tracker unavailable / query failure) tells the caller to fall back
+    to the pre-#3395 timestamp-only grace.
+    """
+    try:
+        from peer_consensus import get_peer_consensus_tracker
+
+        tracker = get_peer_consensus_tracker(self.pipeline_id)
+        if tracker is not None:
+            return tuple(sorted(tracker.get_all_proposal_commit_shas().items()))
+    except Exception:
+        logger.debug("Failed to query proposal SHA fingerprint", exc_info=True)
+    return None
+
+
 async def _check_incomplete_consensus_stall(
     self, consensus: dict, pipeline_status_str: str
 ) -> None:
@@ -227,19 +249,40 @@ async def _check_incomplete_consensus_stall(
         self._incomplete_consensus_absolute_start = now
         return
 
-    # Post-proposal grace: reset if a recent proposal arrived (#1609)
+    # Post-proposal grace: reset if a recent proposal arrived (#1609).
+    # Scoped to *commit-advancing* proposals (#3395): the grace clock
+    # starts when the proposal-SHA fingerprint last changed, not at the
+    # latest CONSENSUS_PROPOSE timestamp — an unchanged-tree re-propose
+    # refreshes the timestamp but not the fingerprint, so a NACK loop of
+    # empty re-proposes spaced under the grace interval can no longer
+    # suppress this detector forever. A ``None`` fingerprint (tracker
+    # unavailable) falls back to the pre-#3395 timestamp-only grace.
     post_proposal_grace = getattr(self.config, "post_proposal_grace_seconds", 300)
     proposal_age = self._get_recent_proposal_age()
     if proposal_age is not None and proposal_age < post_proposal_grace:
+        fingerprint = self._get_proposal_sha_fingerprint()
+        if fingerprint is not None and fingerprint != self._incomplete_consensus_graced_fingerprint:
+            self._incomplete_consensus_graced_fingerprint = fingerprint
+            self._incomplete_consensus_graced_at = now
+        within_fingerprint_grace = (
+            self._incomplete_consensus_graced_at is not None
+            and now - self._incomplete_consensus_graced_at < post_proposal_grace
+        )
+        if fingerprint is None or within_fingerprint_grace:
+            logger.debug(
+                "Recent CONSENSUS_PROPOSE (%.0fs ago) — deferring incomplete consensus check",
+                proposal_age,
+            )
+            self._reset_incomplete_consensus_tracking()
+            self._incomplete_consensus_blocking = current_blocking
+            self._incomplete_consensus_first_seen = now
+            self._incomplete_consensus_absolute_start = now  # restart deferral cap
+            return
         logger.debug(
-            "Recent CONSENSUS_PROPOSE (%.0fs ago) — deferring incomplete consensus check",
+            "Recent CONSENSUS_PROPOSE (%.0fs ago) advanced no commit SHA — "
+            "not deferring incomplete consensus check",
             proposal_age,
         )
-        self._reset_incomplete_consensus_tracking()
-        self._incomplete_consensus_blocking = current_blocking
-        self._incomplete_consensus_first_seen = now
-        self._incomplete_consensus_absolute_start = now  # restart deferral cap
-        return
 
     elapsed = now - self._incomplete_consensus_first_seen
     poll_interval = getattr(self.config, "overseer_poll_interval_seconds", 30)

--- a/orchestrator/peer_consensus/__init__.py
+++ b/orchestrator/peer_consensus/__init__.py
@@ -120,9 +120,10 @@ class PeerConsensusTracker:
         self._auto_repropose_counts: dict[str, int] = {}
         # Consecutive explicit re-proposes rejected for carrying the same
         # commit SHA as the current proposal (#3395). Informational — the
-        # guard in handle_re_propose rejects every unchanged-tree attempt;
-        # the count is surfaced in the rejection envelope. Reset when a
-        # re-propose with a new SHA lands.
+        # unchanged-tree guard rejects every unchanged-tree attempt on both
+        # the handle_re_propose and handle_propose paths (#3415); the count
+        # is surfaced in the rejection envelope. Reset when a re-propose
+        # with a new SHA lands.
         self._unchanged_repropose_counts: dict[str, int] = {}
         # Track when producers explicitly propose (via handle_propose, NOT via
         # auto-repropose).  Used by check_auto_repropose to suppress redundant
@@ -176,6 +177,7 @@ class PeerConsensusTracker:
     handle_confirmed = _confirm.handle_confirmed
     handle_re_propose = _confirm.handle_re_propose
     _open_nacks_barrier_response = _confirm._open_nacks_barrier_response
+    _unchanged_tree_guard_response = _confirm._unchanged_tree_guard_response
     check_auto_repropose = _confirm.check_auto_repropose
     handle_producer_push = _confirm.handle_producer_push
 

--- a/orchestrator/peer_consensus/__init__.py
+++ b/orchestrator/peer_consensus/__init__.py
@@ -118,6 +118,12 @@ class PeerConsensusTracker:
         # Auto re-propose safety: debounce timestamps and counters
         self._last_auto_repropose_timestamp: dict[str, datetime] = {}
         self._auto_repropose_counts: dict[str, int] = {}
+        # Consecutive explicit re-proposes rejected for carrying the same
+        # commit SHA as the current proposal (#3395). Informational — the
+        # guard in handle_re_propose rejects every unchanged-tree attempt;
+        # the count is surfaced in the rejection envelope. Reset when a
+        # re-propose with a new SHA lands.
+        self._unchanged_repropose_counts: dict[str, int] = {}
         # Track when producers explicitly propose (via handle_propose, NOT via
         # auto-repropose).  Used by check_auto_repropose to suppress redundant
         # auto-reproposals when a push arrives shortly after an explicit proposal.
@@ -185,6 +191,7 @@ class PeerConsensusTracker:
 
     # _queries
     get_proposal_commit_sha = _queries.get_proposal_commit_sha
+    get_all_proposal_commit_shas = _queries.get_all_proposal_commit_shas
     get_commit_sha_for_version = _queries.get_commit_sha_for_version
     get_pre_merge_conditions = _queries.get_pre_merge_conditions
     get_latest_proposal_timestamp = _queries.get_latest_proposal_timestamp

--- a/orchestrator/peer_consensus/_confirm.py
+++ b/orchestrator/peer_consensus/_confirm.py
@@ -231,37 +231,9 @@ def handle_re_propose(
         if barrier is not None:
             return barrier
 
-        # Unchanged-tree guard (#3395): a re-propose whose commit SHA
-        # equals the current proposal's SHA carries zero new commits, so
-        # the NACK blockers cannot have been addressed — it would only
-        # bump the version, re-invoke every reviewer, and refresh the
-        # overseer's post-proposal grace window (the v3-v12 ten-cycle
-        # loop). ``check_auto_repropose`` already short-circuits the
-        # push-triggered path on an unchanged SHA; this bounds the
-        # explicit path. Both SHAs must be non-empty so a no-op ↔ real
-        # proposal transition is never caught by the guard.
-        incoming_sha = str(payload.get("commit_sha") or "")
-        current_sha = self._proposal_commit_shas.get(agent_role, "")
-        if incoming_sha and current_sha and incoming_sha == current_sha:
-            attempts = self._unchanged_repropose_counts.get(agent_role, 0) + 1
-            self._unchanged_repropose_counts[agent_role] = attempts
-            return {
-                "status": "unchanged_tree_rejected",
-                "current_version": self.matrix.get_proposal_version(agent_role),
-                "commit_sha": current_sha,
-                "attempts": attempts,
-                "message": (
-                    f"Re-proposal contains zero new commits: commit_sha "
-                    f"{incoming_sha} is already the current proposal. "
-                    "Land commits addressing the NACK blockers before "
-                    "re-proposing. If you believe no code change is "
-                    "needed, make that case to the NACKing reviewer(s) "
-                    "via send_message so they can re-verdict the current "
-                    "version — re-proposing the same tree cannot resolve "
-                    "a NACK."
-                ),
-            }
-        self._unchanged_repropose_counts.pop(agent_role, None)
+        unchanged = self._unchanged_tree_guard_response(agent_role, payload)
+        if unchanged is not None:
+            return unchanged
 
         # First, do scoped re-evaluation
         if changed_artifacts:
@@ -365,6 +337,57 @@ def _open_nacks_barrier_response(self, producer: str) -> dict[str, Any] | None:
             f"finding from every NACKing reviewer in your next re-propose."
         ),
     }
+
+
+def _unchanged_tree_guard_response(
+    self,
+    agent_role: str,
+    payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Return a structured rejection if a re-propose carries no new commits.
+
+    Caller MUST hold ``self._lock``.
+
+    Unchanged-tree guard (#3395): a re-propose whose commit SHA equals the
+    current proposal's SHA carries zero new commits, so the NACK blockers
+    cannot have been addressed — it would only bump the version, re-invoke
+    every reviewer, and refresh the overseer's post-proposal grace window
+    (the v3-v12 ten-cycle loop). ``check_auto_repropose`` already
+    short-circuits the push-triggered path on an unchanged SHA; this bounds
+    both explicit paths.
+
+    Mirrored into ``handle_propose`` as well as ``handle_re_propose``
+    (#3415): a re-propose without ``--changed-artifacts`` routes to
+    ``handle_propose``, so guarding only ``handle_re_propose`` left the
+    exact single-reviewer incident scenario unguarded. Both SHAs must be
+    non-empty so a no-op ↔ real proposal transition — and the initial
+    ``version 0 → 1`` propose where ``current_sha == ""`` — is never
+    caught by the guard. Returns ``None`` (and clears the attempt counter)
+    when the tree has advanced.
+    """
+    incoming_sha = str(payload.get("commit_sha") or "")
+    current_sha = self._proposal_commit_shas.get(agent_role, "")
+    if incoming_sha and current_sha and incoming_sha == current_sha:
+        attempts = self._unchanged_repropose_counts.get(agent_role, 0) + 1
+        self._unchanged_repropose_counts[agent_role] = attempts
+        return {
+            "status": "unchanged_tree_rejected",
+            "current_version": self.matrix.get_proposal_version(agent_role),
+            "commit_sha": current_sha,
+            "attempts": attempts,
+            "message": (
+                f"Re-proposal contains zero new commits: commit_sha "
+                f"{incoming_sha} is already the current proposal. "
+                "Land commits addressing the NACK blockers before "
+                "re-proposing. If you believe no code change is "
+                "needed, make that case to the NACKing reviewer(s) "
+                "via send_message so they can re-verdict the current "
+                "version — re-proposing the same tree cannot resolve "
+                "a NACK."
+            ),
+        }
+    self._unchanged_repropose_counts.pop(agent_role, None)
+    return None
 
 
 def check_auto_repropose(

--- a/orchestrator/peer_consensus/_confirm.py
+++ b/orchestrator/peer_consensus/_confirm.py
@@ -364,6 +364,18 @@ def _unchanged_tree_guard_response(
     ``version 0 → 1`` propose where ``current_sha == ""`` — is never
     caught by the guard. Returns ``None`` (and clears the attempt counter)
     when the tree has advanced.
+
+    Note (#3415): ``reconstruct_tracker_from_messages`` replays every
+    ``CONSENSUS_PROPOSE`` through ``handle_propose``, so reconstruction
+    shares this guard path. A message history that already contained
+    consecutive same-SHA proposes (a pipeline that was itself churning,
+    or a pre-#1473 history whose missing SHAs collapse to the
+    ``RECONSTRUCTED_NO_SHA`` sentinel) will have its later duplicate
+    proposes rejected on replay, so the reconstructed version can land
+    below the pre-restart live state — the de-churned reconstruction is
+    the more correct state, and ``reopen_producer`` (which clears
+    ``_proposal_commit_shas``) still lets a legitimately reopened
+    producer re-propose an unchanged tree on replay.
     """
     incoming_sha = str(payload.get("commit_sha") or "")
     current_sha = self._proposal_commit_shas.get(agent_role, "")
@@ -378,12 +390,12 @@ def _unchanged_tree_guard_response(
             "message": (
                 f"Re-proposal contains zero new commits: commit_sha "
                 f"{incoming_sha} is already the current proposal. "
-                "Land commits addressing the NACK blockers before "
-                "re-proposing. If you believe no code change is "
-                "needed, make that case to the NACKing reviewer(s) "
-                "via send_message so they can re-verdict the current "
-                "version — re-proposing the same tree cannot resolve "
-                "a NACK."
+                "Land new commits before re-proposing. If a reviewer "
+                "NACKed and you believe no code change is needed, make "
+                "that case to them via send_message so they can "
+                "re-verdict the current version — re-proposing the same "
+                "tree cannot advance consensus (it neither resolves a "
+                "NACK nor changes what a withdrawn proposal offered)."
             ),
         }
     self._unchanged_repropose_counts.pop(agent_role, None)

--- a/orchestrator/peer_consensus/_confirm.py
+++ b/orchestrator/peer_consensus/_confirm.py
@@ -231,6 +231,38 @@ def handle_re_propose(
         if barrier is not None:
             return barrier
 
+        # Unchanged-tree guard (#3395): a re-propose whose commit SHA
+        # equals the current proposal's SHA carries zero new commits, so
+        # the NACK blockers cannot have been addressed — it would only
+        # bump the version, re-invoke every reviewer, and refresh the
+        # overseer's post-proposal grace window (the v3-v12 ten-cycle
+        # loop). ``check_auto_repropose`` already short-circuits the
+        # push-triggered path on an unchanged SHA; this bounds the
+        # explicit path. Both SHAs must be non-empty so a no-op ↔ real
+        # proposal transition is never caught by the guard.
+        incoming_sha = str(payload.get("commit_sha") or "")
+        current_sha = self._proposal_commit_shas.get(agent_role, "")
+        if incoming_sha and current_sha and incoming_sha == current_sha:
+            attempts = self._unchanged_repropose_counts.get(agent_role, 0) + 1
+            self._unchanged_repropose_counts[agent_role] = attempts
+            return {
+                "status": "unchanged_tree_rejected",
+                "current_version": self.matrix.get_proposal_version(agent_role),
+                "commit_sha": current_sha,
+                "attempts": attempts,
+                "message": (
+                    f"Re-proposal contains zero new commits: commit_sha "
+                    f"{incoming_sha} is already the current proposal. "
+                    "Land commits addressing the NACK blockers before "
+                    "re-proposing. If you believe no code change is "
+                    "needed, make that case to the NACKing reviewer(s) "
+                    "via send_message so they can re-verdict the current "
+                    "version — re-proposing the same tree cannot resolve "
+                    "a NACK."
+                ),
+            }
+        self._unchanged_repropose_counts.pop(agent_role, None)
+
         # First, do scoped re-evaluation
         if changed_artifacts:
             invalidated = self.matrix.invalidate_overlapping_acks(agent_role, changed_artifacts)

--- a/orchestrator/peer_consensus/_proposals.py
+++ b/orchestrator/peer_consensus/_proposals.py
@@ -45,11 +45,33 @@ def handle_propose(
     ``handle_re_propose``'s aggregation enforcement by omitting the
     ``changed_artifacts`` field.  The barrier self-skips when there are
     fewer than 2 distinct NACKing reviewers.
+
+    **Unchanged-tree guard (#3395, mirrored #3415):** the same bypass
+    surface reintroduces the v3-v12 re-propose churn — a re-propose
+    without ``--changed-artifacts`` routes here, and after a NACK the
+    producer is back in ``WORKING`` so ``check_propose_guard`` allows the
+    call. Without the guard, ``_handle_propose_inner`` would bump the
+    version and re-invoke every reviewer with zero new commits. The guard
+    is applied only when ``check_propose_guard`` would *allow* the propose
+    (phase ``None`` or ``WORKING``); for any other phase — notably a
+    fully-ACKed producer still in ``PROPOSED`` — the propose guard inside
+    ``_handle_propose_inner`` owns the rejection so its phase-specific
+    message ("already fully ACKed → confirm instead") wins. The guard also
+    no-ops on the initial ``version 0 → 1`` propose (``current_sha == ""``)
+    so first proposals are never caught.
     """
     with self._lock:
         barrier = self._open_nacks_barrier_response(agent_role)
         if barrier is not None:
             return barrier
+        # Mirror check_propose_guard's allow condition so its phase-specific
+        # rejections keep precedence: only guard the re-propose-churn path
+        # (a WORKING/unset producer re-proposing an unchanged tree).
+        current_phase = self._producer_phases.get(agent_role)
+        if current_phase is None or current_phase == ConsensusPhase.WORKING:
+            unchanged = self._unchanged_tree_guard_response(agent_role, payload)
+            if unchanged is not None:
+                return unchanged
         result = self._handle_propose_inner(agent_role, payload)
         # Record explicit proposal timestamp (not updated by auto-repropose)
         # so check_auto_repropose can suppress redundant re-reviews when a

--- a/orchestrator/peer_consensus/_queries.py
+++ b/orchestrator/peer_consensus/_queries.py
@@ -21,6 +21,19 @@ def get_proposal_commit_sha(self, role: str) -> str:
     return self._proposal_commit_shas.get(role, "")
 
 
+def get_all_proposal_commit_shas(self) -> dict[str, str]:
+    """Return a snapshot of every producer's current proposal commit SHA.
+
+    Used by the overseer's incomplete-consensus stall detector to
+    fingerprint the proposal set (#3395): a re-propose that does not
+    advance any producer's SHA must not refresh the post-proposal grace
+    window, or back-to-back unchanged re-proposes (spaced under the
+    grace interval) suppress the stall timer forever.
+    """
+    with self._lock:
+        return dict(self._proposal_commit_shas)
+
+
 def get_commit_sha_for_version(self, producer: str, version: int) -> str:
     """Return the commit SHA a producer's proposal was at for ``version``.
 

--- a/orchestrator/peer_consensus/_recovery.py
+++ b/orchestrator/peer_consensus/_recovery.py
@@ -292,6 +292,17 @@ def reopen_producer(self, agent_role: str, reason: str = "") -> dict[str, Any]:
         self._producer_phases[agent_role] = ConsensusPhase.WORKING
         self._confirmed.discard(agent_role)
 
+        # The next propose after a reopen re-converges reviewers on the
+        # (possibly unchanged) deliverable — a reopen is orchestrator-initiated
+        # (task reassignment), not a producer re-proposing the same tree to
+        # dodge a NACK. Clear the tracked current SHA so the unchanged-tree
+        # guard (#3395, mirrored #3415) treats that propose as fresh
+        # (``current_sha == ""`` → guard no-ops), exactly as it exempts the
+        # initial ``version 0 → 1`` propose. The per-version SHA *history*
+        # (``_proposal_commit_sha_history``) is left intact for delta ranges.
+        self._proposal_commit_shas.pop(agent_role, None)
+        self._unchanged_repropose_counts.pop(agent_role, None)
+
         emit_event(
             EventType.CONSENSUS_PRODUCER_REOPENED,
             self.pipeline_id,

--- a/orchestrator/routes/consensus.py
+++ b/orchestrator/routes/consensus.py
@@ -231,6 +231,20 @@ def _has_pending_peer_proposals(
                     # HEAD never contains the producer's commits — that was
                     # the "re-review delta is empty" phantom-NACK.
                     "proposal_commit_sha": str(snapshot.get("commit_sha") or ""),
+                    # Orchestrator-authoritative re-review baseline (#3395):
+                    # the commit this reviewer last VERDICTED for this
+                    # producer (``entry.version`` resolved through the
+                    # per-version commit history). The wrapper's delta
+                    # builder prefers this over the reviewer's self-tracked
+                    # memory bullet, which can silently advance past the fix
+                    # commit and render an empty delta forever. ``""`` on
+                    # first review (no prior verdict / version-0 ACK) —
+                    # those fall back to memory / the degraded artifact list.
+                    "last_reviewed_commit_sha": (
+                        tracker.get_commit_sha_for_version(producer, entry.version)
+                        if entry is not None and entry.version
+                        else ""
+                    ),
                 }
             )
     return bool(pending), pending

--- a/orchestrator/routes/event_prompt/__init__.py
+++ b/orchestrator/routes/event_prompt/__init__.py
@@ -107,6 +107,7 @@ from ._payload import (
     _extract_changed_artifacts,
     _extract_current_producers,
     _extract_iteration_feedback,
+    _extract_last_reviewed_sha_for_producer,
     _extract_nacks,
     _extract_producer_role,
     _extract_proposal_sha_for_producer,
@@ -155,6 +156,7 @@ __all__ = [
     # Event-payload extractors (_payload)
     "_extract_changed_artifacts",
     "_extract_current_producers",
+    "_extract_last_reviewed_sha_for_producer",
     "_extract_proposal_sha_for_producer",
     "_extract_artifacts_for_producer",
     "_extract_producer_role",

--- a/orchestrator/routes/event_prompt/_delta_builder.py
+++ b/orchestrator/routes/event_prompt/_delta_builder.py
@@ -25,6 +25,7 @@ from ._memory_io import _parse_per_producer_sha
 from ._payload import (
     _extract_artifacts_for_producer,
     _extract_current_producers,
+    _extract_last_reviewed_sha_for_producer,
     _extract_proposal_sha_for_producer,
 )
 
@@ -164,7 +165,18 @@ def _build_delta_entries(
 
     out: list[dict[str, Any]] = []
     for producer in scoped_producers:
-        sha = per_producer_sha.get(producer, "")
+        # Baseline priority (#3395): the next-action route's
+        # server-resolved ``last_reviewed_commit_sha`` (advances only
+        # when this reviewer's verdict is recorded) wins over the
+        # agent-self-tracked memory bullet, which can silently advance
+        # to a proposal SHA the reviewer never reviewed — making
+        # ``git log {sha}..{sha}`` empty by construction and the fix
+        # commit unreviewable forever (the permanent-NACK deadlock).
+        # Memory remains the fallback for legacy payloads and first
+        # reviews, where the route carries no baseline.
+        sha = _extract_last_reviewed_sha_for_producer(
+            event_payload, producer
+        ) or per_producer_sha.get(producer, "")
         # The producer's proposed commit SHA from pending_reviews
         # (#3076). When present it is BOTH the delta endpoint (the
         # reviewer's own HEAD never contains the producer's commits —

--- a/orchestrator/routes/event_prompt/_payload.py
+++ b/orchestrator/routes/event_prompt/_payload.py
@@ -111,6 +111,36 @@ def _extract_proposal_sha_for_producer(event_payload: Any, producer: str) -> str
     them. Do not unify — tightening the writer breaks the sentinel
     round-trip; loosening this reader re-opens the shell-injection gap.
     """
+    return _extract_pending_review_sha(event_payload, producer, "proposal_commit_sha")
+
+
+def _extract_last_reviewed_sha_for_producer(event_payload: Any, producer: str) -> str:
+    """Pull the server-resolved re-review baseline for the named producer.
+
+    Reads ``pending_reviews[i].last_reviewed_commit_sha`` — the
+    orchestrator-authoritative baseline the next-action route resolves
+    from this reviewer's last *verdicted* proposal version
+    (``entry.version`` → ``get_commit_sha_for_version``, #3395). Unlike
+    the agent-self-tracked memory bullet, this value advances only when
+    a verdict is recorded, so it can never sit past a commit the
+    reviewer has not actually reviewed. Returns ``""`` for legacy
+    payloads and first reviews (no prior verdict / version-0
+    pre-proposal ACKs), in which case the delta builder falls back to
+    the memory-parsed baseline.
+    """
+    return _extract_pending_review_sha(event_payload, producer, "last_reviewed_commit_sha")
+
+
+def _extract_pending_review_sha(event_payload: Any, producer: str, key: str) -> str:
+    """Pull a hex commit SHA from the producer's ``pending_reviews`` entry.
+
+    Shared reader for the SHA-bearing enrichment keys the next-action
+    route attaches per pending review. The value is sanitised to a
+    strict 7-64 char hex token before callers embed it in rendered
+    shell commands (see ``_extract_proposal_sha_for_producer`` for why
+    this reader is deliberately stricter than the writer-side
+    validator).
+    """
     if not isinstance(event_payload, dict) or not isinstance(producer, str):
         return ""
     producer = producer.strip()
@@ -125,7 +155,7 @@ def _extract_proposal_sha_for_producer(event_payload: Any, producer: str) -> str
         entry_producer = entry.get("producer") or entry.get("producer_role")
         if not isinstance(entry_producer, str) or entry_producer.strip() != producer:
             continue
-        raw = entry.get("proposal_commit_sha")
+        raw = entry.get(key)
         if isinstance(raw, str):
             candidate = raw.strip()
             if re.fullmatch(r"[0-9a-fA-F]{7,64}", candidate):

--- a/orchestrator/routes/signals/_consensus_verdicts.py
+++ b/orchestrator/routes/signals/_consensus_verdicts.py
@@ -665,6 +665,27 @@ def handle_consensus_propose_signal(
                 details=result,
             )
 
+        # Unchanged-tree rejection (#3395): the re_propose carried the same
+        # commit SHA as the current proposal — zero new commits, so the
+        # NACK blockers cannot have been addressed. Reject without bumping
+        # the version, re-invoking reviewers, or emitting a
+        # CONSENSUS_PROPOSE (which would refresh the overseer's
+        # post-proposal grace window and mask the stall).
+        if isinstance(result, dict) and result.get("status") == "unchanged_tree_rejected":
+            _pkg.logger.warning(
+                "re_propose rejected: unchanged tree",
+                pipeline_id=pipeline_id,
+                role=agent_role,
+                version=result.get("current_version"),
+                commit_sha=result.get("commit_sha"),
+                attempts=result.get("attempts"),
+            )
+            return make_error_response(
+                result.get("message", "Re-propose rejected: no new commits"),
+                status_code=409,
+                details=result,
+            )
+
         # Write consensus message to message bus.
         # Tag every CONSENSUS_* message with slice_id metadata when the
         # producer is slice-scoped so the implement-phase BRC writer

--- a/orchestrator/tests/test_brc_unchanged_repropose.py
+++ b/orchestrator/tests/test_brc_unchanged_repropose.py
@@ -3,11 +3,18 @@
 A re-propose whose commit SHA equals the current proposal's SHA carries
 zero new commits, so the NACK blockers cannot have been addressed — it
 would only bump the version, re-invoke every reviewer, and refresh the
-overseer's post-proposal grace window. ``handle_re_propose`` rejects it
-with a structured ``unchanged_tree_rejected`` envelope instead (the
+overseer's post-proposal grace window. Both explicit propose paths reject
+it with a structured ``unchanged_tree_rejected`` envelope instead (the
 push-triggered path was already short-circuited by
 ``check_auto_repropose``; the explicit path was unbounded and produced
 the observed v3-v12 ten-cycle loop).
+
+The guard lives in a shared ``_unchanged_tree_guard_response`` helper
+called from **both** ``handle_re_propose`` and ``handle_propose`` (#3415).
+A re-propose without ``--changed-artifacts`` routes to ``handle_propose``
+(``routes/signals/_consensus_verdicts.py``), so guarding only
+``handle_re_propose`` left the exact single-reviewer incident scenario —
+where the open-NACK barrier self-skips — unguarded.
 """
 
 import sys
@@ -133,3 +140,75 @@ def test_changed_sha_re_propose_unaffected(tracker):
     assert result["status"] == "proposed"
     assert result["version"] == 2
     assert tracker.get_proposal_commit_sha("tester") == "7bb0dbc"
+
+
+# --- handle_propose bypass path (#3415) -------------------------------------
+#
+# A re-propose that omits ``changed_artifacts`` routes to ``handle_propose``,
+# NOT ``handle_re_propose`` (routes/signals/_consensus_verdicts.py). After a
+# NACK the producer is back in WORKING, so ``check_propose_guard`` allows the
+# call and — without the mirrored guard — ``_handle_propose_inner`` would bump
+# the version and re-invoke every reviewer with zero new commits. The
+# single-reviewer graph is exactly the incident scenario: the open-NACK
+# barrier self-skips with <2 distinct NACKing reviewers, so ``handle_propose``
+# had no other churn protection.
+
+
+def _re_propose_via_propose(tracker: PeerConsensusTracker, commit_sha: str) -> dict:
+    """Re-propose through the ``changed_artifacts``-absent route — i.e. the
+    signals handler's ``tracker.handle_propose(...)`` branch."""
+    return tracker.handle_propose(
+        "tester",
+        {
+            "summary": (
+                "Re-proposal with substantive content describing the fix, "
+                "tests run, and tasks satisfied for re-review."
+            ),
+            "artifacts": ["a.py"],
+            "commit_sha": commit_sha,
+        },
+    )
+
+
+def test_unchanged_sha_re_propose_via_handle_propose_rejected(tracker):
+    """The bypass path is guarded: an unchanged-SHA re-propose that omits
+    ``changed_artifacts`` (routing to ``handle_propose``) is rejected and the
+    version does NOT advance."""
+    _propose(tracker, "e29714a")
+    _nack(tracker)
+
+    result = _re_propose_via_propose(tracker, "e29714a")
+
+    assert result["status"] == "unchanged_tree_rejected"
+    assert result["current_version"] == 1
+    assert result["commit_sha"] == "e29714a"
+    assert result["attempts"] == 1
+    # The version must NOT advance through the handle_propose bypass either.
+    assert tracker.matrix.get_proposal_version("tester") == 1
+
+
+def test_handle_propose_bypass_and_re_propose_share_counter(tracker):
+    """The attempt counter is shared across both propose paths — an unchanged
+    attempt via ``handle_propose`` accumulates on the same counter as one via
+    ``handle_re_propose``, and a SHA-advancing propose resets it."""
+    _propose(tracker, "e29714a")
+    _nack(tracker)
+
+    assert _re_propose_via_propose(tracker, "e29714a")["attempts"] == 1
+    assert _re_propose(tracker, "e29714a")["attempts"] == 2
+
+    # A real fix commit lands via the bypass path — it proceeds and resets.
+    result = _re_propose_via_propose(tracker, "7bb0dbc")
+    assert result["status"] == "proposed"
+    assert result["version"] == 2
+
+    _nack(tracker)
+    assert _re_propose_via_propose(tracker, "7bb0dbc")["attempts"] == 1
+
+
+def test_initial_propose_never_caught_by_guard(tracker):
+    """The guard no-ops on the first proposal (``current_sha == ""``) so a
+    version 0 → 1 propose is never mistaken for an unchanged-tree re-propose."""
+    result = _re_propose_via_propose(tracker, "e29714a")
+    assert result["status"] == "proposed"
+    assert result["version"] == 1

--- a/orchestrator/tests/test_brc_unchanged_repropose.py
+++ b/orchestrator/tests/test_brc_unchanged_repropose.py
@@ -1,0 +1,135 @@
+"""Tests for the unchanged-tree re-propose guard (#3395).
+
+A re-propose whose commit SHA equals the current proposal's SHA carries
+zero new commits, so the NACK blockers cannot have been addressed — it
+would only bump the version, re-invoke every reviewer, and refresh the
+overseer's post-proposal grace window. ``handle_re_propose`` rejects it
+with a structured ``unchanged_tree_rejected`` envelope instead (the
+push-triggered path was already short-circuited by
+``check_auto_repropose``; the explicit path was unbounded and produced
+the observed v3-v12 ten-cycle loop).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+from peer_consensus import PeerConsensusTracker
+from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph
+
+
+@pytest.fixture
+def single_reviewer_graph():
+    """One producer, one reviewer — the open-NACK barrier (#2142) needs
+    two or more distinct NACKing reviewers to fire, so a single-reviewer
+    graph isolates the unchanged-tree guard (and mirrors the observed
+    tester ↔ reviewer_code loop, where the barrier never engaged)."""
+    return ReviewGraph(
+        [
+            ReviewEdge("reviewer_code", "tester", ReviewCriticality.CRITICAL),
+        ]
+    )
+
+
+@pytest.fixture
+def tracker(single_reviewer_graph):
+    t = PeerConsensusTracker("test-pipeline-3395", single_reviewer_graph, cooldown_seconds=0)
+    t.register_agent("tester")
+    t.register_agent("reviewer_code")
+    return t
+
+
+def _propose(tracker: PeerConsensusTracker, commit_sha: str) -> None:
+    tracker.handle_propose(
+        "tester",
+        {
+            "summary": (
+                "Proposal with substantive content describing the work, "
+                "tests run, and tasks satisfied for review."
+            ),
+            "artifacts": ["a.py"],
+            "commit_sha": commit_sha,
+        },
+    )
+
+
+def _nack(tracker: PeerConsensusTracker) -> None:
+    tracker.handle_nack(
+        "reviewer_code",
+        "tester",
+        {
+            "artifact_references": ["a.py"],
+            "reason": (
+                "Named blocker on a.py — full reason text long enough to "
+                "satisfy the ≥50 char content gate enforced upstream."
+            ),
+        },
+    )
+
+
+def _re_propose(tracker: PeerConsensusTracker, commit_sha: str) -> dict:
+    return tracker.handle_re_propose(
+        "tester",
+        {
+            "summary": (
+                "Re-proposal with substantive content describing the fix, "
+                "tests run, and tasks satisfied for re-review."
+            ),
+            "artifacts": ["a.py"],
+            "commit_sha": commit_sha,
+        },
+        ["a.py"],
+    )
+
+
+def test_unchanged_sha_re_propose_rejected(tracker):
+    """Re-proposing the current proposal's SHA is rejected without bumping
+    the version or invalidating any reviewer state."""
+    _propose(tracker, "e29714a")
+    _nack(tracker)
+
+    result = _re_propose(tracker, "e29714a")
+
+    assert result["status"] == "unchanged_tree_rejected"
+    assert result["current_version"] == 1
+    assert result["commit_sha"] == "e29714a"
+    assert result["attempts"] == 1
+    assert "zero new commits" in result["message"]
+    # The version must NOT advance — a rejected re-propose re-invokes
+    # nobody and leaves the reviewer's NACK as the live verdict.
+    assert tracker.matrix.get_proposal_version("tester") == 1
+
+
+def test_unchanged_sha_attempts_accumulate_until_sha_advances(tracker):
+    """Consecutive unchanged-tree rejections count up; a re-propose that
+    actually lands new commits proceeds and resets the counter."""
+    _propose(tracker, "e29714a")
+    _nack(tracker)
+
+    assert _re_propose(tracker, "e29714a")["attempts"] == 1
+    assert _re_propose(tracker, "e29714a")["attempts"] == 2
+
+    # The real fix commit lands — the re-propose goes through.
+    result = _re_propose(tracker, "7bb0dbc")
+    assert result["status"] == "proposed"
+    assert result["version"] == 2
+
+    # A later unchanged attempt starts counting from 1 again.
+    _nack(tracker)
+    assert _re_propose(tracker, "7bb0dbc")["attempts"] == 1
+
+
+def test_changed_sha_re_propose_unaffected(tracker):
+    """The guard never fires on a commit-advancing re-propose."""
+    _propose(tracker, "e29714a")
+    _nack(tracker)
+
+    result = _re_propose(tracker, "7bb0dbc")
+    assert result["status"] == "proposed"
+    assert result["version"] == 2
+    assert tracker.get_proposal_commit_sha("tester") == "7bb0dbc"

--- a/orchestrator/tests/test_compose_event_prompt.py
+++ b/orchestrator/tests/test_compose_event_prompt.py
@@ -794,6 +794,100 @@ def test_build_delta_entries_prefers_real_sha_over_fallback() -> None:
 
 
 # ---------------------------------------------------------------------------
+# #3395: the re-review baseline must prefer the payload's server-resolved
+# ``last_reviewed_commit_sha`` (advances only when this reviewer's verdict
+# is recorded) over the agent-self-tracked memory bullet, which can
+# silently advance to the new proposal SHA before the range containing it
+# was reviewed — making ``git log {sha}..{sha}`` empty by construction and
+# the fix commit unreviewable forever (the permanent-NACK deadlock).
+# ---------------------------------------------------------------------------
+
+
+def test_build_delta_entries_prefers_server_baseline_over_poisoned_memory() -> None:
+    """Memory says the reviewer already reviewed the NEW proposal SHA
+    (the observed deadlock state); the server-resolved baseline says the
+    last verdict was on the parent. The delta must run from the server
+    baseline to the proposal SHA — the range that contains the fix."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from orchestrator.routes.event_prompt import _build_delta_entries
+
+    poisoned_memory = (
+        "## Per-producer assessment\n\n"
+        "### tester\n\n"
+        "- producer: tester\n"
+        "- last_reviewed_commit_sha: 7bb0dbc\n"  # advanced PAST the fix commit
+        "- prior_verdict: NACK\n"
+        "- prior_nack_reasons: vacuous-pass guards\n"
+        "- prior_conditional_obligation: -\n"
+        "- summary_of_assessment: blocked.\n"
+    )
+    with patch("orchestrator.routes.event_prompt._run_git_log", return_value="(diff)") as mock_log:
+        entries = _build_delta_entries(
+            action="nack",
+            role="reviewer_code",
+            base_branch="main",
+            repo_path=Path("/tmp"),
+            memory_text=poisoned_memory,
+            event_payload={
+                "pending_reviews": [
+                    {
+                        "producer": "tester",
+                        "proposal_commit_sha": "7bb0dbc",
+                        "last_reviewed_commit_sha": "e29714a",
+                    }
+                ]
+            },
+        )
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["last_reviewed_commit_sha"] == "e29714a", (
+        f"server-resolved baseline must beat the poisoned memory bullet — entry={entry!r}"
+    )
+    mock_log.assert_called_once_with("e29714a", "main", Path("/tmp"), end_ref="7bb0dbc")
+
+
+def test_build_delta_entries_falls_back_to_memory_sha_without_server_baseline() -> None:
+    """Legacy payloads (no ``last_reviewed_commit_sha`` enrichment) keep the
+    pre-#3395 memory-parsed baseline."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from orchestrator.routes.event_prompt import _build_delta_entries
+
+    memory_text = (
+        "## Per-producer assessment\n\n"
+        "### tester\n\n"
+        "- producer: tester\n"
+        "- last_reviewed_commit_sha: 0123abc\n"
+        "- prior_verdict: NACK\n"
+        "- prior_nack_reasons: missing tests\n"
+        "- prior_conditional_obligation: -\n"
+        "- summary_of_assessment: needs revision.\n"
+    )
+    with patch("orchestrator.routes.event_prompt._run_git_log", return_value="(diff)") as mock_log:
+        entries = _build_delta_entries(
+            action="nack",
+            role="reviewer_code",
+            base_branch="main",
+            repo_path=Path("/tmp"),
+            memory_text=memory_text,
+            event_payload={
+                "pending_reviews": [
+                    {
+                        "producer": "tester",
+                        "proposal_commit_sha": "7bb0dbc",
+                    }
+                ]
+            },
+        )
+    assert len(entries) == 1
+    assert entries[0]["last_reviewed_commit_sha"] == "0123abc"
+    mock_log.assert_called_once_with("0123abc", "main", Path("/tmp"), end_ref="7bb0dbc")
+
+
+# ---------------------------------------------------------------------------
 # #3076: the re-review delta must end at the producer's PROPOSAL SHA, not
 # the reviewer's own HEAD (which never contains the producer's commits —
 # per-role worktrees), and the first-review fallback must render concrete

--- a/orchestrator/tests/test_consensus_next_action.py
+++ b/orchestrator/tests/test_consensus_next_action.py
@@ -818,3 +818,66 @@ def test_next_action_reviewer_pending_reviews_includes_proposal_commit_sha(clien
         f"pending_reviews entry must carry the producer's proposed commit "
         f"SHA (abc1234 from _propose) — entry={entry!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# #3395: pending_reviews entries must carry the orchestrator-authoritative
+# last_reviewed_commit_sha (the commit this reviewer last VERDICTED,
+# ``entry.version`` → per-version commit history). The composer prefers it
+# over the reviewer's self-tracked memory bullet, which can silently advance
+# past the fix commit and render an empty delta forever (the permanent-NACK
+# deadlock).
+# ---------------------------------------------------------------------------
+
+
+def test_next_action_pending_reviews_last_reviewed_sha_after_nack_and_repropose(
+    client, simple_tracker
+):
+    """After a NACK on v1 (abc1234) and a re-propose with the fix commit
+    (def5678), the reviewer's pending entry must anchor the re-review
+    baseline at the v1 SHA it actually verdicted — never at the new
+    proposal SHA (which would make ``git log {sha}..{sha}`` empty by
+    construction, #3395)."""
+    _propose(simple_tracker, "coder")
+    _nack(simple_tracker, "reviewer_code", "coder", "Named blocker on a.py")
+    simple_tracker.handle_re_propose(
+        "coder",
+        {
+            "summary": (
+                "Re-proposal v2 landing the fix commit, with substantive "
+                "content describing the work and tests run for re-review."
+            ),
+            "artifacts": ["a.py"],
+            "commit_sha": "def5678",
+        },
+        ["a.py"],
+    )
+
+    resp = _post_next_action(client, "reviewer_code", tracker=simple_tracker)
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    payload = data.get("data", data)
+    pending = (payload.get("event_payload") or {}).get("pending_reviews") or []
+    assert len(pending) >= 1, f"NACKing reviewer must be re-invoked — payload={payload!r}"
+    entry = pending[0]
+    assert entry.get("proposal_commit_sha") == "def5678"
+    assert entry.get("last_reviewed_commit_sha") == "abc1234", (
+        f"baseline must be the last-VERDICTED commit (abc1234), resolved "
+        f"server-side from entry.version — entry={entry!r}"
+    )
+
+
+def test_next_action_pending_reviews_last_reviewed_sha_empty_on_first_review(
+    client, simple_tracker
+):
+    """A first review has no prior verdict, so the server-resolved baseline
+    is empty and the composer falls back to memory / the degraded
+    artifact-list baseline."""
+    _propose(simple_tracker, "coder")
+    resp = _post_next_action(client, "reviewer_code", tracker=simple_tracker)
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    payload = data.get("data", data)
+    pending = (payload.get("event_payload") or {}).get("pending_reviews") or []
+    assert len(pending) >= 1
+    assert pending[0].get("last_reviewed_commit_sha") == ""

--- a/orchestrator/tests/test_incomplete_consensus_stall.py
+++ b/orchestrator/tests/test_incomplete_consensus_stall.py
@@ -744,3 +744,87 @@ class TestIncompleteConsensusStallCheck:
             # Phase 3: second tick without activity — now DEGRADED
             result = check.run(ctx)
             assert result.status == HealthStatus.DEGRADED
+
+
+# ---------------------------------------------------------------------------
+# #3395: post-proposal grace must only be granted for commit-advancing
+# proposals — an unchanged-tree re-propose refreshes the proposal timestamp
+# but not the proposal-SHA fingerprint, so a NACK loop of empty re-proposes
+# spaced under the grace interval must not suppress this check forever.
+# ---------------------------------------------------------------------------
+
+
+class TestUnchangedReproposeGrace:
+    def _mock_modules(self, proposal_shas):
+        """Build sys.modules mocks: concurrent phase, blocking tester,
+        fresh proposal timestamp on every call, fixed proposal SHAs,
+        no progress activity."""
+        mock_ce = MagicMock()
+        mock_ce.is_concurrent_execution.return_value = True
+
+        mock_tracker = MagicMock()
+        mock_tracker.evaluate.return_value = {
+            "is_complete": False,
+            "blocking_agents": ["tester"],
+        }
+        # Each run sees a fresher proposal — simulating repeated re-proposes.
+        mock_tracker.get_latest_proposal_timestamp.side_effect = lambda: (
+            datetime.now(UTC) - timedelta(seconds=10)
+        )
+        mock_tracker.get_all_proposal_commit_shas.return_value = dict(proposal_shas)
+        mock_pc = MagicMock()
+        mock_pc.get_peer_consensus_tracker.return_value = mock_tracker
+
+        mock_progress_store = MagicMock()
+        mock_progress_store.get_events.return_value = []
+        mock_ps = MagicMock()
+        mock_ps.get_progress_store.return_value = mock_progress_store
+
+        return {
+            "concurrent_executor": mock_ce,
+            "peer_consensus": mock_pc,
+            "progress_store": mock_ps,
+        }
+
+    def test_unchanged_sha_repropose_does_not_reopen_grace(self):
+        """Grace already spent on this fingerprint: fresh unchanged-SHA
+        re-proposes must let ticks accumulate to DEGRADED."""
+        import time as _time
+
+        pipeline = _make_concurrent_pipeline()
+        ctx = _make_context(pipeline)
+        check = _make_check(stall_tick_threshold=2)
+
+        # Grace was granted for this fingerprint 600s ago (past 300s grace).
+        check._graced_fingerprints[pipeline.id] = (("tester", "e29714a"),)
+        check._graced_proposal_ts[pipeline.id] = _time.time() - 600
+        check._last_known_proposal_ts[pipeline.id] = _time.time() - 600
+
+        with patch.dict("sys.modules", self._mock_modules({"tester": "e29714a"})):
+            for _ in range(3):
+                result = check.run(ctx)
+
+        assert result.status == HealthStatus.DEGRADED
+        assert "tester" in result.details["blocking_agents"]
+
+    def test_sha_advancing_repropose_reopens_grace(self):
+        """A re-propose that changes the SHA fingerprint re-opens the grace
+        window (pre-#3395 behaviour for genuine proposals)."""
+        import time as _time
+
+        pipeline = _make_concurrent_pipeline()
+        ctx = _make_context(pipeline)
+        check = _make_check(stall_tick_threshold=2)
+
+        check._graced_fingerprints[pipeline.id] = (("tester", "e29714a"),)
+        check._graced_proposal_ts[pipeline.id] = _time.time() - 600
+        check._last_known_proposal_ts[pipeline.id] = _time.time() - 600
+
+        # The fix commit landed — new SHA, fresh timestamp.
+        with patch.dict("sys.modules", self._mock_modules({"tester": "7bb0dbc"})):
+            for _ in range(3):
+                result = check.run(ctx)
+
+        assert result.status == HealthStatus.HEALTHY
+        assert "post-proposal grace" in result.reasoning
+        assert check._graced_fingerprints[pipeline.id] == (("tester", "7bb0dbc"),)

--- a/orchestrator/tests/test_overseer_monitor.py
+++ b/orchestrator/tests/test_overseer_monitor.py
@@ -2193,6 +2193,84 @@ class TestIncompleteConsensusActivityAware:
         monitor._send_message.assert_not_awaited()
         monitor._create_hitl_decision.assert_not_awaited()
 
+    def test_post_proposal_grace_not_regranted_for_unchanged_sha(self):
+        """#3395: an unchanged-tree re-propose refreshes the proposal
+        timestamp but not the SHA fingerprint — it must NOT re-defer the
+        stall check, or a NACK loop of empty re-proposes spaced under the
+        grace interval suppresses this detector forever."""
+        from datetime import UTC, datetime, timedelta
+
+        monitor = self._make_monitor()
+
+        now = time.time()
+        monitor._incomplete_consensus_blocking = frozenset(["tester"])
+        monitor._incomplete_consensus_first_seen = now - 15  # past nudge (10)
+        monitor._incomplete_consensus_absolute_start = now - 15
+        # Grace already granted for this fingerprint, past the 300s window.
+        monitor._incomplete_consensus_graced_fingerprint = (("tester", "e29714a"),)
+        monitor._incomplete_consensus_graced_at = now - 400
+
+        consensus = {"is_complete": False, "blocking_agents": ["tester"]}
+
+        # Empty re-propose 60s ago: fresh timestamp, unchanged SHA.
+        mock_tracker = MagicMock()
+        mock_tracker.get_latest_proposal_timestamp.return_value = datetime.now(UTC) - timedelta(
+            seconds=60
+        )
+        mock_tracker.get_all_proposal_commit_shas.return_value = {"tester": "e29714a"}
+        mock_pc = MagicMock()
+        mock_pc.get_peer_consensus_tracker.return_value = mock_tracker
+
+        # No recent progress events — nothing else defers the nudge.
+        mock_progress_store = MagicMock()
+        mock_progress_store.get_events.return_value = []
+        mock_ps = MagicMock()
+        mock_ps.get_progress_store.return_value = mock_progress_store
+
+        with patch.dict(
+            "sys.modules",
+            {"peer_consensus": mock_pc, "progress_store": mock_ps},
+        ):
+            _run(monitor._check_incomplete_consensus_stall(consensus, "running"))
+
+        # The stall timer kept accumulating: the nudge fired.
+        monitor._send_message.assert_awaited()
+        assert monitor._incomplete_consensus_nudged is True
+
+    def test_post_proposal_grace_regranted_when_sha_advances(self):
+        """A re-propose that advances the SHA fingerprint re-opens the
+        grace window and resets stall tracking (pre-#3395 behaviour for
+        genuine proposals)."""
+        from datetime import UTC, datetime, timedelta
+
+        monitor = self._make_monitor()
+
+        now = time.time()
+        monitor._incomplete_consensus_blocking = frozenset(["tester"])
+        monitor._incomplete_consensus_first_seen = now - 15
+        monitor._incomplete_consensus_absolute_start = now - 15
+        monitor._incomplete_consensus_graced_fingerprint = (("tester", "e29714a"),)
+        monitor._incomplete_consensus_graced_at = now - 400
+
+        consensus = {"is_complete": False, "blocking_agents": ["tester"]}
+
+        # The fix commit landed: fresh timestamp AND a new SHA.
+        mock_tracker = MagicMock()
+        mock_tracker.get_latest_proposal_timestamp.return_value = datetime.now(UTC) - timedelta(
+            seconds=60
+        )
+        mock_tracker.get_all_proposal_commit_shas.return_value = {"tester": "7bb0dbc"}
+        mock_pc = MagicMock()
+        mock_pc.get_peer_consensus_tracker.return_value = mock_tracker
+
+        with patch.dict("sys.modules", {"peer_consensus": mock_pc}):
+            _run(monitor._check_incomplete_consensus_stall(consensus, "running"))
+
+        # Deferred: no nudge, fingerprint recorded for the new SHA set.
+        monitor._send_message.assert_not_awaited()
+        assert monitor._incomplete_consensus_graced_fingerprint == (("tester", "7bb0dbc"),)
+        assert monitor._incomplete_consensus_graced_at >= now
+
     def test_hitl_deferral_capped_when_agents_active_too_long(self):
         """HITL escalation fires even if agents are active once deferral cap is exceeded."""
         monitor = self._make_monitor()

--- a/orchestrator/tests/test_peer_consensus_integration.py
+++ b/orchestrator/tests/test_peer_consensus_integration.py
@@ -1169,10 +1169,11 @@ class TestWithdrawReProposalDeadlock:
         t.handle_confirmed("reviewer_agent_design")
         t.handle_confirmed("reviewer_refine")
 
-        # Withdraw and re-propose
+        # Withdraw and re-propose with a new commit (unchanged-tree re-proposes
+        # are rejected outright now, #3395/#3415)
         t.handle_withdraw("refiner", "Revised approach needed")
         result = t.handle_propose(
-            "refiner", {"summary": "v3", "artifacts": ["design.md"], "commit_sha": "abc1234"}
+            "refiner", {"summary": "v3", "artifacts": ["design.md"], "commit_sha": "def5678"}
         )
 
         # Both reviewers should be in the stale list
@@ -1231,10 +1232,11 @@ class TestWithdrawReProposalDeadlock:
         t.handle_confirmed("reviewer_agent_design")
         t.handle_confirmed("reviewer_refine")
 
-        # Withdraw and re-propose
+        # Withdraw and re-propose with a new commit (unchanged-tree re-proposes
+        # are rejected outright now, #3395/#3415)
         t.handle_withdraw("refiner", "Revised approach")
         t.handle_propose(
-            "refiner", {"summary": "v3", "artifacts": ["design.md"], "commit_sha": "abc1234"}
+            "refiner", {"summary": "v3", "artifacts": ["design.md"], "commit_sha": "def5678"}
         )
 
         # Refiner should NOT be able to confirm (not fully ACKed on v3)
@@ -1279,10 +1281,11 @@ class TestWithdrawReProposalDeadlock:
         assert result["status"] == "pending_acks"
         assert "reviewer_refine" not in t._confirmed
 
-        # refiner withdraws and re-proposes v2
+        # refiner withdraws and re-proposes v2 with a new commit addressing the
+        # NACK (unchanged-tree re-proposes are rejected outright, #3395/#3415)
         t.handle_withdraw("refiner", "Addressing NACK feedback")
         result = t.handle_propose(
-            "refiner", {"summary": "v2", "artifacts": ["design.md"], "commit_sha": "abc1234"}
+            "refiner", {"summary": "v2", "artifacts": ["design.md"], "commit_sha": "def5678"}
         )
 
         # reviewer_agent_design was confirmed on v1, now stale on v2

--- a/orchestrator/tests/test_peer_consensus_integration.py
+++ b/orchestrator/tests/test_peer_consensus_integration.py
@@ -189,7 +189,7 @@ class TestNackAndRePropose:
             {
                 "summary": "Fixed SQL injection",
                 "artifacts": ["src/auth.py"],
-                "commit_sha": "abc1234",
+                "commit_sha": "def5678",
             },
             changed_artifacts=["src/auth.py"],
         )
@@ -670,7 +670,7 @@ class TestScaledReEvaluation:
         # Coder re-proposes — only rev_code needs to re-review
         result = t.handle_re_propose(
             "coder",
-            {"summary": "fixed auth", "artifacts": ["src/auth.py"], "commit_sha": "abc1234"},
+            {"summary": "fixed auth", "artifacts": ["src/auth.py"], "commit_sha": "def5678"},
             changed_artifacts=["src/auth.py"],
         )
         # rev_contract ACKed auth.py, which is the changed artifact,
@@ -735,7 +735,7 @@ class TestScaledReEvaluation:
         )
         t.handle_re_propose(
             "coder",
-            {"summary": "code v2", "artifacts": ["src/auth.py"], "commit_sha": "abc1234"},
+            {"summary": "code v2", "artifacts": ["src/auth.py"], "commit_sha": "def5678"},
             changed_artifacts=["src/auth.py"],
         )
 
@@ -769,7 +769,7 @@ class TestScaledReEvaluation:
         # Coder re-proposes, changing only auth.py
         result = t.handle_re_propose(
             "coder",
-            {"summary": "v2", "artifacts": ["src/auth.py"], "commit_sha": "abc1234"},
+            {"summary": "v2", "artifacts": ["src/auth.py"], "commit_sha": "def5678"},
             changed_artifacts=["src/auth.py"],
         )
 
@@ -802,7 +802,7 @@ class TestScaledReEvaluation:
         # Round 2: fix and re-propose, reviewer ACKs
         t.handle_re_propose(
             "coder",
-            {"summary": "v2 - fixed auth", "artifacts": ["src/auth.py"], "commit_sha": "abc1234"},
+            {"summary": "v2 - fixed auth", "artifacts": ["src/auth.py"], "commit_sha": "def5678"},
             changed_artifacts=["src/auth.py"],
         )
         t.handle_ack("rev_code", "coder", {"artifact_references": ["src/auth.py"]})
@@ -813,7 +813,7 @@ class TestScaledReEvaluation:
             {
                 "summary": "v3 - includes tester changes",
                 "artifacts": ["src/auth.py", "src/db.py"],
-                "commit_sha": "abc1234",
+                "commit_sha": "9876fed",
             },
             changed_artifacts=["src/db.py"],
         )
@@ -917,7 +917,7 @@ class TestScaledReEvaluation:
             {
                 "summary": "Fixed utils",
                 "artifacts": ["src/main.py", "src/utils.py"],
-                "commit_sha": "abc1234",
+                "commit_sha": "def5678",
             },
             changed_artifacts=["src/utils.py"],
         )
@@ -1114,7 +1114,7 @@ class TestWithdrawReProposalDeadlock:
             {
                 "summary": "v2 - added error handling",
                 "artifacts": ["design.md"],
-                "commit_sha": "abc1234",
+                "commit_sha": "def5678",
             },
             changed_artifacts=["design.md"],
         )
@@ -1206,10 +1206,11 @@ class TestWithdrawReProposalDeadlock:
             {"artifact_references": ["design.md"], "reason": "issues"},
         )
 
-        # Re-propose with changed artifacts
+        # Re-propose with changed artifacts (and a new commit — an
+        # unchanged-tree re-propose is rejected outright, #3395)
         result = t.handle_re_propose(
             "refiner",
-            {"summary": "v2", "artifacts": ["design.md"], "commit_sha": "abc1234"},
+            {"summary": "v2", "artifacts": ["design.md"], "commit_sha": "def5678"},
             changed_artifacts=["design.md"],
         )
 
@@ -1482,10 +1483,11 @@ class TestReProposalGuard:
             {"artifact_references": ["src/auth.py"], "reason": "issues found"},
         )
 
-        # Re-proposing after NACK should work (producer phase is WORKING)
+        # Re-proposing after NACK should work when it carries a new
+        # commit (an unchanged-tree re-propose is rejected, #3395)
         result = tracker.handle_re_propose(
             "coder",
-            {"summary": "v2", "artifacts": ["src/auth.py"], "commit_sha": "abc1234"},
+            {"summary": "v2", "artifacts": ["src/auth.py"], "commit_sha": "def5678"},
             changed_artifacts=["src/auth.py"],
         )
         assert result["status"] == "proposed"

--- a/orchestrator/tests/test_pre_proposal_ack_deadlock.py
+++ b/orchestrator/tests/test_pre_proposal_ack_deadlock.py
@@ -72,12 +72,18 @@ def simple_tracker(simple_graph):
     return t
 
 
-def _minimal_proposal(summary="test", artifacts=None):
-    """Build a minimal proposal payload."""
+def _minimal_proposal(summary="test", artifacts=None, commit_sha="abc1234"):
+    """Build a minimal proposal payload.
+
+    ``commit_sha`` is parameterised so a withdraw→re-propose flow can carry a
+    genuinely advanced tree: the unchanged-tree guard (#3395, mirrored into
+    ``handle_propose`` by #3415) rejects a re-propose whose SHA matches the
+    current proposal, so re-proposes in these tests must supply a new SHA.
+    """
     return {
         "summary": summary,
         "artifacts": artifacts or ["file.py"],
-        "commit_sha": "abc1234",
+        "commit_sha": commit_sha,
     }
 
 
@@ -199,9 +205,9 @@ class TestConfirmedStaleAckGuard:
         simple_tracker.handle_ack("reviewer_a", "producer", _minimal_ack())
         simple_tracker.handle_ack("reviewer_b", "producer", _minimal_ack())
 
-        # Producer withdraws and re-proposes v2
+        # Producer withdraws and re-proposes v2 (new commit — the fix landed)
         simple_tracker.handle_withdraw("producer", "Found a bug, re-doing")
-        simple_tracker.handle_propose("producer", _minimal_proposal("v2"))
+        simple_tracker.handle_propose("producer", _minimal_proposal("v2", commit_sha="def5678"))
 
         # reviewer_a tries to confirm without re-ACKing at v2
         result = simple_tracker.handle_confirmed("reviewer_a")
@@ -224,9 +230,10 @@ class TestConfirmedStaleAckGuard:
         simple_tracker.handle_propose("producer", _minimal_proposal())
         simple_tracker.handle_ack("reviewer_a", "producer", _minimal_ack())
 
-        # Re-propose (using withdraw + propose since re_propose needs NACK first)
+        # Re-propose (using withdraw + propose since re_propose needs NACK
+        # first) with a new commit so the unchanged-tree guard doesn't fire.
         simple_tracker.handle_withdraw("producer", "need changes")
-        simple_tracker.handle_propose("producer", _minimal_proposal("v2"))
+        simple_tracker.handle_propose("producer", _minimal_proposal("v2", commit_sha="def5678"))
 
         result = simple_tracker.handle_confirmed("reviewer_a")
         assert result["status"] == "pending_acks"

--- a/orchestrator/tests/test_pre_proposal_ack_deadlock.py
+++ b/orchestrator/tests/test_pre_proposal_ack_deadlock.py
@@ -457,10 +457,16 @@ class TestEdgeCases:
             {"artifact_references": ["file.py"], "reason": "Needs fix"},
         )
 
-        # Producer re-proposes v2 (using handle_re_propose)
+        # Producer re-proposes v2 (using handle_re_propose). The re-propose
+        # must carry a *new* commit SHA — the unchanged-tree guard (#3395)
+        # rejects a re-propose whose commit SHA equals the current
+        # proposal's, since it lands zero new commits and cannot have
+        # addressed the NACK blockers.
+        v2_proposal = _minimal_proposal("v2")
+        v2_proposal["commit_sha"] = "def5678"
         result = simple_tracker.handle_re_propose(
             "producer",
-            _minimal_proposal("v2"),
+            v2_proposal,
             changed_artifacts=["file.py"],
         )
         assert result["version"] == 2

--- a/orchestrator/tests/test_prompt_sync_ratchet.py
+++ b/orchestrator/tests/test_prompt_sync_ratchet.py
@@ -131,8 +131,10 @@ _ALLOWLIST: tuple[tuple[str, str, int], ...] = (
     # comment to drop the literal token would strip the pointer
     # reviewers depend on to navigate the deletion. (#3312 slice-6 moved
     # this comment from event_prompt.py:1429 to the _delta_builder.py
-    # submodule of the routes/event_prompt/ package.)
-    ("_delta_builder.py", "git fetch", 256),
+    # submodule of the routes/event_prompt/ package; #3395's
+    # server-baseline preference in _build_delta_entries shifted it from
+    # line 256 to 268.)
+    ("_delta_builder.py", "git fetch", 268),
 )
 
 

--- a/orchestrator/tests/test_repropose_confirmed_clear.py
+++ b/orchestrator/tests/test_repropose_confirmed_clear.py
@@ -87,11 +87,12 @@ class TestReProposeClearsConfirmed:
         tracker.handle_confirmed("producer")
         assert "producer" in tracker._confirmed
 
-        # NACK triggers re-propose path
+        # NACK triggers re-propose path (with a new commit — an
+        # unchanged-tree re-propose is rejected outright, #3395)
         _nack(tracker, "reviewer_a")
         tracker.handle_re_propose(
             "producer",
-            {"summary": "v2", "artifacts": ["a.py"], "commit_sha": "abc1234"},
+            {"summary": "v2", "artifacts": ["a.py"], "commit_sha": "def5678"},
             changed_artifacts=["a.py"],
         )
         assert "producer" not in tracker._confirmed


### PR DESCRIPTION
Fixes #3395 — all three defects from the issue, bundled as one PR (they are one incident's remediation and each fix is small).

## 1. Re-review baseline channel unification (the deadlock breaker)

Two independent "last reviewed" baselines existed, and the wrapper's delta builder read the unreliable one: the reviewer's self-tracked `last_reviewed_commit_sha` memory bullet, which can silently advance to the new proposal SHA before the range containing it was reviewed — making the re-review delta `git log {sha}..{sha}` empty by construction and the fix commit unreviewable forever.

- The next-action route now enriches each `pending_reviews[]` entry with a server-resolved `last_reviewed_commit_sha`, sourced from the reviewer's last *verdicted* version (`entry.version` → `get_commit_sha_for_version`). This value only advances when `record_ack`/`record_nack` runs, so it can never sit past a commit the reviewer has not reviewed (`orchestrator/routes/consensus.py`).
- `_build_delta_entries` prefers the payload's server-resolved baseline over the memory-parsed one, falling back to memory only for legacy payloads / first reviews (`orchestrator/routes/event_prompt/_delta_builder.py`, new `_extract_last_reviewed_sha_for_producer` extractor with the same strict hex sanitization as the proposal-SHA reader).

## 2. Unchanged-tree re-propose guard

`handle_re_propose` (the explicit propose path) had no unchanged-SHA check and no counter — it unconditionally bumped the version and re-invoked every reviewer, producing the observed v3–v12 ten-cycle loop. (`check_auto_repropose`, the push-triggered path, already short-circuited on an unchanged SHA.)

- A re-propose whose `commit_sha` equals the current proposal's is rejected with a structured `unchanged_tree_rejected` envelope (mirroring the open-NACK barrier shape), returned as a 409 by the propose signal route without emitting a `CONSENSUS_PROPOSE`. The message tells the producer to land commits, or to make a no-change-needed case to the NACKing reviewer via `send_message` so the reviewer can re-verdict the current version.
- Both SHAs must be non-empty, so no-op ↔ real proposal transitions are never caught.
- Consecutive rejected attempts are counted and surfaced in the envelope.

## 3. Post-proposal grace scoped to commit-advancing proposals

Both live incomplete-consensus stall detectors — the overseer monitor's `_check_incomplete_consensus_stall` and the tier-1 `IncompleteConsensusStallCheck` (the issue named the first; the second has the same #1609 grace pattern and would have stayed blind) — reset their stall timers on *any* recent `CONSENSUS_PROPOSE`, so empty re-proposes spaced under the 300 s grace suppressed escalation forever.

- Grace is now keyed to a proposal-SHA fingerprint (new `PeerConsensusTracker.get_all_proposal_commit_shas()` snapshot): a proposal that does not advance any producer's SHA neither resets stall tracking nor re-opens the grace window. A `None` fingerprint (tracker unavailable) conservatively falls back to the previous timestamp-only behaviour.

## Tests

- New `test_brc_unchanged_repropose.py`: rejection envelope, no version bump, attempt counting/reset, changed-SHA pass-through.
- `test_consensus_next_action.py`: `pending_reviews` carries the last-verdicted SHA after NACK + re-propose; empty on first review.
- `test_compose_event_prompt.py`: server baseline beats a poisoned memory bullet (the observed deadlock state, delta runs `e29714a..7bb0dbc`); memory fallback preserved for legacy payloads.
- `test_overseer_monitor.py` / `test_incomplete_consensus_stall.py`: unchanged-SHA re-propose no longer defers the stall check; SHA-advancing proposals still do.
- Existing re-propose fixtures updated to advance the SHA on re-propose (they reused the v1 SHA, which the guard now correctly rejects); the prompt-sync ratchet allowlist line number updated for the shifted comment.

Targeted sweep (`-k "consensus or brc or signal or event_prompt or health or peer or propose or overseer"`): 2072 passed. The one failure, `test_state_store_wedge_propagation.py::test_probe_skipped_when_request_context_missing`, fails identically on a pristine checkout (pre-existing, unrelated). `make lint` clean.