### PR TITLE
Execute adds_task decision options: materialize mandated contract tasks on resolve

### DIFF
--- a/docs/hitl-decisions.md
+++ b/docs/hitl-decisions.md
@@ -638,13 +638,68 @@ Note: #3129 also adds a *separate* auto-reopen mechanism that fires when a task 
 does **not** fire after the operator-completion path above, because the completion flips
 the row to `complete` and `incomplete_tasks` then returns nothing to reopen for.
 
+### Executable `adds_task` Option (#3428)
+
+A `register_open_question` option that mandates a contract mutation — "Add a new
+task/slice to wire X as a dependency" — used to be silently inert: agents have no
+task-add verb, so resolving the decision recorded the choice and materialized
+nothing. The reviewer that raised the question kept withholding ACK (correctly —
+the mandated task still didn't exist), the orchestrator kept re-spawning the
+producer at an unchanged contract, and the slice re-deadlocked *after* the human
+answered.
+
+Such options now carry a structured `adds_task` payload, attached at registration
+time:
+
+```json
+{
+  "question": "Slice-4 needs the secondary-repo worktree wired. How should we proceed?",
+  "options": ["Add a task to wire it as a slice-4 dependency", "Defer to a follow-up"],
+  "adds_task": {
+    "option": 1,
+    "slice_id": "slice-4",
+    "description": "Wire secondary-repo worktree + per-repo work/integration branch creation",
+    "acceptance_criteria": "...",
+    "files_affected": ["..."],
+    "role": "coder"
+  }
+}
+```
+
+When the operator resolves the decision by selecting that option (by label, `opt-N`
+id, or positional `option N` / `N` — free-form prose never fires the executor), the
+orchestrator materializes the task via `add_task_as_operator`: an audited
+`Role.HUMAN` mutation that appends the task to the named slice with a
+lock-allocated `task-<P>-<N>` id. The blocked agents see the new task on their next
+contract poll and the reviewer's precondition becomes satisfiable. Both resolve
+paths dispatch this — the pre-bridge contract fallback (`cq-N` resolved directly)
+and the post-gate bridged queue path (the contract decision is recovered via the
+bridge's context fingerprint). Execution failure is surfaced in the resolve
+response's `executed_action` payload and logged as an error, never silent.
+
+The direct REST surface (no live decision required) mirrors the task-completion
+route:
+
+```bash
+curl -X POST http://egg-orchestrator:9849/api/v1/contracts/<pipeline-id>/tasks \
+  -H "Authorization: Bearer $EGG_LIFECYCLE_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"slice_id": "slice-4", "description": "<task>", "reason": "materialize cq-4 opt-1"}'
+```
+
+**Registration guidance for agents:** if an option means "add a task", it MUST carry
+`adds_task` — without the payload the option is unactionable by anyone. Options that
+only gate agent behavior ("proceed with approach A") need no payload; the blocked
+agent reads the resolution and acts. Structural changes beyond a task append (new
+slices, DAG edits) still go through a replan, not a decision option.
+
 ## Related Files
 
 - `orchestrator/mcp_tools.py` — MCP `get_status` tool; enriches all pending decisions with `draft_content`; enriches `phase_gate` decisions additionally with `completed_agents_summary` and `reviewer_feedback`
 - `orchestrator/models.py` — `HITLDecision` model with `decision_type`, `questions`, `phase`, and `content_changed` fields; `content_changed` is set by the orchestrator on re-run phase gates to indicate whether the draft changed since the previous resolved decision (literal string comparison; `None` on first decision, `True`/`False` on subsequent ones). Also contains `OperatorDirective` (a single timestamped operator directive stored on kickback) and `IterationSummary` (BRC verdict snapshot for a kicked-back iteration), both accumulated on `PhaseExecution.operator_directives` / `PhaseExecution.iteration_history`.
 - `orchestrator/decision_queue.py` — Decision queue handling typed decisions
 - `orchestrator/routes/decisions/` — Decision API endpoints (create, list, resolve), the `POST .../feedback/answer` route for contract-scoped feedback (`answer_feedback` MCP tool; #3007), the contract-decision fallback in `resolve_decision` that writes pre-gate `cq-N` resolutions directly to the contract when the id is not in the queue (#3071), the executable task-completion dispatch (`_maybe_complete_task_from_resolution`) that auto-executes `complete_task_as_operator` when the resolution matches "Mark task `<id>` complete" (#3124), orphaned-driver revival on `phase_gate` resolution: when no live `_run_pipeline` driver thread owns an `AWAITING_HUMAN` pipeline (e.g. after an orchestrator restart), the resolve path re-launches the driver via `start_pipeline`'s recovery branch so the resolution self-heals rather than hanging silently; an `OVERSEER_ALERT` is broadcast on the bus when the orphaned park is detected (before the `start_pipeline` re-launch, so it fires even if that re-launch returns non-200 or raises) (#3233), and the first-principles redirect accept-path (`_maybe_apply_first_principles_redirect`, in `_handlers.py` and re-exported through the package barrel `__init__.py`): when the operator resolves a `first_principles_reviewer` refine-phase decision with "Adopt the redirect", this handler rewrites the pipeline seed via `rewrite_task_description_as_operator` and re-runs the refine phase; "Don't build this" cancels the pipeline; "Proceed as-is" is a no-op (#3385)
-- `orchestrator/operator_actions.py` — Operator-grade contract mutations; `complete_task_as_operator` applies task-status mutations as `Role.HUMAN`, bypassing the implementer/reviewer field-ownership restriction (#3124); `rewrite_task_description_as_operator` rewrites `contract.task_description` as `Role.HUMAN` for the first-principles redirect accept-path (#3385)
+- `orchestrator/operator_actions.py` — Operator-grade contract mutations; `complete_task_as_operator` applies task-status mutations as `Role.HUMAN`, bypassing the implementer/reviewer field-ownership restriction (#3124); `rewrite_task_description_as_operator` rewrites `contract.task_description` as `Role.HUMAN` for the first-principles redirect accept-path (#3385); `add_task_as_operator` appends a task to a slice as `Role.HUMAN` for the executable `adds_task` decision option and the direct `POST /api/v1/contracts/<id>/tasks` route (#3428)
 - `orchestrator/mcp_tools.py` — `answer_feedback` MCP tool (`_handle_answer_feedback`) for host-side answering of pre-proposal contract feedback
 - `orchestrator/routes/pipelines.py` — Phase gate resolution with JSON payload parsing
 - `sandbox/egg_lib/sdlc_hitl.py` — Type-aware terminal HITL handler

--- a/orchestrator/operator_actions.py
+++ b/orchestrator/operator_actions.py
@@ -240,6 +240,16 @@ def add_task_as_operator(
     slice number and ``N`` is one past the highest existing ``task-P-M``
     in that slice, all under the contract lock (no TOCTOU window).
 
+    An omitted ``role`` defaults to ``"coder"`` so the materialized task
+    is always *owned*: the per-producer ACK gate
+    (``contract_completeness.incomplete_tasks``) skips role-less rows, so
+    an unowned task would be invisible to every producer's ACK gate yet
+    still block the enforcer's CONFIRM with no owner to NACK — the same
+    operator-answered-but-still-wedged shape #3428 closes, moved one gate
+    downstream. Defaulting here (the single choke point for both the
+    decision executor and the direct REST route) keeps the loop closed
+    deterministically (#3428 review).
+
     Callers MUST sit behind an operator-authenticated surface
     (lifecycle secret); this function does no authentication itself.
 
@@ -250,6 +260,7 @@ def add_task_as_operator(
     description = (description or "").strip()
     if not description:
         raise OperatorActionError("description must be non-empty", status_code=400)
+    role = role or "coder"
 
     worktree = contract_store.resolve_pipeline_worktree(pipeline_id)
     if worktree is None:

--- a/orchestrator/operator_actions.py
+++ b/orchestrator/operator_actions.py
@@ -214,6 +214,198 @@ def _complete_task_locked(
     }
 
 
+def add_task_as_operator(
+    pipeline_id: str,
+    slice_id: str,
+    description: str,
+    *,
+    acceptance_criteria: str = "",
+    files_affected: list[str] | None = None,
+    role: str | None = None,
+    reason: str = "",
+    actor: str = "operator",
+    issue_number: int | None = None,
+) -> dict[str, Any]:
+    """Append a new task to a contract slice as an audited operator action (#3428).
+
+    The executor for HITL decision options that mandate a contract
+    mutation ("add a new task/slice to wire X as a dependency"): agents
+    have no task-add verb, so without this the resolution is recorded
+    and nothing materializes — the reviewer that raised the question
+    keeps withholding ACK and the slice re-deadlocks. Runs as
+    ``Role.HUMAN`` through ``apply_mutation`` so the audit log records
+    the actor and reason, mirroring :func:`complete_task_as_operator`.
+
+    The new task id is allocated as ``task-<P>-<N>`` where ``P`` is the
+    slice number and ``N`` is one past the highest existing ``task-P-M``
+    in that slice, all under the contract lock (no TOCTOU window).
+
+    Callers MUST sit behind an operator-authenticated surface
+    (lifecycle secret); this function does no authentication itself.
+
+    Raises :class:`OperatorActionError` with an HTTP-ish status code on
+    any failure (worktree/contract/slice not found, mutation rejected,
+    save failed).
+    """
+    description = (description or "").strip()
+    if not description:
+        raise OperatorActionError("description must be non-empty", status_code=400)
+
+    worktree = contract_store.resolve_pipeline_worktree(pipeline_id)
+    if worktree is None:
+        raise OperatorActionError(
+            f"No pipeline worktree found for {pipeline_id} (pipeline not "
+            f"set up on this host, or already cleaned up)",
+            status_code=404,
+        )
+
+    identifiers: list[int | str] = [pipeline_id]
+    if issue_number:
+        identifiers.append(issue_number)
+
+    last_error: str = "contract not found"
+    for identifier in identifiers:
+        with contract_store.lock_for(identifier):
+            try:
+                contract = load_contract(identifier, worktree)
+            except ContractNotFoundError:
+                continue
+            except Exception as exc:
+                last_error = str(exc)
+                continue
+
+            return _add_task_locked(
+                contract,
+                worktree,
+                identifier,
+                slice_id,
+                description,
+                acceptance_criteria=acceptance_criteria,
+                files_affected=files_affected or [],
+                role=role,
+                reason=reason,
+                actor=actor,
+            )
+
+    raise OperatorActionError(
+        f"Contract for {pipeline_id} not loadable ({last_error})",
+        status_code=404,
+    )
+
+
+def _add_task_locked(
+    contract: Any,
+    worktree: Path,
+    identifier: int | str,
+    slice_id: str,
+    description: str,
+    *,
+    acceptance_criteria: str,
+    files_affected: list[str],
+    role: str | None,
+    reason: str,
+    actor: str,
+) -> dict[str, Any]:
+    """Apply the task-add mutation. Caller holds the contract lock."""
+    import re
+
+    from egg_contracts import Task
+
+    slice_num_match = re.match(r"^(?:slice|phase)-([0-9]+)$", slice_id or "")
+    if slice_num_match is None:
+        raise OperatorActionError(
+            f"slice_id must match 'slice-<N>' (got {slice_id!r})",
+            status_code=400,
+        )
+    slice_num = slice_num_match.group(1)
+
+    located: tuple[int, Any] | None = None
+    for slice_idx, slice_obj in enumerate(contract.slices or []):
+        obj_match = re.match(r"^(?:slice|phase)-([0-9]+)$", getattr(slice_obj, "id", "") or "")
+        # Match on the slice number so canonical ``slice-N`` payloads find
+        # legacy ``phase-N`` contracts and vice versa.
+        if obj_match and obj_match.group(1) == slice_num:
+            located = (slice_idx, slice_obj)
+            break
+
+    if located is None:
+        raise OperatorActionError(
+            f"Slice {slice_id!r} not found on contract {identifier}",
+            status_code=404,
+        )
+    slice_idx, slice_obj = located
+
+    tasks = list(slice_obj.tasks or [])
+    max_n = 0
+    for task in tasks:
+        task_match = re.match(rf"^task-{slice_num}-([0-9]+)$", getattr(task, "id", "") or "")
+        if task_match:
+            max_n = max(max_n, int(task_match.group(1)))
+    task_id = f"task-{slice_num}-{max_n + 1}"
+
+    # Build a validated ``Task`` model (not a raw dict): ``_set_value``
+    # appends the value as-is, and downstream consumers
+    # (``Slice.tasks_all_complete``, the slice scheduler) attribute-access
+    # the entries.
+    try:
+        new_task = Task(
+            id=task_id,
+            description=description,
+            acceptance_criteria=acceptance_criteria,
+            files_affected=files_affected,
+            role=role,
+        )
+    except Exception as exc:
+        raise OperatorActionError(
+            f"Invalid task payload: {exc}",
+            status_code=400,
+        ) from exc
+
+    audit_reason = "Operator task add (#3428)"
+    if reason:
+        audit_reason = f"{audit_reason}: {reason}"
+
+    result = apply_mutation(
+        contract,
+        role=Role.HUMAN,
+        actor=actor,
+        field_path=f"phases.{slice_idx}.tasks.{len(tasks)}",
+        new_value=new_task,
+        reason=audit_reason,
+    )
+    if not result.success:
+        raise OperatorActionError(
+            f"Task-add mutation rejected: {result.message}",
+            status_code=400,
+        )
+
+    try:
+        save_contract(contract, worktree)
+    except Exception as exc:
+        raise OperatorActionError(
+            f"Failed to save contract: {exc}",
+            status_code=500,
+        ) from exc
+
+    logger.info(
+        "Operator appended contract task",
+        identifier=str(identifier),
+        task_id=task_id,
+        slice_id=getattr(slice_obj, "id", None),
+        role=role,
+        actor=actor,
+    )
+
+    return {
+        "task_id": task_id,
+        "slice_id": getattr(slice_obj, "id", None),
+        "description": description,
+        "role": role,
+        "status": "pending",
+        "actor": actor,
+    }
+
+
 def rewrite_task_description_as_operator(
     pipeline_id: str,
     new_task_description: str,

--- a/orchestrator/routes/contracts.py
+++ b/orchestrator/routes/contracts.py
@@ -552,6 +552,101 @@ def operator_complete_task(identifier: str, task_id: str) -> tuple[Response, int
     return _success(f"Task {task_id} marked complete by operator", data=result)
 
 
+@contracts_bp.route("/<identifier>/tasks", methods=["POST"])
+@require_lifecycle_secret
+def operator_add_task(identifier: str) -> tuple[Response, int]:
+    """Append a task to a contract slice as an audited operator action (#3428).
+
+    The in-band remediation for a contract that needs a task no agent can
+    add (agents have no task-add verb). Replaces hand-editing the live
+    contract JSON in the pipeline worktree. The HITL ``adds_task`` option
+    executor (``routes/decisions``) calls the same underlying operator
+    action; this route is the direct path for cases where no decision was
+    registered.
+
+    URL params:
+        identifier: Pipeline id (preferred) or issue number.
+
+    Request body::
+
+        {"slice_id": "slice-4",           # required
+         "description": "<task text>",    # required
+         "acceptance_criteria": "...",    # optional
+         "files_affected": ["a.py"],      # optional
+         "role": "coder",                 # optional (defaults to coder downstream)
+         "reason": "<why>"}               # optional
+
+    Auth: lifecycle-secret guarded — operator/host surface only; not
+    proxied by the gateway.
+    """
+    # Lazy import — same heavy-dependency seam as operator_complete_task.
+    from operator_actions import OperatorActionError, add_task_as_operator
+
+    ident = _coerce_identifier(identifier)
+    validation_error = _validate_identifier(ident)
+    if validation_error:
+        return validation_error
+
+    body = request.get_json(silent=True) or {}
+    if not isinstance(body, dict):
+        return _error("Request body must be a JSON object")
+
+    pipeline_id = body.get("pipeline_id") or (str(ident) if not isinstance(ident, int) else None)
+    if not pipeline_id:
+        return _error(
+            "Cannot resolve pipeline worktree: pass the pipeline id as the "
+            "URL identifier or in the request body as 'pipeline_id'",
+            status_code=400,
+        )
+
+    slice_id = body.get("slice_id")
+    description = body.get("description")
+    if not slice_id or not isinstance(slice_id, str):
+        return _error("Missing slice_id", status_code=400)
+    if not description or not isinstance(description, str):
+        return _error("Missing description", status_code=400)
+    files_affected = body.get("files_affected") or []
+    if not isinstance(files_affected, list) or not all(isinstance(f, str) for f in files_affected):
+        return _error("files_affected must be a list of strings", status_code=400)
+
+    # Same operator-namespace scoping rationale as operator_complete_task:
+    # a body-provided actor must not read in the audit log as an agent
+    # mutation.
+    actor_suffix = body.get("actor")
+    actor = f"operator:{actor_suffix}" if actor_suffix else "operator"
+
+    try:
+        result = add_task_as_operator(
+            pipeline_id,
+            slice_id,
+            description,
+            acceptance_criteria=body.get("acceptance_criteria") or "",
+            files_affected=files_affected,
+            role=body.get("role"),
+            reason=body.get("reason", ""),
+            actor=actor,
+            issue_number=ident if isinstance(ident, int) else None,
+        )
+    except OperatorActionError as exc:
+        return _error(exc.message, status_code=exc.status_code)
+
+    logger.info(
+        "Operator appended contract task",
+        extra={
+            "pipeline_id": pipeline_id,
+            "task_id": result.get("task_id"),
+            "slice_id": slice_id,
+            "actor": actor,
+            "source": getattr(request, "egg_source", "unknown"),
+        },
+    )
+
+    return _success(
+        f"Task {result.get('task_id')} added to {result.get('slice_id')} by operator",
+        data=result,
+    )
+
+
 @contract_mutations_bp.route("/validate", methods=["POST"])
 def validate_contract_mutation() -> tuple[Response, int]:
     """Dry-run a mutation and report whether it would be accepted.

--- a/orchestrator/routes/decisions/__init__.py
+++ b/orchestrator/routes/decisions/__init__.py
@@ -92,10 +92,13 @@ from ._handlers import (  # noqa: E402,F401
     _cancel_pipeline_in_process,
     _handle_conditional_ack_gate,
     _handle_restart_agent,
+    _load_contract_decision,
+    _maybe_add_task_from_resolution,
     _maybe_apply_first_principles_redirect,
     _maybe_complete_task_from_resolution,
     _normalize_choice_resolution,
     _read_first_principles_redirect,
+    _resolution_selects_option,
 )
 from ._resolve import (  # noqa: E402,F401
     _outstanding_contract_hitl,

--- a/orchestrator/routes/decisions/_handlers.py
+++ b/orchestrator/routes/decisions/_handlers.py
@@ -313,6 +313,192 @@ def _maybe_complete_task_from_resolution(
 
 
 # ---------------------------------------------------------------------------
+# Executable adds_task option (#3428)
+# ---------------------------------------------------------------------------
+#
+# ``register_open_question`` lets agents pose options that mandate a contract
+# mutation ("Add a new task/slice to wire X as a dependency"), but no agent
+# has a task-add verb — resolving such a decision used to record the choice
+# and materialize nothing, so the reviewer that raised the question kept
+# withholding ACK and the slice re-deadlocked *after* the human answered.
+# Options that mandate the mutation now carry a structured ``adds_task``
+# payload (``egg_contracts.models.AddsTaskPayload``, attached at registration
+# time); when the operator resolves the decision by selecting that option,
+# the hook below executes the mutation via
+# ``operator_actions.add_task_as_operator`` — same audited executor family
+# as the ``Mark task <id> complete`` option (#3124).
+
+# Bridge context fingerprint — must stay in sync with the composer in
+# ``_queue_and_await_contract_decisions`` (routes/pipelines.py) and the
+# post-gate guard in ``_resolve_contract_decision``.
+_BRIDGED_CQ_CONTEXT_RE = re.compile(r"^Open contract question (cq-[0-9]+),")
+
+
+def _resolution_selects_option(option: Any, resolution: str) -> bool:
+    """True when ``resolution`` unambiguously selects ``option``.
+
+    Operators resolve ``choice`` decisions with heterogeneous strings: the
+    bare option label (the SDLC HITL CLI envelope is unwrapped upstream by
+    ``_normalize_choice_resolution``), the option id (``opt-1``), or a
+    positional reference (``option 1`` / ``1``). All are unambiguous
+    identifiers of a single option; anything else (free-form prose) does not
+    select — an audited contract mutation must never fire on a fuzzy match.
+    """
+    normalized = (resolution or "").strip().casefold()
+    if not normalized:
+        return False
+    label = (getattr(option, "label", "") or "").strip().casefold()
+    if label and normalized == label:
+        return True
+    option_id = (getattr(option, "id", "") or "").strip().casefold()
+    if not option_id:
+        return False
+    if normalized == option_id:
+        return True
+    positional = re.match(r"^(?:opt(?:ion)?[\s-]*)?([0-9]+)$", normalized)
+    return bool(positional) and option_id == f"opt-{positional.group(1)}"
+
+
+def _load_contract_decision(pipeline_id: str, decision_id: str) -> Any | None:
+    """Load the contract decision ``decision_id`` (``cq-N``) for ``pipeline_id``.
+
+    Best-effort: returns ``None`` (and logs) when the worktree/contract can't
+    be loaded or no decision matches. Used by resolution-dispatch hooks on the
+    bridged queue path, where the pipeline ``HITLDecision`` carries only bare
+    option labels and the structured payload must be recovered from the
+    contract.
+    """
+    import contract_store
+
+    try:
+        from egg_contracts import load_contract
+        from routes.pipelines import _pipeline_identifier
+
+        store, _ = _pkg.get_state_store_for_pipeline(pipeline_id)
+        pipeline = store.load_pipeline(pipeline_id)
+        worktree = contract_store.resolve_pipeline_worktree(pipeline_id)
+        if worktree is None:
+            return None
+        identifier = _pipeline_identifier(getattr(pipeline, "issue_number", None), pipeline_id)
+        contract = load_contract(identifier, worktree)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Could not load contract to recover decision for resolution dispatch",
+            pipeline_id=pipeline_id,
+            decision_id=decision_id,
+            exc_info=True,
+        )
+        return None
+
+    return next(
+        (d for d in (getattr(contract, "decisions", None) or []) if d.id == decision_id),
+        None,
+    )
+
+
+def _maybe_add_task_from_resolution(
+    pipeline_id: str,
+    decision: Any,
+    resolution: str | None,
+) -> dict[str, Any] | None:
+    """Execute an ``adds_task``-carrying option resolution (#3428).
+
+    ``decision`` is either the contract ``Decision`` (the pre-bridge
+    ``_resolve_contract_decision`` path — its ``options`` carry the
+    structured payload directly) or the pipeline ``HITLDecision`` (the
+    bridged queue path — options are bare labels, so the contract decision
+    is recovered via the bridge's context fingerprint).
+
+    Returns the executed-action payload (merged into the resolve response so
+    the operator sees the materialization happened), or ``None`` when the
+    resolution does not select an ``adds_task`` option. Execution failure is
+    logged AND surfaced in the returned payload — the decision is already
+    marked resolved by the time dispatch runs, so a silent failure here would
+    recreate the records-a-choice-but-executes-nothing gap this hook closes.
+    """
+    if not resolution:
+        return None
+
+    options = list(getattr(decision, "options", None) or [])
+    decision_id = getattr(decision, "id", "?")
+    if not any(getattr(o, "adds_task", None) for o in options):
+        # Bridged queue path (or a decision with no structured payload):
+        # recover the contract decision named in the bridge context. Bail
+        # early when the context carries no fingerprint — that covers every
+        # ordinary queue decision without a contract round-trip.
+        context = getattr(decision, "context", "") or ""
+        match = _BRIDGED_CQ_CONTEXT_RE.match(context)
+        if not match:
+            return None
+        contract_decision = _load_contract_decision(pipeline_id, match.group(1))
+        if contract_decision is None:
+            return None
+        options = list(contract_decision.options or [])
+        if not any(getattr(o, "adds_task", None) for o in options):
+            return None
+
+    selected = next((o for o in options if _resolution_selects_option(o, resolution)), None)
+    payload = getattr(selected, "adds_task", None) if selected is not None else None
+    if payload is None:
+        return None
+
+    from operator_actions import OperatorActionError, add_task_as_operator
+
+    try:
+        result = add_task_as_operator(
+            pipeline_id,
+            payload.slice_id,
+            payload.description,
+            acceptance_criteria=payload.acceptance_criteria,
+            files_affected=list(payload.files_affected or []),
+            role=payload.role,
+            reason=(
+                f"HITL decision {decision_id} resolved with adds_task option "
+                f"{getattr(selected, 'id', '?')}"
+            ),
+            actor=f"operator:decision:{decision_id}",
+        )
+    except OperatorActionError as exc:
+        logger.error(
+            "adds_task resolution failed; mandated task was NOT materialized",
+            pipeline_id=pipeline_id,
+            decision_id=decision_id,
+            slice_id=payload.slice_id,
+            error=exc.message,
+        )
+        return {
+            "action": "add_task",
+            "slice_id": payload.slice_id,
+            "success": False,
+            "error": exc.message,
+        }
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.error(
+            "adds_task resolution raised unexpectedly",
+            pipeline_id=pipeline_id,
+            decision_id=decision_id,
+            slice_id=payload.slice_id,
+            error=str(exc),
+            exc_info=True,
+        )
+        return {
+            "action": "add_task",
+            "slice_id": payload.slice_id,
+            "success": False,
+            "error": str(exc),
+        }
+
+    logger.info(
+        "Executed adds_task materialization from decision resolution",
+        pipeline_id=pipeline_id,
+        decision_id=decision_id,
+        task_id=result.get("task_id"),
+        slice_id=result.get("slice_id"),
+    )
+    return {"action": "add_task", "success": True, **result}
+
+
+# ---------------------------------------------------------------------------
 # First-principles redirect accept-path
 # ---------------------------------------------------------------------------
 #

--- a/orchestrator/routes/decisions/_resolve.py
+++ b/orchestrator/routes/decisions/_resolve.py
@@ -174,6 +174,13 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
             pipeline_id, decision_id, dispatch_resolution
         )
 
+        # Executable adds_task option (#3428): an option registered with a
+        # structured contract mutation ("add a task/slice") materializes it
+        # on resolve instead of recording an inert choice.
+        executed_action = executed_action or _pkg._maybe_add_task_from_resolution(
+            pipeline_id, decision, dispatch_resolution
+        )
+
         # #3233: if the orchestrator restarted while this pipeline was parked
         # AWAITING_HUMAN, the in-memory _run_pipeline driver that polls
         # wait_for_decision is gone — this resolution would otherwise be
@@ -514,6 +521,15 @@ def _resolve_contract_decision(
     # pre-bridge also executes instead of only recording the choice.
     executed_action = first_principles_action or _pkg._maybe_complete_task_from_resolution(
         pipeline_id, decision_id, normalized_resolution
+    )
+
+    # Executable adds_task option (#3428) — same dispatch as the queue
+    # path. This is the PRIMARY trigger: adds_task questions are typically
+    # registered mid-implement by a blocked producer/reviewer pair, so the
+    # operator resolves them here (pre-bridge) and the mandated task must
+    # materialize before the next contract poll.
+    executed_action = executed_action or _pkg._maybe_add_task_from_resolution(
+        pipeline_id, decision, normalized_resolution
     )
 
     return make_success_response(

--- a/orchestrator/tests/test_adds_task_resolution.py
+++ b/orchestrator/tests/test_adds_task_resolution.py
@@ -1,0 +1,510 @@
+"""Tests for the executable ``adds_task`` decision option (#3428).
+
+A ``register_open_question`` option that mandates a contract mutation
+("Add a new task/slice to wire X as a dependency") used to be silently
+inert: agents have no task-add verb, so resolving the decision recorded
+the choice and materialized nothing — the reviewer that raised the
+question kept withholding ACK and the slice re-deadlocked *after* the
+human answered. Options now carry a structured ``adds_task`` payload
+(attached at registration time) that the orchestrator executes on
+resolve.
+
+Covers:
+
+* ``operator_actions.add_task_as_operator`` — the audited ``Role.HUMAN``
+  executor: id allocation, persistence, audit trail, and failure modes.
+* ``routes.decisions._resolution_selects_option`` — the unambiguous
+  option-selection matcher the dispatch keys on.
+* ``routes.decisions._maybe_add_task_from_resolution`` — the resolution
+  dispatch hook, on both the contract-``Decision`` path and the bridged
+  queue path (contract recovery via the bridge context fingerprint).
+* The resolve endpoint end-to-end: resolving a contract ``cq-N`` whose
+  selected option carries ``adds_task`` materializes the task on disk
+  and surfaces ``executed_action`` in the response.
+* The lifecycle-guarded ``POST /api/v1/contracts/<id>/tasks`` operator
+  route — the direct path that replaces hand-editing the contract JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mirror the docker/k8s mocking the other orchestrator tests rely on so
+# lazy imports inside the handlers do not require a real docker SDK.
+_docker_mock = MagicMock()
+sys.modules.setdefault("docker", _docker_mock)
+sys.modules.setdefault("docker.errors", _docker_mock.errors)
+sys.modules.setdefault("docker.types", _docker_mock.types)
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+PIPELINE_ID = "pid-3428"
+
+
+def _contract_dict(*, slice_id: str = "slice-1", task_ids: list[str] | None = None) -> dict:
+    tasks = [
+        {
+            "id": tid,
+            "description": f"existing work {tid}",
+            "role": "coder",
+            "status": "pending",
+        }
+        for tid in (task_ids if task_ids is not None else ["task-1-1"])
+    ]
+    return {
+        "schemaVersion": "1.0",
+        "pipeline_id": PIPELINE_ID,
+        "issue": {"number": 42, "title": "adds_task test", "url": "http://example"},
+        "phases": [{"id": slice_id, "name": "only", "tasks": tasks}],
+    }
+
+
+@pytest.fixture
+def contract_worktree(tmp_path: Path) -> Path:
+    contracts_dir = tmp_path / ".egg-state" / "contracts"
+    contracts_dir.mkdir(parents=True)
+    (contracts_dir / f"{PIPELINE_ID}.json").write_text(json.dumps(_contract_dict()))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# operator_actions.add_task_as_operator
+# ---------------------------------------------------------------------------
+
+
+class TestAddTaskAsOperator:
+    def test_appends_validated_pending_task(self, contract_worktree: Path):
+        from egg_contracts import load_contract
+        from operator_actions import add_task_as_operator
+
+        with patch("contract_store.resolve_pipeline_worktree", return_value=contract_worktree):
+            result = add_task_as_operator(
+                PIPELINE_ID,
+                "slice-1",
+                "Wire secondary-repo worktree creation as a dependency",
+                acceptance_criteria="Worktree exists before slice-4 starts",
+                files_affected=["orchestrator/worktrees.py"],
+                role="coder",
+                reason="cq-4 opt-1 materialization",
+                actor="operator:test",
+            )
+
+        assert result["task_id"] == "task-1-2"
+        assert result["slice_id"] == "slice-1"
+        assert result["status"] == "pending"
+
+        contract = load_contract(PIPELINE_ID, contract_worktree)
+        task = contract.slices[0].tasks[-1]
+        assert task.id == "task-1-2"
+        assert task.description.startswith("Wire secondary-repo")
+        assert task.acceptance_criteria == "Worktree exists before slice-4 starts"
+        assert task.files_affected == ["orchestrator/worktrees.py"]
+        assert task.role == "coder"
+        assert str(task.status) == "pending"
+        # Audited as the operator, not an agent role.
+        audit_actors = {e.actor for e in contract.audit_log}
+        assert "operator:test" in audit_actors
+
+    def test_id_allocation_continues_past_highest_existing(self, tmp_path: Path):
+        from egg_contracts import load_contract
+        from operator_actions import add_task_as_operator
+
+        contracts_dir = tmp_path / ".egg-state" / "contracts"
+        contracts_dir.mkdir(parents=True)
+        (contracts_dir / f"{PIPELINE_ID}.json").write_text(
+            json.dumps(_contract_dict(task_ids=["task-1-1", "task-1-5"]))
+        )
+
+        with patch("contract_store.resolve_pipeline_worktree", return_value=tmp_path):
+            result = add_task_as_operator(PIPELINE_ID, "slice-1", "new work")
+
+        assert result["task_id"] == "task-1-6"
+        contract = load_contract(PIPELINE_ID, tmp_path)
+        assert [t.id for t in contract.slices[0].tasks] == ["task-1-1", "task-1-5", "task-1-6"]
+
+    def test_slice_id_matches_legacy_phase_prefix(self, tmp_path: Path):
+        from operator_actions import add_task_as_operator
+
+        contracts_dir = tmp_path / ".egg-state" / "contracts"
+        contracts_dir.mkdir(parents=True)
+        (contracts_dir / f"{PIPELINE_ID}.json").write_text(
+            json.dumps(_contract_dict(slice_id="phase-1"))
+        )
+
+        with patch("contract_store.resolve_pipeline_worktree", return_value=tmp_path):
+            result = add_task_as_operator(PIPELINE_ID, "slice-1", "new work")
+
+        assert result["task_id"] == "task-1-2"
+
+    def test_unknown_slice_raises_404(self, contract_worktree: Path):
+        from operator_actions import OperatorActionError, add_task_as_operator
+
+        with (
+            patch("contract_store.resolve_pipeline_worktree", return_value=contract_worktree),
+            pytest.raises(OperatorActionError) as exc_info,
+        ):
+            add_task_as_operator(PIPELINE_ID, "slice-9", "new work")
+        assert exc_info.value.status_code == 404
+
+    def test_missing_worktree_raises_404(self):
+        from operator_actions import OperatorActionError, add_task_as_operator
+
+        with (
+            patch("contract_store.resolve_pipeline_worktree", return_value=None),
+            pytest.raises(OperatorActionError) as exc_info,
+        ):
+            add_task_as_operator("pid-gone", "slice-1", "new work")
+        assert exc_info.value.status_code == 404
+
+    def test_empty_description_raises_400(self, contract_worktree: Path):
+        from operator_actions import OperatorActionError, add_task_as_operator
+
+        with (
+            patch("contract_store.resolve_pipeline_worktree", return_value=contract_worktree),
+            pytest.raises(OperatorActionError) as exc_info,
+        ):
+            add_task_as_operator(PIPELINE_ID, "slice-1", "   ")
+        assert exc_info.value.status_code == 400
+
+    def test_malformed_slice_id_raises_400(self, contract_worktree: Path):
+        from operator_actions import OperatorActionError, add_task_as_operator
+
+        with (
+            patch("contract_store.resolve_pipeline_worktree", return_value=contract_worktree),
+            pytest.raises(OperatorActionError) as exc_info,
+        ):
+            add_task_as_operator(PIPELINE_ID, "slice-one", "new work")
+        assert exc_info.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# routes.decisions._resolution_selects_option
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionSelectsOption:
+    def _option(self, opt_id: str = "opt-2", label: str = "Add a new task to slice-4"):
+        return SimpleNamespace(id=opt_id, label=label)
+
+    @pytest.mark.parametrize(
+        "resolution",
+        [
+            "Add a new task to slice-4",
+            "  add a NEW task to slice-4  ",
+            "opt-2",
+            "OPT-2",
+            "option 2",
+            "Option 2",
+            "2",
+        ],
+    )
+    def test_unambiguous_selections_match(self, resolution: str):
+        from routes.decisions import _resolution_selects_option
+
+        assert _resolution_selects_option(self._option(), resolution) is True
+
+    @pytest.mark.parametrize(
+        "resolution",
+        [
+            "",
+            "opt-1",
+            "1",
+            "option 12",
+            "Yes, please add a new task to slice-4 when convenient",
+            "Add a new task",
+        ],
+    )
+    def test_non_selections_do_not_match(self, resolution: str):
+        from routes.decisions import _resolution_selects_option
+
+        assert _resolution_selects_option(self._option(), resolution) is False
+
+
+# ---------------------------------------------------------------------------
+# routes.decisions._maybe_add_task_from_resolution
+# ---------------------------------------------------------------------------
+
+
+def _contract_decision(*, with_payload: bool = True):
+    from egg_contracts.models import (
+        AddsTaskPayload,
+        Decision,
+        DecisionOption,
+        DecisionType,
+        PipelinePhase,
+    )
+
+    payload = (
+        AddsTaskPayload(
+            slice_id="slice-1",
+            description="Wire the dependency",
+            acceptance_criteria="It works",
+            files_affected=["a.py"],
+            role="coder",
+        )
+        if with_payload
+        else None
+    )
+    return Decision(
+        id="cq-4",
+        question="Slice-4 needs the secondary-repo worktree wired. How should we proceed?",
+        type=DecisionType.HITL,
+        phase=PipelinePhase.IMPLEMENT,
+        options=[
+            DecisionOption(
+                id="opt-1",
+                label="Add a new task to wire the dependency",
+                adds_task=payload,
+            ),
+            DecisionOption(id="opt-2", label="Defer to a follow-up pipeline"),
+        ],
+    )
+
+
+class TestMaybeAddTaskFromResolution:
+    def _dispatch(self, decision, resolution, **patch_kwargs):
+        from routes.decisions import _maybe_add_task_from_resolution
+
+        with patch("operator_actions.add_task_as_operator", **patch_kwargs) as add_mock:
+            result = _maybe_add_task_from_resolution(PIPELINE_ID, decision, resolution)
+        return result, add_mock
+
+    def test_selected_payload_option_executes(self):
+        result, add_mock = self._dispatch(
+            _contract_decision(),
+            "Add a new task to wire the dependency",
+            return_value={"task_id": "task-1-2", "slice_id": "slice-1", "status": "pending"},
+        )
+        assert result["success"] is True
+        assert result["action"] == "add_task"
+        assert result["task_id"] == "task-1-2"
+        add_mock.assert_called_once()
+        args, kwargs = add_mock.call_args
+        assert args == (PIPELINE_ID, "slice-1", "Wire the dependency")
+        assert kwargs["role"] == "coder"
+        assert kwargs["actor"] == "operator:decision:cq-4"
+
+    def test_option_id_selection_executes(self):
+        result, add_mock = self._dispatch(
+            _contract_decision(),
+            "opt-1",
+            return_value={"task_id": "task-1-2", "slice_id": "slice-1"},
+        )
+        assert result["success"] is True
+        add_mock.assert_called_once()
+
+    def test_selecting_payload_free_option_is_inert(self):
+        result, add_mock = self._dispatch(_contract_decision(), "Defer to a follow-up pipeline")
+        assert result is None
+        add_mock.assert_not_called()
+
+    def test_decision_without_payload_is_inert(self):
+        result, add_mock = self._dispatch(
+            _contract_decision(with_payload=False),
+            "Add a new task to wire the dependency",
+        )
+        assert result is None
+        add_mock.assert_not_called()
+
+    def test_free_form_prose_does_not_execute(self):
+        result, add_mock = self._dispatch(
+            _contract_decision(),
+            "I think we should add a new task to wire the dependency eventually",
+        )
+        assert result is None
+        add_mock.assert_not_called()
+
+    def test_execution_failure_is_surfaced_not_silent(self):
+        from operator_actions import OperatorActionError
+
+        result, _ = self._dispatch(
+            _contract_decision(),
+            "opt-1",
+            side_effect=OperatorActionError("slice gone", status_code=404),
+        )
+        assert result["success"] is False
+        assert "slice gone" in result["error"]
+        assert result["slice_id"] == "slice-1"
+
+    def test_bridged_queue_decision_recovers_contract_payload(self):
+        # The bridged HITLDecision carries bare option labels; the hook
+        # must recover the contract decision via the bridge's context
+        # fingerprint and execute against its structured payload.
+        queue_decision = SimpleNamespace(
+            id="decision-7",
+            context="Open contract question cq-4, registered by an agent during the implement phase.",
+            options=[
+                "Add a new task to wire the dependency",
+                "Defer to a follow-up pipeline",
+            ],
+        )
+        with patch(
+            "routes.decisions._handlers._load_contract_decision",
+            return_value=_contract_decision(),
+        ) as load_mock:
+            result, add_mock = self._dispatch(
+                queue_decision,
+                "Add a new task to wire the dependency",
+                return_value={"task_id": "task-1-2", "slice_id": "slice-1"},
+            )
+        load_mock.assert_called_once_with(PIPELINE_ID, "cq-4")
+        assert result["success"] is True
+        add_mock.assert_called_once()
+
+    def test_queue_decision_without_bridge_fingerprint_is_inert(self):
+        queue_decision = SimpleNamespace(
+            id="decision-8",
+            context="Agent coder issue: something unrelated",
+            options=["Restart agent", "Ignore"],
+        )
+        with patch("routes.decisions._handlers._load_contract_decision") as load_mock:
+            result, add_mock = self._dispatch(queue_decision, "Restart agent")
+        load_mock.assert_not_called()
+        assert result is None
+        add_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: resolve a contract cq-N whose option carries adds_task
+# ---------------------------------------------------------------------------
+
+
+class TestResolveContractDecisionMaterializesTask:
+    @pytest.fixture
+    def client(self):
+        from flask import Flask
+        from routes.decisions import decisions_bp
+
+        app = Flask(__name__)
+        app.register_blueprint(decisions_bp)
+        app.config["TESTING"] = True
+        return app.test_client()
+
+    def _write_contract(self, worktree: Path):
+        from egg_contracts import Contract, save_contract
+        from egg_contracts.models import PipelinePhase, Slice, Task
+
+        contract = Contract(pipeline_id=PIPELINE_ID, current_phase=PipelinePhase.IMPLEMENT)
+        contract.slices = [
+            Slice(
+                id="slice-1",
+                name="only",
+                tasks=[Task(id="task-1-1", description="existing work", role="coder")],
+            )
+        ]
+        contract.decisions = [_contract_decision()]
+        save_contract(contract, worktree)
+
+    def test_resolution_materializes_task_and_reports_executed_action(self, client, tmp_path: Path):
+        from decision_queue import DecisionNotFoundError
+        from egg_contracts import load_contract
+
+        self._write_contract(tmp_path)
+
+        store_mock = MagicMock(repo_path=tmp_path)
+        pipeline_mock = MagicMock(issue_number=None)
+        queue_mock = MagicMock()
+        queue_mock.resolve_decision.side_effect = DecisionNotFoundError("not in queue")
+        queue_mock.get_pending_decisions.return_value = []
+
+        with (
+            patch(
+                "routes.decisions.get_state_store_for_pipeline",
+                return_value=(store_mock, pipeline_mock),
+            ),
+            patch("routes.decisions.get_decision_queue", return_value=queue_mock),
+            patch("contract_store.resolve_pipeline_worktree", return_value=tmp_path),
+        ):
+            resp = client.post(
+                f"/api/v1/pipelines/{PIPELINE_ID}/decisions/cq-4/resolve",
+                json={"resolution": "Add a new task to wire the dependency"},
+            )
+
+        assert resp.status_code == 200, resp.data
+        payload = resp.get_json()
+        executed = payload["data"]["executed_action"]
+        assert executed["action"] == "add_task"
+        assert executed["success"] is True
+        assert executed["task_id"] == "task-1-2"
+
+        contract = load_contract(PIPELINE_ID, tmp_path)
+        # The mandated task is materialized — the precondition the blocked
+        # reviewer stated is now satisfiable on the next contract poll.
+        assert [t.id for t in contract.slices[0].tasks] == ["task-1-1", "task-1-2"]
+        assert contract.slices[0].tasks[1].description == "Wire the dependency"
+        decision = contract.decisions[0]
+        assert decision.resolved is True
+        assert decision.resolved_by == "human"
+
+
+# ---------------------------------------------------------------------------
+# Operator REST route: POST /api/v1/contracts/<id>/tasks
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorAddTaskRoute:
+    @pytest.fixture
+    def route_client(self, monkeypatch):
+        from flask import Flask
+        from routes.contracts import contracts_bp
+
+        monkeypatch.setenv("EGG_LIFECYCLE_SECRET", "test-secret")
+        app = Flask(__name__)
+        app.register_blueprint(contracts_bp)
+        app.config["TESTING"] = True
+        return app.test_client()
+
+    def test_route_requires_lifecycle_secret(self, route_client):
+        resp = route_client.post(f"/api/v1/contracts/{PIPELINE_ID}/tasks")
+        assert resp.status_code == 401
+
+    def test_route_appends_task(self, route_client, contract_worktree: Path):
+        with patch("contract_store.resolve_pipeline_worktree", return_value=contract_worktree):
+            resp = route_client.post(
+                f"/api/v1/contracts/{PIPELINE_ID}/tasks",
+                headers={"Authorization": "Bearer test-secret"},
+                data=json.dumps(
+                    {
+                        "slice_id": "slice-1",
+                        "description": "Wire the dependency",
+                        "reason": "manual remediation",
+                    }
+                ),
+                content_type="application/json",
+            )
+        assert resp.status_code == 200, resp.data
+        data = json.loads(resp.data)
+        assert data["data"]["task_id"] == "task-1-2"
+        assert data["data"]["status"] == "pending"
+
+    def test_route_rejects_missing_fields(self, route_client):
+        resp = route_client.post(
+            f"/api/v1/contracts/{PIPELINE_ID}/tasks",
+            headers={"Authorization": "Bearer test-secret"},
+            data=json.dumps({"description": "no slice"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_route_scopes_body_actor_under_operator_namespace(self, route_client):
+        with patch("operator_actions.add_task_as_operator") as add_mock:
+            add_mock.return_value = {"task_id": "task-1-2", "slice_id": "slice-1"}
+            route_client.post(
+                f"/api/v1/contracts/{PIPELINE_ID}/tasks",
+                headers={"Authorization": "Bearer test-secret"},
+                data=json.dumps({"slice_id": "slice-1", "description": "x", "actor": "coder"}),
+                content_type="application/json",
+            )
+        assert add_mock.call_args[1]["actor"] == "operator:coder"

--- a/orchestrator/tests/test_adds_task_resolution.py
+++ b/orchestrator/tests/test_adds_task_resolution.py
@@ -134,6 +134,21 @@ class TestAddTaskAsOperator:
         contract = load_contract(PIPELINE_ID, tmp_path)
         assert [t.id for t in contract.slices[0].tasks] == ["task-1-1", "task-1-5", "task-1-6"]
 
+    def test_omitted_role_defaults_to_coder(self, contract_worktree: Path):
+        # A role-less task would be invisible to the per-producer ACK gate yet
+        # still block the enforcer's CONFIRM with no owner to NACK — the wedge
+        # #3428 closes, moved one gate downstream. The executor defaults the
+        # materialized task's role to ``coder`` so it is always owned.
+        from egg_contracts import load_contract
+        from operator_actions import add_task_as_operator
+
+        with patch("contract_store.resolve_pipeline_worktree", return_value=contract_worktree):
+            result = add_task_as_operator(PIPELINE_ID, "slice-1", "new work")
+
+        assert result["role"] == "coder"
+        contract = load_contract(PIPELINE_ID, contract_worktree)
+        assert contract.slices[0].tasks[-1].role == "coder"
+
     def test_slice_id_matches_legacy_phase_prefix(self, tmp_path: Path):
         from operator_actions import add_task_as_operator
 

--- a/sandbox/egg_agent_tools/handlers/sdlc.py
+++ b/sandbox/egg_agent_tools/handlers/sdlc.py
@@ -226,6 +226,24 @@ def register_open_question(req: dict[str, Any]) -> dict[str, Any]:
                     "seed (the operator adopts the originally-registered redirect)",
                     duplicate.get("id"),
                 )
+            # Same silent-loss risk for a differing ``adds_task``: the dedup key
+            # excludes it, so a re-registration that carries a new/changed
+            # executable payload would materialize nothing — the resolution
+            # fires against the stored decision's payload. Warn so that loss is
+            # not invisible (#3428 review), matching the option/seed warnings.
+            new_adds_tasks = [o.get("adds_task") for o in opt_objs]
+            existing_adds_tasks = [
+                o.get("adds_task") for o in (duplicate.get("options") or []) if isinstance(o, dict)
+            ]
+            if adds_task is not None and new_adds_tasks != existing_adds_tasks:
+                _logger.warning(
+                    "register_open_question deduped onto %s but the re-registration's "
+                    "adds_task payload differs from the stored one; keeping the stored "
+                    "payload (new=%r, stored=%r)",
+                    duplicate.get("id"),
+                    new_adds_tasks,
+                    existing_adds_tasks,
+                )
             return {
                 "ok": True,
                 "id": duplicate.get("id"),

--- a/sandbox/egg_agent_tools/handlers/sdlc.py
+++ b/sandbox/egg_agent_tools/handlers/sdlc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from egg_contracts.decisions import (
@@ -61,6 +62,60 @@ def _fetch_contract(identifier: int | str, repo_path: str | None) -> dict[str, A
     return result.get("data") or {}
 
 
+_SLICE_ID_RE = re.compile(r"^(?:slice|phase)-[0-9]+$")
+
+
+def _validate_adds_task(raw: Any, options: list[Any]) -> tuple[int, dict[str, Any]] | None:
+    """Validate the ``adds_task`` request payload (#3428).
+
+    Returns ``(1-based option index, payload dict ready to store on the
+    option)`` or ``None`` when no payload was supplied. The payload shape
+    mirrors ``egg_contracts.models.AddsTaskPayload``; validating here gives
+    the registering agent a clear ``HandlerError`` instead of a gateway-side
+    pydantic rejection on the mutate call.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise HandlerError("'adds_task' must be an object when provided")
+    if not options:
+        raise HandlerError("'adds_task' requires 'options' (it attaches to one of them)")
+
+    option = raw.get("option")
+    if not isinstance(option, int) or isinstance(option, bool) or not (1 <= option <= len(options)):
+        raise HandlerError(
+            f"'adds_task.option' must be a 1-based index into 'options' "
+            f"(1..{len(options)}); got {option!r}. It cannot reference the "
+            f"auto-appended 'Other' option."
+        )
+
+    slice_id = raw.get("slice_id")
+    if not isinstance(slice_id, str) or not _SLICE_ID_RE.match(slice_id):
+        raise HandlerError(f"'adds_task.slice_id' must match 'slice-<N>' (got {slice_id!r})")
+    description = raw.get("description")
+    if not description or not isinstance(description, str):
+        raise HandlerError("'adds_task.description' is required")
+
+    acceptance_criteria = raw.get("acceptance_criteria") or ""
+    if not isinstance(acceptance_criteria, str):
+        raise HandlerError("'adds_task.acceptance_criteria' must be a string")
+    files_affected = raw.get("files_affected") or []
+    if not isinstance(files_affected, list) or not all(isinstance(f, str) for f in files_affected):
+        raise HandlerError("'adds_task.files_affected' must be a list of strings")
+    role = raw.get("role")
+    if role is not None and (not isinstance(role, str) or not role):
+        raise HandlerError("'adds_task.role' must be a non-empty string when provided")
+
+    payload: dict[str, Any] = {
+        "slice_id": slice_id,
+        "description": description,
+        "acceptance_criteria": acceptance_criteria,
+        "files_affected": files_affected,
+        "role": role,
+    }
+    return option, payload
+
+
 def register_open_question(req: dict[str, Any]) -> dict[str, Any]:
     """Create a HITL decision point on the contract.
 
@@ -77,6 +132,15 @@ def register_open_question(req: dict[str, Any]) -> dict[str, Any]:
             contract-mutate RPC that creates the decision), because a BRC
             reviewer has no commit/push path to carry a free-standing
             agent-worktree file into the shared pipeline worktree.
+        adds_task (dict): optional. Structured contract mutation one of the
+            options mandates (#3428): ``{option: <1-based index into
+            options>, slice_id, description, acceptance_criteria?,
+            files_affected?, role?}``. Stored on that option; when the
+            operator resolves the decision by selecting it, the orchestrator
+            appends the described task to ``slice_id`` as an audited
+            operator action. Without this payload an "add a task" option is
+            inert — no agent has a task-add verb, so the resolution records
+            a choice and materializes nothing.
         repo_path (str): optional override for repo path.
         pipeline_id / issue: optional contract identifier.
 
@@ -97,6 +161,7 @@ def register_open_question(req: dict[str, Any]) -> dict[str, Any]:
     redirect_seed = req.get("redirect_seed")
     if redirect_seed is not None and not isinstance(redirect_seed, str):
         raise HandlerError("'redirect_seed' must be a string when provided")
+    adds_task = _validate_adds_task(req.get("adds_task"), options)
     repo_path = req.get("repo_path") or get_repo_path()
 
     identifier = _resolve_identifier(req)
@@ -112,6 +177,9 @@ def register_open_question(req: dict[str, Any]) -> dict[str, Any]:
                 "description": None,
             }
         )
+        if adds_task is not None:
+            option_idx, payload = adds_task
+            opt_objs[option_idx - 1]["adds_task"] = payload
 
     # TOCTOU hardening: two concurrent agents creating decisions may
     # both observe ``len(decisions) == N`` and race on ``decisions.N``.

--- a/sandbox/egg_agent_tools/tools/sdlc.py
+++ b/sandbox/egg_agent_tools/tools/sdlc.py
@@ -34,6 +34,43 @@ _REGISTER_SCHEMA: dict[str, Any] = {
                 "the orchestrator can read it back without a worktree file."
             ),
         },
+        "adds_task": {
+            "type": "object",
+            "description": (
+                "Structured contract mutation one of the options mandates "
+                "(#3428). REQUIRED when an option means 'add a task/slice': "
+                "no agent has a task-add verb, so without this payload the "
+                "resolution records a choice and materializes nothing — the "
+                "blocked slice re-deadlocks. When the operator selects the "
+                "referenced option, the orchestrator appends the described "
+                "task to slice_id as an audited operator action."
+            ),
+            "properties": {
+                "option": {
+                    "type": "integer",
+                    "description": "1-based index into 'options' of the option that mandates the task",
+                },
+                "slice_id": {
+                    "type": "string",
+                    "description": "Slice the new task is appended to (e.g. 'slice-4')",
+                },
+                "description": {"type": "string", "description": "New task description"},
+                "acceptance_criteria": {
+                    "type": "string",
+                    "description": "Acceptance criteria for the new task",
+                },
+                "files_affected": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Files the new task is expected to touch",
+                },
+                "role": {
+                    "type": "string",
+                    "description": "Producer role for the task (defaults to coder)",
+                },
+            },
+            "required": ["option", "slice_id", "description"],
+        },
         "issue": {"type": "integer", "description": "Optional issue-number override"},
         "pipeline_id": {
             "type": "string",

--- a/shared/egg_contracts/__init__.py
+++ b/shared/egg_contracts/__init__.py
@@ -151,6 +151,7 @@ from .loader import (
 )
 from .models import (
     AcceptanceCriterion,
+    AddsTaskPayload,
     AgentExecutionModel,
     AgentExecutionStatus,
     AgentRoleType,
@@ -250,6 +251,7 @@ from .validator import (
 __all__ = [
     # Models
     "AcceptanceCriterion",
+    "AddsTaskPayload",
     "AgentExecutionModel",
     "AgentExecutionStatus",
     "AgentRoleType",

--- a/shared/egg_contracts/models.py
+++ b/shared/egg_contracts/models.py
@@ -463,12 +463,56 @@ class Slice(EggContractBaseModel):
 Phase = Slice
 
 
+class AddsTaskPayload(EggContractBaseModel):
+    """Structured contract mutation a decision option mandates (#3428).
+
+    A ``register_open_question`` option like "Add a new task/slice to wire
+    X as a dependency" used to be silently inert: agents have no task-add
+    verb, so resolving the decision recorded the choice and materialized
+    nothing — the blocked reviewer kept withholding ACK and the slice
+    re-deadlocked. An option carrying this payload is instead **executed**
+    by the orchestrator when the operator selects it: the described task is
+    appended to the named slice as an audited ``Role.HUMAN`` mutation
+    (``operator_actions.add_task_as_operator``), same executor family as
+    the ``Mark task <id> complete`` option (#3124).
+    """
+
+    slice_id: str = Field(
+        ...,
+        pattern=r"^(?:slice|phase)-[0-9]+$",
+        description="Slice the new task is appended to (must exist at resolve time)",
+    )
+    description: str = Field(..., min_length=1, description="Task description")
+    acceptance_criteria: str = Field(default="", description="Acceptance criteria for the new task")
+    files_affected: list[str] = Field(
+        default_factory=list, description="Files the new task is expected to touch"
+    )
+    role: str | None = Field(
+        default=None,
+        description=(
+            "Producer role for the new task (coder/tester/documenter). "
+            "``None`` assigns the default producer (coder) — same fallback "
+            "as ``Task.role``."
+        ),
+    )
+
+
 class DecisionOption(EggContractBaseModel):
     """An option for a decision."""
 
     id: str = Field(..., description="Option identifier")
     label: str = Field(..., description="Option label")
     description: str | None = Field(default=None, description="Option description")
+    adds_task: AddsTaskPayload | None = Field(
+        default=None,
+        description=(
+            "Contract mutation this option mandates (#3428). When the operator "
+            "resolves the decision with this option, the orchestrator appends "
+            "the described task to ``slice_id`` as an audited operator action "
+            "instead of leaving the resolution inert. ``None`` for options "
+            "that only gate agent behavior."
+        ),
+    )
 
 
 class Decision(EggContractBaseModel):

--- a/shared/egg_contracts/models.py
+++ b/shared/egg_contracts/models.py
@@ -491,8 +491,13 @@ class AddsTaskPayload(EggContractBaseModel):
         default=None,
         description=(
             "Producer role for the new task (coder/tester/documenter). "
-            "``None`` assigns the default producer (coder) — same fallback "
-            "as ``Task.role``."
+            "``None`` is defaulted to ``coder`` by "
+            "``operator_actions.add_task_as_operator`` when the task is "
+            "materialized, so the row is always owned (a role-less task is "
+            "invisible to the per-producer ACK gate yet blocks CONFIRM). "
+            "This is the executor's own fallback, not ``Task.role``'s — the "
+            "scheduler and completeness gate treat a role-less ``Task`` as "
+            "unassigned (#3428 review)."
         ),
     )
 

--- a/tests/sandbox/egg_agent_tools/test_handlers_sdlc.py
+++ b/tests/sandbox/egg_agent_tools/test_handlers_sdlc.py
@@ -118,6 +118,97 @@ class TestRegisterOpenQuestion:
         with pytest.raises(HandlerError):
             sdlc.register_open_question({"question": "q?", "redirect_seed": 123})
 
+    def test_adds_task_attached_to_referenced_option(self):
+        # An option that mandates a contract mutation carries the structured
+        # payload the orchestrator executes on resolve (#3428).
+        fake_contract = _fake_contract()
+        responses = [
+            {"success": True, "data": fake_contract},
+            {"success": True, "data": {}},
+        ]
+        with (
+            patch(
+                "egg_agent_tools.handlers.sdlc.gateway_request",
+                side_effect=lambda *a, **kw: responses.pop(0),
+            ) as gr,
+            patch("egg_agent_tools.handlers.sdlc.get_contract_identifier", return_value=42),
+        ):
+            resp = sdlc.register_open_question(
+                {
+                    "question": "Wire the dependency?",
+                    "options": ["Add a task to wire it", "Defer"],
+                    "adds_task": {
+                        "option": 1,
+                        "slice_id": "slice-4",
+                        "description": "Wire secondary-repo worktree creation",
+                        "acceptance_criteria": "Worktree exists",
+                        "files_affected": ["a.py"],
+                        "role": "coder",
+                    },
+                }
+            )
+
+        options = resp["decision"]["options"]
+        assert options[0]["adds_task"] == {
+            "slice_id": "slice-4",
+            "description": "Wire secondary-repo worktree creation",
+            "acceptance_criteria": "Worktree exists",
+            "files_affected": ["a.py"],
+            "role": "coder",
+        }
+        # Only the referenced option carries the payload.
+        assert "adds_task" not in options[1]
+        assert "adds_task" not in options[2]  # the auto-appended Other
+        # And it reaches the gateway mutate payload verbatim.
+        sent = gr.call_args_list[1].kwargs["data"]["new_value"]["options"]
+        assert sent[0]["adds_task"]["slice_id"] == "slice-4"
+
+    def test_adds_task_requires_options(self):
+        with pytest.raises(HandlerError, match="requires 'options'"):
+            sdlc.register_open_question(
+                {
+                    "question": "q?",
+                    "adds_task": {"option": 1, "slice_id": "slice-1", "description": "x"},
+                }
+            )
+
+    @pytest.mark.parametrize("option", [0, 3, "1", None, True])
+    def test_adds_task_option_index_must_reference_a_real_option(self, option):
+        # 2 options → valid indices are 1..2; index 3 would point at the
+        # auto-appended "Other", which cannot mandate a mutation.
+        with pytest.raises(HandlerError, match="adds_task.option"):
+            sdlc.register_open_question(
+                {
+                    "question": "q?",
+                    "options": ["A", "B"],
+                    "adds_task": {
+                        "option": option,
+                        "slice_id": "slice-1",
+                        "description": "x",
+                    },
+                }
+            )
+
+    def test_adds_task_slice_id_validated(self):
+        with pytest.raises(HandlerError, match="slice_id"):
+            sdlc.register_open_question(
+                {
+                    "question": "q?",
+                    "options": ["A"],
+                    "adds_task": {"option": 1, "slice_id": "slice-one", "description": "x"},
+                }
+            )
+
+    def test_adds_task_description_required(self):
+        with pytest.raises(HandlerError, match="description"):
+            sdlc.register_open_question(
+                {
+                    "question": "q?",
+                    "options": ["A"],
+                    "adds_task": {"option": 1, "slice_id": "slice-1"},
+                }
+            )
+
     def test_no_options_keeps_list_empty(self):
         fake_contract = _fake_contract()
         responses = [


### PR DESCRIPTION
Fixes #3428.

## Problem

When an operator resolves a contract HITL decision (`cq-N`) whose chosen option mandates a contract mutation — "Add a new task/slice to wire X as a dependency" — nothing executes that mutation. Agents have no task-add verb, the reviewer that raised the question keeps withholding ACK (correctly — the mandated task still doesn't exist), and the orchestrator keeps re-spawning the producer at an unchanged contract (#3425). The pipeline re-deadlocks *after* the human answered; the concrete issue-3393/slice-4 instance was only recoverable by hand-editing the live contract JSON.

## Approach

Direction 1 from the issue (executor hook), composed from the two existing precedents:

- **`redirect_seed` (#3385)** — a structured machine-consumed payload carried on the decision at registration time, executed by a resolve-time dispatch hook.
- **`Mark task <id> complete` (#3124)** — an executable option that performs the audited operator mutation via `operator_actions`, with the outcome surfaced in the resolve response's `executed_action` and failures logged, never silent.

## Changes

**Payload** (`shared/egg_contracts/models.py`): new `AddsTaskPayload` (`slice_id`, `description`, `acceptance_criteria`, `files_affected`, `role`) + `DecisionOption.adds_task`. Rides the same contract-mutate RPC that creates the decision, so it reaches the shared pipeline worktree even from a BRC reviewer with no push path.

**Registration** (`sandbox/egg_agent_tools/…`): `register_open_question` accepts `adds_task: {option: <1-based index>, slice_id, description, …}` and attaches the validated payload to the referenced option. The MCP schema tells agents an "add a task" option MUST carry the payload (otherwise it is unactionable by anyone). The index cannot reference the auto-appended "Other" option.

**Executor** (`orchestrator/operator_actions.py`): `add_task_as_operator` appends a validated `Task` to the named slice as an audited `Role.HUMAN` mutation, allocating `task-<P>-<N>` under the contract lock (accepts legacy `phase-N` slice ids by number).

**Dispatch** (`orchestrator/routes/decisions/`): `_maybe_add_task_from_resolution` fires only when the resolution unambiguously selects the payload-carrying option (exact label, `opt-N` id, or positional `option N` / `N`; free-form prose never triggers an audited mutation). Wired into both resolve paths:
- the pre-bridge contract fallback (`cq-N` resolved directly — the primary trigger for mid-implement questions), and
- the bridged queue path, where the pipeline `HITLDecision` carries only bare labels — the contract decision is recovered via the bridge's `Open contract question cq-N,` context fingerprint.

Failure is surfaced in `executed_action` (`success: false` + error) and logged as an error — this addresses the issue's third point: the resolve response itself reports whether the precondition the blocked reviewer stated is now satisfiable, instead of the wedge recurring invisibly.

**Direct route** (`orchestrator/routes/contracts.py`): lifecycle-guarded `POST /api/v1/contracts/<id>/tasks` (parity with the #3124 completion route) for cases with no live decision — replaces the hand-edit-the-contract-JSON recovery.

**Docs**: new "Executable `adds_task` Option (#3428)" section in `docs/hitl-decisions.md`.

## Scope notes

- Scoped to **task appends into an existing slice** (the issue's suggested payload shape and the concrete instance). Adding whole slices / DAG edits still goes through a replan — noted in the docs' registration guidance.
- The issue's direction 2 (lint/reject unactionable options) is subsumed for the structural case: such options are now actionable when registered with the payload; detecting *prose-only* "add a task" options reliably would require language heuristics and is not attempted.
- `.egg/schemas/contract.schema.json` is not touched: its `Decision` definition is already stale relative to the pydantic models (no `redirect_seed`, id pattern still excludes `cq-N`), and #3385 set the precedent that pydantic is the authoritative validator.

## Testing

- New `orchestrator/tests/test_adds_task_resolution.py` (33 tests): executor (id allocation, persistence, audit actor, 404/400 modes), option matcher, dispatch hook on both paths (including bridged-context recovery and failure surfacing), end-to-end contract resolve materializing the task on disk, and the REST route (auth, actor namespacing, validation).
- New registration tests in `tests/sandbox/egg_agent_tools/test_handlers_sdlc.py` (payload attachment + validation errors).
- Adjacent suites green: `test_resolve_contract_decision_route`, `test_confirmed_producer_reopen`, `test_first_principles_reviewer`, `test_decisions_routes`, `test_decision_queue`, `test_contract_decision_bridge`, all of `tests/sandbox/egg_agent_tools/`, `tests/shared/egg_contracts/` (3 pre-existing sys.path collection-order failures in `test_agent_roles.py` when run standalone; unrelated).
- `make lint` clean.

## Related

- #3425 (no-op respawn burn) and #3426 (consensus timeout blind to operator-gated wedges) remain open — this PR removes the deadlock they amplify but does not change respawn/timeout behavior.
- #3427 (cq-N id collisions) is orthogonal.