### PR TITLE
Suspend consensus timeout while a slice is operator-gated on unresolved HITL (#3426)

### DIFF
--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -17044,7 +17044,7 @@ def _unresolved_contract_hitl_ids(
             return []
         identifier = _pipeline_identifier(getattr(pipeline, "issue_number", None), pipeline_id)
         contract = load_contract(identifier, worktree)
-    except (OSError, ValueError, ContractNotFoundError, ContractValidationError):
+    except OSError, ValueError, ContractNotFoundError, ContractValidationError:
         # OSError: filesystem failures resolving the worktree / reading the
         # contract. ValueError: pydantic-V2 validation failures. Contract*:
         # missing or corrupt contract JSON. All fail open to ``[]``.

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -16981,6 +16981,63 @@ def _latest_active_role_heartbeat(active_role_names: list[str]) -> datetime | No
         return None
 
 
+def _unresolved_contract_hitl_ids(
+    pipeline_id: str,
+    pipeline: Pipeline,
+    phase_str: str,
+) -> list[str]:
+    """Return ids of unresolved contract HITL (``cq-N``) decisions gating ``phase_str``.
+
+    Feeds the consensus-timeout HITL gate (#3426): while an agent-registered
+    contract question (``register_open_question`` / impasse escalation) for
+    the running phase awaits an operator answer, the slice is *operator-gated*
+    — a reviewer correctly withholding its ACK pending the ruling is not a
+    convergence failure, so the consensus-timeout clock must not expire the
+    phase. Scoped to decisions whose ``phase`` matches the running phase;
+    phase-less decisions are skipped, mirroring
+    ``_collect_unresolved_phase_decisions`` (we cannot prove they gate this
+    phase, and an eternally-unanswered legacy entry must not suspend the
+    timeout forever).
+
+    Contract decisions have no slice tag, so during a sliced implement phase
+    any unresolved implement-tagged question suspends every slice's timeout.
+    That errs toward parking rather than failing — acceptable, since the
+    overseer's "wedged on HITL" alert stays sticky and the operator's answer
+    releases the gate.
+
+    Fail-open: any failure (missing worktree, unloadable contract) returns
+    ``[]`` so a broken scan degrades to the pre-#3426 timeout behaviour
+    rather than suspending the clock indefinitely.
+    """
+    try:
+        import contract_store
+        from egg_contracts import load_contract
+
+        worktree = contract_store.resolve_pipeline_worktree(pipeline_id)
+        if worktree is None:
+            return []
+        identifier = _pipeline_identifier(getattr(pipeline, "issue_number", None), pipeline_id)
+        contract = load_contract(identifier, worktree)
+    except Exception:
+        logger.debug(
+            "Consensus-timeout HITL gate contract scan failed",
+            pipeline_id=pipeline_id,
+            exc_info=True,
+        )
+        return []
+
+    ids: list[str] = []
+    for d in contract.decisions or []:
+        if d.resolved:
+            continue
+        if getattr(d.type, "value", d.type) != "hitl":
+            continue
+        if getattr(d.phase, "value", d.phase) != phase_str:
+            continue
+        ids.append(d.id)
+    return ids
+
+
 def _publish_consensus_timeout_alert(
     pipeline: Pipeline,
     pipeline_id: str,
@@ -20331,6 +20388,10 @@ def _run_concurrent_phase(
     # ``consensus_timeout``.
     _progress_gate_deferring = False
 
+    # #3426 HITL-gate state: same log-once discipline for the
+    # operator-gated suspension of the consensus timeout.
+    _hitl_gate_deferring = False
+
     while True:
         elapsed = time.monotonic() - start_time
 
@@ -20860,6 +20921,40 @@ def _run_concurrent_phase(
 
         # 6. Consensus timeout
         if elapsed >= consensus_timeout:
+            # #3426 HITL gate: while an unresolved operator HITL decision
+            # (contract ``cq-N``) gates the running phase, the slice is
+            # provably operator-gated — a reviewer withholding its ACK
+            # pending a human ruling is the system working as designed, not
+            # a convergence failure. Suspend the timeout (keep polling, no
+            # alert, no failure) until the operator answers. On release,
+            # reset the convergence clock so the agents folding in the
+            # resolution get a full fresh window instead of a clock that
+            # already expired while the human was thinking.
+            _hitl_ids = _unresolved_contract_hitl_ids(pipeline_id, pipeline, phase_str)
+            if _hitl_ids:
+                if not _hitl_gate_deferring:
+                    logger.info(
+                        "Consensus timeout suspended — phase is operator-gated "
+                        "on unresolved HITL decision(s)",
+                        pipeline_id=pipeline_id,
+                        slice_id=slice_id,
+                        elapsed_seconds=round(elapsed, 1),
+                        decision_ids=_hitl_ids,
+                    )
+                    _hitl_gate_deferring = True
+                time.sleep(poll_interval)
+                continue
+            if _hitl_gate_deferring:
+                _hitl_gate_deferring = False
+                start_time = time.monotonic()
+                logger.info(
+                    "Consensus timeout clock reset — operator HITL decision(s) resolved",
+                    pipeline_id=pipeline_id,
+                    slice_id=slice_id,
+                    suspended_after_seconds=round(elapsed, 1),
+                )
+                continue
+
             # #2243 progress gate: keep polling instead of publishing
             # the consensus-timeout alert while producer/reviewer
             # activity is still live on the BRC bus or in container

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -17046,8 +17046,11 @@ def _unresolved_contract_hitl_ids(
         contract = load_contract(identifier, worktree)
     except OSError, ValueError, ContractNotFoundError, ContractValidationError:
         # OSError: filesystem failures resolving the worktree / reading the
-        # contract. ValueError: pydantic-V2 validation failures. Contract*:
-        # missing or corrupt contract JSON. All fail open to ``[]``.
+        # contract. ValueError: identifier / path-resolution failures from
+        # ``_pipeline_identifier`` (``load_contract`` wraps pydantic-V2
+        # validation errors as ContractValidationError, so a raw ValueError
+        # here does not come from schema validation). Contract*: missing or
+        # corrupt contract JSON. All fail open to ``[]``.
         logger.warning(
             "Consensus-timeout HITL gate contract scan failed",
             pipeline_id=pipeline_id,

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -17005,21 +17005,50 @@ def _unresolved_contract_hitl_ids(
     overseer's "wedged on HITL" alert stays sticky and the operator's answer
     releases the gate.
 
+    The gate keys on the *existence* of an operator-facing HITL decision
+    tagged to this phase, not on causal proof that decision is what a
+    reviewer is withholding an ACK for — decisions carry no link to the
+    ACK they block. An unrelated implement-tagged HITL therefore suspends
+    the timeout too; that is the conservative "park rather than fail"
+    direction, self-corrected by the clock reset on release (a genuine
+    stall times out on the fresh window) and by the overseer's other
+    health checks.
+
     Fail-open: any failure (missing worktree, unloadable contract) returns
     ``[]`` so a broken scan degrades to the pre-#3426 timeout behaviour
-    rather than suspending the clock indefinitely.
+    rather than suspending the clock indefinitely. Matching the sibling
+    ``_collect_unresolved_phase_decisions``, the except set is narrowed to
+    the IO/validation failures a real scan can hit and logged at
+    ``warning`` (so a broken scan is observable, not a silent no-op),
+    while programming errors (``AttributeError``/``TypeError``/``NameError``)
+    are left to propagate so they surface during development.
     """
     try:
         import contract_store
         from egg_contracts import load_contract
+        from egg_contracts.loader import (
+            ContractNotFoundError,
+            ContractValidationError,
+        )
+    except ImportError:
+        logger.warning(
+            "Consensus-timeout HITL gate: egg_contracts unavailable, cannot scan",
+            pipeline_id=pipeline_id,
+            exc_info=True,
+        )
+        return []
 
+    try:
         worktree = contract_store.resolve_pipeline_worktree(pipeline_id)
         if worktree is None:
             return []
         identifier = _pipeline_identifier(getattr(pipeline, "issue_number", None), pipeline_id)
         contract = load_contract(identifier, worktree)
-    except Exception:
-        logger.debug(
+    except (OSError, ValueError, ContractNotFoundError, ContractValidationError):
+        # OSError: filesystem failures resolving the worktree / reading the
+        # contract. ValueError: pydantic-V2 validation failures. Contract*:
+        # missing or corrupt contract JSON. All fail open to ``[]``.
+        logger.warning(
             "Consensus-timeout HITL gate contract scan failed",
             pipeline_id=pipeline_id,
             exc_info=True,

--- a/orchestrator/tests/test_consensus_polling.py
+++ b/orchestrator/tests/test_consensus_polling.py
@@ -430,6 +430,186 @@ class TestConsensusTimeout:
         )
 
 
+class TestUnresolvedContractHitlIds:
+    """_unresolved_contract_hitl_ids — the #3426 consensus-timeout HITL gate scan."""
+
+    @staticmethod
+    def _decision(decision_id, *, resolved=False, dtype=None, phase="implement"):
+        from egg_contracts.models import Decision, DecisionType, PipelinePhase
+
+        return Decision(
+            id=decision_id,
+            question="Scope question?",
+            type=dtype if dtype is not None else DecisionType.HITL,
+            phase=PipelinePhase(phase) if phase is not None else None,
+            resolved=resolved,
+        )
+
+    def _scan(self, decisions):
+        from routes.pipelines import _unresolved_contract_hitl_ids
+
+        contract = MagicMock()
+        contract.decisions = decisions
+        pipeline = _make_concurrent_pipeline()
+        with (
+            patch("contract_store.resolve_pipeline_worktree", return_value=Path("/tmp/wt")),
+            patch("egg_contracts.load_contract", return_value=contract),
+        ):
+            return _unresolved_contract_hitl_ids("issue-999", pipeline, "implement")
+
+    def test_returns_unresolved_hitl_for_running_phase(self):
+        ids = self._scan([self._decision("cq-3")])
+        assert ids == ["cq-3"]
+
+    def test_skips_resolved_other_phase_phaseless_and_non_hitl(self):
+        from egg_contracts.models import DecisionType
+
+        ids = self._scan(
+            [
+                self._decision("cq-1", resolved=True),
+                self._decision("cq-2", phase="plan"),
+                self._decision("cq-4", phase=None),
+                self._decision("cq-5", dtype=DecisionType.AUTO),
+                self._decision("cq-6"),
+            ]
+        )
+        assert ids == ["cq-6"]
+
+    def test_missing_worktree_fails_open(self):
+        from routes.pipelines import _unresolved_contract_hitl_ids
+
+        pipeline = _make_concurrent_pipeline()
+        with patch("contract_store.resolve_pipeline_worktree", return_value=None):
+            assert _unresolved_contract_hitl_ids("issue-999", pipeline, "implement") == []
+
+    def test_contract_load_failure_fails_open(self):
+        from routes.pipelines import _unresolved_contract_hitl_ids
+
+        pipeline = _make_concurrent_pipeline()
+        with (
+            patch("contract_store.resolve_pipeline_worktree", return_value=Path("/tmp/wt")),
+            patch("egg_contracts.load_contract", side_effect=OSError("boom")),
+        ):
+            assert _unresolved_contract_hitl_ids("issue-999", pipeline, "implement") == []
+
+
+class TestHitlGatedTimeout:
+    """#3426: the consensus timeout is suspended while operator-gated.
+
+    An unresolved contract HITL decision (``cq-N``) gating the running
+    phase means the slice is waiting on a human, not stalled — the
+    timeout branch must keep polling instead of alerting/failing, and
+    the convergence clock resets once the operator answers.
+    """
+
+    @patch("routes.pipelines.time.sleep")
+    @patch("routes.pipelines.time.monotonic")
+    @patch("routes.pipelines._emit_event")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
+    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
+    def test_timeout_suspended_until_hitl_resolved_then_converges(
+        self, MockExecutor, mock_prompt, mock_lock, mock_emit, mock_monotonic, mock_sleep
+    ):
+        """Operator-gated timeout defers; post-resolution the phase succeeds.
+
+        Sequence: consensus stays incomplete past the 30-min timeout while
+        ``cq-3`` is unresolved (two gated iterations), the operator then
+        resolves it (gate releases, clock resets), and consensus completes
+        on the fresh window → exit 0, no consensus-timeout OVERSEER_ALERT,
+        no CONSENSUS_TIMEOUT event, and the BRC event loop is never stopped.
+        """
+        from events import EventType
+
+        # Small per-call increments after an initial jump past the 1800s
+        # timeout: the post-release clock reset must land elapsed back
+        # under the timeout instead of re-expiring immediately.
+        _calls = [0]
+
+        def _monotonic():
+            _calls[0] += 1
+            if _calls[0] == 1:
+                return 0.0
+            return 1801.0 + _calls[0]
+
+        mock_monotonic.side_effect = _monotonic
+
+        executions = [_make_execution(AgentRole.CODER, "coder-1")]
+        pipeline, mock_store, mock_spawner, mock_docker = _base_mocks(executions)
+
+        # Shared state: consensus completes only after the HITL gate
+        # releases, regardless of how many times each hook is polled.
+        state = {"gated_polls_remaining": 2, "complete": False}
+
+        def _fake_hitl_ids(_pid, _pipeline, _phase):
+            if state["gated_polls_remaining"] > 0:
+                state["gated_polls_remaining"] -= 1
+                return ["cq-3"]
+            state["complete"] = True  # operator resolved cq-3
+            return []
+
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        mock_executor_instance.check_consensus.side_effect = lambda: {
+            "is_complete": state["complete"],
+            "has_objections": False,
+            "has_unresolved_nacks": False,
+            "blocking_agents": [] if state["complete"] else ["coder"],
+        }
+        # Record consensus completeness at each stop_event_loop call: the
+        # giving-up stop in the timeout branch would record False, the
+        # legitimate convergence teardown records True.
+        stop_calls: list = []
+        mock_executor_instance.stop_event_loop.side_effect = lambda: stop_calls.append(
+            state["complete"]
+        )
+        MockExecutor.return_value = mock_executor_instance
+
+        mock_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        captured_alerts: list = []
+        fake_msg_store = MagicMock()
+        fake_msg_store.add_message.side_effect = lambda msg: captured_alerts.append(msg) or msg
+        msg_store_factory = MagicMock(return_value=fake_msg_store)
+
+        with (
+            patch("routes.pipelines._unresolved_contract_hitl_ids", side_effect=_fake_hitl_ids),
+            patch("routes.pipelines._get_message_store", return_value=msg_store_factory),
+        ):
+            exit_code, logs = _run_concurrent_phase(
+                pipeline_id="issue-999",
+                pipeline=pipeline,
+                phase="implement",
+                spawner=mock_spawner,
+                store=mock_store,
+                **_CALL_ARGS,
+            )
+
+        assert exit_code == 0
+        # The gate consumed both gated polls before releasing.
+        assert state["gated_polls_remaining"] == 0
+        # Operator-gated waiting is not a convergence failure: no
+        # consensus-timeout alert, no CONSENSUS_TIMEOUT event, and the
+        # event loop kept running for the post-resolution window.
+        consensus_alerts = [
+            m
+            for m in captured_alerts
+            if m.message_type == "OVERSEER_ALERT"
+            and m.metadata.get("anomaly_type") == "consensus-timeout"
+        ]
+        assert consensus_alerts == []
+        timeout_events = [
+            c
+            for c in mock_emit.call_args_list
+            if c.args and c.args[0] == EventType.CONSENSUS_TIMEOUT
+        ]
+        assert timeout_events == []
+        # Exactly one event-loop stop — the convergence teardown, never
+        # the giving-up stop from the timeout branch.
+        assert stop_calls == [True]
+
+
 class TestObjectionHandling:
     """Objections trigger HITL decisions."""
 

--- a/orchestrator/tests/test_consensus_polling.py
+++ b/orchestrator/tests/test_consensus_polling.py
@@ -609,6 +609,105 @@ class TestHitlGatedTimeout:
         # the giving-up stop from the timeout branch.
         assert stop_calls == [True]
 
+    @patch("routes.pipelines.time.sleep")
+    @patch("routes.pipelines.time.monotonic")
+    @patch("routes.pipelines._emit_event")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines._build_agent_prompt", return_value="test prompt")
+    @patch("concurrent_executor.ConcurrentPhaseExecutor", autospec=False)
+    def test_timeout_suspended_zero_container_orchestrator_mode(
+        self, MockExecutor, mock_prompt, mock_lock, mock_emit, mock_monotonic, mock_sleep
+    ):
+        """Same gate behaviour under the zero-container path the fix targets.
+
+        The `issue-3393` incident is on-demand/orchestrator spawning (#3164):
+        `spawn_all` returns `[]`, so `active_executions == []`, step 5's
+        "all containers exited" completion path is guarded off, and the
+        phase is driven purely off `check_consensus` + the timeout branch —
+        exactly where the HITL gate sits. This variant reproduces that
+        resident-container-less scenario (contrast the sibling test, which
+        keeps one container to exercise the pod path). The gate must still
+        defer the timeout while `cq-3` is unresolved and reset the clock on
+        release → exit 0, no consensus-timeout alert, no CONSENSUS_TIMEOUT
+        event, one convergence teardown.
+        """
+        from events import EventType
+
+        _calls = [0]
+
+        def _monotonic():
+            _calls[0] += 1
+            if _calls[0] == 1:
+                return 0.0
+            return 1801.0 + _calls[0]
+
+        mock_monotonic.side_effect = _monotonic
+
+        # Zero resident containers — the orchestrator-mode path.
+        executions: list = []
+        pipeline, mock_store, mock_spawner, mock_docker = _base_mocks(executions)
+
+        state = {"gated_polls_remaining": 2, "complete": False}
+
+        def _fake_hitl_ids(_pid, _pipeline, _phase):
+            if state["gated_polls_remaining"] > 0:
+                state["gated_polls_remaining"] -= 1
+                return ["cq-3"]
+            state["complete"] = True  # operator resolved cq-3
+            return []
+
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.spawn_all.return_value = executions
+        mock_executor_instance.check_consensus.side_effect = lambda: {
+            "is_complete": state["complete"],
+            "has_objections": False,
+            "has_unresolved_nacks": False,
+            "blocking_agents": [] if state["complete"] else ["coder"],
+        }
+        stop_calls: list = []
+        mock_executor_instance.stop_event_loop.side_effect = lambda: stop_calls.append(
+            state["complete"]
+        )
+        MockExecutor.return_value = mock_executor_instance
+
+        mock_lock.return_value.__enter__ = MagicMock(return_value=None)
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        captured_alerts: list = []
+        fake_msg_store = MagicMock()
+        fake_msg_store.add_message.side_effect = lambda msg: captured_alerts.append(msg) or msg
+        msg_store_factory = MagicMock(return_value=fake_msg_store)
+
+        with (
+            patch("routes.pipelines._unresolved_contract_hitl_ids", side_effect=_fake_hitl_ids),
+            patch("routes.pipelines._get_message_store", return_value=msg_store_factory),
+        ):
+            exit_code, logs = _run_concurrent_phase(
+                pipeline_id="issue-999",
+                pipeline=pipeline,
+                phase="implement",
+                spawner=mock_spawner,
+                store=mock_store,
+                **_CALL_ARGS,
+            )
+
+        assert exit_code == 0
+        assert state["gated_polls_remaining"] == 0
+        consensus_alerts = [
+            m
+            for m in captured_alerts
+            if m.message_type == "OVERSEER_ALERT"
+            and m.metadata.get("anomaly_type") == "consensus-timeout"
+        ]
+        assert consensus_alerts == []
+        timeout_events = [
+            c
+            for c in mock_emit.call_args_list
+            if c.args and c.args[0] == EventType.CONSENSUS_TIMEOUT
+        ]
+        assert timeout_events == []
+        assert stop_calls == [True]
+
 
 class TestObjectionHandling:
     """Objections trigger HITL decisions."""


### PR DESCRIPTION
Fixes #3426.

## Problem

The consensus-timeout branch in `_run_concurrent_phase` treats a slice wedged on an unresolved operator HITL decision the same as a genuinely stalled slice: the convergence clock keeps ticking while the only remaining blocker is a human answer, and on expiry the pipeline **fails**. Under on-demand spawning (#3164) the post-timeout grace (`post_consensus_iteration_budget_seconds`) finds no resident containers to wait for, so the phase dies ~60s after the alert — punishing the operator for exercising a first-class HITL gate. Observed on `issue-3393` implement slice-4: `reviewer_contract` correctly withheld its ACK pending `cq-3`, the 90-minute timeout fired anyway, and recovery required a full `restart_phase(implement)`.

## Fix

A HITL gate at the top of the timeout branch (before the #2243 progress gate):

- **`_unresolved_contract_hitl_ids()`** scans the pipeline worktree's contract for unresolved `type == "hitl"` decisions (`cq-N`) tagged to the running phase. Phase-less decisions are skipped (mirroring `_collect_unresolved_phase_decisions`), so a legacy untagged entry can't suspend the timeout forever. The scan **fails open** — a missing worktree or unloadable contract returns `[]` and the pre-fix timeout behaviour applies, so a broken scan can never strand the pipeline.
- **While gated**: the loop keeps polling — no consensus-timeout `OVERSEER_ALERT`, no `CONSENSUS_TIMEOUT` event, no event-loop teardown, no failure. The overseer's existing sticky "wedged on HITL" alert (#3374) remains the single operator-facing signal.
- **On release** (operator resolved the decision): the convergence clock resets, giving agents a fresh `consensus_timeout_minutes` window to fold in the ruling and converge — instead of a clock that already expired while the human was thinking.

Contract decisions carry no slice tag, so during a sliced implement phase any unresolved implement-tagged question suspends every slice's timeout. That errs toward parking rather than failing, which is the conservative direction here.

## Tests

- `TestUnresolvedContractHitlIds` — scan returns unresolved current-phase HITL ids; skips resolved / other-phase / phase-less / non-hitl entries; fails open on missing worktree and on contract load failure.
- `TestHitlGatedTimeout` — end-to-end loop test: consensus incomplete past the timeout while `cq-3` is unresolved → the timeout defers (no alert, no CONSENSUS_TIMEOUT event, no give-up `stop_event_loop`); on resolution the clock resets and the phase converges to exit 0.

All 28 tests in `test_consensus_polling.py` pass, plus the adjacent timeout-loop suites (`test_post_timeout_rebaseline`, `test_restart_phase_consensus_timer`, `test_slice_run_loop_integration` — 102 total). Ruff clean.

## Related

- #3425 — unbounded no-op re-spawns against a HITL-wedged slice (same incident, deliberately **not** bundled here).
- #3374 — `pending_contract_decisions` surfacing (provides the state this gate consults).
- #2243/#2264 — the progress-gate + alert pattern this follows.