### PR TITLE
Relaunch drivers for RUNNING pipelines at orchestrator boot

### DIFF
--- a/orchestrator/cli.py
+++ b/orchestrator/cli.py
@@ -80,6 +80,61 @@ except ImportError:
 logger = get_logger("orchestrator.cli")
 
 
+def _reconcile_and_relaunch_repo(store, docker_client) -> None:
+    """Reconcile stale containers for one repo store at boot, then relaunch
+    driverless RUNNING pipelines — but ONLY when reconciliation settled state
+    cleanly.
+
+    Split out of ``cmd_serve`` so the ordering invariant is unit-testable
+    (#3469): on reconciliation failure we return early WITHOUT relaunching, so
+    a pipeline that reconciliation would have marked FAILED off unsettled
+    state is never relaunched as a live RUNNING driver. Both steps are
+    best-effort — a failure in either is logged and never fatal to boot.
+    """
+    repo = str(getattr(store, "repo_path", "unknown"))
+    try:
+        from startup_reconciliation import reconcile_stale_containers
+
+        recovered = reconcile_stale_containers(store, docker_client)
+        if recovered:
+            logger.warning(
+                "Recovered stale pipelines on startup",
+                count=recovered,
+                repo=repo,
+            )
+    except Exception as reconcile_err:
+        logger.warning(
+            "Startup reconciliation failed",
+            error=str(reconcile_err),
+            repo=repo,
+        )
+        return
+
+    # Relaunch _run_pipeline drivers for pipelines still RUNNING after
+    # reconciliation (#3469). The driver threads (and the BRC event loop they
+    # own) died with the previous process; reconciliation restores state but
+    # nothing else revives the loop, leaving RUNNING pipelines permanently
+    # driverless. Runs only when reconciliation succeeded above, so pipelines
+    # that reconciliation would have marked FAILED are never relaunched off
+    # unsettled state.
+    try:
+        from routes.pipelines import relaunch_driverless_running_pipelines
+
+        relaunched = relaunch_driverless_running_pipelines(store)
+        if relaunched:
+            logger.warning(
+                "Relaunched drivers for RUNNING pipelines on startup",
+                count=relaunched,
+                repo=repo,
+            )
+    except Exception as relaunch_err:
+        logger.warning(
+            "Startup driver relaunch failed",
+            error=str(relaunch_err),
+            repo=repo,
+        )
+
+
 def cmd_serve(args: argparse.Namespace) -> int:
     """Start the orchestrator API server."""
     # Safety check: refuse to run as root to prevent permission issues.
@@ -174,51 +229,20 @@ def cmd_serve(args: argparse.Namespace) -> int:
             logger.warning("No git repos found under EGG_REPO_PATH", path=repo_path)
         try:
             from docker_client import get_docker_client
-            from startup_reconciliation import reconcile_stale_containers
 
             for rp in repo_paths:
                 try:
                     store = get_state_store(rp)
                     stores.append(store)
-                    recovered = reconcile_stale_containers(store, get_docker_client())
-                    if recovered:
-                        logger.warning(
-                            "Recovered stale pipelines on startup",
-                            count=recovered,
-                            repo=str(rp),
-                        )
-                except Exception as reconcile_err:
+                except Exception as store_err:
                     logger.warning(
                         "Startup reconciliation failed",
-                        error=str(reconcile_err),
+                        error=str(store_err),
                         repo=str(rp),
                     )
                     continue
 
