### PR TITLE
Allow runtime npm dependency installation through the egress proxy

### DIFF
--- a/docs/architecture/network-isolation.md
+++ b/docs/architecture/network-isolation.md
@@ -222,9 +222,11 @@ For truly unsupervised operation with `--dangerously-skip-permissions`, infrastr
 │  │  │  ✓ api.github.com             (GitHub API)                      │   │  │
 │  │  │  ✓ github.com                 (git operations)                  │   │  │
 │  │  │  ✓ *.githubusercontent.com   (GitHub raw content)              │   │  │
+│  │  │  ✓ registry.npmjs.org         (npm installs, lockfile-pinned)   │   │  │
+│  │  │  ✓ npm.pkg.github.com         (GitHub Packages npm registry)    │   │  │
 │  │  │                                                                 │   │  │
 │  │  │  BLOCKED (everything else):                                     │   │  │
-│  │  │  ✗ pypi.org, npmjs.com        (no package installs)             │   │  │
+│  │  │  ✗ pypi.org                   (no Python package installs)      │   │  │
 │  │  │  ✗ google.com, bing.com       (no web search)                   │   │  │
 │  │  │  ✗ *.com, *.io, etc           (no arbitrary endpoints)          │   │  │
 │  │  └─────────────────────────────────────────────────────────────────┘   │  │
@@ -326,6 +328,8 @@ The gateway maintains a strict allowlist of permitted domains:
 | `uploads.github.com` | File uploads | Release asset uploads |
 | `avatars.githubusercontent.com` | Avatars | GitHub user images |
 | `user-images.githubusercontent.com` | User content | GitHub user images |
+| `registry.npmjs.org` | Public npm registry | Runtime lockfile-pinned JS dependency installs |
+| `npm.pkg.github.com` | GitHub Packages npm registry | Runtime installs of registry-scoped packages (reads require caller-supplied auth) |
 
 **Allowlist properties:**
 - **Exhaustive** — only listed domains are permitted; all others blocked
@@ -340,7 +344,7 @@ The gateway maintains a strict allowlist of permitted domains:
 
 | Category | Examples | Impact | Mitigation |
 |----------|----------|--------|------------|
-| Package managers | pypi.org, npmjs.com | Cannot install new packages | Pre-install required packages in image |
+| Python package managers | pypi.org | Cannot install Python packages | Pre-install required packages in image |
 | Web search | google.com, bing.com | Cannot search web | Use GitHub search, local docs |
 | Documentation | docs.python.org | Cannot fetch docs | Bundle offline docs in image |
 | Arbitrary APIs | any other endpoint | Cannot exfiltrate data | **This is the security goal** |
@@ -400,7 +404,8 @@ NO_PROXY=localhost,127.0.0.1,gateway,egg-gateway
 | Anthropic SDK | `HTTP_PROXY`/`HTTPS_PROXY` | Uses httpx, respects proxy env vars |
 | git | Routes through gateway API | Git wrapper calls gateway REST API |
 | gh CLI | Routes through gateway API | gh wrapper calls gateway REST API |
-| npm/pip | N/A in lockdown mode | Package managers blocked; deps pre-installed |
+| npm/pnpm | `HTTP_PROXY`/`HTTPS_PROXY` | Registry hosts allowlisted; installs must be lockfile-pinned |
+| pip | N/A in lockdown mode | PyPI blocked; Python deps pre-installed in image |
 
 ### Squid Configuration Approach
 
@@ -480,6 +485,7 @@ For tasks requiring web access (research, package updates), egg can operate in *
 - **Exfiltration via Claude API** — agent could encode data in prompts; addressed by Anthropic's usage logging.
 - **Malicious code in PRs** — same as Phase 1; human review required.
 - **Supply chain via pre-installed packages** — mitigated by pinned versions and image scanning.
+- **Supply chain via runtime npm installs** — `registry.npmjs.org` and `npm.pkg.github.com` are reachable so agents can install JS dependencies in repos too large to pre-bake. Mitigated by committed lockfiles (`pnpm install --frozen-lockfile` / `npm ci` resolve only pinned, integrity-checked artifacts) and Squid access logs auditing every registry fetch. An agent can still fetch an arbitrary published npm package by name; this is accepted because the same code could be vendored into a branch through the git path, and PR review remains the control for what lands.
 
 ### Rate Limiting
 

