### PR TITLE
Fix empty agent worktree mounts on the reuse path: translate orchestrator-local paths to host paths (#3502)

### DIFF
--- a/orchestrator/kubernetes_spawner/__init__.py
+++ b/orchestrator/kubernetes_spawner/__init__.py
@@ -503,6 +503,9 @@ from ._errors import (  # noqa: E402
 from ._models import SpawnedContainer, _EventJobStatusView  # noqa: E402
 from ._worktree import (  # noqa: E402
     _host_to_local_volumes,
+    _load_local_mount_mapping,
+    _local_to_host_path,
+    _local_to_host_volumes,
     _role_needs_worktree,
     _validate_worktree_for_reuse,
 )
@@ -552,6 +555,9 @@ __all__ = [
     "ContainerInfo",
     "ContainerStatus",
     "_host_to_local_volumes",
+    "_load_local_mount_mapping",
+    "_local_to_host_path",
+    "_local_to_host_volumes",
     "_validate_worktree_for_reuse",
     "_role_needs_worktree",
     "_is_transient_spawn_failure",

--- a/orchestrator/kubernetes_spawner/_events.py
+++ b/orchestrator/kubernetes_spawner/_events.py
@@ -200,6 +200,10 @@ def spawn_event_job(
             upstream=spawn_kwargs.get("upstream"),
             upstream_model=spawn_kwargs.get("upstream_model"),
             jira_ticket=spawn_kwargs.get("jira_ticket"),
+            # Bind a fresh registration to the worktree just validated,
+            # so the gateway looks it up instead of creating an orphan
+            # worktree keyed by the session id (#3502 naming split).
+            worktree_container_id=reuse_worktree_id,
         )
         if session_info is not None:
             reuse_session_token = session_info.session_token

--- a/orchestrator/kubernetes_spawner/_session.py
+++ b/orchestrator/kubernetes_spawner/_session.py
@@ -29,6 +29,7 @@ def _get_or_create_session(
     upstream: str | None = None,
     upstream_model: str | None = None,
     jira_ticket: str | None = None,
+    worktree_container_id: str | None = None,
 ) -> SessionInfo | None:
     """Return a live session for *agent_role*, or register a new one.
 
@@ -37,6 +38,13 @@ def _get_or_create_session(
     still live (:meth:`GatewayClient.heartbeat_session_by_container`),
     it is reused without a round-trip. Otherwise a fresh session is
     registered via the gateway.
+
+    ``worktree_container_id`` binds the fresh registration to an existing
+    per-agent worktree (the gateway looks it up instead of creating one).
+    The worktree re-attach path passes the validated worktree id here;
+    without it, the gateway creates an orphan worktree keyed by the
+    session's ``container_id`` (the ``egg-agent-…`` Job base name) that no
+    Job spec ever mounts (#3502 naming split).
 
     Returns the :class:`SessionInfo` (or a stub with the session token)
     on success, or ``None`` on registration failure.
@@ -101,6 +109,7 @@ def _get_or_create_session(
             branch=branch,
             base_branch=base_branch,
             jira_ticket=jira_ticket,
+            worktree_container_id=worktree_container_id,
             # Per-agent upstream routing — forward so a
             # session reused via this path keeps its litellm routing
             # instead of silently falling back to the Anthropic default.

--- a/orchestrator/kubernetes_spawner/_spawn.py
+++ b/orchestrator/kubernetes_spawner/_spawn.py
@@ -374,6 +374,27 @@ def spawn_agent_job(
             f"operations. See #1869."
         )
 
+    # #3502 tripwire: every hostPath handed to the Job spec below must be a
+    # HOST path (the create path gets them from the gateway's
+    # ``translate_to_host_path``). An orchestrator-LOCAL path here means
+    # kubelet resolves it on the node, ``DirectoryOrCreate``s an empty
+    # root-owned dir, and the agent boots into an empty worktree and no-ops
+    # with rc=0 forever — supervision sees a healthy arm while consensus
+    # silently stalls. Fail the spawn loudly instead so the failure-streak
+    # machinery engages and the next attempt falls back to create.
+    leaked = {
+        owner_repo: path
+        for owner_repo, path in (repo_volumes or {}).items()
+        if _pkg._local_to_host_path(path) != path
+    }
+    if leaked:
+        raise KubernetesSpawnError(
+            f"Refusing to spawn {job_name}: repo_volumes carry "
+            f"orchestrator-local paths that would be mounted as empty "
+            f"hostPath dirs on the node: {leaked}. Translate them via "
+            f"_local_to_host_volumes before spawning — see #3502."
+        )
+
     # Register gateway session (token-only, no container_ip)
     session_info = None
     session_token = existing_session_token  # reuse when supplied
@@ -427,7 +448,13 @@ def spawn_agent_job(
                 # agent_worktree_id.  Without this, the gateway would
                 # race to create a second worktree under job_name and
                 # intermittently fail on .git/config.lock (#1857).
-                worktree_container_id=(agent_worktree_id if worktree_created_this_call else None),
+                # The re-attach path (``reuse_worktree_id``) validated the
+                # same worktree on disk, so it binds too — otherwise the
+                # gateway creates an orphan worktree keyed by the session
+                # id that nothing ever mounts (#3502 naming split).
+                worktree_container_id=(
+                    agent_worktree_id if (worktree_created_this_call or reuse_worktree_id) else None
+                ),
                 # Per-agent upstream routing. Both fields
                 # are forwarded to the gateway only when set, so the
                 # default-Claude case keeps the request body byte-

--- a/orchestrator/kubernetes_spawner/_spawn.py
+++ b/orchestrator/kubernetes_spawner/_spawn.py
@@ -382,6 +382,18 @@ def spawn_agent_job(
     # with rc=0 forever — supervision sees a healthy arm while consensus
     # silently stalls. Fail the spawn loudly instead so the failure-streak
     # machinery engages and the next attempt falls back to create.
+    #
+    # Scope/limits: this only catches leaks the mapping can *translate*. A
+    # genuinely-untranslatable local path (a multi-partition host where the
+    # worktree mount has root=/ and is skipped, with HOST_HOME unset) passes
+    # through as identity and the tripwire stays silent — same limitation
+    # HOST_HOME exists to cover, matching the gateway's own. It also assumes
+    # orchestrator↔gateway mount symmetry: in a (pathological) asymmetric
+    # deployment where the gateway returns a host path the orchestrator's OWN
+    # mountinfo would further translate, this would false-positive on a
+    # working create. Not reachable in symmetric deployments (the
+    # orchestrator has no mount point under the host-home path), so risk is
+    # very low.
     leaked = {
         owner_repo: path
         for owner_repo, path in (repo_volumes or {}).items()

--- a/orchestrator/kubernetes_spawner/_worktree.py
+++ b/orchestrator/kubernetes_spawner/_worktree.py
@@ -39,6 +39,13 @@ def _validate_worktree_for_reuse(
 
     Returns a ``{owner/repo: filesystem_path}`` dict on success, or ``None`` on ANY
     validation mismatch (the caller falls back to create-with-retry). Best-effort logging.
+
+    The returned paths are ORCHESTRATOR-LOCAL (under ``WORKTREE_BASE_DIR``,
+    i.e. this container's own mount of the worktree tree) — suitable for the
+    orchestrator's filesystem ops but NOT for a Job spec's ``hostPath``
+    mounts. :func:`_try_reuse_worktree` translates them to host paths via
+    :func:`_local_to_host_volumes` before handing them to the spawn path
+    (#3502).
     """
     import subprocess as _sp
 
@@ -188,6 +195,95 @@ def _host_to_local_volumes(repo_volumes: dict[str, str]) -> dict[str, str]:
     }
 
 
+# Lazily-loaded (mount_point, host_root) pairs from /proc/self/mountinfo,
+# longest mount_point first. ``None`` until first use; tests may seed it.
+_LOCAL_MOUNT_MAPPING: list[tuple[str, str]] | None = None
+
+
+def _load_local_mount_mapping(source: str = "/proc/self/mountinfo") -> list[tuple[str, str]]:
+    """Read /proc/self/mountinfo and return (mount_point, host_root) pairs.
+
+    Mirrors the gateway's ``_load_mount_mapping`` / ``translate_to_host_path``
+    (``gateway/gateway.py``): for a kubelet- or docker-managed bind mount the
+    mountinfo *root* field (``fields[3]``) records the host path the mount
+    was bound from — exactly the value a Job spec's ``hostPath`` needs.
+
+    Entries that cannot name a host directory are skipped, so translation is
+    a no-op outside a container (unit tests, developer hosts): the rootfs
+    ``/`` entry, entries whose root is ``/`` (tmpfs and other non-bind
+    filesystems), and identity mappings (root == mount_point, e.g. a
+    partition or subvolume mounted at its own path). Skipped entries fall
+    through to the ``HOST_HOME`` env-var fallback in
+    :func:`_local_to_host_path`.
+    """
+    entries: list[tuple[str, str]] = []
+    try:
+        with open(source) as fh:
+            for line in fh:
+                # Format: mount_id parent_id major:minor root mount_point ...
+                fields = line.split()
+                if len(fields) < 5:
+                    continue
+                host_root, mount_point = fields[3], fields[4]
+                if mount_point == "/" or host_root == "/" or host_root == mount_point:
+                    continue
+                entries.append((mount_point, host_root))
+    except OSError:
+        return []
+    entries.sort(key=lambda p: len(p[0]), reverse=True)
+    return entries
+
+
+def _local_to_host_path(local_path: str, mapping: list[tuple[str, str]] | None = None) -> str:
+    """Translate an orchestrator-local path to the host path it is bound from.
+
+    Inverse of :func:`_host_to_local_volumes`, for paths the orchestrator
+    derived from its OWN mounts (``WORKTREE_BASE_DIR``) that must be handed
+    to a Job spec as ``hostPath`` sources. Handing the local path onward
+    makes kubelet ``DirectoryOrCreate`` an empty root-owned dir on the node
+    and the agent boots into an empty worktree, no-ops, and exits rc=0 —
+    the silent consensus stall in #3502.
+
+    Tries the mountinfo mapping first (no configuration needed — the same
+    mechanism the gateway uses to return host paths from
+    ``create_worktrees``), then the ``HOST_HOME`` env var for
+    ``/home/egg``-prefixed paths, and otherwise returns the path unchanged
+    (already a host path, or no translation is known).
+
+    ``mapping`` overrides the lazily-cached mountinfo entries (tests).
+    """
+    global _LOCAL_MOUNT_MAPPING
+    if mapping is None:
+        if _LOCAL_MOUNT_MAPPING is None:
+            _LOCAL_MOUNT_MAPPING = _load_local_mount_mapping()
+        mapping = _LOCAL_MOUNT_MAPPING
+    for mount_point, host_root in mapping:
+        if local_path == mount_point or local_path.startswith(mount_point + "/"):
+            return host_root + local_path[len(mount_point) :]
+
+    host_home = os.environ.get("HOST_HOME", "").rstrip("/")
+    container_home = "/home/egg"
+    if (
+        host_home
+        and host_home != container_home
+        and (local_path == container_home or local_path.startswith(container_home + "/"))
+    ):
+        return host_home + local_path[len(container_home) :]
+    return local_path
+
+
+def _local_to_host_volumes(repo_volumes: dict[str, str]) -> dict[str, str]:
+    """Translate orchestrator-local repo volume paths to host paths (#3502).
+
+    Applied to the volumes :func:`_validate_worktree_for_reuse` builds from
+    ``WORKTREE_BASE_DIR`` so the reuse path hands the spawn path the same
+    kind of value the create path gets from the gateway: a HOST path fit
+    for a ``hostPath`` mount. Paths with no known translation pass through
+    unchanged.
+    """
+    return {name: _local_to_host_path(path) for name, path in repo_volumes.items()}
+
+
 def _try_reuse_worktree(
     self,
     agent_worktree_id: str,
@@ -201,6 +297,13 @@ def _try_reuse_worktree(
     discard + hard-sync). Returns ``(success, repo_volumes)`` on
     success, or ``None`` on any validation or cleanup mismatch (the
     caller falls back to create-with-retry).
+
+    The returned ``repo_volumes`` carry HOST paths (translated via
+    :func:`_local_to_host_volumes`), matching the create path's
+    gateway-returned values, because the caller feeds them straight into
+    the Job spec's ``hostPath`` mounts. Handing the validator's
+    orchestrator-local paths onward instead made every post-restart
+    re-attach spawn mount an empty kubelet-created dir (#3502).
 
     Signature matches the tester's test-first contract:
     ``(agent_worktree_id, branch, repos) -> (bool, dict) | None``.
@@ -216,7 +319,7 @@ def _try_reuse_worktree(
         return None
     if not self._clean_reused_worktree(agent_worktree_id, branch, repos):
         return None
-    return True, vols
+    return True, _local_to_host_volumes(vols)
 
 
 def _clean_reused_worktree(

--- a/orchestrator/kubernetes_spawner/_worktree.py
+++ b/orchestrator/kubernetes_spawner/_worktree.py
@@ -237,7 +237,9 @@ def _load_local_mount_mapping(source: str = "/proc/self/mountinfo") -> list[tupl
 def _local_to_host_path(local_path: str, mapping: list[tuple[str, str]] | None = None) -> str:
     """Translate an orchestrator-local path to the host path it is bound from.
 
-    Inverse of :func:`_host_to_local_volumes`, for paths the orchestrator
+    Counterpart of :func:`_host_to_local_volumes` (not an exact inverse:
+    this uses mountinfo + ``HOST_HOME`` where that does a bare ``HOST_HOME``
+    string replace), for paths the orchestrator
     derived from its OWN mounts (``WORKTREE_BASE_DIR``) that must be handed
     to a Job spec as ``hostPath`` sources. Handing the local path onward
     makes kubelet ``DirectoryOrCreate`` an empty root-owned dir on the node

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -2858,6 +2858,225 @@ class TestSpawnEventJobWorktreeReattach:
         assert head == remote
 
 
+class TestReusePathHostPathTranslation:
+    """Reuse-path ``repo_volumes`` must carry HOST paths (#3502).
+
+    The create path hands the spawn path gateway-returned HOST paths; the
+    re-attach path used to hand the validator's orchestrator-LOCAL paths
+    (under ``WORKTREE_BASE_DIR``) straight into the Job spec's ``hostPath``
+    mounts. On the node kubelet ``DirectoryOrCreate``d an empty root-owned
+    dir at that local path, so every post-restart re-attach spawn booted
+    into an empty worktree and no-oped with rc=0 — silently stalling slice
+    consensus.
+    """
+
+    def test_local_to_host_path_translates_via_mount_mapping(self):
+        from kubernetes_spawner import _local_to_host_path
+
+        mapping = [
+            ("/home/egg/.egg-worktrees", "/home/hostuser/.egg-worktrees"),
+            ("/home/egg", "/home/hostuser"),
+        ]
+        assert (
+            _local_to_host_path("/home/egg/.egg-worktrees/wt-1/repo", mapping)
+            == "/home/hostuser/.egg-worktrees/wt-1/repo"
+        )
+        # Longest prefix wins (mapping is ordered longest-first).
+        assert _local_to_host_path("/home/egg/other", mapping) == "/home/hostuser/other"
+        # Exact mount-point match translates too.
+        assert (
+            _local_to_host_path("/home/egg/.egg-worktrees", mapping)
+            == "/home/hostuser/.egg-worktrees"
+        )
+        # A sibling path that merely shares the string prefix does not match.
+        assert _local_to_host_path("/home/egg-other/x", mapping[:1]) == "/home/egg-other/x"
+
+    def test_local_to_host_path_falls_back_to_host_home(self, monkeypatch):
+        from kubernetes_spawner import _local_to_host_path
+
+        monkeypatch.setenv("HOST_HOME", "/home/hostuser")
+        assert (
+            _local_to_host_path("/home/egg/.egg-worktrees/wt-1/repo", [])
+            == "/home/hostuser/.egg-worktrees/wt-1/repo"
+        )
+        # Non-/home/egg paths (already host paths) pass through unchanged.
+        assert (
+            _local_to_host_path("/home/hostuser/.egg-worktrees/wt-1/repo", [])
+            == "/home/hostuser/.egg-worktrees/wt-1/repo"
+        )
+
+    def test_local_to_host_path_passthrough_without_translation(self, monkeypatch):
+        from kubernetes_spawner import _local_to_host_path
+
+        monkeypatch.delenv("HOST_HOME", raising=False)
+        assert (
+            _local_to_host_path("/home/egg/.egg-worktrees/wt-1/repo", [])
+            == "/home/egg/.egg-worktrees/wt-1/repo"
+        )
+
+    def test_load_local_mount_mapping_skips_non_bind_entries(self, tmp_path):
+        """Rootfs, tmpfs-style (root ``/``), and identity entries are skipped
+        so translation is a no-op outside a container."""
+        from kubernetes_spawner import _load_local_mount_mapping
+
+        mountinfo = tmp_path / "mountinfo"
+        mountinfo.write_text(
+            # rootfs entry: mount_point "/" — skipped
+            "22 1 0:20 / / rw - overlay overlay rw\n"
+            # tmpfs /tmp: root "/" — skipped
+            "40 22 0:33 / /tmp rw - tmpfs tmpfs rw\n"
+            # identity mapping (subvolume mounted at its own path) — skipped
+            "50 22 8:1 /home /home rw - btrfs /dev/sda1 rw\n"
+            # genuine bind mount — kept
+            "60 22 8:1 /home/hostuser/.egg-worktrees /home/egg/.egg-worktrees rw - btrfs x rw\n"
+            # short/malformed line — ignored
+            "61 22 8:1\n"
+        )
+        assert _load_local_mount_mapping(str(mountinfo)) == [
+            ("/home/egg/.egg-worktrees", "/home/hostuser/.egg-worktrees")
+        ]
+
+    def test_try_reuse_returns_host_paths(self, spawner, tmp_path):
+        """The #3502 regression: reuse-path repo_volumes are HOST paths."""
+        repo, _ = _make_worktree(tmp_path, _WT_ID, "repo", _BRANCH, with_origin=True)
+        mapping = [(str(tmp_path), "/home/hostuser/.egg-worktrees")]
+        with (
+            patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path),
+            patch("kubernetes_spawner._worktree._LOCAL_MOUNT_MAPPING", mapping),
+        ):
+            result = spawner._try_reuse_worktree(_WT_ID, _BRANCH, _REPOS)
+
+        assert result is not None
+        _, repo_volumes = result
+        assert repo_volumes["owner/repo"] == f"/home/hostuser/.egg-worktrees/{_WT_ID}/repo"
+
+    def test_try_reuse_no_translation_is_identity(self, spawner, tmp_path):
+        """Without a mount mapping or HOST_HOME the paths pass through
+        unchanged (bare-host behavior; matches the pre-fix return)."""
+        repo, _ = _make_worktree(tmp_path, _WT_ID, "repo", _BRANCH, with_origin=True)
+        with (
+            patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path),
+            patch("kubernetes_spawner._worktree._LOCAL_MOUNT_MAPPING", []),
+        ):
+            result = spawner._try_reuse_worktree(_WT_ID, _BRANCH, _REPOS)
+
+        assert result is not None
+        assert result[1]["owner/repo"] == str(repo)
+
+    def test_spawn_rejects_orchestrator_local_repo_volumes(self, spawner):
+        """The #3502 tripwire: a translatable (i.e. orchestrator-local) path
+        reaching the spawn path's hostPath mounts fails the spawn loudly
+        instead of mounting an empty dir the agent no-ops in."""
+        from kubernetes_spawner import KubernetesSpawnError
+
+        mapping = [("/home/egg/.egg-worktrees", "/home/hostuser/.egg-worktrees")]
+        with (
+            patch("kubernetes_spawner._worktree._LOCAL_MOUNT_MAPPING", mapping),
+            pytest.raises(KubernetesSpawnError, match="orchestrator-local"),
+        ):
+            spawner.spawn_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                repos=["owner/repo"],
+                reuse_worktree_id="pipe-1-coder",
+                repo_volumes={"owner/repo": "/home/egg/.egg-worktrees/pipe-1-coder/repo"},
+            )
+
+    def test_spawn_accepts_host_repo_volumes(self, spawner, mock_k8s_client):
+        """Host paths (untranslatable) pass the tripwire and reach the mounts."""
+        mapping = [("/home/egg/.egg-worktrees", "/home/hostuser/.egg-worktrees")]
+        with patch("kubernetes_spawner._worktree._LOCAL_MOUNT_MAPPING", mapping):
+            spawner.spawn_agent_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                repos=["owner/repo"],
+                reuse_worktree_id="pipe-1-coder",
+                repo_volumes={"owner/repo": "/home/hostuser/.egg-worktrees/pipe-1-coder/repo"},
+            )
+        mounts = mock_k8s_client.create_container.call_args.kwargs["host_path_mounts"]
+        assert mounts == [
+            {
+                "name": "repo-owner-repo",
+                "host_path": "/home/hostuser/.egg-worktrees/pipe-1-coder/repo",
+                "container_path": "/home/egg/repos/repo",
+                "read_only": False,
+            }
+        ]
+
+
+class TestReusePathWorktreeContainerIdBinding:
+    """Reuse-path session registration binds the validated worktree (#3502).
+
+    Without ``worktree_container_id``, a fresh registration on the re-attach
+    path makes the gateway create an orphan worktree keyed by the session's
+    ``container_id`` (the ``egg-agent-…`` Job base name) that no Job spec
+    ever mounts — the naming split observed in the #3502 incident.
+    """
+
+    def test_get_or_create_session_forwards_worktree_container_id(self, spawner, mock_gateway):
+        mock_gateway.heartbeat_session_by_container.return_value = False
+        mock_gateway.register_session.return_value = _FakeSessionInfo(
+            session_token="tok-bound-worktree",
+            container_id="egg-agent-pipe-1-slice-4-coder",
+        )
+
+        session = spawner._get_or_create_session(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.CODER,
+            slice_id="slice-4",
+            mode="public",
+            repos=["owner/repo"],
+            worktree_container_id="pipe-1-slice-4-coder",
+        )
+
+        assert session is not None
+        kwargs = mock_gateway.register_session.call_args.kwargs
+        assert kwargs["container_id"] == "egg-agent-pipe-1-slice-4-coder"
+        assert kwargs["worktree_container_id"] == "pipe-1-slice-4-coder"
+
+    def test_event_reattach_registration_binds_validated_worktree(
+        self, spawner, mock_k8s_client, mock_gateway, tmp_path
+    ):
+        """End-to-end: a re-attach spawn whose session registers fresh passes
+        the validated worktree id to the gateway."""
+        _make_worktree(tmp_path, "pipe-1-slice-4-coder", "repo", _BRANCH, with_origin=True)
+        mock_k8s_client.list_jobs.return_value = []  # no live Job → no adoption
+        mock_gateway.heartbeat_session_by_container.return_value = False
+        mock_gateway.register_session.return_value = _FakeSessionInfo(
+            session_token="tok-reattach",
+            container_id="egg-agent-pipe-1-slice-4-coder",
+        )
+
+        with patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path):
+            spawner.spawn_event_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                action="propose",
+                dedupe_key="c" * 64,
+                slice_id="slice-4",
+                phase="implement",
+                repos=["owner/repo"],
+                branch=_BRANCH,
+                wait_for_gateway=False,
+            )
+
+        kwargs = mock_gateway.register_session.call_args.kwargs
+        assert kwargs["worktree_container_id"] == "pipe-1-slice-4-coder"
+
+    def test_spawn_reuse_path_registration_binds_worktree_container_id(self, spawner, mock_gateway):
+        """``spawn_agent_job``'s own registration (reuse path, no supplied
+        token) also binds the reused worktree instead of ``None``."""
+        spawner.spawn_agent_job(
+            pipeline_id="pipe-1",
+            agent_role=AgentRole.CODER,
+            repos=["owner/repo"],
+            reuse_worktree_id="pipe-1-coder",
+            repo_volumes={"owner/repo": "/home/hostuser/.egg-worktrees/pipe-1-coder/repo"},
+        )
+        kwargs = mock_gateway.register_session.call_args.kwargs
+        assert kwargs["worktree_container_id"] == "pipe-1-coder"
+
+
 class TestSpawnEventJobDirtyWorktree:
     """Dirty-state policy (architect R6) for re-attached worktrees (#3064 slice-4).
 


### PR DESCRIPTION
Fixes #3502.

## Root cause

On the worktree re-attach path, `_validate_worktree_for_reuse` builds `repo_volumes` from the orchestrator's own `WORKTREE_BASE_DIR` mount (`/home/egg/.egg-worktrees/...`) and `spawn_agent_job` consumed those values directly as the Job spec's `hostPath` sources, with no local-to-host back-translation. kubelet resolved them on the node, `DirectoryOrCreate`'d an empty root-owned dir, and the agent booted into an empty worktree, no-oped, and exited rc=0; JobSupervisor recorded success, so a structurally dead arm looked healthy while slice consensus stalled. The create path was unaffected because the gateway's `create_worktrees` already returns host paths via `translate_to_host_path`.

## Changes

**1. Reuse-path volumes are translated to host paths** (`_worktree.py`). `_try_reuse_worktree` now returns `repo_volumes` translated through a new `_local_to_host_path` / `_local_to_host_volumes` pair. Translation reads `/proc/self/mountinfo` (the same zero-config mechanism the gateway's `translate_to_host_path` uses to produce the create path's host paths), with the `HOST_HOME` env var as the documented escape hatch. Entries that cannot name a host directory (the rootfs `/` entry, `root=/` tmpfs-style entries, identity mappings) are skipped, so the translation is a no-op on bare hosts and in unit tests; the `HOST_HOME` fallback matters because the orchestrator deployment, unlike the gateway's, does not set that env var.

**2. Spawn-time tripwire** (`_spawn.py`). The assert requested in the issue: `spawn_agent_job` now refuses to spawn when any `repo_volumes` value is still a translatable orchestrator-local path. A future leak fails the spawn loudly, so the failure-streak machinery engages instead of the fault hiding behind rc=0 no-op successes.

**3. Naming split closed** (`_session.py`, `_events.py`, `_spawn.py`). Fresh session registrations on the reuse path now pass `worktree_container_id`, binding the gateway session to the worktree that re-attach just validated. Previously the gateway created an orphan worktree keyed by the `egg-agent-...` session id that no Job spec ever mounted; this is the second discrepancy observed in the incident (`egg-agent-<id>` vs `<id>` dirs under `~/.egg-worktrees`). The gateway-side `lookup_worktree` is filesystem-based, so the binding survives gateway restarts.

## Not in this PR

- Agent-entrypoint fail-fast on an empty `EGG_REPO_PATH`: worth doing as defense in depth, but it needs care around roles that legitimately spawn without a worktree, and it lives in `sandbox/`; the tripwire above already turns the known leak into a loud failure at its source.
- Wiring the stuck-phase-transition anomaly to forced worktree re-create: separate remediation work in the event loop / overseer.
- Cache invalidation on restart: the pinned root cause showed this incident was a path-translation bug, not a stale cache.

## Testing

- 11 new tests: mountinfo parsing and skip rules, translation and `HOST_HOME` fallback, reuse-path host-path regression, tripwire reject/accept, and `worktree_container_id` binding on all three registration paths (`orchestrator/tests/test_kubernetes_spawner.py`).
- Full `test_kubernetes_spawner.py` suite passes (196 tests).
- `make test` (changeset-aware, ~20.8k tests): 4 failures, all pre-existing local-environment failures; verified they fail identically on the base commit with this diff reverted (missing `/home/egg`, missing container tooling).
- `make lint` clean.

After this lands, the standing host-side workaround from the issue (the `/home/egg/.egg-worktrees -> /home/jwies/.egg-worktrees` symlink) can be reverted; the kubelet-created empty dir tree under the leaked path can be removed.
