### PR TITLE
Accept per-role work branch in worktree re-attach validation

### DIFF
--- a/orchestrator/kubernetes_spawner/_worktree.py
+++ b/orchestrator/kubernetes_spawner/_worktree.py
@@ -24,7 +24,11 @@ def _validate_worktree_for_reuse(
     Checks the filesystem worktree at ``WORKTREE_BASE_DIR / agent_worktree_id / <repo>``
     for directory existence, ``.git`` integrity (``git rev-parse --git-dir``), lock
     files (``.git/*.lock`` and ``.git/refs/*/*.lock``), and expected branch (when
-    ``branch`` is supplied — the worktree's ``HEAD`` should be on the role's branch).
+    ``branch`` is supplied). The gateway materializes every per-agent worktree on
+    its own local work branch ``egg/{agent_worktree_id}/work`` (wired to push to
+    the assigned branch), so ``HEAD`` is never on the assigned branch itself
+    (#3480). The branch check therefore accepts the derived work branch, the
+    assigned ``branch``, or a detached ``HEAD``.
 
     This function performs **validation only** — the caller must also invoke
     :meth:`KubernetesSpawner._clean_reused_worktree` to discard dirty state
@@ -127,12 +131,18 @@ def _validate_worktree_for_reuse(
                     timeout=10,
                     check=True,
                 ).stdout.strip()
-                if cb != branch and cb != "HEAD":
+                # The gateway creates per-agent worktrees on the role's own
+                # local work branch (egg/{container_id}/work), not on the
+                # assigned branch it pushes to; the assigned branch alone
+                # would mismatch on every event spawn and permanently degrade
+                # re-attach to create-with-retry (#3480).
+                work_branch = f"egg/{agent_worktree_id}/work"
+                if cb not in (branch, work_branch, "HEAD"):
                     logger.info(
                         "Worktree re-attach: branch mismatch",
                         agent_worktree_id=agent_worktree_id,
                         repo=n,
-                        expected=branch,
+                        expected=f"{work_branch} or {branch}",
                         actual=cb,
                     )
                     return None

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -2751,6 +2751,30 @@ class TestSpawnEventJobWorktreeReattach:
 
         assert vols is None
 
+    def test_reattach_work_branch_head_validates(self, tmp_path):
+        """The production shape (#3480): the gateway creates per-agent
+        worktrees on ``egg/{container_id}/work``, not on the assigned branch,
+        so a worktree with ``HEAD`` on the derived work branch must validate."""
+        from kubernetes_spawner import _validate_worktree_for_reuse
+
+        repo, _ = _make_worktree(tmp_path, _WT_ID, "repo", f"egg/{_WT_ID}/work")
+        with patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path):
+            vols = _validate_worktree_for_reuse(_WT_ID, _REPOS, _BRANCH)
+
+        assert vols is not None
+        assert vols["owner/repo"] == str(repo)
+
+    def test_reattach_other_agents_work_branch_falls_back(self, tmp_path):
+        """A DIFFERENT agent's work branch is still a mismatch; only the work
+        branch derived from this agent_worktree_id is accepted."""
+        from kubernetes_spawner import _validate_worktree_for_reuse
+
+        _make_worktree(tmp_path, _WT_ID, "repo", "egg/other-agent-id/work")
+        with patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path):
+            vols = _validate_worktree_for_reuse(_WT_ID, _REPOS, _BRANCH)
+
+        assert vols is None
+
     def test_reattach_corrupt_git_falls_back(self, tmp_path):
         """A directory whose ``.git`` is gone ⇒ rev-parse fails ⇒ None."""
         from kubernetes_spawner import _validate_worktree_for_reuse
@@ -2805,6 +2829,33 @@ class TestSpawnEventJobWorktreeReattach:
         success, repo_volumes = result
         assert success
         assert "owner/repo" in repo_volumes
+
+    def test_try_reuse_production_shape_work_branch(self, spawner, tmp_path):
+        """End-to-end for the production shape (#3480): HEAD on the derived
+        work branch, assigned branch only on origin. Validation accepts the
+        work branch and the R6 hard-sync resets to ``origin/{assigned}``."""
+        work_branch = f"egg/{_WT_ID}/work"
+        repo, _ = _make_worktree(tmp_path, _WT_ID, "repo", work_branch, with_origin=True)
+        # Publish the assigned branch on origin (the hard-sync target), then
+        # advance the local work branch past it so the sync has work to do.
+        _git(repo, "push", "origin", f"{work_branch}:{_BRANCH}")
+        (repo / "local.txt").write_text("unpushed\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "local unpushed commit")
+
+        with patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path):
+            result = spawner._try_reuse_worktree(_WT_ID, _BRANCH, _REPOS)
+
+        assert result is not None
+        success, repo_volumes = result
+        assert success
+        assert repo_volumes["owner/repo"] == str(repo)
+        # The predecessor's local, unpushed commit was discarded by the
+        # hard-sync to origin/{assigned} (R6 dirty-state policy).
+        assert not (repo / "local.txt").exists()
+        head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        remote = _git(repo, "rev-parse", f"origin/{_BRANCH}").stdout.strip()
+        assert head == remote
 
 
 class TestSpawnEventJobDirtyWorktree:


### PR DESCRIPTION
Fixes #3480.

## Problem

The event-spawn worktree re-attach fast path could never succeed. `_validate_worktree_for_reuse` compared the worktree's `HEAD` against the assigned branch (e.g. `egg/<pipeline>/slice-9`), but the gateway deliberately materializes every per-agent worktree on its own local work branch `egg/{container_id}/work` (`gateway/worktree_manager/_create.py:205`), wired to push to the assigned branch via `_configure_push_upstream`. The mismatch was structural, so 100% of event spawns logged `branch mismatch` and fell back to create-with-retry, paying a worktree teardown and recreate (~1s plus disk churn) per one-shot invocation.

## Fix

The branch check in `_validate_worktree_for_reuse` now accepts the work branch derived from `agent_worktree_id` (`egg/{agent_worktree_id}/work`) in addition to the assigned branch and detached `HEAD`, per the issue's suggested direction. A different agent's work branch still mismatches.

The R6 hard-sync in `_clean_reused_worktree` is intentionally unchanged: it already fetches and resets to `origin/{assigned_branch}`, which is the work branch's configured push upstream and the correct source of truth for discarding predecessor residue.

## Tests

- `test_reattach_work_branch_head_validates`: production shape, `HEAD` on the derived work branch, validates.
- `test_reattach_other_agents_work_branch_falls_back`: a different agent's work branch still falls back.
- `test_try_reuse_production_shape_work_branch`: end-to-end `_try_reuse_worktree` with the assigned branch only on origin; proves the hard-sync discards a predecessor's local unpushed commit and lands `HEAD` on `origin/{assigned}`.

All 185 tests in `test_kubernetes_spawner.py` and 105 in `test_event_loop.py` pass; ruff clean.