### PR TITLE
Release no-op park on BRC movement via consensus-state fingerprint

### DIFF
--- a/orchestrator/concurrent_executor.py
+++ b/orchestrator/concurrent_executor.py
@@ -521,6 +521,12 @@ class ConcurrentPhaseExecutor:
             agent_failed=self._handle_propose_arm_exhaustion,
             on_exhausted=self._teardown_exhausted_session,
             hitl_probe=self._unresolved_contract_decision_ids,
+            # #3465: a parked arm self-releases on consensus movement (a
+            # cohort proposal/verdict never changes the parked arm's own
+            # dedupe key, so this is the only non-heartbeat wake for an arm
+            # parked while racing its upstream producer). ``getattr`` keeps
+            # test doubles without the method on the heartbeat-only path.
+            brc_probe=getattr(tracker, "consensus_state_fingerprint", None),
         )
 
         # #3064 slice-5: convergence-stall notifier re-uses the same

--- a/orchestrator/event_loop.py
+++ b/orchestrator/event_loop.py
@@ -745,9 +745,7 @@ class JobSupervisor:
         current_brc = self._probe_brc_fingerprint()
         parked_brc = self._noop_brc_fingerprint.get(dedupe_key)
         hitl_moved = current is not None and parked is not None and current != parked
-        brc_moved = (
-            current_brc is not None and parked_brc is not None and current_brc != parked_brc
-        )
+        brc_moved = current_brc is not None and parked_brc is not None and current_brc != parked_brc
         if hitl_moved or brc_moved:
             # Refresh BOTH probe anchors on any release, not just the branch that
             # fired. If a single poll sees the contract-decision set AND the BRC

--- a/orchestrator/event_loop.py
+++ b/orchestrator/event_loop.py
@@ -742,51 +742,64 @@ class JobSupervisor:
         now = self.clock()
         current = self._probe_hitl_fingerprint()
         parked = self._noop_fingerprint.get(dedupe_key)
-        if current is not None and parked is not None and current != parked:
-            self._noop_fingerprint[dedupe_key] = current
+        current_brc = self._probe_brc_fingerprint()
+        parked_brc = self._noop_brc_fingerprint.get(dedupe_key)
+        hitl_moved = current is not None and parked is not None and current != parked
+        brc_moved = (
+            current_brc is not None and parked_brc is not None and current_brc != parked_brc
+        )
+        if hitl_moved or brc_moved:
+            # Refresh BOTH probe anchors on any release, not just the branch that
+            # fired. If a single poll sees the contract-decision set AND the BRC
+            # state move at once (the operator resolves a gating ``cq-N`` while
+            # the cohort proposes), advancing only the firing anchor would leave
+            # the other's park-time digest stale, so the very next poll would
+            # release again — two probe spawns for one wedge. Advancing every
+            # anchor whose probe currently reads a concrete value collapses this
+            # to one probe per poll regardless of how many signals moved. A
+            # ``None`` reading (probe unwired/failed) is left untouched: it can
+            # never compare as moved, so it cannot cause a spurious re-release,
+            # and preserving its park-time value avoids degrading a good anchor
+            # on a transient probe failure.
+            if current is not None:
+                self._noop_fingerprint[dedupe_key] = current
+            if current_brc is not None:
+                self._noop_brc_fingerprint[dedupe_key] = current_brc
             self._noop_last_probe[dedupe_key] = now
-            # Re-arm the once-per-key alert latch only when a decision is *still*
-            # gating (``current`` non-empty). The alert names the decisions
-            # recorded at park time; if the probe spawn no-ops again on a
-            # freshly-gating ``cq-N`` the arm re-parks, and without re-arming the
-            # latch would suppress a new alert, leaving the operator staring at a
-            # stale one naming an already-resolved cq-N. This keeps "one alert
-            # per distinct wedge" rather than "one alert per key lifetime".
+            # Re-arm the once-per-key alert latch only when the contract-decision
+            # set moved AND a decision is *still* gating (``current`` non-empty).
+            # The alert names the decisions recorded at park time; if the probe
+            # spawn no-ops again on a freshly-gating ``cq-N`` the arm re-parks,
+            # and without re-arming the latch would suppress a new alert, leaving
+            # the operator staring at a stale one naming an already-resolved
+            # cq-N. This keeps "one alert per distinct wedge" rather than "one
+            # alert per key lifetime".
             #
