### PR TITLE
Surface slice_consensus through brc_get_state and egg-orch consensus status

### DIFF
--- a/docs/reference/orchestrator-cli.md
+++ b/docs/reference/orchestrator-cli.md
@@ -512,8 +512,11 @@ egg-orch consensus confirmed
 egg-orch consensus status
 
 # Scope to one slice's BRC consensus in a slice-DAG implement phase.
-# Per-slice agents inherit this from $EGG_SLICE_ID automatically;
-# without a slice scope only pipeline-level consensus is shown (#2761).
+# Per-slice agents inherit this from $EGG_SLICE_ID automatically.
+# Without a slice scope, live slice-scoped rounds are reported
+# per-slice (#3487): a single active slice is auto-resolved into the
+# main consensus block, several render one section per slice; they are
+# never merged into one block (#2761).
 egg-orch consensus status --slice-id slice-7
 ```
 

--- a/sandbox/egg_agent_tools/handlers/brc.py
+++ b/sandbox/egg_agent_tools/handlers/brc.py
@@ -839,6 +839,15 @@ def brc_get_state(req: dict[str, Any]) -> dict[str, Any]:
     misleading pipeline-level reconstruction. Pipeline-level agents
     leave it unset and see pipeline-level consensus.
 
+    Slice-id-less queries during a slice-DAG implement phase (#3487):
+    the live trackers are keyed ``{pipeline_id}/{slice_id}`` so there is
+    no pipeline-level block; instead of returning an empty ``consensus``
+    the handler resolves the status route's ``slice_consensus`` map
+    (#3481) the same way the orchestrator MCP ``get_consensus_status``
+    tool does: a single active slice is served directly (with
+    ``resolved_slice_id`` naming the scope), multiple stay keyed
+    per-slice under ``slice_consensus`` (never merged, #2761).
+
     Request:
         pipeline_id: override.
         slice_id: override; defaults to ``EGG_SLICE_ID``.
@@ -846,6 +855,9 @@ def brc_get_state(req: dict[str, Any]) -> dict[str, Any]:
 
     Response:
         { ok: True, consensus: {...}, verbose: bool }
+        plus, on a slice-id-less query with live slice trackers, either
+        ``resolved_slice_id`` (one active slice) or ``active_slice_ids``
+        + ``slice_consensus`` (several).
 
     No CLI counterpart — BRC state is a derived view of the pipeline
     status endpoint; the raw JSON is available via `egg-orch pipeline
@@ -860,15 +872,37 @@ def brc_get_state(req: dict[str, Any]) -> dict[str, Any]:
         endpoint += "?" + urlencode({"slice_id": slice_id})
     result = orchestrator_request(endpoint)
     data = result.get("data", {})
-    consensus = data.get("concurrent", {}).get("consensus", {})
+    concurrent = data.get("concurrent", {}) or {}
+    consensus = concurrent.get("consensus", {})
+    slice_consensus = concurrent.get("slice_consensus", {}) if slice_id is None else {}
 
     response: dict[str, Any] = {
         "ok": True,
         "slice_id": slice_id,
         "consensus": consensus,
-        "is_complete": bool(consensus.get("is_complete", False)),
-        "blocking_agents": list(consensus.get("blocking_agents", []) or []),
     }
+
+    if not consensus and slice_consensus:
+        if len(slice_consensus) == 1:
+            resolved_slice_id, block = next(iter(slice_consensus.items()))
+            consensus = dict(block)
+            consensus["note"] = (
+                f"Resolved the single active slice-scoped tracker "
+                f"'{resolved_slice_id}'; pass slice_id to pin the scope"
+            )
+            response["resolved_slice_id"] = resolved_slice_id
+            response["consensus"] = consensus
+        else:
+            response["active_slice_ids"] = sorted(slice_consensus)
+            response["slice_consensus"] = dict(slice_consensus)
+            response["note"] = (
+                "Multiple slice-scoped consensus rounds are active; "
+                "per-slice snapshots are under 'slice_consensus'. Pass "
+                "slice_id to scope the result to one slice."
+            )
+
+    response["is_complete"] = bool(consensus.get("is_complete", False))
+    response["blocking_agents"] = list(consensus.get("blocking_agents", []) or [])
     if verbose:
         response["raw"] = data
     return response