-                # Relaunch _run_pipeline drivers for pipelines still RUNNING
-                # after reconciliation (#3469). The driver threads (and the
-                # BRC event loop they own) died with the previous process;
-                # reconciliation restores state but nothing else revives the
-                # loop, leaving RUNNING pipelines permanently driverless.
-                # Runs only when reconciliation succeeded for this repo, so
-                # pipelines that reconciliation would have marked FAILED are
-                # never relaunched off unsettled state.
-                try:
-                    from routes.pipelines import relaunch_driverless_running_pipelines
-
-                    relaunched = relaunch_driverless_running_pipelines(store)
-                    if relaunched:
-                        logger.warning(
-                            "Relaunched drivers for RUNNING pipelines on startup",
-                            count=relaunched,
-                            repo=str(rp),
-                        )
-                except Exception as relaunch_err:
-                    logger.warning(
-                        "Startup driver relaunch failed",
-                        error=str(relaunch_err),
-                        repo=str(rp),
-                    )
+                _reconcile_and_relaunch_repo(store, get_docker_client())
         except Exception as reconcile_err:
             logger.warning(
                 "Startup reconciliation failed",

--- a/orchestrator/cli.py
+++ b/orchestrator/cli.py
@@ -193,6 +193,32 @@ def cmd_serve(args: argparse.Namespace) -> int:
                         error=str(reconcile_err),
                         repo=str(rp),
                     )
