### PR TITLE
Restore repo-pinned prebuilt toolchain in k8s agent pods (#3413 step 1)

### DIFF
--- a/orchestrator/consensus_wrapper.py
+++ b/orchestrator/consensus_wrapper.py
@@ -395,6 +395,76 @@ print('\n'.join(out))
     return 0
 }}
 
+# Restore the repo's prebuilt build_commands toolchain (#3413): copy
+# /opt/prebuilt-deps/<owner--repo>/* (the persist_dirs snapshot baked at
+# image build, e.g. the repo's pinned .venv) into the mounted worktree,
+# skipping paths that already exist. This is the agent-path twin of
+# ``sandbox.entrypoint._worktrees.restore_prebuilt_deps`` and the #3412
+# green-gate runner's ``restore_prebuilt``: k8s agent pods override the
+# image ENTRYPOINT (the orchestrator injects this wrapper as the pod
+# command), so the entrypoint's restore never runs on this path and repo
+# checks would otherwise resolve to whatever tools the image happens to
+# install globally instead of the versions the repo pins. Copy-if-missing
+# keeps it idempotent across the many one-shot pods that share a role
+# worktree — only the first pod per worktree pays the copy. No chown
+# needed: this pod runs as the worktree's owning uid, unlike the root
+# entrypoint. Fail-soft: a failed restore logs and continues — the agent
+# invocation is never blocked on it, and a missing toolchain surfaces at
+# check time instead. ``EGG_PREBUILT_DEPS_BASE`` overrides the snapshot
+# source for tests.
+restore_prebuilt_deps() {{
+    local repo="${{EGG_REPO_PATH:-$PWD}}"
+    local out rc
+    out=$(python3 - "$repo" 2>&1 <<'RESTORE_PREBUILT_PY'
+import os
+import shutil
+import sys
+
+repo_dir = sys.argv[1]
+base = os.environ.get("EGG_PREBUILT_DEPS_BASE", "/opt/prebuilt-deps")
+name = os.path.basename(os.path.normpath(repo_dir))
+if not os.path.isdir(base) or not os.path.isdir(repo_dir):
+    print("skipped (no prebuilt base or repo dir)")
+    sys.exit(0)
+
+
+def copy_if_missing(src, dst, **kwargs):
+    if os.path.exists(dst) or os.path.islink(dst):
+        return
+    if os.path.islink(src):
+        os.symlink(os.readlink(src), dst)
+    else:
+        shutil.copy2(src, dst, **kwargs)
+
+
+restored = None
+for entry in sorted(os.listdir(base)):
+    if entry == "__egg_system_dirs__" or not entry.endswith("--" + name):
+        continue
+    shutil.copytree(
+        os.path.join(base, entry),
+        repo_dir,
+        copy_function=copy_if_missing,
+        dirs_exist_ok=True,
+        symlinks=False,
+    )
+    restored = entry
+    break
+if restored is None:
+    print("no prebuilt snapshot for " + name)
+else:
+    print("restored " + restored)
+RESTORE_PREBUILT_PY
+)
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        cw_log "prebuilt-deps restore failed (rc=$rc, fail-soft): ${{out:-<no output>}}"
+    else
+        cw_log "prebuilt-deps restore: $out"
+    fi
+    return 0
+}}
+
 """
 
 
@@ -475,6 +545,12 @@ if [ "$ONE_SHOT_DERIVED" != "$ONE_SHOT_ACTION" ]; then
     cw_log "Injected event is stale (injected=$ONE_SHOT_ACTION, derived=${ONE_SHOT_DERIVED:-<none>}); exiting 0 without invoking the agent."
     exit 0
 fi
+
+# Restore the repo-pinned prebuilt toolchain (#3413) after the freshness
+# re-check (a stale event exits above without paying the copy) and before
+# any arm runs — producer arms run repo checks too. Fail-soft inside the
+# function; the agent invocation is never blocked on it.
+restore_prebuilt_deps
 
 # Use the freshly-derived event_payload (current truth) for the invocation.
 # Reviewer arms (ack/nack) sync the pending proposal commits into the

--- a/orchestrator/consensus_wrapper.py
+++ b/orchestrator/consensus_wrapper.py
@@ -431,10 +431,17 @@ if not os.path.isdir(base) or not os.path.isdir(repo_dir):
 def copy_if_missing(src, dst, **kwargs):
     if os.path.exists(dst) or os.path.islink(dst):
         return
-    if os.path.islink(src):
-        os.symlink(os.readlink(src), dst)
-    else:
-        shutil.copy2(src, dst, **kwargs)
+    # Mirror the entrypoint's _copy_if_missing: log-and-continue per file
+    # so a single unreadable/mode-600 source degrades to a per-file warning
+    # instead of flipping the whole restore to a "restore failed" line via
+    # shutil.copytree's collected shutil.Error.
+    try:
+        if os.path.islink(src):
+            os.symlink(os.readlink(src), dst)
+        else:
+            shutil.copy2(src, dst, **kwargs)
+    except OSError as e:
+        print("  warn: failed to restore " + dst + ": " + str(e))
 
 
 restored = None

--- a/orchestrator/tests/golden/event_pump_wrapper.sh.golden
+++ b/orchestrator/tests/golden/event_pump_wrapper.sh.golden
@@ -325,6 +325,76 @@ print('\n'.join(out))
     return 0
 }
 
+# Restore the repo's prebuilt build_commands toolchain (#3413): copy
+# /opt/prebuilt-deps/<owner--repo>/* (the persist_dirs snapshot baked at
+# image build, e.g. the repo's pinned .venv) into the mounted worktree,
+# skipping paths that already exist. This is the agent-path twin of
+# ``sandbox.entrypoint._worktrees.restore_prebuilt_deps`` and the #3412
+# green-gate runner's ``restore_prebuilt``: k8s agent pods override the
+# image ENTRYPOINT (the orchestrator injects this wrapper as the pod
+# command), so the entrypoint's restore never runs on this path and repo
+# checks would otherwise resolve to whatever tools the image happens to
+# install globally instead of the versions the repo pins. Copy-if-missing
+# keeps it idempotent across the many one-shot pods that share a role
+# worktree — only the first pod per worktree pays the copy. No chown
+# needed: this pod runs as the worktree's owning uid, unlike the root
+# entrypoint. Fail-soft: a failed restore logs and continues — the agent
+# invocation is never blocked on it, and a missing toolchain surfaces at
+# check time instead. ``EGG_PREBUILT_DEPS_BASE`` overrides the snapshot
+# source for tests.
+restore_prebuilt_deps() {
+    local repo="${EGG_REPO_PATH:-$PWD}"
+    local out rc
+    out=$(python3 - "$repo" 2>&1 <<'RESTORE_PREBUILT_PY'
+import os
+import shutil
+import sys
+
+repo_dir = sys.argv[1]
+base = os.environ.get("EGG_PREBUILT_DEPS_BASE", "/opt/prebuilt-deps")
+name = os.path.basename(os.path.normpath(repo_dir))
+if not os.path.isdir(base) or not os.path.isdir(repo_dir):
+    print("skipped (no prebuilt base or repo dir)")
+    sys.exit(0)
+
+
+def copy_if_missing(src, dst, **kwargs):
+    if os.path.exists(dst) or os.path.islink(dst):
+        return
+    if os.path.islink(src):
+        os.symlink(os.readlink(src), dst)
+    else:
+        shutil.copy2(src, dst, **kwargs)
+
+
+restored = None
+for entry in sorted(os.listdir(base)):
+    if entry == "__egg_system_dirs__" or not entry.endswith("--" + name):
+        continue
+    shutil.copytree(
+        os.path.join(base, entry),
+        repo_dir,
+        copy_function=copy_if_missing,
+        dirs_exist_ok=True,
+        symlinks=False,
+    )
+    restored = entry
+    break
+if restored is None:
+    print("no prebuilt snapshot for " + name)
+else:
+    print("restored " + restored)
+RESTORE_PREBUILT_PY
+)
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        cw_log "prebuilt-deps restore failed (rc=$rc, fail-soft): ${out:-<no output>}"
+    else
+        cw_log "prebuilt-deps restore: $out"
+    fi
+    return 0
+}
+
 # --- one-shot event handler (#3164) ------------------------------------
 ONE_SHOT_ACTION="${EGG_EVENT_ACTION:-}"
 if [ -z "$ONE_SHOT_ACTION" ]; then
@@ -381,6 +451,12 @@ if [ "$ONE_SHOT_DERIVED" != "$ONE_SHOT_ACTION" ]; then
     cw_log "Injected event is stale (injected=$ONE_SHOT_ACTION, derived=${ONE_SHOT_DERIVED:-<none>}); exiting 0 without invoking the agent."
     exit 0
 fi
+
+# Restore the repo-pinned prebuilt toolchain (#3413) after the freshness
+# re-check (a stale event exits above without paying the copy) and before
+# any arm runs — producer arms run repo checks too. Fail-soft inside the
+# function; the agent invocation is never blocked on it.
+restore_prebuilt_deps
 
 # Use the freshly-derived event_payload (current truth) for the invocation.
 # Reviewer arms (ack/nack) sync the pending proposal commits into the

--- a/orchestrator/tests/golden/event_pump_wrapper.sh.golden
+++ b/orchestrator/tests/golden/event_pump_wrapper.sh.golden
@@ -361,10 +361,17 @@ if not os.path.isdir(base) or not os.path.isdir(repo_dir):
 def copy_if_missing(src, dst, **kwargs):
     if os.path.exists(dst) or os.path.islink(dst):
         return
-    if os.path.islink(src):
-        os.symlink(os.readlink(src), dst)
-    else:
-        shutil.copy2(src, dst, **kwargs)
+    # Mirror the entrypoint's _copy_if_missing: log-and-continue per file
+    # so a single unreadable/mode-600 source degrades to a per-file warning
+    # instead of flipping the whole restore to a "restore failed" line via
+    # shutil.copytree's collected shutil.Error.
+    try:
+        if os.path.islink(src):
+            os.symlink(os.readlink(src), dst)
+        else:
+            shutil.copy2(src, dst, **kwargs)
+    except OSError as e:
+        print("  warn: failed to restore " + dst + ": " + str(e))
 
 
 restored = None

--- a/orchestrator/tests/test_consensus_wrapper.py
+++ b/orchestrator/tests/test_consensus_wrapper.py
@@ -463,6 +463,48 @@ class TestRestorePrebuiltDeps:
         assert "RESTORE_RC=0" in result.stdout
         assert "skipped" in result.stderr
 
+    def test_behavioral_unreadable_file_degrades_per_file_and_keeps_rc0(self, tmp_path):
+        """Per-file degradation (re-review #2 of commit 7d52eca): a single
+        unreadable (mode 0o000) source file must degrade to a per-file
+        ``warn: failed to restore`` line while its siblings still restore
+        and the overall outcome stays ``restored`` (rc 0) — NOT the whole
+        restore flipping to ``restore failed`` via ``copytree``'s collected
+        ``shutil.Error``. This pins the exact behavior the
+        ``try/except OSError`` in ``copy_if_missing`` introduced."""
+        import pytest
+
+        if os.geteuid() == 0:
+            pytest.skip("root bypasses mode 0o000 read permission")
+
+        base = tmp_path / "prebuilt"
+        (base / "acme--widget" / ".venv" / "bin").mkdir(parents=True)
+        good = base / "acme--widget" / ".venv" / "bin" / "pytest"
+        good.write_text("tool-v1\n")
+        bad = base / "acme--widget" / ".venv" / "bin" / "secret"
+        bad.write_text("unreadable\n")
+        bad.chmod(0o000)
+        repo = tmp_path / "widget"
+        repo.mkdir()
+
+        harness = self._extract_restore_harness(self._script(), str(repo), str(base))
+        try:
+            result = subprocess.run(
+                ["bash", "-c", harness], capture_output=True, text=True, timeout=30
+            )
+        finally:
+            # Restore mode so tmp_path cleanup can remove the file.
+            bad.chmod(0o644)
+
+        # rc stays 0 and the outcome is "restored", not "restore failed".
+        assert "RESTORE_RC=0" in result.stdout, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        assert "restored acme--widget" in result.stderr
+        assert "restore failed" not in result.stderr
+        # The lone unreadable file degraded to a per-file warning...
+        assert "warn: failed to restore" in result.stderr
+        # ...while its sibling still restored intact.
+        assert (repo / ".venv" / "bin" / "pytest").read_text() == "tool-v1\n"
+        assert not (repo / ".venv" / "bin" / "secret").exists()
+
 
 class TestSyncOutcomesAndBanner:
     """R1 non-silent sync banner (#3077 slice-1 TASK-1-3).

--- a/orchestrator/tests/test_consensus_wrapper.py
+++ b/orchestrator/tests/test_consensus_wrapper.py
@@ -325,6 +325,145 @@ class TestSyncToProposals:
         assert "unresolvable" in result.stderr
 
 
+class TestRestorePrebuiltDeps:
+    """Agent-path prebuilt-toolchain restore (#3413, step 1).
+
+    k8s agent pods override the image ENTRYPOINT (this wrapper IS the pod
+    command), so ``sandbox.entrypoint._worktrees.restore_prebuilt_deps``
+    never runs for them and repo checks resolve to globally-installed
+    image tools instead of the repo's pinned ``build_commands`` toolchain
+    (``/opt/prebuilt-deps/<owner--repo>/``, e.g. its ``.venv``). The
+    wrapper now performs the restore itself — copy-if-missing, symlink-
+    preserving, fail-soft — mirroring the entrypoint and the #3412
+    green-gate runner. Requires a relocatable persisted venv (PR #3412's
+    ``make sandbox-deps``) in the image for the restored entry points to
+    work; the restore mechanics here are snapshot-agnostic.
+    """
+
+    def _script(self) -> str:
+        return build_consensus_wrapped_command("Prompt")[2]
+
+    def test_template_defines_restore_prebuilt_deps(self):
+        assert "restore_prebuilt_deps() {" in self._script()
+
+    def test_restore_runs_after_stale_check_before_any_arm(self):
+        """Ordering invariant: a stale event must exit WITHOUT paying the
+        copy, and every non-stale arm (review sync + agent invocation)
+        must see the restored toolchain."""
+        script = self._script()
+        stale_exit = script.index("Injected event is stale")
+        # The bare call in the one-shot handler (the definition is
+        # `restore_prebuilt_deps() {`; the call is the bare name on its
+        # own line).
+        restore_call = script.index("\nrestore_prebuilt_deps\n")
+        sync_call = script.index('sync_to_proposals "$ONE_SHOT_PAYLOAD"')
+        invoke_call = script.index('invoke_agent_for_event "$ONE_SHOT_ACTION" "$ONE_SHOT_PAYLOAD"')
+        assert stale_exit < restore_call < sync_call < invoke_call
+
+    def test_restore_is_fail_soft(self):
+        """The agent invocation must never be blocked on the restore: the
+        function returns 0 on every path (a missing toolchain surfaces at
+        check time instead)."""
+        script = self._script()
+        fn_body = script.split("restore_prebuilt_deps() {", 1)[1].split("\n}\n", 1)[0]
+        assert "fail-soft" in fn_body
+        assert fn_body.rstrip().endswith("return 0")
+
+    def test_restore_skips_system_dirs_and_matches_by_suffix(self):
+        """Pin the two snapshot-selection rules shared with the
+        entrypoint/runner restores: the legacy ``__egg_system_dirs__``
+        entry is never restored into a repo, and matching is by the
+        ``--<repo-basename>`` suffix of the snapshot dir name."""
+        script = self._script()
+        assert "__egg_system_dirs__" in script
+        assert 'entry.endswith("--" + name)' in script
+
+    def _extract_restore_harness(self, script: str, repo: str, base: str) -> str:
+        """Build a runnable bash harness: cw_log + restore_prebuilt_deps."""
+        import re
+
+        cw_match = re.search(r"cw_log\(\) \{.*?\n\}", script, flags=re.DOTALL)
+        assert cw_match is not None
+        restore_match = re.search(r"restore_prebuilt_deps\(\) \{.*?\n\}", script, flags=re.DOTALL)
+        assert restore_match is not None
+        return (
+            "#!/bin/bash\nset -uo pipefail\n"
+            f"EGG_REPO_PATH={shlex.quote(repo)}\n"
+            f"export EGG_PREBUILT_DEPS_BASE={shlex.quote(base)}\n"
+            + cw_match.group(0)
+            + "\n"
+            + restore_match.group(0)
+            + "\nrestore_prebuilt_deps"
+            + '\necho "RESTORE_RC=$?"\n'
+        )
+
+    def test_behavioral_restores_snapshot_copy_if_missing(self, tmp_path):
+        """End-to-end: the matching snapshot is copied into the repo
+        (symlinks preserved), files already present in the worktree are
+        NOT clobbered, and ``__egg_system_dirs__`` is skipped."""
+        base = tmp_path / "prebuilt"
+        (base / "acme--widget" / ".venv" / "bin").mkdir(parents=True)
+        (base / "acme--widget" / ".venv" / "bin" / "pytest").write_text("tool-v1\n")
+        (base / "acme--widget" / ".venv" / "bin" / "py.test").symlink_to("pytest")
+        (base / "acme--widget" / "keep.txt").write_text("from-snapshot\n")
+        (base / "__egg_system_dirs__" / "usr").mkdir(parents=True)
+        repo = tmp_path / "repos" / "widget"
+        repo.mkdir(parents=True)
+        (repo / "keep.txt").write_text("from-worktree\n")
+
+        harness = self._extract_restore_harness(self._script(), str(repo), str(base))
+        result = subprocess.run(["bash", "-c", harness], capture_output=True, text=True, timeout=30)
+        assert "RESTORE_RC=0" in result.stdout, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        assert "restored acme--widget" in result.stderr
+        assert (repo / ".venv" / "bin" / "pytest").read_text() == "tool-v1\n"
+        assert os.readlink(repo / ".venv" / "bin" / "py.test") == "pytest"
+        # Copy-if-missing: the worktree's copy wins over the snapshot's.
+        assert (repo / "keep.txt").read_text() == "from-worktree\n"
+        # The legacy system-dirs entry never lands in a repo worktree.
+        assert not (repo / "usr").exists()
+
+    def test_behavioral_idempotent_across_one_shot_pods(self, tmp_path):
+        """A second run over an already-restored worktree is a no-op —
+        the one-shot model re-runs this restore in every pod sharing the
+        role worktree."""
+        base = tmp_path / "prebuilt"
+        (base / "acme--widget" / ".venv").mkdir(parents=True)
+        (base / "acme--widget" / ".venv" / "cfg").write_text("v1\n")
+        repo = tmp_path / "widget"
+        repo.mkdir()
+
+        harness = self._extract_restore_harness(self._script(), str(repo), str(base))
+        for _ in range(2):
+            result = subprocess.run(
+                ["bash", "-c", harness], capture_output=True, text=True, timeout=30
+            )
+            assert "RESTORE_RC=0" in result.stdout
+        assert (repo / ".venv" / "cfg").read_text() == "v1\n"
+
+    def test_behavioral_no_snapshot_logs_and_continues(self, tmp_path):
+        """No matching snapshot: log it (loud in pod logs) and exit 0."""
+        base = tmp_path / "prebuilt"
+        (base / "acme--other").mkdir(parents=True)
+        repo = tmp_path / "widget"
+        repo.mkdir()
+
+        harness = self._extract_restore_harness(self._script(), str(repo), str(base))
+        result = subprocess.run(["bash", "-c", harness], capture_output=True, text=True, timeout=30)
+        assert "RESTORE_RC=0" in result.stdout
+        assert "no prebuilt snapshot for widget" in result.stderr
+
+    def test_behavioral_missing_base_is_fail_soft(self, tmp_path):
+        """No /opt/prebuilt-deps at all (older image): skip, exit 0."""
+        repo = tmp_path / "widget"
+        repo.mkdir()
+        harness = self._extract_restore_harness(
+            self._script(), str(repo), str(tmp_path / "nonexistent")
+        )
+        result = subprocess.run(["bash", "-c", harness], capture_output=True, text=True, timeout=30)
+        assert "RESTORE_RC=0" in result.stdout
+        assert "skipped" in result.stderr
+
+
 class TestSyncOutcomesAndBanner:
     """R1 non-silent sync banner (#3077 slice-1 TASK-1-3).
 


### PR DESCRIPTION
Step 1 of #3413 (the agent-path restore). Steps 2–3 (removing the repo-specific global pip installs from `sandbox/Dockerfile` and retiring the #3299 ruff image pin) are deliberately **not** in this PR — per the issue's sequencing note, they land in a follow-up only after this restore is verified live (testers observed running `make lint`/`make test` from the restored `.venv`), so in-flight testers always have a working toolchain.

## What

k8s agent pods override the sandbox image ENTRYPOINT — the one-shot BRC wrapper (`consensus_wrapper.py`) *is* the pod command — so `sandbox/entrypoint/_worktrees.py::restore_prebuilt_deps` never runs on the agent path. Agents therefore resolve repo checks to whatever tools the image happens to install globally (the #2065 Makefile fallback papered over this), instead of the repo-pinned `build_commands` toolchain persisted at `/opt/prebuilt-deps/<owner--repo>/`; repos like `jwbron/testing` that genuinely need their persisted `.venv` never get it in k8s pods at all.

This PR wires the restore into the wrapper itself:

- New `restore_prebuilt_deps()` bash function in the wrapper template, mirroring the entrypoint restore and the #3412 green-gate runner's `restore_prebuilt`: copy-if-missing (worktree files always win), symlink-preserving, `__egg_system_dirs__` skipped, snapshot matched by the `--<repo-basename>` suffix. No chown — the pod already runs as the worktree's owning uid, unlike the root entrypoint.
- Invoked in the one-shot handler **after** the freshness re-check (a stale event exits without paying the copy) and **before** any arm runs — producer arms run repo checks too. Copy-if-missing keeps it idempotent across the many one-shot pods sharing a role worktree; only the first pod per worktree pays the copy.
- Fail-soft: a failed restore logs (`cw_log`, visible in pod logs) and continues — the agent invocation is never blocked on it. Until step 2 removes the global installs, the #2065 fallback still covers a failed restore; after step 2, a missing toolchain surfaces loudly at check time, which is the point.
- `EGG_PREBUILT_DEPS_BASE` overrides the snapshot source for tests.

## Sequencing / rollout

- **Merge after #3412** and deploy via `make redeploy` (which rebuilds the sandbox image). The restore requires the relocatable persisted venv from #3412's `make sandbox-deps` — a pre-#3412 image's snapshot has absolute-shebang console scripts that dangle after restore into the worktree. Deploying this wrapper change against an old sandbox image would restore a broken `.venv` that shadows the global tools.
- After deploy, verify a live tester resolves `make lint`/`make test` to the restored `.venv` before landing the follow-up (steps 2–3).

## Testing

- New `TestRestorePrebuiltDeps` in `test_consensus_wrapper.py`: template-structure pins (function defined, call ordered after the stale-check and before sync/invoke, fail-soft `return 0`, system-dirs skip + suffix-match rules) and behavioral tests executing the rendered bash function in a subprocess (snapshot restored with symlinks preserved, copy-if-missing precedence, idempotent second run, no-snapshot and missing-base fail-soft paths).
- Golden `event_pump_wrapper.sh.golden` regenerated (reviewed: the diff is exactly the new function + the one call).
- `orchestrator/tests/test_consensus_wrapper.py` (46 passed) plus the adjacent wrapper-consuming suites `test_sync_to_proposals_role_gate.py`, `test_concurrent_executor.py`, `test_agent_model_resolution.py`, `test_concurrent_integration.py` (186 passed, 1 skipped).

## Follow-up (tracked in #3413)

- Step 2: drop the repo-specific global pip installs from `sandbox/Dockerfile` (keep generic/system utilities).
- Step 3: retire the #3299-style image ruff pin — the pin then lives solely in `pyproject.toml` + `uv.lock`.
