### PR TITLE
Port live overseer_max_turns validation tests into test_models.py

### DIFF
--- a/orchestrator/tests/test_models.py
+++ b/orchestrator/tests/test_models.py
@@ -585,6 +585,57 @@ class TestPipelineConfig:
         assert DEFAULT_MAX_PARALLEL_SLICES == 4
 
 
+class TestOverseerMaxTurns:
+    """Validation bounds for the PipelineConfig.overseer_max_turns field.
+
+    Ported from the deleted orchestrator/tests/test_overseer_max_turns.py
+    (issue #3513): the surrounding respawn-machinery tests in that module
+    were retired with #2270 slice-5, but these bounds are the only coverage
+    of the live overseer_max_turns contract (models/_config.py), consumed by
+    routes/pipelines when building the overseer agent command.
+    """
+
+    def test_default_value_is_2000(self):
+        """Default overseer_max_turns is 2000."""
+        config = PipelineConfig()
+        assert config.overseer_max_turns == 2000
+
+    def test_custom_value_accepted(self):
+        """Custom overseer_max_turns within bounds is accepted."""
+        config = PipelineConfig(overseer_max_turns=5000)
+        assert config.overseer_max_turns == 5000
+
+    def test_minimum_bound_100(self):
+        """overseer_max_turns=100 is the minimum allowed value."""
+        config = PipelineConfig(overseer_max_turns=100)
+        assert config.overseer_max_turns == 100
+
+    def test_maximum_bound_10000(self):
+        """overseer_max_turns=10000 is the maximum allowed value."""
+        config = PipelineConfig(overseer_max_turns=10000)
+        assert config.overseer_max_turns == 10000
+
+    def test_rejects_below_minimum(self):
+        """Values below 100 are rejected by validation."""
+        with pytest.raises(ValueError):
+            PipelineConfig(overseer_max_turns=99)
+
+    def test_rejects_above_maximum(self):
+        """Values above 10000 are rejected by validation."""
+        with pytest.raises(ValueError):
+            PipelineConfig(overseer_max_turns=10001)
+
+    def test_rejects_zero(self):
+        """Zero is below the minimum and rejected."""
+        with pytest.raises(ValueError):
+            PipelineConfig(overseer_max_turns=0)
+
+    def test_rejects_negative(self):
+        """Negative values are rejected."""
+        with pytest.raises(ValueError):
+            PipelineConfig(overseer_max_turns=-1)
+
+
 class TestResolveConsensusTimeoutMinutes:
     """Tests for resolve_consensus_timeout_minutes (issue #2263).
 


### PR DESCRIPTION
Closes #3558

## Context

PR #3553 deleted the permanently-skipped overseer respawn test modules, including `test_overseer_max_turns.py`. The egg-reviewer review of that PR noted that one class in the deleted module, `TestOverseerMaxTurnsConfig`, validated the live `PipelineConfig.overseer_max_turns` field (`orchestrator/models/_config.py`: `default=2000, ge=100, le=10000`) with no dependency on the retired respawn machinery, and was the only bounds coverage of that field in the repo.

Issue #3558 captured the ready-to-apply fix on branch `egg/port-overseer-max-turns-tests-3513` because the gateway policy blocked egg from pushing to #3553's human-authored branch. #3553 has since merged without the port, so this PR lands it on main.

## Changes

- Cherry-pick `696af2b7a` from `egg/port-overseer-max-turns-tests-3513`: adds `TestOverseerMaxTurns` (8 tests) to `orchestrator/tests/test_models.py`, next to the existing `TestPipelineConfig`. That module imports `PipelineConfig` cleanly, so the tests run rather than skip.
- The 9th test from the original class (`test_field_coexists_with_other_overseer_fields`) is intentionally dropped: it asserted the `overseer_max_respawns` field removed in #2270 slice-5.

## Verification

- `pytest orchestrator/tests/test_models.py::TestOverseerMaxTurns`: 8 passed.
- `make test` (changeset-aware full run): 113,555 passed. The 5 failures are pre-existing on origin/main (verified by re-running them on a detached main checkout) and unrelated: host-environment failures in `tests/scripts/test_reap_stale_egg_images.py` (exit 127), `gateway/tests/test_git_client.py`, `orchestrator/tests/test_per_slice_brc_commit.py`, plus a timing flake in `gateway/tests/test_error_paths.py` that passes on re-run.