### PR TITLE
Remove wait-for-checks CI gate from reviewer workflows

### DIFF
--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -143,7 +143,7 @@ jobs:
           echo "PR HEAD SHA: ${head_sha} (${head_ref} -> ${base_ref}, context-pr=${context_pr})"
 
       # NOTE: This step duplicates marker detection logic from the "Find last bot review
-      # commit for re-review context" step in the review job (lines 306-388). This is
+      # commit for re-review context" step in the review job. This is
       # intentional: the should-run job runs first to avoid spinning up unnecessary jobs,
       # while the review job needs the last review commit for context. If the marker format
       # changes, both locations must be updated in sync.
@@ -253,113 +253,14 @@ jobs:
 
           echo "run=true" >> "$GITHUB_OUTPUT"
 
-  wait-for-checks:
-    name: Wait for CI checks
-    needs: should-run
-    if: needs.should-run.outputs.run == 'true' && inputs.event_name != 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 35
-    outputs:
-      all_passed: ${{ steps.wait.outputs.passed }}
-      commit_sha: ${{ steps.wait.outputs.commit_sha }}
-    steps:
-      - name: Generate bot token
-        id: bot-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.BOT_APP_ID }}
-          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
-
-      - name: Wait for all non-review checks to complete
-        id: wait
-        env:
-          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
-          PR_NUMBER: ${{ inputs.pr_number }}
-        run: |
-          set -euo pipefail
-
-          HEAD_SHA=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '.head.sha')
-          echo "Waiting for checks on commit: ${HEAD_SHA}"
-          echo "commit_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
-
-          MAX_WAIT=1500
-          INTERVAL=30
-          start=$(date +%s)
-          no_checks_count=0
-
-          while true; do
-            elapsed=$(( $(date +%s) - start ))
-            if [[ $elapsed -ge $MAX_WAIT ]]; then
-              echo "::warning::Timed out waiting for checks after ${MAX_WAIT}s — proceeding with review"
-              echo "passed=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-
-            # Filter out review bot checks and SDLC pipeline checks to avoid self-deadlock.
-            # Patterns matched (no ^ anchor because GitHub may prefix with workflow name):
-            # - egg-review / matches the standardized prefix for all reviewer caller job names
-            # - egg-reviewer- matches nested reviewer jobs (e.g., "egg-review / Code / egg-reviewer-review")
-            # - SDLC Pipeline matches "egg: SDLC Pipeline / Initialize pipeline", etc.
-            # - SDLC HITL matches "egg: SDLC HITL Decision Handler / Handle HITL decision", etc.
-            # Deduplicate by name: GitHub returns multiple check runs per name when
-            # a workflow re-runs (e.g., superseded PRs, force-pushes). Group by name
-            # and keep only the most recent (last) run for each.
-            checks=$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/check-runs" \
-              --jq '.check_runs | [.[] | select(
-                (.name | test("egg-review /|egg-reviewer-|SDLC Pipeline|SDLC HITL") | not)
-              )] | group_by(.name) | [.[] | sort_by(.id) | last | {name, status, conclusion}]')
-
-            total=$(echo "$checks" | jq 'length')
-
-            if [[ "$total" -eq 0 ]]; then
-              no_checks_count=$((no_checks_count + 1))
-              if [[ $no_checks_count -ge 20 ]]; then
-                echo "No checks found after ${no_checks_count} polls — proceeding"
-                echo "passed=true" >> "$GITHUB_OUTPUT"
-                exit 0
-              fi
-              echo "No checks yet (poll ${no_checks_count}/20)"
-              sleep "$INTERVAL"
-              continue
-            fi
-            no_checks_count=0
-
-            completed=$(echo "$checks" | jq '[.[] | select(.status == "completed")] | length')
-            failed=$(echo "$checks" | jq '[.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral" and .conclusion != "cancelled")] | length')
-
-            echo "Checks: ${completed}/${total} completed, ${failed} failed"
-
-            if [[ "$completed" -eq "$total" ]]; then
-              if [[ "$failed" -gt 0 ]]; then
-                echo "::warning::${failed} check(s) failed — skipping review"
-                echo "$checks" | jq -r '.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral" and .conclusion != "cancelled") | "  FAILED: \(.name) (\(.conclusion))"'
-                echo "passed=false" >> "$GITHUB_OUTPUT"
-              else
-                echo "All ${total} checks passed"
-                echo "passed=true" >> "$GITHUB_OUTPUT"
-              fi
-              exit 0
-            fi
-
-            pending=$(echo "$checks" | jq -r '[.[] | select(.status != "completed") | .name] | join(", ")')
-            echo "Waiting for: ${pending}"
-            sleep "$INTERVAL"
-          done
-
   review:
     name: egg-reviewer-${{ inputs.bot_name }}
