### PR TITLE
Fix divergence-reconcile false conflict on shared pipeline history (#3416)

### DIFF
--- a/orchestrator/gateway_client/_push.py
+++ b/orchestrator/gateway_client/_push.py
@@ -566,7 +566,7 @@ def _rebase_with_agent_output_autoresolve(
             # roll; the decision persists).
             excerpt = _compact_git_output(rebase_result.stderr, rebase_result.stdout)
             detail = (
-                f"conflicts outside .egg-state/agent-outputs/: {', '.join(non_ephemeral)} "
+                f"conflicts outside .egg-state/agent-outputs/: {_compact_path_list(non_ephemeral)} "
                 f"[git {' '.join(rebase_cmd[len(git_base) :])}]"
             )
             if excerpt:
@@ -735,6 +735,37 @@ def _list_unmerged_paths(git_base: list[str]) -> list[str]:
     return [line for line in result.stdout.splitlines() if line.strip()]
 
 
+def _compact_path_list(paths: list[str], *, limit: int = 400) -> str:
+    """Join conflicting paths into a bounded, single-line detail segment.
+
+    The joined string feeds ``PushResult.detail`` and, downstream, the
+    divergence-reconcile HITL question.  Conflict path sets are typically
+    tiny, but a pathological rebase could surface many paths and grow the
+    detail well past its useful length before the git-output excerpt is
+    even appended (#3416).  Show as many whole paths as fit within
+    ``limit`` characters and summarise the remainder as ``(+N more)`` so
+    the operator still learns the true count without the string ballooning.
+    """
+    if not paths:
+        return ""
+    shown: list[str] = []
+    used = 0
+    for index, path in enumerate(paths):
+        # Reserve room for the "(+N more)" suffix the remaining paths need.
+        remaining = len(paths) - index
+        suffix_len = len(f" (+{remaining} more)") if remaining else 0
+        addition = len(path) + (2 if shown else 0)  # ", " separator
+        if shown and used + addition + suffix_len > limit:
+            break
+        shown.append(path)
+        used += addition
+    joined = ", ".join(shown)
+    hidden = len(paths) - len(shown)
+    if hidden:
+        joined = f"{joined} (+{hidden} more)"
+    return joined
+
+
 def _compact_git_output(*streams: str | None, limit: int = 400) -> str:
     """Collapse git stdout/stderr into a single-line excerpt for a detail string.
 
@@ -864,6 +895,17 @@ def _divergence_replay_upstream(
     ``None`` (caller keeps the ``base_ref`` upstream) when the merge-base
     is on the main lineage (#1976/#2222 fresh-worktree topology) or
     cannot be determined.
+
+    Assumes the pipeline branch never carries base-branch (``main``)
+    commits above the shared merge-base that are not yet on
+    ``origin/{branch}``: in the normal orchestrator flow ``main`` enters
+    the pipeline branch only via the orchestrator's controlled rebase,
+    which pushes to origin so those commits land at or below the
+    merge-base.  If a future change to the sync flow ever merged ``main``
+    into the worktree locally without pushing it to the pipeline branch,
+    the rc-1 branch below would replay those un-pushed main commits (the
+    old ``base_ref`` upstream excluded them) — reconsider the
+    discriminator before allowing that topology.
     """
     try:
         merge_base = subprocess.run(

--- a/orchestrator/gateway_client/_push.py
+++ b/orchestrator/gateway_client/_push.py
@@ -553,15 +553,28 @@ def _rebase_with_agent_output_autoresolve(
                 "Push reconcile: rebase failed — conflicts outside agent-outputs, aborting",
                 pipeline_id=pipeline_id,
                 branch=branch,
+                rebase_cmd=rebase_cmd[len(git_base) :],
                 conflicting_paths=unmerged_paths,
                 stdout=rebase_result.stdout,
                 stderr=rebase_result.stderr,
             )
             _abort_rebase_best_effort(git_base, pipeline_id, branch)
+            # Name the conflicting paths, the exact rebase form, and the
+            # git output in the detail: this string is what reaches the
+            # divergence-reconcile HITL decision, and #3416 showed that
+            # an operator cannot judge the pause without it (the logs
+            # roll; the decision persists).
+            excerpt = _compact_git_output(rebase_result.stderr, rebase_result.stdout)
+            detail = (
+                f"conflicts outside .egg-state/agent-outputs/: {', '.join(non_ephemeral)} "
+                f"[git {' '.join(rebase_cmd[len(git_base) :])}]"
+            )
+            if excerpt:
+                detail = f"{detail}: {excerpt}"
             return PushResult(
                 ok=False,
                 category="reconcile_rebase_conflict",
-                detail=f"conflicts outside .egg-state/agent-outputs/: {', '.join(non_ephemeral)}",
+                detail=detail,
             )
 
         _pkg.logger.warning(
@@ -722,6 +735,32 @@ def _list_unmerged_paths(git_base: list[str]) -> list[str]:
     return [line for line in result.stdout.splitlines() if line.strip()]
 
 
+def _compact_git_output(*streams: str | None, limit: int = 400) -> str:
+    """Collapse git stdout/stderr into a single-line excerpt for a detail string.
+
+    Joins the non-empty lines of each stream with ``" | "`` and truncates
+    to ``limit`` characters, so the failing rebase's own explanation
+    (e.g. ``error: could not apply <sha>... <subject>`` and the
+    ``CONFLICT (add/add)`` line) can travel inside a ``PushResult.detail``
+    without flooding it.  ``hint:`` lines (git's resolve-it-yourself
+    boilerplate) are dropped — they would crowd the informative lines out
+    of the limit.
+    """
+    lines: list[str] = []
+    for stream in streams:
+        if not stream:
+            continue
+        lines.extend(
+            stripped
+            for line in stream.splitlines()
+            if (stripped := line.strip()) and not stripped.startswith("hint:")
+        )
+    joined = " | ".join(lines)
+    if len(joined) > limit:
+        joined = joined[: limit - 1] + "…"
+    return joined
+
+
 def _build_rebase_cmd(
     git_base: list[str],
     branch: str,
@@ -736,8 +775,11 @@ def _build_rebase_cmd(
       form.  This preserves pre-#1976 behaviour for any call site that
       still doesn't know the base branch.
     * ``base_branch`` is set and ``origin/{base_branch}`` resolves: return
-      the ``--onto origin/{branch} origin/{base_branch}`` form so only
-      ``origin/{base_branch}..HEAD`` commits are replayed.
+      an ``--onto origin/{branch} <upstream>`` form.  The upstream is
+      chosen by topology (see below) so the replay range contains only
+      the commits that are genuinely local — never commits already on
+      main (#1976) and never commits already shared with
+      ``origin/{branch}`` (#3416).
     * ``base_branch`` is set but ``origin/{base_branch}`` does NOT resolve
       (the upstream best-effort fetch silently failed earlier, or rev-parse
       timed out): return ``None``.  The caller must surface this as a
@@ -748,6 +790,28 @@ def _build_rebase_cmd(
       upstream main commits that landed since the stale snapshot) on top
       of the stale tip, producing a PR full of duplicate-by-content
       commits with rewritten SHAs.
+
+    Upstream selection (#3416): ``--onto origin/{branch}
+    origin/{base_branch}`` replays ``origin/{base_branch}..HEAD`` — on a
+    long-lived pipeline worktree that range is the ENTIRE pipeline
+    history since main, not just the local-only commits.  Git tolerates
+    re-applying the already-shared commits only while each one merges
+    empty against the new tip; a shared commit whose paths were later
+    rewritten on the shared lineage (the ``.egg-state/contracts/*.json``
+    statefile is rewritten on every contract mutation) instead produces
+    a guaranteed add/add or content conflict — a false-positive
+    "unreconcilable divergence" for commits both sides already have.
+    So when ``merge-base(HEAD, origin/{branch})`` resolves and is NOT an
+    ancestor of ``origin/{base_branch}`` — i.e. the shared history
+    extends past the branch point onto the pipeline lineage, the
+    long-lived-worktree topology — use ``--onto origin/{branch}
+    <merge-base>``, which replays exactly the local-only commits.  When
+    the merge-base IS on the main lineage (fresh worktree cut straight
+    from main — the #1976/#2222 topology, where ``merge-base..HEAD``
+    would include upstream main commits), keep the
+    ``origin/{base_branch}`` upstream.  If the merge-base cannot be
+    determined, fall back to ``origin/{base_branch}`` (pre-#3416
+    behaviour).
 
     ``--autostash`` is set on every returned form (#2714): the orchestrator
     writes statefile / agent-output deltas continuously and does not commit
@@ -781,7 +845,57 @@ def _build_rebase_cmd(
     except subprocess.TimeoutExpired:
         verify = None
     if verify and verify.returncode == 0:
-        return [*git_base, "rebase", "--autostash", "--onto", f"origin/{branch}", base_ref]
+        upstream = _divergence_replay_upstream(git_base, branch, base_ref) or base_ref
+        return [*git_base, "rebase", "--autostash", "--onto", f"origin/{branch}", upstream]
+    return None
+
+
+def _divergence_replay_upstream(
+    git_base: list[str],
+    branch: str,
+    base_ref: str,
+) -> str | None:
+    """Pick the rebase upstream that replays only local-only commits (#3416).
+
+    Returns ``merge-base(HEAD, origin/{branch})`` when it resolves and is
+    NOT an ancestor of ``base_ref`` — the long-lived-worktree topology,
+    where that merge-base is a shared pipeline commit and
+    ``<merge-base>..HEAD`` is exactly the local-only commit set.  Returns
+    ``None`` (caller keeps the ``base_ref`` upstream) when the merge-base
+    is on the main lineage (#1976/#2222 fresh-worktree topology) or
+    cannot be determined.
+    """
+    try:
+        merge_base = subprocess.run(
+            [*git_base, "merge-base", "HEAD", f"origin/{branch}"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    merge_base_sha = merge_base.stdout.strip()
+    if merge_base.returncode != 0 or not merge_base_sha:
+        return None
+    try:
+        is_ancestor = subprocess.run(
+            [*git_base, "merge-base", "--is-ancestor", merge_base_sha, base_ref],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    # rc 0 → the merge-base is on the main lineage: HEAD sits directly on
+    # (a snapshot of) main, so the caller must keep the ``base_ref``
+    # upstream to exclude upstream main commits from the replay (#1976).
+    # rc 1 → the merge-base is a shared pipeline commit: replaying from it
+    # yields exactly the local-only commits.  Other rcs are git errors —
+    # be conservative and keep the pre-#3416 upstream.
+    if is_ancestor.returncode == 1:
+        return merge_base_sha
     return None
 
 

--- a/orchestrator/routes/phases/_populate.py
+++ b/orchestrator/routes/phases/_populate.py
@@ -158,6 +158,12 @@ def populate_contract(pipeline_id: str) -> tuple[Response, int]:
         divergence_local_only = (
             list(populate_sync_outcome.local_only_commit_shas) if populate_sync_outcome else []
         )
+        divergence_rebase_category = (
+            populate_sync_outcome.rebase_category if populate_sync_outcome else None
+        )
+        divergence_rebase_detail = (
+            populate_sync_outcome.rebase_detail if populate_sync_outcome else None
+        )
 
         if diverged_unreconciled:
             # Do NOT run the populator against an un-reconciled worktree.
@@ -171,6 +177,8 @@ def populate_contract(pipeline_id: str) -> tuple[Response, int]:
                 pipeline_id=pipeline_id,
                 backup_ref=divergence_backup_ref,
                 local_only_commit_count=len(divergence_local_only),
+                rebase_category=divergence_rebase_category,
+                rebase_detail=divergence_rebase_detail,
             )
             _emit_divergence_reconcile_hitl(
                 pipeline_id,
@@ -178,6 +186,8 @@ def populate_contract(pipeline_id: str) -> tuple[Response, int]:
                 phase=pipeline.current_phase,
                 backup_ref=divergence_backup_ref,
                 local_only_commit_shas=divergence_local_only,
+                rebase_category=divergence_rebase_category,
+                rebase_detail=divergence_rebase_detail,
             )
             return make_error_response(
                 "Worktree diverged from origin during pre-populate sync and "
@@ -190,6 +200,8 @@ def populate_contract(pipeline_id: str) -> tuple[Response, int]:
                     "diverged_unreconciled": True,
                     "backup_ref": divergence_backup_ref,
                     "local_only_commit_shas": divergence_local_only,
+                    "rebase_category": divergence_rebase_category,
+                    "rebase_detail": divergence_rebase_detail,
                 },
             )
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7966,12 +7966,21 @@ class WorktreeSyncOutcome(NamedTuple):
     summaries) that are on HEAD but not yet on origin.  Empty when the
     rev-list itself failed; the divergence is still reported, but the
     operator can't be given the exact commit list inline.
+
+    ``rebase_category`` / ``rebase_detail`` carry the failing rebase's
+    ``PushResult.category`` / ``detail`` (conflicting paths, the rebase
+    argv, and a git-output excerpt) when ``diverged_unreconciled`` is
+    True.  They exist so the reconcile HITL can show the operator *what*
+    failed instead of an unfalsifiable generic claim (#3416) — the log
+    lines carry the same data but roll; the decision persists.
     """
 
     case: str
     diverged_unreconciled: bool = False
     backup_ref: str | None = None
     local_only_commit_shas: tuple[str, ...] = ()
+    rebase_category: str | None = None
+    rebase_detail: str | None = None
 
 
 def _build_sync_recovery_backup_ref(pipeline_id: str, unix_ts: int) -> str:
@@ -8535,6 +8544,8 @@ def _sync_worktree_with_remote(
             diverged_unreconciled=True,
             backup_ref=backup_ref if backup_ok else None,
             local_only_commit_shas=local_only,
+            rebase_category=rebase_outcome.category,
+            rebase_detail=rebase_outcome.detail,
         )
 
     # Step 4: Reset local branch to remote.
@@ -16383,6 +16394,8 @@ def _divergence_reconcile_hitl_question(
     phase: PipelinePhase | None,
     backup_ref: str | None,
     local_only_commit_shas: tuple[str, ...] | list[str],
+    rebase_category: str | None = None,
+    rebase_detail: str | None = None,
 ) -> str:
     """Build the HITL question for the non-destructive divergence pause (#2979).
 
@@ -16393,8 +16406,22 @@ def _divergence_reconcile_hitl_question(
     FAILED).  The operator reconciles the orchestrator-side worktree
     manually, then either resumes (the sync re-runs and the phase's
     post-processing continues from where it paused) or aborts.
+
+    ``rebase_category`` / ``rebase_detail`` name the actual autoresolve
+    failure (conflicting paths, rebase argv, git output excerpt) so the
+    operator can judge the pause from the decision alone (#3416).
     """
     phase_label = phase.value if phase is not None else "current phase"
+    if rebase_category or rebase_detail:
+        failure_label = rebase_category or "unknown failure"
+        failure_line = (
+            f"({failure_label}: {rebase_detail})" if rebase_detail else f"({failure_label})"
+        )
+    else:
+        failure_line = (
+            "(failure detail unavailable — see the divergence_rebase_failed "
+            "log line for the rebase output)"
+        )
     backup_line = (
         f"A backup ref pins the current tip: {backup_ref} (inspect with `git log {backup_ref}`)."
         if backup_ref
@@ -16412,7 +16439,7 @@ def _divergence_reconcile_hitl_question(
     return (
         f"Pipeline {pipeline_id}: the worktree diverged from origin at the "
         f"{phase_label} boundary and the rebase autoresolve could not "
-        f"reconcile it (a conflict outside .egg-state/agent-outputs/). "
+        f"reconcile it {failure_line}. "
         f"Nothing was discarded — the worktree is left at the local HEAD "
         f"with the orchestrator's committed work intact, and the pipeline "
         f"is paused (not failed) for a manual reconcile (#2979). "
@@ -16435,6 +16462,8 @@ def _emit_divergence_reconcile_hitl(
     phase: PipelinePhase | None,
     backup_ref: str | None,
     local_only_commit_shas: tuple[str, ...] | list[str],
+    rebase_category: str | None = None,
+    rebase_detail: str | None = None,
 ):
     """Pin pipeline+phase to AWAITING_HUMAN and persist the reconcile HITL (#2979).
 
@@ -16467,6 +16496,8 @@ def _emit_divergence_reconcile_hitl(
                 phase=phase,
                 backup_ref=backup_ref,
                 local_only_commit_shas=tuple(local_only_commit_shas),
+                rebase_category=rebase_category,
+                rebase_detail=rebase_detail,
             ),
             options=list(_DIVERGENCE_RECONCILE_HITL_OPTIONS),
             phase=phase,
@@ -16625,6 +16656,8 @@ def _sync_worktree_reconciling_divergence(
                     phase=phase,
                     backup_ref=outcome.backup_ref,
                     local_only_commit_shas=outcome.local_only_commit_shas,
+                    rebase_category=outcome.rebase_category,
+                    rebase_detail=outcome.rebase_detail,
                 ),
                 options=list(_DIVERGENCE_RECONCILE_HITL_OPTIONS),
                 phase=phase,
@@ -16646,6 +16679,8 @@ def _sync_worktree_reconciling_divergence(
             phase=phase_label,
             backup_ref=outcome.backup_ref,
             local_only_commit_count=len(outcome.local_only_commit_shas),
+            rebase_category=outcome.rebase_category,
+            rebase_detail=outcome.rebase_detail,
             pause_attempt=pauses,
         )
 

--- a/orchestrator/tests/test_hard_reset_recovery.py
+++ b/orchestrator/tests/test_hard_reset_recovery.py
@@ -186,6 +186,43 @@ class TestDivergenceReconcileHitlQuestion:
         assert "Backup ref write failed" in question
         assert "could not be enumerated" in question
 
+    def test_names_actual_rebase_failure(self):
+        """#3416: the decision names the failing rebase's category and
+        detail (conflicting paths, rebase argv, git output) instead of a
+        generic unfalsifiable conflict claim."""
+        question = _divergence_reconcile_hitl_question(
+            pipeline_id="pipeline-zzz",
+            phase=PipelinePhase.REFINE,
+            backup_ref="refs/egg-backup/sync-recovery/pipeline-zzz/123",
+            local_only_commit_shas=("abc1234 statefile write",),
+            rebase_category="reconcile_rebase_conflict",
+            rebase_detail=(
+                "conflicts outside .egg-state/agent-outputs/: "
+                ".egg-state/contracts/pipeline-zzz.json "
+                "[git rebase --autostash --onto origin/egg/pipeline-zzz/work origin/main]: "
+                "error: could not apply 20b4761... Initialize SDLC contract"
+            ),
+        )
+        assert "reconcile_rebase_conflict" in question
+        assert ".egg-state/contracts/pipeline-zzz.json" in question
+        assert "could not apply 20b4761" in question
+        # The generic pre-#3416 claim must be gone.
+        assert "(a conflict outside .egg-state/agent-outputs/)" not in question
+
+    def test_failure_detail_unavailable_fallback(self):
+        """Without category/detail the decision says the detail is
+        unavailable and points at the log line, rather than asserting a
+        specific conflict shape it cannot know."""
+        question = _divergence_reconcile_hitl_question(
+            pipeline_id="pipeline-zzz",
+            phase=PipelinePhase.PLAN,
+            backup_ref=None,
+            local_only_commit_shas=(),
+        )
+        assert "failure detail unavailable" in question
+        assert "divergence_rebase_failed" in question
+        assert "(a conflict outside .egg-state/agent-outputs/)" not in question
+
     def test_options_are_two_distinct_strings(self):
         assert _DIVERGENCE_RECONCILE_HITL_OPTIONS == [
             _DIVERGENCE_RECONCILE_RESUME,

--- a/orchestrator/tests/test_reconcile_and_push_pr_branch.py
+++ b/orchestrator/tests/test_reconcile_and_push_pr_branch.py
@@ -29,6 +29,7 @@ from gateway_client import (
     PushResult,
     _rebase_with_agent_output_autoresolve,
 )
+from gateway_client._push import _compact_path_list
 
 
 def _run_result(returncode=0, stdout="", stderr=""):
@@ -1091,3 +1092,34 @@ class TestPushWorktreeBranchReconcile:
         # statefile delta the orchestrator was holding.
         stash_list = _git(work, "stash", "list").stdout
         assert "autostash" in stash_list, f"autostash entry missing from stash list: {stash_list!r}"
+
+
+class TestCompactPathList:
+    """`_compact_path_list` bounds the conflicting-paths detail segment (#3416)."""
+
+    def test_small_list_shown_verbatim(self):
+        paths = ["src/app.py", "src/models.py"]
+        assert _compact_path_list(paths) == "src/app.py, src/models.py"
+
+    def test_empty_list_is_empty_string(self):
+        assert _compact_path_list([]) == ""
+
+    def test_large_list_is_bounded_with_remainder_count(self):
+        paths = [f"src/module_{i:03d}/very_long_path_component.py" for i in range(200)]
+        out = _compact_path_list(paths)
+        # The joined segment stays within the cap (plus the short suffix)…
+        assert len(out) <= 400 + len(" (+200 more)")
+        # …every remaining path is accounted for in the (+N more) tail…
+        shown = out.split(" (+")[0].split(", ")
+        hidden = int(out.split(" (+")[1].split(" more)")[0])
+        assert len(shown) + hidden == len(paths)
+        assert hidden > 0
+        # …and the shown paths are whole (never truncated mid-path).
+        assert all(p in paths for p in shown)
+
+    def test_single_path_never_summarised_away(self):
+        # A single path longer than the limit is still shown in full — the
+        # cap only gates *additional* paths, so the operator always sees at
+        # least one concrete conflicting path.
+        long_path = "src/" + "a" * 500 + ".py"
+        assert _compact_path_list([long_path]) == long_path

--- a/orchestrator/tests/test_reconcile_and_push_pr_branch.py
+++ b/orchestrator/tests/test_reconcile_and_push_pr_branch.py
@@ -378,6 +378,13 @@ class TestPushWorktreeBranchReconcile:
         the rebase uses ``--onto origin/{branch} origin/{base_branch}`` so
         only ``origin/{base_branch}..HEAD`` is replayed — commits already
         on main are not duplicated onto the pipeline branch (#1976).
+
+        The ``origin/{base_branch}`` upstream is kept here because the
+        merge-base with ``origin/{branch}`` sits on the main lineage
+        (``--is-ancestor`` rc 0) — the fresh-worktree topology #1976 was
+        opened against.  The long-lived-worktree topology takes the
+        merge-base upstream instead (#3416; see
+        ``test_rebase_with_shared_pipeline_history_uses_merge_base_upstream``).
         """
         client = _make_client([False, True])
         with patch(
@@ -386,6 +393,8 @@ class TestPushWorktreeBranchReconcile:
                 _run_result(),  # fetch origin {branch}
                 _run_result(),  # fetch origin {base_branch}
                 _run_result(),  # rev-parse --verify origin/{base_branch}
+                _run_result(stdout="aaa111\n"),  # merge-base HEAD origin/{branch}
+                _run_result(returncode=0),  # merge-base --is-ancestor (on main lineage)
                 _run_result(),  # rebase --onto ...
                 _run_result(),  # diff --diff-filter=U (autostash pop conflict check)
             ],
@@ -398,13 +407,86 @@ class TestPushWorktreeBranchReconcile:
             )
 
         assert ok.ok is True
-        assert mock_run.call_count == 5
+        assert mock_run.call_count == 7
         base_fetch_cmd = mock_run.call_args_list[1].args[0]
         assert "fetch" in base_fetch_cmd and "main" in base_fetch_cmd
-        rebase_cmd = mock_run.call_args_list[3].args[0]
+        rebase_cmd = mock_run.call_args_list[5].args[0]
         # ``--autostash`` (#2714) precedes ``--onto`` so the rebase can run
         # against a dirty worktree; statefile / agent-output writes are
         # routinely uncommitted at sync time.
+        assert rebase_cmd[-5:] == [
+            "rebase",
+            "--autostash",
+            "--onto",
+            "origin/egg/issue-42",
+            "origin/main",
+        ]
+
+    def test_rebase_with_shared_pipeline_history_uses_merge_base_upstream(self, tmp_path):
+        """When the merge-base with ``origin/{branch}`` is NOT on the main
+        lineage (``--is-ancestor`` rc 1 — the long-lived pipeline-worktree
+        topology), the rebase upstream is the merge-base itself, so only
+        the local-only commits are replayed (#3416).  Replaying from
+        ``origin/{base_branch}`` would re-apply the entire shared pipeline
+        history and conflict on any statefile that was rewritten on the
+        shared lineage.
+        """
+        client = _make_client([False, True])
+        with patch(
+            "gateway_client.subprocess.run",
+            side_effect=[
+                _run_result(),  # fetch origin {branch}
+                _run_result(),  # fetch origin {base_branch}
+                _run_result(),  # rev-parse --verify origin/{base_branch}
+                _run_result(stdout="bbb222\n"),  # merge-base HEAD origin/{branch}
+                _run_result(returncode=1),  # merge-base --is-ancestor (pipeline commit)
+                _run_result(),  # rebase --onto ...
+                _run_result(),  # diff --diff-filter=U (autostash pop conflict check)
+            ],
+        ) as mock_run:
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-3416",
+                repo_path=str(tmp_path),
+                branch="egg/issue-3416/work",
+                base_branch="main",
+            )
+
+        assert ok.ok is True
+        rebase_cmd = mock_run.call_args_list[5].args[0]
+        assert rebase_cmd[-5:] == [
+            "rebase",
+            "--autostash",
+            "--onto",
+            "origin/egg/issue-3416/work",
+            "bbb222",
+        ]
+
+    def test_rebase_keeps_base_upstream_when_merge_base_undeterminable(self, tmp_path):
+        """If ``merge-base HEAD origin/{branch}`` fails (no common history,
+        git error), the pre-#3416 ``origin/{base_branch}`` upstream is kept
+        rather than guessing.
+        """
+        client = _make_client([False, True])
+        with patch(
+            "gateway_client.subprocess.run",
+            side_effect=[
+                _run_result(),  # fetch origin {branch}
+                _run_result(),  # fetch origin {base_branch}
+                _run_result(),  # rev-parse --verify origin/{base_branch}
+                _run_result(returncode=1),  # merge-base HEAD origin/{branch} fails
+                _run_result(),  # rebase --onto ...
+                _run_result(),  # diff --diff-filter=U (autostash pop conflict check)
+            ],
+        ) as mock_run:
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-42",
+                repo_path=str(tmp_path),
+                branch="egg/issue-42",
+                base_branch="main",
+            )
+
+        assert ok.ok is True
+        rebase_cmd = mock_run.call_args_list[4].args[0]
         assert rebase_cmd[-5:] == [
             "rebase",
             "--autostash",
@@ -513,6 +595,111 @@ class TestPushWorktreeBranchReconcile:
         assert len(branch_only_shas) == 2, (
             f"expected 2 branch-only commits, got {len(branch_only_shas)}: {branch_only_shas}"
         )
+
+    def test_shared_statefile_history_does_not_false_conflict(self, tmp_path):
+        """End-to-end regression for #3416.
+
+        Reproduces the ``issue-3393`` production shape on a real repo:
+
+        - The pipeline branch carries shared history that first ADDS a
+          ``.egg-state/contracts/*.json`` statefile and later REWRITES it
+          (contract mutations rewrite the file in place).
+        - The long-lived orchestrator worktree sits on that shared
+          lineage with ONE local-only commit (a statefile write).
+        - Origin has advanced by three commits touching disjoint files.
+
+        Before the fix, ``_build_rebase_cmd`` picked ``origin/main`` as
+        the rebase upstream, so the replay range was the ENTIRE pipeline
+        history — and re-applying the initial contract ADD onto the tip
+        (where the contract had since been rewritten) produced a
+        guaranteed add/add conflict: ``reconcile_rebase_conflict`` for a
+        divergence whose actual local-vs-origin file sets were disjoint.
+        The manual operator rebase (upstream = origin tip) was clean,
+        proving the pause a false positive.  After the fix the upstream
+        is the merge-base (a shared pipeline commit), so only the
+        local-only commit is replayed and the reconcile succeeds.
+        """
+        origin = tmp_path / "origin.git"
+        subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)], check=True)
+
+        # Seed main, then the pipeline branch: contract ADD + contract REWRITE.
+        seed = tmp_path / "seed"
+        seed.mkdir()
+        _git_init(seed, str(origin))
+        (seed / "README.md").write_text("initial\n")
+        _git(seed, "add", "README.md")
+        _git(seed, "commit", "-m", "initial main commit")
+        _git(seed, "push", "origin", "main")
+
+        _git(seed, "checkout", "-b", "egg/issue-3416/work")
+        contract = seed / ".egg-state" / "contracts"
+        contract.mkdir(parents=True)
+        (contract / "issue-3416.json").write_text('{"phase": "refine", "open_questions": []}\n')
+        _git(seed, "add", ".egg-state/contracts/issue-3416.json")
+        _git(seed, "commit", "-m", "Initialize SDLC contract for issue-3416")
+        (contract / "issue-3416.json").write_text(
+            '{"phase": "refine", "open_questions": ["cq-1"]}\n'
+        )
+        _git(seed, "add", ".egg-state/contracts/issue-3416.json")
+        _git(seed, "commit", "-m", "Register open question cq-1")
+        _git(seed, "push", "origin", "egg/issue-3416/work")
+
+        # Long-lived orchestrator worktree cut at the shared tip, with one
+        # local-only statefile commit (the operator's cq-1 resolution).
+        work = tmp_path / "work"
+        work.mkdir()
+        _git_init(work, str(origin))
+        _git(work, "fetch", "origin")
+        _git(work, "checkout", "-b", "egg/issue-3416/work", "origin/egg/issue-3416/work")
+        work_contract = work / ".egg-state" / "contracts" / "issue-3416.json"
+        work_contract.write_text(
+            '{"phase": "refine", "open_questions": [], "resolved": ["cq-1"]}\n'
+        )
+        _git(work, "add", ".egg-state/contracts/issue-3416.json")
+        _git(work, "commit", "-m", "Persist agent statefile writes before refine sync")
+
+        # Origin advances by three commits touching disjoint files (agent
+        # artifacts) — the "remote ahead" half of the divergence.
+        for i in range(3):
+            (seed / f"analysis_v{i}.md").write_text(f"refine analysis v{i}\n")
+            _git(seed, "add", f"analysis_v{i}.md")
+            _git(seed, "commit", "-m", f"Refine analysis v{i}")
+        _git(seed, "push", "origin", "egg/issue-3416/work")
+        _git(work, "fetch", "origin")
+        origin_tip = _git(work, "rev-parse", "origin/egg/issue-3416/work").stdout.strip()
+
+        git_base = [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            f"safe.directory={work}",
+            "-C",
+            str(work),
+        ]
+        result = _rebase_with_agent_output_autoresolve(
+            git_base=git_base,
+            pipeline_id="issue-3416",
+            branch="egg/issue-3416/work",
+            base_branch="main",
+        )
+        assert result.ok, (
+            f"reconcile false-conflicted on shared history: {result.category} {result.detail}"
+        )
+
+        # Exactly the one local-only commit was replayed onto the origin tip.
+        replayed = [
+            s
+            for s in _git(work, "log", "--format=%H", f"{origin_tip}..HEAD")
+            .stdout.strip()
+            .splitlines()
+            if s
+        ]
+        assert len(replayed) == 1, f"expected 1 replayed commit, got {len(replayed)}: {replayed}"
+        assert _git(work, "rev-parse", "HEAD~1").stdout.strip() == origin_tip
+
+        # The local statefile write survived the reconcile.
+        assert "resolved" in work_contract.read_text()
 
     def test_rebase_does_not_contaminate_when_base_fetch_silently_failed(self, tmp_path):
         """End-to-end regression for #2222.

--- a/orchestrator/tests/test_sync_worktree.py
+++ b/orchestrator/tests/test_sync_worktree.py
@@ -292,6 +292,10 @@ class TestSyncWorktreeWithRemote:
                 "abc1234 commit A",
                 "def5678 commit B",
             )
+            # #3416: the failing rebase's category/detail travel on the
+            # outcome so the reconcile HITL can name the actual failure.
+            assert outcome.rebase_category == "reconcile_rebase_conflict"
+            assert outcome.rebase_detail == "conflicts outside agent-outputs"
             # 3 (head detect / rev-parse / rev-list-counts) + 2 (rev-list
             # local-only, update-ref) = 5 subprocess calls. Crucially, NO
             # reset call fired.


### PR DESCRIPTION
Fixes #3416.

## Root cause

The `divergence_reconcile_unacked` pause on `issue-3393` was a real conflict, but a
structural one the autoresolve inflicted on itself — not a race, not a stale fetch,
and not operator-relevant divergence.

`_build_rebase_cmd` builds the #1976-safe form:

```
git rebase --autostash --onto origin/{branch} origin/{base_branch}
```

With upstream = `origin/main`, git's replay range is `origin/main..HEAD` — the
**entire pipeline history since main**, not just the local-only commits (`rev-list`
had measured the divergence as 1 local vs 3 remote; the failing rebase's own output
says `Rebasing (1/8)`). Git tolerates re-applying the already-shared commits only
while each one merges empty against the new tip. The pipeline's first commit —
the *add* of `.egg-state/contracts/<id>.json` — stops merging empty as soon as any
later shared commit rewrites the contract (every contract mutation does), producing
a guaranteed `CONFLICT (add/add)` on a commit **both sides already have**:

```
Rebasing (1/8) error: could not apply 20b476173... Initialize SDLC contract f...
CONFLICT (add/add): .egg-state/contracts/issue-3393.json
```

The operator's manual `git rebase <origin-tip>` was clean because its upstream is
the origin tip, so it replays exactly the 1 local-only commit. Once a pipeline's
contract has mutated on the shared lineage, every subsequent divergence reconcile
on that pipeline fails this way deterministically — a re-fetch + retry (one of the
issue's suggested fixes) would not have helped, so it is deliberately not added.

## Fix 1 — replay only the local-only commits

`_build_rebase_cmd` now picks the `--onto` upstream by topology
(`_divergence_replay_upstream`):

- `merge-base(HEAD, origin/{branch})` is **not** an ancestor of
  `origin/{base_branch}` → the merge-base is a shared pipeline commit (the
  long-lived orchestrator-worktree topology). Use it as the upstream:
  `<merge-base>..HEAD` is exactly the local-only commit set, so shared history is
  never re-applied.
- The merge-base **is** on the main lineage → the fresh-worktree-cut-from-main
  topology that #1976/#2222 were opened against, where `merge-base..HEAD` would
  replay upstream main commits. Keep the `origin/{base_branch}` upstream
  (pre-existing behaviour).
- Merge-base undeterminable → keep `origin/{base_branch}` (pre-existing behaviour).

Both callers are covered (the phase-boundary `_sync_worktree_with_remote` and the
gateway push-reject `_reconcile_and_retry_push`); the #2222 refusal to fall back to
the plain form when `origin/{base_branch}` is unresolvable is untouched.

## Fix 2 — the decision names the actual failure

The decision text previously hardcoded "(a conflict outside
`.egg-state/agent-outputs/`)" with no path, command, or output — unfalsifiable from
the decision alone (#3416's observability complaint). Now:

- `reconcile_rebase_conflict`'s `PushResult.detail` carries the conflicting paths,
  the exact rebase argv, and a compact git stdout/stderr excerpt (`hint:`
  boilerplate dropped), e.g.:
  `conflicts outside .egg-state/agent-outputs/: .egg-state/contracts/issue-3416.json
  [git rebase --autostash --onto origin/egg/issue-3416/work origin/main]:
  Rebasing (1/3) | error: could not apply 536da20... Initialize SDLC contract...`
- `WorktreeSyncOutcome` gains `rebase_category` / `rebase_detail`, threaded into
  the reconcile HITL question, the `populate_contract` 409 `details`, and the
  `OVERSEER_ALERT worktree_divergence_reconcile_pause` log line.

## Tests

- `test_shared_statefile_history_does_not_false_conflict` — real-git end-to-end
  reproduction of the issue-3393 shape (shared contract add + rewrite, 1 local-only
  statefile commit, 3 disjoint origin commits). Fails on the old upstream with the
  exact production error; passes with the fix, replaying exactly 1 commit onto the
  origin tip.
- `test_rebase_with_shared_pipeline_history_uses_merge_base_upstream` /
  `test_rebase_keeps_base_upstream_when_merge_base_undeterminable` — argv-level
  coverage of the topology discriminator.
- Existing #1976 / #2222 / #2714 regression tests unchanged and green (the
  fresh-worktree topology keeps the `origin/{base_branch}` upstream).
- HITL-question tests assert the decision carries category/detail and that the
  hardcoded conflict claim is gone; sync tests assert the outcome threads
  `rebase_category`/`rebase_detail`.
