### PR TITLE
feat(litellm): record the decoding config of every routed call (#3599)

### DIFF
--- a/config/litellm-models.template.yaml
+++ b/config/litellm-models.template.yaml
@@ -44,6 +44,15 @@
 # tunable budget), so per-provider reasoning behavior will differ even
 # after tuning. Leave temperature / top_p / penalties at defaults for
 # cleaner cross-provider comparisons.
+#
+# Whatever you set here (or leave unset), the bundled `cost_callback`
+# records the sampling config each call actually ran under as
+# `request_params` on its per-call log line (#3599) — including which
+# knobs were NOT sent, and therefore fell back to the provider's own
+# server-side default. Two uses: a model-behaviour incident (repetition,
+# degeneration) becomes analysable after the fact, and a knob you set
+# below that `drop_params` silently discarded shows up as missing from
+# the line instead of quietly never taking effect.
 
 data:
   config.yaml: |

--- a/config/litellm/cost_callback.py
+++ b/config/litellm/cost_callback.py
@@ -349,6 +349,11 @@ _REQUEST_PARAM_KEYS = (
 # line for the rest of the session.
 _MAX_PARAM_JSON_CHARS = 512
 
+# Key-count cap for the extra_body remainder. Its values are bounded one by one
+# (so a bulky sibling can't collapse the small, load-bearing provider pin), which
+# leaves the number of keys as the remaining unbounded dimension.
+_MAX_EXTRA_BODY_KEYS = 32
+
 
 def _bounded_param(value):
     """Return ``value`` clamped to something safe to embed in the log line.
@@ -359,10 +364,13 @@ def _bounded_param(value):
     subtlest — ``json.dumps`` emits the non-standard ``NaN``/``Infinity`` tokens
     (invalid JSON), so a downstream ``jq 'fromjson?'`` silently drops the line,
     cost data and all; a misconfigured ``temperature``/``top_p`` is enough to
-    trigger it, so we map non-finite floats to a marker. Otherwise scalars pass
-    through; everything else is round-tripped through JSON — with ``default=str``
-    so an exotic value degrades to its repr instead of raising — and replaced by
-    a size marker when it exceeds the cap."""
+    trigger it, so we map a non-finite scalar to a marker. Nested ones are
+    caught too: the round-trip below passes ``allow_nan=False``, so a
+    ``logit_bias`` of ``{"5": -inf}`` (a real idiom for banning a token) raises
+    and degrades to a marker rather than emitting an invalid token. Otherwise
+    scalars pass through; everything else is round-tripped through JSON — with
+    ``default=str`` so an exotic value degrades to its repr instead of raising —
+    and replaced by a size marker when it exceeds the cap."""
     if isinstance(value, float) and not math.isfinite(value):
         return f"<non-finite: {value}>"
     if value is None or isinstance(value, (bool, int, float)):
@@ -370,7 +378,7 @@ def _bounded_param(value):
     if isinstance(value, str):
         return value if len(value) <= _MAX_PARAM_JSON_CHARS else f"<{len(value)} chars omitted>"
     try:
-        encoded = json.dumps(value, default=str)
+        encoded = json.dumps(value, default=str, allow_nan=False)
     except Exception:
         return "<unserializable>"
     if len(encoded) > _MAX_PARAM_JSON_CHARS:
@@ -445,7 +453,20 @@ def _extract_request_params(mcd):
                 # (it decides WHICH backend served the turn), so bulky sibling
                 # content in extra_body must not collapse the pin along with it
                 # under one shared size cap. Only the oversized value degrades.
-                out["extra_body"] = {k: _bounded_param(v) for k, v in leftover.items()}
+                #
+                # Per-value bounding alone would not be enough: extra_body is
+                # config-supplied and typically pinned in litellm_params, so an
+                # unbounded key COUNT (or a single unbounded key NAME — json.dumps'
+                # default= applies to values only, so a non-str key raises out in
+                # _emit and costs the whole line) would blow up every line for the
+                # life of the config. Bound the keys and cap how many we emit.
+                bounded = {}
+                for key, value in list(leftover.items())[:_MAX_EXTRA_BODY_KEYS]:
+                    bounded[_bounded_param(str(key))] = _bounded_param(value)
+                if len(leftover) > _MAX_EXTRA_BODY_KEYS:
+                    omitted = len(leftover) - _MAX_EXTRA_BODY_KEYS
+                    bounded["<truncated>"] = f"<{omitted} more keys omitted>"
+                out["extra_body"] = bounded
         return out
     except Exception:
         return None

--- a/config/litellm/cost_callback.py
+++ b/config/litellm/cost_callback.py
@@ -162,15 +162,17 @@ def _usage_from_response_obj(response_obj):
     return _coerce_usage(usage)
 
 
+def _finite_number(value):
+    """True for a real, finite number. ``bool`` is excluded because
+    ``isinstance(True, int)`` is True and a boolean is not a measurement —
+    ``float(True)`` would silently record a 1 (one dollar, one token) that was
+    never billed or sent."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
 def _positive(value):
-    """True for a real, finite, positive number. ``bool`` is excluded because
-    ``isinstance(True, int)`` is True and a boolean cost is not a cost."""
-    return (
-        isinstance(value, (int, float))
-        and not isinstance(value, bool)
-        and math.isfinite(value)
-        and value > 0
-    )
+    """True for a real, finite, positive number."""
+    return _finite_number(value) and value > 0
 
 
 def _extract_cost(usage):
@@ -203,8 +205,18 @@ def _extract_cache_stats(usage):
     """Extract input + cache + reasoning counts in a provider-agnostic way.
 
     Returns (prompt_tokens, cached_input_tokens, cache_write_tokens,
-    reasoning_tokens). Each defaults to 0; non-numeric values are treated
-    as 0.
+    reasoning_tokens). Each defaults to 0; anything that is not a real,
+    finite, non-negative number is treated as 0.
+
+    That guard is ``_extract_cost``'s, and it matters MORE here than it does
+    for cost, because ``_record`` emits these counts through ``int(...)``: an
+    ``inf`` raises ``OverflowError`` there, ``_record``'s outer handler
+    swallows it, and the whole line — cost data included — is dropped. Worse,
+    the value has already landed in ``agg[...]`` by then, so the session total
+    stays ``inf`` and EVERY subsequent call in that session emits nothing for
+    the pod's lifetime (the LRU only evicts under 4096-session pressure). A
+    ``bool`` is milder but wrong in the same direction as a boolean cost: one
+    token that was never sent.
 
     Providers expose cache numbers under several competing schemas — we read
     all and merge:
@@ -224,7 +236,7 @@ def _extract_cache_stats(usage):
     u = usage or {}
 
     def _num(x):
-        return float(x) if isinstance(x, (int, float)) else 0.0
+        return float(x) if _finite_number(x) and x >= 0 else 0.0
 
     prompt = _num(u.get("prompt_tokens"))
     pdet = u.get("prompt_tokens_details") or {}
@@ -388,12 +400,12 @@ _MAX_PRIORITY_PARAM_JSON_CHARS = 2048
 
 # Key-count cap for the extra_body remainder. Its values are bounded one by one
 # (so a bulky sibling can't collapse the small, load-bearing provider pin), which
-# leaves the number of keys as the remaining unbounded dimension. With the key
-# cap below, the emitted remainder is bounded at ~21KB worst case — high for a
-# ~800-byte baseline line, but it takes 32 maximal keys carrying 512-char values
-# (one of them a priority key at its larger cap) to get there; a real extra_body
-# is one or two small entries.
-_MAX_EXTRA_BODY_KEYS = 32
+# leaves the number of keys as the remaining unbounded dimension. Sized against
+# the whole-block budget below rather than picked as a round number: 16 keys at
+# their name and value caps (one of them a priority key at its larger cap) emit
+# 11,289 chars, measured, which leaves the aggregate guard nothing to undo in
+# the case this cap already covers. A real extra_body is one or two entries.
+_MAX_EXTRA_BODY_KEYS = 16
 
 # Key-NAME cap for the extra_body remainder. Deliberately far tighter than the
 # value cap: a key name contributes to the emitted line exactly as a value does,
@@ -414,6 +426,20 @@ _EXTRA_BODY_PRIORITY_KEYS = ("provider",)
 # Sentinel for the truncation marker. Namespaced so it cannot collide with (and
 # silently overwrite) a real operator-supplied ``extra_body`` key.
 _EXTRA_BODY_TRUNCATED_KEY = "<egg:truncated>"
+
+# Whole-block budget for the emitted request_params. The caps above bound each
+# dimension separately but compose multiplicatively — 19 allowlisted keys at the
+# 512-char value cap alongside a maximal extra_body clears 20KB with every
+# individual cap intact — so the aggregate needs its own ceiling.
+#
+# 16KiB is the number that matters: Docker's json-file driver and containerd's
+# CRI logger both split a stdout line at that size into `P`-marked partials, and
+# neither fragment is valid JSON. The documented ``jq -Rc 'fromjson?'`` query
+# then drops the line, cost data and all — the same outcome ``allow_nan=False``
+# exists to prevent, reached by size instead of by token. 12KiB leaves headroom
+# for the cost/attribution/session fields that share the line (~800 bytes on a
+# stock line, and themselves bounded only by the model and header names).
+_MAX_REQUEST_PARAMS_CHARS = 12288
 
 
 def _scrub_non_finite(value, _depth=0):
@@ -555,6 +581,45 @@ def _bounded_extra_body(leftover):
     return bounded
 
 
+def _fit_request_params(out):
+    """Clamp the assembled block to ``_MAX_REQUEST_PARAMS_CHARS``, returning it.
+
+    The per-dimension caps each hold on their own and still compose into a line
+    big enough to be split by the container runtime (see the constant), so the
+    aggregate gets a ceiling of its own. Every value here has already been
+    through ``_bounded_param``, so re-encoding one cannot raise.
+
+    Two ordering choices, both about what a truncated line should still be able
+    to answer:
+
+    - **Largest entry first.** The sampling scalars this field exists to record
+      are a handful of bytes each; whatever pushed the block over is not one of
+      them. They are the last to go, not the first.
+    - **``extra_body`` collapses to its priority keys before it collapses
+      entirely.** The provider pin is both the most load-bearing entry in the
+      remainder and one of the smallest, so there is no reason for it to share
+      the fate of the bulk it was sitting next to."""
+    if len(json.dumps(out)) <= _MAX_REQUEST_PARAMS_CHARS:
+        return out
+    for key in sorted(out, key=lambda k: len(json.dumps(out[k])), reverse=True):
+        value = out[key]
+        if key == "extra_body" and isinstance(value, dict):
+            pinned = {k: v for k, v in value.items() if k in _EXTRA_BODY_PRIORITY_KEYS}
+            if pinned and len(json.dumps(pinned)) < len(json.dumps(value)):
+                omitted = len(value) - len(pinned)
+                pinned[_uncollided_key(pinned, _EXTRA_BODY_TRUNCATED_KEY)] = (
+                    f"<{omitted} more keys omitted>"
+                )
+                out[key] = pinned
+                if len(json.dumps(out)) <= _MAX_REQUEST_PARAMS_CHARS:
+                    break
+                value = pinned
+        out[key] = f"<{len(json.dumps(value))} chars omitted>"
+        if len(json.dumps(out)) <= _MAX_REQUEST_PARAMS_CHARS:
+            break
+    return out
+
+
 def _extract_request_params(mcd):
     """Return the decoding configuration this call actually ran under (#3599).
 
@@ -617,7 +682,7 @@ def _extract_request_params(mcd):
                 # Size, key count and key names are all bounded there — see
                 # _bounded_extra_body for why each dimension needs its own cap.
                 out["extra_body"] = _bounded_extra_body(leftover)
-        return out
+        return _fit_request_params(out)
     except Exception:
         return None
 

--- a/config/litellm/cost_callback.py
+++ b/config/litellm/cost_callback.py
@@ -43,6 +43,17 @@ strictly separate from ``cost`` — an estimate from a possibly-stale rate
 card must never be mistaken for a bill — and follows the same null-not-zero
 rule when LiteLLM cannot price the model.
 
+Each line also carries ``request_params``: the decoding configuration that
+actually went upstream on that call (issue #3599). Repetition and
+degeneration are decoding-sensitive failure modes, so an incident report
+that cannot name the temperature / top_p / penalty configuration in play is
+unanalysable after the fact — which is precisely what happened in #3598,
+where a producer emitted 480 identical tool calls and nothing recorded
+whether that was inherent to the model or an artifact of the sampling
+config. See ``_extract_request_params`` for the source and its two
+non-obvious properties (absent key == provider default; post-``drop_params``,
+so config-vs-wire divergence becomes visible).
+
 Each line additionally carries ``pipeline_id`` / ``agent_role`` / ``phase``
 read from the gateway-stamped ``x-egg-*`` request headers (issue #3175),
 so per-role spend is a log query instead of a hand cross-reference against
@@ -297,6 +308,137 @@ def _extract_model(mcd):
         return None
 
 
+# Decoding-relevant request parameters to record per call (#3599).
+#
+# An ALLOWLIST, not a dump of ``optional_params``: that dict also carries the
+# translated ``tools`` schemas (Claude Code sends a dozen-plus per request)
+# and other prompt-adjacent payloads. Emitting it whole would bloat every
+# line by orders of magnitude and spill task text into a stream that is a
+# cost/observability sink, not a transcript sink.
+#
+# ``stream`` is included because it is the reason ``cost`` reads null on a
+# line (see the module docstring) — worth having next to the null rather than
+# inferred. ``max_tokens`` and ``n`` are not sampling knobs but shape the
+# generation, and are cheap to carry.
+_REQUEST_PARAM_KEYS = (
+    "temperature",
+    "top_p",
+    "top_k",
+    "min_p",
+    "typical_p",
+    "seed",
+    "frequency_penalty",
+    "presence_penalty",
+    "repetition_penalty",
+    "logit_bias",
+    "max_tokens",
+    "max_completion_tokens",
+    "stop",
+    "stop_sequences",
+    "n",
+    "reasoning_effort",
+    "reasoning",
+    "thinking",
+    "stream",
+)
+
+# Per-value size cap. Everything on the allowlist is normally a scalar or a
+# small object, but ``logit_bias`` / ``stop`` are client-supplied and
+# unbounded; one pathological request must not be able to blow up every log
+# line for the rest of the session.
+_MAX_PARAM_JSON_CHARS = 512
+
+
+def _bounded_param(value):
+    """Return ``value`` clamped to something safe to embed in the log line.
+
+    Two hazards, both of which would cost us the WHOLE line rather than just
+    this field (``_emit`` swallows a serialization failure):
+    non-JSON-serializable values, and unbounded ones. Scalars pass through;
+    everything else is round-tripped through JSON — with ``default=str`` so an
+    exotic value degrades to its repr instead of raising — and replaced by a
+    size marker when it exceeds the cap."""
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return value if len(value) <= _MAX_PARAM_JSON_CHARS else f"<{len(value)} chars omitted>"
+    try:
+        encoded = json.dumps(value, default=str)
+    except Exception:
+        return "<unserializable>"
+    if len(encoded) > _MAX_PARAM_JSON_CHARS:
+        return f"<{len(encoded)} chars omitted>"
+    try:
+        return json.loads(encoded)
+    except Exception:
+        return "<unserializable>"
+
+
+def _extract_request_params(mcd):
+    """Return the decoding configuration this call actually ran under (#3599).
+
+    Source is ``model_call_details['optional_params']``: LiteLLM's
+    POST-mapping parameter set, i.e. the dict that becomes the upstream
+    request body. Verified against the pinned litellm 1.86.2 on the
+    ``anthropic_messages`` route (the route every Claude Code agent request
+    takes), streaming and non-streaming — the streaming case matters most,
+    since that is essentially all real agent traffic.
+
+    Two properties make this worth having, and both are the difference
+    between a line that answers the question and one that misleads:
+
+    - **An absent key was not sent**, so the provider's own server-side
+      default applied. That is the answer today for ``temperature`` /
+      ``top_p`` / ``top_k`` on every egg route: egg pins none of them, so the
+      effective config is the provider's, and it can change under us with no
+      egg change. Absence is the signal, so we omit missing keys rather than
+      writing nulls that would read as "explicitly unset".
+    - **``drop_params`` has already acted**, so a knob an operator set in
+      ``litellm_params`` that does NOT appear here was silently discarded (or
+      relocated into ``extra_body``) by the mapping layer. Today that
+      divergence between what the config says and what the wire carried is
+      invisible; here it is a diff.
+
+    We deliberately do NOT read ``standard_logging_object.model_parameters``:
+    it filters to OpenAI's declared parameter set, which drops ``top_k``,
+    ``stop_sequences`` and ``extra_body`` — silently under-reporting several
+    of the anti-repetition knobs this exists to capture.
+
+    Returns a dict holding only the keys that were present (possibly empty:
+    "LiteLLM reported the params, none were decoding-relevant"), or None when
+    ``optional_params`` is missing or not a dict ("we could not tell") — the
+    same unknown-is-not-zero discipline the cost fields follow."""
+    try:
+        params = (mcd or {}).get("optional_params")
+        if not isinstance(params, dict):
+            return None
+        out = {}
+        for key in _REQUEST_PARAM_KEYS:
+            if key in params:
+                out[key] = _bounded_param(params[key])
+        extra = params.get("extra_body")
+        if isinstance(extra, dict):
+            leftover = {}
+            for key, value in extra.items():
+                # LiteLLM's param mapper relocates knobs a provider doesn't
+                # declare into extra_body rather than dropping them (e.g.
+                # top_k on an OpenAI-shaped route), so the same knob lands at
+                # different depths depending on model. Hoist allowlisted keys
+                # to the flat level so one query finds them wherever LiteLLM
+                # put them; keep the rest under extra_body — notably the
+                # OpenRouter provider pin, which decides WHICH backend (and
+                # so which quantization) served the turn.
+                if key in _REQUEST_PARAM_KEYS and key not in out:
+                    out[key] = _bounded_param(value)
+                else:
+                    leftover[key] = value
+            if leftover:
+                out["extra_body"] = _bounded_param(leftover)
+        return out
+    except Exception:
+        return None
+
+
 def _emit(payload):
     """One structured JSON line to stdout — captured by egg's log stream.
     Mirrors egg_logging's field shape loosely (timestamp/severity/service/
@@ -349,6 +491,7 @@ class LiteLLMCostLogger(CustomLogger):
             sid = _extract_session_id(mcd) or "_no_session"
             model = _extract_model(mcd)
             attribution = _extract_attribution(mcd)
+            request_params = _extract_request_params(mcd)
             with _lock:
                 agg = _session_totals.get(sid)
                 if agg is None:
@@ -419,6 +562,14 @@ class LiteLLMCostLogger(CustomLogger):
                     # hop. Session-stable, but emitted per line so every log
                     # line is independently queryable by role/pipeline.
                     **attribution,
+                    # The decoding config this call actually ran under
+                    # (#3599). Top-level, not nested under ``call``, so an
+                    # incident query can filter on it the same way it filters
+                    # on model/role. Per line rather than once per session
+                    # because it is NOT session-stable: LiteLLM rewrites
+                    # ``thinking`` into a ``reasoning_effort`` bucket, so the
+                    # effective effort tracks the per-turn thinking budget.
+                    "request_params": request_params,
                     "call": {
                         "cost": cost,
                         "cost_estimated": cost_estimated,

--- a/config/litellm/cost_callback.py
+++ b/config/litellm/cost_callback.py
@@ -306,13 +306,21 @@ def _extract_estimated_cost(mcd):
     fallback hardens against a LiteLLM version where the top-level key is
     absent on the streaming path.
 
+    The fallback is gated on ``_positive``, not on mere presence, so it also
+    fires when the top-level key is present but unusable. ``response_cost:
+    0.0`` is the realistic case — LiteLLM writes it when it cannot price the
+    model, which is exactly the situation this fallback exists for, and a
+    presence check would let that zero suppress a perfectly good estimate in
+    the metrics object. This keeps the gate symmetric with ``_extract_cost``,
+    whose ``cost: 0`` (BYOK) falls through to its own second source.
+
     Non-finite values are rejected for the same reason as in ``_extract_cost``:
     ``+inf`` clears a bare ``> 0`` and would poison the session total and the
     line's JSON validity together."""
     try:
         mcd = mcd or {}
         rc = mcd.get("response_cost")
-        if not isinstance(rc, (int, float)):
+        if not _positive(rc):
             slo = mcd.get("standard_logging_object")
             rc = slo.get("response_cost") if isinstance(slo, dict) else None
         if _positive(rc):
@@ -370,12 +378,21 @@ _REQUEST_PARAM_KEYS = (
 # line for the rest of the session.
 _MAX_PARAM_JSON_CHARS = 512
 
+# Value cap for the priority keys below. Larger than the general cap because
+# "this entry is load-bearing enough to reorder the dict for" and "this entry
+# gets the same size budget as a junk sibling" are in tension: a provider pin
+# carrying an `ignore` list of a few dozen backends clears 512 chars easily,
+# and collapsing it to a size marker loses precisely the backend identity the
+# field exists to record. Still a cap — one entry cannot run away either.
+_MAX_PRIORITY_PARAM_JSON_CHARS = 2048
+
 # Key-count cap for the extra_body remainder. Its values are bounded one by one
 # (so a bulky sibling can't collapse the small, load-bearing provider pin), which
 # leaves the number of keys as the remaining unbounded dimension. With the key
-# cap below, the emitted remainder is bounded at ~19KB worst case — high for a
+# cap below, the emitted remainder is bounded at ~21KB worst case — high for a
 # ~800-byte baseline line, but it takes 32 maximal keys carrying 512-char values
-# to get there; a real extra_body is one or two small entries.
+# (one of them a priority key at its larger cap) to get there; a real extra_body
+# is one or two small entries.
 _MAX_EXTRA_BODY_KEYS = 32
 
 # Key-NAME cap for the extra_body remainder. Deliberately far tighter than the
@@ -385,11 +402,13 @@ _MAX_EXTRA_BODY_KEYS = 32
 # would buy no diagnostic value for that cost.
 _MAX_EXTRA_BODY_KEY_CHARS = 64
 
-# extra_body keys hoisted ahead of the key-count cap. The OpenRouter provider
-# pin decides WHICH backend (and so which quantization) served the turn, which
-# makes it the single most load-bearing entry in the remainder; ordering it
-# first keeps the count cap from being positional, so the pin survives no
-# matter where an operator's config happens to place it.
+# extra_body keys hoisted ahead of the key-count cap, and given the larger
+# value cap above. The OpenRouter provider pin decides WHICH backend (and so
+# which quantization) served the turn, which makes it the single most
+# load-bearing entry in the remainder; ordering it first keeps the count cap
+# from being positional, so the pin survives no matter where an operator's
+# config happens to place it, and the wider size budget keeps it legible when
+# it is a real pin rather than the two-line example.
 _EXTRA_BODY_PRIORITY_KEYS = ("provider",)
 
 # Sentinel for the truncation marker. Namespaced so it cannot collide with (and
@@ -419,7 +438,7 @@ def _scrub_non_finite(value, _depth=0):
     return value
 
 
-def _bounded_param(value):
+def _bounded_param(value, max_chars=_MAX_PARAM_JSON_CHARS):
     """Return ``value`` clamped to something safe to embed in the log line.
 
     Three hazards, all of which would cost us the WHOLE line rather than just
@@ -436,13 +455,14 @@ def _bounded_param(value):
     costs that entry, not the field and not the line. Otherwise scalars pass
     through; everything else is round-tripped through JSON — with
     ``default=str`` so an exotic value degrades to its repr instead of raising —
-    and replaced by a size marker when it exceeds the cap."""
+    and replaced by a size marker when it exceeds ``max_chars``, which callers
+    raise for the entries they consider load-bearing."""
     if isinstance(value, float) and not math.isfinite(value):
         return f"<non-finite: {value}>"
     if value is None or isinstance(value, (bool, int, float)):
         return value
     if isinstance(value, str):
-        return value if len(value) <= _MAX_PARAM_JSON_CHARS else f"<{len(value)} chars omitted>"
+        return value if len(value) <= max_chars else f"<{len(value)} chars omitted>"
     try:
         encoded = json.dumps(value, default=str, allow_nan=False)
     except ValueError:
@@ -455,7 +475,7 @@ def _bounded_param(value):
             return "<unserializable>"
     except Exception:
         return "<unserializable>"
-    if len(encoded) > _MAX_PARAM_JSON_CHARS:
+    if len(encoded) > max_chars:
         return f"<{len(encoded)} chars omitted>"
     try:
         return json.loads(encoded)
@@ -477,6 +497,22 @@ def _bounded_extra_body_key(key):
     return f"{key[:_MAX_EXTRA_BODY_KEY_CHARS]}…<{len(key)} chars omitted>"
 
 
+def _uncollided_key(bounded, emitted_key):
+    """Return ``emitted_key``, suffixed if it is already taken.
+
+    Distinct source keys can still normalize to one name (``1`` and ``"1"``, or
+    two long keys sharing a prefix AND a length), and the truncation marker can
+    land on a key an operator really named that. Suffix rather than overwrite —
+    a lost value reads as a key that was never sent, which is exactly the
+    inference this field invites."""
+    if emitted_key not in bounded:
+        return emitted_key
+    suffix = 2
+    while f"{emitted_key}<{suffix}>" in bounded:
+        suffix += 1
+    return f"{emitted_key}<{suffix}>"
+
+
 def _bounded_extra_body(leftover):
     """Bound the ``extra_body`` remainder along every dimension that can grow.
 
@@ -486,31 +522,36 @@ def _bounded_extra_body(leftover):
 
     - **Value size** — bounded per value rather than over the dict as a whole,
       so a bulky sibling knob degrades on its own instead of collapsing the
-      small, load-bearing provider pin along with it.
+      small, load-bearing provider pin along with it. Priority keys get the
+      wider ``_MAX_PRIORITY_PARAM_JSON_CHARS`` budget, so a real provider pin
+      (an ``ignore`` list of a few dozen backends clears 512 chars) stays
+      legible rather than degrading to the size marker.
     - **Key count** — capped, with the priority keys hoisted first so the cap
       is not positional (a config with the pin at index 40 still records it).
     - **Key name** — capped, and stringified: ``json.dumps``' ``default=`` hook
       applies to values only, so a non-``str`` key would raise out in ``_emit``,
       where the failure is swallowed and the whole line, cost data included, is
-      dropped."""
+      dropped.
+
+    Every emitted key — the truncation marker included — goes through
+    ``_uncollided_key``, so the ``len(...) == _MAX_EXTRA_BODY_KEYS + 1``
+    invariant on a truncated remainder holds for any input rather than only for
+    inputs that happen not to collide with the sentinel."""
     ordered = [(k, v) for k, v in leftover.items() if k in _EXTRA_BODY_PRIORITY_KEYS]
     ordered += [(k, v) for k, v in leftover.items() if k not in _EXTRA_BODY_PRIORITY_KEYS]
     bounded = {}
     for key, value in ordered[:_MAX_EXTRA_BODY_KEYS]:
-        emitted_key = _bounded_extra_body_key(key)
-        if emitted_key in bounded:
-            # Distinct source keys can still normalize to one name (``1`` and
-            # ``"1"``, or two long keys sharing a prefix AND a length). Suffix
-            # rather than overwrite — a lost value reads as a key that was
-            # never sent, which is exactly the inference this field invites.
-            suffix = 2
-            while f"{emitted_key}<{suffix}>" in bounded:
-                suffix += 1
-            emitted_key = f"{emitted_key}<{suffix}>"
-        bounded[emitted_key] = _bounded_param(value)
+        cap = (
+            _MAX_PRIORITY_PARAM_JSON_CHARS
+            if key in _EXTRA_BODY_PRIORITY_KEYS
+            else _MAX_PARAM_JSON_CHARS
+        )
+        emitted_key = _uncollided_key(bounded, _bounded_extra_body_key(key))
+        bounded[emitted_key] = _bounded_param(value, cap)
     if len(ordered) > _MAX_EXTRA_BODY_KEYS:
         omitted = len(ordered) - _MAX_EXTRA_BODY_KEYS
-        bounded[_EXTRA_BODY_TRUNCATED_KEY] = f"<{omitted} more keys omitted>"
+        marker_key = _uncollided_key(bounded, _EXTRA_BODY_TRUNCATED_KEY)
+        bounded[marker_key] = f"<{omitted} more keys omitted>"
     return bounded
 
 

--- a/config/litellm/cost_callback.py
+++ b/config/litellm/cost_callback.py
@@ -162,6 +162,17 @@ def _usage_from_response_obj(response_obj):
     return _coerce_usage(usage)
 
 
+def _positive(value):
+    """True for a real, finite, positive number. ``bool`` is excluded because
+    ``isinstance(True, int)`` is True and a boolean cost is not a cost."""
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        and value > 0
+    )
+
+
 def _extract_cost(usage):
     """Prefer OpenRouter's top-level ``cost`` (what they bill you); under
     BYOK that field is zero because billing routes directly to the upstream
@@ -170,14 +181,20 @@ def _extract_cost(usage):
     number we record matches real spend on that turn. Returns None when no
     positive cost is present — notably on the streaming path, where LiteLLM's
     chunk reassembly drops the upstream cost (see ``_usage_from_response_obj``).
-    Callers must treat None as "unknown", not "$0"."""
+    Callers must treat None as "unknown", not "$0".
+
+    ``_positive`` rejects non-finite values as well as non-positive ones: a
+    ``+inf`` cost passes a bare ``> 0`` and would then be accumulated into the
+    session total, poisoning it as ``Infinity`` for the pod's lifetime AND
+    emitting the non-standard token that makes the line invalid JSON. (``NaN``
+    is already excluded — ``nan > 0`` is False.)"""
     u = usage or {}
     cost = u.get("cost")
-    if isinstance(cost, (int, float)) and cost > 0:
+    if _positive(cost):
         return float(cost)
     details = u.get("cost_details") or {}
     upstream = details.get("upstream_inference_cost")
-    if isinstance(upstream, (int, float)) and upstream > 0:
+    if _positive(upstream):
         return float(upstream)
     return None
 
@@ -287,14 +304,18 @@ def _extract_estimated_cost(mcd):
     ``standard_logging_object.response_cost`` — the latter is LiteLLM's
     aggregated/finalized metrics object, preferred for streaming, so the
     fallback hardens against a LiteLLM version where the top-level key is
-    absent on the streaming path."""
+    absent on the streaming path.
+
+    Non-finite values are rejected for the same reason as in ``_extract_cost``:
+    ``+inf`` clears a bare ``> 0`` and would poison the session total and the
+    line's JSON validity together."""
     try:
         mcd = mcd or {}
         rc = mcd.get("response_cost")
         if not isinstance(rc, (int, float)):
             slo = mcd.get("standard_logging_object")
             rc = slo.get("response_cost") if isinstance(slo, dict) else None
-        if isinstance(rc, (int, float)) and rc > 0:
+        if _positive(rc):
             return float(rc)
         return None
     except Exception:
@@ -351,8 +372,51 @@ _MAX_PARAM_JSON_CHARS = 512
 
 # Key-count cap for the extra_body remainder. Its values are bounded one by one
 # (so a bulky sibling can't collapse the small, load-bearing provider pin), which
-# leaves the number of keys as the remaining unbounded dimension.
+# leaves the number of keys as the remaining unbounded dimension. With the key
+# cap below, the emitted remainder is bounded at ~19KB worst case — high for a
+# ~800-byte baseline line, but it takes 32 maximal keys carrying 512-char values
+# to get there; a real extra_body is one or two small entries.
 _MAX_EXTRA_BODY_KEYS = 32
+
+# Key-NAME cap for the extra_body remainder. Deliberately far tighter than the
+# value cap: a key name contributes to the emitted line exactly as a value does,
+# so reusing _MAX_PARAM_JSON_CHARS here would double the aggregate bound — and
+# no real extra_body key is anywhere near 64 characters, so the extra headroom
+# would buy no diagnostic value for that cost.
+_MAX_EXTRA_BODY_KEY_CHARS = 64
+
+# extra_body keys hoisted ahead of the key-count cap. The OpenRouter provider
+# pin decides WHICH backend (and so which quantization) served the turn, which
+# makes it the single most load-bearing entry in the remainder; ordering it
+# first keeps the count cap from being positional, so the pin survives no
+# matter where an operator's config happens to place it.
+_EXTRA_BODY_PRIORITY_KEYS = ("provider",)
+
+# Sentinel for the truncation marker. Namespaced so it cannot collide with (and
+# silently overwrite) a real operator-supplied ``extra_body`` key.
+_EXTRA_BODY_TRUNCATED_KEY = "<egg:truncated>"
+
+
+def _scrub_non_finite(value, _depth=0):
+    """Replace non-finite floats *inside* a container with their marker.
+
+    Only ever called on the recovery path in ``_bounded_param``, after a strict
+    encode has already told us there is a ``NaN``/``Inf`` in there somewhere.
+    Scrubbing rather than rejecting keeps the finite siblings: a 100-entry
+    ``logit_bias`` with one ``-inf`` is still 99 entries of usable evidence, and
+    the marker preserves the "an operator set an insane value" reading that a
+    flat ``<unserializable>`` would conflate with "we couldn't encode this".
+    Depth-capped so a self-referential structure can't run away here (the caller
+    still degrades it — the retry encode raises on whatever we left behind)."""
+    if _depth > 8:
+        return value
+    if isinstance(value, float) and not math.isfinite(value):
+        return f"<non-finite: {value}>"
+    if isinstance(value, dict):
+        return {k: _scrub_non_finite(v, _depth + 1) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_scrub_non_finite(v, _depth + 1) for v in value]
+    return value
 
 
 def _bounded_param(value):
@@ -364,11 +428,13 @@ def _bounded_param(value):
     subtlest — ``json.dumps`` emits the non-standard ``NaN``/``Infinity`` tokens
     (invalid JSON), so a downstream ``jq 'fromjson?'`` silently drops the line,
     cost data and all; a misconfigured ``temperature``/``top_p`` is enough to
-    trigger it, so we map a non-finite scalar to a marker. Nested ones are
-    caught too: the round-trip below passes ``allow_nan=False``, so a
-    ``logit_bias`` of ``{"5": -inf}`` (a real idiom for banning a token) raises
-    and degrades to a marker rather than emitting an invalid token. Otherwise
-    scalars pass through; everything else is round-tripped through JSON — with
+    trigger it, so we map a non-finite scalar to a marker. Nested ones need
+    their own handling, and are the MORE reachable half: ``{"5": -inf}`` as a
+    ``logit_bias`` is a real idiom for banning a token. ``allow_nan=False``
+    makes the round-trip below raise on them rather than emit an invalid token,
+    and the retry scrubs them to the same marker in place — so one bad entry
+    costs that entry, not the field and not the line. Otherwise scalars pass
+    through; everything else is round-tripped through JSON — with
     ``default=str`` so an exotic value degrades to its repr instead of raising —
     and replaced by a size marker when it exceeds the cap."""
     if isinstance(value, float) and not math.isfinite(value):
@@ -379,6 +445,14 @@ def _bounded_param(value):
         return value if len(value) <= _MAX_PARAM_JSON_CHARS else f"<{len(value)} chars omitted>"
     try:
         encoded = json.dumps(value, default=str, allow_nan=False)
+    except ValueError:
+        # Strictly a non-finite float somewhere below the top level — the only
+        # ValueError allow_nan=False adds. Scrub those in place and retry;
+        # anything still unencodable falls through to the marker.
+        try:
+            encoded = json.dumps(_scrub_non_finite(value), default=str, allow_nan=False)
+        except Exception:
+            return "<unserializable>"
     except Exception:
         return "<unserializable>"
     if len(encoded) > _MAX_PARAM_JSON_CHARS:
@@ -387,6 +461,57 @@ def _bounded_param(value):
         return json.loads(encoded)
     except Exception:
         return "<unserializable>"
+
+
+def _bounded_extra_body_key(key):
+    """Bound one ``extra_body`` key name for emission.
+
+    Oversized names keep a prefix rather than collapsing to a bare size marker:
+    two 600-char keys would otherwise produce the identical marker and one
+    would silently overwrite the other, turning a size problem into a data-loss
+    problem. The prefix also keeps the name diagnostic, which is the whole
+    point of recording the key at all."""
+    key = str(key)
+    if len(key) <= _MAX_EXTRA_BODY_KEY_CHARS:
+        return key
+    return f"{key[:_MAX_EXTRA_BODY_KEY_CHARS]}…<{len(key)} chars omitted>"
+
+
+def _bounded_extra_body(leftover):
+    """Bound the ``extra_body`` remainder along every dimension that can grow.
+
+    ``extra_body`` is config-supplied and typically pinned in ``litellm_params``,
+    so an unbounded remainder is not one bad line — it is EVERY line for the
+    life of the config. Three dimensions, each capped:
+
+    - **Value size** — bounded per value rather than over the dict as a whole,
+      so a bulky sibling knob degrades on its own instead of collapsing the
+      small, load-bearing provider pin along with it.
+    - **Key count** — capped, with the priority keys hoisted first so the cap
+      is not positional (a config with the pin at index 40 still records it).
+    - **Key name** — capped, and stringified: ``json.dumps``' ``default=`` hook
+      applies to values only, so a non-``str`` key would raise out in ``_emit``,
+      where the failure is swallowed and the whole line, cost data included, is
+      dropped."""
+    ordered = [(k, v) for k, v in leftover.items() if k in _EXTRA_BODY_PRIORITY_KEYS]
+    ordered += [(k, v) for k, v in leftover.items() if k not in _EXTRA_BODY_PRIORITY_KEYS]
+    bounded = {}
+    for key, value in ordered[:_MAX_EXTRA_BODY_KEYS]:
+        emitted_key = _bounded_extra_body_key(key)
+        if emitted_key in bounded:
+            # Distinct source keys can still normalize to one name (``1`` and
+            # ``"1"``, or two long keys sharing a prefix AND a length). Suffix
+            # rather than overwrite — a lost value reads as a key that was
+            # never sent, which is exactly the inference this field invites.
+            suffix = 2
+            while f"{emitted_key}<{suffix}>" in bounded:
+                suffix += 1
+            emitted_key = f"{emitted_key}<{suffix}>"
+        bounded[emitted_key] = _bounded_param(value)
+    if len(ordered) > _MAX_EXTRA_BODY_KEYS:
+        omitted = len(ordered) - _MAX_EXTRA_BODY_KEYS
+        bounded[_EXTRA_BODY_TRUNCATED_KEY] = f"<{omitted} more keys omitted>"
+    return bounded
 
 
 def _extract_request_params(mcd):
@@ -448,25 +573,9 @@ def _extract_request_params(mcd):
                 else:
                     leftover[key] = value
             if leftover:
-                # Bound each leftover value individually rather than the dict as
-                # a whole: the OpenRouter provider pin is small and load-bearing
-                # (it decides WHICH backend served the turn), so bulky sibling
-                # content in extra_body must not collapse the pin along with it
-                # under one shared size cap. Only the oversized value degrades.
-                #
-                # Per-value bounding alone would not be enough: extra_body is
-                # config-supplied and typically pinned in litellm_params, so an
-                # unbounded key COUNT (or a single unbounded key NAME — json.dumps'
-                # default= applies to values only, so a non-str key raises out in
-                # _emit and costs the whole line) would blow up every line for the
-                # life of the config. Bound the keys and cap how many we emit.
-                bounded = {}
-                for key, value in list(leftover.items())[:_MAX_EXTRA_BODY_KEYS]:
-                    bounded[_bounded_param(str(key))] = _bounded_param(value)
-                if len(leftover) > _MAX_EXTRA_BODY_KEYS:
-                    omitted = len(leftover) - _MAX_EXTRA_BODY_KEYS
-                    bounded["<truncated>"] = f"<{omitted} more keys omitted>"
-                out["extra_body"] = bounded
+                # Size, key count and key names are all bounded there — see
+                # _bounded_extra_body for why each dimension needs its own cap.
+                out["extra_body"] = _bounded_extra_body(leftover)
         return out
     except Exception:
         return None

--- a/config/litellm/cost_callback.py
+++ b/config/litellm/cost_callback.py
@@ -87,6 +87,7 @@ traffic.
 import collections
 import datetime
 import json
+import math
 import threading
 
 from litellm.integrations.custom_logger import CustomLogger
@@ -352,12 +353,18 @@ _MAX_PARAM_JSON_CHARS = 512
 def _bounded_param(value):
     """Return ``value`` clamped to something safe to embed in the log line.
 
-    Two hazards, both of which would cost us the WHOLE line rather than just
-    this field (``_emit`` swallows a serialization failure):
-    non-JSON-serializable values, and unbounded ones. Scalars pass through;
-    everything else is round-tripped through JSON — with ``default=str`` so an
-    exotic value degrades to its repr instead of raising — and replaced by a
-    size marker when it exceeds the cap."""
+    Three hazards, all of which would cost us the WHOLE line rather than just
+    this field (``_emit`` swallows a serialization failure): non-finite floats,
+    non-JSON-serializable values, and unbounded ones. ``NaN``/``Inf`` are the
+    subtlest — ``json.dumps`` emits the non-standard ``NaN``/``Infinity`` tokens
+    (invalid JSON), so a downstream ``jq 'fromjson?'`` silently drops the line,
+    cost data and all; a misconfigured ``temperature``/``top_p`` is enough to
+    trigger it, so we map non-finite floats to a marker. Otherwise scalars pass
+    through; everything else is round-tripped through JSON — with ``default=str``
+    so an exotic value degrades to its repr instead of raising — and replaced by
+    a size marker when it exceeds the cap."""
+    if isinstance(value, float) and not math.isfinite(value):
+        return f"<non-finite: {value}>"
     if value is None or isinstance(value, (bool, int, float)):
         return value
     if isinstance(value, str):
@@ -433,7 +440,12 @@ def _extract_request_params(mcd):
                 else:
                     leftover[key] = value
             if leftover:
-                out["extra_body"] = _bounded_param(leftover)
+                # Bound each leftover value individually rather than the dict as
+                # a whole: the OpenRouter provider pin is small and load-bearing
+                # (it decides WHICH backend served the turn), so bulky sibling
+                # content in extra_body must not collapse the pin along with it
+                # under one shared size cap. Only the oversized value degrades.
+                out["extra_body"] = {k: _bounded_param(v) for k, v in leftover.items()}
         return out
     except Exception:
         return None

--- a/docs/development/STRUCTURE.md
+++ b/docs/development/STRUCTURE.md
@@ -542,7 +542,7 @@ config/
 ├── litellm/                     # egg-litellm image sources
 │   ├── Dockerfile               # Builds egg-litellm: stock LiteLLM + prompt-cache patches
 │   ├── patch_litellm_cache.py   # Build-time patches for cache_control passthrough on Qwen/DeepSeek routes
-│   └── cost_callback.py         # LiteLLM custom logger: upstream + estimated cost, per-role attribution (x-egg-* headers), cache hit rate -> pod stdout
+│   └── cost_callback.py         # LiteLLM custom logger: upstream + estimated cost, per-role attribution (x-egg-* headers), cache hit rate, per-call decoding config -> pod stdout
 ├── repo_config.py               # Python API for repo access
 └── README.md
 ```

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -608,6 +608,51 @@ data:
 > line to the LiteLLM pod stream, visible via `get_service_logs` / the
 > structured-logging stream.
 
+> **Which decoding config did this run under?** Every `cost_callback` line
+> also carries `request_params` — the sampling configuration that actually
+> went upstream on that call (`temperature`, `top_p`, `top_k`, the penalty
+> family, `seed`, `max_tokens`, `reasoning_effort`, and the OpenRouter
+> provider pin under `extra_body`). This exists because repetition and
+> degeneration are decoding-sensitive failure modes: without it, "was that
+> livelock inherent to the model or an unlucky sampling config?" is
+> unanswerable once the pod is gone (issue #3599; it blocked the #3598
+> post-mortem). Two things to know when reading it:
+>
+> - **An absent key was never sent**, so the provider's server-side default
+>   applied. egg pins no sampling parameters today, so on a stock setup you
+>   will see `max_tokens` and `stream` and nothing else — that is the
+>   expected shape, and it means the effective sampling config is the
+>   provider's and can change under you with no egg change.
+> - **It is read after `drop_params` has acted**, so it reports what the wire
+>   carried, not what your config asked for. A knob you set in
+>   `litellm_params` that does not appear here was silently discarded or
+>   relocated into `extra_body` by LiteLLM's parameter mapper — which is the
+>   fastest way to catch a tuning change that never took effect.
+>
+> Prompt-bearing fields (`messages`, `tools`, `tool_choice`) are excluded by
+> allowlist: the cost stream is not a transcript sink.
+
+The `request_params` field on a stock (nothing pinned) OpenRouter route:
+
+```json
+"request_params": {
+  "max_tokens": 32000,
+  "stream": true,
+  "extra_body": {"provider": {"order": ["Alibaba"], "allow_fallbacks": false}}
+}
+```
+
+So, to pull the decoding config for one agent role out of an incident window:
+
+```bash
+# -R + fromjson?: the pod stream interleaves LiteLLM's own non-JSON logging.
+kubectl logs -n egg-system deploy/litellm \
+  | jq -Rc 'fromjson? | select(.component == "cost_callback")
+            | select(.context.agent_role == "task_planner")
+            | {model: .context.model, params: .context.request_params}' \
+  | sort -u
+```
+
 > **Why the paired `<name>[1m]` row?** Claude Code registers the
 > custom model with a `[1m]` context-window-opt-in suffix
 > (`ANTHROPIC_CUSTOM_MODEL_OPTION=qwen3-max[1m]`) and strips the

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -616,7 +616,7 @@ data:
 > degeneration are decoding-sensitive failure modes: without it, "was that
 > livelock inherent to the model or an unlucky sampling config?" is
 > unanswerable once the pod is gone (issue #3599; it blocked the #3598
-> post-mortem). Two things to know when reading it:
+> post-mortem). Three things to know when reading it:
 >
 > - **An absent key was never sent**, so the provider's server-side default
 >   applied. egg pins no sampling parameters today, so on a stock setup you
@@ -628,10 +628,6 @@ data:
 >   `litellm_params` that does not appear here was silently discarded or
 >   relocated into `extra_body` by LiteLLM's parameter mapper — which is the
 >   fastest way to catch a tuning change that never took effect.
->
-> Prompt-bearing fields (`messages`, `tools`, `tool_choice`) are excluded by
-> allowlist: the cost stream is not a transcript sink.
->
 > - **A `<…>` value is a degradation marker, not a recorded value.** Every
 >   field is bounded so one pathological param cannot cost you the line —
 >   cost data included — when it fails to serialize. `<N chars omitted>` means
@@ -639,7 +635,13 @@ data:
 >   `<non-finite: nan>` that something was set to `NaN`/`Inf`,
 >   `<unserializable>` that the value could not be encoded at all, and
 >   `<egg:truncated>` that `extra_body` carried more keys than the cap. The
->   OpenRouter provider pin is ordered first, so it survives all of these.
+>   OpenRouter provider pin degrades last, not never: it is ordered ahead of
+>   the key-count cap and gets a 2048-char value budget instead of the usual
+>   512, but a pin larger than that still becomes a `<N chars omitted>`
+>   marker.
+>
+> Prompt-bearing fields (`messages`, `tools`, `tool_choice`) are excluded by
+> allowlist: the cost stream is not a transcript sink.
 
 The `request_params` field on a stock (nothing pinned) OpenRouter route:
 

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -638,7 +638,12 @@ data:
 >   OpenRouter provider pin degrades last, not never: it is ordered ahead of
 >   the key-count cap and gets a 2048-char value budget instead of the usual
 >   512, but a pin larger than that still becomes a `<N chars omitted>`
->   marker.
+>   marker. The block as a whole is capped too, at 12KiB — a line above
+>   ~16KiB is split into unparseable fragments by the container log driver, so
+>   an oversized line is dropped by the `fromjson?` query below exactly like a
+>   malformed one. If that cap binds, the largest entries are marked down
+>   first, so a `<N chars omitted>` on a *small* field means the block was
+>   over budget rather than that field being oversized on its own.
 >
 > Prompt-bearing fields (`messages`, `tools`, `tool_choice`) are excluded by
 > allowlist: the cost stream is not a transcript sink.

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -631,6 +631,15 @@ data:
 >
 > Prompt-bearing fields (`messages`, `tools`, `tool_choice`) are excluded by
 > allowlist: the cost stream is not a transcript sink.
+>
+> - **A `<…>` value is a degradation marker, not a recorded value.** Every
+>   field is bounded so one pathological param cannot cost you the line —
+>   cost data included — when it fails to serialize. `<N chars omitted>` means
+>   the value (or `extra_body` key name) exceeded the size cap,
+>   `<non-finite: nan>` that something was set to `NaN`/`Inf`,
+>   `<unserializable>` that the value could not be encoded at all, and
+>   `<egg:truncated>` that `extra_body` carried more keys than the cap. The
+>   OpenRouter provider pin is ordered first, so it survives all of these.
 
 The `request_params` field on a stock (nothing pinned) OpenRouter route:
 

--- a/k8s/base/litellm-configmap.yaml
+++ b/k8s/base/litellm-configmap.yaml
@@ -60,8 +60,10 @@ data:
     # request time and the provider returns silent 401s.
     model_list: []
 
-    # Custom logger: surfaces real upstream cost + prompt-cache stats for
-    # non-Claude routes into the pod log stream. Baked into the egg-litellm
+    # Custom logger: surfaces real upstream cost, prompt-cache stats, and the
+    # per-call decoding config (``request_params`` — sampling params as they
+    # actually went upstream, #3599) for non-Claude routes into the pod log
+    # stream. Baked into the egg-litellm
     # image at /app/cost_callback.py — LiteLLM resolves a config-registered
     # callback as a file next to ``--config`` (here /app/config.yaml), so the
     # name MUST match. LiteLLM resolves it at STARTUP, not at call time: an

--- a/tests/config/test_cost_callback.py
+++ b/tests/config/test_cost_callback.py
@@ -400,6 +400,24 @@ class TestExtractRequestParams:
             "provider": {"order": ["Alibaba"], "allow_fallbacks": False}
         }
 
+    def test_bulky_extra_body_sibling_does_not_collapse_the_provider_pin(self):
+        # extra_body values are bounded individually, so a large sibling knob
+        # degrades to a size marker on its own without taking the small,
+        # load-bearing provider pin down with it under one shared cap.
+        params = cc._extract_request_params(
+            _mcd(
+                "r",
+                optional_params={
+                    "extra_body": {
+                        "provider": {"order": ["Alibaba"]},
+                        "junk": "z" * 600,
+                    }
+                },
+            )
+        )
+        assert params["extra_body"]["provider"] == {"order": ["Alibaba"]}
+        assert "chars omitted" in params["extra_body"]["junk"]
+
     def test_top_level_wins_over_extra_body_duplicate(self):
         params = cc._extract_request_params(
             _mcd("r", optional_params={"top_k": 10, "extra_body": {"top_k": 40}})
@@ -444,6 +462,17 @@ class TestBoundedParam:
         # A pydantic/enum-ish value must not take the log line down with it.
         value = {"effort": types.SimpleNamespace(name="high")}
         assert json.dumps(cc._bounded_param(value))
+
+    def test_non_finite_floats_become_markers(self):
+        # json.dumps emits the non-standard NaN/Infinity tokens for these,
+        # which a downstream `jq 'fromjson?'` silently drops — taking the cost
+        # data with it. Map them to a marker so the line stays valid JSON.
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            bounded = cc._bounded_param(bad)
+            assert isinstance(bounded, str)
+            assert "non-finite" in bounded
+        # A whole line carrying such a param survives round-trip as strict JSON.
+        assert json.loads(json.dumps({"temperature": cc._bounded_param(float("nan"))}))
 
 
 class TestRequestParamsInPayload:

--- a/tests/config/test_cost_callback.py
+++ b/tests/config/test_cost_callback.py
@@ -418,6 +418,40 @@ class TestExtractRequestParams:
         assert params["extra_body"]["provider"] == {"order": ["Alibaba"]}
         assert "chars omitted" in params["extra_body"]["junk"]
 
+    def test_extra_body_stays_bounded_in_aggregate(self):
+        # Per-value bounding leaves the key COUNT and the key NAMES unbounded.
+        # extra_body is config-supplied and usually pinned in litellm_params, so
+        # an unbounded remainder is not one bad line — it is every line for the
+        # life of the config.
+        params = cc._extract_request_params(
+            _mcd(
+                "r",
+                optional_params={
+                    "extra_body": {
+                        "provider": {"order": ["Alibaba"]},
+                        **{f"knob{i}": "v" * 400 for i in range(200)},
+                        "k" * 100000: 1,
+                    }
+                },
+            )
+        )
+        emitted = params["extra_body"]
+        assert len(emitted) == cc._MAX_EXTRA_BODY_KEYS + 1  # + the truncation marker
+        assert "more keys omitted" in emitted["<truncated>"]
+        # The pin is first in insertion order, so the high-value part survives.
+        assert emitted["provider"] == {"order": ["Alibaba"]}
+        assert all(len(k) <= cc._MAX_PARAM_JSON_CHARS for k in emitted)
+        assert len(json.dumps(emitted)) < 32 * (cc._MAX_PARAM_JSON_CHARS * 2 + 32)
+
+    def test_non_str_extra_body_key_degrades_instead_of_costing_the_line(self):
+        # json.dumps' default= hook applies to values only, so an unserializable
+        # KEY raises out in _emit — where the failure is swallowed and the entire
+        # line, cost data included, is dropped. Stringify before emitting.
+        params = cc._extract_request_params(
+            _mcd("r", optional_params={"extra_body": {("a", "b"): 1}})
+        )
+        assert json.dumps(params)
+
     def test_top_level_wins_over_extra_body_duplicate(self):
         params = cc._extract_request_params(
             _mcd("r", optional_params={"top_k": 10, "extra_body": {"top_k": 40}})
@@ -471,8 +505,19 @@ class TestBoundedParam:
             bounded = cc._bounded_param(bad)
             assert isinstance(bounded, str)
             assert "non-finite" in bounded
-        # A whole line carrying such a param survives round-trip as strict JSON.
-        assert json.loads(json.dumps({"temperature": cc._bounded_param(float("nan"))}))
+        # A whole line carrying such a param survives as STRICT JSON. allow_nan
+        # is what makes this assertion mean anything: json.dumps/json.loads both
+        # accept the non-standard NaN token by default, so without it the check
+        # passes identically with the guard reverted.
+        assert json.dumps({"temperature": cc._bounded_param(float("nan"))}, allow_nan=False)
+
+    def test_nested_non_finite_floats_degrade_rather_than_emit_invalid_json(self):
+        # The top-level guard doesn't see these: a -inf logit bias (a real idiom
+        # for banning a token) or a NaN inside `stop` reaches the JSON round-trip,
+        # which without allow_nan=False would happily emit `-Infinity`/`NaN` and
+        # take the whole line out at the `jq 'fromjson?'` on the other end.
+        for bad in ({"5": float("-inf")}, [float("nan")], {"weird": {"x": float("inf")}}):
+            assert json.dumps(cc._bounded_param(bad), allow_nan=False)
 
 
 class TestRequestParamsInPayload:

--- a/tests/config/test_cost_callback.py
+++ b/tests/config/test_cost_callback.py
@@ -146,6 +146,26 @@ class TestExtractCost:
         usage = {"cost": 0, "cost_details": {"upstream_inference_cost": 0.05}}
         assert cc._extract_cost(usage) == 0.05
 
+    def test_non_finite_cost_reads_as_unknown_not_as_spend(self):
+        # `inf > 0` is True, so a bare positivity check would accept it — and
+        # then accumulate it into the session total, which stays Infinity for
+        # the pod's lifetime and emits a non-standard token that invalidates
+        # every subsequent line's JSON. (NaN is already excluded: nan > 0 is
+        # False.) Unknown, not spend.
+        assert cc._extract_cost({"cost": float("inf")}) is None
+        assert cc._extract_cost({"cost": float("nan")}) is None
+        assert (
+            cc._extract_cost({"cost": 0, "cost_details": {"upstream_inference_cost": float("inf")}})
+            is None
+        )
+        # The fallback still fires when only the top-level value is poisoned.
+        usage = {"cost": float("inf"), "cost_details": {"upstream_inference_cost": 0.05}}
+        assert cc._extract_cost(usage) == 0.05
+
+    def test_non_finite_estimated_cost_reads_as_unknown(self):
+        assert cc._extract_estimated_cost({"response_cost": float("inf")}) is None
+        assert cc._extract_estimated_cost({"response_cost": 0.004}) == 0.004
+
 
 class TestRecordCostReporting:
     def setup_method(self):
@@ -437,19 +457,99 @@ class TestExtractRequestParams:
         )
         emitted = params["extra_body"]
         assert len(emitted) == cc._MAX_EXTRA_BODY_KEYS + 1  # + the truncation marker
-        assert "more keys omitted" in emitted["<truncated>"]
-        # The pin is first in insertion order, so the high-value part survives.
+        assert "more keys omitted" in emitted[cc._EXTRA_BODY_TRUNCATED_KEY]
         assert emitted["provider"] == {"order": ["Alibaba"]}
-        assert all(len(k) <= cc._MAX_PARAM_JSON_CHARS for k in emitted)
-        assert len(json.dumps(emitted)) < 32 * (cc._MAX_PARAM_JSON_CHARS * 2 + 32)
+        assert all(len(k) <= cc._MAX_EXTRA_BODY_KEY_CHARS + 32 for k in emitted)
+        assert len(json.dumps(emitted)) < cc._MAX_EXTRA_BODY_KEYS * (
+            cc._MAX_PARAM_JSON_CHARS + cc._MAX_EXTRA_BODY_KEY_CHARS + 64
+        )
+
+    def test_oversized_extra_body_key_name_is_bounded(self):
+        # The key COUNT cap alone doesn't bound the key NAMES: a long key inside
+        # the count cap is emitted verbatim on every line for the life of the
+        # config. (The aggregate test above cannot catch this — its long key
+        # sits past index 32, so the count slice removes it before the name
+        # bound is ever reached.)
+        params = cc._extract_request_params(
+            _mcd("r", optional_params={"extra_body": {"K" * 600: 1}})
+        )
+        [key] = params["extra_body"]
+        assert len(key) <= cc._MAX_EXTRA_BODY_KEY_CHARS + 32
+        assert "600 chars omitted" in key
+        assert params["extra_body"][key] == 1
+
+    def test_two_oversized_keys_do_not_collapse_into_one_entry(self):
+        # A bare size marker would be IDENTICAL for both keys, so one value
+        # would silently overwrite the other — a size problem turned into a
+        # data-loss problem, and a lost knob reads as one that was never sent.
+        params = cc._extract_request_params(
+            _mcd("r", optional_params={"extra_body": {"A" * 600: 1, "B" * 600: 2}})
+        )
+        assert len(params["extra_body"]) == 2
+        assert sorted(params["extra_body"].values()) == [1, 2]
+
+    def test_colliding_normalized_keys_are_disambiguated(self):
+        # Distinct source keys can normalize to the same emitted name (here via
+        # str() on the int). Suffix rather than overwrite.
+        params = cc._extract_request_params(
+            _mcd("r", optional_params={"extra_body": {1: "int", "1": "str"}})
+        )
+        assert len(params["extra_body"]) == 2
+        assert sorted(params["extra_body"].values()) == ["int", "str"]
+
+    def test_truncation_marker_does_not_overwrite_a_real_key(self):
+        # An operator key literally named like the marker must not be clobbered
+        # by it, and must not consume the marker's slot either.
+        params = cc._extract_request_params(
+            _mcd(
+                "r",
+                optional_params={
+                    "extra_body": {
+                        "<truncated>": "real value",
+                        **{f"knob{i}": i for i in range(40)},
+                    }
+                },
+            )
+        )
+        emitted = params["extra_body"]
+        assert emitted["<truncated>"] == "real value"
+        assert "more keys omitted" in emitted[cc._EXTRA_BODY_TRUNCATED_KEY]
+        assert len(emitted) == cc._MAX_EXTRA_BODY_KEYS + 1
+
+    def test_provider_pin_survives_a_late_position_under_the_count_cap(self):
+        # The count cap is a slice, so without hoisting it is POSITIONAL: a
+        # config that happens to place the pin after 32 other knobs would lose
+        # exactly the entry that says which backend served the turn.
+        params = cc._extract_request_params(
+            _mcd(
+                "r",
+                optional_params={
+                    "extra_body": {
+                        **{f"pad{i}": i for i in range(40)},
+                        "provider": {"order": ["Alibaba"]},
+                    }
+                },
+            )
+        )
+        assert params["extra_body"]["provider"] == {"order": ["Alibaba"]}
 
     def test_non_str_extra_body_key_degrades_instead_of_costing_the_line(self):
         # json.dumps' default= hook applies to values only, so an unserializable
         # KEY raises out in _emit — where the failure is swallowed and the entire
         # line, cost data included, is dropped. Stringify before emitting.
+        #
+        # The equality is the load-bearing assertion: `json.dumps(params)` alone
+        # passes on `None` too (it returns the truthy string "null"), so it can't
+        # tell a graceful degrade from _extract_request_params' "we could not
+        # tell" sentinel — which would take temperature/top_p down with it.
         params = cc._extract_request_params(
-            _mcd("r", optional_params={"extra_body": {("a", "b"): 1}})
+            _mcd(
+                "r",
+                optional_params={"temperature": 0.3, "extra_body": {("a", "b"): 1}},
+            )
         )
+        assert params["temperature"] == 0.3
+        assert params["extra_body"] == {"('a', 'b')": 1}
         assert json.dumps(params)
 
     def test_top_level_wins_over_extra_body_duplicate(self):
@@ -518,6 +618,22 @@ class TestBoundedParam:
         # take the whole line out at the `jq 'fromjson?'` on the other end.
         for bad in ({"5": float("-inf")}, [float("nan")], {"weird": {"x": float("inf")}}):
             assert json.dumps(cc._bounded_param(bad), allow_nan=False)
+
+    def test_nested_non_finite_keeps_its_finite_siblings(self):
+        # Rejecting the whole value would throw away the other 99 entries of a
+        # logit_bias, and `<unserializable>` would conflate "an operator set an
+        # insane value" with "we couldn't encode this". Scrub in place instead:
+        # the marker keeps the diagnostic, the siblings keep the evidence.
+        bounded = cc._bounded_param({"5": float("-inf"), "6": 1.5, "7": -2})
+        assert bounded == {"5": "<non-finite: -inf>", "6": 1.5, "7": -2}
+        assert json.dumps(bounded, allow_nan=False)
+
+    def test_genuinely_unserializable_still_degrades_to_a_marker(self):
+        # The non-finite retry must not swallow the OTHER failure mode: a value
+        # that cannot be encoded at all (here a non-str dict key, which
+        # `default=` does not cover) still has to become a marker rather than
+        # raise out into _emit and cost the whole line.
+        assert cc._bounded_param({("a", "b"): float("nan")}) == "<unserializable>"
 
 
 class TestRequestParamsInPayload:

--- a/tests/config/test_cost_callback.py
+++ b/tests/config/test_cost_callback.py
@@ -81,12 +81,33 @@ def _nonstreaming_usage() -> dict:
     }
 
 
+def _streaming_optional_params() -> dict:
+    """``model_call_details['optional_params']`` as litellm 1.86.2 populates it
+    on a streamed ``anthropic_messages`` call to an OpenRouter backend — the
+    route and mode of all real Claude Code agent traffic.
+
+    Captured from a live litellm 1.86.2 run (HTTP mocked at the transport
+    layer, not via ``mock_response``: that short-circuits in
+    ``anthropic_messages_handler`` before the adapter path runs and leaves
+    ``optional_params`` empty, which would make this fixture a lie). Note what
+    is NOT here: no ``temperature``, no ``top_p``, no ``top_k``, no penalty —
+    egg pins none of them, so the provider's server-side defaults applied.
+    That absence is the finding #3599 exists to make visible."""
+    return {
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "max_tokens": 32000,
+        "extra_body": {"provider": {"order": ["Alibaba"], "allow_fallbacks": False}},
+    }
+
+
 def _mcd(
     session_id: str,
     *,
     raw_usage: dict | None = None,
     extra_headers: dict | None = None,
     response_cost: float | None = None,
+    optional_params: dict | None = None,
 ) -> dict:
     """Build a ``model_call_details`` dict the callback understands."""
     headers = {"x-claude-code-session-id": session_id, **(extra_headers or {})}
@@ -98,6 +119,8 @@ def _mcd(
         mcd["original_response"] = json.dumps({"usage": raw_usage})
     if response_cost is not None:
         mcd["response_cost"] = response_cost
+    if optional_params is not None:
+        mcd["optional_params"] = optional_params
     return mcd
 
 
@@ -290,3 +313,168 @@ class TestAttribution:
             types.SimpleNamespace(usage=_streaming_usage()),
         )
         assert emitted[0]["agent_role"] == "coder"
+
+
+class TestExtractRequestParams:
+    """The decoding config a call ran under, read from LiteLLM's post-mapping
+    ``optional_params`` (#3599). Absence of a key is the load-bearing signal:
+    it means the parameter was never sent and the provider's own default
+    applied."""
+
+    def test_streaming_agent_call_shape(self):
+        params = cc._extract_request_params(_mcd("r", optional_params=_streaming_optional_params()))
+        assert params["stream"] is True
+        assert params["max_tokens"] == 32000
+        # Nothing egg pins => the sampling knobs are simply absent, and the
+        # provider default was in force. Never emit them as null: that would
+        # read as "explicitly unset" rather than "never sent".
+        for key in ("temperature", "top_p", "top_k", "frequency_penalty"):
+            assert key not in params
+
+    def test_explicit_sampling_params_are_recorded(self):
+        params = cc._extract_request_params(
+            _mcd(
+                "r",
+                optional_params={
+                    "temperature": 0.3,
+                    "top_p": 0.9,
+                    "top_k": 40,
+                    "seed": 42,
+                    "frequency_penalty": 0.2,
+                    "presence_penalty": 0.1,
+                    "repetition_penalty": 1.05,
+                    "reasoning_effort": "high",
+                },
+            )
+        )
+        assert params["temperature"] == 0.3
+        assert params["top_p"] == 0.9
+        assert params["top_k"] == 40
+        assert params["seed"] == 42
+        assert params["frequency_penalty"] == 0.2
+        assert params["presence_penalty"] == 0.1
+        assert params["repetition_penalty"] == 1.05
+        assert params["reasoning_effort"] == "high"
+
+    def test_prompt_bearing_params_are_excluded(self):
+        # optional_params also carries the translated tool schemas (Claude Code
+        # sends a dozen-plus per request). Dumping it whole would bloat every
+        # line and spill task text into a cost stream. The allowlist is the
+        # guard; this pins it.
+        params = cc._extract_request_params(
+            _mcd(
+                "r",
+                optional_params={
+                    "temperature": 0.3,
+                    "tools": [{"name": "Bash", "input_schema": {"x": "y" * 5000}}],
+                    "tool_choice": "auto",
+                    "messages": [{"role": "user", "content": "secret task text"}],
+                    "user": "someone",
+                },
+            )
+        )
+        assert params == {"temperature": 0.3}
+
+    def test_extra_body_hoists_known_knobs_and_keeps_the_provider_pin(self):
+        # LiteLLM relocates knobs a provider doesn't declare into extra_body
+        # rather than dropping them, so the same knob lands at different
+        # depths per model. Hoisting keeps one query surface; the provider pin
+        # (which backend, so which quantization, served the turn) is kept.
+        params = cc._extract_request_params(
+            _mcd(
+                "r",
+                optional_params={
+                    "temperature": 0.4,
+                    "extra_body": {
+                        "top_k": 40,
+                        "reasoning": {"effort": "high"},
+                        "provider": {"order": ["Alibaba"], "allow_fallbacks": False},
+                    },
+                },
+            )
+        )
+        assert params["temperature"] == 0.4
+        assert params["top_k"] == 40
+        assert params["reasoning"] == {"effort": "high"}
+        assert params["extra_body"] == {
+            "provider": {"order": ["Alibaba"], "allow_fallbacks": False}
+        }
+
+    def test_top_level_wins_over_extra_body_duplicate(self):
+        params = cc._extract_request_params(
+            _mcd("r", optional_params={"top_k": 10, "extra_body": {"top_k": 40}})
+        )
+        assert params["top_k"] == 10
+        # The losing copy is preserved rather than silently dropped, so a
+        # genuine divergence is still visible in the line.
+        assert params["extra_body"] == {"top_k": 40}
+
+    def test_extra_body_omitted_when_fully_hoisted(self):
+        params = cc._extract_request_params(
+            _mcd("r", optional_params={"extra_body": {"top_k": 40}})
+        )
+        assert params == {"top_k": 40}
+
+    def test_missing_or_malformed_optional_params_reads_as_unknown(self):
+        # None means "we could not tell", distinct from {} ("reported, nothing
+        # decoding-relevant") — the same unknown-is-not-zero discipline the
+        # cost fields follow.
+        assert cc._extract_request_params({}) is None
+        assert cc._extract_request_params({"optional_params": "nope"}) is None
+        assert cc._extract_request_params(None) is None
+        assert cc._extract_request_params({"optional_params": {}}) == {}
+
+
+class TestBoundedParam:
+    """``logit_bias`` / ``stop`` are client-supplied and unbounded, and a
+    serialization failure inside ``_emit`` costs the entire line, not just the
+    field. Both hazards are clamped here."""
+
+    def test_scalars_pass_through(self):
+        assert cc._bounded_param(0.3) == 0.3
+        assert cc._bounded_param(True) is True
+        assert cc._bounded_param(None) is None
+        assert cc._bounded_param("high") == "high"
+
+    def test_oversized_values_become_size_markers(self):
+        assert "chars omitted" in cc._bounded_param("x" * 5000)
+        assert "chars omitted" in cc._bounded_param({str(i): i for i in range(500)})
+
+    def test_unserializable_values_degrade_to_repr_not_raise(self):
+        # A pydantic/enum-ish value must not take the log line down with it.
+        value = {"effort": types.SimpleNamespace(name="high")}
+        assert json.dumps(cc._bounded_param(value))
+
+
+class TestRequestParamsInPayload:
+    def setup_method(self):
+        cc._session_totals.clear()
+
+    def _capture(self, monkeypatch) -> list[dict]:
+        emitted: list[dict] = []
+        monkeypatch.setattr(cc, "_emit", lambda payload: emitted.append(payload))
+        return emitted
+
+    def test_emitted_line_carries_request_params(self, monkeypatch):
+        emitted = self._capture(monkeypatch)
+        cc.LiteLLMCostLogger()._record(
+            _mcd("p1", optional_params=_streaming_optional_params()),
+            types.SimpleNamespace(usage=_streaming_usage()),
+        )
+        payload = emitted[0]
+        assert payload["request_params"]["max_tokens"] == 32000
+        assert payload["request_params"]["extra_body"] == {
+            "provider": {"order": ["Alibaba"], "allow_fallbacks": False}
+        }
+        # The whole line must stay serializable — _emit swallows failures, so
+        # an unserializable param field would silently drop cost data too.
+        assert json.dumps(payload)
+
+    def test_absent_optional_params_does_not_suppress_the_line(self, monkeypatch):
+        # Cost/cache visibility must not regress on a LiteLLM shape that
+        # carries no optional_params.
+        emitted = self._capture(monkeypatch)
+        cc.LiteLLMCostLogger()._record(_mcd("p2"), types.SimpleNamespace(usage=_streaming_usage()))
+        payload = emitted[0]
+        assert payload["request_params"] is None
+        assert payload["call"]["cached_tokens"] == 600

--- a/tests/config/test_cost_callback.py
+++ b/tests/config/test_cost_callback.py
@@ -162,6 +162,16 @@ class TestExtractCost:
         usage = {"cost": float("inf"), "cost_details": {"upstream_inference_cost": 0.05}}
         assert cc._extract_cost(usage) == 0.05
 
+    def test_boolean_cost_is_not_a_cost(self):
+        # JSON `"cost": true` deserializes to Python True, and isinstance(True,
+        # int) is True — so a bare numeric check accepts it and float(True)
+        # records a $1.00 charge that was never billed. Unknown, not spend.
+        assert cc._extract_cost({"cost": True}) is None
+        assert (
+            cc._extract_cost({"cost": 0, "cost_details": {"upstream_inference_cost": True}}) is None
+        )
+        assert cc._extract_estimated_cost({"response_cost": True}) is None
+
     def test_non_finite_estimated_cost_reads_as_unknown(self):
         assert cc._extract_estimated_cost({"response_cost": float("inf")}) is None
         assert cc._extract_estimated_cost({"response_cost": 0.004}) == 0.004
@@ -292,6 +302,31 @@ class TestEstimatedCost:
         )
         # A non-dict standard_logging_object is ignored, not raised on.
         assert cc._extract_estimated_cost({"standard_logging_object": "nope"}) is None
+
+    def test_present_but_unusable_top_level_does_not_suppress_the_fallback(self):
+        # The gate is positivity, not presence. `response_cost: 0.0` is what
+        # LiteLLM writes when it cannot price the model — precisely the case
+        # the fallback exists for — so a presence check would let that zero
+        # mask a perfectly good estimate in the finalized metrics object, and
+        # the call would read as unpriceable when it wasn't.
+        assert (
+            cc._extract_estimated_cost(
+                {"response_cost": 0.0, "standard_logging_object": {"response_cost": 0.004}}
+            )
+            == 0.004
+        )
+        assert (
+            cc._extract_estimated_cost(
+                {
+                    "response_cost": float("inf"),
+                    "standard_logging_object": {"response_cost": 0.004},
+                }
+            )
+            == 0.004
+        )
+        # Symmetric with _extract_cost, whose BYOK `cost: 0` falls through to
+        # cost_details in exactly the same way.
+        assert cc._extract_cost({"cost": 0, "cost_details": {"upstream_inference_cost": 0.05}})
 
 
 class TestAttribution:
@@ -438,6 +473,31 @@ class TestExtractRequestParams:
         assert params["extra_body"]["provider"] == {"order": ["Alibaba"]}
         assert "chars omitted" in params["extra_body"]["junk"]
 
+    def test_a_real_sized_provider_pin_is_not_collapsed_by_the_value_cap(self):
+        # Hoisting the pin ahead of the COUNT cap doesn't exempt it from the
+        # SIZE cap, and a pin with an `ignore` list of a few dozen backends
+        # clears 512 chars on its own — so under the general cap the one entry
+        # naming which backend served the turn is the one that degrades, in the
+        # incident reconstruction it exists for. Priority keys get a wider cap.
+        pin = {
+            "order": [f"Provider{i}" for i in range(6)],
+            "ignore": [f"Ignored{i}" for i in range(30)],
+            "allow_fallbacks": False,
+            "quantizations": ["fp8", "bf16"],
+        }
+        assert len(json.dumps(pin)) > cc._MAX_PARAM_JSON_CHARS
+        params = cc._extract_request_params(
+            _mcd("r", optional_params={"extra_body": {"provider": pin, "junk": "z" * 600}})
+        )
+        assert params["extra_body"]["provider"] == pin
+        # Still a cap, not an exemption — one entry cannot run away either.
+        assert "chars omitted" in cc._bounded_param(
+            {"order": ["p" * cc._MAX_PRIORITY_PARAM_JSON_CHARS]},
+            cc._MAX_PRIORITY_PARAM_JSON_CHARS,
+        )
+        # And a non-priority sibling keeps the tighter budget.
+        assert "chars omitted" in params["extra_body"]["junk"]
+
     def test_extra_body_stays_bounded_in_aggregate(self):
         # Per-value bounding leaves the key COUNT and the key NAMES unbounded.
         # extra_body is config-supplied and usually pinned in litellm_params, so
@@ -460,9 +520,11 @@ class TestExtractRequestParams:
         assert "more keys omitted" in emitted[cc._EXTRA_BODY_TRUNCATED_KEY]
         assert emitted["provider"] == {"order": ["Alibaba"]}
         assert all(len(k) <= cc._MAX_EXTRA_BODY_KEY_CHARS + 32 for k in emitted)
+        # The stated worst case: every key at its name cap and its value cap,
+        # with one priority key drawing on the wider value budget.
         assert len(json.dumps(emitted)) < cc._MAX_EXTRA_BODY_KEYS * (
             cc._MAX_PARAM_JSON_CHARS + cc._MAX_EXTRA_BODY_KEY_CHARS + 64
-        )
+        ) + (cc._MAX_PRIORITY_PARAM_JSON_CHARS - cc._MAX_PARAM_JSON_CHARS)
 
     def test_oversized_extra_body_key_name_is_bounded(self):
         # The key COUNT cap alone doesn't bound the key NAMES: a long key inside
@@ -498,22 +560,26 @@ class TestExtractRequestParams:
         assert sorted(params["extra_body"].values()) == ["int", "str"]
 
     def test_truncation_marker_does_not_overwrite_a_real_key(self):
-        # An operator key literally named like the marker must not be clobbered
-        # by it, and must not consume the marker's slot either.
+        # An operator key named exactly like the sentinel must not be clobbered
+        # by the marker, and must not consume the marker's slot either. The
+        # sentinel's own name is what has to be used here: a test written
+        # against some *other* name passes no matter what the marker collides
+        # with, which makes the `_MAX_EXTRA_BODY_KEYS + 1` invariant below
+        # fixture-specific rather than general.
         params = cc._extract_request_params(
             _mcd(
                 "r",
                 optional_params={
                     "extra_body": {
-                        "<truncated>": "real value",
+                        cc._EXTRA_BODY_TRUNCATED_KEY: "real value",
                         **{f"knob{i}": i for i in range(40)},
                     }
                 },
             )
         )
         emitted = params["extra_body"]
-        assert emitted["<truncated>"] == "real value"
-        assert "more keys omitted" in emitted[cc._EXTRA_BODY_TRUNCATED_KEY]
+        assert emitted[cc._EXTRA_BODY_TRUNCATED_KEY] == "real value"
+        assert "more keys omitted" in emitted[f"{cc._EXTRA_BODY_TRUNCATED_KEY}<2>"]
         assert len(emitted) == cc._MAX_EXTRA_BODY_KEYS + 1
 
     def test_provider_pin_survives_a_late_position_under_the_count_cap(self):
@@ -591,6 +657,19 @@ class TestBoundedParam:
     def test_oversized_values_become_size_markers(self):
         assert "chars omitted" in cc._bounded_param("x" * 5000)
         assert "chars omitted" in cc._bounded_param({str(i): i for i in range(500)})
+
+    def test_the_cap_is_caller_settable_on_both_branches(self):
+        # Priority extra_body entries draw on a wider budget, and the cap has to
+        # reach BOTH exits — the raw-string shortcut as well as the JSON
+        # round-trip — or a string-valued priority knob silently keeps the
+        # tighter cap while a dict-valued one gets the wider one.
+        long_str = "z" * (cc._MAX_PARAM_JSON_CHARS + 1)
+        assert "chars omitted" in cc._bounded_param(long_str)
+        assert cc._bounded_param(long_str, cc._MAX_PRIORITY_PARAM_JSON_CHARS) == long_str
+        assert "chars omitted" in cc._bounded_param({"order": long_str})
+        assert cc._bounded_param({"order": long_str}, cc._MAX_PRIORITY_PARAM_JSON_CHARS) == {
+            "order": long_str
+        }
 
     def test_unserializable_values_degrade_to_repr_not_raise(self):
         # A pydantic/enum-ish value must not take the log line down with it.

--- a/tests/config/test_cost_callback.py
+++ b/tests/config/test_cost_callback.py
@@ -177,6 +177,53 @@ class TestExtractCost:
         assert cc._extract_estimated_cost({"response_cost": 0.004}) == 0.004
 
 
+class TestExtractCacheStats:
+    """Token counts get the same guard the cost fields get, for a sharper
+    reason: they are emitted through ``int(...)``, where a non-finite raises
+    rather than merely misreporting."""
+
+    def setup_method(self):
+        cc._session_totals.clear()
+
+    def test_boolean_and_non_finite_token_counts_are_not_counts(self):
+        # Same shapes that make a boolean cost a $1.00 charge: isinstance(True,
+        # int) is True, so a bare numeric check reads `True` as one token that
+        # was never sent, and `inf` as an infinity of them.
+        for bad in (True, float("inf"), float("nan"), -5, "1200", None):
+            assert cc._extract_cache_stats({"prompt_tokens": bad}) == (0.0, 0.0, 0.0, 0.0)
+        assert cc._extract_cache_stats({"prompt_tokens": 1200}) == (1200.0, 0.0, 0.0, 0.0)
+        # The nested schemas are read through the same helper.
+        assert cc._extract_cache_stats(
+            {"prompt_tokens_details": {"cached_tokens": float("inf")}}
+        ) == (0.0, 0.0, 0.0, 0.0)
+        assert cc._extract_cache_stats(
+            {"completion_tokens_details": {"reasoning_tokens": True}}
+        ) == (0.0, 0.0, 0.0, 0.0)
+
+    def test_a_non_finite_count_does_not_silence_the_rest_of_the_session(self, monkeypatch):
+        # The consequence is worse than for cost: `int(inf)` raises OverflowError
+        # inside _record, whose outer handler drops the whole line — and the
+        # value has already landed in the session total, so it stays inf and
+        # every LATER call in that session is dropped too, for the pod's
+        # lifetime (the LRU only evicts under 4096-session pressure).
+        emitted: list[dict] = []
+        monkeypatch.setattr(cc, "_emit", lambda payload: emitted.append(payload))
+        logger = cc.LiteLLMCostLogger()
+        logger._record(
+            _mcd("poisoned"),
+            types.SimpleNamespace(
+                usage={"prompt_tokens": float("inf"), "cache_read_input_tokens": 600}
+            ),
+        )
+        logger._record(
+            _mcd("poisoned"),
+            types.SimpleNamespace(usage={"prompt_tokens": 1000, "cache_read_input_tokens": 600}),
+        )
+        assert len(emitted) == 2
+        assert emitted[-1]["call"]["prompt_tokens"] == 1000
+        assert cc._session_totals["poisoned"]["prompt_tokens"] == 1000.0
+
+
 class TestRecordCostReporting:
     def setup_method(self):
         cc._session_totals.clear()
@@ -325,8 +372,12 @@ class TestEstimatedCost:
             == 0.004
         )
         # Symmetric with _extract_cost, whose BYOK `cost: 0` falls through to
-        # cost_details in exactly the same way.
-        assert cc._extract_cost({"cost": 0, "cost_details": {"upstream_inference_cost": 0.05}})
+        # cost_details in exactly the same way. Pin the value, not truthiness:
+        # a bare `assert` here passes on any non-zero return, including a wrong
+        # one, which is no assertion at all.
+        assert (
+            cc._extract_cost({"cost": 0, "cost_details": {"upstream_inference_cost": 0.05}}) == 0.05
+        )
 
 
 class TestAttribution:
@@ -503,14 +554,27 @@ class TestExtractRequestParams:
         # extra_body is config-supplied and usually pinned in litellm_params, so
         # an unbounded remainder is not one bad line — it is every line for the
         # life of the config.
+        #
+        # The fixture is the stated worst case rather than a merely large one:
+        # every key name past its cap (so each emits the 64-char prefix AND the
+        # size suffix), every value exactly at its cap, and the priority key
+        # drawing on the wider budget. A fixture whose pin is two words leaves
+        # the priority slack term in the bound below as pure headroom — the
+        # assertion then means whatever it meant before that term existed.
+        pin = {"order": [f"backend-{i:03d}" for i in range(130)], "allow_fallbacks": False}
+        # Near the priority cap, not merely over the general one — that is what
+        # makes the slack term below load-bearing rather than headroom.
+        assert cc._MAX_PARAM_JSON_CHARS < len(json.dumps(pin)) <= cc._MAX_PRIORITY_PARAM_JSON_CHARS
         params = cc._extract_request_params(
             _mcd(
                 "r",
                 optional_params={
                     "extra_body": {
-                        "provider": {"order": ["Alibaba"]},
-                        **{f"knob{i}": "v" * 400 for i in range(200)},
-                        "k" * 100000: 1,
+                        "provider": pin,
+                        **{
+                            f"knob{i}" + "k" * 100000: "v" * cc._MAX_PARAM_JSON_CHARS
+                            for i in range(200)
+                        },
                     }
                 },
             )
@@ -518,13 +582,71 @@ class TestExtractRequestParams:
         emitted = params["extra_body"]
         assert len(emitted) == cc._MAX_EXTRA_BODY_KEYS + 1  # + the truncation marker
         assert "more keys omitted" in emitted[cc._EXTRA_BODY_TRUNCATED_KEY]
-        assert emitted["provider"] == {"order": ["Alibaba"]}
+        assert emitted["provider"] == pin
         assert all(len(k) <= cc._MAX_EXTRA_BODY_KEY_CHARS + 32 for k in emitted)
-        # The stated worst case: every key at its name cap and its value cap,
-        # with one priority key drawing on the wider value budget.
-        assert len(json.dumps(emitted)) < cc._MAX_EXTRA_BODY_KEYS * (
-            cc._MAX_PARAM_JSON_CHARS + cc._MAX_EXTRA_BODY_KEY_CHARS + 64
-        ) + (cc._MAX_PRIORITY_PARAM_JSON_CHARS - cc._MAX_PARAM_JSON_CHARS)
+        # The bound stated as it is derived — per key, a name at its cap plus
+        # the size suffix, a value at its cap, and JSON punctuation — with the
+        # one priority key drawing on the wider value budget. Asserted from
+        # below as well as above: a maximal fixture that fits under the general
+        # term alone would leave the slack term unexercised, which is how a
+        # loose bound comes to look like a pinned one.
+        general = cc._MAX_EXTRA_BODY_KEYS * (
+            cc._MAX_EXTRA_BODY_KEY_CHARS + 32 + cc._MAX_PARAM_JSON_CHARS + 8
+        )
+        slack = cc._MAX_PRIORITY_PARAM_JSON_CHARS - cc._MAX_PARAM_JSON_CHARS
+        assert general < len(json.dumps(emitted)) < general + slack
+
+    def test_the_whole_params_block_is_bounded_against_the_log_line_split(self):
+        # Each dimension's cap holds and they still compose: 19 allowlisted keys
+        # at the value cap alongside a maximal extra_body clears 20KB. A line
+        # that long is split into unparseable partials by the container runtime,
+        # so `jq -Rc 'fromjson?'` drops it and the cost data with it — the
+        # outcome allow_nan=False exists to prevent, reached by size instead.
+        params = cc._extract_request_params(
+            _mcd(
+                "r",
+                optional_params={
+                    **dict.fromkeys(cc._REQUEST_PARAM_KEYS, "v" * cc._MAX_PARAM_JSON_CHARS),
+                    "extra_body": {
+                        "provider": {"order": ["Alibaba"]},
+                        **{
+                            f"knob{i}" + "k" * 100000: "v" * cc._MAX_PARAM_JSON_CHARS
+                            for i in range(100)
+                        },
+                    },
+                },
+            )
+        )
+        assert len(json.dumps(params)) <= cc._MAX_REQUEST_PARAMS_CHARS
+        # What survives is what the field exists to answer: the sampling knobs
+        # (a handful of bytes each — never what pushed the block over) and the
+        # provider pin, which collapses out of extra_body rather than with it.
+        assert params["temperature"] == "v" * cc._MAX_PARAM_JSON_CHARS
+        assert params["extra_body"]["provider"] == {"order": ["Alibaba"]}
+        assert "more keys omitted" in params["extra_body"][cc._EXTRA_BODY_TRUNCATED_KEY]
+
+    def test_a_stock_line_is_left_alone_by_the_aggregate_bound(self):
+        # The guard is a backstop, not a filter: nothing a real route emits goes
+        # near the budget, and a trim that fired on stock traffic would be a
+        # regression in exactly the data this PR adds.
+        params = cc._extract_request_params(
+            _mcd(
+                "r",
+                optional_params={
+                    "max_tokens": 32000,
+                    "stream": True,
+                    "temperature": 0.3,
+                    "extra_body": {"provider": {"order": ["Alibaba"], "allow_fallbacks": False}},
+                },
+            )
+        )
+        assert params == {
+            "temperature": 0.3,
+            "max_tokens": 32000,
+            "stream": True,
+            "extra_body": {"provider": {"order": ["Alibaba"], "allow_fallbacks": False}},
+        }
+        assert len(json.dumps(params)) < cc._MAX_REQUEST_PARAMS_CHARS // 10
 
     def test_oversized_extra_body_key_name_is_bounded(self):
         # The key COUNT cap alone doesn't bound the key NAMES: a long key inside


### PR DESCRIPTION
Closes #3599 — implements item 1 of the three it lists. The remaining two are split out and
tracked separately (#3616, #3617), along with a gap this change does not cover (#3618); see
*Not included* below.

## Problem

egg sets no sampling parameters for any agent and **recorded none**, so when a model misbehaved there was no way to determine what decoding configuration produced the behaviour, during the incident or afterwards.

That blocked the #3598 post-mortem outright: a `laguna-s-2.1` producer emitted 480 identical tool calls out of 603, and whether that is inherent to the model or an artifact of an unlucky decoding configuration is unanswerable, because nothing recorded which configuration was in play. Repetition and degeneration are decoding-sensitive failure modes; the one class of incident where this data matters most is precisely the class egg could not reconstruct.

## Change

`config/litellm/cost_callback.py` now emits `request_params` on every per-call log line:

```json
"request_params": {
  "max_tokens": 32000,
  "stream": true,
  "extra_body": {"provider": {"order": ["Alibaba"], "allow_fallbacks": false}}
}
```

That is the shape on a stock egg route today, and it *is* the #3599 finding rendered legible: no `temperature`, no `top_p`, no `top_k`, no penalty. With sampling pinned in `litellm_params`, the same field reads:

```json
{"temperature": 0.3, "top_p": 0.9, "top_k": 40, "seed": 42, "frequency_penalty": 0.2, ...}
```

Source is `model_call_details['optional_params']` — LiteLLM's **post-mapping** parameter set, i.e. the dict that becomes the upstream request body. Two properties earn the field its place:

- **An absent key was never sent**, so the provider's own server-side default applied, and that default can change under us with no egg change. Missing keys are omitted rather than written as `null`, so absence reads as "never sent" and not "explicitly unset".
- **`drop_params` has already acted**, so this reports what the wire carried, not what the config asked for. A knob an operator set that does *not* appear here was silently discarded or relocated by LiteLLM's param mapper. That divergence is invisible today; here it is a diff.

## Verification

Validated end to end by running the real `cost_callback.py` inside the pinned **litellm 1.86.2** on a streamed `anthropic_messages` → OpenRouter call (the route *and* mode of all real Claude Code agent traffic), with HTTP mocked at the transport layer:

| Scenario | Emitted `request_params` |
|---|---|
| egg as shipped | `max_tokens`, `stream`, provider pin — no sampling knobs |
| sampling pinned in config | `temperature`, `top_p`, `top_k`, `seed`, `frequency_penalty` … |
| client sends `thinking: {budget_tokens: 8000}` | `reasoning_effort: "medium"` |

The third row is worth its own note: LiteLLM **rewrites** a `thinking` budget into a `reasoning_effort` bucket, overwriting an explicitly configured `reasoning_effort`. The recorded value is the effective one that went upstream, not the requested one — and it is why the field is emitted per line rather than once per session (it is not session-stable).

`mock_response` is deliberately **not** used anywhere in this verification: it short-circuits in `anthropic_messages_handler` before the adapter path runs and leaves `optional_params` empty. A fixture built that way would have made both the feature and its tests look correct while recording nothing.

## Design notes

- **Allowlist, not a dump of `optional_params`.** That dict also carries the translated `tools` schemas (Claude Code sends a dozen-plus per request). Dumping it whole would bloat every line by orders of magnitude and spill task text into a stream that is a cost/observability sink, not a transcript sink. Values are size-capped and JSON-round-tripped: `_emit` swallows serialization failures, so one unserializable or unbounded field would silently take the whole cost line — including the cost data — with it.
- **Not `standard_logging_object.model_parameters`.** It filters to OpenAI's declared parameter set, which drops `top_k`, `stop_sequences` and `extra_body` — silently under-reporting several of the anti-repetition knobs this exists to capture.
- **`extra_body` knobs are hoisted flat.** LiteLLM relocates knobs a provider doesn't declare into `extra_body` rather than dropping them, so the same knob lands at different depths per model; hoisting keeps one query surface. The remainder (notably the OpenRouter provider pin, which decides which backend — and so which quantization — served the turn) is preserved under `extra_body`.

Line cost: ~130 bytes on an 812-byte line.

## Not included

Items 2 (**pin** `temperature`/`top_p` per model, now #3616) and 3 (**inject** a server-side repetition penalty, now #3617) from #3599 are deliberately left out:

- Both are behaviour changes whose correct values are per-provider judgement calls requiring each provider's published recommended sampling, and item 3 additionally requires verifying the provider honours it (`drop_params: true` hides the failure).
- The model configs in question live in the operator-local `~/.config/egg/litellm-models.yaml`, not the repo — `laguna-s-2.1` appears nowhere in this codebase. The repo carries only a template with one example backend.
- #3599 is explicit that ordering matters: trap frequency is conditional on decoding config, so a threshold measured under one configuration does not transfer to another. Landing 2 or 3 before this measurement exists reproduces the present ambiguity at greater cost.

One further gap, now filed as **#3618**: this covers LiteLLM-routed traffic only. Claude-model agents go direct to Anthropic and never touch this proxy, so nothing is recorded for them. That is a near-static answer today (Claude Code CLI defaults, no egg override) and the incidents driving #3599 are all on LiteLLM routes — but "near-static" is itself an unrecorded assumption, which is why it is tracked rather than dismissed.

## Testing

- 12 new tests in `tests/config/test_cost_callback.py` (26 total in the file, all passing) covering the streaming-agent shape, explicit sampling params, prompt-bearing-field exclusion, `extra_body` hoisting and remainder, the unknown-vs-empty distinction, size capping, and unserializable-value degradation. The fixture is captured from the live litellm 1.86.2 run described above and says so.
- `make lint` clean.
- `make test`: 22022 passed. Four failures, all in `tests/scripts/`, `gateway/tests/` and `orchestrator/tests/` — confirmed pre-existing by reproducing them on a clean worktree at `main` (6e9de942a). No import path connects them to the files touched here.

