### PR TITLE
Persist task-status mutations at write time and release contract-blocked NACKs (#3473)

### DIFF
--- a/orchestrator/approval_matrix.py
+++ b/orchestrator/approval_matrix.py
@@ -360,6 +360,39 @@ class ApprovalMatrix:
             return True
         return False
 
+    def invalidate_nack(
+        self,
+        reviewer: str,
+        producer: str,
+    ) -> bool:
+        """Invalidate a reviewer's NACK so the current version needs re-review.
+
+        Orchestrator-initiated release of an outstanding NACK whose cited
+        blocker was repaired out-of-band (#3470: a ``contract_incomplete``
+        NACK after the producer marked its contract rows complete — a
+        task-status mutation moves no BRC state, so without this the
+        reviewer waits for a re-propose the producer cannot send). The
+        entry returns to PENDING and its version is stepped back below the
+        producer's current proposal version, so the next-action derivation
+        sees an un-verdicted current proposal and re-derives ``ack`` for
+        the reviewer, which re-reviews and re-verdicts freely.
+
+        Returns True if a NACK was invalidated, False if not applicable.
+        """
+        key = (reviewer, producer)
+        entry = self._entries.get(key)
+        if entry and entry.state == ApprovalState.NACKED:
+            entry.state = ApprovalState.PENDING
+            # Step the verdict version below the producer's current
+            # proposal version: pending-review derivation treats
+            # ``entry.version < current_version`` as "verdict needed".
+            entry.version = max(0, entry.version - 1)
+            entry.artifact_refs = []
+            entry.nack_artifact_refs = []
+            entry.reason = ""
+            return True
+        return False
+
     def invalidate_overlapping_acks(
         self,
         producer: str,

--- a/orchestrator/events.py
+++ b/orchestrator/events.py
@@ -91,6 +91,14 @@ class EventType(StrEnum):
     # driven by the persisted ``CONSENSUS_REOPENED`` bus message, not
     # by this event.
     CONSENSUS_PRODUCER_REOPENED = "consensus.producer_reopened"
+    # A reviewer's outstanding NACK was invalidated because its cited
+    # contract blocker was repaired (#3470: producer marked its contract
+    # rows complete after a contract_incomplete NACK). Intentionally has
+    # no subscriber today — emitted by
+    # ``peer_consensus.release_contract_nack`` as a forward-compat hook,
+    # mirroring CONSENSUS_PRODUCER_REOPENED. The release itself is driven
+    # by the persisted ``CONSENSUS_NACK_INVALIDATED`` bus message.
+    CONSENSUS_NACK_INVALIDATED = "consensus.nack_invalidated"
 
     # HITL events
     DECISION_CREATED = "decision.created"

--- a/orchestrator/message_store.py
+++ b/orchestrator/message_store.py
@@ -92,6 +92,15 @@ class MessageType:
     # (the propose guard requires WORKING) and a restart would resurrect
     # the deadlock the reopen resolved. ``to_role`` carries the producer.
     CONSENSUS_REOPENED = "CONSENSUS_REOPENED"
+    # Contract-blocked NACK release (#3470): a producer repaired the
+    # contract_incomplete blocker its reviewer's NACK cited (marked the
+    # owned task rows complete), so the orchestrator invalidated that
+    # NACK for re-review. Persisted so
+    # ``reconstruct_tracker_from_messages`` can replay the release —
+    # without it, a restart would resurrect the NACK and the deadlock it
+    # caused. ``to_role`` carries the reviewer; metadata carries
+    # ``reviewer_role`` / ``producer_role``.
+    CONSENSUS_NACK_INVALIDATED = "CONSENSUS_NACK_INVALIDATED"
     # Overseer anomaly broadcasts (issue #1413)
     OVERSEER_ALERT = "OVERSEER_ALERT"
     # Tier 1 health monitor nudge messages (issue #1428)

--- a/orchestrator/peer_consensus/__init__.py
+++ b/orchestrator/peer_consensus/__init__.py
@@ -188,6 +188,7 @@ class PeerConsensusTracker:
     excuse_reviewer = _recovery.excuse_reviewer
     excuse_producer = _recovery.excuse_producer
     reopen_producer = _recovery.reopen_producer
+    release_contract_nack = _recovery.release_contract_nack
     is_timeout_handled = _recovery.is_timeout_handled
     handle_timeout = _recovery.handle_timeout
 
@@ -358,6 +359,12 @@ def reconstruct_tracker_from_messages(
         # proposal (the propose guard requires WORKING) and resurrect the
         # deadlock the reopen resolved.
         "CONSENSUS_REOPENED",
+        # Contract-blocked NACK release (#3470). Replayed so the
+        # NACKED→PENDING re-review transition survives restarts — without
+        # it, replay would resurrect the NACK against a producer that can
+        # no longer re-propose (zero new commits) and restore the
+        # deadlock the release resolved.
+        "CONSENSUS_NACK_INVALIDATED",
     }
     consensus_msgs = [m for m in messages if m.message_type in consensus_types]
 
@@ -508,6 +515,26 @@ def reconstruct_tracker_from_messages(
                 reopened_producer = msg.to_role
                 if reopened_producer and reopened_producer != "all":
                     tracker.reopen_producer(reopened_producer, reason="replay")
+
+            elif msg.message_type == "CONSENSUS_NACK_INVALIDATED":
+                # Emitted by the orchestrator (contract mutate route) when a
+                # producer repaired the contract_incomplete blocker a
+                # reviewer's NACK cited (#3470). Metadata carries the roles;
+                # ``to_role`` doubles as the reviewer for older messages.
+                # ``from_role`` is the orchestrator and is deliberately not
+                # replayed as a participant. release_contract_nack is
+                # idempotent, so a duplicate message is harmless.
+                metadata = msg.metadata or {}
+                released_reviewer = metadata.get("reviewer_role") or msg.to_role
+                released_producer = metadata.get("producer_role")
+                if not released_reviewer or released_reviewer == "all" or not released_producer:
+                    logger.debug(
+                        "Skipping NACK-invalidation message with missing roles",
+                        pipeline_id=pipeline_id,
+                        message_id=msg.id,
+                    )
+                    continue
+                tracker.release_contract_nack(released_reviewer, released_producer, reason="replay")
 
             elif msg.message_type == "CONSENSUS_OBLIGATION_RESOLVED":
                 # Metadata carries the participant roles plus optional

--- a/orchestrator/peer_consensus/__init__.py
+++ b/orchestrator/peer_consensus/__init__.py
@@ -97,6 +97,14 @@ class PeerConsensusTracker:
         self._reviewer_phases: dict[str, ConsensusPhase] = {}
         # Per-agent confirmed status (both state machines must confirm)
         self._confirmed: set[str] = set()
+        # Producers whose latest action was a withdraw (proposal retracted,
+        # #3470). Set on handle_withdraw, cleared on the next propose /
+        # re-propose. release_contract_nack reads this to avoid restoring
+        # PROPOSED for a producer that retracted its proposal — restoring
+        # would let a released reviewer ACK withdrawn work. Derived purely
+        # from replayed WITHDRAW / PROPOSE messages, so it survives
+        # reconstruct_tracker_from_messages.
+        self._withdrawn_producers: set[str] = set()
         # Timestamp of last proposal per producer (for cooldown)
         self._proposal_timestamps: dict[str, datetime] = {}
         # Flip-flop counter per producer (proposal -> withdraw cycles)

--- a/orchestrator/peer_consensus/_proposals.py
+++ b/orchestrator/peer_consensus/_proposals.py
@@ -125,6 +125,7 @@ def _handle_propose_inner(
     # Transition to PROPOSED
     self._producer_phases[agent_role] = ConsensusPhase.PROPOSED
     self._confirmed.discard(agent_role)  # Clear stale confirmed status (#1411)
+    self._withdrawn_producers.discard(agent_role)  # Fresh proposal (#3470)
     self._proposal_timestamps[agent_role] = datetime.now(UTC)
     self._proposal_artifacts[agent_role] = list(proposal.artifacts)
     self._proposal_commit_shas[agent_role] = proposal.commit_sha
@@ -434,6 +435,10 @@ def handle_withdraw(
         # Transition back to WORKING
         self._producer_phases[agent_role] = ConsensusPhase.WORKING
         self._confirmed.discard(agent_role)  # Clear stale confirmed status (#1411)
+        # Mark the proposal retracted so release_contract_nack won't restore
+        # PROPOSED for it (#3470): a released reviewer must not ACK work the
+        # producer withdrew. Cleared on the next propose / re-propose.
+        self._withdrawn_producers.add(agent_role)
 
         emit_event(
             EventType.CONSENSUS_WITHDRAW_RECEIVED,

--- a/orchestrator/peer_consensus/_recovery.py
+++ b/orchestrator/peer_consensus/_recovery.py
@@ -321,6 +321,85 @@ def reopen_producer(self, agent_role: str, reason: str = "") -> dict[str, Any]:
         return {"status": "reopened", "role": agent_role, "reason": reason}
 
 
+def release_contract_nack(
+    self,
+    reviewer_role: str,
+    producer_role: str,
+    reason: str = "",
+) -> dict[str, Any]:
+    """Invalidate a reviewer's outstanding NACK whose contract blocker was repaired (#3470).
+
+    A contract-enforcer reviewer whose ACK the #3114 completeness gate
+    rejected NACKs the producer citing the incomplete contract rows. When
+    the producer then repairs the cited blocker via ``mcp__task__complete``,
+    the mutation moves only the contract file — never the BRC tracker — so
+    the reviewer keeps deriving ``wait`` (its verdict on the current
+    version stands) while the producer cannot re-propose (zero new
+    commits → the unchanged-re-propose guard rejects it). The slice
+    deadlocks until an operator restarts the reviewer.
+
+    Releasing the NACK returns the review edge to PENDING with its
+    verdict version stepped back, so the next-action poll re-derives
+    ``ack`` for the reviewer and the event loop respawns it to
+    re-verdict — no producer re-propose required.
+
+    Idempotent: returns ``{"status": "noop"}`` when the edge holds no
+    NACK (already released, superseded by a re-propose, or re-verdicted),
+    so message replay can apply it blindly.
+
+    Raises ValueError if there is no ``reviewer -> producer`` review edge.
+    """
+    with self._lock:
+        if self.matrix.get_entry(reviewer_role, producer_role) is None:
+            raise ValueError(f"No review edge: {reviewer_role} -> {producer_role}")
+
+        if not self.matrix.invalidate_nack(reviewer_role, producer_role):
+            return {"status": "noop", "reviewer": reviewer_role, "producer": producer_role}
+
+        # The NACK had flipped the producer back to WORKING. With no
+        # NACKs left against it, its current proposal stands again —
+        # restore PROPOSED so the pending-review derivation surfaces
+        # that proposal to the released reviewer (and the producer's
+        # own arm stops deriving a doomed zero-commit re-propose).
+        # Caveat: a producer that WITHDREW after this NACK is also
+        # WORKING; restoring PROPOSED for it is harmless — re-propose
+        # from PROPOSED is the normal re-propose flow, so its intended
+        # next proposal still lands as the next version.
+        if (
+            self._producer_phases.get(producer_role) == ConsensusPhase.WORKING
+            and self.matrix.get_proposal_version(producer_role) > 0
+            and not self.matrix.has_unresolved_nacks_as_producer(producer_role)
+        ):
+            self._producer_phases[producer_role] = ConsensusPhase.PROPOSED
+
+        emit_event(
+            EventType.CONSENSUS_NACK_INVALIDATED,
+            self.pipeline_id,
+            data={
+                "reviewer": reviewer_role,
+                "producer": producer_role,
+                "reason": reason,
+            },
+        )
+
+        logger.info(
+            "Released contract-blocked NACK for re-review",
+            reviewer=reviewer_role,
+            producer=producer_role,
+            reason=reason,
+            pipeline_id=self.pipeline_id,
+        )
+
+        self._run_invariant_checks("release_contract_nack")
+
+        return {
+            "status": "released",
+            "reviewer": reviewer_role,
+            "producer": producer_role,
+            "reason": reason,
+        }
+
+
 def is_timeout_handled(self) -> bool:
     """Check whether the BRC tracker has already handled the timeout."""
     with self._lock:

--- a/orchestrator/peer_consensus/_recovery.py
+++ b/orchestrator/peer_consensus/_recovery.py
@@ -361,12 +361,17 @@ def release_contract_nack(
         # restore PROPOSED so the pending-review derivation surfaces
         # that proposal to the released reviewer (and the producer's
         # own arm stops deriving a doomed zero-commit re-propose).
-        # Caveat: a producer that WITHDREW after this NACK is also
-        # WORKING; restoring PROPOSED for it is harmless — re-propose
-        # from PROPOSED is the normal re-propose flow, so its intended
-        # next proposal still lands as the next version.
+        #
+        # Skip the restore for a producer that WITHDREW after the NACK
+        # (also WORKING): its proposal is retracted, and restoring
+        # PROPOSED would surface the withdrawn work to the released
+        # reviewer, which could re-review and ACK it before the producer
+        # re-proposes — converging consensus on retracted work. Leaving it
+        # WORKING is correct: the producer's next (re-)propose lands the
+        # replacement as the next version and re-arms the reviewer then.
         if (
             self._producer_phases.get(producer_role) == ConsensusPhase.WORKING
+            and producer_role not in self._withdrawn_producers
             and self.matrix.get_proposal_version(producer_role) > 0
             and not self.matrix.has_unresolved_nacks_as_producer(producer_role)
         ):

--- a/orchestrator/peer_consensus/_state.py
+++ b/orchestrator/peer_consensus/_state.py
@@ -163,6 +163,7 @@ def remove_agent(self, role: str) -> None:
         self._producer_phases.pop(role, None)
         self._reviewer_phases.pop(role, None)
         self._confirmed.discard(role)
+        self._withdrawn_producers.discard(role)
 
 
 def clear(self) -> None:
@@ -171,6 +172,7 @@ def clear(self) -> None:
         self._producer_phases.clear()
         self._reviewer_phases.clear()
         self._confirmed.clear()
+        self._withdrawn_producers.clear()
         self._proposal_timestamps.clear()
         self._flip_flop_counts.clear()
         self._proposal_artifacts.clear()

--- a/orchestrator/routes/contracts.py
+++ b/orchestrator/routes/contracts.py
@@ -405,9 +405,11 @@ def mutate_contract(identifier: str) -> tuple[Response, int]:
         },
     )
 
-    _persist_decision_mutation(field_path, worktree)
+    _persist_durable_mutation(field_path, worktree)
 
     _audit_confirmed_assignee_reassignment(result.contract, field_path, new_value, actor)
+
+    _maybe_release_contract_blocked_nacks(result.contract, field_path, new_value)
 
     return _success(
         "Mutation applied successfully",
@@ -415,20 +417,33 @@ def mutate_contract(identifier: str) -> tuple[Response, int]:
     )
 
 
-def _persist_decision_mutation(field_path: str, worktree: Path) -> None:
-    """Best-effort commit+push after a ``decisions.*`` mutation (#3427).
+# Task rows whose mutation must be durably persisted at write time
+# (#3470): ``status`` is what the #3114 completeness gate reads;
+# ``commit`` is what the #3125 evidence-reachability gate reads.
+_TASK_DURABLE_PATH_RE = re.compile(r"^phases\.\d+\.tasks\.\d+\.(?:status|commit)$")
 
-    Contract HITL decisions written through this RPC (agent
-    ``register_open_question`` etc.) landed only on the worktree file; the
+
+def _persist_durable_mutation(field_path: str, worktree: Path) -> None:
+    """Best-effort commit+push after a durability-critical mutation.
+
+    Contract HITL decisions (#3427) and task ``status``/``commit`` rows
+    (#3470) written through this RPC landed only on the worktree file; the
     phase-(re)start worktree syncs ``git reset --hard`` to origin, so a
-    registration that was not committed+pushed by then was silently
-    reverted — and the next ``cq-N`` mint against the reverted file reused
-    its id, clobbering a live (possibly resolved) decision. Persist at
-    write time so the reset target already contains the decision. Must
-    never fail the mutation response — the write is live on the worktree
-    file regardless.
+    write that was not committed+pushed by then was silently reverted.
+    For decisions that let the next ``cq-N`` mint reuse a live id; for
+    task rows it flipped completed tasks back to pending, so the #3114
+    ACK-guard re-rejected reviewer ACKs with ``contract_incomplete``
+    against work that had already been delivered and marked complete —
+    deadlocking the slice (observed on pipeline-dcdad92d: the driver
+    relaunch's ``_rebase_pipeline_branch_onto_base`` double reset orphaned
+    the un-pushed persist commit and reverted the live completions).
+    Persist at write time so the reset target already contains the write.
+    Must never fail the mutation response — the write is live on the
+    worktree file regardless.
     """
-    if field_path != "decisions" and not field_path.startswith("decisions."):
+    is_decision = field_path == "decisions" or field_path.startswith("decisions.")
+    is_task_row = bool(_TASK_DURABLE_PATH_RE.match(field_path))
+    if not is_decision and not is_task_row:
         return
     try:
         pipeline_id, _ = _pipeline_context()
@@ -436,14 +451,187 @@ def _persist_decision_mutation(field_path: str, worktree: Path) -> None:
             return
         from routes.pipelines import persist_contract_statefiles
 
+        issue_ref = "#3427" if is_decision else "#3470"
         persist_contract_statefiles(
             pipeline_id,
             worktree,
-            f"Persist contract decision mutation {field_path} (#3427)",
+            f"Persist contract mutation {field_path} ({issue_ref})",
         )
     except Exception:
         logger.warning(
-            "Failed to persist decisions mutation to work branch",
+            "Failed to persist contract mutation to work branch",
+            extra={"field_path": field_path},
+            exc_info=True,
+        )
+
+
+_TASK_STATUS_PATH_RE = re.compile(r"^phases\.(\d+)\.tasks\.(\d+)\.status$")
+
+# Heuristic match for a NACK reason that cites contract-task
+# incompleteness. The #3114 ACK-guard's rejection tells the reviewer to
+# "NACK ... citing these task ids" and names the ``contract_incomplete``
+# status; reviewers echo that vocabulary. A false positive costs one
+# re-review cycle (the reviewer re-verdicts freely and re-NACKs a real
+# defect); a false negative leaves the reviewer parked until the next
+# unrelated BRC movement or operator restart.
+_CONTRACT_INCOMPLETE_VOCAB_RE = re.compile(
+    r"incomplete|not\s+(?:yet\s+)?(?:marked\s+)?complete|pending"
+    r"|status=complete|mcp__task__complete|complete-task|task\s+rows?",
+    re.IGNORECASE,
+)
+
+
+def _nack_cites_contract_incompleteness(reason: str) -> bool:
+    text = (reason or "").lower()
+    if "contract_incomplete" in text:
+        return True
+    if "contract" not in text:
+        return False
+    return bool(_CONTRACT_INCOMPLETE_VOCAB_RE.search(text))
+
+
+def _maybe_release_contract_blocked_nacks(
+    contract: Contract,
+    field_path: str,
+    new_value: Any,
+) -> None:
+    """Wake reviewers whose ``contract_incomplete`` NACK blocker was repaired (#3470).
+
+    A contract task-status mutation moves no BRC state: after an enforcer
+    reviewer NACKed a producer citing incomplete contract rows (the #3114
+    ACK-guard's prescribed remediation), the producer's
+    ``mcp__task__complete`` repairs the cited blocker but nothing
+    re-derives the reviewer — it holds a standing verdict on the current
+    proposal version, so the event loop derives ``wait`` for it forever,
+    while the producer cannot re-propose (zero new commits → the
+    unchanged-re-propose guard 409s). The slice deadlocks until an
+    operator restarts the reviewer (observed for ~8h on
+    pipeline-dcdad92d slice-5).
+
+    When a ``status`` mutation flips a task row to ``complete`` and the
+    owning producer now owes no incomplete rows in the slice, release
+    each contract-enforcer NACK on the producer's current version that
+    cited contract incompleteness: a ``CONSENSUS_NACK_INVALIDATED`` bus
+    message is written first (replay parity, #3124 pattern), then the
+    tracker invalidates the NACK so the reviewer's next-action poll
+    re-derives ``ack`` and the event loop respawns it to re-verdict.
+
+    Best-effort: any failure is logged and swallowed — the mutation
+    already succeeded, and the wake can be recovered by an operator
+    restart exactly as before.
+    """
+    try:
+        match = _TASK_STATUS_PATH_RE.match(field_path)
+        if not match or new_value != "complete":
+            return
+
+        pipeline_id, _repo_hint = _pipeline_context()
+        if not pipeline_id:
+            return
+
+        slice_idx, task_idx = int(match.group(1)), int(match.group(2))
+        slices = list(getattr(contract, "slices", None) or [])
+        if slice_idx >= len(slices):
+            return
+        contract_slice = slices[slice_idx]
+        slice_id = getattr(contract_slice, "id", None)
+        tasks = list(getattr(contract_slice, "tasks", None) or [])
+        if task_idx >= len(tasks):
+            return
+        producer_role = getattr(tasks[task_idx], "role", None)
+        if not producer_role:
+            return
+
+        # Same scope and kill switch as the gate that minted the
+        # rejection: only wake when the gate could actually have blocked.
+        import contract_completeness as cc
+
+        if not cc.gate_enabled():
+            return
+        incomplete = cc.incomplete_tasks(contract, slice_id, role=producer_role)
+        if incomplete is None or incomplete:
+            return  # slice not found, or the producer still owes rows
+
+        from peer_consensus import get_peer_consensus_tracker
+
+        tracker = get_peer_consensus_tracker(pipeline_id, slice_id)
+        if tracker is None:
+            return
+
+        from egg_contracts.agent_roles import CONTRACT_ENFORCER_ROLE_NAMES
+
+        # Lock-free selection over a matrix snapshot; release_contract_nack
+        # re-checks the NACK under the tracker lock (same posture as the
+        # #3124 reopen pre-check). Only current-version NACKs are
+        # candidates — a stale-version NACK is already superseded and the
+        # reviewer already derives a re-review for it.
+        current_version = tracker.matrix.get_proposal_version(producer_role)
+        if current_version <= 0:
+            return
+        candidates = [
+            reviewer
+            for reviewer, entry in tracker.matrix.get_nack_entries_for(producer_role)
+            if reviewer in CONTRACT_ENFORCER_ROLE_NAMES
+            and entry.version == current_version
+            and _nack_cites_contract_incompleteness(entry.reason)
+        ]
+        if not candidates:
+            return
+
+        from message_store import Message, MessageType, get_message_store
+
+        store = get_message_store()
+        release_reason = (
+            f"contract task rows for {producer_role} are complete; "
+            f"released {field_path}-blocked NACK for re-review (#3470)"
+        )
+        for reviewer in candidates:
+            # Bus message BEFORE the tracker mutation so message replay
+            # performs the same transition (#3124 pattern). If the write
+            # fails, skip the mutation — replay parity over liveness.
+            try:
+                store.add_message(
+                    Message(
+                        pipeline_id=pipeline_id,
+                        from_role="orchestrator",
+                        to_role=reviewer,
+                        message_type=MessageType.CONSENSUS_NACK_INVALIDATED,
+                        subject=f"NACK on {producer_role} released for re-review",
+                        body=release_reason,
+                        phase="implement",
+                        metadata={
+                            "reviewer_role": reviewer,
+                            "producer_role": producer_role,
+                            "field_path": field_path,
+                            **({"slice_id": slice_id} if slice_id is not None else {}),
+                        },
+                    )
+                )
+            except Exception:
+                logger.warning(
+                    "Skipped contract NACK release: could not persist CONSENSUS_NACK_INVALIDATED",
+                    extra={
+                        "pipeline_id": pipeline_id,
+                        "reviewer": reviewer,
+                        "producer": producer_role,
+                    },
+                    exc_info=True,
+                )
+                continue
+            result = tracker.release_contract_nack(reviewer, producer_role, release_reason)
+            logger.info(
+                "Contract NACK release after task completion",
+                extra={
+                    "pipeline_id": pipeline_id,
+                    "slice_id": slice_id,
+                    "reviewer": reviewer,
+                    "producer": producer_role,
+                    "status": result.get("status"),
+                },
+            )
+    except Exception:  # noqa: BLE001 — wake is best-effort; mutation already succeeded
+        logger.warning(
+            "Contract NACK release check failed",
             extra={"field_path": field_path},
             exc_info=True,
         )

--- a/orchestrator/routes/contracts.py
+++ b/orchestrator/routes/contracts.py
@@ -420,6 +420,14 @@ def mutate_contract(identifier: str) -> tuple[Response, int]:
 # Task rows whose mutation must be durably persisted at write time
 # (#3470): ``status`` is what the #3114 completeness gate reads;
 # ``commit`` is what the #3125 evidence-reachability gate reads.
+#
+# These regexes intentionally track the *wire* field path (``phases.*``),
+# not the model field. Post-#2137 the canonical model attribute is
+# ``slices``, but the mutate RPC's ``field_path`` is always emitted as
+# ``phases.<i>.tasks.<j>.<field>`` by every production producer
+# (sandbox/egg_agent_tools/handlers/task.py, operator_actions.py). Do not
+# "fix" these to ``slices.*`` — production never emits that path, so the
+# rename would silently disable the persist.
 _TASK_DURABLE_PATH_RE = re.compile(r"^phases\.\d+\.tasks\.\d+\.(?:status|commit)$")
 
 
@@ -445,6 +453,7 @@ def _persist_durable_mutation(field_path: str, worktree: Path) -> None:
     is_task_row = bool(_TASK_DURABLE_PATH_RE.match(field_path))
     if not is_decision and not is_task_row:
         return
+    pipeline_id = ""
     try:
         pipeline_id, _ = _pipeline_context()
         if not pipeline_id:
@@ -463,6 +472,46 @@ def _persist_durable_mutation(field_path: str, worktree: Path) -> None:
             extra={"field_path": field_path},
             exc_info=True,
         )
+        # A swallowed persist failure on a task-row mutation silently
+        # reintroduces the exact #3470 deadlock: the completion lands only
+        # on the worktree file, the phase-restart reset reverts it, and the
+        # #3114 ACK-guard re-rejects. Surface it on the bus (not just the
+        # log) so recurrence is observable rather than mysterious — same
+        # posture as the #3233 orphaned-driver alert. Best-effort: an alert
+        # failure never fails the mutation response.
+        if is_task_row and pipeline_id:
+            _alert_persist_failure(pipeline_id, field_path)
+
+
+def _alert_persist_failure(pipeline_id: str, field_path: str) -> None:
+    """Broadcast an OVERSEER_ALERT for a failed durability-critical persist (#3470)."""
+    try:
+        from message_store import Message, MessageType, get_message_store
+
+        get_message_store().add_message(
+            Message(
+                pipeline_id=pipeline_id,
+                from_role="orchestrator",
+                to_role="all",
+                message_type=MessageType.OVERSEER_ALERT,
+                subject="contract_persist_failed: orchestrator [high]",
+                body=(
+                    f"Durable persist of contract task-row mutation "
+                    f"{field_path} failed. The completion is live on the "
+                    f"worktree file but was not committed+pushed, so a "
+                    f"phase-restart reset will revert it and re-open the "
+                    f"#3470 contract_incomplete deadlock. Verify the branch "
+                    f"and re-mark the task complete if needed. See #3470."
+                ),
+                metadata={"reason": "contract_persist_failed", "field_path": field_path},
+            )
+        )
+    except Exception:  # noqa: BLE001 — alert is best-effort; mutation already succeeded
+        logger.warning(
+            "Failed to broadcast contract-persist-failure alert (non-fatal)",
+            extra={"field_path": field_path, "pipeline_id": pipeline_id},
+            exc_info=True,
+        )
 
 
 _TASK_STATUS_PATH_RE = re.compile(r"^phases\.(\d+)\.tasks\.(\d+)\.status$")
@@ -470,10 +519,14 @@ _TASK_STATUS_PATH_RE = re.compile(r"^phases\.(\d+)\.tasks\.(\d+)\.status$")
 # Heuristic match for a NACK reason that cites contract-task
 # incompleteness. The #3114 ACK-guard's rejection tells the reviewer to
 # "NACK ... citing these task ids" and names the ``contract_incomplete``
-# status; reviewers echo that vocabulary. A false positive costs one
-# re-review cycle (the reviewer re-verdicts freely and re-NACKs a real
-# defect); a false negative leaves the reviewer parked until the next
-# unrelated BRC movement or operator restart.
+# status; reviewers echo that vocabulary. A false positive is always
+# self-correcting — the released reviewer re-verdicts freely and re-NACKs
+# any real defect — but the cost is not uniform: when the released edge
+# was the only blocker it's a single re-review cycle, whereas releasing a
+# mis-matched defect NACK that coexists with another reviewer's genuine
+# NACK adds a re-review round without unblocking the slice (the other
+# NACK still holds). A false negative leaves the reviewer parked until the
+# next unrelated BRC movement or operator restart.
 _CONTRACT_INCOMPLETE_VOCAB_RE = re.compile(
     r"incomplete|not\s+(?:yet\s+)?(?:marked\s+)?complete|pending"
     r"|status=complete|mcp__task__complete|complete-task|task\s+rows?",

--- a/orchestrator/tests/test_contract_nack_release.py
+++ b/orchestrator/tests/test_contract_nack_release.py
@@ -571,6 +571,40 @@ class TestMutateRouteTrigger:
         assert entry.state == ApprovalState.NACKED
         fake_store.add_message.assert_not_called()
 
+    def test_persist_failure_broadcasts_overseer_alert(self, client, fake_worktree):
+        """#3470: a swallowed durable-persist failure on a task-row
+        mutation silently re-opens the deadlock (the completion lands only
+        on the worktree file and the phase-restart reset reverts it), so it
+        must surface an ``OVERSEER_ALERT`` on the bus — while the mutation
+        response still succeeds (the write is live on the worktree file
+        regardless).
+        """
+        pipeline_id, _ = fake_worktree
+        fake_store = MagicMock()
+        with (
+            patch(
+                "routes.pipelines.persist_contract_statefiles",
+                side_effect=RuntimeError("gateway push failed"),
+            ),
+            patch("message_store.get_message_store", return_value=fake_store),
+        ):
+            response = _complete_task(client, pipeline_id)
+
+        # The mutation response is still 200 — persist is best-effort.
+        assert response.status_code == 200, response.data
+
+        # An OVERSEER_ALERT was broadcast for the failed persist.
+        alerts = [
+            call.args[0]
+            for call in fake_store.add_message.call_args_list
+            if call.args and call.args[0].message_type == "OVERSEER_ALERT"
+        ]
+        assert len(alerts) == 1, fake_store.add_message.call_args_list
+        alert = alerts[0]
+        assert alert.metadata["reason"] == "contract_persist_failed"
+        assert alert.metadata["field_path"] == "phases.0.tasks.0.status"
+        assert alert.pipeline_id == pipeline_id
+
     def test_gate_kill_switch_disables_release(
         self, client, fake_worktree, slice_tracker, monkeypatch
     ):

--- a/orchestrator/tests/test_contract_nack_release.py
+++ b/orchestrator/tests/test_contract_nack_release.py
@@ -1,0 +1,575 @@
+"""Tests for the contract-blocked NACK release (#3470).
+
+The mark-after-NACK deadlock: the #3114 ACK-guard rejects a contract
+enforcer's ACK while the producer owns incomplete contract rows, so the
+enforcer NACKs citing the rows. The producer then repairs the cited
+blocker via ``mcp__task__complete`` — but a task-status mutation moves no
+BRC state, so the reviewer keeps deriving ``wait`` (its verdict on the
+current version stands) while the producer cannot re-propose (zero new
+commits → the unchanged-re-propose guard rejects it). Observed as an ~8h
+slice-5 deadlock on ``pipeline-dcdad92d`` requiring an operator
+``restart_agent``.
+
+Covers:
+
+* ``ApprovalMatrix.invalidate_nack`` — NACKED→PENDING with the verdict
+  version stepped back; no-op on non-NACKED entries.
+* ``PeerConsensusTracker.release_contract_nack`` — release + re-derived
+  ``ack`` for the reviewer, idempotent no-op, missing-edge rejection,
+  and the full mark-after-NACK convergence (release → re-ACK → confirm)
+  without any producer re-propose.
+* ``reconstruct_tracker_from_messages`` — the
+  ``CONSENSUS_NACK_INVALIDATED`` replay arm: without it a restart
+  resurrects the NACK and the deadlock it caused.
+* The mutate-route trigger — a ``phases.*.tasks.*.status`` → complete
+  mutation durably persists the contract (#3427 pattern extended) and
+  releases enforcer NACKs that cited contract incompleteness.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+# Mock docker before importing route modules that depend on it.
+sys.modules.setdefault("docker", MagicMock())
+sys.modules.setdefault("docker.errors", MagicMock())
+sys.modules.setdefault("docker.types", MagicMock())
+
+import contract_store  # noqa: E402
+from approval_matrix import ApprovalState  # noqa: E402
+from egg_orchestrator.types import ConsensusPhase  # noqa: E402
+from peer_consensus import (  # noqa: E402
+    PeerConsensusTracker,
+    _tracker_key,
+    _trackers,
+    _trackers_lock,
+    reconstruct_tracker_from_messages,
+)
+from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph  # noqa: E402
+from routes.consensus import _derive_next_action  # noqa: E402
+
+PIPELINE_ID = "pipeline-3470-release"
+
+NACK_CONTRACT_REASON = (
+    "contract_incomplete: task-1-1 is not marked complete in the contract; "
+    "deliver the work or mark finished work complete via mcp__task__complete."
+)
+NACK_DEFECT_REASON = (
+    "The retry loop in a.py never backs off, so the gateway is hammered on "
+    "every failure; please add exponential backoff before I can approve."
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _graph() -> ReviewGraph:
+    return ReviewGraph(
+        [
+            ReviewEdge("reviewer_contract", "coder", ReviewCriticality.CRITICAL),
+        ]
+    )
+
+
+def _tracker(pipeline_id: str = PIPELINE_ID) -> PeerConsensusTracker:
+    t = PeerConsensusTracker(pipeline_id, _graph(), cooldown_seconds=0)
+    t.register_agent("coder")
+    t.register_agent("reviewer_contract")
+    return t
+
+
+def _propose(tracker: PeerConsensusTracker, role: str = "coder") -> None:
+    tracker.handle_propose(
+        role,
+        {
+            "summary": (
+                "Proposal with substantive content describing the work, "
+                "tests run, and tasks satisfied for review."
+            ),
+            "artifacts": ["a.py"],
+            "commit_sha": "abc1234",
+        },
+    )
+
+
+def _nack(
+    tracker: PeerConsensusTracker,
+    reviewer: str,
+    producer: str,
+    *,
+    reason: str = NACK_CONTRACT_REASON,
+    version: int = 1,
+) -> None:
+    tracker.handle_nack(
+        reviewer,
+        producer,
+        {
+            "artifact_references": ["a.py"],
+            "reason": reason,
+            "nack_version": version,
+        },
+    )
+
+
+def _ack(tracker: PeerConsensusTracker, reviewer: str, producer: str, *, version: int = 1) -> None:
+    tracker.handle_ack(
+        reviewer,
+        producer,
+        {
+            "artifact_references": ["a.py"],
+            "reason": (
+                "Substantive review verdict satisfying the ≥50 char content "
+                "gate enforced by _validate_brc_content."
+            ),
+            "ack_version": version,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Matrix unit: invalidate_nack
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidateNack:
+    def test_nacked_entry_returns_to_pending_with_version_stepped(self):
+        tracker = _tracker()
+        _propose(tracker)
+        _nack(tracker, "reviewer_contract", "coder")
+
+        assert tracker.matrix.invalidate_nack("reviewer_contract", "coder") is True
+
+        entry = tracker.matrix.get_entry("reviewer_contract", "coder")
+        assert entry.state == ApprovalState.PENDING
+        # Below the current proposal version → pending-review derivation
+        # sees an un-verdicted current proposal.
+        assert entry.version < tracker.matrix.get_proposal_version("coder")
+        assert entry.reason == ""
+        assert entry.nack_artifact_refs == []
+
+    def test_non_nacked_entry_is_noop(self):
+        tracker = _tracker()
+        _propose(tracker)
+        assert tracker.matrix.invalidate_nack("reviewer_contract", "coder") is False
+
+        _ack(tracker, "reviewer_contract", "coder")
+        assert tracker.matrix.invalidate_nack("reviewer_contract", "coder") is False
+        entry = tracker.matrix.get_entry("reviewer_contract", "coder")
+        assert entry.state == ApprovalState.ACKED
+
+
+# ---------------------------------------------------------------------------
+# Tracker unit: release_contract_nack
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseContractNack:
+    def test_release_re_derives_ack_for_reviewer(self):
+        tracker = _tracker()
+        _propose(tracker)
+        _nack(tracker, "reviewer_contract", "coder")
+
+        # Deadlock state: reviewer holds a standing verdict → wait; the
+        # producer derives propose (address NACKs) but has nothing new
+        # to commit.
+        action, _, _ = _derive_next_action(tracker, "reviewer_contract")
+        assert action == "wait"
+
+        result = tracker.release_contract_nack(
+            "reviewer_contract", "coder", "rows complete (#3470)"
+        )
+        assert result["status"] == "released"
+
+        # The reviewer now derives an actionable re-review.
+        action, payload, _ = _derive_next_action(tracker, "reviewer_contract")
+        assert action == "ack"
+        assert payload["pending_reviews"][0]["producer"] == "coder"
+
+        # The producer no longer derives a doomed re-propose.
+        action, _, _ = _derive_next_action(tracker, "coder")
+        assert action == "wait"
+
+    def test_release_is_idempotent(self):
+        tracker = _tracker()
+        _propose(tracker)
+        _nack(tracker, "reviewer_contract", "coder")
+
+        assert tracker.release_contract_nack("reviewer_contract", "coder")["status"] == "released"
+        assert tracker.release_contract_nack("reviewer_contract", "coder")["status"] == "noop"
+
+    def test_release_without_edge_raises(self):
+        tracker = _tracker()
+        with pytest.raises(ValueError, match="No review edge"):
+            tracker.release_contract_nack("reviewer_contract", "documenter")
+
+    def test_mark_after_nack_converges_without_re_propose(self):
+        """The #3470 acceptance sequence: NACK for contract_incomplete →
+        producer marks rows complete (no new commits, no re-propose) →
+        release → reviewer re-ACKs the SAME version → consensus completes.
+        """
+        tracker = _tracker()
+        _propose(tracker)
+        _nack(tracker, "reviewer_contract", "coder")
+
+        tracker.release_contract_nack("reviewer_contract", "coder", "rows complete")
+
+        # Re-verdict on the same proposal version — no producer re-propose.
+        _ack(tracker, "reviewer_contract", "coder", version=1)
+        assert tracker.matrix.get_proposal_version("coder") == 1
+
+        tracker.handle_confirmed("coder")
+        tracker.handle_confirmed("reviewer_contract")
+        assert tracker.evaluate()["is_complete"]
+        assert tracker._producer_phases["coder"] == ConsensusPhase.CONFIRMED
+
+
+# ---------------------------------------------------------------------------
+# Reconstruction: CONSENSUS_NACK_INVALIDATED replay arm
+# ---------------------------------------------------------------------------
+
+
+class _FakeMessage:
+    def __init__(
+        self,
+        message_type: str,
+        from_role: str,
+        to_role: str = "all",
+        metadata: dict | None = None,
+        timestamp: datetime | None = None,
+        msg_id: str = "",
+    ) -> None:
+        self.id = msg_id or f"msg-{message_type.lower()}-{from_role}"
+        self.message_type = message_type
+        self.from_role = from_role
+        self.to_role = to_role
+        self.body = ""
+        self.phase = "implement"
+        self.metadata = metadata or {}
+        self.timestamp = timestamp or datetime.now(UTC)
+
+
+class _FakeMessageStore:
+    def __init__(self, messages: list[_FakeMessage]) -> None:
+        self._messages = list(messages)
+
+    def get_messages(self, pipeline_id: str, *, limit: int = 100) -> list[_FakeMessage]:
+        return list(self._messages)
+
+
+class TestReconstructionReplaysRelease:
+    def _messages(self) -> list[_FakeMessage]:
+        t0 = datetime.now(UTC)
+        propose_payload = {
+            "payload": {
+                "summary": (
+                    "Proposal with substantive content describing the work, "
+                    "tests run, and tasks satisfied for review."
+                ),
+                "artifacts": ["a.py"],
+                "commit_sha": "abc1234",
+            }
+        }
+        nack_payload = {
+            "payload": {
+                "artifact_references": ["a.py"],
+                "reason": NACK_CONTRACT_REASON,
+                "nack_version": 1,
+            }
+        }
+        return [
+            _FakeMessage(
+                "CONSENSUS_PROPOSE", "coder", metadata=propose_payload, timestamp=t0, msg_id="m1"
+            ),
+            _FakeMessage(
+                "CONSENSUS_NACK",
+                "reviewer_contract",
+                to_role="coder",
+                metadata=nack_payload,
+                timestamp=t0 + timedelta(seconds=1),
+                msg_id="m2",
+            ),
+            # Producer marked its rows complete → orchestrator released
+            # the contract-blocked NACK.
+            _FakeMessage(
+                "CONSENSUS_NACK_INVALIDATED",
+                "orchestrator",
+                to_role="reviewer_contract",
+                metadata={"reviewer_role": "reviewer_contract", "producer_role": "coder"},
+                timestamp=t0 + timedelta(seconds=2),
+                msg_id="m3",
+            ),
+        ]
+
+    def test_release_survives_replay(self):
+        pid = "pipeline-3470-reconstruct"
+        store = _FakeMessageStore(self._messages())
+        try:
+            tracker = reconstruct_tracker_from_messages(
+                pid, _graph(), message_store=store, phase="implement"
+            )
+            assert tracker is not None
+
+            entry = tracker.matrix.get_entry("reviewer_contract", "coder")
+            assert entry.state == ApprovalState.PENDING
+            assert not tracker.matrix.has_unresolved_nacks_as_producer("coder")
+
+            # The reviewer re-derives an actionable re-review post-replay,
+            # so a restart does not resurrect the deadlock.
+            action, _, _ = _derive_next_action(tracker, "reviewer_contract")
+            assert action == "ack"
+        finally:
+            with _trackers_lock:
+                _trackers.pop(_tracker_key(pid), None)
+
+    def test_release_message_with_missing_roles_is_skipped(self):
+        pid = "pipeline-3470-reconstruct-skip"
+        messages = self._messages()
+        messages[2].metadata = {}
+        messages[2].to_role = "all"
+        store = _FakeMessageStore(messages)
+        try:
+            tracker = reconstruct_tracker_from_messages(
+                pid, _graph(), message_store=store, phase="implement"
+            )
+            assert tracker is not None
+            # Release skipped → the NACK stands (replay stays faithful to
+            # what the malformed message can prove).
+            entry = tracker.matrix.get_entry("reviewer_contract", "coder")
+            assert entry.state == ApprovalState.NACKED
+        finally:
+            with _trackers_lock:
+                _trackers.pop(_tracker_key(pid), None)
+
+
+# ---------------------------------------------------------------------------
+# Mutate-route trigger: durable persist + NACK release
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client():
+    from api import app
+
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+@pytest.fixture
+def fake_worktree(tmp_path: Path, monkeypatch):
+    """Fake pipeline worktree with a one-slice contract (see
+    ``test_contracts_routes.py`` for the pattern)."""
+    pipeline_id = "pipeline-3470-route"
+    worktrees_base = tmp_path / "worktrees"
+    worktree = worktrees_base / pipeline_id / "egg"
+    worktree.mkdir(parents=True)
+    (worktree / ".git").mkdir()
+    monkeypatch.setattr(contract_store, "_WORKTREE_BASE_DIR", worktrees_base)
+
+    contracts_dir = worktree / ".egg-state" / "contracts"
+    contracts_dir.mkdir(parents=True)
+    (contracts_dir / f"{pipeline_id}.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": "1.0",
+                "pipeline_id": pipeline_id,
+                "issue": {"number": 3470, "title": "release test", "url": "http://example"},
+                "phases": [
+                    {
+                        "id": "slice-1",
+                        "name": "only slice",
+                        "tasks": [
+                            {
+                                "id": "task-1-1",
+                                "description": "coder deliverable",
+                                "role": "coder",
+                                "status": "pending",
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
+    )
+    return pipeline_id, worktree
+
+
+@pytest.fixture
+def slice_tracker(fake_worktree):
+    """A registered slice tracker in the NACKed-producer deadlock state."""
+    pipeline_id, _ = fake_worktree
+    key = _tracker_key(pipeline_id, "slice-1")
+    tracker = PeerConsensusTracker(key, _graph(), cooldown_seconds=0)
+    tracker.register_agent("coder")
+    tracker.register_agent("reviewer_contract")
+    _propose(tracker)
+    _nack(tracker, "reviewer_contract", "coder")
+    with _trackers_lock:
+        _trackers[key] = tracker
+    yield tracker
+    with _trackers_lock:
+        _trackers.pop(key, None)
+
+
+def _complete_task(client, pipeline_id: str):
+    return client.post(
+        f"/api/v1/contracts/{pipeline_id}/mutate",
+        json={
+            "pipeline_id": pipeline_id,
+            "repo": "egg",
+            "field_path": "phases.0.tasks.0.status",
+            "new_value": "complete",
+        },
+        headers={"X-Egg-Role": "implementer"},
+    )
+
+
+class TestMutateRouteTrigger:
+    def test_task_status_mutation_triggers_durable_persist(self, client, fake_worktree):
+        """#3470: a task-status write must commit+push at write time —
+        otherwise the phase-(re)start ``git reset --hard`` reverts the
+        completion and the #3114 ACK-guard re-rejects reviewer ACKs
+        against already-delivered work.
+        """
+        pipeline_id, worktree = fake_worktree
+        with patch("routes.pipelines.persist_contract_statefiles") as persist_mock:
+            response = _complete_task(client, pipeline_id)
+        assert response.status_code == 200, response.data
+        persist_mock.assert_called_once()
+        args = persist_mock.call_args[0]
+        assert args[0] == pipeline_id
+        assert args[1] == worktree
+
+    def test_task_commit_mutation_triggers_durable_persist(self, client, fake_worktree):
+        pipeline_id, _ = fake_worktree
+        with patch("routes.pipelines.persist_contract_statefiles") as persist_mock:
+            response = client.post(
+                f"/api/v1/contracts/{pipeline_id}/mutate",
+                json={
+                    "pipeline_id": pipeline_id,
+                    "repo": "egg",
+                    "field_path": "phases.0.tasks.0.commit",
+                    "new_value": "abc1234",
+                },
+                headers={"X-Egg-Role": "implementer"},
+            )
+        assert response.status_code == 200, response.data
+        persist_mock.assert_called_once()
+
+    def test_mark_after_nack_releases_enforcer_nack(self, client, fake_worktree, slice_tracker):
+        """The #3470 regression: after the enforcer NACKed for
+        contract_incomplete, marking the producer's rows complete must
+        re-derive the reviewer (release the NACK) without any operator
+        intervention or producer re-propose.
+        """
+        pipeline_id, _ = fake_worktree
+        fake_store = MagicMock()
+        with (
+            patch("routes.pipelines.persist_contract_statefiles"),
+            patch("message_store.get_message_store", return_value=fake_store),
+        ):
+            response = _complete_task(client, pipeline_id)
+        assert response.status_code == 200, response.data
+
+        entry = slice_tracker.matrix.get_entry("reviewer_contract", "coder")
+        assert entry.state == ApprovalState.PENDING
+
+        # Replay parity: the release was persisted to the bus first.
+        fake_store.add_message.assert_called_once()
+        message = fake_store.add_message.call_args[0][0]
+        assert message.message_type == "CONSENSUS_NACK_INVALIDATED"
+        assert message.metadata["reviewer_role"] == "reviewer_contract"
+        assert message.metadata["producer_role"] == "coder"
+        assert message.metadata["slice_id"] == "slice-1"
+
+        # The reviewer re-derives an actionable re-review; the producer is
+        # no longer pushed toward a doomed zero-commit re-propose.
+        action, _, _ = _derive_next_action(slice_tracker, "reviewer_contract")
+        assert action == "ack"
+        action, _, _ = _derive_next_action(slice_tracker, "coder")
+        assert action == "wait"
+
+    def test_defect_nack_is_not_released(self, client, fake_worktree, slice_tracker):
+        """A NACK citing a real artifact defect (no contract-incompleteness
+        vocabulary) must survive the task completion — only the blocker the
+        reviewer actually cited is repaired by a status flip.
+        """
+        pipeline_id, _ = fake_worktree
+        slice_tracker.matrix.invalidate_nack("reviewer_contract", "coder")
+        _nack(slice_tracker, "reviewer_contract", "coder", reason=NACK_DEFECT_REASON)
+
+        fake_store = MagicMock()
+        with (
+            patch("routes.pipelines.persist_contract_statefiles"),
+            patch("message_store.get_message_store", return_value=fake_store),
+        ):
+            response = _complete_task(client, pipeline_id)
+        assert response.status_code == 200, response.data
+
+        entry = slice_tracker.matrix.get_entry("reviewer_contract", "coder")
+        assert entry.state == ApprovalState.NACKED
+        fake_store.add_message.assert_not_called()
+
+    def test_gate_kill_switch_disables_release(
+        self, client, fake_worktree, slice_tracker, monkeypatch
+    ):
+        """With the #3114 gate off, consensus can close over incomplete
+        rows, so there is no gate-minted blocker to release."""
+        pipeline_id, _ = fake_worktree
+        monkeypatch.setenv("EGG_CONTRACT_ACK_GATE", "off")
+
+        fake_store = MagicMock()
+        with (
+            patch("routes.pipelines.persist_contract_statefiles"),
+            patch("message_store.get_message_store", return_value=fake_store),
+        ):
+            response = _complete_task(client, pipeline_id)
+        assert response.status_code == 200, response.data
+
+        entry = slice_tracker.matrix.get_entry("reviewer_contract", "coder")
+        assert entry.state == ApprovalState.NACKED
+        fake_store.add_message.assert_not_called()
+
+    def test_incomplete_sibling_row_defers_release(self, client, fake_worktree, slice_tracker):
+        """The release fires only when the producer owes no more rows in
+        the slice — completing one of two owned rows keeps the NACK."""
+        pipeline_id, worktree = fake_worktree
+        contract_path = worktree / ".egg-state" / "contracts" / f"{pipeline_id}.json"
+        data = json.loads(contract_path.read_text())
+        data["phases"][0]["tasks"].append(
+            {
+                "id": "task-1-2",
+                "description": "second coder deliverable",
+                "role": "coder",
+                "status": "pending",
+            }
+        )
+        contract_path.write_text(json.dumps(data))
+
+        fake_store = MagicMock()
+        with (
+            patch("routes.pipelines.persist_contract_statefiles"),
+            patch("message_store.get_message_store", return_value=fake_store),
+        ):
+            response = _complete_task(client, pipeline_id)
+        assert response.status_code == 200, response.data
+
+        entry = slice_tracker.matrix.get_entry("reviewer_contract", "coder")
+        assert entry.state == ApprovalState.NACKED
+        fake_store.add_message.assert_not_called()

--- a/orchestrator/tests/test_contract_nack_release.py
+++ b/orchestrator/tests/test_contract_nack_release.py
@@ -238,6 +238,51 @@ class TestReleaseContractNack:
         assert tracker.evaluate()["is_complete"]
         assert tracker._producer_phases["coder"] == ConsensusPhase.CONFIRMED
 
+    def test_release_does_not_restore_proposed_for_withdrawn_producer(self):
+        """A producer that WITHDREW after the NACK keeps its proposal
+        retracted (#3470): release must not restore PROPOSED, or the freed
+        reviewer could re-review and ACK withdrawn work before the producer
+        re-proposes. The producer stays WORKING until its next (re-)propose.
+        """
+        tracker = _tracker()
+        _propose(tracker)
+        _nack(tracker, "reviewer_contract", "coder")
+
+        # Producer withdraws the proposal after the NACK (both leave it
+        # WORKING, so the restore must distinguish them).
+        tracker.handle_withdraw("coder", "retracting to rework the approach")
+        assert tracker._producer_phases["coder"] == ConsensusPhase.WORKING
+
+        result = tracker.release_contract_nack("reviewer_contract", "coder", "rows complete")
+        assert result["status"] == "released"
+
+        # PROPOSED is NOT restored — the withdrawn proposal is not resurfaced.
+        assert tracker._producer_phases["coder"] == ConsensusPhase.WORKING
+
+        # The freed reviewer therefore does not derive an ACK against the
+        # retracted work; it re-arms only when the producer re-proposes.
+        action, _, _ = _derive_next_action(tracker, "reviewer_contract")
+        assert action != "ack"
+
+        # A subsequent re-propose (new commit SHA, so the unchanged-tree
+        # guard allows it) clears the withdrawn state and the normal flow
+        # resumes: the reviewer derives an actionable re-review.
+        tracker.handle_propose(
+            "coder",
+            {
+                "summary": (
+                    "Reworked proposal with substantive content describing the "
+                    "revised work, tests run, and tasks satisfied for review."
+                ),
+                "artifacts": ["a.py"],
+                "commit_sha": "def5678",
+            },
+        )
+        assert tracker._producer_phases["coder"] == ConsensusPhase.PROPOSED
+        assert "coder" not in tracker._withdrawn_producers
+        action, _, _ = _derive_next_action(tracker, "reviewer_contract")
+        assert action == "ack"
+
 
 # ---------------------------------------------------------------------------
 # Reconstruction: CONSENSUS_NACK_INVALIDATED replay arm


### PR DESCRIPTION
Fixes #3473. Related: #3470 (the wasted-NACK-round pattern this deadlock escalates).

## Problem

The #3114 contract-completeness ACK-guard and `mcp__task__complete` read/write the **same** file (`.egg-state/contracts/<id>.json` in the shared pipeline worktree) — the observed "split-brain" is temporal, not spatial:

1. **Task completions silently revert.** Task status/commit mutations land on the worktree file uncommitted. On a driver relaunch, `_persist_phase_brc_history` commits them locally **without pushing**, and `_rebase_pipeline_branch_onto_base` step 4a then sees HEAD on neither `origin/<work>` nor `origin/<base>` — the #2222 contamination recovery — and double-resets to `origin/<base>` → `origin/<work>`, orphaning the persist commit and reverting the contract to the last *pushed* state. Rows flip back to pending, and the ACK-guard (correctly, per its inputs) re-rejects enforcer ACKs with `contract_incomplete` against work that was already delivered and marked complete. This is the exact bug class #3427 fixed for `decisions.*` writes; task rows never got the same treatment. (Verified live: three orphaned persist commits in the incident pipeline's shared-worktree reflog, each followed 1–2s later by the double reset.)
2. **Repairing the cited blocker wakes nobody.** A task-status mutation moves no BRC state. The reviewer that NACKed citing the rows holds a standing verdict on the current proposal version → derives `wait` forever; the producer has zero new commits → the unchanged-re-propose guard 409s its re-propose and its arm no-op-parks (#3425), with a `brc_probe` fingerprint (#3465) that never changes. The slice deadlocks until an unrelated confirm wave or an operator `restart_agent`.

## Fix

* **Durability** (`routes/contracts.py`): `_persist_decision_mutation` generalized to `_persist_durable_mutation` — the #3427 write-time commit+push now also covers `phases.*.tasks.*.{status,commit}`, so the phase-(re)start reset target already contains the completion.
* **Wake** (`routes/contracts.py` + `peer_consensus` + `approval_matrix`): when a `status→complete` mutation leaves the owning producer with zero incomplete rows in its slice, each contract-enforcer NACK on the current version whose reason cited contract incompleteness is released:
  * `ApprovalMatrix.invalidate_nack` returns the edge to PENDING with the verdict version stepped below the current proposal version;
  * `PeerConsensusTracker.release_contract_nack` restores the producer's FSM to PROPOSED (its proposal still stands) when no NACKs remain;
  * the reviewer's next-action poll re-derives `ack` and the event loop respawns it to re-verdict — no producer re-propose, no operator intervention;
  * a `CONSENSUS_NACK_INVALIDATED` bus message is written **before** the tracker mutation so `reconstruct_tracker_from_messages` replays the release across restarts (#3124 `CONSENSUS_REOPENED` pattern).
* Citation matching is a documented heuristic (`contract_incomplete` literal, or "contract" + completion vocabulary): a false positive costs one re-review cycle (the reviewer re-verdicts freely); a false negative leaves the status quo. The release shares the #3114 `EGG_CONTRACT_ACK_GATE` kill switch — gate off ⇒ nothing to release.

## Acceptance / tests

`orchestrator/tests/test_contract_nack_release.py` (14 tests) reproduces the mark-after-NACK sequence end to end:

* tracker level: NACK for contract incompleteness → release → reviewer derives `ack`, producer derives `wait`, reviewer re-ACKs the **same version**, consensus completes — no re-propose;
* replay level: the release survives `reconstruct_tracker_from_messages` (and a malformed release message is skipped, leaving the NACK);
* route level: a `phases.0.tasks.0.status→complete` mutation triggers the durable persist and the release (bus message first, correct metadata); defect NACKs, incomplete sibling rows, and the gate kill switch all leave the NACK standing.

Targeted suites green (382 tests: contracts routes, completeness gate, producer reopen, peer-consensus integration, event loop). A full `make test` also ran green except the two known host-env reap-script failures (#3222).
