### PR TITLE
Make cq-N contract decisions durable and collision-safe (#3427)

### DIFF
--- a/orchestrator/routes/contracts.py
+++ b/orchestrator/routes/contracts.py
@@ -368,10 +368,17 @@ def mutate_contract(identifier: str) -> tuple[Response, int]:
                     "error_kind": result.error_kind,
                 },
             )
-            # 403 only for authorization rejections; value/path errors
-            # are 400 so a client doesn't retry them as if a different
-            # role might succeed (#2495).
-            status_code = 403 if result.error_kind == "authorization" else 400
+            # 403 only for authorization rejections; lost-update
+            # collisions (append-only decisions[] guard, #3427) are 409
+            # so a client re-reads and re-mints; value/path errors are
+            # 400 so a client doesn't retry them as if a different role
+            # might succeed (#2495).
+            if result.error_kind == "authorization":
+                status_code = 403
+            elif result.error_kind == "conflict":
+                status_code = 409
+            else:
+                status_code = 400
             return _error(
                 result.message,
                 status_code=status_code,
@@ -398,12 +405,48 @@ def mutate_contract(identifier: str) -> tuple[Response, int]:
         },
     )
 
+    _persist_decision_mutation(field_path, worktree)
+
     _audit_confirmed_assignee_reassignment(result.contract, field_path, new_value, actor)
 
     return _success(
         "Mutation applied successfully",
         data={"contract": export_contract(result.contract, include_audit_log=False)},
     )
+
+
+def _persist_decision_mutation(field_path: str, worktree: Path) -> None:
+    """Best-effort commit+push after a ``decisions.*`` mutation (#3427).
+
+    Contract HITL decisions written through this RPC (agent
+    ``register_open_question`` etc.) landed only on the worktree file; the
+    phase-(re)start worktree syncs ``git reset --hard`` to origin, so a
+    registration that was not committed+pushed by then was silently
+    reverted — and the next ``cq-N`` mint against the reverted file reused
+    its id, clobbering a live (possibly resolved) decision. Persist at
+    write time so the reset target already contains the decision. Must
+    never fail the mutation response — the write is live on the worktree
+    file regardless.
+    """
+    if field_path != "decisions" and not field_path.startswith("decisions."):
+        return
+    try:
+        pipeline_id, _ = _pipeline_context()
+        if not pipeline_id:
+            return
+        from routes.pipelines import persist_contract_statefiles
+
+        persist_contract_statefiles(
+            pipeline_id,
+            worktree,
+            f"Persist contract decision mutation {field_path} (#3427)",
+        )
+    except Exception:
+        logger.warning(
+            "Failed to persist decisions mutation to work branch",
+            extra={"field_path": field_path},
+            exc_info=True,
+        )
 
 
 _TASK_ROLE_PATH_RE = re.compile(r"^phases\.(\d+)\.tasks\.\d+\.role$")

--- a/orchestrator/routes/decisions/_resolve.py
+++ b/orchestrator/routes/decisions/_resolve.py
@@ -481,6 +481,29 @@ def _resolve_contract_decision(
         source=getattr(request, "egg_source", "unknown"),
     )
 
