### PR TITLE
health_monitor: anchor never-heartbeated roles at Job start (#3605)

### DIFF
--- a/orchestrator/health_monitor.py
+++ b/orchestrator/health_monitor.py
@@ -183,16 +183,22 @@ class HealthMonitor:
         # Like every other ``now - last_*`` in this module this is wall-clock,
         # not monotonic. A backward clock step (NTP correction, host suspend)
         # shrinks ``monitor_age``, but that alone does not break the guard's
-        # inequality: only a step larger than the monitor's own age pushes
-        # ``now`` behind ``_created_at``, collapsing ``monitor_age`` to 0.0
-        # and making ``_sanitize_elapsed`` flag-and-clamp every anchor
-        # written *after* the step until the skew window passes. A smaller
-        # step — an ordinary sub-second NTP correction — flags nothing at
-        # all, and anchors written before any backward step shrink by the
-        # same delta and stay unflagged either way. Forward steps do not
-        # defeat this guard either: ``now`` inflates ``elapsed`` and
-        # ``monitor_age`` by the same amount, so ``elapsed <= monitor_age``
-        # survives. They are not harmless, though — every ``elapsed`` grows
+        # inequality: only a step exceeding the monitor's own age *plus*
+        # ``_ELAPSED_SANITY_SLACK_SECONDS`` drags post-step anchors behind
+        # ``_created_at`` far enough to make ``_sanitize_elapsed``
+        # flag-and-clamp them. A smaller step — an ordinary sub-second NTP
+        # correction — flags nothing at all, and anchors written before any
+        # backward step shrink by the same delta and stay unflagged either
+        # way. Nor is such flagging self-limiting: once ``now`` climbs back
+        # past ``_created_at`` the condition reduces to ``anchor <
+        # _created_at - slack``, which no longer involves ``now``, so a
+        # ``_job_active_since`` anchor written inside the skew window keeps
+        # being flagged (and keeps bypassing the alive-signal gate) after
+        # the window closes — until the Job ends, the role heartbeats, or
+        # ``reset_agent`` drops it. Forward steps do not defeat this guard
+        # either: ``now`` inflates ``elapsed`` and ``monitor_age`` by the
+        # same amount, so ``elapsed <= monitor_age`` survives. They are not
+        # harmless, though — every ``elapsed`` grows
         # by the step, so a role that heartbeated seconds ago can trip the
         # timeout itself, and the guard cannot catch that precisely because
         # ``monitor_age`` inflated too. Worth revisiting if this module ever
@@ -855,9 +861,15 @@ class HealthMonitor:
             #
             # #3605: anchor those roles at the time their Job was first
             # observed active, NOT at 0.0; ``now - 0.0`` reported a Unix
-            # epoch timestamp as the elapsed stall time. ``setdefault``
-            # covers the case where the role entered ``_active_jobs`` on a
-            # path that never reached ``set_active_roles``.
+            # epoch timestamp as the elapsed stall time.
+            #
+            # ``set_active_roles`` is the sole writer of ``_active_jobs``, so
+            # it normally anchors every role reached here. ``setdefault``
+            # covers the gap ``reset_agent`` opens: it drops the anchor while
+            # deliberately leaving the role in ``_active_jobs``, so a poll
+            # landing before the next ``set_active_roles`` tick re-anchors at
+            # check time (≈ the restart) instead of raising ``KeyError`` or
+            # resurrecting the dead Job's clock.
             known_agent_ids = {a_id for a_id, _, _ in snapshot}
             for role in self._active_jobs:
                 if role not in known_agent_ids:

--- a/orchestrator/health_monitor.py
+++ b/orchestrator/health_monitor.py
@@ -198,11 +198,11 @@ class HealthMonitor:
         # ``reset_agent`` drops it. Forward steps do not defeat this guard
         # either: ``now`` inflates ``elapsed`` and ``monitor_age`` by the
         # same amount, so ``elapsed <= monitor_age`` survives. They are not
-        # harmless, though — every ``elapsed`` grows
-        # by the step, so a role that heartbeated seconds ago can trip the
-        # timeout itself, and the guard cannot catch that precisely because
-        # ``monitor_age`` inflated too. Worth revisiting if this module ever
-        # moves to ``time.monotonic``.
+        # harmless, though — every ``elapsed`` grows by the step, so a role
+        # that heartbeated seconds ago can trip the timeout itself, and the
+        # guard cannot catch that precisely because ``monitor_age`` inflated
+        # too. Worth revisiting if this module ever moves to
+        # ``time.monotonic``.
         self._created_at: float = time.time()
 
         # Subscribe to events
@@ -601,12 +601,16 @@ class HealthMonitor:
         stall-demotion path in ``_run_concurrent``) cannot be tripped by the
         corrupt value.
 
