### PR TITLE
Fix MCP server startup crash on union-typed tool param; fail loudly on MCP startup errors

### DIFF
--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -243,9 +243,14 @@ and shouldn't be needed now that the scoped surface exists.
 The same endpoint and MCP tool also accept the
 `consensus_timeout_minutes` family (`consensus_timeout_minutes`,
 `consensus_timeout_minutes_refine` / `_plan` / `_implement`): an
-integer number of minutes (>= 1) sets the override, an explicit `null`
-clears it (the phase falls back to the resolution chain: per-phase
-override, then legacy global, then the phase-aware default). Unlike
+integer number of minutes (>= 1) sets the override; clearing it makes
+the phase fall back to the resolution chain (per-phase override, then
+legacy global, then the phase-aware default). How you clear depends on
+the surface: the REST `PATCH` takes an explicit `null`, while the MCP
+tool takes `0` — FastMCP materializes omitted optional params as
+`None` before the tool handler runs, so over MCP an explicit `null` is
+indistinguishable from "not provided" and is treated as "leave
+unchanged" (#3499). Unlike
 `agent_models`, no restart is needed: the phase poll loop re-resolves
 the budget from freshly-loaded config right before the consensus wall
 fires, so an operator watching a long-running slice can widen the

--- a/orchestrator/api.py
+++ b/orchestrator/api.py
@@ -223,7 +223,15 @@ def index() -> tuple[Response, int]:
 # The MCP server runs in a background daemon thread and proxies tool calls
 # to the orchestrator's pipeline management API endpoints.
 def _start_mcp_server() -> None:
-    """Start the MCP server sidecar."""
+    """Start the MCP server sidecar.
+
+    A non-import failure is fatal: ``start_mcp_server`` builds the
+    FastMCP app eagerly, so an exception here means the tool schemas
+    are broken and every MCP client would be down while the REST API
+    kept serving.  Swallowing it once left the pod Ready for hours
+    with all MCP tooling dead (#3499) — crash instead so the deploy
+    rolls back visibly.
+    """
     try:
         from mcp_server import start_mcp_server
 
@@ -240,6 +248,7 @@ def _start_mcp_server() -> None:
         logger.warning("MCP server module not available, skipping startup")
     except Exception as e:
         logger.error("Failed to start MCP server", error=str(e))
+        raise
 
 
 _start_mcp_server()

--- a/orchestrator/mcp_server.py
+++ b/orchestrator/mcp_server.py
@@ -205,10 +205,19 @@ class MCPServer:
         Binds to 0.0.0.0 inside the container so Docker port forwarding works.
         Host is set in the FastMCP constructor; localhost-only access is enforced
         by the docker-compose port mapping.
