### PR TITLE
docs: clarify Parallel? column semantics for Utility roles in agent-roles.md

### DIFF
--- a/docs/reference/agent-roles.md
+++ b/docs/reference/agent-roles.md
@@ -38,12 +38,14 @@ Use `get_roles_by_category(AgentCategory.REVIEW)` to dynamically query roles by 
 | `reviewer_contract` | Review | Implement | Yes (with `reviewer_code`, `reviewer_code_holistic`, `reviewer_security`, `reviewer_concurrency`) | coder, tester |
 | `reviewer_security` | Review | Implement | Yes (with `reviewer_code`, `reviewer_code_holistic`, `reviewer_contract`, `reviewer_concurrency`) | coder, tester |
 | `reviewer_concurrency` | Review | Implement | Yes (with `reviewer_code`, `reviewer_code_holistic`, `reviewer_contract`, `reviewer_security`) | coder, tester |
-| `autofixer` | Utility | Any | Yes | — |
-| `conflict_resolver` | Utility | Any | Yes | — |
-| `evidence_gatherer` | Utility | Any (runs ahead of a review wave) | Yes | — |
+| `autofixer` | Utility | Any | — | — |
+| `conflict_resolver` | Utility | Any | — | — |
+| `evidence_gatherer` | Utility | Any (runs ahead of a review wave) | — | — |
 | `overseer` | Interface | Per-phase (spawned/torn down at phase boundaries) | — | — (pipeline health monitoring) |
 
 All agents within a phase run concurrently via BRC consensus. Concurrency is enabled by default for the refine, plan, and implement phases, and can be extended to additional phases via the `concurrent_phases` config.
+
+The "Parallel?" column describes concurrency within a phase's BRC wave: `Yes (with X)` means the role runs as a concurrent BRC peer of X. Utility roles and the interface role are marked `—` because they spawn on-demand through dedicated paths outside standard phase execution and are never BRC peers (see the phase-mapping note in `shared/egg_contracts/agent_roles/_registry.py`); `evidence_gatherer` in particular runs *ahead of* a review wave as a standalone read-only pass, not in parallel with it.
 
 ## Refine Phase
 

--- a/shared/egg_contracts/agent_roles/_registry.py
+++ b/shared/egg_contracts/agent_roles/_registry.py
@@ -264,8 +264,10 @@ def can_run_in_parallel(role1: AgentRole | str, role2: AgentRole | str) -> bool:
 
 
 # Phase-to-role mappings for multi-agent execution
-# Note: Utility roles (AUTOFIXER, CONFLICT_RESOLVER) are excluded
-# by design — they are spawned on-demand, not as part of standard phase execution.
+# Note: Utility roles (AUTOFIXER, CONFLICT_RESOLVER, EVIDENCE_GATHERER) are
+# excluded by design — they are spawned on-demand, not as part of standard
+# phase execution. EVIDENCE_GATHERER in particular runs ahead of a review wave
+# as a read-only pass (see EVIDENCE_GATHERER_ROLE in _oversight_roles.py).
 
 _PHASE_ROLES: dict[str, list[AgentRole]] = {
     "implement": [AgentRole.CODER, AgentRole.TESTER, AgentRole.DOCUMENTER],


### PR DESCRIPTION
Closes #3568.

## What

In `docs/reference/agent-roles.md`, the Role Overview table marked all three Utility roles (`autofixer`, `conflict_resolver`, `evidence_gatherer`) with `Parallel? = Yes`, which reads as "runs concurrently as a BRC peer." None of them is one.

## Why this resolution

The issue asked us to decide the column's intended semantics. The codebase already answers it:

- Every other `Yes` in the table is `Yes (with X)`, i.e. "runs as a concurrent BRC peer of X within its phase wave," matching the paragraph under the table ("All agents within a phase run concurrently via BRC consensus").
- Utility roles never participate in phase waves at all: `shared/egg_contracts/agent_roles/_registry.py` (phase-mapping note) states they "are spawned on-demand, not as part of standard phase execution" and "spawn through dedicated paths."
- `evidence_gatherer` runs ahead of a review wave as a standalone read-only pass (`orchestrator/evidence_gatherer.py`).

So neither of the issue's two framings fits cleanly: a footnoted `Yes` would keep the misleading cell, and `No` would falsely imply these roles serialize a wave. The table already has a convention for roles outside phase waves: the `overseer` (Interface) row uses `—`. This PR applies the same placeholder to the three Utility rows and adds a one-line note under the table defining the column and why Utility/Interface rows are exempt.

## Changes

- The three Utility rows' `Parallel?` cells change from `Yes` to `—` (consistent with the `overseer` row).
- A clarifying note under the table defines `Yes (with X)` and the `—` marking, and calls out that `evidence_gatherer` runs ahead of the review wave rather than in parallel with it.

Docs-only; no behavior change.