### PR TITLE
Fix consensus-stall false positive: ignore slice-tagged confirms in message fallback

### DIFF
--- a/orchestrator/health_checks/tier1/_consensus_messages.py
+++ b/orchestrator/health_checks/tier1/_consensus_messages.py
@@ -1,0 +1,46 @@
+"""Slice-aware helpers for consensus-message fallbacks (#3542).
+
+The tier-1 consensus checks fall back to scanning the pipeline's message
+bus for ``CONSENSUS_CONFIRMED`` when no in-memory tracker is available.
+That scan is pipeline-wide, but during a slice-DAG implement phase every
+slice's agents write their consensus traffic to the same bus, so the
+moment one slice fully confirms, an unscoped scan reports "all roles
+confirmed" for the rest of the pipeline's life. That false positive is
+what let the aggressive stall recovery mark the implement phase COMPLETE
+between slices (the issue-3523 slice-7 to slice-8 transition, and again
+60s after an operator phase restart cleared the slice trackers).
+
+Per-slice agents tag every ``CONSENSUS_*`` message with ``slice_id`` in
+``metadata`` (the ``_slice_meta`` spread in ``routes/signals``);
+pipeline-level messages omit it. The message fallback reconstructs
+*pipeline-level* consensus, so it must only count untagged messages,
+mirroring ``peer_consensus._message_slice_id`` and the executor-side
+skip of the pipeline-wide fallback for slice-scoped trackers (#2535).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+
+def message_slice_id(message: Any) -> str | None:
+    """Return the ``slice_id`` a message was tagged with, or ``None``."""
+    metadata = getattr(message, "metadata", None) or {}
+    if not hasattr(metadata, "get"):
+        return None
+    return metadata.get("slice_id")
+
+
+def pipeline_level_confirmed_roles(messages: Iterable[Any]) -> set[str]:
+    """Roles with a pipeline-level (slice-untagged) CONSENSUS_CONFIRMED.
+
+    Slice-tagged confirmations belong to a per-slice tracker's round and
+    say nothing about pipeline-level consensus; counting them is how a
+    completed early slice masquerades as whole-phase consensus.
+    """
+    return {
+        m.from_role
+        for m in messages
+        if m.message_type == "CONSENSUS_CONFIRMED" and message_slice_id(m) is None
+    }

--- a/orchestrator/health_checks/tier1/consensus_stall.py
+++ b/orchestrator/health_checks/tier1/consensus_stall.py
@@ -31,6 +31,7 @@ except ImportError:
 
 
 from health_checks.context import PipelineHealthContext
+from health_checks.tier1._consensus_messages import pipeline_level_confirmed_roles
 from health_checks.types import (
     HealthAction,
     HealthResult,
@@ -158,9 +159,13 @@ class ConsensusStallCheck:
 
             store = get_message_store()
             messages = store.get_messages(pipeline_id, limit=10000)
-            confirmed_roles = {
-                m.from_role for m in messages if m.message_type == "CONSENSUS_CONFIRMED"
-            }
+            # Slice-tagged confirmations belong to per-slice consensus
+            # rounds and must not count toward pipeline-level consensus
+            # (#3542); otherwise one completed slice makes this fallback
+            # report "consensus complete" for the rest of the pipeline's
+            # life, and the aggressive stall recovery kills the phase
+            # between slices.
+            confirmed_roles = pipeline_level_confirmed_roles(messages)
             return expected_roles.issubset(confirmed_roles)
         except Exception:
             logger.debug(

--- a/orchestrator/health_checks/tier1/incomplete_consensus_stall.py
+++ b/orchestrator/health_checks/tier1/incomplete_consensus_stall.py
@@ -36,6 +36,7 @@ except ImportError:
 
 
 from health_checks.context import PipelineHealthContext
+from health_checks.tier1._consensus_messages import pipeline_level_confirmed_roles
 from health_checks.types import (
     HealthAction,
     HealthResult,
@@ -255,9 +256,10 @@ class IncompleteConsensusStallCheck:
 
             store = get_message_store()
             messages = store.get_messages(pipeline_id, limit=10000)
-            confirmed_roles = {
-                m.from_role for m in messages if m.message_type == "CONSENSUS_CONFIRMED"
-            }
+            # Slice-tagged confirmations belong to per-slice consensus
+            # rounds and must not count toward pipeline-level consensus
+            # (#3542).
+            confirmed_roles = pipeline_level_confirmed_roles(messages)
             blocking = sorted(expected_roles - confirmed_roles)
             return blocking
         except Exception:

--- a/orchestrator/tests/test_consensus_stall_check.py
+++ b/orchestrator/tests/test_consensus_stall_check.py
@@ -213,11 +213,13 @@ class TestConsensusStallCheck:
         mock_pc = MagicMock()
         mock_pc.get_peer_consensus_tracker.return_value = None
 
-        # Message fallback shows consensus complete
+        # Message fallback shows consensus complete (pipeline-level
+        # confirmation: no slice_id tag; #3542)
         mock_msg_store = MagicMock()
         mock_message = MagicMock()
         mock_message.message_type = "CONSENSUS_CONFIRMED"
         mock_message.from_role = "coder"
+        mock_message.metadata = {}
         mock_msg_store.get_messages.return_value = [mock_message]
 
         mock_msg_store_mod = MagicMock()
@@ -243,6 +245,58 @@ class TestConsensusStallCheck:
         # Health check should NOT have called reconstruct (no side effects)
         mock_pc.reconstruct_tracker_from_messages.assert_not_called()
         assert "tracker_reconstructed" not in result.details
+
+    def test_slice_tagged_confirmations_do_not_trigger_stall(self):
+        """Slice-scoped CONSENSUS_CONFIRMED messages are ignored by the fallback (#3542).
+
+        During a slice-DAG implement phase every slice's consensus traffic
+        lands on the same bus. Once one slice fully confirms, an unscoped
+        scan reports "consensus complete" for the rest of the pipeline's
+        life, letting aggressive stall recovery mark the implement phase
+        COMPLETE between slices (issue-3523 slice-7 to slice-8).
+        """
+        pipeline = _make_concurrent_pipeline(phase_started_seconds_ago=120)
+        ctx = _make_context(pipeline)
+
+        mock_ce = MagicMock()
+        mock_ce.is_concurrent_execution.return_value = True
+
+        # No pipeline-level tracker (cleared by a phase restart, or the
+        # phase is between slices).
+        mock_pc = MagicMock()
+        mock_pc.get_peer_consensus_tracker.return_value = None
+
+        # Every role confirmed, but for a *slice* round, not the pipeline.
+        mock_msg_store = MagicMock()
+        messages = []
+        for role in ("coder", "tester"):
+            msg = MagicMock()
+            msg.message_type = "CONSENSUS_CONFIRMED"
+            msg.from_role = role
+            msg.metadata = {"slice_id": "slice-1"}
+            messages.append(msg)
+        mock_msg_store.get_messages.return_value = messages
+
+        mock_msg_store_mod = MagicMock()
+        mock_msg_store_mod.get_message_store.return_value = mock_msg_store
+
+        mock_graph = MagicMock()
+        mock_graph.all_roles.return_value = {"coder", "tester"}
+        mock_graph_mod = MagicMock()
+        mock_graph_mod.get_review_graph_for_phase.return_value = mock_graph
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "concurrent_executor": mock_ce,
+                "peer_consensus": mock_pc,
+                "message_store": mock_msg_store_mod,
+                "review_graph": mock_graph_mod,
+            },
+        ):
+            result = ConsensusStallCheck(consensus_stall_grace_seconds=60).run(ctx)
+
+        assert result.status == HealthStatus.HEALTHY
 
     def test_idempotent(self):
         """Running the check twice produces the same result without side effects."""

--- a/orchestrator/tests/test_incomplete_consensus_stall.py
+++ b/orchestrator/tests/test_incomplete_consensus_stall.py
@@ -291,10 +291,12 @@ class TestIncompleteConsensusStallCheck:
         mock_pc = MagicMock()
         mock_pc.get_peer_consensus_tracker.return_value = None
 
-        # Message store shows documenter hasn't confirmed
+        # Message store shows documenter hasn't confirmed (coder's
+        # confirmation is pipeline-level: no slice_id tag; #3542)
         mock_msg = MagicMock()
         mock_msg.message_type = "CONSENSUS_CONFIRMED"
         mock_msg.from_role = "coder"
+        mock_msg.metadata = {}
 
         mock_store = MagicMock()
         mock_store.get_messages.return_value = [mock_msg]


### PR DESCRIPTION
Fixes the root cause of #3542 (root-cause analysis: https://github.com/jwbron/egg/issues/3542#issuecomment-4907738244).

## Problem

`ConsensusStallCheck` and `IncompleteConsensusStallCheck` fall back to scanning the pipeline's message bus for `CONSENSUS_CONFIRMED` from all expected roles when no pipeline-level tracker answers. The scan had no slice scoping, so during a slice-DAG implement phase, one completed slice's confirmations made the fallback report whole-phase consensus for the rest of the pipeline's life. `KubernetesMonitor`'s aggressive stall recovery then marked the implement phase COMPLETE:

- On issue-3523 this fired 5 seconds after slice-7's last confirmation, while slice-8 was being admitted; slice-8's consensus round froze with no driver and the check went silent (it skips non-RUNNING phases), producing a 14-hour stall.
- It fired again 64 seconds after an operator `restart_phase` (which clears slice trackers), killing the restarted phase one tick past the 60s grace period. `restart_phase` on a multi-slice implement phase with any completed slice on the bus lost to the watchdog deterministically.

The executor side already guards against exactly this (#2535: skip the pipeline-wide message fallback for slice-scoped trackers); the health checks never got the same guard.

## Fix

Per-slice agents tag every `CONSENSUS_*` message with `slice_id` in metadata (the `_slice_meta` spread in `routes/signals`); pipeline-level messages omit it. The fallback reconstructs pipeline-level consensus, so it now counts only untagged messages via a shared helper (`health_checks/tier1/_consensus_messages.py`) mirroring `peer_consensus._message_slice_id`.

Non-sliced pipelines are unaffected: their confirmations carry no slice tag and keep counting (#1471 behavior preserved).

## Follow-ups (tracked in #3542)

- The monitor's tracker lookups use the bare pipeline id and cannot see slice-scoped trackers (Track 1 reconstruction can't save a sliced phase).
- Contract-resident cq-N questions are not bridged into the decision queue.
- `wedged_no_successor` misreports admitted-but-stalled slices.

## Testing

- New test: slice-tagged confirmations from all roles do not trigger the stall path (returns HEALTHY).
- Existing fallback tests updated to model pipeline-level (untagged) messages explicitly.
- `make lint` clean; changeset suite green (842 passed).