### PR TITLE
Fix BRC all-parked stall escalation, restart_agent respawn, and consensus observability (#3548)

### DIFF
--- a/orchestrator/concurrent_executor.py
+++ b/orchestrator/concurrent_executor.py
@@ -94,6 +94,13 @@ ARMS_EXHAUSTED_RESTART_OPTION = "Restart phase"
 # "Abort phase" implied an action the resolution does not take (#3496 review).
 ARMS_EXHAUSTED_ABORT_OPTION = "Abort (manual — recorded only)"
 
+# #3548: all-arms-parked HITL escalation — the no-op-park sibling of the
+# #3496 exhausted wedge. Same single-sourcing pattern; the restart/abort
+# option labels are shared with the exhausted decision so operators see one
+# vocabulary.
+ARMS_PARKED_HITL_CONTEXT = "event_arms_parked"
+ARMS_PARKED_RETRY_OPTION = "Retry arms (release no-op parks)"
+
 # Warm-resume session-store substrate (#3278). The agent's Claude session store
 # lives at ``$CLAUDE_CONFIG_DIR`` (default ``~/.claude`` = ``/home/egg/.claude``);
 # we pin it explicitly so the wrapper's pull/push and the agent agree on the path
@@ -558,6 +565,8 @@ class ConcurrentPhaseExecutor:
             active_roles_notifier=self._publish_active_roles,
             arms_exhausted_notifier=self._handle_arms_exhausted,
             arms_exhausted_cleared_notifier=self._withdraw_arms_exhausted_hitl,
+            arms_parked_notifier=self._handle_arms_parked,
+            arms_parked_cleared_notifier=self._withdraw_arms_parked_hitl,
         )
         self._event_loop = loop
         loop.start()
