### PR TITLE
Derive wait for a producer whose in-slice upstream has not proposed

### DIFF
--- a/docs/architecture/orchestrator.md
+++ b/docs/architecture/orchestrator.md
@@ -822,6 +822,21 @@ re-derives `next-action` once before invoking the agent so a pod spawned
 against an event that another actor has already superseded falls through to
 a no-op rather than acting on stale state.
 
+**First-propose gate ([#3478](https://github.com/jwbron/egg/issues/3478)):**
+a dual-role producer (the tester: producer of tests, reviewer of the coder)
+builds on the artifacts of the producers it reviews. While every one of
+those upstream producers is still pre-first-propose (WORKING at proposal
+version 0), the derivation returns `wait` instead of `propose`; spawning at
+that state could only orient-and-exit, burning the #3425 no-op streak and
+parking the arm. The gate lifts on the upstream's first proposal (the next
+poll tick derives `propose`; the #2749 R11a propose-own-work-first ordering
+is unchanged from that point). Wake-only edges are exempt (the de-roled
+simplifier is deliberately woken by its own propose arm), and the gate only
+engages when at least one upstream producer is terminal (reviews no
+producers itself), so cyclic custom graphs cannot mutually `wait` into a
+deadlock. See `_pre_propose_upstream_producers` in
+`orchestrator/routes/consensus.py`.
+
 ### Wake conditions (pre-confirm vs post-confirm)
 
 The orchestrator derives a role's wake conditions conditionally from

--- a/docs/architecture/orchestrator.md
+++ b/docs/architecture/orchestrator.md
@@ -823,10 +823,13 @@ against an event that another actor has already superseded falls through to
 a no-op rather than acting on stale state.
 
 **First-propose gate ([#3478](https://github.com/jwbron/egg/issues/3478)):**
-a dual-role producer (the tester: producer of tests, reviewer of the coder)
-builds on the artifacts of the producers it reviews. While every one of
-those upstream producers is still pre-first-propose (WORKING at proposal
-version 0), the derivation returns `wait` instead of `propose`; spawning at
+a dual-role producer builds on the artifacts of the producers it reviews.
+This is phase-agnostic — in the default implement graph it is the `tester`
+(producer of tests, reviewer of the `coder`); in the default plan graph it
+is the `risk_analyst` (producer of the risk register, reviewer of
+`architect` + `task_planner`). While every one of those upstream producers
+is still pre-first-propose (WORKING at proposal version 0), the derivation
+returns `wait` instead of `propose`; spawning at
 that state could only orient-and-exit, burning the #3425 no-op streak and
 parking the arm. The gate lifts on the upstream's first proposal (the next
 poll tick derives `propose`; the #2749 R11a propose-own-work-first ordering

--- a/orchestrator/routes/consensus.py
+++ b/orchestrator/routes/consensus.py
@@ -323,9 +323,14 @@ def _producer_has_unresolved_nacks_on_current_version(
 def _pre_propose_upstream_producers(tracker: PeerConsensusTracker, role: str) -> list[str]:
     """Upstream producers that gate ``role``'s first ``propose`` (#3478).
 
-    A dual-role producer (the tester: producer of test files, reviewer
-    of the coder's source) builds on the artifacts of the producers it
-    reviews. Deriving ``propose`` for it while every one of those
+    A dual-role producer builds on the artifacts of the producers it
+    reviews. This is phase-agnostic: in the default implement graph it
+    is the ``tester`` (producer of test files, reviewer of the coder's
+    source, gated on ``coder``); in the default plan graph it is the
+    ``risk_analyst`` (producer of the risk register, reviewer of
+    ``architect`` + ``task_planner``, gated on both). Any future graph
+    with the same shape gates the same way. Deriving ``propose`` for
+    such a role while every one of those
     upstream producers is still pre-first-propose spawns an agent that
     can only orient-and-exit (nothing to build against, nothing to
     review); three such no-ops burn the #3425 streak and park the arm,
@@ -365,11 +370,17 @@ def _pre_propose_upstream_producers(tracker: PeerConsensusTracker, role: str) ->
     """
     graph = tracker.graph
     wake_only = graph.wake_only_producers_for(role)
-    upstream = [
-        producer
-        for producer in graph.producers_for(role)
-        if producer != role and producer not in wake_only
-    ]
+    # dict.fromkeys dedupes while preserving first-seen order:
+    # graph.producers_for(role) yields one element per edge, so a graph
+    # with parallel role->X edges would otherwise repeat X in both the
+    # gate check and the waiting_on_producers payload.
+    upstream = list(
+        dict.fromkeys(
+            producer
+            for producer in graph.producers_for(role)
+            if producer != role and producer not in wake_only
+        )
+    )
     if not upstream:
         return []
 
@@ -413,8 +424,11 @@ def _derive_next_action(
     First-propose gate (#3478): a dual-role producer in WORKING whose
     reviewed peer producers are ALL still pre-first-propose derives
     ``wait`` instead of ``propose`` (see
-    ``_pre_propose_upstream_producers``). R11a is untouched: the moment
-    any upstream producer has proposed, propose-own-work-first applies.
+    ``_pre_propose_upstream_producers``). This is phase-agnostic — it
+    fires for the implement-phase ``tester`` (gated on ``coder``) and
+    the plan-phase ``risk_analyst`` (gated on ``architect`` +
+    ``task_planner``) alike. R11a is untouched: the moment any upstream
+    producer has proposed, propose-own-work-first applies.
     """
     with tracker._lock:
         # ---- 1. role-complete short-circuit ----
@@ -467,7 +481,8 @@ def _derive_next_action(
                 else:
                     # #3478: defer the FIRST propose of a dual-role
                     # producer while every producer it reviews is still
-                    # pre-first-propose (the tester racing its coder).
+                    # pre-first-propose (the tester racing its coder, or
+                    # the risk_analyst racing architect + task_planner).
                     # Spawning at that state can only no-op; the arm
                     # burns its #3425 streak and parks. With unresolved
                     # NACKs the producer has actionable feedback of its

--- a/orchestrator/routes/consensus.py
+++ b/orchestrator/routes/consensus.py
@@ -320,6 +320,80 @@ def _producer_has_unresolved_nacks_on_current_version(
     return out
 
 
+def _pre_propose_upstream_producers(tracker: PeerConsensusTracker, role: str) -> list[str]:
+    """Upstream producers that gate ``role``'s first ``propose`` (#3478).
+
+    A dual-role producer (the tester: producer of test files, reviewer
+    of the coder's source) builds on the artifacts of the producers it
+    reviews. Deriving ``propose`` for it while every one of those
+    upstream producers is still pre-first-propose spawns an agent that
+    can only orient-and-exit (nothing to build against, nothing to
+    review); three such no-ops burn the #3425 streak and park the arm,
+    which the #3465 BRC-movement release then has to claw back.
+
+    Returns the role's upstream producer set (the derivation defers the
+    first propose with ``wait``) when ALL of the following hold, else an
+    empty list (derive ``propose`` exactly as before):
+
+    * ``role`` reviews at least one peer producer, excluding itself and
+      wake-only edges; the same exemptions as
+      ``_has_pending_peer_proposals``. The wake-only exclusion is
+      load-bearing: the de-roled simplifier (#3381) is deliberately
+      woken by its own propose-arm re-spawning until the upstream draft
+      exists, so its wake-only edge must never convert to a ``wait``.
+    * at least one upstream producer is *terminal* (it reviews no peer
+      producers of its own, so it can never derive this wait itself).
+      This keeps the waits-on relation acyclic by construction: a gated
+      role always has an ungated producer to wait on, so a custom
+      review graph with mutual producer edges cannot mutually ``wait``
+      into a deadlock. In the default implement graph the coder is
+      terminal.
+    * every upstream producer is pre-first-propose: WORKING phase at
+      proposal version 0. Any proposal at all (a current one, a
+      withdrawn one, a no-changes one) means there is something to
+      build against or review, and the #2749 R11a propose-first
+      ordering applies unchanged.
+
+    Liveness: the gate can only hold while an ungated terminal producer
+    is pre-propose. Its first propose flips the condition on the next
+    poll tick; a crashed producer resolves via supervision/HITL, and an
+    excused producer is removed from the graph edges entirely, which
+    dissolves the gate.
+
+    Caller must hold ``tracker._lock`` (same contract as the sibling
+    helpers above).
+    """
+    graph = tracker.graph
+    wake_only = graph.wake_only_producers_for(role)
+    upstream = [
+        producer
+        for producer in graph.producers_for(role)
+        if producer != role and producer not in wake_only
+    ]
+    if not upstream:
+        return []
+
+    def _reviews_peer_producers(producer: str) -> bool:
+        producer_wake_only = graph.wake_only_producers_for(producer)
+        return any(
+            peer != producer and peer not in producer_wake_only
+            for peer in graph.producers_for(producer)
+        )
+
+    if all(_reviews_peer_producers(producer) for producer in upstream):
+        # No terminal upstream producer: waiting could form a cycle, so
+        # keep the pre-#3478 behavior and propose immediately.
+        return []
+
+    for producer in upstream:
+        producer_phase = tracker._producer_phases.get(producer, ConsensusPhase.WORKING)
+        if producer_phase != ConsensusPhase.WORKING:
+            return []
+        if tracker.matrix.get_proposal_version(producer) > 0:
+            return []
+    return upstream
+
+
 def _derive_next_action(
     tracker: PeerConsensusTracker, role: str
 ) -> tuple[str, dict[str, Any] | None, str]:
@@ -335,6 +409,12 @@ def _derive_next_action(
         the role's own ``propose`` takes priority, NOT peer review.
       * sub-case b: dual-role post-own-propose with peer reviews
         pending → review the peer (``ack``).
+
+    First-propose gate (#3478): a dual-role producer in WORKING whose
+    reviewed peer producers are ALL still pre-first-propose derives
+    ``wait`` instead of ``propose`` (see
+    ``_pre_propose_upstream_producers``). R11a is untouched: the moment
+    any upstream producer has proposed, propose-own-work-first applies.
     """
     with tracker._lock:
         # ---- 1. role-complete short-circuit ----
@@ -384,6 +464,22 @@ def _derive_next_action(
                 payload: dict[str, Any] = {"producer": role}
                 if nacks:
                     payload["unresolved_nacks"] = nacks
+                else:
+                    # #3478: defer the FIRST propose of a dual-role
+                    # producer while every producer it reviews is still
+                    # pre-first-propose (the tester racing its coder).
+                    # Spawning at that state can only no-op; the arm
+                    # burns its #3425 streak and parks. With unresolved
+                    # NACKs the producer has actionable feedback of its
+                    # own, so the gate never applies.
+                    waiting_on = _pre_propose_upstream_producers(tracker, role)
+                    if waiting_on:
+                        return (
+                            "wait",
+                            {"waiting_on_producers": waiting_on},
+                            "upstream producers have not yet proposed; "
+                            "deferring first propose until their artifacts exist",
+                        )
                 return "propose", payload, "produce and propose"
 
             if producer_phase == ConsensusPhase.PROPOSED:

--- a/orchestrator/tests/test_consensus_next_action.py
+++ b/orchestrator/tests/test_consensus_next_action.py
@@ -1006,3 +1006,35 @@ def test_next_action_multi_upstream_gate_lifts_on_any_upstream_propose(client):
     _propose(tracker, "documenter")
     resp = _post_next_action(client, "tester", tracker=tracker)
     _assert_action(resp, "propose")
+
+
+def test_next_action_plan_phase_risk_analyst_gated_on_architect_and_planner(client):
+    """The gate is phase-agnostic: on the DEFAULT plan graph the dual-role
+    ``risk_analyst`` (producer of the risk register, reviewer of
+    ``architect`` + ``task_planner``, both terminal CRITICAL producers)
+    derives ``wait`` at a fresh slice, naming both upstream producers, and
+    lifts on the first upstream proposal — mirroring the implement-phase
+    ``tester``. This pins production behavior against the real graph so a
+    regression in ``risk_analyst``'s startup ordering is caught."""
+    from review_graph import get_default_plan_graph
+
+    graph = get_default_plan_graph()
+    tracker = PeerConsensusTracker(PIPELINE_ID, graph, cooldown_seconds=0)
+    for role in ("architect", "task_planner", "risk_analyst", "reviewer_plan", "simplifier"):
+        tracker.register_agent(role)
+
+    resp = _post_next_action(client, "risk_analyst", tracker=tracker)
+    payload = _assert_action(resp, "wait")
+    waiting_on = (payload.get("event_payload") or {}).get("waiting_on_producers") or []
+    assert sorted(waiting_on) == ["architect", "task_planner"], payload
+
+    # The terminal producers are unaffected — they derive propose.
+    for role in ("architect", "task_planner"):
+        resp = _post_next_action(client, role, tracker=tracker)
+        _assert_action(resp, "propose")
+
+    # First upstream proposal lifts the gate; risk_analyst proposes its own
+    # work before reviewing (R11a preserved).
+    _propose(tracker, "architect")
+    resp = _post_next_action(client, "risk_analyst", tracker=tracker)
+    _assert_action(resp, "propose")

--- a/orchestrator/tests/test_consensus_next_action.py
+++ b/orchestrator/tests/test_consensus_next_action.py
@@ -881,3 +881,128 @@ def test_next_action_pending_reviews_last_reviewed_sha_empty_on_first_review(
     pending = (payload.get("event_payload") or {}).get("pending_reviews") or []
     assert len(pending) >= 1
     assert pending[0].get("last_reviewed_commit_sha") == ""
+
+
+# ---------------------------------------------------------------------------
+# #3478: first-propose gate: a dual-role producer whose reviewed peer
+# producers are ALL still pre-first-propose derives ``wait``, not
+# ``propose``. Spawning it at that state can only orient-and-exit, which
+# burns the #3425 no-op streak and parks the arm. The gate lifts on the
+# upstream's first proposal (any proposal: current, withdrawn, no-changes),
+# so the #2749 R11a propose-first ordering is untouched.
+# ---------------------------------------------------------------------------
+
+
+def test_next_action_dual_role_all_upstream_pre_propose_returns_wait(client, dual_tracker):
+    """Fresh slice: coder and tester both WORKING at v0. The tester
+    (producer of tests, reviewer of coder) has nothing to build against
+    and nothing to review; it must wait, naming the producers it is
+    waiting on."""
+    resp = _post_next_action(client, "tester", tracker=dual_tracker)
+    payload = _assert_action(resp, "wait")
+    event_payload = payload.get("event_payload") or {}
+    assert event_payload.get("waiting_on_producers") == ["coder"], (
+        f"wait payload must name the pre-propose upstream producers; got {payload!r}"
+    )
+    assert "upstream" in (payload.get("reason") or ""), payload
+
+
+def test_next_action_pure_producer_unaffected_by_first_propose_gate(client, dual_tracker):
+    """The coder reviews no one, so the gate never applies to it: it
+    derives ``propose`` at the same fresh-slice state that gates the
+    tester."""
+    resp = _post_next_action(client, "coder", tracker=dual_tracker)
+    _assert_action(resp, "propose")
+
+
+def test_next_action_first_propose_gate_lifts_on_upstream_propose(client, dual_tracker):
+    """The gate releases on the coder's FIRST proposal: the tester flips
+    from ``wait`` to ``propose`` (R11a: propose own work before reviewing)
+    on the next derivation."""
+    resp = _post_next_action(client, "tester", tracker=dual_tracker)
+    _assert_action(resp, "wait")
+    _propose(dual_tracker, "coder")
+    resp = _post_next_action(client, "tester", tracker=dual_tracker)
+    _assert_action(resp, "propose")
+
+
+def test_next_action_first_propose_gate_off_after_upstream_withdraw(client, dual_tracker):
+    """A withdrawn upstream proposal still means artifacts existed
+    (version > 0): the tester is NOT re-gated when the coder withdraws
+    back to WORKING."""
+    _propose(dual_tracker, "coder")
+    dual_tracker.handle_withdraw(
+        "coder",
+        "New information: the approach conflicts with the slice contract "
+        "and the proposal must be rethought before review.",
+    )
+    resp = _post_next_action(client, "tester", tracker=dual_tracker)
+    _assert_action(resp, "propose")
+
+
+def test_next_action_mutual_producer_review_does_not_wait(client):
+    """Deadlock guard: with mutual producer edges (coder and tester
+    review each other) neither upstream is terminal, so neither role
+    gates; both derive ``propose`` exactly as before #3478."""
+    graph = ReviewGraph(
+        [
+            ReviewEdge("tester", "coder", ReviewCriticality.CRITICAL),
+            ReviewEdge("coder", "tester", ReviewCriticality.CRITICAL),
+            ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL),
+            ReviewEdge("reviewer_code", "tester", ReviewCriticality.CRITICAL),
+        ]
+    )
+    tracker = PeerConsensusTracker(PIPELINE_ID, graph, cooldown_seconds=0)
+    for role in ("coder", "tester", "reviewer_code"):
+        tracker.register_agent(role)
+
+    for role in ("coder", "tester"):
+        resp = _post_next_action(client, role, tracker=tracker)
+        _assert_action(resp, "propose")
+
+
+def test_next_action_wake_only_upstream_never_gates(client):
+    """The de-roled simplifier (#3381) is woken by its own propose-arm
+    re-spawning until the upstream draft exists, so its wake-only edge
+    must never convert to a ``wait``."""
+    graph = ReviewGraph(
+        [
+            ReviewEdge("simplifier", "refiner", ReviewCriticality.ADVISORY, wake_only=True),
+            ReviewEdge("reviewer_plan", "refiner", ReviewCriticality.CRITICAL),
+            ReviewEdge("reviewer_plan", "simplifier", ReviewCriticality.CRITICAL),
+        ]
+    )
+    tracker = PeerConsensusTracker(PIPELINE_ID, graph, cooldown_seconds=0)
+    for role in ("refiner", "simplifier", "reviewer_plan"):
+        tracker.register_agent(role)
+
+    # refiner is WORKING at v0, but the simplifier's only edge to it is
+    # wake-only: the simplifier must keep deriving propose (it self-gates
+    # in-pod on the draft existing).
+    resp = _post_next_action(client, "simplifier", tracker=tracker)
+    _assert_action(resp, "propose")
+
+
+def test_next_action_multi_upstream_gate_lifts_on_any_upstream_propose(client):
+    """With several terminal upstream producers the gate holds only while
+    ALL are pre-propose; the first proposal from any of them releases it
+    (minimal deferral: there is now something to build against)."""
+    graph = ReviewGraph(
+        [
+            ReviewEdge("tester", "coder", ReviewCriticality.CRITICAL),
+            ReviewEdge("tester", "documenter", ReviewCriticality.CRITICAL),
+            ReviewEdge("reviewer_code", "tester", ReviewCriticality.CRITICAL),
+        ]
+    )
+    tracker = PeerConsensusTracker(PIPELINE_ID, graph, cooldown_seconds=0)
+    for role in ("coder", "documenter", "tester", "reviewer_code"):
+        tracker.register_agent(role)
+
+    resp = _post_next_action(client, "tester", tracker=tracker)
+    payload = _assert_action(resp, "wait")
+    waiting_on = (payload.get("event_payload") or {}).get("waiting_on_producers") or []
+    assert sorted(waiting_on) == ["coder", "documenter"], payload
+
+    _propose(tracker, "documenter")
+    resp = _post_next_action(client, "tester", tracker=tracker)
+    _assert_action(resp, "propose")

--- a/orchestrator/tests/test_event_loop.py
+++ b/orchestrator/tests/test_event_loop.py
@@ -2315,3 +2315,89 @@ class TestNoopParkThroughLoop:
         for _ in range(5):
             loop.poll_once(["coder"])
         assert len(spawner.calls) == burned + 1
+
+
+# ---------------------------------------------------------------------------
+# #3478 first-propose gate through the loop: REAL tracker, REAL derivation
+# ---------------------------------------------------------------------------
+
+
+class TestFirstProposeGateThroughLoop:
+    """The #3478 incident shape end-to-end through ``poll_once``.
+
+    Unlike the scripted tests above, this uses a real
+    ``PeerConsensusTracker`` and the real ``routes.consensus`` derivation:
+    the tester's propose arm must dispatch NO spawn while the coder is
+    pre-first-propose (pre-#3478 this burned three no-op spawns and parked
+    the arm), then dispatch exactly one propose spawn on the poll tick
+    after the coder's proposal lands.
+    """
+
+    def _real_tracker(self):
+        from unittest.mock import MagicMock
+
+        # Mock docker before the lazy ``routes.consensus`` import the real
+        # derivation performs (mirrors test_consensus_next_action.py).
+        sys.modules.setdefault("docker", MagicMock())
+        sys.modules.setdefault("docker.errors", MagicMock())
+        sys.modules.setdefault("docker.types", MagicMock())
+        _shared = Path(__file__).parent.parent.parent / "shared"
+        if _shared.exists() and str(_shared) not in sys.path:
+            sys.path.insert(0, str(_shared))
+
+        from peer_consensus import PeerConsensusTracker
+        from review_graph import ReviewCriticality, ReviewEdge, ReviewGraph
+
+        graph = ReviewGraph(
+            [
+                ReviewEdge("tester", "coder", ReviewCriticality.CRITICAL),
+                ReviewEdge("reviewer_code", "coder", ReviewCriticality.CRITICAL),
+                ReviewEdge("reviewer_code", "tester", ReviewCriticality.CRITICAL),
+            ]
+        )
+        tracker = PeerConsensusTracker("issue-3478", graph, cooldown_seconds=0)
+        for role in ("coder", "tester", "reviewer_code"):
+            tracker.register_agent(role)
+        return tracker
+
+    def test_tester_arm_spawns_nothing_until_coder_proposes(self):
+        import event_loop
+
+        tracker = self._real_tracker()
+        spawner = _RecordingSpawner()
+        loop = event_loop.OrchestratorEventLoop(
+            tracker=tracker,
+            spawner=spawner,
+            pipeline_id="issue-3478",
+            slice_id="slice-9",
+            phase="implement",
+            clock=_FakeClock(),
+            agent_free_handler=_AgentFreeRecorder(),
+        )
+
+        # Coder still writing: repeated polls of the tester arm derive
+        # ``wait`` and dispatch nothing (no no-op streak to burn).
+        for _ in range(3):
+            (decision,) = loop.poll_once(["tester"])
+            assert decision.action == "wait"
+            assert decision.spawned is False
+        assert spawner.spawn_count == 0
+
+        tracker.handle_propose(
+            "coder",
+            {
+                "summary": (
+                    "Proposal v1 with substantive content describing the "
+                    "work, tests run, and tasks satisfied for review."
+                ),
+                "artifacts": ["a.py"],
+                "commit_sha": "abc1234",
+            },
+        )
+
+        # Gate lifted on the very next poll tick: one propose spawn.
+        (decision,) = loop.poll_once(["tester"])
+        assert decision.action == "propose"
+        assert decision.spawned is True
+        assert spawner.spawned_actions == ["propose"]
+        assert spawner.calls[0]["role"] == "tester"


### PR DESCRIPTION
Fixes #3478.

## Problem

`_derive_next_action` treats every WORKING producer as immediately propose-able. For a slice whose tester's tasks build on the coder's artifacts, the event loop therefore spawned the tester's propose arm while the coder was still producing; each pod orient-and-exited as a clean no-op, and three of those burned the #3425 streak and parked the arm:

```
19:33:29 event-loop spawn dispatched slice_id=slice-9 role=tester action=propose dedupe_key=c6b3c2d9...
19:34:37 event-loop spawn dispatched slice_id=slice-9 role=tester action=propose dedupe_key=c6b3c2d9...
19:35:20 JobSupervisor: 3 consecutive successful no-op invocations ... parking the arm
```

Not a wedge post-#3467 (BRC movement releases the park), but 3 wasted pod spawns per slice with this shape, and up to 30 minutes of latency when the un-park signal is missed.

## Fix

Add a first-propose gate to the WORKING branch of `_derive_next_action` (`orchestrator/routes/consensus.py`): a dual-role producer derives `wait` (with `waiting_on_producers` in the payload) while every producer it reviews is still pre-first-propose (WORKING at proposal version 0). `wait` dispatches nothing, so the arm never spawns, never builds a no-op streak, and never parks. The gate lifts on the upstream's first proposal; the next 5s poll tick derives `propose`, so the #2749 R11a propose-own-work-first ordering is unchanged from that point on.

The issue's suggested direction was a task-row dependency check, but task rows carry no dependency data (`Task` has no `depends_on`; `Slice.dependencies` is slice-level). The review edge is the one place the system encodes "the tester builds on the coder's artifacts", so the gate keys on `producers_for(role)`, the same relation `_has_pending_peer_proposals` and the health monitor's `are_all_producers_working` BRC-idle suppression already use.

Scope guards (see `_pre_propose_upstream_producers`):

- **Wake-only edges are exempt** and this is load-bearing: the de-roled simplifier (#3381) is deliberately woken by its own propose arm re-spawning until the upstream draft exists, so its wake-only edge must never convert to a `wait`.
- **Terminal-upstream requirement:** the gate engages only when at least one upstream producer reviews no producers itself, keeping the waits-on relation acyclic by construction; a custom graph with mutual producer edges keeps today's behavior instead of mutually waiting into a deadlock. In the default implement graph the coder is terminal.
- **Unresolved NACKs / the open-NACK barrier still derive `propose`:** the producer's own actionable feedback always wins.
- **Any prior proposal disables the gate** (current, withdrawn, or no-changes): version > 0 or phase != WORKING means there is something to build against or review.

Liveness: the gate can only hold while an ungated terminal producer is pre-propose. Its first propose flips the condition on the next poll tick; a crashed producer resolves via supervision/HITL; an excused producer (`excuse_producer`) is removed from the graph edges entirely, which dissolves the gate.

## Testing

- `orchestrator/tests/test_consensus_next_action.py`: fresh-slice tester derives `wait` naming `["coder"]`; pure coder unaffected; gate lifts on the coder's propose (R11a preserved); withdraw does not re-gate; mutual producer edges do not wait; wake-only upstream never gates; multi-upstream gate releases on the first proposal from any upstream.
- `orchestrator/tests/test_event_loop.py`: the incident shape through `poll_once` with a real tracker and real derivation; zero spawns while the coder is pre-propose, exactly one tester propose spawn on the tick after the coder's proposal.
- `make lint` clean; changeset-aware `make test` run: 20708 passed. The 3 local failures are pre-existing on a clean tree: 2 `tests/scripts/test_reap_stale_egg_images.py` rc=127 environment failures and 1 `gateway/tests/test_error_paths.py` session-expiry microsecond-boundary flake that passes on re-run.

Docs: added a "First-propose gate" paragraph to the deterministic-loop section of `docs/architecture/orchestrator.md`.