### PR TITLE
Sync contract.current_phase on orchestrator-driven phase transitions

### DIFF
--- a/orchestrator/events.py
+++ b/orchestrator/events.py
@@ -284,9 +284,16 @@ class EventBus:
         Args:
             event: Event to publish
         """
-        # Assign the monotonic sequence + record history under the lock
-        # so concurrent publishes from different threads stay totally
-        # ordered and history iteration sees a consistent prefix.
+        # Assign the monotonic sequence, record history, and hand the
+        # event to delivery — all under the lock — so concurrent
+        # publishes from different threads stay totally ordered.  If
+        # delivery (sync dispatch / async enqueue) happened after
+        # releasing the lock, a thread that won the sequence race could
+        # still be preempted before delivering, letting a later-sequence
+        # event reach subscribers first and breaking the strictly
+        # increasing ordering guarantee (issue #1932).  ``_lock`` is an
+        # RLock, so the reentrant acquire inside ``_deliver_event`` is
+        # safe.
         with self._lock:
             self._sequence += 1
             event.sequence = self._sequence
@@ -294,16 +301,16 @@ class EventBus:
             if len(self._history) > self._max_history:
                 self._history.pop(0)
 
+            if self._async_delivery:
+                self._event_queue.put(event)
+            else:
+                self._deliver_event(event)
+
         logger.debug(
             "Event published",
             event_type=event.event_type.value,
             pipeline_id=event.pipeline_id,
         )
-
-        if self._async_delivery:
-            self._event_queue.put(event)
-        else:
-            self._deliver_event(event)
 
     def emit(
         self,

--- a/orchestrator/models/_config.py
+++ b/orchestrator/models/_config.py
@@ -294,6 +294,15 @@ class PipelineConfig(BaseModel):
         ge=10,
         description="Seconds before raising HITL propagation failure alert",
     )
+    overseer_phase_desync_alert_seconds: int = Field(
+        default=300,
+        ge=10,
+        description=(
+            "Seconds a pipeline-record vs contract current_phase mismatch may "
+            "persist while status=running before the deterministic desync "
+            "alert fires (#3521)"
+        ),
+    )
     post_proposal_grace_seconds: int = Field(
         default=300,
         ge=30,

--- a/orchestrator/overseer/monitor/__init__.py
+++ b/orchestrator/overseer/monitor/__init__.py
@@ -82,6 +82,7 @@ class _DefaultConfig:
     overseer_rerun_min_work_seconds: int = 60
     overseer_hitl_propagation_timeout_seconds: int = 300
     overseer_infra_error_dedup_window_seconds: int = 300
+    overseer_phase_desync_alert_seconds: int = 300
 
 
 # -- method-body submodules (bound onto OverseerMonitor below) -------------
@@ -193,6 +194,13 @@ class OverseerMonitor:
         self._last_phase_name: str | None = None
         self._cross_phase_checked: set[tuple[str, str]] = set()
 
+        # Contract-phase desync tracking (#3521): (contract, pipeline) phase
+        # pair currently mismatched, when it was first seen, and the pairs
+        # already alerted (alert once per distinct mismatch).
+        self._phase_desync_pair: tuple[str, str] | None = None
+        self._phase_desync_first_seen: float | None = None
+        self._phase_desync_alerted: set[tuple[str, str]] = set()
+
         # Oversight logging to .egg-state/oversight/
         self._oversight_dir = self._resolve_oversight_dir()
         self._jsonl_path: Path | None = None
@@ -260,6 +268,7 @@ class OverseerMonitor:
     _check_rerun_anomaly = _anomaly_checks._check_rerun_anomaly
     _check_status_consistency = _anomaly_checks._check_status_consistency
     _check_hitl_resolution_propagation = _anomaly_checks._check_hitl_resolution_propagation
+    _check_contract_phase_desync = _anomaly_checks._check_contract_phase_desync
     _check_cross_phase_consistency = _anomaly_checks._check_cross_phase_consistency
 
     # -- Alerting / messaging + infra-error dedup (bodies in _alerting.py)

--- a/orchestrator/overseer/monitor/_anomaly_checks.py
+++ b/orchestrator/overseer/monitor/_anomaly_checks.py
@@ -11,6 +11,26 @@ import time
 
 from . import logger
 
+# Forward-only phase ordering, mirroring ``_CONTRACT_PHASE_ORDER`` in
+# ``routes/pipelines/_lifecycle_helpers.py`` (#3521). APPLY sits between PLAN
+# and IMPLEMENT (conditional, epic pipelines only; #1557). Used to make the
+# desync-detector repair text direction-aware. Kept as a local constant rather
+# than importing from ``routes`` to avoid coupling the overseer to the Flask
+# route package.
+_PHASE_ORDER = ("refine", "plan", "apply", "implement")
+
+
+def _phase_is_ahead(candidate: str, reference: str) -> bool:
+    """Return True when ``candidate`` is strictly later than ``reference``.
+
+    Unknown phases (outside ``_PHASE_ORDER``) yield ``False`` so the repair
+    text falls back to the common "contract behind" wording rather than
+    asserting a direction it can't establish.
+    """
+    if candidate not in _PHASE_ORDER or reference not in _PHASE_ORDER:
+        return False
+    return _PHASE_ORDER.index(candidate) > _PHASE_ORDER.index(reference)
+
 
 def _filter_current_phase_agents(self, alerts: list[dict], pipeline_status: dict) -> list[dict]:
     """Filter alerts to only include agents in the current phase.
@@ -336,16 +356,38 @@ async def _check_contract_phase_desync(self, phase_data: dict) -> None:
     if elapsed < threshold or pair in self._phase_desync_alerted:
         return
 
