### PR TITLE
fix(litellm): report provider-automatic cache hits in streamed usage

### DIFF
--- a/config/litellm/patch_litellm_cache.py
+++ b/config/litellm/patch_litellm_cache.py
@@ -70,7 +70,11 @@ OpenRouter. The image pins that same version (see the Dockerfile
      forever), so auto-compaction never triggers and the orchestrator's
      transcript-derived token accounting undercounts. Mirrors the fix
      upstreamed via jwbron/litellm#6 (upstream now falls back to
-     ``prompt_tokens_details.cached_tokens`` natively).
+     ``prompt_tokens_details.cached_tokens`` natively). Unlike Patch 5,
+     this has no sync ``__next__`` twin: the cache-token usage merge
+     exists only in the async ``__anext__`` path upstream (the sync path
+     has no equivalent merge block), and that async path is the one the
+     litellm proxy drives for Claude Code streaming.
 
 Idempotent: each patch detects whether it is already applied. Fails
 loudly (non-zero exit) if a needle is missing, so a LiteLLM version bump

--- a/config/litellm/patch_litellm_cache.py
+++ b/config/litellm/patch_litellm_cache.py
@@ -4,8 +4,8 @@
 LiteLLM's stock Anthropic->OpenAI translation (the path Claude Code's
 ``/v1/messages`` requests take when routed at a non-Claude OpenRouter
 backend) drops prompt-cache hits for Qwen/DeepSeek and mis-streams
-reasoning models. Five independent gaps cause it; this script closes all
-five by editing the installed ``litellm`` package in place, then
+reasoning models. Six independent gaps cause it; this script closes all
+six by editing the installed ``litellm`` package in place, then
 ``config/litellm/Dockerfile`` bakes the result into the ``egg-litellm``
 image.
 
@@ -57,6 +57,20 @@ OpenRouter. The image pins that same version (see the Dockerfile
      thinking block and the first answer token after thinking are silently
      dropped; a one-chunk answer can vanish entirely. Applied to both the
      sync ``__next__`` and async ``__anext__`` paths.
+  6. ``AnthropicStreamWrapper`` usage merge (same streaming_iterator.py)
+     report provider-automatic cache hits in the streamed usage. The stock
+     code subtracts ``prompt_tokens_details.cached_tokens`` from
+     ``input_tokens`` but only emits ``cache_read_input_tokens`` from the
+     internal ``_cache_read_input_tokens`` field, which OpenAI/OpenRouter-
+     style usage never populates (only Anthropic- and DeepSeek-native
+     fields do). On any auto-caching route (Moonshot kimi-k3 ~94% hit
+     rate, Fireworks deepseek-flash, DeepInfra glm) the cached tokens
+     simply vanish from the usage Anthropic-format clients see: Claude
+     Code's context tracking sees only the uncached tail (~0% context
+     forever), so auto-compaction never triggers and the orchestrator's
+     transcript-derived token accounting undercounts. Mirrors the fix
+     upstreamed via jwbron/litellm#6 (upstream now falls back to
+     ``prompt_tokens_details.cached_tokens`` natively).
 
 Idempotent: each patch detects whether it is already applied. Fails
 loudly (non-zero exit) if a needle is missing, so a LiteLLM version bump
@@ -140,7 +154,7 @@ PATCHES: list[dict[str, str]] = [
             '    QWEN = "qwen"\n'
             '    DEEPSEEK = "deepseek"\n'
         ),
-        "label": "Patch 1/5 (CacheControlSupportedModels)",
+        "label": "Patch 1/6 (CacheControlSupportedModels)",
     },
     # Patch 2 — broaden ONLY the cache_control gate (not the shared
     # is_anthropic_claude_model predicate, which also gates thinking
@@ -170,7 +184,7 @@ PATCHES: list[dict[str, str]] = [
             "            )\n"
             "        ):\n"
         ),
-        "label": "Patch 2/5 (cache_control gate)",
+        "label": "Patch 2/6 (cache_control gate)",
     },
     # Patch 3 — drop x-anthropic-billing-header during Anthropic->OpenAI translation.
     {
@@ -204,7 +218,7 @@ PATCHES: list[dict[str, str]] = [
             '                        "text": text,\n'
             "                    }\n"
         ),
-        "label": "Patch 3/5 (x-anthropic-billing-header filter)",
+        "label": "Patch 3/6 (x-anthropic-billing-header filter)",
     },
     # Patch 4 — OpenRouter-style reasoning_content must open a thinking
     # content block, not fall through to a text block. The bare