--- a/docs/architecture/network-isolation.md
+++ b/docs/architecture/network-isolation.md
@@ -218,12 +218,13 @@ For truly unsupervised operation with `--dangerously-skip-permissions`, infrastr
 │  │  │  HTTPS Proxy (squid or envoy)                                   │   │  │
 │  │  │                                                                 │   │  │
 │  │  │  ALLOWLIST (strictly enforced):                                 │   │  │
-│  │  │  ✓ api.anthropic.com          (Claude API)                      │   │  │
-│  │  │  ✓ api.github.com             (GitHub API)                      │   │  │
-│  │  │  ✓ github.com                 (git operations)                  │   │  │
-│  │  │  ✓ *.githubusercontent.com   (GitHub raw content)              │   │  │
-│  │  │  ✓ registry.npmjs.org         (npm installs, lockfile-pinned)   │   │  │
-│  │  │  ✓ npm.pkg.github.com         (GitHub Packages npm registry)    │   │  │
+│  │  │    Via gateway REST API / HTTP endpoint (not Squid):            │   │  │
+│  │  │    ✓ api.anthropic.com        (Claude API)                      │   │  │
+│  │  │    ✓ api.github.com           (GitHub API)                      │   │  │
+│  │  │    ✓ github.com               (git operations)                  │   │  │
+│  │  │    ✓ *.githubusercontent.com  (GitHub raw content)              │   │  │
+│  │  │    Via Squid SNI allowlist (allowed_domains.txt):               │   │  │
+│  │  │    ✓ registry.npmjs.org       (npm/pnpm, lockfile-pinned)       │   │  │
 │  │  │                                                                 │   │  │
 │  │  │  BLOCKED (everything else):                                     │   │  │
 │  │  │  ✗ pypi.org                   (no Python package installs)      │   │  │
@@ -328,8 +329,9 @@ The gateway maintains a strict allowlist of permitted domains:
 | `uploads.github.com` | File uploads | Release asset uploads |
 | `avatars.githubusercontent.com` | Avatars | GitHub user images |
 | `user-images.githubusercontent.com` | User content | GitHub user images |
-| `registry.npmjs.org` | Public npm registry | Runtime lockfile-pinned JS dependency installs |
-| `npm.pkg.github.com` | GitHub Packages npm registry | Runtime installs of registry-scoped packages (reads require caller-supplied auth) |
+| `registry.npmjs.org` | Public npm registry | Runtime lockfile-pinned JS dependency installs (npm/pnpm) |
+
+> **Enforcement path.** Only `registry.npmjs.org` is enforced through the Squid SNI allowlist (`gateway/allowed_domains.txt`). The Anthropic and GitHub rows above are **not** in that file — Anthropic traffic flows through the gateway's HTTP endpoint (credential injection) and GitHub traffic through the gateway's git/gh REST API (policy enforcement). They are reachable *via the gateway*, not spliced through Squid. GitHub Packages (`npm.pkg.github.com`) and Yarn Classic (`registry.yarnpkg.com`) are intentionally out of scope — see the `allowed_domains.txt` comment for why.
 
 **Allowlist properties:**
 - **Exhaustive** — only listed domains are permitted; all others blocked
@@ -404,7 +406,7 @@ NO_PROXY=localhost,127.0.0.1,gateway,egg-gateway
 | Anthropic SDK | `HTTP_PROXY`/`HTTPS_PROXY` | Uses httpx, respects proxy env vars |
 | git | Routes through gateway API | Git wrapper calls gateway REST API |
 | gh CLI | Routes through gateway API | gh wrapper calls gateway REST API |
-| npm/pnpm | `HTTP_PROXY`/`HTTPS_PROXY` | Registry hosts allowlisted; installs must be lockfile-pinned |
+| npm/pnpm | `HTTP_PROXY`/`HTTPS_PROXY` | Public registry (`registry.npmjs.org`) allowlisted; installs must be lockfile-pinned. Yarn Classic / GitHub Packages out of scope |
 | pip | N/A in lockdown mode | PyPI blocked; Python deps pre-installed in image |
 
 ### Squid Configuration Approach
