### PR TITLE
Make re-attach sync fast-forward-aware; keep clean unpushed agent commits

### DIFF
--- a/docs/architecture/on-demand-agent-lifecycle.md
+++ b/docs/architecture/on-demand-agent-lifecycle.md
@@ -168,10 +168,17 @@ Under orchestrator ownership the worktree becomes a hot path.
    (the gateway materializes worktrees on this local branch, wired to push to
    the assigned branch — #3480), or detached `HEAD`.
 2. **On pass:** discard uncommitted changes and untracked staging artifacts
-   (`git reset --hard` + `git clean -fd`) and hard-sync to the role branch tip
-   before agent invocation. (The #3023 post-mortem constraint means a
-   predecessor pod killed mid-event must never leak unproposed residue
-   into a successor's commit.)
+   (`git reset --hard` + `git clean -fd`) and sync to the role branch tip
+   before agent invocation. The sync is **fast-forward-aware** ([#3506](https://github.com/jwbron/egg/issues/3506)):
+   when the pre-discard tree was clean and the local HEAD is a strict
+   descendant of the origin tip, the local commits are the agent's own
+   durable multi-session work and HEAD is kept; hard-reset to the tip
+   happens only on divergence, a behind-tip HEAD, or a dirty pre-discard
+   tree (the killed-mid-event signature; the #3023 post-mortem constraint
+   means a predecessor pod killed mid-event must never leak unproposed
+   residue into a successor's commit). A reset that discards commits ahead
+   of the tip logs their SHAs (salvageable via `salvage_agent_commits`,
+   [#3368](https://github.com/jwbron/egg/issues/3368)).
 3. **Before handing off to spawn:** translate the validated paths from
    orchestrator-local (under `WORKTREE_BASE_DIR`) to host paths, matching
    what the create path already gets from the gateway. An untranslated

--- a/orchestrator/kubernetes_spawner/_events.py
+++ b/orchestrator/kubernetes_spawner/_events.py
@@ -152,8 +152,9 @@ def spawn_event_job(
     candidate_id = self._build_agent_worktree_id(pipeline_id, agent_role, slice_id=slice_id)
     if repos:
         # Use the composed method that validates AND cleans dirty state
-        # (R6 dirty-state policy) so re-attached worktrees are always
-        # pristine before the agent runs.
+        # (R6 dirty-state policy) so re-attached worktrees always start
+        # with a clean tree at the role branch tip, or a clean
+        # fast-forward ahead of it (#3506), before the agent runs.
         result = self._try_reuse_worktree(candidate_id, branch, repos)
         if result is not None:
             reuse_worktree_id = candidate_id

--- a/orchestrator/kubernetes_spawner/_worktree.py
+++ b/orchestrator/kubernetes_spawner/_worktree.py
@@ -32,8 +32,8 @@ def _validate_worktree_for_reuse(
 
     This function performs **validation only** — the caller must also invoke
     :meth:`KubernetesSpawner._clean_reused_worktree` to discard dirty state
-    and hard-sync to the role branch tip (R6 dirty-state policy) before the
-    agent runs. The separation lets the test-first contract
+    and sync to the role branch tip (R6 dirty-state policy, fast-forward-aware
+    per #3506) before the agent runs. The separation lets the test-first contract
     (:meth:`_try_reuse_worktree`) compose validation + cleanup into one call
     while keeping each concern independently testable.
 
@@ -296,7 +296,7 @@ def _try_reuse_worktree(
 
     Composes :func:`_validate_worktree_for_reuse` (filesystem health
     checks) followed by :meth:`_clean_reused_worktree` (R6 dirty-state
-    discard + hard-sync). Returns ``(success, repo_volumes)`` on
+    discard + fast-forward-aware sync, #3506). Returns ``(success, repo_volumes)`` on
     success, or ``None`` on any validation or cleanup mismatch (the
     caller falls back to create-with-retry).
 
@@ -330,12 +330,24 @@ def _clean_reused_worktree(
     branch: str | None,
     repos: list[str] | None,
 ) -> bool:
-    """Discard dirty state and hard-sync a re-attached worktree (R6).
+    """Discard dirty state and sync a re-attached worktree (R6, #3506).
 
     Applies ``git reset --hard && git clean -fd`` to discard uncommitted
-    changes and untracked staging artifacts, then hard-syncs to the role
-    branch tip via ``git fetch origin {branch} && git reset --hard
-    origin/{branch}``.
+    changes and untracked staging artifacts, then syncs to the role
+    branch tip via ``git fetch origin {branch}``.
+
+    The sync is **fast-forward-aware** (#3506): when the pre-discard tree
+    was clean and the local HEAD is a strict descendant of
+    ``origin/{branch}``, the local commits are the agent's own durable
+    multi-session work (a clean session exit that had not pushed yet) and
+    HEAD is kept. Unconditionally hard-resetting here made multi-session
+    slices structurally impossible: every event-pump cycle silently
+    orphaned the previous session's unpushed commits. On divergence, a
+    behind-tip HEAD, or a dirty pre-discard tree (the killed-mid-event
+    signature the R6 residue policy exists to contain), the worktree
+    hard-resets to ``origin/{branch}``; any commits ahead of the tip that
+    the reset discards are first logged with their SHAs so the orphaning
+    is visible and salvageable (``salvage_agent_commits``, #3368).
 
     Returns ``True`` on success, ``False`` on any failure (the caller
     falls back to create-with-retry — never allow a half-cleaned
@@ -345,6 +357,24 @@ def _clean_reused_worktree(
     empty, returns ``True`` (nothing to clean).
     """
     import subprocess as _sp
+
+    def _git(repo_dir: Path, *args: str, timeout: int = 30, check: bool = True):
+        return _sp.run(
+            [
+                "git",
+                "-C",
+                str(repo_dir),
+                "-c",
+                "core.hooksPath=/dev/null",
+                "-c",
+                "safe.directory=*",
+                *args,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=check,
+        )
 
     if not repos or not _pkg.WORKTREE_BASE_DIR.exists():
         return True
@@ -358,25 +388,18 @@ def _clean_reused_worktree(
         if not d.exists():
             continue
 
+        # Record whether the tree carried uncommitted/untracked state
+        # BEFORE the discard below erases the evidence: dirt is the
+        # killed-mid-event signature that disqualifies the fast-forward
+        # keep in the sync step (#3506). Unknown state counts as dirty.
+        try:
+            was_dirty = bool(_git(d, "status", "--porcelain").stdout.strip())
+        except Exception:
+            was_dirty = True
+
         # reset --hard
         try:
-            _sp.run(
-                [
-                    "git",
-                    "-C",
-                    str(d),
-                    "-c",
-                    "core.hooksPath=/dev/null",
-                    "-c",
-                    "safe.directory=*",
-                    "reset",
-                    "--hard",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=30,
-                check=True,
-            )
+            _git(d, "reset", "--hard")
         except Exception as e:
             logger.warning(
                 "Worktree re-attach: reset --hard failed",
@@ -387,23 +410,7 @@ def _clean_reused_worktree(
             return False
         # clean -fd
         try:
-            _sp.run(
-                [
-                    "git",
-                    "-C",
-                    str(d),
-                    "-c",
-                    "core.hooksPath=/dev/null",
-                    "-c",
-                    "safe.directory=*",
-                    "clean",
-                    "-fd",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=30,
-                check=True,
-            )
+            _git(d, "clean", "-fd")
         except Exception as e:
             logger.warning(
                 "Worktree re-attach: clean -fd failed",
@@ -412,71 +419,108 @@ def _clean_reused_worktree(
                 error=str(e),
             )
             return False
-        # Hard-sync to the role branch tip. This is the ONLY step that
-        # removes a predecessor's *local, unpushed* commit — ``reset
+        # Sync to the role branch tip. This is the ONLY step that can
+        # remove a predecessor's *local, unpushed* commit — ``reset
         # --hard`` (above) only discards the uncommitted working tree, so
-        # a pod killed mid-event after a local commit still carries that
-        # commit through to here. If the hard-sync fails we MUST fall back
-        # to recreate (return False): continuing on the current HEAD would
-        # leak the predecessor's unproposed commit into the successor's
-        # worktree — and its next proposal — which is exactly the residue
-        # leak the R6 dirty-state policy exists to forbid. A transient
-        # ``fetch origin`` blip is precisely what this
-        # resilience path must survive, so it is fatal-to-reuse, not
-        # silently swallowed.
+        # a local commit always carries through to here. If the fetch
+        # fails we MUST fall back to recreate (return False): without the
+        # true origin tip we cannot tell the agent's own fast-forward
+        # work from divergent residue. A transient ``fetch origin`` blip
+        # is precisely what this resilience path must survive, so it is
+        # fatal-to-reuse, not silently swallowed.
         if branch:
             try:
-                _sp.run(
-                    [
-                        "git",
-                        "-C",
-                        str(d),
-                        "-c",
-                        "core.hooksPath=/dev/null",
-                        "-c",
-                        "safe.directory=*",
-                        "fetch",
-                        "origin",
-                        branch,
-                    ],
-                    capture_output=True,
-                    text=True,
-                    timeout=60,
-                    check=True,
-                )
-                _sp.run(
-                    [
-                        "git",
-                        "-C",
-                        str(d),
-                        "-c",
-                        "core.hooksPath=/dev/null",
-                        "-c",
-                        "safe.directory=*",
-                        "reset",
-                        "--hard",
-                        f"origin/{branch}",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    timeout=30,
-                    check=True,
-                )
+                _git(d, "fetch", "origin", branch, timeout=60)
             except Exception as e:
                 logger.warning(
-                    "Worktree re-attach: hard-sync failed — falling back "
+                    "Worktree re-attach: fetch failed; falling back "
                     "to recreate (cannot prove worktree is at origin tip)",
                     agent_worktree_id=agent_worktree_id,
                     repo=n,
                     error=str(e),
                 )
-                # Fatal: without a successful hard-sync we cannot guarantee
-                # the worktree carries no predecessor residue ahead of
-                # origin/{branch}. Recreate-with-retry is the safe fallback.
                 return False
 
+            # Fast-forward-aware keep (#3506): equal-to-tip needs no
+            # reset; a clean-tree strict descendant is the agent's own
+            # accumulated work and is kept. Anything else (divergence,
+            # behind-tip, dirty pre-discard tree, or an unreadable
+            # topology) hard-resets to the origin tip.
+            keep_local = False
+            local_head = remote_tip = ""
+            try:
+                local_head = _git(d, "rev-parse", "HEAD").stdout.strip()
+                remote_tip = _git(d, "rev-parse", f"origin/{branch}").stdout.strip()
+                if local_head == remote_tip:
+                    keep_local = True
+                elif not was_dirty:
+                    keep_local = (
+                        _git(
+                            d,
+                            "merge-base",
+                            "--is-ancestor",
+                            remote_tip,
+                            local_head,
+                            check=False,
+                        ).returncode
+                        == 0
+                    )
+            except Exception:
+                keep_local = False
+
+            if keep_local:
+                if local_head != remote_tip:
+                    logger.info(
+                        "Worktree re-attach: keeping local commits "
+                        "(clean fast-forward of origin tip, #3506)",
+                        agent_worktree_id=agent_worktree_id,
+                        repo=n,
+                        branch=branch,
+                        local_head=local_head,
+                        remote_tip=remote_tip,
+                    )
+            else:
+                # Orphan detector (#3506): surface exactly which commits
+                # the reset is about to discard; between-cycle resets
+                # produce the same orphan class as restart-time resets
+                # (#3368) and must not be silent.
+                try:
+                    if local_head and remote_tip:
+                        orphans = _git(
+                            d, "rev-list", f"{remote_tip}..{local_head}", check=False
+                        ).stdout.split()
+                        if orphans:
+                            logger.warning(
+                                "Worktree re-attach: hard-reset is discarding "
+                                "unpushed local commits (dirty or diverged); "
+                                "salvageable via salvage_agent_commits (#3368)",
+                                agent_worktree_id=agent_worktree_id,
+                                repo=n,
+                                branch=branch,
+                                was_dirty=was_dirty,
+                                discarded_commit_count=len(orphans),
+                                discarded_commits=orphans[:20],
+                            )
+                except Exception:
+                    pass
+                try:
+                    _git(d, "reset", "--hard", f"origin/{branch}")
+                except Exception as e:
+                    logger.warning(
+                        "Worktree re-attach: hard-sync failed — falling back "
+                        "to recreate (cannot prove worktree is at origin tip)",
+                        agent_worktree_id=agent_worktree_id,
+                        repo=n,
+                        error=str(e),
+                    )
+                    # Fatal: without a successful hard-sync we cannot
+                    # guarantee the worktree carries no predecessor residue
+                    # ahead of origin/{branch}. Recreate-with-retry is the
+                    # safe fallback.
+                    return False
+
     logger.info(
-        "Worktree re-attach: cleaned and hard-synced",
+        "Worktree re-attach: cleaned and synced",
         agent_worktree_id=agent_worktree_id,
         repos=[r.split("/")[-1] if "/" in r else r for r in repos],
     )

--- a/orchestrator/tests/test_event_loop.py
+++ b/orchestrator/tests/test_event_loop.py
@@ -592,7 +592,7 @@ class TestLatencyBudgetFromTimingField:
     The authoritative budget reads ``EventDecision.timing['spawn_dispatch_seconds']``
     — measured in ``poll_once`` across the WHOLE ``spawner.spawn_event(...)`` call,
     which in orchestrator mode fans out through the slice-4 worktree re-attach
-    validation, ``_clean_reused_worktree`` (fetch + hard-sync), and
+    validation, ``_clean_reused_worktree`` (fetch + fast-forward-aware sync), and
     ``_get_or_create_session`` before the k8s Job is created. A regression that
     slows any of that new code therefore moves this measured interval, so the
     budget actually guards the slice-4 latency (unlike a sub-segment timer that

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -2677,7 +2677,7 @@ def _make_worktree(base, worktree_id, repo_name, branch, *, with_origin=False):
 
     When ``with_origin`` is set, also create a bare ``origin`` repo, wire it as
     the ``origin`` remote, and push *branch* so ``origin/<branch>`` exists (the
-    hard-sync target). Returns ``(repo_path, origin_path_or_None)``.
+    sync/reset target). Returns ``(repo_path, origin_path_or_None)``.
     """
     repo = Path(base) / worktree_id / repo_name
     repo.mkdir(parents=True)

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -2833,15 +2833,18 @@ class TestSpawnEventJobWorktreeReattach:
     def test_try_reuse_production_shape_work_branch(self, spawner, tmp_path):
         """End-to-end for the production shape (#3480): HEAD on the derived
         work branch, assigned branch only on origin. Validation accepts the
-        work branch and the R6 hard-sync resets to ``origin/{assigned}``."""
+        work branch, and the sync KEEPS the clean-tree local commit strictly
+        ahead of ``origin/{assigned}`` (fast-forward-aware, #3506)."""
         work_branch = f"egg/{_WT_ID}/work"
         repo, _ = _make_worktree(tmp_path, _WT_ID, "repo", work_branch, with_origin=True)
-        # Publish the assigned branch on origin (the hard-sync target), then
-        # advance the local work branch past it so the sync has work to do.
+        # Publish the assigned branch on origin (the sync target), then
+        # advance the local work branch past it: the agent's own unpushed
+        # multi-session work, committed on a clean exit.
         _git(repo, "push", "origin", f"{work_branch}:{_BRANCH}")
         (repo / "local.txt").write_text("unpushed\n")
         _git(repo, "add", "-A")
         _git(repo, "commit", "-m", "local unpushed commit")
+        local_head = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
         with patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path):
             result = spawner._try_reuse_worktree(_WT_ID, _BRANCH, _REPOS)
@@ -2850,12 +2853,15 @@ class TestSpawnEventJobWorktreeReattach:
         success, repo_volumes = result
         assert success
         assert repo_volumes["owner/repo"] == str(repo)
-        # The predecessor's local, unpushed commit was discarded by the
-        # hard-sync to origin/{assigned} (R6 dirty-state policy).
-        assert not (repo / "local.txt").exists()
-        head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        # The agent's own clean fast-forward commit survives the re-attach
+        # (#3506); the sync no longer hard-resets a strict descendant.
+        assert (repo / "local.txt").read_text() == "unpushed\n"
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() == local_head
         remote = _git(repo, "rev-parse", f"origin/{_BRANCH}").stdout.strip()
-        assert head == remote
+        assert (
+            _git(repo, "merge-base", "--is-ancestor", remote, local_head, check=False).returncode
+            == 0
+        )
 
 
 class TestReusePathHostPathTranslation:
@@ -3078,13 +3084,16 @@ class TestReusePathWorktreeContainerIdBinding:
 
 
 class TestSpawnEventJobDirtyWorktree:
-    """Dirty-state policy (architect R6) for re-attached worktrees (#3064 slice-4).
+    """Dirty-state policy (architect R6, #3506) for re-attached worktrees.
 
     On every successful re-attach the spawner discards uncommitted changes and
-    untracked artifacts (reset --hard + clean -fd) and hard-syncs to the role
-    branch tip. A predecessor's residue — including a *committed-but-unpushed*
-    commit — must never reach a successor. If discard OR hard-sync fails, the
-    spawner falls back to recreate.
+    untracked artifacts (reset --hard + clean -fd) and syncs to the role
+    branch tip. The sync is fast-forward-aware (#3506): a clean-tree local
+    HEAD that is a strict descendant of the origin tip is the agent's own
+    durable multi-session work and is KEPT. A predecessor's residue (a dirty
+    tree, or commits accompanied by dirt: the killed-mid-event signature)
+    must never reach a successor, nor may a diverged HEAD. If discard, fetch,
+    or hard-sync fails, the spawner falls back to recreate.
     """
 
     def test_reattach_discards_uncommitted_changes(self, spawner, tmp_path):
@@ -3174,6 +3183,93 @@ class TestSpawnEventJobDirtyWorktree:
         assert cleaned is True
         assert _git(repo, "rev-parse", "HEAD").stdout.strip() == origin_head
         assert _git(repo, "status", "--porcelain").stdout.strip() == ""
+
+    def test_reattach_keeps_clean_fast_forward_commits(self, spawner, tmp_path):
+        """A clean-tree local HEAD strictly ahead of the origin tip is KEPT (#3506).
+
+        This is the multi-session accumulation case: the previous session
+        committed durable work, exited cleanly, and had not pushed yet. The
+        sync must not orphan that commit (the Sisyphus loop of #3506).
+        """
+        repo, _ = _make_worktree(tmp_path, _WT_ID, "repo", _BRANCH, with_origin=True)
+        origin_head = _git(repo, "rev-parse", f"origin/{_BRANCH}").stdout.strip()
+        (repo / "work.txt").write_text("durable multi-session work\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "unpushed baseline (clean session exit)")
+        local_head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        assert local_head != origin_head
+
+        with patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path):
+            cleaned = spawner._clean_reused_worktree(_WT_ID, _BRANCH, _REPOS)
+
+        assert cleaned is True
+        # The agent's own fast-forward commit survives the re-attach.
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() == local_head
+        assert (repo / "work.txt").read_text() == "durable multi-session work\n"
+        assert _git(repo, "status", "--porcelain").stdout.strip() == ""
+
+    def test_reattach_dirty_tree_disqualifies_fast_forward_keep(self, spawner, tmp_path):
+        """A fast-forward commit accompanied by tracked dirt is still discarded.
+
+        Tracked modifications alongside a local commit are the
+        killed-mid-event signature, so the R6 hard-reset applies even though
+        the commit alone would qualify as a clean fast-forward.
+        """
+        repo, _ = _make_worktree(tmp_path, _WT_ID, "repo", _BRANCH, with_origin=True)
+        origin_head = _git(repo, "rev-parse", f"origin/{_BRANCH}").stdout.strip()
+        (repo / "work.txt").write_text("committed mid-session\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "commit left by a killed pod")
+        (repo / "seed.txt").write_text("DIRTY tracked edit in flight\n")
+
+        with patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path):
+            cleaned = spawner._clean_reused_worktree(_WT_ID, _BRANCH, _REPOS)
+
+        assert cleaned is True
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() == origin_head
+        assert not (repo / "work.txt").exists()
+        assert _git(repo, "status", "--porcelain").stdout.strip() == ""
+
+    def test_reattach_diverged_head_resets_to_origin(self, spawner, tmp_path):
+        """A clean-tree local HEAD that DIVERGED from origin hard-resets (R6)."""
+        repo, _ = _make_worktree(tmp_path, _WT_ID, "repo", _BRANCH, with_origin=True)
+        # Advance origin past the common base ...
+        (repo / "remote.txt").write_text("landed on origin\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "advance origin")
+        _git(repo, "push", "origin", _BRANCH)
+        origin_head = _git(repo, "rev-parse", f"origin/{_BRANCH}").stdout.strip()
+        # ... then rewind and commit divergent local work (clean tree).
+        _git(repo, "reset", "--hard", "HEAD~1")
+        (repo / "local.txt").write_text("divergent local work\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "divergent local commit")
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() != origin_head
+
+        with patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path):
+            cleaned = spawner._clean_reused_worktree(_WT_ID, _BRANCH, _REPOS)
+
+        assert cleaned is True
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() == origin_head
+        assert not (repo / "local.txt").exists()
+        assert (repo / "remote.txt").read_text() == "landed on origin\n"
+
+    def test_reattach_behind_tip_fast_forwards_to_origin(self, spawner, tmp_path):
+        """A clean-tree local HEAD BEHIND the origin tip resets forward to it."""
+        repo, _ = _make_worktree(tmp_path, _WT_ID, "repo", _BRANCH, with_origin=True)
+        (repo / "remote.txt").write_text("landed on origin\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "advance origin")
+        _git(repo, "push", "origin", _BRANCH)
+        origin_head = _git(repo, "rev-parse", f"origin/{_BRANCH}").stdout.strip()
+        _git(repo, "reset", "--hard", "HEAD~1")  # fall behind the tip
+
+        with patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path):
+            cleaned = spawner._clean_reused_worktree(_WT_ID, _BRANCH, _REPOS)
+
+        assert cleaned is True
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() == origin_head
+        assert (repo / "remote.txt").read_text() == "landed on origin\n"
 
 
 class TestSpawnEventJobSessionReuse:

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -3156,14 +3156,15 @@ class TestSpawnEventJobDirtyWorktree:
         assert not (repo / "dirty.txt").exists()
         assert _git(repo, "status", "--porcelain").stdout.strip() == ""
 
-    def test_reattach_hard_sync_failure_falls_back(self, spawner, tmp_path):
-        """Hard-sync failure is FATAL to reuse (#3064 review): recreate instead.
+    def test_reattach_fetch_failure_falls_back(self, spawner, tmp_path):
+        """Fetch failure is FATAL to reuse (#3064 review): recreate instead.
 
         The worktree is clean and on the right branch, but has no reachable
         ``origin`` remote, so ``git fetch origin <branch>`` fails. Because the
-        hard-sync is the only step that drops a predecessor's unpushed commit,
-        a failure must fall back to recreate rather than continue on the
-        current HEAD (which could still carry residue ahead of origin).
+        fetch is what supplies the ``origin/<branch>`` tip the sync decision
+        (keep vs. reset) relies on, a failure must fall back to recreate rather
+        than continue on the current HEAD (which could still carry residue
+        ahead of origin).
         """
         _make_worktree(tmp_path, _WT_ID, "repo", _BRANCH, with_origin=False)
 


### PR DESCRIPTION
Fixes #3506.

## Problem

`_clean_reused_worktree` (R6 dirty-state policy) hard-reset the agent worktree to `origin/{branch}` on every event-pump cycle. Any commit an agent made locally but did not push within the same cycle was discarded by the next cycle's reset, so multi-session slices could never accumulate work: the slice-4 coder in pipeline issue-3312-v2 ran ~6 productive sessions with zero net branch progress, its baseline commit orphaned with no error signal anywhere.

## Fix (issue ask 1 + ask 4)

The sync step is now fast-forward-aware:

- **Keep** the local HEAD when the pre-discard tree was clean and HEAD is a strict descendant of the origin tip: this is the agent's own durable work from a clean session exit.
- **Hard-reset** to `origin/{branch}` on divergence, a behind-tip HEAD, or a dirty pre-discard tree (the killed-mid-event signature the R6 residue policy exists to contain). Dirt is captured via `git status --porcelain` before the `reset --hard && clean -fd` discard erases the evidence; unknown state counts as dirty.
- **Orphan detector**: when a reset is about to discard commits ahead of the tip, their SHAs are logged loudly (`discarded_commit_count` + up to 20 SHAs) so between-cycle orphaning is visible and salvageable via `salvage_agent_commits` (#3368). Previously this was silent.
- Fetch failure remains fatal-to-reuse (fall back to recreate), now with its own log message: without the true origin tip we cannot tell fast-forward work from divergent residue.

The existing R6 residue guarantees are preserved: `test_reattach_residue_not_in_successor_view` (commit + dirt is discarded) passes unchanged, as do the discard-failure and hard-sync-failure fallback tests.

## Tests

- `test_reattach_keeps_clean_fast_forward_commits`: the multi-session accumulation case; a clean-tree unpushed commit survives re-attach.
- `test_reattach_dirty_tree_disqualifies_fast_forward_keep`: a fast-forward commit accompanied by tracked dirt still resets.
- `test_reattach_diverged_head_resets_to_origin` and `test_reattach_behind_tip_fast_forwards_to_origin`: non-descendant topologies still reset.
- `test_try_reuse_production_shape_work_branch` updated to the new contract: it seeded exactly the clean fast-forward scenario (#3480 work-branch shape, clean tree, one commit strictly ahead of `origin/{assigned}`), so it now asserts the commit is kept.

All 22 re-attach/reuse tests pass; `make lint` clean. Docs updated in `docs/architecture/on-demand-agent-lifecycle.md` (re-attach-first policy step 2).

## Not in scope

Issue asks 2/3 (auto-push at end of cycle, push-before-exit in the producer protocol) are protocol-level changes; this PR takes the surgical orchestrator-side fix the issue lists first. They remain open options if clean-exit detection proves too conservative in practice.