+                    continue
+
+                # Relaunch _run_pipeline drivers for pipelines still RUNNING
+                # after reconciliation (#3469). The driver threads (and the
+                # BRC event loop they own) died with the previous process;
+                # reconciliation restores state but nothing else revives the
+                # loop, leaving RUNNING pipelines permanently driverless.
+                # Runs only when reconciliation succeeded for this repo, so
+                # pipelines that reconciliation would have marked FAILED are
+                # never relaunched off unsettled state.
+                try:
+                    from routes.pipelines import relaunch_driverless_running_pipelines
+
+                    relaunched = relaunch_driverless_running_pipelines(store)
+                    if relaunched:
+                        logger.warning(
+                            "Relaunched drivers for RUNNING pipelines on startup",
+                            count=relaunched,
+                            repo=str(rp),
+                        )
+                except Exception as relaunch_err:
+                    logger.warning(
+                        "Startup driver relaunch failed",
+                        error=str(relaunch_err),
+                        repo=str(rp),
+                    )
         except Exception as reconcile_err:
             logger.warning(
                 "Startup reconciliation failed",

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -26109,6 +26109,72 @@ def has_live_pipeline_driver(pipeline_id: str) -> bool:
     return False
 
 
+def relaunch_driverless_running_pipelines(store) -> int:
+    """Relaunch drivers for RUNNING pipelines orphaned by a restart (#3469).
+
+    Called once per repo store at orchestrator startup, after
+    ``startup_reconciliation.reconcile_stale_containers`` has settled each
+    pipeline's status.  A pipeline still RUNNING at that point was mid-flight
+    when the previous orchestrator process died: its consensus state is fully
+    reconciled at boot, but its ``_run_pipeline`` driver thread — and the BRC
+    event loop the driver owns — died with the old process, and no other code
+    path revives it.  ``restart_agent`` delegates the respawn to the (dead)
+    event loop and returns success, while ``start_pipeline`` rejects
+    status=RUNNING with a 409, so without this sweep the pipeline is
+    permanently driverless and never spawns another pod (#3469).
+
+    Relaunching reuses the proven resume path (the same one
+    ``restart_agent``'s inactive-pipeline branch relies on, #3244):
+    ``_run_pipeline`` re-enters ``pipeline.current_phase``, re-syncs the
+    worktree with the remote, and restarts the event loop, which respawns
+    one-shot agent Jobs within one poll.  The persisted ``run_epoch`` is
+    deliberately NOT bumped: the old process is gone so no stale thread can
+    contend for the epoch, and the relaunched thread derives its own epoch
+    from persisted state exactly as the original did.
+
+    AWAITING_HUMAN pipelines are out of scope — their drivers are revived on
+    decision resolution by ``maybe_revive_orphaned_awaiting_human_driver``
+    (#3233).
+
+    Returns the number of drivers relaunched.  Per-pipeline failures are
+    logged and skipped so one broken record cannot strand the rest.
+    """
+    try:
+        pipeline_ids = store.list_pipelines()
+    except Exception as e:  # noqa: BLE001 - startup sweep must not raise
+        logger.warning(
+            "Driver relaunch sweep skipped: could not list pipelines",
+            error=str(e),
+        )
+        return 0
+
+    relaunched = 0
+    for pipeline_id in pipeline_ids:
+        try:
+            pipeline = store.load_pipeline(pipeline_id)
+            if pipeline.status != PipelineStatus.RUNNING:
+                continue
+            if has_live_pipeline_driver(pipeline_id):
+                continue
+            run_epoch = pipeline.run_epoch or pipeline.created_at
+            _spawn_pipeline_run_thread(pipeline_id, store.repo_path, run_epoch)
+            relaunched += 1
+            logger.warning(
+                "Relaunched _run_pipeline driver for RUNNING pipeline with no "
+                "live driver thread (orchestrator restart recovery, #3469)",
+                pipeline_id=pipeline_id,
+                phase=pipeline.current_phase.value,
+                run_epoch=run_epoch.isoformat() if run_epoch else None,
+            )
+        except Exception as e:  # noqa: BLE001 - per-pipeline isolation
+            logger.warning(
+                "Failed to relaunch driver for RUNNING pipeline (continuing sweep)",
+                pipeline_id=pipeline_id,
+                error=str(e),
+            )
+    return relaunched
+
+
 def _broadcast_orphaned_driver_alert(pipeline_id: str, pipeline: Pipeline) -> None:
     """Surface an orphaned-driver revival as an overseer alert (#3233).
 

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -26143,8 +26143,16 @@ def relaunch_driverless_running_pipelines(store) -> int:
     store would double the boot-time git reads on repos with many historical
     pipelines.
 
-    Returns the number of drivers relaunched.  Per-pipeline failures are
-    logged and skipped so one broken record cannot strand the rest.
+    Returns the number of drivers relaunched.  Failures are isolated at two
+    layers: a record that fails to load with ``StateStoreError`` (corruption)
+    is skipped inside ``get_active_pipelines()``, and a per-pipeline failure
+    during the relaunch itself (driver probe or thread spawn) is logged and
+    skipped so one bad pipeline cannot strand the rest.  The one case that is
+    *not* isolated: a load failure other than ``StateStoreError`` propagates out
+    of ``get_active_pipelines()`` and the outer ``except`` aborts the sweep
+    (returns 0) — an accepted trade for using the canonical active-pipeline
+    accessor, matching how ``get_active_pipelines()`` behaves for its other
+    callers.
     """
     try:
         active_pipelines = store.get_active_pipelines()

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -26136,40 +26136,46 @@ def relaunch_driverless_running_pipelines(store) -> int:
     decision resolution by ``maybe_revive_orphaned_awaiting_human_driver``
     (#3233).
 
+    The sweep iterates ``store.get_active_pipelines()`` rather than the full
+    ``list_pipelines()`` so terminal/historical records (COMPLETE, FAILED,
+    CANCELLED) are skipped without a redundant load — reconciliation already
+    walked every pipeline immediately before this, and re-scanning the whole
+    store would double the boot-time git reads on repos with many historical
+    pipelines.
+
     Returns the number of drivers relaunched.  Per-pipeline failures are
     logged and skipped so one broken record cannot strand the rest.
     """
     try:
-        pipeline_ids = store.list_pipelines()
+        active_pipelines = store.get_active_pipelines()
     except Exception as e:  # noqa: BLE001 - startup sweep must not raise
         logger.warning(
-            "Driver relaunch sweep skipped: could not list pipelines",
+            "Driver relaunch sweep skipped: could not list active pipelines",
             error=str(e),
         )
         return 0
 
     relaunched = 0
-    for pipeline_id in pipeline_ids:
+    for pipeline in active_pipelines:
         try:
-            pipeline = store.load_pipeline(pipeline_id)
             if pipeline.status != PipelineStatus.RUNNING:
                 continue
-            if has_live_pipeline_driver(pipeline_id):
+            if has_live_pipeline_driver(pipeline.id):
                 continue
             run_epoch = pipeline.run_epoch or pipeline.created_at
-            _spawn_pipeline_run_thread(pipeline_id, store.repo_path, run_epoch)
+            _spawn_pipeline_run_thread(pipeline.id, store.repo_path, run_epoch)
             relaunched += 1
             logger.warning(
                 "Relaunched _run_pipeline driver for RUNNING pipeline with no "
                 "live driver thread (orchestrator restart recovery, #3469)",
-                pipeline_id=pipeline_id,
+                pipeline_id=pipeline.id,
                 phase=pipeline.current_phase.value,
-                run_epoch=run_epoch.isoformat() if run_epoch else None,
+                run_epoch=run_epoch.isoformat(),
             )
         except Exception as e:  # noqa: BLE001 - per-pipeline isolation
             logger.warning(
                 "Failed to relaunch driver for RUNNING pipeline (continuing sweep)",
-                pipeline_id=pipeline_id,
+                pipeline_id=getattr(pipeline, "id", "unknown"),
                 error=str(e),
             )
     return relaunched

--- a/orchestrator/tests/test_boot_driver_relaunch.py
+++ b/orchestrator/tests/test_boot_driver_relaunch.py
@@ -34,18 +34,15 @@ def _pipeline(pipeline_id="issue-3469", status=PipelineStatus.RUNNING, run_epoch
 
 
 def _store(pipelines, repo_path=Path("/tmp/repo")):
-    """A StateStore double serving the given ``{id: Pipeline-or-Exception}`` map."""
+    """A StateStore double whose ``get_active_pipelines`` returns ``pipelines``.
+
+    The sweep iterates ``get_active_pipelines()`` (which already filters out
+    terminal records at the store layer), so the double serves the active
+    (non-terminal) pipelines directly rather than an id→record map.
+    """
     store = MagicMock()
     store.repo_path = repo_path
-    store.list_pipelines.return_value = list(pipelines)
-
-    def _load(pid):
-        value = pipelines[pid]
-        if isinstance(value, Exception):
-            raise value
-        return value
-
-    store.load_pipeline.side_effect = _load
+    store.get_active_pipelines.return_value = list(pipelines)
     return store
 
 
@@ -56,7 +53,7 @@ class TestRelaunchDriverlessRunningPipelines:
         from routes.pipelines import relaunch_driverless_running_pipelines
 
         epoch = datetime(2026, 7, 3, 6, 0, 0, tzinfo=UTC)
-        store = _store({"issue-3469": _pipeline(run_epoch=epoch)})
+        store = _store([_pipeline(run_epoch=epoch)])
 
         assert relaunch_driverless_running_pipelines(store) == 1
         mock_spawn.assert_called_once_with("issue-3469", store.repo_path, epoch)
@@ -67,7 +64,7 @@ class TestRelaunchDriverlessRunningPipelines:
         from routes.pipelines import relaunch_driverless_running_pipelines
 
         pipeline = _pipeline(run_epoch=None)
-        store = _store({"issue-3469": pipeline})
+        store = _store([pipeline])
 
         assert relaunch_driverless_running_pipelines(store) == 1
         mock_spawn.assert_called_once_with("issue-3469", store.repo_path, pipeline.created_at)
@@ -77,15 +74,16 @@ class TestRelaunchDriverlessRunningPipelines:
     def test_skips_non_running_pipelines(self, _mock_has_driver, mock_spawn):
         from routes.pipelines import relaunch_driverless_running_pipelines
 
+        # ``get_active_pipelines`` filters terminal records at the store layer,
+        # so the sweep only ever sees non-terminal statuses. The status guard
+        # must still skip the non-RUNNING actives — PENDING (not yet driving)
+        # and AWAITING_HUMAN (#3233's territory: revived on decision
+        # resolution, never at boot).
         store = _store(
-            {
-                "issue-1": _pipeline("issue-1", status=PipelineStatus.FAILED),
-                "issue-2": _pipeline("issue-2", status=PipelineStatus.COMPLETE),
-                "issue-3": _pipeline("issue-3", status=PipelineStatus.CANCELLED),
-                # AWAITING_HUMAN is #3233's territory: revived on decision
-                # resolution, never at boot.
-                "issue-4": _pipeline("issue-4", status=PipelineStatus.AWAITING_HUMAN),
-            }
+            [
+                _pipeline("issue-1", status=PipelineStatus.PENDING),
+                _pipeline("issue-2", status=PipelineStatus.AWAITING_HUMAN),
+            ]
         )
 
         assert relaunch_driverless_running_pipelines(store) == 0
@@ -96,33 +94,42 @@ class TestRelaunchDriverlessRunningPipelines:
     def test_skips_pipeline_with_live_driver(self, _mock_has_driver, mock_spawn):
         from routes.pipelines import relaunch_driverless_running_pipelines
 
-        store = _store({"issue-3469": _pipeline()})
+        store = _store([_pipeline()])
 
         assert relaunch_driverless_running_pipelines(store) == 0
         mock_spawn.assert_not_called()
 
     @patch("routes.pipelines._spawn_pipeline_run_thread")
-    @patch("routes.pipelines.has_live_pipeline_driver", return_value=False)
-    def test_per_pipeline_failure_does_not_abort_sweep(self, _mock_has_driver, mock_spawn):
+    @patch("routes.pipelines.has_live_pipeline_driver")
+    def test_per_pipeline_failure_does_not_abort_sweep(self, mock_has_driver, mock_spawn):
         from routes.pipelines import relaunch_driverless_running_pipelines
 
         epoch = datetime(2026, 7, 3, 6, 0, 0, tzinfo=UTC)
+
+        # A per-pipeline probe failure (here: has_live_pipeline_driver raising
+        # for one record) must be isolated so the rest of the sweep proceeds.
+        def _driver(pid):
+            if pid == "issue-broken":
+                raise RuntimeError("driver probe wedged")
+            return False
+
+        mock_has_driver.side_effect = _driver
         store = _store(
-            {
-                "issue-broken": RuntimeError("corrupt state"),
-                "issue-ok": _pipeline("issue-ok", run_epoch=epoch),
-            }
+            [
+                _pipeline("issue-broken", run_epoch=epoch),
+                _pipeline("issue-ok", run_epoch=epoch),
+            ]
         )
 
         assert relaunch_driverless_running_pipelines(store) == 1
         mock_spawn.assert_called_once_with("issue-ok", store.repo_path, epoch)
 
     @patch("routes.pipelines._spawn_pipeline_run_thread")
-    def test_list_pipelines_failure_returns_zero(self, mock_spawn):
+    def test_get_active_pipelines_failure_returns_zero(self, mock_spawn):
         from routes.pipelines import relaunch_driverless_running_pipelines
 
         store = MagicMock()
-        store.list_pipelines.side_effect = RuntimeError("git wedged")
+        store.get_active_pipelines.side_effect = RuntimeError("git wedged")
 
         assert relaunch_driverless_running_pipelines(store) == 0
         mock_spawn.assert_not_called()
@@ -134,10 +141,10 @@ class TestRelaunchDriverlessRunningPipelines:
 
         mock_spawn.side_effect = [RuntimeError("thread limit"), None]
         store = _store(
-            {
-                "issue-a": _pipeline("issue-a"),
-                "issue-b": _pipeline("issue-b"),
-            }
+            [
+                _pipeline("issue-a"),
+                _pipeline("issue-b"),
+            ]
         )
 
         assert relaunch_driverless_running_pipelines(store) == 1

--- a/orchestrator/tests/test_boot_driver_relaunch.py
+++ b/orchestrator/tests/test_boot_driver_relaunch.py
@@ -1,0 +1,144 @@
+"""Regression tests for boot-time driver relaunch of RUNNING pipelines (#3469).
+
+After an orchestrator restart, a pipeline in status=RUNNING is left
+permanently driverless: startup reconciliation rebuilds consensus state from
+the message store but never relaunches the pipeline's ``_run_pipeline``
+driver thread / event loop.  ``restart_agent`` delegates the respawn into
+the missing loop (and returns success), while ``start_pipeline`` rejects
+status=RUNNING with a 409 — so no recovery verb works.  The startup sweep
+``relaunch_driverless_running_pipelines`` closes the hole by relaunching a
+fresh driver thread for every RUNNING pipeline with no live driver.
+"""
+
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+from models import Pipeline, PipelineStatus  # noqa: E402
+
+
+def _pipeline(pipeline_id="issue-3469", status=PipelineStatus.RUNNING, run_epoch=None):
+    p = Pipeline(id=pipeline_id, issue_number=3469, repo="owner/repo", branch="egg/test")
+    p.status = status
+    p.run_epoch = run_epoch
+    return p
+
+
+def _store(pipelines, repo_path=Path("/tmp/repo")):
+    """A StateStore double serving the given ``{id: Pipeline-or-Exception}`` map."""
+    store = MagicMock()
+    store.repo_path = repo_path
+    store.list_pipelines.return_value = list(pipelines)
+
+    def _load(pid):
+        value = pipelines[pid]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    store.load_pipeline.side_effect = _load
+    return store
+
+
+class TestRelaunchDriverlessRunningPipelines:
+    @patch("routes.pipelines._spawn_pipeline_run_thread")
+    @patch("routes.pipelines.has_live_pipeline_driver", return_value=False)
+    def test_relaunches_running_pipeline_with_no_driver(self, _mock_has_driver, mock_spawn):
+        from routes.pipelines import relaunch_driverless_running_pipelines
+
+        epoch = datetime(2026, 7, 3, 6, 0, 0, tzinfo=UTC)
+        store = _store({"issue-3469": _pipeline(run_epoch=epoch)})
+
+        assert relaunch_driverless_running_pipelines(store) == 1
+        mock_spawn.assert_called_once_with("issue-3469", store.repo_path, epoch)
+
+    @patch("routes.pipelines._spawn_pipeline_run_thread")
+    @patch("routes.pipelines.has_live_pipeline_driver", return_value=False)
+    def test_falls_back_to_created_at_when_run_epoch_unset(self, _mock_has_driver, mock_spawn):
+        from routes.pipelines import relaunch_driverless_running_pipelines
+
+        pipeline = _pipeline(run_epoch=None)
+        store = _store({"issue-3469": pipeline})
+
+        assert relaunch_driverless_running_pipelines(store) == 1
+        mock_spawn.assert_called_once_with("issue-3469", store.repo_path, pipeline.created_at)
+
+    @patch("routes.pipelines._spawn_pipeline_run_thread")
+    @patch("routes.pipelines.has_live_pipeline_driver", return_value=False)
+    def test_skips_non_running_pipelines(self, _mock_has_driver, mock_spawn):
+        from routes.pipelines import relaunch_driverless_running_pipelines
+
+        store = _store(
+            {
+                "issue-1": _pipeline("issue-1", status=PipelineStatus.FAILED),
+                "issue-2": _pipeline("issue-2", status=PipelineStatus.COMPLETE),
+                "issue-3": _pipeline("issue-3", status=PipelineStatus.CANCELLED),
+                # AWAITING_HUMAN is #3233's territory: revived on decision
+                # resolution, never at boot.
+                "issue-4": _pipeline("issue-4", status=PipelineStatus.AWAITING_HUMAN),
+            }
+        )
+
+        assert relaunch_driverless_running_pipelines(store) == 0
+        mock_spawn.assert_not_called()
+
+    @patch("routes.pipelines._spawn_pipeline_run_thread")
+    @patch("routes.pipelines.has_live_pipeline_driver", return_value=True)
+    def test_skips_pipeline_with_live_driver(self, _mock_has_driver, mock_spawn):
+        from routes.pipelines import relaunch_driverless_running_pipelines
+
+        store = _store({"issue-3469": _pipeline()})
+
+        assert relaunch_driverless_running_pipelines(store) == 0
+        mock_spawn.assert_not_called()
+
+    @patch("routes.pipelines._spawn_pipeline_run_thread")
+    @patch("routes.pipelines.has_live_pipeline_driver", return_value=False)
+    def test_per_pipeline_failure_does_not_abort_sweep(self, _mock_has_driver, mock_spawn):
+        from routes.pipelines import relaunch_driverless_running_pipelines
+
+        epoch = datetime(2026, 7, 3, 6, 0, 0, tzinfo=UTC)
+        store = _store(
+            {
+                "issue-broken": RuntimeError("corrupt state"),
+                "issue-ok": _pipeline("issue-ok", run_epoch=epoch),
+            }
+        )
+
+        assert relaunch_driverless_running_pipelines(store) == 1
+        mock_spawn.assert_called_once_with("issue-ok", store.repo_path, epoch)
+
+    @patch("routes.pipelines._spawn_pipeline_run_thread")
+    def test_list_pipelines_failure_returns_zero(self, mock_spawn):
+        from routes.pipelines import relaunch_driverless_running_pipelines
+
+        store = MagicMock()
+        store.list_pipelines.side_effect = RuntimeError("git wedged")
+
+        assert relaunch_driverless_running_pipelines(store) == 0
+        mock_spawn.assert_not_called()
+
+    @patch("routes.pipelines._spawn_pipeline_run_thread")
+    @patch("routes.pipelines.has_live_pipeline_driver", return_value=False)
+    def test_spawn_failure_is_isolated_and_not_counted(self, _mock_has_driver, mock_spawn):
+        from routes.pipelines import relaunch_driverless_running_pipelines
+
+        mock_spawn.side_effect = [RuntimeError("thread limit"), None]
+        store = _store(
+            {
+                "issue-a": _pipeline("issue-a"),
+                "issue-b": _pipeline("issue-b"),
+            }
+        )
+
+        assert relaunch_driverless_running_pipelines(store) == 1
+        assert mock_spawn.call_count == 2

--- a/orchestrator/tests/test_cli.py
+++ b/orchestrator/tests/test_cli.py
@@ -4,6 +4,7 @@ Tests for egg-orchestrator CLI.
 
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
 from threading import Thread
 from unittest.mock import MagicMock, patch
 
@@ -189,6 +190,81 @@ class TestServeProbeListenerStartup:
         assert "port" in call_kwargs, (
             "start_probe_listener must be called with an explicit port kwarg"
         )
+
+
+class TestReconcileAndRelaunchOrdering:
+    """Issue #3469: boot-time driver relaunch of RUNNING pipelines runs only
+    AFTER ``reconcile_stale_containers`` has settled pipeline status for the
+    repo. ``_reconcile_and_relaunch_repo`` encodes that ordering; these tests
+    lock the "never relaunch off unsettled state" invariant the relaunch
+    docstring leans on:
+
+    1. On a clean reconcile, relaunch runs (in that order).
+    2. On a reconcile failure, relaunch is skipped entirely — a pipeline that
+       reconciliation would have marked FAILED off unsettled state is never
+       relaunched as a live RUNNING driver.
+    """
+
+    def _store(self):
+        store = MagicMock()
+        store.repo_path = Path("/tmp/repo")
+        return store
+
+    def test_relaunch_runs_after_successful_reconcile(self):
+        from cli import _reconcile_and_relaunch_repo
+
+        store = self._store()
+        docker_client = MagicMock()
+        call_order = []
+
+        def _reconcile(s, c):
+            call_order.append("reconcile")
+            return 0
+
+        def _relaunch(s):
+            call_order.append("relaunch")
+            return 1
+
+        with patch(
+            "startup_reconciliation.reconcile_stale_containers", side_effect=_reconcile
+        ) as mock_reconcile:
+            with patch(
+                "routes.pipelines.relaunch_driverless_running_pipelines",
+                side_effect=_relaunch,
+            ) as mock_relaunch:
+                _reconcile_and_relaunch_repo(store, docker_client)
+
+        mock_reconcile.assert_called_once_with(store, docker_client)
+        mock_relaunch.assert_called_once_with(store)
+        assert call_order == ["reconcile", "relaunch"], (
+            "relaunch must run only after reconciliation settles status"
+        )
+
+    def test_relaunch_skipped_when_reconcile_raises(self):
+        from cli import _reconcile_and_relaunch_repo
+
+        store = self._store()
+        with patch(
+            "startup_reconciliation.reconcile_stale_containers",
+            side_effect=RuntimeError("k8s query failed"),
+        ):
+            with patch("routes.pipelines.relaunch_driverless_running_pipelines") as mock_relaunch:
+                # Must not raise — startup recovery is best-effort.
+                _reconcile_and_relaunch_repo(store, MagicMock())
+
+        mock_relaunch.assert_not_called()
+
+    def test_relaunch_failure_is_non_fatal(self):
+        from cli import _reconcile_and_relaunch_repo
+
+        store = self._store()
+        with patch("startup_reconciliation.reconcile_stale_containers", return_value=0):
+            with patch(
+                "routes.pipelines.relaunch_driverless_running_pipelines",
+                side_effect=RuntimeError("thread limit"),
+            ):
+                # A relaunch failure is logged and swallowed, never fatal to boot.
+                _reconcile_and_relaunch_repo(store, MagicMock())
 
 
 class MockHealthHandler(BaseHTTPRequestHandler):


### PR DESCRIPTION
## Summary

Fixes the permanently-driverless-pipeline hole from #3469: after an orchestrator restart, a pipeline in status=RUNNING had its state fully reconciled at boot, but nothing relaunched its `_run_pipeline` driver thread / BRC event loop — and every operator recovery verb failed:

- `restart_agent` delegates the respawn to the (dead) event loop and returns success: agent records flip to running with `container_id=null`, no pods ever spawn.
- `start_pipeline` — the verb whose documented purpose is relaunching the driver — returns 409 for status=RUNNING.

This implements the issue's preferred fix direction (boot-time revival).

## Changes

- **`orchestrator/routes/pipelines.py`** — new `relaunch_driverless_running_pipelines(store)`: sweeps the store's pipelines and relaunches a fresh driver thread (via the existing `_spawn_pipeline_run_thread`) for every RUNNING pipeline with no live driver, detected with the existing `has_live_pipeline_driver` from #3233. The relaunch reuses the proven resume path that `restart_agent`'s inactive-pipeline branch relies on (#3244): `_run_pipeline` re-enters `current_phase`, re-syncs the worktree with the remote, and restarts the event loop, which respawns one-shot agent Jobs within one poll. `run_epoch` is deliberately not bumped — the old process is gone, so no stale thread can contend for the epoch, and the relaunched thread derives its epoch from persisted state exactly as the original did. Per-pipeline failures are logged and skipped.
- **`orchestrator/cli.py`** — call the sweep per repo store at startup, immediately after `reconcile_stale_containers` settles pipeline statuses (so pipelines reconciliation marks FAILED are never relaunched off unsettled state). Failures are logged, never fatal to boot.
- **`orchestrator/tests/test_boot_driver_relaunch.py`** — 7 regression tests: relaunch happens for RUNNING + no driver, `run_epoch` → `created_at` fallback, all non-RUNNING statuses skipped (AWAITING_HUMAN stays #3233's decision-resolve territory), live-driver skip, per-pipeline load/spawn failure isolation, list failure returns 0.

## Acceptance

`kubectl rollout restart deploy/orchestrator` mid-implement → on boot the sweep runs after reconciliation, relaunches the driver, the driver restarts the event loop, and the pipeline resumes spawning within one poll cycle with zero operator intervention.

## Testing

```
.venv/bin/pytest orchestrator/tests/test_boot_driver_relaunch.py orchestrator/tests/test_orphaned_driver_revival.py
19 passed
```
ruff check + format clean on all touched files.

Closes #3469