-            # But an *empty* new set means the wedge cleared (the operator
-            # resolved the last gating decision), so the released probe will
-            # proceed and make real progress. Re-arming here would let the next
+            # An *empty* new set means the wedge cleared (the operator resolved
+            # the last gating decision), and a pure BRC-movement release means
+            # the cohort progressed; in both cases the released probe will
+            # proceed and make real progress. Re-arming there would let the next
             # ``record_success`` — which cannot distinguish a productive
             # completion from a repeat no-op (any rc=0 exit maps to SUCCESS) —
             # fire a spurious high-priority alert on the common happy path,
             # falsely claiming zero BRC progress with no visible gating decision.
-            # So only re-arm when a decision remains.
-            if current:
+            # So only re-arm when a gating decision remains.
+            if hitl_moved and current:
                 self._alerted_noop.pop(dedupe_key, None)
-            logger.info(
-                "JobSupervisor: contract-decision set changed for parked key=%s "
-                "(was %s, now %s) — releasing the no-op park for a probe spawn",
-                dedupe_key,
-                sorted(parked),
-                sorted(current),
-            )
-            return False
-        current_brc = self._probe_brc_fingerprint()
-        parked_brc = self._noop_brc_fingerprint.get(dedupe_key)
-        if current_brc is not None and parked_brc is not None and current_brc != parked_brc:
-            self._noop_brc_fingerprint[dedupe_key] = current_brc
-            self._noop_last_probe[dedupe_key] = now
-            # The alert latch is deliberately NOT re-armed here: BRC movement
-            # means the cohort progressed, so the released probe will usually
-            # proceed productively — and ``record_success`` cannot distinguish
-            # a productive completion from a repeat no-op, so re-arming would
-            # fire a spurious high-priority alert on the common happy path
-            # (same reasoning as the empty-set case above).
-            logger.info(
-                "JobSupervisor: BRC state moved for parked key=%s "
-                "— releasing the no-op park for a probe spawn",
-                dedupe_key,
-            )
+            if hitl_moved:
+                logger.info(
+                    "JobSupervisor: contract-decision set changed for parked key=%s "
+                    "(was %s, now %s) — releasing the no-op park for a probe spawn",
+                    dedupe_key,
+                    sorted(parked),
+                    sorted(current),
+                )
+            if brc_moved:
+                logger.info(
+                    "JobSupervisor: BRC state moved for parked key=%s "
+                    "— releasing the no-op park for a probe spawn",
+                    dedupe_key,
+                )
             return False
         last = self._noop_last_probe.get(dedupe_key)
         if last is None or (now - last) >= SUPERVISION_NOOP_PARK_RETRY_SECONDS:

--- a/orchestrator/event_loop.py
+++ b/orchestrator/event_loop.py
@@ -54,7 +54,11 @@ abort does not reset the count — a crash/no-op-flapping wedged arm should stil
 park) and parks the arm at ``SUPERVISION_NOOP_STREAK_PARK`` (sticky alert once).
 Because resolving the ``cq-N`` writes only the contract file — never the
 tracker — the park self-releases on a change in the unresolved
-contract-decision set (``hitl_probe``) and, as a liveness backstop, every
+contract-decision set (``hitl_probe``), on a change in the consensus-relevant
+BRC state (``brc_probe``, #3465 — an arm can park while merely racing its
+upstream producer, e.g. the tester's propose arm no-oping before the coder
+has committed; the producer's proposal moves the tracker but never this arm's
+own dedupe key), and, as a liveness backstop, every
 ``SUPERVISION_NOOP_PARK_RETRY_SECONDS``.
 
 **Slice-5 (#3064): convergence-stall detection (re-homed idle-budget)**
@@ -370,6 +374,7 @@ class JobSupervisor:
         agent_failed: Callable[..., Any] | None = None,
         on_exhausted: Callable[..., Any] | None = None,
         hitl_probe: Callable[[], Iterable[str] | None] | None = None,
+        brc_probe: Callable[[], str | None] | None = None,
     ) -> None:
         self.clock = clock
         self._overseer_alert = overseer_alert