-        The only anchor that can actually go corrupt today is the heartbeat
-        one (``_job_active_since``, via the never-seen path this issue fixed).
-        ``check_progress`` calls this too, but ``AgentState.last_progress`` is
-        only ever assigned ``now``, so its corrupt branch is purely defensive
-        symmetry — kept so a future writer of that anchor inherits the guard
-        rather than reintroducing the epoch bug on the progress side.
+        The only anchor that can go corrupt today by *bookkeeping* is the
+        heartbeat one (``_job_active_since``, via the never-seen path this
+        issue fixed). ``check_progress`` calls this too, but
+        ``AgentState.last_progress`` is only ever assigned ``now``, so its
+        corrupt branch is purely defensive symmetry — kept so a future writer
+        of that anchor inherits the guard rather than reintroducing the epoch
+        bug on the progress side. The one thing that does reach it is the
+        clock skew documented at ``_created_at``: an ``AgentState`` created
+        after a large backward step is anchored behind ``_created_at`` and is
+        flagged like any other such anchor, on either tripwire.
         """
         monitor_age = max(0.0, now - self._created_at)
         if elapsed <= monitor_age + _ELAPSED_SANITY_SLACK_SECONDS:
@@ -1010,8 +1014,9 @@ class HealthMonitor:
 
         for agent_id, last_progress, already_escalated in snapshot:
             # Defensive symmetry only: ``last_progress`` is never anchored at
-            # the epoch, so ``anchor_corrupt`` cannot fire here in production.
-            # The real #3605 trigger is heartbeat-side. See ``_sanitize_elapsed``.
+            # the epoch, so ``anchor_corrupt`` cannot fire here absent the
+            # clock skew documented at ``_created_at``. The real #3605 trigger
+            # is heartbeat-side. See ``_sanitize_elapsed``.
             elapsed, anchor_corrupt = self._sanitize_elapsed(
                 agent_id, now - last_progress, now, "progress"
             )

--- a/orchestrator/health_monitor.py
+++ b/orchestrator/health_monitor.py
@@ -180,6 +180,12 @@ class HealthMonitor:
         # Wall-clock time the monitor started observing this pipeline. Every
         # anchor it reads is written after this instant, so an ``elapsed``
         # larger than the monitor's own age is necessarily corrupt (#3605).
+        # Like every other ``now - last_*`` in this module this is wall-clock,
+        # not monotonic: a backward clock step (NTP correction, host suspend)
+        # shrinks ``monitor_age`` and would make ``_sanitize_elapsed``
+        # flag-and-clamp everything until the skew window passes. Forward
+        # steps are safe — anchors and ``_created_at`` move together. Worth
+        # revisiting if this module ever moves to ``time.monotonic``.
         self._created_at: float = time.time()
 
         # Subscribe to events
@@ -577,6 +583,13 @@ class HealthMonitor:
         consumers keyed on magnitude (notably the ``>= 300s`` BRC
         stall-demotion path in ``_run_concurrent``) cannot be tripped by the
         corrupt value.
+
+        The only anchor that can actually go corrupt today is the heartbeat
+        one (``_job_active_since``, via the never-seen path this issue fixed).
+        ``check_progress`` calls this too, but ``AgentState.last_progress`` is
+        only ever assigned ``now``, so its corrupt branch is purely defensive
+        symmetry — kept so a future writer of that anchor inherits the guard
+        rather than reintroducing the epoch bug on the progress side.
         """
         monitor_age = max(0.0, now - self._created_at)
         if elapsed <= monitor_age + _ELAPSED_SANITY_SLACK_SECONDS:
@@ -973,6 +986,9 @@ class HealthMonitor:
             ]
 
         for agent_id, last_progress, already_escalated in snapshot:
+            # Defensive symmetry only: ``last_progress`` is never anchored at
+            # the epoch, so ``anchor_corrupt`` cannot fire here in production.
+            # The real #3605 trigger is heartbeat-side. See ``_sanitize_elapsed``.
             elapsed, anchor_corrupt = self._sanitize_elapsed(
                 agent_id, now - last_progress, now, "progress"
             )

--- a/orchestrator/health_monitor.py
+++ b/orchestrator/health_monitor.py
@@ -181,17 +181,22 @@ class HealthMonitor:
         # anchor it reads is written after this instant, so an ``elapsed``
         # larger than the monitor's own age is necessarily corrupt (#3605).
         # Like every other ``now - last_*`` in this module this is wall-clock,