@@ -485,7 +487,8 @@ For tasks requiring web access (research, package updates), egg can operate in *
 - **Exfiltration via Claude API** — agent could encode data in prompts; addressed by Anthropic's usage logging.
 - **Malicious code in PRs** — same as Phase 1; human review required.
 - **Supply chain via pre-installed packages** — mitigated by pinned versions and image scanning.
-- **Supply chain via runtime npm installs** — `registry.npmjs.org` and `npm.pkg.github.com` are reachable so agents can install JS dependencies in repos too large to pre-bake. Mitigated by committed lockfiles (`pnpm install --frozen-lockfile` / `npm ci` resolve only pinned, integrity-checked artifacts) and Squid access logs auditing every registry fetch. An agent can still fetch an arbitrary published npm package by name; this is accepted because the same code could be vendored into a branch through the git path, and PR review remains the control for what lands.
+- **Supply chain via runtime npm installs** — `registry.npmjs.org` is reachable so agents can install JS dependencies in repos too large to pre-bake. Mitigated by committed lockfiles (`pnpm install --frozen-lockfile` / `npm ci` resolve only pinned, integrity-checked artifacts). Because Squid splices these connections (no MITM decryption), its access log provides only host-level connection records — the registry host and byte counts, not the package/version fetched — so it is a coarse egress audit, not a per-package manifest. An agent can still fetch an arbitrary published npm package by name; this is accepted because the same code could be vendored into a branch through the git path, and PR review remains the control for what lands.
+- **Exfiltration via `npm publish`** — because splice hides the request body, a `publish` POST to `registry.npmjs.org` is an unaudited egress channel just like a package fetch. Risk is low: publishing requires an npm auth token, which the sandbox does not hold by default. If a repo's workflow ever provisions one, treat it as it would any other outbound credential.
 
 ### Rate Limiting
 

--- a/gateway/allowed_domains.txt
+++ b/gateway/allowed_domains.txt
@@ -38,6 +38,23 @@
 # REST calls — a test in gateway/tests/test_allowed_domains.py asserts that
 # no such entry is present.
 
-# Note: PyPI, npm, and other package managers are intentionally NOT included
-# All dependencies must be pre-installed in the Docker image
-# This prevents supply chain attacks and ensures reproducible builds
+# npm registries — allowed for runtime dependency installation.
+#
+# Some repositories have dependency sets that are too large or too dynamic
+# to bake into the sandbox image at build time (e.g. large JS monorepos).
+# For those, agents run lockfile-pinned installs (`pnpm install
+# --frozen-lockfile` / `npm ci`) inside the sandbox, routed through this
+# proxy. Reproducibility comes from the committed lockfile; Squid access
+# logs provide an audit trail of every registry fetch. This mirrors the
+# DNS/domain-allowlist pattern used by hardened CI runners, which permit
+# exactly these registry hosts for dependency installation.
+#
+# npm.pkg.github.com (GitHub Packages) additionally requires
+# caller-supplied auth for reads, and is a registry-only host — it exposes
+# none of the git/PR API surface the gateway polices, so allowing it does
+# not create a policy bypass for GitHub operations.
+#
+# PyPI and other package managers remain intentionally NOT included —
+# Python dependencies must still be pre-installed in the Docker image.
+registry.npmjs.org
+npm.pkg.github.com

--- a/gateway/allowed_domains.txt
+++ b/gateway/allowed_domains.txt
@@ -38,23 +38,27 @@
 # REST calls — a test in gateway/tests/test_allowed_domains.py asserts that
 # no such entry is present.
 
-# npm registries — allowed for runtime dependency installation.
+# npm registry — allowed for runtime dependency installation.
 #
 # Some repositories have dependency sets that are too large or too dynamic
 # to bake into the sandbox image at build time (e.g. large JS monorepos).
 # For those, agents run lockfile-pinned installs (`pnpm install
 # --frozen-lockfile` / `npm ci`) inside the sandbox, routed through this
-# proxy. Reproducibility comes from the committed lockfile; Squid access
-# logs provide an audit trail of every registry fetch. This mirrors the
+# proxy. Reproducibility comes from the committed lockfile. Because Squid
+# splices these connections (SNI peek, no MITM decryption), its access log
+# captures host-level connection records — the registry host and byte
+# counts — not the individual package or version fetched. This mirrors the
 # DNS/domain-allowlist pattern used by hardened CI runners, which permit