@@ -242,7 +256,7 @@ PATCHES: list[dict[str, str]] = [
             '                choice.delta, "thinking_blocks"\n'
             "            ):\n"
         ),
-        "label": "Patch 4/5 (reasoning_content thinking block)",
+        "label": "Patch 4/6 (reasoning_content thinking block)",
     },
     # Patch 5a — sync __next__: don't drop the first delta on text or
     # thinking block transitions.
@@ -342,7 +356,7 @@ PATCHES: list[dict[str, str]] = [
             "                        ):\n"
             "                            self.chunk_queue.append(processed_chunk)\n"
         ),
-        "label": "Patch 5/5a (sync first-delta requeue)",
+        "label": "Patch 5a/6 (sync first-delta requeue)",
     },
     # Patch 5b — async __anext__: same first-delta preservation.
     {
@@ -440,7 +454,99 @@ PATCHES: list[dict[str, str]] = [
             "                            ):\n"
             "                                self.chunk_queue.append(processed_chunk)\n"
         ),
-        "label": "Patch 5/5b (async first-delta requeue)",
+        "label": "Patch 5b/6 (async first-delta requeue)",
+    },
+    # Patch 6 — streamed usage must report provider-automatic cache hits.
+    # The needle spans the whole usage-merge region so both edit points
+    # (the cached_tokens hoist and the cache_read fallback) land atomically.
+    {
+        "file": F3,
+        "present": "# egg cache patch (streaming cache_read fallback)",
+        "needle": (
+            "                    # Add usage to the held chunk\n"
+            "                    uncached_input_tokens = chunk.usage.prompt_tokens or 0\n"
+            "                    if (\n"
+            '                        hasattr(chunk.usage, "prompt_tokens_details")\n'
+            "                        and chunk.usage.prompt_tokens_details\n"
+            "                    ):\n"
+            "                        cached_tokens = (\n"
+            "                            getattr(\n"
+            '                                chunk.usage.prompt_tokens_details, "cached_tokens", 0\n'
+            "                            )\n"
+            "                            or 0\n"
+            "                        )\n"
+            "                        uncached_input_tokens -= cached_tokens\n"
+            "\n"
+            "                    usage_dict: UsageDelta = {\n"
+            '                        "input_tokens": uncached_input_tokens,\n'
+            '                        "output_tokens": chunk.usage.completion_tokens or 0,\n'
+            "                    }\n"
+            "                    # Add cache tokens if available (for prompt caching support)\n"
+            "                    if (\n"
+            '                        hasattr(chunk.usage, "_cache_creation_input_tokens")\n'
+            "                        and chunk.usage._cache_creation_input_tokens > 0\n"
+            "                    ):\n"
+            '                        usage_dict["cache_creation_input_tokens"] = (\n'
+            "                            chunk.usage._cache_creation_input_tokens\n"
+            "                        )\n"
+            "                    if (\n"
+            '                        hasattr(chunk.usage, "_cache_read_input_tokens")\n'
+            "                        and chunk.usage._cache_read_input_tokens > 0\n"
+            "                    ):\n"
+            '                        usage_dict["cache_read_input_tokens"] = (\n'
+            "                            chunk.usage._cache_read_input_tokens\n"
+            "                        )\n"
+        ),
+        "replacement": (
+            "                    # Add usage to the held chunk\n"
+            "                    uncached_input_tokens = chunk.usage.prompt_tokens or 0\n"
+            "                    cached_tokens = 0\n"
+            "                    if (\n"
+            '                        hasattr(chunk.usage, "prompt_tokens_details")\n'
+            "                        and chunk.usage.prompt_tokens_details\n"
+            "                    ):\n"
+            "                        cached_tokens = (\n"
+            "                            getattr(\n"
+            '                                chunk.usage.prompt_tokens_details, "cached_tokens", 0\n'
+            "                            )\n"
+            "                            or 0\n"
+            "                        )\n"
+            "                        uncached_input_tokens -= cached_tokens\n"
+            "\n"
+            "                    usage_dict: UsageDelta = {\n"
+            '                        "input_tokens": uncached_input_tokens,\n'
+            '                        "output_tokens": chunk.usage.completion_tokens or 0,\n'
+            "                    }\n"
+            "                    # Add cache tokens if available (for prompt caching support)\n"
+            "                    if (\n"
+            '                        hasattr(chunk.usage, "_cache_creation_input_tokens")\n'
+            "                        and chunk.usage._cache_creation_input_tokens > 0\n"
+            "                    ):\n"
+            '                        usage_dict["cache_creation_input_tokens"] = (\n'
+            "                            chunk.usage._cache_creation_input_tokens\n"
+            "                        )\n"
+            "                    if (\n"
+            '                        hasattr(chunk.usage, "_cache_read_input_tokens")\n'
+            "                        and chunk.usage._cache_read_input_tokens > 0\n"
+            "                    ):\n"
+            '                        usage_dict["cache_read_input_tokens"] = (\n'
+            "                            chunk.usage._cache_read_input_tokens\n"
+            "                        )\n"
+            "                    # egg cache patch (streaming cache_read fallback).\n"
+            "                    # OpenAI/OpenRouter-style usage reports the cache hit in\n"
+            "                    # prompt_tokens_details.cached_tokens; Usage.__init__ only\n"
+            "                    # populates _cache_read_input_tokens from Anthropic- or\n"
+            "                    # DeepSeek-native fields. Without this fallback the cached\n"
+            "                    # tokens are subtracted from input_tokens above but never\n"
+            "                    # reported, so Anthropic-format clients (Claude Code\n"
+            "                    # context tracking, the orchestrator token accounting)\n"
+            "                    # undercount the prompt by the cached amount on every\n"
+            "                    # cache hit. Mirrors jwbron/litellm#6 (fixed natively\n"
+            "                    # upstream after v1.86.2).\n"
+            "                    elif cached_tokens > 0:\n"
+            '                        usage_dict["cache_read_input_tokens"] = cached_tokens\n'
+        ),
+        "label": "Patch 6/6 (streaming cache_read fallback)",
     },
 ]
 