-        # not monotonic: a backward clock step (NTP correction, host suspend)
-        # shrinks ``monitor_age`` and would make ``_sanitize_elapsed``
-        # flag-and-clamp every anchor written *after* the step until the skew
-        # window passes (anchors written before it shrink by the same delta
-        # and stay unflagged). Forward steps do not defeat this guard —
-        # anchors and ``_created_at`` move together, so ``elapsed <=
-        # monitor_age`` survives — but they are not harmless: they inflate
-        # every ``elapsed`` by the step, so a role that heartbeated seconds
-        # ago can trip the timeout itself, and the guard cannot catch it
-        # precisely because ``monitor_age`` inflated too. Worth revisiting if
-        # this module ever moves to ``time.monotonic``.
+        # not monotonic. A backward clock step (NTP correction, host suspend)
+        # shrinks ``monitor_age``, but that alone does not break the guard's
+        # inequality: only a step larger than the monitor's own age pushes
+        # ``now`` behind ``_created_at``, collapsing ``monitor_age`` to 0.0
+        # and making ``_sanitize_elapsed`` flag-and-clamp every anchor
+        # written *after* the step until the skew window passes. A smaller
+        # step — an ordinary sub-second NTP correction — flags nothing at
+        # all, and anchors written before any backward step shrink by the
+        # same delta and stay unflagged either way. Forward steps do not
+        # defeat this guard either: ``now`` inflates ``elapsed`` and
+        # ``monitor_age`` by the same amount, so ``elapsed <= monitor_age``
+        # survives. They are not harmless, though — every ``elapsed`` grows
+        # by the step, so a role that heartbeated seconds ago can trip the
+        # timeout itself, and the guard cannot catch that precisely because
+        # ``monitor_age`` inflated too. Worth revisiting if this module ever
+        # moves to ``time.monotonic``.
         self._created_at: float = time.time()
 
         # Subscribe to events

--- a/orchestrator/health_monitor.py
+++ b/orchestrator/health_monitor.py
@@ -183,9 +183,15 @@ class HealthMonitor:
         # Like every other ``now - last_*`` in this module this is wall-clock,
         # not monotonic: a backward clock step (NTP correction, host suspend)
         # shrinks ``monitor_age`` and would make ``_sanitize_elapsed``
-        # flag-and-clamp everything until the skew window passes. Forward
-        # steps are safe — anchors and ``_created_at`` move together. Worth
-        # revisiting if this module ever moves to ``time.monotonic``.
+        # flag-and-clamp every anchor written *after* the step until the skew
+        # window passes (anchors written before it shrink by the same delta
+        # and stay unflagged). Forward steps do not defeat this guard —
+        # anchors and ``_created_at`` move together, so ``elapsed <=
+        # monitor_age`` survives — but they are not harmless: they inflate
+        # every ``elapsed`` by the step, so a role that heartbeated seconds
+        # ago can trip the timeout itself, and the guard cannot catch it
+        # precisely because ``monitor_age`` inflated too. Worth revisiting if
+        # this module ever moves to ``time.monotonic``.
         self._created_at: float = time.time()
 
         # Subscribe to events

--- a/orchestrator/health_monitor.py
+++ b/orchestrator/health_monitor.py
@@ -78,6 +78,12 @@ _NEVER_SEEN_ACTIVITY: float = 0.0
 # literal here to avoid pulling shared/egg_contracts into health_monitor.
 _OVERSEER_AGENT_ID: str = "overseer"
 
+# Slack (seconds) allowed when testing an elapsed value against the monitor's
+# own age. Every anchor the monitor reads is written after construction, so
+# ``elapsed > monitor_age`` can only come from a corrupt anchor; the slack
+# only absorbs float/clock jitter. See ``_sanitize_elapsed`` (#3605).
+_ELAPSED_SANITY_SLACK_SECONDS: float = 5.0
+
 
 @dataclass
 class AgentState:
@@ -157,6 +163,25 @@ class HealthMonitor:
         # idle", so all tripwires are skipped.
         self._active_jobs: set[str] = set()
 
+        # Heartbeat anchor for roles that have an active one-shot Job but have
+        # never emitted anything the monitor can key state on. Valued with the
+        # wall-clock time the role's Job was first observed active, maintained
+        # by ``set_active_roles``. Before #3605 ``check_heartbeats`` anchored
+        # these roles at 0.0, so ``now - 0`` reported a Unix epoch timestamp
+        # (1784944189s ≈ 56 years) as the elapsed stall time.
+        self._job_active_since: dict[str, float] = {}
+
+        # Roles from ``_job_active_since`` that have already produced a
+        # ``heartbeat_timeout`` escalation: the equivalent of
+        # ``AgentState.heartbeat_escalated`` for roles that have no
+        # ``AgentState`` because nothing was ever received from them (#3605).
+        self._never_seen_escalated: set[str] = set()
+
+        # Wall-clock time the monitor started observing this pipeline. Every
+        # anchor it reads is written after this instant, so an ``elapsed``
+        # larger than the monitor's own age is necessarily corrupt (#3605).
+        self._created_at: float = time.time()
+
         # Subscribe to events
         self._event_bus.subscribe(EventType.PROGRESS_EMITTED, self._on_progress)
         self._event_bus.subscribe(EventType.ERROR, self._on_error)
@@ -205,11 +230,26 @@ class HealthMonitor:
         are treated as legitimately idle and are skipped from tripwire
         checks.
 