-# exactly these registry hosts for dependency installation.
+# exactly this registry host for dependency installation.
 #
-# npm.pkg.github.com (GitHub Packages) additionally requires
-# caller-supplied auth for reads, and is a registry-only host — it exposes
-# none of the git/PR API surface the gateway polices, so allowing it does
-# not create a policy bypass for GitHub operations.
+# Scope: public npm registry only, reachable by npm and pnpm. Yarn
+# Classic's default host (registry.yarnpkg.com) is a distinct SNI host and
+# is intentionally NOT included. GitHub Packages (npm.pkg.github.com) is
+# also NOT included: it serves tarballs via a cross-host 302 redirect to a
+# *.githubusercontent.com blob host that would itself need allowlisting,
+# and its auth-delivery story into the sandbox is undesigned. GitHub
+# Packages support is tracked as a follow-up.
 #
 # PyPI and other package managers remain intentionally NOT included —
 # Python dependencies must still be pre-installed in the Docker image.
 registry.npmjs.org
-npm.pkg.github.com

--- a/gateway/tests/test_allowed_domains.py
+++ b/gateway/tests/test_allowed_domains.py
@@ -75,6 +75,54 @@ def test_atlassian_domains_absent(bad_substr: str):
         )
 
 
+@pytest.mark.parametrize(
+    "domain",
+    [
+        # npm registries for runtime, lockfile-pinned dependency
+        # installation (`pnpm install --frozen-lockfile` / `npm ci`) in
+        # repos whose dependency sets are too large or dynamic to bake
+        # into the sandbox image at build time. Removing either entry
+        # silently breaks in-sandbox installs for such repos, so pin
+        # their presence here.
+        "registry.npmjs.org",
+        "npm.pkg.github.com",
+    ],
+)
+def test_npm_registries_present(domain: str):
+    """The npm registry hosts must stay in the Squid allowlist."""
+    text = ALLOWED_DOMAINS_PATH.read_text()
+    lines = list(_iter_non_comment_lines(text))
+    assert domain in lines, (
+        f"{domain!r} missing from allowed_domains.txt. Runtime npm "
+        "dependency installation (lockfile-pinned installs through the "
+        "Squid proxy) requires this registry host."
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_substr",
+    [
+        # Python installs remain image-bake-only: PyPI must not appear in
+        # the runtime egress allowlist.
+        "pypi.org",
+        "files.pythonhosted.org",
+    ],
+)
+def test_pypi_domains_absent(bad_substr: str):
+    """No non-comment line may reference a PyPI host.
+
+    Unlike npm (allowed for runtime lockfile-pinned installs), Python
+    dependencies must be pre-installed in the sandbox image.
+    """
+    text = ALLOWED_DOMAINS_PATH.read_text()
+    for line in _iter_non_comment_lines(text):
+        assert bad_substr not in line.lower(), (
+            f"{bad_substr!r} found in allowed_domains.txt on line: {line!r}. "
+            "Python package installation is image-bake-only; PyPI hosts "
+            "must not be reachable from the sandbox at runtime."
+        )
+
+
 def test_allowed_domains_has_no_bare_wildcard():
     """A bare ``*`` would defeat the purpose of the allowlist entirely."""
     text = ALLOWED_DOMAINS_PATH.read_text()

--- a/gateway/tests/test_allowed_domains.py
+++ b/gateway/tests/test_allowed_domains.py
@@ -78,18 +78,17 @@ def test_atlassian_domains_absent(bad_substr: str):
 @pytest.mark.parametrize(
     "domain",
     [
-        # npm registries for runtime, lockfile-pinned dependency
+        # Public npm registry for runtime, lockfile-pinned dependency
         # installation (`pnpm install --frozen-lockfile` / `npm ci`) in
         # repos whose dependency sets are too large or dynamic to bake
-        # into the sandbox image at build time. Removing either entry
-        # silently breaks in-sandbox installs for such repos, so pin
-        # their presence here.
+        # into the sandbox image at build time. Removing this entry
+        # silently breaks in-sandbox installs for such repos, so pin its
+        # presence here.
         "registry.npmjs.org",
-        "npm.pkg.github.com",
     ],
 )
 def test_npm_registries_present(domain: str):