-    needs: [should-run, wait-for-checks]
-    # Run review if:
-    # - should-run says yes, AND
-    # - wait-for-checks was skipped (workflow_dispatch), OR
-    # - wait-for-checks succeeded and all checks passed
-    # Note: If wait-for-checks fails unexpectedly (token error, API rate limit, etc.),
-    # we intentionally block the review to avoid reviewing potentially broken code.
-    if: >-
-      always() &&
-      needs.should-run.outputs.run == 'true' &&
-      needs.wait-for-checks.result != 'failure' &&
-      (needs.wait-for-checks.result == 'skipped' || needs.wait-for-checks.outputs.all_passed == 'true')
+    needs: [should-run]
+    # Review runs as soon as should-run says yes — deliberately NOT gated on CI
+    # checks. Reviews are commit-anchored (the marker records the reviewed SHA)
+    # and re-reviews cover only the diff since the prior review, so if CI later
+    # fails and a fix is pushed, the fix simply gets its own incremental review.
+    if: needs.should-run.outputs.run == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -415,19 +316,9 @@ jobs:
         id: pr-meta
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
-          VALIDATED_SHA: ${{ needs.wait-for-checks.outputs.commit_sha }}
         run: |
           pr_json=$(gh api repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }})
           current_sha=$(echo "$pr_json" | jq -r '.head.sha')
