### PR TITLE
Fix gateway ls-remote argv order; gate rebase reconciler on extant head branches

### DIFF
--- a/docs/architecture/slice-dag.md
+++ b/docs/architecture/slice-dag.md
@@ -664,13 +664,22 @@ A child slice PR is orphaned when:
    targets the pipeline branch directly).
 2. There is an open PR whose head branch matches the slice's integration
    branch (`egg/issue-N/slice-M`).
-3. The PR's base branch is **not** in the set of extant origin branches.
+3. The PR's head branch **is** in the set of extant origin branches
+   ([#3479](https://github.com/jwbron/egg/issues/3479)): an open PR
+   implies its head exists on origin, so a head missing from the set
+   means the branch listing is stale or broken (or the branch really is
+   gone and the listing hasn't caught up); in every one of those worlds
+   the rebase + force-push cannot succeed, and surfacing the orphan
+   would retry a doomed rebase on every tick. In particular an **empty**
+   extant set (failed listing) yields zero orphans instead of a rebase
+   storm across every open slice PR.
+4. The PR's base branch is **not** in the set of extant origin branches.
 
 The intended new base is sourced from `Slice.parent_branch_at_creation`,
 not inferred from PR metadata — so the reconciler is robust against
-parent slice branches that have been renamed or rebased. Roots, completed
-slices, and slices whose base still exists are silently skipped, making
-each pass idempotent.
+parent slice branches that have been renamed or rebased. Roots, slices
+whose base still exists, and slices whose head cannot be confirmed on
+origin are silently skipped, making each pass idempotent.
 
 The three callables decouple `reconcile_once` from the gateway client and
 GitHub API so unit tests can substitute deterministic fakes. In
@@ -688,10 +697,15 @@ reconciler is fully functional, not a no-op:
   flake does not cause the reconciler to misclassify orphans.
 - **`list_remote_branches`** → `GatewayClient.list_remote_branches(...)`,
   which runs `git ls-remote --heads origin` through the existing
-  per-agent `ls-remote` allowlist (`operation="ls-remote"`). The
-  reconciler treats the returned set as the join key for the orphan
-  check; an empty set on failure preserves the conservative default
-  (no PR is treated as orphaned).
+  per-agent `ls-remote` allowlist (`operation="ls-remote"`). The gateway
+  emits ls-remote flags **before** the repository argument: `git
+  ls-remote` stops option parsing at the first positional, so a post-URL
+  `--heads` is silently treated as a never-matching ref pattern and the
+  listing comes back empty with exit 0
+  ([#3479](https://github.com/jwbron/egg/issues/3479)). The reconciler
+  treats the returned set as the join key for the orphan check; an empty
+  set on failure preserves the conservative default (no PR is treated as
+  orphaned, because no head can be confirmed extant).
 - **`rebase_onto`** → `GatewayClient.rebase_onto(pipeline_id, repo_path,
   branch=..., new_base=..., old_base=...) → bool`. This bridges the
   reconciler's `Callable[[str, str, str], bool]` shape to

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -2962,7 +2962,17 @@ def git_fetch() -> tuple[Response, int] | Response:
         else:
             cmd_args = ["fetch", fetch_target] + validated_args
     else:  # ls-remote
-        cmd_args = ["ls-remote", fetch_target] + validated_args
+        # ``git ls-remote`` stops option parsing at the first positional
+        # argument: anything after <repository> is a <ref> pattern, not a
+        # flag. ``ls-remote <url> --heads`` therefore filters by the
+        # literal pattern "--heads", matching nothing and exiting 0 with
+        # empty output (#3479: the stacked-PR reconciler read that empty
+        # listing as "every branch deleted" and hot-looped rebases of
+        # healthy PRs). Emit flags before the repository and ref patterns
+        # after it.
+        flags = [a for a in validated_args if a.startswith("-")]
+        patterns = [a for a in validated_args if not a.startswith("-")]
+        cmd_args = ["ls-remote", *flags, fetch_target, *patterns]
 
     cmd = git_cmd(*cmd_args)
 

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -2832,6 +2832,15 @@ def git_execute() -> tuple[Response, int] | Response:
         return make_error(f"git {operation} failed: {e}", status_code=500)
 
 
+# ls-remote flags that take a separate-argument value (``--sort <key>``).
+# Used by ``git_fetch`` to keep such a value adjacent to its flag when
+# partitioning validated args into pre-URL flags and post-URL ref patterns,
+# so the value is never stranded after the repository as a bogus ref pattern
+# (#3484). ``--sort`` is the only value-taking flag in the ls-remote allowlist
+# (``git_client._policy.GIT_ALLOWED_COMMANDS``); the rest are booleans.
+LS_REMOTE_VALUE_FLAGS: frozenset[str] = frozenset({"--sort"})
+
+
 @app.route("/api/v1/git/fetch", methods=["POST"])
 @require_session_auth
 def git_fetch() -> tuple[Response, int] | Response:
@@ -2970,8 +2979,39 @@ def git_fetch() -> tuple[Response, int] | Response:
         # listing as "every branch deleted" and hot-looped rebases of
         # healthy PRs). Emit flags before the repository and ref patterns
         # after it.
-        flags = [a for a in validated_args if a.startswith("-")]
-        patterns = [a for a in validated_args if not a.startswith("-")]
+        #
+        # A naive startswith("-") partition would strand a separate-
+        # argument flag *value* after the URL as a bogus ref pattern
+        # (#3484 review note 1): ``--sort committerdate`` is an allowlisted
+        # ls-remote flag whose value does not start with "-", so it would
+        # become ``ls-remote --sort <url> committerdate`` — ``committerdate``
+        # silently matching nothing. Keep such a value adjacent to its flag
+        # on the pre-URL side. No caller passes the separate-value form
+        # today; this hardens the route against a future footgun.
+        flags: list[str] = []
+        patterns: list[str] = []
+        arg_idx = 0
+        while arg_idx < len(validated_args):
+            token = validated_args[arg_idx]
+            if not token.startswith("-"):
+                patterns.append(token)
+                arg_idx += 1
+                continue
+            flags.append(token)
+            # Inline ``--sort=key`` is self-contained; only the separate
+            # ``--sort key`` form needs its value pulled along with it.
+            takes_separate_value = (
+                token.split("=", 1)[0] in LS_REMOTE_VALUE_FLAGS and "=" not in token
+            )
+            if (
+                takes_separate_value
+                and arg_idx + 1 < len(validated_args)
+                and not validated_args[arg_idx + 1].startswith("-")
+            ):
+                flags.append(validated_args[arg_idx + 1])
+                arg_idx += 2
+                continue
+            arg_idx += 1
         cmd_args = ["ls-remote", *flags, fetch_target, *patterns]
 
     cmd = git_cmd(*cmd_args)

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -3325,6 +3325,65 @@ class TestGitFetch:
             assert data["success"] is True
             assert "refs/heads/main" in data["data"]["stdout"]
 
+    def test_ls_remote_flags_precede_repository_and_patterns_follow(self, client, auth_headers):
+        """ls-remote argv puts flags before the repository, ref patterns after.
+
+        ``git ls-remote`` stops option parsing at the first positional
+        argument; anything after <repository> is a <ref> pattern. The
+        pre-#3479 argv (``ls-remote <url> --heads``) therefore filtered
+        by the literal pattern ``--heads``, matching nothing and exiting
+        0 with empty output; the stacked-PR reconciler read that empty
+        listing as "every branch deleted" and hot-looped rebases of
+        healthy slice PRs every ~30s. Lock the corrected ordering here.
+        """
+        with (
+            patch("subprocess.run") as mock_run,
+            patch.object(gateway, "get_token_for_repo") as mock_get_token,
+        ):
+            captured_cmds = []
+
+            def run_side_effect(*args, **kwargs):
+                cmd = args[0] if args else kwargs.get("args", [])
+                captured_cmds.append(list(cmd))
+                result = MagicMock()
+                result.returncode = 0
+                result.stderr = ""
+                if "remote" in cmd and "get-url" in cmd:
+                    result.stdout = "https://github.com/owner/repo.git\n"
+                elif "ls-remote" in cmd:
+                    result.stdout = "abc123\trefs/heads/main\n"
+                else:
+                    result.stdout = ""
+                return result
+
+            mock_run.side_effect = run_side_effect
+            mock_get_token.return_value = ("test-token", "bot", "")
+
+            response = client.post(
+                "/api/v1/git/fetch",
+                headers=auth_headers,
+                data=json.dumps(
+                    {
+                        "repo_path": "/home/egg/repos/test",
+                        "operation": "ls-remote",
+                        "remote": "origin",
+                        "args": ["--heads", "refs/heads/feature-x"],
+                    }
+                ),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 200
+            ls_remote_cmds = [c for c in captured_cmds if "ls-remote" in c]
+            assert len(ls_remote_cmds) == 1
+            cmd = ls_remote_cmds[0]
+            # The remote URL is HTTPS so the named remote is used as-is.
+            repo_idx = cmd.index("origin")
+            # Flag BEFORE the repository so git parses it as an option...
+            assert cmd.index("--heads") < repo_idx
+            # ...and the ref pattern AFTER it so git treats it as a <ref>.
+            assert cmd.index("refs/heads/feature-x") > repo_idx
+
     def test_fetch_with_url_remote(self, client, auth_headers):
         """Fetch succeeds when remote is a URL instead of a named remote."""
         with (

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -3384,6 +3384,65 @@ class TestGitFetch:
             # ...and the ref pattern AFTER it so git treats it as a <ref>.
             assert cmd.index("refs/heads/feature-x") > repo_idx
 
+    def test_ls_remote_separate_argument_flag_value_stays_with_flag(self, client, auth_headers):
+        """A separate-argument flag value is not stranded after the repository.
+
+        #3484 review note 1: the flag/pattern partition splits on
+        ``startswith("-")``, which would push a separate-argument flag
+        *value* (``--sort committerdate`` — ``committerdate`` does not
+        start with ``-``) past the repository as a bogus ref pattern,
+        silently matching nothing. The value must stay adjacent to its
+        flag on the pre-URL side.
+        """
+        with (
+            patch("subprocess.run") as mock_run,
+            patch.object(gateway, "get_token_for_repo") as mock_get_token,
+        ):
+            captured_cmds = []
+
+            def run_side_effect(*args, **kwargs):
+                cmd = args[0] if args else kwargs.get("args", [])
+                captured_cmds.append(list(cmd))
+                result = MagicMock()
+                result.returncode = 0
+                result.stderr = ""
+                if "remote" in cmd and "get-url" in cmd:
+                    result.stdout = "https://github.com/owner/repo.git\n"
+                elif "ls-remote" in cmd:
+                    result.stdout = "abc123\trefs/heads/main\n"
+                else:
+                    result.stdout = ""
+                return result
+
+            mock_run.side_effect = run_side_effect
+            mock_get_token.return_value = ("test-token", "bot", "")
+
+            response = client.post(
+                "/api/v1/git/fetch",
+                headers=auth_headers,
+                data=json.dumps(
+                    {
+                        "repo_path": "/home/egg/repos/test",
+                        "operation": "ls-remote",
+                        "remote": "origin",
+                        "args": ["--heads", "--sort", "committerdate"],
+                    }
+                ),
+                content_type="application/json",
+            )
+
+            assert response.status_code == 200
+            ls_remote_cmds = [c for c in captured_cmds if "ls-remote" in c]
+            assert len(ls_remote_cmds) == 1
+            cmd = ls_remote_cmds[0]
+            repo_idx = cmd.index("origin")
+            # Both the flag AND its value precede the repository...
+            assert cmd.index("--sort") < repo_idx
+            assert cmd.index("committerdate") < repo_idx
+            # ...and the value stays immediately after its flag, not
+            # stranded as a post-URL ref pattern.
+            assert cmd.index("committerdate") == cmd.index("--sort") + 1
+
     def test_fetch_with_url_remote(self, client, auth_headers):
         """Fetch succeeds when remote is a URL instead of a named remote."""
         with (

--- a/integration_tests/test_slice_pipeline_e2e.py
+++ b/integration_tests/test_slice_pipeline_e2e.py
@@ -197,7 +197,9 @@ class TestReconcilerOnProducerShape:
                 "base_ref": "egg/issue-2137/slice-1",
             }
         ]
-        orphans = find_orphaned_child_prs(contract, only_orphan, set())
+        # The orphan's own head branch must be extant; an open PR
+        # implies its head exists on origin (#3479).
+        orphans = find_orphaned_child_prs(contract, only_orphan, {"egg/issue-2137/slice-2"})
         assert len(orphans) == 1
         orphan = orphans[0]
         assert orphan.slice_id == "slice-2"
@@ -237,7 +239,7 @@ class TestReconcilerOnProducerShape:
         result = reconcile_once(
             contract,
             list_open_prs=lambda: producer_prs,
-            list_extant_branches=lambda: set(),
+            list_extant_branches=lambda: {"egg/issue-2137/slice-2"},
             rebase_onto=fake_rebase,
         )
 
@@ -401,7 +403,7 @@ class TestEndToEndOrphanHeal:
         result = reconcile_once(
             contract,
             list_open_prs=lambda: producer_prs,
-            list_extant_branches=lambda: set(),
+            list_extant_branches=lambda: {"egg/issue-2137/slice-2"},
             rebase_onto=rebase_via_gateway,
         )
 

--- a/orchestrator/gateway_client/_branches.py
+++ b/orchestrator/gateway_client/_branches.py
@@ -25,10 +25,12 @@ def list_remote_branches(
     transport is the existing ``/api/v1/git/fetch`` route with
     ``operation="ls-remote"`` — no new privileged surface.
 
-    On error returns an empty set; the reconciler treats this
-    as "every base looks deleted" but since
-    :func:`list_open_prs` is the join key, the empty set is
-    safe — no PRs means no orphans.
+    On error returns an empty set. The reconciler treats an empty
+    set as "nothing confirmable on origin" and skips every
+    candidate (an open PR whose head branch is not in the set is
+    not actionable; see ``find_orphaned_child_prs``), so a failed
+    listing degrades to a no-op pass rather than a storm of doomed
+    rebases (#3479).
     """
     return set(
         self.list_remote_branches_with_shas(

--- a/orchestrator/stacked_pr_reconciler.py
+++ b/orchestrator/stacked_pr_reconciler.py
@@ -162,11 +162,20 @@ def find_orphaned_child_prs(
        not a root slice that targets the pipeline branch directly).
     2. There IS an open PR with a head branch matching the slice's
        integration branch.
-    3. The PR's base branch is NOT in ``extant_branches``.
+    3. The PR's head branch IS in ``extant_branches``: an open PR
+       implies its head exists on origin, so a head missing from the
+       set means the branch listing is stale or broken (or the branch
+       really is gone, in which case the PR is closed/merged and any
+       rebase + force-push of it can never succeed). Either way the
+       orphan is not actionable; retrying it every tick is a
+       permanent hot loop (#3479). This also makes an EMPTY extant
+       set (a failed or misparsed ``ls-remote``) degrade to "no
+       orphans" instead of "rebase every open PR".
+    4. The PR's base branch is NOT in ``extant_branches``.
 
-    Roots, completed slices, and slices whose base still exists
-    are silently skipped so the reconciler is idempotent on each
-    pass.
+    Roots, slices whose base still exists, and slices whose own
+    head branch cannot be confirmed on origin are silently skipped
+    so the reconciler is idempotent on each pass.
 
     PR records missing ``head_ref`` (or its legacy ``head`` alias),
     a real integer ``number``, or ``base_ref`` are dropped — a
@@ -217,6 +226,20 @@ def find_orphaned_child_prs(
         pr = pr_by_head.get(slice_branch)
         if pr is None:
             continue  # slice's PR hasn't been opened yet (or is closed)
+        if slice_branch not in extant_branches:
+            # An open PR implies its head branch exists on origin, so a
+            # head missing from the extant set means the set is stale or
+            # broken; or the branch really was deleted, closing the PR
+            # behind the (now stale) listing. In every one of those
+            # worlds a ``rebase --onto`` + force-push of ``slice_branch``
+            # cannot succeed, and re-attempting it on every tick is the
+            # permanent ~30s hot loop from #3479. Skip; a later pass
+            # with a consistent listing picks the slice up again.
+            logger.debug(
+                "stacked_pr_reconciler: skipping PR whose head branch is not on origin",
+                extra={"slice_id": slice_.id, "head": slice_branch},
+            )
+            continue
         deleted_base = pr.get("base_ref") or pr.get("base")
         if not isinstance(deleted_base, str) or deleted_base in extant_branches:
             continue  # base still alive — GitHub auto-retarget did its job

--- a/orchestrator/stacked_pr_reconciler.py
+++ b/orchestrator/stacked_pr_reconciler.py
@@ -235,10 +235,33 @@ def find_orphaned_child_prs(
             # cannot succeed, and re-attempting it on every tick is the
             # permanent ~30s hot loop from #3479. Skip; a later pass
             # with a consistent listing picks the slice up again.
-            logger.debug(
-                "stacked_pr_reconciler: skipping PR whose head branch is not on origin",
-                extra={"slice_id": slice_.id, "head": slice_branch},
-            )
+            #
+            # Distinguish the two observable regimes so a future silent
+            # ls-remote breakage (or a genuinely wedged PR) is not
+            # indistinguishable from healthy steady state (#3484 review
+            # note 2): an *empty* extant set is the #3479 broken-listing
+            # degraded no-op — log at debug to avoid per-tick noise. A
+            # *non-empty* set that is missing only this head is a real
+            # anomaly — the head was deleted upstream while the PR stayed
+            # open, or the listing is partially broken — so surface it at
+            # info level, keyed enough for an operator to act on.
+            if extant_branches:
+                logger.info(
+                    "stacked_pr_reconciler: open slice PR head missing from a "
+                    "non-empty branch listing; PR may be wedged (head deleted "
+                    "upstream) — skipping rebase",
+                    extra={
+                        "slice_id": slice_.id,
+                        "head": slice_branch,
+                        "pr_number": pr.get("number"),
+                    },
+                )
+            else:
+                logger.debug(
+                    "stacked_pr_reconciler: skipping PR whose head branch is not "
+                    "on origin (empty branch listing; degraded no-op)",
+                    extra={"slice_id": slice_.id, "head": slice_branch},
+                )
             continue
         deleted_base = pr.get("base_ref") or pr.get("base")
         if not isinstance(deleted_base, str) or deleted_base in extant_branches:

--- a/orchestrator/tests/test_stacked_pr_reconciler.py
+++ b/orchestrator/tests/test_stacked_pr_reconciler.py
@@ -21,6 +21,12 @@ Coverage:
 * Slices whose PR has not yet been opened (no matching head) are
   silently skipped — the next reconciliation pass picks them up
   once the PR exists.
+* Slices whose own head branch is missing from ``extant_branches``
+  are skipped (#3479): an open PR implies its head exists on
+  origin, so a missing head means the listing is stale or broken
+  and the rebase could never succeed. In particular an EMPTY
+  extant set (failed/misparsed ``ls-remote``) yields no orphans
+  instead of a doomed rebase of every open PR on every tick.
 * ``reconcile_once`` invokes the rebase callable once per orphan
   and counts successes / failures; rebase exceptions are caught
   and counted, never propagated.
@@ -148,7 +154,9 @@ class TestFindOrphans:
                 base="egg/issue-2137/slice-1",
             )
         ]
-        extant: set[str] = set()  # parent base no longer on origin
+        # Parent base no longer on origin; the orphan's own head still is
+        # (an open PR implies its head exists, #3479).
+        extant: set[str] = {"egg/issue-2137/slice-2"}
         orphans = find_orphaned_child_prs(contract, prs, extant)
         assert len(orphans) == 1
         orphan = orphans[0]
@@ -189,8 +197,9 @@ class TestFindOrphans:
                 base="egg/issue-2137/slice-2",
             )
         ]
-        # slice-2's branch deleted; slice-1's still alive.
-        extant: set[str] = {"egg/issue-2137/slice-1"}
+        # slice-2's branch deleted; slice-1's still alive, and so is
+        # the orphan's own head (open PR ⇒ head extant, #3479).
+        extant: set[str] = {"egg/issue-2137/slice-1", "egg/issue-2137/slice-3"}
         orphans = find_orphaned_child_prs(contract, prs, extant)
         assert len(orphans) == 1
         # Walk: slice-3's parent is slice-2 (deleted) → walk to
@@ -221,8 +230,8 @@ class TestFindOrphans:
                 base="egg/issue-2137/slice-2",
             )
         ]
-        # Both ancestors gone.
-        extant: set[str] = set()
+        # Both ancestors gone; only the orphan's own head survives.
+        extant: set[str] = {"egg/issue-2137/slice-3"}
         orphans = find_orphaned_child_prs(contract, prs, extant)
         assert len(orphans) == 1
         # Pipeline tip lives at ``egg/<id>/work`` — see #2399.
@@ -252,7 +261,7 @@ class TestFindOrphans:
                 base="egg/issue-2137/some-other-thing",
             )
         ]
-        extant: set[str] = {"egg/issue-2137/slice-1"}
+        extant: set[str] = {"egg/issue-2137/slice-1", "egg/issue-2137/slice-2"}
         orphans = find_orphaned_child_prs(contract, prs, extant)
         assert len(orphans) == 1
         # ``intended_new_base`` is computed from the DAG + extant
@@ -294,8 +303,9 @@ class TestFindOrphans:
             )
         )
         prs = [{"number": 11, "head_ref": "egg/issue-2137/slice-2", "base_ref": None}]
-        # Should not raise.
-        orphans = find_orphaned_child_prs(contract, prs, set())
+        # Should not raise. Head is extant so the record reaches the
+        # base-shape check rather than being skipped earlier (#3479).
+        orphans = find_orphaned_child_prs(contract, prs, {"egg/issue-2137/slice-2"})
         # And should NOT count this PR as orphaned (we have no way to
         # know its base disappeared if there's no string to check).
         assert orphans == []
@@ -320,7 +330,7 @@ class TestFindOrphans:
                 "base": "egg/issue-2137/slice-1",
             }
         ]
-        orphans = find_orphaned_child_prs(contract, prs, set())
+        orphans = find_orphaned_child_prs(contract, prs, {"egg/issue-2137/slice-2"})
         assert len(orphans) == 1
         assert orphans[0].pr_number == 11
         assert orphans[0].deleted_base == "egg/issue-2137/slice-1"
@@ -342,7 +352,7 @@ class TestFindOrphans:
                 "base_ref": "egg/issue-2137/slice-1",
             }
         ]
-        orphans = find_orphaned_child_prs(contract, prs, set())
+        orphans = find_orphaned_child_prs(contract, prs, {"egg/issue-2137/slice-2"})
         assert orphans == []
 
     def test_pr_with_zero_number_dropped(self) -> None:
@@ -355,7 +365,7 @@ class TestFindOrphans:
             )
         )
         prs = [_pr(number=0, head="egg/issue-2137/slice-2", base="egg/issue-2137/slice-1")]
-        assert find_orphaned_child_prs(contract, prs, set()) == []
+        assert find_orphaned_child_prs(contract, prs, {"egg/issue-2137/slice-2"}) == []
 
     def test_qualified_pipeline_id_preserves_qualifier_in_issue_branch(self) -> None:
         # Regression for #2370 review: when a contract's pipeline_id
@@ -383,7 +393,7 @@ class TestFindOrphans:
             )
         ]
         # Parent base no longer on origin → must surface as orphan.
-        orphans = find_orphaned_child_prs(contract, prs, set())
+        orphans = find_orphaned_child_prs(contract, prs, {"egg/issue-2137-v3/slice-2"})
         assert len(orphans) == 1
         orphan = orphans[0]
         assert orphan.slice_id == "slice-2"
@@ -420,11 +430,61 @@ class TestFindOrphans:
                 base="egg/issue-2137-v3/slice-2",
             )
         ]
-        # slice-2's branch deleted; slice-1's qualified branch alive.
-        extant: set[str] = {"egg/issue-2137-v3/slice-1"}
+        # slice-2's branch deleted; slice-1's qualified branch alive,
+        # plus the orphan's own head (open PR ⇒ head extant, #3479).
+        extant: set[str] = {"egg/issue-2137-v3/slice-1", "egg/issue-2137-v3/slice-3"}
         orphans = find_orphaned_child_prs(contract, prs, extant)
         assert len(orphans) == 1
         assert orphans[0].intended_new_base == "egg/issue-2137-v3/slice-1"
+
+    def test_pr_whose_head_branch_is_missing_is_skipped(self) -> None:
+        # #3479: an open PR implies its head branch exists on origin.
+        # A head missing from ``extant_branches`` means the listing is
+        # stale/broken or the branch really is gone; either way the
+        # rebase + force-push can never succeed, so surfacing the
+        # orphan would retry a doomed rebase on every ~30s tick,
+        # forever. Skip it.
+        contract = _contract(
+            _slice(
+                "slice-2",
+                deps=["slice-1"],
+                parent_branch="egg/issue-2137/slice-1",
+            )
+        )
+        prs = [
+            _pr(
+                number=11,
+                head="egg/issue-2137/slice-2",
+                base="egg/issue-2137/slice-1",
+            )
+        ]
+        # Base gone AND head gone: nothing actionable.
+        extant: set[str] = {"egg/issue-2137/work"}
+        assert find_orphaned_child_prs(contract, prs, extant) == []
+
+    def test_empty_extant_set_yields_no_orphans(self) -> None:
+        # #3479 root-cause shape: a broken/failed branch listing
+        # (gateway ``ls-remote`` misparse returned zero branches while
+        # every slice PR was open and healthy) must degrade to a no-op
+        # pass, NOT to "every open PR's base looks deleted → rebase
+        # them all every tick".
+        contract = _contract(
+            _slice(
+                "slice-2",
+                deps=["slice-1"],
+                parent_branch="egg/issue-2137/slice-1",
+            ),
+            _slice(
+                "slice-3",
+                deps=["slice-2"],
+                parent_branch="egg/issue-2137/slice-2",
+            ),
+        )
+        prs = [
+            _pr(number=11, head="egg/issue-2137/slice-2", base="egg/issue-2137/slice-1"),
+            _pr(number=12, head="egg/issue-2137/slice-3", base="egg/issue-2137/slice-2"),
+        ]
+        assert find_orphaned_child_prs(contract, prs, set()) == []
 
 
 # ---------- reconcile_once ----------
@@ -474,7 +534,7 @@ class TestProducerConsumerContract:
                 "base_ref": "egg/issue-2137/slice-1",
             }
         ]
-        orphans = find_orphaned_child_prs(contract, producer_shape, set())
+        orphans = find_orphaned_child_prs(contract, producer_shape, {"egg/issue-2137/slice-2"})
         assert len(orphans) == 1
         # ``pr_number`` MUST be the real PR number from the producer
         # — not silently defaulted to 0 — so the production rebase
@@ -524,7 +584,7 @@ class TestReconcileOnce:
         result = reconcile_once(
             contract,
             list_open_prs=lambda: prs,
-            list_extant_branches=lambda: set(),
+            list_extant_branches=lambda: {"egg/issue-2137/slice-2"},
             rebase_onto=rebaser,
         )
         assert result.orphans_detected == 1
@@ -556,7 +616,7 @@ class TestReconcileOnce:
         result = reconcile_once(
             contract,
             list_open_prs=lambda: prs,
-            list_extant_branches=lambda: set(),
+            list_extant_branches=lambda: {"egg/issue-2137/slice-2"},
             rebase_onto=rebaser,
         )
         assert result.rebases_succeeded == 0
@@ -578,7 +638,7 @@ class TestReconcileOnce:
         result = reconcile_once(
             contract,
             list_open_prs=lambda: prs,
-            list_extant_branches=lambda: set(),
+            list_extant_branches=lambda: {"egg/issue-2137/slice-2"},
             rebase_onto=rebaser,
         )
         assert result.rebases_failed == 1

--- a/orchestrator/tests/test_stacked_pr_reconciler.py
+++ b/orchestrator/tests/test_stacked_pr_reconciler.py
@@ -36,9 +36,12 @@ Coverage:
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 from typing import Any
+
+import pytest
 
 # sys.path setup matches test_concurrent_executor_staging_branch.py.
 _project_root = Path(__file__).parent.parent.parent
@@ -437,7 +440,9 @@ class TestFindOrphans:
         assert len(orphans) == 1
         assert orphans[0].intended_new_base == "egg/issue-2137-v3/slice-1"
 
-    def test_pr_whose_head_branch_is_missing_is_skipped(self) -> None:
+    def test_pr_whose_head_branch_is_missing_is_skipped(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         # #3479: an open PR implies its head branch exists on origin.
         # A head missing from ``extant_branches`` means the listing is
         # stale/broken or the branch really is gone; either way the
@@ -458,11 +463,25 @@ class TestFindOrphans:
                 base="egg/issue-2137/slice-1",
             )
         ]
-        # Base gone AND head gone: nothing actionable.
+        # Base gone AND head gone, but the listing is NON-empty (it
+        # enumerates `.../work`): a truthful-looking listing missing only
+        # this open PR's head is a genuinely-wedged PR, not the degraded
+        # empty-listing no-op. #3484 review note 2: surface it at INFO so
+        # an operator can distinguish "PR wedged" from healthy steady
+        # state rather than only a silent debug line.
         extant: set[str] = {"egg/issue-2137/work"}
-        assert find_orphaned_child_prs(contract, prs, extant) == []
+        with caplog.at_level(logging.INFO, logger="stacked_pr_reconciler"):
+            assert find_orphaned_child_prs(contract, prs, extant) == []
+        wedged = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.INFO and "may be wedged" in r.getMessage()
+        ]
+        assert len(wedged) == 1
+        assert getattr(wedged[0], "pr_number", None) == 11
+        assert getattr(wedged[0], "head", None) == "egg/issue-2137/slice-2"
 
-    def test_empty_extant_set_yields_no_orphans(self) -> None:
+    def test_empty_extant_set_yields_no_orphans(self, caplog: pytest.LogCaptureFixture) -> None:
         # #3479 root-cause shape: a broken/failed branch listing
         # (gateway ``ls-remote`` misparse returned zero branches while
         # every slice PR was open and healthy) must degrade to a no-op
@@ -484,7 +503,17 @@ class TestFindOrphans:
             _pr(number=11, head="egg/issue-2137/slice-2", base="egg/issue-2137/slice-1"),
             _pr(number=12, head="egg/issue-2137/slice-3", base="egg/issue-2137/slice-2"),
         ]
-        assert find_orphaned_child_prs(contract, prs, set()) == []
+        # An EMPTY extant set is the degraded broken-listing regime: it
+        # must NOT emit the INFO "wedged" signal (that is reserved for a
+        # non-empty listing missing a single head), only the quiet
+        # per-tick debug no-op (#3484 review note 2).
+        with caplog.at_level(logging.INFO, logger="stacked_pr_reconciler"):
+            assert find_orphaned_child_prs(contract, prs, set()) == []
+        assert not [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.INFO and "may be wedged" in r.getMessage()
+        ]
 
 
 # ---------- reconcile_once ----------


### PR DESCRIPTION
Closes #3479.

## What the issue observed

Once early slices completed, the reconciler retried `rebase_onto` for every slice branch on every ~30s tick, failing each time with `fatal: no such branch/commit ...` / `fatal: invalid upstream ...`, indefinitely. The issue read this as "the reconciler retries deleted integration branches of completed slices."

## What is actually happening

Diagnosed against the live incident (`pipeline-dcdad92d` on `Khan/actions`):

- All seven slice PRs (197-203) are OPEN and healthy, and **every** "deleted" branch, including `egg/pipeline-dcdad92d/work` (the base of PR 197), exists on origin. Nothing was ever deleted.
- The gateway audit log shows `ls-remote_success` on every tick, yet the reconciler behaved as if the extant-branch set were empty. It was.

Root cause: the gateway's `/api/v1/git/fetch` route built the ls-remote argv as `git ls-remote <repository> --heads`. `git ls-remote` stops option parsing at the first positional argument, so the post-URL `--heads` is treated as a literal ref **pattern** that matches nothing; the command exits 0 with empty output:

```
$ git ls-remote https://github.com/Khan/actions --heads | wc -l
0
$ git ls-remote --heads https://github.com/Khan/actions | wc -l
31
```

So the reconciler's extant set was always empty, every open slice PR's base looked deleted, and `reconcile_once` attempted a rebase per open PR per tick. Each rebase then failed locally (the orchestrator worktree has no local refs for the slice branches), producing the observed hot loop. The rebase failure was the only WARNING-level signal; the empty listing itself was silent, which is why the symptom was misattributed to branch deletion.

The probe-style ls-remote callers (`ls_remote_branch`, `get_remote_branch_sha`) kept working by accident: they pass `["--heads", "refs/heads/<x>"]`, and the real ref pattern still matched after the dead `--heads` one. Only the bare `["--heads"]` full listing (the reconciler and the #2446 recovery-ref sweep) was broken.

## The fix

1. **Gateway** (`gateway.py::git_fetch`): for ls-remote, emit flags before the repository argument and ref patterns after it. Route-level test locks the ordering.
2. **Reconciler defense in depth** (`stacked_pr_reconciler.py::find_orphaned_child_prs`): skip any PR whose own head branch is not in `extant_branches`. An open PR implies its head exists on origin, so a missing head means the listing is stale or broken (or the branch is truly gone and the PR closed behind a stale listing); in every one of those worlds the rebase + force-push cannot succeed, and retrying it every tick is exactly the #3479 hot loop. In particular an **empty** extant set now degrades to a no-op pass instead of a rebase storm.

## Why not the issue's suggested "skip completed slices"

A completed slice with an open PR is the reconciler's *primary* customer: the slice reaches `COMPLETE` at consensus, its PR stays open awaiting merge, and it is precisely then that a parent merge can orphan it. Gating on `SliceStatus.COMPLETE` would disable the reconciler for the case it exists for. Gating on head-branch existence keeps the heal path intact while making every stale/broken-listing mode (including this one) non-looping.

## Side effect worth noting

The same argv bug made `list_remote_branches_with_shas` return `{}` for the #2446 recovery-ref cleanup sweep, silently no-op'ing it. This fix revives that sweep as well.

## Testing

- New route-level gateway test asserting flag/pattern placement around the repository argument.
- New reconciler tests: head-missing-from-extant is skipped; empty extant set with open PRs yields zero orphans.
- Existing orphan-detection tests updated to include the orphan's head branch in the extant set (matching what a truthful listing returns for an open PR).
- Full suite: 20704 passed; the only 2 failures are pre-existing environment failures in `tests/scripts/test_reap_stale_egg_images.py` (missing host binary, exit 127), untouched by this diff.