### PR TITLE
Decompose shared/egg_contracts/agent_roles.py into a sub-package (#3543)

### DIFF
--- a/scripts/file-size-allowlist.yaml
+++ b/scripts/file-size-allowlist.yaml
@@ -28,5 +28,3 @@ caps:
 files:
   orchestrator/concurrent_executor.py:
     issue: "3498"
-  shared/egg_contracts/agent_roles.py:
-    issue: "3543"

--- a/scripts/ledger-references-baseline.yaml
+++ b/scripts/ledger-references-baseline.yaml
@@ -106,7 +106,7 @@ files:
   shared/egg_agent/queryable_env.py: 6
   shared/egg_agent/reseed.py: 7
   shared/egg_agent/session.py: 13
-  shared/egg_contracts/agent_roles.py: 1
+  shared/egg_contracts/agent_roles/_registry.py: 1
   shared/egg_contracts/artifact_spec.py: 9
   shared/egg_contracts/dependency_graph.py: 3
   shared/egg_contracts/models.py: 11

--- a/shared/CLAUDE.md
+++ b/shared/CLAUDE.md
@@ -30,3 +30,19 @@ Oversized `shared/` modules are split into **sub-packages with an explicit re-ex
 Pure refactor: every re-exported symbol is AST-identical to the pre-split file. The one intentional seam edit is `validate_plan_preflight`, which calls `parse_plan` **through the package module object** (`import egg_contracts.plan_parser as _pkg`) so the pre-split module-global seam `patch("egg_contracts.plan_parser.parse_plan")` keeps intercepting it. Module-level `patch("egg_contracts.plan_parser._foo")` targets resolve through the barrel; tests that patch a helper **where it is called** target the caller's submodule. `_yaml_parse.py` (832 lines) trips only the 800-line soft advisory — left whole to keep the YAML-extraction seam cohesive ([decomposition pattern §g](../docs/guides/decomposition-pattern.md)).
 
 This is the first `shared/` decomposition; later `shared/` slices append their own rows to this table.
+
+### `egg_contracts/agent_roles/`: canonical agent-role definitions ([#3543](https://github.com/jwbron/egg/issues/3543))
+
+`agent_roles.py` (1,523 lines) → `egg_contracts/agent_roles/` (largest submodule `_registry.py`, 452 lines). The canonical `AgentRole` enum, per-role `AgentRoleDefinition` blocks grouped by pipeline phase, and the registry/query helpers the orchestrator and gateway consult. The barrel does explicit per-symbol re-exports and declares `__all__` (the pre-split module had none); it also re-exports the underscore-prefixed pattern lists and phase maps plus `Role` and `match_pattern`, which were importable module globals on the single-file module and are referenced externally.
+
+| Submodule | Responsibility | Key symbols |
+|-----------|----------------|-------------|
+| `__init__.py` (barrel) | Stable public API: per-symbol re-exports + `__all__`; module-doc on role categories | `AgentRole`, `AGENT_ROLES`, `get_roles_for_phase` (+ re-exports of every symbol below) |
+| `_core.py` | Enums and dataclasses every role definition builds on, plus the shared reviewer blocked-write list | `AgentCategory`, `AgentRole`, `AgentStatus`, `FileAccessPattern`, `AgentRoleDefinition`, `AgentExecution`, `_REVIEWER_BLOCKED_WRITE` |
+| `_refine_roles.py` | Refine-phase producers and reviewers | `REFINER_ROLE`, `SIMPLIFIER_ROLE`, `REVIEWER_REFINE_ROLE`, `REVIEWER_AGENT_DESIGN_ROLE`, `FIRST_PRINCIPLES_REVIEWER_ROLE` |
+| `_plan_roles.py` | Plan-phase producers and reviewer, plus the apply-phase applier (#1557) | `ARCHITECT_ROLE`, `TASK_PLANNER_ROLE`, `RISK_ANALYST_ROLE`, `REVIEWER_PLAN_ROLE`, `APPLIER_ROLE`, `_PLAN_AGENT_BLOCKED_WRITE` |
+| `_implement_roles.py` (largest role module, 314 lines) | Implement-phase producers and reviewers | `CODER_ROLE`, `TESTER_ROLE`, `DOCUMENTER_ROLE`, `REVIEWER_CODE_ROLE`, `REVIEWER_CODE_HOLISTIC_ROLE`, `REVIEWER_CONTRACT_ROLE`, `REVIEWER_SECURITY_ROLE`, `REVIEWER_CONCURRENCY_ROLE`, `_REVIEWER_CONTRACT_BLOCKED_WRITE` |
+| `_oversight_roles.py` | Overseer plus on-demand utility roles | `OVERSEER_ROLE`, `AUTOFIXER_ROLE`, `CONFLICT_RESOLVER_ROLE`, `EVIDENCE_GATHERER_ROLE` |
+| `_registry.py` | `AGENT_ROLES` registry, phase maps, contract-role mapping, and query helpers | `AGENT_ROLES`, `AGENT_ROLE_TO_CONTRACT_ROLE`, `_PHASE_ROLES`, `_PHASE_REVIEWERS`, `MODEL_OVERRIDE_ROLES`, `CONTRACT_ENFORCER_ROLES`, `get_role_definition`, `get_roles_for_phase`, `detect_write_overlaps`, `create_execution_for_role` |
+
+Pure refactor: every re-exported symbol is AST-identical to the pre-split file; the only edit is the relative-import depth of `dependency_graph` inside `detect_write_overlaps` (and of `roles`), forced by the new nesting level. No `unittest.mock.patch` targets against `egg_contracts.agent_roles` exist in the tree, so no patch-seam accommodations were needed.

--- a/shared/egg_contracts/agent_roles/__init__.py
+++ b/shared/egg_contracts/agent_roles/__init__.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from egg_restrictions.matchers import match_pattern
 
-from .roles import Role
+from ..roles import Role
 
 
 class AgentCategory(StrEnum):
@@ -1481,7 +1481,7 @@ def detect_write_overlaps(
     Returns:
         List of (role1, role2, overlapping_patterns) tuples.
     """
-    from .dependency_graph import build_dependency_graph
+    from ..dependency_graph import build_dependency_graph
 
     graph = build_dependency_graph(roles)
     waves = graph.compute_waves()

--- a/shared/egg_contracts/agent_roles/__init__.py
+++ b/shared/egg_contracts/agent_roles/__init__.py
@@ -18,1506 +18,167 @@ The orchestrator uses these definitions to:
 2. Enforce file access restrictions via the gateway
 3. Build role-specific prompts with focused context
 4. Compose dynamic agent teams via category queries
-"""
 
-from dataclasses import dataclass, field
-from enum import StrEnum
-from typing import Any
+Decomposition note (#3543): the pre-split single-file module is now a
+sub-package following the #3312 pattern (see ``plan_parser``). This
+``__init__.py`` is the **stable public API barrel**; every symbol that was
+importable as a module global on the single-file module re-exports here,
+so ``from egg_contracts.agent_roles import X`` keeps resolving unchanged.
+The implementation lives in underscore-prefixed private submodules:
+
+- ``_core``            -- ``AgentCategory`` / ``AgentRole`` / ``AgentStatus``
+  enums, ``FileAccessPattern`` / ``AgentRoleDefinition`` / ``AgentExecution``
+  dataclasses, and the shared reviewer blocked-write list
+- ``_refine_roles``    -- refine-phase producers and reviewers
+- ``_plan_roles``      -- plan-phase producers and reviewer, plus the
+  apply-phase applier (#1557)
+- ``_implement_roles`` -- implement-phase producers and reviewers
+- ``_oversight_roles`` -- overseer plus on-demand utility roles
+- ``_registry``        -- ``AGENT_ROLES`` registry, phase maps, contract-role
+  mapping, and query helpers
+
+Pure refactor, no behaviour change: every re-exported definition is
+AST-identical to the pre-split module (the only edit is the relative-import
+depth of ``dependency_graph`` inside ``detect_write_overlaps``).
+"""
 
 from egg_restrictions.matchers import match_pattern
 
 from ..roles import Role
-
-
-class AgentCategory(StrEnum):
-    """Category classification for agent roles.
-
-    Used for dynamic team composition queries (e.g., "all review agents")
-    and for understanding the high-level purpose of each role.
-    """
-
-    EXECUTION = "execution"
-    ANALYSIS = "analysis"
-    REVIEW = "review"
-    UTILITY = "utility"
-    INTERFACE = "interface"
-
-
-class AgentRole(StrEnum):
-    """Specialized agent roles for multi-agent orchestration.
-
-    This is the **canonical enum** — all other AgentRole definitions in the
-    codebase must import from or stay in sync with this one.
-
-    Each role has a focused responsibility and specific file access patterns.
-    The orchestrator uses these roles to parallelize work where dependencies allow.
-
-    Execution roles: CODER, TESTER, DOCUMENTER
-    Analysis roles: ARCHITECT, TASK_PLANNER, RISK_ANALYST, REFINER, SIMPLIFIER
-    Review roles: REVIEWER_CODE, REVIEWER_CODE_HOLISTIC,
-                  REVIEWER_CONTRACT, REVIEWER_AGENT_DESIGN,
-                  REVIEWER_REFINE, FIRST_PRINCIPLES_REVIEWER,
-                  REVIEWER_PLAN, REVIEWER_SECURITY, REVIEWER_CONCURRENCY
-    Utility roles: AUTOFIXER, CONFLICT_RESOLVER
-    Interface roles: OVERSEER
-    """
-
-    # Execution roles (produce code or artifacts)
-    CODER = "coder"
-    TESTER = "tester"
-    DOCUMENTER = "documenter"
-    # Jira-epic SDLC support (issue #1557). The APPLIER role drives
-    # Jira mutations (epic Description writes, child create/edit/link,
-    # Won't-Do handoff) on operator approval of the refine/plan HITL
-    # gates. It runs inside the sandbox and uses only the agent-facing
-    # gateway Jira routes — credentials never leave the gateway.
-    APPLIER = "applier"
-    # Analysis roles (analyze and plan)
-    ARCHITECT = "architect"
-    TASK_PLANNER = "task_planner"
-    RISK_ANALYST = "risk_analyst"
-    REFINER = "refiner"
-    # Distills a producer's draft (refine analysis / plan) into a
-    # human-focused, jargon-free companion copy. Runs in the refine and
-    # plan phases as a producer gated on the upstream producer's
-    # CONSENSUS_PROPOSE (the coder→tester dependency pattern).
-    SIMPLIFIER = "simplifier"
-    # Review roles
-    REVIEWER_CODE = "reviewer_code"
-    REVIEWER_CODE_HOLISTIC = "reviewer_code_holistic"
-    REVIEWER_CONTRACT = "reviewer_contract"
-    REVIEWER_AGENT_DESIGN = "reviewer_agent_design"
-    REVIEWER_REFINE = "reviewer_refine"
-    # Adversarial first-principles reviewer of the refine phase. Reviews the
-    # pipeline's *seed* (the operator's task statement) and the direction the
-    # refiner's analysis is taking — questioning whether the premise is sound
-    # and the direction appropriate. It never NACKs the refiner (a NACK only
-    # re-runs the producer, which cannot change the operator-owned seed);
-    # instead it ACKs and, when warranted, surfaces a redirect as a
-    # phase-scoped HITL decision for the operator. Named mandate-first rather
-    # than ``reviewer_first_principles`` so the role reads as what it does in
-    # the escalations an operator sees.
-    FIRST_PRINCIPLES_REVIEWER = "first_principles_reviewer"
-    REVIEWER_PLAN = "reviewer_plan"
-    REVIEWER_SECURITY = "reviewer_security"
-    REVIEWER_CONCURRENCY = "reviewer_concurrency"
-    # Utility roles (cross-cutting support)
-    AUTOFIXER = "autofixer"
-    CONFLICT_RESOLVER = "conflict_resolver"
-    # Read-only shared-evidence gatherer (#3523 §5). Assembles the evidence
-    # pack a review wave shares as a byte-identical prompt prefix. Casts no
-    # verdict, posts nothing, has no GitHub access, writes only its handoff
-    # dir — those capabilities are structurally excluded below (file_access +
-    # a SYSTEM contract role + deny-by-default gh restrictions).
-    EVIDENCE_GATHERER = "evidence_gatherer"
-    # Interface roles (external system interaction)
-    OVERSEER = "overseer"
-
-
-class AgentStatus(StrEnum):
-    """Status values for agent executions."""
-
-    PENDING = "pending"
-    RUNNING = "running"
-    COMPLETE = "complete"
-    FAILED = "failed"
-    SKIPPED = "skipped"
-    BLOCKED = "blocked"
-
-
-@dataclass
-class FileAccessPattern:
-    """File access pattern for an agent role.
-
-    Defines what files an agent can read and write. The gateway enforces
-    these restrictions during git push operations.
-    """
-
-    allowed_read: list[str] = field(default_factory=list)
-    allowed_write: list[str] = field(default_factory=list)
-    blocked_write: list[str] = field(default_factory=list)
-
-    def can_read(self, file_path: str) -> bool:
-        """Check if the agent can read this file.
-
-        Args:
-            file_path: Path relative to repo root
-
-        Returns:
-            True if the file can be read (default: all files readable)
-        """
-        if not self.allowed_read:
-            return True  # Empty list means all files readable
-
-        return any(match_pattern(file_path, pattern) for pattern in self.allowed_read)
-
-    def can_write(self, file_path: str) -> bool:
-        """Check if the agent can write to this file.
-
-        Args:
-            file_path: Path relative to repo root
-
-        Returns:
-            True if the file can be written
-        """
-        # Check blocked patterns first
-        if any(match_pattern(file_path, pattern) for pattern in self.blocked_write):
-            return False
-
-        # If no allowed patterns, block all writes
-        if not self.allowed_write:
-            return False
-
-        return any(match_pattern(file_path, pattern) for pattern in self.allowed_write)
-
-
-@dataclass
-class AgentRoleDefinition:
-    """Complete definition of an agent role.
-
-    Combines the role identifier with its responsibilities, dependencies,
-    and access constraints. Used by the orchestrator to plan execution.
-    """
-
-    role: AgentRole
-    description: str
-    responsibilities: list[str]
-    category: AgentCategory | None = None
-    dependencies: list[AgentRole] = field(default_factory=list)
-    file_access: FileAccessPattern = field(default_factory=FileAccessPattern)
-    can_run_in_parallel: bool = True  # Can run in parallel with other agents
-    produces_outputs: list[str] = field(default_factory=list)
-    requires_inputs: list[str] = field(default_factory=list)
-
-    def depends_on(self, other: AgentRole) -> bool:
-        """Check if this role depends on another role.
-
-        Args:
-            other: The role to check dependency against
-
-        Returns:
-            True if this role must wait for the other role to complete
-        """
-        return other in self.dependencies
-
-
-# Default agent role definitions
-# These define the standard agent roles used in multi-agent orchestration
-
-CODER_ROLE = AgentRoleDefinition(
-    role=AgentRole.CODER,
-    description="Implements code changes based on the plan tasks",
-    category=AgentCategory.EXECUTION,
-    responsibilities=[
-        "Read and understand the implementation plan",
-        "Implement code changes for assigned tasks",
-        "Link commits to contract tasks",
-        "Output list of changed files for downstream agents",
-    ],
-    dependencies=[],  # Coder runs first, no dependencies
-    file_access=FileAccessPattern(
-        allowed_read=[],  # Can read all files
-        allowed_write=[
-            "**/*.py",
-            "**/*.ts",
-            "**/*.tsx",
-            "**/*.js",
-            "**/*.jsx",
-            "**/*.go",
-            "**/*.java",
-            "**/*.rb",
-            "**/*.rs",
-            "**/*.sh",
-            "**/*.yml",
-            "**/*.yaml",
-            "**/*.json",
-            ".egg-state/agent-outputs/",  # For handoff data
-            # Issue #2508: staging dir for proposed `.github/` changes.
-            # `.github/` itself is blocked below; the agent stages the
-            # proposed end-state here and calls the staged files out
-            # in its PR body so the human reviewer moves them into
-            # `.github/` before merge.
-            ".github-staging/",
-        ],
-        blocked_write=[
-            "docs/",  # Documenter handles docs
-            "**/README.md",  # Documenter handles READMEs
-            ".egg-state/contracts/",  # Contracts are managed by API
-            # Issue #2508: branch-protection invariant — agents cannot
-            # push to `.github/` directly. Use `.github-staging/` (above)
-            # to propose CI workflow / CODEOWNERS changes for human
-            # review.
-            ".github/",
-        ],
-    ),
-    produces_outputs=["changed_files", "commits"],
-    requires_inputs=[],
+from ._core import (
+    _REVIEWER_BLOCKED_WRITE,
+    AgentCategory,
+    AgentExecution,
+    AgentRole,
+    AgentRoleDefinition,
+    AgentStatus,
+    FileAccessPattern,
+)
+from ._implement_roles import (
+    _REVIEWER_CONTRACT_BLOCKED_WRITE,
+    CODER_ROLE,
+    DOCUMENTER_ROLE,
+    REVIEWER_CODE_HOLISTIC_ROLE,
+    REVIEWER_CODE_ROLE,
+    REVIEWER_CONCURRENCY_ROLE,
+    REVIEWER_CONTRACT_ROLE,
+    REVIEWER_SECURITY_ROLE,
+    TESTER_ROLE,
+)
+from ._oversight_roles import (
+    AUTOFIXER_ROLE,
+    CONFLICT_RESOLVER_ROLE,
+    EVIDENCE_GATHERER_ROLE,
+    OVERSEER_ROLE,
+)
+from ._plan_roles import (
+    _PLAN_AGENT_BLOCKED_WRITE,
+    APPLIER_ROLE,
+    ARCHITECT_ROLE,
+    REVIEWER_PLAN_ROLE,
+    RISK_ANALYST_ROLE,
+    TASK_PLANNER_ROLE,
+)
+from ._refine_roles import (
+    FIRST_PRINCIPLES_REVIEWER_ROLE,
+    REFINER_ROLE,
+    REVIEWER_AGENT_DESIGN_ROLE,
+    REVIEWER_REFINE_ROLE,
+    SIMPLIFIER_ROLE,
+)
+from ._registry import (
+    _PHASE_REVIEWERS,
+    _PHASE_ROLES,
+    AGENT_ROLE_TO_CONTRACT_ROLE,
+    AGENT_ROLES,
+    CONTRACT_ENFORCER_ROLE_NAMES,
+    CONTRACT_ENFORCER_ROLES,
+    EGG_ONLY_REVIEWER_NAMES,
+    EGG_ONLY_REVIEWERS,
+    EGG_REPO,
+    EXECUTION_ROLE_VALUES,
+    MODEL_OVERRIDE_ROLES,
+    REVIEWER_CHECKOUT_ROLE_VALUES,
+    can_run_in_parallel,
+    create_execution_for_role,
+    detect_write_overlaps,
+    get_all_roles,
+    get_contract_role,
+    get_file_patterns,
+    get_role_definition,
+    get_role_dependencies,
+    get_roles_by_category,
+    get_roles_for_phase,
 )
 
-TESTER_ROLE = AgentRoleDefinition(
-    role=AgentRole.TESTER,
-    description="Validates implementation by writing tests, running lint/type-checks, and applying auto-fixes",
-    category=AgentCategory.EXECUTION,
-    responsibilities=[
-        "Read the list of changed files from coder",
-        "Identify gaps in the implementation (missing error handling, boundary conditions, uncovered branches)",
-        "Write or update tests targeting identified gaps",
-        "Run linters and type checkers, apply auto-fixes where possible",
-        "Report test coverage, lint/type-check results, and document deficiencies found",
-    ],
-    dependencies=[AgentRole.CODER],  # Must wait for coder
-    file_access=FileAccessPattern(
-        allowed_read=[],  # Can read all files
-        allowed_write=[
-            # Test files
-            "tests/",
-            "test/",
-            "**/tests/",
-            "**/test/",
-            "**/*_test.py",
-            "**/*_test.go",
-            "**/test_*.py",
-            "**/*.test.ts",
-            "**/*.test.tsx",
-            "**/*.test.js",
-            "**/*.test.jsx",
-            "**/*.spec.ts",
-            "**/*.spec.tsx",
-            "**/*.spec.js",
-            "**/*.spec.jsx",
-            # Source files (for lint/type-check auto-fixes)
-            "**/*.py",
-            "**/*.ts",
-            "**/*.tsx",
-            "**/*.js",
-            "**/*.jsx",
-            "**/*.go",
-            "**/*.java",
-            "**/*.rb",
-            "**/*.rs",
-            "**/*.sh",
-            # Configuration (for auto-fix updates)
-            "**/*.yml",
-            "**/*.yaml",
-            "**/*.json",
-            "**/*.toml",
-            ".egg-state/agent-outputs/",  # For handoff data
-        ],
-        blocked_write=[
-            "docs/",
-            "**/README.md",
-            "**/*.md",
-            ".egg-state/contracts/",
-            # Issue #2508: branch-protection invariant — even a
-            # tester-applied auto-fix to `.github/workflows/*.yml` must
-            # go through the `.github-staging/` convention so a human
-            # reviewer moves it in before merge.
-            ".github/",
-        ],
-    ),
-    produces_outputs=["test_files", "coverage_report", "gaps_found", "check_results"],
-    requires_inputs=["changed_files"],
+# ``__all__`` lists the full re-export surface of the barrel. The pre-split
+# module had no ``__all__``; the entries below are the symbols that were
+# importable as module globals on the single-file module (including the
+# underscore-prefixed pattern lists and phase maps, plus ``Role`` and
+# ``match_pattern``, which external code and tests import by name from this
+# module path). No consumer used ``from egg_contracts.agent_roles import *``.
+__all__ = (
+    # Core types
+    "AgentCategory",
+    "AgentExecution",
+    "AgentRole",
+    "AgentRoleDefinition",
+    "AgentStatus",
+    "FileAccessPattern",
+    # Refine-phase role definitions
+    "FIRST_PRINCIPLES_REVIEWER_ROLE",
+    "REFINER_ROLE",
+    "REVIEWER_AGENT_DESIGN_ROLE",
+    "REVIEWER_REFINE_ROLE",
+    "SIMPLIFIER_ROLE",
+    # Plan/apply-phase role definitions
+    "APPLIER_ROLE",
+    "ARCHITECT_ROLE",
+    "REVIEWER_PLAN_ROLE",
+    "RISK_ANALYST_ROLE",
+    "TASK_PLANNER_ROLE",
+    # Implement-phase role definitions
+    "CODER_ROLE",
+    "DOCUMENTER_ROLE",
+    "REVIEWER_CODE_HOLISTIC_ROLE",
+    "REVIEWER_CODE_ROLE",
+    "REVIEWER_CONCURRENCY_ROLE",
+    "REVIEWER_CONTRACT_ROLE",
+    "REVIEWER_SECURITY_ROLE",
+    "TESTER_ROLE",
+    # Oversight / utility role definitions
+    "AUTOFIXER_ROLE",
+    "CONFLICT_RESOLVER_ROLE",
+    "EVIDENCE_GATHERER_ROLE",
+    "OVERSEER_ROLE",
+    # Registry, phase maps, and role sets
+    "AGENT_ROLES",
+    "AGENT_ROLE_TO_CONTRACT_ROLE",
+    "CONTRACT_ENFORCER_ROLES",
+    "CONTRACT_ENFORCER_ROLE_NAMES",
+    "EGG_ONLY_REVIEWERS",
+    "EGG_ONLY_REVIEWER_NAMES",
+    "EGG_REPO",
+    "EXECUTION_ROLE_VALUES",
+    "MODEL_OVERRIDE_ROLES",
+    "REVIEWER_CHECKOUT_ROLE_VALUES",
+    # Query helpers
+    "can_run_in_parallel",
+    "create_execution_for_role",
+    "detect_write_overlaps",
+    "get_all_roles",
+    "get_contract_role",
+    "get_file_patterns",
+    "get_role_definition",
+    "get_role_dependencies",
+    "get_roles_by_category",
+    "get_roles_for_phase",
+    # Module globals retained from the single-file module
+    "Role",
+    "match_pattern",
+    "_PHASE_REVIEWERS",
+    "_PHASE_ROLES",
+    "_PLAN_AGENT_BLOCKED_WRITE",
+    "_REVIEWER_BLOCKED_WRITE",
+    "_REVIEWER_CONTRACT_BLOCKED_WRITE",
 )
-
-DOCUMENTER_ROLE = AgentRoleDefinition(
-    role=AgentRole.DOCUMENTER,
-    description="Documents the current state of the code",
-    category=AgentCategory.EXECUTION,
-    responsibilities=[
-        "Read the list of changed files from coder",
-        "Describe how the code works now — a snapshot of the current "
-        "state, not a log of what changed or when",
-        "Never embed SDLC artifacts (slice numbers, TASK-N ids, phase or "
-        "HITL iteration numbers) in docs, docstrings, or comments",
-        "Prefer rationale (why it is this way) over chronology; fold new "
-        "state into the snapshot and remove now-stale ledger entries",
-        "Keep README and API documentation current",
-    ],
-    dependencies=[AgentRole.CODER],  # Must wait for coder
-    file_access=FileAccessPattern(
-        allowed_read=[],  # Can read all files
-        allowed_write=[
-            "docs/",
-            "**/README.md",
-            "**/*.md",  # All markdown files
-            ".egg-state/agent-outputs/",  # For handoff data
-        ],
-        blocked_write=[
-            "**/*.py",  # Cannot modify code
-            "**/*.ts",
-            "**/*.tsx",
-            "**/*.js",
-            "**/*.jsx",
-            "**/*.go",
-            "**/*.java",
-            "tests/",  # Cannot modify tests
-            ".egg-state/contracts/",
-            # Issue #2508: branch-protection invariant — even markdown
-            # files under `.github/` (PULL_REQUEST_TEMPLATE.md,
-            # ISSUE_TEMPLATE.md, etc.) must go through the
-            # `.github-staging/` convention so a human reviewer moves
-            # them in before merge.
-            ".github/",
-        ],
-    ),
-    can_run_in_parallel=True,  # Can run in parallel with tester
-    produces_outputs=["doc_files"],
-    requires_inputs=["changed_files"],
-)
-
-# Plan-phase agent role definitions
-# Plan-phase agents (architect, task_planner, risk_analyst) share a
-# blocked_write list mirroring ``_PLAN_AGENT_BLOCKED`` in
-# ``shared/egg_restrictions/patterns.py``. Keeping the two views in
-# lockstep is the invariant issue #2532 closed; using a shared constant
-# eliminates one future drift surface within ``agent_roles.py`` itself.
-_PLAN_AGENT_BLOCKED_WRITE = [
-    "**/*.py",
-    "**/*.ts",
-    "**/*.tsx",
-    "**/*.js",
-    "**/*.jsx",
-    "**/*.go",
-    "**/*.java",
-    ".egg-state/contracts/",
-    # Issue #2532: parity with _PLAN_AGENT_BLOCKED in patterns.py — see #2508 / #2521.
-    ".github/",
-]
-
-ARCHITECT_ROLE = AgentRoleDefinition(
-    role=AgentRole.ARCHITECT,
-    description="Analyzes the task and produces architecture analysis",
-    category=AgentCategory.ANALYSIS,
-    responsibilities=[
-        "Understand the problem or feature request",
-        "Research the codebase to understand existing patterns",
-        "Identify key files, constraints, and dependencies",
-        "Recommend an approach with justification",
-        "Document technical decisions",
-    ],
-    dependencies=[],  # Architect runs first in plan phase
-    file_access=FileAccessPattern(
-        allowed_read=[],  # Can read all files
-        allowed_write=[
-            ".egg-state/drafts/",
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=_PLAN_AGENT_BLOCKED_WRITE,
-    ),
-    produces_outputs=["architecture_analysis", "technical_decisions"],
-    requires_inputs=[],
-)
-
-TASK_PLANNER_ROLE = AgentRoleDefinition(
-    role=AgentRole.TASK_PLANNER,
-    description="Decomposes architecture analysis into discrete tasks",
-    category=AgentCategory.ANALYSIS,
-    responsibilities=[
-        "Review the architecture analysis from the architect",
-        "Break down work into phases with discrete tasks",
-        "Define clear acceptance criteria for each task",
-        "Define dependency ordering between tasks",
-        "Identify the test strategy",
-    ],
-    dependencies=[AgentRole.ARCHITECT],
-    file_access=FileAccessPattern(
-        allowed_read=[],
-        allowed_write=[
-            ".egg-state/drafts/",
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=_PLAN_AGENT_BLOCKED_WRITE,
-    ),
-    produces_outputs=["task_breakdown", "acceptance_criteria"],
-    requires_inputs=["architecture_analysis"],
-)
-
-RISK_ANALYST_ROLE = AgentRoleDefinition(
-    role=AgentRole.RISK_ANALYST,
-    description="Assesses technical risks for the proposed implementation",
-    category=AgentCategory.ANALYSIS,
-    responsibilities=[
-        "Review the architecture analysis from the architect",
-        "Identify technical risks (security, performance, compatibility)",
-        "Assess impact and likelihood of each risk",
-        "Propose mitigation strategies and rollback plans",
-        "Flag areas that need human review",
-    ],
-    dependencies=[AgentRole.ARCHITECT],
-    file_access=FileAccessPattern(
-        allowed_read=[],
-        allowed_write=[
-            ".egg-state/drafts/",
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=_PLAN_AGENT_BLOCKED_WRITE,
-    ),
-    can_run_in_parallel=True,  # Can run in parallel with task_planner
-    produces_outputs=["risk_assessment", "mitigation_plan"],
-    requires_inputs=["architecture_analysis"],
-)
-
-
-# Jira-epic SDLC support (issue #1557). The APPLIER drives Jira
-# mutations after the refine/plan HITL gates resolve. It reads the
-# contract + relevant draft and calls the agent-facing gateway Jira
-# routes (``ticket/edit``, ``ticket/create``, ``issue-link/create``).
-# ``Won't Do`` transitions are **not** in the applier's purview — the
-# applier produces a handoff JSON that the orchestrator drains via the
-# orchestrator-only ``/transition`` route. Restricted to write only the
-# agent-outputs handoff directory; the applier never edits source.
-APPLIER_ROLE = AgentRoleDefinition(
-    role=AgentRole.APPLIER,
-    description=(
-        "Applies Jira mutations (epic Description writes, child "
-        "create/edit/link, Won't-Do handoff) on operator approval of "
-        "refine/plan HITL gates for epic-mode pipelines."
-    ),
-    category=AgentCategory.EXECUTION,
-    responsibilities=[
-        "Read EGG_EPIC_MODE + the just-approved phase + contract path",
-        "For refine-apply: write the analysis to the epic Description",
-        "For plan-apply: walk Task.jira_action and dispatch per-action",
-        "Write jira_action_status='in_flight' before each call; flip to "
-        "'applied' or 'failed' after",
-        "Emit a Won't-Do handoff JSON for the orchestrator to drain",
-        "Refuse to mutate in-flight children without the override marker",
-    ],
-    dependencies=[],
-    file_access=FileAccessPattern(
-        allowed_read=[],
-        allowed_write=[
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=[
-            "src/",
-            "lib/",
-            "shared/",
-            "gateway/",
-            "sandbox/",
-            "action/",
-            "orchestrator/",
-            "plugins/",
-            "docs/",
-            "tests/",
-            "test/",
-            ".egg-state/contracts/",
-            ".egg-state/drafts/",
-            ".github/",
-        ],
-    ),
-    can_run_in_parallel=False,
-    produces_outputs=["jira_apply_report", "wontdo_handoff"],
-    requires_inputs=["analysis_draft", "task_breakdown"],
-)
-
-
-# Refine-phase agent role definitions
-
-REFINER_ROLE = AgentRoleDefinition(
-    role=AgentRole.REFINER,
-    description="Analyzes the task and produces a structured analysis in the refine phase",
-    category=AgentCategory.ANALYSIS,
-    responsibilities=[
-        "Understand the problem or feature request",
-        "Research the current codebase to understand existing patterns",
-        "Identify constraints and dependencies",
-        "Consider multiple implementation approaches with pros/cons",
-        "Recommend an approach with justification",
-        "Surface open questions as HITL decisions or feedback requests",
-        "Write analysis to the draft file (NOT an implementation plan)",
-    ],
-    dependencies=[],  # Refiner runs first, no dependencies
-    file_access=FileAccessPattern(
-        allowed_read=[],  # Can read all files
-        allowed_write=[
-            ".egg-state/drafts/",
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=[
-            "**/*.py",
-            "**/*.ts",
-            "**/*.tsx",
-            "**/*.js",
-            "**/*.jsx",
-            "**/*.go",
-            "**/*.java",
-            ".egg-state/contracts/",
-        ],
-    ),
-    produces_outputs=["analysis_draft"],
-    requires_inputs=[],
-)
-
-# Simplifier role (human-focused draft companions). Runs in BOTH the
-# refine and plan phases as a producer of the ``*-human.md`` companion
-# copy. It does NOT review the upstream producer — its work simply
-# depends on the producer's pushed draft, so it is sequenced via the
-# BRC dependency prompt (the coder→tester convention), not a review
-# edge. ``dependencies`` is left empty: that field feeds the
-# write-overlap / dependency-graph wave analysis (which runs per-phase
-# against the phase's role set), and this single role-def spans two
-# phases with two different upstreams, so coupling it to one producer
-# here would be wrong. File access mirrors the refiner: drafts and
-# agent-outputs only.
-SIMPLIFIER_ROLE = AgentRoleDefinition(
-    role=AgentRole.SIMPLIFIER,
-    description=(
-        "Distills the producer's draft into a jargon-free, human-focused "
-        "companion summary for a broad audience (engineers, PMs, managers) "
-        "in the refine and plan phases"
-    ),
-    category=AgentCategory.ANALYSIS,
-    responsibilities=[
-        "Read the upstream producer's draft (refine analysis or plan)",
-        "Write a simplified, higher-level companion that captures the essence",
-        "Keep it digestible for a broad audience — engineers, PMs, and "
-        "managers — readable by a non-engineer",
-        "Use no egg-internal jargon (no BRC, consensus, slice-DAG, contract, "
-        "propose/ACK/NACK, phase, or agent-role terms) and no implementation "
-        "minutiae (no file:line refs or code identifiers)",
-        "Summarise the draft — do NOT review or critique it; no ACK/NACK or "
-        "constraint-list framing in the companion",
-        "Faithfully reflect the upstream draft — introduce no new scope",
-    ],
-    dependencies=[],
-    file_access=FileAccessPattern(
-        allowed_read=[],  # Can read all files
-        allowed_write=[
-            ".egg-state/drafts/",
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=[
-            "**/*.py",
-            "**/*.ts",
-            "**/*.tsx",
-            "**/*.js",
-            "**/*.jsx",
-            "**/*.go",
-            "**/*.java",
-            ".egg-state/contracts/",
-        ],
-    ),
-    produces_outputs=["analysis_draft_human", "plan_draft_human"],
-    requires_inputs=["analysis_draft", "task_breakdown"],
-)
-
-# Reviewer agent role definitions
-# Reviewers can only write to reviews/ and agent-outputs/ directories.
-# Use directory-based blocks instead of "**/*" which breaks can_write()
-# by always matching before allowed_write is checked.
-
-_REVIEWER_BLOCKED_WRITE = [
-    "src/",
-    "lib/",
-    "docs/",
-    "tests/",
-    "test/",
-    ".egg-state/contracts/",
-    ".egg-state/drafts/",
-    # Issue #2532: parity with _REVIEWER_BLOCKED in patterns.py — see #2508 / #2521.
-    ".github/",
-]
-
-REVIEWER_CODE_ROLE = AgentRoleDefinition(
-    role=AgentRole.REVIEWER_CODE,
-    description="Performs a comprehensive code review",
-    category=AgentCategory.REVIEW,
-    responsibilities=[
-        "Review code quality, security, and correctness",
-        "Check for OWASP top 10 vulnerabilities",
-        "Verify error handling and edge cases",
-    ],
-    dependencies=[AgentRole.TASK_PLANNER, AgentRole.RISK_ANALYST],
-    file_access=FileAccessPattern(
-        allowed_read=[],
-        allowed_write=[
-            ".egg-state/reviews/",
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=_REVIEWER_BLOCKED_WRITE,
-    ),
-    produces_outputs=["review_verdict"],
-    requires_inputs=[],
-)
-
-# Holistic generalist counterpart to ``reviewer_code`` (issue #2126).
-# Skims the full diff once and runs four cross-module passes rather
-# than verifying every line — that is ``reviewer_code``'s job. Its
-# focus is the architectural-coherence question line-by-line review
-# does not own: does the primary advertised use case work end-to-end,
-# do docs and code agree, do synthetic keys round-trip across modules,
-# are silent fallbacks hiding operator-visible failures.
-REVIEWER_CODE_HOLISTIC_ROLE = AgentRoleDefinition(
-    role=AgentRole.REVIEWER_CODE_HOLISTIC,
-    description="Single-pass holistic code review focused on cross-module coherence",
-    category=AgentCategory.REVIEW,
-    responsibilities=[
-        "Walk the primary advertised use case end-to-end across the full diff",
-        "Cross-check doc-claimed behaviour against what the code actually does",
-        "Audit synthetic keys, sentinels, and 'magic' values for cross-module agreement",
-        "Surface silent fallbacks that swallow operator-visible misconfiguration",
-    ],
-    dependencies=[AgentRole.TASK_PLANNER, AgentRole.RISK_ANALYST],
-    file_access=FileAccessPattern(
-        allowed_read=[],
-        allowed_write=[
-            ".egg-state/reviews/",
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=_REVIEWER_BLOCKED_WRITE,
-    ),
-    produces_outputs=["review_verdict"],
-    requires_inputs=[],
-)
-
-# Contract reviewer needs write access to .egg-state/contracts/ to mark
-# items as done, so it uses a custom blocked_write list that excludes it.
-_REVIEWER_CONTRACT_BLOCKED_WRITE = [
-    "src/",
-    "lib/",
-    "docs/",
-    "tests/",
-    "test/",
-    ".egg-state/drafts/",
-    # Issue #2532: parity with _REVIEWER_CONTRACT_BLOCKED in patterns.py — see #2508 / #2521.
-    ".github/",
-]
-
-REVIEWER_CONTRACT_ROLE = AgentRoleDefinition(
-    role=AgentRole.REVIEWER_CONTRACT,
-    description="Verifies implementation matches the contract",
-    category=AgentCategory.REVIEW,
-    responsibilities=[
-        "Verify acceptance criteria are met",
-        "Check task completion status",
-        "Validate contract consistency",
-    ],
-    dependencies=[AgentRole.TASK_PLANNER, AgentRole.RISK_ANALYST],
-    file_access=FileAccessPattern(
-        allowed_read=[],
-        allowed_write=[
-            ".egg-state/reviews/",
-            ".egg-state/agent-outputs/",
-            ".egg-state/contracts/",
-        ],
-        blocked_write=_REVIEWER_CONTRACT_BLOCKED_WRITE,
-    ),
-    produces_outputs=["review_verdict"],
-    requires_inputs=["integration_report"],
-)
-
-REVIEWER_AGENT_DESIGN_ROLE = AgentRoleDefinition(
-    role=AgentRole.REVIEWER_AGENT_DESIGN,
-    description="Reviews agent-mode design alignment",
-    category=AgentCategory.REVIEW,
-    responsibilities=[
-        "Check for agent-mode design anti-patterns",
-        "Verify autonomous operation capability",
-        "Assess human-in-the-loop integration",
-    ],
-    dependencies=[AgentRole.REFINER],
-    file_access=FileAccessPattern(
-        allowed_read=[],
-        allowed_write=[
-            ".egg-state/reviews/",
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=_REVIEWER_BLOCKED_WRITE,
-    ),
-    produces_outputs=["review_verdict"],
-    requires_inputs=["analysis_draft"],
-)
-
-REVIEWER_REFINE_ROLE = AgentRoleDefinition(
-    role=AgentRole.REVIEWER_REFINE,
-    description="Reviews refine phase analysis quality and completeness",
-    category=AgentCategory.REVIEW,
-    responsibilities=[
-        "Verify the analysis correctly identifies the core problem",
-        "Assess research quality and codebase exploration",
-        "Evaluate options analysis and trade-off reasoning",
-        "Check that constraints and dependencies are identified",
-        "Validate the recommendation is justified and actionable",
-    ],
-    dependencies=[AgentRole.REFINER],
-    file_access=FileAccessPattern(
-        allowed_read=[],
-        allowed_write=[
-            ".egg-state/reviews/",
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=_REVIEWER_BLOCKED_WRITE,
-    ),
-    produces_outputs=["review_verdict"],
-    requires_inputs=["analysis_draft"],
-)
-
-# Adversarial first-principles reviewer (refine phase). Unlike
-# ``reviewer_refine`` (which judges the *quality* of the analysis) this role
-# questions the *premise and direction*: is the seed's rationale sound, is the
-# stated direction the right one, or is there a materially simpler path / a
-# better approach / a scope change — or should the work not happen at all? Its
-# subject is the operator's seed (``contract.task_description``), read against
-# codebase reality, plus the direction the refiner's draft is taking. It does
-# NOT NACK the refiner (the refiner cannot rewrite the operator-owned seed, so
-# a NACK is the wrong channel); it ACKs and, when it finds a concern worth a
-# human's call, surfaces a redirect as a phase-scoped HITL decision. Mapped to
-# ``Role.REVIEWER``; reviewers gained decision-create access in roles.py so it
-# can raise that decision itself. File access mirrors the other refine
-# reviewers: it writes its assessment to ``.egg-state/agent-outputs/`` (the
-# accept-path reads the proposed redirect back from there) and its verdict to
-# ``.egg-state/reviews/`` — never source, drafts, or contracts.
-FIRST_PRINCIPLES_REVIEWER_ROLE = AgentRoleDefinition(
-    role=AgentRole.FIRST_PRINCIPLES_REVIEWER,
-    description=(
-        "Adversarially reviews the pipeline's seed and the refiner's direction "
-        "from first principles, surfacing significant redirects as HITL "
-        "decisions in the refine phase"
-    ),
-    category=AgentCategory.REVIEW,
-    responsibilities=[
-        "Read the seed (the operator's task statement) and the refiner's draft",
-        "Question the premise: is the rationale sound and the direction right?",
-        "Surface concrete redirects where warranted — a materially simpler "
-        "path, a different approach, a scope change, or not building it at all",
-        "Raise redirects as phase-scoped HITL decisions for the operator; "
-        "never NACK the refiner on first-principles grounds",
-        "ACK the refiner once the first-principles pass is done",
-    ],
-    dependencies=[AgentRole.REFINER],
-    file_access=FileAccessPattern(
-        allowed_read=[],
-        allowed_write=[
-            ".egg-state/reviews/",
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=_REVIEWER_BLOCKED_WRITE,
-    ),
-    produces_outputs=["review_verdict", "first_principles_assessment"],
-    requires_inputs=["analysis_draft"],
-)
-
-REVIEWER_PLAN_ROLE = AgentRoleDefinition(
-    role=AgentRole.REVIEWER_PLAN,
-    description="Reviews plan phase output quality and completeness",
-    category=AgentCategory.REVIEW,
-    responsibilities=[
-        "Verify task breakdown is discrete, actionable, and properly scoped",
-        "Assess acceptance criteria clarity and testability",
-        "Evaluate dependency ordering between tasks",
-        "Check that risks and mitigations are identified",
-        "Validate test strategy coverage",
-    ],
-    dependencies=[AgentRole.TASK_PLANNER, AgentRole.RISK_ANALYST],
-    file_access=FileAccessPattern(
-        allowed_read=[],
-        allowed_write=[
-            ".egg-state/reviews/",
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=_REVIEWER_BLOCKED_WRITE,
-    ),
-    produces_outputs=["review_verdict"],
-    requires_inputs=["task_breakdown", "risk_assessment"],
-)
-
-REVIEWER_SECURITY_ROLE = AgentRoleDefinition(
-    role=AgentRole.REVIEWER_SECURITY,
-    description="ADVISORY security-lens reviewer for the implement phase",
-    category=AgentCategory.REVIEW,
-    responsibilities=[
-        "Detect cross-file allowlist mismatches",
-        "Flag handler-vs-validator path mismatches",
-        "Identify information-disclosure and authorization-bypass patterns",
-        "Spot uncommitted-artifact / Dockerfile-symlink mismatches",
-        "Catch secret leakage via logs, error text, or environment dumps",
-        "Surface OWASP top-10 patterns spanning more than one changed file",
-    ],
-    dependencies=[AgentRole.TASK_PLANNER, AgentRole.RISK_ANALYST],
-    file_access=FileAccessPattern(
-        allowed_read=[],
-        allowed_write=[
-            ".egg-state/reviews/",
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=_REVIEWER_BLOCKED_WRITE,
-    ),
-    produces_outputs=["review_verdict"],
-    requires_inputs=[],
-)
-
-REVIEWER_CONCURRENCY_ROLE = AgentRoleDefinition(
-    role=AgentRole.REVIEWER_CONCURRENCY,
-    description="ADVISORY concurrency-lens reviewer for the implement phase",
-    category=AgentCategory.REVIEW,
-    responsibilities=[
-        "Identify race conditions and deadlocks",
-        "Flag shared-state mutation and async-context leakage",
-        "Detect retry-storm patterns and resource-cleanup ordering bugs",
-        "Verify BRC-protocol invariants (send→wait, cursor threading, heartbeats)",
-    ],
-    dependencies=[AgentRole.TASK_PLANNER, AgentRole.RISK_ANALYST],
-    file_access=FileAccessPattern(
-        allowed_read=[],
-        allowed_write=[
-            ".egg-state/reviews/",
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=_REVIEWER_BLOCKED_WRITE,
-    ),
-    produces_outputs=["review_verdict"],
-    requires_inputs=[],
-)
-
-
-# Overseer role — monitors pipeline health, classifies anomalies, escalates issues
-OVERSEER_ROLE = AgentRoleDefinition(
-    role=AgentRole.OVERSEER,
-    description="Monitors pipeline health, classifies anomalies, and escalates issues",
-    category=AgentCategory.INTERFACE,
-    responsibilities=[
-        "Monitor agent progress events and heartbeats",
-        "Classify stalls, errors, and loops using Haiku tier",
-        "Decide corrective actions using Sonnet/Opus tier",
-        "Send redirect messages to stuck agents",
-        "Escalate to HITL when redirects are exhausted",
-        "File diagnostic GitHub issues for persistent problems",
-        "Track self-monitoring metrics (poll timing, LLM costs)",
-    ],
-    dependencies=[],
-    file_access=FileAccessPattern(
-        allowed_read=[],
-        allowed_write=[
-            ".egg-state/oversight/",
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=[
-            "src/",
-            "lib/",
-            "shared/",
-            "gateway/",
-            "sandbox/",
-            "action/",
-            "orchestrator/",
-            "docs/",
-            "tests/",
-            "test/",
-            ".egg-state/contracts/",
-            ".egg-state/drafts/",
-            ".egg-state/reviews/",
-            ".github/",
-        ],
-    ),
-    can_run_in_parallel=True,
-    produces_outputs=["health_report", "oversight_logs"],
-)
-
-
-# Utility role definitions
-
-AUTOFIXER_ROLE = AgentRoleDefinition(
-    role=AgentRole.AUTOFIXER,
-    description="Applies automated fixes for lint, type-check, and formatting issues",
-    category=AgentCategory.UTILITY,
-    responsibilities=[
-        "Run linters, type checkers, and formatters on changed files",
-        "Apply auto-fixable corrections (e.g., import sorting, formatting)",
-        "Report unfixable issues for human or coder review",
-        "Commit auto-fix changes with clear attribution",
-    ],
-    dependencies=[AgentRole.CODER],
-    file_access=FileAccessPattern(
-        allowed_read=[],  # Can read all files
-        allowed_write=[
-            # Source code (for auto-fixes)
-            "**/*.py",
-            "**/*.ts",
-            "**/*.tsx",
-            "**/*.js",
-            "**/*.jsx",
-            "**/*.go",
-            "**/*.java",
-            "**/*.rb",
-            "**/*.rs",
-            "**/*.sh",
-            # Configuration (for auto-fix updates)
-            "**/*.yml",
-            "**/*.yaml",
-            "**/*.json",
-            "**/*.toml",
-            # Handoff output
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=[
-            "docs/",
-            "**/*.md",
-            ".egg-state/contracts/",
-            # Issue #2508: branch-protection invariant — even an
-            # auto-fix to `.github/workflows/*.yml` must go through the
-            # `.github-staging/` convention so a human reviewer moves
-            # it in before merge.
-            ".github/",
-        ],
-    ),
-    produces_outputs=["autofix_report", "fixed_files"],
-    requires_inputs=["changed_files"],
-)
-
-CONFLICT_RESOLVER_ROLE = AgentRoleDefinition(
-    role=AgentRole.CONFLICT_RESOLVER,
-    description="Resolves merge conflicts and integration issues between agent branches",
-    category=AgentCategory.UTILITY,
-    responsibilities=[
-        "Detect and resolve merge conflicts between agent work branches",
-        "Ensure combined changes maintain consistency",
-        "Update tests and docs affected by conflict resolution",
-        "Report unresolvable conflicts for human review",
-    ],
-    dependencies=[],  # Runs on-demand, no fixed dependencies
-    file_access=FileAccessPattern(
-        allowed_read=[],  # Can read all files
-        allowed_write=[
-            # Source code
-            "**/*.py",
-            "**/*.ts",
-            "**/*.tsx",
-            "**/*.js",
-            "**/*.jsx",
-            "**/*.go",
-            "**/*.java",
-            "**/*.rb",
-            "**/*.rs",
-            "**/*.sh",
-            # Tests
-            "tests/",
-            "test/",
-            "**/tests/",
-            "**/test/",
-            "**/*_test.py",
-            "**/test_*.py",
-            "**/*.test.ts",
-            "**/*.test.tsx",
-            "**/*.test.js",
-            "**/*.test.jsx",
-            "**/*.spec.ts",
-            "**/*.spec.tsx",
-            "**/*.spec.js",
-            "**/*.spec.jsx",
-            # Documentation
-            "docs/",
-            "**/*.md",
-            # Configuration
-            "**/*.yml",
-            "**/*.yaml",
-            "**/*.json",
-            "**/*.toml",
-            # Handoff output
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=[
-            ".egg-state/contracts/",
-            ".egg-state/drafts/",
-            ".egg-state/pipelines/",
-            ".egg-state/reviews/",
-            ".egg-state/oversight/",
-            # Issue #2508: branch-protection invariant — when resolving
-            # a conflict that touches a workflow / CODEOWNERS file, the
-            # resolution must go through the `.github-staging/`
-            # convention so a human reviewer moves it in before merge.
-            ".github/",
-        ],
-    ),
-    produces_outputs=["conflict_report", "resolved_files"],
-    requires_inputs=[],
-)
-
-
-# Read-only evidence gatherer (#3523 §5, S7 / task-7-1). Assembles the shared
-# evidence pack (diff + changed files + caller/callee context + verified env
-# facts) that every same-model reviewer in a wave consumes as a byte-identical
-# prompt prefix. Its capabilities are the whole point: it is *unprivileged*.
-#   * No verdict-casting: it is NOT a reviewer role (absent from
-#     ``_PHASE_REVIEWERS``) and maps to the coarse ``Role.SYSTEM`` (an
-#     observer, not a contract author) — so it can neither ACK/NACK nor mutate
-#     the contract.
-#   * No posting / no GitHub access: it is deliberately left OUT of
-#     ``gateway.agent_restrictions.AGENT_GH_RESTRICTIONS`` so the gateway's
-#     deny-by-default posture rejects EVERY ``gh`` operation for it (stronger
-#     than the per-op block every producer gets).
-#   * Read-only checkout: ``file_access`` permits writes ONLY to the
-#     agent-outputs handoff dir and blocks source/tests/docs/contracts/reviews/
-#     drafts/.github — it can read everything, write essentially nothing.
-EVIDENCE_GATHERER_ROLE = AgentRoleDefinition(
-    role=AgentRole.EVIDENCE_GATHERER,
-    description="Read-only gatherer that assembles the shared review-wave evidence pack",
-    category=AgentCategory.UTILITY,
-    responsibilities=[
-        "Assemble a slice's evidence pack: diff, changed files with enclosing "
-        "context, caller/callee lists for changed symbols, verified env facts",
-        "Order the pack strictly by path — collect evidence, never analyze it",
-        "Cast no verdict, post nothing, touch no network — read-only",
-    ],
-    dependencies=[],  # Runs on-demand ahead of a review wave; no fixed deps
-    file_access=FileAccessPattern(
-        allowed_read=[],  # Can read all files (read-only by design)
-        allowed_write=[
-            # Handoff output only — the assembled pack. Nothing else.
-            ".egg-state/agent-outputs/",
-        ],
-        blocked_write=[
-            "src/",
-            "lib/",
-            "docs/",
-            "tests/",
-            "test/",
-            ".egg-state/contracts/",
-            ".egg-state/drafts/",
-            ".egg-state/reviews/",
-            ".egg-state/pipelines/",
-            ".egg-state/oversight/",
-            ".github/",
-        ],
-    ),
-    produces_outputs=["evidence_pack"],
-    requires_inputs=[],
-)
-
-
-# Registry of all agent roles
-AGENT_ROLES: dict[AgentRole, AgentRoleDefinition] = {
-    # Execution roles
-    AgentRole.CODER: CODER_ROLE,
-    AgentRole.TESTER: TESTER_ROLE,
-    AgentRole.DOCUMENTER: DOCUMENTER_ROLE,
-    AgentRole.APPLIER: APPLIER_ROLE,
-    # Analysis roles
-    AgentRole.ARCHITECT: ARCHITECT_ROLE,
-    AgentRole.TASK_PLANNER: TASK_PLANNER_ROLE,
-    AgentRole.RISK_ANALYST: RISK_ANALYST_ROLE,
-    AgentRole.REFINER: REFINER_ROLE,
-    AgentRole.SIMPLIFIER: SIMPLIFIER_ROLE,
-    # Review roles
-    AgentRole.REVIEWER_CODE: REVIEWER_CODE_ROLE,
-    AgentRole.REVIEWER_CODE_HOLISTIC: REVIEWER_CODE_HOLISTIC_ROLE,
-    AgentRole.REVIEWER_CONTRACT: REVIEWER_CONTRACT_ROLE,
-    AgentRole.REVIEWER_AGENT_DESIGN: REVIEWER_AGENT_DESIGN_ROLE,
-    AgentRole.REVIEWER_REFINE: REVIEWER_REFINE_ROLE,
-    AgentRole.FIRST_PRINCIPLES_REVIEWER: FIRST_PRINCIPLES_REVIEWER_ROLE,
-    AgentRole.REVIEWER_PLAN: REVIEWER_PLAN_ROLE,
-    AgentRole.REVIEWER_SECURITY: REVIEWER_SECURITY_ROLE,
-    AgentRole.REVIEWER_CONCURRENCY: REVIEWER_CONCURRENCY_ROLE,
-    # Utility roles
-    AgentRole.AUTOFIXER: AUTOFIXER_ROLE,
-    AgentRole.CONFLICT_RESOLVER: CONFLICT_RESOLVER_ROLE,
-    AgentRole.EVIDENCE_GATHERER: EVIDENCE_GATHERER_ROLE,
-    # Interface roles
-    AgentRole.OVERSEER: OVERSEER_ROLE,
-}
-
-
-# Canonical set of execution role string values — used by the schema,
-# plan parser, and orchestrator for role validation and filtering.
-EXECUTION_ROLE_VALUES = frozenset({AgentRole.CODER, AgentRole.TESTER, AgentRole.DOCUMENTER})
-
-
-# Reviewer roles that must have the peer's proposal *merged into their
-# working tree* to do their job — i.e. they EXECUTE the proposal (run
-# the test suite / build against the merged tree) rather than only
-# reading its diff. The BRC event-pump wrapper's ``sync_to_proposals``
-# gate (#3216, WS1 of #3209) runs ``git merge`` only for these roles on
-# a review (``ack``/``nack``) arm; every other reviewer reads peer
-# artifacts via the per-event-prompt ``git show`` / ``egg-artifact``
-# served reads, so merging the peer's whole tree into their worktree
-# only risks the dual-role criss-cross propagation that corrupts shared
-# drafts (#3208). The ``tester`` is the only reviewer that runs the
-# proposed tree; reviewer_code and the refine/plan reviewers read diffs.
-#
-# Residual: the ``tester`` is itself a dual-role agent (producer of test
-# code + reviewer) and must keep merging to execute ``make test`` against
-# the proposed tree, so the #3208 merge-then-commit-on-top criss-cross
-# shape stays *reachable via tester* in the implement phase. This gate
-# therefore does NOT fully close #3208 — it removes the shape for every
-# read-only reviewer (the plan-phase ``risk_analyst`` / ``plan.md``
-# corruption that motivated #3216). The remaining tester surface is an
-# accepted residual of WS1·1a, tracked under the parent #3209 (which
-# supersedes #3208); do not assume #3208 is closed by this set alone.
-REVIEWER_CHECKOUT_ROLE_VALUES = frozenset({AgentRole.TESTER})
-
-
-# Maps the fine-grained ``AgentRole`` shipped in agent sessions to the
-# coarse-grained ``Role`` enum used for contract field-ownership checks.
-# The gateway's contract and phase APIs consult this to authorize an
-# agent's request — without it, a session with ``agent_role="refiner"``
-# fails ``Role("refiner")`` and the API responds 403 (#1766).
-AGENT_ROLE_TO_CONTRACT_ROLE: dict[AgentRole, Role] = {
-    # Execution: produce code, own implementer-owned contract fields
-    AgentRole.CODER: Role.IMPLEMENTER,
-    AgentRole.TESTER: Role.IMPLEMENTER,
-    AgentRole.DOCUMENTER: Role.IMPLEMENTER,
-    # Applier (issue #1557): mutates Task.jira_* lifecycle fields on the
-    # contract during the apply phase; same contract privileges as other
-    # execution producers.
-    AgentRole.APPLIER: Role.IMPLEMENTER,
-    # Analysis: draft plans and analyses; write the same contract fields
-    # an implementer does (commits, notes, decisions).
-    AgentRole.ARCHITECT: Role.IMPLEMENTER,
-    AgentRole.TASK_PLANNER: Role.IMPLEMENTER,
-    AgentRole.RISK_ANALYST: Role.IMPLEMENTER,
-    AgentRole.REFINER: Role.IMPLEMENTER,
-    # Simplifier: produces the human-focused companion draft; writes the
-    # same draft/agent-output contract fields as the other analysis
-    # producers.
-    AgentRole.SIMPLIFIER: Role.IMPLEMENTER,
-    # Review: verdicts and phase-status/current_phase mutations
-    AgentRole.REVIEWER_CODE: Role.REVIEWER,
-    AgentRole.REVIEWER_CODE_HOLISTIC: Role.REVIEWER,
-    AgentRole.REVIEWER_CONTRACT: Role.REVIEWER,
-    AgentRole.REVIEWER_AGENT_DESIGN: Role.REVIEWER,
-    AgentRole.REVIEWER_REFINE: Role.REVIEWER,
-    # Pure reviewer; gains decision-create via the broadened decisions.*
-    # ownership in roles.py (it surfaces seed redirects as HITL decisions).
-    AgentRole.FIRST_PRINCIPLES_REVIEWER: Role.REVIEWER,
-    AgentRole.REVIEWER_PLAN: Role.REVIEWER,
-    AgentRole.REVIEWER_SECURITY: Role.REVIEWER,
-    AgentRole.REVIEWER_CONCURRENCY: Role.REVIEWER,
-    # Utility: apply code fixes, share implementer privileges
-    AgentRole.AUTOFIXER: Role.IMPLEMENTER,
-    AgentRole.CONFLICT_RESOLVER: Role.IMPLEMENTER,
-    # Read-only evidence gatherer: an observer like the overseer, never a
-    # contract author — SYSTEM structurally denies it verdict/contract writes.
-    AgentRole.EVIDENCE_GATHERER: Role.SYSTEM,
-    # Interface: observers, not contract authors
-    AgentRole.OVERSEER: Role.SYSTEM,
-}
-
-
-def get_contract_role(role: AgentRole | str) -> Role | None:
-    """Translate a fine-grained ``AgentRole`` to the coarse contract ``Role``.
-
-    The gateway stores the fine role in session metadata but the contract
-    API enforces field ownership against the coarse ``Role`` enum. Returns
-    ``None`` when the input does not name a known fine role.
-    """
-    if isinstance(role, str):
-        try:
-            role = AgentRole(role)
-        except ValueError:
-            return None
-    return AGENT_ROLE_TO_CONTRACT_ROLE.get(role)
-
-
-def get_role_definition(
-    role: AgentRole | str,
-) -> AgentRoleDefinition:
-    """Get the definition for an agent role.
-
-    Args:
-        role: The role to get (string or AgentRole enum)
-
-    Returns:
-        The AgentRoleDefinition for this role
-
-    Raises:
-        KeyError: If the role is not defined
-    """
-    if isinstance(role, str):
-        role = AgentRole(role)
-    return AGENT_ROLES[role]
-
-
-def get_all_roles() -> list[AgentRoleDefinition]:
-    """Get all defined agent roles.
-
-    Returns:
-        List of all AgentRoleDefinition objects
-    """
-    return list(AGENT_ROLES.values())
-
-
-def get_file_patterns(role_value: str) -> dict[str, list[str]] | None:
-    """Return file write patterns for an agent role, or None if not defined.
-
-    Returns:
-        ``{"allowed": [...], "blocked": [...]}`` or ``None`` if the role is
-        unknown or has no file access patterns.
-    """
-    try:
-        role_def = get_role_definition(role_value)
-    except ValueError, KeyError:
-        return None
-    if not role_def or not role_def.file_access:
-        return None
-    fa = role_def.file_access
-    if not fa.allowed_write and not fa.blocked_write:
-        return None
-    return {"allowed": fa.allowed_write, "blocked": fa.blocked_write}
-
-
-def get_roles_by_category(category: AgentCategory) -> list[AgentRole]:
-    """Get all roles belonging to a given category.
-
-    Args:
-        category: The category to filter by
-
-    Returns:
-        List of AgentRole values with the given category
-    """
-    return [role for role, defn in AGENT_ROLES.items() if defn.category == category]
-
-
-def get_role_dependencies(role: AgentRole | str) -> list[AgentRole]:
-    """Get the dependencies for a role.
-
-    Args:
-        role: The role to get dependencies for
-
-    Returns:
-        List of roles this role depends on
-    """
-    definition = get_role_definition(role)
-    return definition.dependencies
-
-
-def can_run_in_parallel(role1: AgentRole | str, role2: AgentRole | str) -> bool:
-    """Check if two roles can run in parallel.
-
-    Two roles can run in parallel if:
-    1. Neither depends on the other
-    2. Both have can_run_in_parallel set to True
-
-    Args:
-        role1: First role
-        role2: Second role
-
-    Returns:
-        True if the roles can run concurrently
-    """
-    def1 = get_role_definition(role1)
-    def2 = get_role_definition(role2)
-
-    # Check mutual dependencies
-    if def1.depends_on(def2.role) or def2.depends_on(def1.role):
-        return False
-
-    # Both must allow parallel execution
-    return def1.can_run_in_parallel and def2.can_run_in_parallel
-
-
-@dataclass
-class AgentExecution:
-    """Tracks the execution state of a single agent.
-
-    This is used by the orchestrator to track which agents have run,
-    their results, and any handoff data they produced.
-    """
-
-    role: AgentRole
-    status: AgentStatus = AgentStatus.PENDING
-    started_at: str | None = None  # ISO timestamp
-    completed_at: str | None = None  # ISO timestamp
-    commit: str | None = None  # Git commit SHA if agent made changes
-    outputs: dict[str, Any] = field(default_factory=dict)  # Handoff data
-    error: str | None = None  # Error message if failed
-    retry_count: int = 0
-
-    def is_complete(self) -> bool:
-        """Check if the agent has finished (successfully or not)."""
-        return self.status in (AgentStatus.COMPLETE, AgentStatus.FAILED, AgentStatus.SKIPPED)
-
-    def is_successful(self) -> bool:
-        """Check if the agent completed successfully."""
-        return self.status == AgentStatus.COMPLETE
-
-    def can_retry(self, max_retries: int = 2) -> bool:
-        """Check if the agent can be retried."""
-        return self.status == AgentStatus.FAILED and self.retry_count < max_retries
-
-
-# Phase-to-role mappings for multi-agent execution
-# Note: Utility roles (AUTOFIXER, CONFLICT_RESOLVER) are excluded
-# by design — they are spawned on-demand, not as part of standard phase execution.
-
-_PHASE_ROLES: dict[str, list[AgentRole]] = {
-    "implement": [AgentRole.CODER, AgentRole.TESTER, AgentRole.DOCUMENTER],
-    "plan": [
-        AgentRole.ARCHITECT,
-        AgentRole.TASK_PLANNER,
-        AgentRole.RISK_ANALYST,
-        AgentRole.SIMPLIFIER,
-    ],
-    "refine": [AgentRole.REFINER, AgentRole.SIMPLIFIER],
-    # Apply phase (issue #1557): single producer (APPLIER) reviewed by
-    # REVIEWER_CONTRACT on contract-state convergence. Inserted between
-    # PLAN and IMPLEMENT only for epic pipelines — the orchestrator
-    # scheduler skips this phase when ``Pipeline.is_epic == False``.
-    "apply": [AgentRole.APPLIER],
-}
-
-_PHASE_REVIEWERS: dict[str, list[AgentRole]] = {
-    "implement": [
-        AgentRole.REVIEWER_CODE,
-        AgentRole.REVIEWER_CODE_HOLISTIC,
-        AgentRole.REVIEWER_CONTRACT,
-        AgentRole.REVIEWER_SECURITY,
-        AgentRole.REVIEWER_CONCURRENCY,
-    ],
-    "plan": [
-        AgentRole.REVIEWER_PLAN,
-    ],
-    "refine": [
-        AgentRole.REVIEWER_REFINE,
-        AgentRole.REVIEWER_AGENT_DESIGN,
-        AgentRole.FIRST_PRINCIPLES_REVIEWER,
-    ],
-    # Apply phase reviewer (issue #1557 — architect's slice-3 design +
-    # risk_analyst R1 mitigation). REVIEWER_CONTRACT ACKs on
-    # contract-state convergence (every Task with jira_action='create'
-    # has a non-null jira_key matching ^[A-Z][A-Z0-9_]*-[0-9]+$, every
-    # Task has jira_action_status in {'applied', 'failed'}, no in-flight
-    # child mutated without the 'in-flight-confirmed' marker). The
-    # reviewer ACKs on contract state, NOT on prompt-output text
-    # quality.
-    "apply": [
-        AgentRole.REVIEWER_CONTRACT,
-    ],
-}
-
-
-# Roles whose per-pipeline ``PipelineConfig.agent_models`` override is
-# actually honored. ``orchestrator.agent_model_resolution.resolve_agent_model``
-# is consulted only by the concurrent-executor spawn path and the
-# ``restart_agent`` route, which between them spawn every phase producer
-# and reviewer in the two maps above. Utility roles (AUTOFIXER,
-# CONFLICT_RESOLVER) spawn through dedicated paths that never call the
-# resolver. The interface role (OVERSEER) now resolves its base model
-# through ``resolve_overseer_model`` -> ``resolve_agent_model`` (#2270 §1),
-# but is not yet promoted into ``MODEL_OVERRIDE_ROLES``. Either way an
-# ``agent_models`` entry naming one of these roles is not honored today, so
-# ``PipelineConfig``'s validator rejects such keys up front. See #2769.
-MODEL_OVERRIDE_ROLES: frozenset[AgentRole] = frozenset(
-    role
-    for role_group in (*_PHASE_ROLES.values(), *_PHASE_REVIEWERS.values())
-    for role in role_group
-)
-
-
-EGG_REPO = "jwbron/egg"
-
-# Reviewer roles that only apply to the egg repo itself
-EGG_ONLY_REVIEWERS: set[AgentRole] = {AgentRole.REVIEWER_AGENT_DESIGN}
-
-# String values for use by review_graph and other modules
-EGG_ONLY_REVIEWER_NAMES: set[str] = {r.value for r in EGG_ONLY_REVIEWERS}
-
-# Reviewer roles that enforce contract-task completeness at consensus
-# time (#3114). The orchestrator rejects an enforcer's ACK of a producer
-# whose contract task rows in the active slice are not ``complete``, and
-# rejects its CONFIRM while any slice row is incomplete — making the
-# contract reviewer the structural gate that holds a slice's consensus
-# open until the contract is actually delivered. Capability set rather
-# than a hardcoded role string so a future enforcer role inherits the
-# gate without orchestrator changes.
-CONTRACT_ENFORCER_ROLES: frozenset[AgentRole] = frozenset({AgentRole.REVIEWER_CONTRACT})
-
-# String values for use by the orchestrator signal routes.
-CONTRACT_ENFORCER_ROLE_NAMES: frozenset[str] = frozenset(r.value for r in CONTRACT_ENFORCER_ROLES)
-
-
-def get_roles_for_phase(
-    phase: str,
-    include_reviewers: bool = True,
-    include_overseer: bool = False,
-    repo: str | None = None,
-    has_contract: bool = True,
-) -> list[AgentRole]:
-    """Return the agent roles for a given pipeline phase.
-
-    Args:
-        phase: Pipeline phase name (e.g., "implement", "plan")
-        include_reviewers: Whether to include reviewer roles (default True)
-        include_overseer: Whether to include the overseer role (default False).
-            The overseer is cross-phase, so it's opt-in.
-        repo: Repository in owner/name format. When provided, egg-specific
-            reviewer roles (e.g., reviewer_agent_design) are excluded for
-            non-egg repos.
-        has_contract: Whether the pipeline has an upstream SDLC contract
-            (default True). When False, reviewers whose upstream artifacts
-            are absent are filtered out — currently ``reviewer_contract``.
-            ISSUE-mode pipelines set this to False when they haven't yet
-            produced a contract draft.
-
-    Returns:
-        List of AgentRole values for that phase.
-
-    Raises:
-        ValueError: If phase has no defined roles.
-    """
-    roles = _PHASE_ROLES.get(phase)
-    if roles is None:
-        raise ValueError(f"No agent roles defined for phase: {phase}")
-    result = list(roles)
-    if include_reviewers:
-        reviewers = _PHASE_REVIEWERS.get(phase, [])
-        if repo is not None and repo != EGG_REPO:
-            reviewers = [r for r in reviewers if r not in EGG_ONLY_REVIEWERS]
-        if not has_contract:
-            # reviewer_contract has no artifacts to verify without a contract;
-            # filter it out so BRC doesn't wait on an agent that cannot ACK.
-            reviewers = [r for r in reviewers if r != AgentRole.REVIEWER_CONTRACT]
-        result.extend(reviewers)
-    if include_overseer:
-        result.append(AgentRole.OVERSEER)
-    return result
-
-
-def detect_write_overlaps(
-    roles: list[AgentRole],
-) -> list[tuple[AgentRole, AgentRole, list[str]]]:
-    """Detect overlapping write patterns between agents that may run in parallel.
-
-    Only checks roles that can run in the same wave (share no dependency edge).
-
-    Returns:
-        List of (role1, role2, overlapping_patterns) tuples.
-    """
-    from ..dependency_graph import build_dependency_graph
-
-    graph = build_dependency_graph(roles)
-    waves = graph.compute_waves()
-
-    overlaps = []
-    for wave in waves:
-        if len(wave) < 2:
-            continue
-        for i, role1 in enumerate(wave):
-            for role2 in wave[i + 1 :]:
-                role1_def = get_role_definition(role1)
-                role2_def = get_role_definition(role2)
-                # Find common write patterns
-                common = []
-                for p1 in role1_def.file_access.allowed_write:
-                    for p2 in role2_def.file_access.allowed_write:
-                        if p1 == p2:
-                            common.append(p1)
-                        elif p1.endswith("/") and p2.startswith(p1):
-                            common.append(p1)
-                        elif p2.endswith("/") and p1.startswith(p2):
-                            common.append(p2)
-                if common:
-                    overlaps.append((role1, role2, common))
-    return overlaps
-
-
-def create_execution_for_role(role: AgentRole | str) -> AgentExecution:
-    """Create a new AgentExecution for a role.
-
-    Args:
-        role: The role to create execution tracking for
-
-    Returns:
-        A new AgentExecution in PENDING status
-    """
-    if isinstance(role, str):
-        role = AgentRole(role)
-    return AgentExecution(role=role)

--- a/shared/egg_contracts/agent_roles/_core.py
+++ b/shared/egg_contracts/agent_roles/_core.py
@@ -1,0 +1,233 @@
+"""Core types for agent role definitions (#3543 decomposition).
+
+Enums (``AgentCategory``, ``AgentRole``, ``AgentStatus``), the
+``FileAccessPattern`` / ``AgentRoleDefinition`` dataclasses, the
+``AgentExecution`` tracking dataclass, and the write-restriction list
+shared by every reviewer role definition across the per-phase modules.
+"""
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from egg_restrictions.matchers import match_pattern
+
+
+class AgentCategory(StrEnum):
+    """Category classification for agent roles.
+
+    Used for dynamic team composition queries (e.g., "all review agents")
+    and for understanding the high-level purpose of each role.
+    """
+
+    EXECUTION = "execution"
+    ANALYSIS = "analysis"
+    REVIEW = "review"
+    UTILITY = "utility"
+    INTERFACE = "interface"
+
+
+class AgentRole(StrEnum):
+    """Specialized agent roles for multi-agent orchestration.
+
+    This is the **canonical enum** — all other AgentRole definitions in the
+    codebase must import from or stay in sync with this one.
+
+    Each role has a focused responsibility and specific file access patterns.
+    The orchestrator uses these roles to parallelize work where dependencies allow.
+
+    Execution roles: CODER, TESTER, DOCUMENTER
+    Analysis roles: ARCHITECT, TASK_PLANNER, RISK_ANALYST, REFINER, SIMPLIFIER
+    Review roles: REVIEWER_CODE, REVIEWER_CODE_HOLISTIC,
+                  REVIEWER_CONTRACT, REVIEWER_AGENT_DESIGN,
+                  REVIEWER_REFINE, FIRST_PRINCIPLES_REVIEWER,
+                  REVIEWER_PLAN, REVIEWER_SECURITY, REVIEWER_CONCURRENCY
+    Utility roles: AUTOFIXER, CONFLICT_RESOLVER
+    Interface roles: OVERSEER
+    """
+
+    # Execution roles (produce code or artifacts)
+    CODER = "coder"
+    TESTER = "tester"
+    DOCUMENTER = "documenter"
+    # Jira-epic SDLC support (issue #1557). The APPLIER role drives
+    # Jira mutations (epic Description writes, child create/edit/link,
+    # Won't-Do handoff) on operator approval of the refine/plan HITL
+    # gates. It runs inside the sandbox and uses only the agent-facing
+    # gateway Jira routes — credentials never leave the gateway.
+    APPLIER = "applier"
+    # Analysis roles (analyze and plan)
+    ARCHITECT = "architect"
+    TASK_PLANNER = "task_planner"
+    RISK_ANALYST = "risk_analyst"
+    REFINER = "refiner"
+    # Distills a producer's draft (refine analysis / plan) into a
+    # human-focused, jargon-free companion copy. Runs in the refine and
+    # plan phases as a producer gated on the upstream producer's
+    # CONSENSUS_PROPOSE (the coder→tester dependency pattern).
+    SIMPLIFIER = "simplifier"
+    # Review roles
+    REVIEWER_CODE = "reviewer_code"
+    REVIEWER_CODE_HOLISTIC = "reviewer_code_holistic"
+    REVIEWER_CONTRACT = "reviewer_contract"
+    REVIEWER_AGENT_DESIGN = "reviewer_agent_design"
+    REVIEWER_REFINE = "reviewer_refine"
+    # Adversarial first-principles reviewer of the refine phase. Reviews the
+    # pipeline's *seed* (the operator's task statement) and the direction the
+    # refiner's analysis is taking — questioning whether the premise is sound
+    # and the direction appropriate. It never NACKs the refiner (a NACK only
+    # re-runs the producer, which cannot change the operator-owned seed);
+    # instead it ACKs and, when warranted, surfaces a redirect as a
+    # phase-scoped HITL decision for the operator. Named mandate-first rather
+    # than ``reviewer_first_principles`` so the role reads as what it does in
+    # the escalations an operator sees.
+    FIRST_PRINCIPLES_REVIEWER = "first_principles_reviewer"
+    REVIEWER_PLAN = "reviewer_plan"
+    REVIEWER_SECURITY = "reviewer_security"
+    REVIEWER_CONCURRENCY = "reviewer_concurrency"
+    # Utility roles (cross-cutting support)
+    AUTOFIXER = "autofixer"
+    CONFLICT_RESOLVER = "conflict_resolver"
+    # Read-only shared-evidence gatherer (#3523 §5). Assembles the evidence
+    # pack a review wave shares as a byte-identical prompt prefix. Casts no
+    # verdict, posts nothing, has no GitHub access, writes only its handoff
+    # dir — those capabilities are structurally excluded below (file_access +
+    # a SYSTEM contract role + deny-by-default gh restrictions).
+    EVIDENCE_GATHERER = "evidence_gatherer"
+    # Interface roles (external system interaction)
+    OVERSEER = "overseer"
+
+
+class AgentStatus(StrEnum):
+    """Status values for agent executions."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETE = "complete"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    BLOCKED = "blocked"
+
+
+@dataclass
+class FileAccessPattern:
+    """File access pattern for an agent role.
+
+    Defines what files an agent can read and write. The gateway enforces
+    these restrictions during git push operations.
+    """
+
+    allowed_read: list[str] = field(default_factory=list)
+    allowed_write: list[str] = field(default_factory=list)
+    blocked_write: list[str] = field(default_factory=list)
+
+    def can_read(self, file_path: str) -> bool:
+        """Check if the agent can read this file.
+
+        Args:
+            file_path: Path relative to repo root
+
+        Returns:
+            True if the file can be read (default: all files readable)
+        """
+        if not self.allowed_read:
+            return True  # Empty list means all files readable
+
+        return any(match_pattern(file_path, pattern) for pattern in self.allowed_read)
+
+    def can_write(self, file_path: str) -> bool:
+        """Check if the agent can write to this file.
+
+        Args:
+            file_path: Path relative to repo root
+
+        Returns:
+            True if the file can be written
+        """
+        # Check blocked patterns first
+        if any(match_pattern(file_path, pattern) for pattern in self.blocked_write):
+            return False
+
+        # If no allowed patterns, block all writes
+        if not self.allowed_write:
+            return False
+
+        return any(match_pattern(file_path, pattern) for pattern in self.allowed_write)
+
+
+@dataclass
+class AgentRoleDefinition:
+    """Complete definition of an agent role.
+
+    Combines the role identifier with its responsibilities, dependencies,
+    and access constraints. Used by the orchestrator to plan execution.
+    """
+
+    role: AgentRole
+    description: str
+    responsibilities: list[str]
+    category: AgentCategory | None = None
+    dependencies: list[AgentRole] = field(default_factory=list)
+    file_access: FileAccessPattern = field(default_factory=FileAccessPattern)
+    can_run_in_parallel: bool = True  # Can run in parallel with other agents
+    produces_outputs: list[str] = field(default_factory=list)
+    requires_inputs: list[str] = field(default_factory=list)
+
+    def depends_on(self, other: AgentRole) -> bool:
+        """Check if this role depends on another role.
+
+        Args:
+            other: The role to check dependency against
+
+        Returns:
+            True if this role must wait for the other role to complete
+        """
+        return other in self.dependencies
+
+
+@dataclass
+class AgentExecution:
+    """Tracks the execution state of a single agent.
+
+    This is used by the orchestrator to track which agents have run,
+    their results, and any handoff data they produced.
+    """
+
+    role: AgentRole
+    status: AgentStatus = AgentStatus.PENDING
+    started_at: str | None = None  # ISO timestamp
+    completed_at: str | None = None  # ISO timestamp
+    commit: str | None = None  # Git commit SHA if agent made changes
+    outputs: dict[str, Any] = field(default_factory=dict)  # Handoff data
+    error: str | None = None  # Error message if failed
+    retry_count: int = 0
+
+    def is_complete(self) -> bool:
+        """Check if the agent has finished (successfully or not)."""
+        return self.status in (AgentStatus.COMPLETE, AgentStatus.FAILED, AgentStatus.SKIPPED)
+
+    def is_successful(self) -> bool:
+        """Check if the agent completed successfully."""
+        return self.status == AgentStatus.COMPLETE
+
+    def can_retry(self, max_retries: int = 2) -> bool:
+        """Check if the agent can be retried."""
+        return self.status == AgentStatus.FAILED and self.retry_count < max_retries
+
+
+# Reviewer agent role definitions
+# Reviewers can only write to reviews/ and agent-outputs/ directories.
+# Use directory-based blocks instead of "**/*" which breaks can_write()
+# by always matching before allowed_write is checked.
+
+_REVIEWER_BLOCKED_WRITE = [
+    "src/",
+    "lib/",
+    "docs/",
+    "tests/",
+    "test/",
+    ".egg-state/contracts/",
+    ".egg-state/drafts/",
+    # Issue #2532: parity with _REVIEWER_BLOCKED in patterns.py — see #2508 / #2521.
+    ".github/",
+]

--- a/shared/egg_contracts/agent_roles/_implement_roles.py
+++ b/shared/egg_contracts/agent_roles/_implement_roles.py
@@ -1,0 +1,314 @@
+"""Implement-phase agent role definitions (#3543 decomposition).
+
+Execution producers (coder, tester, documenter) and the implement-phase
+reviewer roles (code, code-holistic, contract, security, concurrency).
+``REVIEWER_CONTRACT_ROLE`` also reviews the apply phase.
+"""
+
+from ._core import (
+    _REVIEWER_BLOCKED_WRITE,
+    AgentCategory,
+    AgentRole,
+    AgentRoleDefinition,
+    FileAccessPattern,
+)
+
+# Default agent role definitions
+# These define the standard agent roles used in multi-agent orchestration
+
+CODER_ROLE = AgentRoleDefinition(
+    role=AgentRole.CODER,
+    description="Implements code changes based on the plan tasks",
+    category=AgentCategory.EXECUTION,
+    responsibilities=[
+        "Read and understand the implementation plan",
+        "Implement code changes for assigned tasks",
+        "Link commits to contract tasks",
+        "Output list of changed files for downstream agents",
+    ],
+    dependencies=[],  # Coder runs first, no dependencies
+    file_access=FileAccessPattern(
+        allowed_read=[],  # Can read all files
+        allowed_write=[
+            "**/*.py",
+            "**/*.ts",
+            "**/*.tsx",
+            "**/*.js",
+            "**/*.jsx",
+            "**/*.go",
+            "**/*.java",
+            "**/*.rb",
+            "**/*.rs",
+            "**/*.sh",
+            "**/*.yml",
+            "**/*.yaml",
+            "**/*.json",
+            ".egg-state/agent-outputs/",  # For handoff data
+            # Issue #2508: staging dir for proposed `.github/` changes.
+            # `.github/` itself is blocked below; the agent stages the
+            # proposed end-state here and calls the staged files out
+            # in its PR body so the human reviewer moves them into
+            # `.github/` before merge.
+            ".github-staging/",
+        ],
+        blocked_write=[
+            "docs/",  # Documenter handles docs
+            "**/README.md",  # Documenter handles READMEs
+            ".egg-state/contracts/",  # Contracts are managed by API
+            # Issue #2508: branch-protection invariant — agents cannot
+            # push to `.github/` directly. Use `.github-staging/` (above)
+            # to propose CI workflow / CODEOWNERS changes for human
+            # review.
+            ".github/",
+        ],
+    ),
+    produces_outputs=["changed_files", "commits"],
+    requires_inputs=[],
+)
+
+TESTER_ROLE = AgentRoleDefinition(
+    role=AgentRole.TESTER,
+    description="Validates implementation by writing tests, running lint/type-checks, and applying auto-fixes",
+    category=AgentCategory.EXECUTION,
+    responsibilities=[
+        "Read the list of changed files from coder",
+        "Identify gaps in the implementation (missing error handling, boundary conditions, uncovered branches)",
+        "Write or update tests targeting identified gaps",
+        "Run linters and type checkers, apply auto-fixes where possible",
+        "Report test coverage, lint/type-check results, and document deficiencies found",
+    ],
+    dependencies=[AgentRole.CODER],  # Must wait for coder
+    file_access=FileAccessPattern(
+        allowed_read=[],  # Can read all files
+        allowed_write=[
+            # Test files
+            "tests/",
+            "test/",
+            "**/tests/",
+            "**/test/",
+            "**/*_test.py",
+            "**/*_test.go",
+            "**/test_*.py",
+            "**/*.test.ts",
+            "**/*.test.tsx",
+            "**/*.test.js",
+            "**/*.test.jsx",
+            "**/*.spec.ts",
+            "**/*.spec.tsx",
+            "**/*.spec.js",
+            "**/*.spec.jsx",
+            # Source files (for lint/type-check auto-fixes)
+            "**/*.py",
+            "**/*.ts",
+            "**/*.tsx",
+            "**/*.js",
+            "**/*.jsx",
+            "**/*.go",
+            "**/*.java",
+            "**/*.rb",
+            "**/*.rs",
+            "**/*.sh",
+            # Configuration (for auto-fix updates)
+            "**/*.yml",
+            "**/*.yaml",
+            "**/*.json",
+            "**/*.toml",
+            ".egg-state/agent-outputs/",  # For handoff data
+        ],
+        blocked_write=[
+            "docs/",
+            "**/README.md",
+            "**/*.md",
+            ".egg-state/contracts/",
+            # Issue #2508: branch-protection invariant — even a
+            # tester-applied auto-fix to `.github/workflows/*.yml` must
+            # go through the `.github-staging/` convention so a human
+            # reviewer moves it in before merge.
+            ".github/",
+        ],
+    ),
+    produces_outputs=["test_files", "coverage_report", "gaps_found", "check_results"],
+    requires_inputs=["changed_files"],
+)
+
+DOCUMENTER_ROLE = AgentRoleDefinition(
+    role=AgentRole.DOCUMENTER,
+    description="Documents the current state of the code",
+    category=AgentCategory.EXECUTION,
+    responsibilities=[
+        "Read the list of changed files from coder",
+        "Describe how the code works now — a snapshot of the current "
+        "state, not a log of what changed or when",
+        "Never embed SDLC artifacts (slice numbers, TASK-N ids, phase or "
+        "HITL iteration numbers) in docs, docstrings, or comments",
+        "Prefer rationale (why it is this way) over chronology; fold new "
+        "state into the snapshot and remove now-stale ledger entries",
+        "Keep README and API documentation current",
+    ],
+    dependencies=[AgentRole.CODER],  # Must wait for coder
+    file_access=FileAccessPattern(
+        allowed_read=[],  # Can read all files
+        allowed_write=[
+            "docs/",
+            "**/README.md",
+            "**/*.md",  # All markdown files
+            ".egg-state/agent-outputs/",  # For handoff data
+        ],
+        blocked_write=[
+            "**/*.py",  # Cannot modify code
+            "**/*.ts",
+            "**/*.tsx",
+            "**/*.js",
+            "**/*.jsx",
+            "**/*.go",
+            "**/*.java",
+            "tests/",  # Cannot modify tests
+            ".egg-state/contracts/",
+            # Issue #2508: branch-protection invariant — even markdown
+            # files under `.github/` (PULL_REQUEST_TEMPLATE.md,
+            # ISSUE_TEMPLATE.md, etc.) must go through the
+            # `.github-staging/` convention so a human reviewer moves
+            # them in before merge.
+            ".github/",
+        ],
+    ),
+    can_run_in_parallel=True,  # Can run in parallel with tester
+    produces_outputs=["doc_files"],
+    requires_inputs=["changed_files"],
+)
+
+REVIEWER_CODE_ROLE = AgentRoleDefinition(
+    role=AgentRole.REVIEWER_CODE,
+    description="Performs a comprehensive code review",
+    category=AgentCategory.REVIEW,
+    responsibilities=[
+        "Review code quality, security, and correctness",
+        "Check for OWASP top 10 vulnerabilities",
+        "Verify error handling and edge cases",
+    ],
+    dependencies=[AgentRole.TASK_PLANNER, AgentRole.RISK_ANALYST],
+    file_access=FileAccessPattern(
+        allowed_read=[],
+        allowed_write=[
+            ".egg-state/reviews/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=_REVIEWER_BLOCKED_WRITE,
+    ),
+    produces_outputs=["review_verdict"],
+    requires_inputs=[],
+)
+
+# Holistic generalist counterpart to ``reviewer_code`` (issue #2126).
+# Skims the full diff once and runs four cross-module passes rather
+# than verifying every line — that is ``reviewer_code``'s job. Its
+# focus is the architectural-coherence question line-by-line review
+# does not own: does the primary advertised use case work end-to-end,
+# do docs and code agree, do synthetic keys round-trip across modules,
+# are silent fallbacks hiding operator-visible failures.
+REVIEWER_CODE_HOLISTIC_ROLE = AgentRoleDefinition(
+    role=AgentRole.REVIEWER_CODE_HOLISTIC,
+    description="Single-pass holistic code review focused on cross-module coherence",
+    category=AgentCategory.REVIEW,
+    responsibilities=[
+        "Walk the primary advertised use case end-to-end across the full diff",
+        "Cross-check doc-claimed behaviour against what the code actually does",
+        "Audit synthetic keys, sentinels, and 'magic' values for cross-module agreement",
+        "Surface silent fallbacks that swallow operator-visible misconfiguration",
+    ],
+    dependencies=[AgentRole.TASK_PLANNER, AgentRole.RISK_ANALYST],
+    file_access=FileAccessPattern(
+        allowed_read=[],
+        allowed_write=[
+            ".egg-state/reviews/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=_REVIEWER_BLOCKED_WRITE,
+    ),
+    produces_outputs=["review_verdict"],
+    requires_inputs=[],
+)
+
+# Contract reviewer needs write access to .egg-state/contracts/ to mark
+# items as done, so it uses a custom blocked_write list that excludes it.
+_REVIEWER_CONTRACT_BLOCKED_WRITE = [
+    "src/",
+    "lib/",
+    "docs/",
+    "tests/",
+    "test/",
+    ".egg-state/drafts/",
+    # Issue #2532: parity with _REVIEWER_CONTRACT_BLOCKED in patterns.py — see #2508 / #2521.
+    ".github/",
+]
+
+REVIEWER_CONTRACT_ROLE = AgentRoleDefinition(
+    role=AgentRole.REVIEWER_CONTRACT,
+    description="Verifies implementation matches the contract",
+    category=AgentCategory.REVIEW,
+    responsibilities=[
+        "Verify acceptance criteria are met",
+        "Check task completion status",
+        "Validate contract consistency",
+    ],
+    dependencies=[AgentRole.TASK_PLANNER, AgentRole.RISK_ANALYST],
+    file_access=FileAccessPattern(
+        allowed_read=[],
+        allowed_write=[
+            ".egg-state/reviews/",
+            ".egg-state/agent-outputs/",
+            ".egg-state/contracts/",
+        ],
+        blocked_write=_REVIEWER_CONTRACT_BLOCKED_WRITE,
+    ),
+    produces_outputs=["review_verdict"],
+    requires_inputs=["integration_report"],
+)
+
+REVIEWER_SECURITY_ROLE = AgentRoleDefinition(
+    role=AgentRole.REVIEWER_SECURITY,
+    description="ADVISORY security-lens reviewer for the implement phase",
+    category=AgentCategory.REVIEW,
+    responsibilities=[
+        "Detect cross-file allowlist mismatches",
+        "Flag handler-vs-validator path mismatches",
+        "Identify information-disclosure and authorization-bypass patterns",
+        "Spot uncommitted-artifact / Dockerfile-symlink mismatches",
+        "Catch secret leakage via logs, error text, or environment dumps",
+        "Surface OWASP top-10 patterns spanning more than one changed file",
+    ],
+    dependencies=[AgentRole.TASK_PLANNER, AgentRole.RISK_ANALYST],
+    file_access=FileAccessPattern(
+        allowed_read=[],
+        allowed_write=[
+            ".egg-state/reviews/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=_REVIEWER_BLOCKED_WRITE,
+    ),
+    produces_outputs=["review_verdict"],
+    requires_inputs=[],
+)
+
+REVIEWER_CONCURRENCY_ROLE = AgentRoleDefinition(
+    role=AgentRole.REVIEWER_CONCURRENCY,
+    description="ADVISORY concurrency-lens reviewer for the implement phase",
+    category=AgentCategory.REVIEW,
+    responsibilities=[
+        "Identify race conditions and deadlocks",
+        "Flag shared-state mutation and async-context leakage",
+        "Detect retry-storm patterns and resource-cleanup ordering bugs",
+        "Verify BRC-protocol invariants (send→wait, cursor threading, heartbeats)",
+    ],
+    dependencies=[AgentRole.TASK_PLANNER, AgentRole.RISK_ANALYST],
+    file_access=FileAccessPattern(
+        allowed_read=[],
+        allowed_write=[
+            ".egg-state/reviews/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=_REVIEWER_BLOCKED_WRITE,
+    ),
+    produces_outputs=["review_verdict"],
+    requires_inputs=[],
+)

--- a/shared/egg_contracts/agent_roles/_oversight_roles.py
+++ b/shared/egg_contracts/agent_roles/_oversight_roles.py
@@ -1,0 +1,225 @@
+"""Oversight and utility agent role definitions (#3543 decomposition).
+
+The cross-phase interface role (overseer) and the on-demand utility
+roles (autofixer, conflict_resolver, evidence_gatherer) that spawn
+outside the standard per-phase producer/reviewer sets.
+"""
+
+from ._core import (
+    AgentCategory,
+    AgentRole,
+    AgentRoleDefinition,
+    FileAccessPattern,
+)
+
+# Overseer role — monitors pipeline health, classifies anomalies, escalates issues
+OVERSEER_ROLE = AgentRoleDefinition(
+    role=AgentRole.OVERSEER,
+    description="Monitors pipeline health, classifies anomalies, and escalates issues",
+    category=AgentCategory.INTERFACE,
+    responsibilities=[
+        "Monitor agent progress events and heartbeats",
+        "Classify stalls, errors, and loops using Haiku tier",
+        "Decide corrective actions using Sonnet/Opus tier",
+        "Send redirect messages to stuck agents",
+        "Escalate to HITL when redirects are exhausted",
+        "File diagnostic GitHub issues for persistent problems",
+        "Track self-monitoring metrics (poll timing, LLM costs)",
+    ],
+    dependencies=[],
+    file_access=FileAccessPattern(
+        allowed_read=[],
+        allowed_write=[
+            ".egg-state/oversight/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=[
+            "src/",
+            "lib/",
+            "shared/",
+            "gateway/",
+            "sandbox/",
+            "action/",
+            "orchestrator/",
+            "docs/",
+            "tests/",
+            "test/",
+            ".egg-state/contracts/",
+            ".egg-state/drafts/",
+            ".egg-state/reviews/",
+            ".github/",
+        ],
+    ),
+    can_run_in_parallel=True,
+    produces_outputs=["health_report", "oversight_logs"],
+)
+
+
+# Utility role definitions
+
+AUTOFIXER_ROLE = AgentRoleDefinition(
+    role=AgentRole.AUTOFIXER,
+    description="Applies automated fixes for lint, type-check, and formatting issues",
+    category=AgentCategory.UTILITY,
+    responsibilities=[
+        "Run linters, type checkers, and formatters on changed files",
+        "Apply auto-fixable corrections (e.g., import sorting, formatting)",
+        "Report unfixable issues for human or coder review",
+        "Commit auto-fix changes with clear attribution",
+    ],
+    dependencies=[AgentRole.CODER],
+    file_access=FileAccessPattern(
+        allowed_read=[],  # Can read all files
+        allowed_write=[
+            # Source code (for auto-fixes)
+            "**/*.py",
+            "**/*.ts",
+            "**/*.tsx",
+            "**/*.js",
+            "**/*.jsx",
+            "**/*.go",
+            "**/*.java",
+            "**/*.rb",
+            "**/*.rs",
+            "**/*.sh",
+            # Configuration (for auto-fix updates)
+            "**/*.yml",
+            "**/*.yaml",
+            "**/*.json",
+            "**/*.toml",
+            # Handoff output
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=[
+            "docs/",
+            "**/*.md",
+            ".egg-state/contracts/",
+            # Issue #2508: branch-protection invariant — even an
+            # auto-fix to `.github/workflows/*.yml` must go through the
+            # `.github-staging/` convention so a human reviewer moves
+            # it in before merge.
+            ".github/",
+        ],
+    ),
+    produces_outputs=["autofix_report", "fixed_files"],
+    requires_inputs=["changed_files"],
+)
+
+CONFLICT_RESOLVER_ROLE = AgentRoleDefinition(
+    role=AgentRole.CONFLICT_RESOLVER,
+    description="Resolves merge conflicts and integration issues between agent branches",
+    category=AgentCategory.UTILITY,
+    responsibilities=[
+        "Detect and resolve merge conflicts between agent work branches",
+        "Ensure combined changes maintain consistency",
+        "Update tests and docs affected by conflict resolution",
+        "Report unresolvable conflicts for human review",
+    ],
+    dependencies=[],  # Runs on-demand, no fixed dependencies
+    file_access=FileAccessPattern(
+        allowed_read=[],  # Can read all files
+        allowed_write=[
+            # Source code
+            "**/*.py",
+            "**/*.ts",
+            "**/*.tsx",
+            "**/*.js",
+            "**/*.jsx",
+            "**/*.go",
+            "**/*.java",
+            "**/*.rb",
+            "**/*.rs",
+            "**/*.sh",
+            # Tests
+            "tests/",
+            "test/",
+            "**/tests/",
+            "**/test/",
+            "**/*_test.py",
+            "**/test_*.py",
+            "**/*.test.ts",
+            "**/*.test.tsx",
+            "**/*.test.js",
+            "**/*.test.jsx",
+            "**/*.spec.ts",
+            "**/*.spec.tsx",
+            "**/*.spec.js",
+            "**/*.spec.jsx",
+            # Documentation
+            "docs/",
+            "**/*.md",
+            # Configuration
+            "**/*.yml",
+            "**/*.yaml",
+            "**/*.json",
+            "**/*.toml",
+            # Handoff output
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=[
+            ".egg-state/contracts/",
+            ".egg-state/drafts/",
+            ".egg-state/pipelines/",
+            ".egg-state/reviews/",
+            ".egg-state/oversight/",
+            # Issue #2508: branch-protection invariant — when resolving
+            # a conflict that touches a workflow / CODEOWNERS file, the
+            # resolution must go through the `.github-staging/`
+            # convention so a human reviewer moves it in before merge.
+            ".github/",
+        ],
+    ),
+    produces_outputs=["conflict_report", "resolved_files"],
+    requires_inputs=[],
+)
+
+
+# Read-only evidence gatherer (#3523 §5, S7 / task-7-1). Assembles the shared
+# evidence pack (diff + changed files + caller/callee context + verified env
+# facts) that every same-model reviewer in a wave consumes as a byte-identical
+# prompt prefix. Its capabilities are the whole point: it is *unprivileged*.
+#   * No verdict-casting: it is NOT a reviewer role (absent from
+#     ``_PHASE_REVIEWERS``) and maps to the coarse ``Role.SYSTEM`` (an
+#     observer, not a contract author) — so it can neither ACK/NACK nor mutate
+#     the contract.
+#   * No posting / no GitHub access: it is deliberately left OUT of
+#     ``gateway.agent_restrictions.AGENT_GH_RESTRICTIONS`` so the gateway's
+#     deny-by-default posture rejects EVERY ``gh`` operation for it (stronger
+#     than the per-op block every producer gets).
+#   * Read-only checkout: ``file_access`` permits writes ONLY to the
+#     agent-outputs handoff dir and blocks source/tests/docs/contracts/reviews/
+#     drafts/.github — it can read everything, write essentially nothing.
+EVIDENCE_GATHERER_ROLE = AgentRoleDefinition(
+    role=AgentRole.EVIDENCE_GATHERER,
+    description="Read-only gatherer that assembles the shared review-wave evidence pack",
+    category=AgentCategory.UTILITY,
+    responsibilities=[
+        "Assemble a slice's evidence pack: diff, changed files with enclosing "
+        "context, caller/callee lists for changed symbols, verified env facts",
+        "Order the pack strictly by path — collect evidence, never analyze it",
+        "Cast no verdict, post nothing, touch no network — read-only",
+    ],
+    dependencies=[],  # Runs on-demand ahead of a review wave; no fixed deps
+    file_access=FileAccessPattern(
+        allowed_read=[],  # Can read all files (read-only by design)
+        allowed_write=[
+            # Handoff output only — the assembled pack. Nothing else.
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=[
+            "src/",
+            "lib/",
+            "docs/",
+            "tests/",
+            "test/",
+            ".egg-state/contracts/",
+            ".egg-state/drafts/",
+            ".egg-state/reviews/",
+            ".egg-state/pipelines/",
+            ".egg-state/oversight/",
+            ".github/",
+        ],
+    ),
+    produces_outputs=["evidence_pack"],
+    requires_inputs=[],
+)

--- a/shared/egg_contracts/agent_roles/_plan_roles.py
+++ b/shared/egg_contracts/agent_roles/_plan_roles.py
@@ -1,0 +1,185 @@
+"""Plan- and apply-phase agent role definitions (#3543 decomposition).
+
+Plan producers (architect, task_planner, risk_analyst), the plan-phase
+reviewer, and the apply-phase producer (applier, issue #1557) that runs
+between plan approval and implement for epic pipelines.
+"""
+
+from ._core import (
+    _REVIEWER_BLOCKED_WRITE,
+    AgentCategory,
+    AgentRole,
+    AgentRoleDefinition,
+    FileAccessPattern,
+)
+
+# Plan-phase agent role definitions
+# Plan-phase agents (architect, task_planner, risk_analyst) share a
+# blocked_write list mirroring ``_PLAN_AGENT_BLOCKED`` in
+# ``shared/egg_restrictions/patterns.py``. Keeping the two views in
+# lockstep is the invariant issue #2532 closed; using a shared constant
+# eliminates one future drift surface within ``agent_roles.py`` itself.
+_PLAN_AGENT_BLOCKED_WRITE = [
+    "**/*.py",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.go",
+    "**/*.java",
+    ".egg-state/contracts/",
+    # Issue #2532: parity with _PLAN_AGENT_BLOCKED in patterns.py — see #2508 / #2521.
+    ".github/",
+]
+
+ARCHITECT_ROLE = AgentRoleDefinition(
+    role=AgentRole.ARCHITECT,
+    description="Analyzes the task and produces architecture analysis",
+    category=AgentCategory.ANALYSIS,
+    responsibilities=[
+        "Understand the problem or feature request",
+        "Research the codebase to understand existing patterns",
+        "Identify key files, constraints, and dependencies",
+        "Recommend an approach with justification",
+        "Document technical decisions",
+    ],
+    dependencies=[],  # Architect runs first in plan phase
+    file_access=FileAccessPattern(
+        allowed_read=[],  # Can read all files
+        allowed_write=[
+            ".egg-state/drafts/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=_PLAN_AGENT_BLOCKED_WRITE,
+    ),
+    produces_outputs=["architecture_analysis", "technical_decisions"],
+    requires_inputs=[],
+)
+
+TASK_PLANNER_ROLE = AgentRoleDefinition(
+    role=AgentRole.TASK_PLANNER,
+    description="Decomposes architecture analysis into discrete tasks",
+    category=AgentCategory.ANALYSIS,
+    responsibilities=[
+        "Review the architecture analysis from the architect",
+        "Break down work into phases with discrete tasks",
+        "Define clear acceptance criteria for each task",
+        "Define dependency ordering between tasks",
+        "Identify the test strategy",
+    ],
+    dependencies=[AgentRole.ARCHITECT],
+    file_access=FileAccessPattern(
+        allowed_read=[],
+        allowed_write=[
+            ".egg-state/drafts/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=_PLAN_AGENT_BLOCKED_WRITE,
+    ),
+    produces_outputs=["task_breakdown", "acceptance_criteria"],
+    requires_inputs=["architecture_analysis"],
+)
+
+RISK_ANALYST_ROLE = AgentRoleDefinition(
+    role=AgentRole.RISK_ANALYST,
+    description="Assesses technical risks for the proposed implementation",
+    category=AgentCategory.ANALYSIS,
+    responsibilities=[
+        "Review the architecture analysis from the architect",
+        "Identify technical risks (security, performance, compatibility)",
+        "Assess impact and likelihood of each risk",
+        "Propose mitigation strategies and rollback plans",
+        "Flag areas that need human review",
+    ],
+    dependencies=[AgentRole.ARCHITECT],
+    file_access=FileAccessPattern(
+        allowed_read=[],
+        allowed_write=[
+            ".egg-state/drafts/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=_PLAN_AGENT_BLOCKED_WRITE,
+    ),
+    can_run_in_parallel=True,  # Can run in parallel with task_planner
+    produces_outputs=["risk_assessment", "mitigation_plan"],
+    requires_inputs=["architecture_analysis"],
+)
+
+
+# Jira-epic SDLC support (issue #1557). The APPLIER drives Jira
+# mutations after the refine/plan HITL gates resolve. It reads the
+# contract + relevant draft and calls the agent-facing gateway Jira
+# routes (``ticket/edit``, ``ticket/create``, ``issue-link/create``).
+# ``Won't Do`` transitions are **not** in the applier's purview — the
+# applier produces a handoff JSON that the orchestrator drains via the
+# orchestrator-only ``/transition`` route. Restricted to write only the
+# agent-outputs handoff directory; the applier never edits source.
+APPLIER_ROLE = AgentRoleDefinition(
+    role=AgentRole.APPLIER,
+    description=(
+        "Applies Jira mutations (epic Description writes, child "
+        "create/edit/link, Won't-Do handoff) on operator approval of "
+        "refine/plan HITL gates for epic-mode pipelines."
+    ),
+    category=AgentCategory.EXECUTION,
+    responsibilities=[
+        "Read EGG_EPIC_MODE + the just-approved phase + contract path",
+        "For refine-apply: write the analysis to the epic Description",
+        "For plan-apply: walk Task.jira_action and dispatch per-action",
+        "Write jira_action_status='in_flight' before each call; flip to "
+        "'applied' or 'failed' after",
+        "Emit a Won't-Do handoff JSON for the orchestrator to drain",
+        "Refuse to mutate in-flight children without the override marker",
+    ],
+    dependencies=[],
+    file_access=FileAccessPattern(
+        allowed_read=[],
+        allowed_write=[
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=[
+            "src/",
+            "lib/",
+            "shared/",
+            "gateway/",
+            "sandbox/",
+            "action/",
+            "orchestrator/",
+            "plugins/",
+            "docs/",
+            "tests/",
+            "test/",
+            ".egg-state/contracts/",
+            ".egg-state/drafts/",
+            ".github/",
+        ],
+    ),
+    can_run_in_parallel=False,
+    produces_outputs=["jira_apply_report", "wontdo_handoff"],
+    requires_inputs=["analysis_draft", "task_breakdown"],
+)
+
+
+REVIEWER_PLAN_ROLE = AgentRoleDefinition(
+    role=AgentRole.REVIEWER_PLAN,
+    description="Reviews plan phase output quality and completeness",
+    category=AgentCategory.REVIEW,
+    responsibilities=[
+        "Verify task breakdown is discrete, actionable, and properly scoped",
+        "Assess acceptance criteria clarity and testability",
+        "Evaluate dependency ordering between tasks",
+        "Check that risks and mitigations are identified",
+        "Validate test strategy coverage",
+    ],
+    dependencies=[AgentRole.TASK_PLANNER, AgentRole.RISK_ANALYST],
+    file_access=FileAccessPattern(
+        allowed_read=[],
+        allowed_write=[
+            ".egg-state/reviews/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=_REVIEWER_BLOCKED_WRITE,
+    ),
+    produces_outputs=["review_verdict"],
+    requires_inputs=["task_breakdown", "risk_assessment"],
+)

--- a/shared/egg_contracts/agent_roles/_refine_roles.py
+++ b/shared/egg_contracts/agent_roles/_refine_roles.py
@@ -1,0 +1,196 @@
+"""Refine-phase agent role definitions (#3543 decomposition).
+
+Refine producers (refiner, simplifier; the simplifier also runs in the
+plan phase) and the refine-phase reviewers (reviewer_refine,
+reviewer_agent_design, first_principles_reviewer).
+"""
+
+from ._core import (
+    _REVIEWER_BLOCKED_WRITE,
+    AgentCategory,
+    AgentRole,
+    AgentRoleDefinition,
+    FileAccessPattern,
+)
+
+# Refine-phase agent role definitions
+
+REFINER_ROLE = AgentRoleDefinition(
+    role=AgentRole.REFINER,
+    description="Analyzes the task and produces a structured analysis in the refine phase",
+    category=AgentCategory.ANALYSIS,
+    responsibilities=[
+        "Understand the problem or feature request",
+        "Research the current codebase to understand existing patterns",
+        "Identify constraints and dependencies",
+        "Consider multiple implementation approaches with pros/cons",
+        "Recommend an approach with justification",
+        "Surface open questions as HITL decisions or feedback requests",
+        "Write analysis to the draft file (NOT an implementation plan)",
+    ],
+    dependencies=[],  # Refiner runs first, no dependencies
+    file_access=FileAccessPattern(
+        allowed_read=[],  # Can read all files
+        allowed_write=[
+            ".egg-state/drafts/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=[
+            "**/*.py",
+            "**/*.ts",
+            "**/*.tsx",
+            "**/*.js",
+            "**/*.jsx",
+            "**/*.go",
+            "**/*.java",
+            ".egg-state/contracts/",
+        ],
+    ),
+    produces_outputs=["analysis_draft"],
+    requires_inputs=[],
+)
+
+# Simplifier role (human-focused draft companions). Runs in BOTH the
+# refine and plan phases as a producer of the ``*-human.md`` companion
+# copy. It does NOT review the upstream producer — its work simply
+# depends on the producer's pushed draft, so it is sequenced via the
+# BRC dependency prompt (the coder→tester convention), not a review
+# edge. ``dependencies`` is left empty: that field feeds the
+# write-overlap / dependency-graph wave analysis (which runs per-phase
+# against the phase's role set), and this single role-def spans two
+# phases with two different upstreams, so coupling it to one producer
+# here would be wrong. File access mirrors the refiner: drafts and
+# agent-outputs only.
+SIMPLIFIER_ROLE = AgentRoleDefinition(
+    role=AgentRole.SIMPLIFIER,
+    description=(
+        "Distills the producer's draft into a jargon-free, human-focused "
+        "companion summary for a broad audience (engineers, PMs, managers) "
+        "in the refine and plan phases"
+    ),
+    category=AgentCategory.ANALYSIS,
+    responsibilities=[
+        "Read the upstream producer's draft (refine analysis or plan)",
+        "Write a simplified, higher-level companion that captures the essence",
+        "Keep it digestible for a broad audience — engineers, PMs, and "
+        "managers — readable by a non-engineer",
+        "Use no egg-internal jargon (no BRC, consensus, slice-DAG, contract, "
+        "propose/ACK/NACK, phase, or agent-role terms) and no implementation "
+        "minutiae (no file:line refs or code identifiers)",
+        "Summarise the draft — do NOT review or critique it; no ACK/NACK or "
+        "constraint-list framing in the companion",
+        "Faithfully reflect the upstream draft — introduce no new scope",
+    ],
+    dependencies=[],
+    file_access=FileAccessPattern(
+        allowed_read=[],  # Can read all files
+        allowed_write=[
+            ".egg-state/drafts/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=[
+            "**/*.py",
+            "**/*.ts",
+            "**/*.tsx",
+            "**/*.js",
+            "**/*.jsx",
+            "**/*.go",
+            "**/*.java",
+            ".egg-state/contracts/",
+        ],
+    ),
+    produces_outputs=["analysis_draft_human", "plan_draft_human"],
+    requires_inputs=["analysis_draft", "task_breakdown"],
+)
+
+
+REVIEWER_AGENT_DESIGN_ROLE = AgentRoleDefinition(
+    role=AgentRole.REVIEWER_AGENT_DESIGN,
+    description="Reviews agent-mode design alignment",
+    category=AgentCategory.REVIEW,
+    responsibilities=[
+        "Check for agent-mode design anti-patterns",
+        "Verify autonomous operation capability",
+        "Assess human-in-the-loop integration",
+    ],
+    dependencies=[AgentRole.REFINER],
+    file_access=FileAccessPattern(
+        allowed_read=[],
+        allowed_write=[
+            ".egg-state/reviews/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=_REVIEWER_BLOCKED_WRITE,
+    ),
+    produces_outputs=["review_verdict"],
+    requires_inputs=["analysis_draft"],
+)
+
+REVIEWER_REFINE_ROLE = AgentRoleDefinition(
+    role=AgentRole.REVIEWER_REFINE,
+    description="Reviews refine phase analysis quality and completeness",
+    category=AgentCategory.REVIEW,
+    responsibilities=[
+        "Verify the analysis correctly identifies the core problem",
+        "Assess research quality and codebase exploration",
+        "Evaluate options analysis and trade-off reasoning",
+        "Check that constraints and dependencies are identified",
+        "Validate the recommendation is justified and actionable",
+    ],
+    dependencies=[AgentRole.REFINER],
+    file_access=FileAccessPattern(
+        allowed_read=[],
+        allowed_write=[
+            ".egg-state/reviews/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=_REVIEWER_BLOCKED_WRITE,
+    ),
+    produces_outputs=["review_verdict"],
+    requires_inputs=["analysis_draft"],
+)
+
+# Adversarial first-principles reviewer (refine phase). Unlike
+# ``reviewer_refine`` (which judges the *quality* of the analysis) this role
+# questions the *premise and direction*: is the seed's rationale sound, is the
+# stated direction the right one, or is there a materially simpler path / a
+# better approach / a scope change — or should the work not happen at all? Its
+# subject is the operator's seed (``contract.task_description``), read against
+# codebase reality, plus the direction the refiner's draft is taking. It does
+# NOT NACK the refiner (the refiner cannot rewrite the operator-owned seed, so
+# a NACK is the wrong channel); it ACKs and, when it finds a concern worth a
+# human's call, surfaces a redirect as a phase-scoped HITL decision. Mapped to
+# ``Role.REVIEWER``; reviewers gained decision-create access in roles.py so it
+# can raise that decision itself. File access mirrors the other refine
+# reviewers: it writes its assessment to ``.egg-state/agent-outputs/`` (the
+# accept-path reads the proposed redirect back from there) and its verdict to
+# ``.egg-state/reviews/`` — never source, drafts, or contracts.
+FIRST_PRINCIPLES_REVIEWER_ROLE = AgentRoleDefinition(
+    role=AgentRole.FIRST_PRINCIPLES_REVIEWER,
+    description=(
+        "Adversarially reviews the pipeline's seed and the refiner's direction "
+        "from first principles, surfacing significant redirects as HITL "
+        "decisions in the refine phase"
+    ),
+    category=AgentCategory.REVIEW,
+    responsibilities=[
+        "Read the seed (the operator's task statement) and the refiner's draft",
+        "Question the premise: is the rationale sound and the direction right?",
+        "Surface concrete redirects where warranted — a materially simpler "
+        "path, a different approach, a scope change, or not building it at all",
+        "Raise redirects as phase-scoped HITL decisions for the operator; "
+        "never NACK the refiner on first-principles grounds",
+        "ACK the refiner once the first-principles pass is done",
+    ],
+    dependencies=[AgentRole.REFINER],
+    file_access=FileAccessPattern(
+        allowed_read=[],
+        allowed_write=[
+            ".egg-state/reviews/",
+            ".egg-state/agent-outputs/",
+        ],
+        blocked_write=_REVIEWER_BLOCKED_WRITE,
+    ),
+    produces_outputs=["review_verdict", "first_principles_assessment"],
+    requires_inputs=["analysis_draft"],
+)

--- a/shared/egg_contracts/agent_roles/_registry.py
+++ b/shared/egg_contracts/agent_roles/_registry.py
@@ -1,0 +1,452 @@
+"""Role registry, phase maps, and lookup helpers (#3543 decomposition).
+
+The ``AGENT_ROLES`` registry, the fine-to-coarse ``Role`` mapping, the
+phase-to-role maps, and every query helper (``get_role_definition``,
+``get_roles_for_phase``, ``detect_write_overlaps``, ...).
+"""
+
+from ..roles import Role
+from ._core import (
+    AgentCategory,
+    AgentExecution,
+    AgentRole,
+    AgentRoleDefinition,
+)
+from ._implement_roles import (
+    CODER_ROLE,
+    DOCUMENTER_ROLE,
+    REVIEWER_CODE_HOLISTIC_ROLE,
+    REVIEWER_CODE_ROLE,
+    REVIEWER_CONCURRENCY_ROLE,
+    REVIEWER_CONTRACT_ROLE,
+    REVIEWER_SECURITY_ROLE,
+    TESTER_ROLE,
+)
+from ._oversight_roles import (
+    AUTOFIXER_ROLE,
+    CONFLICT_RESOLVER_ROLE,
+    EVIDENCE_GATHERER_ROLE,
+    OVERSEER_ROLE,
+)
+from ._plan_roles import (
+    APPLIER_ROLE,
+    ARCHITECT_ROLE,
+    REVIEWER_PLAN_ROLE,
+    RISK_ANALYST_ROLE,
+    TASK_PLANNER_ROLE,
+)
+from ._refine_roles import (
+    FIRST_PRINCIPLES_REVIEWER_ROLE,
+    REFINER_ROLE,
+    REVIEWER_AGENT_DESIGN_ROLE,
+    REVIEWER_REFINE_ROLE,
+    SIMPLIFIER_ROLE,
+)
+
+# Registry of all agent roles
+AGENT_ROLES: dict[AgentRole, AgentRoleDefinition] = {
+    # Execution roles
+    AgentRole.CODER: CODER_ROLE,
+    AgentRole.TESTER: TESTER_ROLE,
+    AgentRole.DOCUMENTER: DOCUMENTER_ROLE,
+    AgentRole.APPLIER: APPLIER_ROLE,
+    # Analysis roles
+    AgentRole.ARCHITECT: ARCHITECT_ROLE,
+    AgentRole.TASK_PLANNER: TASK_PLANNER_ROLE,
+    AgentRole.RISK_ANALYST: RISK_ANALYST_ROLE,
+    AgentRole.REFINER: REFINER_ROLE,
+    AgentRole.SIMPLIFIER: SIMPLIFIER_ROLE,
+    # Review roles
+    AgentRole.REVIEWER_CODE: REVIEWER_CODE_ROLE,
+    AgentRole.REVIEWER_CODE_HOLISTIC: REVIEWER_CODE_HOLISTIC_ROLE,
+    AgentRole.REVIEWER_CONTRACT: REVIEWER_CONTRACT_ROLE,
+    AgentRole.REVIEWER_AGENT_DESIGN: REVIEWER_AGENT_DESIGN_ROLE,
+    AgentRole.REVIEWER_REFINE: REVIEWER_REFINE_ROLE,
+    AgentRole.FIRST_PRINCIPLES_REVIEWER: FIRST_PRINCIPLES_REVIEWER_ROLE,
+    AgentRole.REVIEWER_PLAN: REVIEWER_PLAN_ROLE,
+    AgentRole.REVIEWER_SECURITY: REVIEWER_SECURITY_ROLE,
+    AgentRole.REVIEWER_CONCURRENCY: REVIEWER_CONCURRENCY_ROLE,
+    # Utility roles
+    AgentRole.AUTOFIXER: AUTOFIXER_ROLE,
+    AgentRole.CONFLICT_RESOLVER: CONFLICT_RESOLVER_ROLE,
+    AgentRole.EVIDENCE_GATHERER: EVIDENCE_GATHERER_ROLE,
+    # Interface roles
+    AgentRole.OVERSEER: OVERSEER_ROLE,
+}
+
+
+# Canonical set of execution role string values — used by the schema,
+# plan parser, and orchestrator for role validation and filtering.
+EXECUTION_ROLE_VALUES = frozenset({AgentRole.CODER, AgentRole.TESTER, AgentRole.DOCUMENTER})
+
+
+# Reviewer roles that must have the peer's proposal *merged into their
+# working tree* to do their job — i.e. they EXECUTE the proposal (run
+# the test suite / build against the merged tree) rather than only
+# reading its diff. The BRC event-pump wrapper's ``sync_to_proposals``
+# gate (#3216, WS1 of #3209) runs ``git merge`` only for these roles on
+# a review (``ack``/``nack``) arm; every other reviewer reads peer
+# artifacts via the per-event-prompt ``git show`` / ``egg-artifact``
+# served reads, so merging the peer's whole tree into their worktree
+# only risks the dual-role criss-cross propagation that corrupts shared
+# drafts (#3208). The ``tester`` is the only reviewer that runs the
+# proposed tree; reviewer_code and the refine/plan reviewers read diffs.
+#
+# Residual: the ``tester`` is itself a dual-role agent (producer of test
+# code + reviewer) and must keep merging to execute ``make test`` against
+# the proposed tree, so the #3208 merge-then-commit-on-top criss-cross
+# shape stays *reachable via tester* in the implement phase. This gate
+# therefore does NOT fully close #3208 — it removes the shape for every
+# read-only reviewer (the plan-phase ``risk_analyst`` / ``plan.md``
+# corruption that motivated #3216). The remaining tester surface is an
+# accepted residual of WS1·1a, tracked under the parent #3209 (which
+# supersedes #3208); do not assume #3208 is closed by this set alone.
+REVIEWER_CHECKOUT_ROLE_VALUES = frozenset({AgentRole.TESTER})
+
+
+# Maps the fine-grained ``AgentRole`` shipped in agent sessions to the
+# coarse-grained ``Role`` enum used for contract field-ownership checks.
+# The gateway's contract and phase APIs consult this to authorize an
+# agent's request — without it, a session with ``agent_role="refiner"``
+# fails ``Role("refiner")`` and the API responds 403 (#1766).
+AGENT_ROLE_TO_CONTRACT_ROLE: dict[AgentRole, Role] = {
+    # Execution: produce code, own implementer-owned contract fields
+    AgentRole.CODER: Role.IMPLEMENTER,
+    AgentRole.TESTER: Role.IMPLEMENTER,
+    AgentRole.DOCUMENTER: Role.IMPLEMENTER,
+    # Applier (issue #1557): mutates Task.jira_* lifecycle fields on the
+    # contract during the apply phase; same contract privileges as other
+    # execution producers.
+    AgentRole.APPLIER: Role.IMPLEMENTER,
+    # Analysis: draft plans and analyses; write the same contract fields
+    # an implementer does (commits, notes, decisions).
+    AgentRole.ARCHITECT: Role.IMPLEMENTER,
+    AgentRole.TASK_PLANNER: Role.IMPLEMENTER,
+    AgentRole.RISK_ANALYST: Role.IMPLEMENTER,
+    AgentRole.REFINER: Role.IMPLEMENTER,
+    # Simplifier: produces the human-focused companion draft; writes the
+    # same draft/agent-output contract fields as the other analysis
+    # producers.
+    AgentRole.SIMPLIFIER: Role.IMPLEMENTER,
+    # Review: verdicts and phase-status/current_phase mutations
+    AgentRole.REVIEWER_CODE: Role.REVIEWER,
+    AgentRole.REVIEWER_CODE_HOLISTIC: Role.REVIEWER,
+    AgentRole.REVIEWER_CONTRACT: Role.REVIEWER,
+    AgentRole.REVIEWER_AGENT_DESIGN: Role.REVIEWER,
+    AgentRole.REVIEWER_REFINE: Role.REVIEWER,
+    # Pure reviewer; gains decision-create via the broadened decisions.*
+    # ownership in roles.py (it surfaces seed redirects as HITL decisions).
+    AgentRole.FIRST_PRINCIPLES_REVIEWER: Role.REVIEWER,
+    AgentRole.REVIEWER_PLAN: Role.REVIEWER,
+    AgentRole.REVIEWER_SECURITY: Role.REVIEWER,
+    AgentRole.REVIEWER_CONCURRENCY: Role.REVIEWER,
+    # Utility: apply code fixes, share implementer privileges
+    AgentRole.AUTOFIXER: Role.IMPLEMENTER,
+    AgentRole.CONFLICT_RESOLVER: Role.IMPLEMENTER,
+    # Read-only evidence gatherer: an observer like the overseer, never a
+    # contract author — SYSTEM structurally denies it verdict/contract writes.
+    AgentRole.EVIDENCE_GATHERER: Role.SYSTEM,
+    # Interface: observers, not contract authors
+    AgentRole.OVERSEER: Role.SYSTEM,
+}
+
+
+def get_contract_role(role: AgentRole | str) -> Role | None:
+    """Translate a fine-grained ``AgentRole`` to the coarse contract ``Role``.
+
+    The gateway stores the fine role in session metadata but the contract
+    API enforces field ownership against the coarse ``Role`` enum. Returns
+    ``None`` when the input does not name a known fine role.
+    """
+    if isinstance(role, str):
+        try:
+            role = AgentRole(role)
+        except ValueError:
+            return None
+    return AGENT_ROLE_TO_CONTRACT_ROLE.get(role)
+
+
+def get_role_definition(
+    role: AgentRole | str,
+) -> AgentRoleDefinition:
+    """Get the definition for an agent role.
+
+    Args:
+        role: The role to get (string or AgentRole enum)
+
+    Returns:
+        The AgentRoleDefinition for this role
+
+    Raises:
+        KeyError: If the role is not defined
+    """
+    if isinstance(role, str):
+        role = AgentRole(role)
+    return AGENT_ROLES[role]
+
+
+def get_all_roles() -> list[AgentRoleDefinition]:
+    """Get all defined agent roles.
+
+    Returns:
+        List of all AgentRoleDefinition objects
+    """
+    return list(AGENT_ROLES.values())
+
+
+def get_file_patterns(role_value: str) -> dict[str, list[str]] | None:
+    """Return file write patterns for an agent role, or None if not defined.
+
+    Returns:
+        ``{"allowed": [...], "blocked": [...]}`` or ``None`` if the role is
+        unknown or has no file access patterns.
+    """
+    try:
+        role_def = get_role_definition(role_value)
+    except ValueError, KeyError:
+        return None
+    if not role_def or not role_def.file_access:
+        return None
+    fa = role_def.file_access
+    if not fa.allowed_write and not fa.blocked_write:
+        return None
+    return {"allowed": fa.allowed_write, "blocked": fa.blocked_write}
+
+
+def get_roles_by_category(category: AgentCategory) -> list[AgentRole]:
+    """Get all roles belonging to a given category.
+
+    Args:
+        category: The category to filter by
+
+    Returns:
+        List of AgentRole values with the given category
+    """
+    return [role for role, defn in AGENT_ROLES.items() if defn.category == category]
+
+
+def get_role_dependencies(role: AgentRole | str) -> list[AgentRole]:
+    """Get the dependencies for a role.
+
+    Args:
+        role: The role to get dependencies for
+
+    Returns:
+        List of roles this role depends on
+    """
+    definition = get_role_definition(role)
+    return definition.dependencies
+
+
+def can_run_in_parallel(role1: AgentRole | str, role2: AgentRole | str) -> bool:
+    """Check if two roles can run in parallel.
+
+    Two roles can run in parallel if:
+    1. Neither depends on the other
+    2. Both have can_run_in_parallel set to True
+
+    Args:
+        role1: First role
+        role2: Second role
+
+    Returns:
+        True if the roles can run concurrently
+    """
+    def1 = get_role_definition(role1)
+    def2 = get_role_definition(role2)
+
+    # Check mutual dependencies
+    if def1.depends_on(def2.role) or def2.depends_on(def1.role):
+        return False
+
+    # Both must allow parallel execution
+    return def1.can_run_in_parallel and def2.can_run_in_parallel
+
+
+# Phase-to-role mappings for multi-agent execution
+# Note: Utility roles (AUTOFIXER, CONFLICT_RESOLVER) are excluded
+# by design — they are spawned on-demand, not as part of standard phase execution.
+
+_PHASE_ROLES: dict[str, list[AgentRole]] = {
+    "implement": [AgentRole.CODER, AgentRole.TESTER, AgentRole.DOCUMENTER],
+    "plan": [
+        AgentRole.ARCHITECT,
+        AgentRole.TASK_PLANNER,
+        AgentRole.RISK_ANALYST,
+        AgentRole.SIMPLIFIER,
+    ],
+    "refine": [AgentRole.REFINER, AgentRole.SIMPLIFIER],
+    # Apply phase (issue #1557): single producer (APPLIER) reviewed by
+    # REVIEWER_CONTRACT on contract-state convergence. Inserted between
+    # PLAN and IMPLEMENT only for epic pipelines — the orchestrator
+    # scheduler skips this phase when ``Pipeline.is_epic == False``.
+    "apply": [AgentRole.APPLIER],
+}
+
+_PHASE_REVIEWERS: dict[str, list[AgentRole]] = {
+    "implement": [
+        AgentRole.REVIEWER_CODE,
+        AgentRole.REVIEWER_CODE_HOLISTIC,
+        AgentRole.REVIEWER_CONTRACT,
+        AgentRole.REVIEWER_SECURITY,
+        AgentRole.REVIEWER_CONCURRENCY,
+    ],
+    "plan": [
+        AgentRole.REVIEWER_PLAN,
+    ],
+    "refine": [
+        AgentRole.REVIEWER_REFINE,
+        AgentRole.REVIEWER_AGENT_DESIGN,
+        AgentRole.FIRST_PRINCIPLES_REVIEWER,
+    ],
+    # Apply phase reviewer (issue #1557 — architect's slice-3 design +
+    # risk_analyst R1 mitigation). REVIEWER_CONTRACT ACKs on
+    # contract-state convergence (every Task with jira_action='create'
+    # has a non-null jira_key matching ^[A-Z][A-Z0-9_]*-[0-9]+$, every
+    # Task has jira_action_status in {'applied', 'failed'}, no in-flight
+    # child mutated without the 'in-flight-confirmed' marker). The
+    # reviewer ACKs on contract state, NOT on prompt-output text
+    # quality.
+    "apply": [
+        AgentRole.REVIEWER_CONTRACT,
+    ],
+}
+
+
+# Roles whose per-pipeline ``PipelineConfig.agent_models`` override is
+# actually honored. ``orchestrator.agent_model_resolution.resolve_agent_model``
+# is consulted only by the concurrent-executor spawn path and the
+# ``restart_agent`` route, which between them spawn every phase producer
+# and reviewer in the two maps above. Utility roles (AUTOFIXER,
+# CONFLICT_RESOLVER) spawn through dedicated paths that never call the
+# resolver. The interface role (OVERSEER) now resolves its base model
+# through ``resolve_overseer_model`` -> ``resolve_agent_model`` (#2270 §1),
+# but is not yet promoted into ``MODEL_OVERRIDE_ROLES``. Either way an
+# ``agent_models`` entry naming one of these roles is not honored today, so
+# ``PipelineConfig``'s validator rejects such keys up front. See #2769.
+MODEL_OVERRIDE_ROLES: frozenset[AgentRole] = frozenset(
+    role
+    for role_group in (*_PHASE_ROLES.values(), *_PHASE_REVIEWERS.values())
+    for role in role_group
+)
+
+
+EGG_REPO = "jwbron/egg"
+
+# Reviewer roles that only apply to the egg repo itself
+EGG_ONLY_REVIEWERS: set[AgentRole] = {AgentRole.REVIEWER_AGENT_DESIGN}
+
+# String values for use by review_graph and other modules
+EGG_ONLY_REVIEWER_NAMES: set[str] = {r.value for r in EGG_ONLY_REVIEWERS}
+
+# Reviewer roles that enforce contract-task completeness at consensus
+# time (#3114). The orchestrator rejects an enforcer's ACK of a producer
+# whose contract task rows in the active slice are not ``complete``, and
+# rejects its CONFIRM while any slice row is incomplete — making the
+# contract reviewer the structural gate that holds a slice's consensus
+# open until the contract is actually delivered. Capability set rather
+# than a hardcoded role string so a future enforcer role inherits the
+# gate without orchestrator changes.
+CONTRACT_ENFORCER_ROLES: frozenset[AgentRole] = frozenset({AgentRole.REVIEWER_CONTRACT})
+
+# String values for use by the orchestrator signal routes.
+CONTRACT_ENFORCER_ROLE_NAMES: frozenset[str] = frozenset(r.value for r in CONTRACT_ENFORCER_ROLES)
+
+
+def get_roles_for_phase(
+    phase: str,
+    include_reviewers: bool = True,
+    include_overseer: bool = False,
+    repo: str | None = None,
+    has_contract: bool = True,
+) -> list[AgentRole]:
+    """Return the agent roles for a given pipeline phase.
+
+    Args:
+        phase: Pipeline phase name (e.g., "implement", "plan")
+        include_reviewers: Whether to include reviewer roles (default True)
+        include_overseer: Whether to include the overseer role (default False).
+            The overseer is cross-phase, so it's opt-in.
+        repo: Repository in owner/name format. When provided, egg-specific
+            reviewer roles (e.g., reviewer_agent_design) are excluded for
+            non-egg repos.
+        has_contract: Whether the pipeline has an upstream SDLC contract
+            (default True). When False, reviewers whose upstream artifacts
+            are absent are filtered out — currently ``reviewer_contract``.
+            ISSUE-mode pipelines set this to False when they haven't yet
+            produced a contract draft.
+
+    Returns:
+        List of AgentRole values for that phase.
+
+    Raises:
+        ValueError: If phase has no defined roles.
+    """
+    roles = _PHASE_ROLES.get(phase)
+    if roles is None:
+        raise ValueError(f"No agent roles defined for phase: {phase}")
+    result = list(roles)
+    if include_reviewers:
+        reviewers = _PHASE_REVIEWERS.get(phase, [])
+        if repo is not None and repo != EGG_REPO:
+            reviewers = [r for r in reviewers if r not in EGG_ONLY_REVIEWERS]
+        if not has_contract:
+            # reviewer_contract has no artifacts to verify without a contract;
+            # filter it out so BRC doesn't wait on an agent that cannot ACK.
+            reviewers = [r for r in reviewers if r != AgentRole.REVIEWER_CONTRACT]
+        result.extend(reviewers)
+    if include_overseer:
+        result.append(AgentRole.OVERSEER)
+    return result
+
+
+def detect_write_overlaps(
+    roles: list[AgentRole],
+) -> list[tuple[AgentRole, AgentRole, list[str]]]:
+    """Detect overlapping write patterns between agents that may run in parallel.
+
+    Only checks roles that can run in the same wave (share no dependency edge).
+
+    Returns:
+        List of (role1, role2, overlapping_patterns) tuples.
+    """
+    from ..dependency_graph import build_dependency_graph
+
+    graph = build_dependency_graph(roles)
+    waves = graph.compute_waves()
+
+    overlaps = []
+    for wave in waves:
+        if len(wave) < 2:
+            continue
+        for i, role1 in enumerate(wave):
+            for role2 in wave[i + 1 :]:
+                role1_def = get_role_definition(role1)
+                role2_def = get_role_definition(role2)
+                # Find common write patterns
+                common = []
+                for p1 in role1_def.file_access.allowed_write:
+                    for p2 in role2_def.file_access.allowed_write:
+                        if p1 == p2:
+                            common.append(p1)
+                        elif p1.endswith("/") and p2.startswith(p1):
+                            common.append(p1)
+                        elif p2.endswith("/") and p1.startswith(p2):
+                            common.append(p2)
+                if common:
+                    overlaps.append((role1, role2, common))
+    return overlaps
+
+
+def create_execution_for_role(role: AgentRole | str) -> AgentExecution:
+    """Create a new AgentExecution for a role.
+
+    Args:
+        role: The role to create execution tracking for
+
+    Returns:
+        A new AgentExecution in PENDING status
+    """
+    if isinstance(role, str):
+        role = AgentRole(role)
+    return AgentExecution(role=role)


### PR DESCRIPTION
Closes #3543.

`shared/egg_contracts/agent_roles.py` was at 1,523 lines, over the 1,500-line hard cap, and was allowlisted with #3543 as the tracking entry. This PR decomposes it into a sub-package per [docs/guides/decomposition-pattern.md](https://github.com/jwbron/egg/blob/main/docs/guides/decomposition-pattern.md) (the #3312 pattern; `plan_parser/` is the sibling worked reference) and removes the allowlist entry.

## Layout

Two commits per the pattern: a step-0 `git mv` baseline (`agent_roles.py` -> `agent_roles/__init__.py`), then the cluster extraction.

| Submodule | Lines | Responsibility |
|-----------|-------|----------------|
| `__init__.py` (barrel) | 184 | Stable public API: explicit per-symbol re-exports + `__all__` |
| `_core.py` | 233 | `AgentCategory`/`AgentRole`/`AgentStatus` enums, `FileAccessPattern`/`AgentRoleDefinition`/`AgentExecution` dataclasses, shared reviewer blocked-write list |
| `_refine_roles.py` | 196 | Refine-phase producers and reviewers |
| `_plan_roles.py` | 185 | Plan-phase producers and reviewer, plus the apply-phase applier (#1557) |
| `_implement_roles.py` | 314 | Implement-phase producers and reviewers |
| `_oversight_roles.py` | 225 | Overseer plus on-demand utility roles |
| `_registry.py` | 452 | `AGENT_ROLES` registry, phase maps, contract-role mapping, query helpers |

Every submodule is under even the 800-line soft cap.

## Compatibility

- External-importer audit (pattern section d) ran for every symbol; the barrel re-exports the full pre-split module-global surface, including the externally-referenced `_PHASE_ROLES`, `_PHASE_REVIEWERS`, and `_REVIEWER_BLOCKED_WRITE`, plus `Role` and `match_pattern` which were importable module globals on the single-file module.
- No `unittest.mock.patch` targets against `egg_contracts.agent_roles` exist in the tree, so no patch-seam accommodations were needed.
- Pure refactor: an AST-level comparison of every top-level symbol against the pre-split file shows all definitions identical except `detect_write_overlaps`, whose only change is the relative-import depth of `dependency_graph` (plus the `..roles` import depth in the baseline commit) forced by the new nesting level.

## Verification

- `make lint` green (file-size check passes with the allowlist entry removed).
- `make test` (changeset-aware; the diff reaches ~21k tests): the only failures are 6 environment-dependent tests that fail identically on `main` in the same environment (`test_phase_api.py::TestPathTraversalProtection`, `test_git_client.py` worktrees-parent, `test_per_slice_brc_commit.py` gateway-allowlist, `test_state_store_wedge_propagation.py` health-probe), plus 2 parallelism flakes that pass serially. Zero failures introduced by this diff.
- `shared/CLAUDE.md` decomposition-seam table gains the `agent_roles/` row (pattern checklist item).