### PR TITLE
Fix false divergence_reconcile_unacked: topology-aware rebase form + HITL failure detail (#3416)

### DIFF
--- a/orchestrator/gateway_client/_push.py
+++ b/orchestrator/gateway_client/_push.py
@@ -558,10 +558,21 @@ def _rebase_with_agent_output_autoresolve(
                 stderr=rebase_result.stderr,
             )
             _abort_rebase_best_effort(git_base, pipeline_id, branch)
+            # Name the command and the failing apply in the detail: this
+            # string is the only diagnostic that reaches the operator-facing
+            # divergence-reconcile HITL, and #3416 showed that an unnamed
+            # "conflict outside agent-outputs" claim is unfalsifiable from
+            # the decision text alone.
+            rebase_argv = "git " + " ".join(rebase_cmd[len(git_base) :])
+            output_excerpt = (rebase_result.stderr or rebase_result.stdout or "").strip()[:500]
             return PushResult(
                 ok=False,
                 category="reconcile_rebase_conflict",
-                detail=f"conflicts outside .egg-state/agent-outputs/: {', '.join(non_ephemeral)}",
+                detail=(
+                    f"conflicts outside .egg-state/agent-outputs/: "
+                    f"{', '.join(non_ephemeral)} (cmd: {rebase_argv}; "
+                    f"output: {output_excerpt})"
+                ),
             )
 
         _pkg.logger.warning(
@@ -735,9 +746,11 @@ def _build_rebase_cmd(
       pipeline's base): return the plain ``git rebase origin/{branch}``
       form.  This preserves pre-#1976 behaviour for any call site that
       still doesn't know the base branch.
-    * ``base_branch`` is set and ``origin/{base_branch}`` resolves: return
-      the ``--onto origin/{branch} origin/{base_branch}`` form so only
-      ``origin/{base_branch}..HEAD`` commits are replayed.
+    * ``base_branch`` is set and ``origin/{base_branch}`` resolves: pick
+      the form by topology (see below) — the ``--onto origin/{branch}
+      origin/{base_branch}`` form when the worktree's shared history with
+      ``origin/{branch}`` is confined to the base branch, the plain
+      ``git rebase origin/{branch}`` form otherwise.
     * ``base_branch`` is set but ``origin/{base_branch}`` does NOT resolve
       (the upstream best-effort fetch silently failed earlier, or rev-parse
       timed out): return ``None``.  The caller must surface this as a
@@ -748,6 +761,42 @@ def _build_rebase_cmd(
       upstream main commits that landed since the stale snapshot) on top
       of the stale tip, producing a PR full of duplicate-by-content
       commits with rewritten SHAs.
+
+    **Why the form is topology-dependent (#1976 vs #3416).**  The two
+    forms replay different candidate sets:
+
+    * plain ``git rebase origin/{branch}`` replays
+      ``merge-base(HEAD, origin/{branch})..HEAD`` — exactly the
+      local-only commits when local and origin share branch history, but
+      it also absorbs any upstream base commits HEAD has that the stale
+      ``origin/{branch}`` lacks (the #1976/#2222 duplicate-commit
+      contamination).
+    * ``--onto origin/{branch} origin/{base_branch}`` replays
+      ``origin/{base_branch}..HEAD`` — immune to that contamination, but
+      the set includes **every shared pipeline commit** between the base
+      and HEAD.  Git does not drop those already-on-``origin/{branch}``
+      commits up front (same-SHA ancestors of ``<onto>`` are only
+      deduplicated against ``<upstream>``), so each one is re-cherry-
+      picked onto the origin tip.  Replaying an old commit whose hunks
+      were later rewritten (e.g. the contract-init commit vs. the
+      contract's current state) hits a spurious add/add or content
+      conflict on history that needs no reconciling at all — #3416's
+      false ``divergence_reconcile_unacked`` pause, where the identical
+      manual ``git rebase <origin tip>`` was conflict-free.
+
+    :func:`_shared_history_confined_to_base` picks the safe form: when
+    ``merge-base(HEAD, origin/{branch})`` is an ancestor of
+    ``origin/{base_branch}``, the shared history is all base-branch
+    history, the ``--onto`` candidate set is exactly the local-only
+    commits, and the ``--onto`` form is used (the #1976 topology: a
+    fresh worktree cut from a newer base snapshot than the stale origin
+    tip).  Otherwise local and origin share pipeline commits beyond the
+    base (the routine divergence topology: both sides extend the same
+    pipeline branch), the plain form's merge-base range is exactly the
+    local-only commits, and the plain form is used.  Indeterminate
+    ancestry (merge-base failure/timeout) falls back to the ``--onto``
+    form: its failure mode is a non-destructive reconcile pause, while
+    the plain form's is silent PR contamination.
 
     ``--autostash`` is set on every returned form (#2714): the orchestrator
     writes statefile / agent-output deltas continuously and does not commit
@@ -781,8 +830,78 @@ def _build_rebase_cmd(
     except subprocess.TimeoutExpired:
         verify = None
     if verify and verify.returncode == 0:
-        return [*git_base, "rebase", "--autostash", "--onto", f"origin/{branch}", base_ref]
+        if _shared_history_confined_to_base(git_base, branch, base_ref):
+            return [*git_base, "rebase", "--autostash", "--onto", f"origin/{branch}", base_ref]
+        return [*git_base, "rebase", "--autostash", f"origin/{branch}"]
     return None
+
+
+def _shared_history_confined_to_base(
+    git_base: list[str],
+    branch: str,
+    base_ref: str,
+) -> bool:
+    """Return True when HEAD's shared history with ``origin/{branch}`` is all base-branch history.
+
+    True means ``merge-base(HEAD, origin/{branch})`` is an ancestor of
+    ``base_ref`` — the #1976 topology where the ``--onto`` rebase form is
+    both safe and required.  False means local and origin share pipeline
+    commits beyond the base, where the ``--onto`` form would re-replay
+    that shared history onto the origin tip and manufacture conflicts
+    (#3416) — the caller must use the plain form instead.
+
+    Indeterminate ancestry (merge-base failure, empty output, timeout,
+    or an ``--is-ancestor`` exit code other than 0/1) returns True: the
+    ``--onto`` form's failure mode is a non-destructive reconcile pause,
+    while the plain form's is #2222-style silent PR contamination.
+    """
+    try:
+        mb_result = subprocess.run(
+            [*git_base, "merge-base", "HEAD", f"origin/{branch}"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        mb_result = None
+    merge_base_sha = mb_result.stdout.strip() if mb_result else ""
+    if mb_result is None or mb_result.returncode != 0 or not merge_base_sha:
+        _pkg.logger.warning(
+            "Push reconcile: merge-base(HEAD, origin/{branch}) indeterminate — "
+            "keeping the --onto rebase form",
+            branch=branch,
+            base_ref=base_ref,
+        )
+        return True
+    try:
+        ancestry = subprocess.run(
+            [*git_base, "merge-base", "--is-ancestor", merge_base_sha, base_ref],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        ancestry = None
+    if ancestry is not None and ancestry.returncode == 0:
+        return True
+    if ancestry is not None and ancestry.returncode == 1:
+        _pkg.logger.info(
+            "Push reconcile: local and origin share branch history beyond the "
+            "base — using the plain rebase form (#3416)",
+            branch=branch,
+            base_ref=base_ref,
+            merge_base=merge_base_sha,
+        )
+        return False
+    _pkg.logger.warning(
+        "Push reconcile: merge-base --is-ancestor indeterminate — keeping the --onto rebase form",
+        branch=branch,
+        base_ref=base_ref,
+        merge_base=merge_base_sha,
+    )
+    return True
 
 
 def _abort_rebase_best_effort(

--- a/orchestrator/routes/phases/_populate.py
+++ b/orchestrator/routes/phases/_populate.py
@@ -178,6 +178,12 @@ def populate_contract(pipeline_id: str) -> tuple[Response, int]:
                 phase=pipeline.current_phase,
                 backup_ref=divergence_backup_ref,
                 local_only_commit_shas=divergence_local_only,
+                rebase_category=(
+                    populate_sync_outcome.rebase_category if populate_sync_outcome else None
+                ),
+                rebase_detail=(
+                    populate_sync_outcome.rebase_detail if populate_sync_outcome else None
+                ),
             )
             return make_error_response(
                 "Worktree diverged from origin during pre-populate sync and "

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -7977,12 +7977,19 @@ class WorktreeSyncOutcome(NamedTuple):
     summaries) that are on HEAD but not yet on origin.  Empty when the
     rev-list itself failed; the divergence is still reported, but the
     operator can't be given the exact commit list inline.
+
+    ``rebase_category`` / ``rebase_detail`` carry the failed autoresolve's
+    ``PushResult`` category and detail (command, conflicting paths, output
+    excerpt) when divergence is unreconciled, so the reconcile HITL can
+    name the actual failure instead of a generic conflict claim (#3416).
     """
 
     case: str
     diverged_unreconciled: bool = False
     backup_ref: str | None = None
     local_only_commit_shas: tuple[str, ...] = ()
+    rebase_category: str | None = None
+    rebase_detail: str | None = None
 
 
 def _build_sync_recovery_backup_ref(pipeline_id: str, unix_ts: int) -> str:
@@ -8540,12 +8547,15 @@ def _sync_worktree_with_remote(
             backup_ref=backup_ref if backup_ok else None,
             local_only_commit_count=len(local_only),
             rebase_category=rebase_outcome.category,
+            rebase_detail=rebase_outcome.detail,
         )
         return WorktreeSyncOutcome(
             case="divergence_unreconciled",
             diverged_unreconciled=True,
             backup_ref=backup_ref if backup_ok else None,
             local_only_commit_shas=local_only,
+            rebase_category=rebase_outcome.category,
+            rebase_detail=rebase_outcome.detail,
         )
 
     # Step 4: Reset local branch to remote.
@@ -16412,6 +16422,8 @@ def _divergence_reconcile_hitl_question(
     phase: PipelinePhase | None,
     backup_ref: str | None,
     local_only_commit_shas: tuple[str, ...] | list[str],
+    rebase_category: str | None = None,
+    rebase_detail: str | None = None,
 ) -> str:
     """Build the HITL question for the non-destructive divergence pause (#2979).
 
@@ -16438,10 +16450,20 @@ def _divergence_reconcile_hitl_question(
             "The local-only commit list could not be enumerated; check the "
             "WARN log and the backup ref for the exact set."
         )
+    # Name the actual failure (category + command/paths/output from the
+    # autoresolve's PushResult) instead of asserting a generic conflict:
+    # #3416 showed the unnamed claim was unfalsifiable and misdirected the
+    # operator's investigation.
+    if rebase_category or rebase_detail:
+        failure_block = (
+            f"{rebase_category or 'unknown failure'}: {rebase_detail or 'no detail captured'}"
+        )
+    else:
+        failure_block = "no failure detail captured — see the divergence_rebase_failed ERROR log"
     return (
         f"Pipeline {pipeline_id}: the worktree diverged from origin at the "
         f"{phase_label} boundary and the rebase autoresolve could not "
-        f"reconcile it (a conflict outside .egg-state/agent-outputs/). "
+        f"reconcile it ({failure_block}). "
         f"Nothing was discarded — the worktree is left at the local HEAD "
         f"with the orchestrator's committed work intact, and the pipeline "
         f"is paused (not failed) for a manual reconcile (#2979). "
@@ -16464,6 +16486,8 @@ def _emit_divergence_reconcile_hitl(
     phase: PipelinePhase | None,
     backup_ref: str | None,
     local_only_commit_shas: tuple[str, ...] | list[str],
+    rebase_category: str | None = None,
+    rebase_detail: str | None = None,
 ):
     """Pin pipeline+phase to AWAITING_HUMAN and persist the reconcile HITL (#2979).
 
@@ -16496,6 +16520,8 @@ def _emit_divergence_reconcile_hitl(
                 phase=phase,
                 backup_ref=backup_ref,
                 local_only_commit_shas=tuple(local_only_commit_shas),
+                rebase_category=rebase_category,
+                rebase_detail=rebase_detail,
             ),
             options=list(_DIVERGENCE_RECONCILE_HITL_OPTIONS),
             phase=phase,
@@ -16654,6 +16680,8 @@ def _sync_worktree_reconciling_divergence(
                     phase=phase,
                     backup_ref=outcome.backup_ref,
                     local_only_commit_shas=outcome.local_only_commit_shas,
+                    rebase_category=outcome.rebase_category,
+                    rebase_detail=outcome.rebase_detail,
                 ),
                 options=list(_DIVERGENCE_RECONCILE_HITL_OPTIONS),
                 phase=phase,

--- a/orchestrator/tests/test_hard_reset_recovery.py
+++ b/orchestrator/tests/test_hard_reset_recovery.py
@@ -193,6 +193,39 @@ class TestDivergenceReconcileHitlQuestion:
         ]
         assert len(_DIVERGENCE_RECONCILE_HITL_OPTIONS) == 2
 
+    def test_names_actual_rebase_failure(self):
+        """#3416: the question names the autoresolve's real failure
+        (category + command/paths/output) instead of asserting a generic
+        unnamed conflict the operator can't falsify."""
+        question = _divergence_reconcile_hitl_question(
+            pipeline_id="pipeline-zzz",
+            phase=PipelinePhase.REFINE,
+            backup_ref="refs/egg-backup/sync-recovery/pipeline-zzz/123",
+            local_only_commit_shas=("abc1234 persist statefiles",),
+            rebase_category="reconcile_rebase_conflict",
+            rebase_detail=(
+                "conflicts outside .egg-state/agent-outputs/: "
+                ".egg-state/contracts/pipeline-zzz.json "
+                "(cmd: git rebase --autostash --onto origin/egg/pipeline-zzz origin/main; "
+                "output: error: could not apply 20b4761...)"
+            ),
+        )
+        assert "reconcile_rebase_conflict" in question
+        assert ".egg-state/contracts/pipeline-zzz.json" in question
+        assert "could not apply 20b4761" in question
+
+    def test_missing_rebase_failure_detail_is_explicit(self):
+        """Without failure detail, the question says so and points at the
+        ERROR log — it must NOT fabricate a specific conflict claim."""
+        question = _divergence_reconcile_hitl_question(
+            pipeline_id="pipeline-zzz",
+            phase=PipelinePhase.PLAN,
+            backup_ref=None,
+            local_only_commit_shas=(),
+        )
+        assert "no failure detail captured" in question
+        assert "a conflict outside .egg-state/agent-outputs/" not in question
+
 
 class TestDivergenceReconcileIsAbort:
     """Only an explicit abort resolution fails the pipeline; everything

--- a/orchestrator/tests/test_reconcile_and_push_pr_branch.py
+++ b/orchestrator/tests/test_reconcile_and_push_pr_branch.py
@@ -374,9 +374,11 @@ class TestPushWorktreeBranchReconcile:
         assert "--autostash" in rebase_cmd
 
     def test_rebase_with_base_branch_uses_onto_form(self, tmp_path):
-        """With ``base_branch`` and ``origin/{base_branch}`` resolvable,
-        the rebase uses ``--onto origin/{branch} origin/{base_branch}`` so
-        only ``origin/{base_branch}..HEAD`` is replayed — commits already
+        """With ``base_branch`` resolvable and the shared history confined
+        to the base branch (merge-base(HEAD, origin/{branch}) is an
+        ancestor of ``origin/{base_branch}``), the rebase uses
+        ``--onto origin/{branch} origin/{base_branch}`` so only
+        ``origin/{base_branch}..HEAD`` is replayed — commits already
         on main are not duplicated onto the pipeline branch (#1976).
         """
         client = _make_client([False, True])
@@ -386,6 +388,8 @@ class TestPushWorktreeBranchReconcile:
                 _run_result(),  # fetch origin {branch}
                 _run_result(),  # fetch origin {base_branch}
                 _run_result(),  # rev-parse --verify origin/{base_branch}
+                _run_result(stdout="abc123\n"),  # merge-base HEAD origin/{branch}
+                _run_result(returncode=0),  # merge-base --is-ancestor (confined to base)
                 _run_result(),  # rebase --onto ...
                 _run_result(),  # diff --diff-filter=U (autostash pop conflict check)
             ],
@@ -398,10 +402,10 @@ class TestPushWorktreeBranchReconcile:
             )
 
         assert ok.ok is True
-        assert mock_run.call_count == 5
+        assert mock_run.call_count == 7
         base_fetch_cmd = mock_run.call_args_list[1].args[0]
         assert "fetch" in base_fetch_cmd and "main" in base_fetch_cmd
-        rebase_cmd = mock_run.call_args_list[3].args[0]
+        rebase_cmd = mock_run.call_args_list[5].args[0]
         # ``--autostash`` (#2714) precedes ``--onto`` so the rebase can run
         # against a dirty worktree; statefile / agent-output writes are
         # routinely uncommitted at sync time.
@@ -412,6 +416,75 @@ class TestPushWorktreeBranchReconcile:
             "origin/egg/issue-42",
             "origin/main",
         ]
+
+    def test_rebase_uses_plain_form_when_shared_history_beyond_base(self, tmp_path):
+        """Regression for #3416 (form selection, mocked).
+
+        When local and ``origin/{branch}`` share pipeline history beyond
+        the base branch (merge-base(HEAD, origin/{branch}) is NOT an
+        ancestor of ``origin/{base_branch}`` — the routine divergence
+        topology), the ``--onto`` form would replay every shared pipeline
+        commit onto the origin tip and manufacture conflicts.  The helper
+        must pick the plain ``git rebase origin/{branch}`` form, which
+        replays exactly the local-only commits.
+        """
+        client = _make_client([False, True])
+        with patch(
+            "gateway_client.subprocess.run",
+            side_effect=[
+                _run_result(),  # fetch origin {branch}
+                _run_result(),  # fetch origin {base_branch}
+                _run_result(),  # rev-parse --verify origin/{base_branch}
+                _run_result(stdout="abc123\n"),  # merge-base HEAD origin/{branch}
+                _run_result(returncode=1),  # merge-base --is-ancestor: NOT confined
+                _run_result(),  # plain rebase
+                _run_result(),  # diff --diff-filter=U (autostash pop conflict check)
+            ],
+        ) as mock_run:
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-3416",
+                repo_path=str(tmp_path),
+                branch="egg/issue-3416",
+                base_branch="main",
+            )
+
+        assert ok.ok is True
+        assert mock_run.call_count == 7
+        rebase_cmd = mock_run.call_args_list[5].args[0]
+        assert "--onto" not in rebase_cmd
+        assert rebase_cmd[-3:] == ["rebase", "--autostash", "origin/egg/issue-3416"]
+
+    def test_rebase_keeps_onto_form_when_ancestry_indeterminate(self, tmp_path):
+        """Indeterminate merge-base ancestry falls back to the ``--onto`` form.
+
+        The ``--onto`` form's worst case is a non-destructive reconcile
+        pause (#2979); the plain form's is #2222-style silent PR
+        contamination.  When the topology probe can't answer, fail toward
+        the pause.
+        """
+        client = _make_client([False, True])
+        with patch(
+            "gateway_client.subprocess.run",
+            side_effect=[
+                _run_result(),  # fetch origin {branch}
+                _run_result(),  # fetch origin {base_branch}
+                _run_result(),  # rev-parse --verify origin/{base_branch}
+                _run_result(returncode=128, stderr="fatal: no merge base"),  # merge-base fails
+                _run_result(),  # rebase --onto ... (is-ancestor probe skipped)
+                _run_result(),  # diff --diff-filter=U (autostash pop conflict check)
+            ],
+        ) as mock_run:
+            ok = client.push_worktree_branch(
+                pipeline_id="issue-3416",
+                repo_path=str(tmp_path),
+                branch="egg/issue-3416",
+                base_branch="main",
+            )
+
+        assert ok.ok is True
+        assert mock_run.call_count == 6
+        rebase_cmd = mock_run.call_args_list[4].args[0]
+        assert "--onto" in rebase_cmd
 
     def test_rebase_does_not_replay_main_commits_when_base_branch_set(self, tmp_path):
         """End-to-end regression for #1976.
@@ -512,6 +585,117 @@ class TestPushWorktreeBranchReconcile:
         # branch (v1 from origin + v2 from local work) — 0 main-commit replays.
         assert len(branch_only_shas) == 2, (
             f"expected 2 branch-only commits, got {len(branch_only_shas)}: {branch_only_shas}"
+        )
+
+    def test_rebase_no_false_conflict_on_shared_pipeline_history(self, tmp_path):
+        """End-to-end regression for #3416.
+
+        Reproduces the ``issue-3393`` false ``divergence_reconcile_unacked``
+        pause with a real git repo:
+
+        - The pipeline branch has shared history beyond main: a
+          contract-init commit that *adds* the contract file, then a
+          commit that rewrites it.
+        - The local worktree is cut from that shared tip and adds one
+          local-only commit touching the contract file.
+        - Origin then advances by one commit touching a **disjoint** path
+          (an agent-outputs artifact) — true divergence, zero file
+          overlap between the local-only and origin-only commits.
+
+        The pre-fix ``--onto origin/{branch} origin/main`` form replayed
+        the whole ``origin/main..HEAD`` range — including the already-on-
+        origin contract-init commit, whose re-application onto the origin
+        tip hit an add/add conflict on the contract path (outside
+        ``.egg-state/agent-outputs/``) and raised a HITL pause, even
+        though the identical manual ``git rebase <origin tip>`` was
+        conflict-free.  With the topology-aware form selection the
+        autoresolve must reconcile this cleanly.
+        """
+        origin = tmp_path / "origin.git"
+        subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)], check=True)
+
+        # Seed main.
+        seed = tmp_path / "seed"
+        seed.mkdir()
+        _git_init(seed, str(origin))
+        (seed / "README.md").write_text("initial\n")
+        _git(seed, "add", "README.md")
+        _git(seed, "commit", "-m", "initial main commit")
+        _git(seed, "push", "origin", "main")
+
+        # Pipeline branch: contract-init (adds the file) + a rewrite of it.
+        _git(seed, "checkout", "-b", "egg/issue-3416")
+        contracts = seed / ".egg-state" / "contracts"
+        contracts.mkdir(parents=True)
+        (contracts / "issue-3416.json").write_text('{"phase": "refine", "v": 1}\n')
+        _git(seed, "add", ".egg-state/contracts/issue-3416.json")
+        _git(seed, "commit", "-m", "Initialize SDLC contract for issue #3416")
+        (contracts / "issue-3416.json").write_text('{"phase": "refine", "v": 2}\n')
+        _git(seed, "add", ".egg-state/contracts/issue-3416.json")
+        _git(seed, "commit", "-m", "state: contract update (shared)")
+        _git(seed, "push", "origin", "egg/issue-3416")
+
+        # Local worktree: cut from the shared tip, one local-only commit
+        # touching the contract file (the operator-resolution write).
+        work = tmp_path / "work"
+        work.mkdir()
+        _git_init(work, str(origin))
+        _git(work, "fetch", "origin")
+        _git(work, "checkout", "-b", "egg/issue-3416-work", "origin/egg/issue-3416")
+        (work / ".egg-state" / "contracts" / "issue-3416.json").write_text(
+            '{"phase": "refine", "v": 3, "resolved": true}\n'
+        )
+        _git(work, "add", ".egg-state/contracts/issue-3416.json")
+        _git(work, "commit", "-m", "Persist agent statefile writes before refine sync")
+
+        # Origin advances by a disjoint-path commit (agent-outputs artifact).
+        _git(seed, "checkout", "egg/issue-3416")
+        outputs = seed / ".egg-state" / "agent-outputs"
+        outputs.mkdir(parents=True)
+        (outputs / "3416-analysis-human.md").write_text("simplifier artifact v3\n")
+        _git(seed, "add", ".egg-state/agent-outputs/3416-analysis-human.md")
+        _git(seed, "commit", "-m", "Restore simplifier artifact")
+        _git(seed, "push", "origin", "egg/issue-3416")
+        _git(work, "fetch", "origin", "egg/issue-3416")
+
+        git_base = [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            f"safe.directory={work}",
+            "-C",
+            str(work),
+        ]
+        result = _rebase_with_agent_output_autoresolve(
+            git_base=git_base,
+            pipeline_id="issue-3416",
+            branch="egg/issue-3416",
+            base_branch="main",
+        )
+        assert result.ok, (
+            f"disjoint divergence must reconcile cleanly (#3416), got: "
+            f"{result.category} {result.detail}"
+        )
+
+        # Origin's tip must be reachable from HEAD and exactly the one
+        # local-only commit replayed on top of it.
+        remote_sha = _git(work, "rev-parse", "origin/egg/issue-3416").stdout.strip()
+        log_shas = _git(work, "log", "--format=%H", "HEAD").stdout.strip().splitlines()
+        assert remote_sha in log_shas, "origin tip missing from local history after rebase"
+        ahead = _git(work, "rev-list", "--count", "origin/egg/issue-3416..HEAD").stdout.strip()
+        assert ahead == "1", f"expected exactly the local-only commit replayed, got {ahead}"
+
+        # No duplicate-by-content replay of the shared contract-init commit.
+        subjects = _git(work, "log", "--format=%s", "HEAD").stdout
+        assert subjects.count("Initialize SDLC contract") == 1, (
+            f"shared history was re-replayed:\n{subjects}"
+        )
+        # And the reconciled tree holds both sides' content.
+        assert (work / ".egg-state" / "agent-outputs" / "3416-analysis-human.md").exists()
+        assert (
+            '"resolved": true'
+            in (work / ".egg-state" / "contracts" / "issue-3416.json").read_text()
         )
 
     def test_rebase_does_not_contaminate_when_base_fetch_silently_failed(self, tmp_path):

--- a/orchestrator/tests/test_sync_worktree.py
+++ b/orchestrator/tests/test_sync_worktree.py
@@ -292,6 +292,11 @@ class TestSyncWorktreeWithRemote:
                 "abc1234 commit A",
                 "def5678 commit B",
             )
+            # #3416: the outcome carries the autoresolve's failure
+            # category + detail so the reconcile HITL can name the actual
+            # failure instead of a generic conflict claim.
+            assert outcome.rebase_category == "reconcile_rebase_conflict"
+            assert outcome.rebase_detail == "conflicts outside agent-outputs"
             # 3 (head detect / rev-parse / rev-list-counts) + 2 (rev-list
             # local-only, update-ref) = 5 subprocess calls. Crucially, NO
             # reset call fired.


### PR DESCRIPTION
Fixes #3416.

## Root cause (confirmed, not hypothesized)

The incident's orchestrator ERROR log (crashed pod, still retrievable) shows exactly what the autoresolve attempted:

```
Push reconcile: rebase failed — conflicts outside agent-outputs, aborting
pipeline_id=issue-3393 conflicting_paths=['.egg-state/contracts/issue-3393.json']
stdout="Auto-merging .egg-state/contracts/issue-3393.json CONFLICT (add/add): Merge c..."
stderr="Rebasing (1/8) error: could not apply 20b476173... Initialize SDLC contract f..."
```

`Rebasing (1/8)`: the `--onto origin/{branch} origin/{base_branch}` form (#1976/#2222) replays the **full `origin/main..HEAD` range** — all 8 pipeline commits, not just the 1 local-only commit. Git does not pre-drop candidates that are already same-SHA ancestors of `<onto>` (the already-upstream check compares against `<upstream>` only), so the pipeline's own contract-init commit was re-cherry-picked onto the origin tip and hit a deterministic add/add conflict against the contract file's current state. The operator's manual `git rebase 63c824cfe` (plain form) replays only `merge-base..HEAD` = the 1 local-only commit — clean, as observed.

So: not a stale fetch, not dirty-tree interference, not a race — a wrong candidate set. Answers to the issue's root-cause questions: (1) local-onto-origin rebase, same direction as the manual one, but with the `--onto` upstream cut at `origin/main`; (2) fetch was current; (3) no; (4) a retry would have failed identically.

## Fix: topology-aware rebase form selection

`_build_rebase_cmd` now probes the topology (`_shared_history_confined_to_base`):

- `merge-base(HEAD, origin/{branch})` **is an ancestor of** `origin/{base_branch}` → the #1976/#2222 topology (fresh worktree cut from a newer base snapshot than a stale origin tip) → keep the `--onto` form; its candidate set is exactly the local-only commits there, and the plain form would replay upstream base commits (the #2222 contamination).
- Otherwise (routine divergence — both sides extend the same pipeline branch) → plain `git rebase --autostash origin/{branch}`; its candidate set is exactly the local-only commits, and the `--onto` form manufactures conflicts from shared history (this bug).
- Indeterminate ancestry (merge-base failure/timeout) → keep `--onto`: it fails toward a non-destructive pause, the plain form toward silent PR contamination.

The gateway-side push-reject reconcile path (`_reconcile_and_retry_push`) shares the helper and gets the same fix.

## Observability: the HITL now names the actual failure

The decision text hard-coded "a conflict outside `.egg-state/agent-outputs/`" regardless of the failure category — with no paths, command, or output (the issue's "unfalsifiable claim"). Now:

- `reconcile_rebase_conflict`'s `PushResult.detail` includes the rebase command, the conflicting paths, and an output excerpt naming the failing apply.
- `WorktreeSyncOutcome` carries `rebase_category`/`rebase_detail`, threaded into the HITL question through both emit paths (in-loop pause and the non-blocking `populate_contract` route) and the `divergence_unreconciled` log line.

## Deliberately not added

The issue's suggested re-fetch-and-retry: the diagnosed failure is deterministic, not a fetch race, so a retry loop would add mechanism without addressing the cause (it would have paged the operator just the same, two rebase-aborts later).

## Tests

- New e2e regression (`test_rebase_no_false_conflict_on_shared_pipeline_history`) reproduces the incident topology with a real git repo — shared contract-init + rewrite, disjoint local/origin commits. Fails pre-fix with the byte-identical production error (add/add on the contract path, "could not apply ... Initialize SDLC contract"); passes post-fix replaying exactly the 1 local-only commit.
- New mocked form-selection tests: plain form on shared-history topology, `--onto` kept on confined topology and on indeterminate ancestry.
- Existing #1976 and #2222 e2e regressions unchanged and passing (the protected topology still gets `--onto` / fail-closed).
- HITL question tests: names category+paths+output when present; explicit "no failure detail captured" (never a fabricated conflict claim) when absent.

`orchestrator/tests/test_reconcile_and_push_pr_branch.py`, `test_sync_worktree.py`, `test_hard_reset_recovery.py`: 94 passed. Ruff clean.