### PR TITLE
Fix observability gaps: honor messages 'since', surface slice-scoped consensus

### DIFF
--- a/docs/guides/concurrent-execution.md
+++ b/docs/guides/concurrent-execution.md
@@ -162,6 +162,7 @@ Query parameters:
 |-----------|-------------|
 | `role` | Return messages targeted to this role or broadcast to `"all"` |
 | `since_id` | Return only messages after this message ID (for incremental polling). If the cursor is not found (e.g., after a phase-boundary clear or post-compaction anchor recovery), the store falls back to returning all messages rather than an empty list. |
+| `since` | Return only messages at or after this ISO 8601 timestamp (naive values are treated as UTC). Millisecond resolution via the Redis stream ID. Intended for operators debugging a live pipeline; mutually exclusive with `since_id` (400 if both are passed). Invalid timestamps 400 instead of being silently ignored ([#3481](https://github.com/jwbron/egg/issues/3481)). |
 | `limit` | Maximum messages to return (default: 100) |
 
 Messages are returned oldest-first. The `since_id` filter excludes the reference message itself — only messages that follow it are returned. If the cursor ID is no longer present in the store (stale cursor), the endpoint degrades gracefully to a full-history replay instead of silently returning empty — preventing polling agents from stalling after a phase transition or anchor recovery.

--- a/orchestrator/mcp_tools/_consensus.py
+++ b/orchestrator/mcp_tools/_consensus.py
@@ -16,15 +16,40 @@ from urllib.parse import quote
 from mcp_tools import _SLICE_ID_PATTERN
 
 
+def _structured_consensus(consensus: dict[str, Any]) -> dict[str, Any]:
+    """Shape a structured (tracker-backed) consensus block for the tool result.
+
+    Derives ``confirmed_agents`` from the per-role ``confirmed`` flags so
+    the structured path and the message-inference fallback expose the
+    same top-level fields (#3481).
+    """
+    agents = dict(consensus.get("agents", {}))
+    return {
+        "is_complete": consensus.get("is_complete", False),
+        "confirmed_agents": [
+            role
+            for role, info in agents.items()
+            if isinstance(info, dict) and info.get("confirmed")
+        ],
+        "blocking_agents": consensus.get("blocking_agents", []),
+        "has_unresolved_nacks": consensus.get("has_unresolved_nacks", False),
+        "unresolved_nacks": consensus.get("unresolved_nacks", []),
+        "agents": agents,
+    }
+
+
 def _handle_get_consensus_status(self, args: dict[str, Any]) -> dict[str, Any]:
     """Get consensus status for a pipeline's current phase.
 
     ``slice_id`` scopes the result to one slice's BRC consensus in a
     slice-DAG implement phase — each slice runs its own consensus,
-    keyed ``{pipeline_id}/{slice_id}``. Without it, only
-    pipeline-level consensus is reported, and a slice-DAG pipeline
-    yields no consensus rather than a misleading cross-slice view
-    (#2761).
+    keyed ``{pipeline_id}/{slice_id}``. Without it, pipeline-level
+    consensus is reported; when only slice-scoped trackers are live
+    (the slice-DAG case), the active slice trackers are resolved
+    automatically from the status endpoint's ``slice_consensus`` map
+    (#3481), rather than degrading to an empty message-inference view:
+    a single active slice is served directly, multiple are returned
+    per-slice. Slices are never merged into one block (#2761).
     """
     task_id = quote(args["task_id"], safe="")
     raw_slice_id = args.get("slice_id") or None
@@ -64,15 +89,34 @@ def _handle_get_consensus_status(self, args: dict[str, Any]) -> dict[str, Any]:
         concurrent = {}
 
     consensus = concurrent.get("consensus", {})
+    slice_consensus = concurrent.get("slice_consensus", {}) if slice_id is None else {}
 
     if consensus and consensus.get("agents"):
-        result["consensus"] = {
-            "is_complete": consensus.get("is_complete", False),
-            "blocking_agents": consensus.get("blocking_agents", []),
-            "has_unresolved_nacks": consensus.get("has_unresolved_nacks", False),
-            "unresolved_nacks": consensus.get("unresolved_nacks", []),
-            "agents": consensus.get("agents", {}),
-        }
+        result["consensus"] = _structured_consensus(consensus)
+    elif slice_consensus:
+        # Slice-scoped trackers are live but no explicit slice_id was
+        # given (#3481). Serve the real tracker snapshots instead of
+        # degrading to message inference: one active slice resolves
+        # directly (with ``resolved_slice_id`` naming the scope), and
+        # multiple stay keyed per-slice so they are never merged (#2761).
+        if len(slice_consensus) == 1:
+            resolved_slice_id, block = next(iter(slice_consensus.items()))
+            result["resolved_slice_id"] = resolved_slice_id
+            result["consensus"] = _structured_consensus(block)
+            result["consensus"]["note"] = (
+                f"Resolved the single active slice-scoped tracker "
+                f"'{resolved_slice_id}'; pass slice_id to pin the scope"
+            )
+        else:
+            result["active_slice_ids"] = sorted(slice_consensus)
+            result["slice_consensus"] = {
+                sid: _structured_consensus(block) for sid, block in slice_consensus.items()
+            }
+            result["note"] = (
+                "Multiple slice-scoped consensus rounds are active; "
+                "per-slice snapshots are under 'slice_consensus'. Pass "
+                "slice_id to scope the result to one slice."
+            )
     else:
         # Fall back to message-based inference. Filter messages by
         # the requested slice scope — symmetric with

--- a/orchestrator/mcp_tools/_tool_defs.py
+++ b/orchestrator/mcp_tools/_tool_defs.py
@@ -332,11 +332,14 @@ PIPELINE_TOOLS = [
         "name": "get_consensus_status",
         "description": (
             "Get BRC consensus status for a pipeline. Shows which agents have "
-            "proposed, ACKed, NACKed, or confirmed. Falls back to message-based "
-            "inference when structured consensus data is unavailable. In a "
-            "slice-DAG implement phase each slice runs its own consensus — "
-            "pass slice_id to scope the result to one slice; without it, only "
-            "pipeline-level consensus is reported."
+            "proposed, ACKed, NACKed, or confirmed, plus unresolved NACK "
+            "details. Falls back to message-based inference when structured "
+            "consensus data is unavailable. In a slice-DAG implement phase "
+            "each slice runs its own consensus: pass slice_id to scope the "
+            "result to one slice; without it, live slice-scoped rounds are "
+            "resolved automatically (a single active slice is served "
+            "directly, multiple are returned per-slice under "
+            "'slice_consensus')."
         ),
         "inputSchema": {
             "type": "object",

--- a/orchestrator/peer_consensus/__init__.py
+++ b/orchestrator/peer_consensus/__init__.py
@@ -254,6 +254,29 @@ def get_peer_consensus_tracker(
     return _trackers.get(_tracker_key(pipeline_id, slice_id))
 
 
+def get_slice_trackers(pipeline_id: str) -> dict[str, PeerConsensusTracker]:
+    """Return the live slice-scoped trackers for a pipeline, keyed by slice_id.
+
+    Observability accessor (#3481): during a slice-DAG implement phase
+    the registry holds per-slice trackers under ``{pipeline_id}/{slice_id}``
+    and nothing under the bare pipeline id, so a slice-id-less status
+    query cannot see any consensus state. This enumerates the registry
+    so callers (``_get_concurrent_status``) can serve each active
+    slice's real tracker snapshot, explicitly keyed by slice; NOT a
+    merged cross-slice view (#2761's "soup" concern only applies to
+    mingling slices into one tracker). In-memory registry only: after
+    an orchestrator restart slices reappear here as their trackers are
+    reconstructed on first slice-scoped access.
+    """
+    prefix = f"{pipeline_id}/"
+    with _trackers_lock:
+        return {
+            key[len(prefix) :]: tracker
+            for key, tracker in _trackers.items()
+            if key.startswith(prefix)
+        }
+
+
 def create_peer_consensus_tracker(
     pipeline_id: str,
     graph: ReviewGraph,

--- a/orchestrator/redis_message_store.py
+++ b/orchestrator/redis_message_store.py
@@ -59,6 +59,12 @@ _SOCKET_TIMEOUT_SEC = 5
 # and scheduling slack so the slice returns before redis-py trips.
 _MAX_BLOCK_MS = (_SOCKET_TIMEOUT_SEC - 1) * 1000
 
+# Largest sequence number in a Redis Stream ID (64-bit unsigned). Used to
+# name the exclusive predecessor of ``<ms>-0`` when seeking by ``since``
+# timestamp so the exclusive XREAD (long-poll) and inclusive XRANGE
+# (non-blocking) paths agree on the cutoff-millisecond boundary (#3481).
+_MAX_STREAM_SEQ = (1 << 64) - 1
+
 
 def _stream_key(pipeline_id: str) -> str:
     """Get the Redis Stream key for a pipeline."""
@@ -271,7 +277,11 @@ class RedisMessageStore:
         cutoff maps directly to a start stream ID and the read seeks past
         older history instead of scanning from ``0-0`` (which made
         ``limit`` return a window hours before the cutoff). Resolution is
-        the stream ID's millisecond, inclusive of the cutoff millisecond.
+        the stream ID's millisecond, inclusive of the cutoff millisecond on
+        both the non-blocking (XRANGE) and long-poll (XREAD, ``wait > 0``)
+        paths — the seek anchors on the exclusive predecessor of
+        ``<cutoff_ms>-0`` so the exclusive XREAD start and the inclusive
+        XRANGE ``min`` agree on the boundary (#3485 review).
         Ignored when ``since_id`` is supplied; the explicit cursor is
         more precise (the route rejects the combination outright).
 
@@ -344,9 +354,20 @@ class RedisMessageStore:
                         start_id = "0-0"
         elif since is not None:
             # Timestamp seek (#3481). Naive datetimes are treated as UTC
-            # to match ``Message.timestamp``'s default factory.
+            # to match ``Message.timestamp``'s default factory. Seek to the
+            # *exclusive predecessor* of ``<cutoff_ms>-0`` (i.e.
+            # ``<cutoff_ms - 1>`` at the max sequence) rather than to
+            # ``<cutoff_ms>-0`` itself, so both read paths land inclusive of
+            # the cutoff millisecond: the non-blocking XRANGE uses this as an
+            # inclusive ``min`` and the blocking XREAD (long-poll, wait > 0)
+            # treats it as an exclusive start. Anchoring on ``<cutoff_ms>-0``
+            # directly would make the XREAD path skip an entry sitting at
+            # exactly that id, contradicting the "inclusive of the cutoff
+            # millisecond" contract above (#3485 review). ``cutoff_ms == 0``
+            # (epoch or earlier) floors to ``0-0``.
             cutoff = since if since.tzinfo is not None else since.replace(tzinfo=UTC)
-            start_id = f"{max(int(cutoff.timestamp() * 1000), 0)}-0"
+            cutoff_ms = max(int(cutoff.timestamp() * 1000), 0)
+            start_id = f"{cutoff_ms - 1}-{_MAX_STREAM_SEQ}" if cutoff_ms else "0-0"
 
         meta = GetMessagesMeta(since_id_stale=since_id_stale)
         want_types = set(wait_for_types) if wait_for_types else None

--- a/orchestrator/redis_message_store.py
+++ b/orchestrator/redis_message_store.py
@@ -188,6 +188,7 @@ class RedisMessageStore:
         *,
         role: str | None = None,
         since_id: str | None = None,
+        since: datetime | None = None,
         limit: int = 100,
         wait: int = 0,
         wait_for_types: Sequence[str] | None = None,
@@ -206,6 +207,9 @@ class RedisMessageStore:
             pipeline_id: Pipeline ID to query.
             role: If set, return messages where to_role is this role or 'all'.
             since_id: If set, return only messages after this message ID.
+            since: If set (and ``since_id`` is not), return only messages
+                at or after this timestamp. Millisecond stream-ID
+                resolution; see :meth:`get_messages_with_meta` (#3481).
             limit: Maximum messages to return.
             wait: If > 0, block for this many seconds waiting for new messages.
             wait_for_types: If set (and ``wait > 0``), only treat a read as
@@ -233,6 +237,7 @@ class RedisMessageStore:
             pipeline_id,
             role=role,
             since_id=since_id,
+            since=since,
             limit=limit,
             wait=wait,
             wait_for_types=wait_for_types,
@@ -249,6 +254,7 @@ class RedisMessageStore:
         *,
         role: str | None = None,
         since_id: str | None = None,
+        since: datetime | None = None,
         limit: int = 100,
         wait: int = 0,
         wait_for_types: Sequence[str] | None = None,
@@ -259,6 +265,15 @@ class RedisMessageStore:
         _suppress_stale_warning: bool = False,
     ) -> tuple[list[Message], GetMessagesMeta]:
         """Same as :meth:`get_messages` but also returns staleness metadata.
+
+        ``since`` (#3481): timestamp cutoff for operators debugging a live
+        pipeline. Redis Stream auto-IDs are ``<unix-ms>-<seq>``, so the
+        cutoff maps directly to a start stream ID and the read seeks past
+        older history instead of scanning from ``0-0`` (which made
+        ``limit`` return a window hours before the cutoff). Resolution is
+        the stream ID's millisecond, inclusive of the cutoff millisecond.
+        Ignored when ``since_id`` is supplied; the explicit cursor is
+        more precise (the route rejects the combination outright).
 
         ``meta.since_id_stale`` is ``True`` iff the caller supplied a
         non-None ``since_id`` that did not resolve to any stream entry
@@ -327,6 +342,11 @@ class RedisMessageStore:
                     else:
                         since_id_stale = True
                         start_id = "0-0"
+        elif since is not None:
+            # Timestamp seek (#3481). Naive datetimes are treated as UTC
+            # to match ``Message.timestamp``'s default factory.
+            cutoff = since if since.tzinfo is not None else since.replace(tzinfo=UTC)
+            start_id = f"{max(int(cutoff.timestamp() * 1000), 0)}-0"
 
         meta = GetMessagesMeta(since_id_stale=since_id_stale)
         want_types = set(wait_for_types) if wait_for_types else None

--- a/orchestrator/routes/messages.py
+++ b/orchestrator/routes/messages.py
@@ -5,6 +5,7 @@ messages during concurrent phase execution.
 """
 
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -288,6 +289,10 @@ def poll_messages(pipeline_id: str) -> tuple[Response, int]:
     Query params:
         role: Filter messages for this role (returns targeted + broadcast)
         since_id: Return only messages after this ID
+        since: Return only messages at or after this ISO 8601 timestamp
+            (naive values are treated as UTC). Mutually exclusive with
+            since_id. Issue #3481: previously accepted-and-ignored, which
+            silently returned a window hours before the cutoff.
         limit: Max messages to return (default 100)
     """
     # Validate pipeline exists (consistent with send_message)
@@ -300,6 +305,15 @@ def poll_messages(pipeline_id: str) -> tuple[Response, int]:
 
     role = request.args.get("role")
     since_id = request.args.get("since_id")
+    since_raw = request.args.get("since")
+    since: datetime | None = None
+    if since_raw:
+        if since_id:
+            return _make_error("Pass either 'since' or 'since_id', not both.")
+        try:
+            since = datetime.fromisoformat(since_raw.replace("Z", "+00:00"))
+        except ValueError:
+            return _make_error("Invalid 'since' timestamp format. Use ISO 8601.")
     try:
         limit = int(request.args.get("limit", "100"))
     except (ValueError, TypeError):  # fmt: skip
@@ -318,6 +332,7 @@ def poll_messages(pipeline_id: str) -> tuple[Response, int]:
     kwargs: dict[str, Any] = {
         "role": role,
         "since_id": since_id,
+        "since": since,
         "limit": limit,
     }
     if wait > 0:

--- a/orchestrator/routes/pipelines.py
+++ b/orchestrator/routes/pipelines.py
@@ -5426,6 +5426,28 @@ def _get_pr_info(pipeline: Pipeline) -> tuple[str | None, int | None]:
     return pr_url, pr_number
 
 
+def _consensus_block(consensus_state: dict) -> dict:
+    """Slim a tracker ``get_state()`` snapshot down to the status payload.
+
+    Keeps the fields operators act on (per-role phases + confirmed
+    flags, the blocking set, and the unresolved-NACK details: who
+    NACKed whom, on which version, and why; #3481) and drops the
+    bulky ``approval_matrix`` / ``review_graph`` dumps.
+
+    BRC trackers only emit dict-format agent entries (the legacy
+    AgentReadiness object came from the now-deleted ConsensusEvaluator,
+    cq-5 of #2777).
+    """
+    return {
+        "agents": dict(consensus_state.get("agents", {})),
+        "is_complete": consensus_state.get("is_complete", False),
+        "blocking_agents": consensus_state.get("blocking_agents", []),
+        "has_unresolved_nacks": consensus_state.get("has_unresolved_nacks", False),
+        "unresolved_nacks": consensus_state.get("unresolved_nacks", []),
+        "protocol": consensus_state.get("protocol", "brc"),
+    }
+
+
 def _get_concurrent_status(pipeline: Pipeline, slice_id: str | None = None) -> dict | None:
     """Get concurrent execution monitoring data for a pipeline.
 
@@ -5453,9 +5475,11 @@ def _get_concurrent_status(pipeline: Pipeline, slice_id: str | None = None) -> d
     cross-slice reconstruction (#2761). Callers querying a per-slice
     agent's consensus must pass that agent's ``slice_id``; the consensus
     block then reflects exactly that slice's tracker. When omitted, only
-    pipeline-level (non-slice) consensus is reported — a slice-DAG
-    pipeline queried without a slice yields no ``consensus`` block rather
-    than a fabricated one.
+    pipeline-level (non-slice) consensus is reported in ``consensus``;
+    a slice-DAG pipeline queried without a slice yields no ``consensus``
+    block rather than a fabricated one. Instead, live slice-scoped
+    trackers are surfaced under ``slice_consensus`` keyed by slice_id
+    (#3481), so operators still see each active round's real state.
     """
     try:
         from concurrent_executor import is_concurrent_execution
@@ -5554,22 +5578,46 @@ def _get_concurrent_status(pipeline: Pipeline, slice_id: str | None = None) -> d
         consensus_state = None
 
     if consensus_state is not None:
-        # BRC trackers only emit dict-format agent entries (the legacy
-        # AgentReadiness object came from the now-deleted
-        # ConsensusEvaluator, cq-5 of #2777).
-        agents_data = dict(consensus_state.get("agents", {}))
-        result["consensus"] = {
-            "agents": agents_data,
-            "is_complete": consensus_state.get("is_complete", False),
-            "blocking_agents": consensus_state.get("blocking_agents", []),
-            "protocol": consensus_state.get("protocol", "brc"),
-        }
+        result["consensus"] = _consensus_block(consensus_state)
     else:
         # Don't populate consensus with empty placeholder — callers (e.g. the
         # MCP get_consensus_status tool) use truthiness to decide whether to
         # fall back to message-based inference.  An empty-but-truthy dict
         # prevents that fallback from triggering (see issue #1229).
         pass
+
+    # Slice-id-less observability (#3481): in a slice-DAG implement phase
+    # the live trackers are keyed ``{pipeline_id}/{slice_id}``, so the
+    # pipeline-level lookup above finds nothing and an operator querying
+    # without a slice scope saw no structured consensus at all; the only
+    # way to see tracker state was tailing orchestrator pod logs. Surface
+    # each active slice's real snapshot, explicitly keyed by slice. This
+    # is NOT the #2761 cross-slice "soup" (that was mingling every
+    # slice's messages into ONE inferred tracker); the pipeline-level
+    # ``consensus`` block above still never reflects a slice tracker.
+    if slice_id is None:
+        try:
+            try:
+                from peer_consensus import get_slice_trackers
+            except ImportError:
+                from ..peer_consensus import get_slice_trackers  # type: ignore[no-redef]
+
+            slice_trackers = get_slice_trackers(pipeline.id)
+        except ImportError:
+            slice_trackers = {}
+        slice_consensus: dict[str, dict] = {}
+        for sid in sorted(slice_trackers):
+            try:
+                slice_consensus[sid] = _consensus_block(slice_trackers[sid].get_state())
+            except Exception as e:  # noqa: BLE001 - one bad slice must not hide the rest
+                logger.warning(
+                    "Slice consensus snapshot failed",
+                    pipeline_id=pipeline.id,
+                    slice_id=sid,
+                    error=str(e),
+                )
+        if slice_consensus:
+            result["slice_consensus"] = slice_consensus
 
     # Agent lifecycle info from the phase execution record — shows which agents
     # are spawned for the current phase and their container-level status.

--- a/orchestrator/tests/test_concurrent_status.py
+++ b/orchestrator/tests/test_concurrent_status.py
@@ -454,6 +454,135 @@ class TestGetConcurrentStatusSliceAware:
         assert "consensus" not in result
 
 
+class TestConsensusNackDetails:
+    """The consensus block carries the tracker's NACK details (#3481).
+
+    ``evaluate()`` computes ``has_unresolved_nacks`` / ``unresolved_nacks``
+    but the status payload used to drop them, so the MCP tool's structured
+    path always reported ``has_unresolved_nacks: False`` while the
+    executor logs showed the real blocked state.
+    """
+
+    def test_consensus_block_includes_unresolved_nacks(self):
+        pipeline = _make_concurrent_pipeline(pipeline_id="issue-777")
+        tracker = MagicMock()
+        tracker.get_state.return_value = {
+            "is_complete": False,
+            "blocking_agents": ["coder", "tester"],
+            "has_unresolved_nacks": True,
+            "unresolved_nacks": [
+                {
+                    "reviewer": "reviewer_code",
+                    "producer": "coder",
+                    "reason": "off-by-one in pagination",
+                    "version": 2,
+                }
+            ],
+            "agents": {"coder": {"producer_phase": "PROPOSED", "confirmed": False}},
+            "protocol": "brc",
+        }
+
+        with (
+            patch("concurrent_executor.is_concurrent_execution", return_value=True),
+            patch("message_store.get_message_store") as mock_get_store,
+            patch("peer_consensus.get_peer_consensus_tracker", return_value=tracker),
+        ):
+            mock_store = MagicMock()
+            mock_store.get_status.return_value = {"total": 0, "by_type": {}}
+            mock_get_store.return_value = mock_store
+
+            result = _get_concurrent_status(pipeline)
+
+        consensus = result["consensus"]
+        assert consensus["has_unresolved_nacks"] is True
+        assert consensus["unresolved_nacks"] == [
+            {
+                "reviewer": "reviewer_code",
+                "producer": "coder",
+                "reason": "off-by-one in pagination",
+                "version": 2,
+            }
+        ]
+
+
+class TestSliceConsensusSurfacing:
+    """A slice-id-less query surfaces live per-slice trackers (#3481).
+
+    Keyed explicitly by slice; never merged into the pipeline-level
+    ``consensus`` block, so #2761's cross-slice-soup invariant holds.
+    """
+
+    @staticmethod
+    def _brc_state(blocking):
+        return {
+            "is_complete": False,
+            "blocking_agents": blocking,
+            "has_unresolved_nacks": True,
+            "unresolved_nacks": [
+                {"reviewer": "reviewer_code", "producer": "coder", "reason": "bug", "version": 1}
+            ],
+            "agents": {"coder": {"producer_phase": "PROPOSED", "confirmed": False}},
+            "protocol": "brc",
+        }
+
+    def _run(self, pipeline, slice_trackers, slice_id=None):
+        with (
+            patch("concurrent_executor.is_concurrent_execution", return_value=True),
+            patch("message_store.get_message_store") as mock_get_store,
+            patch("peer_consensus.get_peer_consensus_tracker", return_value=None),
+            patch("peer_consensus.reconstruct_tracker_from_messages", return_value=None),
+            patch("peer_consensus.get_slice_trackers", return_value=slice_trackers),
+        ):
+            mock_store = MagicMock()
+            mock_store.get_status.return_value = {"total": 0, "by_type": {}}
+            mock_get_store.return_value = mock_store
+
+            return _get_concurrent_status(pipeline, slice_id=slice_id)
+
+    def test_slice_trackers_surface_under_slice_consensus(self):
+        pipeline = _make_concurrent_pipeline(pipeline_id="issue-888")
+        t1, t3 = MagicMock(), MagicMock()
+        t1.get_state.return_value = self._brc_state(["coder"])
+        t3.get_state.return_value = self._brc_state(["tester"])
+
+        result = self._run(pipeline, {"slice-3": t3, "slice-1": t1})
+
+        # The pipeline-level block stays absent (#2761) ...
+        assert "consensus" not in result
+        # ... but each live slice's real snapshot is served, keyed by slice.
+        assert sorted(result["slice_consensus"]) == ["slice-1", "slice-3"]
+        assert result["slice_consensus"]["slice-3"]["blocking_agents"] == ["tester"]
+        assert result["slice_consensus"]["slice-1"]["has_unresolved_nacks"] is True
+
+    def test_slice_scoped_query_omits_slice_consensus(self):
+        """An explicit slice scope keeps the single-slice response shape."""
+        pipeline = _make_concurrent_pipeline(pipeline_id="issue-888")
+        t1 = MagicMock()
+        t1.get_state.return_value = self._brc_state(["coder"])
+
+        result = self._run(pipeline, {"slice-1": t1}, slice_id="slice-1")
+
+        assert "slice_consensus" not in result
+
+    def test_no_slice_trackers_omits_slice_consensus(self):
+        pipeline = _make_concurrent_pipeline(pipeline_id="issue-888")
+
+        result = self._run(pipeline, {})
+
+        assert "slice_consensus" not in result
+        assert "consensus" not in result
+
+    def test_one_bad_slice_does_not_hide_the_rest(self):
+        pipeline = _make_concurrent_pipeline(pipeline_id="issue-888")
+        good, bad = MagicMock(), MagicMock()
+        good.get_state.return_value = self._brc_state(["coder"])
+        bad.get_state.side_effect = RuntimeError("tracker lock poisoned")
+
+        result = self._run(pipeline, {"slice-1": bad, "slice-2": good})
+
+        assert list(result["slice_consensus"]) == ["slice-2"]
+
+
 class TestPipelineStatusConcurrentEndpoint:
     """Tests for the pipeline status endpoint with concurrent data."""
 

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -406,6 +406,157 @@ class TestGetConsensusStatus:
         assert "note" in result["consensus"]
 
 
+class TestGetConsensusStatusSliceResolution:
+    """A slice-id-less call resolves live slice-scoped trackers (#3481).
+
+    During a slice-DAG implement phase only ``{pipeline_id}/{slice_id}``
+    trackers exist, so the structured pipeline-level block is absent and
+    the tool used to degrade to an empty message-inference view while the
+    executor logs showed the real tracker state. The status endpoint now
+    ships the per-slice snapshots under ``concurrent.slice_consensus``;
+    the tool serves them instead of the empty inference.
+    """
+
+    @staticmethod
+    def _pipeline_resp():
+        return {
+            "data": {
+                "pipeline": {
+                    "id": "issue-42",
+                    "current_phase": "implement",
+                    "status": "running",
+                }
+            }
+        }
+
+    @staticmethod
+    def _slice_block(blocking, confirmed_role=None):
+        agents = {role: {"producer_phase": "PROPOSED", "confirmed": False} for role in blocking}
+        if confirmed_role:
+            agents[confirmed_role] = {"producer_phase": "CONFIRMED", "confirmed": True}
+        return {
+            "is_complete": False,
+            "blocking_agents": blocking,
+            "has_unresolved_nacks": True,
+            "unresolved_nacks": [
+                {"reviewer": "reviewer_code", "producer": "coder", "reason": "bug", "version": 3}
+            ],
+            "agents": agents,
+            "protocol": "brc",
+        }
+
+    def test_single_active_slice_resolves_directly(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.side_effect = [
+                self._pipeline_resp(),
+                {
+                    "data": {
+                        "concurrent": {
+                            "enabled": True,
+                            "slice_consensus": {
+                                "slice-3": self._slice_block(
+                                    ["coder", "tester"], confirmed_role="architect"
+                                )
+                            },
+                        }
+                    }
+                },
+            ]
+            result = handler.handle_tool_call("get_consensus_status", {"task_id": "issue-42"})
+
+        # No message-inference round-trip happened.
+        assert mock_req.call_count == 2
+        assert result["resolved_slice_id"] == "slice-3"
+        consensus = result["consensus"]
+        assert consensus["blocking_agents"] == ["coder", "tester"]
+        assert consensus["confirmed_agents"] == ["architect"]
+        assert consensus["has_unresolved_nacks"] is True
+        assert consensus["unresolved_nacks"][0]["reviewer"] == "reviewer_code"
+        assert "slice-3" in consensus["note"]
+
+    def test_multiple_active_slices_returned_per_slice(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.side_effect = [
+                self._pipeline_resp(),
+                {
+                    "data": {
+                        "concurrent": {
+                            "enabled": True,
+                            "slice_consensus": {
+                                "slice-3": self._slice_block(["coder"]),
+                                "slice-1": self._slice_block(["tester"]),
+                            },
+                        }
+                    }
+                },
+            ]
+            result = handler.handle_tool_call("get_consensus_status", {"task_id": "issue-42"})
+
+        assert mock_req.call_count == 2
+        assert result["active_slice_ids"] == ["slice-1", "slice-3"]
+        # Never merged into one block (#2761); keyed per slice instead.
+        assert "consensus" not in result
+        assert result["slice_consensus"]["slice-3"]["blocking_agents"] == ["coder"]
+        assert result["slice_consensus"]["slice-1"]["blocking_agents"] == ["tester"]
+        assert "slice_id" in result and result["slice_id"] is None
+
+    def test_explicit_slice_id_skips_slice_consensus_map(self, handler):
+        """A slice-scoped call never reads the slice_consensus map.
+
+        The status endpoint doesn't emit it for slice-scoped queries;
+        even if a stale proxy did, the tool must not second-guess the
+        explicit scope. With no structured block it falls back to
+        (slice-filtered) message inference.
+        """
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.side_effect = [
+                self._pipeline_resp(),
+                {
+                    "data": {
+                        "concurrent": {
+                            "enabled": True,
+                            "slice_consensus": {"slice-3": self._slice_block(["coder"])},
+                        }
+                    }
+                },
+                {"data": {"messages": []}},
+            ]
+            result = handler.handle_tool_call(
+                "get_consensus_status", {"task_id": "issue-42", "slice_id": "slice-7"}
+            )
+
+        assert "resolved_slice_id" not in result
+        assert "slice_consensus" not in result
+        assert "note" in result["consensus"]  # inference fallback
+
+    def test_structured_consensus_exposes_confirmed_agents(self, handler):
+        """The structured path derives confirmed_agents for shape parity
+        with the message-inference fallback (#3481)."""
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.side_effect = [
+                self._pipeline_resp(),
+                {
+                    "data": {
+                        "concurrent": {
+                            "consensus": {
+                                "is_complete": False,
+                                "blocking_agents": ["coder"],
+                                "has_unresolved_nacks": False,
+                                "unresolved_nacks": [],
+                                "agents": {
+                                    "coder": {"producer_phase": "PROPOSED", "confirmed": False},
+                                    "tester": {"producer_phase": "CONFIRMED", "confirmed": True},
+                                },
+                            }
+                        }
+                    }
+                },
+            ]
+            result = handler.handle_tool_call("get_consensus_status", {"task_id": "issue-42"})
+
+        assert result["consensus"]["confirmed_agents"] == ["tester"]
+
+
 class TestGetConsensusStatusSliceScope:
     """get_consensus_status scopes to a slice's BRC consensus (#2761).
 

--- a/orchestrator/tests/test_messages.py
+++ b/orchestrator/tests/test_messages.py
@@ -812,6 +812,90 @@ class TestSinceIdRecovery:
                 assert data["data"]["messages"][0]["subject"] == "second"
 
 
+class TestSinceTimestampParam:
+    """GET /messages honors ``since`` (#3481).
+
+    Previously the param was accepted and silently ignored; the
+    response window was driven only by ``limit`` and internal ordering,
+    so operators got messages starting hours before the cutoff.
+    """
+
+    @staticmethod
+    def _msg(subject: str) -> Message:
+        return Message(
+            pipeline_id="test-pipeline",
+            from_role="coder",
+            to_role="all",
+            message_type=MessageType.PROGRESS,
+            subject=subject,
+        )
+
+    def test_since_filters_older_messages(self, client, app):
+        import time
+        from datetime import UTC, datetime
+
+        store = _make_store()
+        store.add_message(self._msg("old"))
+        time.sleep(0.015)
+        cutoff = datetime.now(UTC)
+        time.sleep(0.015)
+        store.add_message(self._msg("new"))
+
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (MagicMock(), _make_pipeline_mock())
+
+                since = cutoff.isoformat().replace("+00:00", "Z")
+                resp = client.get(f"/api/v1/pipelines/test-pipeline/messages?since={since}")
+                data = json.loads(resp.data)
+
+        assert resp.status_code == 200
+        assert data["data"]["count"] == 1
+        assert data["data"]["messages"][0]["subject"] == "new"
+
+    def test_invalid_since_returns_400(self, client, app):
+        store = _make_store()
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (MagicMock(), _make_pipeline_mock())
+
+                resp = client.get("/api/v1/pipelines/test-pipeline/messages?since=3-hours-ago")
+                data = json.loads(resp.data)
+
+        assert resp.status_code == 400
+        assert "since" in data["message"]
+
+    def test_since_with_since_id_returns_400(self, client, app):
+        store = _make_store()
+        with app.test_request_context():
+            with (
+                patch("routes.messages.get_message_store", return_value=store),
+                patch(
+                    "routes.messages.get_state_store_for_pipeline"
+                ) as mock_get_store_for_pipeline,
+            ):
+                mock_get_store_for_pipeline.return_value = (MagicMock(), _make_pipeline_mock())
+
+                resp = client.get(
+                    "/api/v1/pipelines/test-pipeline/messages"
+                    "?since=2026-07-03T18:00:00Z&since_id=abc123"
+                )
+                data = json.loads(resp.data)
+
+        assert resp.status_code == 400
+        assert "not both" in data["message"]
+
+
 class TestSinceIdStaleSignal:
     """Issue #2464 — ``/messages`` and ``/messages/wait`` advertise a
     structured ``since_id_stale: true`` flag when the cursor was unknown,

--- a/orchestrator/tests/test_peer_consensus_integration.py
+++ b/orchestrator/tests/test_peer_consensus_integration.py
@@ -3898,3 +3898,49 @@ class TestConsensusStateFingerprint:
             {"reason": "z" * 60, "artifact_references": ["a.py"]},
         )
         assert tracker.consensus_state_fingerprint() != before
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_slice_trackers (#3481)
+# ---------------------------------------------------------------------------
+
+
+class TestGetSliceTrackers:
+    """Registry enumeration of a pipeline's live slice-scoped trackers."""
+
+    def test_returns_slice_trackers_keyed_by_slice_id(self, simple_graph):
+        from peer_consensus import (
+            create_peer_consensus_tracker,
+            get_slice_trackers,
+            remove_peer_consensus_tracker,
+        )
+
+        try:
+            t1 = create_peer_consensus_tracker("issue-42", simple_graph, slice_id="slice-1")
+            t3 = create_peer_consensus_tracker("issue-42", simple_graph, slice_id="slice-3")
+            # Pipeline-level tracker and a sibling pipeline's slice must
+            # not leak into the result.
+            create_peer_consensus_tracker("issue-42", simple_graph)
+            create_peer_consensus_tracker("issue-99", simple_graph, slice_id="slice-1")
+
+            result = get_slice_trackers("issue-42")
+
+            assert result == {"slice-1": t1, "slice-3": t3}
+        finally:
+            remove_peer_consensus_tracker("issue-42", slice_id="slice-1")
+            remove_peer_consensus_tracker("issue-42", slice_id="slice-3")
+            remove_peer_consensus_tracker("issue-42")
+            remove_peer_consensus_tracker("issue-99", slice_id="slice-1")
+
+    def test_empty_when_no_slice_trackers(self, simple_graph):
+        from peer_consensus import (
+            create_peer_consensus_tracker,
+            get_slice_trackers,
+            remove_peer_consensus_tracker,
+        )
+
+        try:
+            create_peer_consensus_tracker("issue-43", simple_graph)
+            assert get_slice_trackers("issue-43") == {}
+        finally:
+            remove_peer_consensus_tracker("issue-43")

--- a/orchestrator/tests/test_redis_message_store.py
+++ b/orchestrator/tests/test_redis_message_store.py
@@ -362,6 +362,34 @@ class TestSinceTimestampSeek:
         messages = store.get_messages("test-pipeline", since_id=first.id, since=cutoff)
         assert [m.subject for m in messages] == ["second"]
 
+    def test_since_is_inclusive_at_cutoff_ms_on_long_poll_path(self, store):
+        """The long-poll (``wait > 0``) path is inclusive of the cutoff ms.
+
+        Regression guard for the #3485 review note: the blocking read uses
+        XREAD, which is *exclusive* of its start id, so anchoring the seek
+        on ``<cutoff_ms>-0`` skipped an entry sitting at exactly that id —
+        contradicting the "inclusive of the cutoff millisecond" contract
+        that the non-blocking XRANGE path already honoured. The fix seeks
+        to the exclusive predecessor of ``<cutoff_ms>-0`` so both paths
+        agree on the boundary. A single message in its millisecond lands at
+        sequence 0, so this exercises exactly the skipped-entry case.
+        """
+        msg = self._msg("boundary")
+        store.add_message(msg)
+
+        # Recover the entry's assigned stream id and rebuild a cutoff that
+        # maps to exactly its millisecond, so the seek lands on the boundary.
+        stream_id = store._resolve_stream_id("test-pipeline", msg.id)
+        assert stream_id is not None
+        ms_part, seq_part = stream_id.split("-")
+        assert seq_part == "0"  # single message in its ms → sequence 0
+        cutoff = datetime.fromtimestamp(int(ms_part) / 1000, UTC)
+
+        # wait > 0 drives the XREAD (long-poll) path; the pre-existing entry
+        # makes the blocking read return immediately.
+        messages = store.get_messages("test-pipeline", since=cutoff, wait=1)
+        assert [m.subject for m in messages] == ["boundary"]
+
 
 class TestGetStatus:
     """Test message status/statistics."""

--- a/orchestrator/tests/test_redis_message_store.py
+++ b/orchestrator/tests/test_redis_message_store.py
@@ -7,6 +7,7 @@ a real Redis backend without requiring a running Redis server.
 import sys
 import threading
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 
 import fakeredis
@@ -290,6 +291,76 @@ class TestGetMessages:
         msgs_b = store.get_messages("pipeline-b")
         assert len(msgs_a) == 3
         assert len(msgs_b) == 5
+
+
+class TestSinceTimestampSeek:
+    """``since`` timestamp cutoff (#3481).
+
+    Stream auto-IDs are ``<unix-ms>-<seq>``, so the cutoff seeks the
+    read past older history instead of scanning from ``0-0``; the bug
+    was that ``limit`` alone drove the window, returning messages hours
+    before the requested cutoff. Sleeps around the cutoff keep the
+    millisecond-resolution boundary deterministic.
+    """
+
+    @staticmethod
+    def _msg(subject: str) -> Message:
+        return Message(
+            pipeline_id="test-pipeline",
+            from_role="coder",
+            to_role="all",
+            message_type=MessageType.PROGRESS,
+            subject=subject,
+        )
+
+    def test_since_excludes_older_messages(self, store):
+        store.add_message(self._msg("old"))
+        time.sleep(0.015)
+        cutoff = datetime.now(UTC)
+        time.sleep(0.015)
+        store.add_message(self._msg("new"))
+
+        messages, meta = store.get_messages_with_meta("test-pipeline", since=cutoff)
+        assert [m.subject for m in messages] == ["new"]
+        assert meta.since_id_stale is False
+
+    def test_since_before_all_messages_returns_everything(self, store):
+        cutoff = datetime.now(UTC)
+        time.sleep(0.015)
+        store.add_message(self._msg("a"))
+        store.add_message(self._msg("b"))
+
+        messages = store.get_messages("test-pipeline", since=cutoff)
+        assert [m.subject for m in messages] == ["a", "b"]
+
+    def test_since_after_all_messages_returns_empty(self, store):
+        store.add_message(self._msg("old"))
+        time.sleep(0.015)
+        cutoff = datetime.now(UTC)
+
+        messages = store.get_messages("test-pipeline", since=cutoff)
+        assert messages == []
+
+    def test_naive_since_treated_as_utc(self, store):
+        store.add_message(self._msg("old"))
+        time.sleep(0.015)
+        cutoff = datetime.now(UTC).replace(tzinfo=None)
+        time.sleep(0.015)
+        store.add_message(self._msg("new"))
+
+        messages = store.get_messages("test-pipeline", since=cutoff)
+        assert [m.subject for m in messages] == ["new"]
+
+    def test_since_id_takes_precedence_over_since(self, store):
+        cutoff = datetime.now(UTC)
+        time.sleep(0.015)
+        first = self._msg("first")
+        store.add_message(first)
+        store.add_message(self._msg("second"))
+
+        # since alone would return both; the explicit cursor wins.
+        messages = store.get_messages("test-pipeline", since_id=first.id, since=cutoff)
+        assert [m.subject for m in messages] == ["second"]
 
 
 class TestGetStatus:


### PR DESCRIPTION
## Summary

Fixes both operator-observability gaps from #3481, observed while debugging a wedged BRC slice.

## Gap 1: `GET /api/v1/pipelines/<id>/messages` ignored `since`

The route only read `since_id`; a `?since=<ISO timestamp>` was accepted and silently dropped, and the store read oldest-first from `0-0`, so `limit` alone drove the window (hours before the requested cutoff).

- **`orchestrator/redis_message_store.py`**: new `since: datetime | None` on `get_messages_with_meta` / `get_messages`. Redis Stream auto-IDs are `<unix-ms>-<seq>`, so the cutoff maps directly to a start stream ID and the read seeks past older history (millisecond resolution, inclusive of the cutoff millisecond). Naive datetimes are treated as UTC, matching `Message.timestamp`. `since_id` takes precedence at the store layer.
- **`orchestrator/routes/messages.py`**: `poll_messages` parses `since` as ISO 8601 (Z accepted). Malformed values 400 instead of being ignored; `since` + `since_id` together 400 (no legitimate use case, and silent precedence is how this class of bug happens).

## Gap 2: `get_consensus_status` had no structured data for slice-scoped trackers

Three distinct defects stacked here:

1. **The status payload dropped the NACK fields.** `PeerConsensusTracker.evaluate()` computes `has_unresolved_nacks` / `unresolved_nacks` (who NACKed whom, on which version, and why), but `_get_concurrent_status` discarded them when building `concurrent.consensus`; even a correctly slice-scoped query reported `has_unresolved_nacks: false` while the executor logged the real blocked state. The block (extracted as `_consensus_block`) now carries them.
2. **A slice-id-less query could not see slice trackers at all.** Trackers are keyed `{pipeline_id}/{slice_id}`; the bare-pipeline lookup finds nothing, so the tool degraded to an empty message inference. New `peer_consensus.get_slice_trackers(pipeline_id)` enumerates the registry, and `_get_concurrent_status` surfaces each live slice's snapshot under `concurrent.slice_consensus`, keyed by slice. This does not reintroduce the #2761 cross-slice "soup": that concern was mingling every slice's messages into one inferred tracker; here blocks are explicitly keyed and never merged, and the pipeline-level `consensus` block still never reflects a slice tracker. Per-slice snapshot failures are logged and skipped.
3. **The MCP tool now resolves that map.** With no explicit `slice_id`: a single active slice is served directly (`resolved_slice_id` names the scope), multiple active slices are returned per-slice under `slice_consensus` with `active_slice_ids`, and only when neither structured source exists does it fall back to message inference. The structured path also derives `confirmed_agents` for shape parity with the inference fallback.

## Testing

- 5 new store tests (`since` seek semantics, naive-UTC handling, `since_id` precedence), 3 new route tests (filtering, 400 on invalid, 400 on both params).
- 6 new `_get_concurrent_status` tests (NACK passthrough, slice_consensus surfacing, slice-scoped omission, per-slice failure isolation) + 2 registry tests for `get_slice_trackers`.
- 4 new MCP tool tests (single-slice resolution with no inference round-trip, multi-slice map, explicit-slice_id skip, confirmed_agents parity).
- Full suite via `make test`: 20720 passed; the only 2 failures are `tests/scripts/test_reap_stale_egg_images.py` (pre-existing local-environment exit-127, untouched by this diff).
- `ruff check` / `ruff format --check` clean on all touched files.

Closes #3481