-    """The npm registry hosts must stay in the Squid allowlist."""
+    """The npm registry host must stay in the Squid allowlist."""
     text = ALLOWED_DOMAINS_PATH.read_text()
     lines = list(_iter_non_comment_lines(text))
     assert domain in lines, (
@@ -97,6 +96,32 @@ def test_npm_registries_present(domain: str):
         "dependency installation (lockfile-pinned installs through the "
         "Squid proxy) requires this registry host."
     )
+
+
+@pytest.mark.parametrize(
+    "bad_substr",
+    [
+        # GitHub Packages is deliberately NOT allowlisted: it serves
+        # tarballs via a cross-host 302 redirect to a *.githubusercontent.com
+        # blob host that would also need allowlisting, and its auth-delivery
+        # story into the sandbox is undesigned. Allowlisting the registry
+        # host alone yields a confusing failure — metadata resolves 200,
+        # then the tarball download is terminated. Don't re-add it without
+        # also allowlisting the redirect target(s). Tracked as a follow-up.
+        "npm.pkg.github.com",
+    ],
+)
+def test_github_packages_absent(bad_substr: str):
+    """GitHub Packages must not appear until its redirect + auth story lands."""
+    text = ALLOWED_DOMAINS_PATH.read_text()
+    for line in _iter_non_comment_lines(text):
+        assert bad_substr not in line.lower(), (
+            f"{bad_substr!r} found in allowed_domains.txt on line: {line!r}. "
+            "GitHub Packages installs redirect to an un-allowlisted blob "
+            "host and would fail at the tarball step; do not re-add it "
+            "without allowlisting the redirect target(s) and designing the "
+            "auth-delivery path."
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Adds `registry.npmjs.org` and `npm.pkg.github.com` to the Squid egress allowlist (`gateway/allowed_domains.txt`), permitting sandbox agents to install JS dependencies at runtime.

## Motivation

Until now the allowlist policy was "all dependencies must be pre-installed in the sandbox image" via per-repo `build_commands`. That works for small/medium dependency sets, but breaks down for large JS monorepos:

- pnpm workspaces with hundreds of member packages can't enumerate every workspace `package.json` as a `watch_files` entry, so a build-time `pnpm install` isn't reproducible from the build context.
- Packages hosted on GitHub Packages (`npm.pkg.github.com`) require auth even for reads, and the sandbox image build has no secret mechanism — baking them in would mean leaking a token into a build ARG or image layer.

Allowing registry egress at runtime sidesteps both: agents run `pnpm install --frozen-lockfile` / `npm ci` inside the sandbox, routed through the Squid proxy. This mirrors the DNS/domain-allowlist pattern used by hardened CI runners, which permit exactly these registry hosts for dependency installation.

## Security considerations

- **Reproducibility / supply chain**: installs are lockfile-pinned; the lockfile is committed and integrity-checked. Squid access logs audit every registry fetch.
- **No GitHub policy bypass**: `npm.pkg.github.com` is registry-only — it exposes none of the git/PR API surface the gateway polices, and reads require caller-supplied auth.
- **Arbitrary package fetch**: an agent can fetch any published npm package by name. Accepted: the same code could be vendored into a branch via the git path; PR review remains the control for what lands. Documented in `network-isolation.md` residual risks.
- **PyPI stays blocked**: Python deps remain image-bake-only. A new test (`test_pypi_domains_absent`) pins that, alongside `test_npm_registries_present` pinning the new entries.

## Changes

- `gateway/allowed_domains.txt` — the two registry entries + rewritten policy comment
- `gateway/tests/test_allowed_domains.py` — presence invariant for the npm entries; absence invariant for PyPI hosts
- `docs/architecture/network-isolation.md` — allowlist table/diagram, blocked-categories table, proxy-support table, residual-risks section

## Deployment note

The allowlist is baked into the gateway image (`COPY gateway/allowed_domains.txt /etc/squid/allowed_domains.txt`), so this takes effect on the next gateway image rebuild + rollout.