@@ -382,6 +387,14 @@ class JobSupervisor:
         # probe (or no probe wired) means "unknown": the park then releases
         # only via the retry heartbeat.
         self._hitl_probe = hitl_probe
+        # #3465: best-effort probe returning an opaque fingerprint of the
+        # consensus-relevant BRC state (tracker phases / proposals / verdicts).
+        # An arm parked while racing its upstream producer (the tester's
+        # propose arm no-oping before the coder commits) is un-wedged by BRC
+        # movement — but that movement never changes the parked arm's OWN
+        # dedupe key, so without this probe the only wake path is the retry
+        # heartbeat. ``None`` means "unknown", same semantics as ``hitl_probe``.
+        self._brc_probe = brc_probe
         # #3064 slice-4: fired once when a dedupe key crosses into the
         # exhausted set (the ``_exhausted`` transition). The orchestrator
         # wires this to tear down the role's reused gateway session — an
@@ -429,6 +442,9 @@ class JobSupervisor:
         # {dedupe_key: fingerprint-at-park} — the unresolved contract-decision
         # id set observed when the key parked (or on the last probe release).
         self._noop_fingerprint: dict[str, frozenset[str] | None] = {}
+        # {dedupe_key: brc-fingerprint-at-park} — the consensus-state digest
+        # observed when the key parked (or on the last BRC-movement release).
+        self._noop_brc_fingerprint: dict[str, str | None] = {}
         # {dedupe_key: clock() of the last allowed park-probe spawn} — anchors
         # the retry heartbeat.
         self._noop_last_probe: dict[str, float] = {}
@@ -470,6 +486,7 @@ class JobSupervisor:
             self._alerted_noop[dedupe_key] = True
             fingerprint = self._probe_hitl_fingerprint()
             self._noop_fingerprint[dedupe_key] = fingerprint
