### PR TITLE
Reject propose when producer's contract task rows are still pending

### DIFF
--- a/orchestrator/contract_completeness.py
+++ b/orchestrator/contract_completeness.py
@@ -21,7 +21,12 @@ orchestrator's signal routes use these helpers to reject:
   incomplete (covers role-less rows and no-op-proposal bypasses);
 * a ``no_changes_needed`` proposal from a producer that owns incomplete
   rows in the active slice (a no-op proposal is vacuously fully-acked,
-  so without this it would bypass the per-producer ACK gate entirely).
+  so without this it would bypass the per-producer ACK gate entirely);
+* a regular (or re-) proposal from a producer that owns incomplete rows
+  in the active slice (#3470) — finished-but-unmarked work is corrected
+  in-session via ``mcp__task__complete`` instead of drawing a
+  pure-bookkeeping enforcer NACK, which (when the fix is contract-only)
+  deadlocks on the unchanged-tree re-propose guard.
 
 All checks are scoped to the implement phase by the callers — plan and
 refine consensus run against contracts whose task rows are *expected*

--- a/orchestrator/routes/signals/_consensus_verdicts.py
+++ b/orchestrator/routes/signals/_consensus_verdicts.py
@@ -216,7 +216,7 @@ def _contract_completeness_rejection(
     """Contract-task completeness gate for consensus signals (#3114).
 
     Returns a structured rejection response, or ``None`` when the signal
-    may proceed. Three checks share the same contract read:
+    may proceed. Four checks share the same contract read:
 
     * ``check="ack"`` — an enforcer reviewer (see
       ``CONTRACT_ENFORCER_ROLE_NAMES``) may not ACK ``producer_role``
@@ -230,6 +230,19 @@ def _contract_completeness_rejection(
       ``no_changes_needed`` proposal while owning incomplete rows in the
       active slice (a no-op needs no review, so it would bypass the
       per-producer ACK gate entirely).
+    * ``check="propose"`` — ``producer_role`` may not submit a regular
+      (or re-) proposal while owning incomplete rows in the active slice
+      (#3470). Producers routinely finish the work, commit, and propose
+      without calling ``mcp__task__complete``; the enforcer then NACKs
+      on pure bookkeeping, and when the fix is contract-only the
+      re-propose 409s on the unchanged-tree guard (#3395) and the slice
+      deadlocks. Rejecting here — before the tracker records anything —
+      turns that cross-agent review round into a same-session
+      self-correction. No bypass flag: the enforcer ACK gate above
+      already blocks any proposal with incomplete owned rows from
+      reaching consensus, so a "legitimately partial" propose does not
+      exist in the implement phase; ``EGG_CONTRACT_ACK_GATE`` remains
+      the operator escape hatch.
 
     Scope: implement phase only. Plan/refine consensus runs against
     contracts whose rows are expected to be pending, and the apply phase
@@ -336,6 +349,24 @@ def _contract_completeness_rejection(
                 status_code=409,
                 details={
                     "status": "contract_incomplete",
+                    "slice_id": slice_id,
+                    "incomplete_tasks": rows,
+                },
+            )
+        if check == "propose":
+            return make_error_response(
+                f"Propose rejected: {producer_role} owns {len(rows)} contract "
+                f"task(s) in {scope} not marked complete: {summary}. If the "
+                f"work is finished, mark each row complete via "
+                f"mcp__task__complete and propose again — proposing now would "
+                f"only draw a bookkeeping NACK from the contract reviewer, "
+                f"and a contract-only fix cannot re-propose (zero new "
+                f"commits). If a row cannot be delivered in this slice, "
+                f"escalate for a human decision.",
+                status_code=409,
+                details={
+                    "status": "contract_incomplete",
+                    "producer": producer_role,
                     "slice_id": slice_id,
                     "incomplete_tasks": rows,
                 },
@@ -638,6 +669,36 @@ def handle_consensus_propose_signal(
                 worktree_path=worktree_path,
                 branch_verified=branch_verified,
             )
+            # Contract-task completeness gate, propose flavour (#3470): a
+            # producer that finished its work but skipped
+            # mcp__task__complete would sail into review and draw a
+            # pure-bookkeeping NACK from the enforcer — and when the fix
+            # is contract-only, the re-propose 409s on the unchanged-tree
+            # guard (#3395) and the slice deadlocks with no in-protocol
+            # exit. Reject here, before the tracker records the proposal
+            # or any reviewer is invoked, so the producer self-corrects in
+            # the same session. Runs after the content validators so the
+            # producer is only told to mark rows complete once the
+            # artifact checks have passed. Covers the re-propose path too
+            # (the ``changed_artifacts`` dispatch below). Reuse the phase
+            # from ``pipeline_state`` when the commit-on-branch block
+            # already loaded it; otherwise the gate resolves phase itself,
+            # fail-open (#3081 posture).
+            propose_phase: str | None = None
+            if pipeline_state is not None:
+                phase_attr = getattr(pipeline_state, "current_phase", None)
+                if phase_attr is not None:
+                    propose_phase = phase_attr.value
+            gate_rejection = _pkg._contract_completeness_rejection(
+                pipeline_id=pipeline_id,
+                repo_path=repo_path,
+                slice_id=slice_id,
+                check="propose",
+                producer_role=agent_role,
+                current_phase=propose_phase,
+            )
+            if gate_rejection is not None:
+                return gate_rejection
 
         # Check if this is a re-proposal
         changed_artifacts = data.get("changed_artifacts")

--- a/orchestrator/routes/signals/_consensus_verdicts.py
+++ b/orchestrator/routes/signals/_consensus_verdicts.py
@@ -684,6 +684,18 @@ def handle_consensus_propose_signal(
             # from ``pipeline_state`` when the commit-on-branch block
             # already loaded it; otherwise the gate resolves phase itself,
             # fail-open (#3081 posture).
+            #
+            # Passing ``current_phase`` in makes the gate skip its own
+            # state load, so — like the ``noop_propose`` path, which also
+            # feeds a pre-resolved phase — it never resolves
+            # ``issue_number`` and loads the contract keyed on
+            # ``[pipeline_id]`` alone (the ACK/CONFIRM checks, which
+            # self-load, key on ``[pipeline_id, issue_number]``). This is
+            # deliberate parity with ``noop_propose``: harmless in the
+            # pipeline-id-keyed k8s flow (the only production flow), and
+            # fail-open elsewhere. A commit_sha is always present on a
+            # non-no-op propose, so an issue-number-keyed contract would
+            # simply no-op the gate rather than misbehave.
             propose_phase: str | None = None
             if pipeline_state is not None:
                 phase_attr = getattr(pipeline_state, "current_phase", None)

--- a/orchestrator/tests/test_contract_completeness_gate.py
+++ b/orchestrator/tests/test_contract_completeness_gate.py
@@ -5,10 +5,11 @@ Covers:
 * ``contract_completeness`` module — slice/role scoping, the
   unknown-slice ``None`` sentinel, the kill switch, and graceful
   contract loading.
-* ``routes.signals._contract_completeness_rejection`` — the three
-  checks (enforcer ACK, enforcer CONFIRM, no-op propose), the
-  attestation requirement/cross-check on passing ACKs, and the
-  fail-open posture on orchestrator-side read failures.
+* ``routes.signals._contract_completeness_rejection`` — the four
+  checks (enforcer ACK, enforcer CONFIRM, no-op propose, and the
+  propose-time pending-row gate #3470), the attestation
+  requirement/cross-check on passing ACKs, and the fail-open posture
+  on orchestrator-side read failures.
 * ``review_graph`` — the enforcer's CRITICAL edges to every producer.
 """
 
@@ -541,6 +542,22 @@ class TestKillSwitchAllChecks:
             is None
         )
 
+    def test_propose_skipped(
+        self, signals_module, app, gate_env, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(cc.GATE_ENV_VAR, "off")
+        _write_contract(gate_env)
+        assert (
+            _reject(
+                signals_module,
+                app,
+                check="propose",
+                producer_role="coder",
+                current_phase="implement",
+            )
+            is None
+        )
+
 
 class TestSliceless:
     """End-to-end gate behavior for non-sliced (slice_id=None) contracts.
@@ -598,6 +615,22 @@ class TestSliceless:
         assert status == 400
         assert body["details"]["status"] == "contract_incomplete"
         assert [r["id"] for r in body["details"]["incomplete_tasks"]] == ["task-2-3"]
+
+    def test_propose_aggregates_owned_rows_across_slices(
+        self, signals_module, app, gate_env
+    ) -> None:
+        _write_contract(gate_env)
+        status, body = _reject(
+            signals_module,
+            app,
+            check="propose",
+            producer_role="coder",
+            slice_id=None,
+            current_phase="implement",
+        )
+        assert status == 409
+        assert body["details"]["status"] == "contract_incomplete"
+        assert [r["id"] for r in body["details"]["incomplete_tasks"]] == ["task-2-2"]
 
 
 class TestConfirmGate:
@@ -664,6 +697,71 @@ class TestNoopProposeGate:
                 check="noop_propose",
                 producer_role="tester",
                 current_phase="implement",
+            )
+            is None
+        )
+
+
+class TestProposeGate:
+    """Propose-time pending-row gate (#3470)."""
+
+    def test_producer_with_open_rows_rejected_409(self, signals_module, app, gate_env) -> None:
+        _write_contract(gate_env)
+        status, body = _reject(
+            signals_module,
+            app,
+            check="propose",
+            producer_role="coder",
+            current_phase="implement",
+        )
+        assert status == 409
+        assert body["details"]["status"] == "contract_incomplete"
+        assert body["details"]["producer"] == "coder"
+        assert [r["id"] for r in body["details"]["incomplete_tasks"]] == ["task-2-2"]
+        # The rejection must be self-explanatory: name the rows and the
+        # exact call that fixes the omission in-session.
+        assert "task-2-2" in body["message"]
+        assert "mcp__task__complete" in body["message"]
+
+    def test_complete_rows_pass(self, signals_module, app, gate_env) -> None:
+        _write_contract(gate_env, slice2_complete=True)
+        assert (
+            _reject(
+                signals_module,
+                app,
+                check="propose",
+                producer_role="coder",
+                current_phase="implement",
+            )
+            is None
+        )
+
+    def test_producer_without_owned_rows_passes(self, signals_module, app, gate_env) -> None:
+        # The dual-role tester owns no rows in slice-2 (task-2-4 is
+        # role-less); its propose must not be blocked by other roles'
+        # pending rows.
+        _write_contract(gate_env)
+        assert (
+            _reject(
+                signals_module,
+                app,
+                check="propose",
+                producer_role="tester",
+                current_phase="implement",
+            )
+            is None
+        )
+
+    def test_plan_phase_skipped(self, signals_module, app, gate_env) -> None:
+        # Plan/refine contracts have pending rows by design.
+        _write_contract(gate_env)
+        assert (
+            _reject(
+                signals_module,
+                app,
+                check="propose",
+                producer_role="coder",
+                current_phase="plan",
             )
             is None
         )

--- a/orchestrator/tests/test_signals.py
+++ b/orchestrator/tests/test_signals.py
@@ -1399,6 +1399,157 @@ class TestConsensusProposeBranchVerification:
         assert msg.metadata.get("commit_sha") == "deadbeef"
 
 
+class TestConsensusProposePendingTaskGate:
+    """Propose-time contract-bookkeeping gate (#3470).
+
+    A producer proposing while its owned contract task rows are still
+    ``pending`` must be rejected before the tracker records the proposal
+    — otherwise reviewer_contract NACKs on pure bookkeeping, and a
+    contract-only fix cannot re-propose (unchanged-tree 409, #3395),
+    mechanically deadlocking the slice.
+    """
+
+    PIPELINE_ID = "issue-42"
+
+    @staticmethod
+    def _implement_pipeline():
+        from egg_contracts.models import PipelinePhase
+        from models import Pipeline
+
+        return Pipeline(
+            id="issue-42",
+            issue_number=42,
+            repo="owner/repo",
+            branch="egg/issue-42",
+            current_phase=PipelinePhase.IMPLEMENT,
+        )
+
+    @staticmethod
+    def _write_contract(worktree: Path, *, coder_row_status: str) -> None:
+        contracts_dir = worktree / ".egg-state" / "contracts"
+        contracts_dir.mkdir(parents=True, exist_ok=True)
+        contract = {
+            "schemaVersion": "1.0",
+            "issue": {"number": 42, "title": "gate test", "url": "http://example"},
+            "phases": [
+                {
+                    "id": "slice-2",
+                    "name": "second",
+                    "tasks": [
+                        {
+                            "id": "task-2-1",
+                            "description": "open coder work",
+                            "role": "coder",
+                            "status": coder_row_status,
+                        },
+                    ],
+                },
+            ],
+        }
+        (contracts_dir / "issue-42.json").write_text(json.dumps(contract))
+
+    def _propose(self, data_extra=None):
+        from routes.signals import handle_consensus_propose_signal
+
+        data = {
+            "agent_role": "coder",
+            "slice_id": "slice-2",
+            "payload": {
+                "summary": (
+                    "Implemented authentication with JWT validation and "
+                    "session management for issue-42"
+                ),
+                "artifacts": ["src/a.py"],
+            },
+        }
+        data.update(data_extra or {})
+        return handle_consensus_propose_signal(self.PIPELINE_ID, data, Path("/tmp/repo"))
+
+    @patch("routes.signals.resolve_worktree_path")
+    @patch("routes.signals.get_state_store")
+    @patch("peer_consensus.get_peer_consensus_tracker")
+    def test_propose_with_pending_owned_rows_rejected_409(
+        self, mock_get_tracker, mock_get_store, mock_resolve_wt, app, tmp_path
+    ):
+        """Pending owned rows -> immediate 409 naming the rows and the fix."""
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = self._implement_pipeline()
+        mock_get_store.return_value = mock_store
+        mock_resolve_wt.return_value = tmp_path
+        self._write_contract(tmp_path, coder_row_status="pending")
+
+        mock_tracker = MagicMock()
+        mock_get_tracker.return_value = mock_tracker
+
+        with app.app_context():
+            response, status_code = self._propose()
+
+        assert status_code == 409
+        body = response.get_json()
+        assert body["details"]["status"] == "contract_incomplete"
+        assert [r["id"] for r in body["details"]["incomplete_tasks"]] == ["task-2-1"]
+        assert "task-2-1" in body["message"]
+        assert "mcp__task__complete" in body["message"]
+        # Rejected BEFORE the tracker recorded anything: no version bump,
+        # no reviewer invocation.
+        mock_tracker.handle_propose.assert_not_called()
+        mock_tracker.handle_re_propose.assert_not_called()
+
+    @patch("routes.signals.resolve_worktree_path")
+    @patch("routes.signals.get_state_store")
+    @patch("peer_consensus.get_peer_consensus_tracker")
+    def test_re_propose_with_pending_owned_rows_rejected_409(
+        self, mock_get_tracker, mock_get_store, mock_resolve_wt, app, tmp_path
+    ):
+        """The changed_artifacts (re-propose) dispatch is gated too."""
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = self._implement_pipeline()
+        mock_get_store.return_value = mock_store
+        mock_resolve_wt.return_value = tmp_path
+        self._write_contract(tmp_path, coder_row_status="pending")
+
+        mock_tracker = MagicMock()
+        mock_get_tracker.return_value = mock_tracker
+
+        with app.app_context():
+            response, status_code = self._propose({"changed_artifacts": ["src/a.py"]})
+
+        assert status_code == 409
+        assert response.get_json()["details"]["status"] == "contract_incomplete"
+        mock_tracker.handle_re_propose.assert_not_called()
+
+    @patch("routes.signals.resolve_worktree_path")
+    @patch("routes.signals.get_state_store")
+    @patch("peer_consensus.get_peer_consensus_tracker")
+    def test_propose_with_complete_rows_accepted(
+        self, mock_get_tracker, mock_get_store, mock_resolve_wt, app, tmp_path
+    ):
+        """After marking the rows complete, the same propose goes through."""
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = self._implement_pipeline()
+        mock_get_store.return_value = mock_store
+        mock_resolve_wt.return_value = tmp_path
+        self._write_contract(tmp_path, coder_row_status="complete")
+
+        mock_tracker = MagicMock()
+        mock_tracker.handle_propose.return_value = {
+            "version": 1,
+            "status": "proposed",
+            "commit_sha": "",
+            "reviewers": [],
+            "stale_reviewers": [],
+        }
+        mock_get_tracker.return_value = mock_tracker
+
+        with app.app_context():
+            with patch("message_store.get_message_store") as mock_msg_store:
+                mock_msg_store.return_value = MagicMock()
+                response, status_code = self._propose()
+
+        assert status_code == 200
+        mock_tracker.handle_propose.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # consensus_excuse_producer HITL gate tests (#1637)
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_signals.py
+++ b/orchestrator/tests/test_signals.py
@@ -1549,6 +1549,64 @@ class TestConsensusProposePendingTaskGate:
         assert status_code == 200
         mock_tracker.handle_propose.assert_called_once()
 
+    @patch("routes.signals._verify_commit_on_branch", return_value=True)
+    @patch("routes.signals.resolve_worktree_path")
+    @patch("routes.signals.get_state_store")
+    @patch("peer_consensus.get_peer_consensus_tracker")
+    def test_propose_with_commit_sha_rejected_via_preloaded_phase(
+        self,
+        mock_get_tracker,
+        mock_get_store,
+        mock_resolve_wt,
+        mock_verify_branch,
+        app,
+        tmp_path,
+    ):
+        """Production-realistic path: a non-no-op propose carries a
+        ``commit_sha``, so the commit-on-branch block pre-loads
+        ``pipeline_state`` and the gate reuses its phase (lines 687-691)
+        instead of self-loading. Pending owned rows must still 409, and the
+        gate must NOT re-read pipeline state — proving the reject flows
+        through the pre-loaded-phase branch, not the ``current_phase is
+        None`` self-load fallback the other tests exercise.
+        """
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = self._implement_pipeline()
+        mock_get_store.return_value = mock_store
+        mock_resolve_wt.return_value = tmp_path
+        self._write_contract(tmp_path, coder_row_status="pending")
+
+        mock_tracker = MagicMock()
+        mock_get_tracker.return_value = mock_tracker
+
+        with app.app_context():
+            response, status_code = self._propose(
+                {
+                    "payload": {
+                        "summary": (
+                            "Implemented authentication with JWT validation "
+                            "and session management for issue-42"
+                        ),
+                        "artifacts": ["src/a.py"],
+                        "commit_sha": "abc1234",
+                    },
+                }
+            )
+
+        assert status_code == 409
+        body = response.get_json()
+        assert body["details"]["status"] == "contract_incomplete"
+        assert [r["id"] for r in body["details"]["incomplete_tasks"]] == ["task-2-1"]
+        assert "mcp__task__complete" in body["message"]
+        # The commit-on-branch block loaded pipeline state exactly once; the
+        # gate reused that phase rather than self-loading. A second
+        # load_pipeline call would mean the propose_phase reuse regressed to
+        # the self-load fallback.
+        assert mock_store.load_pipeline.call_count == 1
+        # Rejected before the tracker recorded anything.
+        mock_tracker.handle_propose.assert_not_called()
+        mock_tracker.handle_re_propose.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # consensus_excuse_producer HITL gate tests (#1637)


### PR DESCRIPTION
Implements fix (1) from #3470: `mcp__brc__propose` now rejects at propose time when the proposing producer still owns non-`complete` contract task rows in the active slice.

## Problem

Producers routinely finish work, commit, and propose without calling `mcp__task__complete`. reviewer_contract then NACKs on pure bookkeeping ("CONTENT IS APPROVED — this NACK is a contract-bookkeeping block only"), costing a full NACK→fix→re-review round per occurrence — three documented occurrences in pipeline-dcdad92d. Worse, when the fix is contract-only, the re-propose returns 409 'zero new commits' (the #3395 unchanged-tree guard), the enforcer's derived next-action stays `wait`, and the slice mechanically deadlocks with no in-protocol exit (see the escalation comment on #3470).

## Fix

Adds a `check="propose"` flavour to the existing #3114 contract-task completeness gate (`_contract_completeness_rejection`) and calls it from `handle_consensus_propose_signal` for every non-no-op propose **and re-propose**, before the tracker records the proposal or any reviewer is invoked. A producer with incomplete owned rows gets an immediate, self-explanatory 409 naming the rows and the exact `mcp__task__complete` call to make — a same-session self-correction instead of a cross-agent review round. Since the rejection happens before any tracker mutation, the subsequent propose (after marking rows) carries new commits relative to the *recorded* proposal and never trips the unchanged-tree guard — closing the only known entry into the deadlock.

Placement: after the content validators (`_validate_producer_artifacts`), so the producer is only told to mark rows complete once the artifact checks pass; reuses the pipeline state already loaded by the commit-on-branch block when available.

Same scope and posture as the existing ACK / CONFIRM / no-op-propose checks:
- **Implement phase only** — plan/refine contracts have pending rows by design.
- **Fail-open** on orchestrator-side read failures (state store, worktree, contract load, unknown slice) — #3081 posture; reviewers remain the backstop.
- **`EGG_CONTRACT_ACK_GATE`** kill switch covers it.

**No bypass flag** (considered per the issue): the enforcer ACK gate already blocks any proposal with incomplete owned rows from reaching consensus, so a "legitimately partial" propose does not exist in the implement phase — the flag would only re-open the wasted review round. The kill switch remains the operator escape hatch.

## Acceptance criteria → coverage

- Producer proposing with pending owned rows → immediate 409 naming rows + `mcp__task__complete`: `TestProposeGate.test_producer_with_open_rows_rejected_409`, e2e `TestConsensusProposePendingTaskGate.test_propose_with_pending_owned_rows_rejected_409` (also asserts the tracker was never touched).
- After marking rows, propose succeeds: `test_complete_rows_pass`, e2e `test_propose_with_complete_rows_accepted`.
- Existing flows unaffected: dual-role tester with no owned rows passes (`test_producer_without_owned_rows_passes`); v2 re-proposes with complete rows unaffected, re-proposes with pending rows gated (`test_re_propose_with_pending_owned_rows_rejected_409`); plan-phase proposes skipped (`test_plan_phase_skipped`); kill switch + sliceless aggregation covered.

Test run: `test_contract_completeness_gate.py` + `test_signals.py` (174 passed) and the six other propose-path suites (`test_brc_content_validation`, `test_brc_open_nacks_barrier`, `test_brc_phase_propagation`, `test_slice_signal_routing`, `test_artifact_routes`, `test_brc_unchanged_repropose` — 176 passed). Lint clean.

Closes #3470