### PR TITLE
docs: rewrite main README around four principles; retire stale architecture claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,67 @@
 # egg
 
-**Autonomous software engineering with structural guarantees.**
+**Autonomous software engineering that stays aligned with the human who asked for it.**
 
-egg takes an idea, refines it into a plan, and turns that plan into reviewed pull requests. The agents do the labor: they research the codebase, draft requirements, write code and tests, and review each other's work. They do not make the decisions that matter. Whether the requirements are right, whether the plan is sound, how to resolve an ambiguity, whether anything merges: those judgments stay with a human, and the pipeline stops and asks rather than guessing.
+egg turns an idea (a GitHub issue, a Jira epic, a rough description) into reviewed, mergeable pull requests. Agent teams do the labor: they research the codebase, refine requirements, plan the work, write code and tests, and review each other's output across runs that span hours, many slices, and multiple repositories. Humans make every decision that matters: whether the requirements are right, whether the plan is sound, how each ambiguity resolves, and whether anything merges.
 
-Underneath, rule-breaking isn't merely discouraged, it's impossible. Untrusted LLM agents work inside a zero-credential sandbox. A trusted gateway sidecar holds every secret and validates every privileged operation. A deliberative consensus protocol forces agents to review each other's *actual* artifacts before anything ships. The result is autonomy on the work and human authority on the decisions.
+The system's central concern is keeping those two sides aligned. Feedback gates sit where redirecting is cheapest; peer review must cite evidence from real artifacts; context management never lets an agent quietly forget what you asked for; and the environment makes rule-breaking structurally impossible rather than merely discouraged.
 
 > *Inspired by Andy Weir's short story "The Egg": a contained environment where development happens before emerging into the world. The agent works inside the egg; when ready, it "hatches" via human review and merge.*
 
-> **Status:** egg is under heavy development. The core workflow is functional and runs end-to-end, but expect breakages and changing behavior.
+> **Status:** egg is under heavy development. The core workflow is functional and runs end-to-end (egg develops egg, including multi-hour, many-slice pipelines on its own repository), but expect breakages and changing behavior.
 
 ## The Problem
 
-LLM agents are capable enough to write real code. They are not reliable enough to be trusted with real credentials, real branches, and real merge buttons. The standard approach, system prompts that say "please don't merge" or "please run tests first," fails because:
+LLM agents are capable enough to write real code across long, multi-step tasks. Three things stop teams from letting them:
 
-- **Prompts are suggestions, not constraints.** Agents ignore them under pressure.
-- **Agents self-approve their own work.** They hallucinate that tests pass.
-- **Concurrent agents produce sycophantic reviews** ("looks good!") with no actual evaluation.
-- **A single agent writing and reviewing its own code is a conflict of interest,** not a workflow.
+1. **They can't be trusted with real credentials and real merge buttons.** Prompts saying "please don't merge" are suggestions, not constraints. Agents ignore them under pressure, and a prompt injection can turn any instruction against you.
+2. **They are unreliable self-assessors.** An agent announcing its work is done means the agent *thinks* it's done. Agents hallucinate passing tests, and concurrent agents rubber-stamp each other with sycophantic "looks good!" reviews.
+3. **Over long tasks, they quietly lose the plot.** Context windows fill, lossy auto-compaction silently drops the constraints the work depends on, and the output drifts away from what the human actually asked for.
 
-egg moves enforcement out of the prompt and into infrastructure, and keeps a human on every decision the agents should not make alone.
+egg's answer to all three is the same: move the guarantee out of the prompt and into infrastructure, and keep a human on every decision the agents should not make alone.
 
-## What Makes egg Different
+## How egg Works: Four Principles
 
-### 1. The Gateway: Infrastructure Over Prompts
+### 1. Human Authority Is Structural
 
-The gateway is a trusted sidecar that sits between every agent and the outside world. Agents use ordinary tools (`git`, `gh`, `curl`); transparent wrappers route every operation through the gateway for policy enforcement.
-
-**What the gateway enforces:**
+Untrusted agents work inside a zero-credential sandbox. A trusted **gateway sidecar** sits between every agent and the outside world: agents use ordinary tools (`git`, `gh`, `curl`), and transparent wrappers route every operation through the gateway for policy enforcement.
 
 - **No credentials in the sandbox.** The agent environment has zero tokens and zero keys. The gateway holds every credential (GitHub, Anthropic, Jira, Confluence, LiteLLM) and injects them into proxied requests. Agents never see or handle secrets.
-- **No merging.** The merge endpoint doesn't exist. There's no prompt saying "don't merge"; the capability is simply absent from the agent's world.
+- **No merging.** The merge endpoint doesn't exist. There is no prompt saying "don't merge"; the capability is simply absent from the agent's world.
 - **Phase-locked operations.** Every git/gh operation is validated against the pipeline's current SDLC phase. An agent in the plan phase physically cannot push code; an agent implementing one slice cannot rewrite the contract.
-- **Branch ownership.** Agents may only push to `egg/`-prefixed branches (or branches with an open egg-authored PR). Role-based file restrictions reject pushes that touch protected paths with `403 restricted_path_modified`.
-- **Network isolation.** Each pipeline's mode defaults to its repo's GitHub visibility — private or internal repos get private mode (the sandbox reaches the Anthropic API and nothing else, enforced by a Squid proxy and Cilium NetworkPolicies); public repos get public mode (all external access is proxied and audited through the gateway). An explicit `network_mode` on the pipeline config overrides the auto-detect.
-- **Bounded Jira/Confluence access.** Optional, private-mode-only gateway wrappers expose read verbs (ticket/page reads, JQL/CQL search) plus a bounded write extension (create/edit ticket, add comment, create link), gated by a project/space allowlist with per-verb schemas and response redaction.
+- **Branch ownership.** Agents may only push to `egg-`/`egg/`-prefixed branches (or branches with an open egg-authored PR). Role-based file restrictions reject pushes that touch protected paths with `403 restricted_path_modified`.
+- **Network isolation.** Each pipeline's mode defaults to its repo's GitHub visibility. Private or internal repos get private mode: the sandbox reaches the Anthropic API and nothing else, enforced by a Squid proxy and Cilium NetworkPolicies. Public repos get public mode: all external access is proxied and audited through the gateway. Package-manager egress (npm, GitHub Packages) flows through the proxy with credentials injected at the proxy layer, never in the sandbox.
+- **Bounded Jira/Confluence access.** Optional, private-mode-only gateway wrappers expose read verbs plus a bounded write extension, gated by a project/space allowlist with per-verb schemas and response redaction.
 