+            self._noop_brc_fingerprint[dedupe_key] = self._probe_brc_fingerprint()
             self._noop_last_probe[dedupe_key] = self.clock()
             logger.warning(
                 "JobSupervisor: %d consecutive successful no-op invocations for key=%s "
@@ -499,6 +516,7 @@ class JobSupervisor:
         self._exhausted.discard(dedupe_key)
         self._noop_streaks.pop(dedupe_key, None)
         self._noop_fingerprint.pop(dedupe_key, None)
+        self._noop_brc_fingerprint.pop(dedupe_key, None)
         self._noop_last_probe.pop(dedupe_key, None)
         self._alerted_noop.pop(dedupe_key, None)
         logger.debug("JobSupervisor: retired key=%s — all supervision state dropped", dedupe_key)
@@ -704,6 +722,12 @@ class JobSupervisor:
         * immediately, when the unresolved contract-decision set differs from
           the one recorded at park time (e.g. the gating ``cq-N`` was
           resolved) — detected via ``hitl_probe``;
+        * immediately, when the consensus-relevant BRC state differs from the
+          one recorded at park time (#3465) — detected via ``brc_probe``. An
+          arm can also park while merely racing its upstream producer (the
+          tester's propose arm no-ops until the coder commits); the producer's
+          proposal / reviews move the tracker but never this arm's own dedupe
+          key, so without this check the slice wedges until the heartbeat;
         * every ``SUPERVISION_NOOP_PARK_RETRY_SECONDS`` as a liveness
           backstop (also the only release when no probe is wired or it
           fails).
@@ -747,6 +771,23 @@ class JobSupervisor:
                 sorted(current),
             )
             return False
+        current_brc = self._probe_brc_fingerprint()
+        parked_brc = self._noop_brc_fingerprint.get(dedupe_key)
+        if current_brc is not None and parked_brc is not None and current_brc != parked_brc:
+            self._noop_brc_fingerprint[dedupe_key] = current_brc
+            self._noop_last_probe[dedupe_key] = now
+            # The alert latch is deliberately NOT re-armed here: BRC movement
+            # means the cohort progressed, so the released probe will usually
+            # proceed productively — and ``record_success`` cannot distinguish
+            # a productive completion from a repeat no-op, so re-arming would
+            # fire a spurious high-priority alert on the common happy path
+            # (same reasoning as the empty-set case above).
+            logger.info(
+                "JobSupervisor: BRC state moved for parked key=%s "
+                "— releasing the no-op park for a probe spawn",
+                dedupe_key,
+            )
+            return False
         last = self._noop_last_probe.get(dedupe_key)
         if last is None or (now - last) >= SUPERVISION_NOOP_PARK_RETRY_SECONDS:
             self._noop_last_probe[dedupe_key] = now
@@ -779,6 +820,25 @@ class JobSupervisor:
             return None
         return frozenset(result)
 
+    def _probe_brc_fingerprint(self) -> str | None:
+        """Snapshot the consensus-state fingerprint (best-effort, #3465).
+
+        ``None`` means "unknown" (no probe wired, or the probe failed) — the
+        caller must then never treat the fingerprint as comparable, falling
+        back to the retry heartbeat. Same contract as
+        :meth:`_probe_hitl_fingerprint`.
+        """
+        if self._brc_probe is None:
+            return None
+        try:
+            return self._brc_probe()
+        except Exception as exc:  # noqa: BLE001 — probing is best-effort
+            logger.warning(
+                "JobSupervisor: brc probe failed — treating fingerprint as unknown: %s",
+                exc,
+            )
+            return None
+
     def reconcile(self, live_dedupe_keys: Iterable[str]) -> None:
         """When restarting, reconcile from live Job labels.
 
@@ -800,6 +860,7 @@ class JobSupervisor:
         self._exhausted.clear()
         self._noop_streaks.clear()
         self._noop_fingerprint.clear()
+        self._noop_brc_fingerprint.clear()
         self._noop_last_probe.clear()
         self._alerted_noop.clear()
         # Re-initialise live-key set if the caller provides it.

--- a/orchestrator/peer_consensus/__init__.py
+++ b/orchestrator/peer_consensus/__init__.py
@@ -196,6 +196,7 @@ class PeerConsensusTracker:
     get_all_proposal_commit_shas = _queries.get_all_proposal_commit_shas
     get_commit_sha_for_version = _queries.get_commit_sha_for_version
     get_pre_merge_conditions = _queries.get_pre_merge_conditions
+    consensus_state_fingerprint = _queries.consensus_state_fingerprint
     get_latest_proposal_timestamp = _queries.get_latest_proposal_timestamp
     get_latest_progress_timestamp = _queries.get_latest_progress_timestamp
     evaluate = _queries.evaluate

--- a/orchestrator/peer_consensus/_queries.py
+++ b/orchestrator/peer_consensus/_queries.py
@@ -9,6 +9,7 @@ so it stays a single binding.
 
 from __future__ import annotations
 
+import hashlib
 from datetime import datetime
 from typing import Any
 
@@ -62,6 +63,40 @@ def get_pre_merge_conditions(self) -> list[dict[str, Any]]:
     """
     with self._lock:
         return self.matrix.get_pre_merge_conditions()
+
+
+def consensus_state_fingerprint(self) -> str:
+    """Stable digest of the consensus-relevant BRC state (#3465).
+
+    Folds exactly the fields that move when the BRC bus moves — producer /
+    reviewer phases, the confirmed set, proposal versions and commit SHAs,
+    and per-edge approval state (including obligation resolution) — and
+    nothing that can move without bus progress (no timestamps, which the
+    matrix rewrites on idempotent re-verdicts). Wired as the event-loop
+    ``JobSupervisor``'s ``brc_probe``: a no-op-parked arm (#3425) whose own
+    dedupe key cannot observe cohort progress (the tester's propose arm
+    parked while the coder is still writing) self-releases when this digest
+    changes, instead of waiting out the retry heartbeat.
+    """
+    with self._lock:
+        parts: list[str] = []
+        for role in sorted(self._producer_phases):
+            parts.append(
+                f"producer:{role}={self._producer_phases[role].value}"
+                f"@{self._proposal_commit_shas.get(role, '')}"
+            )
+        for role in sorted(self._reviewer_phases):
+            parts.append(f"reviewer:{role}={self._reviewer_phases[role].value}")
+        parts.append("confirmed:" + ",".join(sorted(self._confirmed)))
+        matrix = self.matrix.to_dict()
+        for role, version in sorted(matrix.get("proposal_versions", {}).items()):
+            parts.append(f"version:{role}={version}")
+        for edge_key, entry in sorted(matrix.get("entries", {}).items()):
+            parts.append(
+                f"edge:{edge_key}={entry.get('state', '')}@{entry.get('version', 0)}"
+                f"/{int(bool(entry.get('obligation_resolved')))}"
+            )
+    return hashlib.sha256("\n".join(parts).encode("utf-8")).hexdigest()
 
 
 def get_latest_proposal_timestamp(self) -> datetime | None:

--- a/orchestrator/tests/test_event_loop.py
+++ b/orchestrator/tests/test_event_loop.py
@@ -2069,6 +2069,63 @@ class TestNoopParkSupervisor:
         supervisor.record_success("key-n", action="propose", role="coder")
         assert len(alerts) == 1
 
+    def test_release_on_brc_movement(self):
+        """#3465: cohort BRC progress releases a parked arm for one probe.
+
+        The incident shape: the tester's propose arm parks while the coder is
+        still writing (three fast no-ops), then the coder proposes and is
+        ACKed — the tracker moves, but the tester's own dedupe key never
+        changes, so only the BRC fingerprint can wake it before the heartbeat.
+        """
+        import event_loop
+
+        brc_state = ["coder-working"]
+        supervisor = event_loop.JobSupervisor(
+            clock=_ManualClock(),
+            brc_probe=lambda: brc_state[0],
+        )
+        self._park(supervisor, "key-n", role="tester")
+        assert supervisor.noop_parked("key-n")
+
+        brc_state[0] = "coder-proposed"  # the coder's proposal moved the tracker
+        assert not supervisor.noop_parked("key-n")  # exactly one release
+        assert supervisor.noop_parked("key-n")  # fingerprint refreshed → parked again
+
+    def test_brc_release_does_not_realert(self):
+        """A BRC-movement release must not re-arm the alert latch: the probe
+        usually proceeds productively, and record_success cannot tell a
+        productive completion from a repeat no-op."""
+        import event_loop
+
+        brc_state = ["s1"]
+        alerts: list[dict] = []
+        supervisor = event_loop.JobSupervisor(
+            clock=_ManualClock(),
+            brc_probe=lambda: brc_state[0],
+            overseer_alert=lambda **kw: alerts.append(kw),
+        )
+        self._park(supervisor, "key-n", role="tester")
+        assert len(alerts) == 1
+
+        brc_state[0] = "s2"
+        assert not supervisor.noop_parked("key-n")
+        supervisor.record_success("key-n", action="propose", role="tester")
+        assert len(alerts) == 1
+
+    def test_brc_probe_failure_falls_back_to_heartbeat(self):
+        import event_loop
+        import supervision_policy
+
+        def _broken_probe():
+            raise RuntimeError("tracker gone")
+
+        clock = _ManualClock()
+        supervisor = event_loop.JobSupervisor(clock=clock, brc_probe=_broken_probe)
+        self._park(supervisor, "key-n")
+        assert supervisor.noop_parked("key-n")
+        clock.advance(supervision_policy.SUPERVISION_NOOP_PARK_RETRY_SECONDS + 1)
+        assert not supervisor.noop_parked("key-n")
+
     def test_release_on_heartbeat(self):
         import event_loop
         import supervision_policy
@@ -2129,7 +2186,7 @@ class TestNoopParkSupervisor:
 class TestNoopParkThroughLoop:
     """#3425 driven through ``poll_once`` — the production wiring."""
 
-    def _wedged_loop(self, monkeypatch, *, hitl_probe=None, alerts=None):
+    def _wedged_loop(self, monkeypatch, *, hitl_probe=None, brc_probe=None, alerts=None):
         """A loop whose scripted coder propose always completes as a clean
         no-op: the view reports SUCCESS and the derived event never changes,
         so every completion re-derives the identical dedupe key."""
@@ -2142,6 +2199,7 @@ class TestNoopParkThroughLoop:
             clock=clock,
             overseer_alert=(lambda **kw: alerts.append(kw)) if alerts is not None else None,
             hitl_probe=hitl_probe,
+            brc_probe=brc_probe,
         )
         view = _FakeJobStatusView()
         loop = _make_supervised_loop(spawner, clock=clock, supervisor=supervisor, status_view=view)
@@ -2193,6 +2251,24 @@ class TestNoopParkThroughLoop:
         assert len(spawner.calls) == burned + 1  # exactly one probe spawn
 
         # The probe no-ops again → the arm re-parks under the new fingerprint.
+        for _ in range(5):
+            loop.poll_once(["coder"])
+        assert len(spawner.calls) == burned + 1
+
+    def test_brc_movement_releases_one_probe_spawn(self, monkeypatch):
+        """#3465 through the loop: the upstream producer's proposal moves the
+        tracker → the parked arm probes once, long before the heartbeat."""
+        brc_state = ["upstream-working"]
+        loop, spawner, clock, supervisor, key = self._wedged_loop(
+            monkeypatch, brc_probe=lambda: brc_state[0]
+        )
+        burned = self._drive_to_park(loop, spawner)
+
+        brc_state[0] = "upstream-proposed"  # cohort progress; this arm's key unchanged
+        loop.poll_once(["coder"])
+        assert len(spawner.calls) == burned + 1  # exactly one probe spawn
+
+        # The probe no-ops again with no further movement → re-parked.
         for _ in range(5):
             loop.poll_once(["coder"])
         assert len(spawner.calls) == burned + 1

--- a/orchestrator/tests/test_event_loop.py
+++ b/orchestrator/tests/test_event_loop.py
@@ -2112,6 +2112,34 @@ class TestNoopParkSupervisor:
         supervisor.record_success("key-n", action="propose", role="tester")
         assert len(alerts) == 1
 
+    def test_simultaneous_hitl_and_brc_movement_releases_once(self):
+        """Both signals moving in a single poll must yield exactly one probe.
+
+        Previously each release branch refreshed only its own anchor, so if the
+        operator resolved a gating ``cq-N`` *and* the cohort proposed before the
+        same poll tick, the HITL branch released first leaving the BRC anchor
+        stale, and the next poll released again via the BRC branch — two probe
+        spawns for one wedge. The release now refreshes both anchors, collapsing
+        it to one probe per poll regardless of how many signals moved.
+        """
+        import event_loop
+
+        pending = {"cq-1"}
+        brc_state = ["coder-working"]
+        supervisor = event_loop.JobSupervisor(
+            clock=_ManualClock(),
+            hitl_probe=lambda: set(pending),
+            brc_probe=lambda: brc_state[0],
+        )
+        self._park(supervisor, "key-n", role="tester")
+        assert supervisor.noop_parked("key-n")
+
+        # Both signals move before the same poll tick.
+        pending.clear()  # operator resolved the last gating decision
+        brc_state[0] = "coder-proposed"  # the coder proposed
+        assert not supervisor.noop_parked("key-n")  # exactly one release
+        assert supervisor.noop_parked("key-n")  # both anchors refreshed → no second release
+
     def test_brc_probe_failure_falls_back_to_heartbeat(self):
         import event_loop
         import supervision_policy

--- a/orchestrator/tests/test_peer_consensus_integration.py
+++ b/orchestrator/tests/test_peer_consensus_integration.py
@@ -3843,3 +3843,58 @@ class TestIsProducerPendingConfirm:
     def test_unknown_role_is_not_pending(self):
         t = self._build_tracker()
         assert not t.is_producer_pending_confirm("not_a_real_role")
+
+
+class TestConsensusStateFingerprint:
+    """#3465: the digest a parked no-op arm watches for cohort progress.
+
+    It must move on every consensus-relevant transition (propose, verdict,
+    confirm) and be stable across calls that don't move the bus — otherwise
+    the event-loop park either never releases on BRC movement (the incident)
+    or releases every poll (defeating the #3425 park entirely).
+    """
+
+    def test_stable_when_nothing_moves(self, tracker):
+        assert tracker.consensus_state_fingerprint() == tracker.consensus_state_fingerprint()
+
+    def test_moves_on_propose(self, tracker):
+        before = tracker.consensus_state_fingerprint()
+        tracker.handle_propose(
+            "coder",
+            {"summary": "x" * 60, "artifacts": ["a.py"], "commit_sha": "abc1234"},
+        )
+        assert tracker.consensus_state_fingerprint() != before
+
+    def test_moves_on_ack_and_confirm(self, tracker):
+        tracker.handle_propose(
+            "coder",
+            {"summary": "x" * 60, "artifacts": ["a.py"], "commit_sha": "abc1234"},
+        )
+        after_propose = tracker.consensus_state_fingerprint()
+
+        tracker.handle_ack("reviewer_code", "coder", {"artifact_references": ["a.py"]})
+        after_ack = tracker.consensus_state_fingerprint()
+        assert after_ack != after_propose
+
+        tracker.handle_ack("reviewer_contract", "coder", {"artifact_references": ["a.py"]})
+        tracker.handle_propose(
+            "tester",
+            {"summary": "y" * 60, "artifacts": ["t.py"], "commit_sha": "def5678"},
+        )
+        tracker.handle_ack("reviewer_code", "tester", {"artifact_references": ["t.py"]})
+        pre_confirm = tracker.consensus_state_fingerprint()
+        tracker.handle_confirmed("coder")
+        assert tracker.consensus_state_fingerprint() != pre_confirm
+
+    def test_moves_on_nack(self, tracker):
+        tracker.handle_propose(
+            "coder",
+            {"summary": "x" * 60, "artifacts": ["a.py"], "commit_sha": "abc1234"},
+        )
+        before = tracker.consensus_state_fingerprint()
+        tracker.handle_nack(
+            "reviewer_code",
+            "coder",
+            {"reason": "z" * 60, "artifact_references": ["a.py"]},
+        )
+        assert tracker.consensus_state_fingerprint() != before


### PR DESCRIPTION
Fixes #3465.

## Problem

The #3425 no-op park self-releases on only two triggers: a change in the unresolved contract-decision set (`hitl_probe`) or the 1800s retry heartbeat. The park alert additionally promises release when "the BRC state moves" — but nothing watched the tracker, and BRC movement can't mint a new dedupe key for the parked arm either: a producer's propose identity stays `"v|"` for its whole WORKING lifetime (`event_identity`), so cohort proposals/ACKs are invisible to the parked key.

In `pipeline-dcdad92d` this wedged **every** implement slice: all slice agents spawn together, the tester's propose arm burns its 3-no-op streak (~3 min) before the coder's first commit (~5–6 min), parks, and then sleeps through the coder's CONSENSUS_PROPOSE + 7 ACKs. The only recovery was a manual `restart_agent` or the heartbeat landing ~30 min later — up to ~6 h of pure wait on a 12-slice plan.

## Fix

Make the promised "BRC state moves" release real:

- **`PeerConsensusTracker.consensus_state_fingerprint()`** (`peer_consensus/_queries.py`) — stable digest of exactly the consensus-relevant state: producer/reviewer phases, the confirmed set, proposal versions + commit SHAs, and per-edge approval state incl. obligation resolution. No timestamps (the matrix rewrites those on idempotent re-verdicts, which would release the park every poll and defeat #3425).
- **`JobSupervisor` gains `brc_probe`** (`event_loop.py`), mirroring `hitl_probe`'s `None`-means-unknown contract. `noop_parked` now releases one probe spawn when the digest differs from the one recorded at park time, then re-anchors — if the probe no-ops again with no further movement, the arm re-parks. The alert latch is deliberately **not** re-armed on this path: BRC movement means the probe usually proceeds productively, and `record_success` can't distinguish a productive completion from a repeat no-op, so re-arming would fire spurious alerts on the happy path (same reasoning as the existing empty-set HITL case).
- **Wiring** (`concurrent_executor._start_event_loop`): `brc_probe=getattr(tracker, "consensus_state_fingerprint", None)` — test doubles without the method degrade to the existing heartbeat-only behavior.

With this, the issue's defect 1 (ordering race at spawn) becomes benign: the tester still parks while the coder writes, but wakes on the coder's proposal within one poll tick instead of waiting out the heartbeat. The HITL-wedge scenario the park was built for is unaffected — a wedged slice's tracker doesn't move, so the park holds exactly as before.

## Testing

- `orchestrator/tests/test_event_loop.py`: supervisor-level release-on-BRC-movement (one probe spawn, re-anchor, re-park), no re-alert on BRC release, broken-probe fallback to heartbeat, and a loop-level test through `poll_once` mirroring the incident shape.
- `orchestrator/tests/test_peer_consensus_integration.py`: fingerprint stability across no-movement calls; movement on propose / ack / nack / confirm.
- 238 + 78 tests pass in the touched suites; ruff clean.