-
-          # If we have a validated SHA from wait-for-checks, verify the PR still points to it.
-          # This prevents reviewing code that was pushed after checks completed but before
-          # the concurrency group cancelled this run.
-          if [[ -n "$VALIDATED_SHA" && "$current_sha" != "$VALIDATED_SHA" ]]; then
-            echo "::error::PR HEAD has changed since checks completed (expected ${VALIDATED_SHA}, got ${current_sha})"
-            echo "A new workflow run should be triggered for the new commit. Aborting this review."
-            exit 1
-          fi
 
           {
             echo "head-ref=$(echo "$pr_json" | jq -r '.head.ref')"

--- a/action/review-conventions.md
+++ b/action/review-conventions.md
@@ -60,9 +60,10 @@ avoid the extra API call and log noise.
 
 **Never run `make test`** as part of your review. The egg test suite takes
 10-15 minutes and is causing this workflow to time out. CI runs the configured
-check suite on every PR HEAD — trust those results (the `wait-for-checks` step
-in the workflow gates this review on a green status), and NACK if you have
-concerns about coverage or behavior rather than re-running tests yourself.
+check suite on every PR HEAD in parallel with this review — leave test
+execution to CI (its results may still be pending while you review), and NACK
+if you have concerns about coverage or behavior rather than re-running tests
+yourself.
 
 If you need to validate a specific concern about a single function, you may run
 individual targeted tests (`.venv/bin/pytest path/to/test_x.py::TestY::test_z`),

--- a/docs/guides/github-automation.md
+++ b/docs/guides/github-automation.md
@@ -60,13 +60,7 @@ and via `workflow_dispatch` with a PR number.
    `workflow_dispatch` forces a review regardless. (`reusable-review.yml` retains its own
    narrower multi-slice context-PR skip for any other caller, but for the egg-reviewer path the
    `on-pull-request.yml` gate supersedes it.)
-2. **Wait for CI checks** — Waits for all non-review checks (e.g., lint, tests) to complete
-   before starting the review. Skips checks matching `egg-review /` (the standard reviewer
-   job prefix), `egg-reviewer-` (nested reviewer jobs), `SDLC Pipeline`, or `SDLC HITL` to
-   avoid self-deadlock. If checks fail, the review is skipped. Workflow dispatch triggers
-   bypass this wait and the already-reviewed check. Times out after 25 minutes with a warning
-   and proceeds anyway.
-3. **Re-review detection** — Searches for an `<!-- egg-automated-review bot=<name> commit=<sha> -->`
+2. **Re-review detection** — Searches for an `<!-- egg-automated-review bot=<name> commit=<sha> -->`
    marker in previous reviews/comments to identify the last reviewed commit. On re-review,
    the agent uses `git log <last-commit>..HEAD --not origin/<base> -p` (preceded by a
    `git fetch origin <base>` nudge) to focus only on PR-side commits pushed since the
@@ -76,13 +70,17 @@ and via `workflow_dispatch` with a PR number.
    This prevents the reviewer from attributing merged-in base-branch work to the PR
    itself (see [#1758](https://github.com/jwbron/egg/issues/1758)). First-cycle reviews
    (no prior marker) still use the full-PR `git diff origin/<base>...HEAD` form.
-4. **Stale review dismissal** — Dismisses previous bot reviews before posting a new one.
-5. **Trusted prompt build** — Checks out `main` (not the PR branch) to run
+3. **Stale review dismissal** — Dismisses previous bot reviews before posting a new one.
+4. **Trusted prompt build** — Checks out `main` (not the PR branch) to run
    `build-review-prompt.sh`, preventing prompt injection from malicious PRs.
-6. **SHA validation** — Verifies the PR HEAD still matches the commit that passed checks,
-   aborting if code was pushed after checks completed but before the review started.
-7. **Agent review** — Checks out the PR branch and runs egg with the review prompt.
+5. **Agent review** — Checks out the PR branch and runs egg with the review prompt.
    The agent reads the diff, examines context, and posts its review via `gh pr review`.
+
+The review deliberately does **not** wait on CI checks: it starts as soon as the
+skip checks pass and runs in parallel with lint/tests. Reviews are commit-anchored
+and re-reviews cover only the diff since the last reviewed commit, so if CI fails
+and a fix is pushed, the fix gets its own incremental re-review — cheaper than
+serializing every review behind a full CI run.
 
 ### Review Decisions
 
@@ -111,8 +109,9 @@ by providing different prompt scripts while sharing the review infrastructure.
 ### Reviewer Job Naming Convention
 
 **All reviewer workflows must use the `egg-review /` prefix for their job names.** This
-standardized prefix ensures check-waiting logic correctly filters out all reviewer
-jobs to prevent self-deadlock.
+standardized prefix makes reviewer check runs identifiable, so check-waiting logic
+(e.g., the feedback workflow's wait-for-all-reviewers step) can reliably tell reviewer
+jobs apart from CI checks.
 
 Example job definition:
 ```yaml
@@ -125,9 +124,10 @@ jobs:
       # ...
 ```
 
-Check-waiting logic filters out `egg-review /` in check run names. If a new reviewer
-workflow doesn't follow this convention, it will cause infinite loops where reviewers
-wait on each other indefinitely.
+The feedback workflow identifies reviewer check runs by the nested
+`egg-reviewer-<bot_name>` job name that `reusable-review.yml` produces under this
+prefix. A reviewer workflow that doesn't follow the convention won't be waited on
+before feedback addressing starts, causing duplicate or racing feedback runs.
 
 ## Address Review Feedback
 

--- a/docs/guides/github-automation.md
+++ b/docs/guides/github-automation.md
@@ -109,9 +109,8 @@ by providing different prompt scripts while sharing the review infrastructure.
 ### Reviewer Job Naming Convention
 
 **All reviewer workflows must use the `egg-review /` prefix for their job names.** This
-standardized prefix makes reviewer check runs identifiable, so check-waiting logic
-(e.g., the feedback workflow's wait-for-all-reviewers step) can reliably tell reviewer
-jobs apart from CI checks.
+is a naming-consistency convention that keeps reviewer check runs visually identifiable
+in the PR checks list.
 
 Example job definition:
 ```yaml
@@ -124,10 +123,16 @@ jobs:
       # ...
 ```
 
-The feedback workflow identifies reviewer check runs by the nested
-`egg-reviewer-<bot_name>` job name that `reusable-review.yml` produces under this
-prefix. A reviewer workflow that doesn't follow the convention won't be waited on
-before feedback addressing starts, causing duplicate or racing feedback runs.
+Note that downstream automation does **not** key on this caller-side prefix. The
+functional identifier is the nested `egg-reviewer-<bot_name>` job name that
+`reusable-review.yml` emits (its `review` job), which is present regardless of the
+caller's job name. The feedback workflow's wait-for-all-reviewers step, for example,
+matches reviewer check runs with `test("egg-reviewer-")`, so a caller that omits the
+`egg-review /` prefix is still waited on. The lint that enforces the prefix
+(`scripts/check-reviewer-job-names.py`) is therefore advisory — it preserves naming
+consistency rather than guarding a correctness invariant. Its original functional
+consumer, the `egg-review /` filter in the old `wait-for-checks` gate, was removed when
+that gate was dropped.
 
 ## Address Review Feedback
 

--- a/scripts/check-reviewer-job-names.py
+++ b/scripts/check-reviewer-job-names.py
@@ -3,9 +3,10 @@
 Lint check: Ensure reviewer workflows use the standard job naming convention.
 
 All workflows that use reusable-review.yml must have job names prefixed with
-"egg-review /" to ensure check-waiting logic correctly excludes them.
+"egg-review /" so reviewer check runs are identifiable by name.
 
-This prevents infinite loops where reviewers wait for each other indefinitely.
+Check-waiting logic (e.g., on-review-feedback.yml's wait-for-all-reviewers
+step) relies on this to tell reviewer jobs apart from CI checks.
 
 Usage:
     python3 scripts/check-reviewer-job-names.py
@@ -90,16 +91,17 @@ def main(repo_root: Path | None = None) -> int:
         print("ERROR: Found reviewer jobs without required naming prefix!\n")
         print("=" * 70)
         print("All jobs using reusable-review.yml must have names starting with")
-        print(f"'{REQUIRED_PREFIX}' to prevent self-deadlock in check-waiting logic.")
+        print(f"'{REQUIRED_PREFIX}' so reviewer check runs are identifiable by name.")
         print("=" * 70)
         print()
         for v in all_violations:
             print(v)
             print()
         print("Why this matters:")
-        print("  Check-waiting logic filters out checks matching 'egg-review /'")
-        print("  to prevent reviewers from waiting on each other indefinitely.")
-        print("  Without this prefix, a new reviewer will cause infinite loops.")
+        print("  Check-waiting logic (e.g., the feedback workflow's")
+        print("  wait-for-all-reviewers step) identifies reviewer check runs")
+        print("  by name. Without this prefix, a new reviewer won't be waited")
+        print("  on, causing duplicate or racing feedback runs.")
         print()
         return 1
     else:

--- a/scripts/check-reviewer-job-names.py
+++ b/scripts/check-reviewer-job-names.py
@@ -5,8 +5,12 @@ Lint check: Ensure reviewer workflows use the standard job naming convention.
 All workflows that use reusable-review.yml must have job names prefixed with
 "egg-review /" so reviewer check runs are identifiable by name.
 
-Check-waiting logic (e.g., on-review-feedback.yml's wait-for-all-reviewers
-step) relies on this to tell reviewer jobs apart from CI checks.
+This is a naming-consistency convention, not a correctness guard: downstream
+automation (e.g. on-review-feedback.yml's wait-for-all-reviewers step) keys on
+the nested "egg-reviewer-<bot>" job name that reusable-review.yml emits, which
+is present regardless of the caller's prefix. The prefix's original functional
+consumer, the "egg-review /" filter in the old wait-for-checks gate, is gone,
+so this lint is now advisory.
 
 Usage:
     python3 scripts/check-reviewer-job-names.py
@@ -98,10 +102,10 @@ def main(repo_root: Path | None = None) -> int:
             print(v)
             print()
         print("Why this matters:")
-        print("  Check-waiting logic (e.g., the feedback workflow's")
-        print("  wait-for-all-reviewers step) identifies reviewer check runs")
-        print("  by name. Without this prefix, a new reviewer won't be waited")
-        print("  on, causing duplicate or racing feedback runs.")
+        print("  A naming-consistency convention that keeps reviewer check")
+        print("  runs identifiable in the PR checks list. This is advisory:")
+        print("  downstream automation keys on the nested 'egg-reviewer-<bot>'")
+        print("  job name from reusable-review.yml, not this caller-side prefix.")
         print()
         return 1
     else:


### PR DESCRIPTION
## Summary

GitHub reviewers no longer wait for CI checks before reviewing. The `wait-for-checks` job in `reusable-review.yml` polled up to 25 minutes for all non-review checks to complete (and skipped the review outright if any failed) before every review, for all three callers (code reviewer, design reviewer, contract verifier).

Reviews are commit-anchored (the `egg-automated-review` marker records the reviewed SHA) and re-reviews cover only the diff since the prior review, so serializing reviews behind CI bought little: if CI later fails and a fix is pushed, the fix simply gets its own incremental re-review.

## Changes

- **`.github/workflows/reusable-review.yml`** — drop the `wait-for-checks` job; `review` now needs only `should-run`. Also drop the `VALIDATED_SHA` head-drift abort in `pr-meta`, whose input came from the removed job (the per-PR concurrency group with `cancel-in-progress` still handles superseded runs).
- **`action/review-conventions.md`** — stop telling the reviewer that CI already gated the review on green; CI now runs in parallel and its results may still be pending. The don't-run-`make test` rule is unchanged.
- **`docs/guides/github-automation.md`** — remove the CI-wait step from the reviewer flow description; reword the `egg-review /` job-name prefix rationale around its remaining consumer, `on-review-feedback.yml`'s wait-for-all-reviewers step.
- **`scripts/check-reviewer-job-names.py`** — same rationale reword (the lint itself is unchanged and still enforced).

Not touched: `on-review-feedback.yml`'s wait — that polls for *reviewer* checks (not CI) so feedback addressing fires once after all reviewers finish, which is still needed.

## Testing

- `.venv/bin/pytest tests/scripts/test_check_reviewer_job_names.py tests/config/test_sdlc_pr_bot_skip.py tests/config/test_contract_verify_workflow.py tests/config/test_slice_pr_history_hygiene.py` — 63 passed
- `yamllint` clean on the edited workflow (only pre-existing line-length warnings)
- `scripts/check-reviewer-job-names.py` passes