-This is zero-trust architecture applied to AI agents. The agent doesn't need to be trustworthy because the environment is structurally safe. See [Capability Removal](docs/design/capability-removal.md) for the design philosophy and the [Gateway README](gateway/README.md) for the policy surface.
+Above the enforcement layer, the pipeline funnels every consequential judgment to a person. Each phase boundary is a **human gate**: a person reviews the agents' artifacts and approves before the pipeline advances. Whenever an agent or the monitoring plane hits something it should not resolve alone (ambiguous requirements, a design fork, an infrastructure error, repeated failed cycles), egg pauses and queues a formal **HITL decision** instead of guessing. The operator answers through `provide_input` on the MCP surface and the pipeline resumes exactly where it stopped. egg never auto-resolves these decisions, even in otherwise automated runs.
 
-### 2. Agent Teams: Deliberative Consensus, Not Vote Counting
+The division of labor is explicit:
 
-When multiple agents work concurrently, they must agree that their combined output is coherent. The naive approach, each agent telling a central orchestrator "I'm ready," fails because agents are unreliable self-assessors.
+| The agents do | A human decides |
+|---------------|-----------------|
+| Research the codebase, draft and review requirements | Whether the requirements are right (refine gate) |
+| Propose an approach and slice the work into a DAG | Whether the plan and approach are sound (plan gate) |
+| Draft Jira mutations for an epic | Whether to apply them (apply gate, epic-mode) |
+| Write code, tests, and docs; reach peer consensus | When peer review can't converge, how to break the tie |
+| Surface ambiguities and open questions | How to resolve each one (feedback) |
+| Detect stalls, loops, and errors | How to recover when self-correction fails (escalations) |
+| Open and stack PRs from plan metadata | Whether anything merges (only humans merge) |
 