--- a/sandbox/egg_agent_tools/handlers/brc.py
+++ b/sandbox/egg_agent_tools/handlers/brc.py
@@ -882,7 +882,12 @@ def brc_get_state(req: dict[str, Any]) -> dict[str, Any]:
         "consensus": consensus,
     }
 
-    if not consensus and slice_consensus:
+    # Mirror the #3485 orchestrator guard verbatim (`mcp_tools/_consensus.py`):
+    # fall through to slice resolution whenever the pipeline-level block carries
+    # no agents. Guarding on `not consensus` instead would let a truthy-but-
+    # agent-less block short-circuit and serve empty state over the live
+    # per-slice trackers.
+    if not consensus.get("agents") and slice_consensus:
         if len(slice_consensus) == 1:
             resolved_slice_id, block = next(iter(slice_consensus.items()))
             consensus = dict(block)
@@ -917,11 +922,35 @@ def brc_list_blocking(req: dict[str, Any]) -> dict[str, Any]:
     No CLI counterpart — the same data is reachable via `egg-orch
     pipeline status --json` but the filtered blocking-agents shape is
     an agent-convenience view (decision-13).
+
+    Slice-aware to stay consistent with :func:`brc_get_state` (#3487):
+    when queried without a slice scope in a slice-DAG phase (no
+    pipeline-level block with agents), the blocking roles are unioned
+    across the live per-slice trackers so a pipeline-level caller (the
+    overseer agent, operators) isn't told nothing is blocking while a
+    slice round is wedged.
     """
     pid = _require_pipeline_id(req)
-    result = orchestrator_request(f"/api/v1/pipelines/{pid}/status")
-    consensus = result.get("data", {}).get("concurrent", {}).get("consensus", {})
-    blocking = list(consensus.get("blocking_agents", []) or [])
+    slice_id = resolve_slice_id(req)
+    endpoint = f"/api/v1/pipelines/{pid}/status"
+    if slice_id:
+        endpoint += "?" + urlencode({"slice_id": slice_id})
+    result = orchestrator_request(endpoint)
+    concurrent = result.get("data", {}).get("concurrent", {}) or {}
+    consensus = concurrent.get("consensus", {})
+    slice_consensus = concurrent.get("slice_consensus", {}) if slice_id is None else {}
+
+    if consensus.get("agents") or not slice_consensus:
+        blocking = list(consensus.get("blocking_agents", []) or [])
+    else:
+        # Union across active slice-scoped trackers, preserving first-seen
+        # order. This is a flat role list (not a merged consensus block), so
+        # the #2761 no-cross-slice-soup invariant is untouched.
+        blocking = []
+        for block in slice_consensus.values():
+            for role in (block or {}).get("blocking_agents", []) or []:
+                if role not in blocking:
+                    blocking.append(role)
     return {"ok": True, "blocking_agents": blocking}
 
 

--- a/sandbox/egg_agent_tools/tools/brc.py
+++ b/sandbox/egg_agent_tools/tools/brc.py
@@ -395,7 +395,10 @@ async def brc_confirm(args: dict[str, Any]) -> dict[str, Any]:
 @tool(
     "get_state",
     "Fetch the current BRC consensus state (agent matrix, blocking roles, "
-    "phase). Structured — no text scrape needed.",
+    "phase). Structured — no text scrape needed. In a slice-DAG implement "
+    "phase queried without a slice scope, live slice-scoped rounds are "
+    "resolved automatically: one active slice is served directly "
+    "(resolved_slice_id), several are keyed under slice_consensus.",
     _STATE_SCHEMA,
 )
 async def brc_get_state(args: dict[str, Any]) -> dict[str, Any]:

--- a/sandbox/egg_lib/orch_cli/_brc.py
+++ b/sandbox/egg_lib/orch_cli/_brc.py
@@ -89,9 +89,11 @@ def cmd_brc_get_state(args: argparse.Namespace) -> int:
 
     Verb-level alias for ``mcp__brc__get_state``. The MCP-tool surface
     exposed shape ``{ok, slice_id, consensus, is_complete,
-    blocking_agents, raw?}``; we mirror that exact shape so the
-    event-pump wrapper (#2908 slice-2) can call the CLI form
-    interchangeably with the MCP form.
+    blocking_agents, raw?}``, plus, on a slice-id-less query with live
+    slice trackers (#3487), ``resolved_slice_id`` or
+    ``active_slice_ids`` + ``slice_consensus``; we mirror that exact
+    shape so the event-pump wrapper (#2908 slice-2) can call the CLI
+    form interchangeably with the MCP form.
     """
     from egg_agent_tools.handlers import brc as _handlers
     from egg_agent_tools.handlers.errors import GatewayError, HandlerError

--- a/sandbox/egg_lib/orch_cli/_consensus.py
+++ b/sandbox/egg_lib/orch_cli/_consensus.py
@@ -452,6 +452,12 @@ def cmd_consensus_status(args: argparse.Namespace) -> int:
     :func:`egg_agent_tools.handlers.brc.brc_get_state` so the MCP
     ``mcp__brc__get_state`` tool and this CLI share one handler.  The
     human-readable rendering stays here in the shim.
+
+    In a slice-DAG implement phase queried without a slice scope, the
+    handler resolves the live slice-scoped trackers (#3487): a single
+    active slice renders directly (named as auto-resolved), several
+    render one section per slice under ``slice_consensus``; they are
+    never merged into one block (#2761).
     """
     from egg_agent_tools.handlers import brc as _handlers
     from egg_agent_tools.handlers.errors import GatewayError, HandlerError
@@ -472,8 +478,29 @@ def cmd_consensus_status(args: argparse.Namespace) -> int:
         return _render_handler_error(err)
 
     consensus = resp.get("consensus", {}) or {}
+    slice_consensus = resp.get("slice_consensus", {}) or {}
     if args.json:
-        print_json(consensus)
+        # Top-level shape stays the consensus block (legacy contract);
+        # the slice-scope keys ride alongside when present.
+        payload = dict(consensus)
+        if resp.get("resolved_slice_id"):
+            payload["resolved_slice_id"] = resp["resolved_slice_id"]
+        if slice_consensus:
+            payload["active_slice_ids"] = list(
+                resp.get("active_slice_ids") or sorted(slice_consensus)
+            )
+            payload["slice_consensus"] = slice_consensus
+        print_json(payload)
+        return 0
+
+    if slice_consensus:
+        print(
+            f"No pipeline-level consensus; {len(slice_consensus)} active "
+            f"slice consensus rounds (pass --slice-id to scope to one):"
+        )
+        for sid in sorted(slice_consensus):
+            print(f"\nSlice: {sid}")
+            _render_consensus_block(slice_consensus[sid] or {})
         return 0
 
     if not consensus:
@@ -484,9 +511,18 @@ def cmd_consensus_status(args: argparse.Namespace) -> int:
             print("No consensus data available.")
         return 0
 
+    resolved = resp.get("resolved_slice_id")
     scope = resp.get("slice_id")
-    if scope:
+    if resolved and not scope:
+        print(f"Slice: {resolved} (single active slice, auto-resolved)")
+    elif scope:
         print(f"Slice: {scope}")
+    _render_consensus_block(consensus)
+    return 0
+
+
+def _render_consensus_block(consensus: dict[str, Any]) -> None:
+    """Render one consensus block (agent matrix, blockers, obligations)."""
     is_complete = consensus.get("is_complete", False)
     print(f"Consensus complete: {is_complete}")
 
@@ -532,8 +568,6 @@ def cmd_consensus_status(args: argparse.Namespace) -> int:
                 text = cond.get("condition", "")
                 sha = cond.get("resolved_in_diff", "")
                 print(f"  {reviewer} → {producer}: {text} [resolved in {sha}]")
-
-    return 0
 
 
 # ---------------------------------------------------------------------------

--- a/sandbox/egg_lib/orch_cli/_consensus.py
+++ b/sandbox/egg_lib/orch_cli/_consensus.py
@@ -490,6 +490,11 @@ def cmd_consensus_status(args: argparse.Namespace) -> int:
                 resp.get("active_slice_ids") or sorted(slice_consensus)
             )
             payload["slice_consensus"] = slice_consensus
+        # Carry the handler's top-level multi-slice note so `--json` stays
+        # symmetric with `egg-orch brc get-state`, which dumps the whole
+        # response. (The single-slice note rides inside the consensus block.)
+        if resp.get("note") and "note" not in payload:
+            payload["note"] = resp["note"]
         print_json(payload)
         return 0
 

--- a/sandbox/egg_lib/orch_cli/_parser.py
+++ b/sandbox/egg_lib/orch_cli/_parser.py
@@ -747,8 +747,9 @@ def create_parser() -> argparse.ArgumentParser:
         help=(
             "Slice to scope the consensus status to (e.g. 'slice-7'). In a "
             "slice-DAG implement phase each slice runs its own BRC "
-            "consensus; without a slice scope only pipeline-level "
-            "consensus is shown. Defaults to $EGG_SLICE_ID."
+            "consensus; without a slice scope the live slice-scoped "
+            "rounds are reported per-slice (one active slice is "
+            "auto-resolved). Defaults to $EGG_SLICE_ID."
         ),
     )
     _add_json_flag(cons_status)

--- a/sandbox/tests/test_brc_slice_routing.py
+++ b/sandbox/tests/test_brc_slice_routing.py
@@ -355,6 +355,30 @@ class TestGetStateSliceConsensusResolution:
         assert resp["blocking_agents"] == []
         assert "resolved_slice_id" not in resp
 
+    def test_agentless_pipeline_block_falls_through_to_slices(self):
+        # A truthy-but-agent-less pipeline block must not short-circuit and
+        # serve empty state; it falls through to slice resolution, mirroring
+        # the #3485 orchestrator guard (`consensus.get("agents")`).
+        from egg_agent_tools.handlers import brc as handlers
+
+        with patch(
+            "egg_agent_tools.handlers.brc.orchestrator_request",
+            return_value={
+                "data": {
+                    "concurrent": {
+                        "consensus": {"protocol": "brc", "agents": {}},
+                        "slice_consensus": {
+                            "slice-3": _slice_block(is_complete=False, blocking=["coder"])
+                        },
+                    }
+                }
+            },
+        ):
+            resp = handlers.brc_get_state(dict(_STATE_REQ))
+
+        assert resp["resolved_slice_id"] == "slice-3"
+        assert resp["blocking_agents"] == ["coder"]
+
     def test_pipeline_level_consensus_takes_precedence(self):
         from egg_agent_tools.handlers import brc as handlers
 
@@ -403,3 +427,72 @@ class TestGetStateSliceConsensusResolution:
         assert resp["consensus"] == {}
         assert "resolved_slice_id" not in resp
         assert "slice_consensus" not in resp
+
+
+class TestListBlockingSliceAware:
+    """``brc_list_blocking`` unions blockers across live slices (#3487).
+
+    Kept consistent with ``brc_get_state`` so an overseer keying off
+    ``mcp__brc__list_blocking`` in a slice-DAG phase isn't told nothing
+    is blocking while a per-slice round is wedged.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_slice_env(self, monkeypatch):
+        monkeypatch.delenv("EGG_SLICE_ID", raising=False)
+
+    def test_pipeline_level_block_used_when_present(self):
+        from egg_agent_tools.handlers import brc as handlers
+
+        with patch(
+            "egg_agent_tools.handlers.brc.orchestrator_request",
+            return_value={
+                "data": {
+                    "concurrent": {
+                        "consensus": _slice_block(is_complete=False, blocking=["coder"]),
+                        "slice_consensus": {
+                            "slice-3": _slice_block(is_complete=False, blocking=["tester"])
+                        },
+                    }
+                }
+            },
+        ):
+            resp = handlers.brc_list_blocking(dict(_STATE_REQ))
+
+        # Pipeline-level block (has agents) wins; slices are not unioned in.
+        assert resp["blocking_agents"] == ["coder"]
+
+    def test_unions_blockers_across_slices(self):
+        from egg_agent_tools.handlers import brc as handlers
+
+        slice_map = {
+            "slice-5": _slice_block(is_complete=False, blocking=["coder"]),
+            "slice-3": _slice_block(is_complete=False, blocking=["tester", "coder"]),
+        }
+        with patch(
+            "egg_agent_tools.handlers.brc.orchestrator_request",
+            return_value={"data": {"concurrent": {"slice_consensus": slice_map}}},
+        ):
+            resp = handlers.brc_list_blocking(dict(_STATE_REQ))
+
+        # De-duplicated union across slices; first-seen order preserved.
+        assert resp["blocking_agents"] == ["coder", "tester"]
+
+    def test_explicit_slice_id_reads_only_that_slice(self, monkeypatch):
+        from egg_agent_tools.handlers import brc as handlers
+
+        monkeypatch.setenv("EGG_SLICE_ID", "slice-3")
+        with patch(
+            "egg_agent_tools.handlers.brc.orchestrator_request",
+            return_value={
+                "data": {
+                    "concurrent": {
+                        "consensus": _slice_block(is_complete=False, blocking=["tester"])
+                    }
+                }
+            },
+        ) as mock_request:
+            resp = handlers.brc_list_blocking(dict(_STATE_REQ))
+
+        assert "slice_id=slice-3" in _captured_endpoint(mock_request)
+        assert resp["blocking_agents"] == ["tester"]

--- a/sandbox/tests/test_brc_slice_routing.py
+++ b/sandbox/tests/test_brc_slice_routing.py
@@ -287,3 +287,119 @@ class TestGetStateSliceScope:
         ):
             with pytest.raises(HandlerError, match="slice_id"):
                 handlers.brc_get_state(dict(_STATE_REQ))
+
+
+def _slice_block(*, is_complete: bool, blocking: list[str]) -> dict[str, Any]:
+    return {
+        "agents": {"coder": {"producer_phase": "PROPOSED", "confirmed": is_complete}},
+        "is_complete": is_complete,
+        "blocking_agents": blocking,
+        "has_unresolved_nacks": False,
+        "unresolved_nacks": [],
+        "protocol": "brc",
+    }
+
+
+class TestGetStateSliceConsensusResolution:
+    """Slice-id-less queries resolve live slice trackers (#3487).
+
+    In a slice-DAG implement phase the trackers are keyed
+    ``{pipeline_id}/{slice_id}`` and the status route surfaces them
+    under ``concurrent.slice_consensus`` (#3481). ``brc_get_state``
+    must mirror the orchestrator MCP ``get_consensus_status``
+    semantics: a single active slice is served directly, multiple stay
+    keyed per-slice and are never merged (#2761).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_slice_env(self, monkeypatch):
+        monkeypatch.delenv("EGG_SLICE_ID", raising=False)
+
+    def test_single_active_slice_resolves_directly(self):
+        from egg_agent_tools.handlers import brc as handlers
+
+        block = _slice_block(is_complete=False, blocking=["coder"])
+        with patch(
+            "egg_agent_tools.handlers.brc.orchestrator_request",
+            return_value={"data": {"concurrent": {"slice_consensus": {"slice-3": block}}}},
+        ):
+            resp = handlers.brc_get_state(dict(_STATE_REQ))
+
+        assert resp["resolved_slice_id"] == "slice-3"
+        assert resp["slice_id"] is None
+        assert resp["consensus"]["blocking_agents"] == ["coder"]
+        assert "note" in resp["consensus"]
+        assert resp["is_complete"] is False
+        assert resp["blocking_agents"] == ["coder"]
+        assert "slice_consensus" not in resp
+
+    def test_multiple_active_slices_stay_keyed_per_slice(self):
+        from egg_agent_tools.handlers import brc as handlers
+
+        slice_map = {
+            "slice-5": _slice_block(is_complete=True, blocking=[]),
+            "slice-3": _slice_block(is_complete=False, blocking=["tester"]),
+        }
+        with patch(
+            "egg_agent_tools.handlers.brc.orchestrator_request",
+            return_value={"data": {"concurrent": {"slice_consensus": slice_map}}},
+        ):
+            resp = handlers.brc_get_state(dict(_STATE_REQ))
+
+        assert resp["active_slice_ids"] == ["slice-3", "slice-5"]
+        assert resp["slice_consensus"]["slice-3"]["blocking_agents"] == ["tester"]
+        assert resp["slice_consensus"]["slice-5"]["is_complete"] is True
+        # The top-level block is never a merged cross-slice view (#2761).
+        assert resp["consensus"] == {}
+        assert resp["is_complete"] is False
+        assert resp["blocking_agents"] == []
+        assert "resolved_slice_id" not in resp
+
+    def test_pipeline_level_consensus_takes_precedence(self):
+        from egg_agent_tools.handlers import brc as handlers
+
+        pipeline_block = _slice_block(is_complete=True, blocking=[])
+        with patch(
+            "egg_agent_tools.handlers.brc.orchestrator_request",
+            return_value={
+                "data": {
+                    "concurrent": {
+                        "consensus": pipeline_block,
+                        "slice_consensus": {
+                            "slice-3": _slice_block(is_complete=False, blocking=["coder"])
+                        },
+                    }
+                }
+            },
+        ):
+            resp = handlers.brc_get_state(dict(_STATE_REQ))
+
+        assert resp["consensus"] == pipeline_block
+        assert resp["is_complete"] is True
+        assert "resolved_slice_id" not in resp
+        assert "slice_consensus" not in resp
+
+    def test_explicit_slice_id_skips_resolution(self, monkeypatch):
+        from egg_agent_tools.handlers import brc as handlers
+
+        monkeypatch.setenv("EGG_SLICE_ID", "slice-3")
+        with patch(
+            "egg_agent_tools.handlers.brc.orchestrator_request",
+            return_value={
+                "data": {
+                    "concurrent": {
+                        "slice_consensus": {
+                            "slice-9": _slice_block(is_complete=False, blocking=["coder"])
+                        }
+                    }
+                }
+            },
+        ):
+            resp = handlers.brc_get_state(dict(_STATE_REQ))
+
+        # A slice-scoped query reports only its own (empty here) block;
+        # the surfaced map for other slices is not resolved into it.
+        assert resp["slice_id"] == "slice-3"
+        assert resp["consensus"] == {}
+        assert "resolved_slice_id" not in resp
+        assert "slice_consensus" not in resp

--- a/sandbox/tests/test_consensus_status_render.py
+++ b/sandbox/tests/test_consensus_status_render.py
@@ -290,6 +290,32 @@ class TestStatusRendersSliceConsensus:
         assert payload["active_slice_ids"] == ["slice-3", "slice-5"]
         assert payload["slice_consensus"]["slice-3"]["blocking_agents"] == ["tester"]
 
+    def test_json_carries_multi_slice_note(self, capsys):
+        import json
+
+        # The handler's top-level multi-slice ``note`` must ride through
+        # ``--json`` so it stays symmetric with ``egg-orch brc get-state``,
+        # which dumps the whole handler response.
+        fake_state = {
+            "slice_id": None,
+            "consensus": {},
+            "active_slice_ids": ["slice-3", "slice-5"],
+            "slice_consensus": {
+                "slice-3": _slice_block(False, ["tester"]),
+                "slice-5": _slice_block(True, []),
+            },
+            "note": "Multiple slice-scoped consensus rounds are active; ...",
+        }
+        args = argparse.Namespace(pipeline_id="test-pipeline-1", json=True)
+        with patch(
+            "egg_agent_tools.handlers.brc.brc_get_state",
+            return_value=fake_state,
+        ):
+            rc = cmd_consensus_status(args)
+        payload = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert payload["note"] == fake_state["note"]
+
     def test_json_carries_resolved_slice_id(self, capsys):
         import json
 

--- a/sandbox/tests/test_consensus_status_render.py
+++ b/sandbox/tests/test_consensus_status_render.py
@@ -209,3 +209,102 @@ class TestStatusRendersResolvedSubsection:
         assert "Pending pre-merge obligations:" in out
         assert "still-open obligation" in out
         assert "Resolved within this PR:" not in out
+
+
+def _slice_block(is_complete: bool, blocking: list[str]) -> dict:
+    return {
+        "agents": {"coder": {"producer_phase": "PROPOSED", "confirmed": is_complete}},
+        "is_complete": is_complete,
+        "blocking_agents": blocking,
+    }
+
+
+class TestStatusRendersSliceConsensus:
+    """Slice-id-less queries in a slice-DAG implement phase (#3487).
+
+    The handler resolves live slice trackers: one active slice arrives
+    auto-resolved into ``consensus`` (with ``resolved_slice_id``),
+    several arrive keyed under ``slice_consensus``. The CLI must render
+    both instead of "No consensus data available.".
+    """
+
+    def test_multi_slice_renders_one_section_per_slice(self, capsys):
+        fake_state = {
+            "slice_id": None,
+            "consensus": {},
+            "active_slice_ids": ["slice-3", "slice-5"],
+            "slice_consensus": {
+                "slice-3": _slice_block(False, ["tester"]),
+                "slice-5": _slice_block(True, []),
+            },
+        }
+        with patch(
+            "egg_agent_tools.handlers.brc.brc_get_state",
+            return_value=fake_state,
+        ):
+            rc = cmd_consensus_status(_make_args())
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "2 active slice consensus rounds" in out
+        assert "Slice: slice-3" in out
+        assert "Slice: slice-5" in out
+        assert "Blocking agents: tester" in out
+        assert "No consensus data available" not in out
+
+    def test_single_slice_auto_resolved_names_the_scope(self, capsys):
+        fake_state = {
+            "slice_id": None,
+            "resolved_slice_id": "slice-7",
+            "consensus": _slice_block(False, ["coder"]),
+        }
+        with patch(
+            "egg_agent_tools.handlers.brc.brc_get_state",
+            return_value=fake_state,
+        ):
+            rc = cmd_consensus_status(_make_args())
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Slice: slice-7 (single active slice, auto-resolved)" in out
+        assert "Blocking agents: coder" in out
+
+    def test_json_carries_slice_consensus_alongside_block(self, capsys):
+        import json
+
+        fake_state = {
+            "slice_id": None,
+            "consensus": {},
+            "active_slice_ids": ["slice-3", "slice-5"],
+            "slice_consensus": {
+                "slice-3": _slice_block(False, ["tester"]),
+                "slice-5": _slice_block(True, []),
+            },
+        }
+        args = argparse.Namespace(pipeline_id="test-pipeline-1", json=True)
+        with patch(
+            "egg_agent_tools.handlers.brc.brc_get_state",
+            return_value=fake_state,
+        ):
+            rc = cmd_consensus_status(args)
+        payload = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert payload["active_slice_ids"] == ["slice-3", "slice-5"]
+        assert payload["slice_consensus"]["slice-3"]["blocking_agents"] == ["tester"]
+
+    def test_json_carries_resolved_slice_id(self, capsys):
+        import json
+
+        fake_state = {
+            "slice_id": None,
+            "resolved_slice_id": "slice-7",
+            "consensus": _slice_block(False, ["coder"]),
+        }
+        args = argparse.Namespace(pipeline_id="test-pipeline-1", json=True)
+        with patch(
+            "egg_agent_tools.handlers.brc.brc_get_state",
+            return_value=fake_state,
+        ):
+            rc = cmd_consensus_status(args)
+        payload = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert payload["resolved_slice_id"] == "slice-7"
+        assert payload["blocking_agents"] == ["coder"]


### PR DESCRIPTION
## Summary

Advances #3487: gives the agent-side consensus surface (`mcp__brc__get_state`, `egg-orch consensus status`, `egg-orch brc get-state`) the same slice-consensus visibility #3485 gave the orchestrator MCP `get_consensus_status` tool. It deliberately does **not** close #3487; the overseer stall-detection question there is a product decision this PR leaves open (see "What this PR does not decide" below).

## The gap

In a slice-DAG implement phase the live BRC trackers are keyed `{pipeline_id}/{slice_id}`. #3485 surfaced their snapshots under `concurrent.slice_consensus` in the status route and taught the orchestrator MCP `get_consensus_status` tool to resolve them. But the sandbox-side handler `egg_agent_tools/handlers/brc.py::brc_get_state`, which backs:

- `mcp__brc__get_state` (the tool the on-demand OVERSEER agent's rules key their deterministic stall/consensus triggers on, per `sandbox/agent-config/rules/overseer.md`),
- `egg-orch consensus status` (the CLI path named in #3487),
- `egg-orch brc get-state` (the event-pump wrapper surface),

still read only `concurrent.consensus`. A slice-id-less caller (the overseer agent and operators are pipeline-level; they have no `EGG_SLICE_ID`) therefore saw an empty consensus block while per-slice rounds were live, blocked, or wedged.

## The fix

`brc_get_state` now mirrors the #3485 MCP-tool resolution semantics when queried without a slice scope and no pipeline-level block exists:

- **One active slice**: served directly as `consensus`, with `resolved_slice_id` naming the scope and a note suggesting `slice_id` to pin it. `is_complete` / `blocking_agents` derive from the resolved block, so existing consumers of those top-level fields start seeing real state.
- **Several active slices**: returned per-slice under `slice_consensus` with `active_slice_ids`; the top-level `consensus` stays empty. Blocks are never merged, preserving the #2761 no-cross-slice-soup invariant.
- Explicit `slice_id` queries and pipeline-level consensus (non-slice phases) are unchanged.

`egg-orch consensus status` renders both shapes: `--json` keeps the legacy top-level consensus block and carries `resolved_slice_id` / `active_slice_ids` / `slice_consensus` alongside; human output prints one section per slice (or names the auto-resolved slice) instead of "No consensus data available.". `egg-orch brc get-state` passes the new keys through unchanged.

## What this PR does not decide

Investigation notes for the remaining #3487 scope:

- The `overseer/monitor/` `OverseerMonitor` poll loop named in the issue (`_query_consensus_status` feeding `_check_post_consensus_stall` / `_check_incomplete_consensus_stall`) is the **legacy** monitor; it has no production caller since the #2270 overhaul (`overseer/README.md`: the detection plane + on-demand adjudication replaced the standing loop). Teaching it per-slice stall tracking would wire semantics into code that never runs.
- The live deterministic consensus checks have their own, separate slice blind spots: the tier1 `ConsensusStallCheck` / `IncompleteConsensusStallCheck` call `get_peer_consensus_tracker(pipeline_id)` (pipeline-level only), and `snapshot_from_health_context` never populates `EventStreamSnapshot.consensus`, so `detect_brc_thrash` / `detect_incomplete_consensus_deferral` cannot fire from live state. If per-slice stall detection is a goal, the detection plane / tier1 checks are the layer to teach, and the escalation semantics (single stalled slice vs. whole pipeline, per-slice nudge targeting) still need a decision.

This PR is useful under any outcome of that decision: it fixes the live observers that exist today (the overseer agent and operators), and the per-slice data path it exercises is a prerequisite for whichever detector layer eventually consumes it.

## Testing

- 4 new handler tests (`test_brc_slice_routing.py`): single-slice auto-resolution, multi-slice per-slice map (never merged), pipeline-level precedence, explicit-slice_id skip.
- 4 new CLI tests (`test_consensus_status_render.py`): per-slice human sections, auto-resolved scope line, JSON carrying `slice_consensus` + `active_slice_ids`, JSON carrying `resolved_slice_id`.
- Full suite via `make test`: 20727 passed, 20 failed; all 20 failures are pre-existing local-environment issues untouched by this diff (2x `tests/scripts/test_reap_stale_egg_images.py` exit-127, the same pair called out in #3485, and 18x `orchestrator/tests/test_per_slice_brc_commit.py` PermissionError on the root-owned `/home/egg/.egg-worktrees`; that file imports only orchestrator modules this diff never touches).
- `ruff check` / `ruff format --check` clean on all touched files.

Refs #3487