+
+        Reuses the app built by :func:`start_mcp_server`'s eager
+        ``create_app`` call when present, and logs before dying if the
+        serve loop raises — a daemon thread's traceback otherwise goes
+        to stderr only, invisible to structured-log consumers (#3499).
         """
-        mcp = self.create_app()
+        mcp = self._mcp if self._mcp is not None else self.create_app()
         logger.info("Starting MCP server", port=self.port)
-        mcp.run(transport="streamable-http")
+        try:
+            mcp.run(transport="streamable-http")
+        except Exception as e:
+            logger.error("MCP server thread died", port=self.port, error=str(e))
+            raise
 
 
 def _json_type_to_python(prop_def: dict) -> type:
@@ -223,8 +232,18 @@ def _json_type_to_python(prop_def: dict) -> type:
     ``"Input should be a valid string"`` from Pydantic *before* the
     tool handler ever ran, even though the JSON-Schema input the
     tool advertised said ``object`` / ``array``.
+    JSON Schema allows ``type`` to be a list of types (used for nullable
+    params like ``{"type": ["integer", "null"]}``).  An unhashable list
+    key used to raise TypeError here, which killed ``create_app`` — and
+    with it every MCP tool, not just the union-typed one (#3499).
+    Normalize to the first non-null member; nullability itself is
+    handled by :func:`_build_tool_signature`'s ``T | None`` widening.
     """
     json_type = prop_def.get("type", "string")
+    if isinstance(json_type, list):
+        json_type = next((t for t in json_type if t != "null"), "string")
+    if not isinstance(json_type, str):
+        return str
     mapping: dict[str, type] = {
         "string": str,
         "integer": int,
@@ -289,13 +308,22 @@ def start_mcp_server(
     port: int = DEFAULT_MCP_PORT,
     rate_limit: int = DEFAULT_RATE_LIMIT,
 ) -> MCPServer:
-    """Start the MCP server in a background thread."""
+    """Start the MCP server in a background thread.
+
+    Builds the FastMCP app eagerly on the caller's thread before
+    spawning: tool registration is where schema bugs surface (a broken
+    tool def once raised inside the background thread *after* the
+    "started" log fired, leaving all MCP tooling down while the pod
+    stayed Ready for hours, #3499).  An exception here propagates to
+    the caller so startup fails loudly instead.
+    """
     server = MCPServer(
         orchestrator_url=orchestrator_url,
         gateway_url=gateway_url,
         port=port,
         rate_limit=rate_limit,
     )
+    server.create_app()
 
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()

--- a/orchestrator/mcp_tools/_submit.py
+++ b/orchestrator/mcp_tools/_submit.py
@@ -289,15 +289,26 @@ def _handle_update_pipeline_config(self, args: dict[str, Any]) -> dict[str, Any]
         payload["agent_models"] = agent_models
 
     for timeout_key in _CONSENSUS_TIMEOUT_ARG_KEYS:
-        if timeout_key in args:
-            payload[timeout_key] = args[timeout_key]
+        value = args.get(timeout_key)
+        if value is None:
+            # FastMCP materializes every omitted optional param as None
+            # before the handler runs, so None here cannot mean "clear
+            # the override" — forwarding it would null out all four
+            # timeouts on every call (#3499). Treat None as "leave
+            # unchanged"; clearing is expressed as 0, mapped to the
+            # REST PATCH's null (its valid set is int >= 1 or null).
+            continue
+        if isinstance(value, int) and not isinstance(value, bool) and value == 0:
+            payload[timeout_key] = None
+        else:
+            payload[timeout_key] = value
 
     if not payload:
         return {
             "error": (
                 "Provide at least one mutable config key: agent_models or "
                 f"one of {list(_CONSENSUS_TIMEOUT_ARG_KEYS)}. Timeout values "
-                "are integer minutes >= 1, or null to clear the override."
+                "are integer minutes >= 1, or 0 to clear the override."
             )
         }
 

--- a/orchestrator/mcp_tools/_tool_defs.py
+++ b/orchestrator/mcp_tools/_tool_defs.py
@@ -478,34 +478,43 @@ PIPELINE_TOOLS = [
                         "the role's override."
                     ),
                 },
+                # The timeout params use "0 clears" rather than the REST
+                # endpoint's "null clears": FastMCP materializes omitted
+                # optional params as None before the handler runs, so an
+                # explicit null is indistinguishable from "not provided"
+                # over this transport (#3499).
                 "consensus_timeout_minutes": {
-                    "type": ["integer", "null"],
+                    "type": "integer",
                     "description": (
                         "Legacy global consensus timeout in minutes (>= 1). "
-                        "Applies to every phase when set; null clears the "
+                        "Applies to every phase when set; 0 clears the "
                         "override so each phase falls back to its per-phase "
-                        "override or phase-aware default."
+                        "override or phase-aware default; omit to leave "
+                        "unchanged."
                     ),
                 },
                 "consensus_timeout_minutes_refine": {
-                    "type": ["integer", "null"],
+                    "type": "integer",
                     "description": (
                         "Per-phase consensus timeout for refine, in minutes "
-                        "(>= 1); null clears the override."
+                        "(>= 1); 0 clears the override; omit to leave "
+                        "unchanged."
                     ),
                 },
                 "consensus_timeout_minutes_plan": {
-                    "type": ["integer", "null"],
+                    "type": "integer",
                     "description": (
                         "Per-phase consensus timeout for plan, in minutes "
-                        "(>= 1); null clears the override."
+                        "(>= 1); 0 clears the override; omit to leave "
+                        "unchanged."
                     ),
                 },
                 "consensus_timeout_minutes_implement": {
-                    "type": ["integer", "null"],
+                    "type": "integer",
                     "description": (
                         "Per-phase consensus timeout for implement, in "
-                        "minutes (>= 1); null clears the override."
+                        "minutes (>= 1); 0 clears the override; omit to "
+                        "leave unchanged."
                     ),
                 },
             },

