### PR TITLE
Auto-salvage and durably record commits discarded by the R6 re-attach reset (#3509)

### DIFF
--- a/orchestrator/agent_salvage.py
+++ b/orchestrator/agent_salvage.py
@@ -118,11 +118,23 @@ class AgentWorktree:
     @property
     def scope_label(self) -> str:
         """Stable label used in recovery-ref paths."""
-        if self.agent_role is None:
-            return "pipeline"
-        if self.slice_id is None:
-            return self.agent_role
-        return f"{self.slice_id}-{self.agent_role}"
+        return scope_label(self.agent_role, self.slice_id)
+
+
+def scope_label(agent_role: str | None, slice_id: str | None) -> str:
+    """Stable scope label used in recovery-ref paths.
+
+    ``pipeline`` for the pipeline-level worktree, ``<role>`` for
+    per-role worktrees, ``<slice>-<role>`` for slice-scoped ones.
+    Shared by :attr:`AgentWorktree.scope_label` and callers that have
+    the (role, slice) pair without an ``AgentWorktree`` in hand
+    (:func:`salvage_discarded_tip`).
+    """
+    if agent_role is None:
+        return "pipeline"
+    if slice_id is None:
+        return agent_role
+    return f"{slice_id}-{agent_role}"
 
 
 @dataclass(frozen=True)
@@ -751,6 +763,97 @@ def salvage_worktree(
         recovery_ref=target_ref,
         head_sha=head_sha,
         n_commits=len(report.commits),
+        ok=True,
+    )
+
+
+def salvage_discarded_tip(
+    gateway: GatewayClient,
+    *,
+    pipeline_id: str,
+    worktree_id: str,
+    repo_path: Path,
+    head_sha: str,
+    agent_role: str | None = None,
+    slice_id: str | None = None,
+    n_commits: int = 0,
+    mode: str = "public",
+) -> SalvageResult:
+    """Push a worktree HEAD that is about to be discarded to a recovery ref.
+
+    The R6 re-attach discard path (#3506/#3507,
+    ``KubernetesSpawner._clean_reused_worktree``) hard-resets a reused
+    worktree to ``origin/<branch>``, orphaning any local commits ahead of
+    the tip. Logging their SHAs is not enough: the objects are one gc
+    away from gone and invisible to every salvage tool meanwhile, because
+    ``salvage_agent_commits`` inspects worktree branches that the reset
+    has already moved (#3509). This function is called *before* the reset,
+    while the doomed tip is still ``HEAD``, and pushes it to the same
+    ``egg/recovered/<pipeline>/<scope>/<short_sha>`` namespace as
+    :func:`salvage_worktree` via the gateway's launcher-auth path.
+
+    Unlike :func:`salvage_worktree` it does not enumerate the local work
+    branch: a re-attached worktree may be on the work branch, the
+    assigned branch, or a detached HEAD (#3480), so the caller passes the
+    exact ``head_sha`` its orphan detector resolved and the push targets
+    the current ``HEAD`` (``ref=None``).
+
+    Never raises for gateway/transport failures: returns a
+    ``SalvageResult`` with ``ok=False`` so the discard path can proceed
+    and record the failure durably instead.
+    """
+    target_ref = _recovery_ref(pipeline_id, scope_label(agent_role, slice_id), head_sha)
+    try:
+        push_result = gateway.push_worktree_branch(
+            pipeline_id=pipeline_id,
+            repo_path=str(repo_path),
+            branch=target_ref,
+            mode=mode,  # type: ignore[arg-type]
+            ref=None,
+            force=False,
+        )
+    except Exception as e:
+        # GatewayError or transport failure
+        return SalvageResult(
+            worktree_id=worktree_id,
+            agent_role=agent_role,
+            slice_id=slice_id,
+            recovery_ref=None,
+            head_sha=head_sha,
+            n_commits=n_commits,
+            ok=False,
+            error=str(e),
+        )
+
+    if not push_result.ok:
+        return SalvageResult(
+            worktree_id=worktree_id,
+            agent_role=agent_role,
+            slice_id=slice_id,
+            recovery_ref=None,
+            head_sha=head_sha,
+            n_commits=n_commits,
+            ok=False,
+            error=push_result.describe(),
+        )
+
+    logger.info(
+        "Salvaged to-be-discarded worktree tip to recovery ref",
+        pipeline_id=pipeline_id,
+        worktree_id=worktree_id,
+        agent_role=agent_role,
+        slice_id=slice_id,
+        recovery_ref=target_ref,
+        head_sha=head_sha,
+        n_commits=n_commits,
+    )
+    return SalvageResult(
+        worktree_id=worktree_id,
+        agent_role=agent_role,
+        slice_id=slice_id,
+        recovery_ref=target_ref,
+        head_sha=head_sha,
+        n_commits=n_commits,
         ok=True,
     )
 

--- a/orchestrator/kubernetes_spawner/_events.py
+++ b/orchestrator/kubernetes_spawner/_events.py
@@ -147,6 +147,13 @@ def spawn_event_job(
     reuse_session_token: str | None = None
     branch = spawn_kwargs.get("branch")
     repos = spawn_kwargs.get("repos")
+    # The pipeline's real gateway network mode ("public" / "private").
+    # It MUST reach the discard-salvage push: a private-mode pipeline on a
+    # private repo is DENIED by the gateway's private-repo policy if the
+    # push carries the "public" default, silently degrading auto-salvage
+    # to record-only — exactly the silent-loss class #3509 exists to
+    # prevent. The concurrent spawn fn forwards "mode" in common_kwargs.
+    mode = spawn_kwargs.get("mode", "public")
 
     # Build the candidate worktree id matching the existing convention.
     candidate_id = self._build_agent_worktree_id(pipeline_id, agent_role, slice_id=slice_id)
@@ -155,8 +162,9 @@ def spawn_event_job(
         # (R6 dirty-state policy) so re-attached worktrees always start
         # with a clean tree at the role branch tip, or a clean
         # fast-forward ahead of it (#3506), before the agent runs. The
-        # pipeline/role/slice context lets the cleanup auto-salvage and
-        # durably record any commits its hard-reset discards (#3509).
+        # pipeline/role/slice context (plus the gateway network mode) lets
+        # the cleanup auto-salvage and durably record any commits its
+        # hard-reset discards (#3509).
         result = self._try_reuse_worktree(
             candidate_id,
             branch,
@@ -164,6 +172,7 @@ def spawn_event_job(
             pipeline_id=pipeline_id,
             agent_role=agent_role.value,
             slice_id=slice_id,
+            mode=mode,
         )
         if result is not None:
             reuse_worktree_id = candidate_id

--- a/orchestrator/kubernetes_spawner/_events.py
+++ b/orchestrator/kubernetes_spawner/_events.py
@@ -154,8 +154,17 @@ def spawn_event_job(
         # Use the composed method that validates AND cleans dirty state
         # (R6 dirty-state policy) so re-attached worktrees always start
         # with a clean tree at the role branch tip, or a clean
-        # fast-forward ahead of it (#3506), before the agent runs.
-        result = self._try_reuse_worktree(candidate_id, branch, repos)
+        # fast-forward ahead of it (#3506), before the agent runs. The
+        # pipeline/role/slice context lets the cleanup auto-salvage and
+        # durably record any commits its hard-reset discards (#3509).
+        result = self._try_reuse_worktree(
+            candidate_id,
+            branch,
+            repos,
+            pipeline_id=pipeline_id,
+            agent_role=agent_role.value,
+            slice_id=slice_id,
+        )
         if result is not None:
             reuse_worktree_id = candidate_id
             reuse_repo_volumes = result[1]

--- a/orchestrator/kubernetes_spawner/_worktree.py
+++ b/orchestrator/kubernetes_spawner/_worktree.py
@@ -295,6 +295,7 @@ def _try_reuse_worktree(
     pipeline_id: str | None = None,
     agent_role: str | None = None,
     slice_id: str | None = None,
+    mode: str = "public",
 ) -> tuple[bool, dict[str, str]] | None:
     """Validate an existing worktree and, on success, clean dirty state.
 
@@ -307,6 +308,10 @@ def _try_reuse_worktree(
     ``pipeline_id`` / ``agent_role`` / ``slice_id`` give the cleanup step
     the context it needs to auto-salvage and durably record any commits
     its hard-reset discards (#3509); when omitted the discard is log-only.
+    ``mode`` is the pipeline's gateway network mode ("public" / "private")
+    and MUST match the running pipeline: a "public" salvage push on a
+    private-mode pipeline over a private repo is denied by the gateway's
+    private-repo policy, degrading auto-salvage to record-only.
 
     The returned ``repo_volumes`` carry HOST paths (translated via
     :func:`_local_to_host_volumes`), matching the create path's
@@ -334,6 +339,7 @@ def _try_reuse_worktree(
         pipeline_id=pipeline_id,
         agent_role=agent_role,
         slice_id=slice_id,
+        mode=mode,
     ):
         return None
     return True, _local_to_host_volumes(vols)
@@ -348,6 +354,7 @@ def _clean_reused_worktree(
     pipeline_id: str | None = None,
     agent_role: str | None = None,
     slice_id: str | None = None,
+    mode: str = "public",
 ) -> bool:
     """Discard dirty state and sync a re-attached worktree (R6, #3506).
 
@@ -377,6 +384,20 @@ def _clean_reused_worktree(
     visibility). The salvage/record steps require ``pipeline_id`` (plus
     ``agent_role`` / ``slice_id`` for the recovery-ref scope); legacy
     callers that omit them get the pre-#3509 log-only behaviour.
+
+    ``mode`` is the pipeline's gateway network mode ("public" /
+    "private") and is threaded straight into the salvage push. It MUST
+    match the running pipeline: a "public" push on a private-mode
+    pipeline over a private repo is denied by the gateway's private-repo
+    policy, silently degrading auto-salvage to record-only — the exact
+    silent-loss class this hook exists to prevent.
+
+    Only the committed tip (``HEAD``) is salvaged. The ``git reset
+    --hard`` + ``git clean -fd`` above run *before* orphan detection, so
+    uncommitted tracked edits and untracked files in a killed-mid-event
+    worktree are gone before salvage runs; the recovery ref is therefore
+    a commit snapshot, not a full worktree snapshot. Capturing dirty
+    working-tree state is #2807's domain, deliberately out of scope here.
 
     Returns ``True`` on success, ``False`` on any failure (the caller
     falls back to create-with-retry — never allow a half-cleaned
@@ -539,6 +560,7 @@ def _clean_reused_worktree(
                                 agent_role=agent_role,
                                 slice_id=slice_id,
                                 n_commits=len(orphans),
+                                mode=mode,
                             )
                             recovery_ref = salvage.recovery_ref if salvage.ok else None
                             salvage_error = salvage.error

--- a/orchestrator/kubernetes_spawner/_worktree.py
+++ b/orchestrator/kubernetes_spawner/_worktree.py
@@ -291,6 +291,10 @@ def _try_reuse_worktree(
     agent_worktree_id: str,
     branch: str | None,
     repos: list[str] | None,
+    *,
+    pipeline_id: str | None = None,
+    agent_role: str | None = None,
+    slice_id: str | None = None,
 ) -> tuple[bool, dict[str, str]] | None:
     """Validate an existing worktree and, on success, clean dirty state.
 
@@ -299,6 +303,10 @@ def _try_reuse_worktree(
     discard + fast-forward-aware sync, #3506). Returns ``(success, repo_volumes)`` on
     success, or ``None`` on any validation or cleanup mismatch (the
     caller falls back to create-with-retry).
+
+    ``pipeline_id`` / ``agent_role`` / ``slice_id`` give the cleanup step
+    the context it needs to auto-salvage and durably record any commits
+    its hard-reset discards (#3509); when omitted the discard is log-only.
 
     The returned ``repo_volumes`` carry HOST paths (translated via
     :func:`_local_to_host_volumes`), matching the create path's
@@ -319,7 +327,14 @@ def _try_reuse_worktree(
     vols = _validate_worktree_for_reuse(agent_worktree_id, repos, branch)
     if vols is None:
         return None
-    if not self._clean_reused_worktree(agent_worktree_id, branch, repos):
+    if not self._clean_reused_worktree(
+        agent_worktree_id,
+        branch,
+        repos,
+        pipeline_id=pipeline_id,
+        agent_role=agent_role,
+        slice_id=slice_id,
+    ):
         return None
     return True, _local_to_host_volumes(vols)
 
@@ -329,6 +344,10 @@ def _clean_reused_worktree(
     agent_worktree_id: str,
     branch: str | None,
     repos: list[str] | None,
+    *,
+    pipeline_id: str | None = None,
+    agent_role: str | None = None,
+    slice_id: str | None = None,
 ) -> bool:
     """Discard dirty state and sync a re-attached worktree (R6, #3506).
 
@@ -346,8 +365,18 @@ def _clean_reused_worktree(
     behind-tip HEAD, or a dirty pre-discard tree (the killed-mid-event
     signature the R6 residue policy exists to contain), the worktree
     hard-resets to ``origin/{branch}``; any commits ahead of the tip that
-    the reset discards are first logged with their SHAs so the orphaning
-    is visible and salvageable (``salvage_agent_commits``, #3368).
+    the reset discards are first auto-salvaged and durably recorded
+    (#3509): the doomed tip is pushed to an ``egg/recovered/...``
+    recovery ref through the same gateway launcher-auth path as #3368's
+    ``salvage_agent_commits``, and a message-bus system message to the
+    role records the discarded tip + recovery ref so a resuming agent
+    with zero session memory can find its prior work instead of
+    re-deriving it. Both steps are best-effort: a salvage or record
+    failure is logged and the reset proceeds (blocking reuse would only
+    force a fresh worktree that orphans the same commits with less
+    visibility). The salvage/record steps require ``pipeline_id`` (plus
+    ``agent_role`` / ``slice_id`` for the recovery-ref scope); legacy
+    callers that omit them get the pre-#3509 log-only behaviour.
 
     Returns ``True`` on success, ``False`` on any failure (the caller
     falls back to create-with-retry — never allow a half-cleaned
@@ -484,25 +513,66 @@ def _clean_reused_worktree(
                 # the reset is about to discard; between-cycle resets
                 # produce the same orphan class as restart-time resets
                 # (#3368) and must not be silent.
+                orphans: list[str] = []
                 try:
                     if local_head and remote_tip:
                         orphans = _git(
                             d, "rev-list", f"{remote_tip}..{local_head}", check=False
                         ).stdout.split()
-                        if orphans:
-                            logger.warning(
-                                "Worktree re-attach: hard-reset is discarding "
-                                "unpushed local commits (dirty or diverged); "
-                                "salvageable via salvage_agent_commits (#3368)",
-                                agent_worktree_id=agent_worktree_id,
-                                repo=n,
-                                branch=branch,
-                                was_dirty=was_dirty,
-                                discarded_commit_count=len(orphans),
-                                discarded_commits=orphans[:20],
-                            )
                 except Exception:
-                    pass
+                    orphans = []
+                if orphans:
+                    # Auto-salvage + durable record (#3509). Must run
+                    # BEFORE the reset below: afterwards the tip exists
+                    # only in the object store, where salvage_agent_commits
+                    # cannot see it and gc eventually erases it.
+                    recovery_ref = None
+                    salvage_error: str | None = None
+                    if pipeline_id:
+                        try:
+                            salvage = _pkg.agent_salvage.salvage_discarded_tip(
+                                self.gateway,
+                                pipeline_id=pipeline_id,
+                                worktree_id=agent_worktree_id,
+                                repo_path=d,
+                                head_sha=local_head,
+                                agent_role=agent_role,
+                                slice_id=slice_id,
+                                n_commits=len(orphans),
+                            )
+                            recovery_ref = salvage.recovery_ref if salvage.ok else None
+                            salvage_error = salvage.error
+                        except Exception as e:
+                            salvage_error = str(e)
+                    else:
+                        salvage_error = "no pipeline context (legacy caller)"
+                    logger.warning(
+                        "Worktree re-attach: hard-reset is discarding "
+                        "unpushed local commits (dirty or diverged)",
+                        agent_worktree_id=agent_worktree_id,
+                        repo=n,
+                        branch=branch,
+                        was_dirty=was_dirty,
+                        discarded_commit_count=len(orphans),
+                        discarded_commits=orphans[:20],
+                        recovery_ref=recovery_ref,
+                        salvage_error=salvage_error,
+                    )
+                    if pipeline_id:
+                        _record_discarded_tip(
+                            pipeline_id=pipeline_id,
+                            agent_worktree_id=agent_worktree_id,
+                            repo=n,
+                            branch=branch,
+                            agent_role=agent_role,
+                            slice_id=slice_id,
+                            discarded_tip=local_head,
+                            remote_tip=remote_tip,
+                            n_commits=len(orphans),
+                            was_dirty=was_dirty,
+                            recovery_ref=recovery_ref,
+                            salvage_error=salvage_error,
+                        )
                 try:
                     _git(d, "reset", "--hard", f"origin/{branch}")
                 except Exception as e:
@@ -525,6 +595,95 @@ def _clean_reused_worktree(
         repos=[r.split("/")[-1] if "/" in r else r for r in repos],
     )
     return True
+
+
+def _record_discarded_tip(
+    *,
+    pipeline_id: str,
+    agent_worktree_id: str,
+    repo: str,
+    branch: str | None,
+    agent_role: str | None,
+    slice_id: str | None,
+    discarded_tip: str,
+    remote_tip: str,
+    n_commits: int,
+    was_dirty: bool,
+    recovery_ref: str | None,
+    salvage_error: str | None,
+) -> None:
+    """Durably record a dirty-discard's orphaned tip where the agent looks (#3509).
+
+    A resuming agent whose session state expired and whose durable memory
+    commits rode the discarded lineage has no way to learn its prior tip
+    existed: the #3506 incident showed such an agent silently re-deriving
+    days of completed work while the pipeline reported WORKING. The
+    message bus is the one channel that survives both failure modes (no
+    TTL, replayed into brc history), so record the discarded tip, the
+    reset target, and the recovery ref there as a system message to the
+    role.
+
+    Best-effort: a record failure is logged and swallowed; it must not
+    block the re-attach path.
+    """
+    from message_store import Message, MessageType, get_message_store
+
+    if recovery_ref:
+        recovery_text = (
+            f"The full commit stack is preserved on remote ref {recovery_ref}; "
+            f"run `git fetch origin {recovery_ref}` and inspect it before "
+            "starting work. If it contains completed work, build on it "
+            "(cherry-pick or reset) instead of re-deriving it."
+        )
+    else:
+        recovery_text = (
+            f"Automatic salvage FAILED ({salvage_error or 'unknown error'}); the "
+            "commits survive only in the local git object store until gc. Ask an "
+            "operator to recover them (salvage_agent_commits, #3368) before "
+            "re-deriving any work."
+        )
+    body = (
+        f"Worktree re-attach discarded {n_commits} unpushed commit(s) from "
+        f"{repo} (worktree {agent_worktree_id}). Your previous tip was "
+        f"{discarded_tip}; the worktree was reset to {remote_tip}"
+        + (f" (origin/{branch})." if branch else ".")
+        + " "
+        + recovery_text
+    )
+    try:
+        store = get_message_store()
+        store.add_message(
+            Message(
+                pipeline_id=pipeline_id,
+                from_role="orchestrator",
+                to_role=agent_role or "all",
+                message_type=MessageType.STATUS,
+                subject=f"Unpushed commits discarded on re-attach ({repo})",
+                body=body,
+                metadata={
+                    "event": "dirty_discard_salvage",
+                    "agent_worktree_id": agent_worktree_id,
+                    "repo": repo,
+                    "branch": branch,
+                    "slice_id": slice_id,
+                    "discarded_tip": discarded_tip,
+                    "remote_tip": remote_tip,
+                    "discarded_commit_count": n_commits,
+                    "was_dirty": was_dirty,
+                    "recovery_ref": recovery_ref,
+                    "salvage_error": salvage_error,
+                },
+            )
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to record discarded tip on message bus",
+            pipeline_id=pipeline_id,
+            agent_worktree_id=agent_worktree_id,
+            repo=repo,
+            discarded_tip=discarded_tip,
+            error=str(e),
+        )
 
 
 def _find_missing_worktrees(self, agent_worktree_id: str, repos: list[str]) -> list[str]:

--- a/orchestrator/tests/test_agent_salvage.py
+++ b/orchestrator/tests/test_agent_salvage.py
@@ -18,6 +18,7 @@ from agent_salvage import (
     commit_working_tree,
     enumerate_agent_worktrees,
     list_unpushed_commits,
+    salvage_discarded_tip,
     salvage_worktree,
 )
 from gateway_client import PushResult
@@ -434,6 +435,101 @@ class TestSalvageWorktree:
         result = salvage_worktree(gateway, wt)
         assert result.ok is False
         gateway.push_worktree_branch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# salvage_discarded_tip (#3509)
+# ---------------------------------------------------------------------------
+
+
+class TestSalvageDiscardedTip:
+    """The R6 discard path pushes the doomed HEAD before hard-resetting.
+
+    Unlike ``salvage_worktree`` this takes the exact tip SHA the orphan
+    detector resolved and pushes the current HEAD, so it works on
+    re-attached worktrees regardless of which branch (or detached HEAD)
+    they sit on.
+    """
+
+    _HEAD = "e953a952500000000000000000000000deadbeef"
+
+    def test_pushes_head_to_scoped_recovery_ref(self, tmp_path: Path) -> None:
+        gateway = MagicMock()
+        gateway.push_worktree_branch.return_value = PushResult(ok=True)
+
+        result = salvage_discarded_tip(
+            gateway,
+            pipeline_id="issue-3312-v2",
+            worktree_id="issue-3312-v2-slice-4-coder",
+            repo_path=tmp_path,
+            head_sha=self._HEAD,
+            agent_role="coder",
+            slice_id="slice-4",
+            n_commits=52,
+        )
+
+        expected_ref = f"{RECOVERY_BRANCH_PREFIX}/issue-3312-v2/slice-4-coder/{self._HEAD[:12]}"
+        assert result.ok is True
+        assert result.recovery_ref == expected_ref
+        assert result.head_sha == self._HEAD
+        assert result.n_commits == 52
+        kwargs = gateway.push_worktree_branch.call_args.kwargs
+        assert kwargs["pipeline_id"] == "issue-3312-v2"
+        assert kwargs["repo_path"] == str(tmp_path)
+        assert kwargs["branch"] == expected_ref
+        assert kwargs["ref"] is None  # pushes HEAD, which the caller has not reset yet
+        assert kwargs["force"] is False
+
+    def test_role_scope_without_slice(self, tmp_path: Path) -> None:
+        gateway = MagicMock()
+        gateway.push_worktree_branch.return_value = PushResult(ok=True)
+
+        result = salvage_discarded_tip(
+            gateway,
+            pipeline_id="issue-99",
+            worktree_id="issue-99-coder",
+            repo_path=tmp_path,
+            head_sha=self._HEAD,
+            agent_role="coder",
+        )
+
+        assert result.recovery_ref == f"{RECOVERY_BRANCH_PREFIX}/issue-99/coder/{self._HEAD[:12]}"
+
+    def test_push_failure_returns_not_ok(self, tmp_path: Path) -> None:
+        gateway = MagicMock()
+        gateway.push_worktree_branch.return_value = PushResult(
+            ok=False, category="auth", detail="denied"
+        )
+
+        result = salvage_discarded_tip(
+            gateway,
+            pipeline_id="issue-99",
+            worktree_id="issue-99-coder",
+            repo_path=tmp_path,
+            head_sha=self._HEAD,
+            agent_role="coder",
+        )
+
+        assert result.ok is False
+        assert result.recovery_ref is None
+        assert result.head_sha == self._HEAD
+        assert "auth" in (result.error or "")
+
+    def test_gateway_exception_returns_not_ok(self, tmp_path: Path) -> None:
+        gateway = MagicMock()
+        gateway.push_worktree_branch.side_effect = RuntimeError("boom")
+
+        result = salvage_discarded_tip(
+            gateway,
+            pipeline_id="issue-99",
+            worktree_id="issue-99-coder",
+            repo_path=tmp_path,
+            head_sha=self._HEAD,
+            agent_role="coder",
+        )
+
+        assert result.ok is False
+        assert "boom" in (result.error or "")
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -3273,6 +3273,186 @@ class TestSpawnEventJobDirtyWorktree:
         assert (repo / "remote.txt").read_text() == "landed on origin\n"
 
 
+class _FakePushResult:
+    """Minimal PushResult stand-in (the fixture stubs out gateway_client)."""
+
+    def __init__(self, ok=True, detail="denied"):
+        self.ok = ok
+        self._detail = detail
+
+    def describe(self):
+        return self._detail
+
+
+_PIPE_CTX = {"pipeline_id": "pipe-1", "agent_role": "coder", "slice_id": "slice-4"}
+
+
+class TestDirtyDiscardAutoSalvage:
+    """Auto-salvage + durable record on the R6 discard path (#3509).
+
+    When the re-attach hard-reset is about to discard unpushed local
+    commits, the doomed tip must be pushed to an ``egg/recovered/...``
+    ref BEFORE the reset (afterwards it exists only in the object store)
+    and recorded on the message bus where a memory-less resuming agent
+    will find it. Both steps are best-effort: their failure must never
+    block the re-attach.
+    """
+
+    def _seed_orphan(self, tmp_path, *, dirty=True):
+        """Worktree with an unpushed commit (plus tracked dirt when *dirty*)."""
+        repo, _ = _make_worktree(tmp_path, _WT_ID, "repo", _BRANCH, with_origin=True)
+        origin_head = _git(repo, "rev-parse", f"origin/{_BRANCH}").stdout.strip()
+        (repo / "work.txt").write_text("orphaned work\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "unpushed stack tip")
+        orphan_head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        if dirty:
+            (repo / "seed.txt").write_text("DIRTY tracked edit\n")
+        return repo, origin_head, orphan_head
+
+    def test_discard_salvages_tip_and_records_message(self, spawner, mock_gateway, tmp_path):
+        repo, origin_head, orphan_head = self._seed_orphan(tmp_path)
+        head_at_push = {}
+
+        def _push(**kwargs):
+            # The push must land while the doomed tip is still HEAD.
+            head_at_push["sha"] = _git(repo, "rev-parse", "HEAD").stdout.strip()
+            return _FakePushResult(ok=True)
+
+        mock_gateway.push_worktree_branch.side_effect = _push
+
+        with (
+            patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path),
+            patch("message_store.get_message_store") as get_store,
+        ):
+            cleaned = spawner._clean_reused_worktree(_WT_ID, _BRANCH, _REPOS, **_PIPE_CTX)
+
+        assert cleaned is True
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() == origin_head
+
+        expected_ref = f"egg/recovered/pipe-1/slice-4-coder/{orphan_head[:12]}"
+        mock_gateway.push_worktree_branch.assert_called_once()
+        kwargs = mock_gateway.push_worktree_branch.call_args.kwargs
+        assert kwargs["pipeline_id"] == "pipe-1"
+        assert kwargs["repo_path"] == str(repo)
+        assert kwargs["branch"] == expected_ref
+        assert kwargs["ref"] is None
+        assert head_at_push["sha"] == orphan_head  # pushed before the reset
+
+        msg = get_store.return_value.add_message.call_args.args[0]
+        assert msg.pipeline_id == "pipe-1"
+        assert msg.from_role == "orchestrator"
+        assert msg.to_role == "coder"
+        assert msg.metadata["discarded_tip"] == orphan_head
+        assert msg.metadata["remote_tip"] == origin_head
+        assert msg.metadata["recovery_ref"] == expected_ref
+        assert msg.metadata["discarded_commit_count"] == 1
+        assert expected_ref in msg.body
+        assert orphan_head in msg.body
+
+    def test_salvage_failure_still_resets_and_records_tip(self, spawner, mock_gateway, tmp_path):
+        repo, origin_head, orphan_head = self._seed_orphan(tmp_path)
+        mock_gateway.push_worktree_branch.side_effect = RuntimeError("gateway down")
+
+        with (
+            patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path),
+            patch("message_store.get_message_store") as get_store,
+        ):
+            cleaned = spawner._clean_reused_worktree(_WT_ID, _BRANCH, _REPOS, **_PIPE_CTX)
+
+        assert cleaned is True
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() == origin_head
+        # The tip is still recorded durably even though the push failed.
+        msg = get_store.return_value.add_message.call_args.args[0]
+        assert msg.metadata["discarded_tip"] == orphan_head
+        assert msg.metadata["recovery_ref"] is None
+        assert "gateway down" in msg.metadata["salvage_error"]
+
+    def test_record_failure_does_not_block_reuse(self, spawner, mock_gateway, tmp_path):
+        repo, origin_head, _ = self._seed_orphan(tmp_path)
+        mock_gateway.push_worktree_branch.return_value = _FakePushResult(ok=True)
+
+        with (
+            patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path),
+            patch("message_store.get_message_store", side_effect=RuntimeError("redis down")),
+        ):
+            cleaned = spawner._clean_reused_worktree(_WT_ID, _BRANCH, _REPOS, **_PIPE_CTX)
+
+        assert cleaned is True
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() == origin_head
+
+    def test_legacy_call_without_context_is_log_only(self, spawner, mock_gateway, tmp_path):
+        repo, origin_head, _ = self._seed_orphan(tmp_path)
+
+        with (
+            patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path),
+            patch("message_store.get_message_store") as get_store,
+        ):
+            cleaned = spawner._clean_reused_worktree(_WT_ID, _BRANCH, _REPOS)
+
+        assert cleaned is True
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() == origin_head
+        mock_gateway.push_worktree_branch.assert_not_called()
+        get_store.return_value.add_message.assert_not_called()
+
+    def test_kept_fast_forward_does_not_salvage(self, spawner, mock_gateway, tmp_path):
+        # Clean-tree strict descendant is KEPT (#3506): nothing is
+        # discarded, so nothing may be salvaged or recorded.
+        repo, _, orphan_head = self._seed_orphan(tmp_path, dirty=False)
+
+        with (
+            patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path),
+            patch("message_store.get_message_store") as get_store,
+        ):
+            cleaned = spawner._clean_reused_worktree(_WT_ID, _BRANCH, _REPOS, **_PIPE_CTX)
+
+        assert cleaned is True
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() == orphan_head
+        mock_gateway.push_worktree_branch.assert_not_called()
+        get_store.return_value.add_message.assert_not_called()
+
+    def test_spawn_event_job_threads_pipeline_context(
+        self, spawner, mock_k8s_client, mock_gateway, tmp_path
+    ):
+        """End-to-end: a re-attach spawn with orphaned commits salvages them
+        under the pipeline/slice/role scope taken from the spawn call."""
+        repo, _ = _make_worktree(
+            tmp_path, "pipe-1-slice-4-coder", "repo", _BRANCH, with_origin=True
+        )
+        (repo / "work.txt").write_text("orphaned work\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "unpushed stack tip")
+        orphan_head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        (repo / "seed.txt").write_text("DIRTY tracked edit\n")
+
+        mock_k8s_client.list_jobs.return_value = []  # no live Job → no adoption
+        mock_gateway.heartbeat_session_by_container.return_value = False
+        mock_gateway.register_session.return_value = _FakeSessionInfo(
+            session_token="tok-reattach",
+            container_id="egg-agent-pipe-1-slice-4-coder",
+        )
+        mock_gateway.push_worktree_branch.return_value = _FakePushResult(ok=True)
+
+        with (
+            patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path),
+            patch("message_store.get_message_store"),
+        ):
+            spawner.spawn_event_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                action="propose",
+                dedupe_key="c" * 64,
+                slice_id="slice-4",
+                phase="implement",
+                repos=["owner/repo"],
+                branch=_BRANCH,
+                wait_for_gateway=False,
+            )
+
+        kwargs = mock_gateway.push_worktree_branch.call_args.kwargs
+        assert kwargs["branch"] == f"egg/recovered/pipe-1/slice-4-coder/{orphan_head[:12]}"
+
+
 class TestSpawnEventJobSessionReuse:
     """Per-role gateway-session reuse across one-shot event spawns (#3064 slice-4).
 

--- a/orchestrator/tests/test_kubernetes_spawner.py
+++ b/orchestrator/tests/test_kubernetes_spawner.py
@@ -3411,6 +3411,40 @@ class TestDirtyDiscardAutoSalvage:
         mock_gateway.push_worktree_branch.assert_not_called()
         get_store.return_value.add_message.assert_not_called()
 
+    def test_discard_salvage_forwards_private_mode(self, spawner, mock_gateway, tmp_path):
+        # The salvage push MUST carry the pipeline's real network mode: a
+        # "public" push on a private-mode pipeline over a private repo is
+        # denied by the gateway's private-repo policy, silently degrading
+        # auto-salvage to record-only (#3509).
+        repo, _origin_head, _orphan_head = self._seed_orphan(tmp_path)
+        mock_gateway.push_worktree_branch.return_value = _FakePushResult(ok=True)
+
+        with (
+            patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path),
+            patch("message_store.get_message_store"),
+        ):
+            cleaned = spawner._clean_reused_worktree(
+                _WT_ID, _BRANCH, _REPOS, mode="private", **_PIPE_CTX
+            )
+
+        assert cleaned is True
+        assert mock_gateway.push_worktree_branch.call_args.kwargs["mode"] == "private"
+
+    def test_discard_salvage_mode_defaults_to_public(self, spawner, mock_gateway, tmp_path):
+        # Legacy callers that omit ``mode`` keep the historical public
+        # default (the parameter must not silently become required).
+        repo, _origin_head, _orphan_head = self._seed_orphan(tmp_path)
+        mock_gateway.push_worktree_branch.return_value = _FakePushResult(ok=True)
+
+        with (
+            patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path),
+            patch("message_store.get_message_store"),
+        ):
+            cleaned = spawner._clean_reused_worktree(_WT_ID, _BRANCH, _REPOS, **_PIPE_CTX)
+
+        assert cleaned is True
+        assert mock_gateway.push_worktree_branch.call_args.kwargs["mode"] == "public"
+
     def test_spawn_event_job_threads_pipeline_context(
         self, spawner, mock_k8s_client, mock_gateway, tmp_path
     ):
@@ -3451,6 +3485,47 @@ class TestDirtyDiscardAutoSalvage:
 
         kwargs = mock_gateway.push_worktree_branch.call_args.kwargs
         assert kwargs["branch"] == f"egg/recovered/pipe-1/slice-4-coder/{orphan_head[:12]}"
+
+    def test_spawn_event_job_threads_private_mode(
+        self, spawner, mock_k8s_client, mock_gateway, tmp_path
+    ):
+        """End-to-end: a private-mode re-attach spawn forwards ``mode`` all the
+        way to the salvage push, so private-repo pipelines are not silently
+        degraded to record-only (#3509)."""
+        repo, _ = _make_worktree(
+            tmp_path, "pipe-1-slice-4-coder", "repo", _BRANCH, with_origin=True
+        )
+        (repo / "work.txt").write_text("orphaned work\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "unpushed stack tip")
+        (repo / "seed.txt").write_text("DIRTY tracked edit\n")
+
+        mock_k8s_client.list_jobs.return_value = []  # no live Job → no adoption
+        mock_gateway.heartbeat_session_by_container.return_value = False
+        mock_gateway.register_session.return_value = _FakeSessionInfo(
+            session_token="tok-reattach",
+            container_id="egg-agent-pipe-1-slice-4-coder",
+        )
+        mock_gateway.push_worktree_branch.return_value = _FakePushResult(ok=True)
+
+        with (
+            patch("kubernetes_spawner.WORKTREE_BASE_DIR", tmp_path),
+            patch("message_store.get_message_store"),
+        ):
+            spawner.spawn_event_job(
+                pipeline_id="pipe-1",
+                agent_role=AgentRole.CODER,
+                action="propose",
+                dedupe_key="c" * 64,
+                slice_id="slice-4",
+                phase="implement",
+                repos=["owner/repo"],
+                branch=_BRANCH,
+                mode="private",
+                wait_for_gateway=False,
+            )
+
+        assert mock_gateway.push_worktree_branch.call_args.kwargs["mode"] == "private"
 
 
 class TestSpawnEventJobSessionReuse:


### PR DESCRIPTION
Addresses the two mechanism asks in #3509: auto-salvage on discard and a durable record of the discarded tip where the agent looks.

## What changed

**Auto-salvage on discard** (`agent_salvage.salvage_discarded_tip`, new): when `_clean_reused_worktree`'s hard-reset is about to discard unpushed local commits, the doomed tip is pushed to `egg/recovered/<pipeline>/<scope>/<short_sha>` through the gateway launcher-auth path, i.e. the same mechanism and ref namespace as #3368's `salvage_agent_commits`. The push runs before the reset, while the tip is still `HEAD`; afterwards the commits exist only in the object store, where the existing salvage tooling cannot see them and gc eventually erases them. Unlike `salvage_worktree` it takes the exact tip SHA the orphan detector resolved and pushes `HEAD` directly, so it works regardless of whether the re-attached worktree sits on the work branch, the assigned branch, or a detached HEAD (#3480).

**Durable record where the agent looks** (`_record_discarded_tip`, new): the discard also emits a message-bus STATUS message from `orchestrator` to the role carrying the discarded tip, the reset target, the commit count, and the recovery ref (or the salvage error when the push failed, since the tip SHA is still the only handle an operator has). The message bus has no TTL and is replayed into brc history, so it survives both failure modes from the incident: expired Redis session state, and durable memory commits that rode the discarded lineage.

**Context threading**: `spawn_event_job` passes `pipeline_id` / `agent_role` / `slice_id` through `_try_reuse_worktree` into `_clean_reused_worktree`. Callers without that context keep the pre-#3509 log-only behaviour.

Both new steps are best-effort: a salvage or record failure is logged and the reset proceeds. Blocking reuse would only force a fresh worktree that orphans the same commits with less visibility.

## Tests

- `test_agent_salvage.py::TestSalvageDiscardedTip`: recovery-ref naming per scope, push kwargs, push-failure and gateway-exception paths.
- `test_kubernetes_spawner.py::TestDirtyDiscardAutoSalvage`: real-git discard scenarios asserting the push lands while the doomed tip is still `HEAD`, the bus message carries tip/remote/ref metadata, salvage failure still records the tip, record failure does not block reuse, legacy calls stay log-only, the kept fast-forward path salvages nothing, and an end-to-end `spawn_event_job` re-attach salvages under the pipeline/slice/role scope.

## Out of scope (asks 3 and 4 of #3509)

- Persisting BRC memory out-of-band so a branch discard cannot erase the agent's knowledge of the branch.
- A progress-regression anomaly signal in the overseer.

Both are architectural changes to the memory and observability layers rather than to the discard path; they deserve their own issues/design rather than riding this fix. This PR removes the unrecoverability: the stack now survives on a remote ref and the resuming agent has a deterministic pointer to it.

Closes #3509 is intentionally omitted; the issue should stay open to track the two remaining asks unless they get split into follow-up issues.

Refs #3506 #3507 #3368