-egg replaces orchestrator-decreed consensus with **Deliberative Consensus**: agents review each other's actual work, cite specific evidence, and individually confirm agreement through the **Broadcast-Review-Converge (BRC)** protocol.
+This is zero-trust architecture applied to AI agents: the agent doesn't need to be trustworthy because the environment is structurally safe, and the human doesn't need to audit for danger because the dangerous capabilities don't exist. See [Capability Removal](docs/design/capability-removal.md), the [Gateway README](gateway/README.md), and [HITL Decisions](docs/hitl-decisions.md).
+
+### 2. Review Is Evidence, Not Vibes
+
+When multiple agents work concurrently, they must agree that their combined output is coherent. The naive approach (each agent telling a central orchestrator "I'm ready") fails because agents are unreliable self-assessors. egg replaces orchestrator-decreed consensus with **Deliberative Consensus**: agents review each other's actual work and individually confirm agreement through the **Broadcast-Review-Converge (BRC)** protocol.
 
 ```
 Phase 1: Broadcast     Each producer (coder, tester, documenter) completes work
                        and proposes it with structured attestations: commit SHAs,
                        files changed, tests run, risks considered.
 
-Phase 2: Review        Reviewers evaluate proposals from assigned producers.
-                       ACKs must cite specific file paths, line numbers, commit SHAs.
-                       NACKs must include specific, actionable objections.
-                       Generic "looks good" is rejected by schema validation.
+Phase 2: Review        Reviewers evaluate proposals from assigned producers,
+                       grounded in the actual git artifacts. Objections must be
+                       specific and actionable; generic "looks good" is rejected
+                       by schema validation.
 
 Phase 3: Converge      When all reviewers have ACKed all assigned producers, each
                        agent independently confirms. The orchestrator observes
@@ -61,34 +70,33 @@ Phase 3: Converge      When all reviewers have ACKed all assigned producers, eac
 
 **Anti-sycophancy by design:**
 
-- **Delphi-style ordering.** Reviewers form independent judgments from git artifacts *before* seeing the producer's self-assessment. The server withholds producer metadata until the reviewer submits their own evaluation.
+- **Delphi-style ordering.** Reviewers form independent judgments from git artifacts *before* seeing the producer's self-assessment. The server withholds producer metadata until the reviewer submits its own evaluation.
 - **Costly signals.** Proposals and reviews require structured attestations tied to real artifacts (commit SHAs, file paths, test counts), which are mechanically hard to fake without doing the work.
 - **Commitment devices.** Proposals have cooldown periods; retracting one requires citing specific new information; after repeated flip-flops the agent is locked out and escalated to a human.
-- **Adversarial tester.** The tester is a dual role: it reviews-and-hardens the coder's tests (the coder authors its own tests), adds missing regression and adversarial cases, and probes the coder's implementation for bugs, NACKing with a failing test as the bug report.
+- **Adversarial tester.** The tester is a dual role: it reviews and hardens the coder's tests (the coder authors its own tests), adds missing regression and adversarial cases, and probes the implementation for bugs, NACKing with a failing test as the bug report.
 
-The review topology is asymmetric and sparse: reviewers evaluate producers, not each other, which keeps overhead at a handful of review edges instead of full pairwise review across the team. See [Agent Teams and Deliberative Consensus](docs/guides/agent-teams.md) for the full protocol, research foundations, and failure-mode analysis.
+On top of the protocol sits a **review-quality layer** ([#3523](https://github.com/jwbron/egg/issues/3523), rolling out in stages): reviewers emit versioned **structured findings** (each with a concrete failure scenario) and the server computes the ACK/NACK verdict from them, so models own the judgment and code owns the mechanics; a verification ladder requires blocking findings to be reproduced; a deterministic **risk router** decides which reviewer lenses run at what effort for each slice, with hard floors (unrouted files get full review, security-sensitive paths always get the security reviewer); and a shared-evidence prompt prefix, assembled once by an unprivileged `evidence_gatherer`, lets parallel reviewers start from the same cheap, cached ramp-up. Reviewers can also issue a **conditional ACK** that attaches a merge-time human obligation, surfaced on the PR body.
 
-### 3. The Overseer: AI Monitoring AI
+The review topology is asymmetric and sparse: reviewers evaluate producers, not each other, which keeps overhead at a handful of review edges instead of full pairwise review. See [Agent Teams and Deliberative Consensus](docs/guides/agent-teams.md), [Review Quality](docs/reference/review-quality.md), and [Conditional ACK](docs/reference/conditional-ack.md).
 
-The overseer watches all other agents in real time. It runs on every pipeline automatically, has no code access (it can file GitHub issues but cannot read or modify repository contents), and follows a corrective-action ladder:
+### 3. Mechanics Live in Code; Judgment Lives in Models
 
-```
-Detect anomaly (stall, loop, error, off-track behavior)
-    │
-    ├─→ Auto-nudge: send a corrective message to the stuck agent
-    ├─→ Redirect: send targeted instructions to change approach
-    ├─→ Restart agent: stop and respawn the stuck agent (preserves worktree, up to 2x)
-    ├─→ HITL escalation: queue a decision for human review
-    ├─→ Restart phase (HITL): restart all phase agents after human approval
-    ├─→ File a diagnostic GitHub issue with full context
-    └─→ Slack notification to the team
-```
+egg's longest-running design lesson: never make protocol progress depend on a model volunteering to behave. Everything mechanical (waiting, routing, state exchange, verdict arithmetic, health detection) belongs to deterministic code; the models are consulted only for judgment.
 
-Health monitoring is **two-tier**. Tier 1 is deterministic and LLM-free: orchestrator-side tripwires for heartbeat timeouts and stalls (longer thresholds during the implement phase to accommodate deep work). Tier 2 is the overseer agent itself: a Haiku classifier runs every poll cycle to flag anomalies, a Sonnet-class decision-maker reasons about ambiguous situations and chooses a corrective action, and an Opus-class advisor is consulted only when a Haiku-flagged anomaly *and* a Tier-1 alert are active simultaneously. Infrastructure errors (git failures, gateway rejections, permission denials) fast-path straight to a human-in-the-loop decision.
+- **Orchestrator-owned event loop.** Agents never idle and never wait on a message bus. The orchestrator owns all waiting and spawns a short-lived, one-shot agent pod only when there is an actionable event for it, with a per-event prompt composed deterministically. No idle pods, no model-held control flow. See [On-Demand Agent Lifecycle](docs/architecture/on-demand-agent-lifecycle.md).
+- **Served coordination state.** Anything an agent consumes but doesn't own is served from one authoritative source; workspace synchronization is performed by the harness, deterministically; prompts carry judgment, never sync mechanics. This retired a whole class of replica-drift incidents. See [Served Coordination State](docs/architecture/coordination-state.md).
+- **Deterministic health detection, on-demand adjudication.** Pipeline monitoring is a **detection plane** of pure, exception-isolated detectors evaluated in-process on every tick; the overwhelming majority of observations yield no finding and no LLM call. Only a finding marked as genuinely ambiguous spawns an on-demand **overseer** agent (Opus tier) to adjudicate that one finding. Its verdict is advisory: a bounded corrective vocabulary (`nudge_agent`, `respawn_cohort`, `open_operator_hitl`) is executed by the orchestrator identity, rate-limited, deduplicated, and audited. Infrastructure errors fast-path to a human decision. See [Overseer Architecture](docs/architecture/overseer.md) and [Pipeline Health Monitoring](docs/guides/pipeline-health-monitoring.md).
+- **Degrade safely, never lose work.** Job supervision tracks failure streaks with backoff and escalates instead of retry-looping; a circuit breaker stops non-converging cycles; committed-but-unpushed agent work is auto-salvaged to `egg/recovered/*` refs; uncommitted work on agent exit becomes a HITL recovery decision; API rate-limit exhaustion pauses and paces retries across the cap window instead of failing the run; auth failures fail fast. See [Agent Recovery](docs/reference/agent-recovery.md) and [Post-Agent Commit](docs/reference/post-agent-commit.md).
 
-The overseer is phase-scoped: spawned at the start of each phase (only when agents are actively running — zero-agent HITL parks spawn no overseer) and torn down when that phase completes, advances, or fails, giving each phase a fresh instance with no accumulated state. If it exits mid-phase, any restart goes through the general agent-restart machinery rather than a dedicated respawn loop. See [Pipeline Health Monitoring](docs/guides/pipeline-health-monitoring.md).
+### 4. Context Is a Budgeted Resource
 
-### 4. The SDLC Pipeline: Humans at the Right Moments
+Long-horizon autonomy fails quietly: not with an error, but with an agent that no longer remembers the constraint you gave it four hours ago. egg treats the context window as an engineered, budgeted resource with structural protections:
+
+- **Durable BRC memory.** Each role keeps a distilled, per-pipeline memory artifact (last-reviewed commit, prior verdicts and objections, decision log), written at review time and re-read on re-entry, so a freshly spawned one-shot agent re-enters a review cycle with continuity instead of amnesia. See [BRC Memory Artifact](docs/architecture/brc-memory.md).
+- **Anchors.** The operator's task statement and deterministically derived review anchors are re-asserted in every per-event prompt, and a persistent anchor mechanism recovers agent state after compaction. See [Anchor Recovery](docs/guides/anchor-recovery.md).
+- **Context discipline** ([#3200](https://github.com/jwbron/egg/issues/3200), opt-in via `EGG_CONTEXT_DISCIPLINE`): a small, byte-stable **protected root** (role contract, task anchor, directives) stays resident; bulk content (diffs, transcripts, memory) is demoted to a **queryable environment** pulled just-in-time through served handles; and a proactive, deterministic **threshold reseed** rebuilds the session before the harness's lossy auto-compaction can silently drop the anchors the work depends on. See [BRC Context Discipline](docs/architecture/context-discipline.md).
+
+## The Pipeline
 
 egg structures work into phases with mandatory human gates:
 
@@ -102,12 +110,14 @@ Human gate        Human gate        Human gate*        stacked-PR slices; humans
                                     only)
 ```
 
-1. **Refine.** Agents analyze the task, research the codebase, and produce requirements; reviewers validate. A simplifier also produces a jargon-free human-focused summary of the analysis. A human approves before planning begins.
-2. **Plan.** An architect recommends an approach, a task planner breaks it into discrete tasks with acceptance criteria and a **DAG of slices**, and a risk analyst flags concerns. A simplifier produces a jargon-free human-focused companion to the plan. A human approves before any code is written.
+1. **Refine.** Agents analyze the task, research the codebase, and produce requirements; reviewers validate. A simplifier also produces a jargon-free, human-focused summary of the analysis. A human approves before planning begins.
+2. **Plan.** An architect recommends an approach, a task planner breaks it into discrete tasks with acceptance criteria and a **DAG of slices**, and a risk analyst flags concerns. A simplifier produces a jargon-free companion to the plan. A human approves before any code is written.
 3. **Apply** *(Jira epic-mode only)*. When the task resolves to a Jira Epic, an `applier` role drives Jira mutations (epic description writes, child-ticket creates/edits, link creates, Won't-Do handoffs) on operator approval, before implementation begins.
-4. **Implement.** The plan's slices are scheduled as a **DAG**: each slice runs as its own agent team on its own integration branch, with its own BRC consensus and its own stacked PR. Slices whose dependencies are satisfied run concurrently (per-pipeline cap `PipelineConfig.max_parallel_slices` at pipeline creation, falling back to `EGG_ORCH_MAX_PARALLEL_SLICES`, default 1 — raise on hosts with capacity; process-wide cap `EGG_ORCH_GLOBAL_MAX_PARALLEL_SLICES`, default 4); dependent slices wait for later waves. Within a slice the coder writes code and its own tests, the tester reviews-and-hardens the coder's tests (adding missing coverage and adversarially probing for bugs), and the documenter updates docs, while code, contract, security, and concurrency reviewers provide line-level feedback and can block consensus on a NACK.
+4. **Implement.** The plan's slices are scheduled as a **DAG**: each slice runs as its own agent team on its own integration branch, with its own BRC consensus and its own stacked PR. Slices whose dependencies are satisfied run concurrently, bounded per pipeline and process-wide; dependent slices wait for later waves. Within a slice the coder writes code and its own tests, the tester reviews and hardens those tests while adversarially probing for bugs, and the documenter updates docs, while code, contract, security, and concurrency reviewers provide line-level feedback and can block consensus.
 
-There is **no separate "PR" phase**. The pipeline's context PR (`egg/<id>/work` into `main`) is opened up-front at the plan-to-implement boundary; slice PRs stack onto it and are created automatically by the orchestrator as each slice reaches consensus. Only a human can merge, via the GitHub UI. See the [SDLC Pipeline Guide](docs/guides/sdlc-pipeline.md) and [Slice-DAG Implement Phase](docs/architecture/slice-dag.md).
+Pipelines can also span **multiple repositories**: each slice maps to exactly one repo, cross-repo work is expressed as slices in different repos connected by ordinary dependency edges, and a cross-repo merge gate sequences the dependent PRs (the downstream PR stays draft until its upstream merges). See [Slice-DAG Implement Phase](docs/architecture/slice-dag.md).
+
+There is **no separate "PR" phase**. The pipeline's context PR (`egg/<id>/work` into `main`) is opened up-front at the plan-to-implement boundary; slice PRs stack onto it and are created automatically by the orchestrator as each slice reaches consensus. Only a human can merge, via the GitHub UI. See the [SDLC Pipeline Guide](docs/guides/sdlc-pipeline.md).
 
 A completed pipeline looks like this:
 
@@ -141,69 +151,61 @@ A completed pipeline looks like this:
   stacked PRs on egg/<id>/work into main  (humans merge)
 ```
 
-### 5. Human-in-the-Loop: The Agents Don't Decide
+## Beyond the Pipeline: GitHub Automation
 
-This is the principle the other four pillars exist to serve: agents do the work, but humans make the consequential calls. The gateway, the consensus protocol, and the overseer all funnel uncertainty and risk upward to a person instead of letting an agent resolve it alone.
+egg also ships a suite of sandboxed GitHub Actions bots that run under the same zero-credential, gateway-enforced controls as pipeline agents:
 
-Every phase boundary is a gate where a human reviews the agents' artifacts and approves before the pipeline advances. Beyond those gates, whenever an agent or the overseer hits something it should not resolve on its own (ambiguous requirements, a design fork, an infrastructure error, repeated failed cycles), egg pauses the pipeline and queues a formal HITL decision instead of guessing. The operator answers through `provide_input` on the MCP or CLI surface, and the pipeline resumes exactly where it stopped. egg never auto-resolves these decisions, even in otherwise automated runs.
+- **AI Code Review** reviews PRs and posts line-level feedback; **Address Review Feedback** closes the loop by acting on review comments (from humans or bots), enabling automated review-fix-re-review cycles.
+- **Design Review** and **Contract Verification** apply project-specific rules and check implementations against their SDLC contracts.
+- **Check Autofixer** diagnoses CI failures and fixes them (deterministic fixers first, then an agent); **Conflict Resolver** clears merge conflicts; **Doc Updater** keeps docs in sync with merged code.
 
-The division of labor is explicit:
-
-| The agents do | A human decides |
-|---------------|-----------------|
-| Research the codebase, draft and review requirements | Whether the requirements are right (refine gate) |
-| Propose an approach and slice the work into a DAG | Whether the plan and approach are sound (plan gate) |
-| Draft Jira mutations for an epic | Whether to apply them (apply gate, epic-mode) |
-| Write code, tests, and docs; reach BRC consensus | When peer review can't converge, how to break the tie |
-| Surface ambiguities and open questions | How to resolve each one (feedback) |
-| Flag stalls, loops, and errors (overseer) | How to recover when self-correction fails (escalations) |
-| Open and stack PRs from plan metadata | Whether anything merges (only humans merge) |
-
-See [HITL Decisions](docs/hitl-decisions.md) for the decision, feedback, and approval workflow.
+All of these are packaged as **reusable workflows** that external repositories can call, so a repo can adopt egg's review loop without adopting the full pipeline. See [GitHub Automation](docs/guides/github-automation.md) and [Reusable Workflows](docs/guides/reusable-workflows.md).
 
 ## Architecture
 
 egg deploys as a set of containers on **Kubernetes (k3s)**, split across two namespaces: trusted services in `egg-system` and untrusted agent Jobs in `egg-agents`, with Cilium NetworkPolicies enforcing isolation between them.
 
 ```
-┌─────────────────────────── egg-system (trusted) ───────────────────────────┐
-│                                                                            │
-│  ┌──────────────────────┐   ┌───────────────────────────┐   ┌───────────┐  │
-│  │    Orchestrator      │   │     Gateway Sidecar       │   │  LiteLLM  │  │
-│  │                      │   │                           │   │  (proxy)  │  │
-│  │  • Pipeline state    │   │  • Zero-trust credential  │   │           │  │
-│  │  • Slice scheduler   │◀─▶│    injection              │   │  optional │  │
-│  │  • BRC consensus     │   │  • Phase-locked git/gh    │   │  non-     │  │
-│  │  • Overseer (2-tier) │   │  • Branch ownership       │   │  Claude   │  │
-│  │  • HITL decisions    │   │  • Restricted-path gates  │   │  routing  │  │
-│  │  • MCP server :9850  │   │  • Network isolation      │   │   :4000   │  │
-│  │  • REST API   :9849  │   │  • Jira/Confluence wrap   │   │           │  │
-│  └──────────────────────┘   │   :9848 (+ proxy :3129)   │   └───────────┘  │
-│                             └──────────────▲────────────┘                  │
-└────────────────────────────────────────────┼───────────────────────────────┘
-                                             │ all privileged ops + LLM calls
-┌─────────────────────────── egg-agents ─────┼──────────── (untrusted) ──────┐
-│   ┌────────────────────────────────────────┴─────────────────────────────┐ │
-│   │  Sandbox agent Jobs (one per role per phase/slice)                   │ │
-│   │  • Claude Code via the Agent SDK (egg_agent)                         │ │
-│   │  • Standard git/gh wrappers → gateway   • No credentials             │ │
-│   │  • Per-agent git worktree               • No merge endpoint          │ │
-│   └──────────────────────────────────────────────────────────────────────┘ │
-└────────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────── egg-system (trusted) ────────────────────────────┐
+│                                                                              │
+│  ┌───────────────────────┐   ┌───────────────────────────┐   ┌────────────┐  │
+│  │     Orchestrator      │   │     Gateway Sidecar       │   │   Redis    │  │
+│  │                       │   │                           │   │ (message   │  │
+│  │  • Pipeline state     │   │  • Zero-trust credential  │   │  store)    │  │
+│  │  • Event loop +       │◀─▶│    injection              │   └────────────┘  │
+│  │    slice scheduler    │   │  • Phase-locked git/gh    │   ┌────────────┐  │
+│  │  • BRC consensus      │   │  • Branch ownership       │   │  LiteLLM   │  │
+│  │  • Detection plane    │   │  • Restricted-path gates  │   │  (proxy)   │  │
+│  │  • HITL decisions     │   │  • Network isolation      │   │  optional  │  │
+│  │  • MCP server :9850   │   │  • Jira/Confluence wrap   │   │  non-Claude│  │
+│  │  • REST API   :9849   │   │    :9848 (+ proxy :3129)  │   │  routing   │  │
+│  └───────────────────────┘   └──────────────▲────────────┘   │   :4000    │  │
+│                                             │                └────────────┘  │
+└─────────────────────────────────────────────┼────────────────────────────────┘
+                                              │ all privileged ops + LLM calls
+┌──────────────────────────── egg-agents ─────┼───────────── (untrusted) ──────┐
+│   ┌─────────────────────────────────────────┴────────────────────────────┐  │
+│   │  Sandbox agent Jobs: short-lived, spawned one-shot per event         │  │
+│   │  • Claude Code via the Agent SDK (egg_agent)                         │  │
+│   │  • Standard git/gh wrappers → gateway   • No credentials             │  │
+│   │  • Per-agent git worktree               • No merge endpoint          │  │
+│   └──────────────────────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────────────┘
 ```
 
 **Key principle:** the agent cannot bypass controls because the capabilities don't exist in its environment. This is infrastructure enforcement, not behavioral control. See the [Architecture Overview](docs/architecture/README.md) and [Kubernetes Migration](docs/architecture/kubernetes-migration.md).
 
 | Component | Namespace | Role | Trust |
 |-----------|-----------|------|-------|
-| **Orchestrator** | `egg-system` | Pipeline state, slice scheduling, BRC consensus, overseer, HITL, MCP server (`:9850`) + REST API (`:9849`) | Trusted |
+| **Orchestrator** | `egg-system` | Pipeline state, the BRC event loop, slice scheduling, detection plane, HITL, MCP server (`:9850`) + REST API (`:9849`) | Trusted |
 | **Gateway** | `egg-system` | Credential injection, phase/branch/path enforcement, network isolation, Jira/Confluence wrappers (`:9848`, proxy `:3129`) | Trusted |
-| **LiteLLM** | `egg-system` | Optional proxy for routing individual agent roles to non-Claude models (`:4000`); inert by default (no agent role routes to it unless configured) | Trusted |
-| **Sandbox** | `egg-agents` | Untrusted agent Jobs: Claude Code via the Agent SDK, per-agent worktree, zero credentials | Untrusted |
+| **Redis** | `egg-system` | Message-store backend for the inter-agent bus and coordination state | Trusted |
+| **LiteLLM** | `egg-system` | Optional proxy for routing individual agent roles to non-Claude models (`:4000`); inert by default | Trusted |
+| **Sandbox** | `egg-agents` | Untrusted agent Jobs: Claude Code via the Agent SDK, per-agent worktree, zero credentials, spawned one-shot per event | Untrusted |
 
 ## Driving Pipelines: the MCP Server
 
-The orchestrator exposes an MCP server (port `9850`) so you can drive pipelines from Claude Code or any MCP-compatible client. The legacy interactive CLI (`bin/egg`) and Docker Compose deployment were removed in [#1762](https://github.com/jwbron/egg/issues/1762).
+The orchestrator exposes an MCP server (port `9850`) so you can drive pipelines from Claude Code or any MCP-compatible client. The legacy interactive CLI (`bin/egg`) and Docker Compose deployment were removed in [#1762](https://github.com/jwbron/egg/issues/1762): agents are headless, and the human operates as an MCP client.
 
 ```
 submit_task(issue_number=123, repo="owner/name")
@@ -214,11 +216,23 @@ Representative tools (see the [Orchestrator CLI](docs/reference/orchestrator-cli
 - **Lifecycle:** `submit_task`, `cancel_task`, `list_tasks`, `start_pipeline`
 - **Monitoring:** `get_status`, `get_phase`, `get_pipeline_snapshot`, `get_consensus_status`, `check_health`
 - **HITL & coordination:** `provide_input`, `answer_feedback`, `send_message`
-- **Phase & agent control:** `advance_phase`, `start_phase`, `complete_phase`, `restart_agent`, `restart_phase`, `populate_contract`, `update_pipeline_config`
+- **Phase & agent control:** `advance_phase`, `start_phase`, `complete_phase`, `restart_agent`, `restart_phase`, `populate_contract`
+- **Live operations:** `update_pipeline_config` (swap an agent's model or widen a consensus timeout on a running pipeline)
+- **Recovery:** `list_agent_local_commits`, `salvage_agent_commits`, `prune_stale_worktrees`
 - **Debugging:** `list_containers`, `get_container_logs`, `get_agent_transcript`, `get_service_logs`, `validate_config`
-- **Deployment:** `get_deployment_context`, `validate_deployment_manifests`, `validate_network_isolation`, `prune_stale_worktrees`, `rebuild_and_rollout`
+- **Deployment:** `get_deployment_context`, `validate_deployment_manifests`, `validate_network_isolation`, `rebuild_and_rollout`
 
-Host-side CLIs in `bin/` (`egg-sdlc`, `egg-status`, `egg-pipeline-watch`, `egg-onboarding-docs`) wrap the same APIs for monitoring and visualization.
+Host-side CLIs in `bin/` (`egg-sdlc`, `egg-status`, `egg-pipeline-watch`, `egg-onboarding-docs`) wrap the same APIs for monitoring and visualization, and the `skills/` directory ships operator skills (`sdlc`, `agent-diagnose`, `deployment-diagnose`, `egg-setup`) for MCP-connected Claude Code hosts.
+
+## More Capabilities
+
+| Capability | What it does | Docs |
+|------------|--------------|------|
+| **Jira epic mode** | Epic detection and routing, a reassess sweep that classifies child tickets (done / in-flight / updatable), Won't-Do drain, and a bounded, allowlisted Jira write surface | [Jira Wrapper](docs/reference/jira-wrapper.md) |
+| **Per-agent model routing** | Route any agent role to a non-Claude model through LiteLLM, with a hot-reloadable routing policy, proactive switchover, and reactive fallback chains | [Per-Agent Models](docs/guides/per-agent-models.md) · [Upstream Routing](docs/architecture/upstream-routing.md) |
+| **Observability** | Structured OpenTelemetry-aligned JSON logging, persisted agent transcripts, and diagnostic skills with evidence boundaries and redaction | [Logging](docs/architecture/logging.md) · [Deployment Diagnostics](docs/guides/deployment-diagnostics.md) |
+| **Repo onboarding docs** | Generate baseline repository documentation with `egg-onboarding-docs` | [Documentation Onboarding](docs/guides/github-automation.md#documentation-onboarding) |
+| **Secret redaction** | Defense-in-depth redaction of credentials in logs and agent-visible output | [Redaction](docs/reference/redaction.md) |
 
 ## Quick Start
 
@@ -263,15 +277,18 @@ See:
 
 | Directory | What it is |
 |-----------|------------|
-| `orchestrator/` | Central SDLC pipeline engine: scheduling, slice DAG, BRC consensus, overseer, health monitoring, MCP server |
+| `orchestrator/` | Central SDLC pipeline engine: the event loop, slice DAG scheduling, BRC consensus, detection plane, health monitoring, MCP server |
 | `gateway/` | Trusted policy-enforcement sidecar: validates git/gh/Jira/Confluence operations, injects credentials, enforces network isolation |
 | `sandbox/` | Untrusted agent container: Claude Code config, the `egg_agent` runtime, git/gh wrappers, host-side CLIs |
 | `shared/` | Shared Python packages (`egg_agent`, `egg_config`, `egg_contracts`, `egg_git`, `egg_logging`, `egg_anchor`, …) plus agent prompt templates |
 | `config/` | Repository and host configuration templates; `config/litellm/` builds the LiteLLM image |
 | `k8s/` | Kustomize manifests: `base/` plus `overlays/local/` |
 | `action/` | Composite GitHub Action and review-bot prompt builders |
+| `skills/` | Operator skills for MCP-connected hosts (`sdlc`, `agent-diagnose`, `deployment-diagnose`, `egg-setup`) |
 | `docs/` | All documentation: guides, architecture, references |
+| `tests/` | Unit-test suite (mirrors the component layout) |
 | `integration_tests/` | Cross-component integration and security tests (k3s required) |
+| `metrics/` | Self-improvement metrics data |
 | `scripts/` | Build, release, and CI helpers (incl. changeset-aware test selection) |
 | `bin/` | Host-side CLI entry points |
 
@@ -286,15 +303,19 @@ Start with **[docs/index.md](docs/index.md)**, which has task-specific lookup ta
 | **Why capabilities are removed, not forbidden** | [Capability Removal](docs/design/capability-removal.md) |
 | **Gateway enforcement** | [Gateway README](gateway/README.md) |
 | **Agent teams & deliberative consensus** | [Agent Teams Guide](docs/guides/agent-teams.md) |
-| **Slice-DAG implement phase** | [Slice-DAG Implement Phase](docs/architecture/slice-dag.md) |
+| **Review quality (structured findings, risk router)** | [Review Quality](docs/reference/review-quality.md) |
+| **Slice-DAG implement phase & multi-repo** | [Slice-DAG Implement Phase](docs/architecture/slice-dag.md) |
 | **SDLC pipeline** | [SDLC Pipeline Guide](docs/guides/sdlc-pipeline.md) |
 | **Human-in-the-loop decisions** | [HITL Decisions](docs/hitl-decisions.md) |
-| **Orchestrator & overseer** | [Orchestrator Architecture](docs/architecture/orchestrator.md) · [On-Demand Agent Lifecycle](docs/architecture/on-demand-agent-lifecycle.md) |
-| **Health monitoring** | [Pipeline Health Monitoring](docs/guides/pipeline-health-monitoring.md) |
+| **On-demand agent lifecycle** | [On-Demand Agent Lifecycle](docs/architecture/on-demand-agent-lifecycle.md) |
+| **Overseer & health monitoring** | [Overseer Architecture](docs/architecture/overseer.md) · [Pipeline Health Monitoring](docs/guides/pipeline-health-monitoring.md) |
+| **Long-context discipline** | [BRC Context Discipline](docs/architecture/context-discipline.md) · [BRC Memory](docs/architecture/brc-memory.md) · [Anchor Recovery](docs/guides/anchor-recovery.md) |
+| **GitHub automation & reusable workflows** | [GitHub Automation](docs/guides/github-automation.md) · [Reusable Workflows](docs/guides/reusable-workflows.md) |
 | **Agent roles & permissions** | [Agent Roles Reference](docs/reference/agent-roles.md) |
 | **Non-Claude model routing** | [Upstream Routing](docs/architecture/upstream-routing.md) · [Per-Agent Models](docs/guides/per-agent-models.md) |
 | **Kubernetes / k3s** | [Kubernetes Migration](docs/architecture/kubernetes-migration.md) |
 | **Sandbox environment** | [Sandbox README](sandbox/README.md) |
+| **The feedback-loop model behind the pipeline** | [The Agentic Feedback Loop](docs/architecture/agentic-feedback-loop.md) · [Why egg Works](docs/architecture/collaboration-effectiveness.md) |
 | **Contributing** | [CONTRIBUTING.md](CONTRIBUTING.md) |
 
 ## Development

--- a/docs/architecture/collaboration-effectiveness.md
+++ b/docs/architecture/collaboration-effectiveness.md
@@ -7,18 +7,18 @@ egg offers an alternative: a public, async workflow where every interaction happ
 ## How It Works
 
 ```
-@mention → Plan → Implement → PR → Review → Human merges
+Submit task → Refine → Plan → Implement → Stacked PRs → Human merges
 ```
 
-At each stage, the team has visibility and can intervene: redirect scope at mention, review approach at plan, review code at PR.
+At each stage, the team has visibility and can intervene: redirect scope at submission, review the analysis at refine, review the approach at plan, review code at PR.
 
-**Task assignment is public.** Work starts with an @mention in a GitHub issue or PR comment. Anyone watching the repo sees the request, understands the scope, and can weigh in before the agent starts.
+**Task assignment is public.** Work starts with a GitHub issue (or Jira epic) submitted through the orchestrator's MCP server. Anyone watching the repo sees the request, understands the scope, and can weigh in before the agents start; the pipeline posts its analysis, plan, and phase-completion artifacts back to the issue thread.
 
 **Plans are reviewable before implementation.** For non-trivial work, egg produces a structured plan describing what it intends to do, which files it will change, and how it will verify correctness. This is the highest-leverage collaboration point: five minutes of plan review saves hours of rework.
 
-**All work is async.** You @mention egg, then walk away. It reads the codebase, writes code, runs tests, and opens a PR. You can assign a task from your phone and review the result later.
+**All work is async.** You submit a task, then walk away. The agent teams read the codebase, write code, run tests, and open stacked PRs. You can assign a task from your phone and review the result later.
 
-**Workflow logs are the audit trail.** Every run produces a full GitHub Actions log: what the agent did, what it tried, what output it got. When a colleague gets a good result, you can read the log to see exactly what prompt and approach worked. This is dramatically more useful than "I asked the AI to do X and it worked."
+**The artifacts are the audit trail.** Every run leaves a visible trail: the analysis and plan on the issue, the review deliberation on the PRs, persisted agent transcripts (`get_agent_transcript`), and structured orchestrator logs. When a colleague gets a good result, you can read exactly what prompt and approach worked. This is dramatically more useful than "I asked the AI to do X and it worked."
 
 ## What This Workflow Offers
 
@@ -28,7 +28,7 @@ egg adds a public, async option to your team's AI toolkit. Use it when the task 
 |---|---|
 | Feedback at PR review, after the agent has committed to an approach | Feedback at plan stage, when redirecting costs minutes instead of hours |
 | Prompt knowledge stays with individual developers | Shared prompt playbooks emerge organically from visible issue threads |
-| Reviewing AI work is opaque: just a diff, no reasoning | Full reasoning visible in workflow logs, alongside the code |
+| Reviewing AI work is opaque: just a diff, no reasoning | Full reasoning visible in issue threads, PR deliberation, and agent transcripts, alongside the code |
 | Developers adopt AI tools individually | Common patterns and standards develop naturally across the team |
 
 When teams adopt the public workflow, knowledge compounds. Someone discovers that explicit acceptance criteria produce better tests. Someone else finds that referencing a specific ADR leads to more consistent architecture. These strategies spread because the artifacts are public, not locked in private chat sessions.
@@ -76,7 +76,7 @@ These mechanisms compound: by the time a human reviewer sees the PR, the most co
 
 **When the investment pays off:** Teams with two or more engineers working on the same codebase see the most benefit from the visibility model. Solo developers still gain the safety guarantees and async workflow, but the collaboration benefits compound with team size.
 
-**Interactive CLI mode:** egg also runs as an interactive CLI for rapid prototyping and real-time back-and-forth, where the async workflow's overhead isn't worth it.
+For rapid prototyping and real-time back-and-forth where the async workflow's overhead isn't worth it, use a private AI tool directly; egg's agents are headless by design ([#1762](https://github.com/jwbron/egg/issues/1762)), and the operator drives them as an MCP client.
 
 ## Looking Forward
 

--- a/docs/guides/pipeline-health-monitoring.md
+++ b/docs/guides/pipeline-health-monitoring.md
@@ -1,6 +1,24 @@
 # Pipeline Health Monitoring
 
-Pipeline health monitoring uses a **two-tier architecture** to detect and respond to agent failures during pipeline execution. The orchestrator tier handles clear-cut failures deterministically (no LLM cost), while the overseer agent tier handles ambiguous situations requiring semantic analysis.
+> **Status:** The **Tier 1 deterministic detection** described here — structured
+> progress events, orchestrator tripwires, the alive-signal gates, and
+> branch-divergence detection — is current and authoritative. The **Tier 2
+> "Overseer Agent" internal architecture** below (Haiku classifiers on every
+> cycle, a Sonnet/Opus decision-maker) predates the overseer overhaul
+> ([#2270](https://github.com/jwbron/egg/issues/2270)) and is being retired: the
+> delivered shape is a deterministic **detection plane** plus an **on-demand,
+> advisory adjudicator** (Opus tier) that runs only for the genuinely ambiguous
+> minority, executing a bounded corrective vocabulary under the orchestrator
+> identity. For the current overseer model, see
+> [Overseer Architecture](../architecture/overseer.md), which is authoritative
+> when the two disagree.
+
+Pipeline health monitoring detects and responds to agent failures during
+pipeline execution. The orchestrator resolves clear-cut failures
+deterministically (no LLM cost) via the detection plane described under
+[Tier 1](#tier-1-orchestrator-tripwires); genuinely ambiguous findings are
+handed to the on-demand overseer adjudicator (see
+[Overseer Architecture](../architecture/overseer.md)).
 
 ## Architecture Overview
 


### PR DESCRIPTION
## Summary

The main README's skeleton dated from the #2900 rewrite (mid-May) and has only received incremental doc-updater patches since. Its individual facts were mostly current, but its model of the system was two eras old. This PR is a structured rewrite plus a fix for one drifted architecture doc it links to.

## README changes

**Reframed around four principles** (replacing the five pillars), so the intent (broad, long-horizon, autonomous-but-human-directed work that stays aligned with human ideas) is the organizing story:

1. **Human authority is structural**: merges the old gateway and HITL pillars.
2. **Review is evidence, not vibes**: BRC plus the #3523 review-quality layer (structured findings with server-computed verdicts, verification ladder, risk-routed review graph, evidence_gatherer, conditional ACK).
3. **Mechanics live in code; judgment lives in models**: new pillar covering the orchestrator-owned event loop with one-shot per-event pods (#3064), served coordination state (#3077), the overseer detection plane, and the work-preservation/resilience layer (salvage, paced rate-limit retry, supervision, circuit breaker).
4. **Context is a budgeted resource**: new pillar covering durable BRC memory (#2908), anchors, and the opt-in context discipline (#3200).

**Retired stale architecture claims:**

- The overseer section described the pre-#2270 model (phase-scoped respawning watcher pod, Haiku-classifier-every-poll, Opus advisor on Haiku-flag + Tier-1 coincidence). Rewritten to the delivered shape: deterministic detection plane, on-demand Opus adjudicator (advisory), bounded corrective vocabulary executed under the orchestrator identity.
- The architecture diagram and prose implied resident agent cohorts ("one per role per phase/slice"). Updated to one-shot per-event Jobs.
- `max_parallel_slices` fallback default corrected (4, not 1; raised in #3164). Knob-level detail demoted to doc links.
- Branch-ownership prefix corrected to `egg-`/`egg/`.

**Added previously uncovered capabilities:** multi-repo pipelines with the cross-repo merge gate (#3393), the GitHub automation bot suite and reusable workflows (new "Beyond the Pipeline" section), Redis in the architecture diagram and components table, live pipeline operations (`update_pipeline_config`), a "More Capabilities" table (Jira epic mode depth, model routing, observability, onboarding docs, redaction), and `skills/`, `tests/`, `metrics/` in the repo layout.

**Kept (verified accurate against the code):** the pipeline diagrams and all 17 roles, Quick Start, ports, make targets, MCP tool names, Development section, license.

## Side finding: collaboration-effectiveness.md drift

`docs/architecture/collaboration-effectiveness.md` still described the retired @mention trigger, GitHub Actions workflow logs as the audit trail, and the interactive CLI mode (removed in #1762). Updated the flow to the MCP `submit_task` pipeline, pointed the audit trail at issue artifacts, PR deliberation, and persisted transcripts, and replaced the interactive-CLI paragraph with the headless-agents posture.

## Notes

- Every relative link in the new README was checked against the tree.
- `make lint` fails on main with a pre-existing `orchestrator/tests/test_cli.py:5 I001` import-sort error, unrelated to this markdown-only diff; `lint-custom` and pre-commit hooks pass.
- Not addressed here (flagged for follow-up): `docs/architecture/orchestrator.md` ("Pipeline health monitoring" section) and `orchestrator/README.md` still carry the pre-#2270 overseer description that `docs/architecture/overseer.md` says is being retired.