--- a/orchestrator/tests/test_mcp_server.py
+++ b/orchestrator/tests/test_mcp_server.py
@@ -22,6 +22,11 @@ end-to-end:
   dispatches tool calls into ``anyio.to_thread`` workers, so the
   limiter can be hit from multiple OS threads.  A concurrency test
   guards the invariant that the worst-case overshoot is bounded.
+
+* ``create_app`` smoke test — builds the FastMCP app from the full
+  live ``PIPELINE_TOOLS`` list, so a tool-schema shape the signature
+  builder can't handle fails in CI instead of killing the MCP server
+  thread at deploy time (#3499).
 """
 
 from __future__ import annotations
@@ -73,16 +78,36 @@ class TestJsonTypeToPython:
 
     def test_unknown_type_falls_through_to_str(self) -> None:
         # The fallthrough is intentional — JSON-Schema types we don't
-        # know about (``null``, union-type arrays, etc.) get a string
-        # annotation rather than crashing the server.  We accept the
-        # less-useful annotation in exchange for keeping the registration
-        # path robust against schema drift.
+        # know about get a string annotation rather than crashing the
+        # server.  We accept the less-useful annotation in exchange for
+        # keeping the registration path robust against schema drift.
         assert _json_type_to_python({"type": "something-future"}) is str
 
     def test_missing_type_defaults_to_string(self) -> None:
         # ``prop.get("type", "string")`` — a schema entry that omits
         # ``type`` (rare but valid JSON Schema) maps to ``str``.
         assert _json_type_to_python({}) is str
+
+    @pytest.mark.parametrize(
+        ("json_type", "expected"),
+        [
+            (["integer", "null"], int),  # nullable param, #3494 shape
+            (["null", "string"], str),  # null-first ordering
+            (["boolean", "integer"], bool),  # first member wins
+            (["null"], str),  # degenerate: only null
+            ([], str),  # degenerate: empty union
+        ],
+    )
+    def test_union_type_list_uses_first_non_null(self, json_type, expected) -> None:
+        # JSON Schema allows ``"type": [...]``.  An unhashable list key
+        # used to raise TypeError inside ``create_app`` and take down
+        # EVERY MCP tool, not just the union-typed one (#3499).
+        assert _json_type_to_python({"type": json_type}) is expected
+
+    def test_non_string_non_list_type_falls_through_to_str(self) -> None:
+        # Same robustness rule for any other malformed ``type`` value:
+        # never let a schema entry crash tool registration.
+        assert _json_type_to_python({"type": {"weird": True}}) is str
 
 
 # ---------------------------------------------------------------------------
@@ -183,6 +208,45 @@ class TestBuildToolSignature:
         # Optional, no schema default → synthesized None + widened.
         assert param.default is None
         assert param.annotation == dict | None
+
+
+# ---------------------------------------------------------------------------
+# create_app — startup smoke test over the full live tool list
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAppSmoke:
+    """The tool schemas (``mcp_tools/_tool_defs.py``) and the signature
+    builder here only meet at runtime, inside ``create_app``.  #3499: a
+    union-typed param added to one tool's schema crashed ``create_app``
+    in the background thread and took ALL MCP tooling down while the
+    REST API stayed healthy.  Building the app from the full live tool
+    list at CI time closes that gap.
+    """
+
+    def test_create_app_builds_and_registers_every_pipeline_tool(self) -> None:
+        from mcp_server import MCPServer
+        from mcp_tools import PIPELINE_TOOLS
+
+        app = MCPServer().create_app()
+        registered = {tool.name for tool in asyncio.run(app.list_tools())}
+        expected = {tool["name"] for tool in PIPELINE_TOOLS}
+        assert registered == expected
+
+    def test_start_mcp_server_raises_on_broken_app_build(self, monkeypatch) -> None:
+        """``start_mcp_server`` must build the app eagerly on the
+        caller's thread: a registration failure has to propagate to the
+        caller (failing orchestrator startup loudly) instead of killing
+        the daemon thread after the "started" log already fired.
+        """
+        import mcp_server as mcp_server_mod
+
+        def _boom(self):
+            raise RuntimeError("broken tool schema")
+
+        monkeypatch.setattr(mcp_server_mod.MCPServer, "create_app", _boom)
+        with pytest.raises(RuntimeError, match="broken tool schema"):
+            mcp_server_mod.start_mcp_server()
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -3412,8 +3412,7 @@ class TestUpdatePipelineConfig:
             assert key in properties
 
     def test_consensus_timeout_keys_passed_through(self, handler):
-        """Timeout overrides (#3490) reach the PATCH body, including an
-        explicit null that clears an override."""
+        """Timeout overrides (#3490) reach the PATCH body."""
         with patch.object(handler, "_make_request") as mock_req:
             mock_req.return_value = {"success": True, "data": {}}
             result = handler.handle_tool_call(
@@ -3421,22 +3420,87 @@ class TestUpdatePipelineConfig:
                 {
                     "task_id": "issue-77",
                     "consensus_timeout_minutes_implement": 480,
-                    "consensus_timeout_minutes": None,
                 },
             )
 
         assert mock_req.call_args[1]["data"] == {
             "consensus_timeout_minutes_implement": 480,
-            "consensus_timeout_minutes": None,
         }
         assert result["updated"] is True
 
-    def test_no_mutable_keys_rejected_without_request(self, handler):
+    def test_none_timeout_means_unchanged_not_clear(self, handler):
+        """FastMCP materializes omitted optional params as None before
+        the handler runs, so None must be skipped — forwarding it would
+        clear every timeout override on every call (#3499)."""
         with patch.object(handler, "_make_request") as mock_req:
-            result = handler.handle_tool_call(
+            mock_req.return_value = {"success": True, "data": {}}
+            handler.handle_tool_call(
                 "update_pipeline_config",
-                {"task_id": "issue-77"},
+                {
+                    "task_id": "issue-77",
+                    "agent_models": {"coder": "opus"},
+                    "consensus_timeout_minutes": None,
+                    "consensus_timeout_minutes_refine": None,
+                    "consensus_timeout_minutes_plan": None,
+                    "consensus_timeout_minutes_implement": None,
+                },
             )
+
+        assert mock_req.call_args[1]["data"] == {"agent_models": {"coder": "opus"}}
+
+    def test_zero_timeout_clears_override(self, handler):
+        """0 is the MCP-side clear sentinel (mapped to the REST PATCH's
+        null); valid set values are >= 1 so 0 is unambiguous."""
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {"success": True, "data": {}}
+            handler.handle_tool_call(
+                "update_pipeline_config",
+                {
+                    "task_id": "issue-77",
+                    "consensus_timeout_minutes_implement": 0,
+                },
+            )
+
+        assert mock_req.call_args[1]["data"] == {
+            "consensus_timeout_minutes_implement": None,
+        }
+
+    def test_false_timeout_is_not_treated_as_clear(self, handler):
+        """``False == 0`` in Python; a bool must NOT map to the clear
+        sentinel — it passes through so the route rejects it with its
+        structured validation error."""
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.return_value = {"success": True, "data": {}}
+            handler.handle_tool_call(
+                "update_pipeline_config",
+                {
+                    "task_id": "issue-77",
+                    "consensus_timeout_minutes": False,
+                },
+            )
+
+        assert mock_req.call_args[1]["data"] == {"consensus_timeout_minutes": False}
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            {"task_id": "issue-77"},
+            # All-None timeout args are what FastMCP delivers when the
+            # caller provided nothing — must be "no mutable keys", not
+            # a PATCH that clears all four overrides (#3499).
+            {
+                "task_id": "issue-77",
+                "agent_models": None,
+                "consensus_timeout_minutes": None,
+                "consensus_timeout_minutes_refine": None,
+                "consensus_timeout_minutes_plan": None,
+                "consensus_timeout_minutes_implement": None,
+            },
+        ],
+    )
+    def test_no_mutable_keys_rejected_without_request(self, handler, args):
+        with patch.object(handler, "_make_request") as mock_req:
+            result = handler.handle_tool_call("update_pipeline_config", args)
 
         assert "error" in result
         mock_req.assert_not_called()


### PR DESCRIPTION
Fixes #3499.

## The crash

`_json_type_to_python` (`orchestrator/mcp_server.py`) used the JSON-Schema `type` value as a dict key, assuming a scalar string. The nullable consensus-timeout params from #3494 (`"type": ["integer", "null"]`) made that a list, raising `TypeError: unhashable type` inside `create_app` and killing the MCP server for all 31 tools while the REST API stayed healthy. Union type lists are now normalized to their first non-null member (nullability is already handled by `_build_tool_signature`'s `T | None` widening), and any other malformed `type` shape falls through to `str` instead of crashing registration.

## Startup hardening (the two asks from the issue)

- **No more lying "started" log.** `start_mcp_server` now builds the FastMCP app eagerly on the caller's thread before spawning the serve thread. Tool registration is where schema bugs surface, so this class of failure now propagates synchronously instead of dying in the daemon thread after the "MCP server started in background" log fired.
- **Crash loudly.** `api.py`'s `_start_mcp_server` re-raises on failure instead of swallowing it, so a broken build fails orchestrator startup and crashloops visibly rather than leaving the pod Ready for hours with all MCP tooling down. `ImportError` (mcp package absent) still degrades gracefully as before. Behavior change worth noting: an MCP startup failure now takes down the REST API too; per the incident this is the intended tradeoff.
- **Startup smoke test.** `TestCreateAppSmoke` builds the app from the full live `PIPELINE_TOOLS` list at CI time and asserts every tool registers, closing the gap where the schemas and the signature builder only met at runtime. `run()` also logs through structured logging before dying if the serve loop itself raises (a daemon-thread traceback otherwise only reaches stderr).

## Latent bug the crash was hiding: null-to-clear can't work over MCP

FastMCP materializes every omitted optional param as `None` before the tool handler runs (`model_dump_one_level` iterates all model fields). So the handler's `if timeout_key in args` check was always true: once the crash was fixed, **every** `update_pipeline_config` call (including pure `agent_models` swaps) would have PATCHed all four timeout keys as explicit `null`, silently clearing all consensus-timeout overrides.

The MCP contract for the timeout params is now:
- omit (or send `null`): leave unchanged
- `0`: clear the override (mapped to the REST PATCH's `null`; valid set values are `>= 1`, so `0` is unambiguous; `False` is explicitly not treated as `0` and passes through to the route's validation error)
- `>= 1`: set the override

The REST endpoint keeps its null-to-clear semantics unchanged (it can distinguish present-null from absent). Schema types drop the union back to plain `integer`, tool descriptions are updated, and `docs/guides/per-agent-models.md` documents the REST-vs-MCP difference.

## Out of scope

Thread death *after* a successful bind (e.g. port conflict at serve time) still doesn't fail readiness; it now at least emits a structured `MCP server thread died` error log. Wiring MCP liveness into the probe listener would be a follow-up.

## Testing

- `make lint` clean.
- Full suite: 20761 passed; the only 20 failures are `test_per_slice_brc_commit.py` `PermissionError`s creating directories under `/home/egg/.egg-worktrees` (local sandbox can't write another user's home; pre-existing environment limitation, unrelated to this diff).
- New regression tests: union-type normalization shapes, create_app smoke over the full tool list, start_mcp_server fail-fast, None-means-unchanged / 0-clears / False-is-not-clear handler semantics, and the all-None-args case that previously would have cleared every override.