@@ -1254,6 +1263,166 @@ class ConcurrentPhaseExecutor:
         except Exception as exc:  # noqa: BLE001 — withdrawal must not wedge the loop
             logger.warning(
                 "Failed to auto-withdraw arms-exhausted HITL after wedge cleared",
+                pipeline_id=self.pipeline.id,
+                slice_id=self._slice_id,
+                error=str(exc),
+            )
+
+    def _handle_arms_parked(
+        self,
+        *,
+        report: list[dict[str, Any]],
+        exhausted_report: list[dict[str, Any]],
+        blocked_arms: list[tuple[str, str]],
+    ) -> None:
+        """Escalate the all-arms-parked stall to the operator (#3548).
+
+        Wired as the event loop's ``arms_parked_notifier`` — the no-op-park
+        sibling of :meth:`_handle_arms_exhausted`. Every arm the slice needs
+        in order to advance is blocked on a no-op-parked (or exhausted)
+        dedupe key with nothing in flight. A park does self-release, but
+        only for one probe spawn per fingerprint change or 30-minute
+        heartbeat; the #3548 incident sat silent for the full window with
+        ``pending_decisions`` empty. Same two surfaces and the same
+        dedup/best-effort posture as the exhausted escalation:
+
+        * an ``OVERSEER_ALERT`` broadcast (message-bus listeners), and
+        * a **persisted** HITL decision whose "Retry arms" resolution
+          releases the parks on the live loop(s) in-band
+          (``routes/decisions/_handlers.py``).
+        """
+        detail_lines = [
+            (
+                f"- {entry['role']}/{entry['action']}: "
+                f"{entry['noop_streak']} consecutive no-op completions (parked)"
+            )
+            for entry in report
+        ] + [
+            (
+                f"- {entry['role']}/{entry['action']}: streak={entry['streak']}, "
+                f"recent terminations: {entry['exit_history_text']} (exhausted)"
+            )
+            for entry in exhausted_report
+        ]
+        arms = ", ".join(f"{role}/{action}" for role, action in blocked_arms)
+        slice_label = self._slice_id or "pipeline"
+        detail = (
+            f"Event loop for pipeline={self.pipeline.id} slice={slice_label} "
+            f"phase={self.pipeline.current_phase.value} cannot advance: every "
+            f"derivable spawn arm ({arms}) is blocked on a no-op-parked (or "
+            f"exhausted) dedupe key and no one-shot Job is in flight. Each "
+            f"parked arm's agent keeps completing cleanly with zero BRC "
+            f"progress, so respawning it unchanged cannot converge the round "
+            f"— it is typically blocked on missing upstream state (e.g. a "
+            f"producer that never proposed) or an unresolved operator "
+            f"decision. Blocked arms:\n" + "\n".join(detail_lines)
+        )
+        store = None
+        try:
+            from routes import get_state_store_for_pipeline
+
+            store, disk_pipeline = get_state_store_for_pipeline(self.pipeline.id)
+            already_pending = any(
+                d.context == ARMS_PARKED_HITL_CONTEXT for d in disk_pipeline.get_pending_decisions()
+            )
+        except Exception as exc:  # noqa: BLE001 — escalation must not wedge the loop
+            logger.warning(
+                "Failed to read pending decisions for arms-parked dedup; escalating anyway",
+                pipeline_id=self.pipeline.id,
+                slice_id=self._slice_id,
+                error=str(exc),
+            )
+            already_pending = False
+
+        if already_pending:
+            logger.info(
+                "Arms-parked HITL already pending; not re-alerting or stacking another",
+                pipeline_id=self.pipeline.id,
+                slice_id=self._slice_id,
+            )
+            return
+
+        self._emit_supervision_alert(
+            anomaly="event-arms-parked",
+            priority="high",
+            summary=f"all spawn arms no-op-parked for slice {slice_label} — round stalled",
+            detail=detail,
+        )
+
+        if store is None:
+            return
+        try:
+            from routes.pipelines import _persist_hitl_decision
+
+            question = (
+                f"{detail}\n\n"
+                f"How to proceed?\n"
+                f"- '{ARMS_PARKED_RETRY_OPTION}': release the no-op parks so the "
+                f"blocked arms respawn immediately (in-band; nothing in flight "
+                f"is torn down). If the agents keep no-oping the arms will "
+                f"re-park and this decision will re-fire.\n"
+                f"- '{ARMS_EXHAUSTED_RESTART_OPTION}': tear down and re-run the "
+                f"current phase (work pushed to the shared branch is preserved).\n"
+                f"- '{ARMS_EXHAUSTED_ABORT_OPTION}': recorded only — use cancel_task "
+                f"to stop the pipeline."
+            )
+            decision = _persist_hitl_decision(
+                self.pipeline.id,
+                self.pipeline,
+                store,
+                question=question,
+                options=[
+                    ARMS_PARKED_RETRY_OPTION,
+                    ARMS_EXHAUSTED_RESTART_OPTION,
+                    ARMS_EXHAUSTED_ABORT_OPTION,
+                ],
+                phase=self.pipeline.current_phase,
+                context=ARMS_PARKED_HITL_CONTEXT,
+            )
+            if decision is not None:
+                logger.warning(
+                    "Arms-parked HITL decision created",
+                    pipeline_id=self.pipeline.id,
+                    slice_id=self._slice_id,
+                    decision_id=decision.id,
+                    blocked_arms=arms,
+                )
+        except Exception as exc:  # noqa: BLE001 — escalation must not wedge the loop
+            logger.warning(
+                "Failed to persist arms-parked HITL decision",
+                pipeline_id=self.pipeline.id,
+                slice_id=self._slice_id,
+                error=str(exc),
+            )
+
+    def _withdraw_arms_parked_hitl(self) -> None:
+        """Auto-withdraw a stale arms-parked HITL once the stall clears (#3548).
+
+        Symmetric to :meth:`_handle_arms_parked` and modeled on
+        :meth:`_withdraw_arms_exhausted_hitl`, including the pipeline-wide
+        guard: the decision is deduped across slices, so it must not be
+        withdrawn while another slice's loop is still inside an escalated
+        parked episode.
+        """
+        try:
+            from event_loop import get_live_event_loops
+            from routes import get_state_store_for_pipeline
+            from routes.pipelines import _withdraw_arms_parked_decisions
+
+            if any(loop.arms_parked_escalated for loop in get_live_event_loops(self.pipeline.id)):
+                return
+            store, _ = get_state_store_for_pipeline(self.pipeline.id)
+            withdrawn = _withdraw_arms_parked_decisions(self.pipeline.id, store)
+            if withdrawn:
+                logger.info(
+                    "Auto-withdrew stale arms-parked HITL after the stall cleared",
+                    pipeline_id=self.pipeline.id,
+                    slice_id=self._slice_id,
+                    withdrawn=withdrawn,
+                )
+        except Exception as exc:  # noqa: BLE001 — withdrawal must not wedge the loop
+            logger.warning(
+                "Failed to auto-withdraw arms-parked HITL after stall cleared",
                 pipeline_id=self.pipeline.id,
                 slice_id=self._slice_id,
                 error=str(exc),

--- a/orchestrator/event_loop/__init__.py
+++ b/orchestrator/event_loop/__init__.py
@@ -341,9 +341,11 @@ class EventDecision:
     (a deduped repeat is False). ``agent_free`` is True for confirm/complete.
     ``timing`` is a structured mapping for the slice-4 latency budget on a
     fresh spawn, ``None`` otherwise. ``blocked`` (#3496) names why a
-    spawn-action decision did not spawn when the block is terminal —
-    currently only ``"exhausted"`` — so the all-arms-exhausted detection can
-    distinguish it from the benign not-spawned shapes (dedupe, backoff, park).
+    spawn-action decision did not spawn when the block is operator-relevant:
+    ``"exhausted"`` (terminal retry-budget exhaustion) or ``"parked"``
+    (#3548 — a no-op-park that only the retry heartbeat will release), so
+    the all-arms wedge detections can distinguish them from the benign
+    not-spawned shapes (dedupe, backoff).
     """
 
     role: str
@@ -502,6 +504,8 @@ class JobSupervisor:
     _format_exit_history = _supervisor._format_exit_history
     exhausted_report = _supervisor.exhausted_report
     reset_exhausted = _supervisor.reset_exhausted
+    noop_park_report = _supervisor.noop_park_report
+    reset_noop_parks = _supervisor.reset_noop_parks
     noop_parked = _supervisor.noop_parked
     _probe_hitl_fingerprint = _supervisor._probe_hitl_fingerprint
     _probe_brc_fingerprint = _supervisor._probe_brc_fingerprint
@@ -550,6 +554,8 @@ class OrchestratorEventLoop:
         active_roles_notifier: Callable[[set[str]], Any] | None = None,
         arms_exhausted_notifier: Callable[..., Any] | None = None,
         arms_exhausted_cleared_notifier: Callable[[], Any] | None = None,
+        arms_parked_notifier: Callable[..., Any] | None = None,
+        arms_parked_cleared_notifier: Callable[[], Any] | None = None,
     ) -> None:
         self.tracker = tracker
         self.spawner = spawner
@@ -617,6 +623,14 @@ class OrchestratorEventLoop:
         # cleared when the condition no longer holds (an arm spawned, a new
         # key derived, or an operator reset cleared the exhausted set).
         self._arms_exhausted_alerted = False
+        # #3548: the no-op-park siblings of the two fields above — fired
+        # (once per wedge episode) when every derivable spawn arm is blocked
+        # on a no-op-parked (or exhausted) key with nothing in flight, and on
+        # the wedged→clear transition respectively. ``None`` (unit tests /
+        # pod mode) leaves detection dormant except for the WARN log.
+        self._arms_parked_notifier = arms_parked_notifier
+        self._arms_parked_cleared_notifier = arms_parked_cleared_notifier
+        self._arms_parked_alerted = False
 
     reconcile = _loop.reconcile
     live_dedupe_keys = _loop.live_dedupe_keys
@@ -627,6 +641,11 @@ class OrchestratorEventLoop:
     arms_exhausted_escalated = property(_loop.arms_exhausted_escalated)
     _notify_arms_exhausted_cleared = _loop._notify_arms_exhausted_cleared
     reset_exhausted_arms = _loop.reset_exhausted_arms
+    _check_arms_parked = _loop._check_arms_parked
+    arms_parked_escalated = property(_loop.arms_parked_escalated)
+    _notify_arms_parked_cleared = _loop._notify_arms_parked_cleared
+    reset_parked_arms = _loop.reset_parked_arms
+    invalidate_role_arms = _loop.invalidate_role_arms
     _publish_active_roles = _loop._publish_active_roles
     _handle_role = _loop._handle_role
     _reap_superseded_siblings = _loop._reap_superseded_siblings

--- a/orchestrator/event_loop/_loop.py
+++ b/orchestrator/event_loop/_loop.py
@@ -209,6 +209,17 @@ def poll_once(self, roles: list[str]) -> list[EventDecision]:
             slice_id=self.slice_id,
             error=str(exc),
         )
+    # #3548: judge the all-arms-parked wedge (the no-op-park sibling of the
+    # exhausted wedge) from the same tick's decisions.
+    try:
+        self._check_arms_parked(decisions)
+    except Exception as exc:  # noqa: BLE001 — never wedge the loop
+        logger.warning(
+            "event-loop arms-parked check failed",
+            pipeline_id=self.pipeline_id,
+            slice_id=self.slice_id,
+            error=str(exc),
+        )
     # Publish the post-spawn live-Job role set to the health monitor so
     # its orchestrator-mode tripwires scope to roles that actually have a
     # pod this tick (newly spawned keys above are included).
@@ -344,6 +355,167 @@ def reset_exhausted_arms(self) -> list[str]:
     return cleared
 
 
+def _check_arms_parked(self, decisions: list[EventDecision]) -> None:
+    """Detect the all-arms-parked wedge and escalate once per episode (#3548).
+
+    The no-op-park sibling of :meth:`_check_arms_exhausted`. The wedge shape
+    (the #3548 incident): every arm the tracker currently derives a spawn
+    action for is blocked — at least one on a no-op park (#3425), the rest
+    parked or exhausted — no one-shot Job is in flight, and no agent-free
+    side effect ran this tick. Unlike exhaustion a park self-releases, but
+    only for a single probe spawn per fingerprint change or per
+    ``SUPERVISION_NOOP_PARK_RETRY_SECONDS`` heartbeat; a round that is one
+    verdict away from convergence otherwise sits silent for the full
+    heartbeat window with ``pending_decisions`` empty — exactly the
+    zero-operator-signal stall the incident showed.
+
+    Fires the ``arms_parked_notifier`` (production: OVERSEER_ALERT + HITL
+    decision) with the supervisor's per-key park report, once per episode
+    via a sticky latch. The latch clears when the condition stops holding —
+    a probe spawn released, a fresh key was derived, or an operator reset
+    (:meth:`reset_parked_arms`) cleared the parks — so a wedge that
+    re-forms after a no-op probe re-escalates. The heartbeat probe cycle
+    therefore re-alerts at most once per ``SUPERVISION_NOOP_PARK_RETRY_
+    SECONDS`` while the wedge persists, which is the intended "still
+    wedged" signal, not churn.
+
+    A tick where EVERY blocked arm is exhausted belongs to
+    :meth:`_check_arms_exhausted`; this detector requires at least one
+    parked arm, so mixed parked+exhausted rounds (which the exhausted
+    detector's ``all(== "exhausted")`` predicate cannot see) are covered
+    here rather than falling between the two.
+    """
+    spawn_decisions = [d for d in decisions if d.action in SPAWN_ACTIONS]
+    wedged = (
+        bool(spawn_decisions)
+        and all(d.blocked in ("parked", "exhausted") for d in spawn_decisions)
+        and any(d.blocked == "parked" for d in spawn_decisions)
+        and not self._live_keys
+        and not any(d.agent_free for d in decisions)
+    )
+    if not wedged:
+        if self._arms_parked_alerted:
+            self._arms_parked_alerted = False
+            self._notify_arms_parked_cleared()
+        return
+    if self._arms_parked_alerted:
+        return
+    self._arms_parked_alerted = True
+    # Scope the report to the keys currently blocking a derivable spawn arm
+    # (same rationale as the exhausted check: stale keys from superseded BRC
+    # rounds must not be listed as blockers).
+    blocked_keys = {d.dedupe_key for d in spawn_decisions if d.dedupe_key}
+    report = [e for e in self.supervisor.noop_park_report() if e["dedupe_key"] in blocked_keys]
+    exhausted = [e for e in self.supervisor.exhausted_report() if e["dedupe_key"] in blocked_keys]
+    logger.warning(
+        "event-loop: all derivable spawn arms are no-op-parked (or exhausted) "
+        "— the slice cannot advance before the park retry heartbeat "
+        "(blocked arms: %s)",
+        ", ".join(f"{d.role}/{d.action}" for d in spawn_decisions),
+        pipeline_id=self.pipeline_id,
+        slice_id=self.slice_id,
+        phase=self.phase,
+    )
+    if self._arms_parked_notifier is None:
+        return
+    self._arms_parked_notifier(
+        report=report,
+        exhausted_report=exhausted,
+        blocked_arms=[(d.role, d.action) for d in spawn_decisions],
+    )
+
+
+def arms_parked_escalated(self) -> bool:
+    """True while this loop is inside an escalated all-arms-parked episode.
+
+    Read across the live-loop registry by the pipeline-wide withdrawal
+    guard, mirroring :meth:`arms_exhausted_escalated` (#3548).
+    """
+    return self._arms_parked_alerted
+
+
+def _notify_arms_parked_cleared(self) -> None:
+    """Fire the parked-wedge-cleared notifier best-effort (#3548).
+
+    Isolated so a withdrawal-side failure can never propagate into
+    ``poll_once`` and wedge the loop — same posture as
+    :meth:`_notify_arms_exhausted_cleared`.
+    """
+    if self._arms_parked_cleared_notifier is None:
+        return
+    try:
+        self._arms_parked_cleared_notifier()
+    except Exception:  # noqa: BLE001 — withdrawal must never wedge the loop
+        logger.warning(
+            "event-loop: arms-parked cleared notifier raised; ignoring",
+            pipeline_id=self.pipeline_id,
+            slice_id=self.slice_id,
+            exc_info=True,
+        )
+
+
+def reset_parked_arms(self) -> list[str]:
+    """Clear every no-op-parked key so blocked arms respawn (#3548).
+
+    The in-band recovery surface behind the all-arms-parked HITL's "Retry
+    arms" resolution — the park twin of :meth:`reset_exhausted_arms`, with
+    the same lock-free cross-thread reasoning (atomic dict/set ops under
+    the GIL; ``reset_noop_parks`` snapshots before iterating). Returns the
+    cleared keys.
+    """
+    cleared = self.supervisor.reset_noop_parks()
+    self._arms_parked_alerted = False
+    if cleared:
+        logger.info(
+            "event-loop: no-op-parked keys reset by operator — blocked arms "
+            "will respawn on the next poll",
+            pipeline_id=self.pipeline_id,
+            slice_id=self.slice_id,
+            cleared=len(cleared),
+        )
+    return cleared
+
+
+def invalidate_role_arms(self, role: str) -> list[str]:
+    """Drop all in-memory arm state for ``role`` so its next event derives fresh (#3548).
+
+    The ``restart_agent`` companion: the route deletes the role's Job and
+    resets its consensus state, but the re-derived event carries the same
+    identity — and therefore the same dedupe key — as before the restart.
+    Loop-local state then silently blocks the respawn twice over:
+
+    * the key is still in ``_live_keys`` (the route deleted the Job by
+      label, and ``_observe_jobs`` maps a missing Job to ``running``, so
+      the key never leaves the live set) — the dedupe branch eats every
+      re-derivation;
+    * the supervisor's exhaustion / no-op-park latches for the key survive
+      the restart untouched.
+
+    This drops the role's keys from ``_live_keys`` / ``_key_meta`` and
+    retires their supervisor state, so the next poll re-derives the same
+    key as *fresh* and actually spawns — making the route's "respawn
+    delegated to event loop" claim true. Same lock-free cross-thread
+    reasoning as :meth:`reset_exhausted_arms` (atomic dict/set ops under
+    the GIL, snapshot before iterating). Returns the invalidated keys.
+    """
+    invalidated = sorted(
+        key for key, (_action, key_role) in list(self._key_meta.items()) if key_role == role
+    )
+    for key in invalidated:
+        self._live_keys.discard(key)
+        self._key_meta.pop(key, None)
+        self.supervisor.retire(key)
+    if invalidated:
+        logger.info(
+            "event-loop: invalidated arms for restarted role — next poll derives them fresh",
+            pipeline_id=self.pipeline_id,
+            slice_id=self.slice_id,
+            role=role,
+            invalidated=len(invalidated),
+        )
+    return invalidated
+
+
 def _publish_active_roles(self) -> None:
     """Push the set of roles with a live one-shot Job to the monitor.
 
@@ -447,7 +619,9 @@ def _handle_role(self, role: str) -> EventDecision:
             action=action,
             dedupe_key=key,
         )
-        return EventDecision(role=role, action=action, dedupe_key=key, spawned=False)
+        return EventDecision(
+            role=role, action=action, dedupe_key=key, spawned=False, blocked="parked"
+        )
 
     # #3337: serialize same-role producers. We are about to spawn a *fresh*
     # event for ``role``; any other live key for this same role belongs to

--- a/orchestrator/event_loop/_loop.py
+++ b/orchestrator/event_loop/_loop.py
@@ -497,10 +497,25 @@ def invalidate_role_arms(self, role: str) -> list[str]:
     delegated to event loop" claim true. Same lock-free cross-thread
     reasoning as :meth:`reset_exhausted_arms` (atomic dict/set ops under
     the GIL, snapshot before iterating). Returns the invalidated keys.
+
+    Key discovery must NOT rely on ``_key_meta`` alone (#3548 review): a
+    no-op-parked key has already been popped from ``_key_meta`` (and
+    ``_live_keys``) by ``_observe_jobs`` on the clean completion that
+    parked it, and the park early-return in :meth:`_handle_role` never
+    re-adds it. That is precisely the incident shape — every spawn arm
+    no-op-parked — so a ``_key_meta``-only scan would find nothing and the
+    park latch would survive, re-parking the re-derived key on the next
+    poll and making ``restart_agent`` a silent no-op. So union the
+    ``_key_meta`` keys with the supervisor's own parked/exhausted keys for
+    the role (from :meth:`noop_park_report` / :meth:`exhausted_report`,
+    which carry the role via ``_last_action``), mirroring how
+    :meth:`reset_parked_arms` / :meth:`reset_exhausted_arms` reach into the
+    supervisor's ``_noop_streaks`` / ``_exhausted`` directly.
     """
-    invalidated = sorted(
-        key for key, (_action, key_role) in list(self._key_meta.items()) if key_role == role
-    )
+    keys = {key for key, (_action, key_role) in list(self._key_meta.items()) if key_role == role}
+    keys.update(e["dedupe_key"] for e in self.supervisor.noop_park_report() if e["role"] == role)
+    keys.update(e["dedupe_key"] for e in self.supervisor.exhausted_report() if e["role"] == role)
+    invalidated = sorted(keys)
     for key in invalidated:
         self._live_keys.discard(key)
         self._key_meta.pop(key, None)

--- a/orchestrator/event_loop/_supervisor.py
+++ b/orchestrator/event_loop/_supervisor.py
@@ -55,6 +55,13 @@ def record_success(self, dedupe_key: str, *, action: str = "", role: str = "") -
         dedupe_key,
         streak,
     )
+    if streak >= SUPERVISION_NOOP_STREAK_PARK:
+        # Record the arm labels for the parked key. ``_last_action`` is
+        # otherwise written only by ``record_abort``, so a key that parked
+        # without ever aborting would surface as an anonymous ``/`` row in
+        # ``noop_park_report()`` (#3548).
+        if action or role:
+            self._last_action[dedupe_key] = (action, role)
     if streak >= SUPERVISION_NOOP_STREAK_PARK and not self._alerted_noop.get(dedupe_key, False):
         self._alerted_noop[dedupe_key] = True
         fingerprint = self._probe_hitl_fingerprint()
@@ -369,6 +376,61 @@ def reset_exhausted(self) -> list[str]:
     if cleared:
         logger.info(
             "JobSupervisor: operator reset cleared %d exhausted key(s) — fresh spawn budgets: %s",
+            len(cleared),
+            ", ".join(cleared),
+        )
+    return cleared
+
+
+def noop_park_report(self) -> list[dict[str, Any]]:
+    """Describe every no-op-parked key for operator surfacing (#3548).
+
+    Mirror of :meth:`exhausted_report` for the successful-no-op park
+    (#3425): one entry per key whose clean-completion streak reached
+    ``SUPERVISION_NOOP_STREAK_PARK`` — the arm it belongs to and the no-op
+    streak length. This is what the all-arms-parked HITL escalation embeds
+    so the operator can see WHICH arms keep running to no effect without
+    grepping pod logs. Sorted by (role, action) for stable rendering.
+    """
+    report = []
+    for key, streak in self._noop_streaks.items():
+        if streak < SUPERVISION_NOOP_STREAK_PARK:
+            continue
+        action, role = self._last_action.get(key, ("", ""))
+        report.append(
+            {
+                "dedupe_key": key,
+                "role": role,
+                "action": action,
+                "noop_streak": streak,
+            }
+        )
+    report.sort(key=lambda e: (e["role"], e["action"], e["dedupe_key"]))
+    return report
+
+
+def reset_noop_parks(self) -> list[str]:
+    """Forget ALL supervision state for every no-op-parked key (#3548).
+
+    The in-band recovery primitive behind the all-arms-parked HITL's
+    "Retry arms" resolution — the park twin of :meth:`reset_exhausted`.
+    A park does self-release (fingerprint movement / retry heartbeat),
+    but each release grants only a single probe spawn that re-parks on
+    the next no-op; an operator who has fixed the underlying wedge wants
+    the streaks gone so the arms run freely again. Full ``retire`` for
+    the same latch reasons as :meth:`reset_exhausted`.
+
+    Returns the cleared keys (sorted) so callers can report them.
+    """
+    cleared = sorted(
+        key for key, streak in self._noop_streaks.items() if streak >= SUPERVISION_NOOP_STREAK_PARK
+    )
+    for key in cleared:
+        self.retire(key)
+    if cleared:
+        logger.info(
+            "JobSupervisor: operator reset cleared %d no-op-parked key(s) — "
+            "fresh spawn budgets: %s",
             len(cleared),
             ", ".join(cleared),
         )

--- a/orchestrator/mcp_tools/_consensus.py
+++ b/orchestrator/mcp_tools/_consensus.py
@@ -22,8 +22,23 @@ def _structured_consensus(consensus: dict[str, Any]) -> dict[str, Any]:
     Derives ``confirmed_agents`` from the per-role ``confirmed`` flags so
     the structured path and the message-inference fallback expose the
     same top-level fields (#3481).
+
+    #3548: also surfaces the recorded verdicts (``review_edges`` +
+    ``proposal_versions``) and the ``zero_proposal_producers`` confirm
+    blocker. Before this, a recorded ACK was invisible in the tool result
+    — the reviewer stayed ``reviewer_phase: REVIEWING`` with
+    ``confirmed: false`` both before and after ACKing — and the actual
+    convergence blocker (the global zero-proposal guard rejecting every
+    confirm while some producer has no proposal) was unnamed, which is
+    what let the #3548 incident be misread as "acks accepted but lost".
     """
     agents = dict(consensus.get("agents", {}))
+    # The status route's ``_consensus_block`` computes these compact
+    # projections from the tracker's approval matrix; pass them through
+    # (defaulting to empty for older/inference-shaped blocks).
+    proposal_versions = dict(consensus.get("proposal_versions") or {})
+    review_edges = list(consensus.get("review_edges") or [])
+    zero_proposal_producers = list(consensus.get("zero_proposal_producers") or [])
     return {
         "is_complete": consensus.get("is_complete", False),
         "confirmed_agents": [
@@ -35,6 +50,9 @@ def _structured_consensus(consensus: dict[str, Any]) -> dict[str, Any]:
         "has_unresolved_nacks": consensus.get("has_unresolved_nacks", False),
         "unresolved_nacks": consensus.get("unresolved_nacks", []),
         "agents": agents,
+        "proposal_versions": proposal_versions,
+        "review_edges": review_edges,
+        "zero_proposal_producers": zero_proposal_producers,
     }
 
 

--- a/orchestrator/redis_message_store.py
+++ b/orchestrator/redis_message_store.py
@@ -399,6 +399,18 @@ class RedisMessageStore:
                 return False
             return True
 
+        # Capped tail read (#3548): a non-blocking, cursor-less read is a
+        # "recent messages" query (operator views, the snapshot's
+        # recent_messages, consensus inference, tracker reconstruction).
+        # XRANGE from ``0-0`` with a count cap returns the OLDEST ``count``
+        # entries, so once the stream outgrows the cap these callers saw a
+        # frozen head-of-stream window and concluded the bus was dead — the
+        # #3548 incident's "no CONSENSUS_ACK ever appears on the bus"
+        # misdiagnosis. Read the NEWEST entries instead (XREVRANGE, restored
+        # to chronological order). Cursor / timestamp / from_tip / blocking
+        # reads keep forward semantics — their start id bounds the window.
+        tail_read = since_id is None and since is None and not from_tip and wait <= 0
+
         def _read_once(
             read_start_id: str, block_ms: int | None
         ) -> tuple[list[Message], str | None]:
@@ -411,14 +423,22 @@ class RedisMessageStore:
                         block=block_ms,
                     )
                 else:
-                    # Non-blocking read — XRANGE for everything after
-                    # read_start_id. Exclusive start when since_id is set.
-                    exclusive_start = (
-                        self._increment_stream_id(read_start_id)
-                        if since_id and read_start_id != "0-0"
-                        else read_start_id
-                    )
-                    result_entries = self._redis.xrange(key, min=exclusive_start, count=limit * 3)
+                    if tail_read:
+                        # Newest ``limit * 3`` entries, oldest→newest so the
+                        # downstream filters and ``[-limit:]`` truncation keep
+                        # working unchanged.
+                        result_entries = list(reversed(self._redis.xrevrange(key, count=limit * 3)))
+                    else:
+                        # Non-blocking read — XRANGE for everything after
+                        # read_start_id. Exclusive start when since_id is set.
+                        exclusive_start = (
+                            self._increment_stream_id(read_start_id)
+                            if since_id and read_start_id != "0-0"
+                            else read_start_id
+                        )
+                        result_entries = self._redis.xrange(
+                            key, min=exclusive_start, count=limit * 3
+                        )
                     result = (
                         [
                             (

--- a/orchestrator/routes/decisions/__init__.py
+++ b/orchestrator/routes/decisions/__init__.py
@@ -101,6 +101,7 @@ from ._handlers import (  # noqa: E402,F401
     _maybe_apply_first_principles_redirect,
     _maybe_complete_task_from_resolution,
     _maybe_dispatch_arms_exhausted_resolution,
+    _maybe_dispatch_arms_parked_resolution,
     _maybe_dispatch_consensus_timeout_resolution,
     _normalize_choice_resolution,
     _read_first_principles_redirect,

--- a/orchestrator/routes/decisions/_handlers.py
+++ b/orchestrator/routes/decisions/_handlers.py
@@ -607,6 +607,104 @@ def _maybe_dispatch_arms_exhausted_resolution(
     }
 
 
+def _maybe_dispatch_arms_parked_resolution(
+    pipeline_id: str,
+    decision: Any,
+    resolution_label: str | None,
+) -> dict[str, Any] | None:
+    """Execute an arms-parked HITL resolution (#3548).
+
+    The no-op-park twin of :func:`_maybe_dispatch_arms_exhausted_resolution`:
+
+    - **Retry arms (release no-op parks)** → clear the no-op-parked keys on
+      every live event loop registered for this pipeline so the blocked
+      arms respawn immediately instead of waiting out the park retry
+      heartbeat. Reports the cleared keys per slice; fails informatively
+      when no live loop exists.
+    - **Restart phase** → tear down and re-run the decision's phase
+      (shared ``_execute_restart_phase`` executor).
+    - **Abort (manual — recorded only)** → recorded only; points at
+      ``cancel_task``.
+    """
+    from concurrent_executor import (
+        ARMS_EXHAUSTED_ABORT_OPTION,
+        ARMS_EXHAUSTED_RESTART_OPTION,
+        ARMS_PARKED_HITL_CONTEXT,
+        ARMS_PARKED_RETRY_OPTION,
+    )
+
+    if getattr(decision, "context", "") != ARMS_PARKED_HITL_CONTEXT:
+        return None
+
+    label = (resolution_label or "").strip()
+
+    if label == ARMS_EXHAUSTED_ABORT_OPTION:
+        return {
+            "action": "arms_parked_abort",
+            "success": True,
+            "note": (
+                "Recorded only — aborting is not automated from this "
+                "decision. Use cancel_task to stop the pipeline, or resolve "
+                "again with 'Restart phase' to re-run it."
+            ),
+        }
+
+    if label == ARMS_EXHAUSTED_RESTART_OPTION:
+        return _execute_restart_phase(
+            pipeline_id, decision, log_label="Arms-parked 'Restart phase'"
+        )
+
+    if label != ARMS_PARKED_RETRY_OPTION:
+        return None
+
+    from event_loop import get_live_event_loops
+
+    loops = get_live_event_loops(pipeline_id)
+    if not loops:
+        logger.warning(
+            "Arms-parked 'Retry arms' resolution found no live event loop",
+            pipeline_id=pipeline_id,
+            decision_id=getattr(decision, "id", "?"),
+        )
+        return {
+            "action": "reset_parked_arms",
+            "success": False,
+            "error": (
+                "no live event loop for this pipeline — the orchestrator "
+                "likely restarted since the decision was raised (supervision "
+                "state is per-process and resets on restart). If the "
+                "pipeline is still stalled, resolve with 'Restart phase'."
+            ),
+        }
+
+    cleared_by_slice: dict[str, list[str]] = {}
+    for loop in loops:
+        cleared = loop.reset_parked_arms()
+        if cleared:
+            cleared_by_slice[loop.slice_id or "pipeline"] = cleared
+    total = sum(len(keys) for keys in cleared_by_slice.values())
+    logger.info(
+        "Arms-parked 'Retry arms' resolution released no-op parks",
+        pipeline_id=pipeline_id,
+        decision_id=getattr(decision, "id", "?"),
+        cleared=total,
+        slices=sorted(cleared_by_slice),
+    )
+    return {
+        "action": "reset_parked_arms",
+        "success": True,
+        "cleared_total": total,
+        "cleared_by_slice": cleared_by_slice,
+        "note": (
+            "No-op parks were released; the blocked arms respawn on the "
+            "next event-loop poll. If the agents keep no-oping the arms "
+            "will re-park and this decision will re-fire."
+            if total
+            else "No parked keys were held by the live event loop(s); nothing to clear."
+        ),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Executable adds_task option (#3428)
 # ---------------------------------------------------------------------------

--- a/orchestrator/routes/decisions/_resolve.py
+++ b/orchestrator/routes/decisions/_resolve.py
@@ -192,6 +192,12 @@ def resolve_decision(pipeline_id: str, decision_id: str) -> tuple[Response, int]
             pipeline_id, decision, dispatch_resolution
         )
 
+        # Arms-parked HITL (#3548): the no-op-park sibling — "Retry arms"
+        # releases the no-op parks on the live event loop(s) in-band.
+        executed_action = executed_action or _pkg._maybe_dispatch_arms_parked_resolution(
+            pipeline_id, decision, dispatch_resolution
+        )
+
         # Executable adds_task option (#3428): an option registered with a
         # structured contract mutation ("add a task/slice") materializes it
         # on resolve instead of recording an inert choice.

--- a/orchestrator/routes/pipelines/__init__.py
+++ b/orchestrator/routes/pipelines/__init__.py
@@ -1184,6 +1184,7 @@ from ._decisions import (  # noqa: E402,F401
     _incomplete_consensus_decision_text,
     _persist_hitl_decision,
     _withdraw_arms_exhausted_decisions,
+    _withdraw_arms_parked_decisions,
 )
 
 # drafts helpers live in _drafts.py (#3312 slice-4); re-exported here.

--- a/orchestrator/routes/pipelines/_decisions.py
+++ b/orchestrator/routes/pipelines/_decisions.py
@@ -190,6 +190,36 @@ def _withdraw_arms_exhausted_decisions(pipeline_id: str, store: _pkg.StateStore)
     return withdrawn
 
 
+def _withdraw_arms_parked_decisions(pipeline_id: str, store: _pkg.StateStore) -> int:
+    """Cancel any pending arms-parked HITL on ``pipeline_id`` (#3548).
+
+    The parked twin of :func:`_withdraw_arms_exhausted_decisions`: when the
+    all-arms-parked stall clears by a route other than the operator resolving
+    this decision (a probe spawn made progress, a fresh key was derived, the
+    round converged) the pending ``event_arms_parked`` decision is obsolete,
+    so this withdraws it rather than leaving the operator to dispose of it.
+    Same own-lock load → cancel → save shape.
+    """
+    from concurrent_executor import ARMS_PARKED_HITL_CONTEXT
+
+    with _pkg.get_pipeline_state_lock(pipeline_id):
+        disk_pipeline = store.load_pipeline(pipeline_id)
+        withdrawn = 0
+        for decision in disk_pipeline.get_pending_decisions():
+            if decision.context != ARMS_PARKED_HITL_CONTEXT:
+                continue
+            decision.status = _pkg.DecisionStatus.CANCELLED
+            decision.resolution = (
+                "auto-withdrawn: the stall cleared (blocked arms recovered) "
+                "before this decision was resolved"
+            )
+            decision.resolved_at = _pkg.datetime.now(_pkg.UTC)
+            withdrawn += 1
+        if withdrawn:
+            store.save_pipeline(disk_pipeline)
+    return withdrawn
+
+
 def _find_pending_divergence_reconcile_decision(pipeline: _pkg.Pipeline):
     """Return the oldest pending reconcile HITL on ``pipeline`` (or None).
 

--- a/orchestrator/routes/pipelines/_routes_restart.py
+++ b/orchestrator/routes/pipelines/_routes_restart.py
@@ -444,6 +444,44 @@ def _restart_agent_body(pipeline_id: str, agent_role: str) -> tuple[_pkg.Respons
             error=str(e),
         )
 
+    # Invalidate the role's arms on the live event loop (#3548). The consensus
+    # reset above makes the loop re-derive the role's event, but with the SAME
+    # identity — and therefore the same dedupe key — as before the restart.
+    # Loop-local state then silently blocks the respawn: the key is still in
+    # ``_live_keys`` (the Job deletion above maps to "running" in
+    # ``_observe_jobs``, so the key never leaves the live set), and any
+    # exhaustion / no-op-park latches for it survive untouched. Without this
+    # reach-in the "respawn delegated to event loop" claim below is false —
+    # the loop never derives a spawn for the role (observed twice in the
+    # #3548 incident). Uses the same live-loop registry seam as the
+    # arms-exhausted HITL "Retry arms" resolution.
+    live_loop_found = False
+    invalidated_keys = 0
+    try:
+        from event_loop import get_live_event_loops
+
+        for _loop in get_live_event_loops(pipeline_id):
+            if _loop.slice_id != slice_id:
+                continue
+            live_loop_found = True
+            invalidated_keys += len(_loop.invalidate_role_arms(agent_role))
+        _pkg.logger.info(
+            "restart_agent: invalidated event-loop arms for role",
+            pipeline_id=pipeline_id,
+            agent_role=agent_role,
+            slice_id=slice_id,
+            live_loop_found=live_loop_found,
+            invalidated_keys=invalidated_keys,
+        )
+    except Exception as e:  # noqa: BLE001 - best-effort reach-in
+        _pkg.logger.warning(
+            "Failed to invalidate event-loop arms for restarted role",
+            pipeline_id=pipeline_id,
+            agent_role=agent_role,
+            slice_id=slice_id,
+            error=str(e),
+        )
+
     # Reset health-monitor anchor so the pre-respawn _last_heartbeat does not
     # generate a stale-elapsed heartbeat_timeout alert against the fresh
     # container (issue #2084).
@@ -533,10 +571,26 @@ def _restart_agent_body(pipeline_id: str, agent_role: str) -> tuple[_pkg.Respons
     # on, so it correctly reports the operator's "you've burned N of M
     # restarts" telemetry — the pre-fix read-only ``get_restart_count`` read
     # always reported 0 here because nothing on this path incremented it.
+    # Honest respawn reporting (#3548): "delegated to the event loop" is only
+    # true when a live loop for this (pipeline, slice) exists to honor the
+    # delegation (or the inactive-pipeline branch below relaunches one). When
+    # the pipeline is RUNNING but no loop matched, say so instead of
+    # reporting a success that will never materialize.
+    if live_loop_found:
+        respawn_note = "delegated to orchestrator event loop"
+    elif pipeline_was_inactive:
+        respawn_note = "driver thread relaunched; event loop will respawn the role"
+    else:
+        respawn_note = (
+            "no live event loop for this slice — no respawn will occur; "
+            "restart the phase if the agent must re-run"
+        )
     response_data: dict[str, object] = {
         "agent_role": agent_role,
         "slice_id": slice_id,
-        "respawn": "delegated to orchestrator event loop",
+        "respawn": respawn_note,
+        "live_event_loop": live_loop_found,
+        "arms_invalidated": invalidated_keys,
         "restart_count": new_restart_count,
     }
 

--- a/orchestrator/routes/pipelines/_status_view.py
+++ b/orchestrator/routes/pipelines/_status_view.py
@@ -50,16 +50,47 @@ def _consensus_block(consensus_state: dict) -> dict:
     NACKed whom, on which version, and why; #3481) and drops the
     bulky ``approval_matrix`` / ``review_graph`` dumps.
 
+    #3548: the slimming used to drop the recorded verdicts entirely, so a
+    landed ACK was indistinguishable from a lost one (the reviewer shows
+    ``reviewer_phase: REVIEWING`` + ``confirmed: false`` either way) and
+    the zero-proposal confirm blocker was unnamed. Keep compact
+    projections of both: ``proposal_versions``, a 4-field
+    ``review_edges`` list, and ``zero_proposal_producers`` (producers
+    with no proposal — the global confirm guard rejects every confirm
+    while this set is non-empty).
+
     BRC trackers only emit dict-format agent entries (the legacy
     AgentReadiness object came from the now-deleted ConsensusEvaluator,
     cq-5 of #2777).
     """
+    agents = dict(consensus_state.get("agents", {}))
+    matrix = consensus_state.get("approval_matrix") or {}
+    proposal_versions = dict(matrix.get("proposal_versions") or {})
+    review_edges = [
+        {
+            "reviewer": entry.get("reviewer_role"),
+            "producer": entry.get("producer_role"),
+            "state": entry.get("state"),
+            "version": entry.get("version"),
+        }
+        for entry in (matrix.get("entries") or {}).values()
+        if isinstance(entry, dict)
+    ]
+    review_edges.sort(key=lambda e: (str(e["producer"]), str(e["reviewer"])))
+    zero_proposal_producers = sorted(
+        role
+        for role, info in agents.items()
+        if isinstance(info, dict) and "producer_phase" in info and not proposal_versions.get(role)
+    )
     return {
-        "agents": dict(consensus_state.get("agents", {})),
+        "agents": agents,
         "is_complete": consensus_state.get("is_complete", False),
         "blocking_agents": consensus_state.get("blocking_agents", []),
         "has_unresolved_nacks": consensus_state.get("has_unresolved_nacks", False),
         "unresolved_nacks": consensus_state.get("unresolved_nacks", []),
+        "proposal_versions": proposal_versions,
+        "review_edges": review_edges,
+        "zero_proposal_producers": zero_proposal_producers,
         "protocol": consensus_state.get("protocol", "brc"),
     }
 

--- a/orchestrator/tests/test_arms_parked_stall.py
+++ b/orchestrator/tests/test_arms_parked_stall.py
@@ -1,0 +1,660 @@
+"""Tests for the all-arms-parked stall surfacing + restart-arm invalidation (#3548).
+
+The incident: after a mid-slice orchestrator restart, the producers'
+propose arms no-op-parked (their one-shot agents kept exiting cleanly with
+zero BRC progress) while the round could not converge (the zero-proposal
+guard rejects every confirm until every producer proposes). The event loop
+sat silent for the full 30-minute park heartbeat with ``pending_decisions``
+empty, and ``restart_agent`` reported "respawn delegated to event loop"
+while the loop's ``_live_keys`` dedupe + supervisor latches guaranteed no
+respawn would ever derive. These tests pin the fixes:
+
+* the park early-return tags its decision ``blocked="parked"`` so the
+  wedge detection can see it;
+* the supervisor exposes ``noop_park_report()`` / ``reset_noop_parks()``
+  (the park twins of the #3496 exhausted primitives);
+* the loop detects the all-arms-parked wedge (including mixed
+  parked+exhausted rounds, which fall outside the #3496 detector) and
+  fires ``arms_parked_notifier`` once per episode, with a cleared
+  notifier on the wedged→clear transition;
+* the executor escalates the wedge as an OVERSEER_ALERT + a persisted
+  HITL decision deduped on the ``event_arms_parked`` context;
+* the resolve-decision dispatch executes "Retry arms (release no-op
+  parks)" against the live-loop registry;
+* ``OrchestratorEventLoop.invalidate_role_arms`` drops a restarted role's
+  keys from ``_live_keys`` / ``_key_meta`` and retires their supervisor
+  state, so the restart route's delegation claim is actually true.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_orchestrator_path = Path(__file__).parent.parent
+if str(_orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_path))
+
+_shared_path = Path(__file__).parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+
+# ---------------------------------------------------------------------------
+# Test doubles (mirroring test_arms_exhausted_livelock.py's conventions)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSpawner:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def spawn_event(self, *, role, action, dedupe_key, payload=None):
+        self.calls.append({"role": role, "action": action, "dedupe_key": dedupe_key})
+        return dedupe_key
+
+
+class _ManualClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+class _NotifierSpy:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+class _ClearedSpy:
+    def __init__(self) -> None:
+        self.count = 0
+
+    def __call__(self) -> None:
+        self.count += 1
+
+
+_ACK_PAYLOAD = {"pending_reviews": [{"producer": "documenter", "proposal_commit_sha": "d4df6c7"}]}
+_PROPOSE_PAYLOAD = {"producer": "coder"}
+
+
+def _script(monkeypatch, mapping):
+    import event_loop
+
+    def _fake_derive(tracker, role):
+        return mapping.get(role, ("wait", None, "scripted-default"))
+
+    monkeypatch.setattr(event_loop, "_derive_next_action", _fake_derive, raising=True)
+
+
+def _make_loop(
+    spawner,
+    *,
+    supervisor,
+    clock=None,
+    roles=None,
+    parked_notifier=None,
+    parked_cleared_notifier=None,
+    exhausted_notifier=None,
+    pipeline_id="issue-3548",
+    slice_id="slice-8",
+):
+    import event_loop
+
+    return event_loop.OrchestratorEventLoop(
+        tracker=object(),
+        spawner=spawner,
+        pipeline_id=pipeline_id,
+        slice_id=slice_id,
+        phase="implement",
+        clock=clock or _ManualClock(),
+        roles=roles or ["coder"],
+        job_supervisor=supervisor,
+        arms_exhausted_notifier=exhausted_notifier,
+        arms_parked_notifier=parked_notifier,
+        arms_parked_cleared_notifier=parked_cleared_notifier,
+    )
+
+
+def _key_for(loop, role, action, payload):
+    import event_loop
+
+    identity = event_loop.event_identity(action, payload)
+    return event_loop.compute_dedupe_key(
+        loop.pipeline_id, loop.slice_id, loop.phase, role, action, identity
+    )
+
+
+def _park(supervisor, key, action, role):
+    import supervision_policy
+
+    for _ in range(supervision_policy.SUPERVISION_NOOP_STREAK_PARK):
+        supervisor.record_success(key, action=action, role=role)
+
+
+def _exhaust(supervisor, key, action, role):
+    import supervision_policy
+
+    for _ in range(supervision_policy.SUPERVISION_FAILURE_STREAK_ALERT):
+        supervisor.record_abort(key, action, role)
+    assert supervisor.is_exhausted(key)
+
+
+# ---------------------------------------------------------------------------
+# Supervisor: noop_park_report + reset_noop_parks
+# ---------------------------------------------------------------------------
+
+
+class TestNoopParkPrimitives:
+    def test_park_report_shape(self):
+        import event_loop
+        import supervision_policy
+
+        supervisor = event_loop.JobSupervisor(clock=_ManualClock())
+        _park(supervisor, "key-a", "propose", "coder")
+        supervisor.record_success("key-b", action="ack", role="reviewer_code")  # not parked
+
+        report = supervisor.noop_park_report()
+        assert len(report) == 1
+        entry = report[0]
+        assert entry["dedupe_key"] == "key-a"
+        assert entry["role"] == "coder"
+        assert entry["action"] == "propose"
+        assert entry["noop_streak"] == supervision_policy.SUPERVISION_NOOP_STREAK_PARK
+
+    def test_reset_noop_parks_clears_and_returns_keys(self):
+        import event_loop
+
+        clock = _ManualClock()
+        supervisor = event_loop.JobSupervisor(clock=clock)
+        _park(supervisor, "key-a", "propose", "coder")
+        assert supervisor.noop_parked("key-a")
+
+        cleared = supervisor.reset_noop_parks()
+        assert cleared == ["key-a"]
+        assert not supervisor.noop_parked("key-a")
+        assert supervisor.noop_park_report() == []
+
+    def test_reset_noop_parks_ignores_sub_threshold_streaks(self):
+        import event_loop
+
+        supervisor = event_loop.JobSupervisor(clock=_ManualClock())
+        supervisor.record_success("key-b", action="ack", role="reviewer_code")
+        assert supervisor.reset_noop_parks() == []
+
+
+# ---------------------------------------------------------------------------
+# Loop: park tagging + all-parked wedge detection
+# ---------------------------------------------------------------------------
+
+
+class TestArmsParkedThroughLoop:
+    def test_park_decision_tagged_blocked_parked(self, monkeypatch):
+        import event_loop
+
+        clock = _ManualClock()
+        supervisor = event_loop.JobSupervisor(clock=clock)
+        spawner = _RecordingSpawner()
+        loop = _make_loop(spawner, supervisor=supervisor, clock=clock)
+        _script(monkeypatch, {"coder": ("propose", _PROPOSE_PAYLOAD, "scripted")})
+
+        key = _key_for(loop, "coder", "propose", _PROPOSE_PAYLOAD)
+        _park(supervisor, key, "propose", "coder")
+
+        decisions = loop.poll_once(loop._roles)
+        assert len(decisions) == 1
+        assert decisions[0].blocked == "parked"
+        assert decisions[0].spawned is False
+        assert spawner.calls == []
+
+    def test_all_parked_wedge_fires_notifier_once(self, monkeypatch):
+        import event_loop
+
+        clock = _ManualClock()
+        supervisor = event_loop.JobSupervisor(clock=clock)
+        spawner = _RecordingSpawner()
+        notifier = _NotifierSpy()
+        loop = _make_loop(
+            spawner,
+            supervisor=supervisor,
+            clock=clock,
+            roles=["coder", "tester"],
+            parked_notifier=notifier,
+        )
+        _script(
+            monkeypatch,
+            {
+                "coder": ("propose", _PROPOSE_PAYLOAD, "scripted"),
+                "tester": ("propose", {"producer": "tester"}, "scripted"),
+            },
+        )
+        for role, payload in (("coder", _PROPOSE_PAYLOAD), ("tester", {"producer": "tester"})):
+            _park(supervisor, _key_for(loop, role, "propose", payload), "propose", role)
+
+        loop.poll_once(loop._roles)
+        assert len(notifier.calls) == 1
+        call = notifier.calls[0]
+        assert set(call["blocked_arms"]) == {("coder", "propose"), ("tester", "propose")}
+        roles = {entry["role"] for entry in call["report"]}
+        assert roles == {"coder", "tester"}
+
+        # Sticky latch: a second wedged tick does not re-fire.
+        loop.poll_once(loop._roles)
+        assert len(notifier.calls) == 1
+
+    def test_mixed_parked_and_exhausted_counts_as_wedged(self, monkeypatch):
+        """A round with one parked and one exhausted arm falls outside the
+        #3496 all-exhausted predicate; the parked detector must own it."""
+        import event_loop
+
+        clock = _ManualClock()
+        supervisor = event_loop.JobSupervisor(clock=clock)
+        spawner = _RecordingSpawner()
+        parked_notifier = _NotifierSpy()
+        exhausted_notifier = _NotifierSpy()
+        loop = _make_loop(
+            spawner,
+            supervisor=supervisor,
+            clock=clock,
+            roles=["coder", "reviewer_code"],
+            parked_notifier=parked_notifier,
+            exhausted_notifier=exhausted_notifier,
+        )
+        _script(
+            monkeypatch,
+            {
+                "coder": ("propose", _PROPOSE_PAYLOAD, "scripted"),
+                "reviewer_code": ("ack", _ACK_PAYLOAD, "scripted"),
+            },
+        )
+        _park(supervisor, _key_for(loop, "coder", "propose", _PROPOSE_PAYLOAD), "propose", "coder")
+        _exhaust(
+            supervisor, _key_for(loop, "reviewer_code", "ack", _ACK_PAYLOAD), "ack", "reviewer_code"
+        )
+
+        loop.poll_once(loop._roles)
+        assert len(parked_notifier.calls) == 1
+        assert len(exhausted_notifier.calls) == 0
+        call = parked_notifier.calls[0]
+        assert {entry["role"] for entry in call["report"]} == {"coder"}
+        assert {entry["role"] for entry in call["exhausted_report"]} == {"reviewer_code"}
+
+    def test_not_wedged_when_an_arm_spawns(self, monkeypatch):
+        import event_loop
+
+        clock = _ManualClock()
+        supervisor = event_loop.JobSupervisor(clock=clock)
+        spawner = _RecordingSpawner()
+        notifier = _NotifierSpy()
+        loop = _make_loop(
+            spawner,
+            supervisor=supervisor,
+            clock=clock,
+            roles=["coder", "tester"],
+            parked_notifier=notifier,
+        )
+        _script(
+            monkeypatch,
+            {
+                "coder": ("propose", _PROPOSE_PAYLOAD, "scripted"),
+                "tester": ("propose", {"producer": "tester"}, "scripted"),
+            },
+        )
+        # Only coder is parked; tester spawns freely.
+        _park(supervisor, _key_for(loop, "coder", "propose", _PROPOSE_PAYLOAD), "propose", "coder")
+
+        loop.poll_once(loop._roles)
+        assert notifier.calls == []
+        assert len(spawner.calls) == 1
+
+    def test_cleared_notifier_fires_on_transition(self, monkeypatch):
+        import event_loop
+
+        clock = _ManualClock()
+        supervisor = event_loop.JobSupervisor(clock=clock)
+        spawner = _RecordingSpawner()
+        notifier = _NotifierSpy()
+        cleared = _ClearedSpy()
+        loop = _make_loop(
+            spawner,
+            supervisor=supervisor,
+            clock=clock,
+            parked_notifier=notifier,
+            parked_cleared_notifier=cleared,
+        )
+        _script(monkeypatch, {"coder": ("propose", _PROPOSE_PAYLOAD, "scripted")})
+        key = _key_for(loop, "coder", "propose", _PROPOSE_PAYLOAD)
+        _park(supervisor, key, "propose", "coder")
+
+        loop.poll_once(loop._roles)
+        assert len(notifier.calls) == 1
+        assert loop.arms_parked_escalated
+
+        # The wedge clears by another route (the role's derived action
+        # changes — e.g. the cohort progressed and there is nothing to
+        # spawn): the stale HITL is auto-withdrawn exactly once.
+        _script(monkeypatch, {"coder": ("wait", None, "scripted")})
+        loop.poll_once(loop._roles)
+        assert cleared.count == 1
+        assert not loop.arms_parked_escalated
+
+        # An operator reset, by contrast, resolves the wedge in-band and
+        # clears the latch itself — no auto-withdrawal fires for it.
+        assert loop.reset_parked_arms() == [key]
+        loop.poll_once(loop._roles)
+        assert cleared.count == 1
+
+    def test_reset_parked_arms_rearms_latch_for_reescalation(self, monkeypatch):
+        import event_loop
+        import supervision_policy
+
+        clock = _ManualClock()
+        supervisor = event_loop.JobSupervisor(clock=clock)
+        spawner = _RecordingSpawner()
+        notifier = _NotifierSpy()
+        loop = _make_loop(spawner, supervisor=supervisor, clock=clock, parked_notifier=notifier)
+        _script(monkeypatch, {"coder": ("propose", _PROPOSE_PAYLOAD, "scripted")})
+        key = _key_for(loop, "coder", "propose", _PROPOSE_PAYLOAD)
+        _park(supervisor, key, "propose", "coder")
+
+        loop.poll_once(loop._roles)
+        assert len(notifier.calls) == 1
+        loop.reset_parked_arms()
+
+        # The arm re-parks after another no-op streak; the wedge re-escalates.
+        loop.poll_once(loop._roles)  # spawns the probe
+        loop._live_keys.discard(key)
+        for _ in range(supervision_policy.SUPERVISION_NOOP_STREAK_PARK):
+            supervisor.record_success(key, action="propose", role="coder")
+        loop.poll_once(loop._roles)
+        assert len(notifier.calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Loop: invalidate_role_arms (the restart_agent companion)
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidateRoleArms:
+    def test_live_key_invalidated_and_respawned(self, monkeypatch):
+        import event_loop
+
+        clock = _ManualClock()
+        supervisor = event_loop.JobSupervisor(clock=clock)
+        spawner = _RecordingSpawner()
+        loop = _make_loop(spawner, supervisor=supervisor, clock=clock, roles=["reviewer_code"])
+        _script(monkeypatch, {"reviewer_code": ("ack", _ACK_PAYLOAD, "scripted")})
+        key = _key_for(loop, "reviewer_code", "ack", _ACK_PAYLOAD)
+
+        loop.poll_once(loop._roles)
+        assert len(spawner.calls) == 1
+        # The incident shape: the Job was deleted out-of-band, but the key
+        # stays live (a missing Job maps to "running"), so every subsequent
+        # poll dedupes.
+        loop.poll_once(loop._roles)
+        assert len(spawner.calls) == 1
+
+        invalidated = loop.invalidate_role_arms("reviewer_code")
+        assert invalidated == [key]
+        assert key not in loop._live_keys
+        assert key not in loop._key_meta
+
+        loop.poll_once(loop._roles)
+        assert len(spawner.calls) == 2
+        assert spawner.calls[-1]["dedupe_key"] == key
+
+    def test_invalidation_clears_supervisor_latches(self, monkeypatch):
+        import event_loop
+
+        clock = _ManualClock()
+        supervisor = event_loop.JobSupervisor(clock=clock)
+        spawner = _RecordingSpawner()
+        loop = _make_loop(spawner, supervisor=supervisor, clock=clock, roles=["reviewer_code"])
+        _script(monkeypatch, {"reviewer_code": ("ack", _ACK_PAYLOAD, "scripted")})
+        key = _key_for(loop, "reviewer_code", "ack", _ACK_PAYLOAD)
+
+        loop.poll_once(loop._roles)
+        loop._live_keys.discard(key)
+        _park(supervisor, key, "ack", "reviewer_code")
+        assert loop.poll_once(loop._roles)[0].blocked == "parked"
+
+        loop.invalidate_role_arms("reviewer_code")
+        assert not supervisor.noop_parked(key)
+
+        loop.poll_once(loop._roles)
+        assert len(spawner.calls) == 2
+
+    def test_other_roles_untouched(self, monkeypatch):
+        import event_loop
+
+        clock = _ManualClock()
+        supervisor = event_loop.JobSupervisor(clock=clock)
+        spawner = _RecordingSpawner()
+        loop = _make_loop(
+            spawner, supervisor=supervisor, clock=clock, roles=["reviewer_code", "coder"]
+        )
+        _script(
+            monkeypatch,
+            {
+                "reviewer_code": ("ack", _ACK_PAYLOAD, "scripted"),
+                "coder": ("propose", _PROPOSE_PAYLOAD, "scripted"),
+            },
+        )
+        loop.poll_once(loop._roles)
+        assert len(loop._live_keys) == 2
+
+        loop.invalidate_role_arms("reviewer_code")
+        assert len(loop._live_keys) == 1
+        remaining_key = next(iter(loop._live_keys))
+        assert loop._key_meta[remaining_key] == ("propose", "coder")
+
+    def test_no_keys_returns_empty(self):
+        import event_loop
+
+        supervisor = event_loop.JobSupervisor(clock=_ManualClock())
+        loop = _make_loop(_RecordingSpawner(), supervisor=supervisor)
+        assert loop.invalidate_role_arms("reviewer_code") == []
+
+
+# ---------------------------------------------------------------------------
+# Executor: arms-parked escalation + withdrawal
+# ---------------------------------------------------------------------------
+
+
+_PARK_REPORT = [
+    {
+        "dedupe_key": "key-coder",
+        "role": "coder",
+        "action": "propose",
+        "noop_streak": 3,
+    }
+]
+_EXHAUSTED_REPORT = [
+    {
+        "dedupe_key": "key-rc",
+        "role": "reviewer_code",
+        "action": "ack",
+        "streak": 10,
+        "exit_history": [],
+        "exit_history_text": "2026-07-07T21:00:00 abnormal (exit_code=1)",
+    }
+]
+_BLOCKED = [("coder", "propose"), ("reviewer_code", "ack")]
+
+
+def _make_executor(slice_id="slice-8"):
+    from concurrent_executor import ConcurrentPhaseExecutor
+    from models import Pipeline, PipelineConfig, PipelinePhase, PipelineStatus
+
+    pipeline = Pipeline(
+        id="issue-3548",
+        repo="test/repo",
+        issue_number=3548,
+        status=PipelineStatus.RUNNING,
+        current_phase=PipelinePhase.IMPLEMENT,
+        config=PipelineConfig(),
+    )
+    return ConcurrentPhaseExecutor(pipeline, spawn_fn=MagicMock(), slice_id=slice_id)
+
+
+class TestExecutorParkedEscalation:
+    @patch("routes.pipelines._persist_hitl_decision")
+    @patch("routes.get_state_store_for_pipeline")
+    @patch("concurrent_executor.get_message_store")
+    def test_emits_alert_and_persists_decision(self, mock_store, mock_get_state, mock_persist):
+        from concurrent_executor import (
+            ARMS_EXHAUSTED_ABORT_OPTION,
+            ARMS_EXHAUSTED_RESTART_OPTION,
+            ARMS_PARKED_HITL_CONTEXT,
+            ARMS_PARKED_RETRY_OPTION,
+        )
+        from message_store import MessageType
+
+        disk_pipeline = MagicMock()
+        disk_pipeline.get_pending_decisions.return_value = []
+        mock_get_state.return_value = (MagicMock(), disk_pipeline)
+        mock_persist.return_value = MagicMock(id="decision-48")
+
+        executor = _make_executor()
+        executor._handle_arms_parked(
+            report=_PARK_REPORT, exhausted_report=_EXHAUSTED_REPORT, blocked_arms=_BLOCKED
+        )
+
+        msg = mock_store.return_value.add_message.call_args[0][0]
+        assert msg.message_type == MessageType.OVERSEER_ALERT
+        assert msg.metadata["anomaly"] == "event-arms-parked"
+
+        kwargs = mock_persist.call_args.kwargs
+        assert kwargs["context"] == ARMS_PARKED_HITL_CONTEXT
+        assert kwargs["options"] == [
+            ARMS_PARKED_RETRY_OPTION,
+            ARMS_EXHAUSTED_RESTART_OPTION,
+            ARMS_EXHAUSTED_ABORT_OPTION,
+        ]
+        assert "coder/propose" in kwargs["question"]
+        assert "3 consecutive no-op completions" in kwargs["question"]
+        assert "exit_code=1" in kwargs["question"]
+
+    @patch("routes.pipelines._persist_hitl_decision")
+    @patch("routes.get_state_store_for_pipeline")
+    @patch("concurrent_executor.get_message_store")
+    def test_dedupes_on_pending_decision(self, mock_store, mock_get_state, mock_persist):
+        from concurrent_executor import ARMS_PARKED_HITL_CONTEXT
+
+        pending = MagicMock()
+        pending.context = ARMS_PARKED_HITL_CONTEXT
+        disk_pipeline = MagicMock()
+        disk_pipeline.get_pending_decisions.return_value = [pending]
+        mock_get_state.return_value = (MagicMock(), disk_pipeline)
+
+        executor = _make_executor()
+        executor._handle_arms_parked(
+            report=_PARK_REPORT, exhausted_report=[], blocked_arms=_BLOCKED
+        )
+
+        mock_persist.assert_not_called()
+        mock_store.return_value.add_message.assert_not_called()
+
+    @patch("routes.get_state_store_for_pipeline", side_effect=RuntimeError("store down"))
+    @patch("concurrent_executor.get_message_store")
+    def test_read_failure_still_alerts_and_never_raises(self, mock_store, mock_get_state):
+        from message_store import MessageType
+
+        executor = _make_executor()
+        executor._handle_arms_parked(
+            report=_PARK_REPORT, exhausted_report=[], blocked_arms=_BLOCKED
+        )
+        msg = mock_store.return_value.add_message.call_args[0][0]
+        assert msg.message_type == MessageType.OVERSEER_ALERT
+
+    @patch("routes.pipelines._withdraw_arms_parked_decisions", return_value=1)
+    @patch("routes.get_state_store_for_pipeline")
+    @patch("event_loop.get_live_event_loops", return_value=[])
+    def test_withdrawal_runs_when_no_loop_escalated(
+        self, mock_loops, mock_get_state, mock_withdraw
+    ):
+        mock_get_state.return_value = (MagicMock(), MagicMock())
+        executor = _make_executor()
+        executor._withdraw_arms_parked_hitl()
+        mock_withdraw.assert_called_once()
+
+    @patch("routes.pipelines._withdraw_arms_parked_decisions")
+    @patch("routes.get_state_store_for_pipeline")
+    @patch("event_loop.get_live_event_loops")
+    def test_withdrawal_guarded_by_sibling_slice(self, mock_loops, mock_get_state, mock_withdraw):
+        sibling = MagicMock()
+        sibling.arms_parked_escalated = True
+        mock_loops.return_value = [sibling]
+        executor = _make_executor()
+        executor._withdraw_arms_parked_hitl()
+        mock_withdraw.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Decisions dispatch: "Retry arms (release no-op parks)"
+# ---------------------------------------------------------------------------
+
+
+class TestArmsParkedDispatch:
+    def _decision(self):
+        from concurrent_executor import ARMS_PARKED_HITL_CONTEXT
+
+        decision = MagicMock()
+        decision.context = ARMS_PARKED_HITL_CONTEXT
+        decision.id = "decision-48"
+        return decision
+
+    def test_retry_arms_releases_parks_on_live_loops(self):
+        from concurrent_executor import ARMS_PARKED_RETRY_OPTION
+        from routes.decisions import _maybe_dispatch_arms_parked_resolution
+
+        loop = MagicMock()
+        loop.slice_id = "slice-8"
+        loop.reset_parked_arms.return_value = ["key-coder"]
+        with patch("event_loop.get_live_event_loops", return_value=[loop]):
+            result = _maybe_dispatch_arms_parked_resolution(
+                "issue-3548", self._decision(), ARMS_PARKED_RETRY_OPTION
+            )
+        assert result["action"] == "reset_parked_arms"
+        assert result["success"] is True
+        assert result["cleared_by_slice"] == {"slice-8": ["key-coder"]}
+
+    def test_retry_arms_without_live_loop_fails_informatively(self):
+        from concurrent_executor import ARMS_PARKED_RETRY_OPTION
+        from routes.decisions import _maybe_dispatch_arms_parked_resolution
+
+        with patch("event_loop.get_live_event_loops", return_value=[]):
+            result = _maybe_dispatch_arms_parked_resolution(
+                "issue-3548", self._decision(), ARMS_PARKED_RETRY_OPTION
+            )
+        assert result["success"] is False
+        assert "no live event loop" in result["error"]
+
+    def test_non_parked_context_is_ignored(self):
+        from concurrent_executor import ARMS_PARKED_RETRY_OPTION
+        from routes.decisions import _maybe_dispatch_arms_parked_resolution
+
+        decision = MagicMock()
+        decision.context = "something_else"
+        assert (
+            _maybe_dispatch_arms_parked_resolution("issue-3548", decision, ARMS_PARKED_RETRY_OPTION)
+            is None
+        )
+
+    def test_abort_is_recorded_only(self):
+        from concurrent_executor import ARMS_EXHAUSTED_ABORT_OPTION
+        from routes.decisions import _maybe_dispatch_arms_parked_resolution
+
+        result = _maybe_dispatch_arms_parked_resolution(
+            "issue-3548", self._decision(), ARMS_EXHAUSTED_ABORT_OPTION
+        )
+        assert result["action"] == "arms_parked_abort"
+        assert "cancel_task" in result["note"]

--- a/orchestrator/tests/test_arms_parked_stall.py
+++ b/orchestrator/tests/test_arms_parked_stall.py
@@ -95,6 +95,22 @@ def _script(monkeypatch, mapping):
     monkeypatch.setattr(event_loop, "_derive_next_action", _fake_derive, raising=True)
 
 
+class _SuccessView:
+    """Job-status view that reports every live key as a clean no-op success.
+
+    Drives the production ``_observe_jobs`` → ``record_success`` path so a
+    key climbs the #3425 no-op streak and parks *through the real code path*,
+    rather than being hand-parked via ``record_success`` + a manual
+    ``_live_keys`` mutation (which never pops ``_key_meta`` the way a real
+    clean completion does).
+    """
+
+    def outcome_for(self, dedupe_key: str) -> str:
+        import event_loop
+
+        return event_loop.JOB_OUTCOME_SUCCESS
+
+
 def _make_loop(
     spawner,
     *,
@@ -104,6 +120,7 @@ def _make_loop(
     parked_notifier=None,
     parked_cleared_notifier=None,
     exhausted_notifier=None,
+    job_status_view=None,
     pipeline_id="issue-3548",
     slice_id="slice-8",
 ):
@@ -118,6 +135,7 @@ def _make_loop(
         clock=clock or _ManualClock(),
         roles=roles or ["coder"],
         job_supervisor=supervisor,
+        job_status_view=job_status_view,
         arms_exhausted_notifier=exhausted_notifier,
         arms_parked_notifier=parked_notifier,
         arms_parked_cleared_notifier=parked_cleared_notifier,
@@ -412,25 +430,56 @@ class TestInvalidateRoleArms:
         assert spawner.calls[-1]["dedupe_key"] == key
 
     def test_invalidation_clears_supervisor_latches(self, monkeypatch):
+        # Reach the no-op-parked state through the PRODUCTION code path
+        # (#3548 review): a real clean completion is observed by
+        # ``_observe_jobs``, which records the success AND pops the key from
+        # both ``_live_keys`` and ``_key_meta``. A parked key is therefore
+        # absent from ``_key_meta`` — so ``invalidate_role_arms`` cannot find
+        # it via ``_key_meta`` alone and must union in the supervisor's own
+        # park report. Driving via a ``JOB_OUTCOME_SUCCESS`` status view (not
+        # ``_park`` + a manual ``_live_keys.discard``) guarantees the fixture
+        # reproduces exactly the state production produces.
         import event_loop
+        import supervision_policy
 
         clock = _ManualClock()
         supervisor = event_loop.JobSupervisor(clock=clock)
         spawner = _RecordingSpawner()
-        loop = _make_loop(spawner, supervisor=supervisor, clock=clock, roles=["reviewer_code"])
+        loop = _make_loop(
+            spawner,
+            supervisor=supervisor,
+            clock=clock,
+            roles=["reviewer_code"],
+            job_status_view=_SuccessView(),
+        )
         _script(monkeypatch, {"reviewer_code": ("ack", _ACK_PAYLOAD, "scripted")})
         key = _key_for(loop, "reviewer_code", "ack", _ACK_PAYLOAD)
 
-        loop.poll_once(loop._roles)
-        loop._live_keys.discard(key)
-        _park(supervisor, key, "ack", "reviewer_code")
-        assert loop.poll_once(loop._roles)[0].blocked == "parked"
+        # Poll until the arm parks: each poll observes the prior spawn as a
+        # clean no-op success (streak++) then re-spawns the identical key,
+        # until the streak hits SUPERVISION_NOOP_STREAK_PARK and the spawn is
+        # blocked "parked".
+        for _ in range(supervision_policy.SUPERVISION_NOOP_STREAK_PARK + 2):
+            decision = loop.poll_once(loop._roles)[0]
+            if decision.blocked == "parked":
+                break
+        assert decision.blocked == "parked"
 
-        loop.invalidate_role_arms("reviewer_code")
+        # Production state that the _key_meta-only scan misses: the parked key
+        # has been popped from both structures by _observe_jobs.
+        assert supervisor.noop_parked(key)
+        assert key not in loop._key_meta
+        assert key not in loop._live_keys
+
+        invalidated = loop.invalidate_role_arms("reviewer_code")
+        assert invalidated == [key]
         assert not supervisor.noop_parked(key)
 
+        # The next poll re-derives the key as fresh and actually respawns.
+        spawns_before = len(spawner.calls)
         loop.poll_once(loop._roles)
-        assert len(spawner.calls) == 2
+        assert len(spawner.calls) == spawns_before + 1
+        assert spawner.calls[-1]["dedupe_key"] == key
 
     def test_other_roles_untouched(self, monkeypatch):
         import event_loop

--- a/orchestrator/tests/test_concurrent_status.py
+++ b/orchestrator/tests/test_concurrent_status.py
@@ -868,3 +868,71 @@ class TestJiraPipelineConcurrentStatus:
         assert result is not None
         assert "consensus" in result
         assert result["consensus"]["is_complete"] is True
+
+
+class TestConsensusBlockVerdictVisibility:
+    """The status payload surfaces recorded verdicts + confirm blockers (#3548).
+
+    ``_consensus_block`` used to drop the approval matrix entirely, so a
+    landed ACK was indistinguishable from a lost one (the reviewer shows
+    ``reviewer_phase: REVIEWING`` + ``confirmed: false`` either way) and the
+    zero-proposal confirm blocker — the guard that rejects EVERY confirm
+    while some producer has no proposal — was unnamed.
+    """
+
+    def test_consensus_block_surfaces_edges_versions_and_blockers(self):
+        pipeline = _make_concurrent_pipeline(pipeline_id="issue-3548")
+        tracker = MagicMock()
+        tracker.get_state.return_value = {
+            "is_complete": False,
+            "blocking_agents": ["coder", "tester", "documenter", "reviewer_code"],
+            "has_unresolved_nacks": False,
+            "unresolved_nacks": [],
+            "agents": {
+                "coder": {"producer_phase": "WORKING", "confirmed": False},
+                "tester": {"producer_phase": "WORKING", "confirmed": False},
+                "documenter": {"producer_phase": "PROPOSED", "confirmed": False},
+                "reviewer_code": {"reviewer_phase": "REVIEWING", "confirmed": False},
+            },
+            "approval_matrix": {
+                "entries": {
+                    "reviewer_code->documenter": {
+                        "reviewer_role": "reviewer_code",
+                        "producer_role": "documenter",
+                        "state": "acked",
+                        "version": 1,
+                        "reason": "looks good",
+                    }
+                },
+                "proposal_versions": {"documenter": 1, "coder": 0, "tester": 0},
+                "revision_counts": {},
+            },
+            "protocol": "brc",
+        }
+
+        with (
+            patch("concurrent_executor.is_concurrent_execution", return_value=True),
+            patch("message_store.get_message_store") as mock_get_store,
+            patch("peer_consensus.get_peer_consensus_tracker", return_value=tracker),
+        ):
+            mock_store = MagicMock()
+            mock_store.get_status.return_value = {"total": 0, "by_type": {}}
+            mock_get_store.return_value = mock_store
+
+            result = _get_concurrent_status(pipeline)
+
+        consensus = result["consensus"]
+        assert consensus["proposal_versions"] == {"documenter": 1, "coder": 0, "tester": 0}
+        assert consensus["review_edges"] == [
+            {
+                "reviewer": "reviewer_code",
+                "producer": "documenter",
+                "state": "acked",
+                "version": 1,
+            }
+        ]
+        # The single most load-bearing fact for a stalled round: which
+        # producers block every confirm by never having proposed.
+        assert consensus["zero_proposal_producers"] == ["coder", "tester"]
+        # The bulky raw matrix stays dropped.
+        assert "approval_matrix" not in consensus

--- a/orchestrator/tests/test_mcp_tools.py
+++ b/orchestrator/tests/test_mcp_tools.py
@@ -3504,3 +3504,86 @@ class TestUpdatePipelineConfig:
 
         assert "error" in result
         mock_req.assert_not_called()
+
+
+class TestConsensusStatusVerdictPassThrough:
+    """get_consensus_status passes the compact verdict fields through (#3548)."""
+
+    def test_structured_consensus_includes_verdict_fields(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.side_effect = [
+                {
+                    "data": {
+                        "pipeline": {
+                            "id": "issue-3548",
+                            "current_phase": "implement",
+                            "status": "running",
+                        }
+                    }
+                },
+                {
+                    "data": {
+                        "concurrent": {
+                            "consensus": {
+                                "is_complete": False,
+                                "blocking_agents": ["coder", "tester"],
+                                "has_unresolved_nacks": False,
+                                "unresolved_nacks": [],
+                                "agents": {
+                                    "documenter": {
+                                        "producer_phase": "PROPOSED",
+                                        "confirmed": False,
+                                    }
+                                },
+                                "proposal_versions": {"documenter": 1},
+                                "review_edges": [
+                                    {
+                                        "reviewer": "reviewer_code",
+                                        "producer": "documenter",
+                                        "state": "acked",
+                                        "version": 1,
+                                    }
+                                ],
+                                "zero_proposal_producers": ["coder", "tester"],
+                            }
+                        }
+                    }
+                },
+            ]
+            result = handler.handle_tool_call("get_consensus_status", {"task_id": "issue-3548"})
+
+        consensus = result["consensus"]
+        assert consensus["proposal_versions"] == {"documenter": 1}
+        assert consensus["review_edges"][0]["state"] == "acked"
+        assert consensus["zero_proposal_producers"] == ["coder", "tester"]
+
+    def test_fields_default_empty_for_older_blocks(self, handler):
+        with patch.object(handler, "_make_request") as mock_req:
+            mock_req.side_effect = [
+                {
+                    "data": {
+                        "pipeline": {
+                            "id": "issue-3548",
+                            "current_phase": "implement",
+                            "status": "running",
+                        }
+                    }
+                },
+                {
+                    "data": {
+                        "concurrent": {
+                            "consensus": {
+                                "is_complete": False,
+                                "blocking_agents": [],
+                                "agents": {"coder": {"producer_phase": "PROPOSED"}},
+                            }
+                        }
+                    }
+                },
+            ]
+            result = handler.handle_tool_call("get_consensus_status", {"task_id": "issue-3548"})
+
+        consensus = result["consensus"]
+        assert consensus["proposal_versions"] == {}
+        assert consensus["review_edges"] == []
+        assert consensus["zero_proposal_producers"] == []

--- a/orchestrator/tests/test_redis_message_store.py
+++ b/orchestrator/tests/test_redis_message_store.py
@@ -1561,6 +1561,9 @@ class TestBlockingChunkCap:
             raise redis.TimeoutError("Timeout reading from socket")
 
         monkeypatch.setattr(redis_client, "xrange", timeout_xrange)
+        # The cursor-less non-blocking read goes through XREVRANGE since the
+        # #3548 tail-read fix; cover both non-blocking read shapes.
+        monkeypatch.setattr(redis_client, "xrevrange", timeout_xrange)
         store = RedisMessageStore(redis_client)
 
         # The idle-slice degradation is scoped to blocking reads only —
@@ -1739,3 +1742,65 @@ class TestRedisSliceAndFromRolesCombined:
         assert len(got[0]) == 1
         assert got[0][0].from_role == "orchestrator"
         assert got[0][0].message_type == MessageType.CONSENSUS_RE_REVIEW
+
+
+class TestCappedTailRead:
+    """Capped cursor-less reads return the NEWEST messages (#3548).
+
+    XRANGE from ``0-0`` with a count cap returned the OLDEST entries, so
+    once a stream outgrew the cap every "recent messages" surface (operator
+    views, snapshot recent_messages, consensus inference, reconstruction)
+    saw a frozen head-of-stream window — the #3548 incident's "no
+    CONSENSUS_ACK ever appears on the bus" misdiagnosis.
+    """
+
+    @staticmethod
+    def _add_n(store, n, *, subject_prefix="msg"):
+        for i in range(n):
+            store.add_message(
+                Message(
+                    pipeline_id="test-pipeline",
+                    from_role="coder",
+                    to_role="all",
+                    message_type=MessageType.PROGRESS,
+                    subject=f"{subject_prefix}-{i}",
+                    body=f"body {i}",
+                )
+            )
+
+    def test_capped_read_returns_newest_in_chronological_order(self, store):
+        self._add_n(store, 30)
+        messages = store.get_messages("test-pipeline", limit=10)
+        assert len(messages) == 10
+        assert [m.subject for m in messages] == [f"msg-{i}" for i in range(20, 30)]
+
+    def test_uncapped_read_unchanged(self, store):
+        self._add_n(store, 5)
+        messages = store.get_messages("test-pipeline", limit=100)
+        assert [m.subject for m in messages] == [f"msg-{i}" for i in range(5)]
+
+    def test_since_id_read_keeps_forward_semantics(self, store):
+        self._add_n(store, 30)
+        all_messages = store.get_messages("test-pipeline", limit=1000)
+        cursor = all_messages[4].id
+        after = store.get_messages("test-pipeline", since_id=cursor, limit=100)
+        # Forward from the cursor: everything strictly after it, oldest
+        # first — the tail-read flip must not touch cursor reads.
+        assert [m.subject for m in after] == [f"msg-{i}" for i in range(5, 30)]
+
+    def test_tail_read_applies_filters_then_truncates(self, store):
+        # Interleave to_role targeting so the role filter drops half.
+        for i in range(20):
+            store.add_message(
+                Message(
+                    pipeline_id="test-pipeline",
+                    from_role="coder",
+                    to_role="tester" if i % 2 == 0 else "reviewer_code",
+                    message_type=MessageType.PROGRESS,
+                    subject=f"msg-{i}",
+                    body=f"body {i}",
+                )
+            )
+        messages = store.get_messages("test-pipeline", role="tester", limit=5)
+        # Newest 5 messages addressed to tester (or all), chronological.
+        assert [m.subject for m in messages] == [f"msg-{i}" for i in (10, 12, 14, 16, 18)]

--- a/orchestrator/tests/test_restart_agent.py
+++ b/orchestrator/tests/test_restart_agent.py
@@ -456,10 +456,18 @@ class TestRestartAgentEndpoint:
         mock_spawner.check_and_increment_restart_count.return_value = 1
         mock_spawner_fn.return_value = mock_spawner
 
-        response = client.post(
-            "/api/v1/pipelines/issue-100/agents/coder/restart",
-            json={"reason": "Agent stalled"},
-        )
+        # #3548: a live event loop exists for this (pipeline, slice=None)
+        # scope, so the delegation claim is true and the route invalidates
+        # the role's stale arm state on it.
+        live_loop = MagicMock()
+        live_loop.slice_id = None
+        live_loop.invalidate_role_arms.return_value = ["stale-key-1"]
+
+        with patch("event_loop.get_live_event_loops", return_value=[live_loop]):
+            response = client.post(
+                "/api/v1/pipelines/issue-100/agents/coder/restart",
+                json={"reason": "Agent stalled"},
+            )
 
         assert response.status_code == 200
         data = response.get_json()
@@ -469,10 +477,99 @@ class TestRestartAgentEndpoint:
         assert "container_id" not in data["data"]
         assert data["data"]["agent_role"] == "coder"
         assert data["data"]["respawn"] == "delegated to orchestrator event loop"
+        # #3548: the role's dedupe/supervision state was invalidated so the
+        # loop actually re-derives a fresh spawn.
+        live_loop.invalidate_role_arms.assert_called_once_with("coder")
+        assert data["data"]["live_event_loop"] is True
+        assert data["data"]["arms_invalidated"] == 1
         # restart_count reflects the just-incremented budget (#3244), not 0.
         assert data["data"]["restart_count"] == 1
         # RUNNING pipeline: live event loop owns the respawn; no relaunch.
         mock_spawn_thread.assert_not_called()
+
+    @patch("routes.pipelines._spawn_pipeline_run_thread")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_restart_agent_no_live_loop_reports_honestly(
+        self, mock_repo, mock_resolve, mock_spawner_fn, mock_lock_fn, mock_spawn_thread, client
+    ):
+        """No live event loop → the route says no respawn will occur (#3548).
+
+        The incident shape: the route reported "restarted successfully"
+        with respawn delegated while nothing existed to honor the
+        delegation. A RUNNING pipeline with no registered loop for the
+        requested slice scope must say so.
+        """
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        pipeline = _make_pipeline_with_running_agent()
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_store.repo_path = Path("/repo")
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        mock_spawner.k8s.list_containers.return_value = []
+        mock_spawner.check_and_increment_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        with patch("event_loop.get_live_event_loops", return_value=[]):
+            response = client.post(
+                "/api/v1/pipelines/issue-100/agents/coder/restart",
+                json={"reason": "Agent stalled"},
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["data"]["live_event_loop"] is False
+        assert data["data"]["arms_invalidated"] == 0
+        assert "no live event loop" in data["data"]["respawn"]
+
+    @patch("routes.pipelines._spawn_pipeline_run_thread")
+    @patch("routes.pipelines.get_pipeline_state_lock")
+    @patch("routes.pipelines.get_container_spawner")
+    @patch("routes.pipelines._resolve_pipeline")
+    @patch("routes.pipelines.get_repo_path")
+    def test_restart_agent_slice_scoped_loop_selection(
+        self, mock_repo, mock_resolve, mock_spawner_fn, mock_lock_fn, mock_spawn_thread, client
+    ):
+        """Only the loop matching the requested slice scope is invalidated (#3548)."""
+        mock_repo.return_value = "/repo"
+        mock_lock_fn.return_value = MagicMock()
+        pipeline = _make_pipeline_with_running_agent()
+
+        mock_store = MagicMock()
+        mock_store.load_pipeline.return_value = pipeline
+        mock_store.repo_path = Path("/repo")
+        mock_resolve.return_value = (mock_store, pipeline)
+
+        mock_spawner = MagicMock()
+        mock_spawner.k8s.list_containers.return_value = []
+        mock_spawner.list_slice_jobs.return_value = []
+        mock_spawner.check_and_increment_restart_count.return_value = 1
+        mock_spawner_fn.return_value = mock_spawner
+
+        matching = MagicMock()
+        matching.slice_id = "slice-8"
+        matching.invalidate_role_arms.return_value = ["k1", "k2"]
+        other = MagicMock()
+        other.slice_id = "slice-7"
+
+        with patch("event_loop.get_live_event_loops", return_value=[other, matching]):
+            response = client.post(
+                "/api/v1/pipelines/issue-100/agents/coder/restart",
+                json={"reason": "Agent stalled", "slice_id": "slice-8"},
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        matching.invalidate_role_arms.assert_called_once_with("coder")
+        other.invalidate_role_arms.assert_not_called()
+        assert data["data"]["arms_invalidated"] == 2
+        assert data["data"]["live_event_loop"] is True
 
     @patch("routes.pipelines._spawn_pipeline_run_thread")
     @patch("routes.pipelines.get_pipeline_state_lock")


### PR DESCRIPTION
Fixes the three defects from #3548, with defect 1's mechanism corrected against the live orchestrator logs (full analysis posted on the issue).

## What the logs showed

The 21:07-21:09 reviewer ACKs **were** applied to the live slice-8 tracker and their `CONSENSUS_ACK` messages **did** reach Redis (both `POST /signal` requests returned 200; the 21:49 reconstruction replayed them). The round stalled because the post-restart tracker was fresh (`reclassified_fresh`) and coder/tester never re-proposed: the global zero-proposal guard rejects every confirm while any producer has no proposal (`handle_confirmed rejected: global zero-proposal producers ['tester', 'coder']` at 21:44:21), and those producers' propose arms were no-op-parked. Everything then went silent for the park heartbeat window (defect 2), and `restart_agent`'s delegated respawn was structurally impossible (defect 3). The "acks not visible" and "no CONSENSUS_ACK on the bus" observations were observability bugs, fixed here as defect 1.

## Changes

### Defect 2 — all-parked rounds now escalate
- `_handle_role`'s park early-return tags its decision `blocked="parked"` (previously indistinguishable from benign dedupe/backoff).
- New `OrchestratorEventLoop._check_arms_parked`, the no-op-park sibling of #3496's `_check_arms_exhausted`. It requires at least one parked arm and also covers **mixed parked+exhausted** rounds, which fell between the two predicates before. Sticky latch per episode; cleared notifier on the wedged→clear transition.
- `JobSupervisor.noop_park_report()` / `reset_noop_parks()` — the park twins of `exhausted_report()` / `reset_exhausted()` (`record_success` now records arm labels at park entry so the report is attributable).
- Executor wiring: `_handle_arms_parked` emits an `OVERSEER_ALERT` (`event-arms-parked`) plus a persisted HITL decision (context `event_arms_parked`, deduped, auto-withdrawn via `_withdraw_arms_parked_hitl` with the pipeline-wide sibling-slice guard).
- Resolution dispatch: "Retry arms (release no-op parks)" clears the parks on the live loop(s) via the #3496 registry seam; "Restart phase" / abort mirror the exhausted decision.

### Defect 3 — restart_agent respawn actually happens
- New `OrchestratorEventLoop.invalidate_role_arms(role)`: drops the role's keys from `_live_keys`/`_key_meta` and retires their supervisor state. Without it, the re-derived event carries the identical dedupe key, which stays in `_live_keys` forever because the route's own Job deletion maps to `running` in `_observe_jobs` — so the "delegated" respawn never derived (observed twice in the incident).
- `_restart_agent_body` reaches the live loop for the requested (pipeline, slice) scope via `get_live_event_loops` and invalidates the role's arms; the response now reports honestly: `live_event_loop`, `arms_invalidated`, and a "no respawn will occur" note when no live loop exists (previously it always claimed successful delegation).

### Defect 1 — landed verdicts and the real blocker are visible
- `RedisMessageStore.get_messages`: capped cursor-less non-blocking reads returned the **oldest** N entries (XRANGE from `0-0`), so every "recent messages" surface (operator queries, snapshot `recent_messages`, consensus inference, reconstruction) showed a frozen head-of-stream window once the stream outgrew the cap — the source of the "no CONSENSUS_ACK ever appears on the bus" misdiagnosis. They now return the newest N (XREVRANGE, chronological order). Cursor (`since_id`), timestamp (`since`), `from_tip`, and blocking reads keep forward semantics.
- `_consensus_block` (status route) keeps compact projections the slimming used to drop: `proposal_versions`, a 4-field `review_edges` list, and `zero_proposal_producers` — the set that blocks every confirm. `_structured_consensus` (MCP `get_consensus_status`) passes them through, so a recorded ACK and the actual convergence blocker are both operator-visible.

## Testing

- New `orchestrator/tests/test_arms_parked_stall.py` (22 tests): supervisor park primitives, park tagging, all-parked + mixed wedge detection, sticky latch, cleared-notifier transition semantics, operator reset + re-escalation, `invalidate_role_arms`, executor escalation/dedup/withdrawal, and the resolution dispatch.
- Extended `test_restart_agent.py` (live-loop invalidation, honest no-loop reporting, slice-scoped loop selection), `test_redis_message_store.py` (newest-N semantics, cursor reads unchanged, filter+truncate order), `test_concurrent_status.py` and `test_mcp_tools.py` (verdict/blocker visibility).
- `make lint` clean; `make test` (21,517 tests): 4 failures, all pre-existing on `main` in this environment (gateway worktree-path / image-reap script env dependencies, files untouched by this diff).

Closes #3548.
