### PR TITLE
docs: corepack proxy failures masquerade as blocked egress (#3463)

### DIFF
--- a/config/repositories.yaml.example
+++ b/config/repositories.yaml.example
@@ -94,6 +94,17 @@ readable_repos:
 #       stage into the final Docker image. Use this for system-level tool
 #       installations that build_commands place outside the repo directory.
 #       (e.g., /usr/local/go, /usr/local/node)
+#     NODE TOOLCHAIN NOTE: if your commands unpack a Node tarball, don't rely
+#     on its bundled Corepack shims for pnpm/yarn at runtime. Old Corepack
+#     releases (e.g. 0.25.x with node 20.12.x) cannot fetch the package
+#     manager through the sandbox's egress proxy — every bare `pnpm` fails
+#     with "Internal Error: Error when performing the request to
+#     https://registry.npmjs.org/pnpm", which looks like blocked egress but
+#     is a client-side Corepack bug (#3463). After unpacking Node, either
+#     upgrade the shim (`npm install -g corepack@latest`) or install the real
+#     package manager (`npm install -g pnpm@<version>`). See the
+#     "Corepack Failures That Look Like Blocked Egress" section in
+#     docs/architecture/network-isolation.md.
 #   - role_patterns: Per-repo overrides for the test/code/docs glob lists
 #     that gate coder/tester/documenter file access (#2528). Useful for
 #     non-Python repos with different file conventions (Go uses *_test.go,

--- a/docs/architecture/network-isolation.md
+++ b/docs/architecture/network-isolation.md
@@ -444,6 +444,55 @@ The blob host (`npmregistryv2prod.blob.core.windows.net`) is **hardcoded** in `s
 
 **Diagnosing a broken read-through after a GitHub-side change:** if metadata resolves (200 on `npm.pkg.github.com`) but tarball downloads fail, check the Squid access log — a `TCP_DENIED`/terminate against a `*.blob.core.windows.net` host you don't recognize means the published blob host has changed. Re-fetch `https://api.github.com/meta`, compare `domains.packages`, and update the hardcoded host to match: the `acl npm_pkg_blob` and `acl npm_pkg_blob_dst` lines in `squid-npm-packages-ssl.conf.template` (the value is literal there — there is no `BLOB_HOST` placeholder to substitute), and the `BLOB_HOST` constant in `test_npm_packages_readthrough.py`. This is the one part of the mechanism that can break without a code change on our side, so it is called out here rather than left as a silent constant.
 
+### Troubleshooting: Corepack Failures That Look Like Blocked Egress
+
+A failing `pnpm` / `yarn` / `npx` inside the sandbox is **not** necessarily a
+proxy or allowlist problem — the most common failure never reaches Squid at
+all. When a repo's `build_commands` install a Node toolchain whose `pnpm` is
+a **Corepack shim** (`corepack enable` creates shims instead of real
+binaries), the shim must fetch the actual package manager from
+`registry.npmjs.org` on first use. Old Corepack releases (e.g. 0.25.x, as
+bundled with node 20.12.0) cannot perform that fetch through an HTTP proxy:
+they build a `ProxyAgent` from their *bundled* undici but pass it as the
+`dispatcher` to Node's *builtin* `fetch`, which dies client-side with
+`TypeError: this[kClient].connect is not a function`, surfaced as:
+
+```
+Internal Error: Error when performing the request to https://registry.npmjs.org/pnpm; for
+troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting
+```
+
+Because agent pods always run with `HTTPS_PROXY` set, every bare `pnpm`
+invocation through such a shim fails this way — in **both** public and
+private session modes — and the error text reads exactly like a blocked
+domain, which is how it gets misdiagnosed as an egress problem
+([#3463](https://github.com/jwbron/egg/issues/3463)). Two aggravators make
+the shim always need the network at runtime: `corepack prepare` during the
+image build caches under `/root/.cache`, which is not persisted into the
+final image, and a repo `packageManager` pin can name a version that was
+never prepared at build time anyway.
+
+**Disambiguate in one command** from inside the sandbox:
+
+```bash
+curl --proxy "$HTTPS_PROXY" -sS -o /dev/null -w '%{http_code}\n' https://registry.npmjs.org/
+```
+
+`200` means the egress path (proxy → SNI allowlist → splice) is healthy and
+the failure is client-side toolchain, not network. A Squid denial looks
+different: a 403 with Squid's error page, or a TLS termination with the
+proxy's self-signed certificate.
+
+**Fixes** (in `build_commands` for the repo that installs the toolchain —
+see the Node toolchain note in `config/repositories.yaml.example`):
+
+- Upgrade the shim after unpacking Node: `npm install -g corepack@latest`.
+  Current Corepack fetches through `HTTPS_PROXY` correctly and honors
+  `packageManager` pins; the runtime fetch is permitted because
+  `registry.npmjs.org` is allowlisted ([#3455](https://github.com/jwbron/egg/issues/3455)).
+- Or avoid the shim entirely: install the real package manager with
+  `npm install -g pnpm@<version>`.
+
 ### Breakout Prevention
 
 | Attack Vector | Mitigation |


### PR DESCRIPTION
## Summary

Documentation follow-up to the root-cause diagnosis on #3463 (see [the issue comment](https://github.com/jwbron/egg/issues/3463#issuecomment-4872620473)): the "public-mode sandbox can't reach registry.npmjs.org" report was a misdiagnosis. The egress path (proxy → SNI allowlist → splice) works identically in both session modes; the failure was a client-side corepack bug that never reaches Squid but produces an error indistinguishable from blocked egress.

## What broke (recap)

- Bare `pnpm` in the sandbox resolves to a **corepack 0.25.2 shim** (bundled with node 20.12.0, installed into `/usr/local` by a repo's `build_commands`).
- On first use the shim fetches pnpm itself from `registry.npmjs.org` — but old corepack passes its bundled-undici `ProxyAgent` as `dispatcher` to node's builtin `fetch`, which dies client-side (`TypeError: this[kClient].connect is not a function`), surfaced as `Internal Error: Error when performing the request to https://registry.npmjs.org/pnpm`.
- Agent pods always run with `HTTPS_PROXY` set, so this hits **every** bare pnpm invocation, in **both** modes, and reads exactly like a blocked domain. Verified fixed by `npm install -g corepack@latest` inside the sandbox image: the upgraded shim fetches its `packageManager`-pinned pnpm through the proxy and installs deps normally (egress permitted since #3455).

## Changes

- `docs/architecture/network-isolation.md` — new **Troubleshooting: Corepack Failures That Look Like Blocked Egress** section: the failure signature, why it's mode-independent, the one-command `curl --proxy` disambiguation (200 = egress healthy, failure is toolchain), and the two `build_commands` fixes.
- `config/repositories.yaml.example` — **NODE TOOLCHAIN NOTE** on `build_commands`: don't rely on stock corepack shims; upgrade corepack or install a real pnpm.

Docs-only; no runtime behavior change. The operator-config fix (upgrading corepack in the affected repo's `build_commands`) is deployment-local and rides separately.

Closes #3463.