+    # Durably land the resolution on the work branch (#3427): the contract
+    # file write above is uncommitted, and the phase-(re)start worktree
+    # syncs ``git reset --hard`` to origin — an operator resolution that
+    # was not committed+pushed by then was silently reverted, forcing the
+    # operator to re-answer. Best-effort: the helper logs and swallows
+    # failures.
+    try:
+        from routes.pipelines import persist_contract_statefiles
+
+        persist_contract_statefiles(
+            pipeline_id,
+            worktree,
+            f"Persist HITL resolution {decision_id} (#3427)",
+            pipeline=pipeline,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to persist contract decision resolution to work branch",
+            pipeline_id=pipeline_id,
+            decision_id=decision_id,
+            exc_info=True,
+        )
+
     try:
         _pkg.emit_event(
             EventType.DECISION_RESOLVED,

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -1210,6 +1210,15 @@ def _corrective_open_operator_hitl(
     if not result.success:
         raise RuntimeError(f"failed to open operator HITL decision: {result.message}")
     save_contract(contract, resolved_repo)
+    # NOTE(#3427): like ``route_impasses``, this overseer-corrective writer
+    # lands the ``cq-N`` decision with a bare ``save_contract`` and no
+    # write-time ``persist_contract_statefiles`` — so a HITL opened between
+    # checkpoints shares the same phase-restart volatility window (the
+    # ``git reset --hard origin/<work>`` can revert it). The append-only
+    # guard protects it from id reuse, but not from reversion. Not persisted
+    # here because the corrective seam runs against ``get_repo_path()`` (the
+    # base repo), not a pushable pipeline worktree — wiring a worktree-scoped
+    # persist through the CorrectiveExecutor is the residual follow-up.
     return decision_id
 
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -9497,6 +9497,78 @@ def _commit_statefiles_to_worktree(
     return True
 
 
+def persist_contract_statefiles(
+    pipeline_id: str,
+    worktree_path: Path,
+    message: str,
+    *,
+    pipeline: Pipeline | None = None,
+) -> bool:
+    """Durably persist a contract decision write: commit + push to the work branch.
+
+    Contract HITL decisions (``cq-N`` registrations and resolutions) are
+    written to the shared pipeline worktree's contract file with no git
+    commit; the file was only serialized to the work branch at slice/phase
+    checkpoints. Both phase-(re)start syncs — the gateway's worktree-reuse
+    reset and ``_sync_worktree_with_remote`` step 4 — run
+    ``git reset --hard origin/<work>``, so any decision write that had not
+    been committed AND pushed by then was silently reverted, letting the
+    bootstrap reconciler re-mint the same ``cq-N`` ids and clobber
+    just-resolved operator decisions (#3427). Committing and pushing at
+    write time makes the reset target already contain the decision.
+
+    Best-effort by design: failures are logged and swallowed — the write is
+    still live on the worktree file and the next checkpoint commit retries.
+    Returns ``True`` only when the state was committed and pushed (or there
+    was nothing new to commit).
+    """
+    try:
+        if pipeline is None:
+            _, pipeline = _resolve_pipeline(pipeline_id, get_repo_path())
+        identifier = _pipeline_identifier(getattr(pipeline, "issue_number", None), pipeline_id)
+        committed = _commit_statefiles_to_worktree(
+            worktree_path,
+            message,
+            identifier,
+            pipeline_id=pipeline_id,
+        )
+        if not committed:
+            return True  # Nothing new on disk — already durable.
+        branch = getattr(pipeline, "branch", None)
+        if not branch:
+            logger.warning(
+                "Contract decision write committed but pipeline has no work "
+                "branch to push to; the commit is local-only and a worktree "
+                "reset may still discard it (#3427)",
+                pipeline_id=pipeline_id,
+            )
+            return False
+        gateway_mode, _ = _compute_gateway_mode(pipeline)
+        _get_spawner().gateway.push_worktree_branch(
+            pipeline_id=pipeline_id,
+            repo_path=str(worktree_path),
+            branch=branch,
+            mode=gateway_mode,
+            base_branch=getattr(pipeline, "base_branch", None),
+        )
+        logger.info(
+            "Contract decision write persisted to work branch (#3427)",
+            pipeline_id=pipeline_id,
+            branch=branch,
+            commit_message=message,
+        )
+        return True
+    except Exception as persist_err:  # noqa: BLE001 — best-effort durability
+        logger.warning(
+            "Failed to durably persist contract decision write; the decision "
+            "is live on the worktree file but will not survive a worktree "
+            "reset until the next checkpoint commit (#3427)",
+            pipeline_id=pipeline_id,
+            error=str(persist_err),
+        )
+        return False
+
+
 def _ensure_statefiles_on_branch(
     worktree_repo_path: Path,
     pipeline: Pipeline,
@@ -10441,6 +10513,10 @@ def _persist_phase_brc_history(
             worktree_path,
             f"Persist statefiles after {phase} phase",
             pipeline_identifier=_pipeline_identifier(pipeline.issue_number, pipeline.id),
+            # Contract files are keyed by pipeline_id, not the issue-number
+            # prefix; without this the restart-time persist skipped the
+            # contract entirely (#1829 gap, observed in #3427).
+            pipeline_id=pipeline.id,
         )
     except subprocess.CalledProcessError as git_err:
         logger.warning(
@@ -11833,12 +11909,18 @@ def _escalate_layer_c_hitl(
     one is added in a follow-up.
     """
     try:
-        from egg_contracts.decisions import next_cq_id
+        from egg_contracts.decisions import (
+            find_duplicate_open_question,
+            find_resolved_question,
+            next_cq_id,
+        )
         from egg_contracts.loader import load_contract, save_contract
         from egg_contracts.models import Decision, DecisionOption, DecisionType
     except ImportError:
         try:
             from orchestrator.egg_contracts.decisions import (  # type: ignore[no-redef]
+                find_duplicate_open_question,
+                find_resolved_question,
                 next_cq_id,
             )
             from orchestrator.egg_contracts.loader import (  # type: ignore[no-redef]
@@ -11861,6 +11943,35 @@ def _escalate_layer_c_hitl(
     try:
         with get_pipeline_state_lock(pipeline_id):
             contract_local = load_contract(pipeline_id, worktree_repo_path)
+            existing_decisions = contract_local.decisions or []
+            decision_phase = current_phase or PipelinePhase.IMPLEMENT
+            # Dedupe/carry-forward — parity with ``register_open_question``
+            # (#3374/#3392). The Layer-C question text is deterministic per
+            # (case, slice, pipeline), so every bootstrap re-run after a
+            # ``restart_phase`` re-derives the identical question. Without
+            # this guard each re-run minted a fresh ``cq-N`` (or, against a
+            # reset-stale contract, re-minted an existing one), making the
+            # operator re-answer questions they had already answered (#3427).
+            duplicate = find_duplicate_open_question(existing_decisions, question, decision_phase)
+            if duplicate is not None:
+                logger.info(
+                    "Layer-C HITL escalation adopted existing open decision (slice-4 TASK-4-4)",
+                    pipeline_id=pipeline_id,
+                    slice_id=slice_id,
+                    decision_id=getattr(duplicate, "id", None),
+                )
+                return
+            carried = find_resolved_question(existing_decisions, question, decision_phase)
+            if carried is not None:
+                logger.info(
+                    "Layer-C HITL escalation skipped: identical question "
+                    "already resolved by the operator (slice-4 TASK-4-4)",
+                    pipeline_id=pipeline_id,
+                    slice_id=slice_id,
+                    decision_id=getattr(carried, "id", None),
+                    resolution=str(getattr(carried, "resolution", None))[:200],
+                )
+                return
             # Use the canonical ``cq-N`` allocator from
             # ``shared/egg_contracts/decisions.py``. Orchestrator-side
             # HITL escalations write to the ``cq-N`` namespace; the
@@ -11880,7 +11991,8 @@ def _escalate_layer_c_hitl(
             # bootstrap which can run before any phase walk, and
             # future slice-DAG topologies may span phases.
             #
-            # The ``or PipelinePhase.IMPLEMENT`` arm is defensive: the
+            # The ``or PipelinePhase.IMPLEMENT`` arm (folded into
+            # ``decision_phase`` above) is defensive: the
             # ``Pipeline.current_phase`` field is non-Optional with a
             # default at the schema layer (``models.py:1032``), so
             # in-tree callers should always populate it. The fallback
@@ -11893,7 +12005,7 @@ def _escalate_layer_c_hitl(
                     id=decision_id,
                     question=question,
                     type=DecisionType.HITL,
-                    phase=current_phase or PipelinePhase.IMPLEMENT,
+                    phase=decision_phase,
                     options=options,
                 )
             )
@@ -11903,6 +12015,13 @@ def _escalate_layer_c_hitl(
             pipeline_id=pipeline_id,
             slice_id=slice_id,
             decision_id=decision_id,
+        )
+        # Durably land the new decision on the work branch so the next
+        # phase-(re)start worktree reset cannot revert it (#3427).
+        persist_contract_statefiles(
+            pipeline_id,
+            worktree_repo_path,
+            f"Persist Layer-C HITL escalation {decision_id} (#3427)",
         )
     except Exception as escalate_err:  # noqa: BLE001
         logger.warning(

--- a/orchestrator/tests/test_contracts_routes.py
+++ b/orchestrator/tests/test_contracts_routes.py
@@ -156,6 +156,88 @@ class TestMutateContract:
         decisions = json.loads(consumer.data)["data"]["decisions"]
         assert any(d["id"] == "decision-1" for d in decisions)
 
+    def test_decisions_mutation_triggers_durable_persist(self, client, fake_worktree):
+        """#3427: a ``decisions.*`` write through the RPC must trigger the
+        durable commit+push helper — otherwise the registration lives only
+        on the worktree file and the phase-(re)start ``git reset --hard``
+        reverts it (letting the next ``cq-N`` mint reuse its id).
+        """
+        pipeline_id, worktree = fake_worktree
+        _seed_contract(worktree, pipeline_id)
+
+        decision = {
+            "id": "cq-1",
+            "question": "Register me durably?",
+            "type": "hitl",
+            "options": [],
+            "resolved": False,
+        }
+        with patch("routes.pipelines.persist_contract_statefiles") as persist_mock:
+            response = self._mutate(
+                client,
+                pipeline_id,
+                role="implementer",
+                body_overrides={"field_path": "decisions.0", "new_value": decision},
+            )
+        assert response.status_code == 200, response.data
+        persist_mock.assert_called_once()
+        args = persist_mock.call_args[0]
+        assert args[0] == pipeline_id
+        assert args[1] == worktree
+
+    def test_non_decision_mutation_does_not_persist(self, client, fake_worktree):
+        pipeline_id, worktree = fake_worktree
+        _seed_contract(worktree, pipeline_id)
+
+        with patch("routes.pipelines.persist_contract_statefiles") as persist_mock:
+            response = self._mutate(client, pipeline_id, role="system")
+        assert response.status_code == 200, response.data
+        persist_mock.assert_not_called()
+
+    def test_stale_index_decision_write_rejected_409(self, client, fake_worktree):
+        """#3427 defect 2: a whole-entry write to an existing
+        ``decisions[]`` index (a client that minted against a stale read)
+        must be rejected 409 — never silently overwrite the entry.
+        """
+        pipeline_id, worktree = fake_worktree
+        _seed_contract(worktree, pipeline_id)
+
+        first = {
+            "id": "cq-1",
+            "question": "First registration",
+            "type": "hitl",
+            "options": [],
+            "resolved": False,
+        }
+        with patch("routes.pipelines.persist_contract_statefiles"):
+            response = self._mutate(
+                client,
+                pipeline_id,
+                role="implementer",
+                body_overrides={"field_path": "decisions.0", "new_value": first},
+            )
+            assert response.status_code == 200, response.data
+
+            # A second writer that also observed len(decisions)==0 races
+            # onto the same index with a DIFFERENT question.
+            second = dict(first, id="cq-1", question="Colliding registration")
+            response = self._mutate(
+                client,
+                pipeline_id,
+                role="implementer",
+                body_overrides={"field_path": "decisions.0", "new_value": second},
+            )
+        assert response.status_code == 409, response.data
+        assert "already exists" in json.loads(response.data)["message"]
+
+        # The first registration must be untouched.
+        consumer = client.get(
+            f"/api/v1/contracts/{pipeline_id}",
+            query_string={"pipeline_id": pipeline_id, "repo": "egg"},
+        )
+        decisions = json.loads(consumer.data)["data"]["decisions"]
+        assert [d["question"] for d in decisions] == ["First registration"]
+
     def test_role_validation_enforced(self, client, fake_worktree):
         pipeline_id, worktree = fake_worktree
         _seed_contract(worktree, pipeline_id)

--- a/orchestrator/tests/test_resolve_contract_decision_route.py
+++ b/orchestrator/tests/test_resolve_contract_decision_route.py
@@ -188,6 +188,48 @@ def test_already_resolved_contract_decision_returns_409(client, tmp_path):
     assert "already" in resp.get_json()["message"].lower()
 
 
+def test_resolution_persisted_to_work_branch(client, tmp_path):
+    """#3427: the resolution file write is uncommitted, and the
+    phase-(re)start worktree syncs ``git reset --hard`` to origin — so a
+    successful resolve must trigger the durable commit+push helper, or the
+    operator's answer silently reverts on the next ``restart_phase``.
+    """
+    _write_contract(tmp_path)
+    store_patch, queue_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with (
+        store_patch,
+        queue_patch,
+        worktree_patch,
+        patch("routes.pipelines.persist_contract_statefiles") as persist_mock,
+    ):
+        resp = _post(client, "cq-1", {"resolution": "opt-2"})
+
+    assert resp.status_code == 200
+    persist_mock.assert_called_once()
+    args, _kwargs = persist_mock.call_args
+    assert args[0] == PIPELINE_ID
+    assert args[1] == tmp_path
+    assert "cq-1" in args[2]
+
+
+def test_no_persist_when_resolution_rejected(client, tmp_path):
+    """A 409 (already resolved) must not trigger the durable persist."""
+    _write_contract(tmp_path, resolved=True)
+    store_patch, queue_patch, worktree_patch = _patch_resolution(tmp_path)
+
+    with (
+        store_patch,
+        queue_patch,
+        worktree_patch,
+        patch("routes.pipelines.persist_contract_statefiles") as persist_mock,
+    ):
+        resp = _post(client, "cq-1", {"resolution": "x"})
+
+    assert resp.status_code == 409
+    persist_mock.assert_not_called()
+
+
 def test_no_contract_returns_404(client, tmp_path):
     """No contract on disk at all — the fallback degrades to a 404."""
     store_patch, queue_patch, worktree_patch = _patch_resolution(tmp_path)

--- a/orchestrator/tests/test_slice_phase_restart_hardening.py
+++ b/orchestrator/tests/test_slice_phase_restart_hardening.py
@@ -1509,6 +1509,158 @@ class TestEscalateLayerCHITLPersistence:
             assert True
 
 
+class TestEscalateLayerCDedupeAndDurability:
+    """#3427 hardening for ``_escalate_layer_c_hitl``.
+
+    Two guarantees:
+
+    * **Idempotent across bootstrap re-runs** — the Layer-C question text
+      is deterministic per (case, slice, pipeline), so every
+      ``restart_phase`` re-derives the identical question. The helper must
+      adopt an existing open duplicate and must NOT re-surface a question
+      the operator already resolved (dedupe/carry-forward parity with
+      ``register_open_question``, #3374/#3392).
+    * **Durable at write time** — a newly appended Decision must trigger
+      ``persist_contract_statefiles`` (commit+push to the work branch), so
+      the phase-(re)start ``git reset --hard`` syncs cannot revert it and
+      the next ``next_cq_id`` mint cannot reuse its id (#3427).
+    """
+
+    PIPELINE_ID = "issue-3427-layer-c"
+    QUESTION = (
+        "[#2777 slice-4 TASK-4-4 case 5] Slice slice-4 of pipeline "
+        "issue-3427-layer-c has an impossible status enum value."
+    )
+
+    def _seed_contract(self, repo_root: Path, *, decisions=None) -> None:
+        contract = Contract(
+            schemaVersion="1.2",
+            issue=IssueInfo(number=3427, title="#3427", url=""),
+            pipeline_id=self.PIPELINE_ID,
+            current_phase=ContractPhase.IMPLEMENT,
+            slices=[],
+            decisions=decisions or [],
+        )
+        save_contract(contract, repo_root)
+
+    def _escalate(self, repo_root: Path, question: str | None = None) -> None:
+        from models import PipelinePhase as PipelineModelsPhase
+        from routes.pipelines import _escalate_layer_c_hitl
+
+        _escalate_layer_c_hitl(
+            pipeline_id=self.PIPELINE_ID,
+            slice_id="slice-4",
+            worktree_repo_path=repo_root,
+            current_phase=PipelineModelsPhase.IMPLEMENT,
+            question=question or self.QUESTION,
+        )
+
+    def test_open_duplicate_adopted_not_reminted(self) -> None:
+        """A bootstrap re-run re-deriving an identical, still-open
+        question must adopt the existing ``cq-N`` — not append a second
+        copy the operator has to answer twice.
+        """
+        prior = [
+            Decision(
+                id="cq-1",
+                question=self.QUESTION,
+                type=DecisionType.HITL,
+                phase=ContractPhase.IMPLEMENT,
+            )
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._seed_contract(repo_root, decisions=prior)
+            self._escalate(repo_root)
+            reloaded = load_contract(self.PIPELINE_ID, repo_root)
+            assert [d.id for d in reloaded.decisions] == ["cq-1"], (
+                "identical open Layer-C question must be adopted, not re-minted"
+            )
+
+    def test_resolved_duplicate_not_reasked(self) -> None:
+        """A question the operator already resolved must NOT be
+        re-surfaced by a later bootstrap re-run (#3392 carry-forward);
+        re-asking is exactly the operator pain from #3427.
+        """
+        prior = [
+            Decision(
+                id="cq-1",
+                question=self.QUESTION,
+                type=DecisionType.HITL,
+                phase=ContractPhase.IMPLEMENT,
+                resolved=True,
+                resolution="opt-1",
+            )
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._seed_contract(repo_root, decisions=prior)
+            self._escalate(repo_root)
+            reloaded = load_contract(self.PIPELINE_ID, repo_root)
+            assert len(reloaded.decisions) == 1
+            assert reloaded.decisions[0].resolved is True, (
+                "operator resolution must survive a Layer-C re-run untouched"
+            )
+
+    def test_distinct_question_still_mints_next_id(self) -> None:
+        """Dedupe must not over-match: a different slice's Layer-C
+        question is a distinct decision and gets the next ``cq-N``.
+        """
+        prior = [
+            Decision(
+                id="cq-1",
+                question="[#2777 slice-4 TASK-4-4 case 5] Slice slice-1 is corrupt.",
+                type=DecisionType.HITL,
+                phase=ContractPhase.IMPLEMENT,
+                resolved=True,
+                resolution="opt-1",
+            )
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._seed_contract(repo_root, decisions=prior)
+            self._escalate(repo_root)
+            reloaded = load_contract(self.PIPELINE_ID, repo_root)
+            assert sorted(d.id for d in reloaded.decisions) == ["cq-1", "cq-2"]
+
+    def test_new_decision_triggers_durable_persist(self) -> None:
+        """A newly appended Decision must be committed+pushed at write
+        time via ``persist_contract_statefiles`` — otherwise the next
+        worktree reset reverts it and its id gets re-minted (#3427).
+        """
+        from unittest.mock import patch
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._seed_contract(repo_root)
+            with patch("routes.pipelines.persist_contract_statefiles") as persist_mock:
+                self._escalate(repo_root)
+            persist_mock.assert_called_once()
+            args, _kwargs = persist_mock.call_args
+            assert args[0] == self.PIPELINE_ID
+            assert args[1] == repo_root
+            assert "cq-1" in args[2]
+
+    def test_dedupe_skip_does_not_persist(self) -> None:
+        """An adopted duplicate writes nothing, so nothing to persist."""
+        from unittest.mock import patch
+
+        prior = [
+            Decision(
+                id="cq-1",
+                question=self.QUESTION,
+                type=DecisionType.HITL,
+                phase=ContractPhase.IMPLEMENT,
+            )
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._seed_contract(repo_root, decisions=prior)
+            with patch("routes.pipelines.persist_contract_statefiles") as persist_mock:
+                self._escalate(repo_root)
+            persist_mock.assert_not_called()
+
+
 class TestEscalateCorruptSliceToHITL:
     """``_escalate_corrupt_slice_to_hitl`` — case-5 wrapper that builds
     the question text with the ``[#2777 slice-4 TASK-4-4 case 5]``

--- a/orchestrator/tests/test_slice_phase_restart_hardening.py
+++ b/orchestrator/tests/test_slice_phase_restart_hardening.py
@@ -1264,6 +1264,7 @@ class TestSliceHasPendingDecision:
 # ---------------------------------------------------------------------------
 
 
+import subprocess  # noqa: E402
 import tempfile  # noqa: E402
 
 from egg_contracts.loader import load_contract, save_contract  # noqa: E402
@@ -1659,6 +1660,145 @@ class TestEscalateLayerCDedupeAndDurability:
             with patch("routes.pipelines.persist_contract_statefiles") as persist_mock:
                 self._escalate(repo_root)
             persist_mock.assert_not_called()
+
+
+class TestPersistContractStatefiles:
+    """#3427: direct coverage of ``persist_contract_statefiles``.
+
+    Every *caller* of this helper mocks it (the mutate route, the resolve
+    route, and ``_escalate_layer_c_hitl`` above all patch it out), so its
+    own body — the commit+push wiring that makes a decision survive the
+    phase-restart ``git reset --hard`` — is never exercised by those
+    suites. A signature drift in ``_commit_statefiles_to_worktree`` or
+    ``gateway.push_worktree_branch`` would slip through as a
+    warning-logged no-op — the exact failure mode this fix exists to
+    prevent. This runs the real helper against a temp git repo and
+    asserts a commit lands and is handed to the gateway push.
+    """
+
+    PIPELINE_ID = "issue-3427-persist"
+
+    def _git(self, repo_root: Path, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", "-C", str(repo_root), *args],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+
+    def _init_repo(self, repo_root: Path) -> None:
+        """A real git repo with an initial commit so HEAD resolves
+        (``_commit_statefiles_to_worktree`` runs ``git read-tree HEAD``).
+        """
+        self._git(repo_root, "init", "-q")
+        self._git(repo_root, "config", "user.email", "egg@localhost")
+        self._git(repo_root, "config", "user.name", "egg")
+        (repo_root / "README.md").write_text("seed\n")
+        self._git(repo_root, "add", "README.md")
+        self._git(repo_root, "commit", "-q", "-m", "init")
+
+    def _make_pipeline(self):
+        config = PipelineConfig(concurrent_execution=True, max_concurrent_agents=6)
+        return Pipeline(
+            id=self.PIPELINE_ID,
+            issue_number=3427,
+            repo="owner/repo",
+            branch=f"egg/{self.PIPELINE_ID}/work",
+            base_branch="main",
+            # Explicit mode so ``_compute_gateway_mode`` returns without a
+            # gateway round-trip.
+            network_mode="public",
+            status=PipelineStatus.RUNNING,
+            current_phase=PipelinePhase.IMPLEMENT,
+            config=config,
+        )
+
+    def _seed_contract(self, repo_root: Path) -> None:
+        contract = Contract(
+            schemaVersion="1.2",
+            issue=IssueInfo(number=3427, title="#3427", url=""),
+            pipeline_id=self.PIPELINE_ID,
+            current_phase=ContractPhase.IMPLEMENT,
+            slices=[],
+            decisions=[
+                Decision(
+                    id="cq-1",
+                    question="persist me durably",
+                    type=DecisionType.HITL,
+                    phase=ContractPhase.IMPLEMENT,
+                )
+            ],
+        )
+        save_contract(contract, repo_root)
+
+    def test_commits_and_hands_to_gateway_push(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from routes.pipelines import persist_contract_statefiles
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._init_repo(repo_root)
+            self._seed_contract(repo_root)
+            pipeline = self._make_pipeline()
+
+            spawner = MagicMock()
+            head_before = self._git(repo_root, "rev-parse", "HEAD").stdout.strip()
+
+            with patch("routes.pipelines._get_spawner", return_value=spawner):
+                result = persist_contract_statefiles(
+                    self.PIPELINE_ID,
+                    repo_root,
+                    "Persist contract decision mutation decisions.0 (#3427)",
+                    pipeline=pipeline,
+                )
+
+            assert result is True
+            # A real commit landed on the branch (the reset target now
+            # contains the decision, not just the worktree file).
+            head_after = self._git(repo_root, "rev-parse", "HEAD").stdout.strip()
+            assert head_after != head_before, "expected a new commit for the contract write"
+            subject = self._git(repo_root, "log", "-1", "--pretty=%s").stdout.strip()
+            assert subject == "Persist contract decision mutation decisions.0 (#3427)"
+            # The contract file is what got committed.
+            committed = self._git(repo_root, "show", "--stat", "--pretty=", "HEAD").stdout
+            assert ".egg-state/contracts/" in committed
+
+            # And the commit was pushed to the pipeline's work branch.
+            spawner.gateway.push_worktree_branch.assert_called_once()
+            push_kwargs = spawner.gateway.push_worktree_branch.call_args.kwargs
+            assert push_kwargs["pipeline_id"] == self.PIPELINE_ID
+            assert push_kwargs["branch"] == pipeline.branch
+            assert push_kwargs["base_branch"] == "main"
+
+    def test_no_branch_does_not_push_and_returns_false(self) -> None:
+        """A committed decision with no work branch to push to must not
+        claim durability — it returns ``False`` and skips the push (the
+        commit is local-only and a reset can still discard it).
+        """
+        from unittest.mock import MagicMock, patch
+
+        from routes.pipelines import persist_contract_statefiles
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._init_repo(repo_root)
+            self._seed_contract(repo_root)
+            pipeline = self._make_pipeline()
+            pipeline.branch = None
+
+            spawner = MagicMock()
+            with patch("routes.pipelines._get_spawner", return_value=spawner):
+                result = persist_contract_statefiles(
+                    self.PIPELINE_ID,
+                    repo_root,
+                    "Persist without a branch (#3427)",
+                    pipeline=pipeline,
+                )
+
+            assert result is False
+            spawner.gateway.push_worktree_branch.assert_not_called()
 
 
 class TestEscalateCorruptSliceToHITL:

--- a/sandbox/egg_agent_tools/handlers/sdlc.py
+++ b/sandbox/egg_agent_tools/handlers/sdlc.py
@@ -211,28 +211,37 @@ def register_open_question(req: dict[str, Any]) -> dict[str, Any]:
             new_decision["redirect_seed"] = redirect_seed
 
         reason = f"Created HITL decision: {question[:50]}" + ("..." if len(question) > 50 else "")
-        result = gateway_request(
-            "/api/v1/contract/mutate",
-            method="POST",
-            data={
-                "identifier": identifier,
-                "repo_path": repo_path,
-                "field_path": f"decisions.{next_idx}",
-                "new_value": new_decision,
-                "actor": "egg",
-                "reason": reason,
-                **container_id_field(),
-            },
-        )
-        if result.get("success"):
-            return {
-                "ok": True,
-                "id": new_decision["id"],
-                "decision": new_decision,
-            }
+        # ``gateway_request`` RAISES on non-2xx (the mutate route rejects a
+        # stale-index collision with 409, #3427), so catch it here and feed
+        # the server message through the same retryable check — otherwise
+        # the TOCTOU retry loop never actually retries on a rejection.
+        try:
+            result = gateway_request(
+                "/api/v1/contract/mutate",
+                method="POST",
+                data={
+                    "identifier": identifier,
+                    "repo_path": repo_path,
+                    "field_path": f"decisions.{next_idx}",
+                    "new_value": new_decision,
+                    "actor": "egg",
+                    "reason": reason,
+                    **container_id_field(),
+                },
+            )
+        except GatewayError as exc:
+            message = str(exc)
+            last_error = exc
+        else:
+            if result.get("success"):
+                return {
+                    "ok": True,
+                    "id": new_decision["id"],
+                    "decision": new_decision,
+                }
+            message = result.get("message", "decision mutate failed")
+            last_error = GatewayError(message)
 
-        message = result.get("message", "decision mutate failed")
-        last_error = GatewayError(message)
         retryable = (
             "index" in message.lower()
             or "out of range" in message.lower()

--- a/sandbox/tests/test_register_open_question_retry.py
+++ b/sandbox/tests/test_register_open_question_retry.py
@@ -1,0 +1,124 @@
+"""``register_open_question`` retries a rejected stale-index write (#3427).
+
+The mutate route rejects a whole-entry write to an existing
+``decisions[]`` index with 409 (the append-only guard). The sandbox
+``gateway_request`` RAISES ``GatewayError`` on non-2xx, so the handler's
+TOCTOU retry loop must catch it and feed the server message through the
+retryable check — before #3427 the loop only inspected returned dicts and
+an HTTP rejection escaped on the first attempt, so the loop never
+actually retried.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# The host-side test harness mirrors the sandbox-image layout via
+# PYTHONPATH; insert here for IDE / pytest -m runs that don't go
+# through the Makefile.
+_SANDBOX_DIR = Path(__file__).resolve().parent.parent
+_SHARED_DIR = _SANDBOX_DIR.parent / "shared"
+for p in (_SHARED_DIR, _SANDBOX_DIR):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+from egg_agent_tools.handlers import sdlc  # noqa: E402
+from egg_agent_tools.handlers.errors import GatewayError  # noqa: E402
+
+
+def _req() -> dict:
+    return {
+        "question": "Should we do X?",
+        "pipeline_id": "issue-3427",
+        "repo_path": "/tmp/repo",
+        "phase": "implement",
+    }
+
+
+def test_conflict_rejection_is_retried_with_fresh_read() -> None:
+    """A 409 "already exists" rejection re-reads the contract and
+    re-mints the next free index/id instead of propagating.
+    """
+    contracts = [
+        {"decisions": [], "current_phase": "implement"},
+        # The fresh read reveals the decision another writer landed at
+        # index 0 while we were minting.
+        {
+            "decisions": [
+                {
+                    "id": "cq-1",
+                    "question": "a different question",
+                    "type": "hitl",
+                    "phase": "implement",
+                    "resolved": False,
+                }
+            ],
+            "current_phase": "implement",
+        },
+    ]
+    mutate_calls: list[dict] = []
+
+    def fake_gateway_request(endpoint, *, method="GET", data=None, **_kw):
+        mutate_calls.append(data)
+        if len(mutate_calls) == 1:
+            raise GatewayError(
+                "Decision at index 0 already exists (id=cq-1); decisions "
+                "are append-only — re-read the contract and mint a fresh "
+                "index and id (#3427)",
+                status_code=409,
+            )
+        return {"success": True}
+
+    with (
+        patch.object(sdlc, "_fetch_contract", side_effect=contracts),
+        patch.object(sdlc, "gateway_request", side_effect=fake_gateway_request),
+    ):
+        result = sdlc.register_open_question(_req())
+
+    assert result["ok"] is True
+    assert result["id"] == "cq-2"
+    assert mutate_calls[0]["field_path"] == "decisions.0"
+    assert mutate_calls[1]["field_path"] == "decisions.1"
+
+
+def test_non_retryable_gateway_error_raises_on_first_attempt() -> None:
+    with (
+        patch.object(
+            sdlc,
+            "_fetch_contract",
+            return_value={"decisions": [], "current_phase": "implement"},
+        ),
+        patch.object(
+            sdlc,
+            "gateway_request",
+            side_effect=GatewayError("forbidden", status_code=403),
+        ) as gateway_mock,
+        pytest.raises(GatewayError, match="forbidden"),
+    ):
+        sdlc.register_open_question(_req())
+
+    assert gateway_mock.call_count == 1
+
+
+def test_retries_are_bounded() -> None:
+    """A persistent conflict gives up after ``_DECISION_RETRY_ATTEMPTS``."""
+    with (
+        patch.object(
+            sdlc,
+            "_fetch_contract",
+            return_value={"decisions": [], "current_phase": "implement"},
+        ),
+        patch.object(
+            sdlc,
+            "gateway_request",
+            side_effect=GatewayError("Decision at index 0 already exists", status_code=409),
+        ) as gateway_mock,
+        pytest.raises(GatewayError, match="already exists"),
+    ):
+        sdlc.register_open_question(_req())
+
+    assert gateway_mock.call_count == sdlc._DECISION_RETRY_ATTEMPTS

--- a/shared/egg_contracts/tests/test_decisions_append_only.py
+++ b/shared/egg_contracts/tests/test_decisions_append_only.py
@@ -1,0 +1,132 @@
+"""Whole-entry ``decisions[]`` writes are append-only (#3427).
+
+Every in-tree writer mints its target index as ``len(decisions)`` and
+appends. A whole-entry write landing on an *existing* index means the
+caller minted against a stale read (a TOCTOU race across writers) and
+would silently replace another writer's decision — including a resolved
+one, erasing the operator's answer (the #3427 clobber). ``apply_mutation``
+must reject such writes with ``error_kind="conflict"`` so the caller
+re-reads the contract and re-mints; sub-field writes and true appends are
+unaffected.
+"""
+
+from __future__ import annotations
+
+from egg_contracts.models import (
+    Contract,
+    Decision,
+    DecisionType,
+    IssueInfo,
+    PipelinePhase,
+)
+from egg_contracts.roles import Role
+from egg_contracts.validator import apply_mutation
+
+
+def _contract(decisions: list[Decision] | None = None) -> Contract:
+    return Contract(
+        schemaVersion="1.2",
+        issue=IssueInfo(number=3427, title="#3427", url=""),
+        pipeline_id="issue-3427",
+        current_phase=PipelinePhase.IMPLEMENT,
+        slices=[],
+        decisions=decisions or [],
+    )
+
+
+def _decision(id_: str, *, resolved: bool = False) -> Decision:
+    return Decision(
+        id=id_,
+        question=f"question for {id_}",
+        type=DecisionType.HITL,
+        phase=PipelinePhase.IMPLEMENT,
+        resolved=resolved,
+        resolution="answered" if resolved else None,
+    )
+
+
+def _new_entry(id_: str) -> dict:
+    """The gateway JSON shape ``register_open_question`` sends."""
+    return {
+        "id": id_,
+        "question": "a freshly minted question",
+        "type": "hitl",
+        "phase": "implement",
+        "options": [],
+        "resolved": False,
+        "resolution": None,
+    }
+
+
+class TestDecisionsAppendOnly:
+    def test_overwrite_existing_index_rejected_as_conflict(self) -> None:
+        contract = _contract([_decision("cq-1")])
+        result = apply_mutation(
+            contract,
+            role=Role.IMPLEMENTER,
+            actor="agent",
+            field_path="decisions.0",
+            new_value=_new_entry("cq-1"),
+        )
+        assert result.success is False
+        assert result.error_kind == "conflict"
+        assert "already exists" in result.message
+        # The existing entry must be untouched.
+        assert contract.decisions[0].question == "question for cq-1"
+
+    def test_overwrite_of_resolved_entry_flags_resolved(self) -> None:
+        contract = _contract([_decision("cq-1", resolved=True)])
+        result = apply_mutation(
+            contract,
+            role=Role.IMPLEMENTER,
+            actor="agent",
+            field_path="decisions.0",
+            new_value=_new_entry("cq-2"),
+        )
+        assert result.success is False
+        assert result.error_kind == "conflict"
+        assert "(resolved)" in result.message
+        assert contract.decisions[0].resolved is True
+        assert contract.decisions[0].resolution == "answered"
+
+    def test_append_at_len_still_succeeds(self) -> None:
+        contract = _contract([_decision("cq-1")])
+        result = apply_mutation(
+            contract,
+            role=Role.IMPLEMENTER,
+            actor="agent",
+            field_path="decisions.1",
+            new_value=_new_entry("cq-2"),
+        )
+        assert result.success is True, result.message
+        assert len(contract.decisions) == 2
+
+    def test_past_the_end_index_remains_value_error(self) -> None:
+        """Indices beyond ``len`` are not conflicts — they stay the
+        pre-existing out-of-range ``value`` rejection.
+        """
+        contract = _contract([_decision("cq-1")])
+        result = apply_mutation(
+            contract,
+            role=Role.IMPLEMENTER,
+            actor="agent",
+            field_path="decisions.5",
+            new_value=_new_entry("cq-2"),
+        )
+        assert result.success is False
+        assert result.error_kind == "value"
+
+    def test_subfield_write_on_existing_entry_not_blocked(self) -> None:
+        """Resolution sub-field writes (``decisions.N.<field>``, HUMAN-owned)
+        are not whole-entry writes and must keep working.
+        """
+        contract = _contract([_decision("cq-1")])
+        result = apply_mutation(
+            contract,
+            role=Role.HUMAN,
+            actor="operator",
+            field_path="decisions.0.resolved",
+            new_value=True,
+        )
+        assert result.success is True, result.message
+        assert contract.decisions[0].resolved is True

--- a/shared/egg_contracts/validator.py
+++ b/shared/egg_contracts/validator.py
@@ -5,6 +5,7 @@ This module validates mutations against role permissions, ensuring that
 only authorized roles can modify specific fields.
 """
 
+import re
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -25,7 +26,11 @@ class ValidationResult:
     required_role: str | None = None
 
 
-MutationErrorKind = Literal["authorization", "value"]
+MutationErrorKind = Literal["authorization", "value", "conflict"]
+
+# Whole-entry ``decisions[]`` writes (``decisions.<idx>``, no trailing
+# sub-field) are append-only; see the guard in :func:`apply_mutation`.
+_DECISIONS_ENTRY_PATH_RE = re.compile(r"^decisions\.(\d+)$")
 
 
 @dataclass
@@ -35,7 +40,9 @@ class MutationResult:
     ``error_kind`` discriminates failure causes for the route boundary
     (#2495): ``"authorization"`` is a role-permission rejection (HTTP
     403); ``"value"`` is a malformed path or out-of-domain value (HTTP
-    400/422). ``None`` on success.
+    400/422); ``"conflict"`` is a lost-update collision (a whole-entry
+    write to an existing ``decisions[]`` index, #3427) the caller should
+    retry against a fresh read. ``None`` on success.
     """
 
     success: bool
@@ -147,6 +154,33 @@ def apply_mutation(
             message=validation.message,
             error_kind="authorization",
         )
+
+    # Append-only guard for whole-entry ``decisions[]`` writes (#3427).
+    # Every in-tree writer mints its index as ``len(decisions)`` and
+    # appends; a whole-entry write landing on an existing index means the
+    # caller minted against a stale read (TOCTOU across writers) and would
+    # silently replace another writer's decision — including a *resolved*
+    # one, erasing the operator's answer. Reject so the caller re-reads
+    # and re-mints (the sandbox handler's retry loop treats "already
+    # exists" as retryable). Sub-field writes (``decisions.N.<field>``)
+    # are unaffected.
+    decisions_entry = _DECISIONS_ENTRY_PATH_RE.match(field_path)
+    if decisions_entry:
+        idx = int(decisions_entry.group(1))
+        existing_decisions = contract.decisions or []
+        if idx < len(existing_decisions):
+            existing = existing_decisions[idx]
+            resolved_note = " (resolved)" if getattr(existing, "resolved", False) else ""
+            return MutationResult(
+                success=False,
+                message=(
+                    f"Decision at index {idx} already exists "
+                    f"(id={getattr(existing, 'id', None)}{resolved_note}); "
+                    f"decisions are append-only — re-read the contract and "
+                    f"mint a fresh index and id (#3427)"
+                ),
+                error_kind="conflict",
+            )
 
     # Get the old value and apply the mutation
     try:

--- a/shared/egg_contracts/validator.py
+++ b/shared/egg_contracts/validator.py
@@ -170,12 +170,26 @@ def apply_mutation(
         existing_decisions = contract.decisions or []
         if idx < len(existing_decisions):
             existing = existing_decisions[idx]
-            resolved_note = " (resolved)" if getattr(existing, "resolved", False) else ""
+            # Read ``id``/``resolved`` through a dict-or-object accessor:
+            # production loads pydantic ``Decision`` objects on the mutate
+            # path, but an in-memory contract built from dict-backed
+            # decisions would make a plain ``getattr`` degrade to
+            # ``None``/absent, dropping the identifying detail from the
+            # rejection message the caller logs.
+            existing_id = (
+                existing.get("id") if isinstance(existing, dict) else getattr(existing, "id", None)
+            )
+            existing_resolved = (
+                existing.get("resolved")
+                if isinstance(existing, dict)
+                else getattr(existing, "resolved", False)
+            )
+            resolved_note = " (resolved)" if existing_resolved else ""
             return MutationResult(
                 success=False,
                 message=(
                     f"Decision at index {idx} already exists "
-                    f"(id={getattr(existing, 'id', None)}{resolved_note}); "
+                    f"(id={existing_id}{resolved_note}); "
                     f"decisions are append-only — re-read the contract and "
                     f"mint a fresh index and id (#3427)"
                 ),

--- a/tests/shared/egg_contracts/test_validator.py
+++ b/tests/shared/egg_contracts/test_validator.py
@@ -517,12 +517,17 @@ class TestArrayAppend:
         assert result.contract.decisions[1]["id"] == "decision-2"
 
     def test_overwrite_existing_array_element(self, contract_with_decisions):
-        """Test overwriting an existing array element."""
+        """Whole-entry decisions[] writes are append-only (#3427).
+
+        A whole-entry write landing on an existing index means the caller
+        minted against a stale read and would silently clobber another
+        writer's decision. ``apply_mutation`` must reject it as a conflict.
+        """
         # Add a decision
         decision1 = {"id": "decision-1", "question": "Q1", "resolved": False}
         contract_with_decisions.decisions.append(decision1)
 
-        # Overwrite it (IMPLEMENTER can modify decisions.*)
+        # Attempt to overwrite it — rejected by the append-only guard.
         updated = {"id": "decision-1", "question": "Updated Q1", "resolved": False}
         result = apply_mutation(
             contract=contract_with_decisions,
@@ -532,8 +537,11 @@ class TestArrayAppend:
             new_value=updated,
             reason="Updated decision",
         )
-        assert result.success is True
-        assert result.contract.decisions[0]["question"] == "Updated Q1"
+        assert result.success is False
+        assert result.error_kind == "conflict"
+        assert "append-only" in result.message
+        # Original entry is left untouched.
+        assert contract_with_decisions.decisions[0]["question"] == "Q1"
 
     def test_append_with_gap_fails(self, contract_with_decisions):
         """Test that appending with a gap in indices fails."""


### PR DESCRIPTION
Fixes #3427.

## Root cause (differs slightly from the issue's framing)

The reconciler did not read stale *writer-local* state — the contract file itself had been reverted. Contract HITL decision writes (agent registrations via the contract-mutate RPC, operator resolutions via `_resolve_contract_decision`, Layer-C escalations) are bare `save_contract()` file writes in the shared pipeline worktree, serialized to the work branch only at slice-completion / phase-gate checkpoints. Both phase-(re)start syncs — the gateway worktree-reuse reset (`_reset_reused_worktree_to_safe_ref`) and `_sync_worktree_with_remote` step 4 — run `git reset --hard origin/<work>`, silently discarding every decision write since the last checkpoint.

On issue-3393: the last contract commit before the incident was slice-3 completion (05:49Z), whose committed `decisions[]` ended at an unresolved `cq-2`. Everything after (the `cq-2` resolution, the reviewer's `cq-3` + its resolution) lived only as uncommitted worktree state. `restart_phase` reset the worktree to that commit, the bootstrap reconciler minted `next_cq_id` against the reverted file and re-registered its case-5 question as `cq-3`, and the next slice-completion push made the corruption durable. The same sequence recurred at 17:50Z the same day (live log: `worktree_sync_outcome … case=reset_succeeded` immediately before `Layer-C HITL escalation persisted … decision_id=cq-3`), wiping the operator's re-resolutions a second time.

## Fix

1. **Durability at write time** — new `persist_contract_statefiles()` (routes/pipelines.py): best-effort commit+push of the pipeline's `.egg-state` files to the work branch, invoked from the three decision writers:
   - contract-mutate RPC for `decisions.*` field paths (agent `register_open_question`),
   - `_resolve_contract_decision` (operator resolutions),
   - `_escalate_layer_c_hitl` (bootstrap reconciler).

   With decisions on `origin/<work>` at write time, the reset target already contains them — same pattern as the existing first-principles-redirect persist (#3080) and slice-completion persists (#3117).
2. **Layer-C dedupe/carry-forward** — `_escalate_layer_c_hitl` now adopts an identical open question and never re-surfaces a resolved one (parity with `register_open_question`, #3374/#3392). Layer-C question text is deterministic per (case, slice, pipeline), so every bootstrap re-run previously re-asked the operator.
3. **Append-only `decisions[]` guard** (issue defect 2) — `apply_mutation` rejects a whole-entry write to an existing index with new `error_kind="conflict"` (HTTP 409). Agents mint `decisions.{len}` client-side, and `_set_value` silently overwrote on a TOCTOU race; now the write is refused and the entry (including a resolved one) is immutable.
4. **Retry loop actually retries** — the sandbox `register_open_question` TOCTOU loop only inspected returned dicts, but `gateway_request` raises on non-2xx, so rejections escaped on attempt 1. It now catches `GatewayError` and feeds the server message through the retryable check, re-reading and re-minting on conflict.
5. **Restart-time persist includes the contract** — the `restart_phase`-path `_commit_statefiles_to_worktree` call now passes `pipeline_id`, so the contract file (keyed by pipeline-id, not the issue-number prefix) is staged (#1829 gap; observed as `pipeline_id=None` in the incident logs).

## Testing

Targeted suites (all pass): `test_slice_phase_restart_hardening.py`, `test_contracts_routes.py`, `test_resolve_contract_decision_route.py`, `test_advance_phase_thread.py`, `test_impasse_routing.py`, `test_corrective_executor.py`, `test_contract_decision_bridge.py`, `test_empty_contract_hitl.py`, `test_contract_preserved_across_post_phase_sync.py`, full `shared/egg_contracts/tests/`, plus new `test_decisions_append_only.py` and `test_register_open_question_retry.py`. `make lint-python` (ruff + mypy, 257 files) clean.

## Notes / residual risk

- The persist is best-effort: a failed push leaves the decision live-but-volatile until the next checkpoint (logged as a warning). Push races with agent pushes go through the existing `push_worktree_branch` reconcile path.
- `route_impasses` (orchestrator-side impasse escalations) still writes without an immediate persist; its decisions are covered by the append-only guard but share the volatility window. Left out to keep this PR scoped to the observed writers; can follow up if it bites.
- The sandbox-handler change (retry loop) needs a sandbox image rebuild to take effect in-cluster.