+        Also maintains ``_job_active_since``, the heartbeat anchor
+        ``check_heartbeats`` uses for roles that have an active Job but have
+        never emitted a heartbeat (#3605). A newly-active role is anchored at
+        the time its Job was first observed here; a role that leaves the set
+        drops its anchor (and its never-seen escalation marker) so a later Job
+        for the same role re-anchors from scratch instead of inheriting the
+        previous Job's clock.
+
         Args:
             roles: Set of role names with active one-shot Jobs.
         """
+        now = time.time()
         with self._lock:
             self._active_jobs = set(roles)
+            for role in roles:
+                self._job_active_since.setdefault(role, now)
+            for role in list(self._job_active_since):
+                if role not in roles:
+                    del self._job_active_since[role]
+                    self._never_seen_escalated.discard(role)
 
     def reset_agent(self, agent_id: str) -> None:
         """Drop all per-agent tracking state for *agent_id*.
@@ -226,6 +266,11 @@ class HealthMonitor:
           * ``_agents[agent_id]`` — escalation flags, error counts, message
             timestamps, last progress payload.
           * ``_fully_acked_first_seen[agent_id]`` — BRC progress tracker.
+          * ``_job_active_since[agent_id]`` / ``_never_seen_escalated``:
+            the never-heartbeated anchor for the pre-restart Job (#3605).
+            The next ``set_active_roles`` tick re-anchors the role at the
+            time the respawned Job is first observed, so the restarted agent
+            is measured from its own restart rather than from the dead Job.
           * any ``_active_alerts`` whose ``agent_id`` matches — those
             reference the dead container's anchor.
 
@@ -235,6 +280,8 @@ class HealthMonitor:
             self._agents.pop(agent_id, None)
             self._last_heartbeat.pop(agent_id, None)
             self._fully_acked_first_seen.pop(agent_id, None)
+            self._job_active_since.pop(agent_id, None)
+            self._never_seen_escalated.discard(agent_id)
             # _active_alerts is a bounded deque (maxlen=200).  Filter in
             # place via clear()+extend to preserve the bound — rebinding to
             # ``deque(kept)`` would silently drop the maxlen and let the
@@ -506,7 +553,44 @@ class HealthMonitor:
             self._agents[agent_id].last_heartbeat = now
             self._agents[agent_id].last_progress = now
             self._last_heartbeat[agent_id] = now
+            # The role is no longer "never seen": ``_last_heartbeat`` is now
+            # its anchor, so drop the Job-start fallback (#3605).
+            self._job_active_since.pop(agent_id, None)
+            self._never_seen_escalated.discard(agent_id)
         return self._agents[agent_id]
+
+    def _sanitize_elapsed(
+        self, agent_id: str, elapsed: float, now: float, anchor_kind: str
+    ) -> tuple[float, bool]:
+        """Return ``(elapsed, anchor_corrupt)``, clamping impossible values (#3605).
+
+        Every anchor this monitor reads is written after the monitor was
+        constructed, so no real stall can be older than the monitor itself.
+        An ``elapsed`` beyond that bound means the anchor was corrupted. The
+        #3605 repro was a restarted role anchored at the Unix epoch, reporting
+        1784944189s (≈56 years) of "stall".
+
+        Such a value is a bug signal, not a measurement, so it is logged at
+        ERROR and the caller exempts the resulting alert from the alive-signal
+        gates rather than letting a peer heartbeat silently defer it. The
+        returned elapsed is clamped to the monitor's age so downstream
+        consumers keyed on magnitude (notably the ``>= 300s`` BRC
+        stall-demotion path in ``_run_concurrent``) cannot be tripped by the
+        corrupt value.
+        """
+        monitor_age = max(0.0, now - self._created_at)
+        if elapsed <= monitor_age + _ELAPSED_SANITY_SLACK_SECONDS:
+            return elapsed, False
+
+        logger.error(
+            "Corrupt health anchor: elapsed exceeds monitor age",
+            pipeline_id=self._pipeline_id,
+            agent_id=agent_id,
+            anchor_kind=anchor_kind,
+            raw_elapsed_seconds=int(elapsed),
+            monitor_age_seconds=int(monitor_age),
+        )
+        return monitor_age, True
 
     def _on_progress(self, event: Event) -> None:
         """Handle PROGRESS_EMITTED event (heartbeat or progress)."""
@@ -744,13 +828,22 @@ class HealthMonitor:
             # sent a heartbeat (pod spawned but agent never started).
             # Without this a silent mid-event pod would be invisible to the
             # snapshot and never trip the heartbeat timeout.
+            #
+            # #3605: anchor those roles at the time their Job was first
+            # observed active, NOT at 0.0; ``now - 0.0`` reported a Unix
+            # epoch timestamp as the elapsed stall time. ``setdefault``
+            # covers the case where the role entered ``_active_jobs`` on a
+            # path that never reached ``set_active_roles``.
             known_agent_ids = {a_id for a_id, _, _ in snapshot}
             for role in self._active_jobs:
                 if role not in known_agent_ids:
-                    snapshot.append((role, 0.0, False))
+                    anchor = self._job_active_since.setdefault(role, now)
+                    snapshot.append((role, anchor, role in self._never_seen_escalated))
 
         for agent_id, last_hb, already_escalated in snapshot:
-            elapsed = now - last_hb
+            elapsed, anchor_corrupt = self._sanitize_elapsed(
+                agent_id, now - last_hb, now, "heartbeat"
+            )
             if elapsed <= threshold:
                 continue
 
@@ -781,7 +874,12 @@ class HealthMonitor:
             # Overseer exemption (#2430): the watchdog's silence is the
             # signal regardless of peer activity. Without this, a healthy
             # BRC roster defers overseer escalations indefinitely.
-            if agent_id != _OVERSEER_AGENT_ID:
+            #
+            # Corrupt-anchor exemption (#3605): an impossible elapsed value is
+            # a bug in the monitor's own bookkeeping. Deferring it on a peer's
+            # liveness is how a role with no pod and no Job stayed silently
+            # suppressed for the whole pipeline; surface it instead.
+            if agent_id != _OVERSEER_AGENT_ID and not anchor_corrupt:
                 defer, gate_reason = self._has_recent_activity(agent_id, now)
                 if not defer:
                     defer, gate_reason = self._has_recent_peer_progress(agent_id, now)
@@ -795,11 +893,15 @@ class HealthMonitor:
                     )
                     continue
 
+            reason = f"No heartbeat for {int(elapsed)}s (threshold: {threshold}s)"
+            if anchor_corrupt:
+                reason += " [corrupt heartbeat anchor: elapsed clamped to monitor age]"
             action = {
                 "action": "escalate",
                 "agent_id": agent_id,
-                "reason": f"No heartbeat for {int(elapsed)}s (threshold: {threshold}s)",
+                "reason": reason,
                 "elapsed_seconds": int(elapsed),
+                "anchor_corrupt": anchor_corrupt,
             }
             actions.append(action)
 
@@ -815,6 +917,11 @@ class HealthMonitor:
                 agent_state = self._agents.get(agent_id)
                 if agent_state:
                     agent_state.heartbeat_escalated = True
+                else:
+                    # Never-seen role: it has no ``AgentState`` to carry the
+                    # flag, so dedupe through the parallel marker set (#3605).
+                    # Without this the alert re-fires on every poll tick.
+                    self._never_seen_escalated.add(agent_id)
                 self._active_alerts.append(
                     {
                         "id": str(uuid.uuid4()),
@@ -866,7 +973,9 @@ class HealthMonitor:
             ]
 
         for agent_id, last_progress, already_escalated in snapshot:
-            elapsed = now - last_progress
+            elapsed, anchor_corrupt = self._sanitize_elapsed(
+                agent_id, now - last_progress, now, "progress"
+            )
             if elapsed <= threshold:
                 continue
 
@@ -889,7 +998,8 @@ class HealthMonitor:
             #
             # Overseer exemption (#2430): see check_heartbeats — the
             # watchdog's silence must surface even when peers are alive.
-            if agent_id != _OVERSEER_AGENT_ID:
+            # Corrupt-anchor exemption (#3605): see check_heartbeats.
+            if agent_id != _OVERSEER_AGENT_ID and not anchor_corrupt:
                 defer, gate_reason = self._has_recent_activity(agent_id, now)
                 if not defer:
                     defer, gate_reason = self._has_recent_peer_progress(agent_id, now)
@@ -903,11 +1013,15 @@ class HealthMonitor:
                     )
                     continue
 
+            reason = f"No progress for {int(elapsed)}s (threshold: {threshold}s)"
+            if anchor_corrupt:
+                reason += " [corrupt progress anchor: elapsed clamped to monitor age]"
             action = {
                 "action": "escalate",
                 "agent_id": agent_id,
-                "reason": f"No progress for {int(elapsed)}s (threshold: {threshold}s)",
+                "reason": reason,
                 "elapsed_seconds": int(elapsed),
+                "anchor_corrupt": anchor_corrupt,
             }
             actions.append(action)
 

--- a/orchestrator/tests/test_health_monitor.py
+++ b/orchestrator/tests/test_health_monitor.py
@@ -4075,7 +4075,13 @@ class TestImpossibleElapsedSurfacing:
         assert 195 <= actions[0]["elapsed_seconds"] <= 205
 
     def test_corrupt_progress_anchor_bypasses_gate(self):
-        """The same guard applies to the progress-stall tripwire."""
+        """The same guard applies to the progress-stall tripwire.
+
+        Defensive symmetry: ``last_progress`` is only ever assigned ``now``, so
+        this state is not reachable in production — the corruption is injected
+        here to prove the progress path is wired to ``_sanitize_elapsed`` the
+        same way the heartbeat path is.
+        """
         bus = _make_event_bus()
         config = _make_config(
             orchestrator_heartbeat_timeout_seconds=60,

--- a/orchestrator/tests/test_health_monitor.py
+++ b/orchestrator/tests/test_health_monitor.py
@@ -3843,3 +3843,257 @@ class TestOwnershipModeIdleBudgetAnomaly:
         assert isinstance(EVENT_PUMP_IDLE_BUDGET_MIN_DEFAULT, int)
         assert EVENT_PUMP_IDLE_BUDGET_MIN_DEFAULT == 30
         assert _IDLE_BUDGET_MIN_DEFAULT == EVENT_PUMP_IDLE_BUDGET_MIN_DEFAULT
+
+
+# ---------------------------------------------------------------------------
+# Tests: heartbeat-anchor integrity for never-heartbeated roles (issue #3605)
+# ---------------------------------------------------------------------------
+# A role with an active one-shot Job that has never emitted a heartbeat has no
+# ``AgentState`` to anchor against. #3064 slice-5 anchored it at 0.0, so
+# ``now - 0.0`` reported a Unix epoch timestamp as the elapsed stall time
+# (the repro logged ``elapsed_seconds=1784944189``, ~56 years) and the
+# alive-signal gate then deferred that alert on a peer's heartbeat, hiding a
+# role that had no pod and no Job at all. The anchor is now the time the Job
+# was first observed active, and an elapsed value that exceeds the monitor's
+# own age is treated as a bug signal: logged, clamped, and exempt from the
+# alive-signal gates.
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatAnchorIntegrity:
+    """Issue #3605: never-heartbeated roles anchor at Job start, not epoch 0."""
+
+    ROLE = "task_planner"
+
+    def test_never_heartbeated_role_anchors_at_job_start(self):
+        """Elapsed measures from Job observation, not from the Unix epoch."""
+        bus = _make_event_bus()
+        config = _make_config(
+            orchestrator_heartbeat_timeout_seconds=60,
+            orchestrator_alert_progress_gate_seconds=0,
+        )
+        monitor = _make_monitor(bus, config)
+
+        base = time.time()
+        monitor.set_active_roles({self.ROLE})
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 300
+            actions = monitor.check_heartbeats()
+
+        assert len(actions) == 1
+        assert actions[0]["agent_id"] == self.ROLE
+        # ~300s since the Job was observed, not an epoch timestamp.
+        assert 290 <= actions[0]["elapsed_seconds"] <= 310
+        assert actions[0]["anchor_corrupt"] is False
+
+    def test_no_alert_before_threshold_elapses_from_job_start(self):
+        """A freshly observed Job is not instantly stale."""
+        bus = _make_event_bus()
+        config = _make_config(
+            orchestrator_heartbeat_timeout_seconds=60,
+            orchestrator_alert_progress_gate_seconds=0,
+        )
+        monitor = _make_monitor(bus, config)
+
+        base = time.time()
+        monitor.set_active_roles({self.ROLE})
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 30
+            actions = monitor.check_heartbeats()
+
+        assert actions == []
+
+    def test_restart_reanchors_the_role(self):
+        """``reset_agent`` drops the anchor; the next poll re-anchors it.
+
+        The #3605 repro: ``restart_agent`` reset the role's health state while
+        the role stayed in the active-Job set, leaving it never-seen and
+        anchored at 0.0.
+        """
+        bus = _make_event_bus()
+        config = _make_config(
+            orchestrator_heartbeat_timeout_seconds=60,
+            orchestrator_alert_progress_gate_seconds=0,
+        )
+        monitor = _make_monitor(bus, config)
+        monitor.set_active_roles({self.ROLE})
+        _emit_heartbeat(bus, agent_id=self.ROLE)
+
+        base = time.time()
+        monitor.reset_agent(self.ROLE)
+        assert self.ROLE not in monitor._job_active_since
+
+        # The role still has an active Job, so the next poll tick re-anchors.
+        monitor.set_active_roles({self.ROLE})
+        assert monitor._job_active_since[self.ROLE] >= base
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 30
+            assert monitor.check_heartbeats() == []
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 300
+            actions = monitor.check_heartbeats()
+
+        assert len(actions) == 1
+        assert 290 <= actions[0]["elapsed_seconds"] <= 310
+
+    def test_anchor_dropped_when_role_leaves_active_set(self):
+        """A role that goes idle re-anchors when a later Job spawns."""
+        bus = _make_event_bus()
+        monitor = _make_monitor(bus, _make_config())
+
+        monitor.set_active_roles({self.ROLE})
+        first = monitor._job_active_since[self.ROLE]
+
+        monitor.set_active_roles(set())
+        assert self.ROLE not in monitor._job_active_since
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = first + 500
+            monitor.set_active_roles({self.ROLE})
+
+        assert monitor._job_active_since[self.ROLE] == first + 500
+
+    def test_first_signal_hands_the_anchor_over(self):
+        """Once the role emits anything, ``_last_heartbeat`` owns the clock."""
+        bus = _make_event_bus()
+        monitor = _make_monitor(bus, _make_config())
+
+        monitor.set_active_roles({self.ROLE})
+        assert self.ROLE in monitor._job_active_since
+
+        _emit_heartbeat(bus, agent_id=self.ROLE)
+
+        assert self.ROLE not in monitor._job_active_since
+        assert self.ROLE in monitor._last_heartbeat
+
+    def test_never_heartbeated_alert_is_not_repeated(self):
+        """The never-seen path dedupes like ``heartbeat_escalated`` does."""
+        bus = _make_event_bus()
+        config = _make_config(
+            orchestrator_heartbeat_timeout_seconds=60,
+            orchestrator_alert_progress_gate_seconds=0,
+        )
+        monitor = _make_monitor(bus, config)
+
+        base = time.time()
+        monitor.set_active_roles({self.ROLE})
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 300
+            first = monitor.check_heartbeats()
+            second = monitor.check_heartbeats()
+
+        assert len(first) == 1
+        assert second == []
+
+
+class TestImpossibleElapsedSurfacing:
+    """Issue #3605: an elapsed value larger than the monitor's own age is a
+    bug signal: it must be surfaced, not deferred by the alive-signal gate."""
+
+    ROLE = "task_planner"
+
+    def test_corrupt_anchor_bypasses_peer_progress_gate(self):
+        """A peer heartbeat cannot defer an alert built on a corrupt anchor.
+
+        Reproduces the issue evidence verbatim: the restarted role's anchor is
+        0.0 while a peer heartbeated seconds ago, which previously logged
+        "Heartbeat alert deferred by alive-signal gate ...
+        elapsed_seconds=1784944189" on every poll and never alerted.
+        """
+        bus = _make_event_bus()
+        config = _make_config(
+            orchestrator_heartbeat_timeout_seconds=60,
+            orchestrator_alert_progress_gate_seconds=300,
+        )
+        monitor = _make_monitor(bus, config)
+        monitor.set_active_roles({self.ROLE, AGENT_ID_2})
+
+        base = time.time()
+        # A live peer, heartbeating right now.
+        _emit_heartbeat(bus, agent_id=AGENT_ID_2)
+        # Corrupt the restarted role's anchor the way the pre-fix code did.
+        monitor._job_active_since[self.ROLE] = 0.0
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 400
+            actions = monitor.check_heartbeats()
+
+        firing = [a for a in actions if a["agent_id"] == self.ROLE]
+        assert len(firing) == 1, "Corrupt anchor must not be gated by peer liveness"
+        assert firing[0]["anchor_corrupt"] is True
+        assert "corrupt heartbeat anchor" in firing[0]["reason"]
+
+    def test_corrupt_elapsed_is_clamped_to_monitor_age(self):
+        """The reported elapsed never leaks the epoch-scale value downstream.
+
+        ``_run_concurrent`` demotes a dual-role agent from BRC on
+        ``elapsed_seconds >= 300``; an unclamped 1.7e9 would demote instantly.
+        """
+        bus = _make_event_bus()
+        config = _make_config(
+            orchestrator_heartbeat_timeout_seconds=60,
+            orchestrator_alert_progress_gate_seconds=0,
+        )
+        monitor = _make_monitor(bus, config)
+        monitor.set_active_roles({self.ROLE})
+
+        base = time.time()
+        monitor._job_active_since[self.ROLE] = 0.0
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 400
+            actions = monitor.check_heartbeats()
+
+        assert len(actions) == 1
+        # Clamped to the monitor's age (~400s), not ``now - 0``.
+        assert actions[0]["elapsed_seconds"] < 1000
+
+    def test_sane_anchor_is_not_flagged_corrupt(self):
+        """A normal stall keeps its exact elapsed and stays gate-eligible."""
+        bus = _make_event_bus()
+        config = _make_config(
+            orchestrator_heartbeat_timeout_seconds=60,
+            orchestrator_alert_progress_gate_seconds=0,
+        )
+        monitor = _make_monitor(bus, config)
+        monitor.set_active_roles({AGENT_ID})
+
+        base = time.time()
+        _emit_heartbeat(bus, agent_id=AGENT_ID)
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 200
+            actions = monitor.check_heartbeats()
+
+        assert len(actions) == 1
+        assert actions[0]["anchor_corrupt"] is False
+        assert 195 <= actions[0]["elapsed_seconds"] <= 205
+
+    def test_corrupt_progress_anchor_bypasses_gate(self):
+        """The same guard applies to the progress-stall tripwire."""
+        bus = _make_event_bus()
+        config = _make_config(
+            orchestrator_heartbeat_timeout_seconds=60,
+            orchestrator_alert_progress_gate_seconds=300,
+        )
+        monitor = _make_monitor(bus, config)
+        monitor.set_active_roles({AGENT_ID, AGENT_ID_2})
+
+        base = time.time()
+        _emit_progress(bus, agent_id=AGENT_ID)
+        _emit_heartbeat(bus, agent_id=AGENT_ID_2)
+        monitor._agents[AGENT_ID].last_progress = 0.0
+
+        with patch("health_monitor.time") as mock_time:
+            mock_time.time.return_value = base + 400
+            actions = monitor.check_progress()
+
+        firing = [a for a in actions if a["agent_id"] == AGENT_ID]
+        assert len(firing) == 1
+        assert firing[0]["anchor_corrupt"] is True
+        assert firing[0]["elapsed_seconds"] < 1000

--- a/orchestrator/tests/test_health_monitor.py
+++ b/orchestrator/tests/test_health_monitor.py
@@ -4078,9 +4078,11 @@ class TestImpossibleElapsedSurfacing:
         """The same guard applies to the progress-stall tripwire.
 
         Defensive symmetry: ``last_progress`` is only ever assigned ``now``, so
-        this state is not reachable in production — the corruption is injected
-        here to prove the progress path is wired to ``_sanitize_elapsed`` the
-        same way the heartbeat path is.
+        the epoch anchor injected here is not reachable in production — it
+        stands in to prove the progress path is wired to ``_sanitize_elapsed``
+        the same way the heartbeat path is. (The one production route into
+        this branch is the clock skew documented at ``_created_at``, which
+        anchors behind ``_created_at`` rather than at the epoch.)
         """
         bus = _make_event_bus()
         config = _make_config(


### PR DESCRIPTION
## Summary

Fixes #3605. After `restart_agent`, the health monitor reported an impossible
elapsed time for the restarted role, and the alive-signal gate then suppressed
the resulting alert, so a role with no pod and no Job produced no alert at all.

Both halves of the issue's suggested fix are here. The dependency-blind gate
itself stays out of scope (#3595 root cause 2 / #3596 slice 3).

## Root cause

`check_heartbeats` synthesizes a snapshot entry for every active-Job role that
has never emitted a heartbeat (#3064 slice-5), so a silent mid-event pod still
trips the timeout. It anchored those roles at `0.0`:

```python
for role in self._active_jobs:
    if role not in known_agent_ids:
        snapshot.append((role, 0.0, False))   # <- now - 0.0 == a Unix epoch timestamp
```

`restart_agent` calls `reset_agent`, which correctly drops the role's health
state, but the role stays in the active-Job set, so it lands in that branch and
picks up the epoch anchor.

Reproduced against the pre-fix module, matching the issue's evidence line for
line:

```
# pre-fix
Heartbeat alert deferred by alive-signal gate pipeline_id=issue-3596-v2
  agent_id=task_planner elapsed_seconds=1784996600 reason="peer heartbeat 4s ago"

# post-fix (same scenario, 100s after the restart)
Heartbeat alert deferred by alive-signal gate pipeline_id=issue-3596-v2
  agent_id=task_planner elapsed_seconds=100 reason="peer heartbeat 4s ago"
```

## Changes

**1. Anchor correctness.** `_job_active_since` records when each role's Job was
first observed active. `set_active_roles` anchors newly-active roles and drops
anchors for roles that leave the set; `reset_agent` drops the restarted role's
anchor so the next poll re-anchors it at the restart. Elapsed is measured from
the Job, not from the epoch. This mirrors the `.get(p, now)` idiom
`check_brc_progress` already uses for its own first-seen tracker.

A never-seen role has no `AgentState` to carry `heartbeat_escalated`, so
`_never_seen_escalated` gives it the same once-only escalation semantics.
Without it, the now-truthful alert would re-fire on every poll tick.

**2. Impossible elapsed is a bug signal.** No anchor the monitor reads predates
its own construction, so `elapsed > monitor_age` is by definition corrupt.
`_sanitize_elapsed` logs it at ERROR, exempts the alert from the alive-signal
gates (a bug in the monitor's own bookkeeping must not be deferred on a peer's
liveness), and clamps the reported value to the monitor's age. The clamp is
load-bearing: `_run_concurrent` demotes a dual-role agent from BRC at
`elapsed_seconds >= 300`, so an unclamped `1.7e9` demotes instantly. Applied
symmetrically to the progress tripwire.

Alert dicts gain an `anchor_corrupt` key and a suffix on `reason` when it fires.

## What this does not fix

The gate is still dependency-blind: a *sane* alert about a role that no longer
exists is still deferred while a peer heartbeats (second log line above). That
is #3595 root cause 2 / #3596 slice 3. This change makes the number honest and
makes corrupt anchors unsuppressable, which is what #3605 scopes.

## Testing

- 10 new cases in `orchestrator/tests/test_health_monitor.py`: Job-start
  anchoring, no-alert-before-threshold, restart re-anchoring, anchor drop on
  leaving the active set, anchor handover on first signal, escalation dedup,
  gate bypass on a corrupt anchor, clamping, no false `anchor_corrupt` on a
  normal stall, and the progress-tripwire equivalent.
- `orchestrator/tests/test_health_monitor.py`: 143 passed.
- Full reverse-import closure for `health_monitor.py` (150 test files via
  `scripts/select_tests --impacted-tests`): 4732 passed, 4 skipped, 1 xfailed.
  Two failures are pre-existing and reproduce on an unmodified `main`
  checkout on this host, both environmental:
  `test_per_slice_brc_commit.py::...::test_production_worktree_base_dir_lies_within_gateway_allowlist`
  (asserts a production `/home/egg/...` path) and
  `test_state_store_wedge_propagation.py::...::test_probe_skipped_when_request_context_missing`.
- `ruff check` / `ruff format --check` clean; `scripts/check-file-sizes.py`
  exits 0. The file crosses the 60 KB soft-cap advisory (54.9 KB to 61.3 KB);
  it already tripped the line-count advisory before this change and stays well
  under both hard caps.