-    message = (
+    # Direction-aware repair text (#3521 review). In normal operation the
+    # pipeline advances first and the sync follows, so the contract is
+    # *behind* the pipeline (``contract < pipeline``) — "advance the
+    # contract" is the right fix. But the detector fires on *any* mismatch,
+    # and forward-only sync means a contract that is *ahead* of the pipeline
+    # record only arises from a real bug — exactly the alert an operator
+    # would be staring at. "Advance the contract" is nonsensical there, so
+    # steer them toward reconciliation instead of advancement.
+    contract_ahead = _phase_is_ahead(pair[0], pair[1])
+    header = (
         f"Contract phase desync: the SDLC contract's current_phase is "
         f"'{pair[0]}' but the pipeline record is in phase '{pair[1]}' "
         f"(mismatch observed for {elapsed:.0f}s while status=running). "
-        f"The gateway commit gate keys off the contract phase, so "
-        f"'{pair[1]}'-phase producers cannot commit phase-gated artifacts "
-        f"until the contract advances. Repair: advance the contract phase "
-        f"via the gateway phase API (a REVIEWER-role agent or HUMAN "
-        f"satisfies the transition rules). Pipeline: {self.pipeline_id}"
     )
+    if contract_ahead:
+        repair = (
+            f"The contract is AHEAD of the pipeline record, which forward-only "
+            f"sync never produces — this indicates a state-machine bug (a "
+            f"demoted pipeline record or an out-of-band contract write). Repair: "
+            f"reconcile the two records manually — do NOT simply advance the "
+            f"contract, and investigate how the pipeline record fell behind. "
+            f"Pipeline: {self.pipeline_id}"
+        )
+    else:
+        repair = (
+            f"The gateway commit gate keys off the contract phase, so "
+            f"'{pair[1]}'-phase producers cannot commit phase-gated artifacts "
+            f"until the contract advances. Repair: advance the contract phase "
+            f"via the gateway phase API (a REVIEWER-role agent or HUMAN "
+            f"satisfies the transition rules). Pipeline: {self.pipeline_id}"
+        )
+    message = header + repair
     logger.warning(
         "Contract phase desync detected for pipeline %s: contract=%s pipeline=%s",
         self.pipeline_id,

--- a/orchestrator/overseer/monitor/_anomaly_checks.py
+++ b/orchestrator/overseer/monitor/_anomaly_checks.py
@@ -283,6 +283,89 @@ async def _check_hitl_resolution_propagation(self, decisions: list[dict]) -> Non
         self._hitl_resolution_pending.pop(did, None)
 
 
+async def _check_contract_phase_desync(self, phase_data: dict) -> None:
+    """Deterministic detector for pipeline-record vs contract phase desync (#3521).
+
+    ``pipeline.current_phase != contract.current_phase`` for more than
+    ``overseer_phase_desync_alert_seconds`` while the pipeline is running
+    is never normal: the gateway commit gate keys off the CONTRACT phase,
+    so a lagging contract silently rejects the current phase's producers
+    ("Phase '<old>' cannot modify") and wedges consensus while
+    ``get_status`` still shows a healthy running phase. The orchestrator
+    now syncs the contract on every phase transition
+    (``_sync_contract_phase_to_pipeline``); this check is the structural
+    backstop that surfaces any remaining desync without LLM
+    classification.
+
+    Alerts once per distinct ``(contract_phase, pipeline_phase)`` pair;
+    tracking resets whenever the phases agree again or the mismatch pair
+    changes (a new mismatch restarts the grace window).
+    """
+    if not isinstance(phase_data, dict):
+        # Malformed / unavailable phase data; retry next cycle without
+        # touching the tracking state.
+        return
+    pipeline_phase = phase_data.get("current_phase") or phase_data.get("name")
+    status = phase_data.get("status", "")
+    if not pipeline_phase or status != "running":
+        self._phase_desync_first_seen = None
+        self._phase_desync_pair = None
+        return
+
+    contract_data = await self._query_contract_data()
+    contract_phase = (contract_data or {}).get("current_phase")
+    if not contract_phase:
+        # Contract unavailable; retry next cycle without resetting so a
+        # transient query failure can't restart the grace window.
+        return
+
+    if str(contract_phase) == str(pipeline_phase):
+        self._phase_desync_first_seen = None
+        self._phase_desync_pair = None
+        return
+
+    pair = (str(contract_phase), str(pipeline_phase))
+    now = time.time()
+    if self._phase_desync_pair != pair or self._phase_desync_first_seen is None:
+        self._phase_desync_pair = pair
+        self._phase_desync_first_seen = now
+        return
+
+    threshold = getattr(self.config, "overseer_phase_desync_alert_seconds", 300)
+    elapsed = now - self._phase_desync_first_seen
+    if elapsed < threshold or pair in self._phase_desync_alerted:
+        return
+
+    message = (
+        f"Contract phase desync: the SDLC contract's current_phase is "
+        f"'{pair[0]}' but the pipeline record is in phase '{pair[1]}' "
+        f"(mismatch observed for {elapsed:.0f}s while status=running). "
+        f"The gateway commit gate keys off the contract phase, so "
+        f"'{pair[1]}'-phase producers cannot commit phase-gated artifacts "
+        f"until the contract advances. Repair: advance the contract phase "
+        f"via the gateway phase API (a REVIEWER-role agent or HUMAN "
+        f"satisfies the transition rules). Pipeline: {self.pipeline_id}"
+    )
+    logger.warning(
+        "Contract phase desync detected for pipeline %s: contract=%s pipeline=%s",
+        self.pipeline_id,
+        pair[0],
+        pair[1],
+    )
+    self._log_oversight_event(
+        {
+            "event": "contract_phase_desync",
+            "contract_phase": pair[0],
+            "pipeline_phase": pair[1],
+            "elapsed_seconds": elapsed,
+        }
+    )
+    await self._broadcast_alert("contract_phase_desync", "orchestrator", message, "high")
+    await self._create_hitl_decision("orchestrator", message)
+    await self._send_slack_notification("orchestrator", message)
+    self._phase_desync_alerted.add(pair)
+
+
 async def _check_cross_phase_consistency(
     self,
     phase_data: dict,

--- a/orchestrator/overseer/monitor/_poll.py
+++ b/orchestrator/overseer/monitor/_poll.py
@@ -23,7 +23,8 @@ async def _poll_cycle(self) -> None:
         4-orch. Check orchestrator reachability
         4a. Query decisions for deterministic health checks
         4b. Run deterministic health checks (rerun anomaly, status
-            consistency, HITL resolution propagation)
+            consistency, HITL resolution propagation, contract-phase
+            desync)
         5. Check for escalation messages from orchestrator
         6. Route anomalies through classifier (with consensus context)
         7. Route classified results through decision maker / execute actions
@@ -63,6 +64,7 @@ async def _poll_cycle(self) -> None:
         await self._check_rerun_anomaly(decisions, current_phase)
         await self._check_status_consistency(pipeline_data)
         await self._check_hitl_resolution_propagation(decisions)
+        await self._check_contract_phase_desync(current_phase)
 
         # Filter alerts to only current-phase agents
         if current_phase and pipeline_data:

--- a/orchestrator/routes/phases/_advance.py
+++ b/orchestrator/routes/phases/_advance.py
@@ -492,6 +492,29 @@ def advance_phase(pipeline_id: str) -> tuple[Response, int]:
             # Save updated pipeline with optimistic locking
             store.save_pipeline(pipeline, expected_version=original_version)
 
+        # #3521: advance contract.current_phase in lockstep with the
+        # pipeline record. The gateway commit gate keys off the CONTRACT
+        # phase, so leaving the contract on the previous phase wedges the
+        # target phase's producers until some agent happens to call the
+        # gateway phase API. Best-effort + forward-only (the helper never
+        # raises); the wrapper guards the import / worktree resolution so
+        # a sync problem can never fail the advance itself.
+        try:
+            from routes import resolve_worktree_path as _resolve_wt_for_sync
+            from routes.pipelines import _sync_contract_phase_to_pipeline
+
+            _sync_contract_phase_to_pipeline(
+                pipeline,
+                _resolve_wt_for_sync(pipeline_id, store.repo_path),
+                source="advance_phase",
+            )
+        except Exception as _sync_err:  # noqa: BLE001
+            logger.warning(
+                "Contract phase sync failed at advance_phase (continuing) (#3521)",
+                pipeline_id=pipeline_id,
+                error=str(_sync_err),
+            )
+
         # Persist BRC history for the outgoing phase before the message
         # store is wiped — otherwise advance_phase (and especially
         # --force, used to unstick #1813) silently drops that phase's

--- a/orchestrator/routes/pipelines/__init__.py
+++ b/orchestrator/routes/pipelines/__init__.py
@@ -1242,6 +1242,7 @@ from ._lifecycle_helpers import (  # noqa: E402,F401
     _compute_gateway_mode,
     _mark_pipeline_records_terminated,
     _normalize_submission_repos,
+    _sync_contract_phase_to_pipeline,
 )
 from ._overseer import (  # noqa: E402,F401
     _build_overseer_corrective_executor,

--- a/orchestrator/routes/pipelines/_lifecycle_helpers.py
+++ b/orchestrator/routes/pipelines/_lifecycle_helpers.py
@@ -337,3 +337,115 @@ def _cleanup_remote_branches(
             branches_deleted=deleted,
             branches_total=len(branches),
         )
+
+
+# Forward-only ordering for contract.current_phase advancement (#3521).
+# APPLY sits between PLAN and IMPLEMENT (conditional, epic pipelines only;
+# #1557); index comparison still orders PLAN → IMPLEMENT correctly for
+# non-epic pipelines that skip it.
+_CONTRACT_PHASE_ORDER = (
+    "refine",
+    "plan",
+    "apply",
+    "implement",
+)
+
+
+def _sync_contract_phase_to_pipeline(pipeline, worktree_repo_path, *, source: str) -> bool:
+    """Advance ``contract.current_phase`` to match ``pipeline.current_phase`` (#3521).
+
+    Before this helper, ``contract.current_phase`` was mutated only by
+    whichever agent happened to call the gateway phase API after a phase
+    transition (or by the ``start_phase=implement`` safety-net populate,
+    #2427). Agents are one-shot pods that can exit before doing it, so the
+    contract could silently stay on the previous phase while the pipeline
+    record moved on; and the gateway commit gate keys off the CONTRACT
+    phase, so the next phase's producers were rejected with
+    "Phase '<old>' cannot modify" and consensus wedged (the #3521 incident:
+    refine→plan desync blocked the plan artifacts for ~30 min).
+
+    Called at every orchestrator-driven phase transition (auto-advance in
+    ``_run_pipeline``, the ``advance_phase`` route, and the
+    ``start_pipeline`` HITL-recovery advance) so the agent/gateway mutation
+    path is redundant rather than load-bearing.
+
+    Forward-only: a respawn or stale caller can never demote the contract
+    (same enforcement the safety-net populate uses). Best-effort by design:
+    returns ``True`` when the contract was advanced and ``False`` otherwise
+    (already in sync, contract missing, worktree gone, ...); never raises,
+    because a phase transition must not fail on contract-sync problems the
+    overseer's desync detector will surface anyway.
+
+    Args:
+        pipeline: The pipeline whose ``current_phase`` is the sync target.
+        worktree_repo_path: Shared pipeline worktree checkout holding the
+            live contract file (``.egg-state/contracts/<pipeline_id>.json``).
+        source: Call-site label recorded in the log line (e.g.
+            ``"auto_advance"``, ``"advance_phase"``).
+    """
+    target_phase = pipeline.current_phase
+    if target_phase is None:
+        return False
+    try:
+        from egg_contracts.loader import load_contract, save_contract
+
+        contract = load_contract(pipeline.id, worktree_repo_path)
+    except Exception as load_err:  # noqa: BLE001
+        _pkg.logger.warning(
+            "contract_phase_sync_skipped",
+            pipeline_id=pipeline.id,
+            source=source,
+            target_phase=target_phase.value,
+            reason="contract_load_failed",
+            error=str(load_err),
+        )
+        return False
+
+    contract_phase_value = contract.current_phase.value
+    target_phase_value = target_phase.value
+    if (
+        contract_phase_value not in _CONTRACT_PHASE_ORDER
+        or target_phase_value not in _CONTRACT_PHASE_ORDER
+        or _CONTRACT_PHASE_ORDER.index(target_phase_value)
+        <= _CONTRACT_PHASE_ORDER.index(contract_phase_value)
+    ):
+        # Already in sync, contract ahead (never demote), or a phase
+        # outside the known order: nothing to do.
+        return False
+
+    try:
+        from egg_contracts.audit import create_transition_entry
+        from egg_contracts.models import AuditRole
+
+        contract.audit_log.append(
+            create_transition_entry(
+                actor="orchestrator",
+                role=AuditRole.SYSTEM,
+                from_phase=contract_phase_value,
+                to_phase=target_phase_value,
+                reason=f"orchestrator phase-transition sync ({source}; #3521)",
+            )
+        )
+        # ``models.PipelinePhase`` is a re-export of the egg_contracts enum,
+        # so the pipeline's phase member is assignable directly.
+        contract.current_phase = target_phase
+        save_contract(contract, worktree_repo_path)
+    except Exception as save_err:  # noqa: BLE001
+        _pkg.logger.warning(
+            "contract_phase_sync_skipped",
+            pipeline_id=pipeline.id,
+            source=source,
+            target_phase=target_phase_value,
+            reason="contract_save_failed",
+            error=str(save_err),
+        )
+        return False
+
+    _pkg.logger.info(
+        "contract_phase_synced",
+        pipeline_id=pipeline.id,
+        source=source,
+        from_phase=contract_phase_value,
+        to_phase=target_phase_value,
+    )
+    return True

--- a/orchestrator/routes/pipelines/_routes_lifecycle.py
+++ b/orchestrator/routes/pipelines/_routes_lifecycle.py
@@ -671,6 +671,17 @@ def _start_pipeline_body(pipeline_id: str) -> tuple[_pkg.Response, int]:
 
                 _clear_concurrent_state(pipeline_id)
 
+                # #3521: advance contract.current_phase in lockstep with
+                # the pipeline record on the HITL-recovery advance (this
+                # path does NOT route through advance_phase REST; the
+                # runner thread is spawned inline below). Best-effort +
+                # forward-only; never raises.
+                _pkg._sync_contract_phase_to_pipeline(
+                    pipeline,
+                    _pkg._resolve_pipeline_worktree_path(pipeline, repo_path),
+                    source="hitl_recovery_advance",
+                )
+
             # #2593 review issue 1 — context-PR open moved out of the
             # per-pipeline state lock so the multi-second gateway
             # sequence does not hold the lock and block concurrent

--- a/orchestrator/routes/pipelines/_run_pipeline.py
+++ b/orchestrator/routes/pipelines/_run_pipeline.py
@@ -1068,6 +1068,17 @@ def _run_pipeline(
                 # ``updated_at`` is unconditionally set by ``StateStore.save_pipeline``.
                 store.save_pipeline(pipeline)
 
+            # #3521: advance contract.current_phase in lockstep with the
+            # pipeline record. Historically this mutation was owned by
+            # whichever agent called the gateway phase API after the
+            # transition; when none did, the contract silently stayed on
+            # the previous phase and the gateway commit gate (which keys
+            # off the CONTRACT phase) wedged the next phase's consensus.
+            # Best-effort + forward-only; never raises.
+            _pkg._sync_contract_phase_to_pipeline(
+                pipeline, worktree_repo_path, source="auto_advance"
+            )
+
             # Drop the previous phase's in-memory consensus tracker and
             # message-store entries (#2502).  The other phase-transition
             # paths -- ``advance_phase`` REST handler, HITL-revision

--- a/orchestrator/routes/pipelines/_run_pipeline_setup.py
+++ b/orchestrator/routes/pipelines/_run_pipeline_setup.py
@@ -273,6 +273,16 @@ def _sync_contract_setup(
                 pipeline.error = f"Failed to create contract: {contract_err}"
                 store.save_pipeline(pipeline)
             return pipeline, True
+    # TEST_MARKER: driver_startup_contract_sync
+    # #3521 follow-up: heal a contract-phase desync on every driver
+    # (re)launch. The advance_phase route site syncs best-effort at request
+    # time, but immediately after an orchestrator restart the pipeline
+    # worktree may not be re-provisioned yet, so resolve_worktree_path falls
+    # back to the base repo and that sync skips with contract_load_failed
+    # (observed live on issue-3364). Here the worktree exists and was just
+    # reset to origin, so this call is authoritative. Forward-only +
+    # best-effort; never raises.
+    _pkg._sync_contract_phase_to_pipeline(pipeline, worktree_repo_path, source="driver_startup")
     return pipeline, False
 
 

--- a/orchestrator/routes/pipelines/_run_pipeline_setup.py
+++ b/orchestrator/routes/pipelines/_run_pipeline_setup.py
@@ -282,6 +282,14 @@ def _sync_contract_setup(
     # (observed live on issue-3364). Here the worktree exists and was just
     # reset to origin, so this call is authoritative. Forward-only +
     # best-effort; never raises.
+    #
+    # Awareness: this runs before the start_phase=implement safety-net
+    # populate, so on a fresh start_phase=implement pipeline it advances the
+    # contract REFINE->IMPLEMENT ahead of that populate. If the populate then
+    # fails the empty-contract guard (pipeline -> FAILED), the contract is left
+    # at IMPLEMENT with a driver_startup audit entry rather than staying at
+    # REFINE. This is cosmetic — the operator recovers via the empty-contract
+    # HITL, which re-establishes phase on repopulate/restart-plan.
     _pkg._sync_contract_phase_to_pipeline(pipeline, worktree_repo_path, source="driver_startup")
     return pipeline, False
 

--- a/orchestrator/tests/test_advance_phase_thread.py
+++ b/orchestrator/tests/test_advance_phase_thread.py
@@ -310,7 +310,8 @@ class TestAutoAdvanceRespawnsThread:
         # Widened from 3000 to 5000 in issue #1557 to absorb the epic-mode
         # applier-handoff write + Won't-Do drain hook the auto-advance
         # block now performs before respawning the next-phase thread.
-        return source[idx : idx + 5000]
+        # Widened to 6000 in issue #3521 for the contract-phase sync call.
+        return source[idx : idx + 6000]
 
     def test_auto_advance_bumps_run_epoch(self):
         block = self._auto_advance_block()

--- a/orchestrator/tests/test_contract_phase_sync.py
+++ b/orchestrator/tests/test_contract_phase_sync.py
@@ -1,0 +1,259 @@
+"""Tests for #3521: orchestrator-driven phase transitions must advance
+``contract.current_phase`` in lockstep with ``pipeline.current_phase``.
+
+Before this fix the contract mutation was owned by whichever agent happened
+to call the gateway phase API after a transition; when none did (agents are
+one-shot pods), the contract silently stayed on the previous phase and the
+gateway commit gate (which keys off the CONTRACT phase) rejected the next
+phase's producers ("Phase 'refine' cannot modify"), wedging consensus.
+
+Covers:
+- the ``_sync_contract_phase_to_pipeline`` helper (forward-only advance,
+  audit entry, best-effort failure modes),
+- the ``advance_phase`` route wiring,
+- structural assertions that the ``_run_pipeline`` auto-advance block and
+  the ``start_pipeline`` HITL-recovery advance call the helper.
+"""
+
+import inspect
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+# Mock docker before importing models
+sys.modules.setdefault("docker", MagicMock())
+sys.modules.setdefault("docker.errors", MagicMock())
+sys.modules.setdefault("docker.types", MagicMock())
+
+from egg_contracts.loader import create_contract, load_contract
+from egg_contracts.models import AuditAction
+from models import (
+    Pipeline,
+    PipelinePhase,
+    PipelineStatus,
+)
+
+try:
+    from flask import Flask
+    from routes.phases import phases_bp
+    from routes.pipelines import _sync_contract_phase_to_pipeline
+
+    _HAS_FLASK = True
+except ImportError:
+    _HAS_FLASK = False
+
+
+def _make_pipeline(
+    pipeline_id="issue-3521",
+    phase=PipelinePhase.PLAN,
+    issue_number=3521,
+):
+    return Pipeline(
+        id=pipeline_id,
+        issue_number=issue_number,
+        repo="owner/repo",
+        branch=f"egg/issue-{issue_number}",
+        status=PipelineStatus.RUNNING,
+        current_phase=phase,
+    )
+
+
+@pytest.mark.skipif(not _HAS_FLASK, reason="Flask not available")
+class TestSyncContractPhaseToPipeline:
+    """Unit tests for the forward-only contract phase sync helper."""
+
+    def test_advances_contract_and_appends_audit(self, tmp_path):
+        """refine→plan (the #3521 incident shape) advances the contract with an audit entry."""
+        create_contract(
+            issue_number=3521,
+            title="test",
+            pipeline_id="issue-3521",
+            repo_root=tmp_path,
+            initial_phase=PipelinePhase.REFINE,
+        )
+        pipeline = _make_pipeline(phase=PipelinePhase.PLAN)
+
+        advanced = _sync_contract_phase_to_pipeline(pipeline, tmp_path, source="auto_advance")
+
+        assert advanced is True
+        contract = load_contract("issue-3521", tmp_path)
+        assert contract.current_phase == PipelinePhase.PLAN
+        entry = contract.audit_log[-1]
+        assert entry.action == AuditAction.TRANSITION
+        assert entry.actor == "orchestrator"
+        assert entry.old_value == "refine"
+        assert entry.new_value == "plan"
+        assert "auto_advance" in (entry.reason or "")
+        assert "#3521" in (entry.reason or "")
+
+    def test_noop_when_already_in_sync(self, tmp_path):
+        """No write and no audit entry when the contract already matches."""
+        create_contract(
+            issue_number=3521,
+            title="test",
+            pipeline_id="issue-3521",
+            repo_root=tmp_path,
+            initial_phase=PipelinePhase.PLAN,
+        )
+        pipeline = _make_pipeline(phase=PipelinePhase.PLAN)
+
+        advanced = _sync_contract_phase_to_pipeline(pipeline, tmp_path, source="advance_phase")
+
+        assert advanced is False
+        contract = load_contract("issue-3521", tmp_path)
+        assert contract.current_phase == PipelinePhase.PLAN
+        assert not any(e.action == AuditAction.TRANSITION for e in contract.audit_log)
+
+    def test_never_demotes_contract(self, tmp_path):
+        """A stale caller (contract ahead of the pipeline record) never rolls the contract back."""
+        create_contract(
+            issue_number=3521,
+            title="test",
+            pipeline_id="issue-3521",
+            repo_root=tmp_path,
+            initial_phase=PipelinePhase.IMPLEMENT,
+        )
+        pipeline = _make_pipeline(phase=PipelinePhase.PLAN)
+
+        advanced = _sync_contract_phase_to_pipeline(pipeline, tmp_path, source="advance_phase")
+
+        assert advanced is False
+        contract = load_contract("issue-3521", tmp_path)
+        assert contract.current_phase == PipelinePhase.IMPLEMENT
+
+    def test_epic_apply_transition_advances(self, tmp_path):
+        """plan→apply (epic pipelines, #1557) is a forward transition."""
+        create_contract(
+            issue_number=3521,
+            title="test",
+            pipeline_id="issue-3521",
+            repo_root=tmp_path,
+            initial_phase=PipelinePhase.PLAN,
+        )
+        pipeline = _make_pipeline(phase=PipelinePhase.APPLY)
+
+        advanced = _sync_contract_phase_to_pipeline(pipeline, tmp_path, source="auto_advance")
+
+        assert advanced is True
+        contract = load_contract("issue-3521", tmp_path)
+        assert contract.current_phase == PipelinePhase.APPLY
+
+    def test_missing_contract_returns_false(self, tmp_path):
+        """No contract on disk is a logged no-op, never a raise."""
+        pipeline = _make_pipeline(phase=PipelinePhase.PLAN)
+
+        advanced = _sync_contract_phase_to_pipeline(pipeline, tmp_path, source="auto_advance")
+
+        assert advanced is False
+
+    def test_none_phase_returns_false(self, tmp_path):
+        """A pipeline without a current phase is a no-op."""
+        pipeline = _make_pipeline(phase=PipelinePhase.PLAN)
+        pipeline.current_phase = None
+
+        advanced = _sync_contract_phase_to_pipeline(pipeline, tmp_path, source="auto_advance")
+
+        assert advanced is False
+
+
+@pytest.fixture
+def app():
+    if not _HAS_FLASK:
+        pytest.skip("Flask not available")
+    app = Flask(__name__)
+    app.register_blueprint(phases_bp)
+    app.config["TESTING"] = True
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.mark.skipif(not _HAS_FLASK, reason="Flask not available")
+class TestAdvancePhaseSyncsContract:
+    """advance_phase must invoke the contract phase sync after the mutation."""
+
+    @patch("routes.pipelines._persist_phase_brc_history")
+    @patch("routes.pipelines._spawn_pipeline_run_thread")
+    @patch("routes.pipelines._sync_contract_phase_to_pipeline")
+    @patch("routes.resolve_worktree_path")
+    @patch("routes.phases.get_pipeline_state_lock")
+    @patch("routes.phases.get_state_store_for_pipeline")
+    def test_advance_refine_to_plan_calls_sync(
+        self,
+        mock_get_store,
+        mock_get_lock,
+        mock_resolve_wt,
+        mock_sync,
+        mock_thread,
+        mock_persist,
+        client,
+    ):
+        """A refine→plan advance (the #3521 incident transition) routes through the sync helper."""
+        pipeline = _make_pipeline(phase=PipelinePhase.REFINE)
+        phase_exec = pipeline.get_phase_execution(PipelinePhase.REFINE)
+        phase_exec.status = PipelineStatus.COMPLETE
+        phase_exec.completed_at = datetime.now(UTC)
+
+        mock_store = MagicMock()
+        mock_store.repo_path = Path("/tmp/repo")
+        mock_store.load_pipeline.return_value = pipeline
+        mock_get_store.return_value = (mock_store, pipeline)
+        mock_get_lock.return_value = MagicMock()
+        mock_resolve_wt.return_value = Path("/tmp/wt")
+
+        resp = client.post(
+            "/api/v1/pipelines/issue-3521/phase",
+            json={"target_phase": "plan"},
+        )
+
+        assert resp.status_code == 200
+        mock_sync.assert_called_once()
+        args, kwargs = mock_sync.call_args
+        assert args[0] is pipeline
+        assert args[0].current_phase == PipelinePhase.PLAN
+        assert args[1] == Path("/tmp/wt")
+        assert kwargs.get("source") == "advance_phase"
+
+
+@pytest.mark.skipif(not _HAS_FLASK, reason="Flask not available")
+class TestTransitionSitesCallSync:
+    """Structural assertions that the other orchestrator-driven transition
+    sites call the sync helper (mirrors TestAutoAdvanceRespawnsThread's
+    source-level technique; full behavioral coverage of ``_run_pipeline``
+    would need a heavy mock harness for the entire phase loop).
+    """
+
+    def test_auto_advance_block_calls_sync(self):
+        from routes import pipelines
+
+        source = inspect.getsource(pipelines._run_pipeline).replace("_pkg.", "")
+        marker = "TEST_MARKER: auto_advance_block"
+        assert marker in source
+        block = source[source.index(marker) : source.index(marker) + 6000]
+        assert "_sync_contract_phase_to_pipeline(" in block, (
+            "The auto-advance block must sync contract.current_phase to the "
+            "pipeline record (#3521)."
+        )
+
+    def test_hitl_recovery_advance_calls_sync(self):
+        from routes.pipelines import _routes_lifecycle
+
+        source = inspect.getsource(_routes_lifecycle._start_pipeline_body)
+        assert "_sync_contract_phase_to_pipeline(" in source, (
+            "The start_pipeline HITL-recovery advance must sync "
+            "contract.current_phase to the pipeline record (#3521)."
+        )

--- a/orchestrator/tests/test_contract_phase_sync.py
+++ b/orchestrator/tests/test_contract_phase_sync.py
@@ -257,3 +257,26 @@ class TestTransitionSitesCallSync:
             "The start_pipeline HITL-recovery advance must sync "
             "contract.current_phase to the pipeline record (#3521)."
         )
+
+    def test_driver_startup_calls_sync(self):
+        """The driver must sync after worktree provisioning on every
+        (re)launch. The advance_phase route site runs at request time, when
+        a freshly-restarted orchestrator may not have re-provisioned the
+        pipeline worktree yet — resolve_worktree_path then falls back to the
+        base repo and the sync skips with contract_load_failed (observed
+        live on issue-3364). The driver-startup call runs after the worktree
+        is created and reset to origin, so it heals any desync the route
+        site missed.
+        """
+        from routes import pipelines
+
+        source = inspect.getsource(pipelines._sync_contract_setup).replace("_pkg.", "")
+        marker = "TEST_MARKER: driver_startup_contract_sync"
+        assert marker in source
+        block = source[source.index(marker) : source.index(marker) + 1200]
+        assert "_sync_contract_phase_to_pipeline(" in block, (
+            "The driver's contract-setup step must sync contract.current_phase "
+            "after worktree provisioning so a desync heals on every driver "
+            "(re)launch, including redeploy resume (#3521)."
+        )
+        assert 'source="driver_startup"' in block

--- a/orchestrator/tests/test_contract_phase_sync.py
+++ b/orchestrator/tests/test_contract_phase_sync.py
@@ -273,7 +273,7 @@ class TestTransitionSitesCallSync:
         source = inspect.getsource(pipelines._sync_contract_setup).replace("_pkg.", "")
         marker = "TEST_MARKER: driver_startup_contract_sync"
         assert marker in source
-        block = source[source.index(marker) : source.index(marker) + 1200]
+        block = source[source.index(marker) : source.index(marker) + 2000]
         assert "_sync_contract_phase_to_pipeline(" in block, (
             "The driver's contract-setup step must sync contract.current_phase "
             "after worktree provisioning so a desync heals on every driver "

--- a/orchestrator/tests/test_overseer_monitor.py
+++ b/orchestrator/tests/test_overseer_monitor.py
@@ -1339,6 +1339,113 @@ class TestHitlResolutionPropagation:
 
 
 # ===================================================================
+# test_contract_phase_desync
+# ===================================================================
+
+
+class TestContractPhaseDesync:
+    """Test the deterministic contract-vs-pipeline phase desync detector (#3521)."""
+
+    def _make_monitor(self, pipeline_id: str = "test-desync-001") -> OverseerMonitor:
+        monitor = OverseerMonitor(pipeline_id=pipeline_id, config=_MockConfig())
+        monitor._broadcast_alert = AsyncMock()
+        monitor._create_hitl_decision = AsyncMock()
+        monitor._send_slack_notification = AsyncMock()
+        return monitor
+
+    def test_detects_desync_after_grace(self) -> None:
+        """Flags a persistent contract-vs-pipeline phase mismatch once the grace window elapses."""
+        monitor = self._make_monitor()
+        monitor._query_contract_data = AsyncMock(return_value={"current_phase": "refine"})
+
+        phase_data = {"current_phase": "plan", "status": "running"}
+
+        # First observation: starts the grace window, no alert.
+        _run(monitor._check_contract_phase_desync(phase_data))
+        monitor._broadcast_alert.assert_not_awaited()
+        assert monitor._phase_desync_pair == ("refine", "plan")
+        assert monitor._phase_desync_first_seen is not None
+
+        # Backdate past the threshold.
+        monitor._phase_desync_first_seen = time.time() - 999
+
+        _run(monitor._check_contract_phase_desync(phase_data))
+        monitor._broadcast_alert.assert_awaited_once()
+        monitor._create_hitl_decision.assert_awaited_once()
+        monitor._send_slack_notification.assert_awaited_once()
+        assert ("refine", "plan") in monitor._phase_desync_alerted
+        alert_args = monitor._broadcast_alert.await_args[0]
+        assert alert_args[0] == "contract_phase_desync"
+        assert "refine" in alert_args[2] and "plan" in alert_args[2]
+
+    def test_resets_when_in_sync(self) -> None:
+        """Tracking resets when the contract catches up."""
+        monitor = self._make_monitor("test-desync-002")
+        monitor._query_contract_data = AsyncMock(return_value={"current_phase": "plan"})
+        monitor._phase_desync_pair = ("refine", "plan")
+        monitor._phase_desync_first_seen = time.time() - 999
+
+        _run(monitor._check_contract_phase_desync({"current_phase": "plan", "status": "running"}))
+        assert monitor._phase_desync_pair is None
+        assert monitor._phase_desync_first_seen is None
+        monitor._broadcast_alert.assert_not_awaited()
+
+    def test_no_check_when_not_running(self) -> None:
+        """No contract query or alert when the pipeline is not running."""
+        monitor = self._make_monitor("test-desync-003")
+        monitor._query_contract_data = AsyncMock()
+        monitor._phase_desync_pair = ("refine", "plan")
+        monitor._phase_desync_first_seen = time.time() - 999
+
+        _run(
+            monitor._check_contract_phase_desync(
+                {"current_phase": "plan", "status": "awaiting_human"}
+            )
+        )
+        monitor._query_contract_data.assert_not_awaited()
+        monitor._broadcast_alert.assert_not_awaited()
+        assert monitor._phase_desync_pair is None
+
+    def test_contract_unavailable_keeps_timer(self) -> None:
+        """A transient contract-query failure must not restart the grace window."""
+        monitor = self._make_monitor("test-desync-004")
+        monitor._query_contract_data = AsyncMock(return_value={})
+        first_seen = time.time() - 100
+        monitor._phase_desync_pair = ("refine", "plan")
+        monitor._phase_desync_first_seen = first_seen
+
+        _run(monitor._check_contract_phase_desync({"current_phase": "plan", "status": "running"}))
+        assert monitor._phase_desync_first_seen == first_seen
+        monitor._broadcast_alert.assert_not_awaited()
+
+    def test_alerts_once_per_pair(self) -> None:
+        """Does not re-alert for the same mismatch pair."""
+        monitor = self._make_monitor("test-desync-005")
+        monitor._query_contract_data = AsyncMock(return_value={"current_phase": "refine"})
+        monitor._phase_desync_pair = ("refine", "plan")
+        monitor._phase_desync_first_seen = time.time() - 999
+        monitor._phase_desync_alerted.add(("refine", "plan"))
+
+        _run(monitor._check_contract_phase_desync({"current_phase": "plan", "status": "running"}))
+        monitor._broadcast_alert.assert_not_awaited()
+
+    def test_new_pair_restarts_grace_window(self) -> None:
+        """A different mismatch pair restarts the grace window instead of alerting."""
+        monitor = self._make_monitor("test-desync-006")
+        monitor._query_contract_data = AsyncMock(return_value={"current_phase": "plan"})
+        monitor._phase_desync_pair = ("refine", "plan")
+        monitor._phase_desync_first_seen = time.time() - 999
+
+        _run(
+            monitor._check_contract_phase_desync(
+                {"current_phase": "implement", "status": "running"}
+            )
+        )
+        monitor._broadcast_alert.assert_not_awaited()
+        assert monitor._phase_desync_pair == ("plan", "implement")
+
+
+# ===================================================================
 # test_cross_phase_consistency
 # ===================================================================
 

--- a/orchestrator/tests/test_overseer_monitor.py
+++ b/orchestrator/tests/test_overseer_monitor.py
@@ -1444,6 +1444,38 @@ class TestContractPhaseDesync:
         monitor._broadcast_alert.assert_not_awaited()
         assert monitor._phase_desync_pair == ("plan", "implement")
 
+    def test_repair_text_when_contract_behind(self) -> None:
+        """Normal case (contract behind pipeline): repair steers toward advancing the contract."""
+        monitor = self._make_monitor("test-desync-007")
+        monitor._query_contract_data = AsyncMock(return_value={"current_phase": "refine"})
+        monitor._phase_desync_pair = ("refine", "plan")
+        monitor._phase_desync_first_seen = time.time() - 999
+
+        _run(monitor._check_contract_phase_desync({"current_phase": "plan", "status": "running"}))
+        monitor._broadcast_alert.assert_awaited_once()
+        message = monitor._broadcast_alert.await_args[0][2]
+        assert "advance the contract phase" in message
+        assert "AHEAD" not in message
+
+    def test_repair_text_when_contract_ahead(self) -> None:
+        """Anomalous case (contract ahead of pipeline record): repair steers toward reconciliation.
+
+        Forward-only sync never leaves the contract ahead, so this direction
+        signals a state-machine bug; "advance the contract" would be nonsensical
+        (#3521 review).
+        """
+        monitor = self._make_monitor("test-desync-008")
+        monitor._query_contract_data = AsyncMock(return_value={"current_phase": "implement"})
+        monitor._phase_desync_pair = ("implement", "plan")
+        monitor._phase_desync_first_seen = time.time() - 999
+
+        _run(monitor._check_contract_phase_desync({"current_phase": "plan", "status": "running"}))
+        monitor._broadcast_alert.assert_awaited_once()
+        message = monitor._broadcast_alert.await_args[0][2]
+        assert "AHEAD" in message
+        assert "reconcile" in message
+        assert "advance the contract phase via the gateway phase API" not in message
+
 
 # ===================================================================
 # test_cross_phase_consistency

--- a/orchestrator/tests/test_start_pipeline.py
+++ b/orchestrator/tests/test_start_pipeline.py
@@ -672,7 +672,15 @@ class TestStartAwaitingHumanPipeline:
 
         assert resp.status_code == 200
 
-        mock_resolve_wt.assert_called_once_with(pipeline, Path("/repo"))
+        # Resolved twice: once for the phase-gate persistence below, once
+        # for the #3521 contract-phase sync on the recovery advance. Both
+        # must route through the worktree resolver with the same arguments.
+        assert mock_resolve_wt.call_count == 2, (
+            f"expected 2 worktree resolutions (persistence + #3521 phase "
+            f"sync), got {mock_resolve_wt.call_count}"
+        )
+        for resolve_call in mock_resolve_wt.call_args_list:
+            assert resolve_call.args == (pipeline, Path("/repo"))
 
         persist_args, _ = mock_persist.call_args
         assert persist_args[0] == worktree_path, (


### PR DESCRIPTION
Fixes #3521. Related: #3364 (orchestrator/overseer own state-machine correctness), #2427 (the start_phase=implement safety net this generalizes).

## Problem

On orchestrator-driven phase transitions, only `pipeline.current_phase` was advanced; `contract.current_phase` was left for whichever agent happened to call the gateway phase-advance API (`gateway/phase_api.py`) via `apply_mutation`. Agents are one-shot pods that can exit before doing it, so nothing in the transition path guaranteed the mutation. The gateway commit gate keys off the CONTRACT phase, so a lagging contract silently rejected the next phase's blocking producers ("Phase 'refine' cannot modify") and wedged consensus while `get_status` showed a healthy running phase. Live incident: pipeline issue-3364 (2026-07-06), refine->plan desync for ~30 minutes until the simplifier raised an OVERSEER_ALERT.

## Fix (both items from the issue's proposal)

**1. Orchestrator-owned contract-phase sync.** New `_sync_contract_phase_to_pipeline` helper (`routes/pipelines/_lifecycle_helpers.py`):

- advances `contract.current_phase` to `pipeline.current_phase` with the same forward-only enforcement the `start_phase=implement` safety-net populate uses (a respawn or stale caller can never demote the contract); order is refine -> plan -> apply -> implement, so epic (#1557) transitions are covered
- appends a SYSTEM `create_transition_entry` audit-log entry so operators see the transition in the audit trail
- best-effort by design: returns False and warns on any load/save problem, never raises; a phase transition must not fail on contract-sync problems the desync detector will surface anyway

Called at every orchestrator-driven transition site, making the agent/gateway mutation path redundant rather than load-bearing:

- `_run_pipeline` auto-advance block (the incident path: gate approval -> phase complete -> advance)
- `advance_phase` route (post state-lock mutation, wrapped so sync problems can never fail the advance)
- `start_pipeline` HITL-recovery advance (does not route through advance_phase REST)

**2. Deterministic desync detector.** New overseer check `_check_contract_phase_desync` in the deterministic health-check section of the poll cycle: `pipeline.current_phase != contract.current_phase` for more than `overseer_phase_desync_alert_seconds` (default 300, new `PipelineConfig` knob) while status=running emits a structural OVERSEER_ALERT plus a HITL decision and Slack notification (matching its sibling checks), once per distinct mismatch pair. No LLM classification. Transient contract-query failures do not restart the grace window; a changed mismatch pair does.

## Tests

- `orchestrator/tests/test_contract_phase_sync.py` (new): helper unit tests against a real on-disk contract (forward advance + audit entry for the incident's refine->plan shape, no-op when in sync, never demotes, epic plan->apply, missing contract, None phase), advance_phase route wiring via Flask client, structural assertions that the auto-advance block and the HITL-recovery path call the helper
- `orchestrator/tests/test_overseer_monitor.py`: 6 new detector tests (grace window then alert, reset when in sync, skip when not running, transient contract failure keeps the timer, alert-once dedup, new pair restarts the window)
- `test_advance_phase_thread.py`: auto-advance source window widened 5000 -> 6000 (precedent: #1557 widening)
- `test_start_pipeline.py`: recovery test updated for the second (identical) worktree resolution the sync adds

`make lint` clean. `make test` (changeset-aware, ~200 files / 7178 tests): all pass except two pre-existing local-environment failures (`test_production_worktree_base_dir_lies_within_gateway_allowlist`, `test_probe_skipped_when_request_context_missing`) which fail identically on a clean checkout of main with this diff reverted.