--- a/tests/config/test_patch_litellm_cache.py
+++ b/tests/config/test_patch_litellm_cache.py
@@ -119,7 +119,7 @@ def test_patch4_needle_anchors_on_content_block_function(tmp_path):
     fixture containing a *second* (sibling-function-style) bare
     ``thinking_blocks`` elif — preceded by a ``tool_calls`` block, not the
     text elif — must be left untouched."""
-    patch4 = next(p for p in plc.PATCHES if p["label"].startswith("Patch 4/5"))
+    patch4 = next(p for p in plc.PATCHES if p["label"].startswith("Patch 4/6"))
 
     # Sibling function: bare thinking_blocks elif preceded by a tool_calls
     # branch (mirrors _translate_streaming_openai_chunk_to_anthropic). It must


### PR DESCRIPTION
## Problem

LiteLLM v1.86.2 (the egg-litellm base image) drops provider-automatic cache hits from streamed `/v1/messages` usage. The Anthropic adapter's streaming path subtracts `prompt_tokens_details.cached_tokens` from `input_tokens` but only emits `cache_read_input_tokens` from the internal `_cache_read_input_tokens` field, which OpenAI/OpenRouter-style usage never populates (only Anthropic- and DeepSeek-native response fields do).

On any auto-caching route the cached tokens simply vanish from the usage Anthropic-format clients see:

- **Claude Code context tracking reads ~0% context forever**, so auto-compaction never fires (found on a kimi-k3 session that reported 685 input tokens after 13 minutes of work at a 93.7% cache hit rate)
- transcript-derived token accounting undercounts by the cached amount on every hit

Affected in-cluster routes: Moonshot kimi-k3 (~94% hit rate), Fireworks-pinned deepseek-flash, DeepInfra-pinned glm. Non-streaming translation was already correct; Claude Code always streams.

## Fix

Patch 6 in `config/litellm/patch_litellm_cache.py`: fall back to `prompt_tokens_details.cached_tokens` for `cache_read_input_tokens` when the native fields are absent. Mirrors the fix upstreamed via jwbron/litellm#6; LiteLLM releases after v1.86.2 have it natively, so this patch retires on the next base-image bump (the fail-loud needle check will flag it).

## Verification

- Root-caused and verified live on the host proxy: identical-prefix kimi-k3 streaming call's `message_delta` usage went from `{"input_tokens": 154}` to `{"input_tokens": 154, "cache_read_input_tokens": 3072}`
- Needle verified against the running egg-litellm pod's actual source: matches exactly once, application is idempotent, patched file compiles
- `tests/config/test_patch_litellm_cache.py` (fixture-derived from `PATCHES`, covers the new spec automatically) + `test_litellm_template.py`: 9 passed
- Existing patch labels renumbered /5 to /6

## Rollout

After merge: `make redeploy` (or `mcp rebuild_and_rollout`) rebuilds egg-litellm and rolls the deployment.