### PR TITLE
Harden repo discovery and pipeline lookup against foreign worktrees in ~/repos

### DIFF
--- a/orchestrator/routes/__init__.py
+++ b/orchestrator/routes/__init__.py
@@ -202,6 +202,7 @@ def get_state_store_for_pipeline(
     """
     from state_store import (
         PipelineNotFoundError,
+        StateStoreError,
         discover_repo_paths,
         get_state_store,
         validate_pipeline_id,
@@ -224,10 +225,13 @@ def get_state_store_for_pipeline(
         pipeline = store.load_pipeline(pipeline_id)
         return store, pipeline
 
-    # Multi-repo: search all discovered repos.
-    # Only catch PipelineNotFoundError here — InvalidPipelineIdError and
-    # other StateStoreErrors should propagate immediately since an invalid
-    # ID or infrastructure failure won't resolve in a different repo.
+    # Multi-repo: search all discovered repos.  A repo that fails to load
+    # must not abort the scan; one foreign/broken directory in the repos
+    # dir would 500 every pipeline lookup (#3545).  The failure is not
+    # masked either: when the pipeline is found nowhere, the first
+    # infrastructure error is re-raised so a wedged store still surfaces
+    # as 500 with the real cause, not a misleading 404 (#2167).
+    deferred_error: Exception | None = None
     for repo_path in discover_repo_paths(base_path):
         try:
             store = get_state_store(repo_path)
@@ -235,7 +239,19 @@ def get_state_store_for_pipeline(
             return store, pipeline
         except PipelineNotFoundError:
             continue
+        except (StateStoreError, OSError) as e:
+            logger.warning(
+                "Skipping unreadable repo during pipeline lookup",
+                pipeline_id=pipeline_id,
+                repo_path=str(repo_path),
+                error=str(e),
+            )
+            if deferred_error is None:
+                deferred_error = e
+            continue
 
+    if deferred_error is not None:
+        raise deferred_error
     raise PipelineNotFoundError(f"Pipeline {pipeline_id} not found") from None
 
 

--- a/orchestrator/routes/pipelines/_resolve.py
+++ b/orchestrator/routes/pipelines/_resolve.py
@@ -142,13 +142,22 @@ def _resolve_pipeline(
     Raises:
         PipelineNotFoundError: if the pipeline cannot be found anywhere
         InvalidPipelineIdError: if the ID format is invalid
-        GitOperationError: if the state-store worktree cannot be loaded
-            (e.g. ``git worktree add`` contention).  Callers should
-            surface this as 500, not 404 — it is recoverable
-            infrastructure failure, not a missing pipeline.
+        GitOperationError: if a state-store worktree cannot be loaded
+            (e.g. ``git worktree add`` contention) and the pipeline is
+            found in no other repo.  Callers should surface this as 500,
+            not 404; it is recoverable infrastructure failure, not a
+            missing pipeline.
     """
     from state_store import discover_repo_paths
 
+    # A repo that fails to load must not abort the scan; one
+    # foreign/broken directory in the repos dir would 500 every pipeline
+    # lookup (#3545).  But the failure is not swallowed either: when the
+    # pipeline is found nowhere, the first infrastructure error is
+    # re-raised rather than ``PipelineNotFoundError``, so a state-store
+    # wedge still surfaces to operators as 500 with the actual error,
+    # not a masking 404 (#2167).
+    deferred_error: Exception | None = None
     for repo_path in discover_repo_paths(base_path):
         try:
             store = _pkg.get_state_store(repo_path)
@@ -156,13 +165,19 @@ def _resolve_pipeline(
             return store, pipeline
         except _pkg.PipelineNotFoundError:
             continue
-        # NOTE: do NOT broaden this to ``StateStoreError``.  Swallowing
-        # ``GitOperationError`` here re-raised every state-store wedge
-        # as ``Pipeline not found`` and surfaced to operators as 404,
-        # masking a recoverable git contention as a missing pipeline
-        # (#2167).  Let infrastructure failures propagate so the route
-        # can return 500 with the actual error.
+        except (_pkg.StateStoreError, OSError) as e:
+            _pkg.logger.warning(
+                "Skipping unreadable repo during pipeline lookup",
+                pipeline_id=pipeline_id,
+                repo_path=str(repo_path),
+                error=str(e),
+            )
+            if deferred_error is None:
+                deferred_error = e
+            continue
 
+    if deferred_error is not None:
+        raise deferred_error
     raise _pkg.PipelineNotFoundError(f"Pipeline {pipeline_id} not found") from None
 
 
@@ -184,13 +199,15 @@ def _collect_all_pipelines(base_path: _pkg.Path) -> list:
             try:
                 pipelines.append(store.load_pipeline(pid))
                 seen.add(pid)
-            except _pkg.StateStoreError:
+            except _pkg.StateStoreError, OSError:
                 continue
 
+    # OSError included: an unreachable repo (e.g. a foreign worktree,
+    # #3545) must cost one skipped store, not the whole listing.
     for repo_path in discover_repo_paths(base_path):
         try:
             _add_from_store(_pkg.get_state_store(repo_path))
-        except _pkg.StateStoreError:
+        except _pkg.StateStoreError, OSError:
             continue
 
     return pipelines

--- a/orchestrator/state_store/_factory.py
+++ b/orchestrator/state_store/_factory.py
@@ -15,11 +15,45 @@ import state_store as _pkg
 from ._errors import StateStoreError
 
 
+def _child_is_managed_repo(child: Path, base_path: Path) -> bool:
+    """Return True when *child* can be an egg-managed repo.
+
+    A ``.git`` directory is a normal clone: always managed.  A ``.git``
+    *file* is a worktree (or ``--separate-git-dir``) pointer, which can
+    only belong to an egg-managed repo when the ``gitdir:`` target lives
+    under *base_path*.  A worktree checked out host-side and dropped into
+    the repos dir carries a host-view absolute pointer that does not
+    exist inside the pod; constructing a ``StateStore`` for it crashes on
+    the unreachable gitdir and aborts repo discovery for every pipeline
+    (#3545), so such children are skipped.
+    """
+    git = child / ".git"
+    if git.is_dir():
+        return True
+    if not git.is_file():
+        return False
+    try:
+        content = git.read_text().strip()
+    except OSError:
+        return False
+    if not content.startswith("gitdir:"):
+        return False
+    gitdir = Path(content.split("gitdir:", 1)[1].strip())
+    if not gitdir.is_absolute():
+        gitdir = child / gitdir
+    try:
+        return gitdir.resolve().is_relative_to(base_path.resolve())
+    except OSError:
+        return False
+
+
 def discover_repo_paths(base_path: Path | str) -> list[Path]:
     """Discover git repositories under a base path.
 
     If *base_path* is itself a git repo, returns ``[base_path]``.
-    Otherwise, scans immediate children for directories containing ``.git``.
+    Otherwise, scans immediate children for directories containing
+    ``.git``, skipping foreign worktrees whose ``gitdir:`` points outside
+    *base_path* (#3545).
 
     Args:
         base_path: A git repo or a parent directory containing repos.
@@ -35,7 +69,7 @@ def discover_repo_paths(base_path: Path | str) -> list[Path]:
         return [
             child
             for child in sorted(base_path.iterdir())
-            if child.is_dir() and (child / ".git").exists()
+            if child.is_dir() and _child_is_managed_repo(child, base_path)
         ]
     return []
 

--- a/orchestrator/tests/test_state_store.py
+++ b/orchestrator/tests/test_state_store.py
@@ -558,6 +558,47 @@ class TestDiscoverRepoPaths:
 
         assert discover_repo_paths(tmp_path) == []
 
+    def test_skips_foreign_worktree(self, tmp_path):
+        """A host-created worktree dropped into the repos dir is skipped.
+
+        Its ``.git`` file's ``gitdir:`` pointer targets a host-view path
+        outside the repos dir that does not exist in the pod; treating it
+        as an egg-managed repo crashed every pipeline lookup (#3545).
+        """
+        from state_store import discover_repo_paths
+
+        (tmp_path / "egg" / ".git").mkdir(parents=True)
+        foreign = tmp_path / "actions-slice-10"
+        foreign.mkdir()
+        (foreign / ".git").write_text(
+            "gitdir: /home/jwies/khan/actions/.git/worktrees/actions-slice-10\n"
+        )
+
+        assert discover_repo_paths(tmp_path) == [tmp_path / "egg"]
+
+    def test_keeps_worktree_pointing_inside_base(self, tmp_path):
+        """A worktree whose gitdir resolves under base_path is kept."""
+        from state_store import discover_repo_paths
+
+        main = tmp_path / "egg"
+        admin = main / ".git" / "worktrees" / "wt"
+        admin.mkdir(parents=True)
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        (wt / ".git").write_text(f"gitdir: {admin}\n")
+
+        assert discover_repo_paths(tmp_path) == [main, wt]
+
+    def test_skips_unparseable_git_file(self, tmp_path):
+        """A ``.git`` file without a gitdir: pointer is not a repo."""
+        from state_store import discover_repo_paths
+
+        child = tmp_path / "junk"
+        child.mkdir()
+        (child / ".git").write_text("not a pointer\n")
+
+        assert discover_repo_paths(tmp_path) == []
+
 
 class TestGenerateCommitMessage:
     """Tests for commit message generation."""

--- a/orchestrator/tests/test_state_store_wedge_propagation.py
+++ b/orchestrator/tests/test_state_store_wedge_propagation.py
@@ -90,6 +90,114 @@ class TestResolvePipelinePropagatesGitErrors:
 
 
 # ---------------------------------------------------------------------------
+# 1b. #3545: one broken repo must not abort the multi-repo scan
+# ---------------------------------------------------------------------------
+
+
+class TestScanSurvivesBrokenSiblingRepo:
+    """One unreadable repo in the repos dir must cost a warning, not the API.
+
+    In #3545 a foreign worktree that sorted before ``egg`` made every
+    store construction raise ``OSError`` and aborted the scan, so every
+    pipeline lookup 500'd.  The scan now skips past per-repo failures and
+    only re-raises the deferred error when the pipeline is found nowhere
+    (preserving the #2167 no-masking-as-404 guarantee).
+    """
+
+    def _two_repos(self, tmp_path):
+        broken = tmp_path / "actions-slice-10"
+        good = tmp_path / "egg"
+        for repo in (broken, good):
+            (repo / ".git").mkdir(parents=True)
+        return broken, good
+
+    def test_resolve_pipeline_skips_broken_repo(self, tmp_path):
+        from routes.pipelines import _resolve_pipeline
+
+        broken, good = self._two_repos(tmp_path)
+        pipeline = MagicMock()
+        good_store = MagicMock()
+        good_store.load_pipeline.return_value = pipeline
+
+        def fake_get_state_store(repo_path):
+            if repo_path == broken:
+                raise OSError(30, "Read-only file system", "/home/jwies")
+            return good_store
+
+        with (
+            patch("state_store.discover_repo_paths", return_value=[broken, good]),
+            patch("routes.pipelines.get_state_store", side_effect=fake_get_state_store),
+        ):
+            store, result = _resolve_pipeline("issue-3545", tmp_path)
+
+        assert store is good_store
+        assert result is pipeline
+
+    def test_resolve_pipeline_reraises_when_not_found_anywhere(self, tmp_path):
+        """The deferred infra error surfaces (500), not a masking 404 (#2167)."""
+        from routes.pipelines import _resolve_pipeline
+        from state_store import GitOperationError, PipelineNotFoundError
+
+        broken, good = self._two_repos(tmp_path)
+        good_store = MagicMock()
+        good_store.load_pipeline.side_effect = PipelineNotFoundError("nope")
+
+        def fake_get_state_store(repo_path):
+            if repo_path == broken:
+                raise GitOperationError("worktree wedged")
+            return good_store
+
+        with (
+            patch("state_store.discover_repo_paths", return_value=[broken, good]),
+            patch("routes.pipelines.get_state_store", side_effect=fake_get_state_store),
+        ):
+            with pytest.raises(GitOperationError, match="worktree wedged"):
+                _resolve_pipeline("issue-3545", tmp_path)
+
+    def test_get_state_store_for_pipeline_skips_broken_repo(self, tmp_path):
+        from routes import get_state_store_for_pipeline
+
+        broken, good = self._two_repos(tmp_path)
+        pipeline = MagicMock()
+        good_store = MagicMock()
+        good_store.load_pipeline.return_value = pipeline
+
+        def fake_get_state_store(repo_path):
+            if repo_path == broken:
+                raise OSError(30, "Read-only file system", "/home/jwies")
+            return good_store
+
+        with (
+            patch("state_store.discover_repo_paths", return_value=[broken, good]),
+            patch("state_store.get_state_store", side_effect=fake_get_state_store),
+        ):
+            store, result = get_state_store_for_pipeline("issue-3545", repo_path=tmp_path)
+
+        assert store is good_store
+        assert result is pipeline
+
+    def test_get_state_store_for_pipeline_reraises_when_not_found_anywhere(self, tmp_path):
+        from routes import get_state_store_for_pipeline
+        from state_store import PipelineNotFoundError
+
+        broken, good = self._two_repos(tmp_path)
+        good_store = MagicMock()
+        good_store.load_pipeline.side_effect = PipelineNotFoundError("nope")
+
+        def fake_get_state_store(repo_path):
+            if repo_path == broken:
+                raise OSError(30, "Read-only file system", "/home/jwies")
+            return good_store
+
+        with (
+            patch("state_store.discover_repo_paths", return_value=[broken, good]),
+            patch("state_store.get_state_store", side_effect=fake_get_state_store),
+        ):
+            with pytest.raises(OSError, match="Read-only file system"):
+                get_state_store_for_pipeline("issue-3545", repo_path=tmp_path)
+
+
+# ---------------------------------------------------------------------------
 # 2. Flask app error handler renders StateStoreError → 500 with detail
 # ---------------------------------------------------------------------------
 

--- a/shared/egg_git/cross_process_lock.py
+++ b/shared/egg_git/cross_process_lock.py
@@ -30,11 +30,16 @@ from __future__ import annotations
 
 import contextlib
 import fcntl
+import hashlib
+import logging
 import os
+import tempfile
 import threading
 from collections.abc import Generator
 from pathlib import Path
 from typing import Final
+
+logger = logging.getLogger(__name__)
 
 LOCK_FILENAME: Final = ".egg-cross-process.lock"
 
@@ -93,6 +98,23 @@ def lock_path_for_repo(repo_path: Path | str) -> Path:
     return _resolve_main_repo(Path(repo_path)) / ".git" / LOCK_FILENAME
 
 
+def _fallback_lock_path(key: str) -> Path:
+    """Lock path of last resort when ``<main_repo>/.git/`` is unreachable.
+
+    A worktree whose ``gitdir:`` pointer targets a path that does not
+    exist in this filesystem view (e.g. a host-created worktree dropped
+    into the shared repos mount, #3545) resolves to a main repo whose
+    ``.git/`` cannot be created; the ``mkdir`` lands on the read-only
+    container rootfs.  Such a repo is not egg-managed, so cross-pod lock
+    correctness is not needed; a per-container lock file in the temp dir,
+    keyed by the resolved repo path, still serialises every process and
+    thread inside this container and, critically, does not crash the
+    caller.
+    """
+    digest = hashlib.sha256(key.encode()).hexdigest()[:16]
+    return Path(tempfile.gettempdir()) / f"egg-cross-process-{digest}.lock"
+
+
 class _RepoLockState:
     __slots__ = ("rlock", "fd", "depth")
 
@@ -133,16 +155,28 @@ def _get_state(repo_path: Path) -> _RepoLockState:
         state = _per_repo_state.get(key)
         if state is None:
             lock_path = lock_path_for_repo(repo_path)
-            lock_path.parent.mkdir(parents=True, exist_ok=True)
             # O_CLOEXEC: prevent inheritance into child git subprocesses.
             # flock(2) locks are tied to the open file description and are
             # inherited across fork+exec; without close-on-exec, a stuck
             # git child would keep the parent's flock held until it exits.
-            fd = os.open(
-                str(lock_path),
-                os.O_CREAT | os.O_RDWR | os.O_CLOEXEC,
-                0o644,
-            )
+            flags = os.O_CREAT | os.O_RDWR | os.O_CLOEXEC
+            try:
+                lock_path.parent.mkdir(parents=True, exist_ok=True)
+                fd = os.open(str(lock_path), flags, 0o644)
+            except OSError as exc:
+                # The canonical location under the main repo's .git/ is
+                # unreachable; typically a foreign worktree whose gitdir
+                # pointer targets a path outside this container (#3545).
+                # Degrade to a per-container temp-dir lock instead of
+                # crashing every caller that touches this repo.
+                fallback = _fallback_lock_path(key)
+                logger.warning(
+                    "Cross-process lock path %s unreachable (%s); falling back to %s",
+                    lock_path,
+                    exc,
+                    fallback,
+                )
+                fd = os.open(str(fallback), flags, 0o644)
             state = _RepoLockState(fd=fd)
             _per_repo_state[key] = state
         return state

--- a/shared/tests/test_cross_process_lock.py
+++ b/shared/tests/test_cross_process_lock.py
@@ -135,6 +135,39 @@ def test_main_and_worktree_share_one_lock(tmp_path: Path) -> None:
     assert t2_acquired.is_set(), "worktree caller never acquired — test did not run to completion"
 
 
+def test_unreachable_main_repo_falls_back_instead_of_crashing(tmp_path: Path) -> None:
+    """A worktree whose gitdir target cannot host the lock file must not crash.
+
+    A host-created worktree dropped into the shared repos mount carries a
+    ``gitdir:`` pointer into a filesystem view that does not exist in the
+    container; creating the lock path under the resolved main repo then
+    fails with an ``OSError`` (EROFS in the #3545 incident).  The lock
+    must degrade to a temp-dir fallback so one alien directory does not
+    500 every pipeline that scans past it.
+
+    The unreachable path is simulated with a regular *file* on the main
+    repo's path (mkdir then fails with ``NotADirectoryError``), which is
+    deterministic regardless of the uid the tests run as.
+    """
+    from egg_git.cross_process_lock import _fallback_lock_path
+
+    blocker = tmp_path / "blocker"
+    blocker.write_text("")  # a file where a directory is needed
+    unreachable_admin = blocker / "main" / ".git" / "worktrees" / "wt"
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".git").write_text(f"gitdir: {unreachable_admin}\n")
+
+    expected = _fallback_lock_path(str((blocker / "main").resolve()))
+    with bare_repo_lock(worktree):
+        assert expected.exists()
+    # Reentrancy still works on the fallback state.
+    with bare_repo_lock(worktree):
+        with bare_repo_lock(worktree):
+            pass
+
+
 def test_acquiring_creates_lock_file(repo: Path) -> None:
     expected = repo / ".git" / LOCK_FILENAME
     assert not expected.exists()


### PR DESCRIPTION
Closes #3545.

## Problem

A single host-created git worktree dropped into `~/repos` 500'd every pipeline read endpoint. Its `.git` file's `gitdir:` pointer targets a host-view absolute path that does not exist inside the pod; `get_state_store_for_pipeline` iterates discovered repos, constructing a `StateStore` runs `bare_repo_lock`, and the lock-path `mkdir` landed on the read-only container rootfs (`OSError: [Errno 30] Read-only file system: '/home/jwies'`). The scan loop deliberately propagated everything except `PipelineNotFoundError`, so the alien repo (sorting before `egg`) aborted every lookup.

## Fix (three independent layers, per the issue's suggested hardening)

1. **Root cause; `discover_repo_paths`** (`orchestrator/state_store/_factory.py`): children whose `.git` is a *file* whose `gitdir:` pointer resolves outside the base path are skipped. They cannot be egg-managed repos by construction, so foreign worktrees never enter discovery for any caller (routes, CLI, probe, authorship store). Worktrees pointing inside the base path are kept.

2. **Locking layer; `cross_process_lock._get_state`** (`shared/egg_git/`): when the canonical lock path under the resolved main repo's `.git/` cannot be created (`OSError`: EROFS, EACCES, NotADirectoryError, ...), fall back to a per-container temp-dir lock file keyed by the resolved repo path, with a warning log. Same-container serialisation is preserved; cross-pod correctness is unnecessary for a repo whose gitdir is unreachable in this view, and the alternative was crashing the caller.

3. **Scan layer; `get_state_store_for_pipeline` + `_resolve_pipeline`** (`orchestrator/routes/`): a repo that fails to load costs a logged warning and the scan continues. The refinement over the issue's suggestion 1: the first infrastructure error is **re-raised when the pipeline is found nowhere**, so a wedged store still surfaces as 500 with the real cause rather than a masking 404. This preserves the #2167 guarantee that the previous `NOTE: do NOT broaden this catch` comment protected; the existing #2167 regression tests still pass unchanged. `_collect_all_pipelines` additionally tolerates `OSError` per repo.

## Testing

- New regression tests at each layer: foreign-worktree skipping in `TestDiscoverRepoPaths`, temp-dir fallback in `test_cross_process_lock.py`, and scan-continuation plus deferred-error re-raise in `test_state_store_wedge_propagation.py` (`TestScanSurvivesBrokenSiblingRepo`).
- End-to-end repro of the incident shape (real git repo + foreign worktree with unreachable gitdir, no mocks): discovery skips the alien directory, `get_state_store_for_pipeline` returns the pipeline, and `bare_repo_lock` on the foreign worktree engages the fallback instead of raising.
- `make lint` clean. Full suite: 21,462 passed; the 4 persistent failures (`test_reap_stale_egg_images`, `test_git_client::TestIsReposParentDirectory`, `test_per_slice_brc_commit::TestGatewayAllowlistCompatibility`) reproduce identically on the clean base commit and are pre-existing environmental failures unrelated to this change.